### PR TITLE
delete npx artifacts referencing deleted folders

### DIFF
--- a/dependencies/common/patch-node
+++ b/dependencies/common/patch-node
@@ -30,4 +30,5 @@ if [ "$NODE_VERSION" == "18.19.1" ]; then
 	# remove npm from the node installation
 	rm -rf "${NODE_SUBDIR}/lib/node_modules/npm"
 	rm "${NODE_SUBDIR}/bin/npm"
+	rm "${NODE_SUBDIR}/bin/npx"
 fi

--- a/dependencies/common/patch-node.cmd
+++ b/dependencies/common/patch-node.cmd
@@ -11,6 +11,8 @@ if "%NODE_VERSION%" == "18.19.1" (
 	rd /s /q "%NODE_SUBDIR%\node_modules\npm"
 	del "%NODE_SUBDIR%\npm"
 	del "%NODE_SUBDIR%\npm.cmd"
+	del "%NODE_SUBDIR%\npx"
+	del "%NODE_SUBDIR%\npx.cmd"
 )
 
 exit /b 0


### PR DESCRIPTION
### Intent

Fix build break on macOS.

### Approach

Broken symbolic link `npx` causes signing step to fail on Mac builds.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


