### PR TITLE
stop highlighting \[ \] and \( \) Mathjax eqns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 - RStudio Desktop on Windows and Linux supports auto-hiding the menu bar (#8932)
 - RStudio's GWT sources can now be built with JDKs > 11 (#11242)
 - R projects can be given a custom display name in Project Options (#1909)
-- RStudio no longer highlights `\[ \]` and `\( \)` Mathjax equations; prefer `$ $` and `$$ $$` instead (#12862)
+- RStudio no longer highlights `\[ \]` and `\( \)` Mathjax equations; prefer `$$ $$` and `$ $` instead (#12862)
 
 #### Posit Workbench
 - Show custom project names on Workbench homepage (rstudio-pro#5589)

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - RStudio Desktop on Windows and Linux supports auto-hiding the menu bar (#8932)
 - RStudio's GWT sources can now be built with JDKs > 11 (#11242)
 - R projects can be given a custom display name in Project Options (#1909)
+- RStudio no longer highlights `\[ \]` and `\( \)` Mathjax equations; prefer `$ $` and `$$ $$` instead (#12862)
 
 #### Posit Workbench
 - Show custom project names on Workbench homepage (rstudio-pro#5589)

--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -299,14 +299,6 @@ var MarkdownHighlightRules = function() {
             token : "constant.hr",
             regex : "^\\s*[_](?:\\s*[_]){2,}\\s*$",
             next  : "allowBlock"
-        }, { // MathJax native display \[ ... \]
-            token : "latex.markup.list.string.begin",
-            regex : "\\\\\\[",
-            next  : "mathjaxnativedisplay"
-        }, { // MathJax native inline \( ... \)
-            token : "latex.markup.list.string.begin",
-            regex : "\\\\\\(",
-            next  : "mathjaxnativeinline"
         }, { // $ escape
             token : "text",
             regex : "\\\\\\$"


### PR DESCRIPTION
Addresses https://github.com/rstudio/rstudio/issues/12862.

@cderv, can you think of any reason why we would want to continue supporting highlight of `\[ \]` and `\( \)` equations in R Markdown / Quarto documents? Or is it okay to enforce the usage of `$ $` and `$$ $$` here?