### PR TITLE
cache and reuse compiler hash

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,7 @@
 - Fixed an issue where Shiny onSessionEnded callbacks could be interrupted when stopped in RStudio (#13394)
 - Fixed Copyright date ranges for Release Notes and RStudio IDE User Guide (#14078)
 - Fixed mis-encoded Hunspell dictionaries (#8147)
+- Improved responsiveness of C / C++ editor intelligence features when switching Git branches (#14320)
 
 #### Posit Workbench
 

--- a/src/cpp/session/modules/clang/DefinitionIndex.cpp
+++ b/src/cpp/session/modules/clang/DefinitionIndex.cpp
@@ -236,7 +236,7 @@ void fileChangeHandler(const core::system::FileChangeEvent& event)
       // get the compilation arguments for this file and use them to
       // create a translation unit
       std::vector<std::string> compileArgs =
-         rCompilationDatabase().compileArgsForTranslationUnit(file, true);
+            rCompilationDatabase().compileArgsForTranslationUnit(file, true);
 
       if (!compileArgs.empty())
       {

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -294,7 +294,7 @@ std::string buildFileHash(const FilePath& filePath)
    }
 }
 
-std::string computeCompilerHash(bool isCpp)
+std::string computeCompilerHashImpl(bool isCpp)
 {
    // include hash of default compiler version, so we can
    // detect cases where the compiler version has changed
@@ -349,7 +349,25 @@ std::string computeCompilerHash(bool isCpp)
    
    std::stringstream ss;
    ss << std::hash<std::string>{}(string_utils::trimWhitespace(result.stdOut));
-   return ss.str();
+   std::string hash = ss.str();
+   
+   return hash;
+}
+
+// NOTE: We assume that the compiler will not change within a single R session.
+// If the user wants to change the compiler they're using, they should restart R.
+std::string computeCompilerHash(bool isCpp)
+{
+   if (isCpp)
+   {
+      static std::string hash = computeCompilerHashImpl(true);
+      return hash;
+   }
+   else
+   {
+      static std::string hash = computeCompilerHashImpl(false);
+      return hash;
+   }
 }
 
 std::string computePackageBuildFileHash()
@@ -984,7 +1002,8 @@ bool RCompilationDatabase::shouldIndexConfig(const CompilationConfig& config)
 
 
 std::vector<std::string> RCompilationDatabase::compileArgsForTranslationUnit(
-       const std::string& filename, bool usePrecompiledHeaders)
+      const std::string& filename,
+      bool usePrecompiledHeaders)
 {
    // args to return
    std::vector<std::string> args;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14320.

### Approach

Whenever a C++ source file in the IDE is changed, we attempt to reindex that file with libclang. As part of that, we compute a compiler hash, which allows us to maintain a cache of libclang data that we can discard in future sessions if the compiler were to change.

However, we were recomputing that hash too aggressively -- on every file change, we were recomputing the compiler hash, even though it's very unlikely that would change over the course of a single R session.

This PR lets us cache the computed compiler hash for the duration of a session.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14320.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
