### PR TITLE
invoke restart command before restoring search path

### DIFF
--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -245,12 +245,15 @@ struct RSuspendOptions
         ephemeralEnvVars(ephemeral)
    {
    }
+   
    int status;
-   bool saveMinimal { false };
-   bool saveWorkspace { false };
-   bool excludePackages { false };
+   bool saveMinimal = false;
+   bool saveWorkspace = false;
+   bool excludePackages = false;
    std::string ephemeralEnvVars;
+   std::string afterRestartCommand;
 };
+
 void suspendForRestart(const RSuspendOptions& options);
    
 // set save action

--- a/src/cpp/r/include/r/session/RSessionState.hpp
+++ b/src/cpp/r/include/r/session/RSessionState.hpp
@@ -40,6 +40,13 @@ struct SessionStateInfo
    core::Version activeRVersion;
 };
 
+struct SessionStateCallbacks
+{
+   boost::function<void(const std::string&)> consoleWriteInput;
+};
+
+void initialize(SessionStateCallbacks callbacks);
+
 bool save(const core::FilePath& statePath,
           const std::string& afterRestartCommand,
           bool serverMode,

--- a/src/cpp/r/include/r/session/RSessionState.hpp
+++ b/src/cpp/r/include/r/session/RSessionState.hpp
@@ -41,6 +41,7 @@ struct SessionStateInfo
 };
 
 bool save(const core::FilePath& statePath,
+          const std::string& afterRestartCommand,
           bool serverMode,
           bool excludePackages,
           bool disableSaveCompression,
@@ -48,6 +49,7 @@ bool save(const core::FilePath& statePath,
           const std::string& ephemeralEnvVars);
 
 bool saveMinimal(const core::FilePath& statePath,
+                 const std::string& afterRestartCommand,
                  bool saveGlobalEnvironment);
    
 

--- a/src/cpp/r/session/RInit.cpp
+++ b/src/cpp/r/session/RInit.cpp
@@ -85,7 +85,7 @@ void completeDeferredSessionInit(bool newSession)
 {
    // suppress output which occurs during restore (packages can sometimes
    // print messages to the console indicating they have conflicts -- the
-   // has already seen these messages and doesn't expect them now so 
+   // user has already seen these messages and doesn't expect them now so
    // we suppress them
    utils::SuppressOutputInScope suppressOutput;
    

--- a/src/cpp/r/session/RInit.cpp
+++ b/src/cpp/r/session/RInit.cpp
@@ -83,6 +83,12 @@ Error restoreGlobalEnvFromFile(const std::string& path, std::string* pErrMessage
 
 void completeDeferredSessionInit(bool newSession)
 {
+   // suppress output which occurs during restore (packages can sometimes
+   // print messages to the console indicating they have conflicts -- the
+   // has already seen these messages and doesn't expect them now so 
+   // we suppress them
+   utils::SuppressOutputInScope suppressOutput;
+   
    // always cleanup any restart context here
    restartContext().removeSessionState();
 
@@ -101,12 +107,6 @@ void deferredRestoreSuspendedSession(
    // suppress interrupts which occur during restore
    r::exec::IgnoreInterruptsScope ignoreInterrupts;
  
-   // suppress output which occurs during restore (packages can sometimes
-   // print messages to the console indicating they have conflicts -- the
-   // has already seen these messages and doesn't expect them now so 
-   // we suppress them
-   utils::SuppressOutputInScope suppressOutput;
-   
    // restore action
    Error error = deferredRestoreAction();
    if (error)

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -239,7 +239,8 @@ Error executeAfterRestartCommand(const FilePath& afterRestartFile)
    if (command.empty())
       return Success();
    
-   s_callbacks.consoleWriteInput(command);
+   
+   s_callbacks.consoleWriteInput(core::string_utils::trimWhitespace(command));
    return r::exec::executeString(command);
 }
    

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -77,6 +77,9 @@ std::string s_activeRVersion;
 std::string s_suspendedRVersion;
 bool s_isCompatibleSessionState = true;
 
+// session callbacks
+SessionStateCallbacks s_callbacks;
+
 Error saveLibPaths(const FilePath& libPathsFile)
 {
    std::string file = string_utils::utf8ToSystem(libPathsFile.getAbsolutePath());
@@ -236,7 +239,7 @@ Error executeAfterRestartCommand(const FilePath& afterRestartFile)
    if (command.empty())
       return Success();
    
-   Rprintf("> %s\n", command.c_str());
+   s_callbacks.consoleWriteInput(command);
    return r::exec::executeString(command);
 }
    
@@ -385,7 +388,10 @@ Error saveAfterRestartCommand(const FilePath& afterRestartCommandPath,
 
 } // anonymous namespace
  
-   
+void initialize(SessionStateCallbacks callbacks)
+{
+   s_callbacks = callbacks;
+}
 
 bool save(const FilePath& statePath,
           const std::string& afterRestartCommand,

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -23,6 +23,9 @@
 #include <boost/regex.hpp>
 #include <boost/bind/bind.hpp>
 
+#include <core/FileSerializer.hpp>
+#include <core/RegexUtils.hpp>
+
 #include <r/RExec.hpp>
 #include <r/ROptions.hpp>
 #include <r/RSourceManager.hpp>
@@ -34,9 +37,6 @@
 #include <r/session/RSession.hpp>
 #include <r/session/RSessionState.hpp>
 #include <r/session/RSuspend.hpp>
-
-#include <core/FileSerializer.hpp>
-#include <core/RegexUtils.hpp>
 
 #include "RInit.hpp"
 #include "REmbedded.hpp"
@@ -79,7 +79,7 @@ RCallbacks s_callbacks;
 InternalCallbacks s_internalCallbacks;
 
 // temporarily suppress output
-bool s_suppressOutput = false;
+int s_suppressOutput = 0;
 
 class JumpToTopException
 {
@@ -435,7 +435,7 @@ void RShowMessage(const char* msg)
    CATCH_UNEXPECTED_EXCEPTION
 }
 
-void RWriteConsoleEx (const char *buf, int buflen, int otype)
+void RWriteConsoleEx(const char *buf, int buflen, int otype)
 {
    try
    {
@@ -788,12 +788,12 @@ namespace utils {
 
 SuppressOutputInScope::SuppressOutputInScope()
 {
-  s_suppressOutput = true;
+   s_suppressOutput += 1;
 }
 
 SuppressOutputInScope::~SuppressOutputInScope()
 {
-   s_suppressOutput = false;
+   s_suppressOutput -= 1;
 }
 
 } // namespace utils

--- a/src/cpp/r/session/RSuspend.cpp
+++ b/src/cpp/r/session/RSuspend.cpp
@@ -17,6 +17,7 @@
 
 #include <shared_core/FilePath.hpp>
 
+#include <core/FileSerializer.hpp>
 #include <core/system/Environment.hpp>
 
 #include <r/RExec.hpp>
@@ -70,8 +71,10 @@ bool saveSessionState(const RSuspendOptions& options,
                options.saveWorkspace);
       
       // save minimal
-      return r::session::state::saveMinimal(suspendedSessionPath,
-                                            saveWorkspace);
+      return r::session::state::saveMinimal(
+               suspendedSessionPath,
+               options.afterRestartCommand,
+               saveWorkspace);
 
    }
    else
@@ -83,12 +86,14 @@ bool saveSessionState(const RSuspendOptions& options,
                saveWorkspaceOverride,
                true);
       
-      return r::session::state::save(suspendedSessionPath,
-                                     utils::isServerMode(),
-                                     options.excludePackages,
-                                     disableSaveCompression,
-                                     saveWorkspace,
-                                     options.ephemeralEnvVars);
+      return r::session::state::save(
+               suspendedSessionPath,
+               options.afterRestartCommand,
+               utils::isServerMode(),
+               options.excludePackages,
+               disableSaveCompression,
+               saveWorkspace,
+               options.ephemeralEnvVars);
    }
 }
    
@@ -145,7 +150,7 @@ bool suspend(const RSuspendOptions& options,
    }
    
    // only continue with exiting the process if we actually succeed in saving
-   if(suspend)
+   if (suspend)
    {      
       // set suspended flag so cleanup code can act accordingly
       s_suspended = true;

--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -51,8 +51,10 @@ ConsoleInputQueue s_consoleInputBuffer;
 
 // manage global state indicating whether R is processing input
 volatile sig_atomic_t s_rProcessingInput = 0;
+
 // the saved version of s_rProcessInput - the 'executing' property in the session metadata
 volatile sig_atomic_t s_sessionExecuting = 0;
+
 // Controls access to s_sessionExecuting and the file system
 boost::mutex s_sessionExecutingMutex;
 

--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -115,6 +115,27 @@ void enqueueConsoleInput(const rstudio::r::session::RConsoleInput& input)
    clientEventQueue().add(inputEvent);
 }
 
+bool canSuspend(const std::string& prompt)
+{
+   bool suspendIsBlocked = false;
+   
+   suspendIsBlocked |= session::suspend::checkBlockingOp(main_process::haveDurableChildren(), suspend::kChildProcess);
+   suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::jobs::isSuspendable(), suspend::kActiveJob);
+   suspendIsBlocked |= session::suspend::checkBlockingOp(!rstudio::r::session::isSuspendable(prompt), suspend::kCommandPrompt);
+
+   if (session::options().sessionConnectionsBlockSuspend())
+      suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::connections::isSuspendable(), suspend::kConnection);
+   
+   if (session::options().sessionExternalPointersBlockSuspend())
+      suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::environment::isSuspendable(), suspend::kExternalPointer);
+   
+   suspendIsBlocked |= !modules::overlay::isSuspendable();
+   
+   return !suspendIsBlocked;
+}
+
+} // anonymous namespace
+
 void consolePrompt(const std::string& prompt, bool addToHistory)
 {
    // save the last prompt (for re-issuing)
@@ -139,26 +160,11 @@ void consolePrompt(const std::string& prompt, bool addToHistory)
    module_context::events().onConsolePrompt(prompt);
 }
 
