### PR TITLE
Adds socket option to rserver

### DIFF
--- a/src/cpp/server/ServerInit.cpp
+++ b/src/cpp/server/ServerInit.cpp
@@ -37,7 +37,9 @@ http::AsyncServer* httpServerCreate(const http::Headers& additionalHeaders)
                                  core::FileMode::USER_READ_WRITE_EXECUTE,
                                  !options().wwwEnableOriginCheck(),
                                  options().wwwAllowedOrigins(),
-                                 additionalHeaders);
+                                 additionalHeaders,
+                                 options().statsMonitorSeconds(),
+                                 metrics::statsProvider());
    } else {
       return new http::TcpIpAsyncServer("RStudio",
                                  std::string(),

--- a/src/cpp/server/include/server/ServerOptions.gen.hpp
+++ b/src/cpp/server/include/server/ServerOptions.gen.hpp
@@ -102,6 +102,9 @@ protected:
       ("www-port",
       value<std::string>(&wwwPort_)->default_value(""),
       "The port that RStudio Server will bind to while listening for incoming connections. If left empty, the port will be automatically determined based on your SSL settings (443 for SSL, 80 for no SSL).")
+      ("www-socket",
+      value<std::string>(&wwwSocket_)->default_value(""),
+      "The socket that RStudio Server will bind to while listening for incoming connections. If left empty, a socket will not be used but a port instead.")
       ("www-root-path",
       value<std::string>(&wwwRootPath_)->default_value(kRequestDefaultRootPath),
       "The path prefix added by a proxy to the incoming RStudio URL. This setting is used so RStudio Server knows what path it is being served from. If running RStudio Server behind a path-modifying proxy, this should be changed to match the base RStudio Server URL.")
@@ -303,6 +306,7 @@ protected:
    std::vector<std::string> serverAddHeaders_;
    std::string wwwAddress_;
    std::string wwwPort_;
+   std::string wwwSocket_;
    std::string wwwRootPath_;
    std::string wwwLocalPath_;
    std::string wwwSymbolMapsPath_;

--- a/src/cpp/server/include/server/ServerOptions.hpp
+++ b/src/cpp/server/include/server/ServerOptions.hpp
@@ -71,6 +71,11 @@ public:
       }
    }
 
+   std::string wwwSocket() const
+   {
+      return wwwSocket_;
+   }
+
    std::string monitorSharedSecret() const
    {
       return monitorSharedSecret_;

--- a/src/cpp/server/server-options.json
+++ b/src/cpp/server/server-options.json
@@ -114,6 +114,14 @@
             "description": "The port that RStudio Server will bind to while listening for incoming connections. If left empty, the port will be automatically determined based on your SSL settings (443 for SSL, 80 for no SSL)."
          },
          {
+            "name": "www-socket",
+            "memberName": "wwwSocket_",
+            "type": "string",
+            "defaultValue": "",
+            "skipAccessorGeneration": true,
+            "description": "The socket that RStudio Server will bind to while listening for incoming connections. If left empty, a port will be used."
+         },
+         {
             "name": "www-root-path",
             "memberName": "wwwRootPath_",
             "type": "string",


### PR DESCRIPTION
### Intent

This PR adds the option `www-socket` to allow `rserver` to listen on a unix socket. 

### Approach

It extends `httpServerCreate(..)` to create an instance of `http::LocalStreamAsyncServer` beside `http::TcpIpAsyncServer` if `rserver` is asked to connect through a unix socket.

### Automated Tests
n/a

### QA Notes
n/a

### Documentation
n/a

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


