### PR TITLE
use Java11 for gwt builds on CentOS7

### DIFF
--- a/docker/jenkins/Dockerfile.centos7
+++ b/docker/jenkins/Dockerfile.centos7
@@ -8,7 +8,7 @@ RUN set -x \
     && yum install epel-release -y
 
 RUN yum install -y \
-ant \
+    ant \
     boost-devel \
     bzip2-devel \
     curl \

--- a/docker/jenkins/Dockerfile.centos7
+++ b/docker/jenkins/Dockerfile.centos7
@@ -8,7 +8,7 @@ RUN set -x \
     && yum install epel-release -y
 
 RUN yum install -y \
-    ant \
+ant \
     boost-devel \
     bzip2-devel \
     curl \
@@ -22,8 +22,8 @@ RUN yum install -y \
     gdb \
     gpg \
     gtk3 \
-    java-1.8.0-openjdk \
-    java-1.8.0-openjdk-devel \
+    java-11-openjdk \
+    java-11-openjdk-devel \
     jq \
     libXScrnSaver-devel \
     libXcursor-devel \
@@ -60,6 +60,11 @@ RUN yum install -y \
     xml-commons-apis \
     xorg-x11-server-Xvfb \
     zlib-devel
+
+# ant install triggers java 8 installation but we use java 11 for builds
+RUN JDK_11_PATH=$(dirname $(dirname $(readlink -f $(find /usr/lib/jvm/ -name javac | grep java-11)))) && \
+    alternatives --set java $JDK_11_PATH/bin/java && \
+    alternatives --set javac $JDK_11_PATH/bin/javac
 
 # add scl repo and install additional dependencies
 RUN yum install -y \


### PR DESCRIPTION
### Intent

One step of implementing: #14157

Chipping away at this one platform at a time to make it easier to diagnose any unexpected build issues.

### Approach

Install Java and JDK v11 instead of v8 in the dockerfile. The installation of `ant` on CentOS7 triggers installation of Java8, so have to then activate Java/Javac 11.

I built the image locally, started up the container, confirmed that `javac -version` and `java -version` both report v11, and also did a successful package build of Desktop in the container.

### Automated Tests

N/A

### QA Notes

Nothing to manually test here.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


