### PR TITLE
fixups for layout in untabbed console view

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@
 - Executing `options(warn = ...)` in an R code chunk now persists beyond chunk execution (#15030)
 - Remove focus-visible polyfill and instead use native browser :focus-visible pseudoclass (#14352)
 - Fixed an issue where completion types for objects with a `.DollarNames` method were not properly displayed (#15115)
+- Fixed an issue where the Console header label was not properly layed out when other tabs (e.g. Terminal) were closed (#15106)
 
 #### Posit Workbench
 - Fixed an issue with Workbench login not respecting "Stay signed in when browser closes" when using Single Sign-On (rstudio-pro#5392)

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -825,6 +825,16 @@ table.header > tbody > tr > td {
 
 }
 
+.consoleHeaderLayout .subtitle {
+	position: relative;
+	top: -4px;
+}
+
+.consoleHeaderLayout .toolbarDotSeparator {
+	position: relative;
+	top: -4px;
+}
+
 .consoleMinimizeLayout {
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
@@ -16,7 +16,6 @@ package org.rstudio.studio.client.workbench.ui;
 
 import java.util.ArrayList;
 
-import com.google.gwt.user.client.Command;
 import org.rstudio.core.client.layout.LogicalWindow;
 import org.rstudio.core.client.theme.PrimaryWindowFrame;
 import org.rstudio.core.client.theme.res.ThemeResources;
@@ -31,16 +30,22 @@ import org.rstudio.studio.client.workbench.views.console.ConsoleInterpreterVersi
 import org.rstudio.studio.client.workbench.views.console.ConsoleInterruptButton;
 import org.rstudio.studio.client.workbench.views.console.ConsoleInterruptProfilerButton;
 import org.rstudio.studio.client.workbench.views.console.ConsolePane;
-import org.rstudio.studio.client.workbench.views.console.events.WorkingDirChangedEvent;
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleRestartRCompletedEvent;
+import org.rstudio.studio.client.workbench.views.console.events.WorkingDirChangedEvent;
 import org.rstudio.studio.client.workbench.views.output.find.FindOutputTab;
 import org.rstudio.studio.client.workbench.views.output.markers.MarkersOutputTab;
 
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
 
 public class ConsoleTabPanel extends WorkbenchTabPanel
 {
+   public static final String RSTUDIO_CONSOLE_WIDGET_LAYOUT = "rstudio-console-widget-layout";
+   public static final String RSTUDIO_CONSOLE_HEADER_LAYOUT = "rstudio-console-header-layout";
+   public static final String RSTUDIO_CONSOLE_MINIMIZE_LAYOUT = "rstudio-console-minimize-layout";
+   public static final String RSTUDIO_CONSOLE_MAXIMIZE_LAYOUT = "rstudio-console-maximize-layout";
+   
    @Inject
    public void initialize(ConsoleInterruptButton consoleInterrupt,
                           ConsoleInterruptProfilerButton consoleInterruptProfiler,
@@ -485,10 +490,29 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
                hasMaximizeClass = true;
          }
          
-         if (hasWidgetClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleWidgetLayout());
-         if (hasHeaderClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleHeaderLayout());
-         if (hasMinimizeClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleMinimizeLayout());
-         if (hasMaximizeClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleMaximizeLayout());
+         if (hasWidgetClass)
+         {
+            e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleWidgetLayout());
+            e.addClassName(RSTUDIO_CONSOLE_WIDGET_LAYOUT);
+         }
+         
+         if (hasHeaderClass)
+         {
+            e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleHeaderLayout());
+            e.addClassName(RSTUDIO_CONSOLE_HEADER_LAYOUT);
+         }
+         
+         if (hasMinimizeClass)
+         {
+            e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleMinimizeLayout());
+            e.addClassName(RSTUDIO_CONSOLE_MINIMIZE_LAYOUT);
+         }
+         
+         if (hasMaximizeClass)
+         {
+            e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleMaximizeLayout());
+            e.addClassName(RSTUDIO_CONSOLE_MAXIMIZE_LAYOUT);
+         }
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleInterpreterVersion.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleInterpreterVersion.css
@@ -4,10 +4,15 @@
 
 @external rstudio-themes-default;
 @external rstudio-themes-dark;
+@external rstudio-console-header-layout;
 
 .container {
    display: inline-block;
    cursor: pointer;
+}
+
+.rstudio-console-header-layout .container {
+	margin-top: -2px;
 }
 
 .menuClicked {
@@ -90,7 +95,7 @@
 
 .labelUntabbed {
    display: inline-block;
-   margin-top: 1px;
+   margin-top: 3px;
    margin-right: 6px;
    font-size: 9pt;
 }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15106.

Untabbed view:

<img width="740" alt="Screenshot 2024-09-11 at 10 34 03 AM" src="https://github.com/user-attachments/assets/02fcf1a7-f246-4f97-b935-a5227ffbd70e">

Tabbed view:

<img width="492" alt="Screenshot 2024-09-11 at 10 35 23 AM" src="https://github.com/user-attachments/assets/0528590b-4dba-4eec-90a3-3af58e3f2453">

### Approach

Threw some more gross CSS into the pile.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15106.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

