### PR TITLE
fix go-to-directory button in web-based file dialogs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 #### RStudio
 
 - Fixed an issue where the context menu sometimes did not display when right-clicking a word in the editor. (#14575)
-
+- Fixed an issue where the "Go to directory..." button brought up the wrong dialog (#14501; Desktop)
 
 #### Posit Workbench
 

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/PathBreadcrumbWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/PathBreadcrumbWidget.java
@@ -207,7 +207,7 @@ public class PathBreadcrumbWidget
 
    private void browse()
    {
-      if (Desktop.isDesktop())
+      if (!Desktop.isUsingWebFileDialogs())
       {
          FileSystemContext tempContext =
                RStudioGinjector.INSTANCE.getRemoteFileSystemContext();

--- a/src/gwt/src/org/rstudio/studio/client/application/Desktop.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Desktop.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.application;
 
+import org.rstudio.studio.client.RStudioGinjector;
 import com.google.gwt.core.client.GWT;
 
 public class Desktop
@@ -36,6 +37,13 @@ public class Desktop
    public static DesktopFrame getFrame()
    {
       return desktopFrame_;
+   }
+
+   /**
+    * @return true if using web-based file dialogs
+    */
+   public static boolean isUsingWebFileDialogs() {
+      return !isDesktop() || !RStudioGinjector.INSTANCE.getUserPrefs().nativeFileDialogs().getValue();
    }
 
    private static final DesktopFrame desktopFrame_ = GWT.create(DesktopFrame.class);


### PR DESCRIPTION
### Intent

Addresses [Go to directory... not opening Go to folder dialog #14501](https://github.com/rstudio/rstudio/issues/14501)

### Approach

#### Background

On Linux desktop the IDE defaults to using the web-based file dialogs (e.g. for choosing files and folders) due to a long-standing Electron bug where file dialogs sometimes open behind the main window: https://github.com/electron/electron/issues/32857. There is a user preference for changing this back to the native dialogs under General/Advanced:"Use native file and message dialog boxes".

#### The Fix

The handler for the "..." button at the end of the path breadcrumb component wasn't aware of the possibility of desktop using web-based dialogs, so added a check for that.

On desktop, with web-based dialogs selected, clicking that button will now bring up this dialog (same as on Server):

<img width="358" alt="go-to-folder-dialog" src="https://github.com/rstudio/rstudio/assets/10569626/b61e3f55-a0b1-4923-aae6-d298cb3ea180">

### Automated Tests

None

### QA Notes

You can test this on any platform, not just Linux; it's just that the default on Linux is set to use the web-based dialogs, but the option can be switched on any platform.

The [...] button can be found in the web-based file dialogs, and also in the Files pane. Behavior is the same for all instances.

<img width="526" alt="open-file" src="https://github.com/rstudio/rstudio/assets/10569626/8fec7baa-37e7-4767-9506-ac202ad161ab">

<img width="595" alt="file-pane" src="https://github.com/rstudio/rstudio/assets/10569626/c6276b28-81c6-4b3b-a732-cd198e0cda2a">

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


