### PR TITLE
treat chunks without headers as raw chunks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,7 @@
 - Fixed scroller behavior in Data Viewer when viewing very large datasets (#12834)
 - Fixed an issue where quoted variable names were not completed properly in dplyr pipes (#15161)
 - Fixed issue with highlight of `tikz` code chunks in R Markdown documents (#15019)
+- Fixed issue where collapsed raw chunks were displayed with an incorrect label in the Visual Editor (#14594)
 
 #### Posit Workbench
 - Fixed an issue with Workbench login not respecting "Stay signed in when browser closes" when using Single Sign-On (rstudio-pro#5392)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
@@ -1131,7 +1131,7 @@ public class VisualModeChunk
                engine = "YAML";
                label = "Metadata";
             }
-            else
+            else if (line.startsWith("{") && line.endsWith("}"))
             {
                // This is the first line in the chunk (its header). Parse it, reintroducing
                // the backticks since they aren't present in the embedded editor.
@@ -1152,6 +1152,11 @@ public class VisualModeChunk
                {
                   label = StringUtil.stringValue(labelEngine);
                }
+            }
+            else
+            {
+               // if this is a chunk without a header, it's a 'raw' chunk
+               engine = "raw chunk";
             }
          }
          else


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14594.

### Approach

Raw HTML chunks evidently do not have a single line chunk header of the form `{<engine>}`. Detect and handle that appropriately. The heuristic here isn't perfect, but should hopefully be good enough since a line starting and ending with `{}` should be rare, especially for HTML chunks.

<img width="517" alt="Screenshot 2024-09-17 at 10 13 58 AM" src="https://github.com/user-attachments/assets/5338336b-ccc2-4060-b687-14093ee8bc1b">

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14594.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
