### PR TITLE
Fix error in autocompletion

### DIFF
--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -744,7 +744,9 @@ options(help_type = "html")
    
    if (!length(topic))
       topic <- ""
-   
+   # avoid having file uninitalized
+   # and taken as the base file() function https://github.com/rstudio/rstudio/issues/14273
+   file <- ""
    # Completions from the search path might have the 'package:' prefix, so
    # lets strip that out.
    package <- sub("package:", "", package, fixed = TRUE)


### PR DESCRIPTION
### Intent

Addresses #14273 

### Approach

Simple approach of avoid having file uninitialized.

Not convinced this is the correct fix, but it fixes the specific problem.

### Automated Tests

N/A

### QA Notes

Autocompletion works as expected for dev functions as well as undocumented S3 and regular functions

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

I signed the contributor agreement.

