### PR TITLE
enable soft wrapping for other file types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 
 #### RStudio
 
+- The "Soft-wrap R source files" preference now applies to all source files, and has been re-labelled appropriately. (#10940)
 
 #### Posit Workbench
 

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -845,7 +845,7 @@ public:
    core::Error setVerticallyAlignArgumentsIndent(bool val);
 
    /**
-    * Whether to soft-wrap R source files, wrapping the text for display without inserting newline characters.
+    * Whether to soft-wrap source files, wrapping the text for display without inserting newline characters.
     */
    bool softWrapRFiles();
    core::Error setSoftWrapRFiles(bool val);

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -895,7 +895,7 @@ core::Error UserPrefValues::setVerticallyAlignArgumentsIndent(bool val)
 }
 
 /**
- * Whether to soft-wrap R source files, wrapping the text for display without inserting newline characters.
+ * Whether to soft-wrap source files, wrapping the text for display without inserting newline characters.
  */
 bool UserPrefValues::softWrapRFiles()
 {

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -505,8 +505,8 @@
         "soft_wrap_r_files": {
             "type": "boolean",
             "default": false,
-            "title": "Soft-wrap R source files",
-            "description": "Whether to soft-wrap R source files, wrapping the text for display without inserting newline characters."
+            "title": "Soft-wrap source files",
+            "description": "Whether to soft-wrap source files, wrapping the text for display without inserting newline characters."
         },
         "soft_wrap_rmd_files": {
             "type": "boolean",

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/CppFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/CppFileType.java
@@ -16,12 +16,12 @@ package org.rstudio.studio.client.common.filetypes;
 
 import java.util.HashSet;
 
-import com.google.gwt.resources.client.ImageResource;
-
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.studio.client.common.reditor.EditorLanguage;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.spelling.TokenPredicate;
+
+import com.google.gwt.resources.client.ImageResource;
 
 public class CppFileType extends TextFileType
 {
@@ -29,7 +29,7 @@ public class CppFileType extends TextFileType
                boolean isCpp, boolean canSource)
    {
       super(id, "C/C++", EditorLanguage.LANG_CPP, ext, icon,
-            false, false, isCpp, false, false, false,
+            WordWrap.DEFAULT, false, isCpp, false, false, false,
             false, false, false, true, false, true, false);
 
       isCpp_ = isCpp;

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
@@ -23,6 +23,7 @@ import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.StudioClientCommonConstants;
+import org.rstudio.studio.client.common.filetypes.TextFileType.WordWrap;
 import org.rstudio.studio.client.common.filetypes.model.NavigationMethods;
 import org.rstudio.studio.client.common.reditor.EditorLanguage;
 import org.rstudio.studio.client.common.satellite.Satellite;
@@ -48,7 +49,7 @@ public class FileTypeRegistry
    public static final TextFileType TEXT =
          new TextFileType("text", FileIcon.TEXT_ICON.getDescription(), EditorLanguage.LANG_PLAIN, "",
                           FileIcon.TEXT_ICON.getImageResource(),
-                          true,
+                          WordWrap.DEFAULT,
                           false, false, false, false, false, false, false, false, false, true, false, false);
 
    public static final TextFileType R =
@@ -58,7 +59,7 @@ public class FileTypeRegistry
    public static final TextFileType RD =
       new TextFileType("r_doc", constants_.rdFile(), EditorLanguage.LANG_RDOC, ".Rd",
                        new ImageResource2x(ICONS.iconRd2x()),
-                       true, // word-wrap
+                       WordWrap.DEFAULT, // word-wrap
                        true, // source on save aka preview on save
                        false, false, false,
                        true, // preview html
@@ -68,14 +69,14 @@ public class FileTypeRegistry
                        false);
 
    public static final TextFileType DCF =
-         new TextFileType("dcf", "DCF", EditorLanguage.LANG_DCF, ".dcf",
-                          new ImageResource2x(ICONS.iconDCF2x()), false, false, false, false, false,
+         new TextFileType("dcf", "DCF", EditorLanguage.LANG_DCF, ".dcf", new ImageResource2x(ICONS.iconDCF2x()),
+                          WordWrap.DEFAULT, false, false, false, false,
                           false, false, false, false, false, false, false, false);
 
    public static final TextFileType INI =
-         new TextFileType("ini", "INI", EditorLanguage.LANG_INI, ".ini",
-                          new ImageResource2x(ICONS.iconDCF2x()), false, false, false, false, false,
-                          false, false, false, false, false, false, false, false);
+         new TextFileType("ini", "INI", EditorLanguage.LANG_INI, ".ini", new ImageResource2x(ICONS.iconDCF2x()),
+               WordWrap.DEFAULT, false, false, false, false,
+               false, false, false, false, false, false, false, false);
 
 
    public static final TextFileType STAN = new StanFileType();
@@ -86,7 +87,7 @@ public class FileTypeRegistry
 
    public static final TextFileType NAMESPACE =
      new TextFileType("r_namespace", constants_.namespaceLabel(), EditorLanguage.LANG_R, "",
-                      new ImageResource2x(ICONS.iconText2x()), false, false, false, false, false,
+                      new ImageResource2x(ICONS.iconText2x()), WordWrap.DEFAULT, false, false, false, false,
                       false, false, false, false, false, false, false, false);
 
    public static final TextFileType SWEAVE =
@@ -99,8 +100,7 @@ public class FileTypeRegistry
 
    public static final PlainTextFileType RHISTORY =
       new PlainTextFileType("r_history", constants_.rHistoryLabel(), ".Rhistory",
-                            new ImageResource2x(ICONS.iconRhistory2x()),
-                            true);
+                            new ImageResource2x(ICONS.iconRhistory2x()));
 
    public static final RWebContentFileType RMARKDOWN =
          new RWebContentFileType("r_markdown", constants_.rMarkdownLabel(), EditorLanguage.LANG_RMARKDOWN,
@@ -130,37 +130,37 @@ public class FileTypeRegistry
    public static final TextFileType CSS =
          new TextFileType("css", "CSS", EditorLanguage.LANG_CSS, ".css",
                           new ImageResource2x(ICONS.iconCss2x()),
-                          true,
+                          WordWrap.DEFAULT,
                           false, false, false, false, false, false, false, false, false, false, false, false);
 
    public static final TextFileType SCSS =
          new TextFileType("scss", "SCSS", EditorLanguage.LANG_SCSS, ".scss",
                           new ImageResource2x(ICONS.iconScss2x()),
-                          true,
+                          WordWrap.DEFAULT,
                           false, false, false, false, false, false, false, false, false, false, false, false);
 
    public static final TextFileType SASS =
          new TextFileType("sass", "SASS", EditorLanguage.LANG_SASS, ".sass",
                           new ImageResource2x(ICONS.iconScss2x()),
-                          true,
+                          WordWrap.DEFAULT,
                           false, false, false, false, false, false, false, false, false, false, false, false);
    
    public static final TextFileType LESS =
          new TextFileType("less", "LESS", EditorLanguage.LANG_LESS, ".less",
                           new ImageResource2x(ICONS.iconLess2x()),
-                          true,
+                          WordWrap.DEFAULT,
                           false, false, false, false, false, false, false, false, false, false, false, false);
                  
    public static final TextFileType JS =
          new TextFileType("js", "JavaScript", EditorLanguage.LANG_JAVASCRIPT, ".js",
                           new ImageResource2x(ICONS.iconJavascript2x()),
-                          true,
+                          WordWrap.DEFAULT,
                           true, false, false, false, false, false, false, false, false, false, false, false);
 
    public static final TextFileType JSON =
          new TextFileType("json", "JSON", EditorLanguage.LANG_JAVASCRIPT, ".json",
                           new ImageResource2x(ICONS.iconJavascript2x()),
-                          true,
+                          WordWrap.DEFAULT,
                           false, false, false, false, false, false, false, false, false, false, false, false);
 
 
@@ -169,7 +169,8 @@ public class FileTypeRegistry
 
    public static final TextFileType SQL =
          new TextFileType("sql", "SQL", EditorLanguage.LANG_SQL, ".sql",
-                          new ImageResource2x(ICONS.iconSql2x()), false, true, false, false, false,
+                          new ImageResource2x(ICONS.iconSql2x()),
+                          WordWrap.DEFAULT, true, false, false, false,
                           false, false, false, false, false, false, false, false);
 
    public static final TextFileType SH = new ScriptFileType(
@@ -178,17 +179,20 @@ public class FileTypeRegistry
 
    public static final TextFileType TOML =
          new TextFileType("toml", "TOML", EditorLanguage.LANG_TOML, ".toml",
-                          new ImageResource2x(ICONS.iconToml2x()), false, false, false, false, false,
+                          new ImageResource2x(ICONS.iconToml2x()),
+                          WordWrap.DEFAULT, false, false, false, false,
                           false, false, false, false, false, false, false, false);
 
    public static final TextFileType YAML =
          new TextFileType("yaml", "YAML", EditorLanguage.LANG_YAML, ".yml",
-                          new ImageResource2x(ICONS.iconYaml2x()), false, false, false, false, false,
+                          new ImageResource2x(ICONS.iconYaml2x()),
+                          WordWrap.DEFAULT, false, false, false, false,
                           false, false, false, false, false, false, false, false);
 
    public static final TextFileType XML =
          new TextFileType("xml", "XML", EditorLanguage.LANG_XML, ".xml",
-                          new ImageResource2x(ICONS.iconXml2x()), false, false, false, false, false,
+                          new ImageResource2x(ICONS.iconXml2x()),
+                          WordWrap.DEFAULT, false, false, false, false,
                           false, false, false, false, false, false, false, false);
 
    public static final TextFileType H = new CppFileType("h", ".h", new ImageResource2x(ICONS.iconH2x()), true, false);
@@ -198,103 +202,103 @@ public class FileTypeRegistry
 
    public static final TextFileType CLOJURE =
          new TextFileType("clojure", "Clojure", EditorLanguage.LANG_CLOJURE, ".clj", new ImageResource2x(ICONS.iconClojure2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
    public static final TextFileType COFFEE =
          new TextFileType("coffee", "Coffee", EditorLanguage.LANG_COFFEE, ".coffee", new ImageResource2x(ICONS.iconCoffee2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
    public static final TextFileType CSHARP =
          new TextFileType("csharp", "C#", EditorLanguage.LANG_CSHARP, ".cs", new ImageResource2x(ICONS.iconCsharp2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
 
    public static final TextFileType DOCKERFILE =
          new TextFileType("dockerfile", "Dockerfile", EditorLanguage.LANG_DOCKERFILE, "Dockerfile", new ImageResource2x(ICONS.iconDockerfile2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
    
    public static final TextFileType GITIGNORE =
          new TextFileType("gitignore", "Gitignore", EditorLanguage.LANG_GITIGNORE, ".gitignore", new ImageResource2x(ICONS.iconGitignore2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
    public static final TextFileType GO =
          new TextFileType("go", "Go", EditorLanguage.LANG_GO, ".go", new ImageResource2x(ICONS.iconGo2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
    public static final TextFileType GROOVY =
          new TextFileType("groovy", "Groovy", EditorLanguage.LANG_GROOVY, ".groovy", new ImageResource2x(ICONS.iconGroovy2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
    public static final TextFileType HASKELL =
          new TextFileType("haskell", "Haskell", EditorLanguage.LANG_HASKELL, ".haskell", new ImageResource2x(ICONS.iconHaskell2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
    public static final TextFileType HAXE =
          new TextFileType("haxe", "Haxe", EditorLanguage.LANG_HAXE, ".haxe", new ImageResource2x(ICONS.iconHaxe2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
    public static final TextFileType JAVA =
          new TextFileType("java", "Java", EditorLanguage.LANG_JAVA, ".java", new ImageResource2x(ICONS.iconJava2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
    public static final TextFileType JULIA =
          new TextFileType("julia", "Julia", EditorLanguage.LANG_JULIA, ".jl", new ImageResource2x(ICONS.iconJulia2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
    public static final TextFileType LISP =
          new TextFileType("lisp", "Lisp", EditorLanguage.LANG_LISP, ".lisp", new ImageResource2x(ICONS.iconLisp2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
    public static final TextFileType LUA =
          new TextFileType("lua", "Lua", EditorLanguage.LANG_LUA, ".lua", new ImageResource2x(ICONS.iconLua2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
    public static final TextFileType MAKEFILE =
          new TextFileType("makefile", "Makefile", EditorLanguage.LANG_MAKEFILE, ".makefile", new ImageResource2x(ICONS.iconMakefile2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
    public static final TextFileType MATLAB =
          new TextFileType("matlab", "Matlab", EditorLanguage.LANG_MATLAB, ".m", new ImageResource2x(ICONS.iconMatlab2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
    public static final TextFileType PERL =
          new TextFileType("perl", "Perl", EditorLanguage.LANG_PERL, ".pl", new ImageResource2x(ICONS.iconPerl2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
    public static final TextFileType RUBY =
          new TextFileType("ruby", "Ruby", EditorLanguage.LANG_RUBY, ".rb", new ImageResource2x(ICONS.iconRuby2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
    public static final TextFileType RUST =
          new TextFileType("rust", "Rust", EditorLanguage.LANG_RUST, ".rs", new ImageResource2x(ICONS.iconRust2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
    public static final TextFileType SCALA =
          new TextFileType("scala", "Scala", EditorLanguage.LANG_SCALA, ".scala", new ImageResource2x(ICONS.iconScala2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
    public static final TextFileType SNIPPETS =
          new TextFileType("snippets", "Snippets", EditorLanguage.LANG_SNIPPETS, ".snippets", new ImageResource2x(ICONS.iconSnippets2x()),
-               false, false, false, false, false,
+               WordWrap.DEFAULT, false, false, false, false,
                false, false, false, false, false, false, false, false);
 
    public static final RDataType RDATA = new RDataType();

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
@@ -30,6 +30,7 @@ import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.model.Session;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.views.files.model.FilesServerOperations;
 import org.rstudio.studio.client.workbench.views.source.SourceSatellite;
 
@@ -317,6 +318,7 @@ public class FileTypeRegistry
    public FileTypeRegistry(EventBus eventBus,
                            Satellite satellite,
                            Session session,
+                           UserPrefs userPrefs,
                            GlobalDisplay globalDisplay,
                            FilesServerOperations server)
    {

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/PlainTextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/PlainTextFileType.java
@@ -14,23 +14,23 @@
  */
 package org.rstudio.studio.client.common.filetypes;
 
-import com.google.gwt.resources.client.ImageResource;
 import org.rstudio.studio.client.common.reditor.EditorLanguage;
+
+import com.google.gwt.resources.client.ImageResource;
 
 public class PlainTextFileType extends TextFileType
 {
    PlainTextFileType(String id,
                      String label,
                      String defaultExtension,
-                     ImageResource defaultIcon,
-                     boolean wordWrap)
+                     ImageResource defaultIcon)
    {
       super(id, 
             label, 
             EditorLanguage.LANG_PLAIN, 
             defaultExtension, 
             defaultIcon, 
-            wordWrap,
+            WordWrap.DEFAULT,
             false,
             false,
             false,

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/PreviewableFromRFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/PreviewableFromRFileType.java
@@ -33,7 +33,7 @@ public class PreviewableFromRFileType extends TextFileType
                                    boolean canShowScopeTree)
    {
       super(id, label, editorLanguage, defaultExtension, icon,
-            true, true, false, false, false, false, 
+            WordWrap.DEFAULT, true, false, false, false, false, 
             false, false, false, false, false, canShowScopeTree, true);
       
       previewFunction_ = previewFunction;

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/PythonFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/PythonFileType.java
@@ -14,13 +14,13 @@
  */
 package org.rstudio.studio.client.common.filetypes;
 
-import com.google.gwt.resources.client.ImageResource;
-
 import java.util.HashSet;
 
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.studio.client.common.reditor.EditorLanguage;
 import org.rstudio.studio.client.workbench.commands.Commands;
+
+import com.google.gwt.resources.client.ImageResource;
 
 public class PythonFileType extends TextFileType
 {
@@ -36,7 +36,7 @@ public class PythonFileType extends TextFileType
             editorLanguage,
             defaultExtension,
             defaultIcon,
-            false, // word wrap
+            WordWrap.DEFAULT, // word wrap
             false, // source on save
             true,  // execute code
             true,  // execute all code

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/RFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/RFileType.java
@@ -14,14 +14,15 @@
  */
 package org.rstudio.studio.client.common.filetypes;
 
-import com.google.gwt.resources.client.ImageResource;
+import java.util.HashSet;
+
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.reditor.EditorLanguage;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.spelling.TokenPredicate;
 
-import java.util.HashSet;
+import com.google.gwt.resources.client.ImageResource;
 
 public class RFileType extends TextFileType
 {
@@ -36,7 +37,7 @@ public class RFileType extends TextFileType
             editorLanguage,
             defaultExtension,
             defaultIcon,
-            false, true, true, true, true, false, 
+            WordWrap.DEFAULT, true, true, true, true, false, 
             false, false, false, true, false, true, false);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/RWebContentFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/RWebContentFileType.java
@@ -14,14 +14,15 @@
  */
 package org.rstudio.studio.client.common.filetypes;
 
-import com.google.gwt.resources.client.ImageResource;
+import java.util.HashSet;
+
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.reditor.EditorLanguage;
 import org.rstudio.studio.client.workbench.commands.Commands;
 
-import java.util.HashSet;
+import com.google.gwt.resources.client.ImageResource;
 
 public class RWebContentFileType extends TextFileType
 {
@@ -60,7 +61,7 @@ public class RWebContentFileType extends TextFileType
             editorLanguage, 
             defaultExtension,
             icon,
-            true,    // word-wrap
+            WordWrap.DEFAULT,    // word-wrap
             sourceOnSave, 
             true, 
             true, 

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/ScriptFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/ScriptFileType.java
@@ -16,12 +16,12 @@ package org.rstudio.studio.client.common.filetypes;
 
 import java.util.HashSet;
 
-import com.google.gwt.resources.client.ImageResource;
-
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.studio.client.common.reditor.EditorLanguage;
 import org.rstudio.studio.client.workbench.commands.Commands;
+
+import com.google.gwt.resources.client.ImageResource;
 
 public class ScriptFileType extends TextFileType
 {
@@ -35,7 +35,7 @@ public class ScriptFileType extends TextFileType
                          boolean windowsCompatible)
    {
       super(id, label, language, ext, icon,
-            false, false, canExecuteCode, false, false, false, 
+            WordWrap.DEFAULT, false, canExecuteCode, false, false, false, 
             false, false, false, false, false, false, false);
       interpreter_ = interpreter;
       windowsCompatible_ = windowsCompatible;

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/SweaveFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/SweaveFileType.java
@@ -14,13 +14,15 @@
  */
 package org.rstudio.studio.client.common.filetypes;
 
-import com.google.gwt.resources.client.ImageResource;
+import java.util.HashSet;
+
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.regex.Pattern;
+import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.reditor.EditorLanguage;
 import org.rstudio.studio.client.workbench.commands.Commands;
 
-import java.util.HashSet;
+import com.google.gwt.resources.client.ImageResource;
 
 public class SweaveFileType extends TextFileType
 {
@@ -35,7 +37,7 @@ public class SweaveFileType extends TextFileType
             editorLanguage, 
             defaultExtension,
             icon,
-            true,
+            WordWrap.DEFAULT,
             false, 
             true, 
             true, 
@@ -49,7 +51,12 @@ public class SweaveFileType extends TextFileType
             true,
             false);
    }
-
+   
+   @Override
+   public boolean getWordWrap()
+   {
+      return RStudioGinjector.INSTANCE.getUserPrefs().softWrapRmdFiles().getValue();
+   }
 
    @Override
    public HashSet<AppCommand> getSupportedCommands(Commands commands)

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TexFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TexFileType.java
@@ -14,12 +14,13 @@
  */
 package org.rstudio.studio.client.common.filetypes;
 
-import com.google.gwt.resources.client.ImageResource;
+import java.util.HashSet;
+
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.studio.client.common.reditor.EditorLanguage;
 import org.rstudio.studio.client.workbench.commands.Commands;
 
-import java.util.HashSet;
+import com.google.gwt.resources.client.ImageResource;
 
 public class TexFileType extends TextFileType
 {
@@ -34,7 +35,7 @@ public class TexFileType extends TextFileType
             editorLanguage, 
             defaultExtension,
             icon,
-            true,
+            WordWrap.DEFAULT,
             false, 
             false, 
             false, 

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -21,6 +21,7 @@ import org.rstudio.core.client.UnicodeLetters;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.regex.Pattern;
+import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.StudioClientCommonConstants;
 import org.rstudio.studio.client.common.filetypes.events.OpenSourceFileEvent;
@@ -36,12 +37,17 @@ import com.google.gwt.resources.client.ImageResource;
 
 public class TextFileType extends EditableFileType
 {
+   public static enum WordWrap
+   {
+      YES, NO, DEFAULT
+   }
+   
    TextFileType(String id,
                 String label,
                 EditorLanguage editorLanguage,
                 String defaultExtension,
                 ImageResource defaultIcon,
-                boolean wordWrap,
+                WordWrap wordWrap,
                 boolean canSourceOnSave,
                 boolean canExecuteCode,
                 boolean canExecuteAllCode,
@@ -58,7 +64,7 @@ public class TextFileType extends EditableFileType
       super(id, label, defaultIcon);
       editorLanguage_ = editorLanguage;
       defaultExtension_ = defaultExtension;
-      wordWrap_ = wordWrap;
+      wordWrap_ = resolveWordWrap(wordWrap);
       canSourceOnSave_ = canSourceOnSave;
       canExecuteCode_ = canExecuteCode;
       canExecuteAllCode_ = canExecuteAllCode;
@@ -554,6 +560,22 @@ public class TextFileType extends EditableFileType
    public Pattern getRnwStartPatternEnd()
    {
       return null;
+   }
+   
+   private static boolean resolveWordWrap(WordWrap wordWrap)
+   {
+      switch (wordWrap)
+      {
+      case YES:
+         return true;
+      case NO:
+         return false;
+      case DEFAULT:
+         return RStudioGinjector.INSTANCE.getUserPrefs().softWrapRFiles().getValue();
+      }
+      
+      assert false : "unexpected enumeration value for wordWrap";
+      return false;
    }
 
    private final EditorLanguage editorLanguage_;

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -64,7 +64,7 @@ public class TextFileType extends EditableFileType
       super(id, label, defaultIcon);
       editorLanguage_ = editorLanguage;
       defaultExtension_ = defaultExtension;
-      wordWrap_ = resolveWordWrap(wordWrap);
+      wordWrap_ = wordWrap;
       canSourceOnSave_ = canSourceOnSave;
       canExecuteCode_ = canExecuteCode;
       canExecuteAllCode_ = canExecuteAllCode;
@@ -116,7 +116,15 @@ public class TextFileType extends EditableFileType
 
    public boolean getWordWrap()
    {
-      return wordWrap_;
+      switch (wordWrap_)
+      {
+      case YES:
+         return true;
+      case NO:
+         return false;
+      default:
+         return RStudioGinjector.INSTANCE.getUserPrefs().softWrapRFiles().getValue();
+      }
    }
 
    public boolean canSource()
@@ -562,24 +570,8 @@ public class TextFileType extends EditableFileType
       return null;
    }
    
-   private static boolean resolveWordWrap(WordWrap wordWrap)
-   {
-      switch (wordWrap)
-      {
-      case YES:
-         return true;
-      case NO:
-         return false;
-      case DEFAULT:
-         return RStudioGinjector.INSTANCE.getUserPrefs().softWrapRFiles().getValue();
-      }
-      
-      assert false : "unexpected enumeration value for wordWrap";
-      return false;
-   }
-
    private final EditorLanguage editorLanguage_;
-   private final boolean wordWrap_;
+   private final WordWrap wordWrap_;
    private final boolean canSourceOnSave_;
    private final boolean canExecuteCode_;
    private final boolean canExecuteAllCode_;

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/WebContentFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/WebContentFileType.java
@@ -16,11 +16,11 @@ package org.rstudio.studio.client.common.filetypes;
 
 import java.util.HashSet;
 
-import com.google.gwt.resources.client.ImageResource;
-
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.studio.client.common.reditor.EditorLanguage;
 import org.rstudio.studio.client.workbench.commands.Commands;
+
+import com.google.gwt.resources.client.ImageResource;
 
 public class WebContentFileType extends TextFileType
 {
@@ -37,7 +37,7 @@ public class WebContentFileType extends TextFileType
             editorLanguage, 
             defaultExtension,
             icon,
-            true,    // word-wrap
+            WordWrap.DEFAULT,    // word-wrap
             canSourceOnSave, 
             isMarkdown, // allow code execution in markdown 
             false, 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1052,7 +1052,7 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * Whether to soft-wrap R source files, wrapping the text for display without inserting newline characters.
+    * Whether to soft-wrap source files, wrapping the text for display without inserting newline characters.
     */
    public PrefValue<Boolean> softWrapRFiles()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -596,11 +596,11 @@ public interface UserPrefsAccessorConstants extends Constants {
    String verticallyAlignArgumentsIndentDescription();
 
    /**
-    * Whether to soft-wrap R source files, wrapping the text for display without inserting newline characters.
+    * Whether to soft-wrap source files, wrapping the text for display without inserting newline characters.
     */
-   @DefaultStringValue("Soft-wrap R source files")
+   @DefaultStringValue("Soft-wrap source files")
    String softWrapRFilesTitle();
-   @DefaultStringValue("Whether to soft-wrap R source files, wrapping the text for display without inserting newline characters.")
+   @DefaultStringValue("Whether to soft-wrap source files, wrapping the text for display without inserting newline characters.")
    String softWrapRFilesDescription();
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -303,9 +303,9 @@ reindentOnPasteDescription = Whether to automatically re-indent code when it's p
 verticallyAlignArgumentsIndentTitle = Vertically align function arguments
 verticallyAlignArgumentsIndentDescription = Whether to vertically align arguments to R function calls during automatic indentation.
 
-# Whether to soft-wrap R source files, wrapping the text for display without inserting newline characters.
-softWrapRFilesTitle = Soft-wrap R source files
-softWrapRFilesDescription = Whether to soft-wrap R source files, wrapping the text for display without inserting newline characters.
+# Whether to soft-wrap source files, wrapping the text for display without inserting newline characters.
+softWrapRFilesTitle = Soft-wrap source files
+softWrapRFilesDescription = Whether to soft-wrap source files, wrapping the text for display without inserting newline characters.
 
 # Whether to soft-wrap R Markdown files (and similar types such as R HTML and R Notebooks)
 softWrapRmdFilesTitle = Soft-wrap R Markdown files


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10940.

### Approach

Use the existing "wrap R source files" preference, but allow it to apply to all of the other editable text file types we support.

I added an enum for the WordWrap value to be set for a particular document, but I can't think of a reason why we might want to force enable or disable wrapping for a particular document type.

### Automated Tests

Not included; automated testing would likely be challenging since it would depend on things like font size, window size, pane size, and so on.

### QA Notes

Test that other files (e.g. `.py`) respect the "Soft wrap source files" preference.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
