### PR TITLE
guard against immediate bindings

### DIFF
--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -226,12 +226,15 @@ bool isGlobalEnvironmentSerializable()
          // TODO: If an R environment is updated in-place with a value that
          // makes it no longer serializable, we would fail to detect this.
          // Is this okay? Or should we avoid caching results for environments?
-         SEXP valueSEXP = CAR(frameSEXP);
-         bool canBeSerialized = s_serializationCache.contains(valueSEXP)
-               ? s_serializationCache.at(valueSEXP)
-               : isSerializable(valueSEXP);
-         newCache[valueSEXP] = canBeSerialized;
-         allValuesSerializable = allValuesSerializable && canBeSerialized;
+         if (!r::internal::isImmediateBinding(frameSEXP))
+         {
+            SEXP valueSEXP = CAR(frameSEXP);
+            bool canBeSerialized = s_serializationCache.contains(valueSEXP)
+                  ? s_serializationCache.at(valueSEXP)
+                  : isSerializable(valueSEXP);
+            newCache[valueSEXP] = canBeSerialized;
+            allValuesSerializable = allValuesSerializable && canBeSerialized;
+         }
       }
    }
    


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14222.

### Approach

Because we're attempting to iterate through the R global environment directly, we need to guard against immediate bindings. Note that we do something similar here as well:

https://github.com/rstudio/rstudio/blob/dfa5825c5129cc88ccaebfdbcfa61c25a6c018b3/src/cpp/r/include/r/RHelpers.hpp#L43-L59

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14222.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
