### PR TITLE
remove entry for fix that first shipped in chocolate cosmos patch 2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,6 @@
 
 #### RStudio
 
-- Fixed an issue where insertion of braces in Sweave documents did not function as intended. (#14667; #14646)
 - Fixed an issue where various editor commands (Reindent Lines; Run Chunks) could fail in a document containing Quarto callout blocks. (#14640)
 - Fixed an issue where the context menu sometimes did not display when right-clicking a word in the editor. (#14575)
 - Fixed an issue where the "Go to directory..." button brought up the wrong dialog (#14501; Desktop)


### PR DESCRIPTION
### Intent

Remove NEWS entry for fixes that are released first in patch 2 of Chocolate Cosmos. Those were added here: https://github.com/rstudio/rstudio/pull/14754
