### PR TITLE
UNC path handling fixes in Electron desktop code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 ### Fixed
 #### RStudio
 - Fixed being unable to save file after cancelling the "Choose Encoding" window (#14896)
+- Fixed problems creating new files and projects on a UNC path (#14963, #14964; Windows Desktop)
 
 #### Posit Workbench
 -

--- a/src/node/desktop/src/ui/utils.ts
+++ b/src/node/desktop/src/ui/utils.ts
@@ -64,9 +64,9 @@ export const checkForNewLanguage = async () => {
  * @return {*}
  */
 export function normalizeSeparators(path: string, separator = '/') {
-  // don't mess with leading '\\' on a UNC path
+  // don't mess with leading '\\' or '//' on a UNC path
   let prefix = '';
-  if (path.startsWith('\\\\')) {
+  if (path.startsWith('\\\\') || path.startsWith('//')) {
     prefix = `${separator}${separator}`;
     path = path.substring(2);
   }

--- a/src/node/desktop/test/unit/ui/utils.test.ts
+++ b/src/node/desktop/test/unit/ui/utils.test.ts
@@ -1,0 +1,181 @@
+/*
+ * utils.test.ts
+ *
+ * Copyright (C) 2024 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { assert } from 'chai';
+import { describe } from 'mocha';
+
+import { NullLogger, setLogger } from '../../../src/core/logger';
+import { createAliasedPath, normalizeSeparators } from '../../../src/ui/utils';
+
+describe('utils', () => {
+  before(() => {
+    setLogger(new NullLogger());
+  });
+
+  afterEach(() => {
+    // make sure we leave cwd in a valid place
+    process.chdir(__dirname);
+  });
+
+  describe('Aliased paths', () => {
+    it('Paths are aliased correctly', () => {
+      const path = '/Users/user/path/to/project';
+      const home = '/Users/user';
+      const aliasedPath = createAliasedPath(path, home);
+      assert(aliasedPath === '~/path/to/project');
+    });
+
+    it('Home folder path is aliased correctly', () => {
+      const path = '/Users/user';
+      const home = '/Users/user';
+      const aliasedPath = createAliasedPath(path, home);
+      assert(aliasedPath === '~');
+    });
+
+    it('DOS paths are aliased correctly', () => {
+      const path = 'C:\\Users\\user\\Documents\\path\\to\\project';
+      const home = 'C:\\Users\\user\\Documents';
+      const aliasedPath = createAliasedPath(path, home);
+      assert(aliasedPath === '~/path/to/project');
+    });
+
+    it('DOS home folder path is aliased correctly', () => {
+      const path = 'C:\\Users\\user\\Documents';
+      const home = 'C:\\Users\\user\\Documents';
+      const aliasedPath = createAliasedPath(path, home);
+      assert(aliasedPath === '~');
+    });
+
+
+    it('Paths are aliased correctly, even with trailing slash on home folder', () => {
+      const path = '/Users/user/path/to/project';
+      const home = '/Users/user/';
+      const aliasedPath = createAliasedPath(path, home);
+      assert(aliasedPath === '~/path/to/project');
+    });
+
+    it('Paths are aliased correctly, even with trailing slash on folder', () => {
+      const path = '/Users/user/path/to/project/';
+      const home = '/Users/user';
+      const aliasedPath = createAliasedPath(path, home);
+      assert(aliasedPath === '~/path/to/project');
+    });
+
+    it('Paths are aliased correctly, even with trailing slashes on both folders', () => {
+      const path = '/Users/user/path/to/project/';
+      const home = '/Users/user/';
+      const aliasedPath = createAliasedPath(path, home);
+      assert(aliasedPath === '~/path/to/project');
+    });
+
+    it('Paths with differing slashes are aliased correctly', () => {
+      const path = '//server/home/user/path/to/project';
+      const home = '\\\\server\\home\\user';
+      const aliasedPath = createAliasedPath(path, home);
+      assert(aliasedPath === '~/path/to/project');
+    });
+
+    it('DOS paths are handled', () => {
+      const path = 'C:/Users/user/path/to/project';
+      const home = 'C:\\Users\\user';
+      const aliasedPath = createAliasedPath(path, home);
+      assert(aliasedPath === '~/path/to/project');
+    });
+
+    it('Original path returned is aliasing fails', () => {
+      const path = '/home/other/path/to/project';
+      const home = '/home/user';
+      const aliasedPath = createAliasedPath(path, home);
+      assert(aliasedPath === path);
+    });
+
+    it('Path that matches homepath prefix does not get an alias', () => {
+      const path = '/home/user2/path/to/project';
+      const home = '/home/user';
+      const aliasedPath = createAliasedPath(path, home);
+      assert(aliasedPath === path);
+    });
+  });
+
+  describe('Normalize separators', () => {
+    it('Already normalized posix path not changed', () => {
+      const path = '/Users/user/path/to/project';
+      const normalized = normalizeSeparators(path);
+      assert(path === normalized);
+    });
+    it('Already normalized Windows path not changed', () => {
+      const path = 'C:\\Users\\user\\path\\to\\project';
+      const normalized = normalizeSeparators(path, '\\');
+      assert(path === normalized);
+    });
+    it('Already normalized Windows UNC path not changed', () => {
+      const path = '\\\\machine\\Users\\user\\path\\to\\project';
+      const normalized = normalizeSeparators(path, '\\');
+      assert(path === normalized);
+    });
+    it('Extra posix separators removed', () => {
+      const path = '/Users///user//path//to/project';
+      const expected = '/Users/user/path/to/project';
+      const normalized = normalizeSeparators(path);
+      assert(normalized === expected);
+    });
+    it('Extra Windows separators removed', () => {
+      const path = 'C:\\\\Users\\\\user\\\\path\\to\\project';
+      const expected = 'C:\\Users\\user\\path\\to\\project';
+      const normalized = normalizeSeparators(path, '\\');
+      assert(normalized === expected);
+    });
+    it('Extra Windows separators removed from UNC path', () => {
+      const path = '\\\\machine\\\\Users\\\\user\\path\\to\\\\project';
+      const expected = '\\\\machine\\Users\\user\\path\\to\\project';
+      const normalized = normalizeSeparators(path, '\\');
+      assert(normalized === expected);
+    });
+    it('Extra Windows separators removed and replaced with posix separators', () => {
+      const path = 'C:\\\\Users\\\\user\\\\path\\to\\project';
+      const expected = 'C:/Users/user/path/to/project';
+      const normalized = normalizeSeparators(path, '/');
+      assert(normalized === expected);
+    });
+    it('Extra Windows separators removed from UNC path and replaced with posix separators', () => {
+      const path = '\\\\machine\\\\Users\\\\user\\path\\to\\\\project';
+      const expected = '//machine/Users/user/path/to/project';
+      const normalized = normalizeSeparators(path, '/');
+      assert(normalized === expected);
+    });
+    it('Renormalizing already normalized path is a no-op', () => {
+      const path = '/Users///user//path//to/project';
+      const expected = '/Users/user/path/to/project';
+      const normalized = normalizeSeparators(path);
+      const renormalized = normalizeSeparators(normalized);
+      assert(renormalized === expected);
+    });
+    it('Renormalizing already normalized Windows path is a no-op', () => {
+      const path = 'C:\\\\Users\\\\user\\\\path\\to\\project';
+      const expected = 'C:/Users/user/path/to/project';
+      const normalized = normalizeSeparators(path);
+      const renormalized = normalizeSeparators(normalized);
+      assert(renormalized === expected);
+    });
+    it('Renormalizing already normalized UNC Windows path is a no-op', () => {
+      const path = '\\\\machine\\\\Users\\\\user\\path\\to\\\\project';
+      const expected = '//machine/Users/user/path/to/project';
+      const normalized = normalizeSeparators(path);
+      const renormalized = normalizeSeparators(normalized);
+      assert(renormalized === expected);
+    });
+  });
+
+});


### PR DESCRIPTION
### Intent

Addresses:
- [Cannot save new file to a UNC path on Windows #14963](https://github.com/rstudio/rstudio/issues/14963)
- [Creating a new project on a UNC path stores it in the wrong location #14964](https://github.com/rstudio/rstudio/issues/14964)

### Approach

The bug was that calling `normalizeSeparators()` on a UNC path that used forward slashes (i.e. Posix) instead of backslashes would strip off one of the leading slashes. Fixed to handle either type of leading slash.

### Automated Tests

Added more unit tests around this code.

### QA Notes

Test on Windows as described in the issues.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


