### PR TITLE
guard against potential overflow

### DIFF
--- a/src/cpp/core/MiscellaneousTests.cpp
+++ b/src/cpp/core/MiscellaneousTests.cpp
@@ -323,6 +323,14 @@ test_context("Truncating")
       auto y = x + 1;
       expect_true(y == INT_MAX);
    }
+
+   test_that("we can interact with types of lower size")
+   {
+      Truncating<long> x = 4;
+      Truncating<short> y = 4;
+      expect_equal(x + y, 8);
+      expect_equal(x - y, 0);
+   }
 }
 
 } // namespace unit_tests

--- a/src/cpp/core/MiscellaneousTests.cpp
+++ b/src/cpp/core/MiscellaneousTests.cpp
@@ -293,6 +293,13 @@ test_context("Options")
 
 test_context("Truncating")
 {
+   test_that("Truncating<T> handles non-overflowing operations")
+   {
+      expect_true(Truncating<int>(4) + 4 == 8);
+      expect_true(Truncating<int>(4) - 4 == 0);
+      expect_true(Truncating<int>(4) * 4 == 16);
+   }
+
    test_that("Truncating<T> handles various kinds of overflow")
    {
       expect_true(Truncating<int>(42) + INT_MAX == INT_MAX);

--- a/src/cpp/core/MiscellaneousTests.cpp
+++ b/src/cpp/core/MiscellaneousTests.cpp
@@ -19,12 +19,14 @@
 #include <string>
 #include <iostream>
 
+#include <shared_core/json/Json.hpp>
+
 #include <core/Algorithm.hpp>
 #include <core/RegexUtils.hpp>
+#include <core/Truncating.hpp>
 #include <core/collection/LruCache.hpp>
 #include <core/collection/Position.hpp>
 #include <core/http/Request.hpp>
-#include <shared_core/json/Json.hpp>
 
 #include <core/system/Types.hpp>
 
@@ -286,6 +288,33 @@ test_context("Options")
          expect_true(options[i].first == options2[i].first);
          expect_true(options[i].second == options2[i].second);
       }
+   }
+}
+
+test_context("Truncating")
+{
+   test_that("Truncating<T> handles various kinds of overflow")
+   {
+      expect_true(Truncating<int>(42) + INT_MAX == INT_MAX);
+      expect_true(Truncating<int>(42) + INT_MIN == 42 + INT_MIN);
+      expect_true(Truncating<int>(42) - INT_MAX == 42 - INT_MAX);
+      expect_true(Truncating<int>(42) - INT_MIN == INT_MAX);
+      expect_true(Truncating<int>(42) * INT_MAX == INT_MAX);
+      expect_true(Truncating<int>(42) * INT_MIN == INT_MIN);
+
+      expect_true(Truncating<int>(-42) + INT_MAX == -42 + INT_MAX);
+      expect_true(Truncating<int>(-42) + INT_MIN == INT_MIN);
+      expect_true(Truncating<int>(-42) - INT_MAX == INT_MIN);
+      expect_true(Truncating<int>(-42) - INT_MIN == -42 - INT_MIN);
+      expect_true(Truncating<int>(-42) * INT_MAX == INT_MIN);
+      expect_true(Truncating<int>(-42) * INT_MIN == INT_MAX);
+   }
+
+   test_that("example usage works as expected")
+   {
+      auto x = Truncating<int>(INT_MAX) + 42;
+      auto y = x + 1;
+      expect_true(y == INT_MAX);
    }
 }
 

