### PR TITLE
fix handling of piped completions near start of doc

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 #### RStudio
 - Fixed an issue in the data viewer where list-column cell navigation worked incorrectly when a search filter was active (#9960)
 - Fixed an issue where debugger breakpoints did not function correctly in some cases with R 4.4 (#15072)
+- Fixed an issue where autocompletion results within piped expressions were incorrect in some cases (#13611)
 - Fixed being unable to save file after cancelling the "Choose Encoding" window (#14896)
 - Fixed problems creating new files and projects on a UNC path (#14963, #14964; Windows Desktop)
 - Prevent attempting to start Copilot on a non-main thread (#14952)

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1311,7 +1311,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 .rs.addFunction("heredoc", function(text, ...)
 {
    # remove leading, trailing whitespace
-   trimmed <- gsub("^\\s*\\n|\\n\\s*$", "", text)
+   trimmed <- gsub("^[^\\S\\r\\n]*\\n|\\n[^\\S\\r\\n]$", "", text, perl = TRUE)
    
    # split into lines
    lines <- strsplit(trimmed, "\n", fixed = TRUE)[[1L]]

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -213,6 +213,8 @@ const int kPresentationPreview = 195;
 const int kSuspendBlocked = 196;
 const int kClipboardAction = 197;
 const int kDeploymentRecordsUpdated = 198;
+const int kRunAutomation = 199;
+
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -594,6 +596,8 @@ std::string ClientEvent::typeName() const
          return "clipboard_action";
       case client_events::kDeploymentRecordsUpdated:
          return "deployment_records_updated";
+      case client_events::kRunAutomation:
+         return "run_automation";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -584,7 +584,8 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
 
       // console processes
       (console_process::initialize)
-
+         
+      // http methods
       (http_methods::initialize)
 
       // r utils
@@ -1402,33 +1403,10 @@ void rRunTests()
    exitEarly(status);
 }
 
-void rRunAutomationImpl()
-{
-   // run tests
-   Error error = modules::automation::run();
-   if (error)
-       LOG_ERROR(error);
- 
-   // run cleanup delayed
-   auto cleanup = []()
-   {
-      rCleanup(true);
-      exitEarly(0);
-   };
-   
-   module_context::scheduleDelayedWork(
-            boost::posix_time::milliseconds(3000),
-            cleanup);
-            
-}
-
 void rRunAutomation()
 {
-   // delay execution of automation tests just so we can be sure
-   // the IDE has fully materialized
-   module_context::scheduleDelayedWork(
-            boost::posix_time::milliseconds(3000),
-            rRunAutomationImpl);
+   ClientEvent event(client_events::kRunAutomation);
+   module_context::enqueClientEvent(event);
 }
 
 void ensureRProfile()

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -214,6 +214,8 @@ extern const int kPresentationPreview;
 extern const int kSuspendBlocked;
 extern const int kClipboardAction;
 extern const int kDeploymentRecordsUpdated;
+extern const int kRunAutomation;
+
 }
    
 class ClientEvent

--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -593,10 +593,17 @@
                                            automationMode = NULL,
                                            gitRef = NULL)
 {
+   on.exit(.rs.automation.onFinishedRunningAutomation(), add = TRUE)
+   
    # Resolve the project root. Note that test are expected to be found
    # within the 'src/cpp/session/automation' sub-directory of this path.
    projectRoot <- .rs.nullCoalesce(projectRoot, {
       Sys.getenv("RSTUDIO_AUTOMATION_ROOT", unset = NA)
+   })
+   
+   # Resolve the report file from session options if provided.
+   reportFile <- .rs.nullCoalesce(reportFile, {
+      .Call("rs_automationReportFile", PACKAGE = "(embedding)")
    })
    
    # If the path to a test directory was provided, use that.
@@ -689,4 +696,19 @@
       defaultMode <- .Call("rs_rstudioProgramMode", PACKAGE = "(embedding)")
       Sys.getenv("RSTUDIO_AUTOMATION_MODE", unset = defaultMode)
    })
+})
+
+.rs.addFunction("automation.reportFile", function()
+{
+   .Call("rs_automationReportFile", PACKAGE = "(embedding)")
+})
+
+.rs.addFunction("automation.onFinishedRunningAutomation", function()
+{
+   isJenkins <- Sys.getenv("JENKINS_URL", unset = NA)
+   if (is.na(isJenkins))
+      quit(status = 0L)
+   
+   message("- Automated tests have finished running.")
+   message("- You can now close this instance of RStudio.")
 })

--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -602,9 +602,7 @@
    })
    
    # Resolve the report file from session options if provided.
