### PR TITLE
allow user, admin to configure default .Rproj.user path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ### New
 #### RStudio
 - RStudio now supports the inclusion of environment variables when publishing applications to Posit Connect (#13032)
+- The .Rproj.user folder location can now be customized globally both by users and administrators (#15098)
 - RStudio now supports code formatting using the 'styler' R package, as well via other external applications (#2563)
 - Use native file and message dialogs by default on Linux desktop (#14683; Linux Desktop)
 - Added www-socket option to rserver.conf to enable server to listen on a Unix domain socket (#14938; Open-Source Server)

--- a/src/cpp/core/include/core/r_util/RProjectFile.hpp
+++ b/src/cpp/core/include/core/r_util/RProjectFile.hpp
@@ -76,6 +76,7 @@ struct RProjectConfig
 {
    RProjectConfig()
       : version(1.0),
+        projectId(),
         rVersion(kRVersionDefault),
         saveWorkspace(DefaultValue),
         restoreWorkspace(DefaultValue),
@@ -124,6 +125,7 @@ struct RProjectConfig
    }
 
    double version;
+   std::string projectId;
    RVersionInfo rVersion;
    int saveWorkspace;
    int restoreWorkspace;

--- a/src/cpp/server/include/server/ServerOptions.gen.hpp
+++ b/src/cpp/server/include/server/ServerOptions.gen.hpp
@@ -104,7 +104,7 @@ protected:
       "The port that RStudio Server will bind to while listening for incoming connections. If left empty, the port will be automatically determined based on your SSL settings (443 for SSL, 80 for no SSL).")
       ("www-socket",
       value<std::string>(&wwwSocket_)->default_value(""),
-      "The socket that RStudio Server will bind to while listening for incoming connections. If left empty, a socket will not be used but a port instead.")
+      "The socket that RStudio Server will bind to while listening for incoming connections. If left empty, a port will be used.")
       ("www-root-path",
       value<std::string>(&wwwRootPath_)->default_value(kRequestDefaultRootPath),
       "The path prefix added by a proxy to the incoming RStudio URL. This setting is used so RStudio Server knows what path it is being served from. If running RStudio Server behind a path-modifying proxy, this should be changed to match the base RStudio Server URL.")

--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -246,7 +246,13 @@ protected:
       "Duration in millis before requests that can be handled offline are processed by the offline handler thread.")
       (kSessionUseFileStorage,
       value<bool>(&sessionUseFileStorage_)->default_value(true),
-      "Controls whether the session should store its metadata on the file system or send it to the server to be stored in the internal database.");
+      "Controls whether the session should store its metadata on the file system or send it to the server to be stored in the internal database.")
+      ("session-project-user-data-dir",
+      value<std::string>(&sessionProjectUserDataDir_)->default_value(""),
+      "The folder in which RStudio should store project (.Rproj.user) data.")
+      ("session-allow-project-user-data-dir-override",
+      value<bool>(&sessionAllowProjectUserDataDirOverride_)->default_value(true),
+      "Whether or not users can override the default project (.Rproj.user) data directory via their own user preferences.");
 
    pAllow->add_options()
       ("allow-vcs-executable-edit",
@@ -511,6 +517,8 @@ public:
    bool handleOfflineEnabled() const { return handleOfflineEnabled_; }
    int handleOfflineTimeoutMs() const { return handleOfflineTimeoutMs_; }
    bool sessionUseFileStorage() const { return sessionUseFileStorage_; }
+   std::string sessionProjectUserDataDir() const { return sessionProjectUserDataDir_; }
+   bool sessionAllowProjectUserDataDirOverride() const { return sessionAllowProjectUserDataDirOverride_; }
    bool allowVcsExecutableEdit() const { return allowVcsExecutableEdit_ || allowOverlay(); }
    bool allowCRANReposEdit() const { return allowCRANReposEdit_ || allowOverlay(); }
    bool allowVcs() const { return allowVcs_ || allowOverlay(); }
@@ -628,6 +636,8 @@ protected:
    bool handleOfflineEnabled_;
    int handleOfflineTimeoutMs_;
    bool sessionUseFileStorage_;
+   std::string sessionProjectUserDataDir_;
+   bool sessionAllowProjectUserDataDirOverride_;
    bool allowVcsExecutableEdit_;
    bool allowCRANReposEdit_;
    bool allowVcs_;

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -443,6 +443,7 @@ namespace prefs {
 #define kCodeFormatterStylerStrict "code_formatter_styler_strict"
 #define kCodeFormatterExternalCommand "code_formatter_external_command"
 #define kReformatOnSave "reformat_on_save"
+#define kProjectUserDataDirectory "project_user_data_directory"
 
 class UserPrefValues: public Preferences
 {
@@ -1995,6 +1996,12 @@ public:
     */
    bool reformatOnSave();
    core::Error setReformatOnSave(bool val);
+
+   /**
+    * The folder in which RStudio should store project (.Rproj.user) data.
+    */
+   std::string projectUserDataDirectory();
+   core::Error setProjectUserDataDirectory(std::string val);
 
 };
 

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -1998,7 +1998,7 @@ public:
    core::Error setReformatOnSave(bool val);
 
    /**
-    * The folder in which RStudio should store project (.Rproj.user) data.
+    * The folder in which RStudio should store project .Rproj.user data.
     */
    std::string projectUserDataDirectory();
    core::Error setProjectUserDataDirectory(std::string val);

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -3377,6 +3377,19 @@ core::Error UserPrefValues::setReformatOnSave(bool val)
    return writePref("reformat_on_save", val);
 }
 
+/**
+ * The folder in which RStudio should store project (.Rproj.user) data.
+ */
+std::string UserPrefValues::projectUserDataDirectory()
+{
+   return readPref<std::string>("project_user_data_directory");
+}
+
+core::Error UserPrefValues::setProjectUserDataDirectory(std::string val)
+{
+   return writePref("project_user_data_directory", val);
+}
+
 std::vector<std::string> UserPrefValues::allKeys()
 {
    return std::vector<std::string>({
@@ -3638,6 +3651,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kCodeFormatterStylerStrict,
       kCodeFormatterExternalCommand,
       kReformatOnSave,
+      kProjectUserDataDirectory,
    });
 }
    

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -3378,7 +3378,7 @@ core::Error UserPrefValues::setReformatOnSave(bool val)
 }
 
 /**
- * The folder in which RStudio should store project (.Rproj.user) data.
+ * The folder in which RStudio should store project .Rproj.user data.
  */
 std::string UserPrefValues::projectUserDataDirectory()
 {

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -169,7 +169,6 @@ FilePath computeUserDir(const FilePath& projectFile,
          return defaultUserDir;
       }
       
-      LOG_ERROR_MESSAGE(projectScratchPath.getAbsolutePath());
       return projectScratchPath;
    }
    

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1756,7 +1756,8 @@
         "project_user_data_directory": {
             "type": "string",
             "default": "",
-            "description": "The folder in which RStudio should store project (.Rproj.user) data."
+            "title": "Default project user data directory",
+            "description": "The folder in which RStudio should store project .Rproj.user data."
         }
       }
 }

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1752,6 +1752,11 @@
             "default": false,
             "title": "Reformat documents on save",
             "description": "When set, the selected formatter will be used to reformat documents on save."
