### PR TITLE
detect and use line endings from file when performing replace

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,7 @@
 - Removed extra spaces after package names in warning message about required packages (#14608)
 - Moved the "Sign commit" checkbox to Git/Svn global options panel (##14559)
 - RStudio's editor highlighting no longer accepts embedded spaces in '#|' comment prefixes. (#14592)
+- RStudio now preserves a file's existing line endings when performing a Find and Replace. (#14796)
 
 #### Posit Workbench
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14796.

### Approach

Detect what newlines are used in a file before starting the Find and Replace operation, and use those newlines when running the replace.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14796.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
