### PR TITLE
Publish noble builds under their own OS on the dailies page

### DIFF
--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -356,6 +356,7 @@ pipeline {
                         script {
                           // publish build to dailies page
                           utils.publishToDailiesSite PACKAGE_FILE, DAILIES_PATH, AWS_PATH
+                          utils.optionalPublishToDailies PACKAGE_FILE, DAILIES_PATH, AWS_PATH
                         }
                       }
 
@@ -363,6 +364,7 @@ pipeline {
                         script {
                           if (FLAVOR == "Electron") {
                             utils.publishToDailiesSite TAR_PACKAGE_FILE, "${DAILIES_PATH}-xcopy", AWS_PATH
+                            utils.optionalPublishToDailies PACKAGE_FILE, "${DAILIES_PATH}-xcopy", AWS_PATH
                           }
                         }
                       }

--- a/jenkins/utils.groovy
+++ b/jenkins/utils.groovy
@@ -155,6 +155,21 @@ def publishToDailiesSite(String packageFile, String destinationPath, String urlP
 }
 
 /**
+ * Sometimes a specific OS/ARCH/FLAVOR needs to do an additional publish.
+ * Handle that here.
+ */
+def optionalPublishToDailies(String packageFile, String destinationPath, String urlPath = '') {
+  // Noble and Jammy use the same binaries. Re-publish jammy builds under the noble path on the dailies site.
+  if (env.OS == "jammy") {
+    def noble_dalies_path = "${env.PRODUCT}/noble-${getArchForOs(env.OS, env.ARCH)}"
+    if (destinationPath.contains("-xcopy")) {
+      noble_dalies_path = "${noble_dalies_path}-xcopy"
+    }
+    publishToDailiesSite(packageFile, noble_dalies_path, urlPath)
+  }
+}
+
+/**
  * Return true if the file at the URL exists. Return false otherwise
  */
 def urlExists(String url) {


### PR DESCRIPTION
### Intent

First half of https://github.com/rstudio/rstudio-pro/issues/6566

### Approach

After uploading the jammy build to AWS and dailies page, the jammy build will make another entry for noble on the dailies page. Notably, this does not re-upload the same binary to S3. The noble link on the dailies page will instead point to the jammy build already in S3.

### Automated Tests

N/A Build change

### QA Notes

N/A for now. Build change

### Documentation

N/A Build change

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


