### PR TITLE
allow browsing non-standard R installs from global options

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -425,7 +425,7 @@ export class GwtCallback extends EventEmitter {
       // discover available R installations
       const rInstalls = findRInstallationsWin32();
       if (rInstalls.length === 0) {
-        logger().logErrorMessage('No R installations found via registry or common R install locations.');
+        logger().logInfo('No R installations found via registry or common R install locations.');
       }
 
       // ask the user what version of R they'd like to use

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -426,7 +426,6 @@ export class GwtCallback extends EventEmitter {
       const rInstalls = findRInstallationsWin32();
       if (rInstalls.length === 0) {
         logger().logErrorMessage('No R installations found via registry or common R install locations.');
-        return '';
       }
 
       // ask the user what version of R they'd like to use


### PR DESCRIPTION
### Intent

Addresses [Choose R dialog from global options not showing when R was installed in non-standard location #14456](https://github.com/rstudio/rstudio/issues/14456)

### Approach

Allow "Choose R Installation" dialog to display from Global Options even if no R installations are found in standard locations. That is allowed during startup (via changes in https://github.com/rstudio/rstudio/pull/14197) but I missed this case from Global Options.

### Automated Tests

None

### QA Notes

Per the issue instructions, you need a Windows machine without any remnants of previous R installations and no previous selection of R in RStudio). If you do an uninstall of R from Add/Remove, check to make sure the actual folders were deleted (e.g. `C:\Program Files\R`) as RStudio may find those and not trigger this scenario.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


