### PR TITLE
Show quarto version in About dialog

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,8 @@
 - Show grey background instead of solid-white during Desktop startup (#13768)
 - The 'restartSession()' API method gains the 'clean' argument. (#2841)
 - 'dot' chunks in R Markdown documents are now executable (#14063)
-- (rstudioapi) Fixed an issue where selectFile() did not parse filter strings in a cross-platform way. (#13994)
+- (rstudioapi) Fixed an issue where selectFile() did not parse filter strings in a cross-platform way (#13994)
+- Show Quarto version information in the About dialog (#14263)
 
 #### Posit Workbench
 - Show custom project names on Workbench homepage (rstudio-pro#5589)

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialog.java
@@ -30,6 +30,8 @@ import org.rstudio.studio.client.application.model.ProductInfo;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.workbench.model.Session;
+import org.rstudio.studio.client.workbench.model.SessionInfo;
 
 public class AboutDialog extends ModalDialogBase
 {
@@ -46,7 +48,7 @@ public class AboutDialog extends ModalDialogBase
             "\"" + info.release_name + "\" " + info.build_type +
             " (" + info.commit + ", " + info.date + ") " +
             constants_.forText() + info.os + "\n" +
-            Window.Navigator.getUserAgent());
+            Window.Navigator.getUserAgent() + quartoDetails());
          RStudioGinjector.INSTANCE.getGlobalDisplay().showMessage(GlobalDisplay.MSG_INFO, constants_.versionCopiedText(),
                  constants_.versionInformationCopiedText());
       });
@@ -64,7 +66,7 @@ public class AboutDialog extends ModalDialogBase
          });
          addLeftButton(licenseButton, ElementIds.ABOUT_MANAGE_LICENSE_BUTTON);
       }
-      contents_ = new AboutDialogContents(info, editionInfo_);
+      contents_ = new AboutDialogContents(info, editionInfo_, quartoDetails());
       setARIADescribedBy(contents_.getDescriptionElement());
       setWidth("600px"); //$NON-NLS-1$
    }
@@ -82,12 +84,29 @@ public class AboutDialog extends ModalDialogBase
    }
 
    @Inject
-   private void initialize(ProductEditionInfo editionInfo)
+   private void initialize(ProductEditionInfo editionInfo, Session session)
    {
       editionInfo_ = editionInfo;
+      session_ = session;
+   }
+
+   private String quartoDetails()
+   {
+      String quartoDetails = "";
+      SessionInfo sessionInfo = session_.getSessionInfo();
+      if (sessionInfo.getQuartoConfig().enabled && sessionInfo.getQuartoConfig().version.length() > 0)
+      {
+         quartoDetails = ", Quarto " + sessionInfo.getQuartoConfig().version;
+         if (sessionInfo.getQuartoConfig().user_installed.length() > 0)
+         {
+            quartoDetails += " (" + sessionInfo.getQuartoConfig().user_installed + ")";
+         }
+      }
+      return quartoDetails;
    }
 
    private AboutDialogContents contents_;
    private ProductEditionInfo editionInfo_;
+   private Session session_;
    private static final StudioClientApplicationConstants constants_ = GWT.create(StudioClientApplicationConstants.class);
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.java
@@ -61,7 +61,7 @@ public class AboutDialogContents extends Composite
       uiBinder.createAndBindUi(this);
    }
 
-   public AboutDialogContents(ProductInfo info, ProductEditionInfo editionInfo)
+   public AboutDialogContents(ProductInfo info, ProductEditionInfo editionInfo, String quartoDetails)
    {
       initWidget(uiBinder.createAndBindUi(this));
       versionMajorLabel.setText(info.version_major + "." + info.version_minor + "." + info.version_patch);
@@ -72,8 +72,7 @@ public class AboutDialogContents extends Composite
       gplLinkLabel.getElement().setId("gplLinkLabel");
       Roles.getLinkRole().setAriaDescribedbyProperty(gplLink.getElement(), Id.of(gplLinkLabel.getElement()));
 
-      userAgentLabel.setText(
-            Window.Navigator.getUserAgent());
+      userAgentLabel.setText(Window.Navigator.getUserAgent() + quartoDetails);
       buildLabel.setText(
            "\"" + info.release_name + "\" " + info.build_type + " (" + StringUtil.substring(info.commit, 0, 8) + ", " +
            info.date + constants_.buildLabelForText() + info.os);


### PR DESCRIPTION
### Intent

Addresses #14263

### Approach

Displays the Quarto version (if Quarto is enabled) in the About dialog, appended to the user-agent information.

Additionally, if a custom version of Quarto is being used, show its path after the Quarto version.

Usually it will look like this (bundled Quarto).

<img width="646" alt="screenshot of RStudio about dialog showing quarto version info" src="https://github.com/rstudio/rstudio/assets/10569626/d576e4f6-1366-4800-90f6-b237370af8cf">

If a custom Quarto is being used the path will be shown after the version:

<img width="641" alt="screenshot of RStudio About Dialog showing quarto version and custom path" src="https://github.com/rstudio/rstudio/assets/10569626/ac0b48f4-a149-4905-aa9c-6b48bb131c9b">

### Automated Tests

None

### QA Notes

Confirm About dialog shows the Quarto version, and the path if a custom version has been specified by the user (see issue for techniques for doing this).

Confirm that Copy Version button includes this additional information.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


