### PR TITLE
Post skipped status to snyk code scan

### DIFF
--- a/jenkins/Jenkinsfile.pull-request
+++ b/jenkins/Jenkinsfile.pull-request
@@ -108,6 +108,12 @@ pipeline {
                   if (status == "failure") {
                     throw new Exception("Snyk Code Scan failed")
                   }   
+                } else {
+                  utils.postReviewCheck(
+                    title: 'Snyk Code Scan',
+                    status: 'skipped',
+                    details: 'No code to scan',
+                  )
                 }
               }
             }


### PR DESCRIPTION
If the snyk code scan returned an exit code indicating that no files were scanned, post "skipped" status to the GH check.