### PR TITLE
avoid logging auto-save errors during restart / quit

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -195,6 +195,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.visualmode.
 import org.rstudio.studio.client.workbench.views.source.editors.text.visualmode.VisualModeSpelling;
 import org.rstudio.studio.client.workbench.views.source.editors.text.yaml.YamlEditorToolsProviderQuarto;
 import org.rstudio.studio.client.workbench.views.source.model.CppCompletion;
+import org.rstudio.studio.client.workbench.views.source.model.DocUpdateSentinel;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalInfoDialog;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalList;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalPopupMenu;
@@ -354,6 +355,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(QuartoConnection quartoMessageBus);
    void injectMembers(YamlEditorToolsProviderQuarto yamlCompletionSourceQuarto);
    void injectMembers(TextEditingTargetCopilotHelper copilotHelper);
+   void injectMembers(DocUpdateSentinel sentinel);
 
 
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3080,11 +3080,7 @@ public class TextEditingTarget implements
       if (isSaving_)
          return;
 
-      save(new Command() {
-         @Override
-         public void execute()
-         {
-         }});
+      save(() -> {});
    }
 
    private void autoSave(Command onCompleted, Command onSilentFailure)
@@ -3570,7 +3566,8 @@ public class TextEditingTarget implements
 
    // When the editor loses focus, perform an autosave if enabled, the
    // buffer is dirty, and we have a file to save to
-   private void maybeAutoSaveOnBlur() {
+   private void maybeAutoSaveOnBlur()
+   {
       if (prefs_.autoSaveOnBlur().getValue() &&
           dirtyState_.getValue() &&
           getPath() != null &&
@@ -3623,8 +3620,11 @@ public class TextEditingTarget implements
       return fsi;
    }
 
+   @Override
    public void onDismiss(int dismissType)
    {
+      isClosing_ = true;
+
       docUpdateSentinel_.stop();
 
       if (spelling_ != null)
@@ -3645,6 +3645,12 @@ public class TextEditingTarget implements
 
       if (inlinePreviewer_ != null)
          inlinePreviewer_.onDismiss();
+      
+      if (autoSaveTimer_ != null)
+         autoSaveTimer_.cancel();
+      
+      if (bgIdleMonitor_ != null)
+         bgIdleMonitor_.endMonitoring();
    }
 
    public ReadOnlyValue<Boolean> dirtyState()
@@ -8320,8 +8326,8 @@ public class TextEditingTarget implements
    {
       if (!externalEditCheckInterval_.hasElapsed())
          return;
+      
       externalEditCheckInterval_.reset();
-
       externalEditCheckInvalidation_.invalidate();
 
       // If the doc has never been saved, don't even bother checking
@@ -8330,6 +8336,9 @@ public class TextEditingTarget implements
 
       // If we're already waiting for the user to respond to an edit event, bail
       if (isWaitingForUserResponseToExternalEdit_)
+         return;
+      
+      if (isClosing_)
          return;
 
       final Invalidation.Token token = externalEditCheckInvalidation_.getInvalidationToken();
@@ -8341,6 +8350,9 @@ public class TextEditingTarget implements
                @Override
                public void onResponseReceived(CheckForExternalEditResult response)
                {
+                  if (isClosing_)
+                     return;
+                  
                   if (token.isInvalid())
                      return;
 
@@ -8955,8 +8967,9 @@ public class TextEditingTarget implements
       // register idle monitor; automatically creates/refreshes previews
       // of images and LaTeX equations during idle
       if (bgIdleMonitor_ == null && enabled)
-         bgIdleMonitor_ = new TextEditingTargetIdleMonitor(this,
-               docUpdateSentinel_);
+      {
+         bgIdleMonitor_ = new TextEditingTargetIdleMonitor(this, docUpdateSentinel_);
+      }
       else if (bgIdleMonitor_ != null)
       {
          if (enabled)
@@ -9467,11 +9480,11 @@ public class TextEditingTarget implements
       {
          // It's unlikely, but if we attempt to autosave while running a
          // previous autosave, just nudge the timer so we try again.
-         if (autosaveTimer_ != 0)
+         if (autoSaveInitiatedTime_ != 0)
          {
             // If we've been trying to save for more than 5 seconds, we won't
             // nudge (just fall through and we'll attempt again below)
-            if (System.currentTimeMillis() - autosaveTimer_ < 5000)
+            if (System.currentTimeMillis() - autoSaveInitiatedTime_ < 5000)
             {
                nudgeAutosave();
                return;
@@ -9492,7 +9505,7 @@ public class TextEditingTarget implements
          }
 
          // Save (and keep track of when we initiated it)
-         autosaveTimer_ = System.currentTimeMillis();
+         autoSaveInitiatedTime_ = System.currentTimeMillis();
          try
          {
             autoSave(this::onCompleted, this::onSilentFailure);
@@ -9500,27 +9513,27 @@ public class TextEditingTarget implements
          catch (Exception e)
          {
             // Autosave exceptions are logged rather than displayed
-            autosaveTimer_ = 0;
+            autoSaveInitiatedTime_ = 0;
             Debug.logException(e);
          }
       }
       
       private void onCompleted()
       {
-         autosaveTimer_ = 0;
+         autoSaveInitiatedTime_ = 0;
       }
       
       private void onSilentFailure()
       {
          // if this autosave operation silently fails, we want to automatically restart it
-         autosaveTimer_ = 0;
+         autoSaveInitiatedTime_ = 0;
          nudgeAutosave();
       }
    };
    
    private boolean isAutoSaving()
    {
-      return autosaveTimer_ != 0;
+      return autoSaveInitiatedTime_ != 0;
    }
 
    private HandlerRegistration documentDirtyHandler_ = null;
@@ -9533,7 +9546,10 @@ public class TextEditingTarget implements
    // prevent multiple manual saves from queuing up
    private boolean documentChangedDuringDebugSession_ = false;
    private boolean isSaving_ = false;
-   private long autosaveTimer_ = 0;
+   private long autoSaveInitiatedTime_ = 0;
+   
+   // track whether we're now closing the document
+   private boolean isClosing_ = false;
 
    private abstract class RefactorServerRequestCallback
            extends ServerRequestCallback<JsArrayString>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
@@ -290,6 +290,11 @@ public class DocUpdateSentinel
    }
    private boolean maybeAutoSave()
    {
+      if (quit_.isQuitting() || quit_.isSuspendingAndRestarting())
+      {
+         return false;
+      }
+      
       if (changeTracker_.hasChanged())
       {
          return doSave(null, null, null, false, new ProgressIndicator()


### PR DESCRIPTION
### Intent

Addresses (part of) https://github.com/rstudio/rstudio/issues/11932.

### Approach

Attempts to auto-save open documents while the session is preparing to quit or suspend are likely to fail. Ensure RStudio doesn't perform auto-saves in that state, or if it does for some reason, don't log those errors to the user (since the document would quickly become up-to-date again soon after working in the IDE).

Note that these auto-saves are only related to RStudio's internal source database buffer of open tabs, not attempts to update the actual files on disk being edited by the user.

### Automated Tests

Not included.

### QA Notes

To be verified by community.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
