### PR TITLE
fix GWT compilation warnings

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/JsVectorBoolean.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVectorBoolean.java
@@ -65,7 +65,7 @@ public class JsVectorBoolean extends JavaScriptObject
       fill(value, 0, length());
    }
    
-   public final JsVectorBoolean filter(Predicate predicate)
+   public final JsVectorBoolean filter(Predicate<Boolean> predicate)
    {
       JsVectorBoolean result = JsVectorBoolean.createVector();
       

--- a/src/gwt/src/org/rstudio/core/client/JsVectorInteger.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVectorInteger.java
@@ -65,7 +65,7 @@ public class JsVectorInteger extends JavaScriptObject
       fill(value, 0, length());
    }
    
-   public final JsVectorInteger filter(Predicate predicate)
+   public final JsVectorInteger filter(Predicate<Integer> predicate)
    {
       JsVectorInteger result = JsVectorInteger.createVector();
       

--- a/src/gwt/src/org/rstudio/core/client/JsVectorNumber.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVectorNumber.java
@@ -65,7 +65,7 @@ public class JsVectorNumber extends JavaScriptObject
       fill(value, 0, length());
    }
    
-   public final JsVectorNumber filter(Predicate predicate)
+   public final JsVectorNumber filter(Predicate<Double> predicate)
    {
       JsVectorNumber result = JsVectorNumber.createVector();
       

--- a/src/gwt/src/org/rstudio/core/client/JsVectorString.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVectorString.java
@@ -65,7 +65,7 @@ public class JsVectorString extends JavaScriptObject
       fill(value, 0, length());
    }
    
-   public final JsVectorString filter(Predicate predicate)
+   public final JsVectorString filter(Predicate<String> predicate)
    {
       JsVectorString result = JsVectorString.createVector();
       


### PR DESCRIPTION
### Intent

Address recently introduced GWT compilation warnings introduced by [don't include spellcheck items in gutter #14512](https://github.com/rstudio/rstudio/pull/14512).

These were also being flagged as a warning in VSCode (yellow underline).

```
[javac] /Users/garyritchie/rstudio/src/gwt/src/org/rstudio/core/client/JsVectorString.java:75: warning: [unchecked] unchecked call to test(T) as a member of the raw type Predicate
[javac]          if (predicate.test(value))
[javac]                            ^
[javac]   where T is a type-variable:
[javac]     T extends Object declared in interface Predicate
[javac] /Users/garyritchie/rstudio/src/gwt/src/org/rstudio/core/client/JsVectorInteger.java:75: warning: [unchecked] unchecked call to test(T) as a member of the raw type Predicate
[javac]          if (predicate.test(value))
[javac]                            ^
[javac]   where T is a type-variable:
[javac]     T extends Object declared in interface Predicate
[javac] /Users/garyritchie/rstudio/src/gwt/src/org/rstudio/core/client/JsVectorBoolean.java:75: warning: [unchecked] unchecked call to test(T) as a member of the raw type Predicate
[javac]          if (predicate.test(value))
[javac]                            ^
[javac]   where T is a type-variable:
[javac]     T extends Object declared in interface Predicate
[javac] /Users/garyritchie/rstudio/src/gwt/src/org/rstudio/core/client/JsVectorNumber.java:75: warning: [unchecked] unchecked call to test(T) as a member of the raw type Predicate
[javac]          if (predicate.test(value))
[javac]                            ^
[javac]   where T is a type-variable:
[javac]     T extends Object declared in interface Predicate
```

### Approach

Parameterize the generic Predicate type. An alternative would be to suppress the warnings, but this seems more correct.

### Automated Tests

Confirmed GWT unit tests still pass.

### QA Notes

I checked that https://github.com/rstudio/rstudio/issues/14510 remains fixed (this is the issue that led to the change containing this warning).

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


