### PR TITLE
pin electron-forge and electron-packages to older versions

### DIFF
--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rstudio",
-  "version": "99.9.9",
+  "version": "9999.99.9-dev+1.test9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rstudio",
-      "version": "99.9.9",
+      "version": "9999.99.9-dev+1.test9",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -29,8 +29,9 @@
         "winston-syslog": "2.7.0"
       },
       "devDependencies": {
-        "@electron-forge/cli": "7.4.0",
-        "@electron-forge/plugin-webpack": "7.4.0",
+        "@electron-forge/cli": "7.2.0",
+        "@electron-forge/plugin-webpack": "7.2.0",
+        "@electron/packager": "18.1.1",
         "@types/chai": "4.3.11",
         "@types/crc": "3.8.3",
         "@types/line-reader": "0.0.37",
@@ -568,9 +569,9 @@
       }
     },
     "node_modules/@electron-forge/cli": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-7.4.0.tgz",
-      "integrity": "sha512-a+zZv3ja/IxkJzNyx4sOHSZv6DPV85S0PEVF6pcRjUpbDL5r+DxjRFsNc0Nq4UIWyFm1nw7RWoPdd9uDst4Tvg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-7.2.0.tgz",
+      "integrity": "sha512-FJ8XzT4w6bTC3trvHHWL67W1zp7g2xmCC5riNa1rjk8Gd2C1j8wf0ul4ch9kbcaEAFaXuXwv98QKXxhCn4aLtQ==",
       "dev": true,
       "funding": [
         {
@@ -583,14 +584,14 @@
         }
       ],
       "dependencies": {
-        "@electron-forge/core": "7.4.0",
-        "@electron-forge/shared-types": "7.4.0",
+        "@electron-forge/core": "7.2.0",
+        "@electron-forge/shared-types": "7.2.0",
         "@electron/get": "^3.0.0",
         "chalk": "^4.0.0",
         "commander": "^4.1.1",
         "debug": "^4.3.1",
         "fs-extra": "^10.0.0",
-        "listr2": "^7.0.2",
+        "listr2": "^5.0.3",
         "semver": "^7.2.1"
       },
       "bin": {
@@ -603,9 +604,9 @@
       }
     },
     "node_modules/@electron-forge/core": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-7.4.0.tgz",
-      "integrity": "sha512-pYHKpB2CKeQgWsb+gox+FPkEvP+6Q2zGj2eZtgZRtKppoWIXrHIpOtcm6FllJ/gZ5u4AsQzVIYReAHGaBa0osw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-7.2.0.tgz",
+      "integrity": "sha512-7Sh0KW79Z/y9MStU3sWTBbTkM4SvV6rL557/ndlfAbZrxcGMnmWHrzn/odAZW1eyfhKguBb7C1Ijw0YTpsdVsw==",
       "dev": true,
       "funding": [
         {
@@ -618,19 +619,19 @@
         }
       ],
       "dependencies": {
-        "@electron-forge/core-utils": "7.4.0",
-        "@electron-forge/maker-base": "7.4.0",
-        "@electron-forge/plugin-base": "7.4.0",
-        "@electron-forge/publisher-base": "7.4.0",
-        "@electron-forge/shared-types": "7.4.0",
-        "@electron-forge/template-base": "7.4.0",
-        "@electron-forge/template-vite": "7.4.0",
-        "@electron-forge/template-vite-typescript": "7.4.0",
-        "@electron-forge/template-webpack": "7.4.0",
-        "@electron-forge/template-webpack-typescript": "7.4.0",
-        "@electron-forge/tracer": "7.4.0",
+        "@electron-forge/core-utils": "7.2.0",
+        "@electron-forge/maker-base": "7.2.0",
+        "@electron-forge/plugin-base": "7.2.0",
+        "@electron-forge/publisher-base": "7.2.0",
+        "@electron-forge/shared-types": "7.2.0",
+        "@electron-forge/template-base": "7.2.0",
+        "@electron-forge/template-vite": "7.2.0",
+        "@electron-forge/template-vite-typescript": "7.2.0",
+        "@electron-forge/template-webpack": "7.2.0",
+        "@electron-forge/template-webpack-typescript": "7.2.0",
+        "@electron-forge/tracer": "7.2.0",
         "@electron/get": "^3.0.0",
-        "@electron/packager": "^18.3.1",
+        "@electron/packager": "^18.0.0",
         "@electron/rebuild": "^3.2.10",
         "@malept/cross-spawn-promise": "^2.0.0",
         "chalk": "^4.0.0",
@@ -641,7 +642,7 @@
         "fs-extra": "^10.0.0",
         "got": "^11.8.5",
         "interpret": "^3.1.1",
-        "listr2": "^7.0.2",
+        "listr2": "^5.0.3",
         "lodash": "^4.17.20",
         "log-symbols": "^4.0.0",
         "node-fetch": "^2.6.7",
@@ -659,12 +660,12 @@
       }
     },
     "node_modules/@electron-forge/core-utils": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/core-utils/-/core-utils-7.4.0.tgz",
