### PR TITLE
omit Results section when parsing for testthat errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,7 @@
 - Fixed issue with highlight of `tikz` code chunks in R Markdown documents (#15019)
 - RStudio now uses current session repositories when installing package dependencies via background jobs (#10016)
 - Fixed issue where collapsed raw chunks were displayed with an incorrect label in the Visual Editor (#14594)
+- Fixed issue where test errors were duplicated when presented in Issues tab of Build pane (#14564)
 
 #### Posit Workbench
 - Fixed an issue with Workbench login not respecting "Stay signed in when browser closes" when using Single Sign-On (rstudio-pro#5392)

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -656,7 +656,8 @@ private:
       if (type == kTestFile)
       {
          openErrorList_ = false;
-         if (module_context::isPackageInstalled("testthat")) {
+         if (module_context::isPackageInstalled("testthat"))
+         {
             parsers.add(testthatErrorParser(packagePath.getParent()));
          }
          
@@ -664,7 +665,8 @@ private:
       else if (type == kTestPackage)
       {
          openErrorList_ = false;
-         if (module_context::isPackageInstalled("testthat")) {
+         if (module_context::isPackageInstalled("testthat"))
+         {
             parsers.add(testthatErrorParser(packagePath.completePath("tests/testthat")));
          }
       }
@@ -1708,7 +1710,18 @@ private:
       // call the error parser if one has been specified
       if (errorParser_)
       {
-         std::vector<SourceMarker> errors = errorParser_(outputAsText());
+         std::string output = outputAsText();
+         
+         // remove the testthat summary, since that will cause us to duplicate markers
+         // https://github.com/rstudio/rstudio/issues/14564
+         boost::smatch match;
+         boost::regex reResults("(?:\u2550+|\u003d+)\\s+" kAnsiEscapeRegex "Results");
+         if (boost::regex_search(output, match, reResults))
+         {
+            output = output.substr(0, match.position());
+         }
+         
+         std::vector<SourceMarker> errors = errorParser_(output);
          if (!errors.empty())
          {
             errorsJson_ = sourceMarkersAsJson(errors);

--- a/src/cpp/session/modules/build/SessionBuild.hpp
+++ b/src/cpp/session/modules/build/SessionBuild.hpp
@@ -18,6 +18,9 @@
 
 #include <shared_core/json/Json.hpp>
 
+#define kAnsiEscapeRegex "(?:\033\\[\\d+m)*"
+#define kAnsiUrlRegex "(?:\u001B]8;.*?(?:\u0007|\033\\\\))*"
+
 namespace rstudio {
 namespace core {
    class Error;

--- a/src/cpp/session/modules/build/SessionBuildErrors.cpp
+++ b/src/cpp/session/modules/build/SessionBuildErrors.cpp
@@ -33,8 +33,7 @@
 #include <session/SessionModuleContext.hpp>
 #include <session/projects/SessionProjects.hpp>
 
-#define kAnsiEscapeRegex "(?:\033\\[\\d+m)*"
-#define kAnsiUrlRegex "(?:\u001B]8;.*?(?:\u0007|\033\\\\))*"
+#include "SessionBuild.hpp"
 
 using namespace rstudio::core;
 using namespace boost::placeholders;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14564.

### Approach

Drop the Results section from testthat output, when parsing for testthat test outputs.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14564.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
