### PR TITLE
only put Python on PATH when explicitly configured by user

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@
 - Fixed an issue where autocompletion results did not display for datasets imported via `haven::read_sav()` in some scenarios. (#14672)
 - Fixed an issue where paths were not tilde-aliased after selection in certain desktop dialogs. (#14851)
 - Fixed an issue where the RStudio diagnostics system could emit spurious errors for documents using the R pipebind placeholder `_`. (#14713)
+- Fixed an issue where RStudio incorrectly modified the PATH when "Automatically activate project-local Python environments" was checked. (#14659)
 - Remove superfluous Uninstall shortcut and Start Menu folder (#1900; Desktop installer on Windows)
 - Hide Refresh button while Replace All operation is running in the Find in Files pane (#13873)
 - Stop the File Pane's "Copy To" operation from deleting the file when source and destination are the same (#14525)

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1255,9 +1255,17 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 
 .rs.addFunction("prependToPath", function(entry)
 {
-   oldPath <- Sys.getenv("PATH")
-   newPath <- paste(normalizePath(entry), oldPath, sep = .Platform$path.sep)
-   Sys.setenv(PATH = newPath)
+   # Make sure we use native separators, and expand tildes.
+   entry <- normalizePath(entry, mustWork = FALSE)
+   
+   # Get the current PATH.
+   oldPath <- strsplit(Sys.getenv("PATH"), .Platform$path.sep, fixed = TRUE)[[1L]]
+   
+   # Prepend the new entry, removing it from the old PATH if is already exists.
+   newPath <- c(entry, setdiff(oldPath, entry))
+   
+   # Update the PATH.
+   Sys.setenv(PATH = paste(newPath, collapse = .Platform$path.sep))
 })
 
 .rs.addFunction("callSafely", function(call, args)

--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -337,7 +337,12 @@
   }
   .rs.writePrefInternal("rs_writeUserPref", prefName, value)
 })
+
 .rs.addFunction("writeUserPref", .rs.writeUiPref)
+
+.rs.addFunction("readProjectPref", function(prefName) {
+   .rs.readPrefInternal("rs_readProjectPref", prefName)
+})
 
 .rs.addFunction("readUserState", function(stateName) {
   if (missing(stateName) || is.null(stateName))

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -3402,7 +3402,10 @@ core::Error initialize()
       r::util::setenv("SSH_ASKPASS", "rpostback-askpass");
 
    // add postback directory to PATH
-   r::util::appendToSystemPath(module_context::rPostbackScriptsDir());
+   std::string currentPath = core::system::getenv("PATH");
+   std::string postbackScriptsDir = string_utils::utf8ToSystem(module_context::rPostbackScriptsDir().getAbsolutePath());
+   if (currentPath.find(postbackScriptsDir) == std::string::npos)
+      r::util::appendToSystemPath(postbackScriptsDir);
 
    // add suspend/resume handler
    addSuspendHandler(SuspendHandler(boost::bind(onSuspend, _2), onResume));

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -16,10 +16,10 @@
 .rs.addJsonRpcHandler("python_active_interpreter", function()
 {
    pythonPath <- Sys.getenv("RETICULATE_PYTHON", unset = NA)
-
+   
    if (is.na(pythonPath))
       pythonPath <- Sys.getenv("RETICULATE_PYTHON_FALLBACK", unset = NA)
-
+   
    info <- if (is.na(pythonPath))
    {
       .rs.python.invalidInterpreter(
@@ -32,7 +32,7 @@
    {
       .rs.python.getPythonInfo(pythonPath, strict = TRUE)
    }
-
+   
    .rs.scalarListFromList(info)
 })
 
@@ -52,33 +52,33 @@
    historyFile <- file.path(envPath, "conda-meta/history")
    if (!file.exists(historyFile))
       return("")
-
+   
    # read first few lines
    contents <- readLines(historyFile, n = 2L, warn = FALSE)
    if (length(contents) < 2L)
-    return("")
-
+      return("")
+   
    # parse conda path
    line <- substring(contents[2L], 8L)
    index <- regexpr(" ", line, fixed = TRUE)
    if (index == -1L)
       return("")
-
+   
    conda <- substring(line, 1L, index - 1L)
    if (.rs.platform.isWindows)
       conda <- file.path(dirname(conda), "conda.exe")
-
+   
    # prefer condabin if it exists
    condabin <- file.path(dirname(conda), "../condabin", basename(conda))
    if (file.exists(condabin))
       conda <- condabin
-
+   
    # bail if conda wasn't found
    if (!file.exists(conda))
       return("")
-
+   
    .rs.canonicalizePath(conda)
-
+   
 })
 
 .rs.addFunction("python.findWindowsPython", function()
@@ -86,12 +86,12 @@
    # if `py` and `python` are not available, nothing we can do
    pythonCommands <- c("py", "python3", "python")
    available <- nzchar(Sys.which(pythonCommands))
-
+   
    if (!any(available))
       return("")
    else
       pythonCommand <- pythonCommands[available][1]
-
+   
    # NOTE: ideally, we would just parse the output of 'py --list-paths',
    # but for whatever reason the '*' indicating the default version of
    # Python is omitted when run from RStudio, so we try to explicitly
@@ -108,10 +108,10 @@
          stderr  = TRUE
       )
    )
-
+   
    if (inherits(pythonPath, "error"))
       return("")
-
+   
    Encoding(pythonPath) <- "UTF-8"
    pythonPath
 })
@@ -130,7 +130,7 @@
             return(python)
       }
    }
-
+   
    # check some pre-defined environment variables
    vars <- c("RENV_PYTHON", "RETICULATE_PYTHON", "RETICULATE_PYTHON_FALLBACK")
    for (var in vars)
@@ -139,11 +139,11 @@
       if (!is.na(value))
          return(value)
    }
