### PR TITLE
avoid line selections when toggling breakpoints

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,7 @@
 - Fixed issue where test errors were duplicated when presented in Issues tab of Build pane (#14564)
 - Fixed issue where certain Python variable names were incorrectly quoted when inserted via autocompletion (#14560)
 - RStudio now includes Markdown headers without any label in the document outline (#14552)
+- Clicking in the editor gutter to toggle a breakpoint no longer also selects the associated line
 
 #### Posit Workbench
 - Fixed an issue with Workbench login not respecting "Stay signed in when browser closes" when using Single Sign-On (rstudio-pro#5392)

--- a/NEWS.md
+++ b/NEWS.md
@@ -52,7 +52,7 @@
 - Fixed issue where test errors were duplicated when presented in Issues tab of Build pane (#14564)
 - Fixed issue where certain Python variable names were incorrectly quoted when inserted via autocompletion (#14560)
 - RStudio now includes Markdown headers without any label in the document outline (#14552)
-- Clicking in the editor gutter to toggle a breakpoint no longer also selects the associated line
+- Clicking in the editor gutter to toggle a breakpoint no longer also selects the associated line (#15226)
 
 #### Posit Workbench
 - Fixed an issue with Workbench login not respecting "Stay signed in when browser closes" when using Single Sign-On (rstudio-pro#5392)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -212,6 +212,7 @@ public class AceEditorWidget extends Composite
          }
 
       });
+      
       editor_.onChangeFold(new Command()
       {
          @Override
@@ -220,31 +221,27 @@ public class AceEditorWidget extends Composite
             fireEvent(new FoldChangeEvent());
          }
       });
+      
       editor_.onChangeScrollTop(() -> {
          Position pos = Position.create(editor_.getFirstVisibleRow(), 0);
          fireEvent(new ScrollYEvent(pos));
       });
 
-      editor_.onGutterMouseDown(new CommandWithArg<AceMouseEventNative>()
+      editor_.setHandler("guttermousedown", new CommandWithArg<AceMouseEventNative>()
       {
         @Override
         public void execute(AceMouseEventNative arg)
         {
            // make sure the click is actually intended for the gutter
-           com.google.gwt.dom.client.Element targetElement =
-                 Element.as(arg.getNativeEvent().getEventTarget());
+           Element targetElement = Element.as(arg.getNativeEvent().getEventTarget());
            if (targetElement.getClassName().indexOf("ace_gutter-cell") < 0)
-           {
               return;
-           }
 
            NativeEvent evt = arg.getNativeEvent();
 
            // right-clicking shouldn't set a breakpoint
            if (evt.getButton() != NativeEvent.BUTTON_LEFT)
-           {
               return;
-           }
 
            // make sure that the click was in the left half of the element--
            // clicking on the line number itself (or the gutter near the
@@ -255,8 +252,13 @@ public class AceEditorWidget extends Composite
            {
               toggleBreakpointAtPosition(arg.getDocumentPosition());
            }
+           else
+           {
+              arg.invokeDefaultHandler(getEditor());
+           }
         }
       });
+      
       editor_.getSession().getSelection().addCursorChangeHandler(new CommandWithArg<Position>()
       {
          public void execute(Position arg)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -184,6 +184,15 @@ public class AceEditorNative extends JavaScriptObject
            }));
    }-*/;
 
+   public native final <T> void setHandler(String eventName, CommandWithArg<T> handler)
+   /*-{
+      var defaultHandler = this._defaultHandlers[eventName] || function(evt) {};
+      this.setDefaultHandler(eventName, function(event) {
+         event.defaultHandler = defaultHandler;
+         handler.@org.rstudio.core.client.CommandWithArg::execute(*)(event);
+      });
+   }-*/;
+   
    public native final <T> void onGutterMouseDown(CommandWithArg<T> command) /*-{
       this.on("guttermousedown",
          $entry(function (arg) {
@@ -263,7 +272,7 @@ public class AceEditorNative extends JavaScriptObject
       var loader = require("rstudio/loader");
       return loader.loadEditor(container);
    }-*/;
-   
+  
    public final native void manageDefaultKeybindings() /*-{
       
       // We bind 'Ctrl + Shift + M' to insert a magrittr shortcut on Windows

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceMouseEventNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceMouseEventNative.java
@@ -36,6 +36,11 @@ public class AceMouseEventNative extends JavaScriptObject
    public native final void preventDefault() /*-{
       this.preventDefault();
    }-*/;
+   
+   public native final void invokeDefaultHandler(AceEditorNative editor) /*-{
+      var handler = this.defaultHandler;
+      handler.call(editor, this);
+   }-*/;
 
    public native final Position getDocumentPosition() /*-{
       return this.getDocumentPosition();


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15226.

### Approach

Ace installs a default gutterdown mouse handler, which always gets a chance to fire. Override that by setting our own default handler, but saving and invoking that handler if appropriate (ie: if we didn't try to toggle a breakpoint).

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15226.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
