### PR TITLE
fix config schema violation when zoomLevel setting is absent

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,8 +16,6 @@
 - The New Project dialog in RStudio Pro now defaults to the R version of the current session, rather than the system default (rstudio-pro#4244)
 - Workbench jobs launched from RStudio Pro now default to the R version of the current session, rather than the system default (rstudio-pro#5903)
 
-#### Posit Workbench
-
 ### Fixed
 
 #### RStudio
@@ -30,6 +28,7 @@
 - Hide Refresh button while Replace All operation is running in the Find in Files pane (#13873)
 - Stop the File Pane's "Copy To" operation from deleting the file when source and destination are the same (#14525)
 - Fix keyboard shortcuts acting on the wrong source file when using Visual Editor in source columns or separate windows (#12581, #11684)
+- Fix startup error due to invalid zoom setting triggering a config schema violation (#14690) 
 - Removed extra spaces after package names in warning message about required packages (#14608)
 
 #### Posit Workbench

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -138,6 +138,11 @@ export class DesktopOptionsImpl implements DesktopOptions {
 
     if (!zoomLevel) {
       zoomLevel = this.legacyOptions.zoomLevel() ?? properties.view.default.zoomLevel;
+      const min = properties.view.properties.zoomLevel.minimum;
+      const max = properties.view.properties.zoomLevel.maximum;
+      if (zoomLevel < min || zoomLevel > max) {
+        zoomLevel = properties.view.default.zoomLevel;
+      }
       this.config.set(kZoomLevel, zoomLevel);
     }
 


### PR DESCRIPTION
### Intent

Addresses [Config schema violation" preventing RStudio from launching #14690](https://github.com/rstudio/rstudio/issues/14690)

### Approach

If there is no zoomLevel setting (electron flavor) AND no legacy zoom level setting (from a pre-Electron desktop), then set the zoom level back to 1 instead of throwing errors and failing to start.

### Automated Tests

None

### QA Notes

Test as described in issue.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


