### PR TITLE
avoid recursing into srcrefs not associated with a body / expression

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@
 #### RStudio
 
 - The RStudio diagnostics system no longer automatically loads packages when encountering calls of the form `dplyr::mutate()`. (#9692)
+- Fixed an issue where breakpoints set within `observeEvent()` calls in Shiny applications did not behave correctly. (#14815)
 - Fixed an issue where Build output from 'Run Tests' was not appropriately coloured. (#13088)
 - Fixed an issue where various editor commands (Reindent Lines; Run Chunks) could fail in a document containing Quarto callout blocks. (#14640)
 - Fixed an issue where end fold markers were not rendered correctly in Quarto documents. (#14699)

--- a/src/cpp/session/modules/SessionBreakpoints.R
+++ b/src/cpp/session/modules/SessionBreakpoints.R
@@ -58,7 +58,7 @@
                 (normalizePath(fileattr$filename, mustWork = FALSE) == 
                  normalizePath(fileName)))
             {
-               return (env)
+               return(env)
             }
          }
       }
@@ -71,16 +71,23 @@
 # representation for a step with a given source reference line number.
 .rs.addFunction("stepsAtLine", function(funBody, line)
 {
-   if (typeof(funBody) != "language")
-   {
+   if (!is.call(funBody))
       return(NULL)
-   }
 
-   refs <- attr(funBody, "srcref")
+   # only consider source references attached to braced function bodies.
+   # otherwise, we could end up recursing into source references that
+   # aren't relevant to our current debug attempts.
+   #
+   # https://github.com/rstudio/rstudio/issues/14815
+   refs <- if (identical(funBody[[1L]], as.symbol("{")))
+   {
+      attr(funBody, "srcref", exact = TRUE)
+   }
+   
    for (idx in 1:length(funBody))
    {
       # if there's a source ref on this line, check it against the line number
-      # provided by the caller
+      # provided by the caller.
       ref <- refs[[idx]]
       if (length(ref) > 0)
       {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14815.

### Approach

The way R tags expressions with source references appears to have changed in R 4.4.0, in a way that trips up the Shiny debugger. This PR ensures that we ignore source references that aren't relevant to our attempts to add debug breakpoints.

### Automated Tests

Not included, but this would be nice to have.

### QA Notes

With this Shiny application:

```r
library(shiny)

ui <- fluidPage(
   titlePanel("Old Faithful Geyser Data"),
   actionButton("debugButton", "Debug")
)

server <- function(input, output) {
   
   observeEvent(input$debugButton, {
      1 + 1
      2 + 2
      3 + 3
      4 + 4
      5 + 5
   })
   
}

# Run the application 
shinyApp(ui = ui, server = server)
```

Put this into a file called `app.R`, and save it. Then, try placing breakpoints on the lines like `2 + 2`, and run the application via the Run App button. In the application, you should see a "Debug" button -- click that button, and then return to the R console. You should see the RStudio debugger activate, with the context on the previously-set breakpoint.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
