### PR TITLE
Add homepage tests to the PR pipeline.

### DIFF
--- a/jenkins/Jenkinsfile.pull-request
+++ b/jenkins/Jenkinsfile.pull-request
@@ -55,6 +55,7 @@ pipeline {
       steps {
         sh "mkdir --parents ${TMP_SNYK_PATH}"
         sh "for FILE in \$(git diff --name-only origin/${env.CHANGE_TARGET}...HEAD); do if [ -f \$FILE ]; then cp --parents \$FILE ${TMP_SNYK_PATH}; fi; done"
+        sh "for FILE in \$(git ls-files | grep '/.snyk'); do cp --parents \$FILE ${TMP_SNYK_PATH}; done"
         script {
           exitCode = sh(returnStatus: true, script: "snyk code test ${TMP_SNYK_PATH} > ${TMP_SNYK_PATH}/output.txt")
           sh "cat ${TMP_SNYK_PATH}/output.txt"
@@ -120,6 +121,15 @@ pipeline {
             }
 
           stages {
+            stage('Run Homepage Tests') {
+              when { expression { return FLAVOR == 'Server' && IS_PRO } }
+              steps {
+                dir ("src/cpp/session/workspaces/www-sources") {
+                  sh "./run-tests.sh"
+                }
+              }
+            }
+
             stage('Build Package') {
               steps {
                 dir ("package/linux") {

--- a/jenkins/Jenkinsfile.pull-request
+++ b/jenkins/Jenkinsfile.pull-request
@@ -38,6 +38,17 @@ pipeline {
       }
     }
 
+    stage('Checkout') {
+      steps {
+        checkout([
+          $class: 'GitSCM',
+          branches: scm.branches,
+          doGenerateSubmoduleConfigurations: true,
+          extensions: scm.extensions + [[$class: 'SubmoduleOption', parentCredentials: true]],
+          userRemoteConfigs: scm.userRemoteConfigs])
+      }
+    }
+
     stage('Snyk Code Scan') {
       environment {
         SNYK_TOKEN = credentials('snyk-auth-token')


### PR DESCRIPTION
This goes into OS first and then merges into pro.

See: https://github.com/rstudio/rstudio-pro/issues/5978
And: https://github.com/rstudio/rstudio-pro/issues/2464

And allegedly: https://github.com/rstudio/rstudio-pro/issues/5618

### Intent

I have a memory of these tests running at some point because we used to get failures from them. I'm not sure if we want to also add these back into the main builds as well. I think that we can get away with just running them here since there isn't anything platform specific about them.

### Approach

There was already a script to run the tests in a CI context, so all I had to do was copy one of the existing test steps, change the working directory, and run the script.

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


