### PR TITLE
add support for Rtools 4.4, for R 4.4.x

### DIFF
--- a/CMakeCompiler.txt
+++ b/CMakeCompiler.txt
@@ -99,8 +99,10 @@ if(MSVC)
     -D_CRT_NONSTDC_NO_DEPRECATE
     -D_CRT_SECURE_NO_WARNINGS
     -D_SCL_SECURE_NO_WARNINGS
-    -D_ITERATOR_DEBUG_LEVEL=${ITERATOR_DEBUG_LEVEL}
-    )
+    -D_ITERATOR_DEBUG_LEVEL=${ITERATOR_DEBUG_LEVEL})
+
+   # silence R Complex.h warnings
+   add_definitions(-DR_LEGACY_RCOMPLEX)
 
 else()
   # work around issue with boost 1_69 on Ubuntu 22.04 (Jammy)

--- a/src/cpp/core/include/core/r_util/RToolsInfo.hpp
+++ b/src/cpp/core/include/core/r_util/RToolsInfo.hpp
@@ -33,9 +33,7 @@ class RToolsInfo
 {
 public:
    RToolsInfo() {}
-   RToolsInfo(const std::string& name,
-              const FilePath& installPath,
-              bool usingMingwGcc49);
+   RToolsInfo(const std::string& name, const FilePath& installPath);
 
    bool empty() const { return name_.empty(); }
 
@@ -66,9 +64,7 @@ private:
 
 std::ostream& operator<<(std::ostream& os, const RToolsInfo& info);
 
-void scanForRTools(bool usingMingwGcc49,
-                   const std::string& rVersion,
-                   std::vector<RToolsInfo>* pRTools);
+void scanForRTools(const std::string& rVersion, std::vector<RToolsInfo>* pRTools);
 
 template <typename T>
 void prependToSystemPath(const RToolsInfo& toolsInfo, T* pTarget)

--- a/src/cpp/core/r_util/RToolsInfo.cpp
+++ b/src/cpp/core/r_util/RToolsInfo.cpp
@@ -45,41 +45,15 @@ std::string asRBuildPath(const FilePath& filePath)
    return path;
 }
 
