### PR TITLE
avoid accidental usage of wrong isalnum

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.cpp
+++ b/src/cpp/session/modules/SessionRCompletions.cpp
@@ -15,6 +15,8 @@
 
 #include "SessionRCompletions.hpp"
 
+#include <cctype>
+
 #include <gsl/gsl>
 
 #include <core/Exec.hpp>
@@ -112,7 +114,7 @@ std::string finishExpression(const std::string& expression)
       char ch = expression[i];
       
       // skip over whitespace
-      if (isspace(ch))
+      if (std::isspace((unsigned char) ch))
       {
          // if we see a newline, assume it ends the current expression, so it's okay
          // to have consecutive identifiers if a newline separates them
@@ -179,7 +181,7 @@ std::string finishExpression(const std::string& expression)
       sawOperator = isOperator(ch);
       
       // check for identifiers
-      sawIdentifier = isalnum(ch) || ch == '.' || ch == '_';
+      sawIdentifier = std::isalnum((unsigned char) ch) || ch == '.' || ch == '_';
 
       if (ch == top)
       {

--- a/version/news/NEWS-2024.04.1-chocolate-cosmos.md
+++ b/version/news/NEWS-2024.04.1-chocolate-cosmos.md
@@ -1,0 +1,24 @@
+## RStudio 2024.04.1 "Chocolate Cosmos" Release Notes
+
+
+### New
+
+#### RStudio
+
+#### Posit Workbench
+
+
+### Fixed
+
+#### RStudio
+
+- Fixed an issue where RStudio could crash when requesting completions within a ggplot2 aes() call, for datasets containing multi-byte variable names. (#14625)
+
+
+#### Posit Workbench
+
+
+### Dependencies
+
+
+### Deprecated / Removed


### PR DESCRIPTION
### Intent

Surgical fix for https://github.com/rstudio/rstudio/issues/14625, intended for patch release.

### Approach

Avoid using the wrong `alnum()` defined in StringUtils.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14625.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

