### PR TITLE
quarto variant of rmarkdown tests

### DIFF
--- a/src/cpp/tests/automation/testthat/test-automation-quarto.R
+++ b/src/cpp/tests/automation/testthat/test-automation-quarto.R
@@ -1,0 +1,249 @@
+
+library(testthat)
+
+self <- remote <- .rs.automation.newRemote()
+withr::defer(.rs.automation.deleteRemote())
+
+test_that("the warn option is preserved when running chunks", {
+   
+   contents <- .rs.heredoc('
+      ---
+      title: Chunk Warnings
+      ---
+      
+      ```{r warning=TRUE}
+      # check current option
+      getOption("warn")
+      # setting a global option
+      options(warn = 2)
+      ```
+   ')
+   
+   remote$consoleExecuteExpr({ options(warn = 0) })
+   remote$consoleExecuteExpr({ getOption("warn") })
+   output <- remote$consoleOutput()
+   expect_equal(tail(output, n = 1L), "[1] 0")
+   
+   id <- remote$documentOpen(".qmd", contents)
+   editor <- remote$editorGetInstance()
+   editor$gotoLine(6)
+   remote$keyboardExecute("<Ctrl + Shift + Enter>")
+   remote$consoleExecuteExpr({ getOption("warn") })
+   output <- remote$consoleOutput()
+   expect_equal(tail(output, n = 1L), "[1] 2")
+   
+   remote$documentClose()
+   remote$keyboardExecute("<Ctrl + L>")
+   
+})
+
+# https://github.com/rstudio/rstudio/issues/11745
+# TODO: currently failing due to above issue
+# test_that("the expected chunk widgets show for multiple chunks", {
+
+#    contents <- .rs.heredoc('
+#       ---
+#       title: "Chunk widgets"
+#       ---
+      
+#       ```{r setup, include=FALSE}
+#       knitr::opts_chunk$set(echo = TRUE)
+#       ```
+      
+#       ## Quarto
+      
+#       This is a Quarto document.
+      
+#       ```{r cars}
+#       summary(cars)
+#       ```
+      
+#       ## Including Plots
+      
+#       You can also embed plots, for example:
+      
+#       ```{r pressure, echo=FALSE}
+#       plot(pressure)
+#       ```
+      
+#       The end.
+#    ')
+   
+#    id <- remote$documentOpen(".qmd", contents)
+   
+#    jsChunkOptionWidgets <- remote$jsObjectsViaSelector(".rstudio_modify_chunk")
+#    jsChunkPreviewWidgets <- remote$jsObjectsViaSelector(".rstudio_preview_chunk")
+#    jsChunkRunWidgets <- remote$jsObjectsViaSelector(".rstudio_run_chunk")
+   
+#    expect_equal(length(jsChunkOptionWidgets), 3)
+#    expect_equal(length(jsChunkPreviewWidgets), 3)
+#    expect_equal(length(jsChunkRunWidgets), 3)
+   
+#    # setup chunk's "preview" widget should be aria-hidden and display:none
+#    expect_true(.rs.automation.tools.isAriaHidden(jsChunkPreviewWidgets[[1]]))
+#    expect_equal(jsChunkPreviewWidgets[[1]]$style$display, "none")
+   
+#    # all others should not be hidden
+#    checkWidgetVisible <- function(widget) {
+#       expect_false(.rs.automation.tools.isAriaHidden(widget))
+#       expect_false(widget$style$display == "none")
+#    }
+#    lapply(jsChunkPreviewWidgets[2:3], checkWidgetVisible)
+#    lapply(jsChunkOptionWidgets, checkWidgetVisible)
+#    lapply(jsChunkRunWidgets, checkWidgetVisible)
+   
+#    remote$documentClose()
+#    remote$keyboardExecute("<Ctrl + L>")
+# })
+
+test_that("can cancel switching to visual editor", {
+   contents <- .rs.heredoc('
+      ---
+      title: "Visual Mode Denied"
+      ---
+      
+      ## Quarto
+      
+      This is a Quarto document.
+   ')
+   
+   remote$consoleExecute(".rs.writeUserState(\"visual_mode_confirmed\", FALSE)")
+   remote$consoleExecute(".rs.writeUserPref(\"visual_markdown_editing_is_default\", FALSE)")
+   
+   id <- remote$documentOpen(".qmd", contents)
+   
+   sourceModeToggle <- remote$jsObjectsViaSelector(".rstudio_visual_md_off")[[1]]
+   visualModeToggle <- remote$jsObjectsViaSelector(".rstudio_visual_md_on")[[1]]
+   
+   # do this twice to also check that the "switching to visual mode" dialog appears
+   # the second time (i.e. that it doesn't set the state to prevent its display when
+   # it is canceled)
+   for (i in 1:2) {
+      expect_equal(sourceModeToggle$ariaPressed, "true")
+      expect_equal(visualModeToggle$ariaPressed, "false")
+      
+      remote$domClickElement(".rstudio_visual_md_on")
+      .rs.waitUntil("The switching to visual mode first time dialog appears", function() {
+         tryCatch({
+            cancelBtn <- remote$jsObjectViaSelector("#rstudio_dlg_cancel")
+            grepl("Cancel", cancelBtn$innerText)
+         }, error = function(e) FALSE)
+      })
+      remote$domClickElement("#rstudio_dlg_cancel")
+      expect_equal(sourceModeToggle$ariaPressed, "true")
+      expect_equal(visualModeToggle$ariaPressed, "false")
+   }
+   remote$documentClose()
+   remote$keyboardExecute("<Ctrl + L>")
+})
+
+test_that("can switch to visual editor and back to source editor", {
+   contents <- .rs.heredoc('
+      ---
+      title: "Visual Mode"
+      ---
+      
+      ## Quarto
+      
+      This is a Quarto document.
+   ')
+   
+   remote$consoleExecute(".rs.writeUserState(\"visual_mode_confirmed\", FALSE)")
+   remote$consoleExecute(".rs.writeUserPref(\"visual_markdown_editing_is_default\", FALSE)")
+   
+   id <- remote$documentOpen(".qmd", contents)
+   
+   sourceModeToggle <- remote$jsObjectsViaSelector(".rstudio_visual_md_off")[[1]]
+   visualModeToggle <- remote$jsObjectsViaSelector(".rstudio_visual_md_on")[[1]]
+   
+   # do this twice to check that the "switching to visual mode" dialog doesn't appear
+   # the second time
+   for (i in 1:2) {
+      expect_equal(sourceModeToggle$ariaPressed, "true")
+      expect_equal(visualModeToggle$ariaPressed, "false")
+      
+      remote$domClickElement(".rstudio_visual_md_on")
+      
+      if (i == 1)
+      {
+        .rs.waitUntil("The switching to visual mode first time dialog appears", function() {
+           tryCatch({
+              okBtn <- remote$jsObjectViaSelector("#rstudio_dlg_ok")
+              grepl("Use Visual Mode", okBtn$innerText)
+            }, error = function(e) FALSE)
+         })
+         remote$domClickElement("#rstudio_dlg_ok")
+      }
+      
+      .rs.waitUntil("Visual Editor appears", function() {
+         tryCatch({
+            visualEditor <- remote$jsObjectViaSelector(".ProseMirror")
+            visualEditor$contentEditable
+         }, error = function(e) FALSE)
+      })
+      
+      expect_equal(sourceModeToggle$ariaPressed, "false")
+      expect_equal(visualModeToggle$ariaPressed, "true")
+      
+      # back to source mode
+      remote$domClickElement(".rstudio_visual_md_off")
+   }
+   
+   remote$documentClose()
+   remote$keyboardExecute("<Ctrl + L>")
+})
+
+test_that("visual editor welcome dialog displays again if don't show again is unchecked", {
+   contents <- .rs.heredoc('
+      ---
+      title: "Visual Mode"
+      ---
+      
+      ##  Quarto
+      
+      This is a Quarto document.
+   ')
+   
+   remote$consoleExecute(".rs.writeUserState(\"visual_mode_confirmed\", FALSE)")
+   remote$consoleExecute(".rs.writeUserPref(\"visual_markdown_editing_is_default\", FALSE)")
+   
+   id <- remote$documentOpen(".qmd", contents)
+   
+   sourceModeToggle <- remote$jsObjectsViaSelector(".rstudio_visual_md_off")[[1]]
+   visualModeToggle <- remote$jsObjectsViaSelector(".rstudio_visual_md_on")[[1]]
+   
+   # do this twice to check that the "switching to visual mode" dialog appears second time
+   for (i in 1:2) {
+      expect_equal(sourceModeToggle$ariaPressed, "true")
+      expect_equal(visualModeToggle$ariaPressed, "false")
+      
+      remote$domClickElement(".rstudio_visual_md_on")
+      
+      .rs.waitUntil("The switching to visual mode first time dialog appears", function() {
+         tryCatch({
+            okBtn <- remote$jsObjectViaSelector("#rstudio_dlg_ok")
+            grepl("Use Visual Mode", okBtn$innerText)
+         }, error = function(e) FALSE)
+      })
+      
+      # uncheck "Don't show again"
+      remote$domClickElement(".gwt-DialogBox-ModalDialog input[type=\"checkbox\"]")
+      remote$domClickElement("#rstudio_dlg_ok")
+      
+      .rs.waitUntil("Visual Editor appears", function() {
+         tryCatch({
+           visualEditor <- remote$jsObjectViaSelector(".ProseMirror")
+           visualEditor$contentEditable
+         }, error = function(e) FALSE)
+      })
+      
+      expect_equal(sourceModeToggle$ariaPressed, "false")
+      expect_equal(visualModeToggle$ariaPressed, "true")
+      
+      # back to source mode
+      remote$domClickElement(".rstudio_visual_md_off")
+   }
+   
+   remote$documentClose()
+   remote$keyboardExecute("<Ctrl + L>")
+})


### PR DESCRIPTION
### Intent

Add some integration tests for Quarto.

### Approach

Start with copying the rmarkdown tests; comment out a test that is currently failing due to a known issue.

### Automated Tests

Yes

### QA Notes

Tests only

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


