### PR TITLE
allow inclusion of environment variables during deployment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ### New
 #### RStudio
+- RStudio now supports the inclusion of environment variables when publishing applications to Posit Connect (#13032)
 - RStudio now supports code formatting using the 'styler' R package, as well via other external applications (#2563)
 - Use native file and message dialogs by default on Linux desktop (#14683; Linux Desktop)
 - Added www-socket option to rserver.conf to enable server to listen on a Unix domain socket (#14938; Open-Source Server)

--- a/git_hooks/secrets/.secrets.baseline
+++ b/git_hooks/secrets/.secrets.baseline
@@ -517,7 +517,7 @@
         "filename": "src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java",
         "hashed_secret": "1c60262d3df7b0c6d2d5c52dd5014c985004219f",
         "is_verified": false,
-        "line_number": 7227,
+        "line_number": 7233,
         "is_secret": false
       },
       {
@@ -525,7 +525,7 @@
         "filename": "src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java",
         "hashed_secret": "12106b07b5b299b5e91117791ec7017f0820f84e",
         "is_verified": false,
-        "line_number": 7269,
+        "line_number": 7275,
         "is_secret": false
       }
     ],
@@ -616,5 +616,5 @@
       }
     ]
   },
-  "generated_at": "2024-07-23T07:03:14Z"
+  "generated_at": "2024-09-05T21:49:40Z"
 }

--- a/src/cpp/r/session/RConsoleActions.cpp
+++ b/src/cpp/r/session/RConsoleActions.cpp
@@ -200,6 +200,10 @@ Error ConsoleActions::loadFromFile(const FilePath& filePath)
       if (error && !isFileNotFoundError(error))
          return error;
 
+      // bail if file is empty
+      if (contents.empty())
+         return Success();
+      
       // parse JSON
       json::Object value;
       error = value.parse(contents);

--- a/src/cpp/rserver-dev.in
+++ b/src/cpp/rserver-dev.in
@@ -35,5 +35,5 @@ trap cleanup SIGINT
 RS_CRASH_HANDLER_PATH="$(pwd)/server/crash-handler-proxy/crash-handler-proxy" \
    RS_CRASHPAD_HANDLER_PATH="${RSTUDIO_TOOLS_ROOT}/crashpad/crashpad/out/Default/crashpad_handler" \
    RS_DB_MIGRATIONS_PATH="${CMAKE_CURRENT_SOURCE_DIR}/server/db" \
-   server/rserver --server-user $(whoami) --config-file conf/rserver-dev.conf "$@"
+   server/rserver --server-user $(whoami) --auth-none=1 --config-file conf/rserver-dev.conf "$@"
 

