### PR TITLE
use more prominent background highlight color

### DIFF
--- a/src/cpp/session/resources/R.css
+++ b/src/cpp/session/resources/R.css
@@ -81,6 +81,12 @@ h6 {
    color: #FFF;
 }
 
+/* Force a more prominent background color for selected text. */
+/* This is also used for text search in the Help pane. */
+.rstudio-themes-flat.rstudio-themes-dark.editor_dark.ace_editor_theme ::selection {
+   background: rgb(71, 98, 135) !important;
+}
+
 img.toplogo {
    max-width: 4em;
    vertical-align: middle;


### PR DESCRIPTION
Addresses https://github.com/rstudio/rstudio/issues/13204.

## Before
<img width="779" alt="Screenshot 2024-07-05 at 12 22 12 PM" src="https://github.com/rstudio/rstudio/assets/1976582/03054da5-45d4-4d33-b74c-6dd564f80f7e">

## After
<img width="781" alt="Screenshot 2024-07-05 at 12 21 51 PM" src="https://github.com/rstudio/rstudio/assets/1976582/2042e599-508f-4d05-8bec-1f4a6fd05044">
