### PR TITLE
fix issue with iterating over lint items

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -1252,10 +1252,7 @@ public class AceEditorWidget extends Composite
             clazz = lintStyles_.spelling();
          
          int id = editor_.getSession().addMarker(range, clazz, "text", true);
-         annotations_.add(new AnchoredAceAnnotation(
-            annotations.get(i),
-            range,
-            id));
+         annotations_.add(new AnchoredAceAnnotation(item.asAceAnnotation(), range, id));
       }
    }
 


### PR DESCRIPTION
### Intent

Addresses a JavaScript exception that can be emitted when a document contains spelling mistakes, as well as other diagnostic errors.

### Approach

Recent changes in this code separated out lint that we wanted to display in the gutter, versus lint that we wanted to display inline with Ace markers. However, the loop here assumed that both 'lint' and 'annotations' were still congruent, which they were not. See:

https://github.com/rstudio/rstudio/commit/bba6d24eb6c08516e4a8db9acfe05209e2c15832#diff-5e04b14bd6bfc6ef2e66daaf607100cdfe1a4c4e96edacfec1352316a4d6dff0R1221-R1231

### Automated Tests

N/A

### QA Notes

Double-check that this change does not affect the display of spelling errors, or R diagnostics, within the editor.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
