### PR TITLE
use https when downloading cmake in build images

### DIFF
--- a/package/linux/install-dependencies
+++ b/package/linux/install-dependencies
@@ -20,7 +20,7 @@ fi
 if $install_cmake ; then
  	CMAKE_VERSION=cmake-3.25.2
 	CMAKE_TARBALL=$CMAKE_VERSION.tar.gz
-	wget http://www.cmake.org/files/v3.25/$CMAKE_TARBALL
+	wget https://www.cmake.org/files/v3.25/$CMAKE_TARBALL
 	tar xf $CMAKE_TARBALL
 	cd $CMAKE_VERSION
 	./bootstrap 


### PR DESCRIPTION
### Intent

Addresses #14994

### Approach

Add the letter 's'.

### Automated Tests

This is used in our build pipeline to install cmake in docker images used for building on various Linux distros, so if it fails the build pipeline will tell us.

### QA Notes

Nothing to validate.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


