### PR TITLE
echo at start and end of critical make-package stages

### DIFF
--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -254,6 +254,8 @@ if [ -n "$SCCACHE_ENABLED" ]; then
     fi
 fi
 
+echo "INFO: ---- invoking build command ----"
+
 cmake -G"${CMAKE_GENERATOR}"                           \
       -DRSTUDIO_TARGET=$RSTUDIO_TARGET                 \
       -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE             \
@@ -268,14 +270,20 @@ cmake -G"${CMAKE_GENERATOR}"                           \
 
 cmake --build . --target all -- ${MAKEFLAGS}
 
+echo "INFO: ---- build command completed ----"
+
 if [ -n "$SCCACHE_ENABLED" ]; then
+   echo "INFO: ---- showing sccache stats ----"
    sccache --show-stats
+   echo "INFO: ---- done showing sccache stats ----"
 fi
 
 if [ "$PACKAGE_TARGET" != "DEB" ]
 then
+   echo "INFO: ---- running cpack for non-DEB platform"
    fakeroot cpack --verbose --debug -G "$PACKAGE_TARGET"
 else
+   echo "INFO: ---- running cpack for DEB platform"
    cpack --verbose --debug -G $PACKAGE_TARGET
 
    # Fix permissions for non-development builds
@@ -287,4 +295,5 @@ else
 fi
 
 cd $PREV_WD
+echo "INFO: ---- completed make-package ----"
 


### PR DESCRIPTION
### Intent

Trying to figure out why RHEL9-based builds are getting stuck and being killed after 3 hours.

### Approach

Added echo statements before and after key phases of the make-package script that drives Linux builds.

### Automated Tests

NA

### QA Notes

NA

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


