### PR TITLE
Feature/versioned encryption

### DIFF
--- a/src/cpp/shared_core/CMakeLists.txt
+++ b/src/cpp/shared_core/CMakeLists.txt
@@ -39,6 +39,7 @@ set (SHARED_CORE_SOURCE_FILES
    StderrLogDestination.cpp
    json/Json.cpp
    system/Crypto.cpp
+   system/encryption/EncryptionVersion.cpp
 )
 
 set (SHARED_INCLUDE_DIRS

--- a/src/cpp/shared_core/include/shared_core/system/encryption/EncryptionVersion.hpp
+++ b/src/cpp/shared_core/include/shared_core/system/encryption/EncryptionVersion.hpp
@@ -1,0 +1,210 @@
+/*
+ * EncryptionVersion.hpp
+ *
+ * Copyright (C) 2024 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant to the
+ * terms of a commercial license agreement with Posit Software, then this program is
+ * licensed to you under the following terms:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#ifndef SHARED_CORE_SYSTEM_ENCRYPTION_VERSION_HPP
+#define SHARED_CORE_SYSTEM_ENCRYPTION_VERSION_HPP
+
+#include <vector>
+
+namespace rstudio {
+namespace core {
+
+class Error;
+class ErrorLocation;
+
+} // namespace core
+} // namespace rstudio
+
+namespace rstudio {
+namespace core {
+namespace system {
+namespace crypto {
+
+/**
+ * Encryption Versioning
+ * ---------------------
+ * 
+ * Encryption versioning is used to transition to newer encryption algorithms 
+ * without breaking compatibility with older versions of the software. For newly
+ * encrypted data, the encryption version is stored in the first byte of the 
+ * encrypted data buffer (or, there is no encryption version byte in the case of
+ * version 0 "legacy" encryption).
+ * 
+ * The expectation is that these versioned encryption functions will not be called
+ * directly by the software at large, but rather the interface through Crypto.hpp
+ * will be used. The Crypto::aesDecrypt and Crypto::aesEncrypt functions will
+ * determine which of the versioned functions in this file to use.
+ * 
+ * The versions and their corresponding encryption algorithms are as follows:
+ * 
+ * |Encryption Version | Encryption Used
+ * |-------------------+------------------------------------------|
+ * |     0  (legacy)   | AES 128 CBC, but with no version byte    |
+ * |-------------------+------------------------------------------|
+ * |     1             | AES 128 CBC (with version byte)          |
+ * |-------------------+------------------------------------------|
+ * |     2             | AES 256 GCM                              |
+ * |--------------------------------------------------------------|
+ * 
+ */
+
+namespace v0 {
+
+/**
+ * @brief Legacy AES 128 decrypts the specified data using the specified initialization vector.
+ *
+ * This function is the inverse of v0::aesEncrypt.
+ *
+ * @param in_data           The data to be decrypted.
+ * @param in_key            The key with which to decrypt the data.
+ * @param in_iv             The initialization vector that was used during encryption.
+ * @param out_decrypted     The decrypted data.
+ *
+ * @return Success if the data could be AES 128 decrypted; Error otherwise.
+ */
+Error aesDecrypt(
+   const std::vector<unsigned char>& in_data,
+   const std::vector<unsigned char>& in_key,
+   const std::vector<unsigned char>& in_iv,
+   std::vector<unsigned char>& out_decrypted);
+
+/**
+ * @brief Legacy AES 128 encrypts the specified data using the specified initialization vector.
+ *
+ * This function is the inverse of v0::aesDecrypt.
+ *
+ * @param in_data           The data to be encrypted.
+ * @param in_key            The key with which to encrypt the data.
+ * @param in_iv             The initialization vector to use during encryption.
+ * @param out_encrypted     The encrypted data.
+ *
+ * @return Success if the data could be AES 128 encrypted; Error otherwise.
+ */
+Error aesEncrypt(
+   const std::vector<unsigned char>& in_data,
+   const std::vector<unsigned char>& in_key,
+   const std::vector<unsigned char>& in_iv,
+   std::vector<unsigned char>& out_encrypted);
+
+} // v0
+
+namespace v1 {
+
+/**
+ * @brief AES 128 decrypts the specified v1 data using the specified initialization vector.
+ *
+ * This function is the inverse of v1::aesEncrypt.
+ *
+ * @param in_data           The v1 data to be decrypted.
+ * @param in_key            The key with which to decrypt the v1 data.
+ * @param in_iv             The initialization vector that was used during encryption.
+ * @param out_decrypted     The decrypted data.
+ *
+ * @return Success if the data could be AES 128 decrypted; Error otherwise.
+ */
+Error aesDecrypt(
+   const std::vector<unsigned char>& in_data,
+   const std::vector<unsigned char>& in_key,
+   const std::vector<unsigned char>& in_iv,
+   std::vector<unsigned char>& out_decrypted);
+
+/**
+ * @brief AES 128 encrypts the specified v1 data using the specified initialization vector.
+ *
+ * This function is the inverse of v1::aesDecrypt.
+ *
+ * @param in_data           The v1 data to be encrypted.
+ * @param in_key            The key with which to encrypt the v1 data.
+ * @param in_iv             The initialization vector to use during encryption.
+ * @param out_encrypted     The encrypted data.
+ *
+ * @return Success if the data could be AES 128 encrypted; Error otherwise.
+ */
+Error aesEncrypt(
+   const std::vector<unsigned char>& in_data,
+   const std::vector<unsigned char>& in_key,
+   const std::vector<unsigned char>& in_iv,
+   std::vector<unsigned char>& out_encrypted);
+
+} // v1
+
+namespace v2 {
+
+/**
+ * @brief AES 256 decrypts the specified v2 data using the specified initialization vector.
+ *
+ * This function is the inverse of v2::aesEncrypt.
+ *
+ * @param in_data           The v2 data to be decrypted.
+ * @param in_key            The key with which to decrypt the v2 data.
+ * @param in_iv             The initialization vector that was used during encryption.
+ * @param in_aad            The accompanying Additional Authenticated Data, if any, for this encrypted data.
+ * @param in_mac            The Message Authentication Code for this encrypted data.
+ * @param out_decrypted     The decrypted data.
+ *
+ * @return Success if the data could be AES 256 decrypted; Error otherwise.
+ */
+Error aesDecrypt(
+   const std::vector<unsigned char>& in_data,
+   const std::vector<unsigned char>& in_key,
+   const std::vector<unsigned char>& in_iv,
+   const std::vector<unsigned char>& in_aad,
+   std::vector<unsigned char>& in_mac,
+   std::vector<unsigned char>& out_decrypted);
+
+/**
+ * @brief AES 256 encrypts the specified v2 data using the specified initialization vector.
+ *
+ * This function is the inverse of v2::aesDecrypt.
+ *
+ * @param data              The v2 data to be encrypted.
+ * @param key               The key with which to encrypt the v2 data.
+ * @param iv                The initialization vector to use during encryption.
+ * @param aad               The (optional) Additional Authenticated Data to include.
+ * @param out_mac           The resulting Message Authentication Code of the encrypted data.
+ * @param out_encrypted     The encrypted data.
+ *
+ * @return Success if the data could be AES 256 encrypted; Error otherwise.
+ */
+Error aesEncrypt(
+   const std::vector<unsigned char>& data,
+   const std::vector<unsigned char>& key,
+   const std::vector<unsigned char>& iv,
+   const std::vector<unsigned char>& aad,
+   std::vector<unsigned char>& out_mac,
+   std::vector<unsigned char>& out_encrypted);
+
+} // v2
+
+} // crypto
+} // system
+} // core
+} // rstudio
+
+#endif // SHARED_CORE_SYSTEM_ENCRYPTION_VERSION_HPP

