### PR TITLE
Don't disable staySignedIn when verifying login form

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,7 +25,7 @@
 - Executing `options(warn = ...)` in an R code chunk now persists beyond chunk execution (#15030)
 
 #### Posit Workbench
--
+- Fixed an issue with Workbench login not respecting "Stay signed in when browser closes" when using Single Sign-On (rstudio-pro#5392)
 
 ### Dependencies
 

--- a/src/gwt/www/js/signin.js
+++ b/src/gwt/www/js/signin.js
@@ -61,7 +61,7 @@ function verifyMe() {
    activeSignIn = true;
 
    // Disable all sign-in controls to prevent attempts to sign in multiple times
-   document.getElementById('staySignedIn').disabled = true;
+   document.getElementById('staySignedIn').readOnly = true;
    document.getElementById('signinbutton').disabled = true;
    document.getElementById('signinbutton').classList.add('disabled');
    document.getElementById('spinner').classList.remove('signin-hidden');


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 

Addresses rstudio/rstudio-pro#5392.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

I spent some time trying to identify if this issue could have possibly been a regression, but it looks to me like persisting login will have _never_ worked for any login type except for PAM, and only when encrypting the login password via `auth-encrypt-password`. 

 The server auth code _should_ pick up the `staySignedIn` form element directly that is present in the existing login forms (no need to set a `persist` attribute in the login form like the issue suggests). However, this attribute is not getting picked up because [disabled attributes aren't submitted](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled#attribute_interactions), and we disable the input element in `verifyMe()` to prevent multiple attempts to sign in. 

This PR proposes that we change disabling the input element to simply making it `readOnly`, which should allow the server auth code to pick up the form attribute and set the auth persistence cookies accordingly. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

The auth code doesn't have any unit tests unfortunately :(

I'd wager we don't have any automation tests around auth persistence. Maybe it would be good to add some.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

This should allow auth persistence to work (e.g. closing the browser application entirely and re-opening) for OIDC, SAML, and technically also PAM login with `auth-encrypt-password=0` (I haven't tested that this last sign-in method is broken _without_ this change, but I'm fairly certain that it is since it uses the same code path).

Besides verifying overall functionality, we could also verify a number of things along the way if we wanted to:
- For OIDC, we could check the `stay_signed_in` column in the `login_state` database for the particular login. Note that this would have to be checked after initiating the sign in flow but before completing sign in with the OIDC provider as the database entry is cleared after sign-in completes
- For SAML, we could  check the URL query parameters of the sign in url the user is redirected to after clicking the sign in button. I believe it takes the form of `state={staySignedIn}:{appUri}`, e.g. `state=1:%2F`
- After reaching the home page, we could also grab the cookies from an outgoing request from the browser and check that the `persist-auth` cookie value is `1` and the `user-id` expires column has and actual expiry date 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


