### PR TITLE
Skip parsing of empty `rstudio-prefs.json` files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,7 @@
 - Fixed mis-encoded Hunspell dictionaries (#8147)
 - Fixed an issue where the RStudio debugger failed to step through statements within a tryCatch() call (#14306)
 - Improved responsiveness of C / C++ editor intelligence features when switching Git branches (#14320)
+- An empty `rstudio-prefs.json` no longer logs spurious JSON parsing errors (rstudio-pro#4347)
 
 #### Posit Workbench
 

--- a/src/cpp/session/prefs/PrefLayer.cpp
+++ b/src/cpp/session/prefs/PrefLayer.cpp
@@ -118,16 +118,16 @@ Error PrefLayer::loadPrefsFromFile(const core::FilePath& prefsFile,
    json::Value val;
    std::string contents;
    Error error = readStringFromFile(prefsFile, &contents);
-   if (error)
+   if (error || contents.empty())
    {
-      // No prefs file; use an empty cache
+      // No prefs file or an empty one; use an empty cache
       RECURSIVE_LOCK_MUTEX(mutex_)
       {
          cache_ = boost::make_shared<json::Object>();
       }
       END_LOCK_MUTEX
 
-      if (!isNotFoundError(error))
+      if (error && !isNotFoundError(error))
       {
          // If we hit an unexpected error (e.g. permission denied), it's still not fatal (we can live
          // without a prefs file) but users might like to know.


### PR DESCRIPTION
### Intent

Previously, we would parse these files even if we knew they were empty. This commit fixes an oversight from rstudio/rstudio-pro#4371 and should eliminate confusing errors like the following:

    2024-02-26T17:00:32.155458Z [rsession-Trevor] ERROR pref_error error 1 (Error occurred while loading preferences.); OCCURRED AT rstudio::core::Error rstudio::session::prefs::PrefLayer::loadPrefsFromFile(const rstudio::core::FilePath&, const rstudio::core::FilePath&) src/cpp/session/prefs/PrefLayer.cpp:145; CAUSED BY: json-parse error 1 (An error occurred while parsing json. Offset: 0); OCCURRED AT virtual rstudio::core::Error rstudio::core::json::Value::parse(const char *) src/cpp/shared_core/json/Json.cpp:669; LOGGED FROM: rstudio::core::Error rstudio::session::prefs::Preferences::readLayers() src/cpp/session/prefs/Preferences.cpp:65

This is a second attempt to address rstudio/rstudio-pro#4347.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests