### PR TITLE
Ensure Mac package builds are using desired node.js version

### DIFF
--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -217,6 +217,10 @@ find-program NPX npx \
    "${PKG_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}-arm64/bin" \
    "${PKG_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}/bin"
 
+# put node on the path
+NODE_PATH=$(dirname "${NODE}")
+PATH="${NODE_PATH}:${PATH}"
+
 # determine architectures to build for
 if is-m1-mac; then
    arch=x86_64,arm64


### PR DESCRIPTION
DRAFT until other build issues are resolved; don't want to add more variables.

### Intent

Addresses [Official Mac builds seem confused about which node.js they are using #14236](https://github.com/rstudio/rstudio/issues/14236)

### Approach

Put the node we install via dependency scripts on the path during package build. We already do this in the Linux `make-package` script: 

https://github.com/rstudio/rstudio/blob/be0a9d9d2482833e9bdf0a6909ee65bf1f0a77e6/package/linux/make-package#L181-L183

### Automated Tests

Build tweaks

### QA Notes

Nothing to test here

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


