### PR TITLE
Add MessageDialog variant box that shows a link after the message

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/MessageDisplay.java
+++ b/src/gwt/src/org/rstudio/core/client/MessageDisplay.java
@@ -196,6 +196,20 @@ public abstract class MessageDisplay
       .showModal();
    }
 
+   /**
+    * Show a messagebox with a clickable URL shown below the message text.
+    */
+   public void showMessage(int type,
+                           String caption,
+                           String message,
+                           String urlLabel,
+                           String url)
+   {
+      createDialog(type, caption, message)
+         .addLink(urlLabel, url)
+         .showModal();
+   }
+ 
    public void showYesNoMessage(int type,
                                 String caption,
                                 String message,

--- a/src/gwt/src/org/rstudio/core/client/MessageDisplay.java
+++ b/src/gwt/src/org/rstudio/core/client/MessageDisplay.java
@@ -197,7 +197,11 @@ public abstract class MessageDisplay
    }
 
    /**
-    * Show a messagebox with a clickable URL shown below the message text.
+    * Show a messagebox with a clickable URL shown below the message text. The
+    * link will open in a new tab (e.g. target=_blank). 
+    *
+    * This mode is only supported for RStudio Server; on Desktop the link will not 
+    * be shown in the dialog.
     */
    public void showMessage(int type,
                            String caption,

--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -111,6 +111,7 @@ public interface ThemeStyles extends CssResource
    String searchBox();
    String clearSearch();
 
+   String dialogAnchorPanel();
    String dialogBottomPanel();
 
    String dialogMessage();

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2273,6 +2273,15 @@ input[type="checkbox"]:checked:before {
    padding: 10px 2px 15px 4px;
 }
 
+.gwt-DialogBox .dialogAnchorPanel {
+   margin-top: 0px;
+   padding: 10px 2px 15px 4px;
+}
+
+.gwt-DialogBox .dialogAnchorPanel td {
+   text-align: center
+}
+
 .gwt-DialogBox .dialogContent {
    padding-left: 10px;
    padding-right: 10px;

--- a/src/gwt/src/org/rstudio/core/client/widget/DialogBuilder.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/DialogBuilder.java
@@ -19,6 +19,7 @@ public interface DialogBuilder
    DialogBuilder addButton(String label, String elementId);
    DialogBuilder addButton(String label, String elementId, Operation operation);
    DialogBuilder addButton(String label, String elementId, ProgressOperation operation);
+   DialogBuilder addLink(String label, String url);
 
    DialogBuilder setDefaultButton(int index);
 

--- a/src/gwt/src/org/rstudio/core/client/widget/MessageDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/MessageDialog.java
@@ -181,13 +181,13 @@ public class MessageDialog extends ModalDialogBase
 
    public void addLink(String label, String url)
    {
-      Anchor anchor = new Anchor(label, url);
-      addMiddleWidget(anchor);
+      Anchor anchor = new Anchor(label, url, "_blank");
+      addAnchorWidget(anchor);
    }
 
    public void removeMiddle()
    {
-      removeMiddlePanel();
+      removeAnchorPanel();
    }
 
    private final int type_;

--- a/src/gwt/src/org/rstudio/core/client/widget/MessageDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/MessageDialog.java
@@ -20,6 +20,7 @@ import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.widget.images.MessageDialogImages;
 
 import com.google.gwt.aria.client.Roles;
+import com.google.gwt.user.client.ui.Anchor;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.HorizontalPanel;
@@ -176,6 +177,17 @@ public class MessageDialog extends ModalDialogBase
    public void setHeight(String height)
    {
       messageWidget_.setHeight(height);
+   }
+
+   public void addLink(String label, String url)
+   {
+      Anchor anchor = new Anchor(label, url);
+      addMiddleWidget(anchor);
+   }
+
+   public void removeMiddle()
+   {
+      removeMiddlePanel();
    }
 
    private final int type_;

--- a/src/gwt/src/org/rstudio/core/client/widget/MessageDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/MessageDialog.java
@@ -185,7 +185,7 @@ public class MessageDialog extends ModalDialogBase
       addAnchorWidget(anchor);
    }
 
-   public void removeMiddle()
+   public void removeAnchorRegion()
    {
       removeAnchorPanel();
    }

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -85,9 +85,9 @@ public abstract class ModalDialogBase extends DialogBox
       mainPanel_ = new VerticalPanel();
 
       // panel to display an optional hyperlink; will be removed if it ends up empty
-      middlePanel_ = new HorizontalPanel();
-      middlePanel_.setStyleName(ThemeStyles.INSTANCE.dialogBottomPanel());
-      middlePanel_.setWidth("100%");
+      anchorPanel_ = new HorizontalPanel();
+      anchorPanel_.setStyleName(ThemeStyles.INSTANCE.dialogAnchorPanel());
+      anchorPanel_.setWidth("100%");
 
       bottomPanel_ = new HorizontalPanel();
       bottomPanel_.setStyleName(ThemeStyles.INSTANCE.dialogBottomPanel());
@@ -101,7 +101,7 @@ public abstract class ModalDialogBase extends DialogBox
       bottomPanel_.add(ariaLiveStatusWidget_);
 
       setButtonAlignment(HasHorizontalAlignment.ALIGN_RIGHT);
-      mainPanel_.add(middlePanel_);
+      mainPanel_.add(anchorPanel_);
       mainPanel_.add(bottomPanel_);
 
       // embed main panel in a custom container if specified
@@ -443,15 +443,15 @@ public abstract class ModalDialogBase extends DialogBox
       bottomPanel_.setCellHorizontalAlignment(buttonPanel_, alignment);
    }
 
