### PR TITLE
run desktop automation tests on build

### DIFF
--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -426,6 +426,20 @@ pipeline {
             string(name: 'BRANCH_NAME', value: "${env.BRANCH_NAME}")
           ]
       }
+    }
+
+    stage('Trigger Automation Testing') {
+      agent { label 'linux' }
+
+      when {
+        allOf {
+          expression { return params.DAILY }
+          expression { return params.PUBLISH }
+          expression { return !params.IS_PRO }
+          expression { return env.BRANCH_NAME != "release-ghost-orchid" }
+          expression { return env.BRANCH_NAME != "v1.4-juliet-rose" }
+        }
+      }
 
       steps {
         build(
@@ -437,8 +451,8 @@ pipeline {
           ]
         )
       }
-
     }
+
   }
 
   post {

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -400,7 +400,7 @@ pipeline {
       }
     }
 
-    stage('Trigger Automation Testing') {
+    stage('Trigger Testing Jobs') {
       agent { label 'linux' }
 
       // Skip for hourly builds, non-published builds, and branches that don't 
@@ -414,45 +414,41 @@ pipeline {
         }
       }
 
-      steps {
-        build wait: false,
-          job: "IDE/qa-${IS_PRO ? '' : 'opensource-'}automation",
-          parameters: [
-            string(name: 'RSTUDIO_VERSION_MAJOR', value: "${RSTUDIO_VERSION_MAJOR}"),
-            string(name: 'RSTUDIO_VERSION_MINOR', value: "${RSTUDIO_VERSION_MINOR}"),
-            string(name: 'RSTUDIO_VERSION_PATCH', value: "${RSTUDIO_VERSION_PATCH}"),
-            string(name: 'RSTUDIO_VERSION_SUFFIX', value: "${RSTUDIO_VERSION_SUFFIX}"),
-            string(name: 'SLACK_CHANNEL', value: "${params.SLACK_CHANNEL}"),
-            string(name: 'BRANCH_NAME', value: "${env.BRANCH_NAME}")
-          ]
-      }
-    }
+      stages {
 
-    stage('Trigger Desktop Automation Testing') {
-      agent { label 'linux' }
+        stage('Trigger Automation Testing') {
+          steps {
+            build wait: false,
+            job: "IDE/qa-${IS_PRO ? '' : 'opensource-'}automation",
+            parameters: [
+              string(name: 'RSTUDIO_VERSION_MAJOR', value: "${RSTUDIO_VERSION_MAJOR}"),
+              string(name: 'RSTUDIO_VERSION_MINOR', value: "${RSTUDIO_VERSION_MINOR}"),
+              string(name: 'RSTUDIO_VERSION_PATCH', value: "${RSTUDIO_VERSION_PATCH}"),
+              string(name: 'RSTUDIO_VERSION_SUFFIX', value: "${RSTUDIO_VERSION_SUFFIX}"),
+              string(name: 'SLACK_CHANNEL', value: "${params.SLACK_CHANNEL}"),
+              string(name: 'BRANCH_NAME', value: "${env.BRANCH_NAME}")
+            ]
+          }
+        }
 
-      when {
-        allOf {
-          expression { return params.DAILY }
-          expression { return params.PUBLISH }
-          expression { return !params.IS_PRO }
-          expression { return env.BRANCH_NAME != "release-ghost-orchid" }
-          expression { return env.BRANCH_NAME != "v1.4-juliet-rose" }
+        stage('Trigger Desktop Automation Testing') {
+          when {
+              expression { return !params.IS_PRO }
+          }
+
+          steps {
+            build(
+              wait: false,
+              job: "IDE/rstudio-ide-automation-desktop/desktop-ide-ec2-automation",
+              parameters: [
+                string(name: 'RSTUDIO_VERSION', value: "${RSTUDIO_VERSION}"),
+                string(name: 'GITHUB_BRANCH', value: "${env.BRANCH_NAME}")
+              ]
+            )
+          }
         }
       }
-
-      steps {
-        build(
-          wait: false,
-          job: "IDE/rstudio-ide-automation-desktop/desktop-ide-ec2-automation"
-          parameters: [
-            string(name: 'RSTUDIO_VERSION', value: "${RSTUDIO_VERSION}"),
-            string(name: 'GITHUB_BRANCH', value: "${env.BRANCH_NAME}"),
-          ]
-        )
-      }
     }
-
   }
 
   post {

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -426,6 +426,18 @@ pipeline {
             string(name: 'BRANCH_NAME', value: "${env.BRANCH_NAME}")
           ]
       }
+
+      steps {
+        build(
+          wait: false,
+          job: "IDE/rstudio-ide-automation-desktop/desktop-ide-ec2-automation"
+          parameters: [
+            string(name: 'RSTUDIO_VERSION', value: "${RSTUDIO_VERSION}"),
+            string(name: 'GITHUB_BRANCH', value: "${env.BRANCH_NAME}"),
+          ]
+        )
+      }
+
     }
   }
 

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -428,7 +428,7 @@ pipeline {
       }
     }
 
-    stage('Trigger Automation Testing') {
+    stage('Trigger Desktop Automation Testing') {
       agent { label 'linux' }
 
       when {


### PR DESCRIPTION
This PR intends to hook up our desktop automation tests to the regular build + automation pipeline.

https://build.posit.it/job/IDE/job/rstudio-ide-automation-desktop/job/desktop-ide-ec2-automation/