### PR TITLE
strip chunk header options before requesting YAML completions

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/yaml/YamlEditorContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/yaml/YamlEditorContext.java
@@ -71,7 +71,7 @@ public class YamlEditorContext extends JavaScriptObject
       for (int i = 0, n = lines.length(); i < n; i++)
       {
          String prefix = filetype == FILETYPE_MARKDOWN ? "```" : "";
-         Pattern pattern = Pattern.create("^\\s*" + prefix + "\\{([^\\s}]+).*?\\}\\s*$", "");
+         Pattern pattern = Pattern.create("^\\s*" + prefix + "\\{([^\\s]+).*\\}\\s*$", "");
          Match match = pattern.match(lines.get(i), 0);
          if (match != null)
             lines.set(i, prefix + "{" + match.getGroup(1) + "}");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/yaml/YamlEditorContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/yaml/YamlEditorContext.java
@@ -15,6 +15,8 @@
 
 package org.rstudio.studio.client.workbench.views.source.editors.text.yaml;
 
+import org.rstudio.core.client.regex.Match;
+import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.studio.client.common.filetypes.DocumentMode;
 import org.rstudio.studio.client.common.filetypes.DocumentMode.Mode;
 import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor.EditorBehavior;
@@ -23,6 +25,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
 
 public class YamlEditorContext extends JavaScriptObject
 {
@@ -62,18 +65,30 @@ public class YamlEditorContext extends JavaScriptObject
          filetype = FILETYPE_MARKDOWN;
       }
       
+      // Quarto's YAML autocompletion engine doesn't handle chunk headers
+      // with inline options, so remove those before creating context
+      JsArrayString lines = docDisplay.getLines();
+      for (int i = 0, n = lines.length(); i < n; i++)
+      {
+         String prefix = filetype == FILETYPE_MARKDOWN ? "```" : "";
+         Pattern pattern = Pattern.create("^\\s*" + prefix + "\\{([^\\s}]+).*?\\}\\s*$", "");
+         Match match = pattern.match(lines.get(i), 0);
+         if (match != null)
+            lines.set(i, prefix + "{" + match.getGroup(1) + "}");
+      }
+      String code = lines.join("\n");
+      
       return create(
-        context.getPath(),
-        filetype,
-        docDisplay.getEditorBehavior() == EditorBehavior.AceBehaviorEmbedded,
-        context.getQuartoFormats(),
-        context.getQuartoProjectFormats(),
-        context.getQuartoEngine(),
-        docDisplay.getCurrentLineUpToCursor(),
-        docDisplay.getCode(),
-        docDisplay.getCursorPosition(),
-        explicit
-      );
+            context.getPath(),
+            filetype,
+            docDisplay.getEditorBehavior() == EditorBehavior.AceBehaviorEmbedded,
+            context.getQuartoFormats(),
+            context.getQuartoProjectFormats(),
+            context.getQuartoEngine(),
+            docDisplay.getCurrentLineUpToCursor(),
+            code,
+            docDisplay.getCursorPosition(),
+            explicit);
    }
    
    private static native YamlEditorContext create(


### PR DESCRIPTION
### Intent

Part of https://github.com/rstudio/rstudio/issues/9895.

### Approach

We use Quarto's bundled YAML intelligence tools for providing YAML autocompletion results. However, it doesn't appear to tolerate chunks which contain inline chunk options within the chunk header, which is still common in R Markdown documents. This PR alleviates that issue by stripping out those options before requesting completions.

### Automated Tests

N/A

### QA Notes

Test that you can still receive autocompletion results within Quarto chunk's `#| ` YAML code comments, even if the chunk has a label specified in the chunk header.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
