### PR TITLE
optimize filesystem access in chunk execution

### DIFF
--- a/src/cpp/session/modules/SessionHistory.cpp
+++ b/src/cpp/session/modules/SessionHistory.cpp
@@ -406,10 +406,10 @@ void onHistoryAdd(const std::string& command)
    module_context::enqueClientEvent(event);
 }
 
-SEXP rs_timestamp(SEXP stampSEXP) {
+SEXP rs_timestamp(SEXP stampSEXP)
+{
    std::string stamp = r::sexp::safeAsString(stampSEXP);
    r::session::consoleHistory().add(stamp);
-
    return R_NilValue;
 }
 

--- a/src/cpp/session/modules/SessionHistoryArchive.cpp
+++ b/src/cpp/session/modules/SessionHistoryArchive.cpp
@@ -159,8 +159,7 @@ Error HistoryArchive::add(const std::string& command)
 void HistoryArchive::flush()
 {
    // no-op when buffer is empty
-   std::string buffer = buffer_.str();
-   if (buffer.empty())
+   if (buffer_.tellp() == std::streampos(0))
       return;
    
    // reset the cache (since this write will invalidate the current one,
@@ -172,12 +171,15 @@ void HistoryArchive::flush()
    rotateHistoryDatabase();
    
    // append buffer entries
+   std::string buffer = buffer_.str();
    Error error = appendToFile(historyDatabaseFilePath(), buffer);
    if (error)
       LOG_ERROR(error);
    
-   // clean up
+   // reset buffer
+   buffer_.str(std::string());
    buffer_.clear();
+   
    flushScheduled_ = false;
 }
 

--- a/src/cpp/session/modules/SessionHistoryArchive.cpp
+++ b/src/cpp/session/modules/SessionHistoryArchive.cpp
@@ -18,8 +18,9 @@
 #include <string>
 
 #include <shared_core/Error.hpp>
-#include <core/Log.hpp>
 #include <shared_core/FilePath.hpp>
+
+#include <core/Log.hpp>
 #include <core/DateTime.hpp>
 #include <core/FileSerializer.hpp>
 

--- a/src/cpp/session/modules/SessionHistoryArchive.cpp
+++ b/src/cpp/session/modules/SessionHistoryArchive.cpp
@@ -55,7 +55,7 @@ FilePath historyDatabaseRotatedFilePath()
 void rotateHistoryDatabase()
 {
    FilePath historyDB = historyDatabaseFilePath();
-   if (historyDB.exists() && (historyDB.getSize() > kHistoryMaxBytes))
+   if (historyDB.getSize() > kHistoryMaxBytes)
    {
       // first remove the rotated file if it exists (ignore errors because
       // there's nothing we can do with them at this level)

--- a/src/cpp/session/modules/SessionHistoryArchive.hpp
+++ b/src/cpp/session/modules/SessionHistoryArchive.hpp
@@ -16,6 +16,7 @@
 #ifndef SESSION_HISTORY_ARCHIVE_HPP
 #define SESSION_HISTORY_ARCHIVE_HPP
 
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -51,7 +52,7 @@ HistoryArchive& historyArchive();
 class HistoryArchive : boost::noncopyable
 {
 private:
-   HistoryArchive() : entryCacheLastWriteTime_(-1) {}
+   HistoryArchive();
    friend HistoryArchive& historyArchive();
 
 public:
@@ -59,11 +60,18 @@ public:
 
 public:
    core::Error add(const std::string& command);
-   const std::vector<HistoryEntry>& entries() const;
+   const std::vector<HistoryEntry>& entries();
 
 private:
    mutable time_t entryCacheLastWriteTime_;
    mutable std::vector<HistoryEntry> entries_;
+   
+   mutable std::stringstream buffer_;
+   mutable bool flushScheduled_;
+   void flush();
+   
+private:
+   void onShutdown();
 };
                        
 } // namespace history

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
@@ -475,11 +475,15 @@ void ChunkExecContext::onConsoleText(int type, const std::string& output,
 
    // determine output filename and ensure it exists
    FilePath outputCsv = chunkOutputFile(docId_, chunkId_, nbCtxId_, ChunkOutputText);
-   Error error = outputCsv.ensureFile();
-   if (error)
+   if (outputCsv != consoleChunkOutputFile_)
    {
-      LOG_ERROR(error);
-      return;
+      consoleChunkOutputFile_ = outputCsv;
+      Error error = outputCsv.ensureFile();
+      if (error)
+      {
+         LOG_ERROR(error);
+         return;
+      }
    }
 
    // truncate if necessary

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.hpp
@@ -109,7 +109,8 @@ private:
    int lastOutputType_;
    ExecScope execScope_;
    r::sexp::PreservedSEXP prevWarn_;
-
+   
+   core::FilePath consoleChunkOutputFile_;
    bool hasOutput_;
    bool hasErrors_;
 

--- a/src/cpp/session/modules/rmarkdown/NotebookOutput.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookOutput.cpp
@@ -449,6 +449,7 @@ FilePath chunkOutputFile(const std::string& docId,
    OutputPair output = lastChunkOutput(docId, chunkId, nbCtxId);
    if (output.outputType == outputType)
       return chunkOutputFile(docId, chunkId, nbCtxId, output);
+   
    output.ordinal++;
    output.outputType = outputType;
    updateLastChunkOutput(docId, chunkId, output);


### PR DESCRIPTION
### Intent

A collection of potential resolutions for https://github.com/rstudio/rstudio/issues/14619.

### Approach

- When executing a chunk, avoid checking for and creating the console output file on each line of output; instead, just create the file once on the first piece of chunk output intended for that file.

- Buffer writes into the history database, using an in-memory buffer that gets flushed 1 second after any output is received.

### Automated Tests

Should be covered by existing automation.

### QA Notes

Would be nice if we could find an environment for testing (proejct living on a slow NFS / CIFS server?)

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
