### PR TITLE
provide checkbox for using device pixel ratio on plot save

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 - You can now toggle between R and Python in the Console by clicking on the language's logo in the Console pane header. (#11613)
 - Restart commands are now run after restoring the search path + global environment by default. (#14636)
+- The "Save as Image" dialog now includes a checkbox "Use device pixel ratio", controlling whether plots are scaled according to the current display's DPI. (#14727)
 - The "Soft-wrap R source files" preference now applies to all source files, and has been re-labelled appropriately. (#10940)
 - RStudio now supports Electron flags set via `~/.config/rstudio/electron-flags.conf` or `~/.config/electron-flags.conf` on Linux / macOS. On Windows, the paths are `%LocalAppData%\RStudio\electron-flags.conf` and `%LocalAppData%\electron-flags.conf`. (#14641)
 

--- a/git_hooks/secrets/.secrets.baseline
+++ b/git_hooks/secrets/.secrets.baseline
@@ -520,7 +520,7 @@
         "filename": "src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java",
         "hashed_secret": "1c60262d3df7b0c6d2d5c52dd5014c985004219f",
         "is_verified": false,
-        "line_number": 7171,
+        "line_number": 7203,
         "is_secret": false
       },
       {
@@ -528,7 +528,7 @@
         "filename": "src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java",
         "hashed_secret": "12106b07b5b299b5e91117791ec7017f0820f84e",
         "is_verified": false,
-        "line_number": 7213,
+        "line_number": 7245,
         "is_secret": false
       }
     ],
@@ -619,5 +619,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-07T18:18:55Z"
+  "generated_at": "2024-06-11T22:08:06Z"
 }

--- a/src/cpp/session/modules/SessionPlots.cpp
+++ b/src/cpp/session/modules/SessionPlots.cpp
@@ -134,13 +134,14 @@ Error savePlotAs(const json::JsonRpcRequest& request,
    // get args
    std::string path, format;
    int width, height;
-   bool overwrite;
+   bool overwrite, useDevicePixelRatio;
    Error error = json::readParams(request.params,
                                   &path,
                                   &format,
                                   &width,
                                   &height,
-                                  &overwrite);
+                                  &overwrite,
+                                  &useDevicePixelRatio);
    if (error)
       return error;
 
@@ -157,7 +158,7 @@ Error savePlotAs(const json::JsonRpcRequest& request,
    // save plot
    using namespace rstudio::r::session::graphics;
    Display& display = r::session::graphics::display();
-   error = display.savePlotAsImage(plotPath, format, width, height, true);
+   error = display.savePlotAsImage(plotPath, format, width, height, useDevicePixelRatio);
    if (error)
    {
        LOG_ERROR(error);

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1953,6 +1953,7 @@ public class RemoteServer implements Server
                           int width,
                           int height,
                           boolean overwrite,
+                          boolean useDevicePixelRatio,
                           ServerRequestCallback<Bool> requestCallback)
    {
       JSONArray params = new JSONArray();
@@ -1961,6 +1962,7 @@ public class RemoteServer implements Server
       params.set(2, new JSONNumber(width));
       params.set(3, new JSONNumber(height));
       params.set(4, JSONBoolean.getInstance(overwrite));
+      params.set(5, JSONBoolean.getInstance(useDevicePixelRatio));
       sendRequest(RPC_SCOPE, SAVE_PLOT_AS, params, requestCallback);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/ExportPlotConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/ExportPlotConstants.java
@@ -70,6 +70,24 @@ public interface ExportPlotConstants extends com.google.gwt.i18n.client.Messages
     @DefaultMessage("View plot after saving")
     @Key("viewAfterSaveCheckBoxTitle")
     String viewAfterSaveCheckBoxTitle();
+ 
+    /**
+     * Translated "Use device pixel ratio".
+     *
+     * @return translated "Use device pixel ratio"
+     */
+    @DefaultMessage("Use device pixel ratio")
+    @Key("useDevicePixelRatioCheckBoxLabel")
+    String useDevicePixelRatioCheckBoxLabel();
+    
+    /**
+     * Translated "When set, the plot dimensions will be scaled according to the current display's device pixel ratio.".
+     *
+     * @return translated "When set, the plot dimensions will be scaled according to the current display's device pixel ratio."
+     */
+    @DefaultMessage("When set, the plot dimensions will be scaled according to the current display''s device pixel ratio.")
+    @Key("useDevicePixelRatioCheckBoxTitle")
+    String useDevicePixelRatioCheckBoxTitle();
 
     /**
      * Translated "File Name Required".

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/ExportPlotDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/ExportPlotDialog.java
@@ -14,11 +14,11 @@
  */
 package org.rstudio.studio.client.workbench.exportplot;
 
-import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.Size;
 import org.rstudio.core.client.widget.ModalDialogBase;
 import org.rstudio.studio.client.workbench.exportplot.model.ExportPlotOptions;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
@@ -93,6 +93,7 @@ public class ExportPlotDialog extends ModalDialogBase
                                       sizeEditor.getKeepRatio(),
                                       previous.getFormat(),
                                       previous.getViewAfterSave(),
+                                      previous.getUseDevicePixelRatio(),
                                       previous.getCopyAsMetafile());    
    }
     

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/SavePlotAsImageDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/SavePlotAsImageDialog.java
@@ -14,7 +14,6 @@
  */
 package org.rstudio.studio.client.workbench.exportplot;
 
