### PR TITLE
handle empty labels for headers with attributes

### DIFF
--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -923,14 +923,14 @@ var RCodeModel = function(session, tokenizer,
                   continue;
             }
 
-            // Add to scope tree.
-            if (label.length === 0)
-               label = "(Untitled)";
-
             // Trim off Markdown IDs from the label.
             var reBraces = /{.*}\s*$/;
             label = label.replace(reBraces, "");
 
+            // Make sure we have a non-empty label
+            label = label || "(Untitled)"
+
+            // Add to scope tree
             this.$scopes.onMarkdownHead(label, labelStartPos, labelEndPos, depth, true);
          }
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13159.

### Approach

Make sure we set empty labels to "(Untitled)" only after removing a trailing `{}` attribute block.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13159.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
