### PR TITLE
stop showing hidden command in terminal history when using zsh

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -76,6 +76,7 @@
 - Fixed an issue where custom headers were not propagated to `available.packages()` when calling `install.packages()` (#14282)
 - Fixed an issue where code highlight in Sweave \Sexpr{} expressions was incorrectly handled (#14382)
 - Fixed an issue where the Edit button in the Viewer pane could fail for Quarto documents (#14325)
+- Fixed an issue where terminal history would show internal commands (#9833)
 
 #### Posit Workbench
 - Fixed an issue where Professional Driver installation could fail on macOS (rstudio-pro#5168)

--- a/src/cpp/core/terminal/PrivateCommand.cpp
+++ b/src/cpp/core/terminal/PrivateCommand.cpp
@@ -168,6 +168,24 @@ bool PrivateCommand::onTryCapture(core::system::ProcessOperations& ops, bool has
          lastPrivateCommand_ = boost::posix_time::pos_infin; // disable private commands
          return false;
       }
+      
+      // For zsh, we also have to deal with (from the man page for HIST_IGNORE_SPACE):
+      //
+      // > Note that the command lingers in the internal history until the next command is
+      // > entered before it vanishes, allowing you to briefly reuse or edit the line. If you
+      // > want to make it vanish right away without entering another command, type a space and
+      // > press return.
+      // 
+      // Handle this as suggested by executing a second hidden command consisting only of a space
+      // right after the first hidden command. It's fine to do this in all cases, not just zsh.
+      error = ops.writeToStdin(" \n", false);
+      if (error)
+      {
+         LOG_ERROR(error);
+         privateCommandLoop_ = false;
+         lastPrivateCommand_ = boost::posix_time::pos_infin; // disable private commands
+         return false;
+      }
       return true;
    }
    return false;

--- a/src/cpp/core/terminal/PrivateCommandTests.cpp
+++ b/src/cpp/core/terminal/PrivateCommandTests.cpp
@@ -225,7 +225,7 @@ test_context("Private Terminal Command Tests")
 
       expect_true(cmd.onTryCapture(ops, kNoChildProcess));
       expect_true(cmd.hasCaptured());
-      expect_true(ops.writes.size() == 1);
+      expect_true(ops.writes.size() == 2);
       expect_true(ops.writesEof.size() == ops.writes.size());
       std::string sentCommand = ops.writes[0];
       expect_true(*sentCommand.rbegin() == '\r' || *sentCommand.rbegin() == '\n');
@@ -239,7 +239,7 @@ test_context("Private Terminal Command Tests")
       boost::this_thread::sleep(milliseconds(kUser * 2));
 
       expect_true(cmd.onTryCapture(ops, kNoChildProcess));
-      expect_true(ops.writes.size() == 1);
+      expect_true(ops.writes.size() == 2);
       expect_true(ops.writesEof.size() == ops.writes.size());
       std::string sentCommand = ops.writes[0];
       expect_true(*sentCommand.rbegin() == '\r' || *sentCommand.rbegin() == '\n');
@@ -250,7 +250,7 @@ test_context("Private Terminal Command Tests")
       PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kNotOncePerUserEnter);
 
       expect_true(cmd.onTryCapture(ops, kNoChildProcess));
-      expect_true(ops.writes.size() == 1);
+      expect_true(ops.writes.size() == 2);
       expect_true(ops.writesEof.size() == ops.writes.size());
    }
 


### PR DESCRIPTION
### Intent

Addresses #9833

### Approach

#### Short answer

Read the zsh manual page for `HIST_IGNORE_SPACE`. Do what it says.

#### Long answer

When the terminal is idle, a "hidden" command is executed to capture and save the shell's environment so it can be restored if the session is suspended and later resumed. Terminal shells run as children of the session, so they go away when the session is suspended.

This hidden command isn't intended to show up in the terminal's command history (e.g. when you hit the up-arrow), and we do this for `zsh` by passing the `-g` flag (to enable HIST_IGNORE_SPACE). This causes commands with a leading space to be omitted from command history.

However from the man page, which apparently I didn't read closely:

> HIST_IGNORE_SPACE (-g)
> Remove command lines from the history list when the first character on the line is a space, or when one of the
expanded aliases contains a leading space. Only normal aliases (not global or suffix aliases) have this
behaviour. **Note that the command lingers in the internal history until the next command is entered before it
vanishes, allowing you to briefly reuse or edit the line. If you want to make it vanish right away without
entering another command, type a space and press return.**

So if you run a command in the terminal, then do nothing for at least 2 seconds to allow the hidden command to run and capture the environment, then hit the up-arrow, you'd see the hidden command, something like `echo B7DD2637 && echo $HISTCONTROL && /usr/bin/env && echo 4786854E`.

The fix is to do the equivalent of "type a space and press return" right after running that hidden command.

### Automated Tests

Ensure unit tests still pass.

### QA Notes

- This is a Linux (server or desktop) and Mac (desktop)-only issue; the environment isn't saved and restored on Windows Desktop
- The setting in Global Options / Terminal / Closing: "Save and restore environment variables" must be enabled (it is by default)
- Try using both `zsh` and `bash`; confirm you don't see the hidden command in command-history, especially if you enter a command, then wait > 2 seconds and hit the up-arrow to see history
- If you want to double-check the environment save/restore, try doing `export ZZZ=ZZZ` in the terminal, then wait for the session to suspend, then resume the session and see if the variable is still set in the terminal (e.g. echo $ZZZ)

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


