### PR TITLE
convert '\r' to '\n' when fixing up pasteboard

### DIFF
--- a/src/node/desktop/src/native/desktop/desktop.cc
+++ b/src/node/desktop/src/native/desktop/desktop.cc
@@ -443,6 +443,9 @@ void cleanClipboardImpl(bool stripHtml)
       std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter;
       std::string utf8Text = converter.to_bytes(pBytes, pBytes + length / 2);
 
+      // convert '\r' line endings to '\n' -- not sure why these sneak in?
+      std::replace(utf8Text.begin(), utf8Text.end(), '\r', '\n');
+
       CFReleaseHandle<CFDataRef> utf8TextRef = CFDataCreate(nullptr, (UInt8*) utf8Text.data(), utf8Text.size());
       if (utf8TextRef && utf8TextRef.value())
          ::PasteboardPutItemFlavor(clipboard, (PasteboardItemID) 1, CFSTR("public.utf8-plain-text"), utf8TextRef, 0);


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14470.

### Approach

Straight-forward conversion of `\r` to `\n` when converting UTF-16 data on the pasteboard to UTF-8.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14470.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
