### PR TITLE
Strip out unused npm from node.js used by Copilot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 *
 !dependencies/common/install-*
 !dependencies/common/lockfiles
+!dependencies/common/patch-node*
 !dependencies/linux/install-*
 !dependencies/osx/install-*
 !dependencies/windows/*

--- a/dependencies/common/install-node
+++ b/dependencies/common/install-node
@@ -25,10 +25,15 @@ if ! check_env_vars NODE_VERSION NODE_FOLDER NODE_ROOT NODE_SUBDIR NODE_BASE_URL
 	exit 1 # check_env_vars has already printed an error message
 fi
 
-# if we already have node, nothing to do
 if [ -d "${NODE_SUBDIR}" ]; then
-	echo "node is already installed at '${NODE_SUBDIR}'"
-	exit 0
+	if [ "${1}" == "reinstall" ]; then
+		echo "removing previous ${NODE_VERSION} from '${NODE_SUBDIR}'"
+		rm -rf "${NODE_SUBDIR}"
+	else
+		# if we already have node, nothing to do
+		echo "node ${NODE_VERSION} is already installed at '${NODE_SUBDIR}'"
+		exit 0
+	fi
 fi
 
 # complete url based on platform

--- a/dependencies/common/install-node.cmd
+++ b/dependencies/common/install-node.cmd
@@ -1,0 +1,26 @@
+@echo off
+setlocal
+
+call ..\tools\rstudio-tools.cmd
+set PATH=%CD%\tools;%PATH%
+
+set ACTION=%~1
+
+if exist "%NODE_SUBDIR%" (
+	if "%ACTION%"=="reinstall" (
+		echo removing previous node %NODE_VERSION% from '%NODE_SUBDIR%'
+		rd /s /q "%NODE_SUBDIR%"
+	) else (
+		echo node %NODE_VERSION% is already installed at '%NODE_SUBDIR%'
+		exit /b 0
+	)
+)
+
+wget %WGET_ARGS% %NODE_BASE_URL%%NODE_ARCHIVE_FILE%
+echo Unzipping node %NODE_VERSION%
+if not exist "%NODE_ROOT%" mkdir "%NODE_ROOT%"
+unzip %UNZIP_ARGS% %NODE_ARCHIVE_FILE%
+move %NODE_ARCHIVE_DIR% %NODE_SUBDIR%
+del %NODE_ARCHIVE_FILE%
+
+exit /b 0

--- a/dependencies/common/install-npm-dependencies
+++ b/dependencies/common/install-npm-dependencies
@@ -38,10 +38,19 @@ function install-node() {
 	    export NODE_FOLDER="${NODE_VERSION}-arm64"
 	    export NODE_SUBDIR="${NODE_ROOT}/${NODE_FOLDER}"
 	fi
-	./install-node
+
+	if [ "${2}" == "applypatches" ]; then
+		./install-node reinstall
+		./patch-node
+	else
+		./install-node
+	fi
 }
 
-install-node ${RSTUDIO_INSTALLED_NODE_VERSION}
+# the version of node.js that gets installed with the product
+install-node ${RSTUDIO_INSTALLED_NODE_VERSION} applypatches
+
+# the version we use for building product components
 install-node ${RSTUDIO_NODE_VERSION}
 
 # install yarn

--- a/dependencies/common/install-npm-dependencies
+++ b/dependencies/common/install-npm-dependencies
@@ -39,7 +39,7 @@ function install-node() {
 	    export NODE_SUBDIR="${NODE_ROOT}/${NODE_FOLDER}"
 	fi
 
-	if [ "${2}" == "applypatches" ]; then
+	if [ "${2}" == "apply-patches" ]; then
 		./install-node reinstall
 		./patch-node
 	else
@@ -48,7 +48,7 @@ function install-node() {
 }
 
 # the version of node.js that gets installed with the product
-install-node ${RSTUDIO_INSTALLED_NODE_VERSION} applypatches
+install-node ${RSTUDIO_INSTALLED_NODE_VERSION} apply-patches
 
 # the version we use for building product components
 install-node ${RSTUDIO_NODE_VERSION}

--- a/dependencies/common/install-npm-dependencies.cmd
+++ b/dependencies/common/install-npm-dependencies.cmd
@@ -1,0 +1,41 @@
+@echo off
+
+setlocal
+
+call ..\tools\rstudio-tools.cmd
+set PATH=%CD%\tools;%PATH%
+
+:: the version of node.js that gets installed with the product
+call :install-node %RSTUDIO_INSTALLED_NODE_VERSION% apply-patches
+
+:: the version we use for building product components
+call :install-node %RSTUDIO_NODE_VERSION%
+
+:: install yarn for use during builds
+set YARN_DIR=%NODE_SUBDIR%\node_modules\yarn\bin
+if not exist %YARN_DIR%\yarn (
+	echo "Installing yarn into '%YARN_DIR%'"
+	call %NODE_SUBDIR%\npm install --global yarn
+)
+goto :EOF
+
+:install-node :: version [apply-patches]
+
+	set NODE_VERSION=%~1
+	set APPLY_PATCHES=%~2
+	set NODE_ROOT=node
+	set NODE_SUBDIR=%NODE_ROOT%\%NODE_VERSION%
+	set NODE_BASE_URL=%BASEURL%node/v%NODE_VERSION%/
+	set NODE_ARCHIVE_DIR=node-v%NODE_VERSION%-win-x64
+	set NODE_ARCHIVE_FILE=%NODE_ARCHIVE_DIR%.zip
+
+	if "%APPLY_PATCHES%"=="apply-patches" (
+		call install-node.cmd reinstall
+		call patch-node.cmd
+	) else (
+		call install-node.cmd
+	)
+
+goto :EOF :: end install-node
+
+exit /b 0

--- a/dependencies/common/patch-node
+++ b/dependencies/common/patch-node
@@ -29,4 +29,5 @@ if [ "$NODE_VERSION" == "18.19.1" ]; then
 
 	# remove npm from the node installation
 	rm -rf "${NODE_SUBDIR}/lib/node_modules/npm"
+	rm "${NODE_SUBDIR}/bin/npm"
 fi

--- a/dependencies/common/patch-node
+++ b/dependencies/common/patch-node
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+#
+# patch-node
+#
+# Copyright (C) 2024 Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+set -e
+
+source "$(dirname "${BASH_SOURCE[0]}")/../tools/rstudio-tools.sh"
+
+# check for required ENV vars (as set by install-npm-dependencies)
+if ! check_env_vars NODE_VERSION NODE_FOLDER NODE_ROOT NODE_SUBDIR NODE_BASE_URL; then
+	exit 1 # check_env_vars has already printed an error message
+fi
+
+if [ "$NODE_VERSION" == "18.19.1" ]; then
+	section "Applying patches to node ${NODE_VERSION}"
+
+	# remove npm from the node installation; it is not needed for our purposes and
+	# currently has a component with known security vulnerabilities
+	rm -rf "${NODE_SUBDIR}/lib/node_modules/npm"
+fi

--- a/dependencies/common/patch-node
+++ b/dependencies/common/patch-node
@@ -27,7 +27,6 @@ fi
 if [ "$NODE_VERSION" == "18.19.1" ]; then
 	section "Applying patches to node ${NODE_VERSION}"
 
-	# remove npm from the node installation; it is not needed for our purposes and
-	# currently has a component with known security vulnerabilities
+	# remove npm from the node installation
 	rm -rf "${NODE_SUBDIR}/lib/node_modules/npm"
 fi

--- a/dependencies/common/patch-node.cmd
+++ b/dependencies/common/patch-node.cmd
@@ -1,0 +1,16 @@
+@echo off
+
+setlocal
+
+call ..\tools\rstudio-tools.cmd
+
+if "%NODE_VERSION%" == "18.19.1" (
+	echo Applying patches to node %NODE_VERSION%
+
+	:: remove npm from the node installation
+	rd /s /q "%NODE_SUBDIR%\node_modules\npm"
+	del "%NODE_SUBDIR%\npm"
+	del "%NODE_SUBDIR%\npm.cmd"
+)
+
+exit /b 0

--- a/dependencies/osx/install-dependencies-osx
+++ b/dependencies/osx/install-dependencies-osx
@@ -13,7 +13,6 @@
 # MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
 # AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
 #
-#
 
 set -e
 source "$(dirname "${BASH_SOURCE[0]}")/../tools/rstudio-tools.sh"

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -210,8 +210,7 @@ if not exist libclang\%LIBCLANG_VERSION% (
   del %LIBCLANG_FILE%
 )
 
-call :install-node %RSTUDIO_NODE_VERSION% yarn
-call :install-node %RSTUDIO_INSTALLED_NODE_VERSION%
+call install-npm-dependencies.cmd
 
 if not defined JENKINS_URL (
   if exist C:\Windows\py.exe (
@@ -239,33 +238,3 @@ call install-crashpad.cmd
 call install-soci.cmd
 
 endlocal
-goto :EOF
-
-:: install node and optionally install yarn
-:install-node :: version [yarn]
-
-set NODE_VERSION=%~1
-set NODE_ROOT=node
-set NODE_SUBDIR=%NODE_ROOT%\%NODE_VERSION%
-set NODE_BASE_URL=%BASEURL%node/v%NODE_VERSION%/
-set NODE_ARCHIVE_DIR=node-v%NODE_VERSION%-win-x64
-set NODE_ARCHIVE_FILE=%NODE_ARCHIVE_DIR%.zip
-
-if not exist %NODE_SUBDIR% (
-  wget %WGET_ARGS% %NODE_BASE_URL%%NODE_ARCHIVE_FILE%
-  echo Unzipping node %NODE_VERSION%
-  mkdir %NODE_ROOT%
-  unzip %UNZIP_ARGS% %NODE_ARCHIVE_FILE%
-  move %NODE_ARCHIVE_DIR% %NODE_SUBDIR%
-  del %NODE_ARCHIVE_FILE%
-)
-
-if "%~2"=="yarn" (
-  set YARN_DIR=%NODE_SUBDIR%\node_modules\yarn\bin
-  if not exist %YARN_DIR%\yarn (
-    echo "Installing yarn"
-    call %NODE_SUBDIR%\npm install --global yarn
-  )
-)
-
-goto :EOF


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/6002

### Approach

Copilot doesn't need the `npm` that's bundled with `node`, so remove it. See the issue for more details.

This happens during dependency installation. We want to be sure the "patch" step always runs against a consistent starting point when installing dependencies so the dependency scripts always delete and redownload `node` before running the patch step. This ensures that official builds will always pick up any patches (e.g. if we add new ones in the future).

### Automated Tests

None

### QA Notes

Confirm that the folder `node/lib/node_modules/npm/` in the node.js we install with the product (desktop and server) is absent, and sanity check that Copilot is still functioning.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


