### PR TITLE
ensure LD_LIBRARY_PATH set when starting conda R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -77,6 +77,7 @@
 - Fixed an issue where code highlight in Sweave \Sexpr{} expressions was incorrectly handled (#14382)
 - Fixed an issue where the Edit button in the Viewer pane could fail for Quarto documents (#14325)
 - Fixed an issue where terminal history would show internal commands (#9833)
+- Fixed an issue where RStudio could fail to launch with Conda builds of R (#13184)
 
 #### Posit Workbench
 - Fixed an issue where Professional Driver installation could fail on macOS (rstudio-pro#5168)

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -271,9 +271,15 @@ writeLines(sep = "\x1F", c(
   // if this appears to be a conda installation of R, manually set LD_LIBRARY_PATH appropriately
   // https://github.com/rstudio/rstudio/issues/13184
   if (rLdLibraryPath.length === 0 && rPlatform.indexOf('-conda-') !== -1) {
-    const rLibPath = `${rHome}/lib`;
-    const rootLibraryPath = path.normalize(`${rHome}/../../lib`);
-    rLdLibraryPath = `${rLibPath}:${rootLibraryPath}`;
+
+    const rLibPaths = [
+      `${rHome}/lib`,
+      `${rHome}/../../lib`
+    ]
+      .filter((value) => existsSync(value))
+      .map((value) => path.normalize(value))
+
+    rLdLibraryPath = rLibPaths.join(':');
   }
 
   if (process.platform !== 'win32' && getenv(kLdLibraryPathVariable) != '') {

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -270,7 +270,7 @@ writeLines(sep = "\x1F", c(
 
   // if this appears to be a conda installation of R, manually set LD_LIBRARY_PATH appropriately
   // https://github.com/rstudio/rstudio/issues/13184
-  if (rPlatform.indexOf('-conda-') !== -1) {
+  if (rLdLibraryPath.length === 0 && rPlatform.indexOf('-conda-') !== -1) {
     const rLibPath = `${rHome}/lib`;
     const rootLibraryPath = path.normalize(`${rHome}/../../lib`);
     rLdLibraryPath = `${rLibPath}:${rootLibraryPath}`;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13184.

### Approach

Conda installations of R include a patch which effectively disables the `etc/ldpaths` script, which causes issues for RStudio when loading `libR.so`.

Depending on whether https://github.com/conda/conda/issues/1679 is still a problem or not, we might need to unset `LD_LIBRARY_PATH` after starting R, so that attempts to run tools like `/bin/sh` don't run into trouble when loading libraries from the Conda environment... but let's just solve one bug at a time.

The alternate solution here, I think, would be to set `LD_PRELOAD` to point at the appropriate `libR.so` that we want to load.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13184.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