-import com.google.gwt.core.client.GWT;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
@@ -24,6 +23,8 @@ import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.workbench.exportplot.model.ExportPlotOptions;
 import org.rstudio.studio.client.workbench.exportplot.model.SavePlotAsImageContext;
 
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.ui.CheckBox;
@@ -73,7 +74,13 @@ public class SavePlotAsImageDialog extends ExportPlotDialog
       viewAfterSaveCheckBox_ = new CheckBox(constants_.viewAfterSaveCheckBoxTitle());
       viewAfterSaveCheckBox_.setValue(options.getViewAfterSave());
       addLeftWidget(viewAfterSaveCheckBox_);
-     
+      
+      // use device pixel ratio
+      useDevicePixelRatioCheckBox_ = new CheckBox(constants_.useDevicePixelRatioCheckBoxLabel());
+      useDevicePixelRatioCheckBox_.setTitle(constants_.useDevicePixelRatioCheckBoxTitle());
+      useDevicePixelRatioCheckBox_.setValue(options.getUseDevicePixelRatio());
+      useDevicePixelRatioCheckBox_.getElement().getStyle().setPaddingLeft(6, Unit.PX);
+      addLeftWidget(useDevicePixelRatioCheckBox_);
    }
 
    @Override
@@ -93,10 +100,11 @@ public class SavePlotAsImageDialog extends ExportPlotDialog
    {
       ExportPlotSizeEditor sizeEditor = getSizeEditor();
       return ExportPlotOptions.create(sizeEditor.getImageWidth(), 
-                                      sizeEditor.getImageHeight(), 
+                                      sizeEditor.getImageHeight(),
                                       sizeEditor.getKeepRatio(),
                                       saveAsTarget_.getFormat(),
                                       viewAfterSaveCheckBox_.getValue(),
+                                      useDevicePixelRatioCheckBox_.getValue(),
                                       previous.getCopyAsMetafile());
    }
    
@@ -123,7 +131,8 @@ public class SavePlotAsImageDialog extends ExportPlotDialog
             format, 
             getSizeEditor(), 
             overwrite, 
-            viewAfterSaveCheckBox_.getValue(), 
+            viewAfterSaveCheckBox_.getValue(),
+            useDevicePixelRatioCheckBox_.getValue(),
             onCompleted);    
    }
   
@@ -132,5 +141,6 @@ public class SavePlotAsImageDialog extends ExportPlotDialog
    private final SavePlotAsImageOperation saveOperation_;
    private SavePlotAsImageTargetEditor saveAsTarget_;
    private CheckBox viewAfterSaveCheckBox_;
+   private CheckBox useDevicePixelRatioCheckBox_;
    private static final ExportPlotConstants constants_ = GWT.create(ExportPlotConstants.class);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/SavePlotAsImageOperation.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/SavePlotAsImageOperation.java
@@ -27,5 +27,6 @@ public interface SavePlotAsImageOperation
                     ExportPlotSizeEditor sizeEditor,
                     boolean overwrite,
                     boolean viewAfterSave,
+                    boolean useDevicePixelRatio,
                     Operation onCompleted);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/clipboard/CopyPlotToClipboardDesktopMetafileDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/clipboard/CopyPlotToClipboardDesktopMetafileDialog.java
@@ -15,7 +15,6 @@
 package org.rstudio.studio.client.workbench.exportplot.clipboard;
 
 
-import com.google.gwt.core.client.GWT;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.studio.client.common.Timers;
@@ -25,6 +24,7 @@ import org.rstudio.studio.client.workbench.exportplot.ExportPlotResources;
 import org.rstudio.studio.client.workbench.exportplot.ExportPlotSizeEditor;
 import org.rstudio.studio.client.workbench.exportplot.model.ExportPlotOptions;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.Label;
@@ -87,6 +87,7 @@ public class CopyPlotToClipboardDesktopMetafileDialog extends CopyPlotToClipboar
                                       sizeEditor.getKeepRatio(),
                                       previous.getFormat(),
                                       previous.getViewAfterSave(),
+                                      previous.getUseDevicePixelRatio(),
                                       getCopyAsMetafile());    
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/model/ExportPlotOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/model/ExportPlotOptions.java
@@ -26,6 +26,7 @@ public class ExportPlotOptions extends UserStateAccessor.ExportPlotOptions
                                                        boolean keepRatio,
                                                        String format,
                                                        boolean viewAfterSave,
