### PR TITLE
Add search copy-button and breadcrumbs to News site

### DIFF
--- a/docs/news/_quarto.yml
+++ b/docs/news/_quarto.yml
@@ -6,6 +6,9 @@ website:
   favicon: "images/favicon.svg"
   page-navigation: true
   site-url: https://docs.posit.co/ide/news/
+  search:
+    copy-button: true
+    show-item-context: true
   navbar:
     pinned: true
     logo: images/posit-icon-fullcolor.svg


### PR DESCRIPTION
### Intent

Following on from the quarto features for the IDE User Guide, enable the copy-button and breadcrumbs in search of the news / release notes page.

See #14069 and #13618

### Approach

Update the _quarto.yml file to enable these search features for news / release notes.

### Automated Tests

N/A

### QA Notes

Review the Release Notes search results once this is deployed.

### Documentation

Implementing requested features for search in the Release Notes docs site.


### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


