### PR TITLE
stop offline thread when suspending sessions

### DIFF
--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -65,6 +65,7 @@
 #endif
 
 #include "SessionAsyncRpcConnection.hpp"
+#include "SessionOfflineService.hpp"
 
 using namespace rstudio::core;
 using namespace boost::placeholders;
@@ -808,6 +809,10 @@ void handleConnection(boost::shared_ptr<HttpConnection> ptrConnection,
          }
          else if (jsonRpcRequest.method == kSuspendSession)
          {
+            // stop the offline service thread -- we don't want to service any
+            // more incoming requests while preparing to restart
+            offlineService().stop();
+            
             // check for force
             bool force = true;
             Error error = json::readParams(jsonRpcRequest.params, &force);

--- a/src/cpp/session/SessionOfflineService.cpp
+++ b/src/cpp/session/SessionOfflineService.cpp
@@ -318,6 +318,6 @@ void OfflineService::run()
    }
    CATCH_UNEXPECTED_EXCEPTION
 }
-      
+
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/include/session/SessionConstants.hpp
+++ b/src/cpp/session/include/session/SessionConstants.hpp
@@ -175,6 +175,7 @@ const char * const kQuitSession = "quit_session";
 const char * const kSuspendSession = "suspend_session";
 const char * const kInterrupt = "interrupt";
 const char * const kConsoleInput = "console_input";
+const char * const kSuspendForRestart = "suspend_for_restart";
 const char * const kRStudioAPIShowDialogMethod = "rstudio_api_show_dialog";
 const char * const kPing = "ping";
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionOpener.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionOpener.java
@@ -190,7 +190,7 @@ public class SessionOpener
    
    protected void waitForSessionRestart(Command onCompleted)
    {
-      sendPing(200, 25, onCompleted);
+      sendPing(200, 50, onCompleted);
    }
    
    private void sendPing(int delayMs,


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14432.

### Approach

When enabled, the offline service thread might attempt to service RPC requests while the session is shutting down. This can lead the the offline service thread handling a "ping" request from the client that is actually intended for the next incoming R session.

This PR just makes sure we stop the offline service thread whenever the session is about to be suspended.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
