### PR TITLE
ensure restart command passed along from Build pane

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1406,15 +1406,6 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    utils::browseURL(url)
 })
 
-.rs.addFunction("repairSearchPath", function()
-{
-   toolsEnv <- .rs.toolsEnv()
-   if ("tools:rstudio" %in% search())
-      detach("tools:rstudio")
-   
-   attach(toolsEnv, name = "tools:rstudio")
-})
-
 .rs.addFunction("initTools", function()
 {
    ostype <- .Platform$OS.type

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1406,6 +1406,15 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    utils::browseURL(url)
 })
 
+.rs.addFunction("repairSearchPath", function()
+{
+   toolsEnv <- .rs.toolsEnv()
+   if ("tools:rstudio" %in% search())
+      detach("tools:rstudio")
+   
+   attach(toolsEnv, name = "tools:rstudio")
+})
+
 .rs.addFunction("initTools", function()
 {
    ostype <- .Platform$OS.type

--- a/src/cpp/r/include/r/session/RSessionUtils.hpp
+++ b/src/cpp/r/include/r/session/RSessionUtils.hpp
@@ -97,6 +97,13 @@ public:
    ~SuppressOutputInScope();
 };
 
+class ShowOutputInScope
+{
+public:
+   ShowOutputInScope();
+   ~ShowOutputInScope();
+};
+
 } // namespace utils
 } // namespace session
 } // namespace r

--- a/src/cpp/r/session/RSearchPath.cpp
+++ b/src/cpp/r/session/RSearchPath.cpp
@@ -97,7 +97,7 @@ Error restoreGlobalEnvironment(const core::FilePath& environmentFile)
    if (!environmentFile.exists())
       return Success();
 
-   return RFunction("load", environmentFile.getAbsolutePath()).call();
+   return RFunction("base:::load", environmentFile.getAbsolutePath()).call();
 }
 
 bool isPackage(const std::string& elementName, std::string* pPackageName)
@@ -163,8 +163,8 @@ Error detachSearchPathElementsNotInList(
       std::string detachItem = *it;
       
       // don't allow detach of core packages
-      if ( detachItem == "tools:rstudio" ||
-           detachItem == "package:utils" )
+      if (detachItem == "tools:rstudio" ||
+          detachItem == "package:utils" )
       {
          continue;
       }
@@ -368,7 +368,7 @@ Error restoreSearchPath(const FilePath& statePath)
 
    // get the current search path
    std::vector<std::string> currentSearchPathList;
-   error = r::exec::RFunction("search").call(&currentSearchPathList);
+   error = r::exec::RFunction("base:::search").call(&currentSearchPathList);
    if (error)
       return error;
    
@@ -390,9 +390,9 @@ Error restoreSearchPath(const FilePath& statePath)
       
       // if it is a package then load it if it is not already loaded
       std::string packageName;
-      if ( isPackage(pathElement, &packageName) )
+      if (isPackage(pathElement, &packageName))
       {
-         if ( !packageIsLoaded(packageName, currentSearchPathList) )
+         if (!packageIsLoaded(packageName, currentSearchPathList))
             loadPackage(packageName, packagePaths[packageName]);
       }
       

--- a/src/cpp/r/session/RSearchPath.cpp
+++ b/src/cpp/r/session/RSearchPath.cpp
@@ -470,7 +470,12 @@ Error restoreSearchPath(
       }
    }
    
-   // ensure tools:rstudio is at front of search list
+   // ensure 'tools:rstudio' is placed appropriately in the search list
+   // we want to make sure all of the 'base' R packages are visible to
+   // 'tools:rstudio', but we also need to make sure packages attached
+   // by the user are _not_ visible -- so we need to make sure that
+   // the tools environment is attached after any user-defined packages
+   // (or other attached environments), but before any base R packages
    repairSearchPath();
    
    return Success();

--- a/src/cpp/r/session/RSearchPath.hpp
+++ b/src/cpp/r/session/RSearchPath.hpp
@@ -16,6 +16,9 @@
 #ifndef R_SESSION_SEARCH_PATH_HPP
 #define R_SESSION_SEARCH_PATH_HPP
 
