### PR TITLE
Add ability to check if a ConfigProfile value is defined

### DIFF
--- a/src/cpp/core/ConfigProfile.cpp
+++ b/src/cpp/core/ConfigProfile.cpp
@@ -164,5 +164,19 @@ std::vector<std::string> ConfigProfile::getLevelNames(uint32_t level) const
    return levelNames;
 }
 
+bool ConfigProfile::isParamDefined(const std::string& paramName) const
+{
+   for (const auto& levelValue: levels_)
+   {
+      for (const auto& value: levelValue.second)
+      {
+         if (value.first == paramName)
+            return true;
+      }
+   }
+
+   return false;
+}
+
 } // core
 } // namespace rstudio

--- a/src/cpp/core/include/core/ConfigProfile.hpp
+++ b/src/cpp/core/include/core/ConfigProfile.hpp
@@ -88,6 +88,10 @@ public:
    // must only be called after a call to load()
    std::vector<std::string> getLevelNames(uint32_t level) const;
 
+   // Returns true if named parameter is overridden at any level, and false otherwise.
+   // NOTE: result is only valid after a call to load().
+   bool isParamDefined(const std::string& paramName) const;
+
    // gets a param's value given the level values for each level
    // see unit tests for more examples
    template <typename T>


### PR DESCRIPTION
* Add isParamDefined method that returns true if the supplied parameter is defined.
* Add unit tests to cover new code.


### Intent

The Job Launcher requires the ability to check if a `ConfigProfile` value is defined anywhere in a configuration file. This change adds a new method to that class that enables this check.

### Approach

Add a new method, `bool isParamDefined(std::string paramName)`, to `ConfigProfile` that returns true if the supplied `paramName` names a parameter that's defined anywhere in the associated configuration file.

### Automated Tests

Added unit tests to cover new code.

### QA Notes

Not a user-facing change, explicit QA not likely required.

### Documentation

Not a user-facing change; user-facing documentation update not strictly required.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


