### PR TITLE
provide tools for checking out and running automation tests from ref

### DIFF
--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -550,7 +550,10 @@ std::vector<std::string> fileMonitorIgnoredComponents()
       FilePath projFilePath = projects::projectContext().file();
       if (projFilePath.getFilename() == "rstudio.Rproj")
       {
+         ignores.push_back("/src/build-cpp-");
          ignores.push_back("/dependencies/common/node/");
+         ignores.push_back("/package/osx/build/");
+         ignores.push_back("/package/osx/install/");
       }
    }
 #endif

--- a/src/cpp/tests/automation/testthat.R
+++ b/src/cpp/tests/automation/testthat.R
@@ -18,11 +18,16 @@ test_that <- function(desc, code) {
 }
 
 # Find the test directories.
-projectRoot <- here::here()
-testDir <- file.path(projectRoot, "src/cpp/tests/automation/testthat")
+# Assume that they exist in the 'testthat' directory.
+testDir <- getwd()
+if (!all(file.exists("testthat", "testthat.R"))) {
+   projectRoot <- here::here()
+   testDir <- file.path(projectRoot, "src/cpp/tests/automation/testthat")
+}
 
 # Set the working directory.
-setwd(testDir)
+owd <- setwd(testDir)
+on.exit(setwd(owd), add = TRUE)
 
 # Create a junit-style reporter.
 junitResultsFile <- tempfile("junit-", fileext = ".xml")


### PR DESCRIPTION
With this, you can use `.rs.automation.run(ref = "<hash>")` to run the automation tests associated with a specific commit against the currently-running instance of RStudio.

The most common usage will be to use the commit that RStudio was actually built against, e.g. for CI, but being able to customize this may also be helpful locally and in development scenarios.