### PR TITLE
disable set -e before testing fakeroot for timeout

### DIFF
--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -284,27 +284,30 @@ then
    ulimit -n
    echo "INFO: ---- ulimit -Hn"
    ulimit -Hn
-   # watch for fakeroot hanging and shorten multi-hour build timeout
-   timeout 10s fakeroot echo "Testing fakeroot..."
+
+   # watch for fakeroot hanging and bypass multi-hour build timeout
+   set +e
+   timeout 30s fakeroot echo "Testing fakeroot..."
    if [ $? -eq 124 ]; then
-      echo "ERROR: fakeroot test timed out"
+      echo "ERROR: fakeroot test timed out - terminating"
       exit 1
    fi
+   set -e
    echo "...fakeroot test succeeded"
+
    echo "INFO: ---- running cpack for non-DEB platform"
    fakeroot cpack --verbose --debug -G "$PACKAGE_TARGET"
 else
    echo "INFO: ---- running cpack for DEB platform"
-   cpack --verbose --debug -G $PACKAGE_TARGET
+   cpack --verbose --debug -G "$PACKAGE_TARGET"
 
    # Fix permissions for non-development builds
    if [ -z "${RSTUDIO_DEVELOPMENT_BUILD}" ]
    then
-      $PKG_DIR/fix-debian-permissions `ls *.deb`
+      "$PKG_DIR"/fix-debian-permissions `ls *.deb`
    fi
 
 fi
 
-cd $PREV_WD
+cd "$PREV_WD"
 echo "INFO: ---- completed make-package ----"
-


### PR DESCRIPTION
### Intent

Ongoing work to isolate why rhel9 builds are hanging.
