### PR TITLE
Updating copyright ranges

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,9 +50,11 @@
 - Fixed a regression where the Data Viewer did not display 'variable.labels' for columns (#14265)
 - Fixed an issue where autocompletion help was not properly displayed for development help topics (#14273)
 - Fixed an issue where Shiny onSessionEnded callbacks could be interrupted when stopped in RStudio (#13394)
+- Fixed Copyright date ranges for Release Notes and RStudio IDE User Guide (#14078)
 
 #### Posit Workbench
--
+
+- Fixed Copyright date ranges for Workbench Administrator Guide and Workbench User Guide (#5865)
 
 ### Dependencies
 - Updated Ace to version 1.32.5 (#14227; Desktop + Server)

--- a/NEWS.md
+++ b/NEWS.md
@@ -59,7 +59,7 @@
 
 #### Posit Workbench
 
-- Fixed Copyright date ranges for Workbench Administrator Guide and Workbench User Guide (#5865)
+- Fixed Copyright date ranges for Workbench Administrator Guide and Workbench User Guide (rstudio-pro#5865)
 
 ### Dependencies
 - Updated Ace to version 1.32.5 (#14227; Desktop + Server)

--- a/docs/news/_quarto.yml
+++ b/docs/news/_quarto.yml
@@ -29,7 +29,7 @@ website:
 
   page-footer:
     left: |
-      Copyright © 2022 Posit Software, PBC, formerly RStudio, PBC. All Rights Reserved.
+      Copyright © 2011-2024 Posit Software, PBC, formerly RStudio, PBC. All Rights Reserved.
     right:
       - icon: question-circle-fill
         href: https://support.posit.co/hc/en-us

--- a/docs/user/rstudio/_quarto.yml
+++ b/docs/user/rstudio/_quarto.yml
@@ -113,7 +113,7 @@ website:
           
   page-footer:
     left: |
-      Copyright © 2022 Posit Software, PBC formerly RStudio, PBC. All Rights Reserved.
+      Copyright © 2009-2024 Posit Software, PBC formerly RStudio, PBC. All Rights Reserved.
     right:
       - icon: question-circle-fill
         href: https://support.posit.co/hc/en-us


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 

Issue #14078 

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

After speaking with Amanda/legal, we were directed to add date ranges for the copyright date for each guide. The date should be creation of the product.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

- Updated copyright information in quarto.yml for
    - IDE User Guide
    - News/release notes
- `quarto preview` each guide for testing (see images below)

IDE User Guide
<img width="996" alt="image" src="https://github.com/rstudio/rstudio/assets/31460023/4f968540-995a-4d0c-a368-4de7e3adb7cb">

Release Notes/News
<img width="819" alt="image" src="https://github.com/rstudio/rstudio/assets/31460023/61786dd1-f4ca-4c11-b1a6-bba92e6f1931">

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

- IDE User Guide
- Release Notes / News

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


