### PR TITLE
fix issue with completion type inferrence with .DollarNames methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@
 - Prompt for personal access token instead of password when using github via https (#14103)
 - RStudio now forward the current 'repos' option for actions taken in the Build pane (#5793)
 - Executing `options(warn = ...)` in an R code chunk now persists beyond chunk execution (#15030)
+- Fixed an issue where completion types for objects with a `.DollarNames` method were not properly displayed (#15115)
 
 #### Posit Workbench
 - Fixed an issue with Workbench login not respecting "Stay signed in when browser closes" when using Single Sign-On (rstudio-pro#5392)

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1611,17 +1611,30 @@ assign(x = ".rs.acCompletionTypes",
          
          # detect completion systems that append closing parentheses
          # to the completion item, and assume those are functions
-         # rJava and Rcpp will do this for some objects
-         # for example:
+         # rJava and Rcpp will do this for some objects; for example:
+         #
          # - rJava:::.DollarNames.jobjref
          # - Rcpp:::.DollarNames.C++Object
-         types <- ifelse(
-            grepl("[()]\\s*$", allNames),
-            .rs.acCompletionTypes$FUNCTION,
-            .rs.acCompletionTypes$UNKNOWN
-         )
+         #
+         looksLikeFunction <- grepl("[()]\\s*$", allNames)
+         
+         # Remove any trailing parentheses from the completion items.
          allNames <- gsub("[()]*\\s*$", "", allNames)
-         attr(allNames, "types") <- as.integer(types)
+         
+         # If the completion list contained some function-looking completion
+         # items, then infer the completion results based on that.
+         if (any(looksLikeFunction))
+         {
+            types <- attr(allNames, "types", exact = TRUE)
+            attr(allNames, "types") <- .rs.nullCoalesce(
+               types,
+               ifelse(
+                  looksLikeFunction,
+                  .rs.acCompletionTypes$FUNCTION,
+                  .rs.acCompletionTypes$UNKNOWN
+               )
+            )
+         }
          
          # check for custom helpHandler
          helpHandler <- attr(allNames, "helpHandler", exact = TRUE)

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1680,7 +1680,6 @@ assign(x = ".rs.acCompletionTypes",
       
       names <- .rs.selectFuzzyMatches(allNames, token)
       
-      
       # See if types were provided
       types <- attr(names, "types")
       if (is.integer(types) && length(types) == length(names))

--- a/src/cpp/tests/automation/testthat/test-automation-completions.R
+++ b/src/cpp/tests/automation/testthat/test-automation-completions.R
@@ -122,3 +122,23 @@ test_that("autocompletions within piped expressions work at start of document", 
    })
 
 })
+
+# https://github.com/rstudio/rstudio/issues/15115
+test_that(".DollarNames completions still produce types", {
+   
+   remote$consoleExecuteExpr({
+   
+      className <- basename(tempfile(pattern = "class-"))
+      registerS3method(".DollarNames", className, function(x, pattern) names(x))
+      
+      . <- structure(
+         list(apple = identity, banana = identity),
+         class = className
+      )
+      
+   })
+   
+   completions <- remote$completionsRequest(".$")
+   expect_equal(completions, c("apple", "banana"))
+   
+})

--- a/src/cpp/tests/automation/testthat/test-automation-completions.R
+++ b/src/cpp/tests/automation/testthat/test-automation-completions.R
@@ -141,4 +141,13 @@ test_that(".DollarNames completions still produce types", {
    completions <- remote$completionsRequest(".$")
    expect_equal(completions, c("apple", "banana"))
    
+   remote$consoleExecuteExpr({
+      className <- basename(tempfile(pattern = "class-"))
+      registerS3method(".DollarNames", className, function(x, pattern) c("example1()", "example2()"))
+      . <- structure(list(), class = className)
+   })
+   
+   completions <- remote$completionsRequest(".$")
+   expect_equal(completions, c("example1", "example2"))
+   
 })


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15115.

### Approach

When invoking a `.DollarNames` method (if any) for requesting completions on an object, we were incorrectly forcing types on the completion results in all scenarios -- we should only do this in the special case where a completion item contains a trailing parenthesis.

### Automated Tests

Included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15115.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
