### PR TITLE
retain backwards compatibility with older openssl

### DIFF
--- a/src/cpp/core/include/core/system/Crypto.hpp
+++ b/src/cpp/core/include/core/system/Crypto.hpp
@@ -23,6 +23,8 @@
 #include <shared_core/FilePath.hpp>
 #include <shared_core/system/Crypto.hpp>
 
+#define kRsaKeySizeBits 4096
+
 namespace rstudio {
 namespace core {
 namespace system {

--- a/src/cpp/core/system/Crypto.cpp
+++ b/src/cpp/core/system/Crypto.cpp
@@ -46,9 +46,6 @@
 
 using namespace rstudio::core;
 
-#define kRsaKeySize 4096
-#define kRsaEntropyBytes 4096
-
 namespace rstudio {
 namespace core {
 namespace system {
@@ -270,7 +267,7 @@ Error generateRsa(const std::unique_ptr<BIO, decltype(&BIO_free)>& pBioPub,
                   const std::unique_ptr<BIO, decltype(&BIO_free)>& pBioPem)
 {
    // Generate RSA key
-   std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> pKey(EVP_RSA_gen(kRsaKeySize), EVP_PKEY_free);
+   std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> pKey(EVP_RSA_gen(kRsaKeySizeBits), EVP_PKEY_free);
    
    // Write public key in PEM format
    int status = PEM_write_bio_PUBKEY(pBioPub.get(), pKey.get());
@@ -341,7 +338,7 @@ Error generateRsaCertAndKey(const std::string& certCommonName,
                             const std::unique_ptr<BIO, decltype(&BIO_free)>& pBioCertKey)
 {
    // Generate RSA key
-   std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> pCertKey(EVP_RSA_gen(kRsaKeySize), EVP_PKEY_free);
+   std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> pCertKey(EVP_RSA_gen(kRsaKeySizeBits), EVP_PKEY_free);
    
    // Create certificate
    std::unique_ptr<X509, decltype(&X509_free)> pCert(X509_new(), X509_free);
@@ -458,7 +455,7 @@ core::Error rsaInit()
       return getLastCryptoError(ERROR_LOCATION);
 
    // generate an RSA key pair
-   s_pRSA = EVP_RSA_gen(kRsaKeySize);
+   s_pRSA = EVP_RSA_gen(kRsaKeySizeBits);
 
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
    // extract exponent + modulus for future use

--- a/src/cpp/core/system/Crypto.cpp
+++ b/src/cpp/core/system/Crypto.cpp
@@ -461,40 +461,28 @@ core::Error rsaInit()
    s_pRSA = EVP_RSA_gen(kRsaKeySize);
 
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
-
    // extract exponent + modulus for future use
    const BIGNUM *bn, *be, *bd;
    RSA* pRsaKeyPair = EVP_PKEY_get0_RSA(s_pRSA);
    RSA_get0_key(pRsaKeyPair, &bn, &be, &bd);
-
-   char* n = BN_bn2hex(bn);
-   s_modulo = n;
-   OPENSSL_free(n);
-
-   char* e = BN_bn2hex(be);
-   s_exponent = e;
-   OPENSSL_free(e);
-
 #else
-
-   // read modulo + exponent as hex
+   // extract exponent + modulus for future use
    BIGNUM* bn = nullptr;
    if (EVP_PKEY_get_bn_param(s_pRSA, "n", &bn) != 1)
       return getLastCryptoError(ERROR_LOCATION);
+   
+   BIGNUM* be = nullptr;
+   if (EVP_PKEY_get_bn_param(s_pRSA, "e", &be) != 1)
+      return getLastCryptoError(ERROR_LOCATION);
+#endif
 
    char* n = BN_bn2hex(bn);
    s_modulo = n;
    OPENSSL_free(n);
 
-   BIGNUM* be = nullptr;
-   if (EVP_PKEY_get_bn_param(s_pRSA, "e", &be) != 1)
-      return getLastCryptoError(ERROR_LOCATION);
-
    char* e = BN_bn2hex(be);
    s_exponent = e;
    OPENSSL_free(e);
-
-#endif
 
    return Success();
 }

--- a/src/cpp/core/system/CryptoTests.cpp
+++ b/src/cpp/core/system/CryptoTests.cpp
@@ -132,7 +132,7 @@ test_context("CryptoTests")
       // Sanity checks.
       REQUIRE(pub.rfind("-----BEGIN PUBLIC KEY-----", 0) == 0);
       REQUIRE(priv.rfind("-----BEGIN PRIVATE KEY-----", 0) == 0);
-      REQUIRE(sig.size() == 512);
+      REQUIRE(sig.size() == kRsaKeySizeBits / 8);
    }
 
    test_that("SHA-256 hashing works correctly")

--- a/src/cpp/core/system/CryptoTests.cpp
+++ b/src/cpp/core/system/CryptoTests.cpp
@@ -132,7 +132,7 @@ test_context("CryptoTests")
       // Sanity checks.
       REQUIRE(pub.rfind("-----BEGIN PUBLIC KEY-----", 0) == 0);
       REQUIRE(priv.rfind("-----BEGIN PRIVATE KEY-----", 0) == 0);
-      REQUIRE(sig.size() == 256);
+      REQUIRE(sig.size() == 512);
    }
 
    test_that("SHA-256 hashing works correctly")


### PR DESCRIPTION
So we can continue to build / work against older OpenSSL if necessary.