### PR TITLE
fix thinko when searching for approximate debug location

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -904,7 +904,7 @@ public class EnvironmentPresenter extends BasePresenter
             {
                // Try a fuzzier search, but note that this is now an approximate position.
                int newlineIndex = currentBrowseSource_.indexOf('\n');
-               String firstLine = editorCode.substring(0, newlineIndex);
+               String firstLine = currentBrowseSource_.substring(0, newlineIndex);
                codeIndex = editorCode.indexOf(firstLine);
                if (codeIndex != -1)
                {


### PR DESCRIPTION
### Intent

Addresses #14514.

### Approach

The intention in this code was to perform a fuzzy search based on the first line of `currentBrowseSource_`, but we ended up subsetting the wrong variable. Doh.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14514.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
