### PR TITLE
fix Electron unit test on Windows

### DIFF
--- a/src/node/desktop/test/unit/main/winston-logger.test.ts
+++ b/src/node/desktop/test/unit/main/winston-logger.test.ts
@@ -43,6 +43,7 @@ describe('WinstonLogger', () => {
       const logOptions = new LogOptions(undefined, { config: `[*]\nlog-level=${logLevel}\nlog-dir=./tmp` });
       const logger = new WinstonLogger(logOptions);
       assert.equal(logger.logLevel(), logLevel, 'Logger log level should be ' + logLevel);
+      logger.closeLogFile();
     });
   });
 
@@ -55,6 +56,7 @@ describe('WinstonLogger', () => {
       logger.setLogLevel(logLevel);
 
       assert.equal(logger.logLevel(), logLevel, 'Logger log level should be ' + logLevel);
+      logger.closeLogFile();
     });
   });
 


### PR DESCRIPTION
### Intent

Fix failing Electron unit test on Windows. We don't run these on Windows as part of the build so not sure how long this has been broken (possibly forever).

The failure looks like this:

```
 WinstonLogger
    ✔ Logger is created correctly
    ✔ Logger level is changed correctly
    1) Logger level is changed correctly


  289 passing (5s)
  1 pending
  1 failing

  1) WinstonLogger
       Logger level is changed correctly:
     Uncaught Error: EPERM: operation not permitted, stat 'C:\Users\myaccount\rstudio\src\node\desktop\test\unit\core\tmp\rdesktop.log'
```

### Approach

Explicitly close the logger during the test loops that are creating multiple `WinstonLogger` objects. For whatever reason, on Windows, not doing this results in the above error 100% of the time. Not particularly concerned that there's a product bug here; we never create multiple loggers at the same time in the product, only in these tests.

### Automated Tests

Yes. Yes it is.

### QA Notes

Nothing to verify; only seen when manually running electron unit tests on Windows.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


