### PR TITLE
Show error message when starting RStudio on Mac/Linux without R installed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,7 @@
 - Fixed mis-encoded Hunspell dictionaries (#8147)
 - Fixed an issue where the RStudio debugger failed to step through statements within a tryCatch() call (#14306)
 - Improved responsiveness of C / C++ editor intelligence features when switching Git branches (#14320)
+- Show an error dialog if R is not found when starting RStudio Desktop on Linux and macOS (#14343)
 
 #### Posit Workbench
 

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -350,7 +350,7 @@ export class Application implements AppState {
       const [scannedPath, error] = scanForR();
       if (error) {
         logger().logDebug(`Error scanning for R: ${error}`);
-        showRNotFoundError();
+        await showRNotFoundError();
         return exitFailure();
       }
 

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -361,13 +361,10 @@ export class Application implements AppState {
 
     // prepare the R environment
     logger().logDebug(`Preparing environment using R: ${rPath}`);
-    const prepareError = prepareEnvironment(rPath);
+    const prepareError = await prepareEnvironment(rPath);
     if (prepareError) {
-      await createStandaloneErrorDialog(
-        i18next.t('applicationTs.errorFindingR'),
-        i18next.t('applicationTs.rstudioFailedToFindRInstalationsOnTheSystem'),
-      );
       logger().logError(prepareError);
+      await showRNotFoundError();
       return exitFailure();
     }
 

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -361,7 +361,7 @@ export class Application implements AppState {
 
     // prepare the R environment
     logger().logDebug(`Preparing environment using R: ${rPath}`);
-    const prepareError = await prepareEnvironment(rPath);
+    const prepareError = prepareEnvironment(rPath);
     if (prepareError) {
       logger().logError(prepareError);
       await showRNotFoundError();

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -49,9 +49,9 @@ interface REnvironment {
   ldLibraryPath: string;
 }
 
-export function showRNotFoundError(error?: Error): void {
+export async function showRNotFoundError(error?: Error) {
   const message = error?.message ?? t('detectRTs.couldNotLocateAnRInstallationOnTheSystem');
-  void createStandaloneErrorDialog(t('detectRTs.rNotFound'), message);
+  await createStandaloneErrorDialog(t('detectRTs.rNotFound'), message);
 }
 
 function executeCommand(command: string): Expected<string> {

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -158,7 +158,6 @@ function prepareEnvironmentImpl(rPath: string): Err {
   // attempt to detect R environment
   const [rEnvironment, error] = detectREnvironment(rPath);
   if (error) {
-    showRNotFoundError(error);
     return error;
   }
 


### PR DESCRIPTION
### Intent

Addresses [RStudio Desktop exits silently if started without R installed (Linux/Mac) #14343](https://github.com/rstudio/rstudio/issues/14343)

### Approach

A message was "almost" being shown but code didn't wait for it and terminated before it ever displayed. Now we wait for it.

Linux (appearance will vary by desktop manager, etc.):

<img width="453" alt="screenshot of R not found dialog on linux" src="https://github.com/rstudio/rstudio/assets/10569626/6a8315e6-ac86-4d6f-88d4-a974586caaa5">

Mac (the real build will have the RStudio icon not the electron icon):

<img width="272" alt="screenshot of R not found dialog on Mac" src="https://github.com/rstudio/rstudio/assets/10569626/0ee6df6c-1ba5-4221-bdf3-40009a4e9e20">

Also fixed another code path where multiple error dialogs would attempt to be shown. A failure in `prepareEnvironment()` would display the above dialog, then the caller would display the following somewhat broken dialog. It reused text from a Windows-only dialog (it has yes/no buttons and would navigate to the R for Windows download site if you clicked Yes). The below dialog didn't do that. Now we show only the above dialog in this codepath.

Bogus dialog:

<img width="328" alt="bogus-dialog" src="https://github.com/rstudio/rstudio/assets/10569626/2b02a239-e29b-4201-9348-4244ea4d7356">

### Automated Tests

None

### QA Notes

Test on Linux and Mac with R not installed and make sure you get (one instance of) the error message.

To trigger that second codepath I mentioned above, you can set RSTUDIO_WHICH_R env var to a path that doesn't exist and try launching RStudio. You should get the same error message as the first scenario.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


