### PR TITLE
notify user debug location is approximate when appropriate

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -282,6 +282,7 @@ public class EnvironmentPresenter extends BasePresenter
          {
             if (isApproximateBrowsePosition_)
             {
+               openOrUpdateFileBrowsePoint(true, true);
                requeryContextTimer_.cancel();
                return;
             }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -2090,7 +2090,7 @@ public class Source implements InsertSourceEvent.Handler,
                   position != null &&
                   (position.getLine() != -1 || position.getColumn() != -1);
 
-            if (navigateToPosition)
+            if (isDebugNavigation || navigateToPosition)
             {
                SourcePosition endPosition = null;
                if (isDebugNavigation)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
@@ -14,10 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors;
 
-import com.google.gwt.event.logical.shared.HasCloseHandlers;
-import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.ui.HasValue;
-import com.google.gwt.user.client.ui.IsWidget;
+import java.util.HashSet;
 
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.events.HasEnsureHeightHandlers;
@@ -36,7 +33,10 @@ import org.rstudio.studio.client.workbench.views.source.events.CollabEditStartPa
 import org.rstudio.studio.client.workbench.views.source.model.SourceDocument;
 import org.rstudio.studio.client.workbench.views.source.model.SourcePosition;
 
-import java.util.HashSet;
+import com.google.gwt.event.logical.shared.HasCloseHandlers;
+import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.ui.HasValue;
+import com.google.gwt.user.client.ui.IsWidget;
 
 public interface EditingTarget extends IsWidget,
                                        HasEnsureVisibleHandlers,
@@ -108,7 +108,7 @@ public interface EditingTarget extends IsWidget,
    void highlightDebugLocation(
          SourcePosition startPos,
          SourcePosition endPos,
-         boolean executing);   
+         boolean executing);
    void endDebugHighlighting();
    
    void beginCollabSession(CollabEditStartParams params);


### PR DESCRIPTION
### TODO

- [ ] Don't clear the warning bar on save if we're using an approximate debug location.

### Intent

Addresses https://github.com/rstudio/rstudio/issues/14417#issuecomment-2021296751.

### Approach

When performing code navigation using an approximate debug location, show a warning that this is the case. Code is mostly a clunky bit of threading the needle through existing code paths.

### Automated Tests

N/A

### QA Notes

Create an R document with the code:

```
foo <- function() {
  browser()
  1 + 1
}
```

Save the document, then execute the code with Cmd + Enter. Then, run `foo()`. You should enter the debugger. Now, add a line like `2 + 2` to the function definition, save the document, and press `n` to step forward. You should be presented with a view of the same file, but with a warning displayed.

<img width="837" alt="Screenshot 2024-03-27 at 10 04 15 PM" src="https://github.com/rstudio/rstudio/assets/1976582/6fb2c93e-1018-460f-aef2-df3ac7d2bbb4">


### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
