### PR TITLE
improve heuristics for inferring package NEWS url

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -103,6 +103,7 @@
 - Improved some French translations of the UI
 - Fixed an issue where searches in the Help pane could fail for entries like `[<-` (#10975)
 - Fixed an issue where the "Save workspace on exit" preference was ignored in some cases (#14258)
+- Fixed an issue where the NEWS button in the Update Packages dialog could fail to find the package NEWS file in some cases (#12648)
 
 #### Posit Workbench
 - Fixed an issue where Professional Driver installation could fail on macOS (rstudio-pro#5168)

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -661,11 +661,15 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    cran <- .Call("rs_rstudioCRANReposUrl", PACKAGE = "(embedding)")
    
    # check whether the requested package is from a separate repository URL
+   # note that the 'Repository' entry below will include a suffix based on the
+   # package type, so we need to trim that after
    db <- as.data.frame(available.packages(), stringsAsFactors = FALSE)
    if ("Repository" %in% names(db)) {
       index <- match(packageName, db$Package)
-      if (!is.na(index))
-         cran <- dirname(dirname(db$Repository[index]))
+      if (!is.na(index)) {
+         repo <- db$Repository[index]
+         cran <- gsub("/(?:src|bin)/.*", "", repo)
+      }
    }
    
    # re-route PPM URLs to CRAN for now


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/12648.

### Approach

- Try to infer the appropriate package NEWS URL based on the repository that the package is actually available from.
- Re-route PPM to CRAN for now, as PPM doesn't support NEWS URLs.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/12648. Also test that the NEWS check works in the Update Packages dialog on Posit Cloud.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
