### PR TITLE
use wrapper API for interacting with JS objects

### DIFF
--- a/src/cpp/session/modules/automation/SessionAutomation.cpp
+++ b/src/cpp/session/modules/automation/SessionAutomation.cpp
@@ -59,6 +59,7 @@ Error initialize()
       (boost::bind(sourceModuleRFile, "SessionAutomationClient.R"))
       (boost::bind(sourceModuleRFile, "SessionAutomationConstants.R"))
       (boost::bind(sourceModuleRFile, "SessionAutomationRemote.R"))
+      (boost::bind(sourceModuleRFile, "SessionAutomationRemoteObject.R"))
       (boost::bind(sourceModuleRFile, "SessionAutomationTargets.R"));
    
    Error error = initBlock.execute();

--- a/src/cpp/session/modules/automation/SessionAutomationRemote.R
+++ b/src/cpp/session/modules/automation/SessionAutomationRemote.R
@@ -149,16 +149,6 @@
    nodeId
 })
 
-.rs.automation.addRemoteFunction("domGetObjectId", function(selector)
-{
-   # Query for the requested node.
-   nodeId <- self$domGetNodeId(selector)
-   
-   # Get a JavaScript object ID associated with this node.
-   response <- self$client$DOM.resolveNode(nodeId)
-   response$object$objectId
-})
-
 .rs.automation.addRemoteFunction("domClickElement", function(selector, button = "left")
 {
    # Query for the requested node.
@@ -206,47 +196,6 @@
    
    response <- self$client$Runtime.evaluate(expression = jsCode)
    .rs.automation.wrapJsResponse(self, response)
-})
-
-.rs.automation.addRemoteFunction("editorGetTokens", function(row)
-{
-   jsCode <- .rs.heredoc(r'{
-      var id = $RStudio.last_focused_editor_id;
-      var container = document.getElementById(id);
-      var editor = container.env.editor;
-      var tokens = editor.session.getTokens(%i);
-      return tokens;
-   }', as.integer(row))
-   
-   self$jsExec(jsCode)
-})
-
-.rs.automation.addRemoteFunction("editorGetState", function(row)
-{
-   jsCode <- .rs.heredoc(r'{
-      var id = $RStudio.last_focused_editor_id;
-      var container = document.getElementById(id);
-      var editor = container.env.editor;
-      var state = editor.session.getState(%i);
-      return state;
-   }', as.integer(row))
-   
-   self$jsExec(jsCode)
-})
-
-
-.rs.automation.addRemoteFunction("editorSetCursorPosition", function(row, column = 0L)
-{
-   jsCode <- .rs.heredoc(r'{
-      var id = $RStudio.last_focused_editor_id;
-      var container = document.getElementById(id);
-      var editor = container.env.editor;
-      var position = { row: %i, column: %i };
-      var range = { start: position, end: position };
-      editor.selection.setSelectionRange(range);
-   }', as.integer(row), as.integer(column))
-   
-   self$jsExec(jsCode)
 })
 
 .rs.automation.addRemoteFunction("jsExec", function(expression)

--- a/src/cpp/session/modules/automation/SessionAutomationRemote.R
+++ b/src/cpp/session/modules/automation/SessionAutomationRemote.R
@@ -99,7 +99,7 @@
    self$waitForElement("#rstudio_source_text_editor")
 })
 
-.rs.automation.addRemoteFunction("documentExecute", function(ext, contents, expr)
+.rs.automation.addRemoteFunction("documentExecute", function(ext, contents, callback)
 {
    # Write document contents to file.
    documentPath <- tempfile("document-", fileext = ext)
@@ -122,8 +122,11 @@
       length(className) && grepl("ace_text-input", className)
    })
    
-   # Run the associated expression.
-   force(expr)
+   # Get a reference to the editor in that instance.
+   editor <- self$editorGetInstance()
+   
+   # Invoke callback with the editor instance.
+   callback(editor)
 })
 
 .rs.automation.addRemoteFunction("documentClose", function()
@@ -144,6 +147,16 @@
    
    # Describe the discovered node.
    nodeId
+})
+
+.rs.automation.addRemoteFunction("domGetObjectId", function(selector)
+{
+   # Query for the requested node.
+   nodeId <- self$domGetNodeId(selector)
+   
+   # Get a JavaScript object ID associated with this node.
+   response <- self$client$DOM.resolveNode(nodeId)
+   response$object$objectId
 })
 
 .rs.automation.addRemoteFunction("domClickElement", function(selector, button = "left")
@@ -181,6 +194,18 @@
       y = domRect$y + (domRect$height / 2),
       button = button
    )
