### PR TITLE
fix selection buglet in suggestion menu

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearch.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearch.java
@@ -16,13 +16,13 @@ package org.rstudio.studio.client.workbench.codesearch;
 
 import java.util.ArrayList;
 
+import org.rstudio.core.client.CodeNavigationTarget;
 import org.rstudio.core.client.FilePosition;
 import org.rstudio.core.client.XRef;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.SearchDisplay;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
-import org.rstudio.core.client.CodeNavigationTarget;
 import org.rstudio.studio.client.workbench.views.files.events.FileChangeEvent;
 import org.rstudio.studio.client.workbench.views.source.events.XRefNavigationEvent;
 
@@ -78,7 +78,6 @@ public class CodeSearch
 
       final SearchDisplay searchDisplay = display_.getSearchDisplay();
       searchDisplay.setAutoSelectEnabled(true);
-
       searchDisplay.addSelectionHandler(new SelectionHandler<Suggestion>() {
 
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/ui/CodeSearchWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/ui/CodeSearchWidget.java
@@ -14,7 +14,6 @@
  */
 package org.rstudio.studio.client.workbench.codesearch.ui;
 
-import com.google.gwt.core.client.GWT;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.SearchDisplay;
@@ -24,7 +23,7 @@ import org.rstudio.studio.client.workbench.codesearch.CodeSearch;
 import org.rstudio.studio.client.workbench.codesearch.CodeSearchConstants;
 import org.rstudio.studio.client.workbench.codesearch.CodeSearchOracle;
 
-import com.google.gwt.user.client.ui.SuggestBox;
+import com.google.gwt.core.client.GWT;
 import com.google.inject.Inject;
 
 
@@ -37,9 +36,9 @@ public class CodeSearchWidget extends SearchWidget
       super(constants_.codeSearchLabel(),
             oracle,
             new TextBoxWithCue(constants_.textBoxWithCue()),
-            new SuggestBox.DefaultSuggestionDisplay());
+            null);
       
-      oracle_ = oracle;   
+      oracle_ = oracle;
       
       CodeSearchResources res = CodeSearchResources.INSTANCE;
       setIcon(new ImageResource2x(res.gotoFunction2x()));


### PR DESCRIPTION
This PR fixes a long-standing annoyance that I've had with the "Go to File / Function" search menu. A screencast will help explain:

https://github.com/rstudio/rstudio/assets/1976582/664f5eb9-9d90-49bf-8c8e-780eed62070f

In short, if the mouse cursor happens to lie where the code search menu is presented, the menu item at the cursor location will be selected, even though the user didn't explicitly act to select that item. This contends with the default behavior of selecting the first item in the search list, which users would reasonably expect to happen regardless of the cursor position when the menu is requested.