### PR TITLE
support 'eager' and 'deferred' restart commands

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 
 #### RStudio
 
+- Restart commands are now run after restoring the search path + global environment by default. (#14636)
 - The "Soft-wrap R source files" preference now applies to all source files, and has been re-labelled appropriately. (#10940)
 
 #### Posit Workbench

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -39,7 +39,14 @@
    TYPE_ALL_WINDOWS   = 2L
 ))
 
-.rs.addApiFunction("restartSession", function(command = NULL, clean = FALSE) {
+.rs.addApiFunction("restartSession", function(command = NULL,
+                                              clean = FALSE,
+                                              eager = FALSE)
+{
+   command <- paste(as.character(command), collapse = "\n")
+   if (eager && !grepl("^@", command))
+      command <- paste0("@", command)
+   
    .rs.restartR(
       afterRestartCommand = as.character(command),
       clean = as.logical(clean)

--- a/src/cpp/session/modules/automation/SessionAutomationRemote.R
+++ b/src/cpp/session/modules/automation/SessionAutomationRemote.R
@@ -86,6 +86,12 @@
    self$client$Input.dispatchKeyEvent(type = "rawKeyDown", windowsVirtualKeyCode = 13L)
 })
 
+.rs.automation.addRemoteFunction("consoleOutput", function()
+{
+   consoleOutput <- self$jsObjectViaSelector("#rstudio_console_output")
+   strsplit(consoleOutput$innerText, split = "\n", fixed = TRUE)[[1L]]
+})
+
 .rs.automation.addRemoteFunction("documentOpen", function(ext, contents)
 {
    # Write document contents to file.

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -1886,7 +1886,7 @@ private:
       std::string afterRestartCommand;
       if (restartR_)
       {
-         afterRestartCommand = "library(" + pkgInfo_.name();
+         afterRestartCommand = "@library(" + pkgInfo_.name();
          
          // if --library="" was specified and we're not in devmode,
          // use it

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -1886,7 +1886,7 @@ private:
       std::string afterRestartCommand;
       if (restartR_)
       {
-         afterRestartCommand = "@library(" + pkgInfo_.name();
+         afterRestartCommand = "library(" + pkgInfo_.name();
          
          // if --library="" was specified and we're not in devmode,
          // use it

--- a/src/cpp/tests/automation/testthat/test-automation-restart.R
+++ b/src/cpp/tests/automation/testthat/test-automation-restart.R
@@ -1,0 +1,20 @@
+
+library(testthat)
+
+self <- remote <- .rs.automation.newRemote()
+on.exit(.rs.automation.deleteRemote(), add = TRUE)
+
+# https://github.com/rstudio/rstudio/issues/14636
+test_that("variables can be referenced after restart", {
+   
+   remote$consoleExecute("x <- 1; y <- 2")
+   remote$consoleExecute(".rs.api.restartSession('print(x + y)')")
+   
+   output <- NULL
+   .rs.waitUntil("console output is available", function() {
+      output <<- remote$consoleOutput()
+      output[[length(output)]] == "[1] 3"
+   })
+   
+   expect_equal(output[[length(output)]], "[1] 3")
+})

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -1025,7 +1025,9 @@ public class Packages
             true,
             () ->
             {
-               SuspendOptions options = SuspendOptions.createSaveAll(true, installCmd);
+               // Use '@' prefix to signal this should be executed eagerly
+               String command = installCmd.startsWith("@") ? installCmd : "@" + installCmd;
+               SuspendOptions options = SuspendOptions.createSaveAll(true, command);
                events_.fireEvent(new SuspendAndRestartEvent(options));
             },
             () ->


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14636.

### Approach

This PR implements support for an '@' prefix in restart commands. Any command with an '@' prefix will be executed "eagerly" (before the search path is restored); other commands will be executed "deferred" (after the search path is restored). This effectively reverts the default behavior for restart commands to the prior RStudio release, but gives us a path to support eager commands as required for package loading + installation.

I chose to encode this information in the restart command itself just to reduce the amount of code churn. Let me know if that feels too gross.

### Automated Tests

Included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14636.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