+#include <vector>
+#include <string>
+
 namespace rstudio {
 namespace core {
    class Error;
@@ -30,7 +33,10 @@ namespace search_path {
 
 core::Error save(const core::FilePath& statePath);
 core::Error saveGlobalEnvironment(const core::FilePath& statePath);
-core::Error restore(const core::FilePath& statePath, bool isCompatibleSessionState = true);
+core::Error restore(
+      const core::FilePath& statePath,
+      const std::vector<std::string>& currentSearchPathList,
+      bool isCompatibleSessionState = true);
    
 } // namespace search_path
 } // namespace session

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -593,6 +593,14 @@ Error deferredRestore(const FilePath& statePath, bool serverMode)
 {
    Error error;
    
+   // get current search path list -- need to do this before executing
+   // the after restart command as that might load a package and modify
+   // the search list
+   std::vector<std::string> currentSearchPathList;
+   error = r::exec::RFunction("base:::search").call(&currentSearchPathList);
+   if (error)
+      return error;
+      
    // execute after restart command
    error = executeAfterRestartCommand(statePath.completePath(kAfterRestartCommand));
    if (error)
@@ -600,9 +608,9 @@ Error deferredRestore(const FilePath& statePath, bool serverMode)
    
    // suppress other outputs
    utils::SuppressOutputInScope suppressOutput;
-      
-   // search path
-   error = search_path::restore(statePath, s_isCompatibleSessionState);
+   
+   // restore search path
+   error = search_path::restore(statePath, currentSearchPathList, s_isCompatibleSessionState);
    if (error)
       return error;
    

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -233,12 +233,11 @@ Error executeAfterRestartCommand(const FilePath& afterRestartFile)
 {
    std::string command;
    Error error = core::readStringFromFile(afterRestartFile, &command);
-   if (error)
+   if (error && !isFileNotFoundError(error))
       LOG_ERROR(error);
    
    if (command.empty())
       return Success();
-   
    
    s_callbacks.consoleWriteInput(core::string_utils::trimWhitespace(command));
    return r::exec::executeString(command);

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -85,8 +85,16 @@ std::vector<std::string> s_waitForMethodNames;
 // url for next session
 std::string s_nextSessionUrl;
 
+// are we shutting down?
+bool s_shuttingDown = false;
+
 bool s_protocolDebugEnabled = false;
 bool s_sessionDebugLogCreated = false;
+
+void onShutdown(bool)
+{
+   s_shuttingDown = true;
+}
 
 void processEvents()
 {
@@ -828,10 +836,19 @@ void handleConnection(boost::shared_ptr<HttpConnection> ptrConnection,
                rstudio::r::exec::setInterruptsPending(true);
          }
          
-         // ping
+         // ping -- don't respond if we're shutting down; assume the ping
+         // was intended for a session which will soon be launched anew
          else if (jsonRpcRequest.method == kPing)
          {
-            ptrConnection->sendJsonRpcResponse();
+            if (s_shuttingDown)
+            {
+               Error error = systemError(boost::system::errc::connection_refused, ERROR_LOCATION);
+               ptrConnection->sendJsonRpcError(error);
+            }
+            else
+            {
+               ptrConnection->sendJsonRpcResponse();
+            }
          }
 
          // other rpc method, handle it
@@ -954,9 +971,12 @@ void onUserPrefsChanged(const std::string& layer, const std::string& pref)
 core::Error initialize()
 {
    s_protocolDebugEnabled = prefs::userPrefs().sessionProtocolDebug();
-   prefs::userPrefs().onChanged.connect(onUserPrefsChanged);
    if (s_protocolDebugEnabled)
       initSessionDebugLog();
+   
+   module_context::events().onShutdown.connect(onShutdown);
+   prefs::userPrefs().onChanged.connect(onUserPrefsChanged);
+   
    return Success();
 }
 

--- a/src/cpp/session/modules/jobs/ScriptJob.cpp
+++ b/src/cpp/session/modules/jobs/ScriptJob.cpp
@@ -300,7 +300,7 @@ void ScriptJob::onCompleted(int exitStatus)
    if (!spec_.exportEnv().empty() && export_.exists())
    {
       setJobStatus(job_, "Loading results");
-      r::exec::RFunction load("load");
+      r::exec::RFunction load("base:::load");
       load.addParam("file", string_utils::utf8ToSystem(export_.getAbsolutePath()));
       if (spec_.exportEnv() == "R_GlobalEnv")
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
@@ -200,10 +200,10 @@ public class BuildPresenter extends BasePresenter
             view_.buildCompleted();
             if (event.getRestartR())
             {
+               String afterRestartCommand = event.getAfterRestartCommand();
                SuspendOptions options = userPrefs_.saveAndReloadWorkspaceOnBuild().getValue()
-                     ? SuspendOptions.createSaveAll(false)
-                     : SuspendOptions.createSaveMinimal(false);
-               
+                     ? SuspendOptions.createSaveAll(false, afterRestartCommand)
+                     : SuspendOptions.createSaveMinimal(false, afterRestartCommand);
                eventBus_.fireEvent(new SuspendAndRestartEvent(options));
             }
          }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14419.

### Approach

The restart command got lost in the refactor here; this PR brings it back.

Also fixes an issue that cropped up due to the change in sequencing of restart commands -- since a restart command might load a package, and that load will happen before the search path is restored, we need to ensure that the loaded package is not later unloaded via the attempt to restore the search path.

### Automated Tests

Captured by existing automation.

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
