### PR TITLE
support exit from nested state in chunk

### DIFF
--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -21,8 +21,6 @@ var $colorFunctionCalls = false;
 
 define("mode/r_highlight_rules", ["require", "exports", "module"], function(require, exports, module)
 {
-  var YamlHighlightRules = require("mode/yaml_highlight_rules").YamlHighlightRules;
-
   var Utils = require("mode/utils");
 
   function include(rules) {

--- a/src/gwt/acesupport/acemode/utils.js
+++ b/src/gwt/acesupport/acemode/utils.js
@@ -112,14 +112,23 @@ var YamlHighlightRules = require("mode/yaml_highlight_rules").YamlHighlightRules
       HighlightRules.embedRules(EmbedRules, prefix + "-", [{
          token: "support.function.codeend",
          regex: reEnd,
-         next: "pop"
+         onMatch: function(value, state, stack, line, context) {
+            this.next = context.chunk.state || "start";
+            delete context.chunk;
+            return this.token;
+         }
       }]);
 
       for (var i = 0; i < startStates.length; i++) {
          rules[startStates[i]].unshift({
             token: "support.function.codebegin",
             regex: reStart,
-            push: prefix + "-start"
+            onMatch: function(value, state, stack, line, context) {
+               context.chunk = context.chunk || {};
+               context.chunk.state = state;
+               this.next = prefix + "-start";
+               return this.token;
+            }
          });
       }
    };

--- a/src/gwt/acesupport/acemode/yaml_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/yaml_highlight_rules.js
@@ -40,6 +40,10 @@ define("mode/yaml_highlight_rules", ["require", "exports", "module"], function (
       };
    };
 
+   // NOTE: These highlight rules are embedded in e.g. R, for highlighting of
+   // Quarto YAML. Because the "start" of a YAML string might include the '#|'
+   // comment prefix, we avoid using the '^' anchor in regular expressions below,
+   // and instead just use '\b' to require a word boundary.
    var YamlHighlightRules = function () {
 
       var rules = {};
@@ -75,7 +79,7 @@ define("mode/yaml_highlight_rules", ["require", "exports", "module"], function (
          },
          {
             token: "list.markup",
-            regex: /^(?:-{3}|\.{3})\s*(?=#|$)/
+            regex: /\b(?:-{3}|\.{3})\s*(?=#|$)/
          },
          {
             token: "list.markup.keyword.operator",
@@ -90,16 +94,14 @@ define("mode/yaml_highlight_rules", ["require", "exports", "module"], function (
             regex: "[&\\*][a-zA-Z0-9-_]+"
          },
          {
+            // (package) (::) (function) (:)
             token: ["meta.tag", "keyword", "meta.tag", "keyword.operator"],
-            regex: /^(\s*[\w\-].*?)(:{2,3})(\s*[\w\-].*?)(:(?:\s+|$))/
+            regex: /\b(\s*[\w\-.]*?)(:{2,3})(\s*[\w\-.]*?)(:(?:\s+|$))/
          },
          {
+            // (dictionary-key) (:)
             token: ["meta.tag", "keyword.operator"],
-            regex: /^(\s*[\w\-].*?)(:(?:\s+|$))/
-         },
-         {
-            token: ["meta.tag", "keyword.operator"],
-            regex: /([\w\-]+?)(\s*:(?:\s+|$))/
+            regex: /\b(\s*[\w\-.]*?)(:(?:\s+|$))/
          },
          {
             token: "keyword.operator",


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14544.
Addresses https://github.com/rstudio/rstudio/issues/14545.

### Approach

For R Markdown documents (and other multi-mode documents), when we embed the highlight rules for a particular language in a chunk, we did so under the assumption that only one single set of language highlight rules could exist in that chunk. This was no longer true with some of the changes we made to support Quarto YAML highlight rules, since we now have:

Markdown => R => YAML

And so if we encountered a chunk end marker while we were in the YAML highlight state, we would only pop a single state, hence placing us back into the R state (rather than the top-level Markdown state).

The fix here is fortunately straightforward: save the state we were in when we entered the chunk, and restore that state when we leave, regardless of how many inner language states were pushed while highlighting the inner chunk.

### Automated Tests

N/A, but I intend to take a look at this after fixing the other highlight-related bug.

### QA Notes

Test that highlighting in the following document works as expected:

`````

```{r}
#| message: false
```

This is Markdown, so don't highlight this: 1 + 1
`````

You should see something like:

<img width="441" alt="Screenshot 2024-04-17 at 3 26 13 PM" src="https://github.com/rstudio/rstudio/assets/1976582/c69fbca3-daf5-4c6c-9ac3-df13e54775da">



### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


