### PR TITLE
don't attempt to migrate without active sessions dir

### DIFF
--- a/src/cpp/core/r_util/RActiveSessionsStorage.cpp
+++ b/src/cpp/core/r_util/RActiveSessionsStorage.cpp
@@ -311,12 +311,15 @@ void RpcActiveSessionsStorage::migrateSessions() const
    if (!rootMigratedFile.exists())
    {
       std::vector<FilePath> children;
-      Error error = storagePath_.getChildren(children);
-      if (error)
+      if (storagePath_.isDirectory())
       {
-         error.addProperty("operation", "Attempting to migrate old sessions for user " + user_.getUsername());
-         LOG_ERROR(error);
-         return;
+         Error error = storagePath_.getChildren(children);
+         if (error)
+         {
+            error.addProperty("operation", "Attempting to migrate old sessions for user " + user_.getUsername());
+            LOG_ERROR(error);
+            return;
+         }
       }
 
       for (const FilePath& child: children)


### PR DESCRIPTION
Addresses https://github.com/rstudio/rstudio/issues/14734.

I sort of wonder if we should be creating the `storagePath_` in the constructor here, though:

https://github.com/rstudio/rstudio/blob/5a7d837c69879fcc925af346de91101ef8edaa7e/src/cpp/core/r_util/RActiveSessionsStorage.cpp#L118-L123

We do that here:

https://github.com/rstudio/rstudio/blob/5a7d837c69879fcc925af346de91101ef8edaa7e/src/cpp/core/r_util/RActiveSessionsStorage.cpp#L61-L67