### PR TITLE
avoid loading namespace when computing dependencies

### DIFF
--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -815,7 +815,7 @@ void handleConnection(boost::shared_ptr<HttpConnection> ptrConnection,
          }
 
          // interrupt
-         else if ( jsonRpcRequest.method == kInterrupt )
+         else if (jsonRpcRequest.method == kInterrupt)
          {
             // Discard any buffered input
             console_input::clearConsoleInputBuffer();
@@ -826,6 +826,12 @@ void handleConnection(boost::shared_ptr<HttpConnection> ptrConnection,
             // only accept interrupts while R is processing input
             if (console_input::executing())
                rstudio::r::exec::setInterruptsPending(true);
+         }
+         
+         // ping
+         else if (jsonRpcRequest.method == kPing)
+         {
+            ptrConnection->sendJsonRpcResponse();
          }
 
          // other rpc method, handle it

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -385,12 +385,6 @@ Error suspendForRestart(const core::json::JsonRpcRequest& request,
 }
 
 
-Error ping(const core::json::JsonRpcRequest& request,
-           json::JsonRpcResponse* pResponse)
-{
-   return Success();
-}
-
 Error startClientEventService()
 {
    return clientEventService().start(rsession::persistentState().activeClientId());
@@ -525,7 +519,6 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       // json-rpc listeners
       (bind(registerRpcMethod, kConsoleInput, bufferConsoleInput))
       (bind(registerRpcMethod, "suspend_for_restart", suspendForRestart))
-      (bind(registerRpcMethod, "ping", ping))
 
       // signal handlers
       (registerSignalHandlers)

--- a/src/cpp/session/include/session/SessionConstants.hpp
+++ b/src/cpp/session/include/session/SessionConstants.hpp
@@ -176,6 +176,7 @@ const char * const kSuspendSession = "suspend_session";
 const char * const kInterrupt = "interrupt";
 const char * const kConsoleInput = "console_input";
 const char * const kRStudioAPIShowDialogMethod = "rstudio_api_show_dialog";
+const char * const kPing = "ping";
 
 // session exit codes - note max value supported by Linux is 255
 #define SESSION_EXIT_CODE_OFFSET              200

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -774,13 +774,27 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    .rs.scalar(candidates[[1]])
 })
 
+.rs.addFunction("readPackageImports", function(pkg)
+{
+   pkgPath <- find.package(pkg, quiet = TRUE)
+   if (length(pkgPath) == 0L)
+      return(character())
+   
+   metaPath <- file.path(pkgPath, "Meta/package.rds")
+   if (!file.exists(metaPath))
+      return(character())
+   
+   metaInfo <- readRDS(metaPath)
+   importInfo <- metaInfo$Imports
+   sort(unique(names(importInfo)))
+})
+
 .rs.addFunction("recursivePackageDependenciesImpl", function(pkg, envir)
 {
    if (exists(pkg, envir = envir))
       return()
    
-   imports <- getNamespaceInfo(pkg, "imports")
-   deps <- setdiff(sort(unique(unlist(names(imports)))), "base")
+   deps <- setdiff(.rs.readPackageImports(pkg), "base")
    assign(pkg, deps, envir = envir)
    
    for (dep in deps)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14404.

### Approach

My previous PR inappropriately made use of `getNamespaceInfo()`, which requires the associated package to be loaded (and loads the package if not -- quite undesirably in the case of `install.packages()`!)

The fix here uses the package's installed metadata to learn about the package's dependencies instead.

### Automated Tests

Captured by existing automation tests.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14404.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
