### PR TITLE
support cursor backward, forward CSI codes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/AnsiCode.java
+++ b/src/gwt/src/org/rstudio/core/client/AnsiCode.java
@@ -712,10 +712,6 @@ public class AnsiCode
                   .replace("\b", "<BS>");
    }
 
-   // Control characters handled by R console, plus leading character of
-   // ANSI escape sequences
-   public static final String CONTROL_REGEX = "[\r\b\f\n\u001b\u009b]";
-
    // RegEx to match ANSI escape codes copied from https://github.com/chalk/ansi-regex
    public static final String ANSI_REGEX =
          "[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-nqry=><@]";
@@ -723,9 +719,20 @@ public class AnsiCode
    // Match ANSI escape sequences
    public static final Pattern ANSI_ESCAPE_PATTERN = Pattern.create(ANSI_REGEX);
 
+   // Control characters handled by R console, plus leading character of
+   // ANSI escape sequences
+   public static final String CONTROL_REGEX = "[\r\b\f\n\u001b\u009b]";
+
    // Match control characters and start of ANSI sequences
    public static final Pattern CONTROL_PATTERN = Pattern.create(CONTROL_REGEX);
 
+   // RegEx to match complete CSI codes (only a small subset)
+   public static final String CSI_REGEX =
+         "[\u001b\u009b]\\[([0-9]+)([A-Z])";
+   
+   // Match ANSI SGR escape sequences
+   public static final Pattern CSI_PATTERN = Pattern.create(CSI_REGEX);
+   
    // RegEx to match complete SGR codes (colors, fonts, appearance)
    public static final String SGR_REGEX =
          "[\u001b\u009b]\\[(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[m]";

--- a/src/gwt/src/org/rstudio/core/client/AnsiCode.java
+++ b/src/gwt/src/org/rstudio/core/client/AnsiCode.java
@@ -728,7 +728,7 @@ public class AnsiCode
 
    // RegEx to match complete CSI codes (only a small subset)
    public static final String CSI_REGEX =
-         "[\u001b\u009b]\\[([0-9]+)([A-Z])";
+         "[\u001b\u009b]\\[([0-9]*)([A-Z])";
    
    // Match ANSI SGR escape sequences
    public static final Pattern CSI_PATTERN = Pattern.create(CSI_REGEX);

--- a/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
+++ b/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
@@ -1249,4 +1249,12 @@ public class VirtualConsoleTests extends GWTTestCase
       vc.submit("i Some intermediate step with a \033[32mfield\033[39m-----------------------\r+++++++++++++++++++++++++++++++++++++\r\033[33m!\033[39m An alert message which is long enough\ni Some intermediate step with a \033[32mfield\033[39m\n");
       Assert.assertEquals("<span class=\"xtermColor3\">!</span><span> An alert message which is long enough</span><span>---------------------\ni Some intermediate step with a </span><span class=\"xtermColor2\">field</span><span>\n</span>", ele.getInnerHTML());
    }
+   
+   public void testCsiCursorMovement()
+   {
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = getVC(ele);
+      vc.submit("Hello world!\033[10DLL\033[4CRL");
+      Assert.assertEquals(ele.getInnerText(), "HeLLo woRLd!");
+   }
 }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14941.

### Approach

Add support for [CSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences); specifically, only for the "cursor forward" and "cursor backward".

### Automated Tests

Not included.

### QA Notes

Try executing `writeLines("Hello world!\x1b[10DLL\x1b[4CRL")`. You should see:

```
> writeLines("Hello world!\x1b[10DLL\x1b[4CRL")
HeLLo woRLd!
```

and this should be the same both in "vanilla" R and in RStudio.

### Documentation
N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


