### PR TITLE
build focal on focal instead of bionic

### DIFF
--- a/jenkins/Jenkinsfile.build
+++ b/jenkins/Jenkinsfile.build
@@ -134,7 +134,7 @@ pipeline {
             environment {
               GITHUB_LOGIN = credentials('posit-jenkins')
               DOCKER_TAG = utils.getDockerTag()
-              DOCKER_FILE = "docker/jenkins/Dockerfile.${utils.getDockerBuildOs(env.os)}"
+              DOCKER_FILE = "docker/jenkins/Dockerfile.${env.os}"
             }
 
             steps {

--- a/jenkins/utils.groovy
+++ b/jenkins/utils.groovy
@@ -244,26 +244,12 @@ def updateDailyRedirects(String path) {
 }
 
 /**
-  * This method exists to quickly reenable our builds with 
-  * a bionic docker image, however our builds still need to
-  * be labeled focal. This is to support Debian 10 and
-  * should be retired once Debian 10 falls out of support
-  */
-def getDockerBuildOs(String osName) {
-  if(osName == "focal"){
-    return "bionic"
-  } else {
-    return osName
-  }
-}
-
-/**
   * Don't try to change RSTUDIO_VERSION_FLOWER to env.RSTUDIO_VERSION_FLOWER
   * in order for it to match, because for some reason that causes it to
   * resolve to "null". I don't know why.
   */
 def getDockerTag() {
-  return "${IS_PRO ? 'pro-' : ''}${getDockerBuildOs(env.OS)}-${env.ARCH}-${RSTUDIO_VERSION_FLOWER}"
+  return "${IS_PRO ? 'pro-' : ''}${env.OS}-${env.ARCH}-${RSTUDIO_VERSION_FLOWER}"
 }
 
 /**


### PR DESCRIPTION
### Intent

Cranberry-hibiscus fix for #15167

### Approach

We no longer support debian 10, thus no longer need to build our focal release in a bionic container. This was breaking the build because panmirror (visual editor) recently had a change that makes it no longer build with node 16, and bionic doesn't support node > 16.

So, switching to building in a focal container.

Backport of fix made to main. This change has been in pro for many months, so should be a no-op when merged into pro repo.

### Automated Tests

NA

### QA Notes

NA

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


