### PR TITLE
allow enabling of token diagnostics in visual mode editors

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2241,6 +2241,7 @@ public class TextEditingTarget implements
          dirtyState_,
          docUpdateSentinel_,
          events_,
+         fileTypeRegistry_,
          releaseOnDismiss_
       );
 
@@ -8125,7 +8126,14 @@ public class TextEditingTarget implements
    @Handler
    void onToggleEditorTokenInfo()
    {
-      docDisplay_.toggleTokenInfo();
+      if (visualMode_.isActivated())
+      {
+         visualMode_.toggleEditorTokenInfo();
+      }
+      else
+      {
+         docDisplay_.toggleTokenInfo();
+      }
    }
 
    boolean useScopeTreeFolding()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -37,6 +37,7 @@ import org.rstudio.core.client.widget.images.ProgressImages;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.Value;
+import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.presentation2.model.PresentationEditorLocation;
 import org.rstudio.studio.client.palette.model.CommandPaletteEntryProvider;
 import org.rstudio.studio.client.palette.model.CommandPaletteEntrySource;
@@ -120,6 +121,7 @@ public class VisualMode implements VisualModeEditorSync,
                      DirtyState dirtyState,
                      DocUpdateSentinel docUpdateSentinel,
                      EventBus eventBus,
+                     FileTypeRegistry fileTypes,
                      final ArrayList<HandlerRegistration> releaseOnDismiss)
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
@@ -130,11 +132,12 @@ public class VisualMode implements VisualModeEditorSync,
       dirtyState_ = dirtyState;
       docUpdateSentinel_ = docUpdateSentinel;
       events_ = eventBus;
+      fileTypes_ = fileTypes;
       progress_ = new ProgressPanel(ProgressImages.createSmall(), 200);
       
       // create peer helpers
       visualModeFormat_ = new VisualModePanmirrorFormat(docUpdateSentinel_, docDisplay_, target_, view_);
-      visualModeChunks_ = new VisualModeChunks(docUpdateSentinel_, docDisplay_, target_, events_, releaseOnDismiss, this);
+      visualModeChunks_ = new VisualModeChunks(docUpdateSentinel_, docDisplay_, target_, events_, fileTypes_, releaseOnDismiss, this);
       visualModeLocation_ = new VisualModeEditingLocation(docUpdateSentinel_, docDisplay_);
       visualModeWriterOptions_ = new VisualModeMarkdownWriter(docUpdateSentinel_, docDisplay_, visualModeFormat_);
       visualModeNavigation_ = new VisualModeNavigation(navigationContext_);
@@ -904,6 +907,14 @@ public class VisualMode implements VisualModeEditorSync,
    public void unfoldAll()
    {
       panmirror_.execCommand(PanmirrorCommands.ExpandAllChunks);
+   }
+   
+   public void toggleEditorTokenInfo()
+   {
+      visualModeChunks_.forEachChunk((VisualModeChunk chunk) ->
+      {
+         chunk.getAceInstance().toggleTokenInfo();
+      });
    }
 
    public HasFindReplace getFindReplace()
@@ -1933,6 +1944,7 @@ public class VisualMode implements VisualModeEditorSync,
    private final DirtyState dirtyState_;
    private final DocUpdateSentinel docUpdateSentinel_;
    private final EventBus events_;
+   private final FileTypeRegistry fileTypes_;
    
    private final VisualModePanmirrorFormat visualModeFormat_;
    private final VisualModeChunks visualModeChunks_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
@@ -29,7 +29,9 @@ import org.rstudio.core.client.theme.ThemeFonts;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.common.filetypes.FileType;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
+import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.common.rnw.RnwWeave;
 import org.rstudio.studio.client.panmirror.ui.PanmirrorUIChunkCallbacks;
 import org.rstudio.studio.client.panmirror.ui.PanmirrorUIChunkEditor;
@@ -119,6 +121,7 @@ public class VisualModeChunk
                           DocUpdateSentinel sentinel,
                           TextEditingTarget target,
                           EventBus events,
