### PR TITLE
Updated instructions for database migration tests

### DIFF
--- a/src/cpp/server/db/README.md
+++ b/src/cpp/server/db/README.md
@@ -26,4 +26,27 @@ In order to run any new schemas, you simply need to restart `rstudio-server` to 
 
 ### SQL Naming
 
-Within your schema files, make sure to use `snake_case` naming for all table and column names. There are several reasons for preferring this. For more information, see https://github.com/rstudio/rstudio/issues/65899.
+Within your schema files, make sure to use `snake_case` naming for all table and column names. There are several reasons for preferring this. For more information, see https://github.com/rstudio/rstudio/issues/6589.
+
+### Make Compatible Schema Changes
+
+Ensure old code will work with the new schema for when users upgrade and downgrade. Use default values that makes sense for new columns. Always use column names in the schema (no wildcards), no destructive changes, no name changes. It's ok to abandon columns, that could eventually get cleaned up once affected versions are out of support.
+
+## Documentation
+
+When you change the database schema, ensure you also update the data dictionary in the documentation, found in `docs/server/data_dictionary`.
+
+### Updating Schema Migration Tests
+
+For each workbench version where there's a schema change, we generate a database dump of the previous version to test against the 'alter' script we are adding.
+
+Generating these dumps is automated. Run the script:
+```
+./build-version-dump.sh
+```
+It will prompt you for the previous version's flower and version number, i.e. the current released version, and postgres user/password. It must be run on a system with psql and sqlite3 installed. It generates
+files for the previous version in src/cpp/server/db/test that you commit with your schema changes.
+
+Also update `ServerDatabaseMigrationTests.cpp` and `ServerDatabaseDataset.hpp` to add to the enum and and where it points to the new files in db/test that were just created.
+
+If you are making the schema change in OS, run the script OS with the OS version, then again once the changes have been merged to pro with the pro version. The database dumps are specific to the CreateTables files that are different in OS and pro and so must be generated separately on each branch.

--- a/src/cpp/server/db/build-version-dump.sh
+++ b/src/cpp/server/db/build-version-dump.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+if [ ! -d test ] ; then
+   echo "Must be run in the <rstudio[-pro]>/src/cpp/server/db directory"
+   exit 1
+fi
+
+echo "This script is used to create database dumps from the previous release for testing schema upgrades."
+echo "Run it the first time you make a schema change for any given release (i.e. when you run make-schema.sh)"
+echo "Run it in the repo where the alter script is being committed - either rstudio or rstudio-pro"
+echo "If running it in rstudio, run it again in rstudio-pro after merging"
+echo "Normally, provide the name and version number of the last release. It uses git to get the"
+echo "CreateTables files and populates temp databases with them that are then dumped into db/test to be added to your PR."
+
+read -p "Enter the flower name of the *released* version e.g. Chocolate Cosmos: " flowerName
+read -p "Enter the version string, e.g. 2024.04.2+764 for rstudio, otherwise 2024.04.2+764.pro1: " relVersion
+read -p "Enter postgres database user: " psqluser
+read -p "Enter postgres database password: " PGPASSWORD
+
+encodedFlower=$(echo $flowerName | tr '[:upper:]' '[:lower:]' | tr -s ' ' '-')
+versionSuffix=${encodedFlower}-$(echo $relVersion | tr '+' '-' | sed -e s/.pro.*//)
+
+if [[ "$relVersion" == *"pro"* ]]; then
+   versionSuffix="${versionSuffix}.workbench"
+   echo "Generating schema files for workbench"
+else
+   echo "Generating schema files for open source"
+fi
+
+echo "version-suffix: $versionSuffix"
+
+if git show v${relVersion}:./CreateTables.postgresql > /tmp/${versionSuffix}.psql ; then
+   echo "Found postgres schema for ${relVersion}"
+else
+   echo "Failed to find CreateTables.postgresql with tag: ${relVersion}"
+   exit 
+fi
+
+export PGPASSWORD
+
+db_name=tmp_db_$$
+
+# Create a new database
+if createdb -U $psqluser $db_name ; then
+   echo "Temp database created successfully"
+else
+   echo "Failed to create database with: $psqluser and $PGPASSWORD"
+   exit 1
+fi
+
+
+# Import .sql file into the new database
+psql -U $psqluser -d $db_name -f /tmp/${versionSuffix}.psql
+
+# Create a dump file of the newly created database
+pg_dump -U $psqluser $db_name > "./test/${versionSuffix}.postgresql"
+
+if git show v${relVersion}:./CreateTables.sqlite > /tmp/${versionSuffix}.sqlite ; then
+   echo "Found sqlite schema for ${relVersion}"
+else
+   echo "Failed to find CreateTables.sqlite with tag: ${relVersion}"
+   exit 
+fi
+
+# Create the SQLite database and import the SQL file
+sqlite3 "/tmp/${db_name}.db" < /tmp/${versionSuffix}.sqlite
+
+# Dump the database contents to another file
+sqlite3 "/tmp/${db_name}.db" ".output ./test/${versionSuffix}.sqlite.sql" ".dump"


### PR DESCRIPTION
Added a script to create the database dump files that are used to ensure each version can be upgraded against each new alter script.

No code changes so no testing required. Not needed for CH. 