### PR TITLE
use pandoc from PATH if not bundled

### DIFF
--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -1017,7 +1017,6 @@ core::Error adaptToLanguage(const std::string& language);
 // paths to pandoc and pandoc-citeproc suitable for passing to the shell
 // (string_utils::utf8ToSystem has been called on them)
 std::string pandocPath();
-std::string pandocCiteprocPath();
 
 core::Error runPandoc(const std::string& pandocPath,
                       const std::vector<std::string>& args,


### PR DESCRIPTION
To help support builds of RStudio on e.g. Fedora which use external builds of Quarto / pandoc.

Possibly related to https://github.com/rstudio/rstudio/issues/10823.