-   protected void addMiddleWidget(Widget middle)
+   protected void addAnchorWidget(Widget middle)
    {
-      middlePanel_.add(middle);
+      anchorPanel_.add(middle);
    }
 
-   protected void removeMiddlePanel()
+   protected void removeAnchorPanel()
    {
-      middlePanel_.removeFromParent();
-      middlePanel_ = null;
+      anchorPanel_.removeFromParent();
+      anchorPanel_ = null;
    }
 
    protected ProgressIndicator addProgressIndicator()
@@ -860,7 +860,7 @@ public abstract class ModalDialogBase extends DialogBox
    private boolean enterDisabled_ = false;
    private final SimplePanel containerPanel_;
    private final VerticalPanel mainPanel_;
-   private HorizontalPanel middlePanel_;
+   private HorizontalPanel anchorPanel_;
    private final HorizontalPanel bottomPanel_;
    private final HorizontalPanel buttonPanel_;
    private final HorizontalPanel leftButtonPanel_;

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -443,9 +443,9 @@ public abstract class ModalDialogBase extends DialogBox
       bottomPanel_.setCellHorizontalAlignment(buttonPanel_, alignment);
    }
 
-   protected void addAnchorWidget(Widget middle)
+   protected void addAnchorWidget(Widget widget)
    {
-      anchorPanel_.add(middle);
+      anchorPanel_.add(widget);
    }
 
    protected void removeAnchorPanel()

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -83,6 +83,12 @@ public abstract class ModalDialogBase extends DialogBox
 
       // main panel used to host UI
       mainPanel_ = new VerticalPanel();
+
+      // panel to display an optional hyperlink; will be removed if it ends up empty
+      middlePanel_ = new HorizontalPanel();
+      middlePanel_.setStyleName(ThemeStyles.INSTANCE.dialogBottomPanel());
+      middlePanel_.setWidth("100%");
+
       bottomPanel_ = new HorizontalPanel();
       bottomPanel_.setStyleName(ThemeStyles.INSTANCE.dialogBottomPanel());
       bottomPanel_.setWidth("100%");
@@ -95,6 +101,7 @@ public abstract class ModalDialogBase extends DialogBox
       bottomPanel_.add(ariaLiveStatusWidget_);
 
       setButtonAlignment(HasHorizontalAlignment.ALIGN_RIGHT);
+      mainPanel_.add(middlePanel_);
       mainPanel_.add(bottomPanel_);
 
       // embed main panel in a custom container if specified