-      "integrity": "sha512-9RLG0F9SX466TpkaTcW+V15KmnGuTpmr7NKMRlngtHXmnkBUJz4Mxp1x33WZLgL90dJrxrRgHSfVBtA4lstDPw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/core-utils/-/core-utils-7.2.0.tgz",
+      "integrity": "sha512-PI1wETlF/+Cxm1m/IgURQ9S3LzHU70/S4CHmkw4xJg4wYVRTfiKpH2XRE9VqEJU854hEnsCGynAIn7/Z2h6SIA==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "7.4.0",
+        "@electron-forge/shared-types": "7.2.0",
         "@electron/rebuild": "^3.2.10",
         "@malept/cross-spawn-promise": "^2.0.0",
         "chalk": "^4.0.0",
@@ -680,12 +681,12 @@
       }
     },
     "node_modules/@electron-forge/maker-base": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.4.0.tgz",
-      "integrity": "sha512-LwWS4VPdwjISl1KpLhmM1Qr1M3sRTTQ/RsX+GlFd7cQ1W/FsgxMjaTG4Od1d+a5CGVTh3s6X2g99TSUfxjOveg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.2.0.tgz",
+      "integrity": "sha512-5dCFiVo4WhSlLf/T9MP+jnMqP3qfmwvjCSiTRE08USeotNWhycztcFox94NbxMJkRt329tNeG2RRs7RzdCz21w==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "7.4.0",
+        "@electron-forge/shared-types": "7.2.0",
         "fs-extra": "^10.0.0",
         "which": "^2.0.2"
       },
@@ -694,33 +695,31 @@
       }
     },
     "node_modules/@electron-forge/plugin-base": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-7.4.0.tgz",
-      "integrity": "sha512-LcTNtEc2YaWvhhqWVIfdJ+J0/krSgc2dqYAHhOH2aLUSm9End3dKO/PZ1Y6DPsiPiJKHnSLBJ/XBN/16NY4Sjw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-7.2.0.tgz",
+      "integrity": "sha512-c/pQK36BMBMKiemO68g1ZQOCXBA93x/aeX3lIXwK5bKVuaGt16Unfmby5Q7iIvY+/KsBuLYGkAder8HDN+4Nbw==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "7.4.0"
+        "@electron-forge/shared-types": "7.2.0"
       },
       "engines": {
         "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/plugin-webpack": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-webpack/-/plugin-webpack-7.4.0.tgz",
-      "integrity": "sha512-ziMSsLmN84Ki55jPOg2ei2pmqFzcB4xaX/lXiirGRj+o70M/EL6YQSuLNLRjdS/242oO8uvlmdp4uPEmYZmiCw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-webpack/-/plugin-webpack-7.2.0.tgz",
+      "integrity": "sha512-L/0UDCYwSuxCysJh2QE0P0tIqXQvcTP7vhQwKW7sC9zFqpsfP3dn+xMPsQESZqe97i1k9xNHZnefpFFwrmabYQ==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/core-utils": "7.4.0",
-        "@electron-forge/plugin-base": "7.4.0",
-        "@electron-forge/shared-types": "7.4.0",
-        "@electron-forge/web-multi-logger": "7.4.0",
+        "@electron-forge/core-utils": "7.2.0",
+        "@electron-forge/plugin-base": "7.2.0",
+        "@electron-forge/shared-types": "7.2.0",
+        "@electron-forge/web-multi-logger": "7.2.0",
         "chalk": "^4.0.0",
         "debug": "^4.3.1",
-        "fast-glob": "^3.2.7",
         "fs-extra": "^10.0.0",
         "html-webpack-plugin": "^5.5.3",
-        "listr2": "^7.0.2",
         "webpack": "^5.69.1",
         "webpack-dev-server": "^4.0.0",
         "webpack-merge": "^5.7.3"
@@ -730,39 +729,39 @@
       }
     },
     "node_modules/@electron-forge/publisher-base": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-7.4.0.tgz",
