### PR TITLE
fix handling of tikz highlight rules

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,7 @@
 - Auto-saves will no longer trim trailing whitespace on the line containing the cursor (#14829)
 - Fixed an issue where pressing Tab would insert a literal tab instead of indenting a multi-line selection (#15046)
 - Fixed an issue where quoted variable names were not completed properly in dplyr pipes (#15161)
+- Fixed issue with highlight of `tikz` code chunks in R Markdown documents (#15019)
 
 #### Posit Workbench
 - Fixed an issue with Workbench login not respecting "Stay signed in when browser closes" when using Single Sign-On (rstudio-pro#5392)

--- a/src/cpp/tests/automation/testthat/test-automation-syntax-highlighting.R
+++ b/src/cpp/tests/automation/testthat/test-automation-syntax-highlighting.R
@@ -115,3 +115,39 @@ test_that("The sequence '# |' is not tokenized as a Quarto comment prefix", {
    })
    
 })
+
+# https://github.com/rstudio/rstudio/issues/15019
+test_that("tikz chunks are properly highlighted", {
+   
+   documentContents <- .rs.heredoc('
+      ---
+      title: tikz chunks
+      ---
+      
+      ```{tikz}
+      % This is a tikz chunk.
+      ```
+      
+      ```{r}
+      # This is an R chunk.
+      "hello"
+      ```
+   ')
+   
+   remote$documentExecute(".Rmd", documentContents, function(editor) {
+      
+      token <- as.vector(editor$session$getTokenAt(5, 0))
+      expect_match(token$type, "comment")
+      expect_equal(token$value, "% This is a tikz chunk.")
+      
+      token <- as.vector(editor$session$getTokenAt(9, 0))
+      expect_match(token$type, "comment")
+      expect_equal(token$value, "# This is an R chunk.")
+      
+      token <- as.vector(editor$session$getTokenAt(10, 0))
+      expect_match(token$type, "string")
+      expect_equal(token$value, "\"hello\"")
+      
+   })
+   
+})

--- a/src/gwt/acesupport/acemode/tex_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/tex_highlight_rules.js
@@ -42,7 +42,7 @@ var TexHighlightRules = function(textClass) {
 	        }, {
 	            token : "keyword", // command
 	            regex : "\\\\(?:documentclass|usepackage|newcounter|setcounter|addtocounter|value|arabic|stepcounter|newenvironment|renewenvironment|ref|vref|eqref|pageref|label|cite[a-zA-Z]*|tag|begin|end|bibitem)\\b",
-               next : "nospell"
+               push : "nospell"
 	        }, {
 	            token : "keyword", // command
 	            regex : "\\\\(?:[a-zA-Z0-9]+|[^a-zA-Z0-9])"
@@ -70,7 +70,7 @@ var TexHighlightRules = function(textClass) {
            {
                token : "comment",
                regex : "%.*$",
-               next : "start"
+               next  : "pop"
            }, {
                token : "nospell." + textClass, // non-command
                regex : "\\\\[$&%#\\{\\}]"
@@ -80,7 +80,7 @@ var TexHighlightRules = function(textClass) {
            }, {
                token : "keyword", // command
                regex : "\\\\(?:[a-zA-Z0-9]+|[^a-zA-Z0-9])",
-               next : "start"
+               next  : "pop"
            }, {
                token : "paren.keyword.operator",
                regex : "[[({]"
@@ -90,7 +90,7 @@ var TexHighlightRules = function(textClass) {
            }, {
                token : "paren.keyword.operator",
                regex : "}",
-               next : "start"
+               next  : "pop"
            }, {
                token : "nospell." + textClass,
                regex : "\\s+"
@@ -100,9 +100,11 @@ var TexHighlightRules = function(textClass) {
            }
         ]
     };
+
+    this.normalizeRules();
 };
 
 oop.inherits(TexHighlightRules, TextHighlightRules);
 
-exports.TexHighlightRules = TexHighlightRules;
+exports.TexHighlightRules = exports.LatexHighlightRules = TexHighlightRules;
 });


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15019.

### Approach

The TeX highlight rules we included were not appropriately structured for embedding, and we also (🤦 ) used the wrong name when trying to refer to these rules when embedding them.

### Automated Tests

Included a basic test.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15019.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
