### PR TITLE
test for chunk widgets displaying in RMarkdown source editor

### DIFF
--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -34,7 +34,7 @@
 
 .rs.addFunction("automation.installRequiredPackages", function()
 {
-   packages <- c("here", "httr", "later", "processx", "ps", "usethis", "websocket", "withr", "xml2")
+   packages <- c("here", "httr", "later", "processx", "ps", "styler", "usethis", "websocket", "withr", "xml2")
    pkgLocs <- find.package(packages, quiet = TRUE)
    if (length(packages) == length(pkgLocs))
       return()

--- a/src/cpp/session/modules/automation/SessionAutomation.cpp
+++ b/src/cpp/session/modules/automation/SessionAutomation.cpp
@@ -63,7 +63,8 @@ Error initialize()
       (boost::bind(sourceModuleRFile, "SessionAutomationConstants.R"))
       (boost::bind(sourceModuleRFile, "SessionAutomationRemote.R"))
       (boost::bind(sourceModuleRFile, "SessionAutomationRemoteObject.R"))
-      (boost::bind(sourceModuleRFile, "SessionAutomationTargets.R"));
+      (boost::bind(sourceModuleRFile, "SessionAutomationTargets.R"))
+      (boost::bind(sourceModuleRFile, "SessionAutomationTools.R"));
    
    Error error = initBlock.execute();
    if (error)

--- a/src/cpp/session/modules/automation/SessionAutomationRemote.R
+++ b/src/cpp/session/modules/automation/SessionAutomationRemote.R
@@ -213,6 +213,21 @@
    nodeId
 })
 
+.rs.automation.addRemoteFunction("domGetNodeIds", function(selector)
+{
+   # Query for all nodes matching the selector.
+   document <- self$client$DOM.getDocument(depth = 0L)
+   response <- self$client$DOM.querySelectorAll(document$root$nodeId, selector)
+   
+   # Check for failure.
+   nodeIds <- response$nodeIds
+   if (length(nodeIds) == 0L)
+      stop("No elements matching selector '", selector, "' could be found.")
+   
+   # Return the list of discovered nodes.
+   nodeIds
+})
+
 .rs.automation.addRemoteFunction("domClickElement", function(selector,
                                                              objectId = NULL,
                                                              verticalOffset = 0L,
@@ -341,6 +356,19 @@
    })
    
    .rs.automation.wrapJsResponse(self, response)
+})
+
+.rs.automation.addRemoteFunction("jsObjectsViaSelector", function(selector)
+{
+   response <- .rs.waitFor(selector, function()
+   {
+      nodeIds <- self$domGetNodeIds(selector)
+      resolvedNodes <- lapply(nodeIds, function(nodeId) {
+         self$client$DOM.resolveNode(nodeId)
+      })
+      resolvedNodes
+   })
+   .rs.automation.wrapJsListResponse(self, response)
 })
 
 .rs.automation.addRemoteFunction("keyboardExecute", function(...)

--- a/src/cpp/session/modules/automation/SessionAutomationRemoteObject.R
+++ b/src/cpp/session/modules/automation/SessionAutomationRemoteObject.R
@@ -38,6 +38,16 @@
       return(result$value)
 })
 
+.rs.addFunction("automation.wrapJsListResponse", function(self, response, parentObjectId = NULL)
+{
+   if (is.list(response)) {
+      result_list <- lapply(response, function(element) {
+         .rs.automation.wrapJsResponse(self, element, parentObjectId)
+      })
+      return(result_list)
+   }
+})
+
 .rs.addFunction("automation.wrapJsFunction", function(self, objectId, parentObjectId)
 {
    object <- function(...) {

--- a/src/cpp/session/modules/automation/SessionAutomationRemoteObject.R
+++ b/src/cpp/session/modules/automation/SessionAutomationRemoteObject.R
@@ -40,11 +40,12 @@
 
 .rs.addFunction("automation.wrapJsListResponse", function(self, response, parentObjectId = NULL)
 {
-   if (is.list(response)) {
-      result_list <- lapply(response, function(element) {
+   if (is.list(response))
+   {
+      resultList <- lapply(response, function(element) {
          .rs.automation.wrapJsResponse(self, element, parentObjectId)
       })
-      return(result_list)
+      return(resultList)
    }
 })
 

--- a/src/cpp/session/modules/automation/SessionAutomationTools.R
+++ b/src/cpp/session/modules/automation/SessionAutomationTools.R
@@ -1,0 +1,21 @@
+#
+# SessionAutomationTools.R
+#
+# Copyright (C) 2024 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+.rs.addFunction("automation.tools.isAriaHidden", function(jsObject)
+{
+   isAriaHidden <- .rs.tryCatch(jsObject$ariaHidden)
+   # no aria-hidden attribute is equivalent to FALSE
+   ifelse(inherits(isAriaHidden, "error"), FALSE, as.logical(isAriaHidden))
+})

--- a/src/cpp/tests/automation/testthat/test-automation-rmarkdown.R
+++ b/src/cpp/tests/automation/testthat/test-automation-rmarkdown.R
@@ -36,3 +36,59 @@ test_that("the warn option is preserved when running chunks", {
    remote$keyboardExecute("<Ctrl + L>")
    
 })
+
+test_that("the expected chunk widgets show for multiple chunks", {
+   
+   contents <- .rs.heredoc('
+      ---
+      title: "Chunk widgets"
+      ---
+      
+      ```{r setup, include=FALSE}
+      knitr::opts_chunk$set(echo = TRUE)
+      ```
+      
+      ## R Markdown
+
+      This is an R Markdown document.
+      
+      ```{r cars}
+      summary(cars)
+      ```
+      
+      ## Including Plots
+      
+      You can also embed plots, for example:
+      
+      ```{r pressure, echo=FALSE}
+      plot(pressure)
+      ```
+      
+      The end.
+   ')
+   
+   id <- remote$documentOpen(".Rmd", contents)
+
+   jsChunkOptionWidgets <- remote$jsObjectsViaSelector(".rstudio_modify_chunk")
+   jsChunkPreviewWidgets <- remote$jsObjectsViaSelector(".rstudio_preview_chunk")
+   jsChunkRunWidgets <- remote$jsObjectsViaSelector(".rstudio_run_chunk")
+
+   expect_equal(length(jsChunkOptionWidgets), 3)
+   expect_equal(length(jsChunkPreviewWidgets), 3)
+   expect_equal(length(jsChunkRunWidgets), 3)
+
+   # setup chunk's "preview" widget should be aria-hidden and display:none
+   expect_true(.rs.automation.tools.isAriaHidden(jsChunkPreviewWidgets[[1]]))
+   expect_equal(jsChunkPreviewWidgets[[1]]$style$display, "none")
+
+   # all others should not be hidden
+   checkWidgetVisible <- function(widget) {
+      expect_false(.rs.automation.tools.isAriaHidden(widget))
+      expect_false(widget$style$display == "none")
+   }
+   lapply(jsChunkPreviewWidgets[2:3], checkWidgetVisible)
+   lapply(jsChunkOptionWidgets, checkWidgetVisible)
+   lapply(jsChunkRunWidgets, checkWidgetVisible)
+
+   remote$documentClose()
+})


### PR DESCRIPTION
### Intent

Learn how to use our built-in automation by writing a test.

### Approach

Load RMarkdown with several chunks, then verify that the expected widgets are present and have correct visibility.

- Added methods for fetching a list of nodes based on a selector
- Install "styler" package since I didn't have it installed and format tests require it
- Add a place for general automation tools and a method for testing state of `aria-hidden`

### Automated Tests

Yes

### QA Notes

Added a test, nothing else.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


