### PR TITLE
support display of labels in autocompletion popup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ### New
 #### RStudio
 - RStudio's auto-completion system now supports ggplot2 aesthetic names and data columns (#8444)
+- RStudio's auto-completion system now supports the display of the "label" attribute (#14242)
 - RStudio Desktop on Windows and Linux supports auto-hiding the menu bar (#8932)
 - RStudio Desktop on Windows and Linux supports full-screen mode via F11 (#3243)
 - R projects can be given a custom display name in Project Options (#1909)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -617,7 +617,7 @@
 
 .rs.addFunction("getNamesImpl", function(object)
 {
-   names <-  if (is.environment(object) && !inherits(object, "R6"))
+   names <- if (is.environment(object) && !inherits(object, "R6"))
       ls(object, all.names = TRUE)
    else if (inherits(object, "tbl") && "dplyr" %in% loadedNamespaces())
       dplyr::tbl_vars(object)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -609,19 +609,35 @@
 
 .rs.addFunction("getNames", function(object)
 {
-   tryCatch({
-      if (is.environment(object) && !inherits(object, "R6"))
-         ls(object, all.names = TRUE)
-      else if (inherits(object, "tbl") && "dplyr" %in% loadedNamespaces())
-         dplyr::tbl_vars(object)
-      # For some reason, `jobjRef` objects (from rJava) return names containing
-      # parentheses after the associated function call, which confuses our completion
-      # system.
-      else if (inherits(object, "jobjRef"))
-         gsub("[\\(\\)]", "", names(object))
-      else
-         names(object)
-   }, error = function(e) NULL)
+   tryCatch(
+      .rs.getNamesImpl(object),
+      error = function(e) NULL
+   )
+})
+
+.rs.addFunction("getNamesImpl", function(object)
+{
+   names <-  if (is.environment(object) && !inherits(object, "R6"))
+      ls(object, all.names = TRUE)
+   else if (inherits(object, "tbl") && "dplyr" %in% loadedNamespaces())
+      dplyr::tbl_vars(object)
+   # For some reason, `jobjRef` objects (from rJava) return names containing
+   # parentheses after the associated function call, which confuses our completion
+   # system.
+   else if (inherits(object, "jobjRef"))
+      return(gsub("[\\(\\)]", "", names(object)))
+   else
+      names(object)
+   
+   meta <- if (!inherits(object, "tbl_sql"))
+   {
+      vapply(names, function(name) {
+         .rs.nullCoalesce(attr(object[[name]], "label"), "")
+      }, FUN.VALUE = character(1))
+   }
+   
+   attr(names, "meta") <- unname(meta)
+   names
 })
 
 .rs.addJsonRpcHandler("get_help_at_cursor", function(line, cursorPos)

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/RCompletionType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/RCompletionType.java
@@ -71,7 +71,8 @@ public class RCompletionType
    public static int score(int type, int context) 
    {
       // same logic as .rs.sortCompletions() on the server side
-      switch(type){
+      switch (type)
+      {
          case ARGUMENT: return 1;
          case COLUMN: return 2;
          case DATATABLE_SPECIAL_SYMBOL: return 3;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.css
@@ -40,6 +40,6 @@
 }
 
 .meta {
-	float: right;
-    padding-right: 8px;
+   float: right;
+   padding-right: 8px;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.css
@@ -38,3 +38,9 @@
 .column {
    font-style: italic;
 }
+
+.meta {
+	float: right;
+    padding-right: 8px;
+    font-style: italic;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.css
@@ -42,5 +42,4 @@
 .meta {
 	float: right;
     padding-right: 8px;
-    font-style: italic;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -57,6 +57,7 @@ import com.google.gwt.core.client.JsArrayBoolean;
 import com.google.gwt.core.client.JsArrayInteger;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
@@ -312,6 +313,13 @@ public class CompletionRequester
          {
             callback.onError(error);
          }
+         
+         private boolean isPriorityCompletion(int type)
+         {
+            return
+                  type == RCompletionType.ARGUMENT ||
+                  type == RCompletionType.COLUMN;
+         }
 
          @Override
          public void onResponseReceived(Completions response)
@@ -329,9 +337,10 @@ public class CompletionRequester
             JsArrayString meta = response.getMeta();
             ArrayList<QualifiedName> newComp = new ArrayList<>();
 
+            // Add higher-priority completions first
             for (int i = 0; i < comp.length(); i++)
             {
-               if (comp.get(i).endsWith(" = "))
+               if (isPriorityCompletion(type.get(i)))
                {
                   newComp.add(new QualifiedName(
                      comp.get(i), 
@@ -367,10 +376,10 @@ public class CompletionRequester
                addScopedCompletions(token, newComp, "function");
             }
 
-            // Get other server completions
+            // Add lower-priority completions next
             for (int i = 0; i < comp.length(); i++)
             {
-               if (!comp.get(i).endsWith(" = "))
+               if (!isPriorityCompletion(type.get(i)))
                {
                   newComp.add(new QualifiedName(
                      comp.get(i), 
@@ -923,26 +932,14 @@ public class CompletionRequester
       {
          String style = RES.styles().completion();
          if (type == RCompletionType.COLUMN) 
-         {
             style = style + " " + RES.styles().column();
-         }
 
          // Get the name for the completion
-         if (type == RCompletionType.ROXYGEN)
-         {
-            // remove the snippet part
-            SafeHtmlUtil.appendSpan(
-               sb,
-               style,
-               display.split("\n")[0].replaceFirst(" .*", ""));
-         }
-         else 
-         {
-            SafeHtmlUtil.appendSpan(
-               sb,
-               style,
-               display);
-         }
+         String displayName = (type == RCompletionType.ROXYGEN)
+               ? display.split("\n")[0].replaceFirst(" .*", "")
+               : display;
+         
+         SafeHtmlUtil.appendSpan(sb, style, displayName);
          
          // Display the source for functions and snippets (unless there
          // is a custom helpHandler provided, indicating that the "source"
@@ -975,6 +972,19 @@ public class CompletionRequester
                   RES.styles().argument(),
                   source + "()");
          }
+         
+         // Append metadata for display if available
+         if (type != RCompletionType.ROXYGEN && !StringUtil.isNullOrEmpty(meta))
+         {
+            String displayMeta = StringUtil.truncate(meta, 64, meta);
+            SafeHtml openTag = SafeHtmlUtil.createOpenTag("span",
+                  "class", RES.styles().meta(),
+                  "title", meta);
+            sb.append(openTag);
+            sb.appendEscaped(displayMeta);
+            sb.appendHtmlConstant("</span>");
+         }
+         
       }
 
       private ImageResource getIcon()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -182,8 +182,18 @@ public class CompletionRequester
          }
          else
          {
-            if (StringUtil.isSubsequence(qname.name, tokenFuzzy, true) &&
-                filterStartsWithDot(qname.name, token))
+            String value;
+            if (qname.type == RCompletionType.ROXYGEN)
+            {
+               value = qname.name.replaceAll("\\s.*", "");
+            }
+            else
+            {
+               value = qname.name + qname.meta;
+            }
+            
+            if (StringUtil.isSubsequence(value, tokenFuzzy, true) &&
+                filterStartsWithDot(value, token))
                newCompletions.add(qname);
          }
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequesterResources.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequesterResources.java
@@ -29,6 +29,7 @@ public interface CompletionRequesterResources extends ClientBundle
       String dataframe();
       String column();
       String argument();
+      String meta();
    }
    
    @Source("CompletionRequester.css")


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14242.

<img width="837" alt="Screenshot 2024-02-08 at 11 13 18 AM" src="https://github.com/rstudio/rstudio/assets/1976582/d0a6f4e9-3c86-422d-b068-63f333681656">

### Approach

Some R variables might be annotated with a "label" attribute. This PR bundles that information as part of the completion metadata when available, and uses that in the displayed completion list.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14242.

### Documentation

Not included; not sure if this is worth documenting.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
