### PR TITLE
label the Publish button on editor toolbar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 #### RStudio
 - Use native file and message dialogs by default on Linux desktop (#14683; Linux Desktop)
 - Added www-socket option to rserver.conf to enable server to listen on a Unix domain socket (#14938; Open-Source Server)
+- Display label "Publish" next to the publish icon on editor toolbar (#13604)
 
 #### Posit Workbench
 -

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -593,7 +593,7 @@ public class TextEditingTargetWidget
          toolbar.addRightSeparator();
          publishButton_ = new RSConnectPublishButton(
                RSConnectPublishButton.HOST_EDITOR,
-               RSConnect.CONTENT_TYPE_APP, false, null);
+               RSConnect.CONTENT_TYPE_APP, true, null);
          publishButton_.onPublishInvoked(() ->
          {
             if (!StringUtil.isNullOrEmpty(target_.getPath()))
@@ -1105,17 +1105,18 @@ public class TextEditingTargetWidget
       
       texToolbarButton_.setText(width >= 520, constants_.format());
       runButton_.setText(((width >= 480) && !(isShinyFile() || isPyShinyFile())), constants_.run());
-      compilePdfButton_.setText(width >= 450, constants_.compilePdf());
-      previewHTMLButton_.setText(width >= 450, previewCommandText_);
-      knitDocumentButton_.setText(width >= 450, knitCommandText_);
-      quartoRenderButton_.setText(width >= 450, quartoCommandText_);
+      compilePdfButton_.setText(width >= 560, constants_.compilePdf());
+      previewHTMLButton_.setText(width >= 560, previewCommandText_);
+      knitDocumentButton_.setText(width >= 560, knitCommandText_);
+      quartoRenderButton_.setText(width >= 560, quartoCommandText_);
+      publishButton_.setShowCaption(width >= 530);
 
       String action = getSourceOnSaveAction();
-      srcOnSaveLabel_.setText(width < 450 ? action : constants_.actionOnSave(action));
+      srcOnSaveLabel_.setText(width < 490 ? action : constants_.actionOnSave(action));
       sourceButton_.setText(width >= 400, sourceCommandText_);
       
-      goToNextButton_.setVisible(commands_.goToNextChunk().isVisible() && width >= 650);
-      goToPrevButton_.setVisible(commands_.goToPrevChunk().isVisible() && width >= 650);
+      goToNextButton_.setVisible(commands_.goToNextChunk().isVisible() && width >= 640);
+      goToPrevButton_.setVisible(commands_.goToPrevChunk().isVisible() && width >= 640);
       toolbar_.invalidateSeparators();
    }
    


### PR DESCRIPTION
### Intent

Addresses [Evaluate adding "Publish" next to the blue publish icon #13604](https://github.com/rstudio/rstudio/issues/13604)

### Approach

Display the label "Publish" if the editor toolbar is wide enough.

I also adjusted some of the thresholds for gradually hiding other elements on the toolbar as they were out of date and things were being unnecessarily cut off as the pane narrows.

#### Label visible
<img width="655" alt="full-width-toolbar" src="https://github.com/user-attachments/assets/03436214-aad2-46af-ae0e-6392d278247c">

#### Label hidden due to narrow toolbar
<img width="537" alt="no-publish-label" src="https://github.com/user-attachments/assets/082daa99-ba3e-4e28-8abb-317056665ed9">

### Automated Tests

None

### QA Notes

This ONLY impacts the publish button in the editor toolbar; other instances of this button (e.g. the Plots pane) are not impacted.

Play with narrowing the editor pane for various file types and ensure the new thresholds for when certain commands hide, get shorter (or no) labels, etc. behave reasonably.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


