### PR TITLE
Exclude aes names containing `|` from completion

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -3106,6 +3106,7 @@ assign(x = ".rs.acCompletionTypes",
          )
          
          aestheticNames <- aesthetics[!duplicated(aesthetics)]
+         aestheticNames <- aestheticNames[!grepl("|", aestheticNames, fixed = TRUE)]
          aestheticSource <- geomName
       }
       


### PR DESCRIPTION
### Intent

Follow-up to #14199 
Avoid showing 'fake' aesthetics. ggplot2 uses this internally to specify that the geom only accepts one or the other.

![image](https://github.com/rstudio/rstudio/assets/52606734/c5b399e5-c655-41f8-bfdf-de1a4ad7a569)


### Approach

Remove aesthetics containing `|` from completions.

I have sourced the file in my R session, and with this patch, I don't see the x|y completion.

### Automated Tests

N/A

### QA Notes

Should not show aesthetics with  `|` 

### Documentation

NA 
### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

I have signed the agreement.

