### PR TITLE
dot is now runnable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,10 +11,11 @@
 - RStudio no longer highlights `\[ \]` and `\( \)` Mathjax equations; prefer `$$ $$` and `$ $` instead (#12862)
 - Added cmake option to build RStudio without the check for updates feature (#13236)
 - Allow choosing R from non-standard location at startup (#14180; Windows Desktop)
-- Add `EnvironmentFile` support to systemd service definitions. (#13819)
+- Add `EnvironmentFile` support to systemd service definitions (#13819)
 - RStudio's GWT sources can now be built with JDKs > 11 (#11242)
 - Show grey background instead of solid-white during Desktop startup (#13768)
 - The 'restartSession()' API method gains the 'clean' argument. (#2841)
+- 'dot' and 'mermaid' chunks in R Markdown documents are now executable (#14063)
 
 #### Posit Workbench
 - Show custom project names on Workbench homepage (rstudio-pro#5589)

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@
 - RStudio's GWT sources can now be built with JDKs > 11 (#11242)
 - Show grey background instead of solid-white during Desktop startup (#13768)
 - The 'restartSession()' API method gains the 'clean' argument. (#2841)
-- 'dot' and 'mermaid' chunks in R Markdown documents are now executable (#14063)
+- 'dot' chunks in R Markdown documents are now executable (#14063)
 
 #### Posit Workbench
 - Show custom project names on Workbench homepage (rstudio-pro#5589)

--- a/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.R
+++ b/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.R
@@ -116,6 +116,7 @@
    
    # when invoking engines, we don't want to echo user code
    mergedOptions$echo <- FALSE
+   mergedOptions$message <- FALSE
    
    # invoke engine
    knitrEngine(mergedOptions)

--- a/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.R
+++ b/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.R
@@ -116,6 +116,8 @@
    
    # when invoking engines, we don't want to echo user code
    mergedOptions$echo <- FALSE
+
+   # avoid knitr writing a message re: the command about to be run
    mergedOptions$message <- FALSE
    
    # invoke engine

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetScopeHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetScopeHelper.java
@@ -219,8 +219,9 @@ public class TextEditingTargetScopeHelper
    {
       if (docDisplay.showChunkOutputInline())
       {
-         // treat all chunks as executable in notebook mode
-         List<String> dontRunEngines = Arrays.asList("js", "css", "scss", "sass", "less", "ojs");
+         // treat chunks as executable by default in notebook mode,
+         // but exclude a number of engines known to not be runnable
+         List<String> dontRunEngines = Arrays.asList("js", "css", "scss", "sass", "less", "ojs", "mermaid");
          return !dontRunEngines.contains(engine);
       }
       else

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetScopeHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetScopeHelper.java
@@ -220,7 +220,7 @@ public class TextEditingTargetScopeHelper
       if (docDisplay.showChunkOutputInline())
       {
          // treat all chunks as executable in notebook mode
-         List<String> dontRunEngines = Arrays.asList("js", "css", "scss", "sass", "less", "ojs", "mermaid", "dot");
+         List<String> dontRunEngines = Arrays.asList("js", "css", "scss", "sass", "less", "ojs");
          return !dontRunEngines.contains(engine);
       }
       else

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.java
@@ -64,8 +64,10 @@ public class ChunkContextToolbar extends Composite
    public final static ChunkContextResources RES =
          GWT.create(ChunkContextResources.class);
 
-   public ChunkContextToolbar(Host host, boolean dark, boolean runPrevious,
-         String engine)
+   public ChunkContextToolbar(Host host,
+                              boolean dark,
+                              boolean runPrevious,
+                              String engine)
    {
       host_ = host;
       state_ = STATE_RESTING;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14063.

<img width="267" alt="Screenshot 2024-02-08 at 1 50 38 PM" src="https://github.com/rstudio/rstudio/assets/1976582/84ce33fc-9450-4f25-87cd-d21c4b3be2a7">


### Approach

We had previously disable rendering of the chunk toolbar for `dot` and `mermaid` engines. Now that they're executable, we should provide that UI.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14063.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
