### PR TITLE
Fix windows builds 

### DIFF
--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -47,12 +47,12 @@ RUN "echo 'Remove-Item alias:r' | Out-File $PsHome\Profile.ps1"
 # install R to c:\R, a common c:\Program issue appears to only happen when installing in docker
 RUN $ErrorActionPreference = 'Stop' ;`
   [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48; `
-  (New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/rstudio-buildtools/R/R-${R_VERSION}-win.exe', 'c:\R-${R_VERSION}-win.exe') ;`
-  Start-Process c:\R-${R_VERSION}-win.exe -Wait -ArgumentList '/VERYSILENT /DIR="C:\R\R-${R_VERSION}\"' ;`
-  Remove-Item c:\R-${R_VERSION}-win.exe -Force
+  (New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/rstudio-buildtools/R/R-$(R_VERSION)-win.exe', 'c:\R-$(R_VERSION)-win.exe') ;`
+  Start-Process c:\R-$(R_VERSION)-win.exe -Wait -ArgumentList '/VERYSILENT /DIR="C:\R\R-$(R_VERSION)\"' ;`
+  Remove-Item c:\R-$(R_VERSION)-win.exe -Force
 
 # add R to path
-RUN $env:path += ';C:\R\R-${R_VERSION}\bin\i386\' ;`
+RUN $env:path += ';C:\R\R-$(R_VERSION)\bin\i386\' ;`
   [Environment]::SetEnvironmentVariable('Path', $env:path, [System.EnvironmentVariableTarget]::Machine);
 
 # install qt (note that we are using the current directory's context)


### PR DESCRIPTION
Fix build error caused by windows interpolation syntax error when passing the R version.

I haven't tested this but I think the fastest way is to do so through Jenkins. Merging without review due to broken build. 