### PR TITLE
move Clear List to start of publishing dropdown menu

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
 - Prompt for personal access token instead of password when using github via https (#14103)
 - RStudio now forward the current 'repos' option for actions taken in the Build pane (#5793)
 - Executing `options(warn = ...)` in an R code chunk now persists beyond chunk execution (#15030)
+- Moved the "Clear List" command in publishing dropdown to the beginning in case end of dropdown is unreachable (#10492)
 
 #### Posit Workbench
 -

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishButton.java
@@ -595,6 +595,33 @@ public class RSConnectPublishButton extends Composite
       {
          applyCaption(constants_.republish());
 
+         // put Clear List option first in case the list is too long to see the bottom and
+         // the scrollbar isn't appearing (https://github.com/rstudio/rstudio/issues/10492)
+         publishMenu_.addItem(new MenuItem(
+               AppCommand.formatMenuLabel(null, constants_.clearList(), null),
+               true,
+               new Scheduler.ScheduledCommand()
+               {
+                  @Override
+                  public void execute()
+                  {
+                     String appLabel = StringUtil.isNullOrEmpty(applicationPath_)
+                           ? constants_.thisApplication()
+                           : "'" + applicationPath_ + "'";
+                     
+                     display_.showYesNoMessage(
+                           GlobalDisplay.MSG_INFO,
+                           constants_.clearList(),
+                           constants_.removeLocalDeploymentMessage(appLabel),
+                           false,
+                           () -> { forgetDeployment(); },
+                           null,
+                           false);
+                  }
+               }));
+
+         publishMenu_.addSeparator();
+
          // find the default (last deployed record)--this needs to be done as
          // a first pass so we can identify the associated menu item in one
          // pass 
@@ -624,29 +651,6 @@ public class RSConnectPublishButton extends Composite
                });
             publishMenu_.addItem(menuItem);
          }
-         
-         publishMenu_.addItem(new MenuItem(
-               AppCommand.formatMenuLabel(null, constants_.clearList(), null),
-               true,
-               new Scheduler.ScheduledCommand()
-               {
-                  @Override
-                  public void execute()
-                  {
-                     String appLabel = StringUtil.isNullOrEmpty(applicationPath_)
-                           ? constants_.thisApplication()
-                           : "'" + applicationPath_ + "'";
-                     
-                     display_.showYesNoMessage(
-                           GlobalDisplay.MSG_INFO,
-                           constants_.clearList(),
-                           constants_.removeLocalDeploymentMessage(appLabel),
-                           false,
-                           () -> { forgetDeployment(); },
-                           null,
-                           false);
-                  }
-               }));
          
          publishMenu_.addSeparator();
          


### PR DESCRIPTION
### Intent

Mitigates impact of [Cannot clear connect deployments; missing scroll bar #10492](https://github.com/rstudio/rstudio/issues/10492)

### Approach

Rather than get into the weeds of GWT's scrolling panels, going for the simplest fix which is to move the Clear List option to the start of the list. I added a separator between that and the actual publishing records.

Empty menu (unchanged from before)
<img width="197" alt="publishing menu with no prior publishes" src="https://github.com/user-attachments/assets/7bfa7aab-80db-4bb0-a2cf-61dbebf620ad">

After publishing at least once (new behaviour):
<img width="188" alt="publishing menu after publishing at least once" src="https://github.com/user-attachments/assets/3606020c-8311-4284-bc8a-342057d422ad">

After publishing at least once (old behaviour):
<img width="230" alt="publishing menu before this change" src="https://github.com/user-attachments/assets/2151143f-f14d-4cd4-83a8-d1d9b0f343f5">

Note, the only way I could reproduce the scrollbar on this menu NOT appearing was to first display the menu, then shrink the window vertically while the menu is visible so the bottom becomes clipped. If the menu was clipped as soon as it displayed, I was always able to scroll it.

That said, it is certainly possible that I'm missing some other real-world repro involving a specific browser, operating system setting, etc.

### Automated Tests

None.

### QA Notes

Only real concern is if we have any automation that assumes the ordering of this menu, but we'll find out about that soon enough. Otherwise a quick sanity check that the menu behaves as expected will suffice.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


