### PR TITLE
don't reset 'end' when adding node

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -67,6 +67,7 @@
 - Fixed an issue where RStudio could launch with an incorrect initial working directory when using multiple sessions. (#14695)
 - Fixed an issue where ggplot2 aesthetic completions were not provided for plots assigned to a variable. (#14566)
 - Fixed an issue where attempting to inspect a list-column entry in a View()-ed data.frame with custom row names would fail. (#14509)
+- Fixed an issue where the document outline in Quarto documents could incorrectly render in very long documents in some scenarios. (#14906)
 
 #### Posit Workbench
 

--- a/src/gwt/acesupport/acemode/r_scope_tree.js
+++ b/src/gwt/acesupport/acemode/r_scope_tree.js
@@ -113,16 +113,6 @@ define('mode/r_scope_tree', ["require", "exports", "module"], function(require, 
          if (this.equals(node))
             return;
 
-         // It's possible for this node to be already closed. If that's the
-         // case, we need to open it back up. Example:
-         //
-         // foo <- function() { bar <- function [HERE] }) {
-         //
-         // If [HERE] is replaced with (, then the final brace will cause this
-         // situation to be triggered because the previous brace belonged to
-         // foo but no longer does.
-         this.end = null;
-
          var index = this.$binarySearch(node.preamble);
          if (index >= 0) {
             // This node belongs inside an existing child


### PR DESCRIPTION
Addresses https://github.com/rstudio/rstudio/issues/14906.

As far as I can see, this change resolves the above issue, and (from some manual testing) doesn't regress anything. The provided code example in comments also seems to function as expected.

Do we think we have enough runway to try merging this and see if any issues fall out?