### PR TITLE
Prevent file deletion when attempting to copy a file over itself in File pane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 - Fixed an issue where the "Go to directory..." button brought up the wrong dialog (#14501; Desktop)
 - Remove superfluous Uninstall shortcut and Start Menu folder (#1900; Desktop installer on Windows)
 - Hide Refresh button while Replace All operation is running in the Find in Files pane (#13873)
+- Stop the File Pane's "Copy To" operation from deleting the file when source and destination are the same (#14525)
 
 #### Posit Workbench
 


### PR DESCRIPTION
### Intent

Addresses [RStudio copyTo operation removes file if src = target and 'overwrite' is true #14525](https://github.com/rstudio/rstudio/issues/14525)

### Approach

If the source and destination are the same (after paths have been canonicalized) treat the "copy to" as a successful no-op rather than deleting the file!

### Automated Tests

None

### QA Notes

Test as described in issue. Also try creating a link (symbolic or hard) to the file and make sure it is still a no-op (i.e. recognizes that these are actually the same file).

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


