### PR TITLE
Fix for very intermittent error when connecting using local stream

### DIFF
--- a/src/cpp/core/include/core/http/AsyncClient.hpp
+++ b/src/cpp/core/include/core/http/AsyncClient.hpp
@@ -353,12 +353,18 @@ private:
    virtual void connectAndWriteRequest() = 0;
    virtual std::string getDefaultHostHeader() = 0;
 
+   // A hook for LocalStreamAsyncClient connections to retry on permission denied errors that show up intermittently
+   virtual bool recentConnectionError(const Error& connectionError)
+   {
+      return false;
+   }
+
    bool retryConnectionIfRequired(const Error& connectionError,
                                   Error* pOtherError)
    {
       // retry if this is a connection unavailable error and the
       // caller has provided a connection retry profile
-      if (http::isConnectionUnavailableError(connectionError) &&
+      if ((http::isConnectionUnavailableError(connectionError) || recentConnectionError(connectionError)) &&
           !connectionRetryContext_.profile.empty())
       {
          // if this is our first retry then set our stop trying time


### PR DESCRIPTION
Seen in load tests, there seems to be a race condition where the local stream returns permission denied errors once in a long while.

This PR changes the code so it will retry a permission denied error once.

Reviewed in: https://github.com/rstudio/rstudio-pro/pull/6245