-
-   # check version of Python configured by user
-   prefsPython <- .rs.readUiPref("python_path")
-   if (file.exists(prefsPython))
-      return(path.expand(prefsPython))
+   
+   # check for an explicit Python configured for the project
+   projectPrefsPython <- .rs.readProjectPref("python_path")
+   if (is.character(projectPrefsPython) && file.exists(projectPrefsPython))
+      return(path.expand(projectPrefsPython))
    
    # if this project has a local interpreter, use it
    if (checkProjectEnvs && !is.null(projectDir))
@@ -152,6 +152,11 @@
       if (file.exists(projectPython))
          return(projectPython)
    }
+   
+   # check for a global default Python configured
+   prefsPython <- .rs.readUiPref("python_path")
+   if (is.character(prefsPython) && file.exists(prefsPython))
+      return(path.expand(prefsPython))
    
    # no interpreter configured; return "" as default
    ""
@@ -163,42 +168,42 @@
    # on Windows, help users find a default version of Python if possible
    if (.rs.platform.isWindows)
    {
-     pythonPath <- .rs.python.findWindowsPython()
-     if (file.exists(pythonPath))
-        return(pythonPath)
+      pythonPath <- .rs.python.findWindowsPython()
+      if (file.exists(pythonPath))
+         return(pythonPath)
    }
-
+   
    # look for python + python3 on the PATH
    if (!.rs.platform.isWindows)
    {
-     python3 <- Sys.which("python3")
-     if (nzchar(python3) && python3 != "/usr/bin/python3")
-        return(python3)
-
-     python <- Sys.which("python")
-     if (nzchar(python) && python != "/usr/bin/python")
-     {
-       info <- .rs.python.interpreterInfo(python, NULL)
-       version <- numeric_version(info$version, strict = FALSE)
-       if (!is.na(version) && version >= "3.2")
-          return(python)
-     }
+      python3 <- Sys.which("python3")
+      if (nzchar(python3) && python3 != "/usr/bin/python3")
+         return(python3)
+      
+      python <- Sys.which("python")
+      if (nzchar(python) && python != "/usr/bin/python")
+      {
+         info <- .rs.python.interpreterInfo(python, NULL)
+         version <- numeric_version(info$version, strict = FALSE)
+         if (!is.na(version) && version >= "3.2")
+            return(python)
+      }
    }
-
+   
    # if the user has Anaconda installed, then try auto-activating
    # the base environment of that Anaconda installation
    conda <- .rs.python.findCondaBinary()
    if (file.exists(conda))
    {
-     pythonPath <- if (.rs.platform.isWindows) "../python.exe" else "../bin/python"
-     python <- file.path(dirname(conda), pythonPath)
-     if (file.exists(python))
-        return(python)
+      pythonPath <- if (.rs.platform.isWindows) "../python.exe" else "../bin/python"
+      python <- file.path(dirname(conda), pythonPath)
+      if (file.exists(python))
+         return(python)
    }
-
+   
    # no python found; return empty string placeholder
    ""