-std::vector<std::string> gcc463ClangArgs(const FilePath& installPath)
-{
-   std::vector<std::string> clangArgs;
-   clangArgs.push_back("-I" + installPath.completeChildPath(
-      "gcc-4.6.3/i686-w64-mingw32/include").getAbsolutePath());
-
-   clangArgs.push_back("-I" + installPath.completeChildPath(
-      "gcc-4.6.3/include/c++/4.6.3").getAbsolutePath());
-
-   std::string bits = "-I" + installPath.completeChildPath(
-      "gcc-4.6.3/include/c++/4.6.3/i686-w64-mingw32").getAbsolutePath();
-#ifdef _WIN64
-   bits += "/64";
-#endif
-   clangArgs.push_back(bits);
-   return clangArgs;
-}
-
-void gcc463Configuration(const FilePath& installPath,
-                         std::vector<std::string>* pRelativePathEntries,
-                         std::vector<std::string>* pClangArgs)
-{
-   pRelativePathEntries->push_back("bin");
-   pRelativePathEntries->push_back("gcc-4.6.3/bin");
-   *pClangArgs = gcc463ClangArgs(installPath);
-}
-
 } // anonymous namespace
 
 
 RToolsInfo::RToolsInfo(const std::string& name,
-                       const FilePath& installPath,
-                       bool usingMingwGcc49)
-   : name_(name), installPath_(installPath)
+                       const FilePath& installPath)
+   : name_(name),
+     installPath_(installPath)
 {
+   // NOTE: versionMin is inclusive; versionMax is exclusive
    std::string versionMin, versionMax;
    std::vector<std::string> relativePathEntries;
    std::vector<std::string> clangArgs;
@@ -88,78 +62,13 @@ RToolsInfo::RToolsInfo(const std::string& name,
    std::vector<std::string> cIncludePaths;
    std::vector<std::string> cppIncludePaths;
 
-   if (name == "2.11")
-   {
-      versionMin = "2.10.0";
-      versionMax = "2.11.1";
-      relativePathEntries.push_back("bin");
-      relativePathEntries.push_back("perl/bin");
-      relativePathEntries.push_back("MinGW/bin");
-   }
-   else if (name == "2.12")
-   {
-      versionMin = "2.12.0";
-      versionMax = "2.12.2";
-      relativePathEntries.push_back("bin");
-      relativePathEntries.push_back("perl/bin");
-      relativePathEntries.push_back("MinGW/bin");
-      relativePathEntries.push_back("MinGW64/bin");
-   }
-   else if (name == "2.13")
-   {
-      versionMin = "2.13.0";
-      versionMax = "2.13.2";
-      relativePathEntries.push_back("bin");
-      relativePathEntries.push_back("MinGW/bin");
-      relativePathEntries.push_back("MinGW64/bin");
-   }
-   else if (name == "2.14")
-   {
-      versionMin = "2.13.0";
-      versionMax = "2.14.2";
-      relativePathEntries.push_back("bin");
-      relativePathEntries.push_back("MinGW/bin");
-      relativePathEntries.push_back("MinGW64/bin");
-   }
-   else if (name == "2.15")
-   {
-      versionMin = "2.14.2";
-      versionMax = "2.15.1";
-      relativePathEntries.push_back("bin");
-      relativePathEntries.push_back("gcc-4.6.3/bin");
-      clangArgs = gcc463ClangArgs(installPath);
-   }
-   else if (name == "2.16" || name == "3.0")
-   {
-      versionMin = "2.15.2";
-      versionMax = "3.0.99";
-      gcc463Configuration(installPath, &relativePathEntries, &clangArgs);
-   }
-   else if (name == "3.1")
-   {
-      versionMin = "3.0.0";
-      versionMax = "3.1.99";
-      gcc463Configuration(installPath, &relativePathEntries, &clangArgs);
-   }
-   else if (name == "3.2")
-   {
-      versionMin = "3.1.0";
-      versionMax = "3.2.0";
-      gcc463Configuration(installPath, &relativePathEntries, &clangArgs);
-   }
-   else if (name == "3.3")
-   {
-      versionMin = "3.2.0";
-      versionMax = "3.2.99";
-      gcc463Configuration(installPath, &relativePathEntries, &clangArgs);
-   }
-   else if (name == "3.4" || name == "3.5")
+   if (name == "3.4" || name == "3.5")
    {
       versionMin = "3.3.0";
       if (name == "3.4")
-         versionMax = "3.5.99";  // Rtools 3.4
+         versionMax = "3.6.0";  // Rtools 3.4
       else 
-         versionMax = "3.6.99";  // Rtools 3.5
+         versionMax = "4.0.0";  // Rtools 3.5
 
       relativePathEntries.push_back("bin");
 
@@ -194,7 +103,7 @@ RToolsInfo::RToolsInfo(const std::string& name,
    else if (name == "4.0")
    {
       versionMin = "4.0.0";
-      versionMax = "4.1.99";
+      versionMax = "4.2.0";
 
       // PATH for utilities
       relativePathEntries.push_back("usr/bin");
@@ -260,7 +169,7 @@ RToolsInfo::RToolsInfo(const std::string& name,
    else if (name == "4.2")
    {
       versionMin = "4.2.0";
-      versionMax = "4.2.99";
+      versionMax = "4.3.0";
 
       // PATH for utilities
       relativePathEntries.push_back("usr/bin");
@@ -285,7 +194,7 @@ RToolsInfo::RToolsInfo(const std::string& name,
    else if (name == "4.3")
    {
       versionMin = "4.3.0";
-      versionMax = "5.0.0";
+      versionMax = "4.4.0";
 
       // PATH for utilities
       relativePathEntries.push_back("usr/bin");
@@ -307,6 +216,31 @@ RToolsInfo::RToolsInfo(const std::string& name,
       clangArgs.push_back("-D__GNUC_MINOR__=2");
       clangArgs.push_back("-D__GNUC_PATCHLEVEL__=0");
    }
+   else if (name == "4.4")
+   {
+      versionMin = "4.4.0";
+      versionMax = "5.0.0";
+
+      // PATH for utilities
+      relativePathEntries.push_back("usr/bin");
+
+      // set RTOOLS44_HOME
+      std::string rtoolsPath = installPath.getAbsolutePath();
+      std::replace(rtoolsPath.begin(), rtoolsPath.end(), '/', '\\');
+      environmentVars.push_back({"RTOOLS44_HOME", rtoolsPath});
+
+      // undefine _MSC_VER, so that we can "pretend" to be gcc
+      // this is important for C++ libraries which might try to use
+      // MSVC-specific tools when _MSC_VER is defined (e.g. Eigen), which might
+      // not actually be defined or available in Rtools
+      clangArgs.push_back("-U_MSC_VER");
+
+      // set GNUC levels
+      // (required for _mingw.h, which otherwise tries to use incompatible MSVC defines)
+      clangArgs.push_back("-D__GNUC__=13");
+      clangArgs.push_back("-D__GNUC_MINOR__=2");
+      clangArgs.push_back("-D__GNUC_PATCHLEVEL__=0");
+   }
    else
    {
       LOG_DEBUG_MESSAGE("Unrecognized Rtools installation at path '" + installPath.getAbsolutePath() + "'");
@@ -315,7 +249,7 @@ RToolsInfo::RToolsInfo(const std::string& name,
    // build version predicate and path list if we can
    if (!versionMin.empty())
    {
-      boost::format fmt("getRversion() >= \"%1%\" && getRversion() <= \"%2%\"");
+      boost::format fmt("getRversion() >= \"%1%\" && getRversion() < \"%2%\"");
       versionPredicate_ = boost::str(fmt % versionMin % versionMax);
 
       for (const std::string& relativePath : relativePathEntries)
@@ -341,7 +275,12 @@ std::string RToolsInfo::url(const std::string& repos) const
 {
    std::string url;
 
-   if (name() == "4.3")
+   if (name() == "4.4")
+   {
+      std::string suffix = "bin/windows/Rtools/rtools44/rtools.html";
+      url = core::http::URL::complete(repos, suffix);
+   }
+   else if (name() == "4.3")
    {
       std::string suffix = "bin/windows/Rtools/rtools43/rtools.html";
       url = core::http::URL::complete(repos, suffix);
@@ -403,7 +342,7 @@ Error useRtools(const std::string& rToolsVersion,
    }
 
    // build info
-   RToolsInfo toolsInfo(rToolsVersion, installPath, false);
+   RToolsInfo toolsInfo(rToolsVersion, installPath);
 
    // check that recorded path is valid
    bool ok =
@@ -439,18 +378,21 @@ Error scanEnvironmentForRTools(const std::string& rVersion,
       // use RTOOLS42_HOME
       useRtools("4.2", "RTOOLS42_HOME", "C:/rtools42", pRTools);
    }
-   else if (version < Version("5.0.0"))
+   else if (version < Version("4.4.0"))
    {
       // use RTOOLS43_HOME
       useRtools("4.3", "RTOOLS43_HOME", "C:/rtools43", pRTools);
+   }
+   else if (version < Version("5.0.0"))
+   {
+      // use RTOOLS44_HOME
+      useRtools("4.4", "RTOOLS44_HOME", "C:/rtools44", pRTools);
    }
 
    return Success();
 }
 
-Error scanRegistryForRTools(HKEY key,
-                            bool usingMingwGcc49,
-                            std::vector<RToolsInfo>* pRTools)
+Error scanRegistryForRTools(HKEY key, std::vector<RToolsInfo>* pRTools)
 {
    core::system::RegistryKey regKey;
    Error error = regKey.open(key,
@@ -482,7 +424,7 @@ Error scanRegistryForRTools(HKEY key,
       if (!installPath.empty())
       {
          std::string utf8InstallPath = string_utils::systemToUtf8(installPath);
-         RToolsInfo toolsInfo(name, FilePath(utf8InstallPath), usingMingwGcc49);
+         RToolsInfo toolsInfo(name, FilePath(utf8InstallPath));
          if (toolsInfo.isStillInstalled())
          {
             if (toolsInfo.isRecognized())
@@ -496,31 +438,23 @@ Error scanRegistryForRTools(HKEY key,
    return Success();
 }
 
-void scanRegistryForRTools(bool usingMingwGcc49,
-                           std::vector<RToolsInfo>* pRTools)
+void scanRegistryForRTools(std::vector<RToolsInfo>* pRTools)
 {
    // try HKLM first (backwards compatible with previous code)
-   Error error = scanRegistryForRTools(
-            HKEY_LOCAL_MACHINE,
-            usingMingwGcc49,
-            pRTools);
-
+   Error error = scanRegistryForRTools(HKEY_LOCAL_MACHINE, pRTools);
    if (error)
       LOG_ERROR(error);
 
    // try HKCU as a fallback
    if (pRTools->empty())
    {
-      Error error = scanRegistryForRTools(
-               HKEY_CURRENT_USER,
-               usingMingwGcc49,
-               pRTools);
+      Error error = scanRegistryForRTools(HKEY_CURRENT_USER, pRTools);
       if (error)
          LOG_ERROR(error);
    }
 }
 
-void scanFoldersForRTools(bool usingMingwGcc49, std::vector<RToolsInfo>* pRTools)
+void scanFoldersForRTools(std::vector<RToolsInfo>* pRTools)
 {
    // look for Rtools as installed by RStudio
    std::string systemDrive = core::system::getenv("SYSTEMDRIVE");
@@ -540,7 +474,7 @@ void scanFoldersForRTools(bool usingMingwGcc49, std::vector<RToolsInfo>* pRTools
    // infer Rtools information from each directory
    for (const FilePath& buildDir : buildDirs)
    {
-      RToolsInfo toolsInfo(buildDir.getFilename(), buildDir, usingMingwGcc49);
+      RToolsInfo toolsInfo(buildDir.getFilename(), buildDir);
       if (toolsInfo.isRecognized())
       {
          pRTools->push_back(toolsInfo);
@@ -553,16 +487,14 @@ void scanFoldersForRTools(bool usingMingwGcc49, std::vector<RToolsInfo>* pRTools
 
 } // end anonymous namespace
 
-void scanForRTools(bool usingMingwGcc49,
-                   const std::string& rVersion,
-                   std::vector<RToolsInfo>* pRTools)
+void scanForRTools(const std::string& rVersion, std::vector<RToolsInfo>* pRTools)
 {
    std::vector<RToolsInfo> rtoolsInfo;
 
    // scan for Rtools
    scanEnvironmentForRTools(rVersion, &rtoolsInfo);
-   scanRegistryForRTools(usingMingwGcc49, &rtoolsInfo);
-   scanFoldersForRTools(usingMingwGcc49, &rtoolsInfo);
+   scanRegistryForRTools(&rtoolsInfo);
+   scanFoldersForRTools(&rtoolsInfo);
 
    // remove duplicates
    std::set<FilePath> knownPaths;

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -422,13 +422,6 @@ SEXP rs_rstudioCitation()
    }
 }
 
-SEXP rs_setUsingMingwGcc49(SEXP usingSEXP)
-{
-   bool usingMingwGcc49 = r::sexp::asLogical(usingSEXP);
-   prefs::userState().setUsingMingwGcc49(usingMingwGcc49);
-   return R_NilValue;
-}
-
 // ensure file hidden
 SEXP rs_ensureFileHidden(SEXP fileSEXP)
 {
@@ -2820,29 +2813,6 @@ bool isLoadBalanced()
    return !core::system::getenv(kRStudioSessionRoute).empty();
 }
 
-#ifdef _WIN32
-bool usingMingwGcc49()
-{
-   // return true if the setting is true
-   bool gcc49 = prefs::userState().usingMingwGcc49();
-   if (gcc49)
-      return true;
-
-   // otherwise check R version
-   r::exec::RFunction func(".rs.builtWithRtoolsGcc493");
-   Error error = func.call(&gcc49);
-   if (error)
-      LOG_ERROR(error);
-   return gcc49;
-
-}
-#else
-bool usingMingwGcc49()
-{
-   return false;
-}
-#endif
-
 namespace {
 
 #ifdef __APPLE__
@@ -3069,7 +3039,6 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_rstudioReleaseName);
    RS_REGISTER_CALL_METHOD(rs_sessionModulePath);
    RS_REGISTER_CALL_METHOD(rs_setPersistentValue);
-   RS_REGISTER_CALL_METHOD(rs_setUsingMingwGcc49);
    RS_REGISTER_CALL_METHOD(rs_showErrorMessage);
    RS_REGISTER_CALL_METHOD(rs_sourceDiagnostics);
    RS_REGISTER_CALL_METHOD(rs_threadSleep);

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -969,8 +969,6 @@ void showSourceMarkers(const SourceMarkerSet& markerSet,
 
 bool isLoadBalanced();
 
-bool usingMingwGcc49();
-
 bool isWebsiteProject();
 bool isBookdownWebsite();
 bool isBookdownProject();

--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -363,11 +363,6 @@
   invisible(.Call("rs_removePref", prefName, PACKAGE = "(embedding)"))
 })
 
-.rs.addFunction("setUsingMingwGcc49", function(usingMingwGcc49) {
-  invisible(.Call("rs_setUsingMingwGcc49", usingMingwGcc49, PACKAGE = "(embedding)"))
-})
-
-
 .rs.addGlobalFunction("rstudioDiagnosticsReport", function() {
   invisible(.Call(getNativeSymbolInfo("rs_sourceDiagnostics", PACKAGE="")))
 })

--- a/src/cpp/session/modules/SessionBuild.R
+++ b/src/cpp/session/modules/SessionBuild.R
@@ -41,7 +41,7 @@ Do you want to install the additional tools now?
       return(FALSE)
    
    .Call("rs_installBuildTools", PACKAGE = "(embedding)")
-   return(TRUE)
+   invisible(TRUE)
    
 })
 
@@ -86,13 +86,6 @@ options(buildtools.with = function(code)
          siteDir
    else
       siteDir
-})
-
-.rs.addFunction("builtWithRtoolsGcc493", function()
-{
-   identical(.Platform$OS.type, "windows") &&
-      getRversion() >= "3.3" && 
-      .rs.haveRequiredRSvnRev(70462)
 })
 
 .rs.addFunction("readShinytestResultRds", function(rdsPath)

--- a/src/cpp/session/modules/build/SessionBuildEnvironment.cpp
+++ b/src/cpp/session/modules/build/SessionBuildEnvironment.cpp
@@ -83,9 +83,7 @@ r_util::RToolsInfo scanPathForRTools()
    boost::regex pattern("Rtools version (\\d\\.\\d\\d)[\\d\\.]+$");
    boost::smatch match;
    if (regex_utils::search(contents, match, pattern))
-      return r_util::RToolsInfo(match[1],
-                                installPath,
-                                module_context::usingMingwGcc49());
+      return r_util::RToolsInfo(match[1], installPath);
    else
       return noToolsFound;
 }
@@ -139,9 +137,8 @@ bool doAddRtoolsToPathIfNecessary(T* pTarget,
 
     // ok so scan for R tools
     std::string rVersion = module_context::rVersion();
-    bool usingGcc49 = module_context::usingMingwGcc49();
     std::vector<r_util::RToolsInfo> rTools;
-    core::r_util::scanForRTools(usingGcc49, rVersion, &rTools);
+    core::r_util::scanForRTools(rVersion, &rTools);
 
     // enumerate them to see if we have a compatible version
     // (go in reverse order for most recent first)

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -1353,9 +1353,8 @@ core::r_util::RToolsInfo findRtools()
 {
    // scan for Rtools
    std::string rVersion = module_context::rVersion();
-   bool usingMingwGcc49 = module_context::usingMingwGcc49();
    std::vector<core::r_util::RToolsInfo> rTools;
-   core::r_util::scanForRTools(usingMingwGcc49, rVersion, &rTools);
+   core::r_util::scanForRTools(rVersion, &rTools);
 
    // enumerate them to see if we have a compatible version
    // (go in reverse order for most recent first)

--- a/src/cpp/session/prefs/UserStateComputedLayer.cpp
+++ b/src/cpp/session/prefs/UserStateComputedLayer.cpp
@@ -38,10 +38,6 @@ UserStateComputedLayer::UserStateComputedLayer():
 Error UserStateComputedLayer::readPrefs()
 {
    json::Object layer;
-
-   layer[kUsingMingwGcc49] = boost::algorithm::contains(
-         core::system::getenv("R_COMPILED_BY"), "4.9.3");
-
    cache_ = boost::make_shared<core::json::Object>(layer);
    return Success();
 }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14453.

Also drops support for the older versions of Rtools used with older versions of R which we no longer support.

### Approach

Mostly straightforward plumbing of Rtools 4.4 code, which is fortunately very similar to Rtools 4.3.

### Automated Tests

N/A

### QA Notes

Test that you can install R packages from sources when using RStudio with a recent version of R-devel on Windows. (Development builds of R for Windows are available at https://cran.r-project.org/bin/windows/base/rdevel.html)

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
