### PR TITLE
protect R objects cached for data viewer

### DIFF
--- a/src/cpp/core/ProgramOptions.cpp
+++ b/src/cpp/core/ProgramOptions.cpp
@@ -18,8 +18,9 @@
 #include <iostream>
 
 #include <shared_core/Error.hpp>
-#include <core/Log.hpp>
 #include <shared_core/FilePath.hpp>
+
+#include <core/Log.hpp>
 #include <core/system/System.hpp>
 
 using namespace boost::program_options;

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -1643,15 +1643,16 @@ SEXP createList(const std::vector<std::string>& names, Protect* pProtect)
    return listSEXP;
 }
    
-PreservedSEXP::PreservedSEXP()
-   : sexp_(R_NilValue)
-{
-}
-
 PreservedSEXP::PreservedSEXP(SEXP sexp)
    : sexp_(R_NilValue)
 {
    set(sexp);
+}
+
+PreservedSEXP::PreservedSEXP(PreservedSEXP&& original)
+   : sexp_(original.sexp_)
+{
+   original.sexp_ = R_NilValue;
 }
 
 void PreservedSEXP::set(SEXP sexp)

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -343,14 +343,14 @@ core::Error setNamedListElement(SEXP listSEXP,
 class PreservedSEXP : boost::noncopyable
 {
 public:
-   PreservedSEXP();
-   explicit PreservedSEXP(SEXP sexp);
-   virtual ~PreservedSEXP();
-
+   explicit PreservedSEXP(SEXP sexp = R_NilValue);
+   PreservedSEXP(PreservedSEXP&& other);
+   ~PreservedSEXP();
+   
    void set(SEXP sexp);
    SEXP get() const { return sexp_; }
    bool isNil() const { return sexp_ == R_NilValue; }
-
+   
    explicit operator bool() const
    {
       return !isNil();

--- a/src/cpp/rserver-automation.in
+++ b/src/cpp/rserver-automation.in
@@ -15,8 +15,13 @@
 #
 #
 
+# environment variables set from cmake
+export RS_CRASH_HANDLER_PATH="$(pwd)/server/crash-handler-proxy/crash-handler-proxy"
+export RS_CRASHPAD_HANDLER_PATH="@RSTUDIO_TOOLS_ROOT@/crashpad/crashpad/out/Default/crashpad_handler"
+export RS_DB_MIGRATIONS_PATH="@CMAKE_CURRENT_SOURCE_DIR@/server/db"
+
 # use temporary directory for RStudio state
-ROOT=/tmp/rstudio-automation
+ROOT=$(mktemp -d -p /tmp rstudio-automation-XXXXXX)
 
 export RSTUDIO_CONFIG_HOME="${ROOT}/rstudio-config-home"
 export RSTUDIO_CONFIG_DIR="${ROOT}/rstudio-config-dir"
@@ -28,7 +33,9 @@ directory=${ROOT}
 EOF
 
 # run the usual server development script
-./rserver-dev                                           \
+server/rserver                                          \
+	--server-user="$(whoami)"                           \
+	--config-file="conf/rserver-dev.conf"               \
 	--auth-none=1                                       \
 	--www-port=8788                                     \
 	--server-data-dir="${ROOT}"                         \

--- a/src/cpp/rserver-automation.in
+++ b/src/cpp/rserver-automation.in
@@ -3,7 +3,7 @@
 #
 # rserver-automation
 #
-# Copyright (C) 2022 by Posit Software, PBC
+# Copyright (C) 2024 by Posit Software, PBC
 #
 # Unless you have received this program directly from Posit Software pursuant
 # to the terms of a commercial license agreement with Posit Software, then
@@ -20,6 +20,7 @@ export RS_CRASH_HANDLER_PATH="$(pwd)/server/crash-handler-proxy/crash-handler-pr
 export RS_CRASHPAD_HANDLER_PATH="@RSTUDIO_TOOLS_ROOT@/crashpad/crashpad/out/Default/crashpad_handler"
 export RS_DB_MIGRATIONS_PATH="@CMAKE_CURRENT_SOURCE_DIR@/server/db"
 
+
 # use temporary directory for RStudio state
 ROOT=$(mktemp -d -p /tmp rstudio-automation-XXXXXX)
 
@@ -27,18 +28,32 @@ export RSTUDIO_CONFIG_HOME="${ROOT}/rstudio-config-home"
 export RSTUDIO_CONFIG_DIR="${ROOT}/rstudio-config-dir"
 export RSTUDIO_DATA_HOME="${ROOT}/rstudio-data-home"
 
-cat <<- EOF > /tmp/rserver-database.conf
+
+# use local database file
+cat <<- EOF > "${ROOT}/rserver-database.conf"
 provider=sqlite
 directory=${ROOT}
 EOF
 
+
+# use the development rsession configuration file,
+# but make sure sessions run in automation mode
+RSESSION_CONFIG_FILE="@CMAKE_CURRENT_BINARY_DIR@/conf/rsession-dev.conf"
+cp "${RSESSION_CONFIG_FILE}" "${ROOT}/rsession.conf"
+cat <<- EOF >> "${ROOT}/rsession.conf"
+# enable automation tools
+automation-agent=1
+EOF
+
+
 # run the usual server development script
-server/rserver                                          \
-	--server-user="$(whoami)"                           \
-	--config-file="conf/rserver-dev.conf"               \
-	--auth-none=1                                       \
-	--www-port=8788                                     \
-	--server-data-dir="${ROOT}"                         \
-	--database-config-file="/tmp/rserver-database.conf" \
+server/rserver                                             \
+	--server-user="$(whoami)"                              \
+	--config-file="conf/rserver-dev.conf"                  \
+	--auth-none=1                                          \
+	--www-port=8788                                        \
+	--server-data-dir="${ROOT}"                            \
+	--database-config-file="${ROOT}/rserver-database.conf" \
+	--rsession-config-file="${ROOT}/rsession.conf"         \
 	"$@"
 

--- a/src/cpp/rserver-automation.in
+++ b/src/cpp/rserver-automation.in
@@ -16,12 +16,22 @@
 #
 
 # use temporary directory for RStudio state
-ROOT=$(mktemp -d)
+ROOT=/tmp/rstudio-automation
 
 export RSTUDIO_CONFIG_HOME="${ROOT}/rstudio-config-home"
 export RSTUDIO_CONFIG_DIR="${ROOT}/rstudio-config-dir"
 export RSTUDIO_DATA_HOME="${ROOT}/rstudio-data-home"
 
+cat <<- EOF > /tmp/rserver-database.conf
+provider=sqlite
+directory=${ROOT}
+EOF
+
 # run the usual server development script
-./rserver-dev --auth-none=1 "$@"
+./rserver-dev                                           \
+	--auth-none=1                                       \
+	--www-port=8788                                     \
+	--server-data-dir="${ROOT}"                         \
+	--database-config-file="/tmp/rserver-database.conf" \
+	"$@"
 

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -177,6 +177,7 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
    optionsDesc.commandLine.add(misc);
 
    // define groups included in config-file processing
+   optionsDesc.configFile.add(automation);
    optionsDesc.configFile.add(program);
    optionsDesc.configFile.add(log);
    optionsDesc.configFile.add(docs);

--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -221,6 +221,21 @@
    )
 })
 