--- a/src/cpp/core/include/core/Truncating.hpp
+++ b/src/cpp/core/include/core/Truncating.hpp
@@ -25,7 +25,7 @@ namespace core {
 template <typename T>
 class Truncating
 {
-   static_assert(std::is_integral_v<T> || std::is_floating_point_v<T>, "");
+   static_assert(std::is_integral<T>::value || std::is_floating_point<T>::value, "");
    static const T min = std::numeric_limits<T>::min();
    static const T max = std::numeric_limits<T>::max();
 
@@ -33,9 +33,9 @@ class Truncating
    void static_assert_compatible_types()
    {
       static_assert(sizeof(T) >= sizeof(U), "");
-      static_assert(std::is_floating_point_v<T> == std::is_floating_point_v<U>, "");
-      static_assert(std::is_integral_v<T> == std::is_integral_v<U>, "");
-      static_assert(std::is_signed_v<T> == std::is_signed_v<U>, "");
+      static_assert(std::is_floating_point<T>::value == std::is_floating_point<U>::value, "");
+      static_assert(std::is_integral<T>::value == std::is_integral<U>::value, "");
+      static_assert(std::is_signed<T>::value == std::is_signed<U>::value, "");
    }
 
 public:

--- a/src/cpp/core/include/core/Truncating.hpp
+++ b/src/cpp/core/include/core/Truncating.hpp
@@ -25,9 +25,18 @@ namespace core {
 template <typename T>
 class Truncating
 {
-   static_assert(std::is_integral<T>::value, "");
+   static_assert(std::is_integral_v<T> || std::is_floating_point_v<T>, "");
    static const T min = std::numeric_limits<T>::min();
    static const T max = std::numeric_limits<T>::max();
+
+   template <typename U>
+   void static_assert_compatible_types()
+   {
+      static_assert(sizeof(T) >= sizeof(U), "");
+      static_assert(std::is_floating_point_v<T> == std::is_floating_point_v<U>, "");
+      static_assert(std::is_integral_v<T> == std::is_integral_v<U>, "");
+      static_assert(std::is_signed_v<T> == std::is_signed_v<U>, "");
+   }
 
 public:
 
@@ -41,6 +50,7 @@ public:
       return value_;
    }
 
+   // Addition ----
    static T add(const T& lhs, const T& rhs)
    {
       if (rhs > 0 && lhs > (max - rhs))
@@ -62,6 +72,27 @@ public:
       return add(value_, rhs);
    }
 
+   Truncating<T> operator+(const Truncating<T>& rhs)
+   {
+      return add(value_, rhs);
+   }
+
+   template <typename U>
+   Truncating<T> operator+(const U& rhs)
+   {
+      static_assert_compatible_types<U>();
+      return add(value_, static_cast<T>(rhs));
+   }
+
+   template <typename U>
+   Truncating<T> operator+(const Truncating<U>& rhs)
+   {
+      static_assert_compatible_types<U>();
+      return add(value_, static_cast<T>(rhs));
+   }
+
+
+   // Subtraction ----
    static T sub(const T& lhs, const T& rhs)
    {
       if (rhs > 0 && lhs < min + rhs)
@@ -83,6 +114,27 @@ public:
       return sub(value_, rhs);
    }
 
+   Truncating<T> operator-(const Truncating<T>& rhs)
+   {
+      return sub(value_, rhs);
+   }
+
+   template <typename U>
+   Truncating<T> operator-(const U& rhs)
+   {
+      static_assert_compatible_types<U>();
+      return sub(value_, static_cast<T>(rhs));
+   }
+
+   template <typename U>
+   Truncating<T> operator-(const Truncating<U>& rhs)
+   {
+      static_assert_compatible_types<U>();
+      return sub(value_, static_cast<T>(rhs));
+   }
+
+
+   // Multiplication ----
    static T mul(const T& lhs, const T& rhs)
    {
       if (lhs == 0 || rhs == 0)
@@ -134,6 +186,26 @@ public:
    {
       return mul(value_, rhs);
    }
+
+   Truncating<T> operator*(const Truncating<T>& rhs)
+   {
+      return mul(value_, rhs);
+   }
+
+   template <typename U>
+   Truncating<T> operator*(const U& rhs)
+   {
+      static_assert_compatible_types<U>();
+      return mul(value_, static_cast<U>(rhs));
+   }
+
+   template <typename U>
+   Truncating<T> operator*(const Truncating<U>& rhs)
+   {
+      static_assert_compatible_types<U>();
+      return mul(value_, static_cast<U>(rhs));
+   }
+
 
 private:
    T value_;

--- a/src/cpp/core/include/core/Truncating.hpp
+++ b/src/cpp/core/include/core/Truncating.hpp
@@ -1,0 +1,86 @@
+/*
+ * Truncating.hpp
+ *
+ * Copyright (C) 2024 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_TRUNCATING_HPP
+#define CORE_TRUNCATING_HPP
+
+#include <limits>
+#include <type_traits>
+
+namespace rstudio {
+namespace core {
+
+template <typename T>
+class Truncating
+{
+   static_assert(std::is_integral<T>::value, "");
+
+public:
+
+   Truncating(T value)
+      : value_(value)
+   {
+   }
+
+   operator T() const
+   {
+      return value_;
+   }
+
+   Truncating<T> operator+(const T& rhs)
+   {
+      T result = 0;
+      if (__builtin_add_overflow(value_, rhs, &result))
+      {
+         result = (rhs >= 0)
+               ? std::numeric_limits<T>::max()
+               : std::numeric_limits<T>::min();
+      }
+      return Truncating<T>(result);
+   }
+
+   Truncating<T> operator-(const T& rhs)
+   {
+      T result = 0;
+      if (__builtin_sub_overflow(value_, rhs, &result))
+      {
+         result = (rhs >= 0)
+               ? std::numeric_limits<T>::min()
+               : std::numeric_limits<T>::max();
+      }
+      return Truncating<T>(result);
+   }
+
+   Truncating<T> operator*(const T& rhs)
+   {
+      T result = 0;
+      if (__builtin_mul_overflow(value_, rhs, &result))
+      {
+         result = ((value_ >= 0) == (rhs >= 0))
+               ? std::numeric_limits<T>::max()
+               : std::numeric_limits<T>::min();
+      }
+      return result;
+   }
+
+private:
+   T value_;
+};
+
+} // namespace core
+} // namespace rstudio
+
+#endif // CORE_TRUNACTING_HPP
+

--- a/src/cpp/core/include/core/Truncating.hpp
+++ b/src/cpp/core/include/core/Truncating.hpp
@@ -126,6 +126,8 @@ public:
             }
          }
       }
+
+      return lhs * rhs;
    }
 
    Truncating<T> operator*(const T& rhs)

--- a/src/cpp/core/system/LinuxResources.cpp
+++ b/src/cpp/core/system/LinuxResources.cpp
@@ -17,13 +17,13 @@
 #include <shared_core/FilePath.hpp>
 #include <shared_core/SafeConvert.hpp>
 
-#include <core/system/Resources.hpp>
-
-#include <core/Log.hpp>
-#include <core/Thread.hpp>
-#include <core/StringUtils.hpp>
 #include <core/Algorithm.hpp>
 #include <core/FileSerializer.hpp>
+#include <core/Log.hpp>
+#include <core/StringUtils.hpp>
+#include <core/Thread.hpp>
+#include <core/Truncating.hpp>
+#include <core/system/Resources.hpp>
 
 #include <iostream>
 #include <fstream>
@@ -76,12 +76,7 @@ public:
 
       long pageKib = ::sysconf(_SC_PAGE_SIZE) / 1024;
 
-      // avoid and handle potential overflow
-      if (__builtin_smull_overflow(resident, pageKib, pUsedKb))
-      {
-         *pUsedKb = LONG_MAX;
-      }
-
+      *pUsedKb = Truncating<long>(resident) * pageKib;
       *pProvider = MemoryProviderLinuxProcFs;
       return Success();
    }

--- a/src/cpp/core/system/LinuxResources.cpp
+++ b/src/cpp/core/system/LinuxResources.cpp
@@ -59,6 +59,7 @@ public:
    {
       long size = 0;
       long resident = 0;
+
       try 
       {
          std::ifstream statm("/proc/self/statm");
@@ -74,7 +75,9 @@ public:
       }
 
       long pageKib = ::sysconf(_SC_PAGE_SIZE) / 1024;
-      *pUsedKb = resident * pageKib;
+      long long usedKb = resident * pageKib;
+      *pUsedKb = usedKb >= LONG_MAX ? LONG_MAX : static_cast<long>(usedKb);
+
       *pProvider = MemoryProviderLinuxProcFs;
       return Success();
    }

--- a/src/cpp/core/system/LinuxResources.cpp
+++ b/src/cpp/core/system/LinuxResources.cpp
@@ -75,8 +75,12 @@ public:
       }
 
       long pageKib = ::sysconf(_SC_PAGE_SIZE) / 1024;
-      long long usedKb = static_cast<long long>(resident) * pageKib;
-      *pUsedKb = usedKb >= LONG_MAX ? LONG_MAX : static_cast<long>(usedKb);
+
+      // avoid and handle potential overflow
+      if (__builtin_smull_overflow(resident, pageKib, pUsedKb))
+      {
+         *pUsedKb = LONG_MAX;
+      }
 
       *pProvider = MemoryProviderLinuxProcFs;
       return Success();

--- a/src/cpp/core/system/LinuxResources.cpp
+++ b/src/cpp/core/system/LinuxResources.cpp
@@ -75,7 +75,7 @@ public:
       }
 
       long pageKib = ::sysconf(_SC_PAGE_SIZE) / 1024;
-      long long usedKb = resident * pageKib;
+      long long usedKb = static_cast<long long>(resident) * pageKib;
       *pUsedKb = usedKb >= LONG_MAX ? LONG_MAX : static_cast<long>(usedKb);
 
       *pProvider = MemoryProviderLinuxProcFs;

--- a/src/cpp/session/modules/SessionRCompletionsTests.cpp
+++ b/src/cpp/session/modules/SessionRCompletionsTests.cpp
@@ -30,7 +30,7 @@ test_context("r_completions")
       expect_true(finishExpression(L"(abc") == L"(abc)");
    }
 
-   https://github.com/rstudio/rstudio/issues/14625
+   // https://github.com/rstudio/rstudio/issues/14625
    test_that("finishExpression accepts non-ASCII inputs")
    {
       expect_true(finishExpression(L"(你好") == L"(你好)");


### PR DESCRIPTION
Addresses a Snyk-reported issue in https://build.posit.it/job/IDE/job/OS-Builds/job/open-source-pull-request/job/PR-14644/3/pipeline-console/?selected-node=45.

This PR takes inspiration from https://wiki.sei.cmu.edu/confluence/display/c/INT32-C.+Ensure+that+operations+on+signed+integers+do+not+result+in+overflow, and tries to wrap the compiler builtins described in https://gcc.gnu.org/onlinedocs/gcc/Integer-Overflow-Builtins.html into a C++ class that we can use more readily.