### PR TITLE
support completions for ggplot2 aesthetics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ### New
 #### RStudio
-- RStudio's auto-completion system now supports aesthetic names and data columns (#8444)
+- RStudio's auto-completion system now supports ggplot2 aesthetic names and data columns (#8444)
 - RStudio Desktop on Windows and Linux supports auto-hiding the menu bar (#8932)
 - RStudio's GWT sources can now be built with JDKs > 11 (#11242)
 - R projects can be given a custom display name in Project Options (#1909)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ### New
 #### RStudio
+- RStudio's auto-completion system now supports aesthetic names and data columns (#8444)
 - RStudio Desktop on Windows and Linux supports auto-hiding the menu bar (#8932)
 - RStudio's GWT sources can now be built with JDKs > 11 (#11242)
 - R projects can be given a custom display name in Project Options (#1909)

--- a/src/cpp/session/SessionSourceDatabase.cpp
+++ b/src/cpp/session/SessionSourceDatabase.cpp
@@ -1097,6 +1097,20 @@ SEXP rs_detectExtendedType(SEXP pathSEXP)
    return r::sexp::create(extendedType, &protect);
 }
 
+SEXP rs_getSourceDocument(SEXP idSEXP, SEXP includeContentsSEXP)
+{
+   std::string id = r::sexp::asString(idSEXP);
+   bool includeContents = r::sexp::asLogical(includeContentsSEXP);
+   
+   boost::shared_ptr<SourceDocument> pDoc(new SourceDocument);
+   Error error = source_database::get(id, pDoc);
+   if (error)
+      return R_NilValue;
+
+   r::sexp::Protect protect;
+   SEXP object = pDoc->toRObject(&protect, includeContents);
+   return object;
+}
 
 } // anonymous namespace
 
@@ -1113,8 +1127,9 @@ Error initialize()
    if (error)
       return error;
 
-   RS_REGISTER_CALL_METHOD(rs_getDocumentProperties, 2);
-   RS_REGISTER_CALL_METHOD(rs_detectExtendedType, 1);
+   RS_REGISTER_CALL_METHOD(rs_getSourceDocument);
+   RS_REGISTER_CALL_METHOD(rs_getDocumentProperties);
+   RS_REGISTER_CALL_METHOD(rs_detectExtendedType);
 
    events().onDocUpdated.connect(onDocUpdated);
    events().onDocRemoved.connect(onDocRemoved);

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -73,8 +73,6 @@
       # for plain character variables, we 'mock' the behavior of str()
       # while avoiding the potential for re-encoding (as this could mangle
       # UTF-8 characters on Windows)
-      #
-      # TODO: Trim this out once we drop support for R (<= 4.1.x).
       n <- length(val)
       if (n == 0)
       {
@@ -92,9 +90,8 @@
             na.encode = FALSE
          )
 
-         fmt <- "chr [%s] %s"
-         span <- paste("1", dim(val) %||% length(val), sep = ":", collapse = ", ")
-         txt <- sprintf(fmt, span, paste(encoded, collapse = " "))
+         fmt <- "chr [1:%i] %s"
+         txt <- sprintf(fmt, n, paste(encoded, collapse = " "))
          .rs.truncate(txt)
       }
    }

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -73,6 +73,8 @@
       # for plain character variables, we 'mock' the behavior of str()
       # while avoiding the potential for re-encoding (as this could mangle
       # UTF-8 characters on Windows)
+      #
+      # TODO: Trim this out once we drop support for R (<= 4.1.x).
       n <- length(val)
       if (n == 0)
       {
@@ -90,8 +92,9 @@
             na.encode = FALSE
          )
 
-         fmt <- "chr [1:%i] %s"
-         txt <- sprintf(fmt, n, paste(encoded, collapse = " "))
+         fmt <- "chr [%s] %s"
+         span <- paste("1", dim(val) %||% length(val), sep = ":", collapse = ", ")
+         txt <- sprintf(fmt, span, paste(encoded, collapse = " "))
          .rs.truncate(txt)
       }
    }

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2933,6 +2933,7 @@ assign(x = ".rs.acCompletionTypes",
 {
    c("x", "y", "fill", "colour", "alpha", "shape", "size", "linewidth", "linetype", "group")
 })
