### PR TITLE
trim chunk markers from copilot completions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@
 - Add search results copy button and search results breadcrumbs to RStudio User Guide (#13618, #14069)
 - RStudio now supports generation of a Copilot diagnostic report from the Copilot preferences pane (#14358)
 - The RStudio debugger is now better at matching debugged code to source documents (#13925)
+- RStudio no longer includes spurious chunk markers from Copilot completion results (#13686)
 
 #### Posit Workbench
 - Show custom project names on Workbench homepage (rstudio-pro#5589)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
@@ -162,11 +162,8 @@ public class TextEditingTargetCopilotHelper
                               
                               // Copilot includes trailing '```' for some reason in some cases,
                               // remove those if we're inserting in an R document.
-                              if (completion.text.endsWith("\n```"))
-                                 completion.text = StringUtil.substring(completion.text, 0, completion.text.length() - 3);
-
-                              if (completion.displayText.endsWith("\n```"))
-                                 completion.displayText = StringUtil.substring(completion.displayText, 0, completion.displayText.length() - 3);
+                              completion.text = postProcessCompletion(completion.text);
+                              completion.displayText = postProcessCompletion(completion.displayText);
 
                               activeCompletion_ = completion;
                               display_.setGhostText(activeCompletion_.displayText);
@@ -373,6 +370,16 @@ public class TextEditingTargetCopilotHelper
       {
          display_.setGhostText(activeCompletion_.displayText);
       });
+   }
+   
+   private String postProcessCompletion(String text)
+   {
+      // Exclude chunk markers from completion results
+      int endChunkIndex = text.indexOf("\n```");
+      if (endChunkIndex != -1)
+         text = text.substring(0, endChunkIndex);
+      
+      return text;
    }
    
    @Inject


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13686.
Addresses https://github.com/rstudio/rstudio/issues/13987.
Addresses https://github.com/rstudio/rstudio/issues/13432.

### Approach

Copilot will occasionally include chunk end markers as part of its completion results. When produced, we now just trim those indiscriminately, under the assumption that users would only ever want completion results specific to the current chunk / context.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13686.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
