### PR TITLE
fix issue with staging line / selections in Review Changes dialog

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 #### RStudio
+- Fixed an issue where Stage chunk and Stage line in the Review Changes UI failed in some scenarios (#5476)
 - Fixed shortcut for inserting an assignment operator to work on non-US English keyboards (#12457)
 - Fixed an issue where the menubar would show on secondary windows if Alt key was pressed (#13973)
 - Fixed Windows installer to delete Start Menu shortcut during uninstall (#13936)

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -89,6 +89,13 @@ const char * const kVcsId = "Git";
 
 namespace {
 
+
+bool loggingEnabled()
+{
+   std::string log = core::system::getenv("RSTUDIO_GIT_LOG");
+   return string_utils::isTruthy(log);
+}
+
 // override gitArgs so that we can force Git to avoid
 // escaping UTF-8 paths (as Git understands them natively)
 ShellArgs gitArgs()
@@ -334,8 +341,7 @@ Error gitExec(const ShellArgs& args,
 #endif
 
    // log diagnostics if enabled
-   std::string log = core::system::getenv("RSTUDIO_GIT_LOG");
-   if (string_utils::isTruthy(log))
+   if (loggingEnabled())
       std::cout << gitText(args);
 
    Error error;
@@ -1148,6 +1154,17 @@ public:
       args << "--";
       args << patchFile;
 
+      if (loggingEnabled())
+      {
+         std::string contents;
+         Error error = core::readStringFromFile(patchFile, &contents);
+         if (error)
+            LOG_ERROR(error);
+         
+         std::cerr << "[git] applying patch:" << std::endl;
+         std::cerr << contents << std::endl << std::endl;
+      }
+      
       return runGit(args);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/DiffChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/DiffChunk.java
@@ -23,9 +23,9 @@ public class DiffChunk
                     ArrayList<Line> diffLines,
                     int diffIndex)
    {
-      this.ranges_ = ranges;
-      this.lineText_ = lineText;
-      this.diffLines_ = diffLines;
+      ranges_ = ranges;
+      lineText_ = lineText;
+      diffLines_ = diffLines;
       diffIndex_ = diffIndex;
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/UnifiedEmitter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/UnifiedEmitter.java
@@ -294,27 +294,11 @@ public class UnifiedEmitter
          }
 
          // Finish off the context iterator if necessary
-         if (ctx != null)
-         {
-            while (ctx != null)
-            {
-               ctxPop(true);
-            }
-         }
+         while (ctx != null)
+            ctxPop(true);
 
-         // Finish off the diff iterator if necessary
-         if (dff != null)
-         {
-            // TODO: Why is this necessary? Otherwise, attempts to stage
-            // the final changes in a diff will fail.
-            //
-            // https://github.com/rstudio/rstudio/issues/5476
-            skew++;
-            while (dff != null)
-            {
-               dffPop(true);
-            }
-         }
+         while (dff != null)
+            dffPop(true);
       }
 
       /**
@@ -370,18 +354,18 @@ public class UnifiedEmitter
          switch (dff.getType())
          {
             case Deletion:
+               skew--;
                output.add(new Line(Type.Deletion, dff.getOldLine(),
-                                   dff.getOldLine() + Math.min(-1, skew),
+                                   dff.getOldLine() + skew,
                                    dff.getText(),
                                    dff.getDiffIndex()));
-               skew--;
                break;
             case Insertion:
+               skew++;
                output.add(new Line(Type.Insertion, dff.getOldLine(),
-                                   dff.getOldLine() + Math.max(1, skew),
+                                   dff.getOldLine() + skew,
                                    dff.getText(),
                                    dff.getDiffIndex()));
-               skew++;
                break;
             default:
                assert false : "Unexpected diff line type";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/UnifiedEmitter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/UnifiedEmitter.java
@@ -14,13 +14,13 @@
  */
 package org.rstudio.studio.client.workbench.views.vcs.common.diff;
 
-import org.rstudio.core.client.DuplicateHelper;
-import org.rstudio.studio.client.workbench.views.vcs.common.diff.Line.Type;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+
+import org.rstudio.core.client.DuplicateHelper;
+import org.rstudio.studio.client.workbench.views.vcs.common.diff.Line.Type;
 
 /**
  * This class is used to subset an existing patch (the existing patch is
@@ -65,8 +65,10 @@ public class UnifiedEmitter
    {
       prepareList(contextLines_, Type.Insertion);
       prepareList(diffLines_, Type.Same);
-      final ArrayList<DiffChunk> chunks = toDiffChunks(
-            new OutputLinesGenerator(contextLines_, diffLines_).getOutput());
+      
+      OutputLinesGenerator generator = new OutputLinesGenerator(contextLines_, diffLines_);
+      ArrayList<Line> output = generator.getOutput();
+      ArrayList<DiffChunk> chunks = toDiffChunks(output);
 
       if (chunks.size() == 0)
          return "";
@@ -109,7 +111,6 @@ public class UnifiedEmitter
       StringBuilder sb = new StringBuilder();
 
       // Write chunk header: @@ -A,B +C,D @@
-
       Range[] ranges = chunk.getRanges();
       for (int i = 0; i < ranges.length; i++)
          sb.append('@');
@@ -191,12 +192,9 @@ public class UnifiedEmitter
 
       Range[] ranges = new Range[firstLines.length];
       for (int i = 0; i < firstLines.length; i++)
-         ranges[i] = new Range(firstLines[i], 1 + lastLines[i] - firstLines[i]);
+         ranges[i] = new Range(firstLines[i], lastLines[i] - firstLines[i] + 1);
 
-      return new DiffChunk(ranges,
-                           "",
-                           new ArrayList<>(sublist),
-                           -1);
+      return new DiffChunk(ranges, "", new ArrayList<>(sublist), -1);
    }
 
    private static void prepareList(ArrayList<Line> lines, Type typeToRemove)
@@ -263,9 +261,13 @@ public class UnifiedEmitter
 */
             int cmp = ctx.getDiffIndex() - dff.getDiffIndex();
             if (cmp < 0)
+            {
                ctxPop(true);
+            }
             else if (cmp > 0)
+            {
                dffPop(true);
+            }
             else
             {
                /**
@@ -292,12 +294,27 @@ public class UnifiedEmitter
          }
 
          // Finish off the context iterator if necessary
-         while (ctx != null)
-            ctxPop(true);
+         if (ctx != null)
+         {
+            while (ctx != null)
+            {
+               ctxPop(true);
+            }
+         }
 
          // Finish off the diff iterator if necessary
-         while (dff != null)
-            dffPop(true);
+         if (dff != null)
+         {
+            // TODO: Why is this necessary? Otherwise, attempts to stage
+            // the final changes in a diff will fail.
+            //
+            // https://github.com/rstudio/rstudio/issues/5476
+            skew++;
+            while (dff != null)
+            {
+               dffPop(true);
+            }
+         }
       }
 
       /**
@@ -354,14 +371,14 @@ public class UnifiedEmitter
          {
             case Deletion:
                output.add(new Line(Type.Deletion, dff.getOldLine(),
-                                   dff.getOldLine() + skew,
+                                   dff.getOldLine() + Math.min(-1, skew),
                                    dff.getText(),
                                    dff.getDiffIndex()));
                skew--;
                break;
             case Insertion:
                output.add(new Line(Type.Insertion, dff.getOldLine(),
-                                   dff.getOldLine() + skew,
+                                   dff.getOldLine() + Math.max(1, skew),
                                    dff.getText(),
                                    dff.getDiffIndex()));
                skew++;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/2460.
Addresses https://github.com/rstudio/rstudio/issues/5476.

### Approach

This was a thorny one! In the Review Changes dialog, users can manually stage and unstage lines via the presented UI. We do this by generating a diff, and then sending that to be applied via `git apply`. However, it appears we were generating incorrect ranges in some scenarios: most notably, when attempting to stage a single line change at the end of a document, we were generating a patch like this:

```
--- a/test.R
+++ b/test.R
@@ -1,5 +1,5 @@
 print(1 + 1)
 print(2 + 2)
 print(3 + 3)
 print(4 + 4)
 print(5 + 5)
+456
```

However, the range `@@ -1,5 +1,5 @@` is incorrect -- because we're adding a line, this should be `@@ -1,5 +1,6 @@` instead; that is, the applied diff would have one more line. The code here is rather challenging to parse, but as I understand it, when we parse the diff's generated by `git` we use a `skew` to track insertions + deletions to figure out where the "old" + "new" context for a document starts and ends. However, we were applying the skew _after_ recording each line, instead of before, and that appears to be the cause of our trouble.

I'll confess I don't have a deep understanding of this code but some extensive manual testing seems to confirm this is the right fix.

### Automated Tests

Not included.

### QA Notes

Testing requires some thorough exercising of the Review Changes UI.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
