### PR TITLE
validate we have a function before attempting to get signature

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,7 @@
 - Fixed an issue where the Edit button in the Viewer pane could fail for Quarto documents (#14325)
 - Fixed an issue where terminal history would show internal commands (#9833)
 - Fixed an issue where RStudio could fail to launch with Conda builds of R (#13184)
+- Fixed an issue where hovering over S4 class names in the Help pane could produce an R error (#13344)
 
 #### Posit Workbench
 - Fixed an issue where Professional Driver installation could fail on macOS (rstudio-pro#5168)

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -859,8 +859,11 @@ options(help_type = "html")
          )
       }
       
-      sig <- .rs.getSignature(object)
-      sig <- gsub('^function ', topic, sig)
+      if (is.function(object))
+      {
+         sig <- .rs.getSignature(object)
+         sig <- gsub('^function ', topic, sig)
+      }
    }
    
    list(


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13344.

### Approach

Validate that we do indeed have an R function before attempting to retrieve its arguments. This is necessary as not all help topics are associated with functions -- some might instead by S4 classes, or be unrelated to any R object at all.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13344.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
