### PR TITLE
avoid evaluation of pipe placeholders

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,7 @@
 - Fixed an issue where breakpoints could not be added to an already-sourced file in some cases. (#14682)
 - Fixed an issue where autocompletion results did not display for datasets imported via `haven::read_sav()` in some scenarios. (#14672)
 - Fixed an issue where paths were not tilde-aliased after selection in certain desktop dialogs. (#14851)
+- Fixed an issue where the RStudio diagnostics system could emit spurious errors for documents using the R pipebind placeholder `_`. (#14713)
 - Remove superfluous Uninstall shortcut and Start Menu folder (#1900; Desktop installer on Windows)
 - Hide Refresh button while Replace All operation is running in the Find in Files pane (#13873)
 - Stop the File Pane's "Copy To" operation from deleting the file when source and destination are the same (#14525)

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -93,6 +93,14 @@ Error safeEvaluateString(const std::string& string,
                          SEXP* pSEXP,
                          r::sexp::Protect* pProtect)
 {
+   // don't evaluate pipe placeholders
+   // https://github.com/rstudio/rstudio/issues/14713
+   if (string == "_")
+   {
+      *pSEXP = R_NilValue;
+      return Success();
+   }
+   
    // only evaluate strings that consist of identifiers + extraction
    // operators, e.g. 'foo$bar[[1]]'
    boost::regex reSafeEvaluation("^[a-zA-Z0-9_$@\\[\\]]+$");


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14713.

### Approach

The diagnostics system needs to evaluate symbols and calls in certain scenarios in order to provide diagnostics. Avoid evaluating `_`, since that's only ever used in pipebind expressions (which RStudio currently does not support).

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14713.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
