### PR TITLE
lint usages of '=' in control flow conditionals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - RStudio Desktop on Windows and Linux supports auto-hiding the menu bar (#8932)
 - RStudio Desktop on Windows and Linux supports full-screen mode via F11 (#3243)
 - RStudio Desktop now supports pasting of file paths for files copied to the clipboard (#14240)
+- RStudio now reports a diagnostics warning when `=` (rather than `==`) is used in `if`, `for`, and `while` conditionals (#14455)
 - R projects can be given a custom display name in Project Options (#1909)
 - The automatic display of Copilot code completions can now be controlled via a user preference (#14033)
 - Copilot code suggestions can now be requested via the keyboard shortcut `Ctrl + \`

--- a/src/cpp/session/modules/SessionDiagnosticsTests.cpp
+++ b/src/cpp/session/modules/SessionDiagnosticsTests.cpp
@@ -300,6 +300,8 @@ test_context("Diagnostics")
       EXPECT_NO_LINT("mtcars %>% stats::lm(mpg ~ cyl, data = .)");
       
       EXPECT_NO_LINT("r'())'");
+
+      EXPECT_LINT("if (x = 1) {}");
    }
    
    test_that("RStudio files can be successfully linted")

--- a/src/cpp/session/modules/SessionRParser.hpp
+++ b/src/cpp/session/modules/SessionRParser.hpp
@@ -481,6 +481,15 @@ public:
                LintTypeWarning,
                "unexpected assignment in argument list; did you mean to use '='?");
    }
+
+   void unexpectedAssignmentInConditional(const RToken& rToken)
+   {
+      addLintItem(
+               rToken,
+               LintTypeWarning,
+               "unexpected assignment in conditional expression; did you mean to use '=='?");
+   }
+
    
    void addLintItem(const RToken& rToken,
                     LintType type,


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14455.

![Screenshot 2024-03-20 171755](https://github.com/rstudio/rstudio/assets/1976582/11897e0d-41a8-49a6-a8d7-d0d0ed2ae27e)

### Approach

Our diagnostics parser records when it's within different control flow conditional expressions; use that state to detect unexpected `=` tokens.

### Automated Tests

Unit tests added.

### QA Notes

Test that the following code (or similar) gives diagnostics:

```
if (x = 42) {}
while (a = b) {}
for (a = 5) {}
```

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
