### PR TITLE
fix issue with end fold widgets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 #### RStudio
 
 - Fixed an issue where various editor commands (Reindent Lines; Run Chunks) could fail in a document containing Quarto callout blocks. (#14640)
+- Fixed an issue where end fold markers were not rendered correctly in Quarto documents. (#14699)
 - Fixed an issue where the context menu sometimes did not display when right-clicking a word in the editor. (#14575)
 - Fixed an issue where the "Go to directory..." button brought up the wrong dialog (#14501; Desktop)
 - Remove superfluous Uninstall shortcut and Start Menu folder (#1900; Desktop installer on Windows)

--- a/src/cpp/session/modules/automation/SessionAutomationRemote.R
+++ b/src/cpp/session/modules/automation/SessionAutomationRemote.R
@@ -196,6 +196,19 @@
    self$jsExec(jsCode)
 })
 
+.rs.automation.addRemoteFunction("editorGetFoldWidget", function(row)
+{
+   jsCode <- .rs.heredoc(r'{
+      var id = $RStudio.last_focused_editor_id;
+      var container = document.getElementById(id);
+      var editor = container.env.editor;
+      var widget = editor.session.getFoldWidget(%i);
+      return widget;
+   }', as.integer(row))
+   
+   self$jsExec(jsCode)
+})
+
 .rs.automation.addRemoteFunction("editorGetState", function(row)
 {
    jsCode <- .rs.heredoc(r'{

--- a/src/cpp/tests/automation/testthat/test-automation-quarto.R
+++ b/src/cpp/tests/automation/testthat/test-automation-quarto.R
@@ -64,3 +64,28 @@ test_that("Quarto callout divs are tokenized correctly", {
    remote$consoleExecute(".rs.writeUserPref(\"rainbow_fenced_divs\", FALSE)")
    
 })
+
+# https://github.com/rstudio/rstudio/issues/14699
+test_that("Quarto chunks receive chunk begin / end markers as expected", {
+   
+   documentContents <- .rs.heredoc('
+      ---
+      title: Quarto Document
+      ---
+      
+      ```{r}
+      # This is a code chunk.
+      ```
+   ')
+   
+   remote$documentExecute(".Rmd", documentContents, {
+      Sys.sleep(0.1)
+      
+      startWidget <- remote$editorGetFoldWidget(4L)
+      expect_equal(startWidget, "start")
+      
+      endWidget <- remote$editorGetFoldWidget(6L)
+      expect_equal(endWidget, "end")
+   })
+   
+})


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14699.

### Approach

The way editor states are handled when entering + exiting chunks had changes in a way that broke our custom fold rules. The fix here is to instead rely on the token types + values, and explicitly try to detect `codebegin` / `codeend` chunk boundaries, and `heading` Markdown headers.

### Automated Tests

TODO

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14699.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