+})
+
+.rs.automation.addRemoteFunction("editorGetInstance", function()
+{
+   jsCode <- .rs.heredoc(r'{
+      var id = $RStudio.last_focused_editor_id;
+      var container = document.getElementById(id);
+      container.env.editor
+   }')
+   
+   response <- self$client$Runtime.evaluate(expression = jsCode)
+   .rs.automation.wrapJsResponse(self, response)
 })
 
 .rs.automation.addRemoteFunction("editorGetTokens", function(row)
@@ -249,19 +274,38 @@
    .rs.fromJSON(jsonResponse$result$value)
 })
 
-.rs.automation.addRemoteFunction("jsCall", function(jsFunc,
-                                                    objectId = NULL,
-                                                    nodeId = NULL)
+.rs.automation.addRemoteFunction("jsCall", function(objectId, jsFunc)
 {
-   objectId <- .rs.nullCoalesce(objectId, {
-      resolvedNode <- self$client$DOM.resolveNode(nodeId)
-      objectId <- resolvedNode$object$objectId
-   })
+   # Wrap provided code into a function if necessary.
+   if (!grepl("^function\\b", jsFunc))
+   {
+      # Implicit return for single-line expressions.
+      lines <- strsplit(jsFunc, "\n", fixed = TRUE)[[1L]]
+      if (length(lines) == 1L && !.rs.startsWith(lines, "return "))
+         lines <- paste("return", lines)
+      
+      # Wrap into a function.
+      jsFunc <- sprintf("function() { %s }", paste(lines, collapse = "\n"))
+   }
    
+   # Wrap so that we can return JSON.
    self$client$Runtime.callFunctionOn(
       functionDeclaration = jsFunc,
       objectId = objectId
    )
+})
+
+.rs.automation.addRemoteFunction("jsObjectViaExpression", function(expression)
+{
+   response <- self$client$Runtime.evaluate(expression)
+   .rs.automation.wrapJsResponse(self, response)
+})
+
+.rs.automation.addRemoteFunction("jsObjectViaSelector", function(selector)
+{
+   nodeId <- self$domGetNodeId(selector)
+   response <- self$client$DOM.resolveNode(nodeId)
+   .rs.automation.wrapJsResponse(self, response)
 })
 
 .rs.automation.addRemoteFunction("quit", function()

--- a/src/cpp/session/modules/automation/SessionAutomationRemoteObject.R
+++ b/src/cpp/session/modules/automation/SessionAutomationRemoteObject.R
@@ -1,0 +1,211 @@
+#
+# SessionAutomationRemoteObject.R
+#
+# Copyright (C) 2024 by Posit Software, PBC
+#
+# Unless you have received self program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# self program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. self program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+.rs.addFunction("automation.initJsObject", function(object,
+                                                    self,
+                                                    objectId,
+                                                    objectClass,
+                                                    parentObjectId = NULL) 
+{
+   attr(object, "self")   <- self
+   attr(object, "id")     <- objectId
+   attr(object, "parent") <- parentObjectId
+   
+   class(object) <- objectClass
+   object
+})
+
+.rs.addFunction("automation.wrapJsResponse", function(self, response, parentObjectId = NULL)
+{
+   result <- .rs.nullCoalesce(response$result, response$object)
+   if (identical(result$type, "function"))
+      return(.rs.automation.wrapJsFunction(self, result$objectId, parentObjectId))
+   else if (identical(result$type, "object"))
+      return(.rs.automation.wrapJsObject(self, result$objectId, parentObjectId))
+   else if (!is.null(result$value))
+      return(result$value)
+})
+
+.rs.addFunction("automation.wrapJsFunction", function(self, objectId, parentObjectId)
+{
+   object <- function(...) {
+      .rs.automation.invokeJsFunction(self, objectId, parentObjectId, list(...))
+   }
+   
+   .rs.automation.initJsObject(
+      object         = object,
+      self           = self,
+      objectId       = objectId,
+      objectClass    = c("jsFunction", "jsObject"),
+      parentObjectId = parentObjectId
+   )
+})
+
+.rs.addFunction("automation.wrapJsObject", function(self, objectId, parentObjectId)
+{
+   .rs.automation.initJsObject(
+      object         = objectId,
+      self           = self,
+      objectId       = objectId,
+      objectClass    = "jsObject",
+      parentObjectId = parentObjectId
+   )
+})
+
+
+.rs.addFunction("automation.invokeJsFunction", function(self, objectId, parentObjectId, params)
+{
+   # Create function we'll invoke.
+   jsFunc <- .rs.heredoc(r'{
+      function(context) {
+         return this.apply(context, [].slice.call(arguments, 1));
+      }
+   }')
+ 
+   # Initialize arguments array.
+   arguments <- vector("list", length(params) + 1L)
+   arguments[[1L]] <- list(objectId = parentObjectId)
+   
+   # Insert our parameters into the arguments array.
+   for (i in seq_along(params))
+   {
+      param <- params[[i]]
+      arguments[[i + 1L]] <- if (inherits(param, "jsObject"))
+         list(objectId = attr(param, "id", exact = TRUE))
+      else
+         list(value = param)
+   }
+   
+   # Invoke the function.
+   response <- self$client$Runtime.callFunctionOn(
+      functionDeclaration = jsFunc,
+      objectId = objectId,
+      arguments = arguments
+   )
+   
+   .rs.automation.wrapJsResponse(self, response)
+})
+
+.rs.addFunction("automation.initRemoteMethods", function()
+{
+   registerS3method("format", "jsObject", function(x, ...) {
+      id <- attr(x, "id", exact = TRUE)
+      sprintf("%s <%s>", paste(class(x), collapse = "/"), id)
+   })
+   
+   registerS3method("str", "jsObject", function(object, ...) {
+      writeLines(format(object))
+   })
+   
+   registerS3method("print", "jsObject", function(x, ...) {
+      writeLines(format(x))
+   })
+   
+   registerS3method(".DollarNames", "jsObject", function(x, pattern) {
+      
+      self <- attr(x, "self", exact = TRUE)
+      
+      callback <- .rs.heredoc(r"{
+         function() {
+            var result = {};
+            for (var key in this) {
+               result[key] = typeof this[key];
+            }
+            return JSON.stringify(result);
+         }
+      }")
+      
+      objectId <- attr(x, "id", exact = TRUE)
+      response <- self$jsCall(objectId, callback)
+      value <- .rs.fromJSON(response$result$value)
+      value <- value[sort(names(value))]
+      
+      completions <- names(value)
+      types <- unlist(value, use.names = FALSE)
+      
+      attr(completions, "types") <- ifelse(
+         types == "function",
+         .rs.acCompletionTypes$FUNCTION,
+         .rs.acCompletionTypes$UNKNOWN
+      )
+      
+      completions
+   })
+   
+   registerS3method("$", "jsObject", function(x, name) {
+      
+      self <- attr(x, "self", exact = TRUE)
+      objectId <- attr(x, "id", exact = TRUE)
+      
+      jsFunc <- sprintf("function() { return this[%s]; }", deparse(name))
+      
+      response <- self$client$Runtime.callFunctionOn(
+         functionDeclaration = jsFunc,
+         objectId = objectId
+      )
+      
+      .rs.automation.wrapJsResponse(self, response, objectId)
+      
+   })
+   
+   registerS3method("[[", "jsObject", function(x, i, j, ..., drop = FALSE) {
+      
+      self <- attr(x, "self", exact = TRUE)
+      objectId <- attr(x, "id", exact = TRUE)
+      
+      jsFunc <- sprintf("function() { return this[%s]; }", deparse(i))
+      
+      response <- self$client$Runtime.callFunctionOn(
+         functionDeclaration = jsFunc,
+         objectId = objectId
+      )
+      
+      .rs.automation.wrapJsResponse(self, response, objectId)
+      
+   })
+   
+   registerS3method("length", "jsObject", function(x) {
+      
+      self <- attr(x, "self", exact = TRUE)
+      objectId <- attr(x, "id", exact = TRUE)
+      
+      response <- self$client$Runtime.callFunctionOn(
+         functionDeclaration = "function() { return this.length; }",
+         objectId = objectId
+      )
+      
+      .rs.automation.wrapJsResponse(self, response, objectId)
+      
+   })
+   
+   registerS3method("as.vector", "jsObject", function(x, mode = "any") {
+      
+      self <- attr(x, "self", exact = TRUE)
+      objectId <- attr(x, "id", exact = TRUE)
+      
+      response <- self$client$Runtime.callFunctionOn(
+         functionDeclaration = "function() { return JSON.stringify(this); }",
+         objectId = objectId
+      )
+      
+      .rs.fromJSON(response$result$value)
+   })
+   
+})
+
+if (interactive())
+{
+   .rs.automation.initRemoteMethods()
+}

