### PR TITLE
add (and use) a unique element id for data viewer

### DIFF
--- a/src/cpp/tests/automation/testthat/test-automation-data-viewer.R
+++ b/src/cpp/tests/automation/testthat/test-automation-data-viewer.R
@@ -7,7 +7,7 @@ on.exit(.rs.automation.deleteRemote(), add = TRUE)
 # https://github.com/rstudio/rstudio/pull/14657
 test_that("we can use the data viewer with temporary R expressions", {
    remote$consoleExecute("View(subset(mtcars, mpg >= 30))")
-   viewerFrame <- remote$jsObjectViaSelector("iframe[class=\"gwt-Frame\"]")
+   viewerFrame <- remote$jsObjectViaSelector("#rstudio_data_viewer_frame")
    expect_true(grepl("gridviewer.html", viewerFrame$src))
    remote$commandExecute("closeSourceDoc")
 })

--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -741,6 +741,9 @@ public class ElementIds
    public final static String COPILOT_DIAGNOSTICS_COPY_BUTTON = "copilot_diagnostics_copy_button";
    
    // ProjectGeneralPreferencesPane
-   public final static String PROJ_DISPLAY_NAME= "proj_display_name";
+   public final static String PROJ_DISPLAY_NAME = "proj_display_name";
+   
+   // Data viewer
+   public final static String DATA_VIEWER_FRAME = "data_viewer_frame";
    
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1103,7 +1103,6 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
             @Override
             public void onResponseReceived(SourceDocument response)
             {
-               
                getActive().addTab(response, Source.OPEN_INTERACTIVE);
             }
          });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTargetWidget.java
@@ -16,13 +16,8 @@
 package org.rstudio.studio.client.workbench.views.source.editors.data;
 
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.resources.client.ClientBundle;
-import com.google.gwt.resources.client.CssResource;
-import com.google.gwt.user.client.ui.*;
-
 import org.rstudio.core.client.CommandWith2Args;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.RegexUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.IFrameElementEx;
@@ -42,6 +37,16 @@ import org.rstudio.studio.client.workbench.views.source.ViewsSourceConstants;
 import org.rstudio.studio.client.workbench.views.source.editors.EditingTargetToolbar;
 import org.rstudio.studio.client.workbench.views.source.editors.urlcontent.UrlContentEditingTarget;
 import org.rstudio.studio.client.workbench.views.source.model.DataItem;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.resources.client.CssResource;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.DockLayoutPanel;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.Widget;
 
 public class DataEditingTargetWidget extends Composite
    implements UrlContentEditingTarget.Display, 
@@ -85,6 +90,7 @@ public class DataEditingTargetWidget extends Composite
          null,
          false);
       frame_.setSize("100%", "100%");
+      ElementIds.assignElementId(frame_, ElementIds.DATA_VIEWER_FRAME);
       table_ = new DataTable(this);
       column_ = column;
       


### PR DESCRIPTION
This avoids issues with running this test, where the element could fail to be resolved due to obfuscated GWT classes.