### PR TITLE
add API for listing background jobs

### DIFF
--- a/src/cpp/session/modules/SessionJobs.R
+++ b/src/cpp/session/modules/SessionJobs.R
@@ -28,6 +28,10 @@
 
 # API functions --------------------------------------------------------------
 
+.rs.addApiFunction("listJobs", function() {
+   .Call("rs_listJobs", PACKAGE = "(embedding)")
+})
+
 .rs.addApiFunction("addJob", function(name, status = "", progressUnits = 0L,
       actions = NULL, running = FALSE, autoRemove = TRUE, group = "", show = TRUE,
       launcherJob = FALSE, tags = NULL) {

--- a/src/cpp/session/modules/jobs/SessionJobs.cpp
+++ b/src/cpp/session/modules/jobs/SessionJobs.cpp
@@ -302,6 +302,12 @@ SEXP rs_executeJobAction(SEXP sexpId, SEXP action)
    return R_NilValue;
 }
 
+SEXP rs_listJobs()
+{
+   r::sexp::Protect protect;
+   return r::sexp::create(jobsAsJson(), &protect);
+}
+
 Error getJobs(const json::JsonRpcRequest& request,
               json::JsonRpcResponse* pResponse)
 {
@@ -489,6 +495,7 @@ core::Error initialize()
    RS_REGISTER_CALL_METHOD(rs_stopScriptJob);
    RS_REGISTER_CALL_METHOD(rs_replayScriptJob);
    RS_REGISTER_CALL_METHOD(rs_executeJobAction);
+   RS_REGISTER_CALL_METHOD(rs_listJobs);
 
    module_context::addSuspendHandler(module_context::SuspendHandler(
             onSuspend, onResume));


### PR DESCRIPTION
### Intent

Part of https://github.com/rstudio/rstudioapi/issues/144#issuecomment-1885585414.

### Approach

Add an API method `listJobs`, and use existing tooling for retrieving that job information. Useful for addin authors who want the ability to list and manipulate running jobs.

### Automated Tests

N/A

### QA Notes

Test that `.rs.api.listJobs()` will display information about any Background Jobs which have been run (note: not workbench jobs)

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