--- a/src/cpp/shared_core/system/Crypto.cpp
+++ b/src/cpp/shared_core/system/Crypto.cpp
@@ -28,6 +28,7 @@
  */
 
 #include <shared_core/system/Crypto.hpp>
+#include <shared_core/system/encryption/EncryptionVersion.hpp>
 
 #include <gsl/gsl>
 
@@ -41,8 +42,6 @@
 
 #include <shared_core/Error.hpp>
 #include <shared_core/Logger.hpp>
-
-#include <shared_core/system/encryption/EncryptionVersion.hpp>
 
 namespace rstudio {
 namespace core {
@@ -84,7 +83,7 @@ Error aesDecrypt(
    const std::vector<unsigned char>& in_iv,
    std::vector<unsigned char>& out_decrypted)
 {
-   return v1::aesDecrypt(in_data, in_key, in_iv, out_decrypted);
+   return v0::aesDecrypt(in_data, in_key, in_iv, out_decrypted);
 }
 
 Error aesEncrypt(
@@ -101,7 +100,7 @@ Error aesEncrypt(
    const std::vector<unsigned char>& iv,
    std::vector<unsigned char>& out_encrypted)
 {
-   return v1::aesEncrypt(data, key, iv, out_encrypted);
+   return v0::aesEncrypt(data, key, iv, out_encrypted);
 }
 
 Error base64Encode(const std::vector<unsigned char>& in_data, std::string& out_encoded)

--- a/src/cpp/shared_core/system/Crypto.cpp
+++ b/src/cpp/shared_core/system/Crypto.cpp
@@ -42,16 +42,14 @@
 #include <shared_core/Error.hpp>
 #include <shared_core/Logger.hpp>
 
+#include <shared_core/system/encryption/EncryptionVersion.hpp>
+
 namespace rstudio {
 namespace core {
 namespace system {
 namespace crypto {
 
 namespace {
-
-// openssl encrypt/decrypt constants
-constexpr int s_encrypt = 1;
-constexpr int s_decrypt = 0;
 
 class BIOFreeAllScope : boost::noncopyable
 {
@@ -77,30 +75,8 @@ private:
 
 } // anonymous namespace
 
-Error getLastCryptoError(const ErrorLocation& in_location)
-{
-   // get the error code
-   unsigned long ec = ::ERR_get_error();
-   if (ec == 0)
-   {
-      log::logWarningMessage("getLastCryptoError called with no pending error");
-      return systemError(
-         boost::system::errc::not_supported,
-         "getLastCryptoError called with no pending error",
-         in_location);
-   }
-
-   // get the error message (docs say max len is 120)
-   const int ERR_BUFF_SIZE = 250;
-   char errorBuffer[ERR_BUFF_SIZE];
-   ::ERR_error_string_n(ec, errorBuffer, ERR_BUFF_SIZE);
-
-   // return the error
-   return systemError(
-      boost::system::errc::bad_message,
-      errorBuffer,
-      in_location);
-}
+// Forward Declaration. Defined in EncryptionVersion.cpp
+Error getLastCryptoError(const ErrorLocation& in_location);
 
 Error aesDecrypt(
    const std::vector<unsigned char>& in_data,
@@ -108,36 +84,7 @@ Error aesDecrypt(
    const std::vector<unsigned char>& in_iv,
    std::vector<unsigned char>& out_decrypted)
 {
-   out_decrypted.resize(in_data.size());
-   int outLen = 0;
-   int bytesDecrypted = 0;
-
-   EVP_CIPHER_CTX *ctx;
-   ctx = EVP_CIPHER_CTX_new();
-   EVP_CipherInit_ex(ctx, EVP_aes_128_cbc(), nullptr, &in_key[0], &in_iv[0], s_decrypt);
-
-   // perform the decryption
-   if(!EVP_CipherUpdate(ctx, &out_decrypted[0], &outLen, &in_data[0], gsl::narrow_cast<int>(in_data.size())))
-   {
-      EVP_CIPHER_CTX_free(ctx);
-      return getLastCryptoError(ERROR_LOCATION);
-   }
-   bytesDecrypted += outLen;
-
-   // perform final flush
-   if(!EVP_CipherFinal_ex(ctx, &out_decrypted[outLen], &outLen))
-   {
-      EVP_CIPHER_CTX_free(ctx);
-      return getLastCryptoError(ERROR_LOCATION);
-   }
-   bytesDecrypted += outLen;
-
-   EVP_CIPHER_CTX_free(ctx);
-
-   // resize the container to the amount of actual bytes decrypted (padding is removed)
-   out_decrypted.resize(bytesDecrypted);
-
-   return Success();
+   return v1::aesDecrypt(in_data, in_key, in_iv, out_decrypted);
 }
 
 Error aesEncrypt(
@@ -154,37 +101,7 @@ Error aesEncrypt(
    const std::vector<unsigned char>& iv,
    std::vector<unsigned char>& out_encrypted)
 {
-   // allow enough space in output buffer for additional block
-   out_encrypted.resize(data.size() + EVP_MAX_BLOCK_LENGTH);
-   int outlen = 0;
-   int bytesEncrypted = 0;
-
-   EVP_CIPHER_CTX *ctx;
-   ctx = EVP_CIPHER_CTX_new();
-   EVP_CipherInit_ex(ctx, EVP_aes_128_cbc(), nullptr, &key[0], iv.empty() ? nullptr : &iv[0], s_encrypt);
-
-   // perform the encryption
-   if(!EVP_CipherUpdate(ctx, &out_encrypted[0], &outlen, &data[0], gsl::narrow_cast<int>(data.size())))
-   {
-      EVP_CIPHER_CTX_free(ctx);
-      return getLastCryptoError(ERROR_LOCATION);
-   }
-   bytesEncrypted += outlen;
-
-   // perform final flush including left-over padding
-   if(!EVP_CipherFinal_ex(ctx, &out_encrypted[outlen], &outlen))
-   {
-      EVP_CIPHER_CTX_free(ctx);
-      return getLastCryptoError(ERROR_LOCATION);
-   }
-   bytesEncrypted += outlen;
-
-   EVP_CIPHER_CTX_free(ctx);
-
-   // resize the container to the amount of actual bytes encrypted (including padding)
-   out_encrypted.resize(bytesEncrypted);
-
-   return Success();
+   return v1::aesEncrypt(data, key, iv, out_encrypted);
 }
 
 Error base64Encode(const std::vector<unsigned char>& in_data, std::string& out_encoded)

--- a/src/cpp/shared_core/system/encryption/EncryptionVersion.cpp
+++ b/src/cpp/shared_core/system/encryption/EncryptionVersion.cpp
@@ -1,0 +1,307 @@
+/*
+ * EncryptionVersion.cpp
+ *
+ * Copyright (C) 2024 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant to the
+ * terms of a commercial license agreement with Posit Software, then this program is
+ * licensed to you under the following terms:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <shared_core/system/encryption/EncryptionVersion.hpp>
+
+#include <gsl/gsl>
+
+#include <openssl/err.h>
+#include <openssl/evp.h>
+
+#include <shared_core/Error.hpp>
+
+namespace rstudio {
+namespace core {
+namespace system {
+namespace crypto {
+
+// openssl encrypt/decrypt constants
+constexpr int s_encrypt = 1;
+constexpr int s_decrypt = 0;
+
+Error getLastCryptoError(const ErrorLocation& in_location)
+{
+   // get the error code
+   unsigned long ec = ::ERR_get_error();
+   if (ec == 0)
+   {
+      log::logWarningMessage("getLastCryptoError called with no pending error");
+      return systemError(
+          boost::system::errc::not_supported,
+          "getLastCryptoError called with no pending error",
+          in_location);
+   }
+
+   // get the error message (docs say max len is 120)
+   const int ERR_BUFF_SIZE = 250;
+   char errorBuffer[ERR_BUFF_SIZE];
+   ::ERR_error_string_n(ec, errorBuffer, ERR_BUFF_SIZE);
+
+   // return the error
+   return systemError(
+       boost::system::errc::bad_message,
+       errorBuffer,
+       in_location);
+}
+
+namespace v0 {
+
+/**
+ * v0 decryption is the same as v1. Enforce compatability by calling v1 decryption
+ */
+Error aesDecrypt(
+    const std::vector<unsigned char>& in_data,
+    const std::vector<unsigned char>& in_key,
+    const std::vector<unsigned char>& in_iv,
+    std::vector<unsigned char>& out_decrypted)
+{
+   return v1::aesDecrypt(in_data, in_key, in_iv, out_decrypted);
+}
+
+/**
+ * v0 encryption is the same as v1. Enforce compatability by calling v1 encryption
+ */
+Error aesEncrypt(
+    const std::vector<unsigned char>& data,
+    const std::vector<unsigned char>& key,
+    const std::vector<unsigned char>& iv,
+    std::vector<unsigned char>& out_encrypted)
+{
+   return v1::aesEncrypt(data, key, iv, out_encrypted);
+}
+
+} // namespace v0
+
+namespace v1 {
+
+Error aesDecrypt(
+   const std::vector<unsigned char>& in_data,
+   const std::vector<unsigned char>& in_key,
+   const std::vector<unsigned char>& in_iv,
+   std::vector<unsigned char>& out_decrypted)
+{
+   out_decrypted.resize(in_data.size());
+   int outLen = 0;
+   int bytesDecrypted = 0;
+
+   EVP_CIPHER_CTX *ctx;
+   ctx = EVP_CIPHER_CTX_new();
+   EVP_CipherInit_ex(ctx, EVP_aes_128_cbc(), nullptr, &in_key[0], &in_iv[0], s_decrypt);
+
+   // perform the decryption
+   if(!EVP_CipherUpdate(ctx, &out_decrypted[0], &outLen, &in_data[0], gsl::narrow_cast<int>(in_data.size())))
+   {
+      EVP_CIPHER_CTX_free(ctx);
+      return getLastCryptoError(ERROR_LOCATION);
+   }
+   bytesDecrypted += outLen;
+
+   // perform final flush
+   if(!EVP_CipherFinal_ex(ctx, &out_decrypted[outLen], &outLen))
+   {
+      EVP_CIPHER_CTX_free(ctx);
+      return getLastCryptoError(ERROR_LOCATION);
+   }
+   bytesDecrypted += outLen;
+
+   EVP_CIPHER_CTX_free(ctx);
+
+   // resize the container to the amount of actual bytes decrypted (padding is removed)
+   out_decrypted.resize(bytesDecrypted);
+
+   return Success();
+}
+
+Error aesEncrypt(
+   const std::vector<unsigned char>& data,
+   const std::vector<unsigned char>& key,
+   const std::vector<unsigned char>& iv,
+   std::vector<unsigned char>& out_encrypted)
+{
+   // allow enough space in output buffer for additional block
+   out_encrypted.resize(data.size() + EVP_MAX_BLOCK_LENGTH);
+   int outlen = 0;
+   int bytesEncrypted = 0;
+
+   EVP_CIPHER_CTX *ctx;
+   ctx = EVP_CIPHER_CTX_new();
+   EVP_CipherInit_ex(ctx, EVP_aes_128_cbc(), nullptr, &key[0], iv.empty() ? nullptr : &iv[0], s_encrypt);
+
+   // perform the encryption
+   if(!EVP_CipherUpdate(ctx, &out_encrypted[0], &outlen, &data[0], gsl::narrow_cast<int>(data.size())))
+   {
+      EVP_CIPHER_CTX_free(ctx);
+      return getLastCryptoError(ERROR_LOCATION);
+   }
+   bytesEncrypted += outlen;
+
+   // perform final flush including left-over padding
+   if(!EVP_CipherFinal_ex(ctx, &out_encrypted[outlen], &outlen))
+   {
+      EVP_CIPHER_CTX_free(ctx);
+      return getLastCryptoError(ERROR_LOCATION);
+   }
+   bytesEncrypted += outlen;
+
+   EVP_CIPHER_CTX_free(ctx);
+
+   // resize the container to the amount of actual bytes encrypted (including padding)
+   out_encrypted.resize(bytesEncrypted);
+
+   return Success();
+}
+
+} // namespace v1
+
+namespace v2 {
+
+Error aesDecrypt(
+    const std::vector<unsigned char>& in_data,
+    const std::vector<unsigned char>& in_key,
+    const std::vector<unsigned char>& in_iv,
+    const std::vector<unsigned char>& in_aad,
+    std::vector<unsigned char>& in_mac,
+    std::vector<unsigned char>& out_decrypted)
+{
+   out_decrypted.resize(in_data.size());
+   int outLen = 0;
+   int bytesDecrypted = 0;
+
+   EVP_CIPHER_CTX *ctx;
+   ctx = EVP_CIPHER_CTX_new();
+   EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), nullptr, &in_key[0], &in_iv[0]);
+
+   // provide any AAD data
+   if(!in_aad.empty())
+   {
+      if(!EVP_DecryptUpdate(ctx, nullptr, &outLen, &in_aad[0], gsl::narrow_cast<int>(in_aad.size())))
+      {
+         EVP_CIPHER_CTX_free(ctx);
+         return getLastCryptoError(ERROR_LOCATION);
+      }
+   }
+
+   // perform the decryption
+   if(!EVP_DecryptUpdate(ctx, &out_decrypted[0], &outLen, &in_data[0], gsl::narrow_cast<int>(in_data.size())))
+   {
+      EVP_CIPHER_CTX_free(ctx);
+      return getLastCryptoError(ERROR_LOCATION);
+   }
+   bytesDecrypted += outLen;
+
+   // Set expected tag value
+   if(!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, 16, &in_mac[0]))
+   {
+      EVP_CIPHER_CTX_free(ctx);
+      return getLastCryptoError(ERROR_LOCATION);
+   }
+
+   // perform final flush
+   // A positive return value indicates success,
+   // anything else is a failure - the plaintext is not trustworthy.
+   if(EVP_DecryptFinal_ex(ctx, &out_decrypted[outLen], &outLen) < 0)
+   {
+      EVP_CIPHER_CTX_free(ctx);
+      return getLastCryptoError(ERROR_LOCATION);
+   }
+   bytesDecrypted += outLen;
+
+   EVP_CIPHER_CTX_free(ctx);
+
+   // resize the container to the amount of actual bytes decrypted (padding is removed)
+   out_decrypted.resize(bytesDecrypted);
+
+   return Success();
+}
+
+Error aesEncrypt(
+    const std::vector<unsigned char>& data,
+    const std::vector<unsigned char>& key,
+    const std::vector<unsigned char>& iv,
+    const std::vector<unsigned char>& aad,
+    std::vector<unsigned char>& out_mac,
+    std::vector<unsigned char>& out_encrypted)
+{
+   // allow enough space in output buffer for additional block
+   out_encrypted.resize(data.size() + EVP_MAX_BLOCK_LENGTH);
+
+   // ensure enough room in mac buffer
+   if (out_mac.size() != 2)
+      out_mac.resize(2);
+
+   int outlen = 0;
+   int bytesEncrypted = 0;
+
+   EVP_CIPHER_CTX *ctx;
+   ctx = EVP_CIPHER_CTX_new();
+   EVP_EncryptInit_ex(ctx, EVP_aes_128_cbc(), nullptr, &key[0], iv.empty() ? nullptr : &iv[0]);
+
+   // provide any AAD data
+   if (!aad.empty())
+   {
+      if(!EVP_EncryptUpdate(ctx, NULL, &outlen, &aad[0], gsl::narrow_cast<int>(aad.size())))
+      {
+         EVP_CIPHER_CTX_free(ctx);
+         return getLastCryptoError(ERROR_LOCATION);
+      }
+   }
+
+   // perform the encryption
+   if(!EVP_EncryptUpdate(ctx, &out_encrypted[0], &outlen, &data[0], gsl::narrow_cast<int>(data.size())))
+   {
+      EVP_CIPHER_CTX_free(ctx);
+      return getLastCryptoError(ERROR_LOCATION);
+   }
+   bytesEncrypted += outlen;
+
+   // perform final flush including left-over padding
+   if(!EVP_EncryptFinal_ex(ctx, &out_encrypted[outlen], &outlen))
+   {
+      EVP_CIPHER_CTX_free(ctx);
+      return getLastCryptoError(ERROR_LOCATION);
+   }
+   bytesEncrypted += outlen;
+
+   // get the tag
+   if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, 16, &out_mac[0]))
+
+   EVP_CIPHER_CTX_free(ctx);
+
+   // resize the container to the amount of actual bytes encrypted (including padding)
+   out_encrypted.resize(bytesEncrypted);
+
+   return Success();
+}
+
+} // namespace v2
+
+} // namespace crypto
+} // namespace system
+} // namespace core
+} // namespace rstudio

