### PR TITLE
add support for 'clean' restart

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 - Added cmake option to build RStudio without the check for updates feature (#13236)
 - Allow choosing R from non-standard location at startup (#14180; Windows Desktop)
 - Show grey background instead of solid-white during Desktop startup (#13768)
+- The 'restartSession()' API method gains the 'clean' argument. (#2841)
 
 #### Posit Workbench
 - Show custom project names on Workbench homepage (rstudio-pro#5589)

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -39,9 +39,11 @@
    TYPE_ALL_WINDOWS   = 2L
 ))
 
-.rs.addApiFunction("restartSession", function(command = NULL) {
-   command <- as.character(command)
-   invisible(.rs.restartR(command))
+.rs.addApiFunction("restartSession", function(command = NULL, clean = FALSE) {
+   .rs.restartR(
+      afterRestartCommand = as.character(command),
+      clean = as.logical(clean)
+   )
 })
 
 .rs.addApiFunction("initializeProject", function(path = getwd())

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -507,13 +507,26 @@ SEXP rs_userPrompt(SEXP typeSEXP,
    return r::sexp::create(response, &rProtect);
 }
 
-SEXP rs_restartR(SEXP afterRestartSEXP)
+SEXP rs_restartR(SEXP afterRestartSEXP, SEXP cleanSEXP)
 {
    std::string afterRestart = r::sexp::safeAsString(afterRestartSEXP);
+   bool clean = r::sexp::asLogical(cleanSEXP);
+   
    json::Object dataJson;
    dataJson["after_restart"] = afterRestart;
+   
+   if (clean)
+   {
+      json::Object suspendOptionsJson;
+      suspendOptionsJson["save_minimal"] = true;
+      suspendOptionsJson["save_workspace"] = false;
+      suspendOptionsJson["exclude_packages"] = true;
+      dataJson["options"] = suspendOptionsJson;
+   }
+   
    ClientEvent event(client_events::kSuspendAndRestart, dataJson);
    module_context::enqueClientEvent(event);
+   
    return R_NilValue;
 }
 

--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -291,10 +291,11 @@
       stop("Invalid result")
 })
 
-.rs.addFunction("restartR", function(afterRestartCommand = "") {
-   afterRestartCommand <- paste(as.character(afterRestartCommand),
-                                collapse = "\n")
-   .Call("rs_restartR", afterRestartCommand, PACKAGE = "(embedding)")
+.rs.addFunction("restartR", function(afterRestartCommand = "", clean = FALSE) {
+   afterRestartCommand <- paste(as.character(afterRestartCommand), collapse = "\n")
+   clean <- as.logical(clean)
+   result <- .Call("rs_restartR", afterRestartCommand, clean, PACKAGE = "(embedding)")
+   invisible(result)
 })
 
 .rs.addFunction("markdownToHTML", function(content) {

--- a/src/gwt/src/org/rstudio/studio/client/application/model/SuspendOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/model/SuspendOptions.java
@@ -33,8 +33,8 @@ public class SuspendOptions extends JavaScriptObject
    }
    
    private static native final SuspendOptions create(boolean saveMinimal,
-                                                    boolean saveWorkspace,
-                                                    boolean excludePackages) /*-{
+                                                     boolean saveWorkspace,
+                                                     boolean excludePackages) /*-{
       var options = new Object();
       options.save_minimal = saveMinimal;
       options.save_workspace = saveWorkspace;


### PR DESCRIPTION
Addresses https://github.com/rstudio/rstudio/issues/2841.
Addresses https://github.com/rstudio/rstudio/issues/11378.
Will need follow-up in https://github.com/rstudio/rstudioapi/issues/95 post-merge.


This adds a commonly-requested feature, and allows for users to restart the R session programmatically into a fresh / "clean" state.

For testing, one can confirm that using the "clean" version of a restart ensures that no packages or variables from the previous session are saved and restored.

```
> library(dplyr)
> loadedNamespaces()
 [1] "methods"    "utf8"       "R6"         "tidyselect" "magrittr"   "glue"       "tibble"     "pkgconfig" 
 [9] "dplyr"      "generics"   "lifecycle"  "utils"      "cli"        "fansi"      "vctrs"      "graphics"  
[17] "grDevices"  "stats"      "compiler"   "base"       "rstudioapi" "tools"      "pillar"     "rlang"     
[25] "datasets"  
> .rs.api.restartSession(clean = TRUE)

Restarting R session...

> loadedNamespaces()
[1] "compiler"  "graphics"  "tools"     "utils"     "grDevices" "stats"     "datasets"  "methods"   "base"  
```