### PR TITLE
Restructure Jenkins to keep hourly and daily changes separate

### DIFF
--- a/jenkins/Jenkinsfile.daily
+++ b/jenkins/Jenkinsfile.daily
@@ -24,7 +24,7 @@ pipeline {
     string name: 'ARCH_FILTER', defaultValue: 'all', description: 'Pattern to limit builds by matching ARCH'
     string name: 'SLACK_CHANNEL', defaultValue: '#ide-builds', description: 'Slack channel to publish build message.', trim: true
   }
-  
+  // Release branch daily builds are defined in Jenkinsfile.release
   stages {
     stage('Trigger Main Daily Build') {
       steps {

--- a/jenkins/Jenkinsfile.daily
+++ b/jenkins/Jenkinsfile.daily
@@ -9,13 +9,11 @@ pipeline {
         artifactNumToKeepStr: '',
         daysToKeepStr: '',
         numToKeepStr: '100'))
-    rateLimitBuilds(throttle: [count: 1, durationName: 'minute', userBoost: true])
   }
 
   triggers {
-    // The first Sunday of every month at 2-7am UTC or 12-5am EST
-    // cron '0 0 2-7 * 0'
-    cron '1 23 * * *'
+    // 5-7am UTC or 12-2am EST
+    cron '0 23 * * *'
   }
   
   parameters {
@@ -28,27 +26,7 @@ pipeline {
   }
   
   stages {
-    stage('Trigger Monthly Rebuild') {
-      when { triggeredBy 'TimerTrigger' }
-
-      steps {
-        build wait: false,
-              job: "IDE/${env.JOB_URL.contains('Pro') ? 'Pro' : 'OS'}-Builds/builders/daily-build-pipeline/${env.BRANCH_NAME.replace('/', '%2F')}",
-              parameters: [
-                booleanParam(name: "DAILY", value: true),
-                booleanParam(name: "PUBLISH", value: params.PUBLISH),
-                booleanParam(name: "FORCE_BUILD_BINARIES", value: true),
-                booleanParam(name: "FORCE_BUILD_DOCKER", value: params.FORCE_BUILD_DOCKER),
-                string(name: "OS_FILTER", value: params.OS_FILTER),
-                string(name: "ARCH_FILTER", value: params.ARCH_FILTER),
-                string(name: "SLACK_CHANNEL", value: "${SLACK_CHANNEL}")
-              ]
-      }
-    }
-
-    stage('Trigger Daily Build') {
-      when { not { triggeredBy 'TimerTrigger' } }
-
+    stage('Trigger Main Daily Build') {
       steps {
         build wait: false,
               job: "IDE/${env.JOB_URL.contains('Pro') ? 'Pro' : 'OS'}-Builds/Builders/daily-build-pipeline/${env.BRANCH_NAME.replace('/', '%2F')}",

--- a/jenkins/Jenkinsfile.daily
+++ b/jenkins/Jenkinsfile.daily
@@ -12,8 +12,8 @@ pipeline {
   }
 
   triggers {
-    // 5-7am UTC or 12-2am EST
-    cron '0 23 * * *'
+    // 6am UTC or 1am EST
+    cron '0 6 * * *'
   }
   
   parameters {

--- a/jenkins/Jenkinsfile.hourly
+++ b/jenkins/Jenkinsfile.hourly
@@ -9,7 +9,7 @@ pipeline {
         artifactNumToKeepStr: '',
         daysToKeepStr: '',
         numToKeepStr: '100'))
-    rateLimitBuilds(throttle: [count: 1, durationName: 'minute', userBoost: true])
+    rateLimitBuilds(throttle: [count: 1, durationName: 'hour', userBoost: true])
   }
   
   parameters {
@@ -29,30 +29,6 @@ pipeline {
                 booleanParam(name: "PUBLISH", value: params.PUBLISH),
                 booleanParam(name: "FORCE_BUILD_BINARIES", value: false),
                 booleanParam(name: "FORCE_BUILD_DOCKER", value: false),
-                string(name: "OS_FILTER", value: params.OS_FILTER),
-                string(name: "ARCH_FILTER", value: params.ARCH_FILTER),
-                string(name: "SLACK_CHANNEL", value: "${SLACK_CHANNEL}")
-              ]
-      }
-    }
-
-    // Daily timer triggers daily builds
-    // Manual build with DAILY=true triggers daily builds
-    stage('Trigger Daily Build') {
-      when {
-        anyOf {
-          triggeredBy 'TimerTrigger'
-          expression { return params.DAILY == true }
-        }
-      }
-      steps {
-        build wait: false,
-              job: "IDE/${env.JOB_URL.contains('Pro') ? 'Pro' : 'OS'}-Builds/build-pipeline/${env.BRANCH_NAME.replace('/', '%2F')}",
-              parameters: [
-                booleanParam(name: "DAILY", value: true),
-                booleanParam(name: "PUBLISH", value: params.PUBLISH),
-                booleanParam(name: "FORCE_BUILD_BINARIES", value: params.FORCE_BUILD_BINARIES),
-                booleanParam(name: "FORCE_BUILD_DOCKER", value: params.FORCE_BUILD_DOCKER),
                 string(name: "OS_FILTER", value: params.OS_FILTER),
                 string(name: "ARCH_FILTER", value: params.ARCH_FILTER),
                 string(name: "SLACK_CHANNEL", value: "${SLACK_CHANNEL}")

--- a/jenkins/Jenkinsfile.hourly
+++ b/jenkins/Jenkinsfile.hourly
@@ -9,37 +9,21 @@ pipeline {
         artifactNumToKeepStr: '',
         daysToKeepStr: '',
         numToKeepStr: '100'))
-    rateLimitBuilds(throttle: [count: 1, durationName: 'hour', userBoost: true])
-  }
-
-  // Daily trigger for daily builds
-  triggers {
-    cron 'H H(20-23) * * *'
+    rateLimitBuilds(throttle: [count: 1, durationName: 'minute', userBoost: true])
   }
   
   parameters {
-    booleanParam name: 'DAILY', defaultValue: false, description: 'Builds daily/nightly builds if true; builds hourly builds if false.'
     booleanParam name: 'PUBLISH', defaultValue: true, description: 'Publish the build to S3 and sentry.'
-    booleanParam name: 'FORCE_BUILD_BINARIES', defaultValue: false, description: 'Force build binaries even if there are no changes, and even if they have already been built previously'
-    booleanParam name: 'FORCE_BUILD_DOCKER', defaultValue: false, description: 'Force rebuild docker images even if there are no dockerfile changes'
     string name: 'OS_FILTER', defaultValue: 'all', description: 'Pattern to limit builds by matching OS'
     string name: 'ARCH_FILTER', defaultValue: 'all', description: 'Pattern to limit builds by matching ARCH'
     string name: 'SLACK_CHANNEL', defaultValue: '#ide-builds', description: 'Slack channel to publish build message.', trim: true
   }
 
   stages {
-    // Git commits triggers hourly builds
-    // Manual build with DAILY=false triggers hourly builds
     stage('Trigger Hourly Build') {
-      when {
-        anyOf {
-          triggeredBy 'SCMTrigger'
-          expression { return params.DAILY == false }
-        }
-      }
       steps {
         build wait: false,
-              job: "IDE/${env.JOB_URL.contains('Pro') ? 'Pro' : 'OS'}-Builds/build-pipeline/${env.BRANCH_NAME.replace('/', '%2F')}",
+              job: "IDE/${env.JOB_URL.contains('Pro') ? 'Pro' : 'OS'}-Builds/Builders/hourly-build-pipeline/${env.BRANCH_NAME.replace('/', '%2F')}",
               parameters: [
                 booleanParam(name: "DAILY", value: false),
                 booleanParam(name: "PUBLISH", value: params.PUBLISH),

--- a/jenkins/Jenkinsfile.release
+++ b/jenkins/Jenkinsfile.release
@@ -9,13 +9,12 @@ pipeline {
         artifactNumToKeepStr: '',
         daysToKeepStr: '',
         numToKeepStr: '100'))
-    rateLimitBuilds(throttle: [count: 1, durationName: 'minute', userBoost: true])
+    rateLimitBuilds(throttle: [count: 1, durationName: 'day', userBoost: true])
   }
 
   triggers {
-    // The first Sunday of every month at 2-7am UTC or 12-5am EST
-    // cron '0 0 2-7 * 0'
-    cron '1 23 * * *'
+    // The first Sunday of every month at 6am UTC or 1am EST
+    cron '0 6 1-7 * 0'
   }
   
   parameters {
@@ -33,7 +32,7 @@ pipeline {
 
       steps {
         build wait: false,
-              job: "IDE/${env.JOB_URL.contains('Pro') ? 'Pro' : 'OS'}-Builds/builders/daily-build-pipeline/${env.BRANCH_NAME.replace('/', '%2F')}",
+              job: "IDE/${env.JOB_URL.contains('Pro') ? 'Pro' : 'OS'}-Builds/Builders/daily-build-pipeline/${env.BRANCH_NAME.replace('/', '%2F')}",
               parameters: [
                 booleanParam(name: "DAILY", value: true),
                 booleanParam(name: "PUBLISH", value: params.PUBLISH),

--- a/src/cpp/server/DBActiveSessionsStorage.cpp
+++ b/src/cpp/server/DBActiveSessionsStorage.cpp
@@ -11,7 +11,7 @@
  * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
- */            
+ */
 
 #include <server/DBActiveSessionsStorage.hpp>
 

--- a/src/cpp/server/DBActiveSessionsStorage.cpp
+++ b/src/cpp/server/DBActiveSessionsStorage.cpp
@@ -11,7 +11,7 @@
  * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
- */
+ */            
 
 #include <server/DBActiveSessionsStorage.hpp>
 


### PR DESCRIPTION
### Intent

Split hourly and daily dispatchers for `main` into different Jenkinsfiles. Each dispatcher triggers a corresponding hourly or daily Builder Jenkins job that uses `Jenkinsfile.build`. This allows GitHub changes to be discovered independently by the Hourly Builder and Daily Builder, regardless of which Builder ran last.

### Approach

The organization of Jenkinsfiles and Jenkins Jobs looks like below:

![Screenshot 2024-02-14 at 4 41 55 PM](https://github.com/rstudio/rstudio/assets/56326543/1f9eeac6-c9ef-4a3d-b593-7c0293c4f844)

Hourly Builds are triggered by commits to `main`, and are rate-limited to build no more than once per hour
Daily Builds are triggered by a timer that builds binaries from `main` at 1am Eastern Time
Release Branches will build daily builds on commits, and are rate-limited to build no more than once per day
Release Branches will also build once per month on the first Sunday of every month at 1am Eastern Time

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


