### PR TITLE
Rf_countContexts is now hidden

### DIFF
--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -34,14 +34,15 @@
 #include <core/http/Util.hpp>
 #include <core/http/URL.hpp>
 
-#include <r/RExec.hpp>
-#include <r/RUtil.hpp>
+#include <r/RCntxt.hpp>
 #include <r/RErrorCategory.hpp>
+#include <r/RExec.hpp>
+#include <r/RFunctionHook.hpp>
+#include <r/RInterface.hpp>
 #include <r/ROptions.hpp>
 #include <r/RRoutines.hpp>
-#include <r/RInterface.hpp>
-#include <r/RFunctionHook.hpp>
 #include <r/RSourceManager.hpp>
+#include <r/RUtil.hpp>
 #include <r/session/RSessionState.hpp>
 #include <r/session/RClientState.hpp>
 #include <r/session/RConsoleHistory.hpp>
@@ -68,9 +69,6 @@
 
 #include <gsl/gsl>
 
-extern "C" {
-int Rf_countContexts(int, int);
-}
 #define CTXT_BROWSER 16
 
 // get rid of windows TRUE and FALSE definitions
@@ -507,7 +505,16 @@ bool isSuspendable(const std::string& currentPrompt)
 
 bool browserContextActive()
 {
-   return Rf_countContexts(CTXT_BROWSER, 1) > 0;
+   using namespace r::context;
+   for (auto it = RCntxt::begin(); it != RCntxt::end(); ++it)
+   {
+      if (it->callflag() & CTXT_BROWSER)
+      {
+         return true;
+      }
+   }
+   
+   return false;
 }
    
 namespace utils {


### PR DESCRIPTION
### Intent

Fixes an issue where RStudio would crash on startup with recent builds of R-devel.

### Approach

RStudio was using the `Rf_countContexts()` function to determine if the R debugger was active, but that function is no longer available for us to use as of https://github.com/wch/r-source/commit/7b578a76195292af7577cb13b6d50832ec172a1d.

So instead, we use our own local equivalent.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
