### PR TITLE
use Java 11 in Windows build image

### DIFF
--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -16,7 +16,7 @@ function Test-Administrator
     (New-Object Security.Principal.WindowsPrincipal $user).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
 }
 
-function Download-File ($url, $output) {
+function Invoke-DownloadFile ($url, $output) {
     (New-Object System.Net.WebClient).DownloadFile($url, $output)
 }
 
@@ -45,7 +45,7 @@ if (-Not (Test-Path -Path "C:\R")) {
     $RSetupPackage = "C:\R-3.6.3-win.exe"
     if (-Not (Test-Path -Path $RSetupPackage)) {
         Write-Host "Downloading R 3.6.3..."
-        Download-File https://cran.rstudio.com/bin/windows/base/old/3.6.3/R-3.6.3-win.exe $RSetupPackage
+        Invoke-DownloadFile https://cran.rstudio.com/bin/windows/base/old/3.6.3/R-3.6.3-win.exe $RSetupPackage
     } else {
         Write-Host "Using previously downloaded R installer"
     }
@@ -59,14 +59,14 @@ if (-Not (Test-Path -Path "C:\R")) {
 }
 
 # install chocolatey
-iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 refreshenv
 
 # install some deps via chocolatey
 # pin python to 3.11 while this issue is pending: https://github.com/nodejs/node-gyp/issues/2869
 choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-on-error-output
 refreshenv
-choco install -y jdk8
+choco install -y openjdk11
 choco install -y -i ant
 choco install -y 7zip
 choco install -y git
@@ -87,10 +87,8 @@ if (Test-Path $ChocoCPack) { Remove-Item -Force $ChocoCPack }
 
 Write-Host "-----------------------------------------------------------"
 Write-Host "Core dependencies successfully installed. Next steps:"
-Write-Host "(1) Install Qt 5.12.8 from https://qt.io for MSVC 2017 64-bit with QtWebEngine"
-Write-Host "(2) Start a non-administrator Command Prompt"
-Write-Host "(3) git clone https://github.com/rstudio/rstudio"
-Write-Host "(4) change working dir to rstudio\dependencies\windows"
-Write-Host "(5) install-dependencies.cmd"
-Write-Host "(6) open Qt Creator, load rstudio\src\cpp\CMakelists.txt"
+Write-Host "(1) Start a non-administrator Command Prompt"
+Write-Host "(2) git clone https://github.com/rstudio/rstudio"
+Write-Host "(3) change working dir to rstudio\dependencies\windows"
+Write-Host "(4) install-dependencies.cmd"
 Write-Host "-----------------------------------------------------------"

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -24,7 +24,7 @@ RUN $env:chocolateyUseWindowsCompression = 'true'; `
 # install some deps via chocolatey
 # pin python to 3.11 while this issue is pending: https://github.com/nodejs/node-gyp/issues/2869
 RUN choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-on-error-output; `
-  choco install -y jdk8; `
+  choco install -y openjdk11; `
   choco install -y -i ant; `
   choco install -y windows-sdk-10.1 --version 10.1.19041.0; `
   choco install -y 7zip; `


### PR DESCRIPTION
### Intent

Final change for #14157

With this all build environments for RStudio/Workbench will be using JDK11. Some have been using JDK11 for a while, but several were still on JDK8.

Note that we don't currently REQUIRE jdk11, so dev machines with JDK8 will still be able to build GWT, but we need JDK11 to update to the latest build of elemental2 (https://github.com/rstudio/rstudio/issues/13924), currently slated for Cranberry Hibiscus (release after Chocolate Cosmos).

### Approach

Updated Windows dockerfile to install JDK11 instead of JDK8.

Updated bootstrapping script (optional helper for setting up a dev machine) to install JDK11 instead of JDK8, plus a few small cleanups.

### Automated Tests

N/A

### QA Notes

Nothing to manually test.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


