### PR TITLE
use strict regex for quarto comment prefix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@
 - Fix startup error due to invalid zoom setting triggering a config schema violation (#14690) 
 - Removed extra spaces after package names in warning message about required packages (#14608)
 - Moved the "Sign commit" checkbox to Git/Svn global options panel (##14559)
+- RStudio's editor highlighting no longer accepts embedded spaces in '#|' comment prefixes. (#14592)
 
 #### Posit Workbench
 

--- a/src/cpp/tests/automation/testthat/test-automation-syntax-highlighting.R
+++ b/src/cpp/tests/automation/testthat/test-automation-syntax-highlighting.R
@@ -86,3 +86,31 @@ test_that("Quarto chunks receive chunk begin / end markers as expected", {
    })
    
 })
+
+# https://github.com/rstudio/rstudio/issues/14592
+test_that("The sequence '# |' is not tokenized as a Quarto comment prefix", {
+  
+   documentContents <- .rs.heredoc('
+      #|  yaml: true
+      # | yaml: false
+   ')
+   
+   remote$documentExecute(".R", documentContents, function(editor) {
+      
+      tokens <- as.vector(editor$session$getTokens(0L))
+      firstToken <- tokens[[1L]]
+      expect_equal(firstToken$type, "comment.doc.tag")
+      expect_equal(firstToken$value, "#|")
+      
+      tokens <- as.vector(editor$session$getTokens(1L))
+      expect_equal(tokens, list(
+         list(
+            type   = "comment",
+            value  = "# | yaml: false",
+            column = 0
+         )
+      ))
+      
+   })
+   
+})

--- a/src/gwt/acesupport/acemode/utils.js
+++ b/src/gwt/acesupport/acemode/utils.js
@@ -278,7 +278,7 @@ var YamlHighlightRules = require("mode/yaml_highlight_rules").YamlHighlightRules
          if (state === "start" || state.indexOf("-start") !== -1) {
             self.$rules[state].unshift({
                token: "comment.doc.tag",
-               regex: "^\\s*#\\s*[|]",
+               regex: "^\\s*#[|]",
                push: prefix + "start"
             });
          }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14592.

### Approach

Adjust regex; add automation test.

### Automated Tests

Included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14592.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
