### PR TITLE
clean-rstudio utility script: delete publishing connections and Copilot

### DIFF
--- a/scripts/clean-rstudio
+++ b/scripts/clean-rstudio
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/clean-rstudio
+++ b/scripts/clean-rstudio
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 
 set -e
 
@@ -6,7 +5,7 @@ echo "About to delete all per-user RStudio state and settings, proceed with caut
 echo "(Does not delete Project-specific state in .Rproj.user or global machine state)"
 read -p "Press [enter] to continue or Ctrl+C"
 
-PLATFORM=`uname`
+PLATFORM=$(uname)
 
 # r state
 rm -f ~/.RData
@@ -30,6 +29,12 @@ rm -rf ~/.rstudio-desktop
 rm -f ~/.r/crash-handler-permission
 rm -f ~/.r/crash-handler.conf
 
+# Posit-Connect publishing connections (Linux)
+rm -rf ~/.config/R/rsconnect
+
+# Copilot, misc. cache
+rm -rf ~/.cache/rstudio
+
 if [ "${PLATFORM}" = "Darwin" ]; then
   # Mac session state
   rm -rf ~/Library/Application\ Support/RStudio
@@ -38,6 +43,9 @@ if [ "${PLATFORM}" = "Darwin" ]; then
   defaults delete com.rstudio.desktop > /dev/null 2>&1 || true
   defaults delete com.RStudio.desktop > /dev/null 2>&1 || true
   defaults delete org.rstudio.RStudio > /dev/null 2>&1 || true
+
+  # Posit-Connect publishing connections
+  rm -rf ~/Library/Preferences/org.R-project.R/R/rsconnect
 fi
 
 echo Done cleaning RStudio settings and state

--- a/scripts/clean-rstudio.bat
+++ b/scripts/clean-rstudio.bat
@@ -18,6 +18,12 @@ if EXIST "%localappdata%\R\crash-handler-permission" (
 if EXIST "%localappdata%\R\crash-handler.conf" (
     del "%localappdata%\R\crash-handler.conf"
 )
+if EXIST "%appdata%\R\rsconnect" (
+    rd /q /s "%appdata%\R\rsconnect"
+)
+if EXIST "%appdata%\R\config\R\rsconnect" (
+    rd /q /s "%appdata%\R\config\R\rsconnect"
+)
 
 for /f "tokens=*" %%i in ('powershell /command "[System.Environment]::GetFolderPath([Environment+SpecialFolder]::MyDocuments)"') do set MyDocsDir=%%i
 if EXIST "%MyDocsDir%\.RData" (


### PR DESCRIPTION
Update `clean-rstudio` (Mac/Linux) and `clean-rstudio.bat` (Windows) to delete Copilot cache and publishing connections.

These are purely for manual use, possibly only by me, but I use them frequently.