### PR TITLE
Enable directory only autocompletion for fs dir functions

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2657,7 +2657,14 @@ assign(x = ".rs.acCompletionTypes",
                                              "dir_tree",
                                              "dir_delete",
                                              "dir_info",
-                                             "dir_copy"))
+                                             "dir_copy",
+                                             "fs::dir_ls", # fs dir helpers
+                                             "fs::dir_walk",
+                                             "fs::dir_tree",
+                                             "fs::dir_delete",
+                                             "fs::dir_info",
+                                             "fs::dir_copy",
+                                            ))
          {
             directoriesOnly <- TRUE
          }

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2183,6 +2183,16 @@ assign(x = ".rs.acCompletionTypes",
    frames[[length(frames) - 1L - offset]]
 })
 
+# Only display directory completions (not file completions)
+.rs.addFunction("isDirectoryOnlyCompletionFunction", function(string))
+{
+   # Base R functions + fs functions that deal with dir_
+   # https://fs.r-lib.org/articles/function-comparisons.html#directory-functions
+   dirOnlyFuncs <- c("list.files", "list.dirs", "dir", "setwd")
+   string %in% dirOnlyFuncs || grep("^(?:fs:{2,3})?dir_", string)
+
+}
+
 .rs.addFunction("getCompletionsNativeRoutine", function(token, interface)
 {
    # For a package which has dynamic symbol loading, just get the strings.
@@ -2646,28 +2656,9 @@ assign(x = ".rs.acCompletionTypes",
       tokenToUse <- string[[whichIndex]]
       
       directoriesOnly <- FALSE
-      if (length(string) > whichIndex)
+      if (length(string) > whichIndex && .rs.isDirectoryOnlyCompletionFunction(string[[whichIndex + 1]]))
       {
-         if (string[[whichIndex + 1]] %in% c("list.files",
-                                             "list.dirs",
-                                             "dir",
-                                             "setwd",
-                                             "dir_ls", # fs dir helpers
-                                             "dir_walk",
-                                             "dir_tree",
-                                             "dir_delete",
-                                             "dir_info",
-                                             "dir_copy",
-                                             "fs::dir_ls", # fs dir helpers
-                                             "fs::dir_walk",
-                                             "fs::dir_tree",
-                                             "fs::dir_delete",
-                                             "fs::dir_info",
-                                             "fs::dir_copy",
-                                            ))
-         {
-            directoriesOnly <- TRUE
-         }
+         directoriesOnly <- TRUE
       }
       
       # NOTE: For Markdown link completions, we overload the meaning of the

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2651,7 +2651,13 @@ assign(x = ".rs.acCompletionTypes",
          if (string[[whichIndex + 1]] %in% c("list.files",
                                              "list.dirs",
                                              "dir",
-                                             "setwd"))
+                                             "setwd",
+                                             "dir_ls", # fs dir helpers
+                                             "dir_walk",
+                                             "dir_tree",
+                                             "dir_delete",
+                                             "dir_info",
+                                             "dir_copy"))
          {
             directoriesOnly <- TRUE
          }

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2189,7 +2189,7 @@ assign(x = ".rs.acCompletionTypes",
    # Base R functions + fs functions that deal with dir_
    # https://fs.r-lib.org/articles/function-comparisons.html#directory-functions
    dirOnlyFuncs <- c("list.files", "list.dirs", "dir", "setwd")
-   string %in% dirOnlyFuncs || grep("^(?:fs:{2,3})?dir_", string)
+   string %in% dirOnlyFuncs || grepl("^(?:fs:{2,3})?dir_", string)
 })
 
 .rs.addFunction("getCompletionsNativeRoutine", function(token, interface)

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2184,14 +2184,13 @@ assign(x = ".rs.acCompletionTypes",
 })
 
 # Only display directory completions (not file completions)
-.rs.addFunction("isDirectoryOnlyCompletionFunction", function(string))
+.rs.addFunction("isDirectoryOnlyCompletionFunction", function(string)
 {
    # Base R functions + fs functions that deal with dir_
    # https://fs.r-lib.org/articles/function-comparisons.html#directory-functions
    dirOnlyFuncs <- c("list.files", "list.dirs", "dir", "setwd")
    string %in% dirOnlyFuncs || grep("^(?:fs:{2,3})?dir_", string)
-
-}
+})
 
 .rs.addFunction("getCompletionsNativeRoutine", function(token, interface)
 {


### PR DESCRIPTION
### Intent

Have these functions only display directories, like `.list.files()` and friends.

What you get when completing the first argument of `setwd()`
![image](https://github.com/rstudio/rstudio/assets/52606734/afa0af5e-25fc-4949-bae6-005146b4015c)

Added the prefixed `fs::` to make it work with and without prefixing. 

### Approach

Add functions to list of dir only functions (both prefixed and not prefixed to make sure it works.

Used those functions as a baseline (except for `dir_create()` https://fs.r-lib.org/articles/function-comparisons.html#directory-functions

### Automated Tests

NA

### QA Notes

Check that they complete as expected

### Documentation

Seems minor?

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->

Signed contributor agreement.

