### PR TITLE
unload a loaded package DLL if necessary

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,7 @@
 - Fixed an issue where RStudio could trigger active bindings in environments when requesting completions. (#14784)
 - Fixed an issue where the editor scroll speed had inadvertently been decreased. (#14664)
 - Fixed an issue where external links couldn't be opened from a popped-out Help pane window. (#14801; Desktop)
+- Fixed an issue where loaded package DLLs were not unloaded prior to attempting to build and install an under-development package from the Packages pane. (#13399)
 - Remove superfluous Uninstall shortcut and Start Menu folder (#1900; Desktop installer on Windows)
 - Hide Refresh button while Replace All operation is running in the Find in Files pane (#13873)
 - Stop the File Pane's "Copy To" operation from deleting the file when source and destination are the same (#14525)

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -308,7 +308,6 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       getNamespaceInfo(package, "path")
    }
    
-   
    # Now, try to unload the package. If it's attached, detach it;
    # if the namespace is loaded, unload it.
    searchPathName <- paste("package", package, sep = ":")

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -316,6 +316,10 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    {
       unloadNamespace(package)
    }
+   
+   dllInfo <- getLoadedDLLs()[[package]]
+   if (!is.null(dllInfo))
+      dyn.unload(dllInfo[["path"]])
 })
 
 .rs.addFunction("packageVersion", function(name, libPath, pkgs)

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -326,7 +326,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       unloadNamespace(package)
    }
    
-   # Now, detach a loaded DLL (if any) associated with the package.
+   # Now, unload a loaded DLL (if any) associated with the package.
    dllInfo <- getLoadedDLLs()[[package]]
    if (!is.null(dllInfo) && !is.null(pkgPath))
    {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13399.

### Approach

When unloading a package prior to installation, also make sure to unload any of its loaded DLLs.

### Automated Tests

Not included.

### QA Notes

On Windows, open a package project, using a package which contains some C / C++ sources. https://github.com/r-lib/rlang is a good example. In that project, try to use the Packages -> Install button to install the package. Try to do this two times in a row -- both attempts should succeed, whereas previously the second attempt would have failed.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