-bool canSuspend(const std::string& prompt)
+void consoleInput(const std::string& input)
 {
-   bool suspendIsBlocked = false;
-   
-   suspendIsBlocked |= session::suspend::checkBlockingOp(main_process::haveDurableChildren(), suspend::kChildProcess);
-   suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::jobs::isSuspendable(), suspend::kActiveJob);
-   suspendIsBlocked |= session::suspend::checkBlockingOp(!rstudio::r::session::isSuspendable(prompt), suspend::kCommandPrompt);
-
-   if (session::options().sessionConnectionsBlockSuspend())
-      suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::connections::isSuspendable(), suspend::kConnection);
-   
-   if (session::options().sessionExternalPointersBlockSuspend())
-      suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::environment::isSuspendable(), suspend::kExternalPointer);
-   
-   suspendIsBlocked |= !modules::overlay::isSuspendable();
-   
-   return !suspendIsBlocked;
+   r::session::RConsoleInput consoleInput(input);
+   enqueueConsoleInput(consoleInput);
 }
-
-} // anonymous namespace
 
 // extract console input -- can be either null (user hit escape) or a string
 Error extractConsoleInput(const json::JsonRpcRequest& request)

--- a/src/cpp/session/SessionConsoleInput.hpp
+++ b/src/cpp/session/SessionConsoleInput.hpp
@@ -37,6 +37,9 @@ void reissueLastConsolePrompt();
 void addToConsoleInputBuffer(
       const rstudio::r::session::RConsoleInput& consoleInput);
 
