### PR TITLE
further restrict Copilot completion requests in hidden documents

### DIFF
--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -1438,7 +1438,12 @@ Error copilotGenerateCompletions(const json::JsonRpcRequest& request,
    FilePath docPath = module_context::resolveAliasedPath(documentPath);
    if (!isIndexableFile(docPath))
    {
+      json::Object resultJson;
+      resultJson["enabled"] = false;
+      
       json::JsonRpcResponse response;
+      response.setResult(resultJson);
+      
       continuation(Success(), &response);
       return Success();
    }

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -1456,7 +1456,7 @@ Error copilotGenerateCompletions(const json::JsonRpcRequest& request,
    json::Object docJson;
    docJson["position"] = positionJson;
    docJson["uri"] = uriFromDocumentImpl(documentId, documentPath, isUntitled);
-   docJson["version"] = 0;
+   docJson["version"] = kCopilotDefaultDocumentVersion;
 
    json::Object paramsJson;
    paramsJson["doc"] = docJson;

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -65,14 +65,14 @@
 # define LOG_ERROR(error) LOG_ERROR_NAMED("copilot", error)
 #endif
 
-
 #ifndef _WIN32
 # define kNodeExe "node"
 #else
 # define kNodeExe "node.exe"
 #endif
 
-#define kCopilotAgentDefaultCommitHash ("69455be5d4a892206bc08365ba3648a597485943")
+#define kCopilotAgentDefaultCommitHash ("69455be5d4a892206bc08365ba3648a597485943") // pragma: allowlist secret
+#define kCopilotDefaultDocumentVersion (0)
 #define kMaxIndexingFileSize (1048576)
 
 using namespace rstudio::core;
@@ -261,6 +261,16 @@ bool isIndexableFile(const FilePath& documentPath)
       return false;
    
    return true;
+}
+
+bool isIndexableDocument(const boost::shared_ptr<source_database::SourceDocument>& pDoc)
+{
+   // Don't index binary files.
+   if (pDoc->contents().find('\0') != std::string::npos)
+      return false;
+   
+   FilePath docPath(pDoc->path());
+   return isIndexableFile(docPath);
 }
 
 FilePath copilotAgentPath()
@@ -1029,15 +1039,14 @@ void onDocAdded(boost::shared_ptr<source_database::SourceDocument> pDoc)
 {
    if (!ensureAgentRunning())
       return;
-
-   // Avoid indexing binary files
-   if (pDoc->contents().find('\0') != std::string::npos)
+   
+   if (!isIndexableDocument(pDoc))
       return;
    
    json::Object textDocumentJson;
    textDocumentJson["uri"] = uriFromDocument(pDoc);
    textDocumentJson["languageId"] = languageIdFromDocument(pDoc);
-   textDocumentJson["version"] = 1;
+   textDocumentJson["version"] = kCopilotDefaultDocumentVersion;
    textDocumentJson["text"] = "";
 
    json::Object paramsJson;
@@ -1067,15 +1076,14 @@ void onDocUpdated(boost::shared_ptr<source_database::SourceDocument> pDoc)
    if (!ensureAgentRunning())
       return;
 
-   // Avoid indexing binary files
-   if (pDoc->contents().find('\0') != std::string::npos)
+   if (!isIndexableDocument(pDoc))
       return;
    
    // Synchronize document contents with Copilot
    json::Object textDocumentJson;
    textDocumentJson["uri"] = uriFromDocument(pDoc);
    textDocumentJson["languageId"] = languageIdFromDocument(pDoc);
-   textDocumentJson["version"] = 1;
+   textDocumentJson["version"] = kCopilotDefaultDocumentVersion;
    textDocumentJson["text"] = contentsFromDocument(pDoc);
 
    json::Object paramsJson;
@@ -1204,7 +1212,7 @@ void indexFile(const core::FileInfo& info)
    json::Object textDocumentJson;
    textDocumentJson["uri"] = uriFromDocumentPath(documentPath.getAbsolutePath());
    textDocumentJson["languageId"] = languageId;
-   textDocumentJson["version"] = 1;
+   textDocumentJson["version"] = kCopilotDefaultDocumentVersion;
    textDocumentJson["text"] = contents;
 
    json::Object paramsJson;
@@ -1424,6 +1432,16 @@ Error copilotGenerateCompletions(const json::JsonRpcRequest& request,
       LOG_ERROR(error);
       return error;
    }
+   
+   // Disallow completion request in hidden files, since this might trigger
+   // the copilot agent to attempt to read the contents of that file
+   FilePath docPath = module_context::resolveAliasedPath(documentPath);
+   if (!isIndexableFile(docPath))
+   {
+      json::JsonRpcResponse response;
+      continuation(Success(), &response);
+      return Success();
+   }
 
    // Build completion request
    json::Object positionJson;
@@ -1433,7 +1451,7 @@ Error copilotGenerateCompletions(const json::JsonRpcRequest& request,
    json::Object docJson;
    docJson["position"] = positionJson;
    docJson["uri"] = uriFromDocumentImpl(documentId, documentPath, isUntitled);
-   docJson["version"] = 1;
+   docJson["version"] = 0;
 
    json::Object paramsJson;
    paramsJson["doc"] = docJson;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/copilot/model/CopilotResponseTypes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/copilot/model/CopilotResponseTypes.java
@@ -169,6 +169,9 @@ public class CopilotResponseTypes
    @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
    public static class CopilotGenerateCompletionsResponse extends CopilotResponse
    {
+      // These aren't part of a normal Copilot completions request; we append
+      // this extra information to report whether Copilot is enabled for this document.
+      public Boolean enabled;
    }
 
    private static final CopilotUIConstants constants_ = GWT.create(CopilotUIConstants.class);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
@@ -77,6 +77,9 @@ public class TextEditingTargetCopilotHelper
          @Override
          public void run()
          {
+            if (copilotDisabledInThisDocument_)
+               return;
+            
             target_.withSavedDoc(() ->
             {
                requestId_ += 1;
@@ -105,6 +108,14 @@ public class TextEditingTargetCopilotHelper
                            Position currentCursorPosition = display_.getCursorPosition();
                            if (!currentCursorPosition.isEqualTo(savedCursorPosition))
                               return;
+                           
+                           // Check for null response. This might happen if no completions are permitted in this scope.
+                           if (response == null)
+                           {
+                              copilotDisabledInThisDocument_ = true;
+                              events_.fireEvent(new CopilotEvent(CopilotEventType.COMPLETION_CANCELLED));
+                              return;
+                           }
                            
                            // Check for error.
                            CopilotError error = response.error;
@@ -431,6 +442,7 @@ public class TextEditingTargetCopilotHelper
    
    private int requestId_;
    private boolean suppressCursorChangeHandler_;
+   private boolean copilotDisabledInThisDocument_;
    
    private CopilotCompletion activeCompletion_;
    private boolean automaticCodeSuggestionsEnabled_ = true;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.text;
 
+import java.util.Objects;
+
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.MathUtil;
@@ -109,8 +111,13 @@ public class TextEditingTargetCopilotHelper
                            if (!currentCursorPosition.isEqualTo(savedCursorPosition))
                               return;
                            
-                           // Check for null response. This might happen if no completions are permitted in this scope.
+                           // Check for null completion results -- this may occur if the Copilot
+                           // agent couldn't be started for some reason.
                            if (response == null)
+                              return;
+                           
+                           // Check whether completions are enabled in this document.
+                           if (Objects.equals(response.enabled, false))
                            {
                               copilotDisabledInThisDocument_ = true;
                               events_.fireEvent(new CopilotEvent(CopilotEventType.COMPLETION_CANCELLED));


### PR DESCRIPTION
- Don't allow Copilot to see hidden / "secret" files, even if they're open in an editor buffer.
- Don't attempt to request completions in hidden / "secret" files either.