### PR TITLE
allow for custom certificates file for use with copilot

### DIFF
--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -224,7 +224,7 @@ protected:
       "Duration in millis before requests are converted to async - i.e. how fast will the server free up connections when it's busy")
       (kSessionHandleOfflineEnabled,
       value<bool>(&handleOfflineEnabled_)->default_value(true),
-      "Enables offline request handling. When the R session is busy, some requests are allowed to run")
+      "Enables offline request handling. When the R process is busy, some requests are allowed to run")
       (kSessionHandleOfflineTimeoutMs,
       value<int>(&handleOfflineTimeoutMs_)->default_value(200),
       "Duration in millis before requests that can be handled offline are processed by the offline handler thread.")
@@ -422,6 +422,9 @@ protected:
       ("copilot-auth-provider",
       value<std::string>(&copilotAuthProvider_)->default_value(""),
       "The URL to the authentication provider to be used by GitHub Copilot.")
+      ("copilot-ssl-certificates-file",
+      value<std::string>(&copilotSslCertificatesFile_)->default_value(""),
+      "The path to a file containing one or more trusted certificates in PEM format.")
       ("copilot-proxy-strict-ssl",
       value<bool>(&copilotProxyStrictSsl_)->default_value(true),
       "Should the GitHub Copilot agent perform SSL certificate validation when forming web requests?")
@@ -545,6 +548,7 @@ public:
    bool copilotEnabled() const { return copilotEnabled_; }
    std::string copilotProxyUrl() const { return copilotProxyUrl_; }
    std::string copilotAuthProvider() const { return copilotAuthProvider_; }
+   std::string copilotSslCertificatesFile() const { return copilotSslCertificatesFile_; }
    bool copilotProxyStrictSsl() const { return copilotProxyStrictSsl_; }
    core::FilePath copilotAgentHelper() const { return core::FilePath(copilotAgentHelper_); }
 
@@ -659,6 +663,7 @@ protected:
    bool copilotEnabled_;
    std::string copilotProxyUrl_;
    std::string copilotAuthProvider_;
+   std::string copilotSslCertificatesFile_;
    bool copilotProxyStrictSsl_;
    std::string copilotAgentHelper_;
    virtual bool allowOverlay() const { return false; };

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -865,6 +865,11 @@ Error startAgent()
    // Create environment for agent process
    core::system::Options environment;
    core::system::environment(&environment);
+   
+   // Set NODE_EXTRA_CA_CERTS if a custom certificates file is provided.
+   std::string certificatesFile = session::options().copilotSslCertificatesFile();
+   if (!certificatesFile.empty())
+      environment.push_back(std::make_pair("NODE_EXTRA_CA_CERTS", certificatesFile));
 
    // For Desktop builds of RStudio, use the version of node embedded in Electron.
    FilePath nodePath;

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -855,6 +855,13 @@
             "description": "The URL to the authentication provider to be used by GitHub Copilot."
          },
          {
+            "name": "copilot-ssl-certificates-file",
+            "type": "string",
+            "memberName": "copilotSslCertificatesFile_",
+            "defaultValue": "",
+            "description": "The path to a file containing one or more trusted certificates in PEM format."
+         },
+         {
             "name": "copilot-proxy-strict-ssl",
             "type": "bool",
             "memberName": "copilotProxyStrictSsl_",


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13718.

### Approach

Add a session option allowing for the use of a custom certificates file with Copilot, via the `NODE_EXTRA_CA_CERTS` environment variable. Note that this is documented here: https://nodejs.org/api/cli.html#node_extra_ca_certsfile

### Automated Tests

N/A

### QA Notes

Not sure -- do we have an environment with custom certificates wherein we could test this?

### Documentation

Documentation to be added separately.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
