### PR TITLE
support R 4.4 contexts

### DIFF
--- a/src/cpp/r/RCntxt.cpp
+++ b/src/cpp/r/RCntxt.cpp
@@ -39,18 +39,48 @@ RCntxt::RCntxt(void *rawCntxt)
 {
    if (rawCntxt == nullptr)
       return;
-   else if (contextVersion() == RVersion40)
-      pCntxt_ = boost::make_shared<RIntCntxt<RCNTXT_40> >(
-                                   static_cast<RCNTXT_40*>(rawCntxt));
-   else if (contextVersion() == RVersion34)
-      pCntxt_ = boost::make_shared<RIntCntxt<RCNTXT_34> >(
-                                   static_cast<RCNTXT_34*>(rawCntxt));
-   else if (contextVersion() == RVersion33)
-      pCntxt_ = boost::make_shared<RIntCntxt<RCNTXT_33> >(
-                                   static_cast<RCNTXT_33*>(rawCntxt));
-   else
-      pCntxt_ = boost::make_shared<RIntCntxt<RCNTXT_32> >(
-                                   static_cast<RCNTXT_32*>(rawCntxt));
+   
+   switch (contextVersion())
+   {
+   
+   case RVersion44:
+   {
+      pCntxt_ = boost::make_shared<RIntCntxt<RCNTXT_44>>(rawCntxt);
+      break;
+   }
+   
+   case RVersion40:
+   {
+      pCntxt_ = boost::make_shared<RIntCntxt<RCNTXT_40>>(rawCntxt);
+      break;
+   }
+      
+   case RVersion34:
+   {
+      pCntxt_ = boost::make_shared<RIntCntxt<RCNTXT_34>>(rawCntxt);
+      break;
+   }
+      
+   case RVersion33:
+   {
+      pCntxt_ = boost::make_shared<RIntCntxt<RCNTXT_33>>(rawCntxt);
+      break;
+   }
+      
+   case RVersion32:
+   {
+      pCntxt_ = boost::make_shared<RIntCntxt<RCNTXT_32>>(rawCntxt);
+      break;
+   }
+      
+   case RVersionUnknown:
+   {
+      LOG_WARNING_MESSAGE("Unable to determine R context version; assuming compatbile with version 4.4");
+      pCntxt_ = boost::make_shared<RIntCntxt<RCNTXT_44>>(rawCntxt);
+      break;
+   }
+      
+   }
 }
 
 Error RCntxt::callSummary(std::string* pCallSummary) const

--- a/src/cpp/r/RCntxtUtils.cpp
+++ b/src/cpp/r/RCntxtUtils.cpp
@@ -34,7 +34,9 @@ RCntxtVersion contextVersion()
    if (s_rCntxtVersion == RVersionUnknown)
    {
       // use current R version to divine the memory layout 
-      if (r::util::hasRequiredVersion("4.0"))
+      if (r::util::hasRequiredVersion("4.4"))
+         s_rCntxtVersion = RVersion44;
+      else if (r::util::hasRequiredVersion("4.0"))
          s_rCntxtVersion = RVersion40;
       else if (r::util::hasRequiredVersion("3.4"))
          s_rCntxtVersion = RVersion34;

--- a/src/cpp/r/include/r/RCntxtUtils.hpp
+++ b/src/cpp/r/include/r/RCntxtUtils.hpp
@@ -28,10 +28,11 @@ namespace context {
 // represents the version of the memory layout of the RCNTXT structure
 enum RCntxtVersion
 {
-   RVersion40, // R 4.0 and above
-   RVersion34, // R 3.4 until R 4.0 (exclusive)
-   RVersion33, // R 3.3 (all versions)
-   RVersion32, // R 3.2.5 and below
+   RVersion44, // R (>= 4.4.0)
+   RVersion40, // R (>= 4.0.0)
+   RVersion34, // R (>= 3.4.0
+   RVersion33, // R (== 3.3.0)
+   RVersion32, // R (3.2.x and older)
    RVersionUnknown 
 };
 

--- a/src/cpp/r/include/r/RIntCntxt.hpp
+++ b/src/cpp/r/include/r/RIntCntxt.hpp
@@ -25,14 +25,15 @@ namespace context {
 
 // header-only implementation of the RCntxtInterface; can serve as an 
 // implementation for any memory layout (depending on the template parameter)
-template<typename T> class RIntCntxt: public RCntxtInterface
+template <typename T>
+class RIntCntxt: public RCntxtInterface
 {
 public:
-   explicit RIntCntxt(T *pCntxt) :
-      pCntxt_(pCntxt)
+   explicit RIntCntxt(void* pCntxt)
+      : pCntxt_(static_cast<T*>(pCntxt))
    {
    }
-
+   
    RCntxt nextcontext() const
    {
       if (pCntxt_->nextcontext == nullptr)
@@ -92,7 +93,7 @@ public:
    }
 
 private:
-   const T *pCntxt_;
+   const T* pCntxt_;
 };
 
 } // namespace context

--- a/src/cpp/r/include/r/RInterface.hpp
+++ b/src/cpp/r/include/r/RInterface.hpp
@@ -61,6 +61,47 @@ typedef struct R_BCSTACK_T {
    } u;
 } R_BCSTACK_T;
 
+typedef struct RCNTXT_44 {
+    struct RCNTXT_44 *nextcontext;
+    int callflag;
+#ifdef _WIN32
+    struct
+    {
+      jmp_buf buf;
+      int sigmask;
+      int savedmask;
+    } cjumpbuf;
+#else
+    sigjmp_buf cjmpbuf;
+#endif
+    int cstacktop;
+    int evaldepth;
+    SEXP promargs;
+    SEXP callfun;
+    SEXP sysparent;
+    SEXP call;
+    SEXP cloenv;
+    SEXP conexit;
+    void (*cend)(void *);
+    void *cenddata;
+    void *vmax;
+    int intsusp;
+    int gcenabled;
+    int bcintactive;
+    SEXP bcbody;
+    void *bcpc;
+    SEXP handlerstack;
+    SEXP restartstack;
+    struct RPRSTACK *prstack;
+    R_BCSTACK_T *nodestack;
+    R_BCSTACK_T *bcprottop;
+    SEXP srcref;
+    int browserfinish;
+    R_BCSTACK_T returnValue; // changed in R 4.4
+    struct RCNTXT_44 *jumptarget;
+    int jumpmask;
+} RCNTXT_44;
+
 typedef struct RCNTXT_40 {
     struct RCNTXT_40 *nextcontext;
     int callflag;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14427.

### Approach

Include the updated R 4.4.x context definition, and use it for newer R.

### Automated Tests

Captured by existing automation.

### QA Notes

Test that the R debugger is functional with a development version of R. (The easiest way to do this is with the R-devel Windows builds at https://cran.r-project.org/bin/windows/base/rdevel.html.)

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
