### PR TITLE
third time's the charm

### DIFF
--- a/jenkins/Jenkinsfile.pull-request
+++ b/jenkins/Jenkinsfile.pull-request
@@ -132,15 +132,6 @@ pipeline {
             }
 
           stages {
-            stage('Run Homepage Tests') {
-              when { expression { return FLAVOR == 'Server' && IS_PRO } }
-              steps {
-                dir ("src/cpp/session/workspaces/www-sources") {
-                  sh "npm ci && ./run-tests.sh"
-                }
-              }
-            }
-
             stage('Build Package') {
               steps {
                 dir ("package/linux") {
@@ -196,6 +187,16 @@ pipeline {
                 }
               }
             }
+
+            stage('Run Homepage Tests') {
+              when { expression { return FLAVOR == 'Server' && IS_PRO } }
+              steps {
+                dir ("src/cpp/session/workspaces/www-sources") {
+                  sh "./run-tests.sh"
+                }
+              }
+            }
+
           }
         }
       }


### PR DESCRIPTION
Alright here we go again. I'm trying this by moving the tests after the build because the build also installs the `npm` dependencies for the homepage. We definitely can't run `npm` before the test script because we don't have access to `npm` without doing path acrobatics. The script does the necessary path acrobatics.