### PR TITLE
include Quarto in about dialog trademark list

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.ui.xml
@@ -175,7 +175,7 @@
             </g:HTMLPanel>
             <g:HTMLPanel styleName="{style.trademarkNotice}">
                <g:InlineLabel
-                  text="RStudio and Shiny are registered trademarks of Posit Software, PBC, all rights reserved. See">
+                  text="RStudio, Quarto, and Shiny are registered trademarks of Posit Software, PBC, all rights reserved. See">
                </g:InlineLabel>
                <g:Anchor
                   href="https://www.posit.co/about/trademark/"


### PR DESCRIPTION
### Intent

Addresses #14886

### Approach

Add a word (and two commas) to a string.

<img width="641" alt="screenshot of about dialog with arrow pointing at the added text" src="https://github.com/rstudio/rstudio/assets/10569626/c807d6b2-0bb8-4e42-9c6f-693f34ee7e98">

### Automated Tests

NA

### QA Notes

Stare at the About dialog for at least 3 seconds and make sure the new text doesn't vanish.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


