### PR TITLE
don't use desktop hooks in source satellite for server

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ### New
 #### RStudio
-- RStudio Desktop on Windows and Linux supports auto-hiding the menu bar. (#8932)
+- RStudio Desktop on Windows and Linux supports auto-hiding the menu bar (#8932)
 - RStudio's GWT sources can now be built with JDKs > 11 (#11242)
 - R projects can be given a custom display name in Project Options (#1909)
 
@@ -24,6 +24,7 @@
 - Localize Copilot-related user interface strings into French (#14092)
 - Removed obsolete "Use Internet Explorer library/proxy" checkbox from Packages settings (#13250)
 - Improved error handling for Desktop Pro license handling (rstudio-pro#4873)
+- Fixed exception being logged when copying or cutting from editor in a separate window (#14140)
 
 #### Posit Workbench
 -

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopHooks.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopHooks.java
@@ -92,13 +92,15 @@ public class DesktopHooks
    }
 
    private native void addCopyHook() /*-{
-      var clean = function() {
-         setTimeout(function() {
-            $wnd.desktop.cleanClipboard(false);
-         }, 100)
-      };
-      $wnd.addEventListener("copy", clean, true);
-      $wnd.addEventListener("cut", clean, true);
+      if ($wnd.desktop) {
+         var clean = function() {
+            setTimeout(function() {
+               $wnd.desktop.cleanClipboard(false);
+            }, 100)
+         };
+         $wnd.addEventListener("copy", clean, true);
+         $wnd.addEventListener("cut", clean, true);
+      }
    }-*/;
 
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindow.java
@@ -91,7 +91,8 @@ public class SourceWindow implements LastSourceDocClosedEvent.Handler,
 
       // set up desktop hooks (required to e.g. process commands issued by
       // the desktop frame)
-      pDesktopHooks.get();
+      if (Desktop.isDesktop())
+         pDesktopHooks.get();
 
       // export callbacks for main window
       exportFromSatellite();


### PR DESCRIPTION
### Intent

Addresses [CLIENT_EXCEPTION Errors when using ctrl + c shortcut in satellite window #14140](https://github.com/rstudio/rstudio/issues/14140
)
### Approach

The problem was that the DesktopHooks were being injected into source satellite windows even for non-desktop (server/workbench). The constructor of DesktopHooks would setup a handler for copy and cut which tried to invoke something on the non-existent desktop object, throwing an exception.

The primary fix was to only create the DesktopHooks object when initializing the source satellite if running on Desktop.

I also patched the DesktopHooks itself to double-check and not install the copy/cut handler unless on Desktop (in case there's another case where DesktopHooks are being initialized in server/workbench; I couldn't find any). This exact thing was done in another place in the code (`ShellWidget.addCopyHook()`).

### Automated Tests

None

### QA Notes

Verify the exception is no longer being logged on server/workbench.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


