### PR TITLE
update electron-packager and fix rdp windows build issue

### DIFF
--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -31,7 +31,7 @@
       "devDependencies": {
         "@electron-forge/cli": "7.2.0",
         "@electron-forge/plugin-webpack": "7.2.0",
-        "@electron/packager": "18.1.1",
+        "@electron/packager": "18.3.3",
         "@types/chai": "4.3.11",
         "@types/crc": "3.8.3",
         "@types/line-reader": "0.0.37",
@@ -169,9 +169,9 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.24.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.9.tgz",
-      "integrity": "sha512-G8v3jRg+z8IwY1jHFxvCNhOPYPterE4XljNgdGTYfSTtzzwjIswIzIaSPSLs3R7yFuqnqNeay5rjICfqVr+/6A==",
+      "version": "7.24.10",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.10.tgz",
+      "integrity": "sha512-o9HBZL1G2129luEUlG1hB4N/nlYNWHnpwlND9eOMclRqqu1YDy2sSYVCFUZwl8I1Gxh+QSRrP2vD7EpUmFVXxg==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.24.9",
@@ -904,9 +904,9 @@
       }
     },
     "node_modules/@electron/get": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-3.0.0.tgz",
-      "integrity": "sha512-hLv4BYFiyrNRI+U0Mm2X7RxCCdJLkDUn8GCEp9QJzbLpZRko+UaLlCjOMkj6TEtirNLPyBA7y1SeGfnpOB21aQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
+      "integrity": "sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
@@ -1016,9 +1016,9 @@
       }
     },
     "node_modules/@electron/packager": {
-      "version": "18.1.1",
-      "resolved": "https://registry.npmjs.org/@electron/packager/-/packager-18.1.1.tgz",
-      "integrity": "sha512-NAqcAs/tnGS6O3RuWfTbPsRCBXt96qijFqvAhTtBQfxkL0nlHqnwTnr2HUPpNc5L2Xo/8nBeP8BKfMd+ySLNsQ==",
+      "version": "18.3.3",
+      "resolved": "https://registry.npmjs.org/@electron/packager/-/packager-18.3.3.tgz",
+      "integrity": "sha512-hGXzwbUdxv49XvlYwlVPC6W6j6WaXUAzKkYyyTeiwdhxvHFMfQSEJxVHsQpqMFzZZ7wrr7iqiokOFZ/qkgEzUQ==",
       "dev": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
@@ -1027,7 +1027,6 @@
         "@electron/osx-sign": "^1.0.5",
         "@electron/universal": "^2.0.1",
         "@electron/windows-sign": "^1.0.0",
-        "cross-spawn-windows-exe": "^1.2.0",
         "debug": "^4.0.1",
         "extract-zip": "^2.0.0",
         "filenamify": "^4.1.0",
@@ -1037,7 +1036,7 @@
         "junk": "^3.1.0",
         "parse-author": "^2.0.0",
         "plist": "^3.0.0",
-        "rcedit": "^4.0.0",
+        "resedit": "^2.0.0",
         "resolve": "^1.1.6",
         "semver": "^7.1.3",
         "yargs-parser": "^21.1.1"
@@ -1046,7 +1045,7 @@
         "electron-packager": "bin/electron-packager.js"
       },
       "engines": {
-        "node": ">= 16.4.0"
+        "node": ">= 16.13.0"
       },
       "funding": {
         "url": "https://github.com/electron/packager?sponsor=1"
@@ -2048,9 +2047,9 @@
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.6.tgz",
-      "integrity": "sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA==",
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
+      "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
       "dev": true
     },
     "node_modules/@types/lodash.debounce": {
@@ -4237,52 +4236,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/cross-spawn-windows-exe": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn-windows-exe/-/cross-spawn-windows-exe-1.2.0.tgz",
-      "integrity": "sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/malept"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/subscription/pkg/npm-cross-spawn-windows-exe?utm_medium=referral&utm_source=npm_fund"
-        }
-      ],
-      "dependencies": {
-        "@malept/cross-spawn-promise": "^1.1.0",
-        "is-wsl": "^2.2.0",
-        "which": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/cross-spawn-windows-exe/node_modules/@malept/cross-spawn-promise": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
-      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/malept"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
-        }
-      ],
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/css-loader": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.11.0.tgz",
@@ -4929,9 +4882,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.827",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.827.tgz",
-      "integrity": "sha512-VY+J0e4SFcNfQy19MEoMdaIcZLmDCprqvBtkii1WTCTQHpRvf5N8+3kTYCgL/PcntvwQvmMJWTuDPsq+IlhWKQ==",
+      "version": "1.4.828",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.828.tgz",
+      "integrity": "sha512-QOIJiWpQJDHAVO4P58pwb133Cwee0nbvy/MV1CwzZVGpkH1RX33N3vsaWRCpR6bF63AAq366neZrRTu7Qlsbbw==",
       "dev": true
     },
     "node_modules/electron-window": {
@@ -10101,6 +10054,20 @@
         "node": "*"
       }
     },
