### PR TITLE
unquote quoted variable names in dplyr pipes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,7 @@
 - Fixed an issue where the Console header label was not properly layed out when other tabs (e.g. Terminal) were closed (#15106)
 - Auto-saves will no longer trim trailing whitespace on the line containing the cursor (#14829)
 - Fixed an issue where pressing Tab would insert a literal tab instead of indenting a multi-line selection (#15046)
+- Fixed an issue where quoted variable names were not completed properly in dplyr pipes (#15161)
 
 #### Posit Workbench
 - Fixed an issue with Workbench login not respecting "Stay signed in when browser closes" when using Single Sign-On (rstudio-pro#5392)

--- a/src/cpp/tests/automation/testthat/test-automation-completions.R
+++ b/src/cpp/tests/automation/testthat/test-automation-completions.R
@@ -204,3 +204,19 @@ test_that("code_completion_include_already_used works as expected", {
    })
    
 })
+
+# https://github.com/rstudio/rstudio/issues/15161
+test_that("dplyr piped variable names are properly quoted / unquoted", {
+   
+   contents <- .rs.heredoc('
+      library(dplyr)
+      mtcars |> rename(`zzz A` = 1, `zzz B` = 2) |> select()
+   ')
+   
+   remote$documentOpen(ext = ".R", contents = contents)
+   editor <- remote$editorGetInstance()
+   
+   editor$gotoLine(2, 53)
+   completions <- remote$completionsRequest("zzz")
+   expect_equal(completions, c("zzz A", "zzz B"))
+})

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -322,6 +322,15 @@ var RCodeModel = function(session, tokenizer,
       "outer_join", "full_join"
    ];
 
+   var unquote = function(value) {
+      var match = /^([`'"])(.*)\1$/.exec(value);
+      if (match != null) {
+         var replace = new RegExp("\\\\" + match[1]);
+         return match[2].replace(replace, match[1]);
+      }
+      return value;
+   }
+
    // Add arguments from a function call in a chain.
    //
    //     select(x, y = 1)
@@ -341,7 +350,10 @@ var RCodeModel = function(session, tokenizer,
          return false;
 
       if (cursor.hasType("identifier"))
-         data.additionalArgs.push(cursor.currentValue());
+      {
+         var value = unquote(cursor.currentValue());
+         data.additionalArgs.push(value);
+      }
 
       if (fnName === "rename")
       {
@@ -353,7 +365,8 @@ var RCodeModel = function(session, tokenizer,
             if (!cursor.moveToNextToken())
                return false;
 
-            data.excludeArgs.push(cursor.currentValue());
+            var value = unquote(cursor.currentValue());
+            data.excludeArgs.push(value);
          }
       }
 
@@ -382,7 +395,10 @@ var RCodeModel = function(session, tokenizer,
                return false;
 
             if (cursor.hasType("identifier"))
-               data.additionalArgs.push(cursor.currentValue());
+            {
+               var value = unquote(cursor.currentValue());
+               data.additionalArgs.push(value);
+            }
 
             if (!cursor.moveToNextToken())
                return false;
@@ -393,8 +409,12 @@ var RCodeModel = function(session, tokenizer,
                {
                   if (!cursor.moveToNextToken())
                      return false;
+
                   if (cursor.hasType("identifier"))
-                     data.excludeArgs.push(cursor.currentValue());
+                  {
+                     var value = unquote(cursor.currentValue());
+                     data.excludeArgs.push(value);
+                  }
                }
 
             }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15161.

### Approach

Completions within `dplyr` pipelines are handled specially -- the raw names are taken from tokens in the source document. However, because those names can be quoted, we need to unquote them when returning those as completion items. (The completion manager will take care of re-quoting those names if required.)

<img width="385" alt="Screenshot 2024-09-13 at 9 46 45 AM" src="https://github.com/user-attachments/assets/cb04e5b0-27dd-413f-98dd-a5458a6435da">

<img width="328" alt="Screenshot 2024-09-13 at 9 46 58 AM" src="https://github.com/user-attachments/assets/f9e7d1a6-36c2-4f05-8dfc-b6b33e40003b">

### Automated Tests

Included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15161.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