+                                                       boolean useDevicePixelRatio,
                                                        boolean copyAsMetafile) 
    /*-{
       var options = new Object();
@@ -34,6 +35,7 @@ public class ExportPlotOptions extends UserStateAccessor.ExportPlotOptions
       options.format = format;
       options.keepRatio = keepRatio;
       options.viewAfterSave = viewAfterSave;
+      options.useDevicePixelRatio = useDevicePixelRatio;
       options.copyAsMetafile = copyAsMetafile;
       return options;
    }-*/;
@@ -46,6 +48,7 @@ public class ExportPlotOptions extends UserStateAccessor.ExportPlotOptions
                                       options.getKeepRatio(),
                                       options.getFormat(),
                                       options.getViewAfterSave(),
+                                      options.getUseDevicePixelRatio(),
                                       options.getCopyAsMetafile());
    }
 
@@ -59,6 +62,7 @@ public class ExportPlotOptions extends UserStateAccessor.ExportPlotOptions
              a.height === b.height &&
              a.keepRatio === b.keepRatio &&
              a.viewAfterSave === b.viewAfterSave &&
-             a.copyAsMetafile === b.copyAsMetafile;    
+             a.useDevicePixelRatio === b.useDevicePixelRatio &&
+             a.copyAsMetafile === b.copyAsMetafile;
    }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
@@ -20,17 +20,16 @@
 
 package org.rstudio.studio.client.workbench.prefs.model;
 
-import org.rstudio.core.client.js.JsObject;
-import org.rstudio.studio.client.workbench.model.SessionInfo;
-
-import com.google.gwt.core.client.JavaScriptObject;
-import com.google.gwt.core.client.JsArray;
-import com.google.gwt.core.client.JsArrayString;
-
 import java.util.ArrayList;
 import java.util.List;
 
+import org.rstudio.core.client.js.JsObject;
+import org.rstudio.studio.client.workbench.model.SessionInfo;
+
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.JsArrayString;
 
 /**
  * Accessor class for user state.
@@ -327,6 +326,10 @@ public class UserStateAccessor extends Prefs
 
       public final native boolean getCopyAsMetafile() /*-{
          return this && this.copyAsMetafile || false;
+      }-*/;
+      
+      public final native boolean getUseDevicePixelRatio() /*-{
+         return this && this.useDevicePixelRatio || false;
       }-*/;
 
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/model/PlotsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/model/PlotsServerOperations.java
@@ -67,6 +67,7 @@ public interface PlotsServerOperations
                    int width,
                    int height,
                    boolean overwrite,
+                   boolean useDevicePixelRatio,
                    ServerRequestCallback<Bool> requestCallback);
    
    void savePlotAsPdf(FileSystemItem file,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/export/PlotsPaneSaveAsImageOperation.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/export/PlotsPaneSaveAsImageOperation.java
@@ -41,6 +41,7 @@ public class PlotsPaneSaveAsImageOperation implements SavePlotAsImageOperation
                            final ExportPlotSizeEditor sizeEditor,
                            boolean overwrite, 
                            boolean viewAfterSave,
+                           boolean useDevicePixelRatio,
                            Operation onCompleted)
    {
       // create handler
@@ -60,6 +61,7 @@ public class PlotsPaneSaveAsImageOperation implements SavePlotAsImageOperation
                                      sizeEditor.getImageWidth(), 
                                      sizeEditor.getImageHeight(), 
                                      overwrite,
+                                     useDevicePixelRatio,
                                      requestCallback);
                }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/export/ViewerPaneSaveAsImageDesktopOperation.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/export/ViewerPaneSaveAsImageDesktopOperation.java
@@ -35,6 +35,7 @@ public class ViewerPaneSaveAsImageDesktopOperation implements SavePlotAsImageOpe
                            final ExportPlotSizeEditor sizeEditor,
                            final boolean overwrite,
                            final boolean viewAfterSave,
+                           final boolean useDevicePixelRatio,
                            final Operation onCompleted)
    {
       DesktopExport.export(


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14727.

### Approach

This PR introduces a new option for plot generation, "Use device pixel ratio". Here's how the dialog looks, with hover text included.

<img width="576" alt="Screenshot 2024-06-11 at 3 10 35 PM" src="https://github.com/rstudio/rstudio/assets/1976582/4aefd53c-bbba-4315-9a5e-c4d00d9d6129">

### Automated Tests

Not included.

### QA Notes

On a machine with a high DPI display, try creating a basic plot with e.g. `plot(1)`. Then, in the Plots pane, use Export -> Save as Image..., and try saving two versions of the plot: one with "Use device pixel ratio" checked, and the other without.

If the checkbox is set, the Plot dimensions should be scaled according to the device pixel ratio (so the inherent width / height of the plot will be increased). If the viewer used to observe the plot is decreased in size, it should then appear as a crisp "high DPI" plot.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
