### PR TITLE
allow customization of document outline font size

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - RStudio now supports syntax highlighting for Fortran source files (#10403)
 - Display label "Publish" next to the publish icon on editor toolbar (#13604)
 - RStudio supports `usethis.description` option values when creating projects via the RStudio New Project wizard (#15070)
+- The font size used for the document outline can now be customized (#6887)
 - The RStudio diagnostics system now supports destructuring assignments as implemented and provided in the `dotty` package
 
 #### Posit Workbench

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 - RStudio now supports syntax highlighting for Fortran source files (#10403)
 - Display label "Publish" next to the publish icon on editor toolbar (#13604)
 - RStudio supports `usethis.description` option values when creating projects via the RStudio New Project wizard (#15070)
-- The font size used for the document outline can now be customized (#6887)
+- The font size used for the document outline can now be customized [Accessibility] (#6887)
 - The RStudio diagnostics system now supports destructuring assignments as implemented and provided in the `dotty` package
 
 #### Posit Workbench

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -233,6 +233,7 @@ namespace prefs {
 #define kPublishCaBundle "publish_ca_bundle"
 #define kRmdChunkOutputInline "rmd_chunk_output_inline"
 #define kShowDocOutlineRmd "show_doc_outline_rmd"
+#define kDocumentOutlineFontSize "document_outline_font_size"
 #define kAutoRunSetupChunk "auto_run_setup_chunk"
 #define kHideConsoleOnChunkExecute "hide_console_on_chunk_execute"
 #define kExecutionBehavior "execution_behavior"
@@ -1240,6 +1241,12 @@ public:
     */
    bool showDocOutlineRmd();
    core::Error setShowDocOutlineRmd(bool val);
+
+   /**
+    * The font size to use for items in the document outline.
+    */
+   int documentOutlineFontSize();
+   core::Error setDocumentOutlineFontSize(int val);
 
    /**
     * Whether to automatically run an R Markdown document's Setup chunk before running other chunks.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -1740,6 +1740,19 @@ core::Error UserPrefValues::setShowDocOutlineRmd(bool val)
 }
 
 /**
+ * The font size to use for items in the document outline.
+ */
+int UserPrefValues::documentOutlineFontSize()
+{
+   return readPref<int>("document_outline_font_size");
+}
+
+core::Error UserPrefValues::setDocumentOutlineFontSize(int val)
+{
+   return writePref("document_outline_font_size", val);
+}
+
+/**
  * Whether to automatically run an R Markdown document's Setup chunk before running other chunks.
  */
 bool UserPrefValues::autoRunSetupChunk()
@@ -3525,6 +3538,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kPublishCaBundle,
       kRmdChunkOutputInline,
       kShowDocOutlineRmd,
+      kDocumentOutlineFontSize,
       kAutoRunSetupChunk,
       kHideConsoleOnChunkExecute,
       kExecutionBehavior,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -898,6 +898,12 @@
             "title": "Open document outline by default",
             "description": "Whether to show the document outline by default when opening R Markdown documents."
         },
+        "document_outline_font_size": {
+            "type": "integer",
+            "default": "9",
+            "title": "Font size",
+            "description": "The font size to use for items in the document outline."
+        },
         "auto_run_setup_chunk": {
             "type": "boolean",
             "default": true,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -900,7 +900,7 @@
         },
         "document_outline_font_size": {
             "type": "integer",
-            "default": "9",
+            "default": 9,
             "title": "Document outline font size",
             "description": "The font size to use for items in the document outline."
         },

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -901,7 +901,7 @@
         "document_outline_font_size": {
             "type": "integer",
             "default": "9",
-            "title": "Font size",
+            "title": "Document outline font size",
             "description": "The font size to use for items in the document outline."
         },
         "auto_run_setup_chunk": {

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/outline/PanmirrorOutlineWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/outline/PanmirrorOutlineWidget.java
@@ -20,6 +20,7 @@ package org.rstudio.studio.client.panmirror.outline;
 import java.util.ArrayList;
 import java.util.Iterator;
 
+import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.dom.DomUtils;
@@ -102,7 +103,23 @@ public class PanmirrorOutlineWidget extends Composite
                updateOutline(items_);
             }
          });
+         
+         int fontSize = prefs.get().documentOutlineFontSize().getValue();
+         updateFontSize(fontSize);
+         prefs.get().documentOutlineFontSize().bind(new CommandWithArg<Integer>()
+         {
+            @Override
+            public void execute(Integer fontSize)
+            {
+               updateFontSize(fontSize);
+            }
+         });
       });
+   }
+   
+   private void updateFontSize(int fontSize)
+   {
+      panel_.getElement().getStyle().setFontSize(fontSize, Unit.PT);
    }
   
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants.java
@@ -2864,6 +2864,9 @@ public interface PrefsConstants extends com.google.gwt.i18n.client.Messages {
     @Key("rMarkdownHeaderLabel")
     String rMarkdownHeaderLabel();
 
+    @DefaultMessage("Document Outline")
+    @Key("documentOutlineHeaderLabel")
+    String documentOutlineHeaderLabel();
     /**
      * Translated "Show document outline by default".
      *

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1900,6 +1900,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * The font size to use for items in the document outline.
+    */
+   public PrefValue<Integer> documentOutlineFontSize()
+   {
+      return integer(
+         "document_outline_font_size",
+         _constants.documentOutlineFontSizeTitle(), 
+         _constants.documentOutlineFontSizeDescription(), 
+         9);
+   }
+
+   /**
     * Whether to automatically run an R Markdown document's Setup chunk before running other chunks.
     */
    public PrefValue<Boolean> autoRunSetupChunk()
@@ -3986,6 +3998,8 @@ public class UserPrefsAccessor extends Prefs
          rmdChunkOutputInline().setValue(layer, source.getBool("rmd_chunk_output_inline"));
       if (source.hasKey("show_doc_outline_rmd"))
          showDocOutlineRmd().setValue(layer, source.getBool("show_doc_outline_rmd"));
+      if (source.hasKey("document_outline_font_size"))
+         documentOutlineFontSize().setValue(layer, source.getInteger("document_outline_font_size"));
       if (source.hasKey("auto_run_setup_chunk"))
          autoRunSetupChunk().setValue(layer, source.getBool("auto_run_setup_chunk"));
       if (source.hasKey("hide_console_on_chunk_execute"))
@@ -4376,6 +4390,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(publishCaBundle());
       prefs.add(rmdChunkOutputInline());
       prefs.add(showDocOutlineRmd());
+      prefs.add(documentOutlineFontSize());
       prefs.add(autoRunSetupChunk());
       prefs.add(hideConsoleOnChunkExecute());
       prefs.add(executionBehavior());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -1120,6 +1120,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String showDocOutlineRmdDescription();
 
    /**
+    * The font size to use for items in the document outline.
+    */
+   @DefaultStringValue("Font size")
+   String documentOutlineFontSizeTitle();
+   @DefaultStringValue("The font size to use for items in the document outline.")
+   String documentOutlineFontSizeDescription();
+
+   /**
     * Whether to automatically run an R Markdown document's Setup chunk before running other chunks.
     */
    @DefaultStringValue("Automatically run Setup chunk when needed")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -1122,7 +1122,7 @@ public interface UserPrefsAccessorConstants extends Constants {
    /**
     * The font size to use for items in the document outline.
     */
-   @DefaultStringValue("Font size")
+   @DefaultStringValue("Document outline font size")
    String documentOutlineFontSizeTitle();
    @DefaultStringValue("The font size to use for items in the document outline.")
    String documentOutlineFontSizeDescription();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -566,7 +566,7 @@ showDocOutlineRmdTitle = Open document outline by default
 showDocOutlineRmdDescription = Whether to show the document outline by default when opening R Markdown documents.
 
 # The font size to use for items in the document outline.
-documentOutlineFontSizeTitle = Font size
+documentOutlineFontSizeTitle = Document outline font size
 documentOutlineFontSizeDescription = The font size to use for items in the document outline.
 
 # Whether to automatically run an R Markdown document's Setup chunk before running other chunks.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -565,6 +565,10 @@ rmdChunkOutputInlineDescription = Whether to show chunk output inline for ordina
 showDocOutlineRmdTitle = Open document outline by default
 showDocOutlineRmdDescription = Whether to show the document outline by default when opening R Markdown documents.
 
+# The font size to use for items in the document outline.
+documentOutlineFontSizeTitle = Font size
+documentOutlineFontSizeDescription = The font size to use for items in the document outline.
+
 # Whether to automatically run an R Markdown document's Setup chunk before running other chunks.
 autoRunSetupChunkTitle = Automatically run Setup chunk when needed
 autoRunSetupChunkDescription = Whether to automatically run an R Markdown document's Setup chunk before running other chunks.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.java
@@ -54,7 +54,7 @@ public class PreferencesDialog extends PreferencesDialogBase<UserPrefs>
                             EditingPreferencesPane source,
                             ConsolePreferencesPane console,
                             RMarkdownPreferencesPane rmarkdown,
-                            CompilePdfPreferencesPane compilePdf,
+                            SweavePreferencesPane compilePdf,
                             AppearancePreferencesPane appearance,
                             PaneLayoutPreferencesPane paneLayout,
                             PackagesPreferencesPane packages,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/RMarkdownPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/RMarkdownPreferencesPane.java
@@ -74,26 +74,13 @@ public class RMarkdownPreferencesPane extends PreferencesPane
       VerticalTabPanel basic = new VerticalTabPanel(ElementIds.RMARKDOWN_BASIC_PREFS);
 
       basic.add(headerLabel(constants_.rMarkdownHeaderLabel()));
-
-      basic.add(checkboxPref(constants_.rMarkdownShowLabel(), prefs_.showDocOutlineRmd()));
       basic.add(checkboxPref(constants_.rMarkdownSoftWrapLabel(), prefs_.softWrapRmdFiles()));
 
-      docOutlineDisplay_ = new SelectWidget(
-            constants_.docOutlineDisplayLabel(),
-            new String[] {
-                  constants_.docOutlineSectionsOption(),
-                  constants_.docOutlineSectionsNamedChunksOption(),
-                  constants_.docOutlineSectionsAllChunksOption()
-            },
-            new String[] {
-                 UserPrefs.DOC_OUTLINE_SHOW_SECTIONS_ONLY,
-                 UserPrefs.DOC_OUTLINE_SHOW_SECTIONS_AND_CHUNKS,
-                 UserPrefs.DOC_OUTLINE_SHOW_ALL
-            },
-            false,
-            true,
-            false);
-      basic.add(docOutlineDisplay_);
+      // show output inline for all Rmds
+      final CheckBox rmdInlineOutput = checkboxPref(
+            constants_.rmdInlineOutputLabel(),
+            prefs_.rmdChunkOutputInline());
+      basic.add(rmdInlineOutput);
 
       rmdViewerMode_ = new SelectWidget(
             constants_.rmdViewerModeLabel(),
@@ -112,13 +99,7 @@ public class RMarkdownPreferencesPane extends PreferencesPane
             false);
       basic.add(rmdViewerMode_);
 
-
-      // show output inline for all Rmds
-      final CheckBox rmdInlineOutput = checkboxPref(
-            constants_.rmdInlineOutputLabel(),
-            prefs_.rmdChunkOutputInline());
-      basic.add(rmdInlineOutput);
-
+      
       // behavior for latex and image preview popups
       latexPreviewWidget_ = new SelectWidget(
             constants_.latexPreviewWidgetLabel(),
@@ -160,6 +141,28 @@ public class RMarkdownPreferencesPane extends PreferencesPane
       {
          knitWorkingDir_ = null;
       }
+      
+      basic.add(spacedBefore(headerLabel(constants_.documentOutlineHeaderLabel())));
+      basic.add(checkboxPref(constants_.rMarkdownShowLabel(), prefs_.showDocOutlineRmd()));
+      
+      docOutlineDisplay_ = new SelectWidget(
+            constants_.docOutlineDisplayLabel(),
+            new String[] {
+                  constants_.docOutlineSectionsOption(),
+                  constants_.docOutlineSectionsNamedChunksOption(),
+                  constants_.docOutlineSectionsAllChunksOption()
+            },
+            new String[] {
+                 UserPrefs.DOC_OUTLINE_SHOW_SECTIONS_ONLY,
+                 UserPrefs.DOC_OUTLINE_SHOW_SECTIONS_AND_CHUNKS,
+                 UserPrefs.DOC_OUTLINE_SHOW_ALL
+            },
+            false,
+            true,
+            false);
+      basic.add(docOutlineDisplay_);
+      basic.add(numericPref(prefs_.documentOutlineFontSize()));
+
 
       basic.add(spacedBefore(headerLabel(constants_.rNotebooksCaption())));
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/SweavePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/SweavePreferencesPane.java
@@ -32,10 +32,10 @@ import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.Label;
 import com.google.inject.Inject;
 
-public class CompilePdfPreferencesPane extends PreferencesPane
+public class SweavePreferencesPane extends PreferencesPane
 {
    @Inject
-   public CompilePdfPreferencesPane(UserPrefs prefs,
+   public SweavePreferencesPane(UserPrefs prefs,
                                     PreferencesDialogResources res)
    {
       prefs_ = prefs;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
@@ -55,7 +55,7 @@ import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.WorkbenchMetrics;
 import org.rstudio.studio.client.workbench.prefs.views.AccessibilityPreferencesPane;
 import org.rstudio.studio.client.workbench.prefs.views.AppearancePreferencesPane;
-import org.rstudio.studio.client.workbench.prefs.views.CompilePdfPreferencesPane;
+import org.rstudio.studio.client.workbench.prefs.views.SweavePreferencesPane;
 import org.rstudio.studio.client.workbench.prefs.views.ConsolePreferencesPane;
 import org.rstudio.studio.client.workbench.prefs.views.EditingPreferencesPane;
 import org.rstudio.studio.client.workbench.prefs.views.PackagesPreferencesPane;
@@ -439,7 +439,7 @@ public class WorkbenchScreen extends Composite
    @Handler
    void onShowSweaveOptions()
    {
-      optionsLoader_.showOptions(CompilePdfPreferencesPane.class, true);
+      optionsLoader_.showOptions(SweavePreferencesPane.class, true);
    }
 
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.css
@@ -63,7 +63,6 @@
 .nodeLabel {
    white-space: nowrap;
    font-family: sans-serif;
-   font-size: 0.9em;
    text-overflow: ellipsis;
    overflow: hidden;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
@@ -14,8 +14,6 @@
  */
 package org.rstudio.studio.client.workbench.views.source;
 
-import com.google.gwt.aria.client.OrientationValue;
-import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.ClassIds;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Counter;
@@ -38,6 +36,8 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.events.Scop
 import org.rstudio.studio.client.workbench.views.source.model.SourceDocument;
 import org.rstudio.studio.client.workbench.views.source.model.SourcePosition;
 
+import com.google.gwt.aria.client.OrientationValue;
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.Scheduler;
@@ -244,6 +244,29 @@ public class DocumentOutlineWidget extends Composite
    private void initialize(UserPrefs uiPrefs)
    {
       userPrefs_ = uiPrefs;
+      
+      Scheduler.get().scheduleDeferred(new ScheduledCommand()
+      {
+         @Override
+         public void execute()
+         {
+            int fontSize = userPrefs_.documentOutlineFontSize().getValue();
+            updateFontSize(fontSize);
+            userPrefs_.documentOutlineFontSize().bind(new CommandWithArg<Integer>()
+            {
+               @Override
+               public void execute(Integer fontSize)
+               {
+                  updateFontSize(fontSize);
+               }
+            });
+         }
+      });
+   }
+   
+   private void updateFontSize(int fontSize)
+   {
+      container_.getElement().getStyle().setFontSize(fontSize, Unit.PT);
    }
 
    public DocumentOutlineWidget(TextEditingTarget target)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/6887.

<img width="675" alt="Screenshot 2024-09-11 at 1 02 33 PM" src="https://github.com/user-attachments/assets/1c8e2f81-a960-46f2-a23f-9ec15200efd6">

Example with font size of 12:

<img width="523" alt="Screenshot 2024-09-11 at 1 02 49 PM" src="https://github.com/user-attachments/assets/c4849363-0c7c-4e79-bd45-66e16ac770ec">

### Approach

Mostly straightforward addition of preference, tweak of UI, and applying of font size preference in the appropriate locations.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/6887. Note that the source editor and visual editor use different document outline implementations under the hood, so it's a good idea to check both.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
