### PR TITLE
preserve variable labels when subsetting data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@
 - Fixed regression that caused extra whitespace at bottom of some popups (#14223)
 - Fix type dropdowns not working in dataset import when user-interface is in French (#14224)
 - Fixed an issue where RStudio failed to retrieve help for certain S3 methods (#14232)
+- Fixed a regression where the Data Viewer did not display 'variable.labels' for columns (#14265)
 
 #### Posit Workbench
 -

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -276,16 +276,24 @@
                                              sliceEnd = 1)
 {
    totalCols <- ncol(x)
-   
    if (totalCols == 0)
       return(NULL)
    
    if (sliceEnd > totalCols || sliceEnd < 1)
       sliceEnd <- totalCols
+   
    if (sliceStart > totalCols || sliceStart < 1 || sliceStart > sliceEnd)
       sliceStart <- 1
    
-   colSlice <- x[sliceStart:sliceEnd]
+   indices <- sliceStart:sliceEnd
+   colSlice <- x[indices]
+   
+   # Make sure we preserve variable.labels if set
+   # https://github.com/rstudio/rstudio/issues/14265
+   colLabels <- attr(x, "variable.labels", exact = TRUE)
+   if (!is.null(colLabels))
+      attr(colSlice, "variable.labels") <- colLabels[indices]
+   
    .rs.describeCols(colSlice, -1, -1, 64, totalCols)
 })
 

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -179,10 +179,17 @@
       }
       else if (idx <= length(colLabels))
       {
-         if (col_name %in% names(colLabels))
-            colLabels[[col_name]]
+         if (!is.null(names(colLabels)))
+         {
+            if (col_name %in% names(colLabels))
+               colLabels[[col_name]]
+            else
+               ""
+         }
          else
+         {
             colLabels[[idx]]
+         }
       }
       else
       {
@@ -288,11 +295,30 @@
    indices <- sliceStart:sliceEnd
    colSlice <- x[indices]
    
-   # Make sure we preserve variable.labels if set
+   # Make sure we preserve variable.labels if set.
+   #
+   # The structure of 'variable.labels' is not documented,
+   # but it appears that the expectation is that it's a character
+   # vector of the same length as 'x'.
+   #
+   # The vector can be optionally named (with names matching that of 'x'),
+   # or it can be an unnamed vector -- in which case, the order of labels
+   # needs to match the column order of 'x'.
+   #
    # https://github.com/rstudio/rstudio/issues/14265
    colLabels <- attr(x, "variable.labels", exact = TRUE)
    if (!is.null(colLabels))
-      attr(colSlice, "variable.labels") <- colLabels[indices]
+   {
+      # Only subset 'variable.labels' if it's not named, since a named
+      # attribute could potentially be in a different order than the
+      # columns of 'x' itself. If 'variable.labels' is named, then all
+      # we require is that it's a super-set of the names of 'x'.
+      if (is.null(names(colLabels)))
+         colLabels <- colLabels[indices]
+      
+      attr(colSlice, "variable.labels") <- colLabels
+   }
+      
    
    .rs.describeCols(colSlice, -1, -1, 64, totalCols)
 })


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14265.

### Approach

If `variable.labels` is set, propagate it appropriately when subsetting data.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14265.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