+        },
+        "project_user_data_directory": {
+            "type": "string",
+            "default": "",
+            "description": "The folder in which RStudio should store project (.Rproj.user) data."
         }
       }
 }

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -435,6 +435,20 @@
             "memberName": "sessionUseFileStorage_",
             "defaultValue": true,
             "description": "Controls whether the session should store its metadata on the file system or send it to the server to be stored in the internal database."
+         },
+         {
+            "name": "session-project-user-data-dir",
+            "type": "string",
+            "memberName": "sessionProjectUserDataDir_",
+            "defaultValue": "",
+            "description": "The folder in which RStudio should store user-specific project (.Rproj.user) data."
+         },
+         {
+            "name": "session-allow-project-user-data-dir-override",
+            "type": "bool",
+            "memberName": "sessionAllowProjectUserDataDirOverride_",
+            "defaultValue": true,
+            "description": "Whether or not users can override the default project (.Rproj.user) data directory via their own user preferences."
          }
       ],
       "allow": [

--- a/src/gwt/src/org/rstudio/core/client/CoreClientConstants.java
+++ b/src/gwt/src/org/rstudio/core/client/CoreClientConstants.java
@@ -24,6 +24,15 @@ public interface CoreClientConstants extends com.google.gwt.i18n.client.Messages
     @DefaultMessage("Cancel")
     @Key("cancelLabel")
     String cancelLabel();
+    
+    /**
+     * Translated "Reset".
+     *
+     * @return translated "Reset"
+     */
+    @DefaultMessage("Reset")
+    @Key("resetLabel")
+    String resetLabel();
 
     /**
      * Translated "No".
@@ -313,6 +322,15 @@ public interface CoreClientConstants extends com.google.gwt.i18n.client.Messages
     @Key("projectIconDesc")
     String projectIconDesc();
 
+    /**
+     * Translated "Projects".
+     *
+     * @return translated "Projects"
+     */
+    @DefaultMessage("Projects")
+    @Key("projectsLabel")
+    String projectsLabel();
+    
     /**
      * Translated "Home".
      *

--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -321,6 +321,7 @@ public class ElementIds
       CA_BUNDLE("ca_bundle"),
       DEFAULT_WORKING_DIR("default_working_dir"),
       DEFAULT_OPEN_PROJECT_DIR("default_open_project_dir"),
+      PROJECT_USER_DATA_DIR("project_user_data_dir"),
       ZOTERO_DATA_DIRECTORY("zotero_data_directory"),
       EXISTING_PROJECT_DIR("existing_project_dir"),
       FIND_IN("find_in"),

--- a/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
@@ -104,7 +104,7 @@ public class TextBoxWithButton extends Composite
       
       clearButton_ = new ThemedButton(constants_.clearLabel(), (ClickEvent event) ->
       {
-         setText("");
+         setText(clearLabel_);
       });
       
       clearButton_.getElement().getStyle().setMarginLeft(0, Unit.PX);
@@ -298,6 +298,23 @@ public class TextBoxWithButton extends Composite
    
    public void addClearButton()
    {
+      addClearButton(null, "");
+   }
+   
+   public void addClearButton(String buttonLabel)
+   {
+      addClearButton(buttonLabel, "");
+   }
+   
+   public void addClearButton(String buttonLabel,
+                              String clearLabel)
+   {
+      if (buttonLabel != null)
+      {
+         clearButton_.setText(buttonLabel);
+      }
+      
+      clearLabel_ = clearLabel;
       inner_.add(clearButton_);
    }
 
@@ -308,6 +325,7 @@ public class TextBoxWithButton extends Composite
    private HelpButton helpButton_;
    private final ThemedButton themedButton_;
    private final ThemedButton clearButton_;
+   private String clearLabel_ = "";
    private final String emptyLabel_;
    private String useDefaultValue_;
    private String uniqueId_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -3708,6 +3708,18 @@ public class UserPrefsAccessor extends Prefs
          false);
    }
 
+   /**
+    * The folder in which RStudio should store project (.Rproj.user) data.
+    */
+   public PrefValue<String> projectUserDataDirectory()
+   {
+      return string(
+         "project_user_data_directory",
+         _constants.projectUserDataDirectoryTitle(), 
+         _constants.projectUserDataDirectoryDescription(), 
+         "");
+   }
+
    public void syncPrefs(String layer, JsObject source)
    {
       if (source.hasKey("run_rprofile_on_resume"))
@@ -4226,6 +4238,8 @@ public class UserPrefsAccessor extends Prefs
          codeFormatterExternalCommand().setValue(layer, source.getString("code_formatter_external_command"));
       if (source.hasKey("reformat_on_save"))
          reformatOnSave().setValue(layer, source.getBool("reformat_on_save"));
+      if (source.hasKey("project_user_data_directory"))
+         projectUserDataDirectory().setValue(layer, source.getString("project_user_data_directory"));
    }
    public List<PrefValue<?>> allPrefs()
    {
@@ -4488,6 +4502,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(codeFormatterStylerStrict());
       prefs.add(codeFormatterExternalCommand());
       prefs.add(reformatOnSave());
+      prefs.add(projectUserDataDirectory());
       return prefs;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -3709,7 +3709,7 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * The folder in which RStudio should store project (.Rproj.user) data.
+    * The folder in which RStudio should store project .Rproj.user data.
     */
    public PrefValue<String> projectUserDataDirectory()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -2162,11 +2162,11 @@ public interface UserPrefsAccessorConstants extends Constants {
    String reformatOnSaveDescription();
 
    /**
-    * The folder in which RStudio should store project (.Rproj.user) data.
+    * The folder in which RStudio should store project .Rproj.user data.
     */
-   @DefaultStringValue("")
+   @DefaultStringValue("Default project user data directory")
    String projectUserDataDirectoryTitle();
-   @DefaultStringValue("The folder in which RStudio should store project (.Rproj.user) data.")
+   @DefaultStringValue("The folder in which RStudio should store project .Rproj.user data.")
    String projectUserDataDirectoryDescription();
 
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -2161,6 +2161,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    @DefaultStringValue("When set, the selected formatter will be used to reformat documents on save.")
    String reformatOnSaveDescription();
 
+   /**
+    * The folder in which RStudio should store project (.Rproj.user) data.
+    */
+   @DefaultStringValue("")
+   String projectUserDataDirectoryTitle();
+   @DefaultStringValue("The folder in which RStudio should store project (.Rproj.user) data.")
+   String projectUserDataDirectoryDescription();
+
 
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -1086,4 +1086,8 @@ codeFormatterExternalCommandDescription = The external command to be used when r
 reformatOnSaveTitle = Reformat documents on save
 reformatOnSaveDescription = When set, the selected formatter will be used to reformat documents on save.
 
+# The folder in which RStudio should store project (.Rproj.user) data.
+projectUserDataDirectoryTitle = 
+projectUserDataDirectoryDescription = The folder in which RStudio should store project (.Rproj.user) data.
+
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -1086,8 +1086,8 @@ codeFormatterExternalCommandDescription = The external command to be used when r
 reformatOnSaveTitle = Reformat documents on save
 reformatOnSaveDescription = When set, the selected formatter will be used to reformat documents on save.
 
-# The folder in which RStudio should store project (.Rproj.user) data.
-projectUserDataDirectoryTitle = 
-projectUserDataDirectoryDescription = The folder in which RStudio should store project (.Rproj.user) data.
+# The folder in which RStudio should store project .Rproj.user data.
+projectUserDataDirectoryTitle = Default project user data directory
+projectUserDataDirectoryDescription = The folder in which RStudio should store project .Rproj.user data.
 
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15098.

### Approach

This PR augments each project's `.Rproj` file with a new ProjectId entry. This entry is just a GUID, but it's used to map to an external `.Rproj.user` folder when the user or administrator has enabled this.

Users can set a default "project user data directory" within Global Options... -> General -> Advanced:

<img width="678" alt="Screenshot 2024-09-10 at 4 06 32 PM" src="https://github.com/user-attachments/assets/5c564f8a-62db-4e5c-a3d1-3f625b3f393f">

If this value is set, then the project's state is then written to a folder at the path:

```
<projectUserDataDir>/<projectId>
```

instead of just the project's `.Rproj.user`.

The project ID above is generated on demand as a GUID, and stored as part of the project's `.Rproj` file.

### Automated Tests

Not included.

### QA Notes

Using the new UI mentioned above, try setting this directory to some value, e.g. `/tmp/rstudio-data`. Try creating a new project. After doing so, look within this directory -- you should see files like (for example):

```
$ tree /tmp/rstudio-data/
/tmp/rstudio-data/
└── 06e384c5-7599-4618-9656-c9c150e7d83a
    ├── B9D11BAB
    │   ├── bibliography-index
    │   ├── ctx
    │   ├── pcs
    │   │   ├── files-pane.pper
    │   │   ├── source-pane.pper
    │   │   ├── windowlayoutstate.pper
    │   │   └── workbench-pane.pper
    │   ├── persistent-state
    │   ├── presentation
    │   ├── profiles-cache
    │   ├── sources
    │   │   └── session-64440e8d
    │   │       └── lock_file
    │   └── tutorial
    └── shared
        └── notebooks
            └── patch-chunk-names
```

### Documentation

TODO: We'll probably want to add some detail in the RStudio user guide + admin guide

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