--- a/src/cpp/shared_core/system/encryption/EncryptionVersionTests.cpp
+++ b/src/cpp/shared_core/system/encryption/EncryptionVersionTests.cpp
@@ -1,0 +1,143 @@
+/*
+ * EncryptionVersionTests.cpp
+ *
+ * Copyright (C) 2024 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <iterator>
+
+#include <gsl/gsl>
+
+#include <shared_core/system/encryption/EncryptionVersion.hpp>
+
+#include <tests/TestThat.hpp>
+
+#include <fcntl.h>
+
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+
+#include <shared_core/Error.hpp>
+
+namespace rstudio {
+namespace core {
+namespace system {
+namespace tests {
+
+using namespace core;
+
+std::vector<unsigned char> g_key;
+std::vector<unsigned char> g_iv;
+std::string g_payload = "Hello, world! This is a secret.";
+std::vector<unsigned char> g_data;
+
+// Simplified random function mirrored after core::system::crypto::random()
+bool random(uint32_t in_length, std::vector<unsigned char>& out_randomData)
+{
+   out_randomData.resize(in_length);
+
+   if (!RAND_bytes(&out_randomData[0], in_length))
+      return false;
+
+   return true;
+}
+
+bool generateKeys()
+{
+   // construct the data to encrypt in tests
+   if (g_data.empty())
+      std::copy(g_payload.begin(), g_payload.end(), std::back_inserter(g_data));
+
+   // generate a random 128-bit key and IV
+   return random(16, g_key) && random(16, g_iv);
+}
+
+bool decryptedPayloadMatches(std::vector<unsigned char>& decryptedData)
+{
+   std::string decryptedPayload;
+   std::copy(decryptedData.begin(), decryptedData.end(), std::back_inserter(decryptedPayload));
+   return g_payload == decryptedPayload;
+}
+
+test_context("EncryptionVersionTests")
+{
+   test_that("v0: Can AES encrypt/decrypt")
+   {
+      // setup
+      REQUIRE(generateKeys());
+
+      // encrypt the data
+      std::vector<unsigned char> encryptedData;
+      Error error = core::system::crypto::v0::aesEncrypt(g_data, g_key, g_iv, encryptedData);
+      REQUIRE_FALSE(error);
+
+      // decrypt the encrypted data
+      std::vector<unsigned char> decryptedData;
+      error = core::system::crypto::v0::aesDecrypt(encryptedData, g_key, g_iv, decryptedData);
+      REQUIRE_FALSE(error);
+
+      // verify that the decryption gives us back the original data
+      REQUIRE(decryptedPayloadMatches(decryptedData));
+   }
+
+   test_that("v1: Can AES encrypt/decrypt")
+   {
+      // setup
+      REQUIRE(generateKeys());
+
+      // encrypt the data
+      std::vector<unsigned char> encryptedData;
+      Error error = core::system::crypto::v1::aesEncrypt(g_data, g_key, g_iv, encryptedData);
+      REQUIRE_FALSE(error);
+
+      // decrypt the encrypted data
+      std::vector<unsigned char> decryptedData;
+      error = core::system::crypto::v1::aesDecrypt(encryptedData, g_key, g_iv, decryptedData);
+      REQUIRE_FALSE(error);
+
+      // verify that the decryption gives us back the original data
+      REQUIRE(decryptedPayloadMatches(decryptedData));
+   }
+
+   test_that("Are v0/v1 AES encrypt/decrypt enterchangable")
+   {
+      // setup
+      REQUIRE(generateKeys());
+
+      // encrypt with v0, decrypt with v1
+      std::vector<unsigned char> encryptedData;
+      Error error = core::system::crypto::v0::aesEncrypt(g_data, g_key, g_iv, encryptedData);
+      REQUIRE_FALSE(error);
+      std::vector<unsigned char> decryptedData;
+      error = core::system::crypto::v1::aesDecrypt(encryptedData, g_key, g_iv, decryptedData);
+      REQUIRE_FALSE(error);
+      REQUIRE(decryptedPayloadMatches(decryptedData));
+
+      // re-setup
+      REQUIRE(generateKeys());
+      encryptedData = {};
+      decryptedData = {};
+
+      // encrypt with v1, decrypt with v0
+      error = core::system::crypto::v1::aesEncrypt(g_data, g_key, g_iv, encryptedData);
+      REQUIRE_FALSE(error);
+      error = core::system::crypto::v0::aesDecrypt(encryptedData, g_key, g_iv, decryptedData);
+      REQUIRE_FALSE(error);
+      REQUIRE(decryptedPayloadMatches(decryptedData));
+   }
+}
+
+} // end namespace tests
+} // end namespace system
+} // end namespace core
+} // end namespace rstudio

--- a/src/cpp/shared_core/system/encryption/EncryptionVersionTests.cpp
+++ b/src/cpp/shared_core/system/encryption/EncryptionVersionTests.cpp
@@ -135,6 +135,69 @@ test_context("EncryptionVersionTests")
       REQUIRE_FALSE(error);
       REQUIRE(decryptedPayloadMatches(decryptedData));
    }
+
+   test_that("v2: Can AES encrypt/decrypt")
+   {
+      // setup
+      REQUIRE(generateKeys());
+
+      // encrypt the data
+      std::vector<unsigned char> encryptedData;
+      std::vector<unsigned char> aad = {2};
+      std::vector<unsigned char> mac;
+      Error error = core::system::crypto::v2::aesEncrypt(g_data, g_key, g_iv, aad, mac, encryptedData);
+      REQUIRE_FALSE(error);
+
+      // decrypt the encrypted data
+      std::vector<unsigned char> decryptedData;
+      error = core::system::crypto::v2::aesDecrypt(encryptedData, g_key, g_iv, aad, mac, decryptedData);
+      REQUIRE_FALSE(error);
+
+      // verify that the decryption gives us back the original data
+      REQUIRE(decryptedPayloadMatches(decryptedData));
+   }
+
+   test_that("v2: Can AES encrypt/decrypt detect tampering/corruption")
+   {
+      // setup
+      REQUIRE(generateKeys());
+
+      // encrypt the data
+      std::vector<unsigned char> encryptedData;
+      std::vector<unsigned char> aad = {2};
+      std::vector<unsigned char> mac;
+      Error error = core::system::crypto::v2::aesEncrypt(g_data, g_key, g_iv, aad, mac, encryptedData);
+      REQUIRE_FALSE(error);
+
+      // decrypt the encrypted data with wrong AAD
+      std::vector<unsigned char> decryptedData;
+      std::vector<unsigned char> bad_aad = {0};
+      error = core::system::crypto::v2::aesDecrypt(encryptedData, g_key, g_iv, bad_aad, mac, decryptedData);
+      REQUIRE(decryptedData.size() == 0);
+      REQUIRE(error != Success());
+
+      // decrypt the encrypted data with changed data
+
+      std::vector<unsigned char> bad_encryptedData = encryptedData;
+      bad_encryptedData[0] += 1;
+      error = core::system::crypto::v2::aesDecrypt(bad_encryptedData, g_key, g_iv, aad, mac, decryptedData);
+      REQUIRE(decryptedData.size() == 0);
+      REQUIRE(error != Success());
+
+      // decrypt the encrypted data with wrong MAC
+      std::vector<unsigned char> bad_mac(16);
+      error = core::system::crypto::v2::aesDecrypt(encryptedData, g_key, g_iv, aad, bad_mac, decryptedData);
+      REQUIRE(decryptedData.size() == 0);
+      REQUIRE(error != Success());
+
+      // Finally, decrypt the encrypted data correctly
+      error = core::system::crypto::v2::aesDecrypt(encryptedData, g_key, g_iv, aad, mac, decryptedData);
+      REQUIRE(decryptedData.size() > 0);
+      REQUIRE_FALSE(error);
+
+      // verify that the decryption gives us back the original data
+      REQUIRE(decryptedPayloadMatches(decryptedData));
+   }
 }
 
 } // end namespace tests


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/6412 by adding versioned encryption functions.

Also:

- Sets default encryption to Version 0 (which is what it's always been. Now it just has a name)
- Adds unit tests around each encryption version

### Approach

This PR just introduces versions and sets us to use Version 0. Future PRs will add logic to use them.

### Automated Tests

Unit tests updated to include tests for each version of encryption

### QA Notes

Expectation is that no current tests should fail. We're using the same encryption code, it just now has a new name and a new home. The new unit tests should cover the added encryption versions

### Documentation

None yet until feature is complete.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


