### PR TITLE
support electron-flags.conf

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 - Restart commands are now run after restoring the search path + global environment by default. (#14636)
 - The "Soft-wrap R source files" preference now applies to all source files, and has been re-labelled appropriately. (#10940)
-- RStudio now supports Electron flags set via `~/.config/electron-flags.conf` (or equivalent on other platforms). (#14641)
+- RStudio now supports Electron flags set via `~/.config/rstudio/electron-flags.conf` or `~/.config/electron-flags.conf` on Linux / macOS. (#14641)
 
 #### Posit Workbench
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 - Restart commands are now run after restoring the search path + global environment by default. (#14636)
 - The "Soft-wrap R source files" preference now applies to all source files, and has been re-labelled appropriately. (#10940)
-- RStudio now supports Electron flags set via `~/.config/rstudio/electron-flags.conf` or `~/.config/electron-flags.conf` on Linux / macOS. (#14641)
+- RStudio now supports Electron flags set via `~/.config/rstudio/electron-flags.conf` or `~/.config/electron-flags.conf` on Linux / macOS. On Windows, the paths are `%LocalAppData%\RStudio\electron-flags.conf` and `%LocalAppData%\electron-flags.conf`. (#14641)
 
 #### Posit Workbench
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 - Restart commands are now run after restoring the search path + global environment by default. (#14636)
 - The "Soft-wrap R source files" preference now applies to all source files, and has been re-labelled appropriately. (#10940)
-
+- RStudio now supports Electron flags set via `~/.config/electron-flags.conf` (or equivalent on other platforms). (#14641)
 
 #### Posit Workbench
 

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -200,6 +200,7 @@ function findBuildRootImpl(rootDir: string): string {
   // root directories to search
   const buildDirParents = [
     `${rootDir}`,
+    `${rootDir}/build`,
     `${rootDir}/src`,
     `${rootDir}/src/cpp`,
     `${rootDir}/src/cpp/build`,
@@ -214,7 +215,7 @@ function findBuildRootImpl(rootDir: string): string {
     if (fs.existsSync(buildDirParent)) {
       const buildDirFiles = fs.readdirSync(buildDirParent);
       for (const buildDirFile of buildDirFiles) {
-        if (/^(?:build|cmake-build-|Desktop-)/.test(buildDirFile)) {
+        if (/^(?:build|cmake-build-|Desktop)/.test(buildDirFile)) {
           const buildDirPath = `${buildDirParent}/${buildDirFile}`;
           for (const buildFile of ['.ninja_log', 'CMakeFiles']) {
             const buildPath = `${buildDirPath}/${buildFile}`;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14641.

### Approach

Check for files at these locations:

- `~/.config/rstudio/electron-flags.conf`
- `~/.config/electron-flags.conf`

Use the first one that exists, and then read lines and apply flags.

### Automated Tests

Not included; testing was done manually.

### QA Notes

One way to test is to do something like this from the terminal (on macOS or Linux)

```
echo "--disable-gpu" > ~/.config/rstudio/electron-flags.conf
```

Then, start RStudio, and check Help -> Diagnostics -> Show GPU Diagnostics. You should see something like:

<img width="912" alt="Screenshot 2024-06-04 at 10 07 16 AM" src="https://github.com/rstudio/rstudio/assets/1976582/ce7990fb-7a19-4edc-9a88-a3db0dd4b791">

Next, remove that file, and then restart RStudio. You should see something like:

<img width="912" alt="Screenshot 2024-06-04 at 10 08 02 AM" src="https://github.com/rstudio/rstudio/assets/1976582/81726a8e-21e9-4567-a3a2-587fb81d3867">

The specifics may differ from platform to platform; the main thing to note is you shouldn't see any "Hardware accelerated" output with `--disable-gpu` set.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
