### PR TITLE
Update opensuse15 dockerfile to Java 11

### DIFF
--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -17,7 +17,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     gcc-c++ \
     gdb \
     git \
-    java-1_8_0-openjdk-devel  \
+    java-11-openjdk-devel \
     jq \
     libXcursor-devel \
     libXrandr-devel \
@@ -78,8 +78,8 @@ RUN bash /tmp/install-dependencies
 COPY dependencies/common/install-crashpad /tmp/
 RUN bash /tmp/install-crashpad opensuse15
 
-# ensure we use the java 8 compiler
-RUN update-alternatives --set java /usr/lib64/jvm/jre-1.8.0-openjdk/bin/java
+# ensure we use the java 11 compiler
+RUN update-alternatives --set java /usr/lib64/jvm/jre-11-openjdk/bin/java
 
 # copy common dependency installation scripts
 RUN mkdir -p /opt/rstudio-tools/dependencies/common


### PR DESCRIPTION
### Intent

Part of implementing: https://github.com/rstudio/rstudio/issues/14157

Chipping away at this one platform at a time to make it easier to diagnose any unexpected build issues.

### Approach

Install Java and JDK v11 instead of v8 in the dockerfile.

I built the image locally, started up the container, confirmed that javac -version and java -version both report v11.

### Automated Tests

N/A

### QA Notes

Nothing to manually test.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


