### PR TITLE
initialize PATH from /etc/paths earlier on in session init

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -63,6 +63,7 @@
 - Show an error dialog if R is not found when starting RStudio Desktop on Linux and macOS (#14343)
 - An empty `rstudio-prefs.json` no longer logs spurious JSON parsing errors (rstudio-pro#4347)
 - Help pane's Next and Previous find-in-topic buttons now have meaningful accessible labels [Accessibility] (#14347)
+- Fixed an issue where PATH modifications in .Renviron / .Rprofile could be lost on macOS (#9815)
 
 #### Posit Workbench
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -570,7 +570,6 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       // modules with c++ implementations
       (modules::spelling::initialize)
       (modules::lists::initialize)
-      (modules::path::initialize)
       (modules::limits::initialize)
       (modules::ppe::initialize)
       (modules::ask_pass::initialize)
@@ -1961,6 +1960,14 @@ int main(int argc, char * const argv[])
       // initialize thread id
       core::thread::initializeMainThreadId(boost::this_thread::get_id());
       core::system::setEnableCallbacksRequireMainThread(true);
+      
+      // initialize PATH -- needs to happen early on to avoid stomping on environment
+      // variables set in a users .Renviron or .Rprofile
+      {
+         Error error = modules::path::initialize();
+         if (error)
+            LOG_ERROR(error);
+      }
 
       // terminate immediately with given exit code (for testing/debugging)
       std::string exitOnStartup = core::system::getenv("RSTUDIO_SESSION_EXIT_ON_STARTUP");


### PR DESCRIPTION
### Intent

Addresses the macOS part of https://github.com/rstudio/rstudio/issues/9815.

### Approach

Previously, RStudio was attempting to initialize the PATH environment variable as part of the regular R initialization step. However, this happens too late -- we need to initialize the PATH early on in the session startup, so that modifications from `.Renviron` and `.Rprofile` can persist over whatever else we might want to do.

### Automated Tests

N/A

### QA Notes

Test that setting the PATH environment variable within `~/.Renviron` is persisted in the session. This is a macOS-only change.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
