### PR TITLE
improve highlight of nested chunks in R Markdown documents

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 - The font size used for the document outline can now be customized [Accessibility] (#6887)
 - The RStudio diagnostics system now supports destructuring assignments as implemented and provided in the `dotty` package
 - The "Insert Chunk" button now acts as a menu in Quarto documents as well as R Markdown documents (#14785)
+- Improved support for highlighting of nested chunks in R Markdown and Quarto documents (#10079)
 
 #### Posit Workbench
 -

--- a/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
@@ -307,7 +307,7 @@ oop.inherits(RMarkdownHighlightRules, TextHighlightRules);
    this.$reScssChunkStartString       = engineRegex("scss");
    this.$reSassChunkStartString       = engineRegex("sass");
    this.$reLessChunkStartString       = engineRegex("less");
-   this.$reTextChunkStartString       = engineRegex("(?:asis|text)");
+   this.$reTextChunkStartString       = engineRegex("(?:asis|text|verbatim)");
    this.$reLatexChunkStartString      = engineRegex("(?:tikz|latex|tex)");
 
 }).call(RMarkdownHighlightRules.prototype);

--- a/src/gwt/acesupport/acemode/utils.js
+++ b/src/gwt/acesupport/acemode/utils.js
@@ -113,6 +113,17 @@ var YamlHighlightRules = require("mode/yaml_highlight_rules").YamlHighlightRules
          token: "support.function.codeend",
          regex: reEnd,
          onMatch: function(value, state, stack, line, context) {
+
+            // Check whether the width of this chunk tail matches
+            // the width of the chunk header that started this chunk.
+            var match = /^\s*((?:`|-)+)/.exec(value);
+            var width = match[1].length;
+            if (context.chunk.width !== width) {
+               this.next = state;
+               return this.token;
+            }
+
+            // Update the next state and return the matched token.
             this.next = context.chunk.state || "start";
             delete context.chunk;
             return this.token;
@@ -124,8 +135,23 @@ var YamlHighlightRules = require("mode/yaml_highlight_rules").YamlHighlightRules
             token: "support.function.codebegin",
             regex: reStart,
             onMatch: function(value, state, stack, line, context) {
+
+               // Check whether we're already within a chunk. If so,
+               // skip this chunk header -- assume that it's embedded
+               // within another active chunk.
                context.chunk = context.chunk || {};
+               if (context.chunk.state != null) {
+                  this.next = state;
+                  return this.token;
+               }
+
+               // A chunk header was found; record the state we entered
+               // from, and also the width of the chunk header.
+               var match = /^\s*((?:`|-)+)/.exec(value);
+               context.chunk.width = match[1].length;
                context.chunk.state = state;
+
+               // Update the next state and return the matched token.
                this.next = prefix + "-start";
                return this.token;
             }

--- a/src/gwt/src/org/rstudio/core/client/regex/Match.java
+++ b/src/gwt/src/org/rstudio/core/client/regex/Match.java
@@ -35,6 +35,11 @@ public class Match extends JavaScriptObject
    public final native String getGroup(int number) /*-{
       return this.match[number];
    }-*/;
+   
+   public final native String getGroupOrDefault(int number, String defaultValue) /*-{
+      return this.match[number] || defaultValue;
+   }-*/;
+   
 
    public final native boolean hasGroup(int number) /*-{
       return typeof(this.match[number]) != 'undefined';


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10079.

### Approach

- Updated our Ace highlight embed rules to also take into account the size of the chunk header, and use that to require that the closing rule matches a chunk of the appropriate length.

- Also use similar logic in our background chunk highlighter, which is implemented on the GWT side.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/10079.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

