### PR TITLE
fix display of RStudio.Version() on pro desktop/server

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -366,8 +366,16 @@ SEXP rs_rstudioEdition()
 // get version
 SEXP rs_rstudioVersion()
 {
+   std::string numericVersion(RSTUDIO_VERSION_MAJOR);
+   numericVersion.append(".")
+      .append(RSTUDIO_VERSION_MINOR).append(".")
+      .append(RSTUDIO_VERSION_PATCH).append(".")
+      .append(boost::regex_replace(
+         std::string(RSTUDIO_VERSION_SUFFIX),
+         boost::regex("[a-zA-Z\\-+]"),
+         ""));
    r::sexp::Protect rProtect;
-   return r::sexp::create(rstudioVersion(true), &rProtect);
+   return r::sexp::create(numericVersion, &rProtect);
 }
 
 // get long form version
@@ -2994,23 +3002,6 @@ Error adaptToLanguage(const std::string& language)
    }
    
    return Success();
-}
-
-std::string rstudioVersion(bool normalizeSuffix)
-{
-   std::string suffix = RSTUDIO_VERSION_SUFFIX;
-   if (normalizeSuffix)
-   {
-      boost::regex reNonDigit("[^0-9]");
-      suffix = boost::regex_replace(suffix, reNonDigit, "");
-   }
-
-   return fmt::format(
-            "{}.{}.{}.{}",
-            RSTUDIO_VERSION_MAJOR,
-            RSTUDIO_VERSION_MINOR,
-            RSTUDIO_VERSION_PATCH,
-            suffix);
 }
 
 Error initialize()

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -1045,8 +1045,6 @@ core::Error sendSessionRequest(const std::string& uri,
                                const std::string& body,
                                core::http::Response* pResponse);
 
-std::string rstudioVersion(bool normalizeSuffix = false);
-
 } // namespace module_context
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -36,6 +36,9 @@
 #include <core/system/ShellUtils.hpp>
 #include <core/r_util/RPackageInfo.hpp>
 
+#include <session/SessionOptions.hpp>
+#include "../modules/rmarkdown/SessionRMarkdown.hpp"
+
 #ifdef _WIN32
 # include <core/r_util/RToolsInfo.hpp>
 #endif
@@ -354,7 +357,7 @@ private:
             core::system::setenv(&environment, "R_LIBS", rLibs);
 
          // pass along RSTUDIO_VERSION
-         core::system::setenv(&environment, "RSTUDIO_VERSION", module_context::rstudioVersion(true));
+         core::system::setenv(&environment, "RSTUDIO_VERSION", modules::rmarkdown::parsableRStudioVersion());
          core::system::setenv(&environment, "RSTUDIO_LONG_VERSION", RSTUDIO_VERSION);
 
          options.environment = environment;
@@ -979,9 +982,11 @@ private:
                  const core::system::ProcessOptions& pkgOptions,
                  const core::system::ProcessCallbacks& cb)
    {
+      Error error;
+      
       // Find the path to R
       FilePath rProgramPath;
-      Error error = module_context::rScriptPath(&rProgramPath);
+      error = module_context::rScriptPath(&rProgramPath);
       if (error)
       {
          terminateWithError("attempting to locate R binary", error);
@@ -993,9 +998,26 @@ private:
       if (vanilla)
          args.push_back("--vanilla");
 
-      args.push_back("-s");
-      args.push_back("-e");
-      args.push_back(command);
+      // build script to be executed
+      std::string scriptPath;
+      error = r::exec::RFunction(".rs.generateCommandScript")
+            .addUtf8Param(command)
+            .callUtf8(&scriptPath);
+      
+      if (error)
+      {
+         // fall back to executing command directly, just in case
+         args.push_back("-s");
+         args.push_back("-e");
+         args.push_back(command);
+      }
+      else
+      {
+         // execute command from script
+         args.push_back("-s");
+         args.push_back("-f");
+         args.push_back(scriptPath);
+      }
 
       // run it
       module_context::processSupervisor().runProgram(

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -20,6 +20,8 @@
 #include <gsl/gsl>
 
 #include "SessionRmdNotebook.hpp"
+#include "../SessionHTMLPreview.hpp"
+#include "../build/SessionBuildErrors.hpp"
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string.hpp>
@@ -57,7 +59,6 @@
 
 #include "SessionBlogdown.hpp"
 #include "RMarkdownPresentation.hpp"
-#include "../SessionHTMLPreview.hpp"
 
 #define kRmdOutput "rmd_output"
 #define kRmdOutputLocation "/" kRmdOutput "/"
@@ -618,7 +619,7 @@ private:
          LOG_ERROR(error);
 
       // pass along the RSTUDIO_VERSION
-      environment.push_back(std::make_pair("RSTUDIO_VERSION", module_context::rstudioVersion(true)));
+      environment.push_back(std::make_pair("RSTUDIO_VERSION", parsableRStudioVersion()));
       environment.push_back(std::make_pair("RSTUDIO_LONG_VERSION", RSTUDIO_VERSION));
 
       // inform that this runs in the Render pane

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.hpp
@@ -45,6 +45,8 @@ bool pptAvailable();
 
 core::Error evaluateRmdParams(const std::string& docId);
 
+std::string parsableRStudioVersion();
+
 core::Error initialize();
 
 } // namespace rmarkdown


### PR DESCRIPTION
### Intent

Addresses [RStudio pro versions are missing the last period in RStudio.Version()$version #6659](https://github.com/rstudio/rstudio-pro/issues/6659)

### Approach

Reverted the refactoring from [this commit](https://github.com/rstudio/rstudio/pull/14775/commits/c64ed1730719f41158a7086a73f7a577a9500666) and confirmed it restored the expected behaviour.

### Automated Tests

None

### QA Notes

Test desktop pro and server pro, and a quick sanity check on open-source.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


