### PR TITLE
propagate source references into s3 methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -72,6 +72,7 @@
 - Fixed an issue where the document outline in Quarto documents could incorrectly render in very long documents in some scenarios. (#14906)
 - Fixed an issue with a once-in-a-long-while auto-save error dialog. (rstudio-pro#6468)
 - Fixed an issue with linux PAM session error handling. (#12116)
+- Fixed an issue where the RStudio debugger location could be incorrect when debugging a package's S3 method. (#14499)
 
 #### Posit Workbench
 


### PR DESCRIPTION
### Intent

Addresses #14499.

### Approach

For S3 methods, R will place a separate copy of that function within the `.__S3MethodsTable__.` table for the package's namespace. Unfortunately, because it's a copy, mutating the function body for the version that lives in the package namespace doesn't also mutate the version in the methods table. It seems like this might be something that's changed in recent versions of R, given that this code hasn't changed in many moons.

### Automated Tests

Not included.

### QA Notes

Test via notes in #14499.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

