### PR TITLE
Update roxygen skeleton function doc template

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/r/roxygen/RoxygenHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/r/roxygen/RoxygenHelper.java
@@ -687,7 +687,7 @@ public class RoxygenHelper
                   "#' Title\n" +
                   "#'\n" +
                   roxygenParams +
-                  "#' @return\n" +
+                  "#' @returns\n" +
                   "#' @export\n" +
                   "#'\n" +
                   "#' @examples\n";


### PR DESCRIPTION
### Intent

This is the template that gets inserted if you call this to insert a skeleton roxygen2 template
![image](https://github.com/user-attachments/assets/366a723f-79d0-4863-895b-df01f7f22a1f)


This change is because `@return` is superseded by `@returns` in roxygen2. Source: https://roxygen2.r-lib.org/reference/tags-rd.html#ref-usage:~:text=%40return%20%24%7B1%3Adescription%7D%3A%20Describe%20the%20function%27s%20output.%20Superseded%20in%20favour%20of%20%40returns.

### Approach

Update the template

### Automated Tests

NA

### QA Notes

NA

### Documentation

NA

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

I signed the CLA.

