### PR TITLE
fix issue with sync of R save action

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -92,6 +92,7 @@
 - Fixed an issue where Quarto dashboards could not be previewed if their file path contained a single quote (#13900)
 - Fixed an issue where language objects (calls, formulas) were not described in the Environment pane (#14446)
 - Fixed an issue where searches in the Help pane could fail for entries like `[<-` (#10975)
+- Fixed an issue where the "Save workspace on exit" preference was ignored in some cases (#14258)
 
 #### Posit Workbench
 - Fixed an issue where Professional Driver installation could fail on macOS (rstudio-pro#5168)

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -789,7 +789,7 @@ const int kSaveActionAsk = -1;
 
 void setSaveAction(int saveAction)
 {
-   switch(saveAction)
+   switch (saveAction)
    {
    case kSaveActionNoSave:
       SaveAction = SA_NOSAVE;
@@ -802,7 +802,6 @@ void setSaveAction(int saveAction)
       SaveAction = SA_SAVEASK;
       break;
    }
-
 }
 
 namespace utils {

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -815,6 +815,7 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
 
 void rInitComplete()
 {
+   module_context::syncRSaveAction();
    module_context::events().onInitComplete();
 }
 
@@ -1673,7 +1674,7 @@ int saveWorkspaceAction()
    const projects::ProjectContext& projContext = projects::projectContext();
    if (projContext.hasProject())
    {
-      switch(projContext.config().saveWorkspace)
+      switch (projContext.config().saveWorkspace)
       {
       case r_util::YesValue:
          return rstudio::r::session::kSaveActionSave;
@@ -1701,7 +1702,7 @@ int saveWorkspaceAction()
 
 void syncRSaveAction()
 {
-   rstudio::r::session::setSaveAction(saveWorkspaceOption());
+   return r::session::setSaveAction(saveWorkspaceAction());
 }
 
 } // namespace module_context

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1702,7 +1702,7 @@ int saveWorkspaceAction()
 
 void syncRSaveAction()
 {
-   return r::session::setSaveAction(saveWorkspaceAction());
+   r::session::setSaveAction(saveWorkspaceAction());
 }
 
 } // namespace module_context


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14258.

### Approach

We were erroneously passing in R's `SA_TYPE` save action into our `setSaveAction()`, which instead requires our own alternate encoding of R's "save workspace on exit" option.

Also ensure we synchronize this setting on startup, after the session has finished initialization.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14258.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
