### PR TITLE
check callflag when comparing contexts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -64,7 +64,8 @@
 - An empty `rstudio-prefs.json` no longer logs spurious JSON parsing errors (rstudio-pro#4347)
 - Help pane's Next and Previous find-in-topic buttons now have meaningful accessible labels [Accessibility] (#14347)
 - Fixed an issue where the RStudio debugger would re-focus a debugged context over-aggressively (#10664)
-- The RStudio debugger makes better use of available source references (#13295)
+- Fixed handling of duplicated calls in debugger when source references not available (#14276)
+- Fixed issue where stepping through lines of code in tryCatch() would provide incorrect debug highlight (#14306)
 
 #### Posit Workbench
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -63,6 +63,8 @@
 - Show an error dialog if R is not found when starting RStudio Desktop on Linux and macOS (#14343)
 - An empty `rstudio-prefs.json` no longer logs spurious JSON parsing errors (rstudio-pro#4347)
 - Help pane's Next and Previous find-in-topic buttons now have meaningful accessible labels [Accessibility] (#14347)
+- Fixed an issue where the RStudio debugger would re-focus a debugged context over-aggressively (#10664)
+- The RStudio debugger makes better use of available source references (#13295)
 
 #### Posit Workbench
 

--- a/src/cpp/r/RCntxt.cpp
+++ b/src/cpp/r/RCntxt.cpp
@@ -198,6 +198,7 @@ bool RCntxt::operator==(const RCntxt& other) const
    if (other.isNull() == isNull() &&
        other.call() == call() &&
        other.callflag() == callflag() &&
+       other.cloenv() == cloenv() &&
        other.evaldepth() == evaldepth() &&
        other.srcref() == srcref())
    {

--- a/src/cpp/r/RCntxt.cpp
+++ b/src/cpp/r/RCntxt.cpp
@@ -194,13 +194,14 @@ bool RCntxt::operator==(const RCntxt& other) const
    if (other.isNull() && isNull())
       return true;
 
-   // Otherwise, check for matching fields in the context
+   // Otherwise, check for matching fields in the context.
+   // Note that some fields, e.g. the source references,
+   // could change over time in a context (e.g. as a user
+   // steps through in a debugging session).
    if (other.isNull() == isNull() &&
        other.call() == call() &&
        other.callflag() == callflag() &&
-       other.cloenv() == cloenv() &&
-       other.evaldepth() == evaldepth() &&
-       other.srcref() == srcref())
+       other.evaldepth() == evaldepth())
    {
       return true;
    }

--- a/src/cpp/r/RCntxt.cpp
+++ b/src/cpp/r/RCntxt.cpp
@@ -229,6 +229,11 @@ bool RCntxt::isNull() const
    return pCntxt_ == nullptr;
 }
 
+SEXP RCntxt::promargs() const
+{
+   return pCntxt_ ? pCntxt_->promargs() : R_NilValue;
+}
+
 SEXP RCntxt::callfun() const
 {
    return pCntxt_ ? pCntxt_->callfun() : R_NilValue;
@@ -273,13 +278,14 @@ SEXP RCntxt::dump() const
 {
    r::sexp::Protect protect;
    r::sexp::ListBuilder builder(&protect);
+   builder.add("callflag", callflag());
+   builder.add("evaldepth", evaldepth());
+   builder.add("promargs", promargs());
    builder.add("callfun", callfun());
    builder.add("sysparent", sysparent());
-   builder.add("callflag", callflag());
    builder.add("call", call());
-   builder.add("srcref", srcref());
    builder.add("cloenv", cloenv());
-   builder.add("evaldepth", evaldepth());
+   builder.add("srcref", srcref());
    return r::sexp::create(builder, &protect);
 }
 

--- a/src/cpp/r/RCntxt.cpp
+++ b/src/cpp/r/RCntxt.cpp
@@ -268,7 +268,7 @@ RCntxt RCntxt::nextcontext() const
    return pCntxt_ ? pCntxt_->nextcontext() : RCntxt(nullptr);
 }
 
-void RCntxt::dump() const
+SEXP RCntxt::dump() const
 {
    r::sexp::Protect protect;
    r::sexp::ListBuilder builder(&protect);
@@ -279,23 +279,16 @@ void RCntxt::dump() const
    builder.add("srcref", srcref());
    builder.add("cloenv", cloenv());
    builder.add("evaldepth", evaldepth());
-   SEXP resultSEXP = r::sexp::create(builder, &protect);
-   
-   Error error = r::exec::RFunction("utils:::str")
-         .addParam(resultSEXP)
-         .call();
-   
-   if (error)
-      LOG_ERROR(error);
+   return r::sexp::create(builder, &protect);
 }
 
-void dumpContexts()
+SEXP dumpContexts()
 {
    r::sexp::Protect protect;
-   r::sexp::ListBuilder contextList(&protect);
-   
+   r::sexp::ListBuilder builder(&protect);
    for (auto it = RCntxt::begin(); it != RCntxt::end(); ++it)
-      it->dump();
+      builder.add(it->dump());
+   return r::sexp::create(builder, &protect);
 }
 
 } // namespace context

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -1542,21 +1542,24 @@ SEXP create(const std::set<std::string> &value, Protect *pProtect)
 
 SEXP create(const ListBuilder& builder, Protect *pProtect)
 {
-   int n = gsl::narrow_cast<int>(builder.names().size());
+   const auto& objects = builder.objects();
+   const auto& names = builder.names();
+   
+   int n = gsl::narrow_cast<int>(names.size());
 
    SEXP resultSEXP;
    pProtect->add(resultSEXP = Rf_allocVector(VECSXP, n));
 
    SEXP namesSEXP;
    pProtect->add(namesSEXP = Rf_allocVector(STRSXP, n));
-
+   
    for (int i = 0; i < n; i++)
    {
-      SET_VECTOR_ELT(resultSEXP, i, builder.objects()[i]);
-      SET_STRING_ELT(namesSEXP, i, Rf_mkChar(builder.names()[i].c_str()));
+      SET_VECTOR_ELT(resultSEXP, i, objects[i] == nullptr ? R_NilValue : objects[i]);
+      SET_STRING_ELT(namesSEXP, i, Rf_mkChar(names[i].c_str()));
    }
 
-   // NOTE: empty lists are unnamed
+   // NOTE: empty lists are intentionally left unnamed
    if (n > 0)
       Rf_setAttrib(resultSEXP, R_NamesSymbol, namesSEXP);
    

--- a/src/cpp/r/RUtil.cpp
+++ b/src/cpp/r/RUtil.cpp
@@ -430,6 +430,16 @@ void synchronizeLocale()
 #endif
 }
 
+void str(SEXP objectSEXP)
+{
+   Error error = r::exec::RFunction("utils:::str")
+         .addParam(objectSEXP)
+         .call();
+   
+   if (error)
+      LOG_ERROR(error);
+}
+
 } // namespace util
 } // namespace r
 } // namespace rstudio

--- a/src/cpp/r/include/r/RCntxt.hpp
+++ b/src/cpp/r/include/r/RCntxt.hpp
@@ -91,7 +91,7 @@ public:
    RCntxt nextcontext() const;
    
    // for debugging
-   void dump() const;
+   SEXP dump() const;
 
    // define an iterator for easy traversal of the context stack
    template <class Value>
@@ -145,7 +145,7 @@ private:
 };
 
 // for debugging
-void dumpContexts();
+SEXP dumpContexts();
 
 } // namespace context
 } // namespace r

--- a/src/cpp/r/include/r/RCntxt.hpp
+++ b/src/cpp/r/include/r/RCntxt.hpp
@@ -81,13 +81,14 @@ public:
    // NOTE: 'srcref()' attribute may be set to <in-bc-interp>
    // symbol for contexts associated with bytecode evaluation!
    bool isNull() const;
-   SEXP callfun() const;
-   SEXP sysparent() const;
    int callflag() const;
    int evaldepth() const;
+   SEXP promargs() const;
+   SEXP callfun() const;
+   SEXP sysparent() const;
    SEXP call() const;
-   SEXP srcref() const;
    SEXP cloenv() const;
+   SEXP srcref() const;
    RCntxt nextcontext() const;
    
    // for debugging

--- a/src/cpp/r/include/r/RCntxt.hpp
+++ b/src/cpp/r/include/r/RCntxt.hpp
@@ -89,6 +89,9 @@ public:
    SEXP srcref() const;
    SEXP cloenv() const;
    RCntxt nextcontext() const;
+   
+   // for debugging
+   void dump() const;
 
    // define an iterator for easy traversal of the context stack
    template <class Value>
@@ -141,9 +144,8 @@ private:
                                     std::string* pResult) const;
 };
 
