### PR TITLE
provide a fixed id for the project display-name textbox

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -740,4 +740,7 @@ public class ElementIds
    public final static String COPILOT_DIAGNOSTICS_CLOSE_BUTTON = "copilot_diagnostics_close_button";
    public final static String COPILOT_DIAGNOSTICS_COPY_BUTTON = "copilot_diagnostics_copy_button";
    
+   // ProjectGeneralPreferencesPane
+   public final static String PROJ_DISPLAY_NAME= "proj_display_name";
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectGeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectGeneralPreferencesPane.java
@@ -27,6 +27,7 @@ import org.rstudio.studio.client.projects.model.RProjectRVersion;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.SessionInfo;
 import org.rstudio.core.client.dom.DomUtils;
+import org.rstudio.core.client.ElementIds;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.resources.client.ImageResource;
@@ -47,6 +48,7 @@ public class ProjectGeneralPreferencesPane extends ProjectPreferencesPane
       
       String textboxWidth = "100%";
       projectName_ = new TextBox();
+      ElementIds.assignElementId(projectName_.getElement(), ElementIds.PROJ_DISPLAY_NAME);
       DomUtils.disableSpellcheck(projectName_);
       DomUtils.setPlaceholder(projectName_, sessionInfo_.getActiveProjectDir().getName());
       projectName_.setWidth(textboxWidth);


### PR DESCRIPTION
### Intent

Addresses #14390 

### Approach

Set textbox's ID to `rstudio_proj_display_name`. I confirmed that the label references the new id correctly via `for`.

<img width="623" alt="proj-name-id" src="https://github.com/rstudio/rstudio/assets/10569626/fcf49a47-4e84-45db-8230-9f8007cb6d0e">


### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


