### PR TITLE
ensure desktop frame callbacks are properly sequenced when saving page region as image

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@
 - Fixed an issue where end fold markers were not rendered correctly in Quarto documents. (#14699)
 - Fixed an issue where the context menu sometimes did not display when right-clicking a word in the editor. (#14575)
 - Fixed an issue where the "Go to directory..." button brought up the wrong dialog (#14501; Desktop)
+- Fixed an issue where "View plot after saving" in the Save Plot as Image dialog sometimes did not work. (#14702)
 - Remove superfluous Uninstall shortcut and Start Menu folder (#1900; Desktop installer on Windows)
 - Hide Refresh button while Replace All operation is running in the Find in Files pane (#13873)
 - Stop the File Pane's "Copy To" operation from deleting the file when source and destination are the same (#14525)

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -102,7 +102,8 @@ public interface DesktopFrame extends JavaScriptPassthrough
                                int left, 
                                int top, 
                                int width, 
-                               int height);
+                               int height,
+                               CommandWithArg<Void> callback);
 
    void printText(String text);
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/export/ViewerPaneSaveAsImageDesktopOperation.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/export/ViewerPaneSaveAsImageDesktopOperation.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.workbench.views.viewer.export;
 
+import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Rectangle;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemItem;
@@ -42,6 +43,12 @@ public class ViewerPaneSaveAsImageDesktopOperation implements SavePlotAsImageOpe
                @Override
                public void execute(Rectangle viewerRect)
                {
+                  CommandWithArg<Void> callback = (Void nil) ->
+                  {
+                     if (viewAfterSave)
+                        Desktop.getFrame().showFile(StringUtil.notNull(targetPath.getPath()));
+                  };
+                  
                   // perform the export
                   Desktop.getFrame().exportPageRegionToFile(
                         StringUtil.notNull(targetPath.getPath()),
@@ -49,10 +56,8 @@ public class ViewerPaneSaveAsImageDesktopOperation implements SavePlotAsImageOpe
                         viewerRect.getLeft(),
                         viewerRect.getTop(),
                         viewerRect.getWidth(),
-                        viewerRect.getHeight());
-
-                  if (viewAfterSave)
-                     Desktop.getFrame().showFile(StringUtil.notNull(targetPath.getPath()));
+                        viewerRect.getHeight(),
+                        callback);
                }
             },
             onCompleted

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -556,7 +556,7 @@ export class GwtCallback extends EventEmitter {
       }
     });
 
-    ipcMain.on('desktop_export_page_region_to_file', (event, targetPath, format, left, top, width, height, callback) => {
+    ipcMain.on('desktop_export_page_region_to_file', (event, targetPath, format, left, top, width, height) => {
       const rect: Rectangle = { x: left, y: top, width, height };
       targetPath = resolveAliasedPath(targetPath);
       this.mainWindow.window
@@ -569,7 +569,6 @@ export class GwtCallback extends EventEmitter {
             buffer = image.toPNG();
           }
           writeFileSync(targetPath, buffer);
-          callback();
         })
         .catch((error) => {
           logger().logError(error);

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -556,7 +556,7 @@ export class GwtCallback extends EventEmitter {
       }
     });
 
-    ipcMain.on('desktop_export_page_region_to_file', (event, targetPath, format, left, top, width, height) => {
+    ipcMain.on('desktop_export_page_region_to_file', (event, targetPath, format, left, top, width, height, callback) => {
       const rect: Rectangle = { x: left, y: top, width, height };
       targetPath = resolveAliasedPath(targetPath);
       this.mainWindow.window
@@ -569,6 +569,7 @@ export class GwtCallback extends EventEmitter {
             buffer = image.toPNG();
           }
           writeFileSync(targetPath, buffer);
+          callback();
         })
         .catch((error) => {
           logger().logError(error);

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -534,17 +534,15 @@ export class GwtCallback extends EventEmitter {
 
     ipcMain.handle(
       'desktop_copy_page_region_to_clipboard',
-      (_event, x: number, y: number, width: number, height: number) => {
-        const rect: Rectangle = { x, y, width, height };
-        this.mainWindow.window
-          .capturePage(rect)
-          .then((image) => {
-            clipboard.writeImage(image);
-          })
-          .catch((error) => {
-            logger().logError(error);
-          });
-      },
+      async (_event, x: number, y: number, width: number, height: number) => {
+        try {
+          const rect: Rectangle = { x, y, width, height };
+          const image = await this.mainWindow.window.capturePage(rect);
+          clipboard.writeImage(image);
+        } catch (e: unknown) {
+          logger().logError(e);
+        }
+      }
     );
 
     ipcMain.handle('desktop_copy_image_at_xy_to_clipboard', (_event, x: number, y: number) => {

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -323,7 +323,10 @@ export function getDesktopBridge() {
       height: number,
       callback: () => void
     ) => {
-      ipcRenderer.send('desktop_export_page_region_to_file', targetPath, format, left, top, width, height, callback);
+      ipcRenderer
+        .invoke('desktop_export_page_region_to_file', targetPath, format, left, top, width, height)
+        .then(() => callback())
+        .catch((error) => reportIpcError('desktop_export_page_region_to_file', error));
     },
 
     supportsClipboardMetafile: (callback: VoidCallback<boolean>) => {

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -321,8 +321,9 @@ export function getDesktopBridge() {
       top: number,
       width: number,
       height: number,
+      callback: () => void
     ) => {
-      ipcRenderer.send('desktop_export_page_region_to_file', targetPath, format, left, top, width, height);
+      ipcRenderer.send('desktop_export_page_region_to_file', targetPath, format, left, top, width, height, callback);
     },
 
     supportsClipboardMetafile: (callback: VoidCallback<boolean>) => {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14702.

### Approach

Since desktop frame invocations are no longer synchronous, we need to sequence their invocations via callbacks.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14702. Note that the issue is likely to reproduce only stochastically, so it may take a number of tries to reproduce.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
