### PR TITLE
Suppress package version warning

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -303,8 +303,9 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 
 .rs.addFunction("getPackageVersion", function(packageName)
 {
-   package_version(utils:::packageDescription(packageName, 
-                                              fields="Version"))   
+   v <- suppressWarnings(utils:::packageDescription(packageName, 
+                                              fields="Version"))
+   package_version(v)   
 })
 
 # save an environment to a file


### PR DESCRIPTION
### Intent

Suppress an unnecessary warning on startup with a non-installed package. I couldn't reproduce this very reliably, but I am confident this produces warnings where they are not needed.

It happened during load time with a package that was not installed for me.

An alternative would be to try to use `pkgload::pkg_version()`

```r
.rs.addFunction("getPackageVersion", function(packageName)
{  
    version <- suppressWarnings(utils:::packageDescription(packageName, 
                                                           fields = "Version"))
    if (!is.na(version)) {
        return(package_version(version))
    }
    # Try to see if unloaded package (can happen at startup)
    if (requireNamespace("pkgload", quietly = TRUE)) {
        return(tryCatch(pkgload::pkg_version(), error = function(e) NA))
    }
    NA
})
# not sure that replacement function would be useful, as I don't really see where it is called
```

### Approach

Suppress warning 

As a background

```r
#  this warns
utils::packageDescription("notinstalled")
#> Warning in  packageDescription("notinstalled") :
#>   package 'noninstalled' is not found
#> [1] NA
# this errors for non-existing, but works properly otherwise
utils::packageVersion(notinstalled)
#> Error: no package named notinstalled
# this errors
package_version(NA)

# this works without load_all()
pkgload::pkg_version()  # type = package_version
#> [1] "correct version"

# works after load_all()
pkgload::load_all("~/path/to/notinstalled")
utils::packageDescription("notinstalled", fields = "Version") # type = character
#> [1] "correct_version" 
utils::packageVersion(notinstalled) # type = package_version
#> [1] "correct_version"
```

I also use the option 

```r
options( showWarnCalls = TRUE)
```

```
Warnings:
1: In utils::packageDescription(package, fields = "Version") :
  package 'notinstalled' not found
Calls: .rs.Rd2HTML -> <Anonymous> -> <Anonymous>
2: In utils::packageDescription(package, fields = "Version") :
  package 'notinstalled' not found
Calls: .rs.Rd2HTML -> <Anonymous> -> <Anonymous>
```

### Automated Tests

Will not change any behavior

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

Signed contributor agreement.

