### PR TITLE
copilot: use ctrl + right to insert next word

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,9 @@
 - RStudio Desktop on Windows and Linux supports full-screen mode via F11 (#3243)
 - RStudio Desktop now supports pasting of file paths for files copied to the clipboard (#14240)
 - R projects can be given a custom display name in Project Options (#1909)
-- The automatic display of Copilot code completions can now be controlled via a user preference. (#14033)
-- Copilot code suggestions can now be requested via the keyboard shortcut `Ctrl + \`.
+- The automatic display of Copilot code completions can now be controlled via a user preference (#14033)
+- Copilot code suggestions can now be requested via the keyboard shortcut `Ctrl + \`
+- The next word in a Copilot code suggestion can now be accepted via `Ctrl + Right` (`Cmd + Right` on macOS) (#14395)
 - RStudio now highlights and lints Quarto chunk options in Python code chunks
 - RStudio no longer highlights `\[ \]` and `\( \)` Mathjax equations; prefer `$$ $$` and `$ $` instead (#12862)
 - Added cmake option to build RStudio without the check for updates feature (#13236)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1195,6 +1195,23 @@ public class AceEditor implements DocDisplay,
       insertCode(code);
    }
    
+   public void insertCode(String code, InsertionBehavior behavior)
+   {
+      if (behavior == InsertionBehavior.EditorBehaviorsEnabled)
+      {
+         insertCode(code);
+      }
+      else
+      {
+         // RStudio attaches a lot of custom behaviors to the 'insert' functions
+         // for AceEditor.insert and EditSession.insert, so side-step that by
+         // using the methods defined on the underyling document
+         widget_.getEditor().getSession().getDocument().insert(
+               widget_.getEditor().getCursorPosition(),
+               StringUtil.normalizeNewLines(code));
+      }
+   }
+   
    public void insertCode(String code)
    {
       String normalizedCode = StringUtil.normalizeNewLines(code);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -107,6 +107,13 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
       void apply();
       void detach();
    }
+   
+   public enum InsertionBehavior
+   {
+      EditorBehaviorsEnabled,
+      EditorBehaviorsDisabled,
+   }
+   
    TextFileType getFileType();
    void setFileType(TextFileType fileType);
    void setFileType(TextFileType fileType, boolean suppressCompletion);
@@ -124,6 +131,7 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    void setCode(String code, boolean preserveCursorPosition);
    void insertCode(String code);
    void insertCode(String code, boolean unused);
+   void insertCode(String code, InsertionBehavior behavior);
    void insertCode(InputEditorPosition position, String code);
    void applyChanges(TextChange[] changes);
    void applyChanges(TextChange[] changes, boolean preserveCursorPosition);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Document.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Document.java
@@ -25,6 +25,10 @@ public class Document extends JavaScriptObject
    public native final void setValue(String value) /*-{
       this.setValue(value);
    }-*/;
+   
+   public native final void insert(Position position, String text) /*-{
+      this.insert(position, text);
+   }-*/;
 
    public native final String getLine(int row) /*-{
       return this.getLine(row);


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14395.

### Approach

Hook up a (non-configurable) keybinding for accepting the next selection when a Copilot suggestion is available. Also some tweaks overall to how the command is executed.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14395.

### Documentation

Perhaps worth documenting / adding in the Copilot getting started guide?

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x]  If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
