### PR TITLE
Switch forum references to forum.posit.co

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 <!--
 IMPORTANT: Please fill out this template fully! Failure to do so will result in the issue being closed automatically.
 
-This issue tracker is for bugs and feature requests in the RStudio IDE. If you're having trouble with R itself or an R package, see https://www.r-project.org/help.html, and if you want to ask a question rather than report a bug, go to https://community.rstudio.com/. Finally, if you use RStudio Server Pro, get in touch with Posit Support at support@posit.co.
+This issue tracker is for bugs and feature requests in the RStudio IDE. If you're having trouble with R itself or an R package, see https://www.r-project.org/help.html, and if you want to ask a question rather than report a bug, go to https://forum.posit.co/. Finally, if you use RStudio Server Pro, get in touch with Posit Support at support@posit.co.
 
 -->
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a Question
-    url: https://community.rstudio.com/c/rstudio-ide/9
+    url: https://forum.posit.co/c/rstudio-ide/9
     about: This issue tracker is not for questions -- please ask questions on our community forum.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ If you're experiencing behavior that appears to be a bug in RStudio, you're welc
 
 1. Is the source of the error or problem the RStudio IDE itself? Many errors you see inside RStudio come from R or R packages. If you're having trouble with R, read [Getting Help with R](https://www.r-project.org/help.html) for pointers.
 
-2. Is your issue a bug rather than a question? If you're having general trouble with RStudio or have questions for the RStudio community, the [RStudio Community Forum](https://community.rstudio.com/c/rstudio-ide) is an excellent resource.
+2. Is your issue a bug rather than a question? If you're having general trouble with RStudio or have questions for the RStudio community, the [RStudio Community Forum](https://forum.posit.co/c/rstudio-ide) is an excellent resource.
 
 3. Are you the first person to report this issue? [Search the issue list](https://github.com/rstudio/rstudio/issues) to find out. If you aren't, the most helpful thing you can do is vote for the existing issue (add a +1 reaction to it), and optionally add a comment describing your own experience.
 

--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ See also the following files included with the distribution:
 - INSTALL - How to build and install RStudio from source
 
 If you have problems or want to share feedback with us please visit our
-[community forum](https://community.rstudio.com/c/rstudio-ide). For other
+[community forum](https://forum.posit.co/c/rstudio-ide). For other
 inquiries you can also email us at [info@posit.co](mailto:info@posit.co). 

--- a/src/cpp/session/resources/help_resources/index.htm
+++ b/src/cpp/session/resources/help_resources/index.htm
@@ -75,7 +75,7 @@
          RStudio
       </h3>
       <a href="https://support.posit.co/hc/en-us">Posit Support</a>
-      <a href="https://community.rstudio.com/c/rstudio-ide/9">Posit Community Forum for the RStudio IDE</a>
+      <a href="https://forum.posit.co/c/rstudio-ide/9">Posit Community Forum for the RStudio IDE</a>
       <a href="https://posit.co/resources/cheatsheets/">Posit Cheat Sheets</a>
       <a href="https://posit.co/products/open-source/rpackages/">RStudio Packages</a>
       <a href="https://posit.co/products/">Posit Products</a>


### PR DESCRIPTION
Forum domain changed from community.rstudio.com to forum.posit.co, update links as necessary. All links tested through VS Code clicks

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


