### PR TITLE
clear Viewer history when navigating to non-widget

### DIFF
--- a/src/cpp/session/modules/viewer/SessionViewer.cpp
+++ b/src/cpp/session/modules/viewer/SessionViewer.cpp
@@ -427,6 +427,10 @@ void viewer(const std::string& url,
          }
          else
          {
+            // clear the existing viewer history
+            viewerHistory().clear();
+            
+            // navigate to the requested file
             viewerNavigate(module_context::sessionTempDirUrl(path),
                            height,
                            false,


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13321.

### Approach

When viewing a plain HTML file (as opposed to an HTML widget), clear the Viewer history. This makes the user experience more consistent, as we normally hide the Back + Forward buttons when viewing such files, implying the history has indeed been cleared.

The alternative here would be to also include these files in the Viewer history, but it seems like this decision was made rather intentionally in a number of places, e.g.

https://github.com/rstudio/rstudio/blob/f96fa983948a2d036e01ad8e8d06d8d07c403600/src/cpp/session/modules/viewer/SessionViewer.cpp#L71-L72

but unfortunately I lack the context to say whether this could be safely relaxed or not.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13321.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
