### PR TITLE
Hide refresh button while replace-all operation is running in Find in Files pane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 - Fixed an issue where the context menu sometimes did not display when right-clicking a word in the editor. (#14575)
 - Fixed an issue where the "Go to directory..." button brought up the wrong dialog (#14501; Desktop)
 - Remove superfluous Uninstall shortcut and Start Menu folder (#1900; Desktop installer on Windows)
+- Hide Refresh button while Replace All operation is running in the Find in Files pane (#13873)
 
 #### Posit Workbench
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
@@ -302,8 +302,8 @@ public class FindOutputPresenter extends BasePresenter
                      @Override
                      public void execute()
                      {
-                        view_.setStopReplaceButtonVisible(true);
                         stopAndClear();
+                        view_.setStopReplaceButtonVisible(true);
                         FileSystemItem searchPath =
                                                   FileSystemItem.createDir(dialogState_.getPath());
                         JsArrayString includeFilePatterns = JsArrayString.createArray().cast();


### PR DESCRIPTION
### Intent

Addresses [Refresh find button is not disabled when stop replace is visible, allowing the user to crash RStudio #13873](https://github.com/rstudio/rstudio/issues/13873)

### Approach

`view_.setStopReplaceButtonVisible(true);` is hiding the refresh button, but `stopAndClear()` puts it back. So, reverse the order of these calls.

### Automated Tests

None.

### QA Notes

When running a "Replace All" in the find-in-files pane, the refresh button (the circular arrow) will now be hidden.

I couldn't reproduce the reported crash when clicking this button during a replace-all, perhaps because the replace operation was too quick for me to click it in time. Now the button is hidden, so can't be clicked, so don't know that it's worth trying to reproduce the actual crash.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


