### PR TITLE
pin electron-packager to work around issue with RDP version numbering…

### DIFF
--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -32,6 +32,7 @@
       "devDependencies": {
         "@electron-forge/cli": "7.2.0",
         "@electron-forge/plugin-webpack": "7.2.0",
+        "@electron/packager": "18.1.1",
         "@types/chai": "4.3.11",
         "@types/crc": "3.8.3",
         "@types/line-reader": "0.0.37",
@@ -66,6 +67,7 @@
         "node-loader": "2.0.0",
         "nyc": "15.1.0",
         "prettier": "3.1.1",
+        "process": "0.11.10",
         "sinon": "17.0.1",
         "style-loader": "3.3.3",
         "ts-loader": "9.5.1",
@@ -1018,9 +1020,9 @@
       }
     },
     "node_modules/@electron/packager": {
-      "version": "18.3.2",
-      "resolved": "https://registry.npmjs.org/@electron/packager/-/packager-18.3.2.tgz",
-      "integrity": "sha512-orjylavppgIh24qkNpWm2B/LQUpCS/YLOoKoU+eMK/hJgIhShLDsusPIQzgUGVwNCichu8/zPAGfdQZXHG0gtw==",
+      "version": "18.1.1",
+      "resolved": "https://registry.npmjs.org/@electron/packager/-/packager-18.1.1.tgz",
+      "integrity": "sha512-NAqcAs/tnGS6O3RuWfTbPsRCBXt96qijFqvAhTtBQfxkL0nlHqnwTnr2HUPpNc5L2Xo/8nBeP8BKfMd+ySLNsQ==",
       "dev": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
@@ -1029,6 +1031,7 @@
         "@electron/osx-sign": "^1.0.5",
         "@electron/universal": "^2.0.1",
         "@electron/windows-sign": "^1.0.0",
+        "cross-spawn-windows-exe": "^1.2.0",
         "debug": "^4.0.1",
         "extract-zip": "^2.0.0",
         "filenamify": "^4.1.0",
@@ -1038,7 +1041,7 @@
         "junk": "^3.1.0",
         "parse-author": "^2.0.0",
         "plist": "^3.0.0",
-        "resedit": "^2.0.0",
+        "rcedit": "^4.0.0",
         "resolve": "^1.1.6",
         "semver": "^7.1.3",
         "yargs-parser": "^21.1.1"
@@ -1047,7 +1050,7 @@
         "electron-packager": "bin/electron-packager.js"
       },
       "engines": {
-        "node": ">= 16.13.0"
+        "node": ">= 16.4.0"
       },
       "funding": {
         "url": "https://github.com/electron/packager?sponsor=1"
@@ -4240,6 +4243,52 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn-windows-exe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn-windows-exe/-/cross-spawn-windows-exe-1.2.0.tgz",
+      "integrity": "sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-cross-spawn-windows-exe?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^1.1.0",
+        "is-wsl": "^2.2.0",
+        "which": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cross-spawn-windows-exe/node_modules/@malept/cross-spawn-promise": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/css-loader": {
@@ -10734,20 +10783,6 @@
         "node": "*"
       }
     },
-    "node_modules/pe-library": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-1.0.1.tgz",
-      "integrity": "sha512-nh39Mo1eGWmZS7y+mK/dQIqg7S1lp38DpRxkyoHf0ZcUs/HDc+yyTjuOtTvSMZHmfSLuSQaX945u05Y2Q6UWZg==",
-      "dev": true,
-      "engines": {
-        "node": ">=14",
-        "npm": ">=7"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/jet2jet"
-      }
-    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -11138,6 +11173,15 @@
         "renderkid": "^3.0.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -11308,6 +11352,18 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rcedit": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rcedit/-/rcedit-4.0.1.tgz",
+      "integrity": "sha512-bZdaQi34krFWhrDn+O53ccBDw0MkAT2Vhu75SqhtvhQu4OPyFM4RoVheyYiVQYdjhUi6EJMVWQ0tR6bCIYVkUg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn-windows-exe": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/read-binary-file-arch": {
@@ -11562,23 +11618,6 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
-    },
-    "node_modules/resedit": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/resedit/-/resedit-2.0.2.tgz",
-      "integrity": "sha512-UKTnq602iVe+W5SyRAQx/WdWMnlDiONfXBLFg/ur4QE4EQQ8eP7Jgm5mNXdK12kKawk1vvXPja2iXKqZiGDW6Q==",
-      "dev": true,
-      "dependencies": {
-        "pe-library": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=7"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/jet2jet"
-      }
     },
     "node_modules/resolve": {
       "version": "1.22.8",

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -26,6 +26,7 @@
     "forge": "./forge.config.js"
   },
   "devDependencies": {
+    "@electron/packager": "18.1.1",
     "@electron-forge/cli": "7.2.0",
     "@electron-forge/plugin-webpack": "7.2.0",
     "@types/chai": "4.3.11",
@@ -61,6 +62,7 @@
     "nan": "2.18.0",
     "node-loader": "2.0.0",
     "nyc": "15.1.0",
+    "process": "0.11.10",
     "prettier": "3.1.1",
     "sinon": "17.0.1",
     "style-loader": "3.3.3",


### PR DESCRIPTION
### Intent

Fix RDP build for Chocolate Cosmos. This was caused by updating Electron, and is the same issue seen here: [Pro versioning scheme breaks builds for Desktop Pro (Windows) with latest electron-forge version #6242](https://github.com/rstudio/rstudio-pro/issues/6242)

### Approach

Pin electron-packager to older version that didn't break on our RDP versioning scheme.

### Automated Tests

NA

### QA Notes

NA

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


