### PR TITLE
provide tools for debugging active session remotely

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -175,6 +175,7 @@ set(SESSION_SOURCE_FILES
    modules/SessionConsole.cpp
    modules/SessionCopilot.cpp
    modules/SessionCpp.cpp
+   modules/SessionDebugging.cpp
    modules/SessionDependencies.cpp
    modules/SessionDependencyList.cpp
    modules/SessionDiagnostics.cpp

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -144,6 +144,7 @@
 #include "modules/SessionCopilot.hpp"
 #include "modules/SessionCRANMirrors.hpp"
 #include "modules/SessionCrypto.hpp"
+#include "modules/SessionDebugging.hpp"
 #include "modules/SessionErrors.hpp"
 #include "modules/SessionFiles.hpp"
 #include "modules/SessionFind.hpp"
@@ -549,9 +550,12 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
 
       // signal handlers
       (registerSignalHandlers)
-
+         
       // main module context
       (module_context::initialize)
+
+      // debugging
+      (modules::debugging::initialize)
 
       // prefs (early init required -- many modules including projects below require
       // preference access)

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -19,9 +19,10 @@
 
 #include <string>
 
-#include <boost/utility.hpp>
+#include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/utility.hpp>
 
 #include <core/BoostSignals.hpp>
 #include <core/HtmlUtils.hpp>

--- a/src/cpp/session/modules/SessionDebugging.R
+++ b/src/cpp/session/modules/SessionDebugging.R
@@ -17,8 +17,8 @@
 
 .rs.addFunction("debugging.beginSinkOutput", function(file)
 {
-   # Open write connection to fifo.
-   conn <- file(file, open = "wb")
+   # Open write connection to file.
+   conn <- file(file, open = "a")
    .rs.setVar("debugging.activeSink", conn)
    
    # Sink output to this file.

--- a/src/cpp/session/modules/SessionDebugging.R
+++ b/src/cpp/session/modules/SessionDebugging.R
@@ -1,0 +1,52 @@
+#
+# SessionDebugging.R
+#
+# Copyright (C) 2024 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+.rs.setVar("debugging.activeSink", NULL)
+
+.rs.addFunction("debugging.beginSinkOutput", function(file)
+{
+   # Open write connection to fifo.
+   conn <- file(file, open = "wb")
+   .rs.setVar("debugging.activeSink", conn)
+   
+   # Sink output to this file.
+   sink(conn, append = TRUE, type = "output")
+   sink(conn, append = TRUE, type = "message")
+})
+
+.rs.addFunction("debugging.endSinkOutput", function()
+{
+   # Close the sinks.
+   sink(NULL, type = "output")
+   sink(NULL, type = "message")
+   
+   # Close the fifo connection.
+   conn <- .rs.getVar("debugging.activeSink")
+   close(conn)
+})
+
+.rs.addFunction("debugging.printTraceback", function()
+{
+   if (requireNamespace("rlang", quietly = TRUE))
+   {
+      opts <- options("rlang:::visible_bottom" = parent.frame())
+      on.exit(options(opts), add = TRUE)
+      print(rlang::trace_back())
+   }
+   else
+   {
+      print(sys.calls())
+   }
+})

--- a/src/cpp/session/modules/SessionDebugging.cpp
+++ b/src/cpp/session/modules/SessionDebugging.cpp
@@ -156,9 +156,17 @@ SEXP rs_traceback()
 __declspec(dllexport) void rd_evaluate(const char* code)
 {
    RedirectOutputScope scope(debugFilename());
-   Error error = r::exec::executeString(code);
+   
+   r::sexp::Protect protect;
+   SEXP resultSEXP = R_NilValue;
+   Error error = r::exec::evaluateString(code, &resultSEXP, &protect);
    if (error)
+   {
       LOG_ERROR(error);
+      return;
+   }
+   
+   Rf_PrintValue(resultSEXP);
 }
 
 SEXP rs_evaluate(SEXP codeSEXP)

--- a/src/cpp/session/modules/SessionDebugging.cpp
+++ b/src/cpp/session/modules/SessionDebugging.cpp
@@ -16,7 +16,6 @@
 #include "SessionDebugging.hpp"
 
 #ifdef _WIN32
-# include <Windows.h>
 # include <io.h>
 #endif
 
@@ -38,10 +37,8 @@
 
 #include <session/SessionModuleContext.hpp>
 
-#ifdef _WIN32
-# define DLL_EXPORT _declspec(dllexport)
-#else
-# define DLL_EXPORT
+#ifndef __declspec
+# define __declspec(...)
 #endif
 
 
@@ -144,7 +141,7 @@ void printTraceback()
 
 extern "C" {
 
-DLL_EXPORT void rd_traceback()
+__declspec(dllexport) void rd_traceback()
 {
    RedirectOutputScope scope(debugFilename());
    printTraceback();
@@ -156,7 +153,7 @@ SEXP rs_traceback()
    return R_NilValue;
 }
 
-DLL_EXPORT void rd_evaluate(const char* code)
+__declspec(dllexport) void rd_evaluate(const char* code)
 {
    RedirectOutputScope scope(debugFilename());
    Error error = r::exec::executeString(code);

--- a/src/cpp/session/modules/SessionDebugging.cpp
+++ b/src/cpp/session/modules/SessionDebugging.cpp
@@ -1,0 +1,121 @@
+/*
+ * SessionDebugging.cpp
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "SessionDebugging.hpp"
+
+#include <fcntl.h>
+
+#include <core/Exec.hpp>
+
+#include <r/RExec.hpp>
+#include <r/RRoutines.hpp>
+
+#include <session/SessionModuleContext.hpp>
+
+using namespace rstudio;
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace debugging {
+
+namespace {
+
+class RedirectOutputScope
+{
+public:
+   RedirectOutputScope(const char* filename)
+   {
+      // Save references to the stdout, stderr streams.
+      stdout_ = ::dup(STDOUT_FILENO);
+      stderr_ = ::dup(STDERR_FILENO);
+      
+      // Open file for writing.
+      int fd = ::open(filename, O_WRONLY | O_APPEND | O_CREAT, 0600);
+      
+      // Redirect stdout, stderr to this file.
+      ::dup2(fd, STDOUT_FILENO);
+      ::dup2(fd, STDERR_FILENO);
+      
+      // Remove reference.
+      ::close(fd);
+      
+      // Also redirect R output streams.
+      Error error = r::exec::RFunction(".rs.debugging.beginSinkOutput")
+            .addParam("file", filename)
+            .call();
+      
+      if (error)
+         LOG_ERROR(error);
+   }
+   
+   ~RedirectOutputScope()
+   {
+      // Restore R output streams.
+      Error error = r::exec::RFunction(".rs.debugging.endSinkOutput")
+            .call();
+      
+      if (error)
+         LOG_ERROR(error);
+      
+      // Restore stdout, stderr
+      ::dup2(stdout_, STDOUT_FILENO);
+      ::close(stdout_);
+      
+      ::dup2(stderr_, STDERR_FILENO);
+      ::close(stderr_);
+   }
+   
+private:
+   int stdout_;
+   int stderr_;
+};
+
+void printTraceback()
+{
+   RedirectOutputScope scope("/tmp/rstudio-debug.log");
+   
+   Error error = r::exec::RFunction(".rs.debugging.printTraceback")
+         .call();
+   
+   if (error)
+      LOG_ERROR(error);
+}
+
+extern "C" SEXP rs_traceback()
+{
+   printTraceback();
+   return R_NilValue;
+}
+
+} // end anonymous namespace
+
+core::Error initialize()
+{
+   using namespace module_context;
+   
+   RS_REGISTER_CALL_METHOD(rs_traceback);
+   
+   ExecBlock initBlock;
+   initBlock.addFunctions()
+         (bind(sourceModuleRFile, "SessionDebugging.R"));
+   return initBlock.execute();
+}
+
+} // namespace debugging
+} // namespace modules
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/session/modules/SessionDebugging.hpp
+++ b/src/cpp/session/modules/SessionDebugging.hpp
@@ -1,0 +1,33 @@
+/*
+ * SessionDebugging.hpp
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SESSION_DEBUGGING_HPP
+#define SESSION_DEBUGGING_HPP
+
+#include <shared_core/Error.hpp>
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace debugging {
+
+core::Error initialize();
+
+} // namespace debugging
+} // namespace modules
+} // namespace session
+} // namespace rstudio
+
+#endif // SESSION_DEBUGGING_HPP

--- a/src/cpp/shared_core/include/shared_core/Error.hpp
+++ b/src/cpp/shared_core/include/shared_core/Error.hpp
@@ -571,9 +571,14 @@ std::ostream& operator<<(std::ostream& io_ostream, const Error& in_error);
 // the ERROR_LOCATION macro may evaluate first and reset the Win32 error code to
 // zero (no error), causing the wrong value to be passed to systemError. This is currently
 // the case on debug builds using MSVC.
-#define LAST_SYSTEM_ERROR() []() {auto lastErr = ::GetLastError(); return systemError(lastErr, ERROR_LOCATION);}()
+# define LAST_SYSTEM_ERROR() []() {auto lastErr = ::GetLastError(); return systemError(lastErr, ERROR_LOCATION);}()
+
+#else
+
+# define LAST_SYSTEM_ERROR() []() { auto _errno = errno; return systemError(_errno, ERROR_LOCATION); }()
 
 #endif // _WIN32
+
 
 /**
  * @brief Function which creates a system error.


### PR DESCRIPTION
This is intended as an internal-use tool, for introspecting running R sessions. Here's a screencast to show the intended use, simulating a "busy" session in some state.

https://github.com/rstudio/rstudio/assets/1976582/22762f53-f71f-486a-84df-1cbf3f939f1c

Effectively, it allows us to drive an `rsession` from LLDB, and capture certain kinds of output in a separate Terminal. This can be useful is the session is frozen or busy, and so console output isn't being reflected in the Console pane in the IDE.