-// debugging helper
-SEXP dumpContexts();
-
+// for debugging
+void dumpContexts();
 
 } // namespace context
 } // namespace r

--- a/src/cpp/r/include/r/RCntxtInterface.hpp
+++ b/src/cpp/r/include/r/RCntxtInterface.hpp
@@ -31,13 +31,14 @@ class RCntxtInterface
 {
 public:
    // accessors for RCNTXT entries
-   virtual SEXP callfun() const       = 0;
-   virtual SEXP sysparent() const     = 0;
    virtual int callflag() const       = 0;
    virtual int evaldepth() const      = 0;
+   virtual SEXP promargs() const      = 0;
+   virtual SEXP callfun() const       = 0;
+   virtual SEXP sysparent() const     = 0;
    virtual SEXP call() const          = 0;
-   virtual SEXP srcref() const        = 0;
    virtual SEXP cloenv() const        = 0;
+   virtual SEXP srcref() const        = 0;
 
    // computed properties
    virtual bool isNull() const        = 0;

--- a/src/cpp/r/include/r/RIntCntxt.hpp
+++ b/src/cpp/r/include/r/RIntCntxt.hpp
@@ -29,42 +29,8 @@ template<typename T> class RIntCntxt: public RCntxtInterface
 {
 public:
    explicit RIntCntxt(T *pCntxt) :
-     pCntxt_(pCntxt)
-   { }
-
-   SEXP callfun() const
+      pCntxt_(pCntxt)
    {
-      return pCntxt_->callfun;
-   }
-   
-   SEXP sysparent() const
-   {
-      return pCntxt_->sysparent;
-   }
-
-   int callflag() const
-   {
-      return pCntxt_->callflag;
-   }
-   
-   int evaldepth() const
-   {
-      return pCntxt_->evaldepth;
-   }
-
-   SEXP call() const
-   {
-      return pCntxt_->call;
-   }
-
-   SEXP srcref() const
-   {
-      return pCntxt_->srcref;
-   }
-
-   SEXP cloenv() const
-   {
-      return pCntxt_->cloenv;
    }
 
    RCntxt nextcontext() const
@@ -75,6 +41,46 @@ public:
          return RCntxt(pCntxt_->nextcontext);
    }
    
+   int callflag() const
+   {
+      return pCntxt_->callflag;
+   }
+   
+   int evaldepth() const
+   {
+      return pCntxt_->evaldepth;
+   }
+
+   SEXP promargs() const
+   {
+      return pCntxt_->promargs;
+   }
+   
+   SEXP callfun() const
+   {
+      return pCntxt_->callfun;
+   }
+   
+   SEXP sysparent() const
+   {
+      return pCntxt_->sysparent;
+   }
+   
+   SEXP call() const
+   {
+      return pCntxt_->call;
+   }
+
+   SEXP cloenv() const
+   {
+      return pCntxt_->cloenv;
+   }
+
+   SEXP srcref() const
+   {
+      return pCntxt_->srcref;
+   }
+
    bool isNull() const
    {
       return false;

--- a/src/cpp/r/include/r/RUtil.hpp
+++ b/src/cpp/r/include/r/RUtil.hpp
@@ -16,7 +16,10 @@
 #ifndef R_UTIL_HPP
 #define R_UTIL_HPP
 
+#define R_INTERNAL_FUNCTIONS
+
 #include <string>
+#include <r/RInternal.hpp>
 
 #ifdef _WIN32
 # include <core/system/Win32RuntimeLibrary.hpp>
@@ -89,6 +92,8 @@ bool isWindowsOnlyFunction(const std::string& name);
 bool isPackageAttached(const std::string& packageName);
 
 void synchronizeLocale();
+
+void str(SEXP objectSEXP);
 
 } // namespace util   
 } // namespace r

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -202,9 +202,11 @@
       srcfile <- srcfile$original
    
    lines <- srcfile$lines
+   if (length(lines) == 1L && grepl("\n", lines[[1L]], fixed = TRUE))
+      lines <- unlist(strsplit(lines, "\n", fixed = TRUE))
+   
    code <- if (is.character(lines))
    {
-      lines <- unlist(strsplit(lines, "\n", fixed = TRUE))
       srcpos <- .rs.parseSrcref(srcref)
       lines[srcpos$first_parsed:srcpos$last_parsed]
    }

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -180,6 +180,44 @@
    !is.null(attr(func, "srcref"))
 })
 
+.rs.addFunction("parseSrcref", function(srcref)
+{
+   srcref <- unclass(srcref)
+   
+   names(srcref) <- c(
+      "first_line", "first_byte",
+      "last_line", "last_byte",
+      "first_column", "last_column",
+      "first_parsed", "last_parsed"
+   )
+   
+   as.list(srcref)
+})
+
+.rs.addFunction("deparseSrcref", function(srcref, asString)
+{
+   # Try to retrieve source references from srcfile if available
+   srcfile <- attr(srcref, "srcfile", exact = TRUE)
+   lines <- srcfile$original$lines
+   code <- if (is.character(lines))
+   {
+      srcpos <- .rs.parseSrcref(srcref)
+      lines[srcpos$first_parsed:srcpos$last_parsed]
+   }
+   else
+   {
+      as.character(srcref, useSource = TRUE)
+   }
+   
+   if (asString)
+   {
+      code <- paste(code, collapse = "\n")
+   }
+   
+   code
+   
+})
+
 # Returns a function's code as a string. Arguments:
 # useSource -- Whether to use the function's source references (if available)
 # asString -- Whether to return the result as a single string
