### PR TITLE
remove obsolete set msvs_version 2019

### DIFF
--- a/package/win32/make-package.bat
+++ b/package/win32/make-package.bat
@@ -267,9 +267,6 @@ if "%RSTUDIO_TARGET%" == "Electron" (
       echo DEBUG: In if in set-version function
       pushd %ELECTRON_SOURCE_DIR%
 
-      echo ensure msvs_version=2019
-      call %NPM% set msvs_version 2019
-
       echo ensure node-gyp installed for node %RSTUDIO_NODE_VERSION%
       call %NPX% node-gyp install %RSTUDIO_NODE_VERSION%
       echo %LOCALAPPDATA%\node-gyp\Cache\%RSTUDIO_NODE_VERSION%\include\node


### PR DESCRIPTION
### Intent

Addresses [obsolete npm usage in Windows build #14599](https://github.com/rstudio/rstudio/issues/14599)

### Approach

Remove the failing call to `npm set msvs_version 2019` as it is no longer supported or necessary. This gets rid of the (non-fatal) error message during Windows builds.

### Automated Tests

NA - purely a build-time thing

### QA Notes

NA - purely a build-time thing (it works or it doesn't work)

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


