### PR TITLE
avoid using available.packages() when checking loaded dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,7 @@
 - Fixed handling of duplicated calls in debugger when source references not available (#14276)
 - Fixed issue where stepping through lines of code in tryCatch() would provide incorrect debug highlight (#14306)
 - Fixed an issue where PATH modifications in .Renviron / .Rprofile could be lost on macOS (#9815)
+- Fixed an issue where custom headers were not propagated to `available.packages()` when calling `install.packages()` (#14282)
 
 #### Posit Workbench
 

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -252,7 +252,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
   .libPaths()[1]
 })
 
-.rs.addJsonRpcHandler("is_package_attached", function(packageName, libName)
+.rs.addJsonRpcHandler("is_package_attached", function(packageName, libPath)
 {
    # quick check first if the package is loaded
    if (!isNamespaceLoaded(packageName))
@@ -263,11 +263,11 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    if (length(packagePath) == 0L)
       return(.rs.scalar(FALSE))
    
-   # libName from client is aliased, so compare aliased paths
+   # library path from client is aliased, so compare aliased paths
    packagePath <- .rs.createAliasedPath(packagePath)
    
    # compare with the library given by the client
-   samePath <- identical(packagePath, paste(libName, packageName, sep = "/"))
+   samePath <- identical(dirname(packagePath), libPath)
    .rs.scalar(samePath)
 })
 

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -774,6 +774,27 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    .rs.scalar(candidates[[1]])
 })
 
+.rs.addFunction("recursivePackageDependenciesImpl", function(pkg, envir)
+{
+   if (exists(pkg, envir = envir))
+      return()
+   
+   imports <- getNamespaceInfo(pkg, "imports")
+   deps <- setdiff(sort(unique(unlist(names(imports)))), "base")
+   assign(pkg, deps, envir = envir)
+   
+   for (dep in deps)
+      .rs.recursivePackageDependenciesImpl(dep, envir)
+})
+
+.rs.addFunction("recursivePackageDependencies", function(pkgs)
+{
+   envir <- new.env(parent = emptyenv())
+   for (pkg in pkgs)
+      .rs.recursivePackageDependenciesImpl(pkg, envir)
+   as.list(envir, all.names = TRUE)
+})
+
 .rs.addFunction("packagesLoaded", function(pkgs)
 {
    # first check loaded namespaces

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1375,7 +1375,7 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, GET_PACKAGE_INSTALL_CONTEXT, requestCallback);
    }
 
-   public void isPackageLoaded(
+   public void isPackageAttached(
                        String packageName,
                        String libName,
                        ServerRequestCallback<Boolean> requestCallback)
@@ -1383,7 +1383,7 @@ public class RemoteServer implements Server
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(packageName));
       params.set(1, new JSONString(libName));
-      sendRequest(RPC_SCOPE, IS_PACKAGE_LOADED, params, requestCallback);
+      sendRequest(RPC_SCOPE, IS_PACKAGE_ATTACHED, params, requestCallback);
    }
 
    public void isPackageHyperlinkSafe(
@@ -6811,7 +6811,7 @@ public class RemoteServer implements Server
    private static final String IGNORE_NEXT_LOADED_PACKAGE_CHECK = "ignore_next_loaded_package_check";
    private static final String GET_PACKAGE_NEWS_URL = "get_package_news_url";
    private static final String GET_PACKAGE_INSTALL_CONTEXT = "get_package_install_context";
-   private static final String IS_PACKAGE_LOADED = "is_package_loaded";
+   private static final String IS_PACKAGE_ATTACHED = "is_package_attached";
    private static final String IS_PACKAGE_HYPERLINK_SAFE = "is_package_hyperlink_safe";
    private static final String IS_PACKAGE_INSTALLED = "is_package_installed";
    private static final String SET_CRAN_MIRROR = "set_cran_mirror";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -896,7 +896,7 @@ public class Packages
                removeConsolePromptHandler();
 
                // check status and set it
-               server_.isPackageLoaded(
+               server_.isPackageAttached(
                          packageName,
                          libName,
                          new ServerRequestCallback<Boolean>() {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackagesServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackagesServerOperations.java
@@ -16,13 +16,13 @@ package org.rstudio.studio.client.workbench.views.packages.model;
 
 import java.util.List;
 
+import org.rstudio.studio.client.packrat.model.PackratServerOperations;
+import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.server.Void;
+
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.JsArrayString;
-
-import org.rstudio.studio.client.packrat.model.PackratServerOperations;
-import org.rstudio.studio.client.server.Void;
-import org.rstudio.studio.client.server.ServerRequestCallback;
 
 public interface PackagesServerOperations extends PackratServerOperations
 {
@@ -34,8 +34,9 @@ public interface PackagesServerOperations extends PackratServerOperations
          String repository,
          ServerRequestCallback<JsArrayString> requestCallback);
    
-   void isPackageLoaded(String packageName, String libName,
-                        ServerRequestCallback<Boolean> requestCallback);
+   void isPackageAttached(String packageName,
+                          String libName,
+                          ServerRequestCallback<Boolean> requestCallback);
    
    void isPackageHyperlinkSafe(String packageName,
                                ServerRequestCallback<Boolean> requestCallback);


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14282.

### Approach

We had a few code paths which used `available.packages()` when attempting to build a package's set of recursive dependencies. However, strictly speaking, that is not the correct approach as the currently-installed packages might not match whatever is currently available in the user's `getOption("repos")`. Instead, we resolve a package's recursive dependencies by looking at what packages are actually loaded, and what packages are explicitly imported by that package.

For reference, using the test from the original issue:

```
> options(internet.info = 1)
> install.packages("R6", headers = c(Authorization = "Bearer test123"))
Installing package into '/Users/kevin/Library/R/arm64/4.3/library'
(as 'lib' is unspecified)
* WARNING: failed to open cookie file ""
*   Trying 3.163.189.27:443...
* Connected to cloud.R-project.org (3.163.189.27) port 443
* ALPN: curl offers h2,http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=cran.rstudio.com
*  start date: May 17 00:00:00 2023 GMT
*  expire date: Jun 13 23:59:59 2024 GMT
*  subjectAltName: host "cloud.R-project.org" matched cert's "cloud.r-project.org"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://cloud.R-project.org/src/contrib/PACKAGES.rds
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: cloud.R-project.org]
* [HTTP/2] [1] [:path: /src/contrib/PACKAGES.rds]
* [HTTP/2] [1] [user-agent: RStudio Server (2024.3.999.999); R (4.3.2 aarch64-apple-darwin20 aarch64 darwin20)]
* [HTTP/2] [1] [accept: */*]
* [HTTP/2] [1] [authorization: Bearer test123]
* [HTTP/2] [1] [pragma: no-cache]
> GET /src/contrib/PACKAGES.rds HTTP/2
Host: cloud.R-project.org
User-Agent: RStudio Server (2024.3.999.999); R (4.3.2 aarch64-apple-darwin20 aarch64 darwin20)
Accept: */*
Authorization: Bearer test123
Pragma: no-cache

< HTTP/2 200 
< content-length: 946508
< date: Wed, 06 Mar 2024 18:28:38 GMT
< server: Apache/2.4.58 (Unix)
< last-modified: Wed, 06 Mar 2024 17:41:00 GMT
< etag: "e714c-6130176469fda"
< accept-ranges: bytes
< cache-control: max-age=1800
< expires: Wed, 06 Mar 2024 18:58:38 GMT
< x-cache: Hit from cloudfront
< via: 1.1 156a404018e26073003553397d28f4ea.cloudfront.net (CloudFront)
< x-amz-cf-pop: SEA900-P3
< x-amz-cf-id: zKnox86jK7014mTNGkTfSj6FsIjYZ8GGcaNXCEwkHIKmlmBycDdcZA==
< age: 253
< 
* Connection #0 to host cloud.R-project.org left intact
* WARNING: failed to open cookie file ""
*   Trying 3.163.189.27:443...
* Connected to cloud.R-project.org (3.163.189.27) port 443
* ALPN: curl offers h2,http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=cran.rstudio.com
*  start date: May 17 00:00:00 2023 GMT
*  expire date: Jun 13 23:59:59 2024 GMT
*  subjectAltName: host "cloud.R-project.org" matched cert's "cloud.r-project.org"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://cloud.R-project.org/bin/macosx/big-sur-arm64/contrib/4.3/PACKAGES.rds
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: cloud.R-project.org]
* [HTTP/2] [1] [:path: /bin/macosx/big-sur-arm64/contrib/4.3/PACKAGES.rds]
* [HTTP/2] [1] [user-agent: RStudio Server (2024.3.999.999); R (4.3.2 aarch64-apple-darwin20 aarch64 darwin20)]
* [HTTP/2] [1] [accept: */*]
* [HTTP/2] [1] [authorization: Bearer test123]
* [HTTP/2] [1] [pragma: no-cache]
> GET /bin/macosx/big-sur-arm64/contrib/4.3/PACKAGES.rds HTTP/2
Host: cloud.R-project.org
User-Agent: RStudio Server (2024.3.999.999); R (4.3.2 aarch64-apple-darwin20 aarch64 darwin20)
Accept: */*
Authorization: Bearer test123
Pragma: no-cache

< HTTP/2 200 
< content-length: 642476
< date: Wed, 06 Mar 2024 18:15:37 GMT
< server: Apache/2.4.58 (Unix)
< last-modified: Wed, 06 Mar 2024 13:22:54 GMT
< etag: "9cdac-612fddb356780"
< accept-ranges: bytes
< cache-control: max-age=1800
< expires: Wed, 06 Mar 2024 18:45:37 GMT
< x-cache: Hit from cloudfront
< via: 1.1 da37f9d14579e71e6ccdf22a428360fe.cloudfront.net (CloudFront)
< x-amz-cf-pop: SEA900-P3
< x-amz-cf-id: VEoDSBdM1Hq4A3mVAx9YMr_GFALN4a8Nr-Y3sY8Ak1EsuIjzxeI_Rg==
< age: 1034
< 
* Connection #0 to host cloud.R-project.org left intact
trying URL 'https://cloud.R-project.org/bin/macosx/big-sur-arm64/contrib/4.3/R6_2.5.1.tgz'
* WARNING: failed to open cookie file ""
*   Trying 3.163.189.27:443...
* Connected to cloud.R-project.org (3.163.189.27) port 443
* ALPN: curl offers h2,http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=cran.rstudio.com
*  start date: May 17 00:00:00 2023 GMT
*  expire date: Jun 13 23:59:59 2024 GMT
*  subjectAltName: host "cloud.R-project.org" matched cert's "cloud.r-project.org"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://cloud.R-project.org/bin/macosx/big-sur-arm64/contrib/4.3/R6_2.5.1.tgz
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: cloud.R-project.org]
* [HTTP/2] [1] [:path: /bin/macosx/big-sur-arm64/contrib/4.3/R6_2.5.1.tgz]
* [HTTP/2] [1] [user-agent: RStudio Server (2024.3.999.999); R (4.3.2 aarch64-apple-darwin20 aarch64 darwin20)]
* [HTTP/2] [1] [accept: */*]
* [HTTP/2] [1] [authorization: Bearer test123]
> GET /bin/macosx/big-sur-arm64/contrib/4.3/R6_2.5.1.tgz HTTP/2
Host: cloud.R-project.org
User-Agent: RStudio Server (2024.3.999.999); R (4.3.2 aarch64-apple-darwin20 aarch64 darwin20)
Accept: */*
Authorization: Bearer test123

< HTTP/2 200 
< content-type: application/x-gzip
< content-length: 83054
< server: Apache/2.4.58 (Unix)
< last-modified: Tue, 11 Apr 2023 04:31:19 GMT
< accept-ranges: bytes
< date: Wed, 06 Mar 2024 18:32:52 GMT
< cache-control: max-age=1800
< expires: Wed, 06 Mar 2024 19:02:52 GMT
< etag: "1446e-5f907f67c93c0"
< vary: Accept-Encoding
< x-cache: RefreshHit from cloudfront
< via: 1.1 5ec0bf2e2989d32424ea5c25c712de64.cloudfront.net (CloudFront)
< x-amz-cf-pop: SEA900-P3
< x-amz-cf-id: ZZu2ypWdg-px0Qi80LeRqD3sUR9O_m1fMlRsl4fyykIH7lz9wF20bQ==
< 
Content type 'application/x-gzip' length 83054 bytes (81 KB)
==================================================
downloaded 81 KB

* Connection #0 to host cloud.R-project.org left intact

The downloaded binary packages are in
	/tmp/RtmpPNgQPH/downloaded_packages
```

and we can see that the Authorization header is passed along in each request.

This PR also renames an RPC `is_package_loaded` to `is_package_attached`, to better match its actual behavior.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14282.

Some additional things that are worth verifying:

- Check that packages can be attached and detached by clicking their respective checkboxes in the Packages pane. Note that attempting to detach a package which is required by another package may fail; this is expected.
- Check that attempting to install a package which is already loaded still prompts you to restart and install that package; e.g. `library(dplyr); install.packages("dplyr")`.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
