### PR TITLE
Select specific file type filter by default in Save dialog (Desktop) instead of All Files

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -203,7 +203,7 @@ export class GwtCallback extends EventEmitter {
         const filters: FileFilter[] = [{ name: i18next.t('common.allFiles'), extensions: ['*'] }];
         if (defaultExtension) {
           const extension = defaultExtension.replace('.', '');
-          filters.push({ name: extension, extensions: [extension] });
+          filters.unshift({ name: extension, extensions: [extension] });
         }
         saveDialogOptions['filters'] = filters;
         let focusedWindow = BrowserWindow.getFocusedWindow();


### PR DESCRIPTION
### Intent

Addresses [File name doesn't include extension #14261](https://github.com/rstudio/rstudio/issues/14261)

### Approach

Fix by having the Save dialog show the specific filter type (e.g. .R for an unsaved R file) instead of "All files" by default.

This is done by putting the specific type at the start of the filter array instead of the end.

Now you get this view by default when you save a new .R file (or any type with a known extension):

<img width="817" alt="save-dialog-r-type" src="https://github.com/rstudio/rstudio/assets/10569626/034bc04f-8ff6-49cd-815d-6d0187bbbb3f">

Compared to before (as reported in the issue):

<img width="820" alt="save-dialog-no-type" src="https://github.com/rstudio/rstudio/assets/10569626/797969d3-d5bc-4307-8e53-7554b881d5e9">

### Automated Tests

None

### QA Notes

Desktop-specific.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


