### PR TITLE
ensure testthat test output is colored appropriately

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@
 
 #### RStudio
 
+- Fixed an issue where Build output from 'Run Tests' was not appropriately coloured. (#13088)
 - Fixed an issue where various editor commands (Reindent Lines; Run Chunks) could fail in a document containing Quarto callout blocks. (#14640)
 - Fixed an issue where end fold markers were not rendered correctly in Quarto documents. (#14699)
 - Fixed an issue where the context menu sometimes did not display when right-clicking a word in the editor. (#14575)

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -3002,7 +3002,7 @@ std::string rstudioVersion(bool normalizeSuffix)
    if (normalizeSuffix)
    {
       boost::regex reNonDigit("[^0-9]");
-      std::string suffix = boost::regex_replace(suffix, reNonDigit, "");
+      suffix = boost::regex_replace(suffix, reNonDigit, "");
    }
 
    return fmt::format(

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -366,17 +366,8 @@ SEXP rs_rstudioEdition()
 // get version
 SEXP rs_rstudioVersion()
 {
-   std::string numericVersion(RSTUDIO_VERSION_MAJOR);
-   numericVersion.append(".")
-      .append(RSTUDIO_VERSION_MINOR).append(".")
-      .append(RSTUDIO_VERSION_PATCH).append(".")
-      .append(boost::regex_replace(
-         std::string(RSTUDIO_VERSION_SUFFIX),
-         boost::regex("[a-zA-Z\\-+]"),
-         ""));
-
    r::sexp::Protect rProtect;
-   return r::sexp::create(numericVersion, &rProtect);
+   return r::sexp::create(rstudioVersion(true), &rProtect);
 }
 
 // get long form version
@@ -3003,6 +2994,23 @@ Error adaptToLanguage(const std::string& language)
    }
    
    return Success();
+}
+
+std::string rstudioVersion(bool normalizeSuffix)
+{
+   std::string suffix = RSTUDIO_VERSION_SUFFIX;
+   if (normalizeSuffix)
+   {
+      boost::regex reNonDigit("[^0-9]");
+      std::string suffix = boost::regex_replace(suffix, reNonDigit, "");
+   }
+
+   return fmt::format(
+            "{}.{}.{}.{}",
+            RSTUDIO_VERSION_MAJOR,
+            RSTUDIO_VERSION_MINOR,
+            RSTUDIO_VERSION_PATCH,
+            suffix);
 }
 
 Error initialize()

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -1046,6 +1046,8 @@ core::Error sendSessionRequest(const std::string& uri,
                                const std::string& body,
                                core::http::Response* pResponse);
 
+std::string rstudioVersion(bool normalizeSuffix = false);
+
 } // namespace module_context
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/modules/SessionConsole.cpp
+++ b/src/cpp/session/modules/SessionConsole.cpp
@@ -184,13 +184,15 @@ void syncConsoleColorEnv()
    // as package builds, which cannot query RStudio IDE settings.
    if (modeFromPref(prefs::userPrefs().ansiConsoleMode()) == core::text::AnsiColorOn)
    {
+      core::system::setenv("R_CLI_NUM_COLORS", "256");
       core::system::setenv("RSTUDIO_CONSOLE_COLOR", "256");
 
       if (rsession::options().defaultConsoleTerm().length() > 0)
          core::system::setenv("TERM", rsession::options().defaultConsoleTerm());
+
       if (rsession::options().defaultCliColorForce())
          core::system::setenv("CLICOLOR_FORCE", "1");
-      
+
       // Allow cli::style_hyperlink()
       core::system::setenv("RSTUDIO_CLI_HYPERLINKS", "true");
 
@@ -201,6 +203,7 @@ void syncConsoleColorEnv()
    }
    else
    {
+      core::system::unsetenv("R_CLI_NUM_COLORS");
       core::system::unsetenv("RSTUDIO_CONSOLE_COLOR");
       core::system::unsetenv("TERM");
       core::system::unsetenv("CLICOLOR_FORCE");

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -1166,7 +1166,6 @@ private:
       cmd << "--vanilla";
       cmd << "-s";
       cmd << "-e";
-      std::vector<std::string> rSourceCommands;
       
       boost::format fmt(
          "setwd('%1%');"
@@ -1293,7 +1292,6 @@ private:
       cmd << "--vanilla";
       cmd << "-s";
       cmd << "-e";
-      std::vector<std::string> rSourceCommands;
       
       if (type == kTestShiny)
       {

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -36,11 +36,8 @@
 #include <core/system/ShellUtils.hpp>
 #include <core/r_util/RPackageInfo.hpp>
 
-#include <session/SessionOptions.hpp>
-#include "../modules/rmarkdown/SessionRMarkdown.hpp"
-
 #ifdef _WIN32
-#include <core/r_util/RToolsInfo.hpp>
+# include <core/r_util/RToolsInfo.hpp>
 #endif
 
 #include <r/RExec.hpp>
@@ -50,9 +47,10 @@
 #include <r/session/RSessionUtils.hpp>
 #include <r/session/RConsoleHistory.hpp>
 
-#include <session/projects/SessionProjects.hpp>
 #include <session/SessionModuleContext.hpp>
+#include <session/SessionOptions.hpp>
 #include <session/SessionQuarto.hpp>
+#include <session/projects/SessionProjects.hpp>
 #include <session/prefs/UserPrefs.hpp>
 
 #include "SessionBuildErrors.hpp"
@@ -358,7 +356,7 @@ private:
             core::system::setenv(&environment, "R_LIBS", rLibs);
 
          // pass along RSTUDIO_VERSION
-         core::system::setenv(&environment, "RSTUDIO_VERSION", modules::rmarkdown::parsableRStudioVersion());
+         core::system::setenv(&environment, "RSTUDIO_VERSION", module_context::rstudioVersion(true));
          core::system::setenv(&environment, "RSTUDIO_LONG_VERSION", RSTUDIO_VERSION);
 
          options.environment = environment;

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -20,8 +20,6 @@
 #include <gsl/gsl>
 
 #include "SessionRmdNotebook.hpp"
-#include "../SessionHTMLPreview.hpp"
-#include "../build/SessionBuildErrors.hpp"
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string.hpp>
@@ -39,6 +37,7 @@
 #include <core/StringUtils.hpp>
 #include <core/Algorithm.hpp>
 #include <core/YamlUtil.hpp>
+#include <core/r_util/RProjectFile.hpp>
 
 #include <r/RExec.hpp>
 #include <r/RJson.hpp>
@@ -46,8 +45,6 @@
 #include <r/RUtil.hpp>
 #include <r/RRoutines.hpp>
 #include <r/RCntxtUtils.hpp>
-
-#include <core/r_util/RProjectFile.hpp>
 
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionConsoleProcess.hpp>
@@ -60,6 +57,7 @@
 
 #include "SessionBlogdown.hpp"
 #include "RMarkdownPresentation.hpp"
+#include "../SessionHTMLPreview.hpp"
 
 #define kRmdOutput "rmd_output"
 #define kRmdOutputLocation "/" kRmdOutput "/"
@@ -620,7 +618,7 @@ private:
          LOG_ERROR(error);
 
       // pass along the RSTUDIO_VERSION
-      environment.push_back(std::make_pair("RSTUDIO_VERSION", parsableRStudioVersion()));
+      environment.push_back(std::make_pair("RSTUDIO_VERSION", module_context::rstudioVersion(true)));
       environment.push_back(std::make_pair("RSTUDIO_LONG_VERSION", RSTUDIO_VERSION));
 
       // inform that this runs in the Render pane

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.hpp
@@ -45,8 +45,6 @@ bool pptAvailable();
 
 core::Error evaluateRmdParams(const std::string& docId);
 
-std::string parsableRStudioVersion();
-
 core::Error initialize();
 
 } // namespace rmarkdown

--- a/src/node/desktop/src/assets/locales/en.json
+++ b/src/node/desktop/src/assets/locales/en.json
@@ -74,6 +74,7 @@
     "rLogo": "R Logo",
     "warning": "Warning",
     "rstudioVersion": "RStudio Version",
+    "sessionPath": "Session Path",
     "errorMessage": "Error Message",
     "processOutput": "Process Output",
     "rSessionExitedWithCode": "The R session process exited with code {{- exitCode}}.",

--- a/src/node/desktop/src/assets/locales/fr.json
+++ b/src/node/desktop/src/assets/locales/fr.json
@@ -74,6 +74,7 @@
     "rLogo": "Logo de R",
     "warning": "Avertissement",
     "rstudioVersion": "Version de RStudio",
+    "sessionPath": "Chemin de Session",
     "errorMessage": "Message d'erreur",
     "processOutput": "Sortie du processus",
     "rSessionExitedWithCode": "Le processus de la session R a quitté avec le code {{- exitCode}}.",

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -603,7 +603,6 @@ export class SessionLauncher {
     // to a separate location, so we can more easily build and restart
     // with an "active" rsession executable
     if (!app.isPackaged && process.platform == 'win32') {
-
       const sessionPath = this.sessionPath.getAbsolutePath();
       const sessionDir = path.dirname(sessionPath);
       const sessionName = path.basename(sessionPath).replaceAll('development-', '');
@@ -611,7 +610,6 @@ export class SessionLauncher {
       const newSessionPath = `${sessionDir}/development-${sessionName}`;
       fs.copyFileSync(this.sessionPath.getAbsolutePath(), newSessionPath);
       this.sessionPath = new FilePath(newSessionPath);
-      console.log(newSessionPath);
     }
 
     const sessionProc = launchProcess(this.sessionPath, argList);

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -349,6 +349,7 @@ export class SessionLauncher {
     if (this.sessionProcess && this.sessionProcess.exitCode) {
       exitCode = this.sessionProcess.exitCode;
     }
+    vars.set('session_path', this.sessionPath.getAbsolutePath());
     vars.set('exit_code', exitCode.toString());
 
     // Read standard output and standard error streams
@@ -596,6 +597,21 @@ export class SessionLauncher {
         setenv('RSTUDIO_AUTOMATION_ROOT', projectRoot);
         setenv('RSTUDIO_AUTOMATION_ARGS', process.cwd());
       }
+    }
+
+    // in Windows development builds, move the session executable
+    // to a separate location, so we can more easily build and restart
+    // with an "active" rsession executable
+    if (!app.isPackaged && process.platform == 'win32') {
+
+      const sessionPath = this.sessionPath.getAbsolutePath();
+      const sessionDir = path.dirname(sessionPath);
+      const sessionName = path.basename(sessionPath).replaceAll('development-', '');
+
+      const newSessionPath = `${sessionDir}/development-${sessionName}`;
+      fs.copyFileSync(this.sessionPath.getAbsolutePath(), newSessionPath);
+      this.sessionPath = new FilePath(newSessionPath);
+      console.log(newSessionPath);
     }
 
     const sessionProc = launchProcess(this.sessionPath, argList);

--- a/src/node/desktop/src/ui/error/error.html
+++ b/src/node/desktop/src/ui/error/error.html
@@ -89,6 +89,7 @@
         if (ver) {
           ver.innerText += '\n\n' + navigator.userAgent;
         }
+        replaceVar('session_path');
         replaceVar('launch_failed');
         replaceVar('exit_code');
         replaceVar('process_error');
@@ -168,6 +169,8 @@
     <p id="i18n-rSessionFailedToStart"></p>
     <h2 id="i18n-rstudioVersion"></h2>
     <code id="version"></code>
+    <h2 id="i18n-sessionPath"></h2>
+    <code id="session_path"></code>
     <h2 id="i18n-errorMessage"></h2>
     <code id="launch_failed"></code>
     <h2 id="i18n-processOutput"></h2>
@@ -209,7 +212,7 @@ user_agent
 
 ### Process Output
 
-The R session exited with code #exit_code#. 
+The R session exited with code #exit_code#.
 
 Error output:
 

--- a/src/node/desktop/src/ui/error/error.ts
+++ b/src/node/desktop/src/ui/error/error.ts
@@ -25,6 +25,7 @@ const loadPageLocalization = () => {
       'errorStartingR',
       'rLogo',
       'errorStartingR',
+      'sessionPath',
       'rSessionFailedToStart',
       'rstudioVersion',
       'output',


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13088.

### Approach

The underlying fix here is very simple -- set `R_CLI_NUM_COLORS = 256`, as supported via https://github.com/r-lib/cli/blob/71fd2a58b79b63672d0d52fc69982fd3a6913952/R/num-ansi-colors.R#L45-L47.

The rest of this PR mostly improves the ergonomics of the development cycle on Windows. In particular, this PR lets us rebuild the RStudio R session even while a development instance of RStudio is running. This is accomplished by copying the `rsession.exe` executable to a new location in the same directory, then running that executable instead. This allows us to rebuild and update the original `rsession.exe` while RStudio is running, and then that updated executable will be picked up on session restarts.

In essence, this allows us to rebuild and restart the R session to get a "new" development build of the RStudio R session, without forcing a full stop and start of the IDE (which can be much slower).

### Automated Tests

TODO

### QA Notes

Test via notes in issue.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

