### PR TITLE
rebuild publish button when deployment records updated

### DIFF
--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -212,6 +212,7 @@ const int kJobsActivate = 194;
 const int kPresentationPreview = 195;
 const int kSuspendBlocked = 196;
 const int kClipboardAction = 197;
+const int kDeploymentRecordsUpdated = 198;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -591,6 +592,8 @@ std::string ClientEvent::typeName() const
          return "session_suspend_blocked";
       case client_events::kClipboardAction:
          return "clipboard_action";
+      case client_events::kDeploymentRecordsUpdated:
+         return "deployment_records_updated";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -213,6 +213,7 @@ extern const int kJobsActivate;
 extern const int kPresentationPreview;
 extern const int kSuspendBlocked;
 extern const int kClipboardAction;
+extern const int kDeploymentRecordsUpdated;
 }
    
 class ClientEvent

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -2209,8 +2209,8 @@ std::string githubUrl(const std::string& view,
       }
       else if (commitId.exitStatus != 0)
       {
-         if (!commitId.stdErr.empty())
-            LOG_ERROR_MESSAGE(commitId.stdErr);
+         // errors are common for repositories without an initial commit,
+         // don't log such errors here
          return std::string();
       }
       upstreamBranch = boost::algorithm::trim_copy(commitId.stdOut);

--- a/src/gwt/src/org/rstudio/studio/client/application/events/DeploymentRecordsUpdatedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/DeploymentRecordsUpdatedEvent.java
@@ -22,6 +22,9 @@ public class DeploymentRecordsUpdatedEvent extends GwtEvent<DeploymentRecordsUpd
 {
    public static class Data extends JavaScriptObject
    {
+      protected Data ()
+      {
+      }
    }
 
    public DeploymentRecordsUpdatedEvent(Data data)

--- a/src/gwt/src/org/rstudio/studio/client/application/events/DeploymentRecordsUpdatedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/DeploymentRecordsUpdatedEvent.java
@@ -1,0 +1,60 @@
+/*
+ * DeploymentRecordsUpdatedEvent.java
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.application.events;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class DeploymentRecordsUpdatedEvent extends GwtEvent<DeploymentRecordsUpdatedEvent.Handler>
+{
+   public static class Data extends JavaScriptObject
+   {
+   }
+
+   public DeploymentRecordsUpdatedEvent(Data data)
+   {
+      data_ = data;
+   }
+
+   public Data getData()
+   {
+      return data_;
+   }
+
+   private final Data data_;
+
+   // Boilerplate ----
+
+   public interface Handler extends EventHandler
+   {
+      void onDeploymentRecordsUpdated(DeploymentRecordsUpdatedEvent event);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onDeploymentRecordsUpdated(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}
+

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishButton.java
@@ -31,6 +31,7 @@ import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.events.DeploymentRecordsUpdatedEvent;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.FilePathUtils;
 import org.rstudio.studio.client.common.GlobalDisplay;
@@ -80,7 +81,8 @@ import com.google.inject.Provider;
 
 public class RSConnectPublishButton extends Composite
    implements RSConnectDeploymentCompletedEvent.Handler,
-              RPubsUploadStatusEvent.Handler
+              RPubsUploadStatusEvent.Handler,
+              DeploymentRecordsUpdatedEvent.Handler
 {
 
    class DeploymentPopupMenu extends ToolbarPopupMenu
@@ -93,8 +95,10 @@ public class RSConnectPublishButton extends Composite
       }
    }
 
-   public RSConnectPublishButton(String host, int contentType, boolean showCaption,
-         AppCommand boundCommand)
+   public RSConnectPublishButton(String host,
+                                 int contentType,
+                                 boolean showCaption,
+                                 AppCommand boundCommand)
    {
       host_ = host;
       contentType_ = contentType;
@@ -142,14 +146,14 @@ public class RSConnectPublishButton extends Composite
    
    @Inject
    public void initialize(RSConnectServerOperations server,
-         RMarkdownServerOperations rmdServer,
-         EventBus events, 
-         Commands commands,
-         GlobalDisplay display,
-         Provider<UserPrefs> pUserPrefs,
-         Provider<UserState> pUserState,
-         Session session,
-         PlotPublishMRUList plotMru)
+                          RMarkdownServerOperations rmdServer,
+                          EventBus events, 
+                          Commands commands,
+                          GlobalDisplay display,
+                          Provider<UserPrefs> pUserPrefs,
+                          Provider<UserState> pUserState,
+                          Session session,
+                          PlotPublishMRUList plotMru)
    {
       server_ = server;
       rmdServer_ = rmdServer;
@@ -187,6 +191,7 @@ public class RSConnectPublishButton extends Composite
       
       events_.addHandler(RSConnectDeploymentCompletedEvent.TYPE, this);
       events_.addHandler(RPubsUploadStatusEvent.TYPE, this);
+      events_.addHandler(DeploymentRecordsUpdatedEvent.TYPE, this);
    }
    
    public void onPublishInvoked(Command onPublishInvoked)
@@ -400,6 +405,12 @@ public class RSConnectPublishButton extends Composite
       {
          populateDeployments(true);
       }
+   }
+   
+   @Override
+   public void onDeploymentRecordsUpdated(DeploymentRecordsUpdatedEvent event)
+   {
+      populateDeployments(true);
    }
    
    public void setShowCaption(boolean show)

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -203,6 +203,7 @@ class ClientEvent extends JavaScriptObject
    public static final String PresentationPreview = "presentation_preview";
    public static final String SuspendBlocked = "session_suspend_blocked";
    public static final String ClipboardAction = "clipboard_action";
+   public static final String DeploymentRecordsUpdated = "deployment_records_updated";
    
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -27,6 +27,7 @@ import org.rstudio.core.client.jsonrpc.RpcObjectList;
 import org.rstudio.studio.client.application.events.ClipboardActionEvent;
 import org.rstudio.studio.client.application.events.ComputeThemeColorsEvent;
 import org.rstudio.studio.client.application.events.DeferredInitCompletedEvent;
+import org.rstudio.studio.client.application.events.DeploymentRecordsUpdatedEvent;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.HandleUnsavedChangesEvent;
 import org.rstudio.studio.client.application.events.QuitEvent;
@@ -1172,6 +1173,11 @@ public class ClientEventDispatcher
          {
             ClipboardActionEvent.Data data = event.getData();
             eventBus_.dispatchEvent(new ClipboardActionEvent(data));
+         }
+         else if (type == ClientEvent.DeploymentRecordsUpdated)
+         {
+            DeploymentRecordsUpdatedEvent.Data data = event.getData();
+            eventBus_.dispatchEvent(new DeploymentRecordsUpdatedEvent(data));
          }
          else
          {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13855.

### Approach

Use the project file monitor to detect changes to files in the `rsconnect` directory. Upon change, fire a (debounced) client event triggering an update of the publish button and its cached deployment list.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13855.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
