### PR TITLE
ensure output from restart commands is printed appropriately

### DIFF
--- a/src/cpp/r/RExec.cpp
+++ b/src/cpp/r/RExec.cpp
@@ -119,8 +119,6 @@ private:
    r::sexp::PreservedSEXP preservedSEXP_;
 };
 
-namespace {
-
 struct ParseStringData
 {
    SEXP codeSEXP;
@@ -143,7 +141,7 @@ Error parseString(const std::string& code, SEXP* pSEXP, sexp::Protect* pProtect)
    SEXP codeSEXP = sexp::create(code, pProtect);
 
    // NOTE: R_ParseVector can emit an R parse error, so we need
-   // to defend againts such longjmps here
+   // to defend against such longjmps here
    ParseStringData parseData;
    parseData.codeSEXP = codeSEXP;
    parseData.resultSEXP = R_NilValue;
@@ -174,6 +172,7 @@ Error parseString(const std::string& code, SEXP* pSEXP, sexp::Protect* pProtect)
    return Success();
 }
 
+namespace {
 
 // evaluate expressions without altering the error handler (use with caution--
 // a user-supplied error handler may be invoked if the expression raises

--- a/src/cpp/r/include/r/RExec.hpp
+++ b/src/cpp/r/include/r/RExec.hpp
@@ -88,6 +88,10 @@ inline EvalFlags operator|(EvalFlags lhs, EvalFlags rhs)
    return static_cast<EvalFlags>(static_cast<int>(lhs) | static_cast<int>(rhs));
 }
 
+core::Error parseString(const std::string& code,
+                        SEXP* pSEXP,
+                        sexp::Protect* pProtect);
+
 core::Error executeString(const std::string& str);
 
 core::Error evaluateString(const std::string& str,

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -268,8 +268,15 @@ Error executeAfterRestartCommand(const std::string& command)
    if (error)
       return error;
    
+   // if parsing returns an EXPRSXP, then we want to just evaluate the
+   // first element of that expression vector
+   if (TYPEOF(parsedSEXP) == EXPRSXP)
+   {
+      parsedSEXP = VECTOR_ELT(parsedSEXP, 0);
+   }
+   
    SEXP resultSEXP = R_NilValue;
-   protect.add(resultSEXP = Rf_eval(VECTOR_ELT(parsedSEXP, 0), R_GlobalEnv));
+   protect.add(resultSEXP = Rf_eval(parsedSEXP, R_GlobalEnv));
    if (resultSEXP == R_NilValue)
       return Success();
    
@@ -285,7 +292,7 @@ Error executeAfterRestartCommand(const std::string& command)
       if (error)
          return error;
       
-      Rf_PrintValue(valueSEXP);
+      r::sexp::printValue(valueSEXP);
    }
    
    return Success();


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14636#issuecomment-2165908592.

### Approach

Previously, restart commands were executed via a basic "send to console" RPC request. However, now that we're trying to sequence command execution (and output) during session restore, we need to more manually take control of console input + output presentation in the console. This PR attempts to accomplish that.

This PR makes use of:

- `base::try()`, which allows us to catch R errors and avoid longjmps past our C++ stack frames;
- `base::withVisible()`, which captures an R result with a "visible" flag which lets us know if R would have printed that result in a "regular" REPL execution.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14636#issuecomment-2165908592.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
