### PR TITLE
Fix Electron unit test on Windows

### DIFF
--- a/src/node/desktop/test/unit/core/xdg.test.ts
+++ b/src/node/desktop/test/unit/core/xdg.test.ts
@@ -175,10 +175,13 @@ describe('Xdg', () => {
   describe('Misc helpers', () => {
     it('SHGetKnownFolderPath returns a string', () => {
       if (process.platform === 'win32') {
-        const user = os.userInfo().username;
-        const expectedLocalAppData = `C:\\Users\\${user}\\AppData\\Local`;
+        // Can't use node's os.userInfo().username because on Windows the username and the
+        // name of the user's home directory are not necessarily the same.
+        const userProfile = process.env.USERPROFILE;
+        const profileFolderName = userProfile ? path.basename(userProfile) : '';
+        const expectedLocalAppData = `C:\\Users\\${profileFolderName}\\AppData\\Local`;
         const expectedProgramData = 'C:\\ProgramData';
-        const expectedRoamingAppData = `C:\\Users\\${user}\\AppData\\Roaming`;
+        const expectedRoamingAppData = `C:\\Users\\${profileFolderName}\\AppData\\Roaming`;
 
         let result = SHGetKnownFolderPath(WinFolderID.FOLDERID_LocalAppData);
         assert.strictEqual(result, expectedLocalAppData);


### PR DESCRIPTION
### Intent

Fix an Electron unit test that was failing on Windows if the user's profile folder had a different name than their user account. For example, on my PC my username is "gary" but the home folder is "gary_".

### Approach

Use more reliable method (environment variable) to get profile folder name.

### Automated Tests

Unit test fix. Windows-only, and AFAIK we don't run these tests as part of our Windows build, only on Linux, so this shouldn't impact anything.

### QA Notes

Nothing to verify.

### Documentation
N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


