### PR TITLE
link yaml-cpp using static library to fix Windows build

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -34,6 +34,7 @@ if(WIN32)
    set(RSTUDIO_DEPENDENCIES_DICTIONARIES_DIR "${RSTUDIO_DEPENDENCIES_DIR}/common/dictionaries")
    set(RSTUDIO_DEPENDENCIES_MATHJAX_DIR      "${RSTUDIO_DEPENDENCIES_DIR}/common/mathjax-27")
    set(RSTUDIO_DEPENDENCIES_QUARTO_DIR       "${RSTUDIO_DEPENDENCIES_DIR}/common/quarto")
+   add_definitions(-DYAML_CPP_STATIC_DEFINE)
 else()
 
    # indirection to help build machine find these libraries?


### PR DESCRIPTION
### Intent

Getting linker errors building rsession on Windows:

```
[2024-01-31T00:39:58.391Z] [562/567] Linking CXX executable src\cpp\session\rsession-utf8.exe
[2024-01-31T00:39:58.391Z] FAILED: src/cpp/session/rsession-utf8.exe 
[2024-01-31T00:39:58.391Z] cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_exe --intdir=src\cpp\session\CMakeFiles\rsession-utf8.dir --rc="C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\rc.exe" --mt="C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\mt.exe" --manifests  -- "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\bin\Hostx64\x64\link.exe" /nologo @CMakeFiles\rsession-utf8.rsp  /out:src\cpp\session\rsession-utf8.exe /implib:src\cpp\session\rsession-utf8.lib /pdb:src\cpp\session\rsession-utf8.pdb /version:0.0 /machine:x64 /MANIFEST:NO /INCREMENTAL /largeaddressaware /stack:0x1000000 /debug /INCREMENTAL /subsystem:console  && cd ."
[2024-01-31T00:39:58.391Z] LINK: command "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\rsession-utf8.rsp /out:src\cpp\session\rsession-utf8.exe /implib:src\cpp\session\rsession-utf8.lib /pdb:src\cpp\session\rsession-utf8.pdb /version:0.0 /machine:x64 /MANIFEST:NO /INCREMENTAL /largeaddressaware /stack:0x1000000 /debug /INCREMENTAL /subsystem:console" failed (exit code 1120) with the following output:
[2024-01-31T00:39:58.391Z] client.lib(client.crashpad_client_win.obj) : MSIL .netmodule or module compiled with /GL found; restarting link with /LTCG; add /LTCG to the link command line to improve linker performance
[2024-01-31T00:39:58.391Z] LINK : warning LNK4075: ignoring '/INCREMENTAL' due to '/LTCG' specification
[2024-01-31T00:39:58.391Z] SessionRUtil.cpp.obj : error LNK2001: unresolved external symbol "__declspec(dllimport) class YAML::Node __cdecl YAML::Load(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (__imp_?Load@YAML@@YA?AVNode@1@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
[2024-01-31T00:39:58.391Z] SessionQuarto.cpp.obj : error LNK2001: unresolved external symbol "__declspec(dllimport) class YAML::Node __cdecl YAML::Load(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (__imp_?Load@YAML@@YA?AVNode@1@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
[2024-01-31T00:39:58.391Z] SessionQuarto.cpp.obj : error LNK2001: unresolved external symbol "__declspec(dllimport) public: bool __cdecl YAML::Node::IsMap(void)const " (__imp_?IsMap@Node@YAML@@QEBA_NXZ)
[2024-01-31T00:39:58.391Z] SessionQuarto.cpp.obj : error LNK2001: unresolved external symbol "__declspec(dllimport) public: class YAML::detail::iterator_base<struct YAML::detail::iterator_value> __cdecl YAML::Node::begin(void)" (__imp_?begin@Node@YAML@@QEAA?AV?$iterator_base@Uiterator_value@detail@YAML@@@detail@2@XZ)
[2024-01-31T00:39:58.391Z] SessionQuarto.cpp.obj : error LNK2001: unresolved external symbol "__declspec(dllimport) public: class YAML::detail::iterator_base<struct YAML::detail::iterator_value> __cdecl YAML::Node::end(void)" (__imp_?end@Node@YAML@@QEAA?AV?$iterator_base@Uiterator_value@detail@YAML@@@detail@2@XZ)
[2024-01-31T00:39:58.391Z] src\cpp\session\rsession-utf8.exe : fatal error LNK1120: 4 unresolved externals
[2024-01-31T00:39:58.391Z] [563/567] Linking CXX executable src\cpp\session\rsession.exe
[2024-01-31T00:39:58.391Z] FAILED: src/cpp/session/rsession.exe 
[2024-01-31T00:39:58.391Z] cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_exe --intdir=src\cpp\session\CMakeFiles\rsession.dir --rc="C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\rc.exe" --mt="C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\mt.exe" --manifests  -- "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\bin\Hostx64\x64\link.exe" /nologo @CMakeFiles\rsession.rsp  /out:src\cpp\session\rsession.exe /implib:src\cpp\session\rsession.lib /pdb:src\cpp\session\rsession.pdb /version:0.0 /machine:x64 /MANIFEST:NO /INCREMENTAL /largeaddressaware /stack:0x1000000 /debug /INCREMENTAL /subsystem:console  && cd ."
[2024-01-31T00:39:58.391Z] LINK: command "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\rsession.rsp /out:src\cpp\session\rsession.exe /implib:src\cpp\session\rsession.lib /pdb:src\cpp\session\rsession.pdb /version:0.0 /machine:x64 /MANIFEST:NO /INCREMENTAL /largeaddressaware /stack:0x1000000 /debug /INCREMENTAL /subsystem:console" failed (exit code 1120) with the following output:
[2024-01-31T00:39:58.391Z] client.lib(client.crashpad_client_win.obj) : MSIL .netmodule or module compiled with /GL found; restarting link with /LTCG; add /LTCG to the link command line to improve linker performance
[2024-01-31T00:39:58.391Z] LINK : warning LNK4075: ignoring '/INCREMENTAL' due to '/LTCG' specification
[2024-01-31T00:39:58.391Z] SessionRUtil.cpp.obj : error LNK2001: unresolved external symbol "__declspec(dllimport) class YAML::Node __cdecl YAML::Load(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (__imp_?Load@YAML@@YA?AVNode@1@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
[2024-01-31T00:39:58.391Z] SessionQuarto.cpp.obj : error LNK2001: unresolved external symbol "__declspec(dllimport) class YAML::Node __cdecl YAML::Load(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (__imp_?Load@YAML@@YA?AVNode@1@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
[2024-01-31T00:39:58.391Z] SessionQuarto.cpp.obj : error LNK2001: unresolved external symbol "__declspec(dllimport) public: bool __cdecl YAML::Node::IsMap(void)const " (__imp_?IsMap@Node@YAML@@QEBA_NXZ)
[2024-01-31T00:39:58.391Z] SessionQuarto.cpp.obj : error LNK2001: unresolved external symbol "__declspec(dllimport) public: class YAML::detail::iterator_base<struct YAML::detail::iterator_value> __cdecl YAML::Node::begin(void)" (__imp_?begin@Node@YAML@@QEAA?AV?$iterator_base@Uiterator_value@detail@YAML@@@detail@2@XZ)
[2024-01-31T00:39:58.391Z] SessionQuarto.cpp.obj : error LNK2001: unresolved external symbol "__declspec(dllimport) public: class YAML::detail::iterator_base<struct YAML::detail::iterator_value> __cdecl YAML::Node::end(void)" (__imp_?end@Node@YAML@@QEAA?AV?$iterator_base@Uiterator_value@detail@YAML@@@detail@2@XZ)
[2024-01-31T00:39:58.391Z] src\cpp\session\rsession.exe : fatal error LNK1120: 4 unresolved externals
[2024-01-31T00:39:58.391Z] [564/567] Linking CXX executable src\cpp\session\postback\rpostback.exe
[2024-01-31T00:39:5
```

### Approach

For some reason the `-DYAML_CPP_STATIC_DEFINE` being set in src\cpp\CMakeLists.txt isn't being propagated to src\cpp\session\CMakeLists.txt. Set it directly in that file. Probably not the "right" way but should get the build working.

### Automated Tests

None

### QA Notes

Build break fix attempt

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


