### PR TITLE
avoid loading packages when running diagnostics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 
 #### RStudio
 
+- The RStudio diagnostics system no longer automatically loads packages when encountering calls of the form `dplyr::mutate()`. (#9692)
 - Fixed an issue where Build output from 'Run Tests' was not appropriately coloured. (#13088)
 - Fixed an issue where various editor commands (Reindent Lines; Run Chunks) could fail in a document containing Quarto callout blocks. (#14640)
 - Fixed an issue where end fold markers were not rendered correctly in Quarto documents. (#14699)

--- a/src/cpp/session/modules/SessionDiagnostics.cpp
+++ b/src/cpp/session/modules/SessionDiagnostics.cpp
@@ -651,6 +651,8 @@ ParseResults parse(const std::wstring& rCode,
    ParseResults results;
    ParseOptions options;
    
+   options.setIsExplicit(isExplicit);
+   
    options.setLintRFunctions(
             prefs::userPrefs().diagnosticsInRFunctionCalls());
    

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -13,12 +13,12 @@
  *
  */
 
-// #define RSTUDIO_DEBUG_LABEL "r_parser"
-// #define RSTUDIO_ENABLE_DEBUG_MACROS
+#define RSTUDIO_DEBUG_LABEL "r_parser"
+#define RSTUDIO_ENABLE_DEBUG_MACROS
 
 // Define this if you want extra debug printing for how
 // RStudio attempts to parse and diagnose glue expressions.
-// #define RSTUDIO_ENABLE_GLUE_DEBUG
+#define RSTUDIO_ENABLE_GLUE_DEBUG
 
 // We use a couple internal R functions here; in particular,
 // simple accessors (which we know will not longjmp)
@@ -252,12 +252,20 @@ SEXP resolveObjectAssociatedWithCall(RTokenCursor cursor,
       std::string ns = string_utils::strippedOfQuotes(
                cursor.previousSignificantToken(2).contentAsUtf8());
       
-      DEBUG("Resolving: '" << ns << ":::" << symbol << "'");
+      SEXP namespaceSEXP = r::sexp::findNamespace(ns);
+      if (TYPEOF(namespaceSEXP) == ENVSXP)
+      {
+         DEBUG("Resolving: '" << ns << ":::" << symbol << "'");
       
-      if (functionsOnly)
-         symbolSEXP = r::sexp::findFunction(symbol, ns);
+         if (functionsOnly)
+            symbolSEXP = r::sexp::findFunction(symbol, ns);
+         else
+            symbolSEXP = r::sexp::findVar(symbol, ns);
+      }
       else
-         symbolSEXP = r::sexp::findVar(symbol, ns);
+      {
+         DEBUG("Not resolving: '" << ns << ":::" << symbol << "' (not loaded)");
+      }
    }
    else
    {

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -253,7 +253,10 @@ SEXP resolveObjectAssociatedWithCall(RTokenCursor cursor,
       std::string symbol  = string_utils::strippedOfQuotes(symbolToken.contentAsUtf8());
       std::string package = string_utils::strippedOfQuotes(packageToken.contentAsUtf8());
       
-      SEXP namespaceSEXP = r::sexp::findNamespace(package);
+      SEXP namespaceSEXP = status.parseOptions().isExplicit()
+            ? r::sexp::asNamespace(package)
+            : r::sexp::findNamespace(package);
+ 
       if (TYPEOF(namespaceSEXP) == ENVSXP)
       {
          DEBUG("Resolving: '" << package << ":::" << symbol << "'");
@@ -265,7 +268,7 @@ SEXP resolveObjectAssociatedWithCall(RTokenCursor cursor,
       }
       else
       {
-         DEBUG("Not resolving: '" << ns << ":::" << symbol << "' (not loaded)");
+         DEBUG("Not resolving: '" << ns << ":::" << symbol << "' (not available)");
          
          // Only display these warnings in 'explicit' requests (avoid being too noisy).
          if (status.parseOptions().isExplicit())

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -837,7 +837,7 @@ FunctionInformation getInfoAssociatedWithFunctionAtCursor(
    {
       if (info.binding())
       {
-         DEBUG("***** Using definition from search path (" << info.binding()->name << " from " << info.binding()->origin);
+         DEBUG("***** Using definition from search path (" << info.binding()->name << " from " << info.binding()->origin << ")");
       }
       else
       {

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -13,12 +13,12 @@
  *
  */
 
-#define RSTUDIO_DEBUG_LABEL "r_parser"
-#define RSTUDIO_ENABLE_DEBUG_MACROS
+// #define RSTUDIO_DEBUG_LABEL "r_parser"
+// #define RSTUDIO_ENABLE_DEBUG_MACROS
 
 // Define this if you want extra debug printing for how
 // RStudio attempts to parse and diagnose glue expressions.
-#define RSTUDIO_ENABLE_GLUE_DEBUG
+// #define RSTUDIO_ENABLE_GLUE_DEBUG
 
 // We use a couple internal R functions here; in particular,
 // simple accessors (which we know will not longjmp)

--- a/src/cpp/session/modules/SessionRParser.hpp
+++ b/src/cpp/session/modules/SessionRParser.hpp
@@ -404,7 +404,7 @@ public:
                          const RToken& symbolToken)
    {
       std::string message = fmt::format(
-               "package '{}' is not currently loaded; argument diagnostics unavailable",
+               "package '{}' is not available; cannot provide argument diagnostics",
                packageToken.contentAsUtf8());
       
       add(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
@@ -14,14 +14,8 @@
  */
 package org.rstudio.studio.client.workbench.views.output.lint;
 
-import com.google.gwt.core.client.JsArray;
-import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
-import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.Timer;
-import com.google.inject.Inject;
+import java.util.List;
+
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.Invalidation;
 import org.rstudio.core.client.StringUtil;
@@ -48,7 +42,14 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppComp
 import org.rstudio.studio.client.workbench.views.source.editors.text.yaml.YamlDocumentLinter;
 import org.rstudio.studio.client.workbench.views.source.model.CppDiagnostic;
 
-import java.util.List;
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Timer;
+import com.google.inject.Inject;
 
 public class LintManager
 {
@@ -177,7 +178,7 @@ public class LintManager
                return;
             
             if (userPrefs_.diagnosticsOnSave().getValue())
-               lint(false, true, false);
+               lint(false, false, false);
          }
       }));
    }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9692.

With this change, we no longer attempt to automatically load packages when diagnosing calls of the form `dplyr::mutate()`.

I'm a bit on the fence on what we should do for "explicit" diagnostics requests -- should we inform the user that the package isn't loaded, or should we just load it on their behalf in this scenario, so we can provide accurate diagnostics?

### Approach

Mostly straightforward changes to the diagnostics engine.

For explicit diagnostics requests, e.g. those triggered via this menu item:

<img width="289" alt="Screenshot 2024-06-06 at 10 48 45 AM" src="https://github.com/rstudio/rstudio/assets/1976582/912ad425-4112-478c-8a45-2b4097a9f13d">

we will provide an "info" diagnostic saying we couldn't provide function diagnostics.

<img width="723" alt="Screenshot 2024-06-06 at 10 49 00 AM" src="https://github.com/rstudio/rstudio/assets/1976582/6dd2e8a4-d752-414f-845c-04681d58a1a3">


### Automated Tests

TODO

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/9692.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
