### PR TITLE
don't include spellcheck items in gutter

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/JsVector.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVector.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.core.client;
 
+import java.util.function.Predicate;
+
 import com.google.gwt.core.client.JavaScriptObject;
 
 public class JsVector<T> extends JavaScriptObject
@@ -61,6 +63,20 @@ public class JsVector<T> extends JavaScriptObject
    public final void fill(T value)
    {
       fill(value, 0, length());
+   }
+   
+   public final JsVector<T> filter(Predicate<T> predicate)
+   {
+      JsVector<T> result = JsVector.createVector();
+      
+      for (int i = 0, n = length(); i < n; i++)
+      {
+         T value = get(i);
+         if (predicate.test(value))
+            result.push(value);
+      }
+      
+      return result;
    }
 
    public final T get(int index)

--- a/src/gwt/src/org/rstudio/core/client/JsVectorBoolean.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVectorBoolean.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.core.client;
 
+import java.util.function.Predicate;
+
 import com.google.gwt.core.client.JavaScriptObject;
 
 public class JsVectorBoolean extends JavaScriptObject
@@ -61,6 +63,20 @@ public class JsVectorBoolean extends JavaScriptObject
    public final void fill(boolean value)
    {
       fill(value, 0, length());
+   }
+   
+   public final JsVectorBoolean filter(Predicate predicate)
+   {
+      JsVectorBoolean result = JsVectorBoolean.createVector();
+      
+      for (int i = 0, n = length(); i < n; i++)
+      {
+         boolean value = get(i);
+         if (predicate.test(value))
+            result.push(value);
+      }
+      
+      return result;
    }
 
    public final boolean get(int index)

--- a/src/gwt/src/org/rstudio/core/client/JsVectorInteger.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVectorInteger.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.core.client;
 
+import java.util.function.Predicate;
+
 import com.google.gwt.core.client.JavaScriptObject;
 
 public class JsVectorInteger extends JavaScriptObject
@@ -61,6 +63,20 @@ public class JsVectorInteger extends JavaScriptObject
    public final void fill(int value)
    {
       fill(value, 0, length());
+   }
+   
+   public final JsVectorInteger filter(Predicate predicate)
+   {
+      JsVectorInteger result = JsVectorInteger.createVector();
+      
+      for (int i = 0, n = length(); i < n; i++)
+      {
+         int value = get(i);
+         if (predicate.test(value))
+            result.push(value);
+      }
+      
+      return result;
    }
 
    public final int get(int index)

--- a/src/gwt/src/org/rstudio/core/client/JsVectorNumber.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVectorNumber.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.core.client;
 
+import java.util.function.Predicate;
+
 import com.google.gwt.core.client.JavaScriptObject;
 
 public class JsVectorNumber extends JavaScriptObject
@@ -61,6 +63,20 @@ public class JsVectorNumber extends JavaScriptObject
    public final void fill(double value)
    {
       fill(value, 0, length());
+   }
+   
+   public final JsVectorNumber filter(Predicate predicate)
+   {
+      JsVectorNumber result = JsVectorNumber.createVector();
+      
+      for (int i = 0, n = length(); i < n; i++)
+      {
+         double value = get(i);
+         if (predicate.test(value))
+            result.push(value);
+      }
+      
+      return result;
    }
 
    public final double get(int index)

--- a/src/gwt/src/org/rstudio/core/client/JsVectorString.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVectorString.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.core.client;
 
+import java.util.function.Predicate;
+
 import com.google.gwt.core.client.JavaScriptObject;
 
 public class JsVectorString extends JavaScriptObject
@@ -61,6 +63,20 @@ public class JsVectorString extends JavaScriptObject
    public final void fill(String value)
    {
       fill(value, 0, length());
+   }
+   
+   public final JsVectorString filter(Predicate predicate)
+   {
+      JsVectorString result = JsVectorString.createVector();
+      
+      for (int i = 0, n = length(); i < n; i++)
+      {
+         String value = get(i);
+         if (predicate.test(value))
+            result.push(value);
+      }
+      
+      return result;
    }
 
    public final String get(int index)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -4288,7 +4288,7 @@ public class AceEditor implements DocDisplay,
    @Override
    public void showLint(JsArray<LintItem> lint)
    {
-      widget_.showLint(lint);
+      widget_.showLint(lint.cast());
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -17,10 +17,12 @@ package org.rstudio.studio.client.workbench.views.source.editors.text;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.JsVector;
 import org.rstudio.core.client.JsVectorString;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.elemental2.overlay.File;
@@ -1212,10 +1214,21 @@ public class AceEditorWidget extends Composite
       editor_.getSession().setAnnotations(annotations);
    }
 
-   public void showLint(JsArray<LintItem> lint)
+   public void showLint(JsVector<LintItem> lint)
    {
       clearAnnotations();
-      JsArray<AceAnnotation> annotations = LintItem.asAceAnnotations(lint);
+      
+      // Set gutter annotations. Don't include 'spelling' items in gutter.
+      JsVector<LintItem> gutterLint = lint.filter(new Predicate<LintItem>()
+      {
+         @Override
+         public boolean test(LintItem item)
+         {
+            return item.getType() != "spelling";
+         }
+      });
+      
+      JsArray<AceAnnotation> annotations = LintItem.asAceAnnotations(gutterLint.cast());
       editor_.getSession().setAnnotations(annotations);
 
       // Now, set (and cache) inline markers.


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14510.

### Approach

Explicitly exclude "spelling" lint from the gutter annotations we prepare.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14510.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
