### PR TITLE
allow execution of commands which are not visible

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -14,19 +14,6 @@
  */
 package org.rstudio.core.client.command;
 
-import com.google.gwt.aria.client.MenuitemRole;
-import com.google.gwt.aria.client.Roles;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.event.shared.HandlerManager;
-import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.resources.client.ImageResource;
-import com.google.gwt.safehtml.shared.SafeHtml;
-import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
-import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.ui.Image;
-import com.google.gwt.user.client.ui.MenuItem;
-
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.SafeHtmlUtil;
 import org.rstudio.core.client.StringUtil;
@@ -43,6 +30,19 @@ import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.common.satellite.SatelliteManager;
+
+import com.google.gwt.aria.client.MenuitemRole;
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.ui.Image;
+import com.google.gwt.user.client.ui.MenuItem;
 
 public class AppCommand implements Command, ClickHandler, ImageResourceProvider
 {
@@ -156,9 +156,6 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
    {
       assert enabled_ : "AppCommand executed when it was not enabled";
       if (!enabled_)
-         return;
-      assert visible_ : "AppCommand executed when it was not visible";
-      if (!visible_)
          return;
 
       // if this window is a satellite but the command only wants to be handled


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13321.

### Approach

See:

https://github.com/rstudio/rstudio/blob/9fa21761dd070ed39aea7d18b63e207fb33b92ed/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPresenter.java#L147-L160

The Viewer pane tries to toggle whether or not the UI for the "Clear" and "Clear All" buttons are enabled based on whether the R session is executing code. Unfortunately, this leads to trouble when users want to interact with the Viewer pane from `rstudioapi`, as:

- By executing code, the state of the "interrupt R" command is toggled;
- The Viewer pane then toggles the visibility of the "Clear" and "Clear All" commands;
- The executing code tries to execute the "Clear All" command;
- The execution request is discarded, as we don't allow "invisible" commands to be executed.

The fix here is straightforward, in that we now allow execution of enabled-but-not-visible commands, which at least seems semantically consistent, even though it's a fairly large change from the previous behavior. I can't think of a reason why we would want to disallow execution of commands that aren't visible, though!

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13321#issue-1787466029.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
