### PR TITLE
Add `npm ci` before homepage tests script to attempt to fix

### DIFF
--- a/jenkins/Jenkinsfile.pull-request
+++ b/jenkins/Jenkinsfile.pull-request
@@ -136,7 +136,7 @@ pipeline {
               when { expression { return FLAVOR == 'Server' && IS_PRO } }
               steps {
                 dir ("src/cpp/session/workspaces/www-sources") {
-                  sh "./run-tests.sh"
+                  sh "npm ci && ./run-tests.sh"
                 }
               }
             }


### PR DESCRIPTION
It looks like I introduced a bug in the homepage tests script runner in the PR build. I'm not sure why it worked fine on the pro repo when I was testing it and now it's not, but I suspect it's because the deps weren't installed. I'm hoping that installing the node deps will resolve it.