### PR TITLE
avoid potentially discarding aesthetics

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -3092,8 +3092,8 @@ assign(x = ".rs.acCompletionTypes",
             "group"
          )
          
-         aestheticNames <- aesthetics[!duplicated(aesthetics)]
-         aestheticNames <- aestheticNames[!grepl("|", aestheticNames, fixed = TRUE)]
+         aestheticNames <- unlist(strsplit(aesthetics, "|", fixed = TRUE))
+         aestheticNames <- aestheticNames[!duplicated(aestheticNames)]
          aestheticSource <- geomName
       }
       


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14586.

### Approach

Instead of just discarding aesthetics separated via `|`, split on that delimiter and then include + drop duplicates after.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14586.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
