### PR TITLE
forward repos during build

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 - Prevent attempting to start Copilot on a non-main thread (#14952)
 - Reformat Code no longer inserts whitespace around '^' operator (#14973)
 - Prompt for personal access token instead of password when using github via https (#14103)
+- RStudio now forward the current 'repos' option for actions taken in the Build pane (#5793)
 
 #### Posit Workbench
 -

--- a/src/cpp/session/modules/SessionBuild.R
+++ b/src/cpp/session/modules/SessionBuild.R
@@ -112,3 +112,19 @@ options(buildtools.with = function(code)
    
 })
 
+.rs.addFunction("generateCommandScript", function(command)
+{
+   # Generate header, which allows us to forward the 'repos' option.
+   header <- substitute({
+      options(repos = repos)
+   }, list(repos = getOption("repos")))
+   
+   # Append the command to be executed.
+   all <- c(deparse(header), command)
+   
+   # Write to file and return that path.
+   scriptPath <- tempfile("rstudio-script-", fileext = ".R")
+   writeLines(all, con = scriptPath)
+   
+   scriptPath
+})


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/5793.

### Approach

When executing R for build pane actions, forward the current repositories. This is done by generating an R script with the requisite code to set the `repos` option, as well as the primary command to be executed. Includes a paranoid fallback just in case script generation fails for some reason (R temporary directory not writable / accessible?)

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/5793.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