+    "node_modules/pe-library": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-1.0.1.tgz",
+      "integrity": "sha512-nh39Mo1eGWmZS7y+mK/dQIqg7S1lp38DpRxkyoHf0ZcUs/HDc+yyTjuOtTvSMZHmfSLuSQaX945u05Y2Q6UWZg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14",
+        "npm": ">=7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -10646,18 +10613,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/rcedit": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/rcedit/-/rcedit-4.0.1.tgz",
-      "integrity": "sha512-bZdaQi34krFWhrDn+O53ccBDw0MkAT2Vhu75SqhtvhQu4OPyFM4RoVheyYiVQYdjhUi6EJMVWQ0tR6bCIYVkUg==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn-windows-exe": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
     "node_modules/read-binary-file-arch": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
@@ -10880,6 +10835,23 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
+    },
+    "node_modules/resedit": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/resedit/-/resedit-2.0.2.tgz",
+      "integrity": "sha512-UKTnq602iVe+W5SyRAQx/WdWMnlDiONfXBLFg/ur4QE4EQQ8eP7Jgm5mNXdK12kKawk1vvXPja2iXKqZiGDW6Q==",
+      "dev": true,
+      "dependencies": {
+        "pe-library": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -11948,9 +11920,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.31.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.2.tgz",
-      "integrity": "sha512-LGyRZVFm/QElZHy/CPr/O4eNZOZIzsrQ92y4v9UJe/pFJjypje2yI3C2FmPtvUEnhadlSbmG2nXtdcjHOjCfxw==",
+      "version": "5.31.3",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.3.tgz",
+      "integrity": "sha512-pAfYn3NIZLyZpa83ZKigvj6Rn9c/vd5KfYGX7cN1mnzqgDcxWvrU5ZtAfIKhEXz9nRecw4z3LXkjaq96/qZqAA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -27,7 +27,7 @@
     "forge": "./forge.config.js"
   },
   "devDependencies": {
-    "@electron/packager": "18.1.1",
+    "@electron/packager": "18.3.3",
     "@electron-forge/cli": "7.2.0",
     "@electron-forge/plugin-webpack": "7.2.0",
     "@types/chai": "4.3.11",


### PR DESCRIPTION
### Intent

Addresses [Pro versioning scheme breaks builds for Desktop Pro (Windows) with latest electron-forge version #6242](https://github.com/rstudio/rstudio-pro/issues/6242)

### Approach

Updated electron-packager to most recent, and tweaked the Windows make-package script to strip off the ".pro#" suffix, if present, to avoid tripping up electron-packager on Windows.

This doesn't impact the version number shown in About dialog or elsewhere; only place impacted is the file version info for binaries such as rstudio.exe, but they cannot store the full version due to limitations with Windows versioninfo resources (hence this issue).

### Automated Tests

Build-time thing.

### QA Notes

Verify that the product version in Help / About is correct on RStudio for Windows for both open-source and pro.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


