### PR TITLE
change startup behavior on Windows when R not found

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - R projects can be given a custom display name in Project Options (#1909)
 - RStudio no longer highlights `\[ \]` and `\( \)` Mathjax equations; prefer `$$ $$` and `$ $` instead (#12862)
 - Added cmake option to build RStudio without the check for updates feature (#13236)
+- Allow choosing R from non-standard location at startup (#14180; Windows Desktop)
 
 #### Posit Workbench
 - Show custom project names on Workbench homepage (rstudio-pro#5589)

--- a/src/node/desktop/src/assets/locales/en.json
+++ b/src/node/desktop/src/assets/locales/en.json
@@ -3,6 +3,7 @@
     "buttonOk": "OK",
     "buttonCancel": "Cancel",
     "buttonBrowse": "Browse...",
+    "buttonDownloadR": "Download R...",
     "unknownErrorOccurred": "An unknown error occurred.",
     "workingOnIt": "Working on it...",
     "buttonYes": "Yes",

--- a/src/node/desktop/src/assets/locales/fr.json
+++ b/src/node/desktop/src/assets/locales/fr.json
@@ -3,6 +3,7 @@
     "buttonOk": "OK",
     "buttonCancel": "Annuler",
     "buttonBrowse": "Parcourir...",
+    "buttonDownloadR": "Télécharger R...",
     "unknownErrorOccurred": "Une erreur inconnue s'est produite.",
     "workingOnIt": "En cours d'élaboration...",
     "buttonYes": "Oui",

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { app, BrowserWindow, dialog, Event, Menu, screen, shell, WebContents } from 'electron';
+import { app, BrowserWindow, dialog, Event, Menu, screen, WebContents } from 'electron';
 import i18next from 'i18next';
 import path from 'path';
 import { getenv, setenv } from '../core/environment';
@@ -39,6 +39,7 @@ import {
   findComponents,
   initializeLang,
   initializeSharedSecret,
+  loadRWebsite,
   raiseAndActivateWindow,
   removeStaleOptionsLockfile,
   resolveAliasedPath,
@@ -324,8 +325,7 @@ export class Application implements AppState {
           .then((result) => {
             logger().logDebug(`You clicked ${result.response == 0 ? 'Yes' : 'No'}`);
             if (result.response == 0) {
-              const rProjectUrl = 'https://www.rstudio.org/links/r-project';
-              void shell.openExternal(rProjectUrl);
+              loadRWebsite();
             }
           })
           .catch((error: unknown) => logger().logError(error));

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -89,7 +89,7 @@ export async function promptUserForR(platform = process.platform): Promise<Expec
     // discover available R installations
     const rInstalls = findRInstallationsWin32();
     if (rInstalls.length === 0) {
-      return err(new Error('No R installations found via registry or common R install locations.'));
+      logger().logDebug('No R installations found via registry or common R install locations.');
     }
 
     // ask the user what version of R they'd like to use

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -17,7 +17,7 @@ import fs, { existsSync } from 'fs';
 import os from 'os';
 import path from 'path';
 import { sep } from 'path';
-import { app, BrowserWindow, Cookie, dialog, FileFilter, MessageBoxOptions, WebContents, WebRequest } from 'electron';
+import { app, BrowserWindow, Cookie, dialog, FileFilter, MessageBoxOptions, shell, WebContents, WebRequest } from 'electron';
 
 import { Xdg } from '../core/xdg';
 import { getenv, setenv } from '../core/environment';
@@ -626,4 +626,12 @@ export function removeTrailingSlashes(str: string): string {
     return str.substring(0, trailingSlashesIndex);
   }
   return str;
+}
+
+/**
+ * Load the R website in the user's default browser.
+ */
+export function loadRWebsite() {
+  const rProjectUrl = 'https://www.rstudio.org/links/r-project';
+  void shell.openExternal(rProjectUrl);
 }

--- a/src/node/desktop/src/ui/widgets/choose-r.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r.ts
@@ -27,6 +27,7 @@ import { existsSync } from 'fs';
 import { normalize } from 'path';
 import { kWindowsRExe } from '../utils';
 import { appState } from '../../main/app-state';
+import { loadRWebsite } from '../../main/utils';
 
 declare const CHOOSE_R_WEBPACK_ENTRY: string;
 declare const CHOOSE_R_PRELOAD_WEBPACK_ENTRY: string;
@@ -151,6 +152,11 @@ export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
         }
 
         return false;
+      });
+
+      this.addIpcHandler('download-r', () => {
+        loadRWebsite();
+        return resolve(null);
       });
 
       this.addIpcHandler('cancel', () => {

--- a/src/node/desktop/src/ui/widgets/choose-r/load.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/load.ts
@@ -53,6 +53,7 @@ radioButtons.forEach((radioButton) => {
 const buttonOk = document.getElementById('button-ok') as HTMLButtonElement;
 const buttonCancel = document.getElementById('button-cancel') as HTMLButtonElement;
 const buttonBrowse = document.getElementById('button-browse') as HTMLButtonElement;
+const buttonDownload = document.getElementById('button-download') as HTMLButtonElement;
 
 // get reference to rendering engine select widget
 const renderingEngineSelect = document.getElementById('rendering-engine') as HTMLSelectElement;
@@ -94,6 +95,10 @@ buttonBrowse.addEventListener('click', async () => {
       isBrowseDialogOpen = false;
     }, 150);
   }
+});
+
+buttonDownload.addEventListener('click', async () => {
+  window.callbacks.downloadR();
 });
 
 window.addEventListener('load', () => {

--- a/src/node/desktop/src/ui/widgets/choose-r/preload.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/preload.ts
@@ -27,6 +27,7 @@ export interface Callbacks {
   use(data: CallbackData): Promise<boolean>;
   browse(data: CallbackData): Promise<boolean>;
   cancel(): void;
+  downloadR(): void;
 }
 
 // this needs to be done in the preload of any widget wanting to use logging
@@ -46,6 +47,7 @@ ipcRenderer.on('initialize', (_event, data) => {
   const useCustomEl = document.getElementById('use-custom') as HTMLInputElement;
   const selectCustom = document.getElementById('select') as HTMLSelectElement;
   const buttonOk = document.getElementById('button-ok') as HTMLButtonElement;
+  const buttonDownload = document.getElementById('button-download') as HTMLButtonElement;
 
   // if we have a default 32-bit R installation, enable it
   const default32Bit = data.default32bitPath as string;
@@ -148,6 +150,9 @@ ipcRenderer.on('initialize', (_event, data) => {
 
   useCustomEl.checked = !default32Bit && !default64Bit && rInstalls.length > 0;
   selectWidget.disabled = !useCustomEl.checked;
+  if (rInstalls.length > 0) {
+    buttonDownload.remove();
+  }
 
   buttonOk.disabled = !((useCustomEl.checked && selectCustom.value) || use32.checked || use64.checked);
 });
@@ -176,6 +181,10 @@ const callbacks: Callbacks = {
 
   cancel: () => {
     ipcRenderer.send('cancel');
+  },
+
+  downloadR: async () => {
+    await ipcRenderer.invoke('download-r');
   },
 };
 

--- a/src/node/desktop/src/ui/widgets/choose-r/styles.css
+++ b/src/node/desktop/src/ui/widgets/choose-r/styles.css
@@ -30,10 +30,14 @@ label {
   right: 12px;
 }
 
-.button {
+button {
   width: 72px;
   padding: 3px 4px;
   margin: 4px 0 4px 4px;
   font-size: 8pt;
   user-select: none;
+}
+
+button.buttonDownload {
+  width: 82px;
 }

--- a/src/node/desktop/src/ui/widgets/choose-r/ui.html
+++ b/src/node/desktop/src/ui/widgets/choose-r/ui.html
@@ -39,6 +39,7 @@
 
     <div class="footer-left">
       <button data-i18n="common.buttonBrowse" id="button-browse" class="button" type="button"></button>
+      <button data-i18n="common.buttonDownloadR" id="button-download" class="buttonDownload" type="button"></button>
     </div>
 
     <div class="footer-right">


### PR DESCRIPTION
### Intent

Addresses #14180 (draft - we haven't decided if we're taking this for chocolate cosmos)

### Approach

This is specifically for RStudio Desktop and Desktop Pro (Electron) on Windows.

At startup, if we don't find an R installation, we no longer show the "R Not Installed" dialog but instead show the Choose R dialog with a Download R... button added in the lower left region.

![download-r-button](https://github.com/rstudio/rstudio/assets/10569626/a864d7e2-4e3e-4e74-93eb-88c3b3f425c2)

Clicking this button launches https://www.rstudio.org/links/r-project in the user's default browser (i.e. same thing the "R Not Installed" dialog would do) and closes RStudio. I could have left the dialog open, but most likely a user that goes this route is going to install R in a normal location, and then when they relaunch RStudio we'll find it.

Alternatively, a user can use Browse... to choose an R installation in a location we don't automatically locate (this is what they couldn't do before this change).

If an R installation is found at startup we don't show the Download button.

### Automated Tests

None

### QA Notes

To test you'll want to install R somewhere we don't automatically find it, and uncheck "Save version number in registry". Be sure you have a clean state for RStudio (have never chosen R before), and you should see Choose R dialog with the new button instead of the "R Not Installed" dialog.

Check that clicking the Download button opens browser to correct page, and closes RStudio.

Spot-check that the dialog works the same as before in other scenarios.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


