### PR TITLE
Quarto: expand inputFile template when used / assigned

### DIFF
--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -772,28 +772,33 @@ void addViewerHistoryEntry(const ViewerHistoryEntry& entry);
 
 struct QuartoNavigate
 {
-   QuartoNavigate() : website(false) {}
-   bool empty() const { return !website && source.empty(); }
-   static QuartoNavigate navWebsite(const std::string& jobId)
+   QuartoNavigate()
+      : website(false)
+   {}
+   
+   bool empty() const
    {
-      QuartoNavigate nav;
-      nav.website = true;
-      nav.job_id = jobId;
-      return nav;
+      return !website && source.empty();
    }
-   static QuartoNavigate navDoc(const std::string& source, const std::string& output, const std::string& jobId)
+   
+   static QuartoNavigate navigate(
+         const std::string& source,
+         const std::string& output,
+         const std::string& jobId,
+         bool isWebsite)
    {
       QuartoNavigate nav;
-      nav.website = false;
       nav.source = source;
       nav.output = output;
       nav.job_id = jobId;
+      nav.website = isWebsite;
       return nav;
    }
-   bool website;
+   
    std::string source;
    std::string output;
    std::string job_id;
+   bool website;
 };
 
 core::json::Value quartoNavigateAsJson(const QuartoNavigate& quartoNav);

--- a/src/cpp/session/modules/quarto/SessionQuartoPreview.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoPreview.cpp
@@ -360,15 +360,24 @@ private:
          std::string outputFile;
          if (!outputFile_.isEmpty())
             outputFile = module_context::createAliasedPath(outputFile_);
+         
          QuartoNavigate quartoNav;
+         std::string sourceFile = module_context::createAliasedPath(previewTarget_);
          if ((previewTarget()) == projDir || isFileInSessionQuartoProject((previewTarget())))
          {
-            quartoNav = module_context::QuartoNavigate::navWebsite(pJob_->id());
+            quartoNav = QuartoNavigate::navigate(
+                     sourceFile,
+                     "",
+                     pJob_->id(),
+                     true);
          }
-         else if (!this->previewTarget_.isDirectory())
+         else if (!previewTarget_.isDirectory())
          {
-           std::string sourceFile = module_context::createAliasedPath(previewTarget_);
-           quartoNav = QuartoNavigate::navDoc(sourceFile, outputFile, jobId());
+           quartoNav = QuartoNavigate::navigate(
+                    sourceFile,
+                    outputFile,
+                    jobId(),
+                    false);
          }
 
          // route to either viewer or presentation pane (for reveal)
@@ -394,9 +403,9 @@ private:
                 (outputFile_.getExtensionLowerCase() == ".docx" ||
                  outputFile_.getExtensionLowerCase() == ".epub"))
             {
-               std::string sourceFile = module_context::createAliasedPath(previewDir()
-                   .completeChildPath("index.qmd"));
-               quartoNav = QuartoNavigate::navDoc(sourceFile, outputFile, jobId());
+               FilePath indexPath = previewDir().completeChildPath("index.qmd");
+               std::string sourceFile = module_context::createAliasedPath(indexPath);
+               quartoNav = QuartoNavigate::navigate(sourceFile, outputFile, jobId(), false);
             }
 
             module_context::viewer(url,  minHeight, quartoNav);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
@@ -317,20 +317,7 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
    @Override
    public void editSource()
    {
-      String file = quartoConnection_.getRawSrcFile();
-      if (file == null)
-         return;
-      
-      // https://github.com/rstudio/rstudio/issues/14325
-      if (file == "<%- inputFile %>")
-      {
-         if (quartoNav_ != null)
-         {
-            file = quartoNav_.getSourceFile();
-         }
-      }
-      
-      FileSystemItem srcFile = FileSystemItem.createFile(file);
+      FileSystemItem srcFile = quartoConnection_.getSrcFile();
       fileTypeRegistry_.editFile(srcFile, FilePosition.create(-1, -1));
       
       Timers.singleShot(200, () ->
@@ -452,6 +439,11 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
       
       // save quarto navigation
       quartoNav_ = quartoNav;
+      
+      if (quartoConnection_ != null)
+      {
+         quartoConnection_.setQuartoNav(quartoNav);
+      }
 
       // in desktop mode we need to be careful about loading URLs which are
       // non-local; before changing the URL, set the iframe to be sandboxed


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14277.

### Approach

- Make sure `sourceFile` is propagated for website projects as well.
- Use this to expand the template item in `srcFile_` where appropriate.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14277.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


