### PR TITLE
avoid logging warnings in forked sessions

### DIFF
--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -379,10 +379,7 @@ bool rConsoleRead(const std::string& prompt,
 {
    // this is an invalid state in a forked (multicore) process
    if (main_process::wasForked())
-   {
-      LOG_WARNING_MESSAGE("rConsoleRead called in forked process");
       return false;
-   }
 
    // r is not processing input
    setExecuting(false);

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -456,10 +456,7 @@ bool waitForMethod(const std::string& method,
                    core::json::JsonRpcRequest* pRequest)
 {
    if (main_process::wasForked())
-   {
-      LOG_ERROR_MESSAGE("Waiting for method " + method + " after fork");
       return false;
-   }
    
    if (!ASSERT_MAIN_THREAD(method))
    {

--- a/src/cpp/session/modules/SessionSystemResources.cpp
+++ b/src/cpp/session/modules/SessionSystemResources.cpp
@@ -267,9 +267,7 @@ void emitMemoryChangedEvent()
 {
    // Ensure we don't emit memory stats from child processes
    if (main_process::wasForked())
-   {
       return;
-   }
 
    boost::shared_ptr<MemoryUsage> pUsage;
    Error error = getMemoryUsage(&pUsage);


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15221.

### Approach

Don't log warnings in forked sessions; just quietly discard the requests it cannot handle.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15221.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
