### PR TITLE
refactoring for better testability

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/DefaultChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/DefaultChunkOptionsPopupPanel.java
@@ -128,8 +128,8 @@ public class DefaultChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
       return null;
    }
 
-   public static String extractChunkPreamble(String extractedChunkHeader,
-                                             String modeId)
+   private static String extractChunkPreamble(String extractedChunkHeader,
+                                              String modeId)
    {
       if (modeId == "mode/sweave")
          return "";

--- a/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
+++ b/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
@@ -33,6 +33,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.assist.RChu
 import org.rstudio.studio.client.workbench.views.terminal.TerminalLocalEchoTests;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalSessionSocketTests;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkContextUiTests;
+import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.DefaultChunkOptionsPopupPanelTests;
 
 import com.google.gwt.junit.tools.GWTTestSuite;
 
@@ -54,6 +55,7 @@ public class RStudioUnitTestSuite extends GWTTestSuite
       suite.addTestSuite(JobManagerTests.class);
       suite.addTestSuite(URIUtilsTests.class);
       suite.addTestSuite(RChunkHeaderParserTests.class);
+      suite.addTestSuite(DefaultChunkOptionsPopupPanelTests.class);
       suite.addTestSuite(TextCursorTests.class);
       suite.addTestSuite(SessionScopeTests.class);
       suite.addTestSuite(JobsListTests.class);

--- a/src/gwt/test/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/DefaultChunkOptionsPopupPanelTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/DefaultChunkOptionsPopupPanelTests.java
@@ -1,0 +1,86 @@
+/*
+ * DefaultChunkOptionsPopupPanelTests.java
+ *
+ * Copyright (C) 2024 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text.rmd;
+
+import com.google.gwt.junit.client.GWTTestCase;
+
+import org.rstudio.core.client.StringUtil;
+import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.display.DefaultChunkOptionsPopupPanel;
+import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.display.DefaultChunkOptionsPopupPanel.ChunkHeaderInfo;
+
+import java.util.HashMap;
+
+public class DefaultChunkOptionsPopupPanelTests extends GWTTestCase
+{
+   @Override
+   public String getModuleName()
+   {
+      return "org.rstudio.studio.RStudioTests";
+   }
+
+   public void testRMarkdownChunkHeader()
+   {
+      String header = "```{r label, echo=TRUE}";
+      ChunkHeaderInfo extraInfo = new ChunkHeaderInfo();
+      HashMap<String, String> pieces = new HashMap<String, String>();
+      DefaultChunkOptionsPopupPanel.parseChunkHeader(header, "mode/rmarkdown", pieces, extraInfo);
+
+      assertEquals("label", extraInfo.chunkLabel);
+      assertEquals("r", extraInfo.chunkPreamble);
+      assertTrue(pieces.containsKey("echo"));
+      assertEquals("TRUE", pieces.get("echo"));
+   }
+
+   public void testNoCommaBeforeFirstItem()
+   {
+      String header = "```{r echo=TRUE}";
+      ChunkHeaderInfo extraInfo = new ChunkHeaderInfo();
+      HashMap<String, String> pieces = new HashMap<String, String>();
+      DefaultChunkOptionsPopupPanel.parseChunkHeader(header, "mode/rmarkdown", pieces, extraInfo);
+
+      assertTrue(pieces.containsKey("echo"));
+      assertEquals("r", extraInfo.chunkPreamble);
+      assertTrue(StringUtil.isNullOrEmpty(extraInfo.chunkLabel));
+      assertEquals("TRUE", pieces.get("echo"));
+   }
+
+   public void testCommaBeforeFirstItem()
+   {
+      String header = "```{r, echo=TRUE}";
+      ChunkHeaderInfo extraInfo = new ChunkHeaderInfo();
+      HashMap<String, String> pieces = new HashMap<String, String>();
+      DefaultChunkOptionsPopupPanel.parseChunkHeader(header, "mode/rmarkdown", pieces, extraInfo);
+
+      assertTrue(pieces.containsKey("echo"));
+      assertEquals("r", extraInfo.chunkPreamble);
+      assertTrue(StringUtil.isNullOrEmpty(extraInfo.chunkLabel));
+      assertEquals("TRUE", pieces.get("echo"));
+   }
+
+   public void testComplicatedExpression()
+   {
+      String header = "```{r, echo= {1 + 1}, message=FALSE}";
+      ChunkHeaderInfo extraInfo = new ChunkHeaderInfo();
+      HashMap<String, String> pieces = new HashMap<String, String>();
+      DefaultChunkOptionsPopupPanel.parseChunkHeader(header, "mode/rmarkdown", pieces, extraInfo);
+
+      assertEquals("r", extraInfo.chunkPreamble);
+      assertTrue(StringUtil.isNullOrEmpty(extraInfo.chunkLabel));
+      assertTrue(pieces.containsKey("echo"));
+      assertEquals("{1 + 1}", pieces.get("echo"));
+      assertTrue(pieces.containsKey("message"));
+      assertEquals("FALSE", pieces.get("message"));
+   }
+}


### PR DESCRIPTION
### Intent

We have at least two places that implement chunk header parsing:

- `class RChunkHeaderParser`
- `DefaultChunkOptionsPopupPanel.parseChunkHeader()`

I'm not ready to attempt consolidation, but this PR puts some unit tests in place for `DefaultChunkOptionsPopupPanel.parseChunkHeader()` (the other one already has some).

### Approach

Make the method `public static` and pass in the info needed instead of relying on the class, and return all info instead of setting class members.

Then added tests, essentially identical to those running against  `class RChunkHeaderParser`.

### Automated Tests

Yes

### QA Notes

Refactoring to expose code for unit testing and added such tests.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


