### PR TITLE
fix handling of editor scroll speed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,7 @@
 - Fixed an issue where the "Go to directory..." button brought up the wrong dialog (#14501; Desktop)
 - Fixed an issue where "View plot after saving" in the Save Plot as Image dialog sometimes did not work. (#14702)
 - Fixed an issue where RStudio could trigger active bindings in environments when requesting completions. (#14784)
+- Fixed an issue where the editor scroll speed had inadvertently been decreased. (#14664)
 - Remove superfluous Uninstall shortcut and Start Menu folder (#1900; Desktop installer on Windows)
 - Hide Refresh button while Replace All operation is running in the Find in Files pane (#13873)
 - Stop the File Pane's "Copy To" operation from deleting the file when source and destination are the same (#14525)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -159,7 +159,6 @@ public class AceEditorWidget extends Composite
       editor_.setHighlightGutterLine(false);
       editor_.setFixedWidthGutter(true);
       editor_.setIndentedSoftWrap(false);
-      editor_.setAnimatedScroll(true);
       editor_.setTheme(themes_.getCurrentTheme());
       editor_.delegateEventsTo(AceEditorWidget.this);
       editor_.onChange(new CommandWithArg<AceDocumentChangeEventNative>()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -159,7 +159,6 @@ public class AceEditorWidget extends Composite
       editor_.setHighlightGutterLine(false);
       editor_.setFixedWidthGutter(true);
       editor_.setIndentedSoftWrap(false);
-      editor_.setScrollSpeed(WindowEx.get().getDevicePixelRatio());
       editor_.setAnimatedScroll(true);
       editor_.setTheme(themes_.getCurrentTheme());
       editor_.delegateEventsTo(AceEditorWidget.this);
@@ -644,13 +643,15 @@ public class AceEditorWidget extends Composite
          }
       }));
       
+      syncScrollSpeed();
       aceEventHandlers_.add(
             uiPrefs_.editorScrollMultiplier().bind(new CommandWithArg<Integer>()
             {
                @Override
-               public void execute(Integer scrollFactor)
+               public void execute(Integer scrollPercentage)
                {
-                  syncScrollSpeed(scrollFactor);
+                  double scrollRatio = ((double) scrollPercentage) / 100.0;
+                  syncScrollSpeed(scrollRatio);
                }
             })
       );
@@ -839,9 +840,10 @@ public class AceEditorWidget extends Composite
    
    public void syncScrollSpeed(double scrollRatio)
    {
+      final double DEFAULT_SCROLL_FACTOR = 2.0;
       double devicePixelRatio = WindowEx.get().getDevicePixelRatio();
       double scrollSpeed = devicePixelRatio * scrollRatio;
-      editor_.setScrollSpeed(2 * scrollSpeed);
+      editor_.setScrollSpeed(DEFAULT_SCROLL_FACTOR * scrollSpeed);
    }
    
    public void syncScrollSpeed()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -25,6 +25,7 @@ import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.JsVector;
 import org.rstudio.core.client.JsVectorString;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.elemental2.overlay.File;
 import org.rstudio.core.client.js.JsMap;
 import org.rstudio.core.client.widget.CanSetControlId;
@@ -158,6 +159,8 @@ public class AceEditorWidget extends Composite
       editor_.setHighlightGutterLine(false);
       editor_.setFixedWidthGutter(true);
       editor_.setIndentedSoftWrap(false);
+      editor_.setScrollSpeed(WindowEx.get().getDevicePixelRatio());
+      editor_.setAnimatedScroll(true);
       editor_.setTheme(themes_.getCurrentTheme());
       editor_.delegateEventsTo(AceEditorWidget.this);
       editor_.onChange(new CommandWithArg<AceDocumentChangeEventNative>()
@@ -640,6 +643,17 @@ public class AceEditorWidget extends Composite
             }
          }
       }));
+      
+      aceEventHandlers_.add(
+            uiPrefs_.editorScrollMultiplier().bind(new CommandWithArg<Integer>()
+            {
+               @Override
+               public void execute(Integer scrollFactor)
+               {
+                  syncScrollSpeed(scrollFactor);
+               }
+            })
+      );
 
       editor_.getRenderer().updateFontSize();
       onResize();
@@ -821,6 +835,19 @@ public class AceEditorWidget extends Composite
    public void forceCursorChange()
    {
       editor_.onCursorChange();
+   }
+   
+   public void syncScrollSpeed(double scrollRatio)
+   {
+      double devicePixelRatio = WindowEx.get().getDevicePixelRatio();
+      double scrollSpeed = devicePixelRatio * scrollRatio;
+      editor_.setScrollSpeed(2 * scrollSpeed);
+   }
+   
+   public void syncScrollSpeed()
+   {
+      double scrollPercentage = (double) uiPrefs_.editorScrollMultiplier().getValue();
+      syncScrollSpeed(scrollPercentage / 100.0);
    }
 
    public void addOrUpdateBreakpoint(Breakpoint breakpoint)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -679,6 +679,10 @@ public class AceEditorNative extends JavaScriptObject
       this.setOption("scrollSpeed", speed);
    }-*/;
    
+   public final native void setAnimatedScroll(boolean shouldAnimate) /*-{
+      this.setAnimatedScroll(shouldAnimate);
+   }-*/;
+   
    public final native void setIndentedSoftWrap(boolean softWrap) /*-{
       this.setOption("indentedSoftWrap", softWrap);
    }-*/;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14664.

### Approach

Tweak how we check and synchronize the editor scroll speed when the monitor DPI changes.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14664.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
