### PR TITLE
remove dupbuild from soci ninja build

### DIFF
--- a/dependencies/common/install-soci
+++ b/dependencies/common/install-soci
@@ -81,7 +81,6 @@ rm -f CMakeCache.txt
 if has-program ninja
 then 
    CMAKE_GENERATOR="Ninja"
-   MAKEFLAGS="-w dupbuild=warn ${MAKEFLAGS}"
 else
    CMAKE_GENERATOR="Unix Makefiles"
 fi


### PR DESCRIPTION
### Intent

Set up a couple of Mac IDE dev machines from scratch recently and both failed to build SOCI via the dependency scripts with the error: `ninja: error: unknown warning flag 'dupbuild=warn'`

### Approach

Remove that option. Confirmed can now build SOCI with ninja on Mac (and one Linux that I tried it on).

### Automated Tests

NA

### QA Notes

Build-time stuff.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