-      "integrity": "sha512-PiJk4RfaC55SnVnteLW2ZIQNM9DpGOi6YoUn5t8i9UcVp2rFIdya7bJY/b9u1hwubm4d5+TdypMVEuJjM44CJQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-7.2.0.tgz",
+      "integrity": "sha512-c0pwcQeMZi0S4iLlgA3pqm6ZdW2u7Ea4Ynat04Gw7su5GLtbrKRgYSL36ZRhzz7sgm4372niI0k91KaH5KToHg==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "7.4.0"
+        "@electron-forge/shared-types": "7.2.0"
       },
       "engines": {
         "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/shared-types": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.4.0.tgz",
-      "integrity": "sha512-5Ehy6enUjBaU08odf9u9TOhmOVXlqobzMvKUixtkdAWgV1XZAUJmn+p21xhj0IkO92MQiXMGv66w9pDNjRT8uQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.2.0.tgz",
+      "integrity": "sha512-d8i+pwPwBnlmFTRkq7QfaoRS9LywfyjDdHqQZuArFbL6NLAEbZ52irFiAE3NSLf4STew/BA6IK9sTPz3KRmvQw==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/tracer": "7.4.0",
-        "@electron/packager": "^18.3.1",
+        "@electron-forge/tracer": "7.2.0",
+        "@electron/packager": "^18.0.0",
         "@electron/rebuild": "^3.2.10",
-        "listr2": "^7.0.2"
+        "listr2": "^5.0.3"
       },
       "engines": {
         "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/template-base": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-base/-/template-base-7.4.0.tgz",
-      "integrity": "sha512-3YWdRSGzQfQPQkQxStn2wkJ/SuNGGKo9slwFJGvqMV+Pbx3/M/hYi9sMXOuaqVZgeaBp8Ap27yFPxaIIOC3vcA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-base/-/template-base-7.2.0.tgz",
+      "integrity": "sha512-X7JrgQctgN0saFih/kKWVJ3KxiI1BpzdrkW58vs5H0kXXmA6UObE16/dWuKYfB06j0yIsfMbZ32Md1yAkgdCfg==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "7.4.0",
+        "@electron-forge/shared-types": "7.2.0",
         "@malept/cross-spawn-promise": "^2.0.0",
         "debug": "^4.3.1",
         "fs-extra": "^10.0.0",
@@ -773,13 +772,13 @@
       }
     },
     "node_modules/@electron-forge/template-vite": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite/-/template-vite-7.4.0.tgz",
