### PR TITLE
Open source companion to rstudio/rstudio-pro#5905

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/model/RVersionsInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/model/RVersionsInfo.java
@@ -65,4 +65,9 @@ public class RVersionsInfo extends JavaScriptObject
       return this.available_r_versions;
    }-*/;
    
+   public final RVersionSpec getRVersionSpec()
+   {
+      return RVersionSpec.create(getRVersion(), getRVersionHome(),
+                                 getRVersionLabel(), getRVersionModule());
+   }
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RVersionSelectWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RVersionSelectWidget.java
@@ -54,6 +54,19 @@ public class RVersionSelectWidget extends SelectWidget
                                boolean fillContainer,
                                boolean includeUserSpecified)
    {
+      this(caption, uniqueId, rVersions, includeSystemDefault, includeHelpButton,
+           fillContainer, includeUserSpecified, null);
+   }
+
+   public RVersionSelectWidget(String caption,
+                               ElementIds.SelectWidgetId uniqueId,
+                               JsArray<RVersionSpec> rVersions,
+                               boolean includeSystemDefault,
+                               boolean includeHelpButton,
+                               boolean fillContainer,
+                               boolean includeUserSpecified,
+                               RVersionSpec defaultRVersion)
+   {
       super(caption,
             uniqueId,
             rVersionChoices(rVersions, includeSystemDefault, includeUserSpecified),
@@ -67,6 +80,8 @@ public class RVersionSelectWidget extends SelectWidget
       includeUserSpecified_ = includeUserSpecified;
       if (includeHelpButton)
          HelpButton.addHelpButton(this, "multiple_r_versions", constants_.helpOnRVersionsTitle());
+
+      setValue(rVersionSpecToString(defaultRVersion));
    }
 
    public void setIncludeUserSpecified(boolean includeUserSpecified) {
@@ -85,10 +100,13 @@ public class RVersionSelectWidget extends SelectWidget
    }
 
    private void updateChoices() {
+      String current = getValue();
       setChoices(
          rVersionChoices(rVersions_, includeSystemDefault_, includeUserSpecified_),
          rVersionValues(rVersions_, includeSystemDefault_, includeUserSpecified_)
       );
+      if (current != null)
+         setValue(current);
    }
    
    public void setRVersion(RVersionSpec version)

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewProjectWizard.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewProjectWizard.java
@@ -66,12 +66,10 @@ public class NewProjectWizard extends Wizard<NewProjectInput,NewProjectResult>
            rVersions.getAvailableRVersions(),
            false,
            false,
-           false);
-         RVersionSpec rVersion = RVersionSpec.create(
-               rVersions.getDefaultRVersion(),
-               rVersions.getDefaultRVersionHome(),
-               rVersions.getRVersionLabel());
-         rVersionSelector_.setRVersion(rVersion);
+           false,
+           false,
+           // Use the current version by default.
+           rVersions.getRVersionSpec());
          addLeftWidget(rVersionSelector_);
          rVersionSelector_.getElement().getStyle().setMarginRight(8, Unit.PX);
          rVersionSelector_.setVisible(false);


### PR DESCRIPTION
Adds machinery to control the default R version shown in the version dropdown widget.


