### PR TITLE
Support Snakemake files as Python

### DIFF
--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -106,6 +106,7 @@ MimeType s_mimeTypes[] =
       // programming language types
       { "f",            "text/x-fortran" },
       { "py",           "text/x-python" },
+      { "smk",          "text/x-python" },
       { "sh",           "text/x-shell" },
       { "sql",          "text/x-sql" },
       { "stan",         "text/x-stan" },

--- a/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
+++ b/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
@@ -387,6 +387,7 @@ public class FileSystemItem extends JavaScriptObject
       // programming languages
       MIME_TYPES.put( "f",         "text/x-fortran" );
       MIME_TYPES.put( "py",        "text/x-python" );
+      MIME_TYPES.put( "smk",       "text/x-python" );
       MIME_TYPES.put( "sh",        "text/x-shell" );
       MIME_TYPES.put( "sql",       "text/x-sql" );
       MIME_TYPES.put( "stan",      "text/x-stan" );

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
@@ -427,6 +427,8 @@ public class FileTypeRegistry
       register("*.gv", GRAPHVIZ, new ImageResource2x(icons.iconGraphviz2x()));
       register("*.dot", GRAPHVIZ, new ImageResource2x(icons.iconGraphviz2x()));
       register("*.py", PYTHON, new ImageResource2x(icons.iconPython2x()));
+      register("Snakefile", PYTHON, new ImageResource2x(icons.iconPython2x()));
+      register("*.smk", PYTHON, new ImageResource2x(icons.iconPython2x()));
       register("*.sql", SQL, new ImageResource2x(icons.iconSql2x()));
       register("*.sh", SH, new ImageResource2x(icons.iconSh2x()));
       register("*.tml", TOML, new ImageResource2x(icons.iconToml2x()));


### PR DESCRIPTION
### Intent

This enables Snakemake files to be recognized as Python text. See #11677 (closed as stale before resolving Snakemake part).

### Approach

Identical approach to #11988. No special consideration is given to Snakemake-specific keywords; this merely registers Snakemake files (.smk and Snakefile) to be treated as Python text.

### Automated Tests

None.

### QA Notes
N/A

### Documentation
N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

I have signed the Posit ICA.