### PR TITLE
also skip files in version/news for rebuilding

### DIFF
--- a/jenkins/Jenkinsfile.pull-request
+++ b/jenkins/Jenkinsfile.pull-request
@@ -35,8 +35,9 @@ pipeline {
           RSTUDIO_VERSION_FLOWER = readFile(file: 'version/RELEASE').replaceAll(" ", "-").toLowerCase().trim()
           IS_PRO = JOB_URL.contains('Pro')
           BASE_IMAGE = "jenkins/ide:pro-jammy-x86_64-${RSTUDIO_VERSION_FLOWER}"
-          // Passing true makes this return true if there are any changes outside of 'docs'
-          BUILD = utils.hasChangesIn('docs/', true)
+          // Invert the check and use regex - passing true makes this return true if 
+          //there are any changes outside of 'docs' and 'version/news'
+          BUILD = utils.hasChangesIn('docs/|version/news/', true)
         }
       }
     }

--- a/jenkins/utils.groovy
+++ b/jenkins/utils.groovy
@@ -4,9 +4,11 @@
   * Returns true if branch has changes in the specified path with the target branch.
   * If invertMatch is true, returns true if branch has changes that do not match the specified path.
   */
-boolean hasChangesIn(String module, boolean invertMatch = false) {
+boolean hasChangesIn(String module, boolean invertMatch = false, boolean useRegex = false) {
   sh "echo 'Comparing changes in ${module} with ${env.CHANGE_TARGET}..${env.BRANCH_NAME}'"
-  grepArgs = invertMatch ? '-v' : ''
+  grepArgs = invertMatch ? 'v' : ''
+  grepArgs = useRegex ? 'P' : grepArgs
+  grepArgs = grepArgs.empty() ? '' : "-${grepArgs}"
   mergeBase = sh(
     returnStdout: true, script: "git merge-base origin/${env.BRANCH_NAME} origin/${env.CHANGE_TARGET}").trim()
   return !env.CHANGE_TARGET ||

--- a/jenkins/utils.groovy
+++ b/jenkins/utils.groovy
@@ -8,7 +8,7 @@ boolean hasChangesIn(String module, boolean invertMatch = false, boolean useRege
   sh "echo 'Comparing changes in ${module} with ${env.CHANGE_TARGET}..${env.BRANCH_NAME}'"
   grepArgs = invertMatch ? 'v' : ''
   grepArgs = useRegex ? 'P' : grepArgs
-  grepArgs = grepArgs.empty() ? '' : "-${grepArgs}"
+  grepArgs = grepArgs.isEmpty() ? '' : "-${grepArgs}"
   mergeBase = sh(
     returnStdout: true, script: "git merge-base origin/${env.BRANCH_NAME} origin/${env.CHANGE_TARGET}").trim()
   return !env.CHANGE_TARGET ||


### PR DESCRIPTION
### Intent

I noticed we're building on PR whenever there are changes only in version/news. Since that doesn't get compiled into the product, it should be excluded.

### Approach

1. Add an option to `util.hasChangesIn` that sets `-P` (perl regex) on the grep command when true.
2. Add version/news to the exclude list.

### Automated Tests

N/A - build system change

### QA Notes

N/A - build system change


### Documentation

N/A - build system change

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


