### PR TITLE
Bugfix/qvm support fixes

### DIFF
--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -182,10 +182,11 @@ std::tuple<FilePath,Version,bool> userInstalledQuarto()
             if (quartoFolder.exists())
             {
 #ifndef _WIN32
-               quartoPath = quartoFolder.completeChildPath("quarto");
+               const std::string quarto = "quarto";
 #else
-               quartoPath = FilePath(quartoFolder.completeChildPath("quarto.cmd").getCanonicalPath());
+               const std::string quarto = "quarto.cmd";
 #endif
+               quartoPath = FilePath(quartoFolder.completeChildPath(quarto).getCanonicalPath());
             }
          }
       }

--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -76,14 +76,6 @@ FilePath s_userInstalledPath;
 FilePath s_quartoPath;
 std::string s_quartoVersion;
 
-#ifndef WIN32
-const std::string quarto = "quarto";
-const std::string qvm = "qvm";
-#else
-const std::string quarto = "quarto.exe";
-const std::string qvm = "qvm.exe";
-#endif
-
 /*
 bool haveRequiredQuartoVersion(const std::string& version)
 {
@@ -178,7 +170,7 @@ std::tuple<FilePath,Version,bool> userInstalledQuarto()
          core::system::ProcessOptions options;
          options.workingDir = qvmPath.getParent();
          Error error = core::system::runProgram(
-                  qvm,
+                  "qvm",
                   { "path", "active" },
                   options,
                   &result);
@@ -189,7 +181,11 @@ std::tuple<FilePath,Version,bool> userInstalledQuarto()
             FilePath quartoFolder = FilePath(core::string_utils::trimWhitespace(result.stdOut));
             if (quartoFolder.exists())
             {
-               quartoPath = quartoFolder.completeChildPath(quarto);
+#ifndef _WIN32
+               quartoPath = quartoFolder.completeChildPath("quarto");
+#else
+               quartoPath = FilePath(quartoFolder.completeChildPath("quarto.cmd").getCanonicalPath());
+#endif
             }
          }
       }
@@ -271,9 +267,15 @@ void detectQuartoInstallation()
    }
 
    // embedded version of quarto (subject to required version)
+#ifndef WIN32
+   std::string target = "quarto";
+#else
+   std::string target = "quarto.exe";
+#endif
+
    FilePath embeddedQuartoPath = session::options().quartoPath()
       .completeChildPath("bin")
-      .completeChildPath(quarto);
+      .completeChildPath(target);
 
    if (embeddedQuartoPath.isEmpty())
       return;

--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -167,12 +167,10 @@ std::tuple<FilePath,Version,bool> userInstalledQuarto()
       if (qvmPath.exists())
       {
          core::system::ProcessResult result;
-         core::system::ProcessOptions options;
-         options.workingDir = qvmPath.getParent();
          Error error = core::system::runProgram(
-                  "qvm",
+                  qvmPath.getAbsolutePath(),
                   { "path", "active" },
-                  options,
+                  core::system::ProcessOptions(),
                   &result);
          if (error)
             LOG_ERROR(error);

--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -186,7 +186,9 @@ std::tuple<FilePath,Version,bool> userInstalledQuarto()
 #else
                const std::string quarto = "quarto.cmd";
 #endif
-               quartoPath = FilePath(quartoFolder.completeChildPath(quarto).getCanonicalPath());
+               FilePath qvmLink = quartoFolder.completeChildPath(quarto);
+               if (qvmLink.exists())
+                  quartoPath = FilePath(qvmLink.getCanonicalPath());
             }
          }
       }

--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -147,11 +147,11 @@ std::tuple<FilePath,Version,bool> userInstalledQuarto()
    bool env = false;
    FilePath quartoPath;
 
-      // first check RSTUDIO_QUARTO environment variable
+   // first check RSTUDIO_QUARTO environment variable
    std::string rstudioQuarto = core::system::getenv(kRStudioQuarto);
    if (!rstudioQuarto.empty())
    {
-      #ifdef WIN32
+#ifdef WIN32
       if (!boost::algorithm::ends_with(rstudioQuarto, ".cmd"))
          rstudioQuarto = rstudioQuarto + ".cmd";
 #endif


### PR DESCRIPTION
### Intent

While validating https://github.com/rstudio/rstudio/issues/14177 I ran into some problems. The attempt to query `qvm` was failing and in some cases causing the rsession to terminate.

### Approach

- `core::system::runProgram` doesn't search the path, so invoke qvm with its full path
- The path returned by `qvm path active` doesn't include `quarto`, just the folder, so add that on
- Check to confirm the link is there before trying to resolve it
-  Resolve the link to it's actual location (not strictly necessary on Mac/Linux, but was needed on Windows so doing it for all of them; this means the path shown in the About dialog will be the actual location of quarto, not the location of the qvm link)
- The link on Windows is `quarto.cmd` instead of just `quarto`

### Automated Tests

None

### QA Notes

Part of testing https://github.com/rstudio/rstudio/issues/14177.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


