### PR TITLE
Update release notes for 2023.12.1+402.pro1

### DIFF
--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -9,6 +9,33 @@ format:
 
 This page provides the release notes associated with each release of RStudio and Posit Workbench. Please contact customer support (<a href="mailto:support@posit.co">support@posit.co</a>) for questions about the described changes.
 
+## RStudio 2023.12.1
+
+**"Ocean Storm"**
+
+>Date: 2024-01-29
+
+### New
+#### RStudio
+- Changed the failure message for server no-responses (http code 0) to be more helpful to the user (rstudio/rstudio-pro#5646)
+
+
+#### Posit Workbench
+
+### Fixed
+#### RStudio
+- Removed GitHub Copilot preview label and disclaimer in Copilot options panes (#14067)
+- Fixed an issue where GitHub Copilot indexed binary files when project indexing enabled (#14106)
+- Fixed regression that prevented opening help topics in separate window (#14097)
+- Increased open files limit (rstduio/rstudio#14148)
+
+#### Posit Workbench
+- Fixed join session when ready control not responding to mouse clicks in all areas. (rstudio/rstudio-pro#5609)
+- Fixed intermittent rserver crash when joining a session started with the job launcher that is not immediately available (rstudio-pro#5579)
+- Fixed regression introduced in 2023.06 with `rstudio-server reload` where permission changed on nginx directories caused intermittent content loading errors (rstudio-pro#5636)
+- Fixed intermittent rworkspaces performance problem where in unusual circumstances, it would make repeated get_jobs requests (rstudio-pro#5690)
+- Fixed rworkspaces crash with debug logging enabled when get_jobs request returned an error (rstudio/rstudio-pro#5690)
+
 ## RStudio 2023.12.0
 
 **"Ocean Storm"**

--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -30,7 +30,7 @@ This page provides the release notes associated with each release of RStudio and
 - Increased open files limit (rstduio/rstudio#14148)
 
 #### Posit Workbench
-- Fixed join session when ready control not responding to mouse clicks in all areas. (rstudio/rstudio-pro#5609)
+- Fixed join session when ready control not responding to mouse clicks in all areas (rstudio/rstudio-pro#5609)
 - Fixed intermittent rserver crash when joining a session started with the job launcher that is not immediately available (rstudio-pro#5579)
 - Fixed regression introduced in 2023.06 with `rstudio-server reload` where permission changed on nginx directories caused intermittent content loading errors (rstudio-pro#5636)
 - Fixed intermittent rworkspaces performance problem where in unusual circumstances, it would make repeated get_jobs requests (rstudio-pro#5690)


### PR DESCRIPTION

Update release notes for IDE / Workbench 2023.12.1+402.pro1 release.

:warning: **Before converting from Draft PR:** :warning:

This change has been generated by the release script. Content is generated based on `version/news/NEWS-2023.12.1-ocean-storm.md`. If this file was not in sync with Pro or did not include items from other sources (i.e. the vscode extension), then some items may be missing.  Please verify content/formatting is correct and make changes if necessary.