-
+   
 })
 
 .rs.addFunction("python.projectInterpreterPath", function(projectDir)
@@ -208,14 +213,14 @@
       c("Scripts/python.exe", "python.exe")
    else
       c("bin/python3", "bin/python")
-
+   
    # look within all top-level directories for an environment
    envPaths <- list.dirs(
       path = projectDir,
       full.names = TRUE,
       recursive = FALSE
    )
-
+   
    for (envPath in envPaths)
    {
       for (pythonSuffix in pythonSuffixes)
@@ -225,7 +230,7 @@
             return(pythonPath)
       }
    }
-
+   
    ""
 })
 
@@ -236,50 +241,50 @@
    pythonPath <- .rs.python.configuredInterpreterPath(projectDir, checkProjectEnvs)
    if (!file.exists(pythonPath))
       return()
-
+   
    # normalize path (avoid following symlinks)
    pythonPath <- file.path(
       normalizePath(dirname(pythonPath), winslash = "/", mustWork = FALSE),
       basename(pythonPath)
    )
-
+   
    # add the Python directory to the PATH
    pythonBin <- dirname(pythonPath)
    .rs.prependToPath(pythonBin)
-
+   
    # if we have a Scripts directory, place that on the PATH as well
    # (primarily for Windows + conda environments)
    scriptsPath <- file.path(pythonBin, "Scripts")
    if (file.exists(scriptsPath))
       .rs.prependToPath(scriptsPath)
-
+   
    pythonInfo <- .rs.python.getPythonInfo(pythonPath, strict = TRUE)
-
+   
    # if this is a virtual environment, set VIRTUAL_ENV
    if (identical(pythonInfo$type, "virtualenv"))
    {
       envPath <- dirname(dirname(pythonPath))
       Sys.setenv(VIRTUAL_ENV = envPath)
    }
-
+   
    # if this is a conda environment, set CONDA_PREFIX
    if (identical(pythonInfo$type, "conda"))
    {
       condaPrefix <- pythonBin
       if (!.rs.platform.isWindows)
          condaPrefix <- dirname(condaPrefix)
-
+      
       Sys.setenv(CONDA_PREFIX = condaPrefix)
-
+      
       # also ensure that conda is placed on the PATH
       condaPath <- .rs.python.findCondaForEnvironment(condaPrefix)
       if (file.exists(condaPath))
          .rs.prependToPath(dirname(condaPath))
    }
-
+   
    # also set RETICULATE_PYTHON_FALLBACK so this python is used by default
    Sys.setenv(RETICULATE_PYTHON_FALLBACK = pythonPath)
-
+   
    # return path to python
    invisible(pythonPath)
 })
@@ -287,17 +292,17 @@
 .rs.addFunction("python.execute", function(python, code)
 {
    python <- normalizePath(python, winslash = "/", mustWork = TRUE)
-
+   
    args <- c("-E", "-c", shQuote(code))
    result <- suppressWarnings(
       system2(python, args, stdout = TRUE, stderr = TRUE)
    )
-
+   
    # propagate failure as error
    status <- .rs.nullCoalesce(attr(result, "status", exact = TRUE), 0L)
    if (!identical(status, 0L))
       .rs.stopf("error retrieving Python version [error code %i]", status)
-
+   
    paste(result, collapse = "\n")
 })
 
@@ -315,26 +320,26 @@
 {
    # default to concluding python binary path == requested path
    pythonPath <- path
-
+   
    # if this is the path to an existing file, use the directory path
    info <- file.info(path, extra_cols = FALSE)
    if (identical(info$isdir, FALSE))
       path <- dirname(path)
-
+   
    # if this is the path to the 'root' of an environment,
    # start from the associated bin / scripts directory
    binExt <- if (.rs.platform.isWindows) "Scripts" else "bin"
    binPath <- file.path(path, binExt)
    if (file.exists(binPath))
       path <- binPath
-
+   
    # now form the python path
    if (!strict)
    {
       exe <- if (.rs.platform.isWindows) "python.exe" else "python"
       pythonPath <- file.path(path, exe)
    }
-
+   
    # if this python doesn't exist, bail
    if (!file.exists(pythonPath))
    {
@@ -343,42 +348,42 @@
          type = NULL,
          reason = "There is no Python interpreter available at this location."
       )
-
+      
       return(info)
    }
-
+   
    # check for conda environment
    # (look for folders normally seen in conda installations)
    condaFiles <- c("../conda-meta", "../condabin")
    condaPaths <- file.path(path, condaFiles)
    if (any(file.exists(condaPaths)))
       return(.rs.python.interpreterInfo(pythonPath, "conda"))
