### PR TITLE
improve handling of Sexpr for sweave

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,7 @@
 - Fixed handling of duplicated calls in debugger when source references not available (#14276)
 - Fixed issue where stepping through lines of code in tryCatch() would provide incorrect debug highlight (#14306)
 - Fixed an issue where PATH modifications in .Renviron / .Rprofile could be lost on macOS (#9815)
+- Fixed an issue where code highlight in Sweave \Sexpr{} expressions was incorrectly handled (#14382)
 
 #### Posit Workbench
 

--- a/src/gwt/acesupport/acemode/sweave_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/sweave_highlight_rules.js
@@ -73,9 +73,12 @@ var SweaveHighlightRules = function() {
         merge : false,
         onMatch: function(value, state, stack, line, context) {
             context.sexpr.count -= 1;
-            this.next = (context.sexpr.count === 0)
-                ? context.sexpr.state
-                : state;
+            if (context.sexpr.count === 0) {
+                this.next = context.sexpr.state;
+                delete context.sexpr;
+            } else {
+                this.next = state;
+            }
             return this.token;
         }
     });

--- a/src/gwt/acesupport/acemode/sweave_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/sweave_highlight_rules.js
@@ -41,10 +41,10 @@ var SweaveHighlightRules = function() {
     this.$rules["start"].unshift({
         regex: "(\\\\Sexpr)([{])",
         next: "r-start",
-        onMatch: function(value, state, stack, line) {
-            stack.length = 2;
-            stack[0] = state;
-            stack[1] = 1;
+        onMatch: function(value, state, stack, line, context) {
+            context.sexpr = context.sexpr || {};
+            context.sexpr.state = state;
+            context.sexpr.count = 1;
             return [
                 { type: "keyword", value: "\\Sexpr" },
                 { type: "paren.keyword.operator", value: "{" }
@@ -61,9 +61,8 @@ var SweaveHighlightRules = function() {
         token : "paren.keyword.operator",
         regex : "[{]",
         merge : false,
-        onMatch: function(value, state, stack, line) {
-            if (stack.length)
-                stack[1] += 1;
+        onMatch: function(value, state, stack, line, context) {
+            context.sexpr.count += 1;
             return this.token;
         }
     });
@@ -72,15 +71,11 @@ var SweaveHighlightRules = function() {
         token : "paren.keyword.operator",
         regex : "[}]",
         merge : false,
-        onMatch: function(value, state, stack, line) {
-            this.next = "r-start";
-            if (stack.length) {
-                stack[1] -= 1;
-                if (stack[1] == 0) {
-                    this.next = stack[0];
-                    stack.splice(0);
-                }
-            }
+        onMatch: function(value, state, stack, line, context) {
+            context.sexpr.count -= 1;
+            this.next = (context.sexpr.count === 0)
+                ? context.sexpr.state
+                : state;
             return this.token;
         }
     });


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14382.

### Approach

Update the Sweave highlight rules, to use the new (and more robust) `context` object for storing tokenizer state.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14382.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
