### PR TITLE
Tests for toggling visual mode

### DIFF
--- a/src/cpp/tests/automation/testthat/test-automation-rmarkdown.R
+++ b/src/cpp/tests/automation/testthat/test-automation-rmarkdown.R
@@ -128,7 +128,6 @@ test_that("can cancel switching to visual editor", {
          }, error = function(e) FALSE)
       })
       remote$domClickElement("#rstudio_dlg_cancel")
-      Sys.sleep(1)
       expect_equal(sourceModeToggle$ariaPressed, "true")
       expect_equal(visualModeToggle$ariaPressed, "false")
    }

--- a/src/cpp/tests/automation/testthat/test-automation-rmarkdown.R
+++ b/src/cpp/tests/automation/testthat/test-automation-rmarkdown.R
@@ -38,7 +38,7 @@ test_that("the warn option is preserved when running chunks", {
 })
 
 test_that("the expected chunk widgets show for multiple chunks", {
-   
+
    contents <- .rs.heredoc('
       ---
       title: "Chunk widgets"
@@ -49,7 +49,7 @@ test_that("the expected chunk widgets show for multiple chunks", {
       ```
       
       ## R Markdown
-
+      
       This is an R Markdown document.
       
       ```{r cars}
@@ -72,15 +72,15 @@ test_that("the expected chunk widgets show for multiple chunks", {
    jsChunkOptionWidgets <- remote$jsObjectsViaSelector(".rstudio_modify_chunk")
    jsChunkPreviewWidgets <- remote$jsObjectsViaSelector(".rstudio_preview_chunk")
    jsChunkRunWidgets <- remote$jsObjectsViaSelector(".rstudio_run_chunk")
-
+   
    expect_equal(length(jsChunkOptionWidgets), 3)
    expect_equal(length(jsChunkPreviewWidgets), 3)
    expect_equal(length(jsChunkRunWidgets), 3)
-
+   
    # setup chunk's "preview" widget should be aria-hidden and display:none
    expect_true(.rs.automation.tools.isAriaHidden(jsChunkPreviewWidgets[[1]]))
    expect_equal(jsChunkPreviewWidgets[[1]]$style$display, "none")
-
+   
    # all others should not be hidden
    checkWidgetVisible <- function(widget) {
       expect_false(.rs.automation.tools.isAriaHidden(widget))
@@ -89,6 +89,108 @@ test_that("the expected chunk widgets show for multiple chunks", {
    lapply(jsChunkPreviewWidgets[2:3], checkWidgetVisible)
    lapply(jsChunkOptionWidgets, checkWidgetVisible)
    lapply(jsChunkRunWidgets, checkWidgetVisible)
-
+   
    remote$documentClose()
+   remote$keyboardExecute("<Ctrl + L>")
+})
+
+test_that("can cancel switching to visual editor", {
+   contents <- .rs.heredoc('
+      ---
+      title: "Visual Mode Denied"
+      ---
+      
+      ## R Markdown
+      
+      This is an R Markdown document.
+   ')
+   
+   remote$consoleExecute(".rs.writeUserState(\"visual_mode_confirmed\", FALSE)")
+   remote$consoleExecute(".rs.writeUserPref(\"visual_markdown_editing_is_default\", FALSE)")
+   
+   id <- remote$documentOpen(".Rmd", contents)
+   
+   sourceModeToggle <- remote$jsObjectsViaSelector(".rstudio_visual_md_off")[[1]]
+   visualModeToggle <- remote$jsObjectsViaSelector(".rstudio_visual_md_on")[[1]]
+   
+   # do this twice to also check that the "switching to visual mode" dialog appears
+   # the second time (i.e. that it doesn't set the state to prevent its display when
+   # it is canceled)
+   for (i in 1:2) {
+      expect_equal(sourceModeToggle$ariaPressed, "true")
+      expect_equal(visualModeToggle$ariaPressed, "false")
+   
+      remote$domClickElement(".rstudio_visual_md_on")
+      .rs.waitUntil("The switching to visual mode first time dialog appears", function() {
+         tryCatch({
+            cancelBtn <- remote$jsObjectViaSelector("#rstudio_dlg_cancel")
+            grepl("Cancel", cancelBtn$innerText)
+         }, error = function(e) FALSE)
+      })
+      remote$domClickElement("#rstudio_dlg_cancel")
+      Sys.sleep(1)
+      expect_equal(sourceModeToggle$ariaPressed, "true")
+      expect_equal(visualModeToggle$ariaPressed, "false")
+   }
+   remote$documentClose()
+   remote$keyboardExecute("<Ctrl + L>")
+})
+
+test_that("can switch to visual editor", {
+   contents <- .rs.heredoc('
+      ---
+      title: "Visual Mode"
+      ---
+      
+      ## R Markdown
+      
+      This is an R Markdown document.
+   ')
+   
+   remote$consoleExecute(".rs.writeUserState(\"visual_mode_confirmed\", FALSE)")
+   remote$consoleExecute(".rs.writeUserPref(\"visual_markdown_editing_is_default\", FALSE)")
+   
+   id <- remote$documentOpen(".Rmd", contents)
+   
+   sourceModeToggle <- remote$jsObjectsViaSelector(".rstudio_visual_md_off")[[1]]
+   visualModeToggle <- remote$jsObjectsViaSelector(".rstudio_visual_md_on")[[1]]
+   
+   # do this twice to check that the "switching to visual mode" dialog doesn't appear
+   # the second time
+   for (i in 1:2) {
+      expect_equal(sourceModeToggle$ariaPressed, "true")
+      expect_equal(visualModeToggle$ariaPressed, "false")
+   
+      remote$domClickElement(".rstudio_visual_md_on")
+   
+      if (i == 1)
+      {
+        .rs.waitUntil("The switching to visual mode first time dialog appears", function() {
+           tryCatch({
+              okBtn <- remote$jsObjectViaSelector("#rstudio_dlg_ok")
+              grepl("Use Visual Mode", okBtn$innerText)
+            }, error = function(e) FALSE)
+         })
+         remote$domClickElement("#rstudio_dlg_ok")
+         Sys.sleep(1)
+      }
+      else
+      {
+        .rs.waitUntil("Visual Editor appears", function() {
+           tryCatch({
+              visualEditor <- remote$jsObjectViaSelector(".ProseMirror")
+              visualEditor$contentEditable
+            }, error = function(e) FALSE)
+         })
+      }
+
+      expect_equal(sourceModeToggle$ariaPressed, "false")
+      expect_equal(visualModeToggle$ariaPressed, "true")
+
+      # back to source mode
+      remote$domClickElement(".rstudio_visual_md_off")
+   }
+   
+   remote$documentClose()
+   remote$keyboardExecute("<Ctrl + L>")
 })

--- a/src/gwt/src/org/rstudio/core/client/ClassIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ClassIds.java
@@ -97,4 +97,15 @@ public class ClassIds
    // VersionsPopupMenu
    public final static String VERSIONS_POPUP_VALUE = "versions_popup_value";
    public final static String VERSIONS_POPUP_CHECKED = "versions_popup_checked";
+
+   // Visual Editor mode switch buttons
+   public final static String VISUAL_MD_TOGGLE_OFF = "visual_md_off";
+   public final static String VISUAL_MD_TOGGLE_ON = "visual_md_on";
+
+   // Data Table filter button
+   public final static String DATA_TABLE_FILTER_TOGGLE = "dt_filter_toggle";
+
+   // Document outline toggle button
+   public final static String VISUAL_OUTLINE_TOGGLE = "visual_md_outline_toggle";
+   public final static String SOURCE_OUTLINE_TOGGLE = "source_outline_toggle";
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/LatchingToolbarButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/LatchingToolbarButton.java
@@ -16,6 +16,8 @@ package org.rstudio.core.client.widget;
 
 import com.google.gwt.aria.client.PressedValue;
 import com.google.gwt.aria.client.Roles;
+
+import org.rstudio.core.client.ClassIds;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 
 import com.google.gwt.event.dom.client.ClickHandler;
@@ -31,10 +33,12 @@ public class LatchingToolbarButton extends ToolbarButton
    public LatchingToolbarButton(String text, 
                                 String title,
                                 boolean textIndicatesState,
+                                String cssClass, // for automation
                                 ImageResource leftImage,
                                 ClickHandler clickHandler)
    {
       super(text, title, leftImage, clickHandler);
+      cssClass_ = cssClass;
       textIndicatesState_ = textIndicatesState;
       if (!textIndicatesState_)
          Roles.getButtonRole().setAriaPressedState(getElement(), PressedValue.FALSE);
@@ -61,7 +65,15 @@ public class LatchingToolbarButton extends ToolbarButton
          getElement().removeClassName(ThemeStyles.INSTANCE.toolbarButtonLatched());
       }
    }
-   
+
+   @Override
+   protected void onAttach()
+   {
+      super.onAttach();
+      ClassIds.assignClassId(getElement(), cssClass_);
+   }
+
    private boolean latched_ = false;
    private boolean textIndicatesState_;
+   private String cssClass_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/dataviewer/DataTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/dataviewer/DataTable.java
@@ -18,6 +18,7 @@ package org.rstudio.studio.client.dataviewer;
 import java.util.ArrayList;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.ClassIds;
 import org.rstudio.core.client.CommandWith2Args;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.command.ShortcutManager;
@@ -66,6 +67,7 @@ public class DataTable
               constants_.filterButtonText(),
               ToolbarButton.NoTitle,
               false, /* textIndicatesState */
+              ClassIds.DATA_TABLE_FILTER_TOGGLE,
               new ImageResource2x(DataViewerResources.INSTANCE.filterIcon2x()),
               new ClickHandler() {
                  public void onClick(ClickEvent event)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/MarkdownToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/MarkdownToolbar.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.source.editors.text;
 
 import java.util.ArrayList;
 
+import org.rstudio.core.client.ClassIds;
 import org.rstudio.core.client.widget.LatchingToolbarButton;
 import org.rstudio.core.client.widget.SecondaryToolbar;
 import org.rstudio.studio.client.workbench.commands.Commands;
@@ -25,10 +26,9 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
-import com.google.gwt.user.client.ui.RequiresResize;
 import com.google.gwt.user.client.ui.Widget;
 
-public class MarkdownToolbar extends SecondaryToolbar implements RequiresResize
+public class MarkdownToolbar extends SecondaryToolbar
 {
    public MarkdownToolbar(Commands commands, ClickHandler visualModeClickHandler)
    {
@@ -39,6 +39,7 @@ public class MarkdownToolbar extends SecondaryToolbar implements RequiresResize
             constants_.source(),
             commands.toggleRmdVisualMode().getTooltip(),
             false,
+            ClassIds.VISUAL_MD_TOGGLE_OFF,
             null,
             visualModeClickHandler
       );
@@ -50,6 +51,7 @@ public class MarkdownToolbar extends SecondaryToolbar implements RequiresResize
             constants_.visual(),
             commands.toggleRmdVisualMode().getTooltip(),
             false,
+            ClassIds.VISUAL_MD_TOGGLE_ON,
             null,
             visualModeClickHandler
       );

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -886,8 +886,6 @@ public class TextEditingTargetWidget
       boolean canPreviewFromR = fileType.canPreviewFromR();
       boolean terminalAllowed = session_.getSessionInfo().getAllowShell();
       
-      boolean canReformatDocument = fileType.isR() || fileType.isRmd() || fileType.isQuartoMarkdown();
-      
       panel_.showSecondaryToolbar(isMarkdown);
 
       if (isScript && !terminalAllowed)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.ClassIds;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
@@ -628,6 +629,7 @@ public class TextEditingTargetWidget
             ToolbarButton.NoText,
             ToolbarButton.NoTitle,
             false, /* textIndicatesState */
+            ClassIds.SOURCE_OUTLINE_TOGGLE,
             new ImageResource2x(StandardIcons.INSTANCE.outline2x()),
             event -> {
                final double initialSize = editorPanel_.getWidgetSize(docOutlineWidget_);
@@ -741,6 +743,7 @@ public class TextEditingTargetWidget
       AppCommand cmdOutline = commands_.toggleDocumentOutline();
       toggleVisualModeOutlineButton_ = new LatchingToolbarButton(cmdOutline.getButtonLabel(),
             ToolbarButton.NoTitle, false, /* textIndicatesState */
+            ClassIds.VISUAL_OUTLINE_TOGGLE,
             new ImageResource2x(StandardIcons.INSTANCE.outline2x()), event -> {
                target_.setPreferredOutlineWidgetVisibility(
                      !target_.getPreferredOutlineWidgetVisibility());


### PR DESCRIPTION
### Intent

Add Tests for switching RMarkdown docs into and out of Visual Mode.

### Approach

Added some unique IDs, wrote tests.

### Automated Tests

Yes.

### QA Notes

Automation-only change.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


