### PR TITLE
fix debugger in braced expressions

### DIFF
--- a/src/cpp/session/modules/SessionBreakpoints.R
+++ b/src/cpp/session/modules/SessionBreakpoints.R
@@ -163,7 +163,9 @@
 # source references to the injected trace code from the line being traced
 .rs.addFunction("tracedSourceRefs", function(funBody, originalFunBody)
 {
-   if (is.call(funBody))
+   if (is.call(funBody) &&
+       is.call(originalFunBody) &&
+       length(funBody) == length(originalFunBody))
    {
       for (i in seq_along(funBody))
       {
@@ -183,6 +185,9 @@
          
          if (isTraceCall)
          {
+            # We found a trace call; copy the source references from
+            # the original function body into each node of the call
+            # to `.doTrace(browser())`.
             srcRefs <- .rs.nullCoalesce(
                attr(funBody, "srcref")[[i]],
                attr(originalFunBody, "srcref")[[i]]
@@ -191,7 +196,9 @@
             repSrcRefs <- rep(list(srcRefs), length(funBody[[i]]))
             attr(funBody[[i]], "srcref") <- repSrcRefs
          }
-         else if (is.call(funBody[[i]]))
+         else if (is.call(funBody[[i]]) &&
+                  is.call(originalFunBody[[i]]) &&
+                  length(funBody[[i]]) == length(originalFunBody[[i]]))
          {
             # Recurse into non-traced body elements
             funBody[[i]] <- .rs.tracedSourceRefs(

--- a/src/cpp/session/modules/SessionBreakpoints.R
+++ b/src/cpp/session/modules/SessionBreakpoints.R
@@ -161,51 +161,48 @@
 # given a traced function body and the original function body, recursively copy
 # the source references from the original body to the traced body, adding
 # source references to the injected trace code from the line being traced
-.rs.addFunction("tracedSourceRefs",function(funBody, originalFunBody)
+.rs.addFunction("tracedSourceRefs", function(funBody, originalFunBody)
 {
-  if (is.symbol(funBody) || is.symbol(originalFunBody))
-  {
-    return (funBody)
-  }
-
-  # start with a copy of the original source references
-  attr(funBody, "srcref") <- attr(originalFunBody, "srcref")
-
-  for (idx in 1:length(funBody))
-  {
-    # Check to see if this is one of the several types of objects we can't do
-    # equality testing for. Note that these object types are all leaf nodes in
-    # the parse tree, so it's safe to stop recursion here. Also note that we
-    # can't use the helpful is.na() here since that function emits warnings
-    # for some types of objects in the parse tree.
-    if (is.null(funBody[[idx]]) || 
-        identical(funBody[[idx]], NA) || 
-        identical(funBody[[idx]], NA_character_) || 
-        identical(funBody[[idx]], NA_complex_) || 
-        identical(funBody[[idx]], NA_integer_) || 
-        identical(funBody[[idx]], NA_real_) || 
-        identical(funBody[[idx]], NaN) ||
-        is.pairlist(funBody[[idx]])) 
-       next
-
-    # if this expression was replaced by trace(), copy the source references
-    # from the original expression over each expression injected by trace()
-    if (length(funBody[[idx]]) != length(originalFunBody[[idx]]) ||
-        isTRUE(sum(funBody[[idx]] != originalFunBody[[idx]]) > 0))
-    {
-      attr(funBody[[idx]], "srcref") <-
-        rep(list(attr(originalFunBody, "srcref")[[idx]]), length(funBody[[idx]]))
-    }
-
-    # recurse to symbol level
-    else if (is.language(funBody[[idx]]))
-    {
-      funBody[[idx]] <- .rs.tracedSourceRefs(
-         funBody[[idx]],
-         originalFunBody[[idx]])
-    }
-  }
-  return(funBody)
+   if (is.call(funBody))
+   {
+      for (i in seq_along(funBody))
+      {
+         # Check for an invocation of trace.
+         #
+         # {
+         #   .doTrace(browser())
+         #   <expr>
+         # }
+         #
+         isTraceCall <-
+            is.call(funBody[[i]]) &&
+            length(funBody[[i]]) >= 2 &&
+            identical(funBody[[i]][[1L]], as.symbol("{")) &&
+            is.call(funBody[[i]][[2L]]) &&
+            identical(funBody[[i]][[2L]][[1L]], as.symbol(".doTrace"))
+         
+         if (isTraceCall)
+         {
+            srcRefs <- .rs.nullCoalesce(
+               attr(funBody, "srcref")[[i]],
+               attr(originalFunBody, "srcref")[[i]]
+            )
+            
+            repSrcRefs <- rep(list(srcRefs), length(funBody[[i]]))
+            attr(funBody[[i]], "srcref") <- repSrcRefs
+         }
+         else if (is.call(funBody[[i]]))
+         {
+            # Recurse into non-traced body elements
+            funBody[[i]] <- .rs.tracedSourceRefs(
+               funBody[[i]],
+               originalFunBody[[i]]
+            )
+         }
+      }
+   }
+   
+   funBody
 })
 
 .rs.addFunction("getFunctionSteps", function(fun, functionName, lineNumbers)

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -345,7 +345,7 @@
      return(c(0L, 0L, 0L, 0L, 0L, 0L))
 
   pos <- gregexpr(calltext, singleline, fixed = TRUE)[[1]]
-  if (length(pos) > 1)
+  if (length(pos) > 1 && linepref > 0)
   {
      # There is more than one instance of the call text in the function; try
      # to pick the first match past the preferred line.

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -345,7 +345,12 @@
      return(c(0L, 0L, 0L, 0L, 0L, 0L))
 
   pos <- gregexpr(calltext, singleline, fixed = TRUE)[[1]]
-  if (length(pos) > 1 && linepref > 0)
+  if (length(linepref) == 0L || linepref <= 0L)
+  {
+     pos <- pos[[1L]]
+     endpos <- pos + attr(pos, "match.length")
+  }
+  else if (length(pos) > 1)
   {
      # There is more than one instance of the call text in the function; try
      # to pick the first match past the preferred line.
@@ -365,6 +370,7 @@
   }
   else
   {
+     pos <- pos[[1L]]
      endpos <- pos + attr(pos, "match.length")
   }
 

--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -120,6 +120,15 @@
       params <- list()
    }
    
+   # Convert jsobject to character.
+   for (i in seq_along(params))
+   {
+      if (inherits(params[[i]], "jsObject"))
+      {
+         params[[i]] <- as.character(unclass(params[[i]]))
+      }
+   }
+   
    # Generate an id for this request.
    id <- .rs.automation.messageId
    .rs.setVar("automation.messageId", .rs.automation.messageId + 1L)

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -1355,7 +1355,11 @@ SEXP inferDebugSrcrefs(
    
    srcref = simulatedSourceRefsOfContext(srcContext, RCntxt(), pLineDebugState.get());
    if (pLineDebugState && isValidSrcref(srcref))
-      pLineDebugState->lastDebugLine = INTEGER(srcref)[0] - 1;
+   {
+      int lastDebugLine = INTEGER(srcref)[0] - 1;
+      pLineDebugState->lastDebugLine = lastDebugLine;
+   }
+   
    return srcref;
 }
 

--- a/src/cpp/tests/automation/testthat/test-automation-debugger.R
+++ b/src/cpp/tests/automation/testthat/test-automation-debugger.R
@@ -1,0 +1,59 @@
+
+library(testthat)
+
+self <- remote <- .rs.automation.newRemote()
+withr::defer(.rs.automation.deleteRemote())
+
+# https://github.com/rstudio/rstudio/issues/15072
+test_that("the debug position is correct in braced expressions", {
+
+   contents <- .rs.heredoc('
+      f <- function() {
+         1 + 1
+         {
+            2 + 2
+         }
+      }
+   ')
+   
+   remote$documentOpen(".R", contents)
+   on.exit(remote$documentClose(), add = TRUE)
+   
+   # Click to set a breakpoint.
+   gutterLayer <- remote$jsObjectViaSelector(".ace_gutter-layer")
+   gutterCell <- gutterLayer$children[[3]]
+   remote$domClickElement(objectId = gutterCell, horizontalOffset = -6L)
+   
+   # Clear the current selection if we have one.
+   editor <- remote$editorGetInstance()
+   editor$clearSelection()
+   
+   # Source the file.
+   remote$commandExecute("sourceActiveDocument")
+   
+   # Execute the function.
+   remote$consoleExecute("f()")
+   
+   # Check that debug highlighting was set on the fourth row.
+   gutterCell <- remote$jsObjectViaSelector(".ace_executing-line")
+   gutterParent <- gutterCell$parentElement
+   gutterChild <- gutterParent$children[[3]]
+   expect_equal(gutterCell$innerText, gutterChild$innerText)
+   
+   # Get the screen position of the debug rectangle.
+   debugLine <- remote$jsObjectViaSelector(".ace_active_debug_line")
+   debugRect <- debugLine$getBoundingClientRect()
+   
+   # Figure out what row that maps to in the editor.
+   screenCoords <- editor$session$renderer$pixelToScreenCoordinates(
+      debugRect$x + debugRect$width / 2,
+      debugRect$y + debugRect$height / 2
+   )
+   expect_equal(screenCoords$row, 3)
+   
+   # Exit the debugger.
+   remote$keyboardExecute("<Ctrl + 2>", "c", "<Enter>")
+   remote$consoleExecuteExpr(rm(list = "f"))
+   remote$keyboardExecute("<Ctrl + L>")
+   
+})


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15072.

### Approach

- Make sure we handle cases where `linepref` is a zero-length vector, or negative.
- Re-implement the computation of where source references are copied for traced functions.

### Automated Tests

Automated test included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15072.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

