### PR TITLE
Update gh URL

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
@@ -323,7 +323,7 @@ public class AceEditorBackgroundLinkHighlighter
 
          if (remote == null || StringUtil.equals(remote, "github::"))
          {
-            globalDisplay_.openWindow("https://www.github.com/" + orgRepo + "/issues/" + issue);
+            globalDisplay_.openWindow("https://github.com/" + orgRepo + "/issues/" + issue);
          } 
          else if (StringUtil.equals(remote, "gitlab::"))
          {


### PR DESCRIPTION
### Intent

The link created of an issue in the IDE contains an extra `www`.
![image](https://github.com/romainfrancois/rstudio/assets/52606734/eae464d7-ddc3-4e37-8435-ec38c732a36f)

This is very minor. Avoid a redirect when clicking links to the link.

Great feature implemented first in #11553.

I don't know if the same is needed for gitlab, but since I do not use it, I am not going to touch it.

### Approach

Remove www from URL.


### Automated Tests

N/A

### QA Notes

there are n

### Checklist

No need for tests or NEWS as far as I can tell. 

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
I signed the Contributor Agreement.


