### PR TITLE
allow customization of project scratch path location

### DIFF
--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -82,26 +82,6 @@ void onProjectFilesChanged(const std::vector<core::system::FileChangeEvent>& eve
    }
 }
 
-Error computeProjectId(const FilePath& userDir, std::string* pProjectId)
-{
-   FilePath projectIdPath = userDir.completePath("project-id");
-   if (!projectIdPath.exists())
-   {
-      std::string projectId = core::system::generateUuid();
-      Error error = core::writeStringToFile(projectIdPath, projectId);
-      if (error)
-         return error;
-   }
-   
-   std::string projectId;
-   Error error = core::readStringFromFile(projectIdPath, &projectId);
-   if (error)
-      return error;
-   
-   *pProjectId = projectId;
-   return Success();
-}
-
 FilePath computeUserDir(const FilePath& projectFile)
 {
    // compute default .Rproj.user path

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -104,26 +104,45 @@ Error computeProjectId(const FilePath& userDir, std::string* pProjectId)
 
 FilePath computeUserDir(const FilePath& projectFile)
 {
+   // compute default .Rproj.user path
    FilePath defaultUserDir = projectFile.getParent().completePath(".Rproj.user");
    
-   std::string userDir = core::system::getenv("RSTUDIO_PROJECT_SCRATCH_PATH");
-   if (userDir.empty())
+   // check for an external scratch path location -- if that exists,
+   // and it appears to be a usable scratch path, use it
+   FilePath scratchPathFile = defaultUserDir
+         .completePath(prefs::userState().contextId())
+         .completePath("scratch-path");
+   
+   std::string scratchPathContents;
+   Error error = core::readStringFromFile(scratchPathFile, &scratchPathContents);
+   if (error && !isFileNotFoundError(error))
+      LOG_ERROR(error);
+   
+   FilePath scratchPath(scratchPathContents);
+   if (scratchPath.isEmpty())
       return defaultUserDir;
    
-   std::string projectId;
-   Error error = computeProjectId(defaultUserDir, &projectId);
+   error = scratchPath.ensureDirectory();
    if (error)
    {
       LOG_ERROR(error);
       return defaultUserDir;
    }
    
-   FilePath customUserDir = FilePath(userDir).completePath(projectId);
-   error = customUserDir.ensureDirectory();
+   bool writable = false;
+   error = scratchPath.isWriteable(writable);
    if (error)
+   {
+      LOG_ERROR(error);
       return defaultUserDir;
+   }
+   else if (!writable)
+   {
+      ELOGF("Project is configured with scratch-path {}, but that path is not writable", scratchPathContents);
+      return defaultUserDir;
+   }
    
-   return customUserDir;
+   return scratchPath;
 }
 
 }  // anonymous namespace

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -25,6 +25,7 @@
 #include <session/SessionScopes.hpp>
 #include <session/SessionQuarto.hpp>
 #include <session/prefs/UserPrefs.hpp>
+#include <session/prefs/UserState.hpp>
 
 #include <r/RExec.hpp>
 #include <r/RRoutines.hpp>
@@ -46,6 +47,7 @@ ProjectContext s_projectContext;
 core::r_util::ProjectId s_projectId;
 
 
+
 void onSuspend(Settings*)
 {
    // on suspend write out current project path as the one to use
@@ -57,6 +59,45 @@ void onSuspend(Settings*)
 }
 
 void onResume(const Settings&) {}
+
+FilePath projectScratchPathFile()
+{
+   static FilePath instance = s_projectContext
+         .file()
+         .getParent()
+         .completePath(".Rproj.user")
+         .completePath(prefs::userState().contextId())
+         .completePath("scratch-path");
+   
+   return instance;
+}
+
+Error readProjectScratchPath(std::string* pScratchPath)
+{
+   return core::readStringFromFile(projectScratchPathFile(), pScratchPath);
+}
+
+Error writeProjectScratchPath(const json::Object& configJson)
+{
+   std::string scratchPath;
+   Error error = json::readObject(configJson, "scratch_path", scratchPath);
+   if (error)
+      return error;
+   
+   FilePath scratchPathFile = projectScratchPathFile();
+   if (scratchPath.empty())
+      return scratchPathFile.removeIfExists();
+   
+   error = scratchPathFile.getParent().ensureDirectory();
+   if (error)
+      return error;
+
+   error = core::writeStringToFile(scratchPathFile, scratchPath);
+   if (error)
+      return error;
+   
+   return Success();
+}
 
 Error validateProjectPath(const json::JsonRpcRequest& request,
                           json::JsonRpcResponse* pResponse)
@@ -418,6 +459,16 @@ json::Object projectConfigJson(const r_util::RProjectConfig& config)
    else
       configJson["zotero_libraries"] = json::Value(); // null
    configJson["project_name"] = config.projectName;