+                          FileTypeRegistry fileTypes,
                           VisualModeEditorSync sync)
    {
       element_ = element;
@@ -128,6 +131,7 @@ public class VisualModeChunk
       parent_ = target.getDocDisplay();
       target_ = target;
       events_ = events;
+      fileTypes_ = fileTypes;
       active_ = false;
       markdownIndex_ = index;
       releaseOnDismiss_ = new ArrayList<>();
@@ -735,6 +739,13 @@ public class VisualModeChunk
    
    private void setMode(AceEditor editor, String mode)
    {
+      FileType fileType = fileTypes_.getTypeByTypeName(mode);
+      if (fileType != null && fileType instanceof TextFileType)
+      {
+         editor.setFileType((TextFileType) fileType);
+         return;
+      }
+      
       switch(mode.toLowerCase())
       {
       case "r":
@@ -1250,6 +1261,7 @@ public class VisualModeChunk
    private final Map<Integer,VisualModeChunkRowState> rowState_;
    private final TextEditingTarget target_;
    private final EventBus events_;
+   private final FileTypeRegistry fileTypes_;
    private final int markdownIndex_;
    private static final ViewsSourceConstants constants_ = GWT.create(ViewsSourceConstants.class);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunks.java
@@ -19,12 +19,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.Timer;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.panmirror.ui.PanmirrorUIChunks;
 import org.rstudio.studio.client.workbench.views.output.lint.model.LintItem;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
@@ -38,6 +37,8 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.TextEdi
 import org.rstudio.studio.client.workbench.views.source.model.DocUpdateSentinel;
 
 import com.google.gwt.core.client.JsArray;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Timer;
 
 public class VisualModeChunks implements ChunkDefinition.Provider
 {
@@ -45,11 +46,13 @@ public class VisualModeChunks implements ChunkDefinition.Provider
                            DocDisplay display,
                            TextEditingTarget target,
                            EventBus events,
+                           FileTypeRegistry fileTypes,
                            final ArrayList<HandlerRegistration> releaseOnDismiss,
                            VisualModeEditorSync sync)
    {
       target_ = target;
       events_ = events;
+      fileTypes_ = fileTypes;
       sentinel_ = sentinel;
       parent_ = display;
       sync_ = sync;
@@ -91,7 +94,7 @@ public class VisualModeChunks implements ChunkDefinition.Provider
          }
 
          VisualModeChunk chunk = new VisualModeChunk(
-               ele, index, expanded, classes, callbacks, sentinel_, target_, events_, sync_);
+               ele, index, expanded, classes, callbacks, sentinel_, target_, events_, fileTypes_, sync_);
 
          // Add the chunk to our index, and remove it when the underlying chunk
          // is removed in Prosemirror
@@ -318,6 +321,14 @@ public class VisualModeChunks implements ChunkDefinition.Provider
       // No chunk found; execute without one
       command.execute(null);
    }
+   
+   public void forEachChunk(CommandWithArg<VisualModeChunk> command)
+   {
+      for (VisualModeChunk chunk : chunks_)
+      {
+         command.execute(chunk);
+      }
+   }
 
    /**
     * Nudges the timer that saves the expansion state of each code chunk.
@@ -451,6 +462,7 @@ public class VisualModeChunks implements ChunkDefinition.Provider
    private final DocDisplay parent_;
    private final TextEditingTarget target_;
    private final EventBus events_;
+   private final FileTypeRegistry fileTypes_;
    private final Timer saveCollapseTimer_;
    private ArrayList<Integer> collapsedChunkPos_;
    private String collapseState_;


### PR DESCRIPTION
Purely an internal / developer nicety. Allows Help -> Diagnostics -> Toggle Editor Token Information to function in visual mode documents.

<img width="397" alt="Screenshot 2024-09-18 at 10 49 08 AM" src="https://github.com/user-attachments/assets/206e8c54-f5ae-4cfd-97d3-aa4a60c0feaa">
