### PR TITLE
avoid triggering active bindings when completing names in environment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@
 - Fixed an issue where the context menu sometimes did not display when right-clicking a word in the editor. (#14575)
 - Fixed an issue where the "Go to directory..." button brought up the wrong dialog (#14501; Desktop)
 - Fixed an issue where "View plot after saving" in the Save Plot as Image dialog sometimes did not work. (#14702)
+- Fixed an issue where RStudio could trigger active bindings in environments when requesting completions. (#14784)
 - Remove superfluous Uninstall shortcut and Start Menu folder (#1900; Desktop installer on Windows)
 - Hide Refresh button while Replace All operation is running in the Find in Files pane (#13873)
 - Stop the File Pane's "Copy To" operation from deleting the file when source and destination are the same (#14525)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -748,9 +748,29 @@
    
    meta <- if (!inherits(object, "tbl_sql"))
    {
-      vapply(names, function(name) {
-         .rs.nullCoalesce(attr(object[[name]], "label"), "")
-      }, FUN.VALUE = character(1))
+      if (is.environment(object))
+      {
+         vapply(names, function(name)
+         {
+            if (bindingIsActive(name, object))
+            {
+               ""
+            }
+            else
+            {
+               label <- attr(object[[name]], "label", exact = TRUE)
+               .rs.nullCoalesce(label, "")
+            }
+         }, FUN.VALUE = character(1))
+      }
+      else
+      {
+         vapply(names, function(name)
+         {
+            label <- attr(object[[name]], "label", exact = TRUE)
+            .rs.nullCoalesce(label, "")
+         }, FUN.VALUE = character(1))
+      }
    }
    
    attr(names, "meta") <- unname(meta)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -748,7 +748,7 @@
    
    meta <- if (!inherits(object, "tbl_sql"))
    {
-      if (is.environment(object))
+      if (is.environment(object) && is.character(names))
       {
          vapply(names, function(name)
          {

--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -283,6 +283,9 @@
    envVars[rstudioEnvVars] <- list(NULL)
    envVars["R_SESSION_TMPDIR"] <- list(NULL)
    
+   # Make sure the automation server uses the same R session executable.
+   envVars[["RSTUDIO_WHICH_R"]] <- ps::ps_exe()
+   
    # Ensure that the new RStudio instance uses temporary storage.
    stateDir <- tempfile("rstudio-automation-state-")
    dir.create(stateDir, recursive = TRUE)

--- a/src/cpp/session/modules/automation/SessionAutomationRemote.R
+++ b/src/cpp/session/modules/automation/SessionAutomationRemote.R
@@ -264,6 +264,23 @@
    .rs.automation.wrapJsResponse(self, response)
 })
 
+.rs.automation.addRemoteFunction("keyboardExecute", function(...)
+{
+   reShortcut <- "^\\<(.*)\\>$"
+   for (input in list(...))
+   {
+      if (grepl(reShortcut, input, perl = TRUE))
+      {
+         shortcut <- sub(reShortcut, "\\1", input, perl = TRUE)
+         self$shortcutExecute(shortcut)
+      }
+      else
+      {
+         self$client$Input.insertText(input)
+      }
+   }
+})
+
 .rs.automation.addRemoteFunction("quit", function()
 {
    # Close the websocket connection.

--- a/src/cpp/tests/automation/testthat/test-automation-completions.R
+++ b/src/cpp/tests/automation/testthat/test-automation-completions.R
@@ -23,6 +23,7 @@ test_that("autocompletion doesn't trigger active bindings", {
    expect_false(tail(output, 1) == "[1] \"active\"")
    
    remote$keyboardExecute("n", "<Tab>", "<Escape>", "<Backspace>")
+   output <- remote$consoleOutput()
    expect_false(tail(output, 1) == "[1] \"active\"")
    
 })

--- a/src/cpp/tests/automation/testthat/test-automation-completions.R
+++ b/src/cpp/tests/automation/testthat/test-automation-completions.R
@@ -22,4 +22,7 @@ test_that("autocompletion doesn't trigger active bindings", {
    output <- remote$consoleOutput()
    expect_false(tail(output, 1) == "[1] \"active\"")
    
+   remote$keyboardExecute("n", "<Tab>", "<Escape>", "<Backspace>")
+   expect_false(tail(output, 1) == "[1] \"active\"")
+   
 })

--- a/src/cpp/tests/automation/testthat/test-automation-completions.R
+++ b/src/cpp/tests/automation/testthat/test-automation-completions.R
@@ -1,0 +1,25 @@
+
+library(testthat)
+
+self <- remote <- .rs.automation.newRemote()
+on.exit(.rs.automation.deleteRemote(), add = TRUE)
+
+# https://github.com/rstudio/rstudio/issues/14784
+test_that("autocompletion doesn't trigger active bindings", {
+   
+   code <- .rs.heredoc(r'{
+      Test <- R6::R6Class("Test",
+        active  = list(active_test  = function(value) print("active")),
+        private = list(private_test = function(value) print("private")),
+        public  = list(public_test  = function(value) print("public"))
+      )
+      
+      n <- Test$new()
+      nms <- .rs.getNames(n)
+   }')
+   
+   remote$consoleExecute(code)
+   output <- remote$consoleOutput()
+   expect_false(tail(output, 1) == "[1] \"active\"")
+   
+})


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14784.

### Approach

Check for active bindings in `.rs.getNames()`, and avoid triggering those bindings when requesting object attributes.

### Automated Tests

Included in PR.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14784.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