-
+   
    # check for virtual environment
    # (look for files normally seen in virtual envs)
    venvFiles <- c("activate", "pyvenv.cfg", "../pyvenv.cfg")
    venvPaths <- file.path(path, venvFiles)
    if (any(file.exists(venvPaths)))
       return(.rs.python.interpreterInfo(pythonPath, "virtualenv"))
-
+   
    # default to assuming a system interpreter
    .rs.python.interpreterInfo(pythonPath, "system")
-
+   
 })
 
 .rs.addFunction("python.interpreterInfo", function(path, type)
 {
    # prefer UTF-8 path when possible
    path <- enc2utf8(path)
-
+   
    # prefer unix-style slashes
    path <- chartr("\\", "/", path)
-
+   
    # defaults for version, description
    valid <- TRUE
    version <- "[unknown]"
    description <- "[unknown]"
-
+   
    # determine interpreter version
    version <- tryCatch(
       .rs.python.getPythonVersion(path),
@@ -387,7 +392,7 @@
          conditionMessage(e)
       }
    )
-
+   
    # determine interpreter description
    description <- tryCatch(
       .rs.python.getPythonDescription(path),
@@ -396,7 +401,7 @@
          conditionMessage(e)
       }
    )
-
+   
    list(
       path        = .rs.createAliasedPath(path),
       type        = type,
@@ -430,14 +435,14 @@
       .rs.python.findPythonVirtualEnvironments(),
       .rs.python.findPythonCondaEnvironments()
    ))
-
+   
    default <- Sys.getenv("RETICULATE_PYTHON", unset = "")
-
+   
    list(
       python_interpreters = .rs.scalarListFromList(interpreters),
       default_interpreter = .rs.scalar(default)
    )
