### PR TITLE
fix indent for 'authorsDefault'

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1000,7 +1000,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    
    authors <- getDevtoolsOption(
       "Authors@R",
-      authorsDefault,
+      gsub("\n", "\n  ", authorsDefault, fixed = TRUE),
       collapse = "\n"
    )
    
@@ -1018,7 +1018,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       "Authors@R" = authors,
       Description = c(
          "More about what it does (maybe more than one line).",
-         "Use four spaces when indenting paragraphs within the Description."
+         "Continuation lines should be indented."
       ),
       License = license,
       Encoding = "UTF-8",


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15086.

### Approach

Some recent changes were causing RStudio to generate an invalid `DESCRIPTION` file when creating a new package project, leading to RStudio failing to read that file and so failing to determine that the project was an R package project. This PR resolves that.

### Automated Tests

Covered by existing automation.

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
