### PR TITLE
support usethis description + person objects in package skeleton

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - Added www-socket option to rserver.conf to enable server to listen on a Unix domain socket (#14938; Open-Source Server)
 - RStudio now supports syntax highlighting for Fortran source files (#10403)
 - Display label "Publish" next to the publish icon on editor toolbar (#13604)
+- RStudio supports `usethis.description` option values when creating projects via the RStudio New Project wizard (#15070)
 
 #### Posit Workbench
 -

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1460,6 +1460,30 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    utils::browseURL(url)
 })
 
+.rs.addFunction("mapChr", function(x, f, ...)
+{
+   f <- match.fun(f)
+   vapply(x, f, ..., FUN.VALUE = character(1))
+})
+
+.rs.addFunction("mapDbl", function(x, f, ...)
+{
+   f <- match.fun(f)
+   vapply(x, f, ..., FUN.VALUE = double(1))
+})
+
+.rs.addFunction("mapInt", function(x, f, ...)
+{
+   f <- match.fun(f)
+   vapply(x, f, ..., FUN.VALUE = integer(1))
+})
+
+.rs.addFunction("mapLgl", function(x, f, ...)
+{
+   f <- match.fun(f)
+   vapply(x, f, ..., FUN.VALUE = logical(1))
+})
+
 .rs.addFunction("initTools", function()
 {
    ostype <- .Platform$OS.type

--- a/src/cpp/session/SessionSourceDatabaseSupervisor.cpp
+++ b/src/cpp/session/SessionSourceDatabaseSupervisor.cpp
@@ -146,8 +146,9 @@ Error removeSessionDir(const FilePath& sessionDir)
    // first remove children
    std::vector<FilePath> children;
    Error error = sessionDir.getChildren(children);
-   if (error)
+   if (error && !isFileNotFoundError(error))
       LOG_ERROR(error);
+
    for (const FilePath& filePath : children)
    {
       error = filePath.remove();

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2750,9 +2750,14 @@
    result
 })
 
-.rs.addFunction("nullCoalesce", function(x, y)
+.rs.addFunction("nullCoalesce", function(...)
 {
-   if (is.null(x)) y else x
+   for (i in seq_len(...length()))
+   {
+      value <- ...elt(i)
+      if (!is.null(value))
+         return(value)
+   }
 })
 
 .rs.addFunction("truncate", function(string, n = 200, marker = "<...>")

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -962,29 +962,59 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    ## Create a DESCRIPTION file
    
    # Fill some bits based on devtools options if they're available.
-   # Protect against vectors with length > 1
-   getDevtoolsOption <- function(optionName, default, collapse = " ")
+   # Protect against vectors with length > 1.
+   getDevtoolsOption <- function(optionName,
+                                 default = NULL,
+                                 collapse = " ")
    {
-      devtoolsDesc <- getOption("devtools.desc")
-      if (!length(devtoolsDesc))
-         return(default)
+      for (descKey in c("usethis.description", "devtools.desc"))
+      {
+         descValue <- getOption(descKey)
+         if (length(descValue))
+         {
+            optionValue <- descValue[[optionName]]
+            if (length(optionValue))
+            {
+               if (inherits(optionValue, "person"))
+               {
+                  optionValue <- .rs.formatPerson(optionValue)
+               }
+               else if (is.list(optionValue))
+               {
+                  for (i in seq_along(optionValue))
+                  {
+                     if (inherits(optionValue[[i]], "person"))
+                     {
+                        optionValue[[i]] <- .rs.formatPerson(optionValue[[i]])
+                     }
+                  }
+               }
+               
+               return(paste(optionValue, collapse = collapse))
+            }
+         }
+      }
       
-      option <- devtoolsDesc[[optionName]]
-      if (is.null(option))
-         return(default)
-      
-      paste(option, collapse = collapse)
+      default
    }
    
+   authorsDefault <- .rs.heredoc('
+      c(
+         person(
+            "Jane", "Doe",
+            email = "jane@example.com",
+            role = c("aut", "cre")
+         )
+      )
+   ')
    
-   Author <- getDevtoolsOption("Author", "Who wrote it")
-   
-   Maintainer <- getDevtoolsOption(
-      "Maintainer",
-      "The package maintainer <yourself@somewhere.net>"
+   authors <- getDevtoolsOption(
+      "Authors@R",
+      authorsDefault,
+      collapse = "\n"
    )
    
-   License <- getDevtoolsOption(
+   license <- getDevtoolsOption(
       "License",
       "What license is it under?",
       ", "
@@ -995,13 +1025,12 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       Type = "Package",
       Title = "What the Package Does (Title Case)",
       Version = "0.1.0",
-      Author = Author,
-      Maintainer = Maintainer,
+      "Authors@R" = authors,
       Description = c(
-         "More about what it does (maybe more than one line)",
+         "More about what it does (maybe more than one line).",
          "Use four spaces when indenting paragraphs within the Description."
       ),
-      License = License,
+      License = license,
       Encoding = "UTF-8",
       LazyData = "true"
    )
@@ -1041,19 +1070,27 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    }
    
    # Get other fields from devtools options
-   if (length(getOption("devtools.desc.suggests")))
-      DESCRIPTION$Suggests <- getOption("devtools.desc.suggests")
+   suggests <- .rs.nullCoalesce(
+      getOption("devtools.desc.suggests"),
+      getDevtoolsOption("Suggests")
+   )
    
-   if (length(getOption("devtools.desc")))
+   if (length(suggests))
+      DESCRIPTION$Suggests <- suggests
+   
+   # Add in any other options
+   desc <- .rs.nullCoalesce(
+      getOption("usethis.description"),
+      getOption("devtools.desc")
+   )
+   
+   .rs.enumerate(desc, function(key, value)
    {
-      devtools.desc <- getOption("devtools.desc")
-      for (i in seq_along(devtools.desc))
-      {
-         name <- names(devtools.desc)[[i]]
-         value <- devtools.desc[[i]]
-         DESCRIPTION[[name]] <- value
-      }
-   }
+      DESCRIPTION[[key]] <<- .rs.nullCoalesce(
+         DESCRIPTION[[key]],
+         value
+      )
+   })
    
    # If we are using 'testthat' and 'devtools' is available, use it to
    # add test infrastructure
@@ -1086,10 +1123,11 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    if (grepl("MIT\\s+\\+\\s+file\\s+LICEN[SC]E", DESCRIPTION$License, perl = TRUE))
    {
       # Guess the copyright holder
-      holder <- if (!is.null(getOption("devtools.name")))
-         Author
-      else
+      holder <- .rs.nullCoalesce(
+         getOption("usethis.full_name"),
+         getOption("devtools.name"),
          "<Copyright holder>"
+      )
       
       msg <- c(
          paste("YEAR:", format(Sys.time(), "%Y")),
@@ -1346,6 +1384,55 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    
 })
 
+# Formats a person object in a way suitable for the Authors@R
+# section of a DESCRIPTION file.
+.rs.addFunction("formatPerson", function(person)
+{
+   personFields <- unclass(person)
+   if (length(personFields) == 1L)
+   {
+      formattedPerson <- .rs.formatPersonImpl(personFields[[1L]])
+      return(gsub("\n", "\n  ", formattedPerson))
+   }
+   
+   formattedPersons <- paste(
+      .rs.mapChr(personFields, .rs.formatPersonImpl, indent = "    "),
+      collapse = ",\n"
+   )
+   
+   paste(c("c(", formattedPersons, "  )"), collapse = "\n")
+})
+
+.rs.addFunction("formatPersonImpl", function(fields, indent = identity)
+{
+   if (is.character(indent))
+   {
+      indentWidth <- indent
+      indent <- function(x) sprintf("%s%s", indentWidth, x)
+   }
+   
+   # Build header from given + family name.
+   fullName <- c(fields$given, fields$family, fields$middle)
+   header <- paste(shQuote(fullName, type = "cmd"), collapse = ", ")
+   
+   # Build body from remaining fields
+   rest <- fields[setdiff(names(fields), c("given", "family", "middle"))]
+   other <- .rs.enumerate(rest, function(key, value)
+   {
+      sprintf("%s = %s", key, .rs.deparse(value))
+   })
+   
+   body <- as.character(c(header, other))
+   body <- sprintf("  %s", body)
+   
+   parts <- c(
+      indent("person("),
+      paste(indent(body), collapse = ",\n"),
+      indent(")")
+   )
+   
+   paste(parts, collapse = "\n")
+})
 
 .rs.addFunction("secureDownloadMethod", function()
 {

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -970,29 +970,19 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       for (descKey in c("usethis.description", "devtools.desc"))
       {
          descValue <- getOption(descKey)
-         if (length(descValue))
-         {
-            optionValue <- descValue[[optionName]]
-            if (length(optionValue))
-            {
-               if (inherits(optionValue, "person"))
-               {
-                  optionValue <- .rs.formatPerson(optionValue)
-               }
-               else if (is.list(optionValue))
-               {
-                  for (i in seq_along(optionValue))
-                  {
-                     if (inherits(optionValue[[i]], "person"))
-                     {
-                        optionValue[[i]] <- .rs.formatPerson(optionValue[[i]])
-                     }
-                  }
-               }
-               
-               return(paste(optionValue, collapse = collapse))
-            }
-         }
+         if (length(descValue) == 0L)
+            next
+         
+         optionValue <- descValue[[optionName]]
+         if (length(optionValue) == 0L)
+            next
+         
+         # Check for 'person' objects, and expand those in a way
+         # that will be formatted nicely in the DESCRIPTION file.
+         if (inherits(optionValue, "person"))
+            optionValue <- .rs.formatPerson(optionValue)
+         
+         return(paste(optionValue, collapse = collapse))
       }
       
       default
@@ -1000,11 +990,11 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    
    authorsDefault <- .rs.heredoc('
       c(
-         person(
-            "Jane", "Doe",
-            email = "jane@example.com",
-            role = c("aut", "cre")
-         )
+        person(
+          "Jane", "Doe",
+          email = "jane@example.com",
+          role = c("aut", "cre")
+        )
       )
    ')
    

--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -171,7 +171,8 @@
    
    # Handle errors.
    error <- response[["error"]]
-   if (!is.null(error)) {
+   if (!is.null(error))
+   {
       fmt <- "execution of '%s' failed: %s [error code %i]"
       msg <- sprintf(fmt, method, error[["message"]], error[["code"]])
       stop(msg, call. = FALSE)


### PR DESCRIPTION
### Intent

This PR allows RStudio to read and use some of the `usethis` options described in https://usethis.r-lib.org/articles/usethis-setup.html#store-default-values-for-description-fields-and-other-preferences.

### Approach

The features are mostly bolted on to RStudio's existing package skeleton, to retain support for creating projects with existing source files.

### Automated Tests

N/A

### QA Notes

To be verified by community.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
