### PR TITLE
pin visual editor for chocolate-cosmos and cranberry-hibiscus

### DIFF
--- a/dependencies/common/install-panmirror
+++ b/dependencies/common/install-panmirror
@@ -32,8 +32,8 @@ info "QUARTO_DIR: ${QUARTO_DIR}"
 # clone quarto monorepo if not already cloned
 if ! test -e "$QUARTO_DIR"; then
   echo "Cloning quarto repo"
-  git clone https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
-  # git clone --branch release/rstudio-mountain-hydrangea https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
+  # git clone https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
+  git clone --branch release/rstudio-chocolate-cosmos https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
   pushd $QUARTO_DIR
   git rev-parse HEAD
   popd
@@ -43,8 +43,8 @@ else
   pushd $QUARTO_DIR
   git fetch
   git reset --hard && git clean -dfx
-  git checkout main
-  # git checkout release/rstudio-mountain-hydrangea
+  # git checkout main
+  git checkout release/rstudio-chocolate-cosmos
   git pull
   git rev-parse HEAD
   popd

--- a/dependencies/windows/install-panmirror/clone-quarto-repo.cmd
+++ b/dependencies/windows/install-panmirror/clone-quarto-repo.cmd
@@ -4,8 +4,8 @@ pushd ..\..\..\src\gwt\lib
 
 if not exist quarto (
   echo "Cloning quarto repo"
-  git clone https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
-  REM git clone --branch release/rstudio-mountain-hydrangea https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
+  REM git clone https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
+  git clone --branch release/rstudio-chocolate-cosmos https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
   pushd ..\..\..\src\gwt\lib\quarto
   git rev-parse HEAD
   popd
@@ -16,8 +16,8 @@ if not exist quarto (
   git fetch
   git reset --hard
   git clean -dfx
-  git checkout main
-  REM git checkout release/rstudio-mountain-hydrangea
+  REM git checkout main
+  git checkout release/rstudio-chocolate-cosmos
   git pull
   git rev-parse HEAD
   popd


### PR DESCRIPTION
### Intent

Addresses #15004

### Approach

I created branches off `main` in quarto-dev/quarto named `release/rstudio-chocolate-cosmos` and `release/rstudio-cranberry-hibiscus`. 

Then update dependency scripts for chocolate-cosmos to use corresponding branch instead of main.

When I merge this change and pull it forward into cranberry-hibiscus, I will change it to point to `release/rstudio-chocolate-cosmos`, and when I merge into `main`, I will leave it pulling from `main`.

### Automated Tests

Build-time stuff. At this point the two branches (and main) are identical in quarto-dev/quarto, so this is more to cover us once I start making Visual Editor changes (i.e. so they aren't unintentionally pulled into a patch release).

### QA Notes

Nothing to specifically test; this should be a no-op in terms of what is actually built and if it isn't should fail either build or automation.

### Documentation

None -- though I will open an issue for kousa-dogwood reminding us to do this exercise for it as we approach end of coding. (https://github.com/rstudio/rstudio/issues/15006)

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


