### PR TITLE
use config_url for redeployment

### DIFF
--- a/src/cpp/session/modules/SessionRSConnect.R
+++ b/src/cpp/session/modules/SessionRSConnect.R
@@ -215,8 +215,10 @@
       error = identity
    )
    
-   if (inherits(apps, "error"))
-      return(list(error = .rs.scalar(apps), app = NULL))
+   if (inherits(apps, "error")) {
+      message <- conditionMessage(apps)
+      return(list(error = .rs.scalar(message), app = NULL))
+   }
 
    # drop __api__ suffix from hostUrl if necessary
    hostUrl <- sub("/__api__$", "/", hostUrl)

--- a/src/cpp/session/modules/SessionRSConnect.R
+++ b/src/cpp/session/modules/SessionRSConnect.R
@@ -206,8 +206,7 @@
 .rs.addJsonRpcHandler("get_rsconnect_app", function(id, account, server, hostUrl) {
    
    # NOTE: We previously used `rsconnect:::getAppById()`, but this API did not
-   # provide the requisite 'config_url' entry, which we display in UI for
-   # redeployments.
+   # provide the requisite 'config_url' entry, which we display in UI for redeployments.
    
    # collect application list
    apps <- tryCatch(
@@ -223,13 +222,13 @@
    # drop __api__ suffix from hostUrl if necessary
    hostUrl <- sub("/__api__$", "/", hostUrl)
    
-   # keep only those which start with the provided host URL
+   # keep only application records which:
+   # - start with the provided host URL;
+   # - have a matching id
    apps <- apps[.rs.startsWith(apps$url, hostUrl) & apps$id == id, ]
    
-   list(
-      error = NULL,
-      app   = .rs.scalarListFromList(apps)
-   )
+   # TODO: What should we do if we have nrow(apps) != 1?
+   list(error = NULL, app = .rs.scalarListFromList(apps))
 
 })
 

--- a/src/cpp/session/modules/SessionRSConnect.R
+++ b/src/cpp/session/modules/SessionRSConnect.R
@@ -204,26 +204,36 @@
 })
 
 .rs.addJsonRpcHandler("get_rsconnect_app", function(id, account, server, hostUrl) {
-   # init with empty list
-   appList <- list()
-   appError <- ""
+   
+   # NOTE: We previously used `rsconnect:::getAppById()`, but this API did not
+   # provide the requisite 'config_url' entry, which we display in UI for
+   # redeployments.
+   
+   # collect application list
+   apps <- tryCatch(
+      rsconnect::applications(account = account, server = server),
+      error = identity
+   )
+   
+   if (inherits(apps, "error"))
+      return(list(error = .rs.scalar(apps), app = NULL))
 
-   # attempt to get app ID from server
-   tryCatch({
-     appList <- rsconnect:::getAppById(id = id, account = account, server = server,
-                                       hostUrl = hostUrl)
-   }, error = function(e) {
-      # record the error message when a failure occurs (will be passed to the client for display)
-      appError <<- conditionMessage(e)
-   })
+   # drop __api__ suffix from hostUrl if necessary
+   hostUrl <- sub("/__api__$", "/", hostUrl)
+   
+   # keep only those which start with the provided host URL
+   apps <- apps[.rs.startsWith(apps$url, hostUrl) & apps$id == id, ]
+   
+   list(
+      error = NULL,
+      app   = .rs.scalarListFromList(apps)
+   )
 
-   list(error = .rs.scalar(appError),
-        app   = if(length(appList) > 0) .rs.scalarListFromList(appList) else NULL)
 })
 
 .rs.addJsonRpcHandler("validate_server_url", function(url) {
-   # suppress output when validating server URL (timeouts otherwise emitted to
-   # console)
+   # suppress output when validating server URL
+   # (timeouts otherwise emitted to console)
    capture.output(serverInfo <- rsconnect:::validateServerUrl(url = url))
    .rs.scalarListFromList(serverInfo)
 })

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -383,9 +383,14 @@ public class RSConnectDeploy extends Composite
    {
       if (info != null)
       {
-         urlAnchor_.setText(info.getUrl());
-         urlAnchor_.setHref(info.getUrl());
+         String url = info.getConfigUrl();
+         if (StringUtil.isNullOrEmpty(url))
+            url = info.getUrl();
+         
+         urlAnchor_.setText(url);
+         urlAnchor_.setHref(url);
       }
+      
       appDetailsPanel_.setVisible(true);
 
       if (isUpdate())


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/12708.

### Approach

- Use `config_url` rather than `url` in the "Updated:" UI.
- Use `rsconnect::applications()` rather than `rsconnect:::getAppById()` as the latter does not provide `config_url`.

<img width="612" alt="Screenshot 2024-01-26 at 12 43 29 PM" src="https://github.com/rstudio/rstudio/assets/1976582/e8f4ce51-8bc1-44cd-9402-31e6f4bf0f98">

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/12708.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
 