### PR TITLE
allow empty labels for markdown headers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@
 - Fixed issue with highlight of `tikz` code chunks in R Markdown documents (#15019)
 - RStudio now uses current session repositories when installing package dependencies via background jobs (#10016)
 - Fixed issue where collapsed raw chunks were displayed with an incorrect label in the Visual Editor (#14594)
+- RStudio now includes Markdown headers without any label in the document outline (#14552)
 
 #### Posit Workbench
 - Fixed an issue with Workbench login not respecting "Stay signed in when browser closes" when using Single Sign-On (rstudio-pro#5392)

--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -231,7 +231,7 @@ var MarkdownHighlightRules = function () {
          token: function (value) {
             return "markup.heading." + value.length;
          },
-         regex: /^#{1,6}(?=\s*[^ #]|\s+#.)/,
+         regex: /^#{1,6}/,
          next: "header"
       }, { // ioslides-style bullet
          token: "string.blockquote",


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14552.

### Approach

In our Markdown highlight rules, allow the rule matching headers to be more permissive.

### Automated Tests

Included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14552.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
