### PR TITLE
Fix extra whitespace bug in some dialogs/popups

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,7 @@
 - Fixed exception being logged when copying or cutting from editor in a separate window (#14140)
 - Fixed an issue where RStudio's R diagnostics warned about potentially missing arguments even when disabled via preferences (#14046)
 - Fixed an issue where the Visual Editor's toolbar controls were duplicated on format change (#12227)
+- Fixed regression that caused extra whitespace at bottom of some popups (#14223)
 
 #### Posit Workbench
 -

--- a/src/gwt/src/org/rstudio/core/client/widget/MessageDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/MessageDialog.java
@@ -186,11 +186,6 @@ public class MessageDialog extends ModalDialogBase
       addAnchorWidget(anchor);
    }
 
-   public void removeAnchorRegion()
-   {
-      removeAnchorPanel();
-   }
-
    private final int type_;
    private final Widget messageWidget_;
    private ProgressIndicator progress_;

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -101,7 +101,6 @@ public abstract class ModalDialogBase extends DialogBox
       bottomPanel_.add(ariaLiveStatusWidget_);
 
       setButtonAlignment(HasHorizontalAlignment.ALIGN_RIGHT);
-      mainPanel_.add(anchorPanel_);
       mainPanel_.add(bottomPanel_);
 
       // embed main panel in a custom container if specified
@@ -446,12 +445,7 @@ public abstract class ModalDialogBase extends DialogBox
    protected void addAnchorWidget(Widget widget)
    {
       anchorPanel_.add(widget);
-   }
-
-   protected void removeAnchorPanel()
-   {
-      anchorPanel_.removeFromParent();
-      anchorPanel_ = null;
+      mainPanel_.insert(anchorPanel_, 0);
    }
 
    protected ProgressIndicator addProgressIndicator()

--- a/src/gwt/src/org/rstudio/studio/client/common/dialog/WebDialogBuilderFactory.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dialog/WebDialogBuilderFactory.java
@@ -67,8 +67,6 @@ public class WebDialogBuilderFactory implements DialogBuilderFactory
 
          if (anchor_ != null)
             messageDialog.addLink(anchor_.label, anchor_.url);
-         else
-            messageDialog.removeAnchorRegion();
 
          if (options_ != null)
          {


### PR DESCRIPTION
### Intent

Addresses [go to files/function box is too large #14223](https://github.com/rstudio/rstudio/issues/14223)

### Approach

Instead of adding the region for the optional anchor and removing it if not needed, only add it when known it is needed.

The problem was the original approach only worked for components that used `ModalDialogBase` via the `WebDialogBuilderFactory`, but there are some that use `ModalDialogBase` directly, and they didn't remove the unused region.

I did test that the Message dialog variant with a link in it (which we added but ended up not using in the ocean-storm patch) still works as expected.

### Automated Tests

None, purely a visual layout issue.

### QA Notes

Layout of mentioned UI elements should be back to normal (no extra whitespace). There are likely other places that were impacted by this, but this change puts them all back to the old behaviour.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


