### PR TITLE
Feature/decryption versioning

### DIFF
--- a/src/cpp/shared_core/include/shared_core/system/encryption/EncryptionVersion.hpp
+++ b/src/cpp/shared_core/include/shared_core/system/encryption/EncryptionVersion.hpp
@@ -91,6 +91,7 @@ public:
 namespace v0 {
 
 const unsigned char VERSION_BYTE = 0;
+const int KEY_LENGTH_BYTES = 16;
 
 /**
  * @brief Legacy AES 128 decrypts the specified data using the specified initialization vector.
@@ -133,6 +134,7 @@ Error aesEncrypt(
 namespace v1 {
 
 const unsigned char VERSION_BYTE = 1;
+const int KEY_LENGTH_BYTES = 16;
 
 /**
  * @brief AES 128 decrypts the specified v1 data using the specified initialization vector.
@@ -175,6 +177,7 @@ Error aesEncrypt(
 namespace v2 {
 
 const unsigned char VERSION_BYTE = 2;
+const int KEY_LENGTH_BYTES = 32;
 const unsigned char MAC_SIZE_BYTES = 16;
 
 /**

--- a/src/cpp/shared_core/include/shared_core/system/encryption/EncryptionVersion.hpp
+++ b/src/cpp/shared_core/include/shared_core/system/encryption/EncryptionVersion.hpp
@@ -30,6 +30,7 @@
 #ifndef SHARED_CORE_SYSTEM_ENCRYPTION_VERSION_HPP
 #define SHARED_CORE_SYSTEM_ENCRYPTION_VERSION_HPP
 
+#include <stdexcept>
 #include <vector>
 
 namespace rstudio {
@@ -78,6 +79,14 @@ namespace crypto {
 
 const std::size_t ENCRYPTION_VERSION_SIZE_BYTES = 1;
 const int VERSION_BYTE_INDEX = 0;
+
+// Custom exception for handling the 1/256 chance that the first byte of a
+// v0 buffer is a valid version byte value
+class EncryptionVersionMismatchException : public std::logic_error {
+public:
+   EncryptionVersionMismatchException()
+       : std::logic_error("Encryption version mismatch error") {}
+};
 
 namespace v0 {
 

--- a/src/cpp/shared_core/include/shared_core/system/encryption/EncryptionVersion.hpp
+++ b/src/cpp/shared_core/include/shared_core/system/encryption/EncryptionVersion.hpp
@@ -77,7 +77,7 @@ namespace crypto {
  * internally by the versioned functions.
  */
 
-const std::size_t ENCRYPTION_VERSION_SIZE_BYTES = 1;
+const int ENCRYPTION_VERSION_SIZE_BYTES = 1;
 const int VERSION_BYTE_INDEX = 0;
 
 // Custom exception for handling the 1/256 chance that the first byte of a
@@ -178,7 +178,7 @@ namespace v2 {
 
 const unsigned char VERSION_BYTE = 2;
 const int KEY_LENGTH_BYTES = 32;
-const unsigned char MAC_SIZE_BYTES = 16;
+const int MAC_SIZE_BYTES = 16;
 
 /**
  * @brief AES 256 decrypts the specified v2 data using the specified initialization vector.

--- a/src/cpp/shared_core/system/Crypto.cpp
+++ b/src/cpp/shared_core/system/Crypto.cpp
@@ -43,8 +43,6 @@
 #include <shared_core/Error.hpp>
 #include <shared_core/Logger.hpp>
 
-#include <shared_core/system/encryption/EncryptionVersion.hpp>
-
 namespace rstudio {
 namespace core {
 namespace system {

--- a/src/cpp/shared_core/system/Crypto.cpp
+++ b/src/cpp/shared_core/system/Crypto.cpp
@@ -43,6 +43,8 @@
 #include <shared_core/Error.hpp>
 #include <shared_core/Logger.hpp>
 
+#include <shared_core/system/encryption/EncryptionVersion.hpp>
+
 namespace rstudio {
 namespace core {
 namespace system {

--- a/src/cpp/shared_core/system/Crypto.cpp
+++ b/src/cpp/shared_core/system/Crypto.cpp
@@ -84,7 +84,7 @@ Error aesDecrypt(
    std::vector<unsigned char>& out_decrypted)
 {
    // Attempt versioned decryption. If unsuccessful, default to v0 decryption
-   // Decrypting with incompatible buffer sizes can cause segfaults.
+   // Decrypting with incompatible buffer or key sizes can cause segfaults.
    // Wrap in a try/catch block to gracefully handle version decryption mismatches
    try
    {

--- a/src/cpp/shared_core/system/encryption/EncryptionVersion.cpp
+++ b/src/cpp/shared_core/system/encryption/EncryptionVersion.cpp
@@ -97,6 +97,10 @@ Error aesDecrypt(
     const std::vector<unsigned char>& in_iv,
     std::vector<unsigned char>& out_decrypted)
 {
+   // Key size mismatches can silently read more/less data than intended. Prevent that upfront.
+   if (in_key.size() != KEY_LENGTH_BYTES )
+      throw EncryptionVersionMismatchException();
+
    out_decrypted.resize(gsl::narrow_cast<int>(in_v0_data.size()));
 
    return v1::aesDecrypt(in_v0_data.data(),
@@ -115,6 +119,10 @@ Error aesEncrypt(
     const std::vector<unsigned char>& iv,
     std::vector<unsigned char>& out_v0_encrypted)
 {
+   // Key size mismatches can silently read more/less data than intended. Prevent that upfront.
+   if (key.size() != KEY_LENGTH_BYTES )
+      throw EncryptionVersionMismatchException();
+
    int encryptedBytes = 0;
    // allow enough space in output buffer for version byte, data, and potential additional block
    out_v0_encrypted.resize(data.size() + EVP_MAX_BLOCK_LENGTH);
@@ -212,6 +220,10 @@ Error aesDecrypt(
    const std::vector<unsigned char>& in_iv,
    std::vector<unsigned char>& out_decrypted)
 {
+   // Key size mismatches can silently read more/less data than intended. Prevent that upfront.
+   if (in_key.size() != KEY_LENGTH_BYTES )
+      throw EncryptionVersionMismatchException();
+
    // Extract v1 byte info and only decrypt actual encrypted data:
    // [ version byte ][ v1 encrypted data ]
    // Use std::max to prevent index math going negative.
@@ -230,6 +242,10 @@ Error aesEncrypt(
     const std::vector<unsigned char>& iv,
     std::vector<unsigned char>& out_v1_encrypted)
 {
+   // Key size mismatches can silently read more/less data than intended. Prevent that upfront.
+   if (key.size() != KEY_LENGTH_BYTES )
+      throw EncryptionVersionMismatchException();
+
    int bytesEncrypted = 0;
 
    // allow enough space in output buffer for version byte, data, and potential additional block
@@ -376,6 +392,10 @@ Error aesDecrypt(
     const std::vector<unsigned char>& in_iv,
     std::vector<unsigned char>& out_decrypted)
 {
+   // Key size mismatches can silently read more/less data than intended. Prevent that upfront.
+   if (in_key.size() != KEY_LENGTH_BYTES )
+      throw EncryptionVersionMismatchException();
+
    // Index maths. v2 buffer structure is: [ version byte ][ v2 encrypted data ][ mac ]
    // Use std::max to prevent index math going negative.
    int dataLength = std::max(in_v2_data.size() - ENCRYPTION_VERSION_SIZE_BYTES - MAC_SIZE_BYTES, (size_t)0);
@@ -405,6 +425,10 @@ Error aesEncrypt(
     const std::vector<unsigned char>& iv,
     std::vector<unsigned char>& out_v2_encrypted)
 {
+   // Key size mismatches can silently read more/less data than intended. Prevent that upfront.
+   if (key.size() != KEY_LENGTH_BYTES )
+      throw EncryptionVersionMismatchException();
+
    int bytesEncrypted = 0;
 
    // allow enough space in output buffer for data and potential additional block

--- a/src/cpp/shared_core/system/encryption/EncryptionVersion.cpp
+++ b/src/cpp/shared_core/system/encryption/EncryptionVersion.cpp
@@ -97,8 +97,8 @@ Error aesDecrypt(
     const std::vector<unsigned char>& in_iv,
     std::vector<unsigned char>& out_decrypted)
 {
-   // Key size mismatches can silently read more/less data than intended. Prevent that upfront.
-   if (in_key.size() != KEY_LENGTH_BYTES )
+   // Key size mismatches can silently read more data than intended. Prevent that upfront.
+   if (in_key.size() < KEY_LENGTH_BYTES )
       throw EncryptionVersionMismatchException();
 
    out_decrypted.resize(gsl::narrow_cast<int>(in_v0_data.size()));
@@ -119,8 +119,8 @@ Error aesEncrypt(
     const std::vector<unsigned char>& iv,
     std::vector<unsigned char>& out_v0_encrypted)
 {
-   // Key size mismatches can silently read more/less data than intended. Prevent that upfront.
-   if (key.size() != KEY_LENGTH_BYTES )
+   // Key size mismatches can silently read more data than intended. Prevent that upfront.
+   if (key.size() < KEY_LENGTH_BYTES )
       throw EncryptionVersionMismatchException();
 
    int encryptedBytes = 0;
@@ -220,8 +220,8 @@ Error aesDecrypt(
    const std::vector<unsigned char>& in_iv,
    std::vector<unsigned char>& out_decrypted)
 {
-   // Key size mismatches can silently read more/less data than intended. Prevent that upfront.
-   if (in_key.size() != KEY_LENGTH_BYTES )
+   // Key size mismatches can silently read more data than intended. Prevent that upfront.
+   if (in_key.size() < KEY_LENGTH_BYTES )
       throw EncryptionVersionMismatchException();
 
    // Extract v1 byte info and only decrypt actual encrypted data:
@@ -242,8 +242,8 @@ Error aesEncrypt(
     const std::vector<unsigned char>& iv,
     std::vector<unsigned char>& out_v1_encrypted)
 {
-   // Key size mismatches can silently read more/less data than intended. Prevent that upfront.
-   if (key.size() != KEY_LENGTH_BYTES )
+   // Key size mismatches can silently read more data than intended. Prevent that upfront.
+   if (key.size() < KEY_LENGTH_BYTES )
       throw EncryptionVersionMismatchException();
 
    int bytesEncrypted = 0;
@@ -392,8 +392,8 @@ Error aesDecrypt(
     const std::vector<unsigned char>& in_iv,
     std::vector<unsigned char>& out_decrypted)
 {
-   // Key size mismatches can silently read more/less data than intended. Prevent that upfront.
-   if (in_key.size() != KEY_LENGTH_BYTES )
+   // Key size mismatches can silently read more data than intended. Prevent that upfront.
+   if (in_key.size() < KEY_LENGTH_BYTES )
       throw EncryptionVersionMismatchException();
 
    // Index maths. v2 buffer structure is: [ version byte ][ v2 encrypted data ][ mac ]
@@ -425,8 +425,8 @@ Error aesEncrypt(
     const std::vector<unsigned char>& iv,
     std::vector<unsigned char>& out_v2_encrypted)
 {
-   // Key size mismatches can silently read more/less data than intended. Prevent that upfront.
-   if (key.size() != KEY_LENGTH_BYTES )
+   // Key size mismatches can silently read more data than intended. Prevent that upfront.
+   if (key.size() < KEY_LENGTH_BYTES )
       throw EncryptionVersionMismatchException();
 
    int bytesEncrypted = 0;

--- a/src/cpp/shared_core/system/encryption/EncryptionVersion.cpp
+++ b/src/cpp/shared_core/system/encryption/EncryptionVersion.cpp
@@ -190,11 +190,6 @@ Error aesDecrypt(
     std::vector<unsigned char>& out_decrypted)
 {
    out_decrypted.resize(in_data.size());
-
-   // if in_mac is wrong size, we'll fail below. Resize here to prevent other problems
-   if (in_mac.size() != 16)
-      in_mac.resize(16);
-
    int outLen = 0;
    int bytesDecrypted = 0;
 
@@ -227,14 +222,12 @@ Error aesDecrypt(
       return getLastCryptoError(ERROR_LOCATION);
    }
 
-   // Finalize encryption
+   // perform final flush
    // A positive return value indicates success,
    // anything else is a failure - the plaintext is not trustworthy.
-   int finalLen = gsl::narrow_cast<int>(out_decrypted.size()) == outLen ? outLen - 1 : outLen;
-   if(EVP_DecryptFinal_ex(ctx, &out_decrypted[finalLen], &outLen) <= 0)
+   if(EVP_DecryptFinal_ex(ctx, &out_decrypted[outLen], &outLen) < 0)
    {
       EVP_CIPHER_CTX_free(ctx);
-      out_decrypted.resize(0);
       return getLastCryptoError(ERROR_LOCATION);
    }
    bytesDecrypted += outLen;

--- a/src/cpp/shared_core/system/encryption/EncryptionVersion.cpp
+++ b/src/cpp/shared_core/system/encryption/EncryptionVersion.cpp
@@ -70,18 +70,40 @@ Error getLastCryptoError(const ErrorLocation& in_location)
        in_location);
 }
 
+// Forward declare v1 low-level functions for use by v0
+namespace v1 {
+Error aesDecrypt(
+    const unsigned char* const in_data, const int data_len,
+    const std::vector<unsigned char>& in_key,
+    const std::vector<unsigned char>& in_iv,
+    std::vector<unsigned char>& out_decrypted);
+
+Error aesEncrypt(
+    const unsigned char* const data, const int data_length,
+    const std::vector<unsigned char>& key,
+    const std::vector<unsigned char>& iv,
+    int& out_bytes_encrypted,
+    unsigned char* out_encrypted);
+}
+
 namespace v0 {
 
 /**
  * v0 decryption is the same as v1. Enforce compatability by calling v1 decryption
  */
 Error aesDecrypt(
-    const std::vector<unsigned char>& in_data,
+    const std::vector<unsigned char>& in_v0_data,
     const std::vector<unsigned char>& in_key,
     const std::vector<unsigned char>& in_iv,
     std::vector<unsigned char>& out_decrypted)
 {
-   return v1::aesDecrypt(in_data, in_key, in_iv, out_decrypted);
+   out_decrypted.resize(gsl::narrow_cast<int>(in_v0_data.size()));
+
+   return v1::aesDecrypt(in_v0_data.data(),
+                         gsl::narrow_cast<int>(in_v0_data.size()),
+                         in_key,
+                         in_iv,
+                         out_decrypted);
 }
 
 /**
@@ -91,31 +113,41 @@ Error aesEncrypt(
     const std::vector<unsigned char>& data,
     const std::vector<unsigned char>& key,
     const std::vector<unsigned char>& iv,
-    std::vector<unsigned char>& out_encrypted)
+    std::vector<unsigned char>& out_v0_encrypted)
 {
-   return v1::aesEncrypt(data, key, iv, out_encrypted);
+   int encryptedBytes = 0;
+   // allow enough space in output buffer for version byte, data, and potential additional block
+   out_v0_encrypted.resize(data.size() + EVP_MAX_BLOCK_LENGTH);
+
+   Error result = v1::aesEncrypt(data.data(),
+                                 gsl::narrow_cast<int>(data.size()),
+                                 key,
+                                 iv,
+                                 encryptedBytes,
+                                 out_v0_encrypted.data());
+
+   out_v0_encrypted.resize(encryptedBytes);
+   return result;
 }
 
 } // namespace v0
 
 namespace v1 {
-
 Error aesDecrypt(
-   const std::vector<unsigned char>& in_data,
+   const unsigned char* const in_data, const int data_len,
    const std::vector<unsigned char>& in_key,
    const std::vector<unsigned char>& in_iv,
    std::vector<unsigned char>& out_decrypted)
 {
-   out_decrypted.resize(in_data.size());
    int outLen = 0;
    int bytesDecrypted = 0;
 
    EVP_CIPHER_CTX *ctx;
    ctx = EVP_CIPHER_CTX_new();
-   EVP_CipherInit_ex(ctx, EVP_aes_128_cbc(), nullptr, &in_key[0], &in_iv[0], s_decrypt);
+   EVP_CipherInit_ex(ctx, EVP_aes_128_cbc(), nullptr, in_key.data(), in_iv.data(), s_decrypt);
 
    // perform the decryption
-   if(!EVP_CipherUpdate(ctx, &out_decrypted[0], &outLen, &in_data[0], gsl::narrow_cast<int>(in_data.size())))
+   if(!EVP_CipherUpdate(ctx, out_decrypted.data(), &outLen, in_data, data_len))
    {
       EVP_CIPHER_CTX_free(ctx);
       return getLastCryptoError(ERROR_LOCATION);
@@ -139,42 +171,83 @@ Error aesDecrypt(
 }
 
 Error aesEncrypt(
-   const std::vector<unsigned char>& data,
-   const std::vector<unsigned char>& key,
-   const std::vector<unsigned char>& iv,
-   std::vector<unsigned char>& out_encrypted)
+    const unsigned char* const data, const int data_length,
+    const std::vector<unsigned char>& key,
+    const std::vector<unsigned char>& iv,
+    int& out_bytes_encrypted,
+    unsigned char* out_encrypted)
 {
-   // allow enough space in output buffer for additional block
-   out_encrypted.resize(data.size() + EVP_MAX_BLOCK_LENGTH);
    int outlen = 0;
-   int bytesEncrypted = 0;
 
    EVP_CIPHER_CTX *ctx;
    ctx = EVP_CIPHER_CTX_new();
-   EVP_CipherInit_ex(ctx, EVP_aes_128_cbc(), nullptr, &key[0], iv.empty() ? nullptr : &iv[0], s_encrypt);
+   EVP_CipherInit_ex(ctx, EVP_aes_128_cbc(), nullptr, key.data(), iv.empty() ? nullptr : iv.data(), s_encrypt);
 
    // perform the encryption
-   if(!EVP_CipherUpdate(ctx, &out_encrypted[0], &outlen, &data[0], gsl::narrow_cast<int>(data.size())))
+   if(!EVP_CipherUpdate(ctx, out_encrypted, &outlen, data, data_length))
    {
       EVP_CIPHER_CTX_free(ctx);
+      out_bytes_encrypted = 0;
       return getLastCryptoError(ERROR_LOCATION);
    }
-   bytesEncrypted += outlen;
+   out_bytes_encrypted += outlen;
 
    // perform final flush including left-over padding
    if(!EVP_CipherFinal_ex(ctx, &out_encrypted[outlen], &outlen))
    {
       EVP_CIPHER_CTX_free(ctx);
+      out_bytes_encrypted = 0;
       return getLastCryptoError(ERROR_LOCATION);
    }
-   bytesEncrypted += outlen;
+   out_bytes_encrypted += outlen;
 
    EVP_CIPHER_CTX_free(ctx);
 
-   // resize the container to the amount of actual bytes encrypted (including padding)
-   out_encrypted.resize(bytesEncrypted);
-
    return Success();
+}
+
+Error aesDecrypt(
+   const std::vector<unsigned char>& in_v1_data,
+   const std::vector<unsigned char>& in_key,
+   const std::vector<unsigned char>& in_iv,
+   std::vector<unsigned char>& out_decrypted)
+{
+   // Extract v1 byte info and only decrypt actual encrypted data:
+   // [ version byte ][ v1 encrypted data ]
+   // Use std::max to prevent index math going negative.
+   out_decrypted.resize(std::max(in_v1_data.size() - ENCRYPTION_VERSION_SIZE_BYTES, (size_t)0));
+
+   return aesDecrypt(&in_v1_data[ENCRYPTION_VERSION_SIZE_BYTES],
+                     gsl::narrow_cast<int>(std::max(in_v1_data.size() - ENCRYPTION_VERSION_SIZE_BYTES, (size_t)0)),
+                     in_key,
+                     in_iv,
+                     out_decrypted);
+}
+
+Error aesEncrypt(
+    const std::vector<unsigned char>& data,
+    const std::vector<unsigned char>& key,
+    const std::vector<unsigned char>& iv,
+    std::vector<unsigned char>& out_v1_encrypted)
+{
+   int bytesEncrypted = 0;
+
+   // allow enough space in output buffer for version byte, data, and potential additional block
+   out_v1_encrypted.resize(data.size() + EVP_MAX_BLOCK_LENGTH + ENCRYPTION_VERSION_SIZE_BYTES);
+
+   Error result = aesEncrypt(
+       data.data(),
+       gsl::narrow_cast<int>(data.size()),
+       key,
+       iv,
+       bytesEncrypted,
+       &out_v1_encrypted[ENCRYPTION_VERSION_SIZE_BYTES]);
+
+   // resize the container to the version byte and amount of actual bytes encrypted (including padding)
+   out_v1_encrypted.resize(bytesEncrypted + ENCRYPTION_VERSION_SIZE_BYTES);
+   out_v1_encrypted[VERSION_BYTE_INDEX] = VERSION_BYTE;
+
+   return result;
 }
 
 } // namespace v1
@@ -182,30 +255,24 @@ Error aesEncrypt(
 namespace v2 {
 
 Error aesDecrypt(
-    const std::vector<unsigned char>& in_data,
+    const unsigned char* const in_data, const int data_length,
     const std::vector<unsigned char>& in_key,
     const std::vector<unsigned char>& in_iv,
-    const std::vector<unsigned char>& in_aad,
-    std::vector<unsigned char>& in_mac,
+    const unsigned char* const in_aad, const int aad_length,
+    unsigned char* const in_mac, const int mac_length,
     std::vector<unsigned char>& out_decrypted)
 {
-   out_decrypted.resize(in_data.size());
-
-   // if in_mac is wrong size, we'll fail below. Resize here to prevent other problems
-   if (in_mac.size() != 16)
-      in_mac.resize(16);
-
    int outLen = 0;
    int bytesDecrypted = 0;
 
    EVP_CIPHER_CTX *ctx;
    ctx = EVP_CIPHER_CTX_new();
-   EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), nullptr, &in_key[0], &in_iv[0]);
+   EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), nullptr, in_key.data(), in_iv.data());
 
    // provide any AAD data
-   if(!in_aad.empty())
+   if(aad_length > 0)
    {
-      if(!EVP_DecryptUpdate(ctx, nullptr, &outLen, &in_aad[0], gsl::narrow_cast<int>(in_aad.size())))
+      if(!EVP_DecryptUpdate(ctx, nullptr, &outLen, in_aad, aad_length))
       {
          EVP_CIPHER_CTX_free(ctx);
          return getLastCryptoError(ERROR_LOCATION);
@@ -213,7 +280,7 @@ Error aesDecrypt(
    }
 
    // perform the decryption
-   if(!EVP_DecryptUpdate(ctx, &out_decrypted[0], &outLen, &in_data[0], gsl::narrow_cast<int>(in_data.size())))
+   if(!EVP_DecryptUpdate(ctx, out_decrypted.data(), &outLen, in_data, data_length))
    {
       EVP_CIPHER_CTX_free(ctx);
       return getLastCryptoError(ERROR_LOCATION);
@@ -221,17 +288,16 @@ Error aesDecrypt(
    bytesDecrypted += outLen;
 
    // Set expected tag value
-   if(!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, 16, &in_mac[0]))
+   if(!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, mac_length, in_mac))
    {
       EVP_CIPHER_CTX_free(ctx);
       return getLastCryptoError(ERROR_LOCATION);
    }
 
-   // Finalize encryption
+   // Finalize encryption. Additional encryption data is not written here for GCM
    // A positive return value indicates success,
    // anything else is a failure - the plaintext is not trustworthy.
-   int finalLen = gsl::narrow_cast<int>(out_decrypted.size()) == outLen ? outLen - 1 : outLen;
-   if(EVP_DecryptFinal_ex(ctx, &out_decrypted[finalLen], &outLen) <= 0)
+   if(EVP_DecryptFinal_ex(ctx, &out_decrypted[outLen - 1], &outLen) <= 0)
    {
       EVP_CIPHER_CTX_free(ctx);
       out_decrypted.resize(0);
@@ -248,62 +314,135 @@ Error aesDecrypt(
 }
 
 Error aesEncrypt(
-    const std::vector<unsigned char>& data,
+    const unsigned char* const data, const int data_length,
     const std::vector<unsigned char>& key,
     const std::vector<unsigned char>& iv,
-    const std::vector<unsigned char>& aad,
+    const unsigned char* const aad, const int aad_length,
     std::vector<unsigned char>& out_mac,
-    std::vector<unsigned char>& out_encrypted)
+    int& out_bytesEncrypted,
+    unsigned char* out_encrypted)
 {
-   // allow enough space in output buffer for additional block
-   out_encrypted.resize(data.size() + EVP_MAX_BLOCK_LENGTH);
-
-   // ensure enough room in mac buffer
-   if (out_mac.size() != 16)
-      out_mac.resize(16);
-
    int outlen = 0;
-   int bytesEncrypted = 0;
 
    EVP_CIPHER_CTX *ctx;
    ctx = EVP_CIPHER_CTX_new();
-   EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), nullptr, &key[0], iv.empty() ? nullptr : &iv[0]);
+   EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), nullptr, key.data(), iv.empty() ? nullptr : iv.data());
 
    // provide any AAD data
-   if (!aad.empty())
+   if (aad_length > 0)
    {
-      if(!EVP_EncryptUpdate(ctx, NULL, &outlen, &aad[0], gsl::narrow_cast<int>(aad.size())))
+      if(!EVP_EncryptUpdate(ctx, NULL, &outlen, aad, gsl::narrow_cast<int>(aad_length)))
       {
          EVP_CIPHER_CTX_free(ctx);
+         out_bytesEncrypted = 0;
          return getLastCryptoError(ERROR_LOCATION);
       }
    }
 
    // perform the encryption
-   if(!EVP_EncryptUpdate(ctx, &out_encrypted[0], &outlen, &data[0], gsl::narrow_cast<int>(data.size())))
+   if(!EVP_EncryptUpdate(ctx, out_encrypted, &outlen, data, data_length))
    {
       EVP_CIPHER_CTX_free(ctx);
+      out_bytesEncrypted = 0;
       return getLastCryptoError(ERROR_LOCATION);
    }
-   bytesEncrypted += outlen;
+   out_bytesEncrypted += outlen;
 
    // perform final flush including left-over padding
    if(!EVP_EncryptFinal_ex(ctx, &out_encrypted[outlen], &outlen))
    {
       EVP_CIPHER_CTX_free(ctx);
+      out_bytesEncrypted = 0;
       return getLastCryptoError(ERROR_LOCATION);
    }
-   bytesEncrypted += outlen;
+   out_bytesEncrypted += outlen;
 
    // get the tag
-   if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, 16, &out_mac[0]))
+   if (1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, MAC_SIZE_BYTES, out_mac.data()))
+   {
+      EVP_CIPHER_CTX_free(ctx);
+      out_bytesEncrypted = 0;
+      return getLastCryptoError(ERROR_LOCATION);
+   }
 
    EVP_CIPHER_CTX_free(ctx);
 
-   // resize the container to the amount of actual bytes encrypted (including padding)
-   out_encrypted.resize(bytesEncrypted);
-
    return Success();
+}
+
+Error aesDecrypt(
+    const std::vector<unsigned char>& in_v2_data,
+    const std::vector<unsigned char>& in_key,
+    const std::vector<unsigned char>& in_iv,
+    std::vector<unsigned char>& out_decrypted)
+{
+   // Index maths. v2 buffer structure is: [ version byte ][ v2 encrypted data ][ mac ]
+   // Use std::max to prevent index math going negative.
+   int dataLength = std::max(in_v2_data.size() - ENCRYPTION_VERSION_SIZE_BYTES - MAC_SIZE_BYTES, (size_t)0);
+   int macIndex = ENCRYPTION_VERSION_SIZE_BYTES + dataLength;
+
+   out_decrypted.resize(dataLength);
+
+   // For some reason the decryption doesn't like const data for the mac
+   // Copy it out of the original v2 buffer to remove the const
+   std::vector<unsigned char> mac(in_v2_data.begin() + macIndex, in_v2_data.end());
+
+   // Decrypt just the data
+   return aesDecrypt(&in_v2_data[ENCRYPTION_VERSION_SIZE_BYTES],
+                     gsl::narrow_cast<int>(dataLength),
+                     in_key,
+                     in_iv,
+                     &in_v2_data[VERSION_BYTE_INDEX],
+                     ENCRYPTION_VERSION_SIZE_BYTES,
+                     mac.data(),
+                     MAC_SIZE_BYTES,
+                     out_decrypted);
+}
+
+Error aesEncrypt(
+    const std::vector<unsigned char>& data,
+    const std::vector<unsigned char>& key,
+    const std::vector<unsigned char>& iv,
+    std::vector<unsigned char>& out_v2_encrypted)
+{
+   int bytesEncrypted = 0;
+
+   // allow enough space in output buffer for data and potential additional block
+   out_v2_encrypted.resize(data.size() + EVP_MAX_BLOCK_LENGTH + ENCRYPTION_VERSION_SIZE_BYTES + MAC_SIZE_BYTES);
+   std::vector <unsigned char> mac(MAC_SIZE_BYTES);
+
+   // Encrypt the data
+   Error result = aesEncrypt(
+       data.data(),
+       gsl::narrow_cast<int>(data.size()),
+       key,
+       iv,
+       &VERSION_BYTE,
+       ENCRYPTION_VERSION_SIZE_BYTES,
+       mac,
+       bytesEncrypted,
+       &out_v2_encrypted[ENCRYPTION_VERSION_SIZE_BYTES]);
+
+   // Add v2 metadata
+   if (result == Success())
+   {
+      // resize the container to the amount of actual bytes encrypted (including padding)
+      // plus any
+      out_v2_encrypted.resize(ENCRYPTION_VERSION_SIZE_BYTES + bytesEncrypted + MAC_SIZE_BYTES);
+
+      // Add the AAD
+      out_v2_encrypted[VERSION_BYTE_INDEX] = VERSION_BYTE;
+
+      // Add the MAC
+      std::copy(mac.begin(), mac.end(), out_v2_encrypted.begin() + ENCRYPTION_VERSION_SIZE_BYTES + bytesEncrypted);
+   }
+   else
+   {
+      out_v2_encrypted.resize(0);
+   }
+
+   return result;
+
 }
 
 } // namespace v2

--- a/src/cpp/shared_core/system/encryption/EncryptionVersionTests.cpp
+++ b/src/cpp/shared_core/system/encryption/EncryptionVersionTests.cpp
@@ -81,7 +81,7 @@ test_context("EncryptionVersionTests")
    test_that("v0: Can AES encrypt/decrypt")
    {
       // setup
-      REQUIRE(generateKeys(0));
+      REQUIRE(generateKeys(crypto::v0::VERSION_BYTE));
 
       // encrypt the data
       std::vector<unsigned char> encryptedData;
@@ -175,6 +175,21 @@ test_context("EncryptionVersionTests")
       // verify that the decryption gives us back the original data
       REQUIRE(decryptedPayloadMatches(decryptedData));
    }
+
+   test_that("Key size mismatches aren't allowed")
+   {
+      std::vector<unsigned char> iv(16);
+      std::vector<unsigned char> encryptedData;
+
+      // Encrypting v0/v1 with v2 key size throws
+      std::vector<unsigned char> key(crypto::v2::KEY_LENGTH_BYTES);
+      REQUIRE_THROWS(core::system::crypto::v0::aesEncrypt(g_data, key, iv, encryptedData));
+      REQUIRE_THROWS(core::system::crypto::v1::aesEncrypt(g_data, key, iv, encryptedData));
+
+      // Encrypting v2 with v1 key size throws
+      key.resize(crypto::v1::KEY_LENGTH_BYTES);
+      REQUIRE_THROWS(core::system::crypto::v2::aesEncrypt(g_data, key, iv, encryptedData));
+   }
 }
 
 test_context("Versioned Crypto Calls")
@@ -182,7 +197,7 @@ test_context("Versioned Crypto Calls")
    test_that("Crypto can decrypt v0 data")
    {
       // setup
-      REQUIRE(generateKeys(0));
+      REQUIRE(generateKeys(crypto::v0::VERSION_BYTE));
 
       // encrypt the data
       std::vector<unsigned char> encryptedData;
@@ -239,7 +254,7 @@ test_context("Versioned Crypto Calls")
    test_that("Crypto can decrypt v0 data with v1 version byte")
    {
       // setup
-      REQUIRE(generateKeys(0));
+      REQUIRE(generateKeys(crypto::v0::VERSION_BYTE));
 
       // Use a key/iv combo that will generate a v0 encrypted buffer that starts with a v1 version byte
       std::vector<unsigned char> encryptedData;
@@ -262,7 +277,7 @@ test_context("Versioned Crypto Calls")
    test_that("Crypto can decrypt v0 data with v2 version byte")
    {
       // setup
-      REQUIRE(generateKeys(0));
+      REQUIRE(generateKeys(crypto::v0::VERSION_BYTE));
 
       // Use a key/iv combo that will generate a v0 encrypted buffer that starts with a v2 version byte
       std::vector<unsigned char> encryptedData;

--- a/src/cpp/shared_core/system/encryption/EncryptionVersionTests.cpp
+++ b/src/cpp/shared_core/system/encryption/EncryptionVersionTests.cpp
@@ -181,8 +181,8 @@ test_context("EncryptionVersionTests")
       std::vector<unsigned char> iv(16);
       std::vector<unsigned char> encryptedData;
 
-      // Encrypting v0/v1 with v2 key size throws
-      std::vector<unsigned char> key(crypto::v2::KEY_LENGTH_BYTES);
+      // Encrypting v0/v1 with too small key size throws
+      std::vector<unsigned char> key = {};
       REQUIRE_THROWS(core::system::crypto::v0::aesEncrypt(g_data, key, iv, encryptedData));
       REQUIRE_THROWS(core::system::crypto::v1::aesEncrypt(g_data, key, iv, encryptedData));
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/6413 by allowing Crypto.cpp understand and decrypt different encryption versions. All encryption will still be made with v0 encryption for now.

### Approach

The diff is a little messy, so here's an overview of what changed

1. The aesEncrypt/aesDecrypt interface in EncryptionVersions.hpp was simplified to keep the prototypes the same across all versions. Version-specific metadata handling happens internally.
    a. The exposed aesEncrypt/aesDecrypt functions perform checks and do any metadata handling before and after passing the data to the lower-level functions.
    b. The lower-level aesEncrypt/aesDecrypt functions take raw pointers to do the actual encryption on just the data of interest
2. I added an exception in EncryptionVersions.hpp and relevant handling into Crypto.cpp. This shouldn't be an issue because the versioned functions aren't intended to be used directly, and the exception will catch a developer's attention if they're making a mistake and mismatching key lengths (the tests from the previous PR were silently doing exactly that)
3. Formatting/name changes

### Automated Tests

Unit tests now cover

1. Encrypting/decrypting all versions
2. Key length mismatches between versions
3. Crypto.cpp decrypting all versions successfully
4. Crypto.cpp handling v0 data that initially looks like v1 or v2 data

Because I moved the lower-level encryption logic behind EncryptionVersions.hpp's interface, I had to remove the test that verified v0/v1 encryption/decryption algorithms were the same, which is okay because that's not technically a hard requirement.

### QA Notes

Similar to the last PR, this is a code change that should effectively do nothing atm. All our tests should continue to be unaffected because we're still using the same encryption code, it just lives in a different house with a different name. Future PRs will give us something to actually test

### Documentation

Will be added once feature is complete

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


