### PR TITLE
use alternate strategy when waiting for session restart

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
@@ -522,7 +522,8 @@ public class ApplicationQuit implements SaveActionChangedEvent.Handler,
             globalDisplay_.getProgressIndicator(constants_.progressErrorCaption()));
       progress.onTimedProgress(constants_.restartingRMessage(), 1000);
       
-      final Operation onRestartComplete = () -> {
+      final Operation onRestartComplete = () ->
+      {
          suspendingAndRestarting_ = false;
          progress.onCompleted();
          eventBus_.fireEvent(new RestartStatusEvent(RestartStatusEvent.RESTART_COMPLETED));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionOpener.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionOpener.java
@@ -56,6 +56,9 @@ public class SessionOpener
       pServer_ = pServer;
       pEventBus_ = pEventBus;
       
+      // This timer gets started once we attempt to restart the R session, and
+      // should be cancelled once we receive a signal that we have successfully
+      // connected with the newly-launched session.
       sessionRestartFailedTimer_ = new Timer()
       {
          @Override
@@ -65,6 +68,8 @@ public class SessionOpener
          }
       };
       
+      // Listen for deferred initialization events; R sessions fire these after
+      // a new session has been fully initialized.
       Scheduler.get().scheduleDeferred(new ScheduledCommand()
       {
          @Override


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14432. This is definitely a riskier PR so it might warrant some extra scrutiny.

### Approach

From what I could see, the "ping" request could occasionally be quietly dropped by rserver when the session is restarting, if the session takes a long time to restart. I'm not entirely sure why, but it's possible that:

1. The "old" session takes too long to shut down, so even though the session is preparing to shut down, the server still tries to deliver the "ping" request to the "old" session;

2. The "new" session takes too long to start up, so long that the rserver simply gives up on delivering the request to the new session.

Instead of attempting to ping the soon-to-be-started session, wait for a deferred initialization event to be emitted via the newly-launched session.

This PR also removes some apparently unused "waitForSessionJobExit" code -- it appears to be a stub both in Workbench and here, so I'm wondering if that's code that is no longer needed?

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
