### PR TITLE
ensure Tab keypresses indent instead of literal tabbing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,7 @@
 - Remove focus-visible polyfill and instead use native browser :focus-visible pseudoclass (#14352)
 - Fixed an issue where completion types for objects with a `.DollarNames` method were not properly displayed (#15115)
 - Fixed an issue where the Console header label was not properly layed out when other tabs (e.g. Terminal) were closed (#15106)
+- Fixed an issue where pressing Tab would insert a literal tab instead of indenting a multi-line selection (#15046)
 
 #### Posit Workbench
 - Fixed an issue with Workbench login not respecting "Stay signed in when browser closes" when using Single Sign-On (rstudio-pro#5392)

--- a/rstudio.Rproj
+++ b/rstudio.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: af2287d0-9868-4a70-a5f7-4bd23683dea3
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/src/cpp/tests/automation/testthat/test-automation-completions.R
+++ b/src/cpp/tests/automation/testthat/test-automation-completions.R
@@ -151,3 +151,28 @@ test_that(".DollarNames completions still produce types", {
    expect_equal(completions, c("example1", "example2"))
    
 })
+
+# https://github.com/rstudio/rstudio/issues/15046
+test_that("Tab keypresses indent multi-line selections", {
+   
+   contents <- .rs.heredoc('
+      ---
+      title: R Markdown Document
+      ---
+      
+      This is some prose.
+      This is some more prose.
+   ')
+   
+   remote$documentOpen(ext = ".Rmd", contents = contents)
+   
+   editor <- remote$editorGetInstance()
+   editor$gotoLine(5)
+   editor$selectPageDown()
+   
+   remote$keyboardExecute("<Tab>")
+   expect_equal(editor$session$getLine(4), "  This is some prose.")
+   expect_equal(editor$session$getLine(5), "  This is some more prose.")
+   
+   remote$documentClose()
+})

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
@@ -224,7 +224,7 @@ public abstract class CompletionManagerBase
          // only a single completion with the same value as the token, we need
          // to insert a literal tab to 'play' the tab key back into the document
          if (data.isTabTriggeredCompletion())
-            docDisplay_.insertCode("\t");
+            docDisplay_.blockIndent();
          
          return;
       }
@@ -308,14 +308,7 @@ public abstract class CompletionManagerBase
       if (completionCache_.satisfyRequest(line, context))
          return true;
       
-      boolean canComplete = getCompletions(line, context);
-      
-      // if tab was used to trigger the completion, but no completions
-      // are available in that context, then insert a literal tab
-      if (!canComplete && isTabTriggered)
-         docDisplay_.insertCode("\t");
-      
-      return canComplete;
+      return getCompletions(line, context);
    }
    
    public Invalidation.Token getInvalidationToken()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1827,7 +1827,7 @@ public class RCompletionManager implements CompletionManager
             // Insert tab if tab auto completion was disabled or the line is all whitespace.
             if (lastInputWasTab && (lineIsWhitespace || !userPrefs_.tabCompletion().getValue()))
             {
-               docDisplay_.insertCode("\t");
+               docDisplay_.blockIndent();
                return;
             }
             


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15046.

### Approach

In our completion manager, we had some places where we attempted to insert a literal tab instead of indenting. This PR fixes that.

### Automated Tests

Integration tests provided in PR.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15046.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
