### PR TITLE
Clean of some diagnostics in OS

### DIFF
--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -2646,6 +2646,7 @@ void resetKeyring()
    // just in case permanentlyDropPrivs was used to change back to root for some reason
    if (realUserIsRoot())
       return;
+
    /*
     * Create a new session keyring, replacing the one owned by root. When the name arg is NULL, an anonymous keyring
     * is created and attached to the process.
@@ -2655,7 +2656,10 @@ void resetKeyring()
                      NULL);
    if (ret < 0)
    {
-      LOG_ERROR_MESSAGE("Unable to create new session keyring - errno: " + std::to_string(errno));
+      // EPERM is returned in a docker container when SYS_ADMIN capability is not present. In that case, nothing in
+      // the container can change the keyring omitting the error in that case.
+      if (errno != EPERM)
+         LOG_ERROR_MESSAGE("Unable to create new session keyring - errno: " + std::to_string(errno));
       return;
    }
 

--- a/src/cpp/core/system/User.cpp
+++ b/src/cpp/core/system/User.cpp
@@ -142,7 +142,6 @@ Error updateUserCacheByUsername(const std::string& in_username, User& out_user, 
    if (!error)
    {
       addUserToCache(out_user);
-      LOG_DEBUG_MESSAGE(opNameForLog + " user to cache for user: " + in_username + ":" + std::to_string(out_user.getUserId()) + " by name");
 
       return Success();
    }
@@ -159,7 +158,6 @@ Error updateUserCacheByUserId(const UidType& in_userId, User& out_user, const st
    if (!error)
    {
       addUserToCache(out_user);
-      LOG_DEBUG_MESSAGE("Added user: " + out_user.getUsername() + ":" + std::to_string(in_userId) + " from id lookup");
 
        return Success();
    }

--- a/src/cpp/core/system/Xdg.cpp
+++ b/src/cpp/core/system/Xdg.cpp
@@ -214,7 +214,7 @@ FilePath resolveXdgPath(
       if (file)
          resolvedXdgPath = rstudioXdgPath.completePath(file.get());
       
-      DLOGF("Using RStudio XDG path: {} => {}", rstudioEnvVar, resolvedXdgPath.getAbsolutePath());
+      //DLOGF("Using RStudio XDG path: {} => {}", rstudioEnvVar, resolvedXdgPath.getAbsolutePath());
       return resolveXdgDirImpl(resolvedXdgPath, user, homeDir, suffix);
    }
    
@@ -255,7 +255,8 @@ FilePath resolveXdgPath(
       FilePath resolvedXdgPath = xdgPath.completePath(targetFile);
       if (resolvedXdgPath.exists())
       {
-         DLOGF("Using pre-existing XDG path: {} => {}", xdgEnvVar, resolvedXdgPath.getAbsolutePath());
+         // This is the common case so not logging here
+         // DLOGF("Using pre-existing XDG path: {} => {}", xdgEnvVar, resolvedXdgPath.getAbsolutePath());
          return resolveXdgDirImpl(resolvedXdgPath, user, homeDir, suffix);
       }
    }
@@ -271,7 +272,7 @@ FilePath resolveXdgPath(
          if (xdgPath.exists())
          {
             FilePath resolvedXdgPath = FilePath(xdgPath).completePath(targetFile);
-            DLOGF("Using new XDG path: {} => {}", xdgEnvVar, resolvedXdgPath.getAbsolutePath());
+            //DLOGF("Using new XDG path: {} => {}", xdgEnvVar, resolvedXdgPath.getAbsolutePath());
             return resolveXdgDirImpl(resolvedXdgPath, user, homeDir, suffix);
          }
       }
@@ -279,7 +280,7 @@ FilePath resolveXdgPath(
    
    // If none of the provided directories exist (very unexpected!) use the default.
    FilePath resolvedXdgPath = xdgDefaultHome.completePath(targetFile);
-   DLOGF("Using fallback XDG path: {}", xdgDefaultHome.getAbsolutePath());
+   //DLOGF("Using fallback XDG path: {}", xdgDefaultHome.getAbsolutePath());
    return resolveXdgDirImpl(resolvedXdgPath, user, homeDir, suffix);
 }
 

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -201,7 +201,15 @@ void handleClientInit(const boost::function<void()>& initFunction,
 
    // calculate initialization parameters
    std::string clientId = persistentState().newActiveClientId();
-   bool resumed = suspend::sessionResumed() || init::isSessionInitialized();
+   // session was previously suspended
+   bool resumed = suspend::sessionResumed();
+   bool isSessionInitialized = init::isSessionInitialized();
+
+   LOG_DEBUG_MESSAGE("Begin /rpc/client_init for client: " + clientId + ": initialized: " + std::to_string(isSessionInitialized) + " resumed: " + std::to_string(resumed));
+
+   // resumed now also means re-joining
+   if (isSessionInitialized)
+     resumed = true;
 
    // if we are resuming then we don't need to worry about events queued up
    // by R during startup (e.g. printing of the banner) being sent to the
@@ -699,6 +707,8 @@ void handleClientInit(const boost::function<void()>& initFunction,
    
    // call the init function
    initFunction();
+
+   LOG_DEBUG_MESSAGE("End /rpc/client_init for client: " + clientId);
 }
 
 } // namespace init

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -210,6 +210,9 @@ bool s_copilotEnabled = false;
 // Whether Copilot has been allowed to index project files.
 bool s_copilotIndexingEnabled = false;
 
+// Have we checked the config files at least once
+bool s_copilotInitialized = false;
+
 // The PID of the active Copilot agent process.
 PidType s_agentPid = -1;
 
@@ -923,7 +926,7 @@ void stopAgent()
 {
    if (s_agentPid == -1)
    {
-      DLOG("No agent running; nothing to do.");
+      //DLOG("No agent running; nothing to do.");
       return;
    }
 
@@ -1070,21 +1073,29 @@ bool ensureAgentRunning(Error* pAgentLaunchError = nullptr)
    // with a running Copilot process, or just handle that separately?
    if (s_agentPid != -1)
    {
-      DLOG("Copilot is already running; nothing to do.");
+      //DLOG("Copilot is already running; nothing to do.");
       return true;
    }
 
    // bail if we haven't enabled copilot
    if (!s_copilotEnabled)
    {
-      DLOG("Copilot is not enabled; not starting agent.");
+      if (!s_copilotInitialized)
+      {
+         DLOG("Copilot is not enabled; not starting agent.");
+         s_copilotInitialized = true;
+      }
       return false;
    }
 
    // bail if we're shutting down
    if (s_isSessionShuttingDown)
    {
-      DLOG("Session is shutting down; not starting agent.");
+      if (!s_copilotInitialized)
+      {
+         DLOG("Session is shutting down; not starting agent.");
+         s_copilotInitialized = true;
+      }
       return false;
    }
 
@@ -1095,6 +1106,7 @@ bool ensureAgentRunning(Error* pAgentLaunchError = nullptr)
    if (pAgentLaunchError)
       *pAgentLaunchError = error;
    
+   s_copilotInitialized = true;
    return error == Success();
 }
 


### PR DESCRIPTION
### Intent

- removed error for EPERM when resetting keyring: https://github.com/rstudio/rstudio-pro/issues/6444

- removed user cache and xdg debug messages since they show up at weird times like in rserver-launcher that go to stderr and look like errors in the application

For the XDG messages, I believe we should log the location of the config file once it's found, rather than the search process.

- Added debug messages for the all important client_init request

- The session copilot messages are useful, but only log them once by keeping track of whether we've initialized it or not.

### Approach

removed one error, added two new debug logs, and removed a number of debug logs. No code logic changes. 

### Automated Tests

Automation should cover these changes