+void consolePrompt(const std::string& prompt, bool addToHistory);
+void consoleInput(const std::string& input);
+
 bool rConsoleRead(const std::string& prompt,
                   bool addToHistory,
                   r::session::RConsoleInput* pConsoleInput);

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -385,7 +385,18 @@ Error suspendForRestart(const core::json::JsonRpcRequest& request,
    return Success();
 }
 
+Error initializeSessionState()
+{
+   using namespace rstudio::r::session;
+   
+   state::SessionStateCallbacks callbacks;
+   callbacks.consoleWriteInput = console_input::emitConsoleInput;
+   state::initialize(callbacks);
+   
+   return Success();
+}
 
+   
 Error startClientEventService()
 {
    return clientEventService().start(rsession::persistentState().activeClientId());
@@ -516,6 +527,9 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
 
       // client event service
       (startClientEventService)
+         
+      // session state
+      (initializeSessionState)
 
       // json-rpc listeners
       (bind(registerRpcMethod, kConsoleInput, bufferConsoleInput))

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -385,12 +385,20 @@ Error suspendForRestart(const core::json::JsonRpcRequest& request,
    return Success();
 }
 
+void consoleWriteInput(const std::string& input)
+{
+   using namespace console_input;
+   
+   std::string prompt = rstudio::r::options::getOption<std::string>("prompt");
+   consoleInput(prompt + input);
+}
+
 Error initializeSessionState()
 {
    using namespace rstudio::r::session;
    
    state::SessionStateCallbacks callbacks;
-   callbacks.consoleWriteInput = console_input::emitConsoleInput;
+   callbacks.consoleWriteInput = consoleWriteInput;
    state::initialize(callbacks);
    
    return Success();

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -373,10 +373,11 @@ Error suspendForRestart(const core::json::JsonRpcRequest& request,
 
    rstudio::r::session::RSuspendOptions options(exitStatus);
    Error error = json::readObjectParam(
-                               request.params, 0,
-                               "save_minimal", &(options.saveMinimal),
-                               "save_workspace", &(options.saveWorkspace),
-                               "exclude_packages", &(options.excludePackages));
+            request.params, 0,
+            "save_minimal", &(options.saveMinimal),
+            "save_workspace", &(options.saveWorkspace),
+            "exclude_packages", &(options.excludePackages),
+            "after_restart", &(options.afterRestartCommand));
    if (error)
       return error;
 

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
@@ -488,7 +488,7 @@ public class ApplicationQuit implements SaveActionChangedEvent.Handler,
                terminalHelper_.warnBusyTerminalBeforeCommand(() ->
                {
                   boolean saveChanges = saveAction_.getAction() != SaveAction.NOSAVE;
-                  SuspendOptions options = SuspendOptions.createSaveMinimal(saveChanges, null);
+                  SuspendOptions options = SuspendOptions.createSaveMinimal(saveChanges);
                   eventBus_.fireEvent(new SuspendAndRestartEvent(options));
                }, constants_.restartRCaption(), constants_.terminalJobTerminatedQuestion(),
                   pUserPrefs_.get().busyDetection().getValue());

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
@@ -488,9 +488,8 @@ public class ApplicationQuit implements SaveActionChangedEvent.Handler,
                terminalHelper_.warnBusyTerminalBeforeCommand(() ->
                {
                   boolean saveChanges = saveAction_.getAction() != SaveAction.NOSAVE;
-                  eventBus_.fireEvent(new SuspendAndRestartEvent(
-                        SuspendOptions.createSaveMinimal(saveChanges),
-                        null));
+                  SuspendOptions options = SuspendOptions.createSaveMinimal(saveChanges, null);
+                  eventBus_.fireEvent(new SuspendAndRestartEvent(options));
                }, constants_.restartRCaption(), constants_.terminalJobTerminatedQuestion(),
                   pUserPrefs_.get().busyDetection().getValue());
             }
@@ -533,7 +532,6 @@ public class ApplicationQuit implements SaveActionChangedEvent.Handler,
       suspendingAndRestarting_ = true;
       eventBus_.fireEvent(new RestartStatusEvent(RestartStatusEvent.RESTART_INITIATED));
       pSessionOpener_.get().suspendForRestart(
-         event.getAfterRestartCommand(),
          event.getSuspendOptions(),
          () -> { // success
             onRestartComplete.execute();

--- a/src/gwt/src/org/rstudio/studio/client/application/events/SuspendAndRestartEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/SuspendAndRestartEvent.java
@@ -14,10 +14,10 @@
  */
 package org.rstudio.studio.client.application.events;
 
-import com.google.gwt.event.shared.EventHandler;
 import org.rstudio.studio.client.application.model.SuspendOptions;
 
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
 public class SuspendAndRestartEvent extends GwtEvent<SuspendAndRestartEvent.Handler>
@@ -33,29 +33,21 @@ public class SuspendAndRestartEvent extends GwtEvent<SuspendAndRestartEvent.Hand
       public native final SuspendOptions getOptions() /*-{
          return this.options;
       }-*/;
-
-      public native final String getAfterRestartCommand() /*-{
-         return this.after_restart;
-      }-*/;
    }
 
    public SuspendAndRestartEvent(Data data)
    {
-      this(data.getOptions(), data.getAfterRestartCommand());
+      this(data.getOptions());
    }
 
-   public SuspendAndRestartEvent(SuspendOptions suspendOptions,
-                                 String afterRestartCommand)
+   public SuspendAndRestartEvent(SuspendOptions suspendOptions)
    {
-      if (suspendOptions == null)
-         suspendOptions = SuspendOptions.createSaveAll(false);
       suspendOptions_ = suspendOptions;
-      afterRestartCommand_ = afterRestartCommand;
    }
 
    public SuspendAndRestartEvent(String afterRestartCommand)
    {
-      this(null, afterRestartCommand);
+      this(SuspendOptions.createSaveAll(false, afterRestartCommand));
    }
 
    public SuspendOptions getSuspendOptions()
@@ -63,11 +55,10 @@ public class SuspendAndRestartEvent extends GwtEvent<SuspendAndRestartEvent.Hand
       return suspendOptions_;
    }
 
-   public String getAfterRestartCommand()
-   {
-      return afterRestartCommand_;
-   }
+   private final SuspendOptions suspendOptions_;
 
+   // Boilerplate ----
+   
    @Override
    protected void dispatch(Handler handler)
    {
@@ -79,9 +70,6 @@ public class SuspendAndRestartEvent extends GwtEvent<SuspendAndRestartEvent.Hand
    {
       return TYPE;
    }
-
-   private final SuspendOptions suspendOptions_;
-   private final String afterRestartCommand_;
 
    public interface Handler extends EventHandler
    {

--- a/src/gwt/src/org/rstudio/studio/client/application/model/SuspendOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/model/SuspendOptions.java
@@ -22,24 +22,29 @@ public class SuspendOptions extends JavaScriptObject
    {  
    }
    
-   public static final SuspendOptions createSaveAll(boolean excludePackages) 
+   public static final SuspendOptions createSaveAll(boolean excludePackages,
+                                                    String afterRestart)
    {
-      return create(false, false, excludePackages);
+      return create(false, false, excludePackages, afterRestart);
    }
    
-   public static final SuspendOptions createSaveMinimal(boolean saveWorkspace) 
+   public static final SuspendOptions createSaveMinimal(boolean saveWorkspace,
+                                                        String afterRestart)
    {
-      return create(true, saveWorkspace, false);
+      return create(true, saveWorkspace, false, afterRestart);
    }
    
    private static native final SuspendOptions create(boolean saveMinimal,
                                                      boolean saveWorkspace,
-                                                     boolean excludePackages) /*-{
-      var options = new Object();
-      options.save_minimal = saveMinimal;
-      options.save_workspace = saveWorkspace;
-      options.exclude_packages = excludePackages;
-      return options;
+                                                     boolean excludePackages,
+                                                     String afterRestart)
+   /*-{
+      return {
+         save_minimal: saveMinimal,
+         save_workspace: saveWorkspace,
+         exclude_packages: excludePackages,
+         after_restart: afterRestart || ""
+      };
    }-*/;
    
    /*

--- a/src/gwt/src/org/rstudio/studio/client/application/model/SuspendOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/model/SuspendOptions.java
@@ -21,17 +21,27 @@ public class SuspendOptions extends JavaScriptObject
    protected SuspendOptions()
    {  
    }
-   
+ 
    public static final SuspendOptions createSaveAll(boolean excludePackages,
                                                     String afterRestart)
    {
       return create(false, false, excludePackages, afterRestart);
    }
    
+   public static final SuspendOptions createSaveAll(boolean excludePackages)
+   {
+      return createSaveAll(excludePackages, null);
+   }
+ 
    public static final SuspendOptions createSaveMinimal(boolean saveWorkspace,
                                                         String afterRestart)
    {
       return create(true, saveWorkspace, false, afterRestart);
+   }
+   
+   public static final SuspendOptions createSaveMinimal(boolean saveWorkspace)
+   {
+      return createSaveMinimal(saveWorkspace, null);
    }
    
    private static native final SuspendOptions create(boolean saveMinimal,

--- a/src/gwt/src/org/rstudio/studio/client/common/dialog/DesktopDialogBuilderFactory.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dialog/DesktopDialogBuilderFactory.java
@@ -140,6 +140,8 @@ public class DesktopDialogBuilderFactory implements DialogBuilderFactory
       }
 
       private final String message_;
+      
+      @SuppressWarnings("unused")
       private final DialogOptions options_;
       
       private Command dismissProgress_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
@@ -17,7 +17,6 @@ package org.rstudio.studio.client.workbench.prefs.views;
 
 import java.util.ArrayList;
 
-import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.prefs.RestartRequirement;
@@ -27,7 +26,6 @@ import org.rstudio.core.client.theme.VerticalTabPanel;
 import org.rstudio.core.client.widget.FormLabel;
 import org.rstudio.core.client.widget.HelpButton;
 import org.rstudio.core.client.widget.InfoBar;
-import org.rstudio.core.client.widget.MessageDialog;
 import org.rstudio.core.client.widget.SelectWidget;
 import org.rstudio.core.client.widget.TextBoxWithButton;
 import org.rstudio.studio.client.common.HelpLink;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
@@ -201,8 +201,8 @@ public class BuildPresenter extends BasePresenter
             if (event.getRestartR())
             {
                SuspendOptions options = userPrefs_.saveAndReloadWorkspaceOnBuild().getValue()
-                     ? SuspendOptions.createSaveAll(false, null)
-                     : SuspendOptions.createSaveMinimal(false, null);
+                     ? SuspendOptions.createSaveAll(false)
+                     : SuspendOptions.createSaveMinimal(false);
                
                eventBus_.fireEvent(new SuspendAndRestartEvent(options));
             }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
@@ -201,13 +201,10 @@ public class BuildPresenter extends BasePresenter
             if (event.getRestartR())
             {
                SuspendOptions options = userPrefs_.saveAndReloadWorkspaceOnBuild().getValue()
-                     ? SuspendOptions.createSaveAll(false)
-                     : SuspendOptions.createSaveMinimal(false);
+                     ? SuspendOptions.createSaveAll(false, null)
+                     : SuspendOptions.createSaveMinimal(false, null);
                
-               eventBus_.fireEvent(
-                  new SuspendAndRestartEvent(
-                        options,
-                        event.getAfterRestartCommand()));
+               eventBus_.fireEvent(new SuspendAndRestartEvent(options));
             }
          }
       });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -14,12 +14,14 @@
  */
 package org.rstudio.studio.client.workbench.views.packages;
 
-import com.google.gwt.core.client.JsArray;
-import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.Timer;
-import com.google.inject.Inject;
-import com.google.inject.Provider;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
@@ -66,8 +68,8 @@ import org.rstudio.studio.client.workbench.views.BasePresenter;
 import org.rstudio.studio.client.workbench.views.console.events.ConsolePromptEvent;
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
 import org.rstudio.studio.client.workbench.views.help.events.ShowHelpEvent;
-import org.rstudio.studio.client.workbench.views.packages.events.PackageStateChangedEvent;
 import org.rstudio.studio.client.workbench.views.packages.events.LoadedPackageUpdatesEvent;
+import org.rstudio.studio.client.workbench.views.packages.events.PackageStateChangedEvent;
 import org.rstudio.studio.client.workbench.views.packages.events.PackageStatusChangedEvent;
 import org.rstudio.studio.client.workbench.views.packages.events.RaisePackagePaneEvent;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageInfo;
@@ -84,14 +86,12 @@ import org.rstudio.studio.client.workbench.views.packages.model.PackratActions;
 import org.rstudio.studio.client.workbench.views.packages.ui.CheckForUpdatesDialog;
 import org.rstudio.studio.client.workbench.views.packages.ui.CleanUnusedDialog;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Timer;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 public class Packages
       extends BasePresenter
@@ -1025,8 +1025,8 @@ public class Packages
             true,
             () ->
             {
-               events_.fireEvent(new SuspendAndRestartEvent(
-                      SuspendOptions.createSaveAll(true), installCmd));
+               SuspendOptions options = SuspendOptions.createSaveAll(true, installCmd);
+               events_.fireEvent(new SuspendAndRestartEvent(options));
             },
             () ->
             {

--- a/src/gwt/test/org/rstudio/studio/client/common/r/RTokenizerTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/common/r/RTokenizerTests.java
@@ -14,11 +14,9 @@
  */
 package org.rstudio.studio.client.common.r;
 
-import junit.framework.Assert;
-
 import com.google.gwt.junit.client.GWTTestCase;
-import org.rstudio.studio.client.common.r.RToken;
-import org.rstudio.studio.client.common.r.RTokenizer;
+
+import junit.framework.Assert;
 
 public class RTokenizerTests extends GWTTestCase
 {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14404.
Addresses https://github.com/rstudio/rstudio/issues/2656.

### Approach

Previously, when attempting to execute a command after restart, this would be issued by the client after it had received a signal from the new session that it had come alive. This meant that the timing of the execution of that command was somewhat non-deterministic, but it would happen after the vast majority of RStudio's session initialization had completed.

This is problematic for restart commands which install packages, because the act of restoring the old search path could also imply reloading the package which we wanted to install. The fix here is to instead move the responsibility of after restart command execution from the client to the session, and to allow the session to execute that command with more appropriate sequencing regarding the rest of the session initialization. (In particular, we now execute this just before restoring the search path.)

The PR is large, but is mostly mechanical threading of the restart command through the session suspended state.


### Automated Tests

Covered by existing automation.

### QA Notes

Further verify that installation of an already-loaded package functions as expected.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
