### PR TITLE
document GitHub Education program for Copilot

### DIFF
--- a/docs/user/rstudio/ide/guide/tools/copilot.qmd
+++ b/docs/user/rstudio/ide/guide/tools/copilot.qmd
@@ -8,6 +8,7 @@ date-meta: 2023-08-25
 ## Prerequisites
 
 -   To use GitHub Copilot, you must have a GitHub account and an active subscription to Copilot for Individuals or Copilot for Business. For more information, see [billing for GitHub Copilot](https://docs.github.com/en/billing/managing-billing-for-github-copilot/about-billing-for-github-copilot).
+-   Students and faculty can use GitHub Copilot for free as part of the GitHub Education program. For more information, see the [GitHub Education page](https://education.github.com/).
 -   To use GitHub Copilot in RStudio, you must have a compatible version of RStudio installed. GitHub Copilot is available for RStudio Desktop 2023.09.0 and later. GitHub Copilot is disabled by default in RStudio Server and Posit Workbench, but can be enabled by an administrator.
 -   To use GitHub Copilot, you must have access to the internet in order to send requests to the Copilot APIs and receive suggestions from GitHub Copilot.
 
@@ -294,5 +295,7 @@ function resetClicks() {
 Posit does not provide support or assistance for any code written or generated in RStudio, with or without Copilot. Posit does not support the Copilot output, or test the logic used by Copilot to generate code from prompts.
 
 GitHub Copilot is a proprietary tool from GitHub. If you want to use GitHub Copilot, you need a [subscription for GitHub Copilot](https://docs.github.com/en/billing/managing-billing-for-github-copilot/about-billing-for-github-copilot) in your personal GitHub account or to be assigned a seat by an organization with a subscription for GitHub Copilot for Business. Individual snippets of source code or the contents of entire files may be sent to GitHub's servers to generate suggestions, for more information about how this information is handled, please see the [Copilot Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-copilot-for-business-privacy-statement).
+
+Students and faculty can use GitHub Copilot for free as part of the GitHub Education program. For more information, see the [GitHub Education page](https://education.github.com/).
 
 By using GitHub Copilot, you acknowledge that your use of GitHub Copilot is governed by their terms of service and you agree to abide by their [terms of service](https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#github-copilot). GitHub Copilot is considered “Third Party Materials” as defined in the [RStudio End User License Agreement](https://posit.co/about/eula/) and Posit assumes no liability or other obligations with respect thereto and, without limiting the foregoing, is not liable for any loss or damage resulting from the use or access thereof.


### PR DESCRIPTION
### Intent

Addresses [Docs: GitHub Copilot free for students and faculty #14302](https://github.com/rstudio/rstudio/issues/14302)

### Approach

Added same text in two places: (1) prerequisites near beginning of page and (2) "support and terms of service" near end of page.

> Students and faculty can use GitHub Copilot for free as part of the GitHub Education program. For more information, see the [GitHub Education page](https://education.github.com/).

### Automated Tests

NA

### QA Notes

Copilot page in user guide

### Documentation

Yes it is

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