+.rs.addFunction("automation.ensureRunningServerInstance", function()
+{
+   # Check and see if we already have an rserver instance listening.
+   procs <- subset(ps::ps(), name == "rserver")
+   for (i in seq_len(nrow(procs)))
+   {
+      proc <- procs[i, ]
+      conns <- ps::ps_connections(proc$ps_handle[[1L]])
+      if (8788L %in% conns$lport)
+         return(TRUE)
+   }
+   
+   stop("rserver does not appear to be running on port 8788")
+})
+
 .rs.addFunction("automation.initialize", function(appPath = NULL,
                                                   mode = c("server", "desktop"),
                                                   port = NULL)
@@ -231,6 +246,10 @@
    # Resolve arguments.
    mode <- match.arg(mode)
    port <- .rs.nullCoalesce(port, if (mode == "server") 9999L else 9998L)
+   
+   # Ensure that we have a running rserver instance.
+   if (mode == "server")
+      .rs.automation.ensureRunningServerInstance()
    
    # Check for an existing session we can attach to.
    baseUrl <- sprintf("http://localhost:%i", port)
@@ -291,7 +310,7 @@
          "--no-first-run",
          "--disable-extensions",
          "--disable-features=PrivacySandboxSettings4",
-         "about:blank"
+         "http://localhost:8788"
       )
    )
    
