### PR TITLE
improve resolution of quarto's pandoc

### DIFF
--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -445,16 +445,10 @@ bool ChildProcess::hasRecentOutput() const
 
 Error ChildProcess::run()
 {  
-   // verify that the executable pointed at via 'exe_' exists
-   struct stat sb;
-   int status = ::stat(exe_.c_str(), &sb);
+   // verify that the executable pointed at via 'exe_' is executable
+   int status = ::access(exe_.c_str(), X_OK);
    if (status == -1)
       return systemError(errno, ERROR_LOCATION);
-   
-   // if it does exist, verify that it's actually executable
-   bool isExecutable = sb.st_mode & S_IXUSR;
-   if (!isExecutable)
-      return systemError(EACCES, ERROR_LOCATION);
 
    // declarations
    PidType pid = 0;

--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -445,6 +445,17 @@ bool ChildProcess::hasRecentOutput() const
 
 Error ChildProcess::run()
 {  
+   // verify that the executable pointed at via 'exe_' exists
+   struct stat sb;
+   int status = ::stat(exe_.c_str(), &sb);
+   if (status == -1)
+      return systemError(errno, ERROR_LOCATION);
+   
+   // if it does exist, verify that it's actually executable
+   bool isExecutable = sb.st_mode & S_IXUSR;
+   if (!isExecutable)
+      return systemError(EACCES, ERROR_LOCATION);
+
    // declarations
    PidType pid = 0;
    int fdInput[2] = {0,0};

--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -833,11 +833,11 @@ Error ChildProcess::run()
          savedErrno = errno;
       }
 
+      // in the normal case control should never return from execv (it starts
+      // anew at main of the process pointed to by path). therefore, if we get
+      // here then there was an error
       if (!options_.threadSafe)
       {
-         // in the normal case control should never return from execv (it starts
-         // anew at main of the process pointed to by path). therefore, if we get
-         // here then there was an error
          Error error = systemError(errno, ERROR_LOCATION);
          error.addProperty("exe", exe_);
          LOG_ERROR(error);

--- a/src/cpp/session/include/session/SessionQuarto.hpp
+++ b/src/cpp/session/include/session/SessionQuarto.hpp
@@ -55,6 +55,7 @@ struct QuartoConfig
    std::string version;
    std::string bin_path;
    std::string resources_path;
+   std::string pandoc_path;
 
    // project info
    bool is_project;

--- a/src/cpp/session/modules/quarto/SessionQuartoXRefs.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoXRefs.cpp
@@ -36,18 +36,6 @@
 
 #include "SessionQuarto.hpp"
 
-#ifdef _WIN32
-# define kPandocExe "pandoc.exe"
-#else
-# define kPandocExe "pandoc"
-#endif
-
-#ifdef __aarch64__
-# define kArchDir "aarch64"
-#else
-# define kArchDir "x86_64"
-#endif
-
 using namespace rstudio::core;
 using namespace rstudio::session::module_context;
 using namespace boost::placeholders;

--- a/src/cpp/session/modules/quarto/SessionQuartoXRefs.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoXRefs.cpp
@@ -36,6 +36,18 @@
 
 #include "SessionQuarto.hpp"
 
+#ifdef _WIN32
+# define kPandocExe "pandoc.exe"
+#else
+# define kPandocExe "pandoc"
+#endif
+
+#ifdef __aarch64__
+# define kArchDir "aarch64"
+#else
+# define kArchDir "x86_64"
+#endif
+
 using namespace rstudio::core;
 using namespace rstudio::session::module_context;
 using namespace boost::placeholders;
@@ -163,27 +175,6 @@ json::Array readXRefIndex(const FilePath& indexPath, const std::string& filename
    return xrefs;
 }
 
-FilePath quartoPandocPath(const QuartoConfig& config)
-{
-#ifndef WIN32
-   std::string target = "pandoc";
-#else
-   std::string target = "pandoc.exe";
-#endif
-
-   // find quarto pandoc (it could be directly in the bin_path or it could be in the "tools"dir)
-   FilePath quartoPandoc = FilePath(config.bin_path).completeChildPath(target);
-   if (!quartoPandoc.exists())
-   {
-      FilePath quartoTools = FilePath(config.bin_path).completeChildPath("tools");
-      if (quartoTools.exists())
-      {
-         quartoPandoc = quartoTools.completeChildPath(target);
-      }
-   }
-  return quartoPandoc;
-}
-
 json::Array indexSourceFile(const std::string& contents, const std::string& filename)
 {
    QuartoConfig config = quartoConfig();
@@ -255,14 +246,13 @@ json::Array indexSourceFile(const std::string& contents, const std::string& file
    args.push_back(core::string_utils::utf8ToSystem(dataDirPath.getAbsolutePath()));
 
    core::system::ProcessResult result;
-
    error = module_context::runPandoc(
-      quartoPandocPath(config).getAbsolutePath(),
-      args,
-      contents,
-      options,
-      &result
-   );
+            config.pandoc_path,
+            args,
+            contents,
+            options,
+            &result);
+   
    if (!error)
    {
       if (result.exitStatus == EXIT_SUCCESS)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10823.

### Approach

This PR fixes two issues:

- The path to Quarto's `pandoc` has changed over time. This PR allows us to search the various locations it can be found.
- When running a child process, if the call to `::exec()` fails, we originally tried to quit using `::exit()`. This is problematic, as it implies that things like static destructors in the parent process will be run -- something we definitely don't want! Instead, we can use `::_exit()` unconditionally.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/10823.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