-      "integrity": "sha512-YPVyCGiBKmZPCxK/Bd2louV3PBcxI2nT2+tRKP+mlEHOWrxbZIfmZSR2lIAFvK/ALKlwUKROdmlwyi7ZcdT7JQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite/-/template-vite-7.2.0.tgz",
+      "integrity": "sha512-Q5FSD+NVNMJKuAo/htQXpk3Q/eo116Xhx0zTzhSldAqpsgfxdAIJhl8TFmdVvCJIig1vEcLG2n/PgudxnuDuEQ==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "7.4.0",
-        "@electron-forge/template-base": "7.4.0",
+        "@electron-forge/shared-types": "7.2.0",
+        "@electron-forge/template-base": "7.2.0",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -787,13 +786,13 @@
       }
     },
     "node_modules/@electron-forge/template-vite-typescript": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite-typescript/-/template-vite-typescript-7.4.0.tgz",
-      "integrity": "sha512-wdByG807VWcUd81E6572b/G/Ki8gb+GrCIWxO7Cl3qBa+yNaU1sHhBwB1RyTbQy1r8ubSBtsWrRD1J/yzHKWoQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite-typescript/-/template-vite-typescript-7.2.0.tgz",
+      "integrity": "sha512-knN3lxJY6UyXa2u5957K4ZyItCoCw22wrUhQARvdHOcgXvMFAcwvfEDT8zOQy6ki6A9W3cMHhSTys7dC8/ChVw==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "7.4.0",
-        "@electron-forge/template-base": "7.4.0",
+        "@electron-forge/shared-types": "7.2.0",
+        "@electron-forge/template-base": "7.2.0",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -801,13 +800,13 @@
       }
     },
     "node_modules/@electron-forge/template-webpack": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-7.4.0.tgz",
-      "integrity": "sha512-W558AEGwQrwEtKIbIJPPs0LIsaC/1Vncj5NgqKehEMJjBb0KQq4hwBu/6dauQrfun4jRCOp7LV+OVrf5XPJ7QA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-7.2.0.tgz",
+      "integrity": "sha512-h2LQ3vAzIraRqLUM5fKOLXknp7n5hrQXudRjO/vEEbm1a0jbl4yjp6liKk3yx8MFFO4eAHVDrXwRSsLR3a2Wew==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "7.4.0",
-        "@electron-forge/template-base": "7.4.0",
+        "@electron-forge/shared-types": "7.2.0",
+        "@electron-forge/template-base": "7.2.0",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -815,13 +814,13 @@
       }
     },
     "node_modules/@electron-forge/template-webpack-typescript": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack-typescript/-/template-webpack-typescript-7.4.0.tgz",
-      "integrity": "sha512-O5gwjNSGFNRdJWyiCtevcOBDPAMhgOPvLORh9qR1GcjyTutWwHWmZzycqH+MmkhpQPgrAYDEeipXcOQhSbzNZA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack-typescript/-/template-webpack-typescript-7.2.0.tgz",
+      "integrity": "sha512-eshvPcYXUgmpB+ts9/xRPvQexY46unfe0mGmLDaj8s/5fqCANgyUO5jusvMXlJdf3qwJ/rfi3jS0NuqnjsqskQ==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "7.4.0",
-        "@electron-forge/template-base": "7.4.0",
+        "@electron-forge/shared-types": "7.2.0",
+        "@electron-forge/template-base": "7.2.0",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -829,9 +828,9 @@
       }
     },
     "node_modules/@electron-forge/tracer": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.4.0.tgz",
-      "integrity": "sha512-F4jbnDn4yIZjmky1FZ6rgBKTM05AZQQfHkyJW2hdS4pDKJjdKAqWytoZKDi1/S6Cr6tN+DD0TFGD3V0i6HPHYQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.2.0.tgz",
+      "integrity": "sha512-EoJ07nptEuuY2fcs/bUWzIf11RQRx6Ch/dZ6A9WIRcFYe9cFrslQwvyUf0siY3jcqVvxETCz69JGuBxKGwak7A==",
       "dev": true,
       "dependencies": {
         "chrome-trace-event": "^1.0.3"
@@ -841,9 +840,9 @@
       }
     },
     "node_modules/@electron-forge/web-multi-logger": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@electron-forge/web-multi-logger/-/web-multi-logger-7.4.0.tgz",