@@ -194,13 +232,7 @@
    {
       srcref <- attr(func, "srcref", exact = TRUE)
       if (!is.null(srcref))
-      {
-         code <- as.character(srcref, useSource = TRUE)
-         if (asString)
-           return(paste(code, collapse = "\n"))
-         else
-           return(code)
-      }
+         return(.rs.deparseSrcref(srcref, asString))
    }
 
    control <- c("keepInteger", "keepNA")

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -201,6 +201,9 @@
    if (!is.null(srcfile$original))
       srcfile <- srcfile$original
    
+   # It appears the 'lines' variable can either be a single string
+   # with embedded newlines, or a character vector already split by newlines.
+   # Normalize here so that we're always working with a split-by-newline vector.
    lines <- srcfile$lines
    if (length(lines) == 1L && grepl("\n", lines[[1L]], fixed = TRUE))
       lines <- unlist(strsplit(lines, "\n", fixed = TRUE))

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -239,7 +239,8 @@
       if (length(index))
       {
          lines <- tail(lines, n = -index)
-         lines <- lines[srcref[[1L]]:srcref[[3L]]]
+         boundaries <- c(grep("#line 1 ", lines, fixed = TRUE), length(lines) + 1L)
+         lines <- head(lines, n = boundaries[[1L]] - 1)
       }
    }
    

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -182,7 +182,25 @@
 
 .rs.addFunction("parseSrcref", function(srcref)
 {
-   srcref <- unclass(srcref)
+   srcref <- as.list(unclass(srcref))
+   
+   # Bytes (elements 2, 4) and columns (elements 5, 6) may be different due to
+   # multibyte characters. If only four values are given, the columns and bytes
+   # are assumed to match. Lines (elements 1, 3) and parsed lines (elements 7,
+   # 8) may differ if a #line directive is used in code: the former will respect
+   # the directive, the latter will just count lines. If only 4 or 6 elements
+   srcref <- if (length(srcref) == 4L)
+   {
+      c(srcref, srcref[c(2L, 4L, 1L, 3L)])
+   }
+   else if (length(srcref) == 6L)
+   {
+      c(srcref, srcref[c(1L, 3L)])
+   }
+   else
+   {
+      srcref
+   }
    
    names(srcref) <- c(
       "first_line", "first_byte",

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -213,6 +213,26 @@
    as.list(srcref)
 })
 
+.rs.addFunction("readSrcrefLines", function(srcref, asString)
+{
+   # Try to retrieve source references from srcfile if available
+   srcfile <- attr(srcref, "srcfile", exact = TRUE)
+   if (!is.null(srcfile$original))
+      srcfile <- srcfile$original
+   
+   # It appears the 'lines' variable can either be a single string
+   # with embedded newlines, or a character vector already split by newlines.
+   # Normalize here so that we're always working with a split-by-newline vector.
+   lines <- srcfile$lines
+   if (length(lines) == 1L && grepl("\n", lines[[1L]], fixed = TRUE))
+      lines <- unlist(strsplit(lines, "\n", fixed = TRUE))
+   
+   if (asString)
+      paste(lines, collapse = "\n")
+   else
+      lines
+})
+
 .rs.addFunction("deparseSrcref", function(srcref, asString)
 {
    # Try to retrieve source references from srcfile if available
@@ -243,7 +263,6 @@
    }
    
    code
-   
 })
 
 # Returns a function's code as a string. Arguments:

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -198,9 +198,13 @@
 {
    # Try to retrieve source references from srcfile if available
    srcfile <- attr(srcref, "srcfile", exact = TRUE)
-   lines <- srcfile$original$lines
+   if (!is.null(srcfile$original))
+      srcfile <- srcfile$original
+   
+   lines <- srcfile$lines
    code <- if (is.character(lines))
    {
+      lines <- unlist(strsplit(lines, "\n", fixed = TRUE))
       srcpos <- .rs.parseSrcref(srcref)
       lines[srcpos$first_parsed:srcpos$last_parsed]
    }

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -279,6 +279,11 @@
    if (length(lines) == 1L && grepl("\n", lines[[1L]], fixed = TRUE))
       lines <- unlist(strsplit(lines, "\n", fixed = TRUE))
    
+   # We previously used 'as.character(srcref, useSource = TRUE)' by default, but
+   # this also trims the leading indent from the function definition. This
+   # causes issues when highlighting the first part of a source reference, as
+   # the expectation here is that the full line is preserved. For that reason,
+   # if we're able to, we keep all relevant lines from the source reference.
    code <- if (is.character(lines))
    {
       srcpos <- .rs.parseSrcref(srcref)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -189,6 +189,7 @@
    # are assumed to match. Lines (elements 1, 3) and parsed lines (elements 7,
    # 8) may differ if a #line directive is used in code: the former will respect
    # the directive, the latter will just count lines. If only 4 or 6 elements
+   # are given, the parsed lines will be assumed to match the lines.
    srcref <- if (length(srcref) == 4L)
    {
       c(srcref, srcref[c(2L, 4L, 1L, 3L)])

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -184,6 +184,8 @@
 {
    srcref <- as.list(unclass(srcref))
    
+   # From ?srcref:
+   #
    # Bytes (elements 2, 4) and columns (elements 5, 6) may be different due to
    # multibyte characters. If only four values are given, the columns and bytes
    # are assumed to match. Lines (elements 1, 3) and parsed lines (elements 7,

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -356,7 +356,10 @@
         best <- which.min(abs(linepref - pos))
      }
      else
+     {
         best <- best[1]
+     }
+     
      endpos <- pos[best] + attr(pos, "match.length")[best]
      pos <- pos[best]
   }
@@ -396,10 +399,14 @@
      lastchar <- lastchar + indents[lastline] - 1
   }
 
-  result <- as.integer(c(firstline, firstchar,
-                         lastline,  lastchar,
-                         firstchar, lastchar))
-  return(result)
+  result <- c(
+     firstline, firstchar,
+     lastline,  lastchar,
+     firstchar, lastchar
+  )
+
+  as.integer(result)
+  
 })
 
 .rs.addFunction("functionNameFromCall", function(val)

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -295,7 +295,7 @@
       (is.null(call) && is.null(calltext)) )
      return(c(0L, 0L, 0L, 0L, 0L, 0L))
 
-  lines <- .rs.deparseFunction(fun, FALSE, FALSE)
+  lines <- .rs.deparseFunction(fun, TRUE, FALSE)
 
   # Remember the indentation level on each line (added by deparse), and remove
   # it along with any other leading or trailing whitespace.

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -393,7 +393,7 @@
   else
   {
      lastchar <- endpos - (if (lastline == 1) 0 else offsets[lastline - 1])
-     lastchar <- lastchar + indents[lastline]
+     lastchar <- lastchar + indents[lastline] - 1
   }
 
   result <- as.integer(c(firstline, firstchar,

--- a/src/cpp/session/modules/SessionRUtil.cpp
+++ b/src/cpp/session/modules/SessionRUtil.cpp
@@ -340,6 +340,13 @@ SEXP rs_utf8ToSystem(SEXP stringSEXP)
    return r::sexp::create(asNative, &protect);
 }
 
+SEXP rs_promiseCode(SEXP promiseSEXP)
+{
+   return TYPEOF(promiseSEXP) == PROMSXP
+         ? PRCODE(promiseSEXP)
+         : R_NilValue;
+}
+
 } // anonymous namespace
 
 Error initialize()
