### PR TITLE
support dotty assignments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 - RStudio now supports syntax highlighting for Fortran source files (#10403)
 - Display label "Publish" next to the publish icon on editor toolbar (#13604)
 - RStudio supports `usethis.description` option values when creating projects via the RStudio New Project wizard (#15070)
+- The RStudio diagnostics system now supports destructuring assignments as implemented and provided in the `dotty` package
 
 #### Posit Workbench
 -

--- a/src/cpp/session/modules/SessionDiagnosticsTests.cpp
+++ b/src/cpp/session/modules/SessionDiagnosticsTests.cpp
@@ -302,6 +302,9 @@ test_context("Diagnostics")
       EXPECT_ERRORS("if (x = 1) {}");
       EXPECT_ERRORS("while (x = 42) {}");
       EXPECT_ERRORS("for (x = 1:5) {}");
+      
+      EXPECT_NO_LINT("{ apple <- banana <- 42; apple + banana }");
+      EXPECT_NO_LINT("{ .[apple, banana] <- c(1, 2); apple + banana }");
    }
    
    test_that("RStudio files can be successfully linted")


### PR DESCRIPTION
### Intent

The recently-released `dotty` R package implements support for destructuring assignments; e.g.

```
.[nr, nc] <- dim(cars)
```

defines variables `nr` and `nc` pulled from the result produced by `dim(cars)`.

For example:

<img width="352" alt="Screenshot 2024-08-31 at 3 40 02 PM" src="https://github.com/user-attachments/assets/a762896e-2907-45d5-b1e3-0ee0ad911a02">

### Approach

Mostly straightforward extension to existing diagnostics tooling.

### Automated Tests

Included unit tests.

### QA Notes

To be verified by community.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
