### PR TITLE
make sure we auto-refresh if object changes

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/dataviewer/DataViewerResources.java
+++ b/src/gwt/src/org/rstudio/studio/client/dataviewer/DataViewerResources.java
@@ -1,4 +1,5 @@
-/* DataViewerResources.java
+/*
+ * DataViewerResources.java
  *
  * Copyright (C) 2022 by Posit Software, PBC
  *

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
@@ -14,7 +14,9 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.data;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.SimplePanelWithProgress;
@@ -36,6 +38,7 @@ import org.rstudio.studio.client.workbench.views.source.model.SourceServerOperat
 
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
@@ -55,9 +58,12 @@ public class DataEditingTarget extends UrlContentEditingTarget
                             EventBus events)
    {
       super(server, commands, globalDisplay, events);
+      
       events_ = events;
       isActive_ = true;
-      events.addHandler(DataViewChangedEvent.TYPE, this);
+      handlers_ = new ArrayList<>();
+      
+      handlers_.add(events.addHandler(DataViewChangedEvent.TYPE, this));
    }
 
    @Override
@@ -148,6 +154,9 @@ public class DataEditingTarget extends UrlContentEditingTarget
    {
       // explicitly avoid calling super method as we don't
       // have an associated content URL to clean up
+      for (HandlerRegistration handler : handlers_)
+         handler.removeHandler();
+      handlers_.clear();
    }
    
    private void doQueuedRefresh()
@@ -259,5 +268,6 @@ public class DataEditingTarget extends UrlContentEditingTarget
    private final EventBus events_;
    private boolean isActive_;
    private QueuedRefreshType queuedRefresh_;
+   private final List<HandlerRegistration> handlers_;
    private static final ViewsSourceConstants constants_ = GWT.create(ViewsSourceConstants.class);
 }


### PR DESCRIPTION
### Intent

Addresses #14082.

### Approach

Check if the monitored `SEXP` object has changed, in addition to its type + structure. If it has, then update the view.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14082. Also verify that https://github.com/rstudio/rstudio/issues/13856 hasn't been re-introduced.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