--- a/src/cpp/session/modules/SessionRSConnect.R
+++ b/src/cpp/session/modules/SessionRSConnect.R
@@ -15,15 +15,20 @@
 
 .rs.addJsonRpcHandler("get_deployment_env_vars", function()
 {
+   # Find active .Renviron file
    environFile <- .rs.findEnvironFile()
    if (!nzchar(environFile))
       return(character())
    
+   # Read environment variable names from the file
    contents <- readLines(environFile, warn = FALSE)
-   
    pattern <- "^\\s*([\\w_]+)\\s*="
    matchedLines <- grep(pattern, contents, perl = TRUE, value = TRUE)
-   gsub("\\s*=.*", "", matchedLines)
+   envVars <- gsub("\\s*=.*", "", matchedLines)
+   
+   # Keep only those tokens which would likely have secrets of interest
+   pattern <- "(?:^|[\\b_])(?:api|key|pass|pat|secret|token)(?:$|[\\b_])"
+   grep(pattern, envVars, perl = TRUE, value = TRUE, ignore.case = TRUE)
 })
 
 .rs.addJsonRpcHandler("forget_rsconnect_deployments", function(sourcePath, outputPath)

--- a/src/cpp/session/modules/SessionRSConnect.R
+++ b/src/cpp/session/modules/SessionRSConnect.R
@@ -17,7 +17,7 @@
 {
    # Find active .Renviron file
    environFile <- .rs.findEnvironFile()
-   if (!nzchar(environFile))
+   if (!nzchar(environFile) || !file.exists(environFile))
       return(character())
    
    # Read environment variable names from the file

--- a/src/cpp/session/modules/SessionRSConnect.cpp
+++ b/src/cpp/session/modules/SessionRSConnect.cpp
@@ -143,6 +143,7 @@ public:
          const std::string& websiteDir,
          const json::Array& additionalFilesList,
          const json::Array& ignoredFilesList,
+         const json::Array& envVarsList,
          bool asMultiple,
          bool asStatic,
          bool isQuarto,
@@ -220,10 +221,9 @@ public:
       }
 
       // join and quote incoming filenames to deploy
-      std::string additionalFiles = quotedFilesFromArray(additionalFilesList,
-            false);
-      std::string ignoredFiles = quotedFilesFromArray(ignoredFilesList,
-            false);
+      std::string additionalFiles = quotedFilesFromArray(additionalFilesList, false);
+      std::string ignoredFiles = quotedFilesFromArray(ignoredFilesList, false);
+      std::string envVars = quotedFilesFromArray(envVarsList, true);
 
       // if an R Markdown document or HTML document is being deployed, mark it
       // as the primary file, unless deploying a website
@@ -298,10 +298,9 @@ public:
                  quarto +
              "   asMultiple = " + (asMultiple ? "TRUE" : "FALSE") + ", "
              "   asStatic = " + (asStatic ? "TRUE" : "FALSE") + 
-                 (additionalFiles.empty() ? "" : ", additionalFiles = '" + 
-                    additionalFiles + "'") + 
-                 (ignoredFiles.empty() ? "" : ", ignoredFiles = '" + 
-                    ignoredFiles + "'") + 
+                 (additionalFiles.empty() ? "" : ", additionalFiles = '" +  additionalFiles + "'") + 
+                 (ignoredFiles.empty() ? "" : ", ignoredFiles = '" +  ignoredFiles + "'") + 
+                 (envVars.empty() ? "" : ", envVars = c(" + envVars + ")") +
              ")" + 
              (prefs::userPrefs().showPublishDiagnostics() ? ", logLevel = 'verbose'" : "") + 
              ")}";
@@ -428,10 +427,11 @@ Error rsconnectPublish(const json::JsonRpcRequest& request,
 
    // read publish settings
    bool asMultiple = false, asStatic = false;
-   json::Array deployFiles, additionalFiles, ignoredFiles;
+   json::Array deployFiles, additionalFiles, ignoredFiles, envVars;
    error = json::readObject(settings, "deploy_files",     deployFiles,
                                       "additional_files", additionalFiles,
                                       "ignored_files",    ignoredFiles,
+                                      "env_vars",         envVars,
                                       "as_multiple",      asMultiple,
                                       "as_static",        asStatic);
    if (error)
@@ -444,13 +444,23 @@ Error rsconnectPublish(const json::JsonRpcRequest& request,
    }
    else
    {
-      error = RSConnectPublish::create(sourceDir, deployFiles, 
-                                       sourceFile, sourceDoc, 
-                                       account, server, appName, appTitle, appId, 
+      error = RSConnectPublish::create(sourceDir,
+                                       deployFiles, 
+                                       sourceFile,
+                                       sourceDoc, 
+                                       account,
+                                       server,
+                                       appName,
+                                       appTitle,
+                                       appId,
                                        contentCategory,
                                        websiteDir,
                                        additionalFiles,
-                                       ignoredFiles, asMultiple, asStatic, isQuarto,
+                                       ignoredFiles,
+                                       envVars,
+                                       asMultiple,
+                                       asStatic,
+                                       isQuarto,
                                        &s_pRSConnectPublish_);
       if (error)
          return error;

--- a/src/cpp/session/modules/SessionRSConnect.cpp
+++ b/src/cpp/session/modules/SessionRSConnect.cpp
@@ -292,7 +292,8 @@ public:
              "launch.browser = function (url) { "
              "   message('" kFinishedMarker "', url) "
              "}, "
-             "lint = FALSE," +
+             "lint = FALSE, " +
+             (envVars.empty() ? "" : "envVars = c(" + envVars + "), ") +
              appModeOverride +
              "metadata = list(" +
                  quarto +
@@ -300,7 +301,6 @@ public:
              "   asStatic = " + (asStatic ? "TRUE" : "FALSE") + 
                  (additionalFiles.empty() ? "" : ", additionalFiles = '" +  additionalFiles + "'") + 
                  (ignoredFiles.empty() ? "" : ", ignoredFiles = '" +  ignoredFiles + "'") + 
-                 (envVars.empty() ? "" : ", envVars = c(" + envVars + ")") +
              ")" + 
              (prefs::userPrefs().showPublishDiagnostics() ? ", logLevel = 'verbose'" : "") + 
              ")}";

--- a/src/cpp/session/resources/dependencies/r-packages.json
+++ b/src/cpp/session/resources/dependencies/r-packages.json
@@ -251,7 +251,7 @@
             "source": false
         },
         "rsconnect": {
-            "version": "0.8.24",
+            "version": "1.3.1",
             "location": "cran",
             "source": true
         },

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -334,6 +334,11 @@ public abstract class ModalDialogBase extends DialogBox
       FocusHelper.setFocusDeferred(okButton_);
       return true;
    }
+   
+   protected void setCancelButtonCaption(String caption)
+   {
+      cancelButton_.setText(caption);
+   }
 
    protected void enableCancelButton(boolean enabled)
    {

--- a/src/gwt/src/org/rstudio/core/client/widget/SelectWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SelectWidget.java
@@ -14,6 +14,9 @@
  */
 package org.rstudio.core.client.widget;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.rstudio.core.client.CoreClientConstants;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
@@ -309,6 +312,21 @@ public class SelectWidget extends Composite
       return listBox_.getValue(listBox_.getSelectedIndex());
    }
 
+   public List<String> getValues()
+   {
+      List<String> values = new ArrayList<String>();
+      
+      for (int i = 0, n = listBox_.getItemCount(); i < n; i++)
+      {
+         if (listBox_.isItemSelected(i))
+         {
+            values.add(listBox_.getItemText(i));
+         }
+      }
+      
+      return values;
+   }
+   
    public int getIntValue()
    {
       return Integer.parseInt(getValue());

--- a/src/gwt/src/org/rstudio/studio/client/common/HelpLink.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/HelpLink.java
@@ -78,6 +78,11 @@ public class HelpLink extends Composite
 
       initWidget(helpPanel);
    }
+   
+   public static HelpLink createExternal(String caption, String link)
+   {
+      return new HelpLink(caption, link, false, false);
+   }
 
    public void setCaption(String caption)
    {

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
@@ -1124,8 +1124,8 @@ public class RSConnect implements SessionInitEvent.Handler,
    private final native void exportNativeCallbacks() /*-{
       var thiz = this;
       $wnd.deployToRSConnect = $entry(
-         function(sourceFile, deployDir, deployFile, websiteDir, description, deployFiles, additionalFiles, ignoredFiles, isSelfContained, isShiny, asMultiple, asStatic, isQuarto, launch, record) {
-            thiz.@org.rstudio.studio.client.rsconnect.RSConnect::deployToRSConnect(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/google/gwt/core/client/JsArrayString;Lcom/google/gwt/core/client/JsArrayString;Lcom/google/gwt/core/client/JsArrayString;ZZZZZZLcom/google/gwt/core/client/JavaScriptObject;)(sourceFile, deployDir, deployFile, websiteDir, description, deployFiles, additionalFiles, ignoredFiles, isSelfContained, isShiny, asMultiple, asStatic, isQuarto, launch, record);
+         function(sourceFile, deployDir, deployFile, websiteDir, description, deployFiles, additionalFiles, ignoredFiles, envVars, isSelfContained, isShiny, asMultiple, asStatic, isQuarto, launch, record) {
+            thiz.@org.rstudio.studio.client.rsconnect.RSConnect::deployToRSConnect(*)(sourceFile, deployDir, deployFile, websiteDir, description, deployFiles, additionalFiles, ignoredFiles, envVars, isSelfContained, isShiny, asMultiple, asStatic, isQuarto, launch, record);
          }
       );
    }-*/;
@@ -1138,6 +1138,7 @@ public class RSConnect implements SessionInitEvent.Handler,
                                   JsArrayString deployFiles,
                                   JsArrayString additionalFiles,
                                   JsArrayString ignoredFiles,
+                                  JsArrayString envVars,
                                   boolean isSelfContained,
                                   boolean isShiny,
                                   boolean asMultiple,
@@ -1153,19 +1154,21 @@ public class RSConnect implements SessionInitEvent.Handler,
       else
          WindowEx.get().focus();
 
-      ArrayList<String> deployFilesList =
+      List<String> deployFilesList =
             JsArrayUtil.fromJsArrayString(deployFiles);
-      ArrayList<String> additionalFilesList =
+      List<String> additionalFilesList =
             JsArrayUtil.fromJsArrayString(additionalFiles);
-      ArrayList<String> ignoredFilesList =
+      List<String> ignoredFilesList =
             JsArrayUtil.fromJsArrayString(ignoredFiles);
+      List<String> envVarsList =
+            JsArrayUtil.fromJsArrayString(envVars);
 
       RSConnectDeploymentRecord record = jsoRecord.cast();
       events_.fireEvent(new RSConnectDeployInitiatedEvent(
             new RSConnectPublishSource(sourceFile, deployDir, deployFile,
                   websiteDir, isSelfContained, asStatic, isShiny, isQuarto, description),
             new RSConnectPublishSettings(deployFilesList,
-                  additionalFilesList, ignoredFilesList, asMultiple, asStatic),
+                  additionalFilesList, ignoredFilesList, envVarsList, asMultiple, asStatic),
             launch, record));
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RsconnectConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RsconnectConstants.java
@@ -1491,4 +1491,9 @@ public interface RsconnectConstants extends com.google.gwt.i18n.client.Messages{
     @DefaultMessage("Our online service that lets you do, share, teach and learn data science in your web browser.")
     @Key("newPositCloudPageSubTitle")
     String newPositCloudPageSubTitle();
+    
+    @DefaultMessage("{0,number} environment variables will be published with this application.")
+    @AlternateMessage({"one", "1 environment variable will be published with this application."})
+    String envVarsPublishMessage(@PluralCount int itemCount);
+    
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RsconnectConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RsconnectConstants.java
@@ -1492,8 +1492,8 @@ public interface RsconnectConstants extends com.google.gwt.i18n.client.Messages{
     @Key("newPositCloudPageSubTitle")
     String newPositCloudPageSubTitle();
     
-    @DefaultMessage("{0,number} environment variables will be published with this application.")
-    @AlternateMessage({"one", "1 environment variable will be published with this application."})
-    String envVarsPublishMessage(@PluralCount int itemCount);
+    @DefaultMessage("{0,number} environment variables will be published with this {1}.")
+    @AlternateMessage({"one", "1 environment variable will be published with this {1}."})
+    String envVarsPublishMessage(@PluralCount int itemCount, String contentType);
     
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RsconnectConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RsconnectConstants.java
@@ -1499,4 +1499,16 @@ public interface RsconnectConstants extends com.google.gwt.i18n.client.Messages{
     @DefaultMessage("Select one or more environment variables to publish with this {0}.")
     String envVarsSelectMessage(String contentType);
     
+    @DefaultMessage("Close")
+    String close();
+    
+    @DefaultMessage("Environment variables")
+    String environmentVariablesDialogTitle();
+    
+    @DefaultMessage("Environment Variables")
+    String environmentVariablesHelpLinkLabel();
+    
+    @DefaultMessage("No environment variables are currently available.")
+    String noEnvVarsAvailable();
+    
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RsconnectConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RsconnectConstants.java
@@ -1496,4 +1496,7 @@ public interface RsconnectConstants extends com.google.gwt.i18n.client.Messages{
     @AlternateMessage({"one", "1 environment variable will be published with this {1}."})
     String envVarsPublishMessage(@PluralCount int itemCount, String contentType);
     
+    @DefaultMessage("Select one or more environment variables to publish with this {0}.")
+    String envVarsSelectMessage(String contentType);
+    
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectApplicationInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectApplicationInfo.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.rsconnect.model;
 
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
 
 public class RSConnectApplicationInfo extends JavaScriptObject
 {
@@ -52,5 +53,9 @@ public class RSConnectApplicationInfo extends JavaScriptObject
 
    public final native String getUpdatedTime() /*-{
       return this.updated_time;
+   }-*/;
+   
+   public final native JsArrayString getEnvVars() /*-{
+      return this.envVars || [];
    }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectApplicationResult.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectApplicationResult.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.rsconnect.model;
 
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
 
 public class RSConnectApplicationResult extends JavaScriptObject
 {
@@ -28,5 +29,9 @@ public class RSConnectApplicationResult extends JavaScriptObject
 
    public final native String getError() /*-{
       return this.error;
+   }-*/;
+   
+   public final native JsArrayString getEnvVars() /*-{
+      return this.envVars || [];
    }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishResult.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishResult.java
@@ -28,23 +28,20 @@ public class RSConnectPublishResult
       appId_       = "";
       account_     = null; 
       source_      = source;
-      settings_    = new RSConnectPublishSettings(deployFiles, null, null, false,
-         true);
+      settings_    = new RSConnectPublishSettings(deployFiles);
       isUpdate_    = false;
    }
 
    public RSConnectPublishResult(String appName, 
-         String appTitle,
-         String appId,
-         RSConnectAccount account, 
-         RSConnectPublishSource source,
-         RSConnectPublishSettings settings,
-         boolean isUpdate)
+                                 String appTitle,
+                                 String appId,
+                                 RSConnectAccount account, 
+                                 RSConnectPublishSource source,
+                                 RSConnectPublishSettings settings,
+                                 boolean isUpdate)
    {     
-      this(settings.getAsStatic() ? 
-               PUBLISH_STATIC : PUBLISH_CODE, 
-           appName, appTitle, appId, account, source, settings,
-           isUpdate);
+      this(settings.getAsStatic() ? PUBLISH_STATIC : PUBLISH_CODE, 
+           appName, appTitle, appId, account, source, settings, isUpdate);
    }
    
    private RSConnectPublishResult(int publishType, 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSettings.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSettings.java
@@ -14,39 +14,47 @@
  */
 package org.rstudio.studio.client.rsconnect.model;
 
-import java.util.ArrayList;
+import java.util.List;
 
 import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.js.JsObject;
+import org.rstudio.core.client.js.JsUtil;
 
 import com.google.gwt.core.client.JavaScriptObject;
 
 public class RSConnectPublishSettings
 {
-   public RSConnectPublishSettings(ArrayList<String> deployFiles, 
-         ArrayList<String> additionalFiles, 
-         ArrayList<String> ignoredFiles,
-         boolean asMultiple,
-         boolean asStatic)
+   public RSConnectPublishSettings(List<String> deployFiles, 
+                                   List<String> additionalFiles, 
+                                   List<String> ignoredFiles,
+                                   List<String> envVars,
+                                   boolean asMultiple,
+                                   boolean asStatic)
    {
       deployFiles_ = deployFiles;
       additionalFiles_ = additionalFiles;
       ignoredFiles_ = ignoredFiles;
+      envVars_ = envVars;
       asMultiple_ = asMultiple;
       asStatic_ = asStatic;
    }
 
-   public ArrayList<String> getDeployFiles()
+   public RSConnectPublishSettings(List<String> deployFiles)
+   {
+      this(deployFiles, null, null, null, false, true);
+   }
+   
+   public List<String> getDeployFiles()
    {
       return deployFiles_;
    }
 
-   public ArrayList<String> getAdditionalFiles()
+   public List<String> getAdditionalFiles()
    {
       return additionalFiles_;
    }
 
-   public ArrayList<String> getIgnoredFiles()
+   public List<String> getIgnoredFiles()
    {
       return ignoredFiles_;
    }
@@ -70,14 +78,17 @@ public class RSConnectPublishSettings
             JsArrayUtil.toJsArrayString(getAdditionalFiles()));
       obj.setJsArrayString("ignored_files", 
             JsArrayUtil.toJsArrayString(getIgnoredFiles()));
+      obj.setJsArrayString("env_vars",
+            JsUtil.toJsArrayString(envVars_));
       obj.setBoolean("as_multiple", getAsMultiple());
       obj.setBoolean("as_static", getAsStatic());
       return obj.cast();
    }
 
-   private final ArrayList<String> deployFiles_;
-   private final ArrayList<String> additionalFiles_;
-   private final ArrayList<String> ignoredFiles_;
+   private final List<String> deployFiles_;
+   private final List<String> additionalFiles_;
+   private final List<String> ignoredFiles_;
+   private final List<String> envVars_;
    private final boolean asMultiple_;
    private final boolean asStatic_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectServerOperations.java
@@ -50,6 +50,8 @@ public interface RSConnectServerOperations extends QuartoServerOperations
                String quartoSrcFile,
                ServerRequestCallback<RSConnectDeploymentFiles> requestCallback);
    
+   void getDeploymentEnvVars(ServerRequestCallback<JsArrayString> resultCallback);
+   
    void publishContent(RSConnectPublishSource source, 
                String account, String server, String appName, String appTitle, String appId,
                RSConnectPublishSettings settings,
@@ -86,6 +88,4 @@ public interface RSConnectServerOperations extends QuartoServerOperations
    
    void generateAppName(String title, String appPath, String accountName,
                 ServerRequestCallback<RSConnectAppName> resultCallback);
-   
-   void listEnvironmentVariables(ServerRequestCallback<JsArrayString> resultCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectServerOperations.java
@@ -45,7 +45,7 @@ public interface RSConnectServerOperations extends QuartoServerOperations
                                    String outputFile,
                                    ServerRequestCallback<Void> requestCallback);
    
-   void getDeploymentFiles (String target, 
+   void getDeploymentFiles(String target, 
                boolean asMultipleRmd,
                String quartoSrcFile,
                ServerRequestCallback<RSConnectDeploymentFiles> requestCallback);
@@ -86,4 +86,6 @@ public interface RSConnectServerOperations extends QuartoServerOperations
    
    void generateAppName(String title, String appPath, String accountName,
                 ServerRequestCallback<RSConnectAppName> resultCallback);
+   
+   void listEnvironmentVariables(ServerRequestCallback<JsArrayString> resultCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.css
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.css
@@ -20,6 +20,13 @@
    margin-left: 0;
 }
 
+.envVarsLabel
+{
+	margin-top: 6px;
+	margin-bottom: 6px;
+	font-style: oblique;
+}
+
 .sourceDestLabels
 {
    color: #808080;
@@ -85,7 +92,7 @@
 
 .wizard .fileList
 {
-   height: 140px;
+   height: 126px;
 }
 
 .fileList .gwt-CheckBox,

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -354,7 +354,7 @@ public class RSConnectDeploy extends Composite
          @Override
          public void onClick(ClickEvent arg0)
          {
-            server_.listEnvironmentVariables(new ServerRequestCallback<JsArrayString>()
+            server_.getDeploymentEnvVars(new ServerRequestCallback<JsArrayString>()
             {
                @Override
                public void onResponseReceived(JsArrayString response)

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -166,12 +166,14 @@ public class RSConnectDeploy extends Composite
    {
       public EnvironmentVariablesDialog(String contentType,
                                         List<String> envVars,
-                                        OperationWithInput<List<String>> onClosed)
+                                        OperationWithInput<List<String>> onClosed,
+                                        Operation onCancel)
       {
          super(
                "Environment variables",
                Roles.getDialogRole(),
-               onClosed);
+               onClosed,
+               onCancel);
          
          HelpLink publishLink = HelpLink.createExternal(
                "Environment Variables",
@@ -233,6 +235,18 @@ public class RSConnectDeploy extends Composite
          }
          
          return values;
+      }
+      
+      public void setItemSelected(String item)
+      {
+         for (int i = 0, n = listBox_.getItemCount(); i < n; i++)
+         {
+            if (StringUtil.equals(listBox_.getItemText(i), item))
+            {
+               listBox_.setItemSelected(i, true);
+               break;
+            }
+         }
       }
       
       private final VerticalPanel container_;
@@ -350,12 +364,11 @@ public class RSConnectDeploy extends Composite
             server_.getDeploymentEnvVars(new ServerRequestCallback<JsArrayString>()
             {
                @Override
-               public void onResponseReceived(JsArrayString response)
+               public void onResponseReceived(JsArrayString envVars)
                {
-                  List<String> envVars = JsUtil.toList(response);
                   EnvironmentVariablesDialog dialog = new EnvironmentVariablesDialog(
                         appContentType(),
-                        envVars,
+                        JsUtil.toList(envVars),
                         new OperationWithInput<List<String>>()
                         {
                            @Override
@@ -364,7 +377,21 @@ public class RSConnectDeploy extends Composite
                               appEnvVars_ = envVars;
                               updateEnvVarsLabel();
                            }
+                        },
+                        new Operation()
+                        {
+                           @Override
+                           public void execute()
+                           {
+                              appEnvVars_.clear();;
+                              updateEnvVarsLabel();
+                           }
                         });
+                  
+                  for (String envVar : appEnvVars_)
+                  {
+                     dialog.setItemSelected(envVar);
+                  }
                   
                   dialog.showModal();
                }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -1430,8 +1430,32 @@ public class RSConnectDeploy extends Composite
       }
       else
       {
-         envVarsLabel_.setText(constants_.envVarsPublishMessage(appEnvVars_.size()));
+         envVarsLabel_.setText(constants_.envVarsPublishMessage(appEnvVars_.size(), appContentType()));
          envVarsLabel_.setVisible(true);
+      }
+   }
+   
+   private String appContentType()
+   {
+      switch (contentType_)
+      {
+      case RSConnect.CONTENT_TYPE_NONE:
+      case RSConnect.CONTENT_TYPE_APP:
+      case RSConnect.CONTENT_TYPE_APP_SINGLE:
+         return "application";
+      case RSConnect.CONTENT_TYPE_PLOT:
+      case RSConnect.CONTENT_TYPE_HTML:
+         return "plot";
+      case RSConnect.CONTENT_TYPE_PRES:
+         return "presentation";
+      case RSConnect.CONTENT_TYPE_DOCUMENT:
+         return "document";
+      case RSConnect.CONTENT_TYPE_PLUMBER_API:
+         return "plumber API";
+      case RSConnect.CONTENT_TYPE_QUARTO_WEBSITE:
+         return "Quarto website";
+      default:
+         return "application";
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -170,13 +170,13 @@ public class RSConnectDeploy extends Composite
                                         Operation onCancel)
       {
          super(
-               "Environment variables",
+               constants_.environmentVariablesDialogTitle(),
                Roles.getDialogRole(),
                onClosed,
                onCancel);
          
          HelpLink publishLink = HelpLink.createExternal(
-               "Environment Variables",
+               constants_.environmentVariablesHelpLinkLabel(),
                "https://docs.posit.co/connect/admin/process-management/index.html#environment-variables");
          publishLink.getElement().getStyle().setMarginTop(4, Unit.PX);
          addLeftWidget(publishLink);
@@ -188,10 +188,15 @@ public class RSConnectDeploy extends Composite
          listBox_ = new ListBox();
          if (envVars.isEmpty())
          {
-            setWidth("360px");
+            setOkButtonVisible(false);
+            setCancelButtonCaption(constants_.close());
             
-            container_.add(new Label("No environment variables are currently available."));
-            container_.add(new VerticalSpacer("12px"));
+            VerticalPanel containerPanel = new VerticalPanel();
+            containerPanel.setWidth("360px");
+            Label noEnvVarsLabel = new Label(constants_.noEnvVarsAvailable());
+            containerPanel.add(noEnvVarsLabel);
+            containerPanel.add(new VerticalSpacer("12px"));
+            container_.add(containerPanel);
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -15,10 +15,7 @@
 package org.rstudio.studio.client.rsconnect.ui;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
@@ -166,8 +163,7 @@ public class RSConnectDeploy extends Composite
    
    public static class EnvironmentVariablesDialog extends ModalDialog<List<String>>
    {
-      public EnvironmentVariablesDialog(List<String> sessionEnvVars,
-                                        List<String> appEnvVars,
+      public EnvironmentVariablesDialog(List<String> envVars,
                                         OperationWithInput<List<String>> onClosed)
       {
          super(
@@ -190,34 +186,12 @@ public class RSConnectDeploy extends Composite
          listBox_.setMultipleSelect(true);
          listBox_.setWidth("100%");
          
-         // Initialize the list box values. We round trip between a set and a
-         // list here to remove duplicates, and also to ensure that environment
-         // variables are alphabetically sorted within.
-         Set<String> envVarsSet = new HashSet<String>();
-         envVarsSet.addAll(sessionEnvVars);
-         envVarsSet.addAll(appEnvVars);
-         
-         List<String> allEnvVars = new ArrayList<String>();
-         allEnvVars.addAll(envVarsSet);
-         Collections.sort(allEnvVars);
-         for (String envVar : allEnvVars)
+         for (String envVar : envVars)
          {
             listBox_.addItem(envVar);
          }
          
-         // Ensure any environment variables which were previously set for an application
-         // are also selected.
-         for (int i = 0, n = listBox_.getItemCount(); i < n; i++)
-         {
-            String itemText = listBox_.getItemText(i);
-            if (appEnvVars.contains(itemText))
-            {
-               listBox_.setItemSelected(i, true);
-            }
-         }
-         
          container_.add(listBox_);
-         
       }
 
       @Override
@@ -359,10 +333,9 @@ public class RSConnectDeploy extends Composite
                @Override
                public void onResponseReceived(JsArrayString response)
                {
-                  List<String> sessionEnvVars = JsUtil.toList(response);
+                  List<String> envVars = JsUtil.toList(response);
                   EnvironmentVariablesDialog dialog = new EnvironmentVariablesDialog(
-                        sessionEnvVars,
-                        appEnvVars_,
+                        envVars,
                         new OperationWithInput<List<String>>()
                         {
                            @Override

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -39,6 +39,7 @@ import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.FileDialogs;
 import org.rstudio.studio.client.common.FilePathUtils;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.rsconnect.RSConnect;
 import org.rstudio.studio.client.rsconnect.RsconnectConstants;
 import org.rstudio.studio.client.rsconnect.model.RSConnectAccount;
@@ -163,7 +164,8 @@ public class RSConnectDeploy extends Composite
    
    public static class EnvironmentVariablesDialog extends ModalDialog<List<String>>
    {
-      public EnvironmentVariablesDialog(List<String> envVars,
+      public EnvironmentVariablesDialog(String contentType,
+                                        List<String> envVars,
                                         OperationWithInput<List<String>> onClosed)
       {
          super(
@@ -171,27 +173,44 @@ public class RSConnectDeploy extends Composite
                Roles.getDialogRole(),
                onClosed);
          
-         setWidth("300px");
-         setHeight("300px");
+         HelpLink publishLink = HelpLink.createExternal(
+               "Environment Variables",
+               "https://docs.posit.co/connect/admin/process-management/index.html#environment-variables");
+         publishLink.getElement().getStyle().setMarginTop(4, Unit.PX);
+         addLeftWidget(publishLink);
          
          container_ = new VerticalPanel();
          container_.setWidth("100%");
          container_.setHeight("100%");
          
-         container_.add(new Label("Select one more environment variables to publish with this application."));
-         container_.add(new VerticalSpacer("12px"));
-         
          listBox_ = new ListBox();
-         listBox_.setHeight("200px");
-         listBox_.setMultipleSelect(true);
-         listBox_.setWidth("100%");
-         
-         for (String envVar : envVars)
+         if (envVars.isEmpty())
          {
-            listBox_.addItem(envVar);
+            setWidth("360px");
+            
+            container_.add(new Label("No environment variables are currently available."));
+            container_.add(new VerticalSpacer("12px"));
+         }
+         else
+         {
+            setWidth("360px");
+            setHeight("300px");
+         
+            container_.add(new Label(constants_.envVarsSelectMessage(contentType)));
+            container_.add(new VerticalSpacer("12px"));
+
+            listBox_.setHeight("200px");
+            listBox_.setMultipleSelect(true);
+            listBox_.setWidth("100%");
+
+            for (String envVar : envVars)
+            {
+               listBox_.addItem(envVar);
+            }
+
+            container_.add(listBox_);
          }
          
-         container_.add(listBox_);
       }
 
       @Override
@@ -335,6 +354,7 @@ public class RSConnectDeploy extends Composite
                {
                   List<String> envVars = JsUtil.toList(response);
                   EnvironmentVariablesDialog dialog = new EnvironmentVariablesDialog(
+                        appContentType(),
                         envVars,
                         new OperationWithInput<List<String>>()
                         {

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -493,7 +493,7 @@ public class RSConnectDeploy extends Composite
          
          urlAnchor_.setText(url);
          urlAnchor_.setHref(url);
-         appEnvVars_ = JsUtil.toList(info.getEnvVars());
+         // appEnvVars_ = JsUtil.toList(info.getEnvVars());
          updateEnvVarsLabel();
       }
       

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
@@ -38,7 +38,7 @@
                   <ui:attribute name="text" key="addMoreButtonText"/>
               </rw:ThemedButton>
               <rw:ThemedButton ui:field="envVarsButton_" 
-                               text="Environment variables..."
+                               text="Add environment variables..."
                                visible="true">
                   <ui:attribute name="text" key="addEnvironmentVariablesButtonText"/>
               </rw:ThemedButton>

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
@@ -12,7 +12,8 @@
 
     <g:HTMLPanel ui:field="rootPanel_">
     <rw:DecorativeImage ui:field="deployIllustration_"/>
-    <rw:LayoutGrid><rw:row>
+    <rw:LayoutGrid>
+    <rw:row>
     <rw:customCell styleName="{res.style.rootCell}">
       <g:HTMLPanel>
          <g:VerticalPanel ui:field="filePanel_">
@@ -35,6 +36,11 @@
                                text="Add more..."
                                visible="false">
                   <ui:attribute name="text" key="addMoreButtonText"/>
+              </rw:ThemedButton>
+              <rw:ThemedButton ui:field="envVarsButton_" 
+                               text="Environment variables..."
+                               visible="true">
+                  <ui:attribute name="text" key="addEnvironmentVariablesButtonText"/>
               </rw:ThemedButton>
            </g:HorizontalPanel>
          </g:VerticalPanel>
@@ -125,6 +131,9 @@
          </g:HTMLPanel>
       </g:HTMLPanel>
      </rw:customCell>
-   </rw:row></rw:LayoutGrid>
+   </rw:row>
+   </rw:LayoutGrid>
+   <g:Label styleName="{res.style.envVarsLabel}" ui:field="envVarsLabel_" visible="true">
+   </g:Label>
    </g:HTMLPanel>
 </ui:UiBinder> 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishButton.java
@@ -723,7 +723,8 @@ public class RSConnectPublishButton extends Composite
                            new RSConnectPublishSettings(
                                  deployFiles, 
                                  new ArrayList<>(), 
-                                 new ArrayList<>(), 
+                                 new ArrayList<>(),
+                                 new ArrayList<>(),
                                  false, true);
                      events_.fireEvent(
                            new RSConnectDeployInitiatedEvent(source, settings,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -5473,9 +5473,9 @@ public class RemoteServer implements Server
    }
    
    @Override
-   public void listEnvironmentVariables(ServerRequestCallback<JsArrayString> resultCallback)
+   public void getDeploymentEnvVars(ServerRequestCallback<JsArrayString> resultCallback)
    {
-      sendRequest(RPC_SCOPE, "list_environment_variables", resultCallback);
+      sendRequest(RPC_SCOPE, "get_deployment_env_vars", resultCallback);
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -5471,7 +5471,13 @@ public class RemoteServer implements Server
       params.set(2, new JSONString(accountName));
       sendRequest(RPC_SCOPE, "generate_app_name", params, resultCallback);
    }
-
+   
+   @Override
+   public void listEnvironmentVariables(ServerRequestCallback<JsArrayString> resultCallback)
+   {
+      sendRequest(RPC_SCOPE, "list_environment_variables", resultCallback);
+   }
+   
    @Override
    public void getEditPublishedDocs(String appPath,
          ServerRequestCallback<JsArrayString> resultCallback)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -8756,14 +8756,16 @@ public class TextEditingTarget implements
       return docDisplay_;
    }
 
-   private void addAdditionalResourceFiles(ArrayList<String> additionalFiles)
+   private void addAdditionalResourceFiles(List<String> additionalFiles)
    {
       // it does--get the YAML front matter and modify it to include
       // the additional files named in the deployment
       String yaml = getRmdFrontMatter();
       if (yaml == null)
          return;
-      rmarkdownHelper_.addAdditionalResourceFiles(yaml,
+      
+      rmarkdownHelper_.addAdditionalResourceFiles(
+            yaml,
             additionalFiles,
             new CommandWithArg<String>()
             {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
@@ -877,8 +877,8 @@ public class TextEditingTargetRMarkdownHelper
    }
 
    public void addAdditionalResourceFiles(String yaml,
-         final ArrayList<String> files,
-         final CommandWithArg<String> onCompleted)
+                                          final List<String> files,
+                                          final CommandWithArg<String> onCompleted)
    {
       convertFromYaml(yaml, new CommandWithArg<RmdYamlData>()
       {
@@ -886,10 +886,13 @@ public class TextEditingTargetRMarkdownHelper
          public void execute(RmdYamlData arg)
          {
             if (!arg.parseSucceeded())
+            {
                onCompleted.execute(null);
+            }
             else
-               addAdditionalResourceFiles(arg.getFrontMatter(), files,
-                     onCompleted);
+            {
+               addAdditionalResourceFiles(arg.getFrontMatter(), files, onCompleted);
+            }
          }
       });
    }
@@ -1192,8 +1195,8 @@ public class TextEditingTargetRMarkdownHelper
    }
 
    private void addAdditionalResourceFiles(RmdFrontMatter frontMatter,
-         ArrayList<String> additionalFiles,
-         CommandWithArg<String> onCompleted)
+                                           List<String> additionalFiles,
+                                           CommandWithArg<String> onCompleted)
    {
       for (String file: additionalFiles)
       {


### PR DESCRIPTION
### TODO

- [x] Consider updating the required version of `rsconnect`; it looks like `envVars` have been supported since 1.0.0.
- [x] Add placeholder UI for case where no environment variables are available, or `.Renviron` does not exist.
- [x] Add a help link into the environment variables modal (https://docs.posit.co/connect/admin/process-management/index.html#environment-variables)
- [x] Consider whether we want to allow auto-updating of environment variables. (I'm leaning towards _no_, and that users should have to manually select and publish environment variables each time, but can be convinced otherwise!)

### Intent

Addresses https://github.com/rstudio/rstudio/issues/13032.

### Approach

Recent releases of `rsconnect` include support for publishing environment variables alongside a particular deployment. This is typically useful for secrets / API keys which the application might need in order to access external web services. This PR adds some basic UI to make this possible. Example:

<img width="605" alt="Screenshot 2024-09-09 at 3 31 30 PM" src="https://github.com/user-attachments/assets/18d47a8a-405f-457b-98b1-99f974299d67">

Note the new `Add environment variables...` button. Clicking that brings up a simple modal dialog:

<img width="315" alt="Screenshot 2024-09-09 at 3 31 57 PM" src="https://github.com/user-attachments/assets/b7a7d7f1-4547-43a4-96fc-d7f4b3375fb1">

The names of environment variables are pulled from either the project's `.Renviron`, or from the user `.Renviron`. Currently, names are filtered to those which "look like" secret keys; we might reconsider this design in the future if needed.

After selecting some environment variables and clicking Ok, we add a small blurb to indicate these variables were set:

<img width="601" alt="Screenshot 2024-09-09 at 3 33 09 PM" src="https://github.com/user-attachments/assets/9a1cc41d-ab92-4d4f-939c-b428682cfd10">

These environment variable names then become part of the `deployApp()` call generates to start the deployment.

The empty placeholder is fairly minimal; the hope is that interested users will click and appropriate help link. We can add more information if needed.

<img width="375" alt="Screenshot 2024-09-10 at 11 47 58 AM" src="https://github.com/user-attachments/assets/59e043f3-7cd9-443a-a166-3e62ae54799b">

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13032.

### Documentation

To be added.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests
