### PR TITLE
Remove PATCH default value in versioning script

### DIFF
--- a/docker/jenkins/rstudio-version.sh
+++ b/docker/jenkins/rstudio-version.sh
@@ -80,7 +80,7 @@ function help() {
 }
 
 # Default values
-PATCH=0
+PATCH=""
 DEBUG=false
 CUSTOM_BUILD_TYPE=""
 HELP=false


### PR DESCRIPTION
### Intent

A default PATCH value in the script was causing the versioning script to ignore the value in `version/PATCH`, causing CC builds to continue building with 2024.04.0 instead of 2024.04.1 versioning. Removing the default value fixes this.

> rstudio-pro git:(rel-chocolate-cosmos) $ ./docker/jenkins/rstudio-version.sh
2024.04.1+743.pro4

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