-   reportFile <- .rs.nullCoalesce(reportFile, {
-      .Call("rs_automationReportFile", PACKAGE = "(embedding)")
-   })
+   reportFile <- .rs.nullCoalesce(reportFile, .rs.automation.reportFile())
    
    # If the path to a test directory was provided, use that.
    if (!is.na(projectRoot))

--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -706,7 +706,7 @@
 .rs.addFunction("automation.onFinishedRunningAutomation", function()
 {
    isJenkins <- Sys.getenv("JENKINS_URL", unset = NA)
-   if (is.na(isJenkins))
+   if (!is.na(isJenkins))
       quit(status = 0L)
    
    message("- Automated tests have finished running.")

--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -359,7 +359,7 @@
       baseArgs,
       sprintf("--remote-debugging-port=%i", port),
       sprintf("--user-data-dir=%s", tempdir()),
-      if (mode == "desktop") "--automation-agent",
+      if (mode == "desktop") c("--automation-agent"),
       if (mode == "server") c(
          "--no-default-browser-check",
          "--no-first-run",

--- a/src/cpp/session/modules/automation/SessionAutomation.cpp
+++ b/src/cpp/session/modules/automation/SessionAutomation.cpp
@@ -22,6 +22,8 @@
 #include <core/Exec.hpp>
 
 #include <r/RExec.hpp>
+#include <r/RRoutines.hpp>
+#include <r/RSexp.hpp>
 
 #include <session/SessionModuleContext.hpp>
 
@@ -36,22 +38,23 @@ namespace automation {
 
 namespace {
 
-} // end anonymous namespace
-
-Error run()
+SEXP rs_automationReportFile()
 {
    FilePath reportFile = session::options().automationReportFile();
    if (reportFile.isEmpty())
-      reportFile = module_context::tempFile("automation-", "xml");
+      return R_NilValue;
    
-   return r::exec::RFunction(".rs.automation.run")
-         .addParam("reportFile", reportFile.getAbsolutePath())
-         .call();
+   r::sexp::Protect protect;
+   return r::sexp::create(reportFile.getAbsolutePath(), &protect);
 }
+
+} // end anonymous namespace
 
 Error initialize()
 {
    using namespace module_context;
+   
+   RS_REGISTER_CALL_METHOD(rs_automationReportFile);
    
    ExecBlock initBlock;
    initBlock.addFunctions()

--- a/src/cpp/session/modules/automation/SessionAutomation.hpp
+++ b/src/cpp/session/modules/automation/SessionAutomation.hpp
@@ -27,8 +27,6 @@ namespace session {
 namespace modules {
 namespace automation {
 
-core::Error run();
-
 core::Error initialize();
 
 } // namespace source_control

--- a/src/cpp/session/modules/automation/SessionAutomationRemote.R
+++ b/src/cpp/session/modules/automation/SessionAutomationRemote.R
@@ -186,6 +186,9 @@
    # Get a reference to the editor in that instance.
    editor <- self$editorGetInstance()
    
+   # Wait a small bit, so Ace can tokenize the document.
+   Sys.sleep(0.2)
+   
    # Invoke callback with the editor instance.
    callback(editor)
 })

--- a/src/cpp/tests/automation/testthat/test-automation-completions.R
+++ b/src/cpp/tests/automation/testthat/test-automation-completions.R
@@ -35,70 +35,41 @@ test_that("autocompletion in console produces the expected completion list for n
       foobaz <- 42
    ')
    
-   remote$keyboardExecute("foo", "<Tab>")
-   completionListEl <- remote$jsObjectViaSelector("#rstudio_popup_completions")
-   completionText <- completionListEl$innerText
-   
-   expect_true(grepl("foobar", completionText, fixed = TRUE))
-   expect_true(grepl("foobaz", completionText, fixed = TRUE))
+   completions <- remote$completionsRequest("foo")
+   expect_equal(completions, c("foobar", "foobaz"))
    
 })
 
 # https://github.com/rstudio/rstudio/issues/13196
 test_that("autocompletion in console produces the expected completion list in an existing base function", {
    
-   remote$keyboardExecute("cat(", "<Tab>")
-   completionListEl <- remote$jsObjectViaSelector("#rstudio_popup_completions")
-   completionText <- completionListEl$innerText
-   
-   expect_true(grepl("...", completionText, fixed = TRUE))
-   expect_true(grepl("file", completionText, fixed = TRUE))
-   expect_true(grepl("sep", completionText, fixed = TRUE))
+   completions <- remote$completionsRequest("cat(")
+   expect_equal(completions, c("... =", "file =", "sep =", "fill =", "labels =", "append ="))
    
 })
 
 # https://github.com/rstudio/rstudio/issues/13196
 test_that("autocompletion in console produces the expected completion list in an existing non-base function", {
    
-   remote$keyboardExecute("stats::rnorm(", "<Tab>")
-   completionListEl <- remote$jsObjectViaSelector("#rstudio_popup_completions")
-   completionText <- completionListEl$innerText
-   
-   expect_true(grepl("n =", completionText, fixed = TRUE))
-   expect_true(grepl("mean =", completionText, fixed = TRUE))
-   expect_true(grepl("sd =", completionText, fixed = TRUE))
-   
-})
-
-# https://github.com/rstudio/rstudio/issues/13196
-test_that("autocompletion in console produces the expected completion list in a new function defintion", {
-   
-   remote$keyboardExecute("sumWithEllipsesArg <- function(x, y, ..., a, b) { x+y+a+b+sum(", "<Tab>")
-   completionListEl <- remote$jsObjectViaSelector("#rstudio_popup_completions")
-   completionText <- completionListEl$innerText
-   
-   expect_true(grepl("...", completionText, fixed = TRUE))
-   expect_true(grepl("na.rm", completionText, fixed = TRUE))
-   expect_true(grepl("sumWithEllipsesArg", completionText, fixed = TRUE))
+   completions <- remote$completionsRequest("stats::rnorm(")
+   expect_equal(completions, c("n =", "mean =", "sd ="))
    
 })
 
 # https://github.com/rstudio/rstudio/issues/13196
 test_that("autocompletion in console produces the expected completion list when using a new function", {
    
-   remote$keyboardExecute("a <- function (..., x, y) { print(x + y) }", "<Enter>")
-   remote$keyboardExecute("a(", "<Tab>")
-   completionListEl <- remote$jsObjectViaSelector("#rstudio_popup_completions")
-   completionText <- completionListEl$innerText
+   # Define a function accepting some parameters.
+   remote$keyboardExecute("a <- function(x, y, z) { print(x + y) }", "<Enter>")
    
-   expect_true(grepl("...", completionText, fixed = TRUE))
-   expect_true(grepl("x", completionText, fixed = TRUE))
-   expect_true(grepl("y", completionText, fixed = TRUE))
+   # Request completions for that function.
+   completions <- remote$completionsRequest("a(")
+   expect_equal(completions, c("x =", "y =", "z ="))
    
 })
 
 # https://github.com/rstudio/rstudio/issues/13291
-test_that("autocompletion in console produces the expected completion list in a preview of data frames that are part of another object.", {
+test_that("list names are provided as completions following '$'", {
    
    code <- .rs.heredoc('
       test_df <- data.frame(
@@ -115,12 +86,8 @@ test_that("autocompletion in console produces the expected completion list in a 
    
    remote$consoleExecute(code)
    
-   remote$keyboardExecute("test_ls$", "<Tab>")
-   completionListEl <- remote$jsObjectViaSelector("#rstudio_popup_completions")
-   completionText <- completionListEl$innerText
-   
-   expect_true(grepl("a", completionText, fixed = TRUE))
-   expect_true(grepl("b", completionText, fixed = TRUE))
+   completions <- remote$completionsRequest("test_ls$")
+   expect_equal(completions, c("a", "b"))
    
 })
 

--- a/src/cpp/tests/automation/testthat/test-automation-completions.R
+++ b/src/cpp/tests/automation/testthat/test-automation-completions.R
@@ -28,3 +28,26 @@ test_that("autocompletion doesn't trigger active bindings", {
    expect_false(tail(output, 1) == "[1] \"active\"")
    
 })
+
+# https://github.com/rstudio/rstudio/issues/13611
+test_that("autocompletions within piped expressions work at start of document", {
+   
+   code <- .rs.heredoc('
+      
+      mtcars |> mutate(x = mean())
+   ')
+   
+   remote$documentOpen(".R", code)
+   editor <- remote$editorGetInstance()
+   editor$gotoLine(2L, 26L)
+   remote$keyboardExecute("<Tab>")
+   popupEl <- remote$jsObjectViaSelector("#rstudio_popup_completions")
+   popupText <- popupEl$innerText
+   expect_true(grepl("trim =",  popupText, fixed = TRUE))
+   expect_true(grepl("na.rm =", popupText, fixed = TRUE))
+   expect_true(grepl("... =",   popupText, fixed = TRUE))
+   remote$keyboardExecute("<Escape>")
+   remote$documentClose()
+   remote$keyboardExecute("<Ctrl + L>")
+
+})

--- a/src/cpp/tests/automation/testthat/test-automation-sweave.R
+++ b/src/cpp/tests/automation/testthat/test-automation-sweave.R
@@ -18,7 +18,7 @@ test_that("Braces are inserted and highlighted correctly in Sweave documents", {
    remote$documentExecute(".Rnw", documentContents, function(editor) {
       editor$gotoLine(4L, 0L)
       remote$client$Input.insertText(text = "{ 1 + 1 }")
-      Sys.sleep(0.1)  # wait for Ace to tokenize
+      Sys.sleep(1)  # wait for Ace to tokenize
       tokens <- as.vector(editor$session$getTokens(3L))
       values <- vapply(tokens, `[[`, "value", FUN.VALUE = character(1))
       expected <- c("{", " ", "1", " ", "+", " ", "1", " ", "}")

--- a/src/cpp/tests/automation/testthat/test-automation-sweave.R
+++ b/src/cpp/tests/automation/testthat/test-automation-sweave.R
@@ -18,6 +18,7 @@ test_that("Braces are inserted and highlighted correctly in Sweave documents", {
    remote$documentExecute(".Rnw", documentContents, function(editor) {
       editor$gotoLine(4L, 0L)
       remote$client$Input.insertText(text = "{ 1 + 1 }")
+      Sys.sleep(0.1)  # wait for Ace to tokenize
       tokens <- as.vector(editor$session$getTokens(3L))
       values <- vapply(tokens, `[[`, "value", FUN.VALUE = character(1))
       expected <- c("{", " ", "1", " ", "+", " ", "1", " ", "}")

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -501,17 +501,13 @@ var RCodeModel = function(session, tokenizer,
             addDplyrArguments(clone.cloneCursor(), data, tokenCursor, value);
 
          // Move off of identifier, on to new infix operator.
-         // Note that we may already be at the start of the document,
-         // so check for that.
+         // If this fails (e.g. we're already at the start of the document)
+         // then just return the associated data object.
          if (!clone.moveToPreviousToken())
          {
-            if (clone.$row === 0 && clone.$offset === 0)
-            {
-               tokenCursor.$row = 0;
-               tokenCursor.$offset = 0;
-               return data;
-            }
-            return false;
+            tokenCursor.$row = clone.$row;
+            tokenCursor.$offset = clone.$offset;
+            return data;
          }
 
          // Move over '::' qualifiers

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -47,6 +47,7 @@ import org.rstudio.studio.client.application.events.QuitEvent;
 import org.rstudio.studio.client.application.events.ReloadEvent;
 import org.rstudio.studio.client.application.events.ReloadWithLastChanceSaveEvent;
 import org.rstudio.studio.client.application.events.RestartStatusEvent;
+import org.rstudio.studio.client.application.events.RunAutomationEvent;
 import org.rstudio.studio.client.application.events.ServerOfflineEvent;
 import org.rstudio.studio.client.application.events.ServerUnavailableEvent;
 import org.rstudio.studio.client.application.events.SessionAbendWarningEvent;
@@ -88,6 +89,7 @@ import org.rstudio.studio.client.workbench.prefs.model.LocaleCookie;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UserState;
 import org.rstudio.studio.client.workbench.prefs.model.WebDialogCookie;
+import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.RunAsyncCallback;
@@ -186,6 +188,7 @@ public class Application implements ApplicationEventHandlers
       events.addHandler(FileUploadEvent.TYPE, this);
       events.addHandler(AriaLiveStatusEvent.TYPE, this);
       events.addHandler(ClipboardActionEvent.TYPE, this);
+      events.addHandler(RunAutomationEvent.TYPE, this);
       
       // register for uncaught exceptions
       uncaughtExHandler.register();
@@ -490,6 +493,12 @@ public class Application implements ApplicationEventHandlers
       }
       
       }
+   }
+   
+   @Override
+   public void onRunAutomation(RunAutomationEvent event)
+   {
+      events_.fireEvent(new SendToConsoleEvent(".rs.automation.run()", true));
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/application/events/ApplicationEventHandlers.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/ApplicationEventHandlers.java
@@ -35,6 +35,7 @@ public interface ApplicationEventHandlers extends LogoutRequestedEvent.Handler,
                                                   RestartStatusEvent.Handler,
                                                   FileUploadEvent.Handler,
                                                   AriaLiveStatusEvent.Handler,
-                                                  ClipboardActionEvent.Handler
+                                                  ClipboardActionEvent.Handler,
+                                                  RunAutomationEvent.Handler
 {
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/events/RunAutomationEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/RunAutomationEvent.java
@@ -1,0 +1,46 @@
+/*
+ * RunAutomationEvent.java
+ *
+ * Copyright (C) 2024 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.application.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class RunAutomationEvent extends GwtEvent<RunAutomationEvent.Handler>
+{
+   public RunAutomationEvent()
+   {
+   }
+
+   // Boilerplate ----
+
+   public interface Handler extends EventHandler
+   {
+      void onRunAutomation(RunAutomationEvent event);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onRunAutomation(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -205,6 +205,7 @@ class ClientEvent extends JavaScriptObject
    public static final String ClipboardAction = "clipboard_action";
    public static final String DeploymentRecordsUpdated = "deployment_records_updated";
    public static final String FormatDocumentCompleted = "format_document_completed";
+   public static final String RunAutomation = "run_automation";
    
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -33,6 +33,7 @@ import org.rstudio.studio.client.application.events.HandleUnsavedChangesEvent;
 import org.rstudio.studio.client.application.events.QuitEvent;
 import org.rstudio.studio.client.application.events.RVersionsChangedEvent;
 import org.rstudio.studio.client.application.events.ReloadWithLastChanceSaveEvent;
+import org.rstudio.studio.client.application.events.RunAutomationEvent;
 import org.rstudio.studio.client.application.events.SaveActionChangedEvent;
 import org.rstudio.studio.client.application.events.SessionAbendWarningEvent;
 import org.rstudio.studio.client.application.events.SessionCountChangedEvent;
@@ -1178,6 +1179,10 @@ public class ClientEventDispatcher
          {
             DeploymentRecordsUpdatedEvent.Data data = event.getData();
             eventBus_.dispatchEvent(new DeploymentRecordsUpdatedEvent(data));
+         }
+         else if (type == ClientEvent.RunAutomation)
+         {
+            eventBus_.dispatchEvent(new RunAutomationEvent());
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1235,7 +1235,9 @@ public class RCompletionManager implements CompletionManager
             // Try to see if there's an object name we should use to supplement
             // completions
             if (cursor.moveToPosition(input_.getCursorPosition()))
+            {
                infixData = codeModel.getDataFromInfixChain(cursor);
+            }
          }
       }
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1656,18 +1656,15 @@ public class RCompletionManager implements CompletionManager
             break;
          
          numCommas = commaCount;
+         dataType = tokenCursor.currentValue() == "("
+               ? AutocompletionContext.TYPE_FUNCTION
+               : AutocompletionContext.TYPE_SINGLE_BRACKET;
          
          TokenCursor declEnd = tokenCursor.cloneCursor();
          if (!tokenCursor.moveToPreviousToken())
             return context;
          
-         if (tokenCursor.currentValue() == "(")
-         {
-            dataType = AutocompletionContext.TYPE_FUNCTION;
-            if (!tokenCursor.moveToPreviousToken())
-               return context;
-         }
-         else if (tokenCursor.currentValue() == "[")
+         if (tokenCursor.currentValue() == "[")
          {
             if (!declEnd.moveToPreviousToken())
                return context;
@@ -1676,13 +1673,8 @@ public class RCompletionManager implements CompletionManager
             if (!tokenCursor.moveToPreviousToken())
                return context;
          }
-         else
-         {
-            dataType = AutocompletionContext.TYPE_SINGLE_BRACKET;
-         }
          
          tokenCursor.findStartOfEvaluationContext();
-         
          assocData =
             docDisplay_.getTextForRange(Range.fromPoints(
                   tokenCursor.currentPosition(),

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -388,7 +388,6 @@ export class SessionLauncher {
   }
 
   onRSessionExited(): void {
-
     // if this is a verify-installation session then just quit
     if (appState().runDiagnostics) {
       this.mainWindow?.quit();
@@ -597,6 +596,11 @@ export class SessionLauncher {
         setenv('RSTUDIO_AUTOMATION_ROOT', projectRoot);
         setenv('RSTUDIO_AUTOMATION_ARGS', process.cwd());
       }
+    }
+
+    // if we're an automation agent, forward that to the R session
+    if (app.commandLine.hasSwitch('automation-agent')) {
+      argList.push('--automation-agent');
     }
 
     // In Windows development builds, move the session executable


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13611.

### Approach

We have some internal logic that attempts to find the lead "data" object from a piped expression. However, this lookup was short-circuiting if the head of the pipe happened to be the first token in the document, but didn't exist at the very first row / column.

### Automated Tests

Included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13611.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
