### PR TITLE
resolve aliased paths in getOpenFileName

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,7 @@
 - Fixed an issue where loaded package DLLs were not unloaded prior to attempting to build and install an under-development package from the Packages pane. (#13399)
 - Fixed an issue where breakpoints could not be added to an already-sourced file in some cases. (#14682)
 - Fixed an issue where autocompletion results did not display for datasets imported via `haven::read_sav()` in some scenarios. (#14672)
+- Fixed an issue where paths were not tilde-aliased after selection in certain desktop dialogs. (#14851)
 - Remove superfluous Uninstall shortcut and Start Menu folder (#1900; Desktop installer on Windows)
 - Hide Refresh button while Replace All operation is running in the Find in Files pane (#13873)
 - Stop the File Pane's "Copy To" operation from deleting the file when source and destination are the same (#14525)

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { ipcRenderer, SaveDialogReturnValue, webContents } from 'electron';
+import { ipcRenderer, OpenDialogReturnValue, SaveDialogReturnValue, webContents } from 'electron';
 import { logString } from './logger-bridge';
 import { normalizeSeparators } from '../ui/utils';
 import { safeError } from '../core/err';
@@ -31,6 +31,15 @@ function reportIpcError(name: string, error: Error) {
   logString('err', `IpcError: ${name}: ${error.message}`);
 }
 
+function resolveAliasedPath(filePath: string, userHomePath: string) {
+  filePath = normalizeSeparators(filePath);
+  const expandedHomePath = normalizeSeparators(userHomePath || '', '/');
+  if (expandedHomePath.length && filePath.startsWith(expandedHomePath)) {
+    filePath = '~' + filePath.substring(expandedHomePath.length);
+  }
+  return filePath;
+}
+
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function getDesktopBridge() {
   return {
@@ -38,7 +47,7 @@ export function getDesktopBridge() {
       ipcRenderer.send('desktop_browse_url', url);
     },
 
-    getOpenFileName: (
+    getOpenFileName: async (
       caption: string,
       label: string,
       dir: string,
@@ -47,16 +56,28 @@ export function getDesktopBridge() {
       focusOwner: boolean,
       callback: VoidCallback<string>,
     ) => {
-      ipcRenderer
-        .invoke('desktop_get_open_file_name', caption, label, dir, filter, canChooseDirectories, focusOwner)
-        .then((result) => {
-          if (result.canceled as boolean) {
-            callback('');
-          } else {
-            callback(result.filePaths[0]);
-          }
-        })
-        .catch((error) => reportIpcError('getOpenFileName', error));
+      try {
+        const result: OpenDialogReturnValue = await ipcRenderer.invoke(
+          'desktop_get_open_file_name',
+          caption,
+          label,
+          dir,
+          filter,
+          canChooseDirectories,
+          focusOwner,
+        );
+
+        if (result.canceled || result.filePaths.length === 0) {
+          return callback('');
+        }
+
+        const selectedPath = result.filePaths[0];
+        const userHomePath: string = await ipcRenderer.invoke('desktop_get_user_home_path');
+        const aliasedPath = resolveAliasedPath(selectedPath, userHomePath);
+        return callback(aliasedPath);
+      } catch (error: unknown) {
+        reportIpcError('desktop_get_open_file_name', error as Error);
+      }
     },
 
     getSaveFileName: (
@@ -94,19 +115,22 @@ export function getDesktopBridge() {
             filePath = normalizeSeparators(filePath, '/');
           }
 
-          ipcRenderer.invoke('desktop_get_user_home_path').then((userHomePath: string) => {
-            const expandedHomePath = normalizeSeparators(userHomePath.length > 0 ? userHomePath : '', '/');
-            const homePath = '~';
+          ipcRenderer
+            .invoke('desktop_get_user_home_path')
+            .then((userHomePath: string) => {
+              const expandedHomePath = normalizeSeparators(userHomePath.length > 0 ? userHomePath : '', '/');
+              const homePath = '~';
 
-            /* this makes sure the file path and HOME path
+              /* this makes sure the file path and HOME path
               only contains forward slashes as separators for correct comparison */
-            if (expandedHomePath.length && filePath.startsWith(expandedHomePath)) {
-              filePath = homePath + filePath.substring(expandedHomePath.length);
-            }
+              if (expandedHomePath.length && filePath.startsWith(expandedHomePath)) {
+                filePath = homePath + filePath.substring(expandedHomePath.length);
+              }
 
-            // invoke callback
-            return callback(filePath);
-          });
+              // invoke callback
+              return callback(filePath);
+            })
+            .catch((error) => reportIpcError('getSaveFileName', error));
         })
         .catch((error) => reportIpcError('getSaveFileName', error));
     },
@@ -321,7 +345,7 @@ export function getDesktopBridge() {
       top: number,
       width: number,
       height: number,
-      callback: () => void
+      callback: () => void,
     ) => {
       ipcRenderer
         .invoke('desktop_export_page_region_to_file', targetPath, format, left, top, width, height)


### PR DESCRIPTION
Addresses https://github.com/rstudio/rstudio/issues/14851.

### Intent

This PR resolves a small infelicity from the port to Electron. We weren't creating aliased paths in 'getOpenFileName', leading to "full" paths when selected in dialogs like the following:

<img width="545" alt="Screenshot 2024-06-14 at 10 39 41 AM" src="https://github.com/rstudio/rstudio/assets/1976582/224e1513-7cfa-40a1-a6a9-80a08fba32f7">

This PR ensures that such paths are properly aliased, as they were in the Qt builds of RStudio.

https://github.com/rstudio/rstudio/blob/ce38002964824bf3cfdc7f0cbd9c42173f91147f/src/cpp/desktop/DesktopGwtCallback.cpp#L248

### Approach

Mostly straightforward use and resolution of user home path, using existing IPC methods.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14851.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