@@ -356,7 +375,7 @@
    client <- .rs.automation.createClient(socket)
    
    # Find and record the active session id.
-   sessionId <- .rs.automation.attachToSession(client, mode)
+   .rs.automation.attachToSession(client, mode)
    
    # Wait until the Console is available.
    document <- client$DOM.getDocument(depth = 0L)
@@ -447,9 +466,6 @@
    # Update our global variables.
    .rs.setVar("automation.client", client)
    .rs.setVar("automation.sessionId", sessionId)
-   
-   # Navigate the page to RStudio Server.
-   client$Page.navigate("http://localhost:8787")
    
    # TODO: Handle input of authentication credentials?
    # Should that happen here, or elsewhere?

--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -233,7 +233,21 @@
          return(TRUE)
    }
    
-   stop("rserver does not appear to be running on port 8788")
+   # See if we can figure out how the parent was launched, and use that
+   # to infer whether we can launch the automation helper.
+   parentHandle <- ps::ps_parent()
+   parentEnv <- ps::ps_environ(parentHandle)
+   parentPwd <- parentEnv[["PWD"]]
+   automationScript <- file.path(parentPwd, "rserver-automation")
+   if (file.exists(automationScript))
+   {
+      message("-- Starting rserver-automation ...")
+      withr::with_dir(parentPwd, system2(automationScript, wait = FALSE))
+   }
+   else
+   {
+      stop("rserver does not appear to be running on port 8788")
+   }
 })
 
 .rs.addFunction("automation.initialize", function(appPath = NULL,

--- a/src/cpp/session/modules/automation/SessionAutomationRemote.R
+++ b/src/cpp/session/modules/automation/SessionAutomationRemote.R
@@ -227,10 +227,3 @@
    if (alive)
       .rs.automation.agentProcess$kill()
 })
-
-.rs.automation.addRemoteFunction("waitFor", function(callback)
-{
-   # TODO
-   client
-})
-

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -898,7 +898,6 @@ Error getGridData(const http::Request& request,
          auto it = s_cachedFrames.find(cacheKey);
          if (it == s_cachedFrames.end())
          {
-            // CachedFrame cachedFrame(envName, objName, objSEXP);
             s_cachedFrames.emplace(cacheKey, CachedFrame(envName, objName, objSEXP));
          }
       }

--- a/src/cpp/tests/automation/testthat/test-automation-data-viewer.R
+++ b/src/cpp/tests/automation/testthat/test-automation-data-viewer.R
@@ -1,0 +1,14 @@
+
+library(testthat)
+
+self <- remote <- .rs.automation.createRemote()
+client <- remote$client
+
+# https://github.com/rstudio/rstudio/pull/14657
+test_that("we can use the data viewer with temporary R expressions", {
+   remote$consoleExecute("View(subset(mtcars, mpg >= 30))")
+   nodeId <- remote$domGetNodeId("iframe[class=\"gwt-Frame\"]")
+   viewerSrc <- remote$jsCall("function() { return this.src; }", nodeId = nodeId)
+   expect_true(grepl("gridviewer.html", viewerSrc$result$value))
+   remote$commandExecute("closeSourceDoc")
+})

--- a/src/cpp/tests/automation/testthat/test-automation-sweave.R
+++ b/src/cpp/tests/automation/testthat/test-automation-sweave.R
@@ -1,7 +1,7 @@
 
 library(testthat)
 
-self <- remote <- .rs.automation.createRemote(mode = "server")
+self <- remote <- .rs.automation.createRemote()
 client <- remote$client
 
 test_that("Braces are inserted and highlighted correctly in Sweave documents", {

--- a/src/cpp/tests/automation/testthat/test-automation-syntax-highlighting.R
+++ b/src/cpp/tests/automation/testthat/test-automation-syntax-highlighting.R
@@ -1,7 +1,7 @@
 
 library(testthat)
 
-self <- remote <- .rs.automation.createRemote(mode = "desktop")
+self <- remote <- .rs.automation.createRemote()
 client <- remote$client
 
 test_that("Quarto Documents are highlighted as expected", {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14643.

### Approach

Now that we try to introspect the contents of the observed R object shown in the data viewer, we need to protect that object from the GC.

### Automated Tests

A basic automation test is included, but unfortunately is not sufficient to capture the underlying crash due to the stochastic nature of the problem.

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