--- a/src/cpp/tests/automation/testthat/test-automation-data-viewer.R
+++ b/src/cpp/tests/automation/testthat/test-automation-data-viewer.R
@@ -7,8 +7,8 @@ on.exit(.rs.automation.deleteRemote(), add = TRUE)
 # https://github.com/rstudio/rstudio/pull/14657
 test_that("we can use the data viewer with temporary R expressions", {
    remote$consoleExecute("View(subset(mtcars, mpg >= 30))")
-   nodeId <- remote$domGetNodeId("iframe[class=\"gwt-Frame\"]")
-   viewerSrc <- remote$jsCall("function() { return this.src; }", nodeId = nodeId)
+   objectId <- remote$domGetObjectId("iframe[class=\"gwt-Frame\"]")
+   viewerSrc <- remote$jsCall("function() { return this.src; }", objectId = objectId)
    expect_true(grepl("gridviewer.html", viewerSrc$result$value))
    remote$commandExecute("closeSourceDoc")
 })

--- a/src/cpp/tests/automation/testthat/test-automation-sweave.R
+++ b/src/cpp/tests/automation/testthat/test-automation-sweave.R
@@ -15,10 +15,10 @@ test_that("Braces are inserted and highlighted correctly in Sweave documents", {
       @
    ')
       
-   remote$documentExecute(".Rnw", documentContents, {
-      remote$editorSetCursorPosition(3, 0)
+   remote$documentExecute(".Rnw", documentContents, function(editor) {
+      editor$gotoLine(4L, 0L)
       remote$client$Input.insertText(text = "{ 1 + 1 }")
-      tokens <- remote$editorGetTokens(row = 3L)
+      tokens <- as.vector(editor$session$getTokens(3L))
       values <- vapply(tokens, `[[`, "value", FUN.VALUE = character(1))
       expected <- c("{", " ", "1", " ", "+", " ", "1", " ", "}")
       expect_equal(values, expected)

--- a/src/cpp/tests/automation/testthat/test-automation-syntax-highlighting.R
+++ b/src/cpp/tests/automation/testthat/test-automation-syntax-highlighting.R
@@ -77,7 +77,7 @@ test_that("Quarto chunks receive chunk begin / end markers as expected", {
       ```
    ')
    
-   remote$documentExecute(".Rmd", documentContents, function(editor) {
+   remote$documentExecute(".qmd", documentContents, function(editor) {
       startWidget <- editor$session$getFoldWidget(4L)
       expect_equal(startWidget, "start")
       

--- a/src/cpp/tests/automation/testthat/test-automation-syntax-highlighting.R
+++ b/src/cpp/tests/automation/testthat/test-automation-syntax-highlighting.R
@@ -63,3 +63,26 @@ test_that("Quarto callout divs are tokenized correctly", {
    remote$consoleExecute(".rs.writeUserPref(\"rainbow_fenced_divs\", FALSE)")
    
 })
+
+# https://github.com/rstudio/rstudio/issues/14699
+test_that("Quarto chunks receive chunk begin / end markers as expected", {
+   
+   documentContents <- .rs.heredoc('
+      ---
+      title: Quarto Document
+      ---
+      
+      ```{r}
+      # This is a code chunk.
+      ```
+   ')
+   
+   remote$documentExecute(".Rmd", documentContents, function(editor) {
+      startWidget <- editor$session$getFoldWidget(4L)
+      expect_equal(startWidget, "start")
+      
+      endWidget <- editor$session$getFoldWidget(6L)
+      expect_equal(endWidget, "end")
+   })
+   
+})

--- a/src/cpp/tests/automation/testthat/test-automation-syntax-highlighting.R
+++ b/src/cpp/tests/automation/testthat/test-automation-syntax-highlighting.R
@@ -18,8 +18,8 @@ test_that("Quarto Documents are highlighted as expected", {
       1 + 1
    ')
    
-   remote$documentExecute(".Rmd", documentContents, {
-      tokens <- remote$editorGetTokens(8L)
+   remote$documentExecute(".Rmd", documentContents, function(editor) {
+      tokens <- as.vector(editor$session$getTokens(8L))
       expect_length(tokens, 1L)
       expect_equal(tokens[[1]]$type,  "text")
       expect_equal(tokens[[1]]$value, "1 + 1")
@@ -41,24 +41,23 @@ test_that("Quarto callout divs are tokenized correctly", {
    ')
    
    remote$consoleExecute(".rs.writeUserPref(\"rainbow_fenced_divs\", TRUE)")
-   remote$documentExecute(".Rmd", documentContents, {
-      Sys.sleep(0.1)
+   remote$documentExecute(".Rmd", documentContents, function(editor) {
       
-      tokens <- remote$editorGetTokens(0L)
+      tokens <- as.vector(editor$session$getTokens(0L))
       expect_length(tokens, 2L)
       expect_equal(tokens[[1]]$type,  "fenced_div_0")
       expect_equal(tokens[[1]]$value, ":::")
       expect_equal(tokens[[2]]$type,  "fenced_div_text_0")
       expect_equal(tokens[[2]]$value, " {.callout 0}")
       
-      tokens <- remote$editorGetTokens(4L)
+      tokens <- as.vector(editor$session$getTokens(4L))
       expect_length(tokens, 2L)
       expect_equal(tokens[[1]]$type,  "fenced_div_1")
       expect_equal(tokens[[1]]$value, ":::")
       expect_equal(tokens[[2]]$type,  "fenced_div_text_1")
       expect_equal(tokens[[2]]$value, " {.callout 1}")
       
-      state <- remote$editorGetState(5L)
+      state <- editor$session$getState(5L)
       expect_equal(state, "start")
    })
    remote$consoleExecute(".rs.writeUserPref(\"rainbow_fenced_divs\", FALSE)")


### PR DESCRIPTION
This PR makes it easier to interact with Javascript objects from R. In particular, this PR introduces a `jsObject` object, which wraps a remote JavaScript object in the current Chromium session, which can then be interacted with via the "regular" R operators. For example:

<img width="732" alt="Screenshot 2024-05-29 at 9 50 50 AM" src="https://github.com/rstudio/rstudio/assets/1976582/4b5dfafc-877a-46ea-be47-462713ff5488">

This lets us write R code that "mimics" the underlying JavaScript code we would normally need to write by hand.