### PR TITLE
accessible labels for next/prev find in Help topic pane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,7 @@
 - Improved responsiveness of C / C++ editor intelligence features when switching Git branches (#14320)
 - Show an error dialog if R is not found when starting RStudio Desktop on Linux and macOS (#14343)
 - An empty `rstudio-prefs.json` no longer logs spurious JSON parsing errors (rstudio-pro#4347)
+- Help pane's Next and Previous find-in-topic buttons now have meaningful accessible labels [Accessibility] (#14347)
 
 #### Posit Workbench
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -609,6 +609,7 @@ public class HelpPane extends WorkbenchPane
       toolbar.getWrapper().addStyleName(styles.tallerToolbarWrapper());
 
       final SmallButton btnNext = new SmallButton("&gt;", true);
+      btnNext.getElement().setAttribute("aria-label", constants_.findNextLabel());
       btnNext.setTitle(constants_.findNextLabel());
       btnNext.addStyleName(RES.styles().topicNavigationButton());
       btnNext.setVisible(false);
@@ -621,6 +622,7 @@ public class HelpPane extends WorkbenchPane
       });
 
       final SmallButton btnPrev = new SmallButton("&lt;", true);
+      btnPrev.getElement().setAttribute("aria-label", constants_.findPreviousLabel());
       btnPrev.setTitle(constants_.findPreviousLabel());
       btnPrev.addStyleName(RES.styles().topicNavigationButton());
       btnPrev.setVisible(false);


### PR DESCRIPTION
### Intent

Addresses [Next/Prev find in topic buttons in Help pane don't have accessible labels #14347](https://github.com/rstudio/rstudio/issues/14347)

### Approach

Use the existing `title` text for `aria-label` on these buttons.

- "Find previous"
- "Find next (Enter)"

### Automated Tests

None

### QA Notes

Test per notes in issue.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


