### PR TITLE
be more permissive when parsing file filter strings

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -48,7 +48,7 @@ import { MainWindow } from './main-window';
 import { openMinimalWindow } from './minimal-window';
 import { defaultFonts, ElectronDesktopOptions } from './preferences/electron-desktop-options';
 import {
-  parseFilter as parseFilter,
+  parseFilter,
   findRepoRoot,
   getAppPath,
   handleLocaleCookies,

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -48,7 +48,7 @@ import { MainWindow } from './main-window';
 import { openMinimalWindow } from './minimal-window';
 import { defaultFonts, ElectronDesktopOptions } from './preferences/electron-desktop-options';
 import {
-  filterFromQFileDialogFilter,
+  parseFilter as parseFilter,
   findRepoRoot,
   getAppPath,
   handleLocaleCookies,
@@ -165,7 +165,7 @@ export class GwtCallback extends EventEmitter {
         }
 
         if (filter) {
-          openDialogOptions.filters = filterFromQFileDialogFilter(filter);
+          openDialogOptions.filters = parseFilter(filter);
         }
 
         let focusedWindow = BrowserWindow.getFocusedWindow();

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -361,7 +361,7 @@ export function parseFilter(filters: string): FileFilter[] {
     //    Data Files (*.csv; *.xls)
     //    Data Files (*.csv | *.xls)
     //
-    const extensions = exts.trim().split(/[\s;|]+/g).map((value) => {
+    const extensions = exts.trim().split(/[\s;,|]+/g).map((value) => {
       if (value.startsWith('*.')) {
         return value.substring(2);
       } else if (value.startsWith('.')) {

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -325,37 +325,60 @@ export function resolveAliasedPath(path: string): string {
   return resolved.getAbsolutePath();
 }
 
-export function filterFromQFileDialogFilter(qtFilters: string): FileFilter[] {
-  // Qt filters are specified in this format:
-  //   "Images (*.png *.xpm *.jpg);;Text files (*.txt);;XML files (*.xml)"
+export function parseFilter(filters: string): FileFilter[] {
 
+  // This function receives a variety of filter types, including the old-fashioned
+  // Qt filter (as used with older releases of RStudio) which separates disparate
+  // filters with the ';;' delimiter. We intentionally try to be permissive
+  // when parsing the filter entries.
   const result: FileFilter[] = [];
 
-  const filters = qtFilters.split(';;');
-  for (const filter of filters) {
-    // get the name portion
-    const extopen = filter.indexOf(' (*.');
-    if (extopen === -1) {
-      logger().logDebug(`Skipping malformed filter: '${filter}'`);
+  for (const filter of filters.split(';;')) {
+
+    // Find the opening parenthesis
+    const openIndex = filter.indexOf('(', 0);
+    if (openIndex === -1) {
       continue;
     }
-    const name = filter.substring(0, extopen);
 
-    // remove the name and opening ' (*.'
-    let extensions = filter.substring(extopen + 4);
+    // Consume the name
+    const name = filter.substring(0, openIndex).trim();
 
-    // remove the trailing ')'
-    const extclose = extensions.lastIndexOf(')');
-    if (extclose === -1) {
-      logger().logDebug(`Skipping malformed filter: '${filter}`);
+    // Find the closing parenthesis
+    const closeIndex = filter.indexOf(')', openIndex + 1);
+    if (closeIndex === -1) {
       continue;
     }
-    extensions = extensions.substring(0, extclose);
 
-    // capture the extensions minus each ' *.'
-    const exts: string[] = extensions.split(' *.');
-    result.push({ name: name, extensions: exts });
+    // Grab the extensions string within
+    const exts = filter.substring(openIndex + 1, closeIndex).trim();
+
+    // Split when multiple etensions are provided.
+    // Intentionally allow multiple different kinds of delimiters here;
+    // for example, the following should be accepted.
+    //
+    //    Data Files (*.csv *.xls)
+    //    Data Files (*.csv; *.xls)
+    //    Data Files (*.csv | *.xls)
+    //
+    const extensions = exts.trim().split(/[\s;|]+/g).map((value) => {
+      if (value.startsWith('*.')) {
+        return value.substring(2);
+      } else if (value.startsWith('.')) {
+        return value.substring(1);
+      } else {
+        return value;
+      }
+    });
+
+    // Add our result
+    result.push({
+      name: name,
+      extensions: extensions
+    });
+
   }
+
   return result;
 }
 

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -353,9 +353,9 @@ export function parseFilter(filters: string): FileFilter[] {
     // Grab the extensions string within
     const exts = filter.substring(openIndex + 1, closeIndex).trim();
 
-    // Split when multiple etensions are provided.
+    // Split when multiple extensions are provided.
     // Intentionally allow multiple different kinds of delimiters here;
-    // for example, the following should be accepted.
+    // for example, the following should all be accepted.
     //
     //    Data Files (*.csv *.xls)
     //    Data Files (*.csv; *.xls)

--- a/src/node/desktop/test/unit/main/utils.test.ts
+++ b/src/node/desktop/test/unit/main/utils.test.ts
@@ -116,24 +116,32 @@ describe('Utils', () => {
     assert.notEqual(resultStr.charAt(0), '~');
     assert.isAbove(resultStr.lastIndexOf('/foo/bar'), -1);
   });
-  it('filterFromQFileDialogFilter converts file filter with one extension', () => {
+  it('parseFilter converts file filter with one extension', () => {
     const input = 'R Projects (*.Rproj)';
     const expected: FileFilter[] = [{ name: 'R Projects', extensions: ['Rproj'] }];
     const result = Utils.parseFilter(input);
     assert.deepEqual(expected, result);
   });
-  it('filterFromQFileDialogFilter converts file filter with multiple extensions', () => {
+  it('parseFilter converts file filter with multiple extensions', () => {
     const input = 'Theme Files (*.tmTheme *.rstheme)';
     const expected: FileFilter[] = [{ name: 'Theme Files', extensions: ['tmTheme', 'rstheme'] }];
     const result = Utils.parseFilter(input);
     assert.deepEqual(expected, result);
   });
-  it('filterFromQFileDialogFilter converts file filter with file types', () => {
+  it('parseFilter converts file filter with file types', () => {
     const input = 'Images (*.png *.xpm *.jpg);;Text files (*.txt);;XML files (*.xml)';
     const expected: FileFilter[] = [
       { name: 'Images', extensions: ['png', 'xpm', 'jpg'] },
       { name: 'Text files', extensions: ['txt'] },
       { name: 'XML files', extensions: ['xml'] },
+    ];
+    const result = Utils.parseFilter(input);
+    assert.deepEqual(expected, result);
+  });
+  it('parseFilter accepts a variety of delimiters between extensions', () => {
+    const input = 'Images (*.png; *.xpm, *.jpg *.tiff)';
+    const expected: FileFilter[] = [
+      { name: 'Images', extensions: ['png', 'xpm', 'jpg', 'tiff'] },
     ];
     const result = Utils.parseFilter(input);
     assert.deepEqual(expected, result);

--- a/src/node/desktop/test/unit/main/utils.test.ts
+++ b/src/node/desktop/test/unit/main/utils.test.ts
@@ -119,13 +119,13 @@ describe('Utils', () => {
   it('filterFromQFileDialogFilter converts file filter with one extension', () => {
     const input = 'R Projects (*.Rproj)';
     const expected: FileFilter[] = [{ name: 'R Projects', extensions: ['Rproj'] }];
-    const result = Utils.filterFromQFileDialogFilter(input);
+    const result = Utils.parseFilter(input);
     assert.deepEqual(expected, result);
   });
   it('filterFromQFileDialogFilter converts file filter with multiple extensions', () => {
     const input = 'Theme Files (*.tmTheme *.rstheme)';
     const expected: FileFilter[] = [{ name: 'Theme Files', extensions: ['tmTheme', 'rstheme'] }];
-    const result = Utils.filterFromQFileDialogFilter(input);
+    const result = Utils.parseFilter(input);
     assert.deepEqual(expected, result);
   });
   it('filterFromQFileDialogFilter converts file filter with file types', () => {
@@ -135,7 +135,7 @@ describe('Utils', () => {
       { name: 'Text files', extensions: ['txt'] },
       { name: 'XML files', extensions: ['xml'] },
     ];
-    const result = Utils.filterFromQFileDialogFilter(input);
+    const result = Utils.parseFilter(input);
     assert.deepEqual(expected, result);
   });
   it('getNumericEnvVar returns number for numeric values', () => {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13994.

### Approach

RStudio users can use `rstudioapi::selectFile(filter = <...>)` to open a file selection dialog with the associated filter. However, the `rstudioapi` package doesn't document how one should supply multiple extensions to the filter. This PR alleviates the issue by intentionally allowing extension parsing to be more permissive here, so that both internal and external usages of `selectFile()` can be functional.

### Automated Tests

Captured by existing unit tests.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


