### PR TITLE
improve support for folding of variable-width chunk headers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 - The RStudio diagnostics system now supports destructuring assignments as implemented and provided in the `dotty` package
 - The "Insert Chunk" button now acts as a menu in Quarto documents as well as R Markdown documents (#14785)
 - Improved support for highlighting of nested chunks in R Markdown and Quarto documents (#10079)
+- Improved support for variable-width chunk headers and footers in R Markdown / Quarto documents (#15191)
 - The "Include all function arguments in completion list" user preference can be used to control whether RStudio includes function arguments which appear to have already been used in the current context (#13065)
 
 #### Posit Workbench

--- a/src/cpp/tests/automation/testthat/test-automation-quarto.R
+++ b/src/cpp/tests/automation/testthat/test-automation-quarto.R
@@ -247,3 +247,49 @@ test_that("visual editor welcome dialog displays again if don't show again is un
    remote$documentClose()
    remote$keyboardExecute("<Ctrl + L>")
 })
+
+# https://github.com/rstudio/rstudio/issues/15191
+test_that("variable-width nested chunks can be folded", {
+   
+   contents <- .rs.heredoc('
+      ---
+      title: Folding
+      ---
+ 
+      `````{verbatim}
+      
+      This is some text.
+      
+      ```{r nested}
+      print(1 + 1)
+      ```
+      
+      `````
+      
+      # Header
+   ')
+   
+   remote$documentExecute(".qmd", contents, function(editor) {
+      
+      # Check the fold widget strings.
+      session <- editor$session
+      expect_equal(session$getFoldWidget(4), "start")
+      expect_equal(session$getFoldWidget(8), "")
+      expect_equal(session$getFoldWidget(10), "")
+      expect_equal(session$getFoldWidget(12), "end")
+      
+      # Check the computed ranges for the folds.
+      expected <- list(
+         start = list(row = 4, column = 15),
+         end = list(row = 12, column = 0)
+      )
+      
+      range <- as.vector(session$getFoldWidgetRange(4))
+      expect_equal(range, expected)
+      
+      range <- as.vector(session$getFoldWidgetRange(12))
+      expect_equal(range, expected)
+      
+   })
+   
+})

--- a/src/gwt/acesupport/acemode/utils.js
+++ b/src/gwt/acesupport/acemode/utils.js
@@ -110,7 +110,6 @@ var YamlHighlightRules = require("mode/yaml_highlight_rules").YamlHighlightRules
       var rules = HighlightRules.$rules;
 
       HighlightRules.embedRules(EmbedRules, prefix + "-", [{
-         token: "support.function.codeend",
          regex: reEnd,
          onMatch: function(value, state, stack, line, context) {
 
@@ -120,19 +119,18 @@ var YamlHighlightRules = require("mode/yaml_highlight_rules").YamlHighlightRules
             var width = match[1].length;
             if (context.chunk.width !== width) {
                this.next = state;
-               return this.token;
+               return "text";
             }
 
             // Update the next state and return the matched token.
             this.next = context.chunk.state || "start";
             delete context.chunk;
-            return this.token;
+            return "support.function.codeend";
          }
       }]);
 
       for (var i = 0; i < startStates.length; i++) {
          rules[startStates[i]].unshift({
-            token: "support.function.codebegin",
             regex: reStart,
             onMatch: function(value, state, stack, line, context) {
 
@@ -142,7 +140,7 @@ var YamlHighlightRules = require("mode/yaml_highlight_rules").YamlHighlightRules
                context.chunk = context.chunk || {};
                if (context.chunk.state != null) {
                   this.next = state;
-                  return this.token;
+                  return "text";
                }
 
                // A chunk header was found; record the state we entered
@@ -153,7 +151,7 @@ var YamlHighlightRules = require("mode/yaml_highlight_rules").YamlHighlightRules
 
                // Update the next state and return the matched token.
                this.next = prefix + "-start";
-               return this.token;
+               return "support.function.codebegin";
             }
          });
       }

--- a/src/gwt/acesupport/acemode/utils.js
+++ b/src/gwt/acesupport/acemode/utils.js
@@ -115,7 +115,7 @@ var YamlHighlightRules = require("mode/yaml_highlight_rules").YamlHighlightRules
 
             // Check whether the width of this chunk tail matches
             // the width of the chunk header that started this chunk.
-            var match = /^\s*((?:`|-)+)/.exec(value);
+            var match = /^\s*((?:`|-|\.)+)/.exec(value);
             var width = match[1].length;
             if (context.chunk.width !== width) {
                this.next = state;
@@ -145,7 +145,7 @@ var YamlHighlightRules = require("mode/yaml_highlight_rules").YamlHighlightRules
 
                // A chunk header was found; record the state we entered
                // from, and also the width of the chunk header.
-               var match = /^\s*((?:`|-)+)/.exec(value);
+               var match = /^\s*((?:`|-|\.)+)/.exec(value);
                context.chunk.width = match[1].length;
                context.chunk.state = state;
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15191.

### Approach

This PR specifically targets the fold rules for R Markdown documents. Previously, the rules checked only for chunk headers with three backticks; this PR generalizes that to any number of backticks.

<img width="435" alt="Screenshot 2024-09-18 at 2 30 00 PM" src="https://github.com/user-attachments/assets/6630f641-db48-485d-90db-4f5a88004e62">

### Automated Tests

Basic automation included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15191.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