-      "integrity": "sha512-XHKs37q4S8BzH1lTKhuOFO6k4R7XdrsZfox+qlp4HpiYKw8yq4rcasB0zUO5YKZ2aTJ1t79X1jxSJb5qhImdHA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/web-multi-logger/-/web-multi-logger-7.2.0.tgz",
+      "integrity": "sha512-RILwNWrcPvMIefpwho/xVu38cyjeAcJCfuJ9YpQDgsVyJzGtPVXbLeKCL8lepMu+I2j9lnYPMKkp2QzycLwMcg==",
       "dev": true,
       "dependencies": {
         "express": "^4.17.1",
@@ -1022,9 +1021,9 @@
       }
     },
     "node_modules/@electron/packager": {
-      "version": "18.3.2",
-      "resolved": "https://registry.npmjs.org/@electron/packager/-/packager-18.3.2.tgz",
-      "integrity": "sha512-orjylavppgIh24qkNpWm2B/LQUpCS/YLOoKoU+eMK/hJgIhShLDsusPIQzgUGVwNCichu8/zPAGfdQZXHG0gtw==",
+      "version": "18.1.1",
+      "resolved": "https://registry.npmjs.org/@electron/packager/-/packager-18.1.1.tgz",
+      "integrity": "sha512-NAqcAs/tnGS6O3RuWfTbPsRCBXt96qijFqvAhTtBQfxkL0nlHqnwTnr2HUPpNc5L2Xo/8nBeP8BKfMd+ySLNsQ==",
       "dev": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
@@ -1033,6 +1032,7 @@
         "@electron/osx-sign": "^1.0.5",
         "@electron/universal": "^2.0.1",
         "@electron/windows-sign": "^1.0.0",
+        "cross-spawn-windows-exe": "^1.2.0",
         "debug": "^4.0.1",
         "extract-zip": "^2.0.0",
         "filenamify": "^4.1.0",
@@ -1042,7 +1042,7 @@
         "junk": "^3.1.0",
         "parse-author": "^2.0.0",
         "plist": "^3.0.0",
-        "resedit": "^2.0.0",
+        "rcedit": "^4.0.0",
         "resolve": "^1.1.6",
         "semver": "^7.1.3",
         "yargs-parser": "^21.1.1"
@@ -1051,7 +1051,7 @@
         "electron-packager": "bin/electron-packager.js"
       },
       "engines": {
-        "node": ">= 16.13.0"
+        "node": ">= 16.4.0"
       },
       "funding": {
         "url": "https://github.com/electron/packager?sponsor=1"
@@ -2920,24 +2920,24 @@
       }
     },
     "node_modules/ansi-escapes": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
-      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "dev": true,
       "dependencies": {
-        "type-fest": "^1.0.2"
+        "type-fest": "^0.21.3"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -3071,6 +3071,15 @@
       "dev": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/async": {
@@ -3730,19 +3739,62 @@
       }
     },
     "node_modules/cli-truncate": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
-      "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
       "dev": true,
       "dependencies": {
-        "slice-ansi": "^5.0.0",
-        "string-width": "^5.0.0"
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cliui": {
@@ -4221,6 +4273,52 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn-windows-exe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn-windows-exe/-/cross-spawn-windows-exe-1.2.0.tgz",
+      "integrity": "sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-cross-spawn-windows-exe?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^1.1.0",
+        "is-wsl": "^2.2.0",
+        "which": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cross-spawn-windows-exe/node_modules/@malept/cross-spawn-promise": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/css-loader": {
@@ -8027,20 +8125,76 @@
       }
     },
     "node_modules/listr2": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-7.0.2.tgz",
