### PR TITLE
Update Ubuntu Focal and RHEL8 Dockerfiles to Java 11

### DIFF
--- a/docker/jenkins/Dockerfile.focal
+++ b/docker/jenkins/Dockerfile.focal
@@ -49,7 +49,7 @@ RUN apt-get update && \
     libxslt1-dev \
     lsof \
     ninja-build \
-    openjdk-8-jdk \
+    openjdk-11-jdk \
     p7zip-full \
     pkg-config \
     python \
@@ -72,8 +72,8 @@ RUN if [ "$ARCH" = "amd64" ]; then \
     ; fi
 
 
-# ensure we use the java 8 compiler
-RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)/jre/bin/java
+# ensure we use the java 11 compiler
+RUN update-alternatives --set java /usr/lib/jvm/java-11-openjdk-$(dpkg --print-architecture)/bin/java
 
 ## build patchelf
 RUN cd /tmp \

--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -24,8 +24,8 @@ RUN yum install -y \
     gdb \
     git \
     gtk3 \
-    java-1.8.0-openjdk \
-    java-1.8.0-openjdk-devel \
+    java-11-openjdk \
+    java-11-openjdk-devel \
     jq \
     libXScrnSaver-devel \
     libXcursor-devel \
@@ -64,6 +64,11 @@ RUN yum install -y \
     whois \
     xorg-x11-server-Xvfb \
     zlib-devel
+
+# ant install triggers java 8 installation but we use java 11 for builds
+RUN JDK_11_PATH=$(dirname $(dirname $(readlink -f $(find /usr/lib/jvm/ -name javac | grep java-11)))) && \
+    alternatives --set java $JDK_11_PATH/bin/java && \
+    alternatives --set javac $JDK_11_PATH/bin/javac
 
 # copy RStudio tools (needed so that our other dependency scripts can find it)
 RUN mkdir -p /tools


### PR DESCRIPTION
### Intent

Final batch of Linux dockerfile updates for #14157

With this all the Linux build environments will be using Java 11 (instead of Java 8). Note that Ubuntu Jammy and RHEL9 already use Java 11. This leaves Windows to be updated (Mac is already using Java 11).

### Approach

Update dockerfiles, tested locally.

### Automated Tests

N/A

### QA Notes

Nothing to manually test.

### Documentation
N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


