### PR TITLE
use virtualized data grid for Files pane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@
 - Fixed an issue where the context menu sometimes did not display when right-clicking a word in the editor. (#14575)
 - Fixed an issue where the "Go to directory..." button brought up the wrong dialog (#14501; Desktop)
 - Fixed an issue where "View plot after saving" in the Save Plot as Image dialog sometimes did not work. (#14702)
+- Fixed an issue where the IDE could hang when navigating the Files pane to a directory containing a very large number of files. (#13426)
 - Remove superfluous Uninstall shortcut and Start Menu folder (#1900; Desktop installer on Windows)
 - Hide Refresh button while Replace All operation is running in the Find in Files pane (#13873)
 - Stop the File Pane's "Copy To" operation from deleting the file when source and destination are the same (#14525)

--- a/src/gwt/src/org/rstudio/core/client/widget/VirtualizedDataGrid.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/VirtualizedDataGrid.java
@@ -99,6 +99,10 @@ public abstract class VirtualizedDataGrid<T> extends RStudioDataGrid<T>
    // These two fields allow us to compute the expected total size of the widget.
    public abstract double getRowHeight();
    public abstract int getTotalNumberOfRows();
+   
+   // This field is primarily used to ensure the top + bottom padding rows
+   // are drawn with a matching style for the rest of the data grid.
+   // This can return 'null' if no special styling is required.
    public abstract String getBorderColor();
    
    public VirtualizedDataGrid()

--- a/src/gwt/src/org/rstudio/core/client/widget/VirtualizedDataGrid.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/VirtualizedDataGrid.java
@@ -49,15 +49,21 @@ public abstract class VirtualizedDataGrid<T> extends RStudioDataGrid<T>
       {
          // if this is the first row, draw padding
          if (index == 0)
+         {
             drawTopRowPadding();
-         
-         // draw this row if it's in the visibility range
-         if (firstActiveRow_ <= index && index <= lastActiveRow_)
-            super.buildRowImpl(data, index);
+         }
          
          // if this is the last row, draw padding
-         if (index == lastActiveRow_)
+         else if (index == lastActiveRow_)
+         {
             drawBottomRowPadding();
+         }
+         
+         else if (firstActiveRow_ <= index && index <= lastActiveRow_)
+         {
+            // draw this row if it's in the visibility range
+            super.buildRowImpl(data, index);
+         }
       }
       
       private void drawTopRowPadding()
@@ -90,8 +96,7 @@ public abstract class VirtualizedDataGrid<T> extends RStudioDataGrid<T>
       }
    }
    
-   // These two fields allow us to compute the expected
-   // total size of the widget.
+   // These two fields allow us to compute the expected total size of the widget.
    public abstract double getRowHeight();
    public abstract int getTotalNumberOfRows();
    public abstract String getBorderColor();
@@ -249,6 +254,7 @@ public abstract class VirtualizedDataGrid<T> extends RStudioDataGrid<T>
       // determine the total number of rows visible
       int rowsActive = (int) (getOffsetHeight() / rowHeight);
       
+      // set our active rows -- use padding to allow smoother scrolling
       firstActiveRow_ = Math.max(0, numRowsScrolled - ROW_PADDING);
       lastActiveRow_ = Math.min(n, numRowsScrolled + rowsActive + ROW_PADDING);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesList.java
@@ -98,6 +98,12 @@ public class FilesList extends Composite
          {
             return "transparent";
          }
+         
+         @Override
+         protected boolean resetFocusOnCell()
+         {
+            return false;
+         }
       };
             
       selectionModel_ = new MultiSelectionModel<>(KEY_PROVIDER);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesList.java
@@ -19,7 +19,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
-import com.google.gwt.core.client.GWT;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.cellview.AriaLabeledCheckboxCell;
@@ -28,7 +27,7 @@ import org.rstudio.core.client.cellview.LabeledBoolean;
 import org.rstudio.core.client.cellview.LinkColumn;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.OperationWithInput;
-import org.rstudio.core.client.widget.RStudioDataGrid;
+import org.rstudio.core.client.widget.VirtualizedDataGrid;
 import org.rstudio.studio.client.ResizableHeader;
 import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.common.filetypes.FileIconResourceCell;
@@ -37,6 +36,7 @@ import org.rstudio.studio.client.workbench.views.files.Files;
 import org.rstudio.studio.client.workbench.views.files.FilesConstants;
 import org.rstudio.studio.client.workbench.views.files.model.FileChange;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
@@ -46,12 +46,11 @@ import com.google.gwt.event.logical.shared.ResizeEvent;
 import com.google.gwt.event.logical.shared.ResizeHandler;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
-import com.google.gwt.user.cellview.client.DataGrid;
 import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.user.cellview.client.ColumnSortEvent;
+import com.google.gwt.user.cellview.client.ColumnSortEvent.Handler;
 import com.google.gwt.user.cellview.client.ColumnSortList;
 import com.google.gwt.user.cellview.client.TextColumn;
-import com.google.gwt.user.cellview.client.ColumnSortEvent.Handler;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.ResizeLayoutPanel;
@@ -80,10 +79,27 @@ public class FilesList extends Composite
       sortHandler_ = new ColumnSortEvent.ListHandler<>(dataProvider_.getList());
 
       // create cell table
-      filesDataGrid_ = new RStudioDataGrid<>(
-                                          15,
-                                          FilesListDataGridResources.INSTANCE,
-                                          KEY_PROVIDER);
+      filesDataGrid_ = new VirtualizedDataGrid<FileSystemItem>(FilesListDataGridResources.INSTANCE, KEY_PROVIDER)
+      {
+         @Override
+         public double getRowHeight()
+         {
+            return 22.5;
+         }
+
+         @Override
+         public int getTotalNumberOfRows()
+         {
+            return dataProvider_.getList().size();
+         }
+         
+         @Override
+         public String getBorderColor()
+         {
+            return "transparent";
+         }
+      };
+            
       selectionModel_ = new MultiSelectionModel<>(KEY_PROVIDER);
       filesDataGrid_.setSelectionModel(
          selectionModel_,
@@ -399,11 +415,14 @@ public class FilesList extends Composite
          fileList.add(parentPath_);
 
       // add files to table
-      for (int i=0; i<files.length(); i++)
+      for (int i = 0, n = files.length(); i < n; i++)
          fileList.add(files.get(i));
 
       // apply sort list
       applyColumnSortList();
+      
+      // force redraw of data grid
+      filesDataGrid_.redraw();
 
       // fire selection changed
       observer_.onFileSelectionChanged();
@@ -684,7 +703,7 @@ public class FilesList extends Composite
    private FileSystemItem containingPath_ = null;
    private FileSystemItem parentPath_ = null;
 
-   private final DataGrid<FileSystemItem> filesDataGrid_;
+   private final VirtualizedDataGrid<FileSystemItem> filesDataGrid_;
    private final LinkColumn<FileSystemItem> nameColumn_;
    private final TextColumn<FileSystemItem> sizeColumn_;
    private final TextColumn<FileSystemItem> modifiedColumn_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesListDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesListDataGridStyle.css
@@ -17,12 +17,21 @@
   border-right: none;
 }
 
-.dataGridEvenRowCell, .dataGridOddRowCell, .dataGridHoveredRowCell, .dataGridSelectedRowCell, .dataGridKeyboardSelectedRowCell, .dataGridKeyboardSelectedCell   {
+.dataGridHoveredRowCell {
+  border: none;
+}
+
+.dataGridEvenRowCell,
+.dataGridOddRowCell,
+.dataGridHoveredRowCell,
+.dataGridSelectedRowCell,
+.dataGridKeyboardSelectedRowCell,
+.dataGridKeyboardSelectedCell {
   border: selectionBorderWidth solid #ffffff;
 }
 
 .rstudio-themes-dark .dataGridCell img {
-   filter: brightness(90%) saturate(90%);
+  filter: brightness(90%) saturate(90%);
 }
 
 .dataGridWidget {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
@@ -21,9 +21,9 @@ import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.JsVectorString;
 import org.rstudio.core.client.ListUtil;
 import org.rstudio.core.client.ListUtil.FilterPredicate;
-import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.SafeHtmlUtil;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.DomUtils.ElementPredicate;
 import org.rstudio.core.client.theme.RStudioDataGridResources;
@@ -1272,7 +1272,7 @@ public class ObjectExplorerDataGrid
    }
 
    @Override
-   public int getRowHeight()
+   public double getRowHeight()
    {
       return 24;
    }
@@ -1283,6 +1283,12 @@ public class ObjectExplorerDataGrid
       if (dataProvider_ == null)
          return 0;
       return getData().size();
+   }
+   
+   @Override
+   public String getBorderColor()
+   {
+      return null;
    }
 
    public Data getCurrentSelection()


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13426.

### Approach

A while ago, we built a virtualized GWT data grid for the object explorer. This PR makes use of that same class for the Files pane, allowing us to virtualize the display of a large number of file entries.

This allows the IDE to remain performant even if one attempts to view a directory containing a very large number of files (although the initial file list call may be slow).

### Automated Tests

TODO: Include some basic interactions with the Files pane.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13426.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
