### PR TITLE
Add cmake option to disable check for updates feature

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -21,6 +21,12 @@ if(WIN32 AND NOT RSTUDIO_SESSION_WIN32)
    set(RSTUDIO_WIN32_BUILD_UTF8_SESSION TRUE)
 endif()
 
+option(RSTUDIO_DISABLE_CHECK_FOR_UPDATES "Disable the check for updates feature" OFF)
+if(RSTUDIO_DISABLE_CHECK_FOR_UPDATES)
+   add_definitions(-DDISABLE_UPDATE_CHECK)
+   message(STATUS "Configured to remove check for updates feature")
+endif()
+
 # verify that install-dictionaries, install-mathjax, install-pandoc,
 # and install-rmarkdown have been run as required
 

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -494,7 +494,11 @@ void handleClientInit(const boost::function<void()>& initFunction,
    sessionInfo["disable_packages"] = module_context::disablePackages();
 
    sessionInfo["disable_check_for_updates"] =
+#ifdef DISABLE_UPDATE_CHECK // via cmake option RSTUDIO_DISABLE_CHECK_FOR_UPDATES=1
+          true;
+#else
           !core::system::getenv("RSTUDIO_DISABLE_CHECK_FOR_UPDATES").empty();
+#endif
 
    sessionInfo["allow_vcs_exe_edit"] = options.allowVcsExecutableEdit();
    sessionInfo["allow_cran_repos_edit"] = options.allowCRANReposEdit();


### PR DESCRIPTION
### Intent

Addresses [Build option to disable automatic version check #13236](https://github.com/rstudio/rstudio/issues/13236)

### Approach

Added cmake option `RSTUDIO_DISABLE_CHECK_FOR_UPDATES` to enable building RStudio Desktop without the automatic check for updates feature.

When generating the build via cmake, use `RSTUDIO_DISABLE_CHECK_FOR_UPDATES=1`, e.g.:

`cmake .. -GNinja -DRSTUDIO_DISABLE_CHECK_FOR_UPDATES=1`.

This leverages the existing feature for doing this via an environment variable.

### Automated Tests

None

### QA Notes

Nothing to really test here unless you want to build your own RStudio without "check for updates" support.

You could sanity check that "check for updates " IS present in normal builds, I suppose.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