+   
+   // scratch path
+   std::string scratchPath;
+   Error error = readProjectScratchPath(&scratchPath);
+   if (error && !isFileNotFoundError(error))
+      LOG_ERROR(error);
+
+   if (!scratchPath.empty())
+      configJson["scratch_path"] = scratchPath;
+   
    return configJson;
 }
 
@@ -609,6 +660,7 @@ Error rProjectCopilotOptionsFromJson(const json::Object& optionsJson,
    return Success();
 }
 
+
 Error writeProjectConfig(const json::Object& configJson)
 {
    // read the config
@@ -752,9 +804,12 @@ Error writeProjectConfig(const json::Object& configJson)
    // set the config
    setProjectConfig(config);
 
+   // persist the project scratch path if set
+   error = writeProjectScratchPath(configJson);
+   if (error)
+      LOG_ERROR(error);
+   
    return Success();
-
-
 }
 
 Error writeProjectConfigRpc(const json::JsonRpcRequest& request,
@@ -1201,7 +1256,8 @@ void addFirstRunDocs(const FilePath& projectFilePath, const std::vector<std::str
             &scratchPath,
             &sharedScratchPath);
 
-   for(auto doc : docs) {
+   for (auto&& doc : docs)
+   {
       addFirstRunDoc(scratchPath, doc);
    }
 }

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -804,7 +804,7 @@ Error writeProjectConfig(const json::Object& configJson)
    // set the config
    setProjectConfig(config);
 
-   // persist the project scratch path if set
+   // persist the project scratch path
    error = writeProjectScratchPath(configJson);
    if (error)
       LOG_ERROR(error);

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -60,6 +60,9 @@ void onSuspend(Settings*)
 
 void onResume(const Settings&) {}
 
+// the project scratch path file, if it exists, contains the path
+// to an external project scratch path -- basically allowing users
+// to move .Rproj.user to an external location for a particular project
 FilePath projectScratchPathFile()
 {
    static FilePath instance = s_projectContext

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -66,8 +66,7 @@ void onResume(const Settings&) {}
 FilePath projectScratchPathFile()
 {
    static FilePath instance = s_projectContext
-         .file()
-         .getParent()
+         .directory()
          .completePath(".Rproj.user")
          .completePath(prefs::userState().contextId())
          .completePath("scratch-path");

--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -352,7 +352,8 @@ public class ElementIds
       VCS_IGNORE("vcs_ignore"),
       VCS_TERMINAL("vcs_terminal"),
       CHOOSE_IMAGE("choose_image"),
-      PYTHON_PATH("python_path");
+      PYTHON_PATH("python_path"),
+      PROJECT_SCRATCH_PATH("project_scratch_path");
 
       TextBoxButtonId(String value)
       {

--- a/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
@@ -295,6 +295,11 @@ public class TextBoxWithButton extends Composite
       if (lblCaption_ != null)
          lblCaption_.setFor(textBox_);
    }
+   
+   public void addClearButton()
+   {
+      inner_.add(clearButton_);
+   }
 
 
    private final HorizontalPanel inner_;

--- a/src/gwt/src/org/rstudio/studio/client/projects/StudioClientProjectConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/StudioClientProjectConstants.java
@@ -2179,4 +2179,14 @@ public interface StudioClientProjectConstants extends com.google.gwt.i18n.client
     @DefaultMessage("Project display name (defaults to folder name):")
     @Key("customProjectNameLabel")
     String customProjectNameLabel();
+    
+    /**
+     * Translated "Project scratch path:".
+     *
+     * @return translated "Project scratch path:"
+     */
+    @DefaultMessage("Project scratch path:")
+    @Key("scratchPathLabel")
+    String scratchPathLabel();
+    
 }

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
@@ -458,7 +458,7 @@ public class RProjectConfig extends JavaScriptObject
    }-*/;
    
    public native final String getScratchPath() /*-{
-      return this.scratch_path;
+      return this.scratch_path || "";
    }-*/;
    
    public native final void setScratchPath(String scratchPath) /*-{

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
@@ -456,4 +456,12 @@ public class RProjectConfig extends JavaScriptObject
    public native final void setProjectName(String projectName) /*-{
       this.project_name = projectName;
    }-*/;
+   
+   public native final String getScratchPath() /*-{
+      return this.scratch_path;
+   }-*/;
+   
+   public native final void setScratchPath(String scratchPath) /*-{
+      this.scratch_path = scratchPath;
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectGeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectGeneralPreferencesPane.java
@@ -64,8 +64,9 @@ public class ProjectGeneralPreferencesPane extends ProjectPreferencesPane
       scratchPath_.setPlaceholder(".Rproj.user");
       scratchPath_.addClearButton();
       scratchPath_.getElement().setTitle(
-            "You may want to customize the project scratch path if this project is located on a high-latency network filesystem.\n\n" +
-            "Consider using a local filesystem for RStudio's project scratch path.");
+            "The project scratch path is used to store internal RStudio state for this project. " +
+            "You may want to customize this path if the project is located on a high-latency network filesystem.\n\n" +
+            "In this scenario, consider using a local filesystem for RStudio's project scratch path.");
       
       if (sessionInfo_.getAllowFullUI())
       {

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectGeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectGeneralPreferencesPane.java
@@ -59,17 +59,19 @@ public class ProjectGeneralPreferencesPane extends ProjectPreferencesPane
       projectNameLabel_.getElement().getStyle().setMarginBottom(2, Unit.PX);
       
       scratchPath_ = new DirectoryChooserTextBox(
-            "Project scratch path",
+            constants_.scratchPathLabel(),
             ElementIds.TextBoxButtonId.PROJECT_SCRATCH_PATH);
       scratchPath_.setPlaceholder(".Rproj.user");
       scratchPath_.addClearButton();
+      scratchPath_.getElement().setTitle(
+            "You may want to customize the project scratch path if this project is located on a high-latency network filesystem.\n\n" +
+            "Consider using a local filesystem for RStudio's project scratch path.");
       
       if (sessionInfo_.getAllowFullUI())
       {
          container.add(headerLabel(constants_.generalTitle()));
          container.add(spacedBefore(projectNameLabel_));
          container.add(spaced(projectName_));
-         container.add(spaced(scratchPath_));
       }
  
       container.add(headerLabel(constants_.workspaceTitle()));
@@ -110,6 +112,12 @@ public class ProjectGeneralPreferencesPane extends ProjectPreferencesPane
       quitChildProcessesOnExit_ = new CheckBox(constants_.quitChildProcessesOnExitText());
       container.add(nudgeRight(quitChildProcessesOnExit_));
 
+      if (sessionInfo_.getAllowFullUI())
+      {
+         container.add(spacedBefore(headerLabel("Advanced")));
+         container.add(spaced(scratchPath_));
+      }
+      
       add(container);
    }
 
@@ -199,11 +207,11 @@ public class ProjectGeneralPreferencesPane extends ProjectPreferencesPane
 
       config.setQuitChildProcessesOnExit(quitChildProcessesOnExit);
       config.setProjectName(projectName_.getValue());
+      config.setScratchPath(scratchPath_.getText());
       
       if (!StringUtil.equals(scratchPath_.getText(), initialConfig_.getScratchPath()))
       {
          needsRestart = true;
-         config.setScratchPath(scratchPath_.getText());
       }
       
       return new RestartRequirement(needsRestart, needsRestart, needsRestart);


### PR DESCRIPTION
### Intent

This PR allows users to customize the project scratch path used by RStudio for any projects they open. (Typically, this is the `.Rproj.user` folder within a project.)

Addresses: https://github.com/rstudio/rstudio/issues/14778, https://github.com/rstudio/rstudio/issues/7131, https://github.com/rstudio/rstudio/issues/14619

### Approach

This is implemented by allowing for a file located at:

```
.Rproj.user/<userContextId>/scratch-path
```

This path contains a file, which itself is the external location of the `.Rproj.user` directory. Conceptually, it's a symlink, but we handle the path resolution by hand to avoid platform-specific concerns.

This file is read on start-up when resolving the scratch path, and can be set by the user via the project options dialog.

<img width="570" alt="Screenshot 2024-06-20 at 10 38 19 PM" src="https://github.com/rstudio/rstudio/assets/1976582/76ca413f-fd66-4b3d-a3b3-e307053f950b">


Note that both the user-specific and shared scratch data is set when using this setting. For example, after setting the above:

```
$ tree /tmp/renv/
/tmp/renv/
├── 164C4DDE
│   ├── bibliography-index
│   ├── build_options
│   ├── copilot_options
│   ├── cpp-definition-cache
│   ├── ctx
│   ├── explorer-cache
│   ├── pcs
│   │   ├── debug-breakpoints.pper
│   │   ├── files-pane.pper
│   │   ├── source-pane.pper
│   │   ├── windowlayoutstate.pper
│   │   └── workbench-pane.pper
│   ├── persistent-state
│   ├── presentation
│   ├── profiles-cache
│   ├── rmd-outputs
│   ├── saved_source_markers
│   ├── sources
│   │   ├── per
│   │   │   ├── t
│   │   │   └── u
│   │   └── session-9a2db95c
│   │       ├── 4619CA27
│   │       ├── 4619CA27-contents
│   │       └── lock_file
│   ├── tutorial
│   ├── viewer-cache
│   └── viewer_history
└── shared
    └── notebooks
        └── patch-chunk-names

$ (cd ~/r/pkg/renv; tree .Rproj.user/164C4DDE/)
.Rproj.user/164C4DDE/
└── scratch-path
```



### Automated Tests

TODO

### QA Notes

TODO

### Documentation

TODO

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests
