### PR TITLE
fix RMD chunk label parser to handle comma before label

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 ### Fixed
 #### RStudio
 - "Run All" now only executes R chunks when "Chunk Output in Console" is set (#11995)
+- Fixed an issue where the chunk options popup didn't recognize chunk labels preceded by a comma (#15156)
 - Fixed an issue in the data viewer where list-column cell navigation worked incorrectly when a search filter was active (#9960)
 - Fixed an issue where debugger breakpoints did not function correctly in some cases with R 4.4 (#15072)
 - Fixed an issue where autocompletion results within piped expressions were incorrect in some cases (#13611)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/DefaultChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/DefaultChunkOptionsPopupPanel.java
@@ -25,6 +25,7 @@ import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkContextUi;
+import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkContextUi.ChunkLabelInfo;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -183,19 +184,11 @@ public class DefaultChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
       String extracted = match.getGroup(1);
       extraInfo.chunkPreamble = extractChunkPreamble(extracted, modeId);
 
-      extraInfo.chunkLabel = ChunkContextUi.extractChunkLabel(extracted);
+      ChunkLabelInfo labelDetails = ChunkContextUi.extractChunkLabel(extracted);
+      extraInfo.chunkLabel = labelDetails.label;
 
-      // if we had a chunk label, then we want to navigate our cursor to
-      // the first comma in the chunk header; otherwise, we start at the
-      // first space. this is done to accept chunk headers of the form
-      //
-      //    ```{r message=FALSE}
-      //
-      // ie, those with no comma after the engine used
-      int argsStartIdx = StringUtil.isNullOrEmpty(extraInfo.chunkLabel)
-            ? extracted.indexOf(' ')
-            : extracted.indexOf(',');
-
+      // continue parsing after the label
+      int argsStartIdx = labelDetails.nextSepIndex;
       String arguments = StringUtil.substring(extracted, argsStartIdx + 1);
       TextCursor cursor = new TextCursor(arguments);
 

--- a/src/gwt/test/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUiTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUiTests.java
@@ -15,7 +15,7 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text.rmd;
 
 import com.google.gwt.junit.client.GWTTestCase;
-import org.rstudio.core.client.Pair;
+import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkContextUi.ChunkLabelInfo;
 
 import java.util.List;
 import java.util.ArrayList;
@@ -27,18 +27,46 @@ public class ChunkContextUiTests extends GWTTestCase
    {
       return "org.rstudio.studio.RStudioTests";
    }
+   private static class TestCase
+   {
+      public TestCase(String input, String label, int nextTokenIdx)
+      {
+         this.input = input;
+         this.label = label;
+         this.nextTokenIdx = nextTokenIdx;
+      }
    
+      public String input;
+      public String label;
+      public int nextTokenIdx;
+   }
+
    public void testExtractChunkLabel()
    {
-      List<Pair<String, String>> testList = new ArrayList<>();
-      testList.add(new Pair<>("```{r echo=FALSE}",        ""));
-      testList.add(new Pair<>("```{r testingChunks}",        "testingChunks"));
-      testList.add(new Pair<>("```{r testingChunks, echo=FALSE}",        "testingChunks"));
+      // input string, expected results, expected position
+      List<TestCase> tests = new ArrayList<>();
+      tests.add(new TestCase("```{r}",                            "",                6));
+      tests.add(new TestCase("```{r,foo=BAR}",                    "",                5));
+      tests.add(new TestCase("```{r, foo=BAR}",                   "",                6));
+      tests.add(new TestCase("```{r testingChunks}",              "testingChunks",  20));
+      tests.add(new TestCase("```{r  testingChunks  }",           "testingChunks",  23));
+      tests.add(new TestCase("```{r   testing-Chunks}",           "testing-Chunks", 23));
+      tests.add(new TestCase("```{r, testingChunks}",             "testingChunks",  21));
+      tests.add(new TestCase("```{r,testingChunks}",              "testingChunks",  20));
+      tests.add(new TestCase("```{r echo=FALSE}",                 "",                5));
+      tests.add(new TestCase("```{r,echo=FALSE}",                 "",                5));
+      tests.add(new TestCase("```{r, echo=FALSE}",                "",                6));
+      tests.add(new TestCase("```{r testingChunks, echo=FALSE}",  "testingChunks",  19));
+      tests.add(new TestCase("```{r testingChunks,echo=FALSE}",   "testingChunks",  19));
+      tests.add(new TestCase("```{r, testingChunks, echo=FALSE}", "testingChunks",  20));
+      tests.add(new TestCase("```{r, label, echo=FALSE, ab=cd}",  "label",          12));
+      tests.add(new TestCase("```{r,label,echo=FALSE,ab=cd}",     "label",          11));
 
-      for (Pair<String, String> td  : testList)
+      for (TestCase test: tests)
       {
-         String result = ChunkContextUi.extractChunkLabel(td.first);
-         assertTrue(result.equals(td.second));
+         ChunkLabelInfo result = ChunkContextUi.extractChunkLabel(test.input);
+         assertEquals(test.input, test.label, result.label);
+         assertEquals(test.input, test.nextTokenIdx, result.nextSepIndex);
       }
    }
 }

--- a/src/gwt/test/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/DefaultChunkOptionsPopupPanelTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/DefaultChunkOptionsPopupPanelTests.java
@@ -43,6 +43,19 @@ public class DefaultChunkOptionsPopupPanelTests extends GWTTestCase
       assertEquals("TRUE", pieces.get("echo"));
    }
 
+   public void testCommaBeforeChunkLabel()
+   {
+      String header = "```{r, label, echo=TRUE}";
+      ChunkHeaderInfo extraInfo = new ChunkHeaderInfo();
+      HashMap<String, String> pieces = new HashMap<String, String>();
+      DefaultChunkOptionsPopupPanel.parseChunkHeader(header, "mode/rmarkdown", pieces, extraInfo);
+
+      assertEquals("label", extraInfo.chunkLabel);
+      assertEquals("r", extraInfo.chunkPreamble);
+      assertTrue(pieces.containsKey("echo"));
+      assertEquals("TRUE", pieces.get("echo"));
+   }
+
    public void testNoCommaBeforeFirstItem()
    {
       String header = "```{r echo=TRUE}";


### PR DESCRIPTION
### Intent

Addresses #15156

### Approach

Improve RMD chunk header popup to understand a comma after the engine, e.g.:

`{r, label, echo=TRUE}`

in addition to the already supported:

`{r label, echo=TRUE}`

Specifically, enhanced existing `extractChunkLabel()` method to understand this and to also return a hint about where to continue parsing the rest of the chunk header to the caller.

### Automated Tests

Added lots of unit tests around this change.

### QA Notes

Test various chunk types in RMarkdown, where you put a comma after the engine (language specifier, e.g. "r"). Try with and without a label.

It is expected that if you use the chunk option popup and hit Apply it will remove the comma.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


