### PR TITLE
use shiny::stopApp() when stopping applications

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,7 @@
 - Fixed an issue where RStudio failed to retrieve help for certain S3 methods (#14232)
 - Fixed a regression where the Data Viewer did not display 'variable.labels' for columns (#14265)
 - Fixed an issue where autocompletion help was not properly displayed for development help topics (#14273)
+- Fixed an issue where Shiny onSessionEnded callbacks could be interrupted when stopped in RStudio (#13394)
 
 #### Posit Workbench
 -

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplication.java
@@ -14,14 +14,11 @@
  */
 package org.rstudio.studio.client.shiny;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.core.client.JavaScriptObject;
-import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.Command;
-import com.google.inject.Inject;
-import com.google.inject.Provider;
-import com.google.inject.Singleton;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.Size;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.CommandBinder;
@@ -29,7 +26,6 @@ import org.rstudio.core.client.command.Handler;
 import org.rstudio.core.client.dom.WindowCloseMonitor;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.studio.client.application.ApplicationInterrupt;
-import org.rstudio.studio.client.application.ApplicationInterrupt.InterruptHandler;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.RestartStatusEvent;
@@ -41,6 +37,7 @@ import org.rstudio.studio.client.common.satellite.events.WindowClosedEvent;
 import org.rstudio.studio.client.common.shiny.model.ShinyServerOperations;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.shiny.events.LaunchShinyApplicationEvent;
 import org.rstudio.studio.client.shiny.events.ShinyApplicationStatusEvent;
@@ -59,8 +56,13 @@ import org.rstudio.studio.client.workbench.views.jobs.model.JobManager;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobsServerOperations;
 import org.rstudio.studio.client.workbench.views.viewer.events.ViewerClearedEvent;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Command;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
 
 @Singleton
 public class ShinyApplication implements ShinyApplicationStatusEvent.Handler,
@@ -289,6 +291,30 @@ public class ShinyApplication implements ShinyApplicationStatusEvent.Handler,
 
    // Private methods ---------------------------------------------------------
    
+   private void stopShinyApplication(String id)
+   {
+      stopShinyApplication(id, null);
+   }
+   
+   private void stopShinyApplication(String id, Command onStopped)
+   {
+      server_.stopShinyApp(id, new ServerRequestCallback<Void>()
+      {
+         @Override
+         public void onResponseReceived(Void response)
+         {
+            onStopped.execute();
+         }
+         
+         @Override
+         public void onError(ServerError error)
+         {
+            Debug.logError(error);
+            onStopped.execute();
+         }
+      });
+   }
+   
    private void launchShinyApplication(final String filePath, 
          final String destination,
          final String extendedType)
@@ -321,14 +347,9 @@ public class ShinyApplication implements ShinyApplicationStatusEvent.Handler,
          if (StringUtil.equals(destination, FOREGROUND_APP) && isBusy_ && 
                params.getId() == ShinyApplicationParams.ID_FOREGROUND)
          {
-            // There's another app running in the main session. Interrupt it and
-            // then start this one.
-            interrupt_.interruptR(new InterruptHandler() {
-               @Override
-               public void onInterruptFinished()
-               {
-                  launchShinyFile(filePath, destination, extendedType);
-               }
+            stopShinyApplication(params.getId(), () ->
+            {
+               launchShinyFile(filePath, destination, extendedType);
             });
             return;
          }
@@ -450,10 +471,7 @@ public class ShinyApplication implements ShinyApplicationStatusEvent.Handler,
       {
          if (appState.getId() == ShinyApplicationParams.ID_FOREGROUND)
          {
-            // If this app is running in the foreground, stop it now. Background jobs will be stopped when we fire the
-            // status event (below).
-            if (commands_.interruptR().isEnabled())
-               commands_.interruptR().execute();
+            stopShinyApplication(appState.getId());
          }
          appState.setState(ShinyApplicationParams.STATE_STOPPED);
       }

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplication.java
@@ -303,14 +303,16 @@ public class ShinyApplication implements ShinyApplicationStatusEvent.Handler,
          @Override
          public void onResponseReceived(Void response)
          {
-            onStopped.execute();
+            if (onStopped != null)
+               onStopped.execute();
          }
          
          @Override
          public void onError(ServerError error)
          {
             Debug.logError(error);
-            onStopped.execute();
+            if (onStopped != null)
+               onStopped.execute();
          }
       });
    }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13394.

### Approach

Rather than stopping the application via an interrupt, use an RPC which invokes `shiny::stopApp()`. Also add some tooling around suspending of interrupts, to help protect in case there are hooks that the user would like invoked on application end.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13394.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
