### PR TITLE
tidying up in Ace change handler

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -171,12 +171,13 @@ public class AceEditorWidget extends Composite
             // recursion here.
             if (inOnChangeHandler_)
             {
-               Debug.log("Warning: ignoring recursive ACE change event");
+               Debug.log("Warning: ignoring recursive Ace editor change event");
                return;
             }
-            inOnChangeHandler_ = true;
+            
             try
             {
+               inOnChangeHandler_ = true;
                ValueChangeEvent.fire(AceEditorWidget.this, null);
                AceEditorWidget.this.fireEvent(new DocumentChangedEvent(event));
 
@@ -197,12 +198,17 @@ public class AceEditorWidget extends Composite
                   });
                }
             }
+            
             catch (Exception ex)
             {
-               Debug.log("Exception occurred during ACE change event: " +
+               Debug.log("Exception occurred during Ace editor change event: " +
                          ex.getMessage());
             }
-            inOnChangeHandler_ = false;
+            
+            finally
+            {
+               inOnChangeHandler_ = false;
+            }
          }
 
       });


### PR DESCRIPTION
Doesn't fix any specific issues, except that not all things that can be thrown will inherit from Exception (e.g. `assert` gives an `AssertionError` which wouldn't be caught here).

This just helps make sure we do always correctly unset the flag we set here.