### PR TITLE
improve detection of changes in global 'warn' option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 - Reformat Code no longer inserts whitespace around '^' operator (#14973)
 - Prompt for personal access token instead of password when using github via https (#14103)
 - RStudio now forward the current 'repos' option for actions taken in the Build pane (#5793)
+- Executing `options(warn = ...)` in an R code chunk now persists beyond chunk execution (#15030)
 
 #### Posit Workbench
 -

--- a/src/cpp/session/modules/rmarkdown/NotebookChunkOptions.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookChunkOptions.hpp
@@ -32,18 +32,26 @@ public:
    ChunkOptions(const core::json::Object& defaultOptions, 
                 const core::json::Object& chunkOptions);
 
-   template<typename T> T getOverlayOption(const std::string& key, 
-                                           T defaultValue) const
+   template <typename T>
+   T getOverlayOption(const std::string& key, T defaultValue) const
    {
+      using namespace core::json;
+      
       // check overlay first
-      core::Error error = core::json::readObject(chunkOptions_, key, 
-            defaultValue);
+      core::Error error = readObject(chunkOptions_, key, defaultValue);
 
       // no overlay option, check base
       if (error)
-         core::json::readObject(defaultOptions_, key, defaultValue);
+         readObject(defaultOptions_, key, defaultValue);
 
       return defaultValue;
+   }
+   
+   bool hasOverlayOption(const std::string& key)
+   {
+      return
+            chunkOptions_.hasMember(key) ||
+            defaultOptions_.hasMember(key);
    }
 
    // return overlay only

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.hpp
@@ -108,7 +108,13 @@ private:
    int prevCharWidth_;
    int lastOutputType_;
    ExecScope execScope_;
-   r::sexp::PreservedSEXP prevWarn_;
+   
+   // we save both the previous R warning level,
+   // as well as the chunk warning level, so that
+   // we can detect if users try to set options(warn = 2)
+   // within a chunk directly (affecting global state)
+   int rWarningLevel_;
+   int chunkWarningLevel_;
    
    core::FilePath consoleChunkOutputFile_;
    bool hasOutput_;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15030.

### Approach

When executing a chunk, we try to take control of the `warn` R option. This causes challenges if that chunk also wants to change the global `warn` value. This PR tries to help accommodate this, and allows for an explicitly-changed `warn` option to persist beyond the end of the chunk.

`````
```{r warning=TRUE}
options(warn = 1)
```
`````

as the R code here sets the `warn` option to match the implicit `warn` set during chunk execution. Detecting this is surprisingly challenging without some pretty heavy-handed fixes. Still, this PR fixes the most common case of a user wanting to promote warnings to errors.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15030.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
