### PR TITLE
support Quarto enabled without embedded Quarto

### DIFF
--- a/cmake/globals.cmake
+++ b/cmake/globals.cmake
@@ -234,8 +234,13 @@ set(RSTUDIO_NODE_VERSION "18.18.2" CACHE INTERNAL "Node version for building")
 set(RSTUDIO_INSTALLED_NODE_VERSION "18.20.3" CACHE INTERNAL "Node version installed with product")
 
 # quarto support
-set(QUARTO_ENABLED TRUE CACHE INTERNAL "")
-add_definitions(-DQUARTO_ENABLED)
+
+# set QUARTO_ENABLED = TRUE to have RStudio bundle an embedded copy of Quarto (default)
+# set QUARTO_ENABLED = FALSE to force the use of an external Quarto installation
+if(NOT DEFINED QUARTO_ENABLED)
+   set(QUARTO_ENABLED TRUE CACHE INTERNAL "")
+   add_definitions(-DQUARTO_ENABLED)
+endif()
 
 # install freedesktop integration files if we are installing into /usr
 if(NOT DEFINED RSTUDIO_INSTALL_FREEDESKTOP)

--- a/cmake/globals.cmake
+++ b/cmake/globals.cmake
@@ -234,16 +234,8 @@ set(RSTUDIO_NODE_VERSION "18.18.2" CACHE INTERNAL "Node version for building")
 set(RSTUDIO_INSTALLED_NODE_VERSION "18.20.3" CACHE INTERNAL "Node version installed with product")
 
 # quarto support
-if(NOT DEFINED QUARTO_ENABLED)
-   if(LINUX AND UNAME_M STREQUAL aarch64)
-     message(STATUS "RStudio aarch64 builds supports quarto experimentally")
-   endif()
-   set(QUARTO_ENABLED TRUE CACHE INTERNAL "")
-endif()
-
-if(QUARTO_ENABLED)
-   add_definitions(-DQUARTO_ENABLED)
-endif()
+set(QUARTO_ENABLED TRUE CACHE INTERNAL "")
+add_definitions(-DQUARTO_ENABLED)
 
 # install freedesktop integration files if we are installing into /usr
 if(NOT DEFINED RSTUDIO_INSTALL_FREEDESKTOP)

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -277,7 +277,6 @@ if has-scope "r"; then
    export RS_CRASH_HANDLER_PATH="@CMAKE_CURRENT_BINARY_DIR@/server/crash-handler-proxy/crash-handler-proxy"
    export RS_CRASHPAD_HANDLER_PATH="@RSTUDIO_TOOLS_ROOT@/crashpad/crashpad/out/Default/crashpad_handler"
 
-   export QUARTO_ENABLED="@QUARTO_ENABLED@"
    runWatchdogProcess 5m false                                                   \
       "@CMAKE_CURRENT_BINARY_DIR@/session/${RSTUDIO_SESSION_BIN}"                \
       --run-script "\"source('${TESTTHAT_TESTS_DIR}/run-tests.R'); runTests()\"" \

--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -57,12 +57,12 @@ using namespace rstudio::core;
 
 const char * const kRStudioQuarto = "RSTUDIO_QUARTO";
 
-#ifndef WIN32
-# define kQuartoCmd "quarto.cmd"
-# define kQuartoExe "quarto.exe"
-#else
+#ifndef _WIN32
 # define kQuartoCmd "quarto"
 # define kQuartoExe "quarto"
+#else
+# define kQuartoCmd "quarto.cmd"
+# define kQuartoExe "quarto.exe"
 #endif
 
 namespace rstudio {
@@ -160,7 +160,7 @@ std::tuple<FilePath,Version,bool> userInstalledQuarto()
    std::string rstudioQuarto = core::system::getenv(kRStudioQuarto);
    if (!rstudioQuarto.empty())
    {
-#ifdef WIN32
+#ifdef _WIN32
       if (!boost::algorithm::ends_with(rstudioQuarto, ".cmd"))
          rstudioQuarto = rstudioQuarto + ".cmd";
 #endif


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14505.

cc: @Enchufa2

### Approach

The `QUARTO_ENABLED` CMake variable now only controls whether we bundle a Quarto installation with RStudio. We keep the "regular" Quarto machinery turned on, but provide a warning in the situation where someone is running a Quarto-less RStudio but attempts to take some action that requires Quarto.

### Automated Tests

N/A; to be verified externally.

### QA Notes

N/A; to be verified externally.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
