### PR TITLE
update electron 28.2.2 to 28.2.6

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -80,7 +80,7 @@
 
 ### Dependencies
 - Updated Ace to version 1.32.5 (#14227; Desktop + Server)
-- Updated Electron to version 28.2.2 (#14055; Desktop)
+- Updated Electron to version 28.2.6 (#14055; Desktop)
 - Updated GWT to version 2.10.0 (#11505; Desktop + Server)
 - Updated NSIS to version 3.09 (#14123; Windows Desktop)
 - Updated OpenSSL to version 3.1.4 (Windows Desktop)

--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -48,7 +48,7 @@
         "chai": "4.3.10",
         "copy-webpack-plugin": "11.0.0",
         "css-loader": "6.8.1",
-        "electron": "28.2.2",
+        "electron": "28.2.6",
         "electron-mocha": "12.2.0",
         "eslint": "8.55.0",
         "eslint-config-prettier": "9.1.0",
@@ -5297,9 +5297,9 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "28.2.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-28.2.2.tgz",
-      "integrity": "sha512-8UcvIGFcjplHdjPFNAHVFg5bS0atDyT3Zx21WwuE4iLfxcAMsyMEOgrQX3im5LibA8srwsUZs7Cx0JAUfcQRpw==",
+      "version": "28.2.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-28.2.6.tgz",
+      "integrity": "sha512-RuhbW+ifvh3DqnVlHCcCKhKIFOxTktq1GN1gkIkEZ8y5LEZfcjOkxB2s6Fd1S6MzsMZbiJti+ZJG5hXS4SDVLQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -18694,9 +18694,9 @@
       "dev": true
     },
     "electron": {
-      "version": "28.2.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-28.2.2.tgz",
-      "integrity": "sha512-8UcvIGFcjplHdjPFNAHVFg5bS0atDyT3Zx21WwuE4iLfxcAMsyMEOgrQX3im5LibA8srwsUZs7Cx0JAUfcQRpw==",
+      "version": "28.2.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-28.2.6.tgz",
+      "integrity": "sha512-RuhbW+ifvh3DqnVlHCcCKhKIFOxTktq1GN1gkIkEZ8y5LEZfcjOkxB2s6Fd1S6MzsMZbiJti+ZJG5hXS4SDVLQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -44,7 +44,7 @@
     "chai": "4.3.10",
     "copy-webpack-plugin": "11.0.0",
     "css-loader": "6.8.1",
-    "electron": "28.2.2",
+    "electron": "28.2.6",
     "electron-mocha": "12.2.0",
     "eslint": "8.55.0",
     "eslint-config-prettier": "9.1.0",


### PR DESCRIPTION
### Intent

Pick up the latest fixes for Electron 28. This will be the last Electron update we do for Chocolate Cosmos unless something really nasty gets found and fixed in Electron that we absolutely need to take.

https://releases.electronjs.org/release/compare/v28.2.2/v28.2.6

### Approach

Bump version, install, build, run tests, play with program.

### Automated Tests

Nothing specific to Electron version.

### QA Notes

Chromium version is `120.0.6099.291`.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


