### PR TITLE
Use a strand to prevent concurrent callbacks

### DIFF
--- a/src/cpp/core/include/core/http/TcpIpAsyncClient.hpp
+++ b/src/cpp/core/include/core/http/TcpIpAsyncClient.hpp
@@ -67,11 +67,12 @@ private:
       pAsyncConnector->connect(
             address_,
             port_,
-            boost::bind(&TcpIpAsyncClient::writeRequest,
-                        TcpIpAsyncClient::sharedFromThis()),
-            boost::bind(&TcpIpAsyncClient::handleConnectionError,
-                        TcpIpAsyncClient::sharedFromThis(),
-                        _1),
+            boost::asio::bind_executor(strand_,
+                 boost::bind(&TcpIpAsyncClient::writeRequest,
+                             TcpIpAsyncClient::sharedFromThis())),
+            boost::asio::bind_executor(strand_,
+                 boost::bind(&TcpIpAsyncClient::handleConnectionError,
+                             TcpIpAsyncClient::sharedFromThis(), _1)),
             connectionTimeout_);
 
    }

--- a/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
+++ b/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
@@ -80,11 +80,11 @@ protected:
       pAsyncConnector->connect(
             address_,
             port_,
-            boost::bind(&TcpIpAsyncClientSsl::performHandshake,
-                        TcpIpAsyncClientSsl::sharedFromThis()),
-            boost::bind(&TcpIpAsyncClientSsl::handleConnectionError,
-                        TcpIpAsyncClientSsl::sharedFromThis(),
-                        _1),
+            boost::asio::bind_executor(strand_, boost::bind(&TcpIpAsyncClientSsl::performHandshake,
+                                                            TcpIpAsyncClientSsl::sharedFromThis())),
+            boost::asio::bind_executor(strand_, boost::bind(&TcpIpAsyncClientSsl::handleConnectionError,
+                                                            TcpIpAsyncClientSsl::sharedFromThis(),
+                                                            _1)),
             connectionTimeout_);
    }
 
@@ -113,9 +113,9 @@ private:
 
       ptrSslStream_->async_handshake(
             boost::asio::ssl::stream_base::client,
-            boost::bind(&TcpIpAsyncClientSsl::handleHandshake,
-                        sharedFromThis(),
-                        boost::asio::placeholders::error));
+            boost::asio::bind_executor(strand_, boost::bind(&TcpIpAsyncClientSsl::handleHandshake,
+                                                            sharedFromThis(),
+                                                            boost::asio::placeholders::error)));
    }
 
    void handleHandshake(const boost::system::error_code& ec)


### PR DESCRIPTION
(on the same client connection)

### Intent

Addresses: rstudio/vscode-server#108

Reviewed in PR: https://github.com/rstudio/rstudio-pro/pull/6790

### Approach

This affects SocketProxy that sets up concurrent callbacks on the same AsyncClient connection