-      "integrity": "sha512-rJysbR9GKIalhTbVL2tYbF2hVyDnrf7pFUZBwjPaMIdadYHmeT+EVi/Bu3qd7ETQPahTotg2WRCatXwRBW554g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.8.tgz",
+      "integrity": "sha512-mC73LitKHj9w6v30nLNGPetZIlfpUniNSsxxrbaPcWOjDb92SHPzJPi/t+v1YC/lxKz/AJ9egOjww0qUuFxBpA==",
       "dev": true,
       "dependencies": {
-        "cli-truncate": "^3.1.0",
-        "colorette": "^2.0.20",
-        "eventemitter3": "^5.0.1",
-        "log-update": "^5.0.1",
+        "cli-truncate": "^2.1.0",
+        "colorette": "^2.0.19",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
         "rfdc": "^1.3.0",
-        "wrap-ansi": "^8.1.0"
+        "rxjs": "^7.8.0",
+        "through": "^2.3.8",
+        "wrap-ansi": "^7.0.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "enquirer": ">= 2.3.0 < 3"
+      },
+      "peerDependenciesMeta": {
+        "enquirer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/listr2/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/load-json-file": {
@@ -8163,49 +8317,112 @@
       }
     },
     "node_modules/log-update": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-5.0.1.tgz",
-      "integrity": "sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
       "dev": true,
       "dependencies": {
-        "ansi-escapes": "^5.0.0",
-        "cli-cursor": "^4.0.0",
-        "slice-ansi": "^5.0.0",
-        "strip-ansi": "^7.0.1",
-        "wrap-ansi": "^8.0.1"
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/log-update/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/log-update/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+    "node_modules/log-update/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "restore-cursor": "^3.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/logform": {
@@ -10012,20 +10229,6 @@
         "node": "*"
       }
     },
-    "node_modules/pe-library": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-1.0.1.tgz",
-      "integrity": "sha512-nh39Mo1eGWmZS7y+mK/dQIqg7S1lp38DpRxkyoHf0ZcUs/HDc+yyTjuOtTvSMZHmfSLuSQaX945u05Y2Q6UWZg==",
-      "dev": true,
-      "engines": {
-        "node": ">=14",
-        "npm": ">=7"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/jet2jet"
-      }
-    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -10570,6 +10773,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rcedit": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rcedit/-/rcedit-4.0.1.tgz",
+      "integrity": "sha512-bZdaQi34krFWhrDn+O53ccBDw0MkAT2Vhu75SqhtvhQu4OPyFM4RoVheyYiVQYdjhUi6EJMVWQ0tR6bCIYVkUg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn-windows-exe": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/read-binary-file-arch": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
@@ -10793,23 +11008,6 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
     },
-    "node_modules/resedit": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/resedit/-/resedit-2.0.2.tgz",
-      "integrity": "sha512-UKTnq602iVe+W5SyRAQx/WdWMnlDiONfXBLFg/ur4QE4EQQ8eP7Jgm5mNXdK12kKawk1vvXPja2iXKqZiGDW6Q==",
-      "dev": true,
-      "dependencies": {
-        "pe-library": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=7"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/jet2jet"
-      }
-    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -10981,6 +11179,15 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -12080,6 +12287,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true
     },
     "node_modules/thunky": {
       "version": "1.1.0",

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rstudio",
   "productName": "RStudio",
-  "version": "99.9.9",
+  "version": "9999.99.9-dev+1.test9",
   "description": "RStudio",
   "main": "./.webpack/main",
   "repository": "https://github.com/rstudio/rstudio",
@@ -26,8 +26,9 @@
     "forge": "./forge.config.js"
   },
   "devDependencies": {
-    "@electron-forge/cli": "7.4.0",
-    "@electron-forge/plugin-webpack": "7.4.0",
+    "@electron/packager": "18.1.1",
+    "@electron-forge/cli": "7.2.0",
+    "@electron-forge/plugin-webpack": "7.2.0",
     "@types/chai": "4.3.11",
     "@types/crc": "3.8.3",
     "@types/line-reader": "0.0.37",


### PR DESCRIPTION
This is to work around an issue where our Desktop Pro version numbers break the Windows build. See https://github.com/rstudio/rstudio-pro/issues/6242 for more details.