@@ -434,6 +441,17 @@ public abstract class ModalDialogBase extends DialogBox
    protected void setButtonAlignment(HorizontalAlignmentConstant alignment)
    {
       bottomPanel_.setCellHorizontalAlignment(buttonPanel_, alignment);
+   }
+
+   protected void addMiddleWidget(Widget middle)
+   {
+      middlePanel_.add(middle);
+   }
+
+   protected void removeMiddlePanel()
+   {
+      middlePanel_.removeFromParent();
+      middlePanel_ = null;
    }
 
    protected ProgressIndicator addProgressIndicator()
@@ -842,6 +860,7 @@ public abstract class ModalDialogBase extends DialogBox
    private boolean enterDisabled_ = false;
    private final SimplePanel containerPanel_;
    private final VerticalPanel mainPanel_;
+   private HorizontalPanel middlePanel_;
    private final HorizontalPanel bottomPanel_;
    private final HorizontalPanel buttonPanel_;
    private final HorizontalPanel leftButtonPanel_;

--- a/src/gwt/src/org/rstudio/studio/client/common/dialog/DialogBuilderBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dialog/DialogBuilderBase.java
@@ -30,6 +30,12 @@ public abstract class DialogBuilderBase implements DialogBuilder
       public ProgressOperation progressOperation;
    }
 
+   protected static class AnchorSpec
+   {
+      public String label;
+      public String url;
+   }
+
    public DialogBuilderBase(int type, String caption)
    {
       this.type = type;
@@ -67,6 +73,16 @@ public abstract class DialogBuilderBase implements DialogBuilder
    }
 
    @Override
+   public DialogBuilder addLink(String label, String url)
+   {
+      anchor_ = new AnchorSpec();
+      anchor_.label = label;
+      anchor_.url = url;
+
+      return this;
+   }
+
+   @Override
    public DialogBuilder setDefaultButton(int index)
    {
       defaultButton_ = index;
@@ -78,5 +94,6 @@ public abstract class DialogBuilderBase implements DialogBuilder
    protected final int type;
    protected final String caption;
    protected ArrayList<ButtonSpec> buttons_ = new ArrayList<>();
+   protected AnchorSpec anchor_;
    protected int defaultButton_ = 0;
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/dialog/WebDialogBuilderFactory.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dialog/WebDialogBuilderFactory.java
@@ -68,7 +68,7 @@ public class WebDialogBuilderFactory implements DialogBuilderFactory
          if (anchor_ != null)
             messageDialog.addLink(anchor_.label, anchor_.url);
          else
-            messageDialog.removeMiddle();
+            messageDialog.removeAnchorRegion();
 
          if (options_ != null)
          {

--- a/src/gwt/src/org/rstudio/studio/client/common/dialog/WebDialogBuilderFactory.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dialog/WebDialogBuilderFactory.java
@@ -64,7 +64,12 @@ public class WebDialogBuilderFactory implements DialogBuilderFactory
                                        i == buttons_.size() - 1);
             }
          }
-         
+
+         if (anchor_ != null)
+            messageDialog.addLink(anchor_.label, anchor_.url);
+         else
+            messageDialog.removeMiddle();
+
          if (options_ != null)
          {
             if (options_.width != null)


### PR DESCRIPTION
### Intent

First draft of of a request by Workbench team: a message dialog that includes a link. The link is opened with target=_blank.

This MessageDialog variant only works on RStudio Server; the link won't be shown on Desktop.

### Approach

New `showMessage` variant that takes a link label and destination (url), along with a message and dialog caption.

Example:

<img width="457" alt="Screenshot of new dialog mode example" src="https://github.com/rstudio/rstudio/assets/10569626/c4f483d1-59fe-4d6e-af14-3b1e383af9d3">

This was created with:

```java
globalDisplay_.showMessage(
         GlobalDisplay.MSG_INFO,
         "Window Caption",
         "Here is a message that I am displaying because I need to display something here.",
         "Go to Posit Website",
         "https://posit.co/");
```

### Automated Tests

None

### QA Notes

TBD

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