-
+   
 })
 
 .rs.addFunction("python.findPythonProjectInterpreters", function()
@@ -445,13 +450,13 @@
    projectDir <- .rs.getProjectDirectory()
    if (is.null(projectDir))
       return(list())
-
+   
    candidateDirs <- list.files(
       path = projectDir,
       all.files = TRUE,
       full.names = TRUE
    )
-
+   
    pythonSuffix <- if (.rs.platform.isWindows) "Scripts/python.exe" else "bin/python"
    candidatePaths <- file.path(candidateDirs, pythonSuffix)
    pythonPaths <- Filter(file.exists, candidatePaths)
@@ -461,35 +466,35 @@
 .rs.addFunction("python.findPythonSystemInterpreters", function()
 {
    interpreters <- list()
-
+   
    # look for interpreters on the PATH
    paths <- strsplit(Sys.getenv("PATH"), split = .Platform$path.sep, fixed = TRUE)[[1]]
    paths <- unique(normalizePath(paths, winslash = "/", mustWork = FALSE))
-
+   
    for (path in paths)
    {
-
+      
       # skip fake broken Windows Python interpreters
       skip <-
          .rs.platform.isWindows &&
          grepl("AppData\\Local\\Microsoft\\WindowsApps", path, fixed = TRUE)
-
+      
       if (skip)
          next
-
+      
       # create pattern matching interpreter paths
       pattern <- if (.rs.platform.isWindows)
          "^python[[:digit:].]*exe$"
       else
          "^python[[:digit:].]*$"
-
+      
       # look for python installations
       pythons <- list.files(
          path       = path,
          pattern    = pattern,
          full.names = TRUE
       )
-
+      
       # loop over interpreters and add them
       for (python in pythons)
       {
@@ -502,63 +507,63 @@
             if (grepl(pattern, link))
                next
          }
-
+         
          # add the interpreter
          info <- .rs.python.getPythonInfo(python, strict = TRUE)
          interpreters[[length(interpreters) + 1]] <- info
       }
-
+      
    }
-
+   
    interpreters
-
+   
 })
 
 .rs.addFunction("python.findPythonInterpretersInKnownLocations", function()
 {
    # set of discovered paths
    pythonPaths <- character()
-
+   
    # Python root paths we'll search in
    roots <- if (.rs.platform.isWindows) {
-
+      
       # find path to Windows local app data folder
       localAppData <- local({
-
+         
          path <- Sys.getenv("LOCALAPPDATA", unset = NA)
          if (!is.na(path))
             return(path)
-
+         
          profile <- Sys.getenv("USERPROFILE", unset = NA)
          if (!is.na(profile))
             return(file.path(profile, "AppData\\Local"))
-
+         
          ""
-
+         
       })
-
+      
       # system-installs of Python might be in one of these folders
       drive <- Sys.getenv("SYSTEMDRIVE", unset = "C:")
       suffixes <- c("/", "/Program Files", "/Program Files (x86)")
-
+      
       c(
          paste0(drive, suffixes),
          file.path(localAppData, "Programs/Python")
       )
-
+      
    } else {
-
+      
       c(
          "/opt/python",
          "/opt/local/python",
          "/usr/local/opt/python"
       )
-
+      
    }
-
+   
    # also include those defined via option
    roots <- c(roots, getOption("rstudio.python.installationPath"))
-
+   
    # check and see if any of these roots point directly
    # to a particular version of Python.
    #
@@ -569,58 +574,58 @@
    } else {
       c("bin/python3", "bin/python")
    }
-
+   
    paths <- vapply(roots, function(root) {
       paths <- file.path(root, suffixes)
       paths[file.exists(paths)][1]
    }, FUN.VALUE = character(1))
-
+   
    # collect the discovered python paths, if any
    exists <- !is.na(paths)
    pythonPaths <- c(pythonPaths, paths[exists])
    roots <- roots[!exists]
-
+   
    # treat any remaining root directories as versioned roots
    roots <- list.files(roots, full.names = TRUE)
-
+   
    # check and see if any of these roots point directly
    # to a particular version of Python
    paths <- vapply(roots, function(root) {
       paths <- file.path(root, suffixes)
       paths[file.exists(paths)][1]
    }, FUN.VALUE = character(1))
-
+   
    # collect the discovered python paths, if any
    exists <- !is.na(paths)
    pythonPaths <- c(pythonPaths, paths[exists])
-
+   
    # return the discovered paths
    lapply(pythonPaths, .rs.python.getPythonInfo, strict = TRUE)
-
+   
 })
 
 .rs.addFunction("python.findPythonPyenvInterpreters", function()
 {
    root <- Sys.getenv("PYENV_ROOT", unset = "~/.pyenv")
-
+   
    # on Windows, Python interpreters are normally part of pyenv-windows
    if (.rs.platform.isWindows)
       root <- file.path(root, "pyenv-win")
-
+   
    # get path to roots of Python installations
    versionsPath <- file.path(root, "versions")
    pythonRoots <- list.files(versionsPath, full.names = TRUE)
-
+   
    # form path to Python binaries
    stem <- if (.rs.platform.isWindows) "python.exe" else "bin/python"
    pythonPaths <- file.path(pythonRoots, stem)
-
+   
    # exclude anything that doesn't exist for some reason
    pythonPaths <- pythonPaths[file.exists(pythonPaths)]
-
+   
    # get interpreter info for each found
    lapply(pythonPaths, .rs.python.getPythonInfo, strict = TRUE)
-
+   
 })
 
 .rs.addFunction("python.findCondaBinary", function()
@@ -633,12 +638,12 @@
       if (nzchar(conda))
          return(conda)
    }
-
+   
    # look on PATH
    conda <- Sys.which("conda")
    if (nzchar(conda))
       return(conda)
-
+   
    # look in some default locations
    if (.rs.platform.isWindows)
    {
@@ -661,19 +666,19 @@
          "/miniforge3"
       )
    }
-
+   
    condaSuffix <- if (.rs.platform.isWindows)
       "condabin/conda.bat"
    else
       "condabin/conda"
-
+   
    condaPaths <- file.path(condaRoots, condaSuffix)
    for (condaPath in condaPaths)
       if (file.exists(condaPath))
          return(path.expand(condaPath))
-
+   
    ""
-
+   
 })
 
 .rs.addFunction("python.findPythonCondaEnvironments", function()
@@ -682,39 +687,39 @@
    conda <- .rs.python.findCondaBinary()
    if (!file.exists(conda))
       return(NULL)
-
+   
    # ask it for environments
    args <- c("env", "list", "--json", "--quiet")
    tmp <- tempfile()
    output <- system2(conda, args, stdout = TRUE, stderr = tmp)
-
+   
    status <- .rs.nullCoalesce(attr(output, "status", exact = TRUE), 0L)
    if (!identical(status, 0L)) {
-     errors <- paste(readLines(tmp), collapse = "\n")
-     .rs.stopf("Error executing %s %s:\n%s", conda, paste(args, collapse = " "), errors)
+      errors <- paste(readLines(tmp), collapse = "\n")
+      .rs.stopf("Error executing %s %s:\n%s", conda, paste(args, collapse = " "), errors)
    }
    json <- .rs.fromJSON(paste(output, collapse = "\n"))
    envList <- unlist(json$envs)
-
+   
    # prefer unix separators
    if (.rs.platform.isWindows)
       envList <- chartr("\\", "/", envList)
-
+   
    # ignore certain special environments
    ignorePatterns <- c("/revdep/", "/basilisk/", "/renv/python/condaenvs/")
    pattern <- sprintf("(?:%s)", paste(ignorePatterns, collapse = "|"))
    envList <- grep(pattern, envList, value = TRUE, invert = TRUE)
-
+   
    # get paths to Python in each environment
    pythonSuffix <- if (.rs.platform.isWindows) "python.exe" else "bin/python"
    pythonPaths <- file.path(envList, pythonSuffix)
-
+   
    # only keep existing
    pythonPaths <- Filter(file.exists, pythonPaths)
-
+   
    # drop duplicates, just in case
    pythonPaths <- unique(normalizePath(pythonPaths, winslash = "/"))
-
+   
    # get information for each environment
    lapply(pythonPaths, .rs.python.getCondaEnvironmentInfo)
 })
