### PR TITLE
keep dockerfiles in sync between open-source and pro

### DIFF
--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -45,7 +45,6 @@ RUN apt-get update && \
     libssl-dev \
     libssh2-1-dev \
     libtiff5-dev\
-    libuser1-dev \
     libxml2-dev \
     libxslt1-dev \
     lsof \
@@ -140,3 +139,5 @@ RUN groupadd -g $JENKINS_GID jenkins && \
     useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
     echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
+
+RUN if [ -d "/src" ]; then git config --global --add safe.directory /src; fi

--- a/docker/jenkins/Dockerfile.focal
+++ b/docker/jenkins/Dockerfile.focal
@@ -44,7 +44,6 @@ RUN apt-get update && \
     libsqlite3-dev \
     libssl-dev \
     libtiff5-dev \
-    libuser1-dev \
     libxml2-dev \
     libxslt1-dev \
     lsof \
@@ -62,6 +61,7 @@ RUN apt-get update && \
     whois \
     xvfb \
     zlib1g-dev
+
 
 # If ARCH=amd64, install gcc-multilib
 RUN if [ "$ARCH" = "amd64" ]; then \
@@ -140,3 +140,4 @@ RUN groupadd -g $JENKINS_GID jenkins && \
     useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
     echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
+RUN if [ -d "/src" ]; then git config --global --add safe.directory /src; fi

--- a/docker/jenkins/Dockerfile.jammy
+++ b/docker/jenkins/Dockerfile.jammy
@@ -45,7 +45,6 @@ RUN apt-get update && \
     libsqlite3-dev \
     libssl-dev \
     libtiff5-dev\
-    libuser1-dev \
     libxml2-dev \
     libxslt1-dev \
     lsof \
@@ -133,3 +132,4 @@ RUN groupadd -g $JENKINS_GID jenkins && \
     useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
     echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
+RUN if [ -d "/src" ]; then git config --global --add safe.directory /src; fi

--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -33,7 +33,6 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     libopenssl-devel \
     libpng-devel  \
     libtiff-devel  \
-    libuser-devel \
     libuuid-devel \
     libxml2-devel \
     lsof \
@@ -130,3 +129,5 @@ ARG JENKINS_UID=999
 RUN groupadd -g $JENKINS_GID jenkins && \
     useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
     echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+RUN if [ -d "/src" ]; then git config --global --add safe.directory /src; fi

--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -34,7 +34,6 @@ RUN yum install -y \
     libcap-devel \ 
     libcurl-devel \
     libpq-devel \
-    libuser \
     libuuid-devel \
     libxml2-devel \
     llvm-devel \
@@ -146,3 +145,5 @@ RUN /tmp/clean-uid.sh $JENKINS_UID && \
 RUN groupadd -g $JENKINS_GID jenkins && \
     useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
     echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+RUN if [ -d "/src" ]; then git config --global --add safe.directory /src; fi

--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -41,7 +41,6 @@ RUN dnf install -y \
     libjpeg-turbo-devel \
     libpng-devel \
     libtiff-devel \
-    libuser-devel \
     libuuid-devel \
     llvm-devel \
     lsof \
@@ -136,3 +135,5 @@ RUN /tmp/clean-uid.sh $JENKINS_UID && \
 RUN groupadd -g $JENKINS_GID jenkins && \
     useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
     echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+RUN if [ -d "/src" ]; then git config --global --add safe.directory /src; fi


### PR DESCRIPTION
### Intent

A couple of changes were made to the Dockerfiles on the pro-side, but not on the open-source side.

* [Feature/replace lib user calls #6075](https://github.com/rstudio/rstudio-pro/pull/6075)
* [add safe directory config to dockerfiles](https://github.com/rstudio/rstudio-pro/commit/8c3765e8366e8882d91af71a7cf88928c7c78773)

### Approach

Confirmed with @MariaSemple that these changes are fine to be in open-source, and copied them over.

### Automated Tests

The build pipeline would be happy to test this change for us.

### QA Notes

NA

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


