### PR TITLE
only quote non-syntactic variable names for non-Python completions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,7 @@
 - Fixed issue with highlight of `tikz` code chunks in R Markdown documents (#15019)
 - RStudio now uses current session repositories when installing package dependencies via background jobs (#10016)
 - Fixed issue where collapsed raw chunks were displayed with an incorrect label in the Visual Editor (#14594)
+- Fixed issue where certain Python variable names were incorrectly quoted when inserted via autocompletion (#14560)
 
 #### Posit Workbench
 - Fixed an issue with Workbench login not respecting "Stay signed in when browser closes" when using Single Sign-On (rstudio-pro#5392)

--- a/src/cpp/tests/automation/testthat/test-automation-python.R
+++ b/src/cpp/tests/automation/testthat/test-automation-python.R
@@ -1,0 +1,16 @@
+
+library(testthat)
+
+self <- remote <- .rs.automation.newRemote()
+withr::defer(.rs.automation.deleteRemote())
+
+# https://github.com/rstudio/rstudio/issues/14560
+test_that("attributes like __foo__ are not quoted when inserted via completions", {
+   remote$consoleExecute("reticulate::repl_python()")
+   remote$consoleExecute("import sys")
+   remote$keyboardExecute("sys.__name", "<Tab>", "<Enter>")
+   output <- remote$consoleOutput()
+   expect_equal(tail(output, n = 2L), c(">>> sys.__name__", "'sys'"))
+   remote$consoleExecute("exit")
+   remote$consoleClear()
+})

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -2125,8 +2125,9 @@ public class RCompletionManager implements CompletionManager
          if (qualifiedName.type == RCompletionType.DIRECTORY)
             value = value + "/";
          
-         if (!RCompletionType.isFileType(qualifiedName.type) &&
-             !shouldQuote)
+         if (!shouldQuote &&
+             !RCompletionType.isFileType(qualifiedName.type) &&
+             !StringUtil.equals(qualifiedName.language, "Python"))
          {
             value = quoteIfNotSyntacticNameCompletion(qualifiedName);
          }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14560.

### Approach

The R completion manager also handles autocompletion results generated by reticulate, when the Python REPL is active. In this scenario, because R and Python have different rules for what is a "syntactic" variable name, we need to suppress the regular quotation rules when using a Python completion result.

### Automated Tests

Included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14560.

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


