### PR TITLE
Bugfix/windows signing

### DIFF
--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -54,15 +54,12 @@ RUN $env:path += ';C:\R\R-3.6.3\bin\i386\' ;`
   [Environment]::SetEnvironmentVariable('Path', $env:path, [System.EnvironmentVariableTarget]::Machine);
 
 # install smtools 
+# TODO: remove the installation from the jenkinsfile once this is built into the base image
 RUN $ErrorActionPreference = 'Stop' ;`
-  [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48;`
+  [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48 ;`
   (New-Object System.Net.WebClient).DownloadFile('https://rstudio-buildtools.s3.amazonaws.com/posit-dev/smtools-windows-x64.msi', 'smtools-windows-x64.msi') ;`
-  Start-Process 'msiexec' -ArgumentList '/i smtools-windows-x64.msi /quiet /qn /norestart';`
+  Start-Process 'msiexec' -ArgumentList '/i smtools-windows-x64.msi /quiet /qn /norestart' ;`
   Remove-Item smtools-windows-x64.msi -Force
-
-# add smtools to path
-RUN $env:path += ';C:\Program Files\DigiCert\DigiCert One Signing Manager Tools\' ;`
-  [Environment]::SetEnvironmentVariable('Path', $env:path, [System.EnvironmentVariableTarget]::Machine);
 
 # cpack (an alias from chocolatey) and cmake's cpack conflict.
 # Newer choco doesn't have this so don't fail if not found

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -53,6 +53,17 @@ RUN $ErrorActionPreference = 'Stop' ;`
 RUN $env:path += ';C:\R\R-3.6.3\bin\i386\' ;`
   [Environment]::SetEnvironmentVariable('Path', $env:path, [System.EnvironmentVariableTarget]::Machine);
 
+# install smtools 
+RUN $ErrorActionPreference = 'Stop' ;`
+  [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48;`
+  (New-Object System.Net.WebClient).DownloadFile('https://rstudio-buildtools.s3.amazonaws.com/posit-dev/smtools-windows-x64.msi', 'smtools-windows-x64.msi') ;`
+  Start-Process 'msiexec' -ArgumentList '/i smtools-windows-x64.msi /quiet /qn /norestart';`
+  Remove-Item smtools-windows-x64.msi -Force
+
+# add smtools to path
+RUN $env:path += ';C:\Program Files\DigiCert\DigiCert One Signing Manager Tools\' ;`
+  [Environment]::SetEnvironmentVariable('Path', $env:path, [System.EnvironmentVariableTarget]::Machine);
+
 # cpack (an alias from chocolatey) and cmake's cpack conflict.
 # Newer choco doesn't have this so don't fail if not found
 RUN if (Test-Path 'C:\ProgramData\chocolatey\bin\cpack.exe') { Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe' }

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -175,14 +175,21 @@ pipeline {
                 stages {
                   stage('Sign') {
                     environment {
-                      PFX_FILE = credentials('SM_CLIENT_CERT_FILE')
-                      PFX_PASS = credentials('SM_CLIENT_CERT_PASSWORD')
-                      PFX_ALIAS = credentials('DIGICERT_KEYPAIR_ALIAS')
-                      FINGERPRINT = credentials('DIGICERT_CERTIFICATE_FINGERPRINT')
+                      SM_HOST = credentials('SM_HOST')
+                      SM_API_KEY = credentials('SM_API_KEY')
+                      SM_CLIENT_CERT_FILE = credentials('SM_CLIENT_CERT_FILE')
+                      SM_CLIENT_CERT_PASSWORD = credentials('SM_CLIENT_CERT_PASSWORD')
+                      DIGICERT_KEYPAIR_ALIAS = credentials('DIGICERT_KEYPAIR_ALIAS')
+                      DIGICERT_CERTIFICATE_FINGERPRINT = credentials('DIGICERT_CERTIFICATE_FINGERPRINT')
                     }
 
                     steps {
-                      bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x86\\signtool" sign /v /debug /sha1 %FINGERPRINT% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 package\\win32\\build\\' + LONG_PACKAGE_NAME + '.exe'
+                      bat 'curl -o smtools-windows-x64.msi "https://rstudio-buildtools.s3.amazonaws.com/posit-dev/smtools-windows-x64.msi"' 
+                      bat 'msiexec /i smtools-windows-x64.msi /quiet /qn /L*V smtools-windows-x64.log'
+                      bat 'type smtools-windows-x64.log'
+                      bat 'C:\\Windows\\System32\\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user'
+                      bat '"C:\\Program Files\\DigiCert\\DigiCert One Signing Manager Tools\\smksp_cert_sync"'
+                      bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x86\\signtool" sign /sha1 %DIGICERT_CERTIFICATE_FINGERPRINT% /td SHA256 /fd SHA256 package\\win32\\build\\' + LONG_PACKAGE_NAME + '.exe'
                       bat "\"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x86\\signtool\" verify /v /pa package\\win32\\build\\${LONG_PACKAGE_NAME}.exe"
                     }
                   }

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -181,7 +181,7 @@ pipeline {
                     }
 
                     steps {
-                      bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x86\\signtool" sign /csp "DigiCert Signing Manager KSP" /kc %PFX_ALIAS% /f %PFX_FILE% /p %PFX_PASS% /v /debug /n "Posit, PBC" /t http://timestamp.digicert.com /td SHA256 /fd SHA256 package\\win32\\build\\' + LONG_PACKAGE_NAME + '.exe'
+                      bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x86\\signtool" sign /csp "DigiCert Signing Manager KSP" /kc %PFX_ALIAS% /f %PFX_FILE% /p %PFX_PASS% /v /debug /n "Posit, PBC" /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 package\\win32\\build\\' + LONG_PACKAGE_NAME + '.exe'
                       bat "\"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x86\\signtool\" verify /v /pa package\\win32\\build\\${LONG_PACKAGE_NAME}.exe"
                     }
                   }

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -178,10 +178,11 @@ pipeline {
                       PFX_FILE = credentials('SM_CLIENT_CERT_FILE')
                       PFX_PASS = credentials('SM_CLIENT_CERT_PASSWORD')
                       PFX_ALIAS = credentials('DIGICERT_KEYPAIR_ALIAS')
+                      FINGERPRINT = credentials('DIGICERT_CERTIFICATE_FINGERPRINT')
                     }
 
                     steps {
-                      bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x86\\signtool" sign /csp "DigiCert Signing Manager KSP" /kc %PFX_ALIAS% /f %PFX_FILE% /p %PFX_PASS% /v /debug /n "Posit, PBC" /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 package\\win32\\build\\' + LONG_PACKAGE_NAME + '.exe'
+                      bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x86\\signtool" sign /v /debug /sha1 %FINGERPRINT% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 package\\win32\\build\\' + LONG_PACKAGE_NAME + '.exe'
                       bat "\"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x86\\signtool\" verify /v /pa package\\win32\\build\\${LONG_PACKAGE_NAME}.exe"
                     }
                   }

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -180,8 +180,8 @@ pipeline {
                 stages {
                   stage('Sign') {
                     environment {
-                      PFX_FILE = credentials('ide-windows-signing-pfx')
-                      PFX_PASS = credentials('ide-pfx-passphrase')
+                      PFX_FILE = credentials('SM_CLIENT_CERT_FILE')
+                      PFX_PASS = credentials('SM_CLIENT_CERT_PASSWORD')
                     }
 
                     steps {

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -138,11 +138,6 @@ pipeline {
               }
 
               stage('Build') {
-                environment {
-                  CODESIGN_KEY = credentials('ide-windows-signing-pfx')
-                  CODESIGN_PASS = credentials('ide-pfx-passphrase')
-                }
-
                 steps {
                   // set requisite environment variables and build rstudio
                   bat "cd package/win32 &&" +
@@ -182,10 +177,11 @@ pipeline {
                     environment {
                       PFX_FILE = credentials('SM_CLIENT_CERT_FILE')
                       PFX_PASS = credentials('SM_CLIENT_CERT_PASSWORD')
+                      PFX_ALIAS = credentials('DIGICERT_KEYPAIR_ALIAS')
                     }
 
                     steps {
-                      bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x86\\signtool" sign /f %PFX_FILE% /p %PFX_PASS% /v /debug /n "RStudio PBC" /t http://timestamp.digicert.com  package\\win32\\build\\' + LONG_PACKAGE_NAME + '.exe'
+                      bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x86\\signtool" sign /csp "DigiCert Signing Manager KSP" /kc %PFX_ALIAS% /f %PFX_FILE% /p %PFX_PASS% /v /debug /n "Posit, PBC" /t http://timestamp.digicert.com /td SHA256 /fd SHA256 package\\win32\\build\\' + LONG_PACKAGE_NAME + '.exe'
                       bat "\"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x86\\signtool\" verify /v /pa package\\win32\\build\\${LONG_PACKAGE_NAME}.exe"
                     }
                   }


### PR DESCRIPTION
Fix the failing Windows builds due expired cert

Build passed and signed: https://build.posit.it/job/IDE/job/OS-Builds/job/Platforms/job/windows-pipeline/job/bugfix%252Fwindows-signing/10/

### Intent

We have to use Digicert process now.

### Approach

Plagiarize the positron GHA setup/install step into Jenkins [from here](https://github.com/posit-dev/positron-builds/blob/main/.github/workflows/build-prerelease-windows.yml#L162-L171). I've also added an install step to the windows dockerfile. Once that builds (I couldn't get it to work on a separate branch) then we can remove those steps from the Jankins file.

I have no idea if the windows Docker image build is going to work yet, but it should work in theory because I ran all the steps independently on a windows machine and it installed the tools.