@@ -741,7 +746,7 @@
       "Scripts/python.exe"
    else
       "bin/python"
-
+   
    # form executable path (ensure it exists)
    exePath <- file.path(envPath, exeSuffix)
    if (!file.exists(exePath))
@@ -754,12 +759,12 @@
          reason = reason
       ))
    }
-
+   
    .rs.python.interpreterInfo(
       path = exePath,
       type = "virtualenv"
    )
-
+   
 })
 
 .rs.addFunction("python.describeInterpreter", function(pythonPath)

--- a/src/cpp/session/modules/SessionUserPrefs.cpp
+++ b/src/cpp/session/modules/SessionUserPrefs.cpp
@@ -20,18 +20,19 @@
 #include <boost/bind/bind.hpp>
 
 #include <core/Exec.hpp>
-
 #include <core/system/Xdg.hpp>
-
-#include <session/prefs/UserPrefs.hpp>
-#include <session/prefs/UserState.hpp>
-#include <session/SessionModuleContext.hpp>
 
 #include <r/RExec.hpp>
 #include <r/RSexp.hpp>
 #include <r/ROptions.hpp>
 #include <r/RRoutines.hpp>
 #include <r/RJson.hpp>
+
+#include <session/prefs/UserPrefs.hpp>
+#include <session/prefs/UserState.hpp>
+#include <session/projects/SessionProjects.hpp>
+#include <session/SessionModuleContext.hpp>
+
 
 using namespace rstudio::core;
 using namespace rstudio::session::prefs;
@@ -250,6 +251,23 @@ SEXP rs_writeUserState(SEXP stateName, SEXP value)
    return R_NilValue;
 }
 
+SEXP rs_readProjectPref(SEXP prefNameSEXP)
+{
+   if (!projects::projectContext().hasProject())
+      return R_NilValue;
+   
+   std::string prefName = r::sexp::asString(prefNameSEXP);
+   if (prefName.empty())
+      return R_NilValue;
+   
+   auto value = userPrefs().readValue(kUserPrefsProjectLayer, prefName);
+   if (!value)
+      return R_NilValue;
+   
+   r::sexp::Protect protect;
+   return r::sexp::create(*value, &protect);
+}
+
 SEXP rs_allPrefs()
 {
    r::sexp::Protect protect;
@@ -384,6 +402,7 @@ core::Error initialize()
    RS_REGISTER_CALL_METHOD(rs_writeApiPref);
    RS_REGISTER_CALL_METHOD(rs_readUserState);
    RS_REGISTER_CALL_METHOD(rs_writeUserState);
+   RS_REGISTER_CALL_METHOD(rs_readProjectPref);
    RS_REGISTER_CALL_METHOD(rs_allPrefs);
    RS_REGISTER_CALL_METHOD(rs_removePref);
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14861.
Addresses https://github.com/rstudio/rstudio/issues/14659.

### Approach

When "Automatically activate project-local python environments" was set, we were putting Python on the PATH even if it wasn't a project-local Python. This PR adjusts that behavior, and also adjusts the precedence of Python usage. The precedence is now:

1. An explicitly-configured project Python instance,
2. When enabled, an implicitly-discovered project Python environment,
3. An explicitly-configured global Python instance.

Note that environment variables like `RETICULATE_PYTHON` remain as overrides.

### Automated Tests

N/A

### QA Notes

In addition to the notes in the associated issues, you can test that:

```
Sys.getenv("PATH")
```

reports the same value before and after building a package in an R package project.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