@@ -353,6 +360,7 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_runAsyncRProcess);
    RS_REGISTER_CALL_METHOD(rs_systemToUtf8);
    RS_REGISTER_CALL_METHOD(rs_utf8ToSystem);
+   RS_REGISTER_CALL_METHOD(rs_promiseCode);
    
    using boost::bind;
    using namespace module_context;

--- a/src/cpp/session/modules/environment/EnvironmentUtils.cpp
+++ b/src/cpp/session/modules/environment/EnvironmentUtils.cpp
@@ -307,21 +307,19 @@ bool functionDiffersFromSource(
 // from the source reference to the JSON object.
 void sourceRefToJson(const SEXP srcref, json::Object* pObject)
 {
-   if (srcref == nullptr ||
-       r::sexp::isNull(srcref) ||
-       r::context::isByteCodeSrcRef(srcref))
-   {
-      (*pObject)["line_number"] = 0;
-      (*pObject)["end_line_number"] = 0;
-      (*pObject)["character_number"] = 0;
-      (*pObject)["end_character_number"] = 0;
-   }
-   else
+   if (srcref != nullptr && TYPEOF(srcref) == INTSXP)
    {
       (*pObject)["line_number"] = INTEGER(srcref)[0];
       (*pObject)["end_line_number"] = INTEGER(srcref)[2];
       (*pObject)["character_number"] = INTEGER(srcref)[4];
       (*pObject)["end_character_number"] = INTEGER(srcref)[5];
+   }
+   else
+   {
+      (*pObject)["line_number"] = 0;
+      (*pObject)["end_line_number"] = 0;
+      (*pObject)["character_number"] = 0;
+      (*pObject)["end_character_number"] = 0;
    }
 }
 

--- a/src/cpp/session/modules/environment/EnvironmentUtils.cpp
+++ b/src/cpp/session/modules/environment/EnvironmentUtils.cpp
@@ -278,17 +278,17 @@ bool functionDiffersFromSource(
    // read the portion of the file pointed to by the source refs from disk
    // the sourceref structure (including the array offsets used below)
    // is documented here:
+   //
    // http://journal.r-project.org/archive/2010-2/RJournal_2010-2_Murdoch.pdf
    std::string fileContent;
    error = readStringFromFile(
          sourceFilePath,
          &fileContent,
          string_utils::LineEndingPosix,
-         INTEGER(srcRef)[0],  // the first line
-         INTEGER(srcRef)[2],  // the last line
-         INTEGER(srcRef)[4],  // character position on the first line
-         INTEGER(srcRef)[5]   // character position on the last line
-         );
+         INTEGER(srcRef)[0],    // the first line
+         INTEGER(srcRef)[2] + 1 // the last line
+   );
+   
    if (error)
    {
       LOG_ERROR(error);

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -675,7 +675,7 @@ json::Array callFramesAsJson(
    // map source contexts to closures
    for (auto context = RCntxt::begin(); context != RCntxt::end(); context++)
    {
-      bool isFunctionContext = (context->callflag() & CTXT_FUNCTION);
+      bool isFunctionContext = (context->callflag() & (CTXT_FUNCTION | CTXT_BROWSER));
       if (!isFunctionContext)
          continue;
       
@@ -1152,7 +1152,7 @@ json::Object commonEnvironmentStateData(
                // see if the function to be debugged is out of sync with its saved
                // sources (if available).
                useProvidedSource =
-                     functionIsOutOfSync(srcContext, &functionCode) &&
+                     functionIsOutOfSync(context, &functionCode) &&
                      functionCode != "NULL";
             }
          }

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -784,8 +784,8 @@ json::Array callFramesAsJson(LineDebugState* pLineDebugState)
          varFrame["shiny_function_label"] = context->shinyFunctionLabel();
 
          listFrames.push_back(varFrame);
+         prevContext = *context;
       }
-      prevContext = *context;
    }
    return listFrames;
 }

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -731,8 +731,6 @@ json::Array callFramesAsJson(LineDebugState* pLineDebugState)
          varFrame["aliased_file_name"] =
                module_context::createAliasedPath(FilePath(filename));
 
-         // Only use source references with the top context if they are
-         // associated with a real file.
          if (isValidSrcref(srcref))
          {
             varFrame["real_sourceref"] = true;
@@ -775,24 +773,6 @@ json::Array callFramesAsJson(LineDebugState* pLineDebugState)
 
          varFrame["function_line_number"] = 1;
          
-         // TODO: Is this code still necessary?
-         //
-         // // extract the first line of the function. the client can optionally
-         // // use this to compute the source location as an offset into the
-         // // function rather than as an absolute file position (useful when
-         // // we need to debug a copy of the function rather than the real deal).
-         // srcref = context->callFunSourceRefs();
-         // if (isValidSrcref(srcref) && TYPEOF(srcref) == INTSXP)
-         // {
-         //    varFrame["function_line_number"] = INTEGER(srcref)[0];
-         // }
-         // else
-         // {
-         //    // if we don't have a source ref, we'll debug using a deparsed
-         //    // version of the function that starts on line 1
-         //    varFrame["function_line_number"] = 1;
-         // }
-
          std::string callSummary;
          error = context->callSummary(&callSummary);
          if (error)

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -1,4 +1,6 @@
 /*
+ * SessionEnvironment.cpp
+ *
  * Copyright (C) 2022 by Posit Software, PBC
  *
  * Unless you have received this program directly from Posit Software pursuant

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -1330,20 +1330,6 @@ void onDetectChanges(module_context::ChangeSource /* source */)
 
 namespace {
 
-bool isEvalContext(const r::context::RCntxt& ctx)
-{
-   SEXP call = ctx.call();
-   if (TYPEOF(call) != LANGSXP)
-      return false;
-   
-   SEXP lhs = CAR(call);
-   if (TYPEOF(lhs) != SYMSXP)
-      return false;
-   
-   std::string name = CHAR(PRINTNAME(lhs));
-   return name == "eval" || name == "evalq";
-}
-
 SEXP inferDebugSrcrefs(
       int depth,
       boost::shared_ptr<LineDebugState> pLineDebugState)

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -1676,7 +1676,8 @@ SEXP rs_isBrowserActive()
 
 SEXP rs_dumpContexts()
 {
-   return r::context::dumpContexts();
+   r::context::dumpContexts();
+   return R_NilValue;
 }
 
 bool isSuspendable()
@@ -1693,6 +1694,7 @@ Error initialize()
 
    boost::shared_ptr<int> pContextDepth =
          boost::make_shared<int>(0);
+   
    boost::shared_ptr<r::context::RCntxt> pCurrentContext =
          boost::make_shared<r::context::RCntxt>(r::context::globalContext());
    

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -773,21 +773,25 @@ json::Array callFramesAsJson(LineDebugState* pLineDebugState)
             sourceRefToJson(simulatedSrcref, &varFrame);
          }
 
