### PR TITLE
handle tryCatch without srcrefs

### DIFF
--- a/src/cpp/r/RCntxt.cpp
+++ b/src/cpp/r/RCntxt.cpp
@@ -226,6 +226,11 @@ SEXP RCntxt::callfun() const
    return pCntxt_ ? pCntxt_->callfun() : R_NilValue;
 }
 
+SEXP RCntxt::sysparent() const
+{
+   return pCntxt_ ? pCntxt_->sysparent() : R_NilValue;
+}
+
 int RCntxt::callflag() const
 {
    return pCntxt_ ? pCntxt_->callflag() : 0;
@@ -254,6 +259,31 @@ SEXP RCntxt::cloenv() const
 RCntxt RCntxt::nextcontext() const
 {
    return pCntxt_ ? pCntxt_->nextcontext() : RCntxt(nullptr);
+}
+
+SEXP dumpContexts()
+{
+   r::sexp::Protect protect;
+   r::sexp::ListBuilder contextList(&protect);
+   
+   for (auto it = RCntxt::begin();
+        it != RCntxt::end();
+        ++it)
+   {
+      r::sexp::ListBuilder builder(&protect);
+      builder.add("callfun", it->callfun());
+      builder.add("sysparent", it->sysparent());
+      builder.add("callflag", it->callflag());
+      builder.add("call", it->call());
+      builder.add("srcref", it->srcref());
+      builder.add("cloenv", it->cloenv());
+      builder.add("evaldepth", it->evaldepth());
+   
+      SEXP elt = r::sexp::create(builder, &protect);
+      contextList.add(elt);
+   }
+   
+   return r::sexp::create(contextList, &protect);
 }
 
 } // namespace context

--- a/src/cpp/r/RCntxtUtils.cpp
+++ b/src/cpp/r/RCntxtUtils.cpp
@@ -67,9 +67,11 @@ RCntxt getFunctionContext(const int depth,
       {
          browseEnv = ctxt->cloenv();
       }
+      
       if (ctxt->callflag() & CTXT_FUNCTION)
       {
          currentDepth++;
+         
          if (depth == BROWSER_FUNCTION && ctxt->cloenv() == browseEnv)
          {
             foundDepth = currentDepth;
@@ -93,12 +95,14 @@ RCntxt getFunctionContext(const int depth,
    {
       *pFoundDepth = foundDepth;
    }
+   
    if (pEnvironment)
    {
       *pEnvironment = (foundDepth == 0 || foundContext.isNull()) ?
          R_GlobalEnv : 
          foundContext.cloenv();
    }
+   
    return foundContext;
 }
 

--- a/src/cpp/r/RCntxtUtils.cpp
+++ b/src/cpp/r/RCntxtUtils.cpp
@@ -51,16 +51,6 @@ RCntxt globalContext()
    return RCntxt(R_GlobalContext);
 }
 
-RCntxt firstFunctionContext()
-{
-   RCntxt::iterator firstFunContext = RCntxt::begin();
-   while ((firstFunContext->callfun() == nullptr ||
-           firstFunContext->callfun() == R_NilValue) &&
-          firstFunContext->callflag())
-      firstFunContext++;
-   return *firstFunContext;
-}
-
 RCntxt getFunctionContext(const int depth,
                           int* pFoundDepth,
                           SEXP* pEnvironment)

--- a/src/cpp/r/include/r/RCntxt.hpp
+++ b/src/cpp/r/include/r/RCntxt.hpp
@@ -52,7 +52,7 @@ public:
    {
       return pCntxt_ != nullptr;
    }
-
+   
    // utility/accessor functions
    bool hasSourceRefs() const;
    bool isDebugHidden() const;
@@ -82,6 +82,7 @@ public:
    // symbol for contexts associated with bytecode evaluation!
    bool isNull() const;
    SEXP callfun() const;
+   SEXP sysparent() const;
    int callflag() const;
    int evaldepth() const;
    SEXP call() const;
@@ -139,6 +140,10 @@ private:
    core::Error invokeFunctionOnCall(const char* rFunction, 
                                     std::string* pResult) const;
 };
+
+// debugging helper
+SEXP dumpContexts();
+
 
 } // namespace context
 } // namespace r

--- a/src/cpp/r/include/r/RCntxtInterface.hpp
+++ b/src/cpp/r/include/r/RCntxtInterface.hpp
@@ -32,6 +32,7 @@ class RCntxtInterface
 public:
    // accessors for RCNTXT entries
    virtual SEXP callfun() const       = 0;
