### PR TITLE
'Run All' now runs only R chunks in console output mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 #### RStudio
+- "Run All" now only executes R chunks when "Chunk Output in Console" is set (#11995)
 - Fixed an issue in the data viewer where list-column cell navigation worked incorrectly when a search filter was active (#9960)
 - Fixed an issue where debugger breakpoints did not function correctly in some cases with R 4.4 (#15072)
 - Fixed an issue where autocompletion results within piped expressions were incorrect in some cases (#13611)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -6531,17 +6531,15 @@ public class TextEditingTarget implements
    private boolean isRChunk(Scope scope)
    {
       String labelText = docDisplay_.getLine(scope.getPreamble().getRow());
-      Pattern reEngine = Pattern.create(".*engine\\s*=\\s*['\"]([^'\"]*)['\"]");
-      Match match = reEngine.match(labelText, 0);
-      if (match == null)
+      Map<String, String> chunkOptions = RChunkHeaderParser.parse(labelText);
+      if (!chunkOptions.containsKey("engine"))
          return true;
-
-      String engine = match.getGroup(1).toLowerCase();
-
+      
       // NOTE: We might want to include 'Rscript' but such chunks are typically
       // intended to be run in their own process so it might not make sense to
       // collect those here.
-      return engine.equals("r");
+      String engine = chunkOptions.get("engine").toLowerCase();
+      return engine == "\"r\"";
    }
    
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11995.

### Approach

The helper function `isRChunk()` was put together in the old days, before `rmarkdown` and `knitr` supported declaring the engine name directly at the start of a chunk. Because it specifically tried to pull out a chunk option set via `engine =`, it fell to the default behavior of assuming everything was an R chunk.

Note that non-R chunks are still not executed in this mode; I think we're still advocating that users who want all chunks to be executed (even non-R chunks) will need to enable inline chunk outputs?

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/11995.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