+
 .rs.addFunction("getCompletionsGgplot2", function(token,
                                                   contextData,
                                                   statementBounds,
@@ -3030,7 +3031,8 @@ assign(x = ".rs.acCompletionTypes",
             layerInfo$geom$required_aes,
             layerInfo$stat$required_aes,
             names(layerInfo$geom$default_aes),
-            names(layerInfo$stat$default_aes)
+            names(layerInfo$stat$default_aes),
+            "group"
          )
          aesthetics <- aesthetics[!duplicated(aesthetics)]
          results <- .rs.selectFuzzyMatches(aesthetics, token)

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2986,13 +2986,16 @@ assign(x = ".rs.acCompletionTypes",
       {
          defaultAesthetics <- c("x", "y", "fill", "colour", "shape", "size")
          results <- .rs.selectFuzzyMatches(defaultAesthetics, token)
-         completions <- .rs.makeCompletions(
-            token = token,
-            results = paste(results, "= "),
-            packages = "ggplot",
-            type = .rs.acCompletionTypes$ARGUMENT,
-            quote = FALSE
-         )
+         if (length(results))
+         {
+            completions <- .rs.makeCompletions(
+               token = token,
+               results = paste(results, "= "),
+               packages = "ggplot",
+               type = .rs.acCompletionTypes$ARGUMENT,
+               quote = FALSE
+            )
+         }
       }
       else
       {
@@ -3006,13 +3009,16 @@ assign(x = ".rs.acCompletionTypes",
          )
          aesthetics <- aesthetics[!duplicated(aesthetics)]
          results <- .rs.selectFuzzyMatches(aesthetics, token)
-         completions <- .rs.makeCompletions(
-            token = token,
-            results = paste(results, "= "),
-            packages = geomContext$data,
-            type = .rs.acCompletionTypes$ARGUMENT,
-            quote = FALSE
-         )
+         if (length(results))
+         {
+            completions <- .rs.makeCompletions(
+               token = token,
+               results = paste(results, "= "),
+               packages = geomContext$data,
+               type = .rs.acCompletionTypes$ARGUMENT,
+               quote = FALSE
+            )
+         }
       }
    }
    

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2895,7 +2895,6 @@ assign(x = ".rs.acCompletionTypes",
    inner[[n]] <- substring(inner[[n]], 1L, range$end$column)
    
    # return collapsed text
-   writeLines(inner)
    paste(inner, collapse = "\n")
 })
 

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2321,6 +2321,16 @@ assign(x = ".rs.acCompletionTypes",
                                                   line,
                                                   isConsole)
 {
+   # Map from 0-based indexes to 1-based indexes in ranges
+   for (i in seq_along(contextData))
+   {
+      range <- contextData[[i]]$range
+      if (!is.null(range))
+         contextData[[i]]$range <- .rs.reindexRange(range)
+   }
+   
+   statementBounds <- .rs.reindexRange(statementBounds)
+   
    # To avoid too much code churn, unpack the contextData members into
    # the expected (older) variable names.
    string <- lapply(contextData, `[[`, 1L)
@@ -2876,15 +2886,16 @@ assign(x = ".rs.acCompletionTypes",
 .rs.addFunction("getTextRange", function(contents, range)
 {
    # extract text from the rows in use
-   rows <- seq(from = range$start$row + 1L, to = range$end$row + 1L)
+   rows <- seq(from = range$start$row, to = range$end$row)
    inner <- contents[rows]
    n <- length(inner)
    
    # subset based on provided columns
-   inner[[1L]] <- substring(inner[[1L]], range$start$column + 1L)
-   inner[[n]] <- substring(inner[[n]], 1L, range$end$column + 1L)
+   inner[[1L]] <- substring(inner[[1L]], range$start$column)
+   inner[[n]] <- substring(inner[[n]], 1L, range$end$column)
    
    # return collapsed text
+   writeLines(inner)
    paste(inner, collapse = "\n")
 })
 

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -848,12 +848,10 @@ assign(x = ".rs.acCompletionTypes",
    formals <- NULL
    
    ## Special cases
-   # We handle special cases for function argument
-   # completions first.
+   # We handle special cases for function argument completions first.
    # If we're completing a knitr getter function, then try
-   # to produce auto-completions for potential argument
-   # names
-   if (.rs.isKnitrObject(object))
+   # to produce auto-completions for potential argument names
+   if (.rs.isKnitrObject(object) && "knitr" %in% loadedNamespaces())
    {
       ns <- asNamespace("knitr")
       
@@ -961,8 +959,7 @@ assign(x = ".rs.acCompletionTypes",
    # by looking at which arguments have yet to be matched, and using the
    # first argument in that list.
    activeArg <- .rs.getActiveArgument(object, matchedCall)
-   
-   if (!length(activeArg) || is.na(activeArg))
+   if (length(activeArg) == 0L || is.na(activeArg))
       activeArg <- ""
    
    # Special casing for 'group_by' from dplyr

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2351,11 +2351,7 @@ assign(x = ".rs.acCompletionTypes",
 {
    # Map from 0-based indexes to 1-based indexes in ranges
    for (i in seq_along(contextData))
-   {
-      range <- contextData[[i]]$range
-      if (!is.null(range))
-         contextData[[i]]$range <- .rs.reindexRange(range)
-   }
+      contextData[[i]]$range <- .rs.reindexRange(contextData[[i]]$range)
    
    statementBounds <- .rs.reindexRange(statementBounds)
    

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2964,7 +2964,7 @@ assign(x = ".rs.acCompletionTypes",
          results <- .rs.selectFuzzyMatches(defaultAesthetics, token)
          completions <- .rs.makeCompletions(
             token = token,
-            results = paste(results, "="),
+            results = paste(results, "= "),
             packages = "ggplot",
             type = .rs.acCompletionTypes$ARGUMENT,
             quote = FALSE
@@ -2984,7 +2984,7 @@ assign(x = ".rs.acCompletionTypes",
          results <- .rs.selectFuzzyMatches(aesthetics, token)
          completions <- .rs.makeCompletions(
             token = token,
-            results = paste(results, "="),
+            results = paste(results, "= "),
             packages = geomContext$data,
             type = .rs.acCompletionTypes$ARGUMENT,
             quote = FALSE

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2904,11 +2904,14 @@ assign(x = ".rs.acCompletionTypes",
    })
    
    # retrieve the data object used by this expression
-   data <- .rs.nullCoalesce(expr[["data"]], expr[[2L]])
+   if (is.call(expr))
+      expr <- .rs.nullCoalesce(expr[["data"]], expr[[2L]])
    
    # NOTE: We use 'eval()' here to ensure that things like datasets
    # are properly resolved; e.g. if working with mtcars from the datasets package.
-   value <- eval(data, envir = envir)
+   value <- eval(expr, envir = envir)
+   if (inherits(value, "gg"))
+      value <- value$data
    
    .rs.makeCompletions(
       token = token,

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2313,7 +2313,7 @@ assign(x = ".rs.acCompletionTypes",
                                                   context,
                                                   numCommas,
                                                   functionCallString,
-                                                  contextLines,
+                                                  statementBounds,
                                                   chainObjectName,
                                                   additionalArgs,
                                                   excludeArgs,
@@ -2526,7 +2526,12 @@ assign(x = ".rs.acCompletionTypes",
    if (is.call(functionCall) &&
        identical(functionCall[[1L]], as.symbol("aes")))
    {
-      return(.rs.getCompletionsAesthetics(token, string, context, contextLines, envir))
+      completions <- tryCatch(
+         .rs.getCompletionsAesthetics(token, string, context, statementBounds, documentId, envir),
+         error = function(e) .rs.emptyCompletions(token)
+      )
+      
+      return(completions)
    }
    
    # Python virtual environments
@@ -2864,20 +2869,15 @@ assign(x = ".rs.acCompletionTypes",
    
 })
 
-.rs.addFunction("getCompletionsAesthetics", function(...)
+.rs.addFunction("getCompletionsAesthetics", function(token,
+                                                     string,
+                                                     context,
+                                                     statementBounds,
+                                                     documentId,
+                                                     envir)
 {
-   tryCatch(
-      .rs.getCompletionsAestheticsImpl(...),
-      error = function(e) .rs.emptyCompletions(..1)
-   )
-})
-
-.rs.addFunction("getCompletionsAestheticsImpl", function(token,
-                                                         string,
-                                                         context,
-                                                         contextLines,
-                                                         envir)
-{
+   browser()
+   
    # pass in the provided expression
    text <- .rs.finishExpression(contextLines)
    expr <- parse(text = text)[[1L]]

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2080,7 +2080,7 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("finishExpression", function(string)
 {
-   .Call("rs_finishExpression", as.character(string))
+   .Call("rs_finishExpression", as.character(string), PACKAGE = "(embedding)")
 })
 
 .rs.addFunction("getCompletionsAttr", function(token,
@@ -2909,6 +2909,7 @@ assign(x = ".rs.acCompletionTypes",
    
    # NOTE: We use 'eval()' here to ensure that things like datasets
    # are properly resolved; e.g. if working with mtcars from the datasets package.
+   source <- .rs.deparse(expr)
    value <- eval(expr, envir = envir)
    if (inherits(value, "gg"))
       value <- value$data
@@ -2918,6 +2919,7 @@ assign(x = ".rs.acCompletionTypes",
       results = .rs.selectFuzzyMatches(names(value), token),
       quote = FALSE,
       type = .rs.acCompletionTypes$COLUMN,
+      packages = source,
       excludeOtherCompletions = TRUE,
       excludeOtherArgumentCompletions = TRUE
    )

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1031,7 +1031,35 @@ assign(x = ".rs.acCompletionTypes",
       # arguments that are already used by the matched call
       used <- names(as.list(matchedCall)[-1]) 
       keep <- !names(formals$formals) %in% used
-
+      
+      # # TODO: Should we include aesthetics for 'geom_*()' functions?
+      # # for 'geom_' functions, try to get aesthetic names
+      # if (grepl("^geom_", fguess))
+      # {
+      #    .rs.tryCatch({
+      #       geomFunc <- eval(as.symbol(fguess), envir = envir)
+      #       layerInfo <- geomFunc()
+      #       aesthetics <- c(
+      #          layerInfo$geom$required_aes,
+      #          layerInfo$stat$required_aes,
+      #          names(layerInfo$geom$default_aes),
+      #          names(layerInfo$stat$default_aes)
+      #       )
+      #       aesthetics <- aesthetics[!duplicated(aesthetics)]
+      #       results <- .rs.selectFuzzyMatches(aesthetics, token)
+      #       argCompletions <- .rs.appendCompletions(
+      #          argCompletions,
+      #          .rs.makeCompletions(
+      #             token = token,
+      #             results = paste(results, "= "),
+      #             packages = fguess,
+      #             type = .rs.acCompletionTypes$ARGUMENT,
+      #             quote = FALSE
+      #          )
+      #       )
+      #    })
+      # }
+      
       result <- .rs.appendCompletions(
          argCompletions,
          .rs.makeCompletions(

--- a/src/cpp/session/modules/SessionRUtil.R
+++ b/src/cpp/session/modules/SessionRUtil.R
@@ -209,5 +209,5 @@
 
 .rs.addFunction("reindexRange", function(range, offset = 1)
 {
-   rapply(range, `+`, e2 = offset, how = "replace")
+   rapply(as.list(range), `+`, e2 = offset, how = "replace")
 })

--- a/src/cpp/session/modules/SessionRUtil.R
+++ b/src/cpp/session/modules/SessionRUtil.R
@@ -206,3 +206,8 @@
 {
    .Call("rs_isSerializable", object, PACKAGE = "(embedding)")
 })
+
+.rs.addFunction("reindexRange", function(range, offset = 1)
+{
+   rapply(range, `+`, e2 = offset, how = "replace")
+})

--- a/src/cpp/session/modules/SessionRUtil.R
+++ b/src/cpp/session/modules/SessionRUtil.R
@@ -209,5 +209,6 @@
 
 .rs.addFunction("reindexRange", function(range, offset = 1)
 {
-   rapply(as.list(range), `+`, e2 = offset, how = "replace")
+   if (is.list(range))
+      rapply(range, `+`, e2 = offset, how = "replace")
 })

--- a/src/cpp/session/modules/SessionSource.R
+++ b/src/cpp/session/modules/SessionSource.R
@@ -308,6 +308,16 @@
    })
 })
 
+.rs.addFunction("getSourceDocument", function(id, includeContents = FALSE)
+{
+   .Call(
+      "rs_getSourceDocument",
+      as.character(id),
+      as.logical(includeContents),
+      PACKAGE = "(embedding)"
+   )
+})
+
 .rs.addFunction("getSourceDocumentProperties", function(path, includeContents = FALSE)
 {
    if (is.null(path) || !file.exists(path))

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/CodeToolsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/CodeToolsServerOperations.java
@@ -17,7 +17,7 @@ package org.rstudio.studio.client.common.codetools;
 import java.util.List;
 
 import org.rstudio.core.client.js.JsObject;
-import org.rstudio.studio.client.server.*;
+import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.codesearch.model.CodeSearchServerOperations;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.PythonCompletionContext;
@@ -44,8 +44,9 @@ public interface CodeToolsServerOperations extends HelpServerOperations,
          List<String> assocData,
          List<Integer> dataType,
          List<Integer> numCommas,
-         String chainObjectName,
          String functionCallString,
+         String contextLines,
+         String chainObjectName,
          JsArrayString chainAdditionalArgs,
          JsArrayString chainExcludeArgs,
          boolean chainExcludeArgsFromObject,

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/CodeToolsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/CodeToolsServerOperations.java
@@ -14,13 +14,13 @@
  */
 package org.rstudio.studio.client.common.codetools;
 
-import java.util.List;
-
+import org.rstudio.core.client.JsVector;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.codesearch.model.CodeSearchServerOperations;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.PythonCompletionContext;
+import org.rstudio.studio.client.workbench.views.console.shell.assist.RCompletionManager.AutocompletionContextData;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.SqlCompletionParseContext;
 import org.rstudio.studio.client.workbench.views.help.model.HelpServerOperations;
 import org.rstudio.studio.client.workbench.views.output.lint.model.AceAnnotation;
@@ -42,9 +42,7 @@ public interface CodeToolsServerOperations extends HelpServerOperations,
    
    void getCompletions(
          String token,
-         List<String> assocData,
-         List<Integer> dataType,
-         List<Integer> numCommas,
+         JsVector<AutocompletionContextData> contextData,
          String functionCallString,
          Range statementBounds,
          String chainObjectName,

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/CodeToolsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/CodeToolsServerOperations.java
@@ -24,6 +24,7 @@ import org.rstudio.studio.client.workbench.views.console.shell.assist.PythonComp
 import org.rstudio.studio.client.workbench.views.console.shell.assist.SqlCompletionParseContext;
 import org.rstudio.studio.client.workbench.views.help.model.HelpServerOperations;
 import org.rstudio.studio.client.workbench.views.output.lint.model.AceAnnotation;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
 import org.rstudio.studio.client.workbench.views.source.model.CppServerOperations;
 
 import com.google.gwt.core.client.JavaScriptObject;
@@ -45,7 +46,7 @@ public interface CodeToolsServerOperations extends HelpServerOperations,
          List<Integer> dataType,
          List<Integer> numCommas,
          String functionCallString,
-         String contextLines,
+         Range statementBounds,
          String chainObjectName,
          JsArrayString chainAdditionalArgs,
          JsArrayString chainExcludeArgs,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1087,8 +1087,9 @@ public class RemoteServer implements Server
          List<String> assocData,
          List<Integer> dataType,
          List<Integer> numCommas,
-         String chainObjectName,
          String functionCallString,
+         String contextLines,
+         String chainObjectName,
          JsArrayString additionalArgs,
          JsArrayString excludeArgs,
          boolean excludeArgsFromObject,
@@ -1103,15 +1104,16 @@ public class RemoteServer implements Server
       setArrayString(params, 1, assocData);
       setArrayNumber(params, 2, dataType);
       setArrayNumber(params, 3, numCommas);
-      params.set(4, new JSONString(chainObjectName));
-      params.set(5, new JSONString(functionCallString));
-      setArrayString(params, 6, additionalArgs);
-      setArrayString(params, 7, excludeArgs);
-      params.set(8, JSONBoolean.getInstance(excludeArgsFromObject));
-      params.set(9, new JSONString(filePath));
-      params.set(10, new JSONString(documentId));
-      params.set(11, new JSONString(line));
-      params.set(12, JSONBoolean.getInstance(isConsole));
+      params.set(4, new JSONString(functionCallString));
+      params.set(5, new JSONString(contextLines));
+      params.set(6, new JSONString(chainObjectName));
+      setArrayString(params, 7, additionalArgs);
+      setArrayString(params, 8, excludeArgs);
+      params.set(9, JSONBoolean.getInstance(excludeArgsFromObject));
+      params.set(10, new JSONString(filePath));
+      params.set(11, new JSONString(documentId));
+      params.set(12, new JSONString(line));
+      params.set(13, JSONBoolean.getInstance(isConsole));
 
       sendRequest(RPC_SCOPE,
                   GET_COMPLETIONS,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -214,6 +214,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.explorer.model.O
 import org.rstudio.studio.client.workbench.views.source.editors.profiler.model.ProfileOperationRequest;
 import org.rstudio.studio.client.workbench.views.source.editors.profiler.model.ProfileOperationResponse;
 import org.rstudio.studio.client.workbench.views.source.editors.text.IconvListResult;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkDefinition;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceTheme;
 import org.rstudio.studio.client.workbench.views.source.events.AvailablePackagesReadyEvent;
@@ -1088,7 +1089,7 @@ public class RemoteServer implements Server
          List<Integer> dataType,
          List<Integer> numCommas,
          String functionCallString,
-         String contextLines,
+         Range statementBounds,
          String chainObjectName,
          JsArrayString additionalArgs,
          JsArrayString excludeArgs,
@@ -1105,7 +1106,7 @@ public class RemoteServer implements Server
       setArrayNumber(params, 2, dataType);
       setArrayNumber(params, 3, numCommas);
       params.set(4, new JSONString(functionCallString));
-      params.set(5, new JSONString(contextLines));
+      params.set(5, new JSONObject(statementBounds));
       params.set(6, new JSONString(chainObjectName));
       setArrayString(params, 7, additionalArgs);
       setArrayString(params, 8, excludeArgs);

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.JsVector;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.files.FileSystemItem;
@@ -185,6 +186,7 @@ import org.rstudio.studio.client.workbench.views.connections.model.NewConnection
 import org.rstudio.studio.client.workbench.views.connections.model.NewConnectionInfo;
 import org.rstudio.studio.client.workbench.views.console.model.ProcessBufferChunk;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.PythonCompletionContext;
+import org.rstudio.studio.client.workbench.views.console.shell.assist.RCompletionManager.AutocompletionContextData;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.SqlCompletionParseContext;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.DataImportOptions;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
@@ -1085,9 +1087,7 @@ public class RemoteServer implements Server
 
    public void getCompletions(
          String token,
-         List<String> assocData,
-         List<Integer> dataType,
-         List<Integer> numCommas,
+         JsVector<AutocompletionContextData> contextData,
          String functionCallString,
          Range statementBounds,
          String chainObjectName,
@@ -1100,21 +1100,20 @@ public class RemoteServer implements Server
          boolean isConsole,
          ServerRequestCallback<Completions> requestCallback)
    {
-      JSONArray params = new JSONArray();
-      params.set(0, new JSONString(token));
-      setArrayString(params, 1, assocData);
-      setArrayNumber(params, 2, dataType);
-      setArrayNumber(params, 3, numCommas);
-      params.set(4, new JSONString(functionCallString));
-      params.set(5, new JSONObject(statementBounds));
-      params.set(6, new JSONString(chainObjectName));
-      setArrayString(params, 7, additionalArgs);
-      setArrayString(params, 8, excludeArgs);
-      params.set(9, JSONBoolean.getInstance(excludeArgsFromObject));
-      params.set(10, new JSONString(filePath));
-      params.set(11, new JSONString(documentId));
-      params.set(12, new JSONString(line));
-      params.set(13, JSONBoolean.getInstance(isConsole));
+      JSONArray params = new JSONArrayBuilder()
+            .add(token)
+            .add(contextData)
+            .add(functionCallString)
+            .add(statementBounds)
+            .add(chainObjectName)
+            .add(additionalArgs)
+            .add(excludeArgs)
+            .add(excludeArgsFromObject)
+            .add(filePath)
+            .add(documentId)
+            .add(line)
+            .add(isConsole)
+            .get();
 
       sendRequest(RPC_SCOPE,
                   GET_COMPLETIONS,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -14,19 +14,18 @@
  */
 package org.rstudio.studio.client.workbench.views.console.shell.assist;
 
-import com.google.gwt.core.client.JsArray;
-import com.google.gwt.core.client.JsArrayBoolean;
-import com.google.gwt.core.client.JsArrayInteger;
-import com.google.gwt.core.client.JsArrayString;
-import com.google.gwt.resources.client.ImageResource;
-import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
-import com.google.inject.Inject;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
 
-import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.SafeHtmlUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.js.JsUtil;
 import org.rstudio.core.client.regex.Pattern;
+import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.codetools.CodeToolsServerOperations;
 import org.rstudio.studio.client.common.codetools.Completions;
@@ -52,12 +51,13 @@ import org.rstudio.studio.client.workbench.views.source.model.RnwChunkOptions;
 import org.rstudio.studio.client.workbench.views.source.model.RnwChunkOptions.RnwOptionCompletionResult;
 import org.rstudio.studio.client.workbench.views.source.model.RnwCompletionContext;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.JsArrayBoolean;
+import com.google.gwt.core.client.JsArrayInteger;
+import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.inject.Inject;
 
 public class CompletionRequester
 {
@@ -280,6 +280,7 @@ public class CompletionRequester
          final List<Integer> dataType,
          final List<Integer> numCommas,
          final String functionCallString,
+         final String contextLines,
          final String chainDataName,
          final JsArrayString chainAdditionalArgs,
          final JsArrayString chainExcludeArgs,
@@ -303,6 +304,7 @@ public class CompletionRequester
             dataType,
             numCommas,
             functionCallString,
+            contextLines,
             chainDataName,
             chainAdditionalArgs,
             chainExcludeArgs,
@@ -629,6 +631,7 @@ public class CompletionRequester
          final List<Integer> dataType,
          final List<Integer> numCommas,
          final String functionCallString,
+         final String contextLines,
          final String chainObjectName,
          final JsArrayString chainAdditionalArgs,
          final JsArrayString chainExcludeArgs,
@@ -653,6 +656,7 @@ public class CompletionRequester
                dataType,
                numCommas,
                functionCallString,
+               contextLines,
                chainObjectName,
                chainAdditionalArgs,
                chainExcludeArgs,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -19,8 +19,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.List;
 
+import org.rstudio.core.client.JsVector;
 import org.rstudio.core.client.SafeHtmlUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.js.JsUtil;
@@ -39,6 +39,7 @@ import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.snippets.SnippetHelper;
 import org.rstudio.studio.client.workbench.views.console.shell.ConsoleLanguageTracker;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.RCompletionManager.AutocompletionContext;
+import org.rstudio.studio.client.workbench.views.console.shell.assist.RCompletionManager.AutocompletionContextData;
 import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.RFunction;
@@ -277,9 +278,7 @@ public class CompletionRequester
 
    public void getCompletions(
          final String token,
-         final List<String> assocData,
-         final List<Integer> dataType,
-         final List<Integer> numCommas,
+         final JsVector<AutocompletionContextData> contextData,
          final String functionCallString,
          final Range statementBounds,
          final String chainDataName,
@@ -293,17 +292,16 @@ public class CompletionRequester
          final boolean implicit,
          final ServerRequestCallback<CompletionResult> callback)
    {
-      boolean isHelp = dataType.size() > 0 &&
-            dataType.get(0) == AutocompletionContext.TYPE_HELP;
+      boolean isHelp =
+            contextData.length() > 0 &&
+            contextData.get(0).getType() == AutocompletionContext.TYPE_HELP;
 
       if (usingCache(token, isHelp, callback))
          return;
 
       doGetCompletions(
             token,
-            assocData,
-            dataType,
-            numCommas,
+            contextData,
             functionCallString,
             statementBounds,
             chainDataName,
@@ -628,9 +626,7 @@ public class CompletionRequester
 
    private void doGetCompletions(
          final String token,
-         final List<String> assocData,
-         final List<Integer> dataType,
-         final List<Integer> numCommas,
+         final JsVector<AutocompletionContextData> contextData,
          final String functionCallString,
          final Range statementBounds,
          final String chainObjectName,
@@ -653,9 +649,7 @@ public class CompletionRequester
       {
          server_.getCompletions(
                token,
-               assocData,
-               dataType,
-               numCommas,
+               contextData,
                functionCallString,
                statementBounds,
                chainObjectName,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -46,6 +46,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ScopeFuncti
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.CodeModel;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.RScopeObject;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.TokenCursor;
 import org.rstudio.studio.client.workbench.views.source.model.RnwChunkOptions;
 import org.rstudio.studio.client.workbench.views.source.model.RnwChunkOptions.RnwOptionCompletionResult;
@@ -280,7 +281,7 @@ public class CompletionRequester
          final List<Integer> dataType,
          final List<Integer> numCommas,
          final String functionCallString,
-         final String contextLines,
+         final Range statementBounds,
          final String chainDataName,
          final JsArrayString chainAdditionalArgs,
          final JsArrayString chainExcludeArgs,
@@ -304,7 +305,7 @@ public class CompletionRequester
             dataType,
             numCommas,
             functionCallString,
-            contextLines,
+            statementBounds,
             chainDataName,
             chainAdditionalArgs,
             chainExcludeArgs,
@@ -631,7 +632,7 @@ public class CompletionRequester
          final List<Integer> dataType,
          final List<Integer> numCommas,
          final String functionCallString,
-         final String contextLines,
+         final Range statementBounds,
          final String chainObjectName,
          final JsArrayString chainAdditionalArgs,
          final JsArrayString chainExcludeArgs,
@@ -656,7 +657,7 @@ public class CompletionRequester
                dataType,
                numCommas,
                functionCallString,
-               contextLines,
+               statementBounds,
                chainObjectName,
                chainAdditionalArgs,
                chainExcludeArgs,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 
-import org.rstudio.core.client.JsVector;
 import org.rstudio.core.client.SafeHtmlUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.js.JsUtil;
@@ -39,15 +38,15 @@ import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.snippets.SnippetHelper;
 import org.rstudio.studio.client.workbench.views.console.shell.ConsoleLanguageTracker;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.RCompletionManager.AutocompletionContext;
-import org.rstudio.studio.client.workbench.views.console.shell.assist.RCompletionManager.AutocompletionContextData;
 import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor;
+import org.rstudio.studio.client.workbench.views.source.editors.text.CompletionContext;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.RFunction;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ScopeFunction;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.CodeModel;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.RInfixData;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.RScopeObject;
-import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.TokenCursor;
 import org.rstudio.studio.client.workbench.views.source.model.RnwChunkOptions;
 import org.rstudio.studio.client.workbench.views.source.model.RnwChunkOptions.RnwOptionCompletionResult;
@@ -59,23 +58,29 @@ import com.google.gwt.core.client.JsArrayInteger;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
 
 public class CompletionRequester
 {
-   private CodeToolsServerOperations server_;
-   private UserPrefs uiPrefs_;
+   private final CompletionContext context_;
+   private final RnwCompletionContext rnwContext_;
    private final DocDisplay docDisplay_;
    private final SnippetHelper snippets_;
-
+   
    private String cachedLinePrefix_;
    private HashMap<String, CompletionResult> cachedCompletions_ = new HashMap<>();
-   private RnwCompletionContext rnwContext_;
 
-   public CompletionRequester(RnwCompletionContext rnwContext,
+   // Injected ----
+   private CodeToolsServerOperations server_;
+   private UserPrefs uiPrefs_;
+   
+   public CompletionRequester(CompletionContext context,
+                              RnwCompletionContext rnwContext,
                               DocDisplay docDisplay,
                               SnippetHelper snippets)
    {
+      context_ = context;
       rnwContext_ = rnwContext;
       docDisplay_ = docDisplay;
       snippets_ = snippets;
@@ -276,38 +281,26 @@ public class CompletionRequester
       return !RE_EXTRACTION.test(line);
    }
 
-   public void getCompletions(
-         final String token,
-         final JsVector<AutocompletionContextData> contextData,
-         final String functionCallString,
-         final Range statementBounds,
-         final String chainDataName,
-         final JsArrayString chainAdditionalArgs,
-         final JsArrayString chainExcludeArgs,
-         final boolean chainExcludeArgsFromObject,
-         final String filePath,
-         final String documentId,
-         final String line,
-         final boolean isConsole,
-         final boolean implicit,
-         final ServerRequestCallback<CompletionResult> callback)
+   public void getCompletions(final AutocompletionContext context,
+                              final RInfixData infixData,
+                              final String filePath,
+                              final String documentId,
+                              final String line,
+                              final boolean isConsole,
+                              final boolean implicit,
+                              final ServerRequestCallback<CompletionResult> callback)
    {
+      String token = context.getToken();
       boolean isHelp =
-            contextData.length() > 0 &&
-            contextData.get(0).getType() == AutocompletionContext.TYPE_HELP;
+            context.getContextData().length() > 0 &&
+            context.getContextData().get(0).getType() == AutocompletionContext.TYPE_HELP;
 
       if (usingCache(token, isHelp, callback))
          return;
 
       doGetCompletions(
-            token,
-            contextData,
-            functionCallString,
-            statementBounds,
-            chainDataName,
-            chainAdditionalArgs,
-            chainExcludeArgs,
-            chainExcludeArgsFromObject,
+            context,
+            infixData,
             filePath,
             documentId,
             line,
@@ -624,43 +617,50 @@ public class CompletionRequester
       }
    }
 
-   private void doGetCompletions(
-         final String token,
-         final JsVector<AutocompletionContextData> contextData,
-         final String functionCallString,
-         final Range statementBounds,
-         final String chainObjectName,
-         final JsArrayString chainAdditionalArgs,
-         final JsArrayString chainExcludeArgs,
-         final boolean chainExcludeArgsFromObject,
-         final String filePath,
-         final String documentId,
-         final String line,
-         final boolean isConsole,
-         final ServerRequestCallback<Completions> requestCallback)
+   private void doGetCompletions(AutocompletionContext context,
+                                 RInfixData infixData,
+                                 final String filePath,
+                                 final String documentId,
+                                 final String line,
+                                 final boolean isConsole,
+                                 final ServerRequestCallback<Completions> requestCallback)
    {
-      int optionsStartOffset;
-      if (rnwContext_ != null &&
-          (optionsStartOffset = rnwContext_.getRnwOptionsStart(token, token.length())) >= 0)
+      if (rnwContext_ != null)
       {
-         doGetSweaveCompletions(token, optionsStartOffset, token.length(), requestCallback);
+         String token = context.getToken();
+         int offset = rnwContext_.getRnwOptionsStart(token, token.length());
+         if (offset >= 0)
+         {
+            doGetSweaveCompletions(token, offset, token.length(), requestCallback);
+            return;
+         }
       }
-      else
+      
+      Command command = () ->
       {
          server_.getCompletions(
-               token,
-               contextData,
-               functionCallString,
-               statementBounds,
-               chainObjectName,
-               chainAdditionalArgs,
-               chainExcludeArgs,
-               chainExcludeArgsFromObject,
+               context.getToken(),
+               context.getContextData(),
+               context.getFunctionCallString(),
+               context.getStatementBounds(),
+               infixData.getDataName(),
+               infixData.getAdditionalArgs(),
+               infixData.getExcludeArgs(),
+               infixData.getExcludeArgsFromObject(),
                filePath,
                documentId,
                line,
                isConsole,
                requestCallback);
+      };
+         
+      if (context_ != null && context.getNeedsDocSync())
+      {
+         context_.withSavedDocument(command);
+      }
+      else
+      {
+         command.execute();
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1036,7 +1036,7 @@ public class RCompletionManager implements CompletionManager
 
       public void setToken(String token)
       {
-         this.token_ = token;
+         token_ = token;
       }
 
       public List<String> getAssocData()
@@ -1046,7 +1046,7 @@ public class RCompletionManager implements CompletionManager
 
       public void setAssocData(List<String> assocData)
       {
-         this.assocData_ = assocData;
+         assocData_ = assocData;
       }
 
       public List<Integer> getDataType()
@@ -1056,7 +1056,7 @@ public class RCompletionManager implements CompletionManager
 
       public void setDataType(List<Integer> dataType)
       {
-         this.dataType_ = dataType;
+         dataType_ = dataType;
       }
 
       public List<Integer> getNumCommas()
@@ -1066,7 +1066,7 @@ public class RCompletionManager implements CompletionManager
 
       public void setNumCommas(List<Integer> numCommas)
       {
-         this.numCommas_ = numCommas;
+         numCommas_ = numCommas;
       }
 
       public String getFunctionCallString()
@@ -1079,14 +1079,14 @@ public class RCompletionManager implements CompletionManager
          this.functionCallString_ = functionCallString;
       }
       
-      public String getContextLines()
+      public Range getStatementBounds()
       {
-         return contextLines_;
+         return statementBounds_;
       }
       
-      public void setContextLines(String contextLines)
+      public void setStatementBounds(Range statementBounds)
       {
-         contextLines_ = contextLines;
+         statementBounds_ = statementBounds;
       }
       
       public void add(String assocData, Integer dataType, Integer numCommas)
@@ -1111,7 +1111,7 @@ public class RCompletionManager implements CompletionManager
       private List<Integer> dataType_;
       private List<Integer> numCommas_;
       private String functionCallString_;
-      private String contextLines_ = "";
+      private Range statementBounds_;
       
    }
    
@@ -1276,7 +1276,7 @@ public class RCompletionManager implements CompletionManager
             context.getDataType(),
             context.getNumCommas(),
             context.getFunctionCallString(),
-            context.getContextLines(),
+            context.getStatementBounds(),
             infixData.getDataName(),
             infixData.getAdditionalArgs(),
             infixData.getExcludeArgs(),
@@ -1706,6 +1706,7 @@ public class RCompletionManager implements CompletionManager
          
          tokenCursor.findStartOfEvaluationContext();
          
+         // TODO: Include inner contents here as well.
          assocData =
             docDisplay_.getTextForRange(Range.fromPoints(
                   tokenCursor.currentPosition(),
@@ -1767,9 +1768,8 @@ public class RCompletionManager implements CompletionManager
       }
       contextEndPos = cursor.currentPosition();
       
-      Range contextRange = Range.fromPoints(contextStartPos, contextEndPos);
-      String contextLines = docDisplay_.getTextForRange(contextRange).trim();
-      context.setContextLines(contextLines);
+      Range statementBounds = Range.fromPoints(contextStartPos, contextEndPos);
+      context.setStatementBounds(statementBounds);
       
       return context;
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -122,7 +122,7 @@ public class RCompletionManager implements CompletionManager
       
       suggestTimer_ = new SuggestionTimer(this, userPrefs_);
       snippets_ = new SnippetHelper((AceEditor) docDisplay, getSourceDocumentPath());
-      requester_ = new CompletionRequester(rnwContext, docDisplay, snippets_);
+      requester_ = new CompletionRequester(rContext, rnwContext, docDisplay, snippets_);
       handlers_ = new HandlerRegistrations();
       
       handlers_.add(input_.addClickHandler(event ->
@@ -1052,6 +1052,16 @@ public class RCompletionManager implements CompletionManager
          return contextData_;
       }
       
+      public void setNeedsDocSync(boolean needsDocSync)
+      {
+         needsDocSync_ = needsDocSync;
+      }
+      
+      public boolean getNeedsDocSync()
+      {
+         return needsDocSync_;
+      }
+      
       public void add(AutocompletionContextData data)
       {
          contextData_.push(data);
@@ -1077,6 +1087,7 @@ public class RCompletionManager implements CompletionManager
       private JsVector<AutocompletionContextData> contextData_ = JsVector.createVector().cast();
       
       private Range statementBounds_ = null;
+      private boolean needsDocSync_ = false;
    }
    
    private boolean isLineInRoxygenComment(String line)
@@ -1235,14 +1246,8 @@ public class RCompletionManager implements CompletionManager
       String line = docDisplay_.getCurrentLineUpToCursor();
       
       requester_.getCompletions(
-            context.getToken(),
-            context.getContextData(),
-            context.getFunctionCallString(),
-            context.getStatementBounds(),
-            infixData.getDataName(),
-            infixData.getAdditionalArgs(),
-            infixData.getExcludeArgs(),
-            infixData.getExcludeArgsFromObject(),
+            context,
+            infixData,
             filePath,
             docId,
             line,
@@ -1733,6 +1738,7 @@ public class RCompletionManager implements CompletionManager
       
       Range statementBounds = Range.fromPoints(contextStartPos, contextEndPos);
       context.setStatementBounds(statementBounds);
+      context.setNeedsDocSync(true);
       
       return context;
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/CompletionContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/CompletionContext.java
@@ -15,6 +15,8 @@
 
 package org.rstudio.studio.client.workbench.views.source.editors.text;
 
+import com.google.gwt.user.client.Command;
+
 public interface CompletionContext
 {
    String getId();
@@ -23,5 +25,5 @@ public interface CompletionContext
    String[] getQuartoFormats();
    String[] getQuartoProjectFormats();
    String getQuartoEngine();
-   
+   void withSavedDocument(Command command);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -8375,8 +8375,8 @@ public class TextEditingTarget implements
       }
    };
 
-   private final CompletionContext rContext_ = new CompletionContext() {
-
+   private final CompletionContext rContext_ = new CompletionContext()
+   {
       @Override
       public String getId()
       {
@@ -8490,6 +8490,19 @@ public class TextEditingTarget implements
          }
          
          return null;   
+      }
+      
+      @Override
+      public void withSavedDocument(Command command)
+      {
+         if (docUpdateSentinel_ != null)
+         {
+            docUpdateSentinel_.withSavedDoc(command);
+         }
+         else
+         {
+            command.execute();
+         }
       }
       
       // cache front matter parse

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
@@ -245,7 +245,7 @@ public class DocUpdateSentinel
 
    private void withSavedDocImpl(final boolean retryWrite,
                                  final Command onSaved,
-         final CommandWithArg<String> onError)
+                                 final CommandWithArg<String> onError)
    {
       if (changeTracker_.hasChanged())
       {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8444. Implements autocompletion of column names within `aes()` calls. For example:

<img width="348" alt="Screenshot 2024-01-31 at 3 28 32 PM" src="https://github.com/rstudio/rstudio/assets/1976582/79a5b03e-0613-4999-903b-040bb712e2bf">

We also support inline data + aesthetic mappings; for example, the (admittedly nonsensical example):

<img width="346" alt="Screenshot 2024-01-31 at 3 29 26 PM" src="https://github.com/rstudio/rstudio/assets/1976582/341ad1b2-8840-4ee4-89c8-11dfc8130396">

Finally, when available within the R session, we can also extract data attributes from `gg` objects as created via `ggplot2` calls, for plots which are built piece-by-piece.

<img width="443" alt="Screenshot 2024-01-31 at 3 33 04 PM" src="https://github.com/rstudio/rstudio/assets/1976582/11f832cd-a144-44fe-ab2a-9c7d775dc7b8">

### Approach

This PR uses a small extension to the R completion context builder, and now attempts to capture the entirety of the current R expression. Then, from that expression, we can try to pull out details like the `data` argument in a `ggplot2` call.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8444. This PR also necessitates smoke testing of other autocompletion features, but this PR has been implemented in a way that should hopefully avoid intruding on already-existing completion code paths.


### Documentation

Not included.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
