### PR TITLE
use pattern to exclude baseline files from secrets scan

### DIFF
--- a/git_hooks/secrets/run-detect-secrets
+++ b/git_hooks/secrets/run-detect-secrets
@@ -33,6 +33,7 @@ fi
 
 # This baseline file needs to be consistent with the baseline file in git_hooks/hooks/pre-commit
 baseline_file="git_hooks/secrets/.secrets.baseline"
+baseline_file_pattern="${baseline_file}.*"
 # Use the pro baseline file if the repo is rstudio-pro
 if git remote -v | grep -q rstudio-pro; then
     is_pro=true
@@ -56,7 +57,7 @@ no_verify="--no-verify"
 #   - This array of excluded files needs to be consistent with the array in git_hooks/hooks/pre-commit
 # The baseline file needs to be excluded explicitly. This seems like a bug in detect-secrets since
 # the default filter `detect_secrets.filters.common.is_baseline_file` should exclude the baseline file.
-exclude_files=(--exclude-files ${baseline_file} --exclude-files '.*/.*.min.js' --exclude-files 'src/cpp/ext/fmt/doc/html/api.html' --exclude-files 'src/cpp/ext/fmt/doc/html/searchindex.js' --exclude-files 'dependencies/submodules/.*')
+exclude_files=(--exclude-files ${baseline_file_pattern} --exclude-files '.*/.*.min.js' --exclude-files 'src/cpp/ext/fmt/doc/html/api.html' --exclude-files 'src/cpp/ext/fmt/doc/html/searchindex.js' --exclude-files 'dependencies/submodules/.*')
 
 if [ "$command" = "init-baseline" ]; then
     echo "Initializing detect-secrets baseline file ${baseline_file}"


### PR DESCRIPTION
### Intent

- Lil' follow-up to https://github.com/rstudio/rstudio/pull/14131 to use a secrets baseline file pattern to exclude the baseline file
- Part of addressing: https://github.com/rstudio/rstudio-pro/issues/5605

### Approach

Running the secret detection in pro, the open source baseline was getting included in the results. Using a file pattern ensures that any files in the secrets directory starting with `.secrets.baseline` will be excluded.


