### PR TITLE
Fix snyk code scan scanning irrelevant files

### DIFF
--- a/jenkins/Jenkinsfile.pull-request
+++ b/jenkins/Jenkinsfile.pull-request
@@ -54,7 +54,7 @@ pipeline {
       }
       steps {
         sh "mkdir --parents ${TMP_SNYK_PATH}"
-        sh "for FILE in \$(git diff --name-only origin/${env.CHANGE_TARGET}); do if [ -f \$FILE ]; then cp --parents \$FILE ${TMP_SNYK_PATH}; fi; done"
+        sh "for FILE in \$(git diff --name-only origin/${env.CHANGE_TARGET}...HEAD); do if [ -f \$FILE ]; then cp --parents \$FILE ${TMP_SNYK_PATH}; fi; done"
         script {
           exitCode = sh(returnStatus: true, script: "snyk code test ${TMP_SNYK_PATH} > ${TMP_SNYK_PATH}/output.txt")
           sh "cat ${TMP_SNYK_PATH}/output.txt"


### PR DESCRIPTION
There's a bunch of Slack threads about this since we added code scanning. I think I've figured it out.

### Intent

There's a big in the snyk code scan where it'll diff against main indiscriminately, which means it picks up and scans files that it shouldn't if main has changed since opening the commit. It should actually be diffing against the commit ancestor of main and HEAD in order to avoid this.

### Approach

It looks like this triple dot syntax `{branch}...HEAD` is a shorthand for `git merge-base {branch} HEAD`. My testing indicates that this is the case. I've purposely branched off from an older commit to see if this will work.

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

