### PR TITLE
Avoid getCurrentUser call after fork

### DIFF
--- a/src/cpp/core/include/core/system/PosixSystem.hpp
+++ b/src/cpp/core/include/core/system/PosixSystem.hpp
@@ -156,7 +156,8 @@ void setProcessLimits(ProcessLimits limits);
 struct ProcessConfig
 {
    ProcessConfig()
-      : stdStreamBehavior(StdStreamInherit)
+      : stdStreamBehavior(StdStreamInherit),
+        user(User(true))
    {
    }
    core::system::Options args;
@@ -164,6 +165,7 @@ struct ProcessConfig
    std::string stdInput;
    StdStreamBehavior stdStreamBehavior;
    ProcessLimits limits;
+   User user;
 };
 
 core::Error waitForProcessExit(PidType processId);


### PR DESCRIPTION
### Intent

Reviewed in PR: https://github.com/rstudio/rstudio-pro/pull/6658

- Call getUser in the parent process, before the fork and pass in the User object to the child
- after the fork, before the exec, libraries like libnss can misbehave due to locking and other odd behavior when running in a copy of the parent processes memory image.

Reviewed in PR: https://github.com/rstudio/rstudio-pro/pull/6658

