### PR TITLE
PAM callback should not return error for error msg

### DIFF
--- a/src/cpp/server_core/system/Pam.cpp
+++ b/src/cpp/server_core/system/Pam.cpp
@@ -126,7 +126,11 @@ int conv(int num_msg,
          case PAM_PROMPT_ECHO_ON:
          case PAM_ERROR_MSG:
          default:
-            return PAM_CONV_ERR;
+            // Don't return an error here - some errors are for 'sufficient' steps that
+            // should not cause a login failure and this callback doesn't have the ability
+            // to differentiate them
+            // return PAM_CONV_ERR;
+            break;
          }
       }
 


### PR DESCRIPTION
### Intent

Addresses: https://github.com/rstudio/rstudio/issues/12116

### Approach

It's up to the PAM system to decide to accept or reject the PAM operation and returning error fails the login, even if there's an optional (sufficient) step that returns an error

### QA Notes

See the issue for a test case.  On the rhel8 system, the rserver-pam caused a segfault and on ubuntu20, it just did not allow the login. We should make sure to test this on both rhel8 and debian just because it's so system specific. 

Look in /var/log/auth.log and /var/log/{syslog,messages}