+   virtual SEXP sysparent() const     = 0;
    virtual int callflag() const       = 0;
    virtual int evaldepth() const      = 0;
    virtual SEXP call() const          = 0;

--- a/src/cpp/r/include/r/RCntxtUtils.hpp
+++ b/src/cpp/r/include/r/RCntxtUtils.hpp
@@ -43,8 +43,6 @@ bool inBrowseContext();
 
 bool inDebugHiddenContext();
 
-RCntxt firstFunctionContext();
-
 RCntxt getFunctionContext(const int depth, 
                           int* pFoundDepth = nullptr,
                           SEXP* pEnvironment = nullptr);

--- a/src/cpp/r/include/r/RIntCntxt.hpp
+++ b/src/cpp/r/include/r/RIntCntxt.hpp
@@ -36,6 +36,11 @@ public:
    {
       return pCntxt_->callfun;
    }
+   
+   SEXP sysparent() const
+   {
+      return pCntxt_->sysparent;
+   }
 
    int callflag() const
    {

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -1238,7 +1238,7 @@ void onDetectChanges(module_context::ChangeSource /* source */)
 
 namespace {
 
-SEXP inferDebugSourceRefs(boost::shared_ptr<LineDebugState> pLineDebugState)
+SEXP inferDebugSrcrefs(boost::shared_ptr<LineDebugState> pLineDebugState)
 {
    using namespace r::context;
    
@@ -1249,11 +1249,10 @@ SEXP inferDebugSourceRefs(boost::shared_ptr<LineDebugState> pLineDebugState)
       return srcref;
    
    // no source reference available; try to find an appropriate context
-   // first, check and see if we can map the browser context to a closure
-   // on the context stack
    for (auto it = RCntxt::begin(); it != RCntxt::end(); ++it)
    {
       // if we find a CTXT_BROWSER context, try to find its matching CTXT_FUNCTION
+      // these contexts are occasionally created when e.g. stepping into tryCatch
       if (it->callflag() & CTXT_BROWSER)
       {
          SEXP cloenv = it->cloenv();
@@ -1348,7 +1347,7 @@ void onConsolePrompt(boost::shared_ptr<int> pContextDepth,
    // if we're debugging and stayed in the same frame, update the line number
    else if (depth > 0 && !r::context::inDebugHiddenContext())
    {
-      SEXP srcref = inferDebugSourceRefs(pLineDebugState);
+      SEXP srcref = inferDebugSrcrefs(pLineDebugState);
       enqueBrowserLineChangedEvent(srcref);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -14,8 +14,9 @@
  */
 package org.rstudio.studio.client.workbench.views.environment;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.core.client.JsArrayString;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.DebugFilePosition;
@@ -65,11 +66,6 @@ import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.views.BasePresenter;
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleWriteInputEvent;
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
-
-import com.google.gwt.core.client.JsArray;
-import com.google.gwt.user.client.Timer;
-import com.google.inject.Inject;
-
 import org.rstudio.studio.client.workbench.views.environment.dataimport.DataImportPresenter;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.ImportFileSettings;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.ImportFileSettingsDialog;
@@ -96,9 +92,11 @@ import org.rstudio.studio.client.workbench.views.source.events.CodeBrowserNaviga
 import org.rstudio.studio.client.workbench.views.source.events.ScrollToPositionEvent;
 import org.rstudio.studio.client.workbench.views.source.model.SourceServerOperations;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.user.client.Timer;
+import com.google.inject.Inject;
 
 public class EnvironmentPresenter extends BasePresenter
         implements OpenDataFileEvent.Handler
@@ -788,8 +786,7 @@ public class EnvironmentPresenter extends BasePresenter
           contextDepth > 0)
       {
          view_.setCallFrames(callFrames, enteringDebugMode);
-         CallFrame browseFrame = callFrames.get(
-                 contextDepth_ - 1);
+         CallFrame browseFrame = callFrames.get(contextDepth_ - 1);
          String newBrowseFile = browseFrame.getAliasedFileName().trim();
          boolean sourceChanged = false;
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14306.

### Approach

Instead of always using the first function context, if there is a CTXT_BROWSER on the stack, prefer using the CTXT_FUNCTION it's associated with. We already do this elsewhere, e.g.

https://github.com/rstudio/rstudio/blob/66ea74b4422c2442bf6c1ad985407930bf16971c/src/cpp/r/RCntxtUtils.cpp#L58-L90

So this seems reasonable.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14306.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
