### PR TITLE
fix check for 'in-sync' function when adding breakpoints

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@
 - Fixed an issue where the editor scroll speed had inadvertently been decreased. (#14664)
 - Fixed an issue where external links couldn't be opened from a popped-out Help pane window. (#14801; Desktop)
 - Fixed an issue where loaded package DLLs were not unloaded prior to attempting to build and install an under-development package from the Packages pane. (#13399)
+- Fixed an issue where breakpoints could not be added to an already-sourced file in some cases. (#14682)
 - Remove superfluous Uninstall shortcut and Start Menu folder (#1900; Desktop installer on Windows)
 - Hide Refresh button while Replace All operation is running in the Find in Files pane (#13873)
 - Stop the File Pane's "Copy To" operation from deleting the file when source and destination are the same (#14525)

--- a/src/cpp/session/modules/SessionBreakpoints.R
+++ b/src/cpp/session/modules/SessionBreakpoints.R
@@ -338,6 +338,44 @@
    .rs.untraced(get(functionName, mode = "function", envir = envir))
 })
 
+.rs.addFunction("isFunctionInSync", function(functionName,
+                                             filePath,
+                                             packageName)
+{
+   tryCatch(
+      .rs.isFunctionInSyncImpl(functionName, filePath, packageName),
+      error = function(e) FALSE
+   )
+})
+
+.rs.addFunction("isFunctionInSyncImpl", function(functionName,
+                                                 filePath,
+                                                 packageName)
+{
+   # Screen out ~/.active-rstudio-document, just in case.
+   if (identical(filePath, "~/.active-rstudio-document"))
+      return(FALSE)
+   
+   # Find the function definition.
+   functionName <- .rs.unquote(functionName)
+   fun <- .rs.getUntracedFunction(functionName, filePath, packageName)
+   if (is.null(fun))
+      return(FALSE)
+   
+   # Get the source definition of this function.
+   srcref <- attr(fun, "srcref")
+   functionLines <- .rs.deparseSrcref(srcref, FALSE)
+   
+   # Check if this matches the file contents.
+   fileContents <- .rs.readLines(filePath)
+   srcpos <- .rs.parseSrcref(srcref)
+   functionSrcLines <- fileContents[srcpos$first_parsed:srcpos$last_parsed]
+   
+   # Check if they match.
+   identical(functionLines, functionSrcLines)
+   
+})
+
 .rs.addFunction("getFunctionSourceRefs", function(
    functionName, fileName, packageName)
 {

--- a/src/cpp/session/modules/SessionBreakpoints.R
+++ b/src/cpp/session/modules/SessionBreakpoints.R
@@ -376,27 +376,6 @@
    
 })
 
-.rs.addFunction("getFunctionSourceRefs", function(
-   functionName, fileName, packageName)
-{
-   functionName <- .rs.unquote(functionName)
-   fun <- .rs.getUntracedFunction(functionName, fileName, packageName)
-   if (is.null(fun))
-   {
-      return(NULL)
-   }
-   attr(fun, "srcref")
-})
-
-.rs.addFunction("getFunctionSourceCode", function(
-   functionName, fileName, packageName)
-{
-   functionName <- .rs.unquote(functionName)
-   paste(capture.output(
-      .rs.getFunctionSourceRefs(functionName, fileName, packageName)),
-      collapse="\n")
-})
-
 # Parses and executes a file for debugging
 .rs.addFunction("executeDebugSource", function(fileName, encoding, breaklines, local)
 {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14682. I suspect this regressed as part of the work in https://github.com/rstudio/rstudio/pull/14360, although I'm not sure of the exact change.

### Approach

Re-implement the in-sync checks in R, using the tools built for reading and parsing source references in https://github.com/rstudio/rstudio/pull/14360. I wanted to avoid changing `environment::functionDiffersFromSource` just to keep risk of regression lower.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14682. In particular, I believe the issue here is that if you:

1. Source a file, and then
2. Attempt to add breakpoints to the function after-the-fact

then RStudio will complain that the function needs to be sourced first. This PR fixes that behavior.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
