### PR TITLE
attempt to work around fakeroot hang in rhel9 build

### DIFF
--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -281,6 +281,8 @@ fi
 if [ "$PACKAGE_TARGET" != "DEB" ]
 then
    echo "INFO: ---- running cpack for non-DEB platform"
+   # workaround for fakeroot hangs in Docker: https://github.com/moby/moby/issues/27195
+   sleep 1
    fakeroot cpack --verbose --debug -G "$PACKAGE_TARGET"
 else
    echo "INFO: ---- running cpack for DEB platform"


### PR DESCRIPTION
### Intent

Fix hanging rhel9 builds. 

### Approach

This is a workaround for fakeroot hangs in docker taken from https://github.com/moby/moby/issues/27195. Worth a shot...