### PR TITLE
implement fallback when computing user session directory

### DIFF
--- a/src/cpp/core/system/Win32System.cpp
+++ b/src/cpp/core/system/Win32System.cpp
@@ -48,7 +48,6 @@
 #include <core/DateTime.hpp>
 #include <core/StringUtils.hpp>
 #include <core/system/Environment.hpp>
-#include <core/system/Xdg.hpp>
 
 #ifndef JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
 #define JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE 0x2000

--- a/src/cpp/core/system/Win32System.cpp
+++ b/src/cpp/core/system/Win32System.cpp
@@ -37,17 +37,18 @@
 #include <boost/bind/bind.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
+#include <shared_core/Error.hpp>
+#include <shared_core/FilePath.hpp>
+#include <shared_core/SafeConvert.hpp>
+#include <shared_core/system/User.hpp>
+
 #include <core/Algorithm.hpp>
 #include <core/Log.hpp>
 #include <core/FileInfo.hpp>
 #include <core/DateTime.hpp>
 #include <core/StringUtils.hpp>
 #include <core/system/Environment.hpp>
-
-#include <shared_core/Error.hpp>
-#include <shared_core/FilePath.hpp>
-#include <shared_core/SafeConvert.hpp>
-#include <shared_core/system/User.hpp>
+#include <core/system/Xdg.hpp>
 
 #ifndef JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
 #define JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE 0x2000
@@ -322,43 +323,30 @@ FilePath userSettingsPath(const FilePath& userHomeDirectory,
                           const std::string& appName,
                           bool ensureDirectory)
 {
-   wchar_t path[MAX_PATH + 1];
-   std::wstring appNameWide(appName.begin(), appName.end());
-   int csidl = CSIDL_LOCAL_APPDATA;
-   if (ensureDirectory)
-      csidl |= CSIDL_FLAG_CREATE;
-
-   HRESULT hr = ::SHGetFolderPathAndSubDirW(
-         nullptr,
-         csidl,
-         nullptr,
-         SHGFP_TYPE_CURRENT,
-         appNameWide.c_str(),
-         path);
-
-   if (hr == S_OK)
-      return FilePath(std::wstring(path));
-
-   std::string localAppData = core::system::getenv("LOCALAPPDATA");
-   if (!localAppData.empty())
+   wchar_t* path = nullptr;
+   HRESULT result = SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &path);
+   if (result != S_OK || path == nullptr)
    {
-      FilePath settingsPath = FilePath(localAppData).completeChildPath(appName);
-      if (ensureDirectory)
-      {
-         Error error = settingsPath.ensureDirectory();
-         if (error)
-            LOG_ERROR(error);
-      }
-      return settingsPath;
+      Error error = systemError(
+          boost::system::errc::no_such_file_or_directory,
+          "unable to compute user settings (LocalAppData) path",
+          ERROR_LOCATION);
+
+      error.addProperty("error-code", core::safe_convert::numberToHexString(result));
+      LOG_ERROR(error);
+      return FilePath();
    }
 
-   Error error = systemError(
-       boost::system::errc::no_such_file_or_directory,
-       "unable to compute user settings path",
-       ERROR_LOCATION);
+   FilePath localAppData = FilePath(std::wstring(path));
+   FilePath settingsPath = localAppData.completeChildPath(appName);
+   if (ensureDirectory)
+   {
+      Error error = settingsPath.ensureDirectory();
+      if (error)
+         LOG_ERROR(error);
+   }
 
-   LOG_ERROR(error);
-   return FilePath();
+   return settingsPath;
 }
 
 FilePath systemSettingsPath(const std::string& appName, bool create)


### PR DESCRIPTION
### Intent

Addresses https://forum.posit.co/t/rstudio-cannot-connect-to-r-tried-several-versions/181677.

### Approach

- Return the computed FilePath even if the `ensureDirectory` request failed.
- Use a fallback in case the Windows API call failed.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
