### PR TITLE
fix ob1 error when searching console history

### DIFF
--- a/src/cpp/session/modules/SessionHistory.cpp
+++ b/src/cpp/session/modules/SessionHistory.cpp
@@ -271,13 +271,9 @@ Error searchHistory(const json::JsonRpcRequest& request,
 
    // get all entries from console history
    std::vector<std::string> entries;
-   r::session::consoleHistory().subset(
-         0, r::session::consoleHistory().size() - 1, &entries);
+   r::session::consoleHistory().subset(0, r::session::consoleHistory().size(), &entries);
    std::vector<HistoryEntry> matchingEntries;
-   for (std::vector<std::string>::const_reverse_iterator 
-            it = entries.rbegin();
-            it != entries.rend();
-            ++it)
+   for (auto it = entries.rbegin(); it != entries.rend(); ++it)
    {
       // check limit
       if (matchingEntries.size() >= static_cast<std::size_t>(maxEntries))


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14167.

### Approach

Fixes an Obi-Wan error; the end range in the `.subset()` call is exclusive, not inclusive, so we shouldn't try to subtract one.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14167.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
