### PR TITLE
work around un-expanded quarto template

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,7 @@
 - Fixed handling of duplicated calls in debugger when source references not available (#14276)
 - Fixed issue where stepping through lines of code in tryCatch() would provide incorrect debug highlight (#14306)
 - Fixed an issue where PATH modifications in .Renviron / .Rprofile could be lost on macOS (#9815)
+- Fixed an issue where the Edit button in the Viewer pane could fail for Quarto documents (#14325)
 
 #### Posit Workbench
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
@@ -238,9 +238,8 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
    @Override
    public void previewQuarto(String url, QuartoNavigate quartoNav)
    {
-      quartoNav_ = quartoNav;
       rmdPreviewParams_ = null;
-      navigate(url, false, false);
+      navigate(url, false, false, quartoNav);
       quartoConnection_.setQuartoUrl(url, quartoNav.isWebsite());
       publishButton_.setManuallyHidden(false);
       if (quartoNav.isWebsite())
@@ -324,7 +323,12 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
       
       // https://github.com/rstudio/rstudio/issues/14325
       if (file == "<%- inputFile %>")
-         file = quartoNav_.getSourceFile();
+      {
+         if (quartoNav_ != null)
+         {
+            file = quartoNav_.getSourceFile();
+         }
+      }
       
       FileSystemItem srcFile = FileSystemItem.createFile(file);
       fileTypeRegistry_.editFile(srcFile, FilePosition.create(-1, -1));
@@ -438,8 +442,16 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
    
    private void navigate(String url, boolean useRawURL, boolean viewerPaneParam)
    {
+      navigate(url, useRawURL, viewerPaneParam, null);
+   }
+   
+   private void navigate(String url, boolean useRawURL, boolean viewerPaneParam, QuartoNavigate quartoNav)
+   {
       // save the unmodified URL for pop-out
       unmodifiedUrl_ = url;
+      
+      // save quarto navigation
+      quartoNav_ = quartoNav;
 
       // in desktop mode we need to be careful about loading URLs which are
       // non-local; before changing the URL, set the iframe to be sandboxed

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
@@ -12,17 +12,9 @@
  */
 package org.rstudio.studio.client.workbench.views.viewer;
 
-import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.event.dom.client.LoadHandler;
-import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.Timer;
-import com.google.gwt.user.client.ui.CheckBox;
-import com.google.gwt.user.client.ui.Widget;
-import com.google.inject.Inject;
-import com.google.inject.Provider;
-
-import org.rstudio.core.client.HtmlMessageListener;
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.FilePosition;
+import org.rstudio.core.client.HtmlMessageListener;
 import org.rstudio.core.client.Size;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.URIConstants;
@@ -38,6 +30,7 @@ import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.AutoGlassPanel;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.common.Timers;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.icons.StandardIcons;
 import org.rstudio.studio.client.plumber.model.PlumberAPIParams;
@@ -55,6 +48,14 @@ import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
 import org.rstudio.studio.client.workbench.views.viewer.events.ViewerNavigatedEvent;
 import org.rstudio.studio.client.workbench.views.viewer.model.ViewerServerOperations;
 import org.rstudio.studio.client.workbench.views.viewer.quarto.QuartoConnection;
+
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.dom.client.LoadHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.ui.CheckBox;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
 {
@@ -237,6 +238,7 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
    @Override
    public void previewQuarto(String url, QuartoNavigate quartoNav)
    {
+      quartoNav_ = quartoNav;
       rmdPreviewParams_ = null;
       navigate(url, false, false);
       quartoConnection_.setQuartoUrl(url, quartoNav.isWebsite());
@@ -316,18 +318,21 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
    @Override
    public void editSource()
    {
-      FileSystemItem srcFile = quartoConnection_.getSrcFile();
-      if (srcFile != null)
+      String file = quartoConnection_.getRawSrcFile();
+      if (file == null)
+         return;
+      
+      // https://github.com/rstudio/rstudio/issues/14325
+      if (file == "<%- inputFile %>")
+         file = quartoNav_.getSourceFile();
+      
+      FileSystemItem srcFile = FileSystemItem.createFile(file);
+      fileTypeRegistry_.editFile(srcFile, FilePosition.create(-1, -1));
+      
+      Timers.singleShot(200, () ->
       {
-         fileTypeRegistry_.editFile(srcFile);
-         new Timer() {
-            @Override
-            public void run()
-            {
-               commands_.activateSource();
-            }
-         }.schedule(200);
-      }
+         commands_.activateSource();
+      });
    }
 
    @Override
@@ -495,6 +500,7 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
 
    private RStudioFrame frame_;
    private String unmodifiedUrl_;
+   private QuartoNavigate quartoNav_;
    private RmdPreviewParams rmdPreviewParams_;
    private final Commands commands_;
    private final GlobalDisplay globalDisplay_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/quarto/QuartoConnection.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/quarto/QuartoConnection.java
@@ -76,6 +76,11 @@ public class QuartoConnection
          return null;
    }
    
+   public String getRawSrcFile()
+   {
+      return srcFile_;
+   }
+   
    public boolean isWebsite()
    {
       return url_ != null && website_;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14325.

### Approach

Some versions of Quarto fail to expand the `inputFile` template parameter. Since we know the source file in these instances, use that for the resulting navigation.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14325.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
