### PR TITLE
point dependency scripts at new mathjax

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,5 +35,6 @@
 
 ### Dependencies
 
+- Updated MathJax to version 2.7.9 (#11535)
 - Updated Electron to version 30.x (#14582; Desktop)
 

--- a/dependencies/common/install-mathjax
+++ b/dependencies/common/install-mathjax
@@ -32,6 +32,7 @@ fi
 sudo-if-necessary-for "${RSTUDIO_TOOLS_ROOT}" "$@"
 cd "${RSTUDIO_TOOLS_ROOT}"
 
+# NOTE: Unpacks to 'mathjax-27' directory
 MATHJAX=mathjax-2.7.9.zip
 download "${URL}/${MATHJAX}"
 rm -rf "${MATHJAX_DIR}"

--- a/dependencies/common/install-mathjax
+++ b/dependencies/common/install-mathjax
@@ -32,7 +32,7 @@ fi
 sudo-if-necessary-for "${RSTUDIO_TOOLS_ROOT}" "$@"
 cd "${RSTUDIO_TOOLS_ROOT}"
 
-MATHJAX=mathjax-27.zip
+MATHJAX=mathjax-2.7.9.zip
 download "${URL}/${MATHJAX}"
 rm -rf "${MATHJAX_DIR}"
 unzip -q "$MATHJAX"

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -169,7 +169,7 @@ if not exist "dictionaries\en_US.dic" (
   )
 )
 
-set MATHJAX=mathjax-27.zip
+set MATHJAX=mathjax-2.7.9.zip
 if not exist "mathjax-27" (
   wget %WGET_ARGS% "%BASEURL%%MATHJAX%"
   if exist "%MATHJAX%" (

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -169,6 +169,7 @@ if not exist "dictionaries\en_US.dic" (
   )
 )
 
+REM NOTE: Unpacks to 'mathjax-27' directory
 set MATHJAX=mathjax-2.7.9.zip
 if not exist "mathjax-27" (
   wget %WGET_ARGS% "%BASEURL%%MATHJAX%"


### PR DESCRIPTION
Addresses https://github.com/rstudio/rstudio/issues/11535.

The new MathJax bundle was made by hand with the following steps:

- Download the MathJax release from https://github.com/mathjax/MathJax/releases/tag/2.7.9,
- Use [this script](https://github.com/rstudio/rstudio/blob/feature/mathjax-2.7.9/dependencies/tools/prune-mathjax) to trim out the pieces we don't need,
- Upload to S3,
- Use that download archive where appropriate.

We'll have to double-check that this is sufficient to trigger a rebuild of our Docker images + dependencies so that the newer MathJax is picked up, but I think it should work.