### PR TITLE
Add a global error message suppression flag to address NPE for error

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/MessageDisplay.java
+++ b/src/gwt/src/org/rstudio/core/client/MessageDisplay.java
@@ -44,6 +44,8 @@ public abstract class MessageDisplay
    public final static int INPUT_NUMERIC = 3;
    public final static int INPUT_USERNAME = 4;
 
+   public static boolean suppressAllErrors = false;
+
    public static class PromptWithOptionResult
    {
       public String input;
@@ -355,6 +357,7 @@ public abstract class MessageDisplay
 
    public void showErrorMessage(String caption, String message)
    {
+      if (suppressAllErrors || message.isEmpty()) { return; }
       createDialog(MSG_ERROR, caption, message).showModal();
    }
 
@@ -362,6 +365,11 @@ public abstract class MessageDisplay
                                 String message,
                                 Operation dismissed)
    {
+      if (suppressAllErrors || message.isEmpty())
+      {
+         dismissed.execute();
+         return; 
+      }
       createDialog(MSG_ERROR, caption, message)
             .addButton(constants_.okayLabel(), ElementIds.DIALOG_OK_BUTTON, dismissed)
             .showModal();
@@ -371,6 +379,7 @@ public abstract class MessageDisplay
                                 String message,
                                 Focusable focusAfter)
    {
+      if (suppressAllErrors || message.isEmpty()) { return; }
       showMessage(MSG_ERROR, caption, message, focusAfter);
    }
 
@@ -378,6 +387,7 @@ public abstract class MessageDisplay
                                 String message,
                                 CanFocus focusAfter)
    {
+      if (suppressAllErrors || message.isEmpty()) { return; }
       showMessage(MSG_ERROR, caption, message, focusAfter);
    }
 

--- a/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcRequest.java
+++ b/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcRequest.java
@@ -23,6 +23,7 @@ import com.google.gwt.json.client.JSONString;
 import com.google.gwt.user.client.Random;
 import org.rstudio.core.client.CoreClientConstants;
 import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.MessageDisplay;
 import org.rstudio.core.client.jsonrpc.RequestLogEntry.ResponseType;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.ApplicationCsrfToken;
@@ -177,34 +178,30 @@ public class RpcRequest
                   // override error message for status code 0
                   if (status == 0)
                   {
+                     type = RpcError.TRANSMISSION_ERROR_NO_RESPONSE;
+                     message = constants_.rpcOverrideErrorMessage((Desktop.isDesktop() ? constants_.rSessionMessage() : constants_.rStudioServerMessage()), getMethod());
+
                      if (!Desktop.isDesktop())
                      {
                         // only show this error if not desktop and return early. Otherwise handle error as normal
-                        message = constants_.rpcOverrideErrorMessageServer(constants_.rStudioServerMessage());
                      
                         if (!showingNoConnectError_) 
                         {
                            showingNoConnectError_ = true;
+                           MessageDisplay.suppressAllErrors = true;
                            RStudioGinjector.INSTANCE.getGlobalDisplay().showMessage(
                               GlobalDisplay.MSG_ERROR,
                               constants_.rpcErrorMessageCaption(),
-                              message,
+                              constants_.rpcOverrideErrorMessageServer(constants_.rStudioServerMessage()),
                               constants_.rpcOverrideErrorMessageLink(),
                               "/",
                               () -> {
                                  showingNoConnectError_ = false;
+                                 MessageDisplay.suppressAllErrors = false;
                               }
                            );
                         }
-                        requestLogEntry_.logResponse(ResponseType.Unknown,
-                              message);
-                        // trigger any error handlers, but pass a null error to suppress dialogs
-                        requestCallback.onError(enclosingRequest, null);
-                        return;
                      }
-
-                     type = RpcError.TRANSMISSION_ERROR_NO_RESPONSE;
-                     message = constants_.rpcOverrideErrorMessage((Desktop.isDesktop() ? constants_.rSessionMessage() : constants_.rStudioServerMessage()), getMethod());
                   }
 
                   requestLogEntry_.logResponse(ResponseType.Unknown,


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/5733

Fix a bug in an issue that Jeff noticed after we merged this feature. 

### Approach

Add a global flag to the MessageDisplay that can disable all error messages, and use that to suppress errors instead. This allows us to keep the rest of the error handlers that would otherwise be managing state.

### Automated Tests

N / A - manual testing required

### QA Notes

I'll have to spin up a new Fuzzbucket with a modified rsession to simulate the no response condition.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
