### PR TITLE
use native dialogs by default on Linux desktop

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ### New
 #### RStudio
--
+- Use native file and message dialogs by default on Linux desktop (#14683; Linux Desktop)
 
 #### Posit Workbench
 -
@@ -15,4 +15,3 @@
 
 #### Posit Workbench
 -
-

--- a/src/cpp/session/prefs/UserPrefsComputedLayer.cpp
+++ b/src/cpp/session/prefs/UserPrefsComputedLayer.cpp
@@ -86,10 +86,6 @@ Error UserPrefsComputedLayer::readPrefs()
    defaultRVersionJson["label"] = versionSettings.defaultRVersionLabel();
    layer[kDefaultRVersion] = defaultRVersionJson;
 
-   #ifdef __linux__
-   layer[kNativeFileDialogs] = false;
-   #endif
-
    // Synctex viewer ----------------------------------------------------------
 #ifdef __APPLE__
 # define kDefaultDesktopPdfPreviewer kPdfPreviewerRstudio


### PR DESCRIPTION
### Intent

Addresses #14683

### Approach

On Linux Desktop, default to using the native file and message dialogs instead of the web-based ones.

This can still be changed via Global Options / General / Advanced: "Use native file and message dialog boxes"; just the default (for Linux) has been changed.

### Automated Tests

None, but we are keeping the option to use web-based dialogs largely because they are used by desktop automation, which cannot drive the native dialogs.

### QA Notes

Confirm that on Linux desktop you now get the native desktop file and message dialogs (e.g. try opening a file), but can still switch back to the web-based ones if you so desire.

Also be sure these native dialogs are opening above the main RStudio window and not behind it (this was what motivated us to use the web dialogs on Linux: https://github.com/rstudio/rstudio/issues/11100).

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


