### PR TITLE
Remove doc-only release icon from release notes

### DIFF
--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -170,7 +170,7 @@ This page provides the release notes associated with each release of RStudio and
 - Changed the failure message for server no-responses (http code 0) to be more helpful to the user (rstudio/rstudio-pro#5646)
 
 #### Posit Workbench
-- Added Reference Architectures (ParallelCluster) documentation to the Posit Workbench Administration Guide (rstudio-pro#6178) <i class="bi bi-info-circle-fill" title="Documentation change since last release/patch."></i>
+- Added Reference Architectures (ParallelCluster) documentation to the Posit Workbench Administration Guide (rstudio-pro#6178)
 
 ### Fixed
 #### RStudio
@@ -178,7 +178,7 @@ This page provides the release notes associated with each release of RStudio and
 - Fixed an issue where GitHub Copilot indexed binary files when project indexing enabled (#14106)
 - Fixed regression that prevented opening help topics in separate window (#14097)
 - Increased open files limit (#14148)
-- Fixed an issue with saving pane layouts for Desktop Pro and Workbench (rstudio-pro#5612) <i class="bi bi-info-circle-fill" title="Documentation change since last release/patch."></i>
+- Fixed an issue with saving pane layouts for Desktop Pro and Workbench (rstudio-pro#5612)
  
 #### Posit Workbench
 - Fixed join session when ready control not responding to mouse clicks in all areas (rstudio/rstudio-pro#5609)
@@ -186,9 +186,9 @@ This page provides the release notes associated with each release of RStudio and
 - Fixed regression introduced in 2023.06 with `rstudio-server reload` where permission changed on nginx directories caused intermittent content loading errors (rstudio-pro#5636)
 - Fixed intermittent rworkspaces performance problem where in unusual circumstances, it would make repeated get_jobs requests (rstudio-pro#5690)
 - Fixed rworkspaces crash with debug logging enabled when get_jobs request returned an error (rstudio/rstudio-pro#5690)
-- Fixed supported Slurm versions in Integrating with Slurm - Administration Guide (rstudio-pro#5857) <i class="bi bi-info-circle-fill" title="Documentation change since last release/patch."></i>
-- Added missing Slurm dependency to Integrating with Slurm documentation (rstudio-pro#5876) <i class="bi bi-info-circle-fill" title="Documentation change since last release/patch."></i>
-- Removal of Debian 10 due to end of support (rstudio-pro#5925) <i class="bi bi-info-circle-fill" title="Documentation change since last release/patch."></i>
+- Fixed supported Slurm versions in Integrating with Slurm - Administration Guide (rstudio-pro#5857)
+- Added missing Slurm dependency to Integrating with Slurm documentation (rstudio-pro#5876)
+- Removal of Debian 10 due to end of support (rstudio-pro#5925)
 
 ## RStudio 2023.12.0
 


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 
As part of the release process, we were supposed to remove the "doc only release" icon `<i class="bi bi-info-circle-fill" title="Documentation change since last release/patch."></i>` from the news file.

We should add this to the release checklist if it can't be automated.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


