### PR TITLE
Fix file save/load issues in Desktop with certain folder combinations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,7 @@
 - Moved the "Sign commit" checkbox to Git/Svn global options panel (##14559)
 - RStudio's editor highlighting no longer accepts embedded spaces in '#|' comment prefixes. (#14592)
 - RStudio now preserves a file's existing line endings when performing a Find and Replace. (#14796)
+- Fixed an issue with loading and saving files to folders whose path partially patches the user's home folder (#14764)
 - Fixed an issue where headers without a label in R Markdown documents were not shown in the scope tree. (#13159)
 - Fixed an issue where ggplot2 aesthetic completions were not provided for plots assigned to a variable. (#14566)
 

--- a/src/node/desktop/.vscode/settings.json
+++ b/src/node/desktop/.vscode/settings.json
@@ -74,7 +74,8 @@
 
   // Help Windows find node, npm
   "terminal.integrated.env.windows": {
-    "PATH": "${workspaceFolder}\\..\\..\\..\\dependencies\\common\\node\\16.20.2;${env:PATH}"
+    "PATH": "${workspaceFolder}\\..\\..\\..\\dependencies\\common\\node\\18.20.3;${env:PATH}"
   },
-  "cmake.configureOnOpen": false
+  "cmake.configureOnOpen": false,
+  "r.lsp.promptToInstall": false
 }

--- a/src/node/desktop/.vscode/settings.json
+++ b/src/node/desktop/.vscode/settings.json
@@ -74,7 +74,7 @@
 
   // Help Windows find node, npm
   "terminal.integrated.env.windows": {
-    "PATH": "${workspaceFolder}\\..\\..\\..\\dependencies\\common\\node\\18.20.3;${env:PATH}"
+    "PATH": "${workspaceFolder}\\..\\..\\..\\dependencies\\common\\node\\20.14.0;${env:PATH}"
   },
   "cmake.configureOnOpen": false,
   "r.lsp.promptToInstall": false

--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -23,6 +23,7 @@ import { userHomePath } from './user';
 import { err, Expected, ok } from './expected';
 import os from 'os';
 import { randomString } from '../main/utils';
+import { createAliasedPath, normalizeSeparators, normalizeSeparatorsNative } from '../ui/utils';
 
 /** An Error containing 'path' that triggered the error */
 export class FilePathError extends Error {
@@ -33,30 +34,7 @@ export class FilePathError extends Error {
   }
 }
 
-const homePathAlias = '~/';
 const homePathLeafAlias = '~';
-
-/**
- * Normalize separators of a given path.
- *
- * @param {string} path
- * @param {string} [separator='/']
- * @return {*}
- */
-function normalizeSeparators(path: string, separator = '/') {
-  return path.replace(/[\\/]/g, separator);
-}
-
-/**
- * Normalizes separators of a given path based on the current platform.
- *
- * @export
- * @param {string} path
- * @return {*}
- */
-export function normalizeSeparatorsNative(path: string) {
-  return normalizeSeparators(path, sep);
-}
 
 /**
  * Creates a random file name located in the tmp directory
@@ -108,21 +86,7 @@ export class FilePath {
     // first, retrieve and normalize paths
     const file = filePath.getAbsolutePath();
     const home = userHomePath.getAbsolutePath();
-    if (file === home) {
-      return homePathLeafAlias;
-    }
-
-    // try to compute home-relative path -- if that fails,
-    // or the computed path does not appear to be relative,
-    // then just return the original file path
-    const relative = path.relative(home, file);
-    if (!relative || path.isAbsolute(relative) || relative.startsWith('..')) {
-      return file;
-    }
-
-    // we computed a relative path; prefix it with tilde
-    const aliased = path.join(homePathLeafAlias, relative);
-    return normalizeSeparators(aliased);
+    return createAliasedPath(file, home);
   }
 
   /**

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -29,13 +29,14 @@ import {
 } from 'electron';
 import { IpcMainEvent, MessageBoxOptions, OpenDialogOptions, SaveDialogOptions } from 'electron/main';
 import EventEmitter from 'events';
-import { existsSync, writeFile, writeFileSync } from 'fs';
+import { existsSync, writeFileSync } from 'fs';
 import { platform, release } from 'os';
 import i18next from 'i18next';
 import { findFontsSync } from 'node-system-fonts';
 import path, { dirname } from 'path';
 import { pathToFileURL } from 'url';
-import { FilePath, normalizeSeparatorsNative, tempFilename } from '../core/file-path';
+import { FilePath, tempFilename } from '../core/file-path';
+import { normalizeSeparatorsNative } from '../ui/utils';
 import { logger } from '../core/logger';
 import { isCentOS } from '../core/system';
 import { resolveTemplateVar } from '../core/template-filter';

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -19,7 +19,7 @@ import Store from 'electron-store';
 import { existsSync, lstatSync } from 'fs';
 import { basename, dirname, join } from 'path';
 import { properties } from '../../../../../cpp/session/resources/schema/user-state-schema.json';
-import { normalizeSeparatorsNative } from '../../core/file-path';
+import { normalizeSeparatorsNative } from '../../ui/utils';
 import { logger } from '../../core/logger';
 import { RStudioUserState } from '../../types/user-state-schema';
 

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -34,6 +34,16 @@ function reportIpcError(name: string, error: Error) {
 function resolveAliasedPath(filePath: string, userHomePath: string) {
   filePath = normalizeSeparators(filePath);
   const expandedHomePath = normalizeSeparators(userHomePath || '', '/');
+  if (expandedHomePath.length && filePath.startsWith(expandedHomePath)) {
+    filePath = '~' + filePath.substring(expandedHomePath.length);
+  }
+  return filePath;
+}
+
+
+function resolveAliasedPathNew(filePath: string, userHomePath: string) {
+  filePath = normalizeSeparators(filePath);
+  const expandedHomePath = normalizeSeparators(userHomePath || '', '/');
   if (expandedHomePath.length) {
     if (expandedHomePath === filePath) {
       return '~';

--- a/src/node/desktop/src/ui/utils.ts
+++ b/src/node/desktop/src/ui/utils.ts
@@ -13,6 +13,8 @@
  *
  */
 
+/****** NOTE: This code cannot use node.js. It is invoked from the renderer process. ******/
+
 const isLocalStorageItemSet = (key: string) => {
   if (typeof window !== 'undefined') {
     const value = window.localStorage.getItem(key);
@@ -69,6 +71,31 @@ export function normalizeSeparators(path: string, separator = '/') {
     path = path.substring(2);
   }
   return `${prefix}${path.replace(/[\\/]+/g, separator)}`;
+}
+
+/**
+ * Creates a path in which the user home path will be replaced by the ~ alias.
+ */
+export function createAliasedPath(filePath: string, userHomePath: string): string {
+  // first, retrieve and normalize paths
+  filePath = normalizeSeparators(filePath);
+  let home = normalizeSeparators(userHomePath || '');
+  if (home.endsWith('/')) {
+    home = home.slice(0, -1); // remove trailing slash
+  }
+
+  if (filePath === home) {
+    return '~';
+  }
+
+  if (filePath.startsWith(home)) {
+    // watch out for case where homepath is /user/foo and filePath is /user/foobar/
+    const remainingPath = filePath.substring(home.length);
+    if (remainingPath.startsWith('/')) {
+      filePath = '~' + filePath.substring(home.length);
+    }
+  }
+  return normalizeSeparators(filePath);
 }
 
 /**

--- a/src/node/desktop/src/ui/utils.ts
+++ b/src/node/desktop/src/ui/utils.ts
@@ -80,8 +80,13 @@ export function createAliasedPath(filePath: string, userHomePath: string): strin
   // first, retrieve and normalize paths
   filePath = normalizeSeparators(filePath);
   let home = normalizeSeparators(userHomePath || '');
+
+  // remove trailing slashes
+  if (filePath.endsWith('/')) {
+    filePath = filePath.slice(0, -1);
+  }
   if (home.endsWith('/')) {
-    home = home.slice(0, -1); // remove trailing slash
+    home = home.slice(0, -1);
   }
 
   if (filePath === home) {

--- a/src/node/desktop/test/unit/core/file-path.test.ts
+++ b/src/node/desktop/test/unit/core/file-path.test.ts
@@ -23,7 +23,8 @@ import path from 'path';
 
 import { clearCoreSingleton } from '../../../src/core/core-state';
 import { isFailure, isSuccessful } from '../../../src/core/err';
-import { FilePath, normalizeSeparatorsNative } from '../../../src/core/file-path';
+import { FilePath } from '../../../src/core/file-path';
+import { normalizeSeparatorsNative } from '../../../src/ui/utils';
 import { NullLogger, setLogger } from '../../../src/core/logger';
 import { userHomePath } from '../../../src/core/user';
 import { randomString } from '../../../src/main/utils';
@@ -665,6 +666,13 @@ describe('FilePath', () => {
 
     it('Original path returned is aliasing fails', () => {
       const path = new FilePath('/home/other/path/to/project');
+      const home = new FilePath('/home/user');
+      const aliasedPath = FilePath.createAliasedPath(path, home);
+      assert(new FilePath(aliasedPath).getAbsolutePath() === path.getAbsolutePath());
+    });
+
+    it('Path that matches homepath prefix does not get an alias', () => {
+      const path = new FilePath('/home/user2/path/to/project');
       const home = new FilePath('/home/user');
       const aliasedPath = FilePath.createAliasedPath(path, home);
       assert(new FilePath(aliasedPath).getAbsolutePath() === path.getAbsolutePath());

--- a/src/node/desktop/test/unit/core/file-path.test.ts
+++ b/src/node/desktop/test/unit/core/file-path.test.ts
@@ -643,6 +643,28 @@ describe('FilePath', () => {
       assert(aliasedPath === '~/path/to/project');
     });
 
+    it('Home folder path is aliased correctly', () => {
+      const path = new FilePath('/Users/user');
+      const home = new FilePath('/Users/user');
+      const aliasedPath = FilePath.createAliasedPath(path, home);
+      assert(aliasedPath === '~');
+    });
+
+    it('DOS paths are aliased correctly', () => {
+      const path = new FilePath('C:\\Users\\user\\Documents\\path\\to\\project');
+      const home = new FilePath('C:\\Users\\user\\Documents');
+      const aliasedPath = FilePath.createAliasedPath(path, home);
+      assert(aliasedPath === '~/path/to/project');
+    });
+
+    it('DOS home folder path is aliased correctly', () => {
+      const path = new FilePath('C:\\Users\\user\\Documents');
+      const home = new FilePath('C:\\Users\\user\\Documents');
+      const aliasedPath = FilePath.createAliasedPath(path, home);
+      assert(aliasedPath === '~');
+    });
+
+
     it('Paths are aliased correctly, even with trailing slash on home folder', () => {
       const path = new FilePath('/Users/user/path/to/project');
       const home = new FilePath('/Users/user/');

--- a/src/node/desktop/test/unit/core/file-path.test.ts
+++ b/src/node/desktop/test/unit/core/file-path.test.ts
@@ -643,8 +643,22 @@ describe('FilePath', () => {
       assert(aliasedPath === '~/path/to/project');
     });
 
-    it('Paths are aliased correctly, even with trailing slashes', () => {
+    it('Paths are aliased correctly, even with trailing slash on home folder', () => {
       const path = new FilePath('/Users/user/path/to/project');
+      const home = new FilePath('/Users/user/');
+      const aliasedPath = FilePath.createAliasedPath(path, home);
+      assert(aliasedPath === '~/path/to/project');
+    });
+
+    it('Paths are aliased correctly, even with trailing slash on folder', () => {
+      const path = new FilePath('/Users/user/path/to/project/');
+      const home = new FilePath('/Users/user');
+      const aliasedPath = FilePath.createAliasedPath(path, home);
+      assert(aliasedPath === '~/path/to/project');
+    });
+
+    it('Paths are aliased correctly, even with trailing slashes on both folders', () => {
+      const path = new FilePath('/Users/user/path/to/project/');
       const home = new FilePath('/Users/user/');
       const aliasedPath = FilePath.createAliasedPath(path, home);
       assert(aliasedPath === '~/path/to/project');

--- a/src/node/desktop/test/unit/main/desktop-options.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-options.test.ts
@@ -19,7 +19,8 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import { properties } from '../../../../../cpp/session/resources/schema/user-state-schema.json';
 import { Err, isSuccessful } from '../../../src/core/err';
-import { FilePath, normalizeSeparatorsNative } from '../../../src/core/file-path';
+import { FilePath } from '../../../src/core/file-path';
+import { normalizeSeparatorsNative } from '../../../src/ui/utils';
 import DesktopOptions from '../../../src/main/preferences/desktop-options';
 import {
   clearOptionsSingleton,


### PR DESCRIPTION
### Intent

Addresses [Cannot save files to certains paths that worked in previous release #14764](https://github.com/rstudio/rstudio/issues/14764)

Note, this has been broken since the move to Electron.

### Approach

Our test to see if a path was in the user's home folder relied on a `startsWith()` check that didn't take into account the possibility of something like:

- home folder: `/Users/gary`
- folder containing files to save/load: `/Users/garywashere`

When asked to alias `/Users/garywashere` our old code would return `~washere` leading to i/o errors.

As part of the fix I consolidated duplicate implementations; we had some in `FilePath` class (which uses node.js thus can't be used from the renderer process), and some in `ui/util.ts` and `desktop-bridge` (both of which cannot use node). Moved the common implementation to `ui/util.ts` and use it from elsewhere (including existing unit tests).

### Automated Tests

Added more unit tests, and confirmed the integrated desktop automation is still passing as well.

### QA Notes

See [the issue](https://github.com/rstudio/rstudio/issues/14764) for various scenarios to test. This is a Desktop-only change (no code was touched that impacts Server or Workbench). Recommend testing both on Windows and at least one of Linux and macOS.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


