### PR TITLE
update to electron 31.2.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,3 +17,7 @@
 
 #### Posit Workbench
 -
+
+### Dependencies
+
+- Updated Electron to version 31.2.1 (#14982; Desktop)

--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -48,7 +48,7 @@
         "chai": "4.4.1",
         "copy-webpack-plugin": "12.0.2",
         "css-loader": "7.1.2",
-        "electron": "30.2.0",
+        "electron": "31.2.1",
         "electron-mocha": "12.3.1",
         "eslint": "8.57",
         "fork-ts-checker-webpack-plugin": "9.0.2",
@@ -5171,9 +5171,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-30.2.0.tgz",
-      "integrity": "sha512-x4/pUsOyWReAAo3/ZfvL7AvNbfS5dE8HqMC1mjFM/mL847KE/LpRFfOe5DjKqI2OQMTNvSth1mH0LJageHB0Zg==",
+      "version": "31.2.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-31.2.1.tgz",
+      "integrity": "sha512-g3CLKjl4yuXt6VWm/KpgEjYYhFiCl19RgUn8lOC8zV/56ZXAS3+mqV4wWzicE/7vSYXs6GRO7vkYRwrwhX3Gaw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5249,9 +5249,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.829",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.829.tgz",
-      "integrity": "sha512-5qp1N2POAfW0u1qGAxXEtz6P7bO1m6gpZr5hdf5ve6lxpLM7MpiM4jIPz7xcrNlClQMafbyUDDWjlIQZ1Mw0Rw==",
+      "version": "1.4.830",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.830.tgz",
+      "integrity": "sha512-TrPKKH20HeN0J1LHzsYLs2qwXrp8TF4nHdu4sq61ozGbzMpWhI7iIOPYPPkxeq1azMT9PZ8enPFcftbs/Npcjg==",
       "dev": true,
       "license": "ISC"
     },

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -46,7 +46,7 @@
     "chai": "4.4.1",
     "copy-webpack-plugin": "12.0.2",
     "css-loader": "7.1.2",
-    "electron": "30.2.0",
+    "electron": "31.2.1",
     "electron-mocha": "12.3.1",
     "eslint": "8.57",
     "fork-ts-checker-webpack-plugin": "9.0.2",


### PR DESCRIPTION
### Intent

Addresses #14982

### Approach

Update from electron 30 to 31.

This bumps Chromium to `126.0.6478.127`

### Automated Tests

NA

### QA Notes

Verify Electron version in Help / About, otherwise covered by general usage / automation.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


