### PR TITLE
infer document source from debugged srcref

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
 - The working directory of a background job now defaults to the .Rproj location when a project is open (#12600)
 - Add search results copy button and search results breadcrumbs to RStudio User Guide (#13618, #14069)
 - RStudio now supports generation of a Copilot diagnostic report from the Copilot preferences pane (#14358)
+- The RStudio debugger is now better at matching debugged code to source documents (#13925)
 
 #### Posit Workbench
 - Show custom project names on Workbench homepage (rstudio-pro#5589)

--- a/src/cpp/tests/debugger/debugging-cmd-enter.R
+++ b/src/cpp/tests/debugger/debugging-cmd-enter.R
@@ -6,6 +6,8 @@
 # on some heuristics (matching source references against
 # the document contents itself) so it may not be perfect.
 #
+# https://github.com/rstudio/rstudio/issues/13925
+#
 
 inner <- function() {
    3 + 3

--- a/src/cpp/tests/debugger/debugging-cmd-enter.R
+++ b/src/cpp/tests/debugger/debugging-cmd-enter.R
@@ -1,0 +1,22 @@
+
+#
+# Test that the debugger is able to highlight within
+# files that are currently open, even for code that
+# was executed via 'Cmd + Enter'. Note that this relies
+# on some heuristics (matching source references against
+# the document contents itself) so it may not be perfect.
+#
+
+test1 <- function() {
+   1 + 1
+   test2()
+   2 + 2
+}
+
+test2 <- function() {
+   3 + 3
+   browser()
+   4 + 4
+}
+
+test()

--- a/src/cpp/tests/debugger/debugging-cmd-enter.R
+++ b/src/cpp/tests/debugger/debugging-cmd-enter.R
@@ -7,16 +7,16 @@
 # the document contents itself) so it may not be perfect.
 #
 
-test1 <- function() {
-   1 + 1
-   test2()
-   2 + 2
-}
-
-test2 <- function() {
+inner <- function() {
    3 + 3
-   browser()
    4 + 4
 }
 
-test()
+outer <- function() {
+   1 + 1
+   inner()
+   2 + 2
+}
+
+debugonce(outer)
+outer()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -86,6 +86,11 @@ import org.rstudio.studio.client.workbench.views.environment.model.RObject;
 import org.rstudio.studio.client.workbench.views.environment.view.EnvironmentClientState;
 import org.rstudio.studio.client.workbench.views.environment.view.MemoryUsageSummaryDialog;
 import org.rstudio.studio.client.workbench.views.source.Source;
+import org.rstudio.studio.client.workbench.views.source.SourceColumn;
+import org.rstudio.studio.client.workbench.views.source.SourceColumnManager;
+import org.rstudio.studio.client.workbench.views.source.editors.EditingTarget;
+import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTarget;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.events.CodeBrowserFinishedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.CodeBrowserHighlightEvent;
 import org.rstudio.studio.client.workbench.views.source.events.CodeBrowserNavigationEvent;
@@ -868,8 +873,7 @@ public class EnvironmentPresenter extends BasePresenter
       // if we have a real filename and sign from the server that the file
       // is in sync with the actual copy of the function, navigate to the
       // file itself
-      if (currentBrowsePosition_ != null &&
-          !useCurrentBrowseSource_)
+      if (currentBrowsePosition_ != null && !useCurrentBrowseSource_)
       {
          FileSystemItem sourceFile = FileSystemItem.createFile(file);
          eventBus_.fireEvent(new OpenSourceFileEvent(sourceFile,
@@ -878,12 +882,58 @@ public class EnvironmentPresenter extends BasePresenter
                                 debugging ?
                                       NavigationMethods.DEBUG_STEP :
                                       NavigationMethods.DEBUG_END));
+         return;
       }
+      
+      // if we have a copy of the source to be browsed, check and see
+      // if we can find that within any of the currently open files
+      // if so, open that file
+      boolean tryOpenDoc =
+            useCurrentBrowseSource_ &&
+            currentBrowseSource_.length() > 0 &&
+            debugging;
+      
+      if (tryOpenDoc)
+      {
+         SourceColumnManager manager = RStudioGinjector.INSTANCE.getSourceColumnManager();
+         for (SourceColumn column : manager.getColumnList())
+         {
+            for (EditingTarget editingTarget : column.getEditors())
+            {
+               if (editingTarget instanceof TextEditingTarget)
+               {
+                  TextEditingTarget target = (TextEditingTarget) editingTarget;
+                  String editorCode = target.getDocDisplay().getCode();
+                  int codeIndex = editorCode.indexOf(currentBrowseSource_);
+                  if (codeIndex != -1)
+                  {
+                     // We've found the start of the function being debugged in a
+                     // currently-open tab. Try to set the browse position accordingly.
+                     Position position = target.getDocDisplay().positionFromIndex(codeIndex);
+                     currentFunctionLineNumber_ = 0;
+                     currentBrowseFile_ = target.getPath();
+                     currentBrowsePosition_ = DebugFilePosition.create(
+                           currentBrowsePosition_.getLine() + position.getRow(),
+                           currentBrowsePosition_.getEndLine() + position.getRow(),
+                           currentBrowsePosition_.getColumn(),
+                           currentBrowsePosition_.getEndColumn());
+                     OpenSourceFileEvent event = new OpenSourceFileEvent(
+                           FileSystemItem.createFile(target.getPath()),
+                           (FilePosition) currentBrowsePosition_.cast(),
+                           FileTypeRegistry.R,
+                           NavigationMethods.DEBUG_STEP);
+                     eventBus_.fireEvent(event);
+                     return;
+                  }
+               }
+            }
+         }
+      }
+            
 
       // otherwise, if we have a copy of the source from the server, load
       // the copy from the server into the code browser window
-      else if (useCurrentBrowseSource_ &&
-               currentBrowseSource_.length() > 0)
+      if (useCurrentBrowseSource_ && currentBrowseSource_.length() > 0)
       {
          if (debugging)
          {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13925.

### Approach

When code is executed via Cmd + Enter, its original source file is lost. However, the function definitions themselves do retain source references so we can retain the original textual definition of that code. When such code is available, we now try matching that against code available in documents already open in RStudio. If we find a match, we choose to open that document as the debug context, instead of using the code browser with a separate read-only view of the debugged code.

In the example below, I execute code via Cmd + Enter, and then step through the debugger with `n` in the usual way.

https://github.com/rstudio/rstudio/assets/1976582/2af78e54-29be-4c59-8440-4bd5acc31cc1

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13925.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


