### PR TITLE
I am once again updating docs/news/index.qmd

### DIFF
--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -26,8 +26,9 @@ This page provides the release notes associated with each release of RStudio and
 - Removed GitHub Copilot preview label and disclaimer in Copilot options panes (#14067)
 - Fixed an issue where GitHub Copilot indexed binary files when project indexing enabled (#14106)
 - Fixed regression that prevented opening help topics in separate window (#14097)
-- Increased open files limit (rstduio/rstudio#14148)
-
+- Increased open files limit (#14148)
+- Fixed an issue with saving pane layouts for Desktop Pro (rstudio-pro#5612)
+ 
 #### Posit Workbench
 - Fixed join session when ready control not responding to mouse clicks in all areas (rstudio/rstudio-pro#5609)
 - Fixed intermittent rserver crash when joining a session started with the job launcher that is not immediately available (rstudio-pro#5579)
@@ -264,7 +265,7 @@ This page provides the release notes associated with each release of RStudio and
 - Fixed issue with Slurm and load balancing that could delay session starts or occasionally fail to start (rstudio/rstudio-pro#4971)
 - Updated jupyterlab buildutils package to fix vulnerability (rstudio/rstudio-pro#4951)
 - Updated the SAML helper program to fix problem found in vulnerability scan (rstudio/rstudio-pro#4903)
-- Add support for newer Slurm v23 (rstduio/rstudio-pro#4766)
+- Add support for newer Slurm v23 (rstudio/rstudio-pro#4766)
 
 ### Deprecated / Removed
 


### PR DESCRIPTION
This one was added last-minute and slipped through. It's already in `version/news/NEWS-2023.12.1-ocean-storm.md` (because you have to update like three different files for news-related things).