-         // extract the first line of the function. the client can optionally
-         // use this to compute the source location as an offset into the
-         // function rather than as an absolute file position (useful when
-         // we need to debug a copy of the function rather than the real deal).
-         srcref = context->callFunSourceRefs();
-         if (isValidSrcref(srcref) && TYPEOF(srcref) == INTSXP)
-         {
-            varFrame["function_line_number"] = INTEGER(srcref)[0];
-         }
-         else
-         {
-            // if we don't have a source ref, we'll debug using a deparsed
-            // version of the function that starts on line 1
-            varFrame["function_line_number"] = 1;
-         }
+         varFrame["function_line_number"] = 1;
+         
+         // TODO: Is this code still necessary?
+         //
+         // // extract the first line of the function. the client can optionally
+         // // use this to compute the source location as an offset into the
+         // // function rather than as an absolute file position (useful when
+         // // we need to debug a copy of the function rather than the real deal).
+         // srcref = context->callFunSourceRefs();
+         // if (isValidSrcref(srcref) && TYPEOF(srcref) == INTSXP)
+         // {
+         //    varFrame["function_line_number"] = INTEGER(srcref)[0];
+         // }
+         // else
+         // {
+         //    // if we don't have a source ref, we'll debug using a deparsed
+         //    // version of the function that starts on line 1
+         //    varFrame["function_line_number"] = 1;
+         // }
 
          std::string callSummary;
          error = context->callSummary(&callSummary);

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -633,7 +633,6 @@ SEXP simulatedSourceRefsOfContext(const r::context::RCntxt& context,
    // Attach them to a carrier SEXP as attributes rather than passing directly.
    SEXP info = r::sexp::create("_rs_sourceinfo", &protect);
    r::sexp::setAttrib(info, "_rs_callfun", context.callfun());
-   r::sexp::setAttrib(info, "_rs_srcref", context.srcref());
    
    if (lineContext)
    {
@@ -732,6 +731,8 @@ json::Array callFramesAsJson(LineDebugState* pLineDebugState)
          varFrame["aliased_file_name"] =
                module_context::createAliasedPath(FilePath(filename));
 
+         // Only use source references with the top context if they are
+         // associated with a real file.
          if (isValidSrcref(srcref))
          {
             varFrame["real_sourceref"] = true;
@@ -1119,7 +1120,7 @@ json::Object commonEnvironmentStateData(
             if (!lines.empty())
             {
                hasCodeInFrame = true;
-               useProvidedSource = filename.empty();
+               useProvidedSource = filename.empty() || !module_context::resolveAliasedPath(filename).exists();
                functionCode = lines;
             }
          }

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -631,6 +631,8 @@ SEXP simulatedSourceRefsOfContext(const r::context::RCntxt& context,
    // Attach them to a carrier SEXP as attributes rather than passing directly.
    SEXP info = r::sexp::create("_rs_sourceinfo", &protect);
    r::sexp::setAttrib(info, "_rs_callfun", context.callfun());
+   r::sexp::setAttrib(info, "_rs_srcref", context.srcref());
+   
    if (lineContext)
    {
       r::sexp::setAttrib(info, "_rs_callobj", lineContext.call());
@@ -728,7 +730,7 @@ json::Array callFramesAsJson(LineDebugState* pLineDebugState)
          varFrame["aliased_file_name"] =
                module_context::createAliasedPath(FilePath(filename));
 
-         if (contextDepth != 1 && isValidSrcref(srcref))
+         if (isValidSrcref(srcref))
          {
             varFrame["real_sourceref"] = true;
             sourceRefToJson(srcref, &varFrame);

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -694,8 +694,7 @@ json::Array callFramesAsJson(LineDebugState* pLineDebugState)
 
          // attempt to find the refs for the source that invoked this function;
          // use our own refs otherwise
-         std::map<SEXP,r::context::RCntxt>::iterator srcCtx =
-            envSrcrefCtx.find(context->cloenv());
+         auto srcCtx = envSrcrefCtx.find(context->cloenv());
          if (srcCtx != envSrcrefCtx.end())
             srcContext = srcCtx->second;
          else
@@ -1699,8 +1698,7 @@ SEXP rs_isBrowserActive()
 
 SEXP rs_dumpContexts()
 {
-   r::context::dumpContexts();
-   return R_NilValue;
+   return r::context::dumpContexts();
 }
 
 bool isSuspendable()

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -769,20 +769,6 @@ json::Array callFramesAsJson(LineDebugState* pLineDebugState)
                         *context, prevContext, nullptr);
             }
 
-            // // store the line stepped over in the top frame, so we can infer
-            // // that the next line stepped over will be near this one
-            // if (contextDepth == 1 &&
-            //     pLineDebugState != nullptr &&
-            //     pLineDebugState->lastDebugLine == 0 &&
-            //     isValidSrcref(simulatedSrcref))
-            // {
-            //    int stepLine = INTEGER(simulatedSrcref)[0];
-            //    if (stepLine > 0)
-            //    {
-            //       pLineDebugState->lastDebugLine = stepLine;
-            //    }
-            // }
-
             sourceRefToJson(simulatedSrcref, &varFrame);
          }
 
@@ -1700,7 +1686,7 @@ void onConsoleOutput(boost::shared_ptr<LineDebugState> pLineDebugState,
    else if (type == module_context::ConsoleOutputNormal)
    {
       boost::smatch match;
-      boost::regex reLine("debug at ([^#]*)#([^:]+): ");
+      boost::regex reDebugAtPosition("debug at ([^#]*)#([^:]+): ");
       
       // start capturing debug output when R outputs "debug: "
       if (output == "debug: ")
@@ -1711,7 +1697,7 @@ void onConsoleOutput(boost::shared_ptr<LineDebugState> pLineDebugState,
       }
       
       // emitted when browsing with srcref
-      else if (boost::regex_match(output, match, reLine))
+      else if (boost::regex_match(output, match, reDebugAtPosition))
       {
          std::string lineText = match[2];
          auto lineNumber = safe_convert::stringTo<int>(lineText);

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -1255,7 +1255,7 @@ void enqueBrowserLineChangedEvent(const SEXP srcref)
 {
    json::Object varJson;
    sourceRefToJson(srcref, &varJson);
-   ClientEvent event (client_events::kBrowserLineChanged, varJson);
+   ClientEvent event(client_events::kBrowserLineChanged, varJson);
    module_context::enqueClientEvent(event);
 }
 

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -656,30 +656,6 @@ SEXP simulatedSourceRefsOfContext(const r::context::RCntxt& context,
    return simulatedSrcref;
 }
 
-r::context::RCntxt findParentContext(
-      const r::context::RCntxt& context,
-      const r::context::RCntxt& prevContext)
-{
-   SEXP sysparent = context.sysparent();
-   if (R_IsPackageEnv(sysparent) || R_IsNamespaceEnv(sysparent))
-      return prevContext;
-   
-   using namespace r::context;
-   for (auto it = RCntxt::begin(); it != RCntxt::end(); ++it)
-   {
-      if (it->callflag() & CTXT_FUNCTION)
-      {
-         SEXP cloenv = it->cloenv();
-         if (cloenv == sysparent)
-         {
-            return *it;
-         }
-      }
-   }
-   
-   return prevContext;
-}
-
 // Return the call frames and debug information as a JSON object.
 json::Array callFramesAsJson(
       int depth,
@@ -833,10 +809,9 @@ json::Array callFramesAsJson(
             }
             else
             {
-               // TODO: Figure out the parent context in a more robust way
                simulatedSrcref =
                      simulatedSourceRefsOfContext(
-                        *context, findParentContext(*context, prevContext), nullptr);
+                        *context, prevContext, nullptr);
             }
 
             sourceRefToJson(simulatedSrcref, &varFrame);

--- a/src/cpp/tests/debugger/debugging-14276.R
+++ b/src/cpp/tests/debugger/debugging-14276.R
@@ -1,0 +1,20 @@
+
+#
+# Make sure the debug position always advances when stepping through.
+#
+# https://github.com/rstudio/rstudio/issues/14276
+#
+
+# trace(.rs.simulateSourceRefs, quote(str(var)))
+eval(parse(text = "fn <- function() {
+  x <- 1
+  1 + 1
+  x <- 1
+  2 + 2
+  3 + 3
+  x <- 1
+  4 + 4
+}", keep.source = FALSE))
+
+debugonce(fn)
+fn()

--- a/src/cpp/tests/debugger/debugging-14276.R
+++ b/src/cpp/tests/debugger/debugging-14276.R
@@ -18,3 +18,19 @@ eval(parse(text = "fn <- function() {
 
 debugonce(fn)
 fn()
+
+
+# No issue stepping through when we have srcrefs.
+fn <- function() {
+  x <- 1
+  1 + 1
+  x <- 1
+  2 + 2
+  3 + 3
+  x <- 1
+  4 + 4
+}
+
+debugonce(fn)
+fn()
+

--- a/src/cpp/tests/debugger/debugging-14306.R
+++ b/src/cpp/tests/debugger/debugging-14306.R
@@ -1,0 +1,16 @@
+
+#
+# https://github.com/rstudio/rstudio/issues/14306
+#
+
+eval(parse(text = "fn <- function() {
+  tryCatch({
+    1 + 1
+    2 + 2
+    3 + 3
+  })
+}
+", keep.source = FALSE))
+
+debugonce(fn)
+fn()

--- a/src/cpp/tests/debugger/debugging-14306.R
+++ b/src/cpp/tests/debugger/debugging-14306.R
@@ -4,13 +4,11 @@
 #
 
 # trace(.rs.simulateSourceRefs, quote(str(var)), print = FALSE)
-eval(parse(text = "fn <- function() {
+fn <- NULL
+eval(parse(text = "
+fn <- function() {
   identity({
-    1 + 1
     browser()
-    3 + 3
-    4 + 4
-    5 + 5
   })
 }
 ", keep.source = FALSE))
@@ -19,16 +17,10 @@ fn()
 
 
 # Compare with source references
-fn2 <- function() {
-   identity({
-     identity({
-      1 + 1
-      browser()
-      3 + 3
-      4 + 4
-      5 + 5
-     })
-   })
+fn <- function() {
+  identity({
+    browser()
+  })
 }
 
-fn2()
+fn()

--- a/src/cpp/tests/debugger/debugging-14306.R
+++ b/src/cpp/tests/debugger/debugging-14306.R
@@ -3,14 +3,32 @@
 # https://github.com/rstudio/rstudio/issues/14306
 #
 
+# trace(.rs.simulateSourceRefs, quote(str(var)), print = FALSE)
 eval(parse(text = "fn <- function() {
-  tryCatch({
+  identity({
     1 + 1
-    2 + 2
+    browser()
     3 + 3
+    4 + 4
+    5 + 5
   })
 }
 ", keep.source = FALSE))
 
-debugonce(fn)
 fn()
+
+
+# Compare with source references
+fn2 <- function() {
+   identity({
+     identity({
+      1 + 1
+      browser()
+      3 + 3
+      4 + 4
+      5 + 5
+     })
+   })
+}
+
+fn2()

--- a/src/cpp/tests/debugger/debugging-14306.R
+++ b/src/cpp/tests/debugger/debugging-14306.R
@@ -8,19 +8,25 @@ fn <- NULL
 eval(parse(text = "
 fn <- function() {
   identity({
-    browser()
+    1 + 1
+    2 + 2
+    3 + 3
   })
 }
 ", keep.source = FALSE))
 
+debugonce(fn)
 fn()
 
 
 # Compare with source references
 fn <- function() {
   identity({
-    browser()
+    1 + 1
+    2 + 2
+    3 + 3
   })
 }
 
+debugonce(fn)
 fn()

--- a/src/cpp/tests/debugger/debugging-example.R
+++ b/src/cpp/tests/debugger/debugging-example.R
@@ -7,10 +7,10 @@
 
 bar <- function()
 {
+   browser()
    { 1 + 1; 2 +
          2}
    1 + 1
-   browser()
    3 + 3
 }
 

--- a/src/cpp/tests/debugger/debugging-example.R
+++ b/src/cpp/tests/debugger/debugging-example.R
@@ -7,6 +7,8 @@
 
 bar <- function()
 {
+   { 1 + 1; 2 +
+         2}
    1 + 1
    browser()
    3 + 3

--- a/src/cpp/tests/debugger/debugging-example.R
+++ b/src/cpp/tests/debugger/debugging-example.R
@@ -9,15 +9,17 @@ bar <- function()
 {
    1 + 1
    browser()
-   2 + 2
+   3 + 3
 }
 
 foo <- function() {
    withCallingHandlers({
       tryCatch({
          identity({
-            bar()
-            2 + 2
+            eval({
+               bar()
+               2 + 2
+            })
          })
       })
    })

--- a/src/cpp/tests/debugger/debugging-example.R
+++ b/src/cpp/tests/debugger/debugging-example.R
@@ -1,0 +1,25 @@
+
+#
+# Try debugging this file with:
+# - First, source() this file, then run foo().
+# - Try executing code via Cmd + Enter, then run foo().
+#
+
+bar <- function()
+{
+   1 + 1
+   browser()
+   2 + 2
+}
+
+foo <- function() {
+   withCallingHandlers({
+      tryCatch({
+         identity({
+            bar()
+            2 + 2
+         })
+      })
+   })
+}
+

--- a/src/cpp/tests/debugger/debugging-nested.R
+++ b/src/cpp/tests/debugger/debugging-nested.R
@@ -1,0 +1,24 @@
+
+test <- function() {
+   a1()
+}
+
+a1 <- function() {
+   a2()
+}
+
+a2 <- function() {
+   a3()
+}
+
+a3 <- function() {
+   a4()
+}
+
+a4 <- function() {
+   a5()
+}
+
+a5 <- function() {
+   browser()
+}

--- a/src/cpp/tests/debugger/debugging-nested.R
+++ b/src/cpp/tests/debugger/debugging-nested.R
@@ -1,24 +1,15 @@
 
-test <- function() {
-   a1()
-}
-
-a1 <- function() {
-   a2()
-}
-
-a2 <- function() {
-   a3()
-}
-
-a3 <- function() {
-   a4()
-}
-
-a4 <- function() {
-   a5()
-}
-
-a5 <- function() {
+bottom <- function() {
+   "bottom"
    browser()
+}
+
+middle <- function() {
+   "middle"
+   bottom()
+}
+
+top <- function() {
+   "top"
+   middle()
 }

--- a/src/cpp/tests/debugger/debugging-no-srcrefs.R
+++ b/src/cpp/tests/debugger/debugging-no-srcrefs.R
@@ -1,0 +1,26 @@
+
+#
+# Source this file, run test(), and then check whether the highlighted code is correct.
+#
+
+eval(parse(keep.source = FALSE, text = "
+test <- function() {
+   apple() + banana() + cherry()
+}
+
+apple <- function() {
+   1 + 1 # comment
+   browser()
+   2 + 2 # comment
+}
+
+banana <- function() {
+   3 + 3
+   browser()
+   4 + 4
+}
+
+cherry <- function() {
+   browser()
+}
+"))

--- a/src/cpp/tests/debugger/debugging-no-srcrefs.R
+++ b/src/cpp/tests/debugger/debugging-no-srcrefs.R
@@ -9,18 +9,17 @@ test <- function() {
 }
 
 apple <- function() {
-   1 + 1 # comment
+   'apple'
    browser()
-   2 + 2 # comment
 }
 
 banana <- function() {
-   3 + 3
+   'banana'
    browser()
-   4 + 4
 }
 
 cherry <- function() {
+   'cherry'
    browser()
 }
 "))

--- a/src/cpp/tests/debugger/debugging-package-code.R
+++ b/src/cpp/tests/debugger/debugging-package-code.R
@@ -1,0 +1,5 @@
+
+# Run this code, and then try to explore the Traceback frames.
+# You should get sensible views into the running code.
+debugonce(dplyr:::new_error_context)
+dplyr::mutate(mtcars, mpg2 = mpg * 2)

--- a/src/cpp/tests/debugger/debugging-package-code.R
+++ b/src/cpp/tests/debugger/debugging-package-code.R
@@ -1,5 +1,8 @@
 
+#
 # Run this code, and then try to explore the Traceback frames.
 # You should get sensible views into the running code.
+#
+
 debugonce(dplyr:::new_error_context)
 dplyr::mutate(mtcars, mpg2 = mpg * 2)

--- a/src/cpp/tests/debugger/debugging-slider-example.R
+++ b/src/cpp/tests/debugger/debugging-slider-example.R
@@ -6,6 +6,10 @@
 # even after evaluating some of the variables during the
 # debug session.
 #
+# Install the package with:
+#
+# install.packages("slider", type = "source", INSTALL_opts = "--with-keep.source")
+#
 
 library(slider)
 debugonce(slider:::slide_impl)

--- a/src/cpp/tests/debugger/debugging-slider-example.R
+++ b/src/cpp/tests/debugger/debugging-slider-example.R
@@ -1,0 +1,12 @@
+
+#
+# https://github.com/rstudio/rstudio/issues/10664
+#
+# Make sure that you can still step through the function
+# even after evaluating some of the variables during the
+# debug session.
+#
+
+library(slider)
+debugonce(slider:::slide_impl)
+slide_dbl(1:5, identity)

--- a/src/cpp/tests/testthat/test-environment.R
+++ b/src/cpp/tests/testthat/test-environment.R
@@ -98,11 +98,14 @@ test_that("all objects are removed when requested", {
 })
 
 test_that("functions with backslashes deparse correctly", {
+   # make diagnostics happy
+   f <- NULL
+   
    # character vector with code for a simple function
-   code <- "function() { \"first line\\nsecond line\" }"
+   code <- "f <- function() { \"first line\\nsecond line\" }"
 
    # parse and evaluate the expression (yielding a function f)
-   eval(parse(text = paste0("f <- ", code)))
+   eval(parse(text = code))
 
    # immediately deparse f back into a string
    output <- .rs.deparseFunction(f, TRUE, TRUE)

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -761,7 +761,7 @@ public class ClientEventDispatcher
          {
             SearchPathFunctionDefinition data = event.getData();
             eventBus_.dispatchEvent(new CodeBrowserNavigationEvent(
-                  data, null, false, true));
+                  data, null, false, true, false));
          }
          else if (type == ClientEvent.MarkersChanged)
          {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -606,7 +606,8 @@ public class ClientEventDispatcher
             PrefLayer data = event.getData();
             eventBus_.dispatchEvent(new UserStateChangedEvent(data));
          }
-         else if (type == ClientEvent.ContextDepthChanged) {
+         else if (type == ClientEvent.ContextDepthChanged)
+         {
             EnvironmentContextData data = event.getData();
             eventBus_.dispatchEvent(new ContextDepthChangedEvent(data, true));
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/model/SearchPathFunctionDefinition.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/model/SearchPathFunctionDefinition.java
@@ -27,12 +27,14 @@ public class SearchPathFunctionDefinition extends JavaScriptObject
    public final static native SearchPathFunctionDefinition create(String name, 
          String namespace, String code, boolean debugCode)
    /*-{
-     return { name: name,
-              namespace: namespace,
-              code: code,
-              methods: [],
-              from_src_attrib: true,
-              active_debug_code: debugCode };
+     return {
+        name: name,
+        namespace: namespace,
+        code: code,
+        methods: [],
+        from_src_attrib: true,
+        active_debug_code: debugCode
+     };
    }-*/;
    
    public final native String getName() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -921,9 +921,10 @@ public class EnvironmentPresenter extends BasePresenter
                // open it
                eventBus_.fireEvent(new CodeBrowserNavigationEvent(
                      searchFunction_,
-                     currentBrowsePosition_.functionRelativePosition(
-                           currentFunctionLineNumber_),
-                     contextDepth_ == 1, false));
+                     currentBrowsePosition_.functionRelativePosition(currentFunctionLineNumber_),
+                     contextDepth_ == 1,
+                     false,
+                     true));
             }
             else if (currentBrowsePosition_.getLine() > 0)
             {
@@ -931,8 +932,8 @@ public class EnvironmentPresenter extends BasePresenter
                // highlight
                eventBus_.fireEvent(new CodeBrowserHighlightEvent(
                      searchFunction_,
-                     currentBrowsePosition_.functionRelativePosition(
-                           currentFunctionLineNumber_)));
+                     currentBrowsePosition_.functionRelativePosition(currentFunctionLineNumber_),
+                     true));
             }
          }
          else

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -2566,6 +2566,7 @@ public class Source implements InsertSourceEvent.Handler,
          columnManager_.activateCodeBrowser(
             navigation.getPath(),
             false,
+            false,
             new SourceNavigationResultCallback<>(navigation.getPosition(), retryCommand));
       }
 
@@ -2613,7 +2614,8 @@ public class Source implements InsertSourceEvent.Handler,
             columnManager_.activateCodeBrowser(
                CodeBrowserEditingTarget.getCodeBrowserPath(event.getFunction()),
                !event.serverDispatched(),
-               new ResultCallback<CodeBrowserEditingTarget,ServerError>() {
+               event.closeOnDebugSessionEnded(),
+               new ResultCallback<CodeBrowserEditingTarget, ServerError>() {
                @Override
                public void onSuccess(CodeBrowserEditingTarget target)
                {
@@ -2633,16 +2635,6 @@ public class Source implements InsertSourceEvent.Handler,
    @Override
    public void onCodeBrowserFinished(final CodeBrowserFinishedEvent event)
    {
-      tryExternalCodeBrowser(event.getFunction(), event, new Command()
-      {
-         @Override
-         public void execute()
-         {
-            final String path = CodeBrowserEditingTarget.getCodeBrowserPath(
-                  event.getFunction());
-            columnManager_.closeTabWithPath(path, false);
-         }
-      });
    }
 
    @Override
@@ -2657,6 +2649,7 @@ public class Source implements InsertSourceEvent.Handler,
             columnManager_.activateCodeBrowser(
                CodeBrowserEditingTarget.getCodeBrowserPath(event.getFunction()),
                false,
+               event.closeOnDebugSessionEnded(),
                new ResultCallback<CodeBrowserEditingTarget,ServerError>() {
                @Override
                public void onSuccess(CodeBrowserEditingTarget target)
@@ -2665,8 +2658,8 @@ public class Source implements InsertSourceEvent.Handler,
                   // we may need to repopulate it
                   if (StringUtil.isNullOrEmpty(target.getContext()))
                      target.showFunction(event.getFunction());
-                  highlightDebugBrowserPosition(target, event.getDebugPosition(),
-                        true);
+                  
+                  highlightDebugBrowserPosition(target, event.getDebugPosition(), true);
                }
             });
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -2099,7 +2099,7 @@ public class Source implements InsertSourceEvent.Handler,
                         (DebugFilePosition) position.cast();
                   endPosition = SourcePosition.create(
                         filePos.getEndLine() - 1,
-                        filePos.getEndColumn() + 1);
+                        filePos.getEndColumn());
 
                   if (Desktop.hasDesktopFrame() &&
                       navMethod != NavigationMethods.DEBUG_END)
@@ -2690,12 +2690,9 @@ public class Source implements InsertSourceEvent.Handler,
                                               DebugFilePosition pos,
                                               boolean executing)
    {
-      target.highlightDebugLocation(SourcePosition.create(
-               pos.getLine(),
-               pos.getColumn() - 1),
-            SourcePosition.create(
-               pos.getEndLine(),
-               pos.getEndColumn() + 1),
+      target.highlightDebugLocation(
+            SourcePosition.create(pos.getLine(), pos.getColumn() - 1),
+            SourcePosition.create(pos.getEndLine(), pos.getEndColumn()),
             executing);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CodeBrowserHighlightEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CodeBrowserHighlightEvent.java
@@ -35,14 +35,16 @@ public class CodeBrowserHighlightEvent
    
    public CodeBrowserHighlightEvent()
    {
-      this(null, null);
+      this(null, null, false);
    }
    
    public CodeBrowserHighlightEvent(SearchPathFunctionDefinition function,
-         DebugFilePosition debugPosition)
+                                    DebugFilePosition debugPosition,
+                                    boolean closeOnDebugSessionEnded)
    {
       function_ = function;
       debugPosition_ = debugPosition;
+      closeOnDebugSessionEnded_ = closeOnDebugSessionEnded;
    }
    
    public DebugFilePosition getDebugPosition()
@@ -53,6 +55,11 @@ public class CodeBrowserHighlightEvent
    public SearchPathFunctionDefinition getFunction()
    {
       return function_;
+   }
+   
+   public boolean closeOnDebugSessionEnded()
+   {
+      return closeOnDebugSessionEnded_;
    }
    
    @Override
@@ -75,4 +82,5 @@ public class CodeBrowserHighlightEvent
 
    private DebugFilePosition debugPosition_;
    private SearchPathFunctionDefinition function_;
+   private boolean closeOnDebugSessionEnded_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CodeBrowserNavigationEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CodeBrowserNavigationEvent.java
@@ -14,11 +14,12 @@
  */
 package org.rstudio.studio.client.workbench.views.source.events;
 
-import com.google.gwt.event.shared.EventHandler;
 import org.rstudio.core.client.DebugFilePosition;
 import org.rstudio.core.client.js.JavaScriptSerializable;
 import org.rstudio.studio.client.application.events.CrossWindowEvent;
 import org.rstudio.studio.client.workbench.codesearch.model.SearchPathFunctionDefinition;
+
+import com.google.gwt.event.shared.EventHandler;
 
 
 @JavaScriptSerializable
@@ -39,18 +40,20 @@ public class CodeBrowserNavigationEvent
 
    public CodeBrowserNavigationEvent(SearchPathFunctionDefinition function)
    {
-      this(function, null, false, false);
+      this(function, null, false, false, false);
    }
 
    public CodeBrowserNavigationEvent(SearchPathFunctionDefinition function,
                                      DebugFilePosition debugPosition,
                                      boolean executing,
-                                     boolean serverDispatched)
+                                     boolean serverDispatched,
+                                     boolean closeOnDebugSessionEnded)
    {
       function_ = function;
       debugPosition_ = debugPosition;
       executing_ = executing;
       serverDispatched_ = serverDispatched;
+      closeOnDebugSessionEnded_ = closeOnDebugSessionEnded;
    }
 
    public SearchPathFunctionDefinition getFunction()
@@ -71,6 +74,11 @@ public class CodeBrowserNavigationEvent
    public boolean serverDispatched()
    {
       return serverDispatched_;
+   }
+   
+   public boolean closeOnDebugSessionEnded()
+   {
+      return closeOnDebugSessionEnded_;
    }
 
    @Override
@@ -95,5 +103,6 @@ public class CodeBrowserNavigationEvent
    SearchPathFunctionDefinition function_;
    boolean executing_;
    boolean serverDispatched_;
+   boolean closeOnDebugSessionEnded_;
 }
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10664, which appears to have regressed.
Addresses https://github.com/rstudio/rstudio/issues/14306.
Addresses https://github.com/rstudio/rstudio/issues/14276.

QA note: it's possible that this issue may only occur with the latest release of R; perhaps older versions of R are fine?

### Approach

Similar to the last fix, tighten up the checks on whether two contexts can be considered equal.

### Automated Tests

N/A

### QA Notes

This PR adds a number of files for manual testing of the debugger, located in the RStudio repository at `src/cpp/tests/debugger`. The intention here is that these files can be opened in RStudio, and one can follow the instructions in each file to test various debug cases.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
