### PR TITLE
explicitly check for launch failure when running automation

### DIFF
--- a/src/cpp/tests/automation/testthat/test-automation-build-pane.R
+++ b/src/cpp/tests/automation/testthat/test-automation-build-pane.R
@@ -2,7 +2,8 @@
 library(testthat)
 
 self <- remote <- .rs.automation.newRemote()
-on.exit(.rs.automation.deleteRemote(), add = TRUE)
+withr::defer(.rs.automation.deleteRemote())
+
 
 test_that("we can test a file in the build pane", {
    

--- a/src/cpp/tests/automation/testthat/test-automation-completions.R
+++ b/src/cpp/tests/automation/testthat/test-automation-completions.R
@@ -2,7 +2,8 @@
 library(testthat)
 
 self <- remote <- .rs.automation.newRemote()
-on.exit(.rs.automation.deleteRemote(), add = TRUE)
+withr::defer(.rs.automation.deleteRemote())
+
 
 # https://github.com/rstudio/rstudio/issues/14784
 test_that("autocompletion doesn't trigger active bindings", {

--- a/src/cpp/tests/automation/testthat/test-automation-data-viewer.R
+++ b/src/cpp/tests/automation/testthat/test-automation-data-viewer.R
@@ -2,7 +2,8 @@
 library(testthat)
 
 self <- remote <- .rs.automation.newRemote()
-on.exit(.rs.automation.deleteRemote(), add = TRUE)
+withr::defer(.rs.automation.deleteRemote())
+
 
 # https://github.com/rstudio/rstudio/pull/14657
 test_that("we can use the data viewer with temporary R expressions", {

--- a/src/cpp/tests/automation/testthat/test-automation-reformat.R
+++ b/src/cpp/tests/automation/testthat/test-automation-reformat.R
@@ -2,7 +2,7 @@
 library(testthat)
 
 self <- remote <- .rs.automation.newRemote()
-on.exit(.rs.automation.deleteRemote(), add = TRUE)
+withr::defer(.rs.automation.deleteRemote())
 
 
 test_that("Documents can be reformatted on save", {

--- a/src/cpp/tests/automation/testthat/test-automation-restart.R
+++ b/src/cpp/tests/automation/testthat/test-automation-restart.R
@@ -2,7 +2,8 @@
 library(testthat)
 
 self <- remote <- .rs.automation.newRemote()
-on.exit(.rs.automation.deleteRemote(), add = TRUE)
+withr::defer(.rs.automation.deleteRemote())
+
 
 # https://github.com/rstudio/rstudio/issues/14636
 test_that("variables can be referenced after restart", {

--- a/src/cpp/tests/automation/testthat/test-automation-sweave.R
+++ b/src/cpp/tests/automation/testthat/test-automation-sweave.R
@@ -2,7 +2,7 @@
 library(testthat)
 
 self <- remote <- .rs.automation.newRemote()
-on.exit(.rs.automation.deleteRemote(), add = TRUE)
+withr::defer(.rs.automation.deleteRemote())
 
 
 test_that("Braces are inserted and highlighted correctly in Sweave documents", {

--- a/src/cpp/tests/automation/testthat/test-automation-syntax-highlighting.R
+++ b/src/cpp/tests/automation/testthat/test-automation-syntax-highlighting.R
@@ -2,7 +2,8 @@
 library(testthat)
 
 self <- remote <- .rs.automation.newRemote()
-on.exit(.rs.automation.deleteRemote(), add = TRUE)
+withr::defer(.rs.automation.deleteRemote())
+
 
 test_that("Quarto Documents are highlighted as expected", {
    


### PR DESCRIPTION
Resolves a few issues seen when trying to run embedded automation tests on Linux.