### PR TITLE
Avoid deprecated options for recent pandoc

### DIFF
--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -410,7 +410,13 @@
    args <- c(c("+RTS", paste0("-K", stack_size), "-RTS"), args)
    
    # additional options
-   args <- c(args, "--self-contained")
+   if (requireNamespace("rmarkdown", quietly = TRUE) && rmarkdown::pandoc_available("2.19")) {
+     args <- c(args, "--embed-resources", "--standalone")
+   } else {
+     # --self-contained deprecated in pandoc 2.19
+     # https://github.com/rstudio/rstudio/issues/14332
+     args <- c(args, "--self-contained")
+   }
    args <- c(args, "--template", template)
    
    # build the conversion command

--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -410,13 +410,10 @@
    args <- c(c("+RTS", paste0("-K", stack_size), "-RTS"), args)
    
    # additional options
-   if (requireNamespace("rmarkdown", quietly = TRUE) && rmarkdown::pandoc_available("2.19")) {
-     args <- c(args, "--embed-resources", "--standalone")
-   } else {
-     # --self-contained deprecated in pandoc 2.19
-     # https://github.com/rstudio/rstudio/issues/14332
-     args <- c(args, "--self-contained")
-   }
+   # --self-contained deprecated in pandoc 2.19
+   # https://github.com/rstudio/rstudio/issues/14332
+   args <- c(args, "--embed-resources", "--standalone")
+
    args <- c(args, "--template", template)
    
    # build the conversion command


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 

Addresses #14332


### Approach

Use condition on pandoc version to use correct options, suggested from pandoc 2.19. 

### Automated Tests

N/A

### QA Notes

Test the example in issue in pandoc < 2.19 and pandoc > 2.19

May be hard to test for older pandoc versions since RStudio bundles 3.1.1,1 (with Quarto currently) , but nothing should change for previous pandoc versions.

I tested with ‘3.1.11’

### Documentation

N/A minor

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

Signed community agreement.

