### PR TITLE
fix checks for function-in-sync

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,7 @@
 - Fixed issue where collapsed raw chunks were displayed with an incorrect label in the Visual Editor (#14594)
 - Fixed issue where test errors were duplicated when presented in Issues tab of Build pane (#14564)
 - Fixed issue where certain Python variable names were incorrectly quoted when inserted via autocompletion (#14560)
+- Fixed an issue where RStudio over-aggressively required packages to be rebuilt when setting breakpoints (#15201)
 - RStudio now includes Markdown headers without any label in the document outline (#14552)
 - RStudio no longer logs warning / error messages related to disabled R actions (e.g. ReadConsole) in forked sessions (#15221)
 

--- a/src/cpp/session/modules/SessionBreakpoints.R
+++ b/src/cpp/session/modules/SessionBreakpoints.R
@@ -376,12 +376,12 @@
    
    # Find the function definition.
    functionName <- .rs.unquote(functionName)
-   fun <- .rs.getUntracedFunction(functionName, filePath, packageName)
-   if (is.null(fun))
+   funcDefn <- .rs.getUntracedFunction(functionName, filePath, packageName)
+   if (is.null(funcDefn))
       return(FALSE)
    
    # Get the source definition of this function.
-   srcref <- attr(fun, "srcref")
+   srcref <- attr(funcDefn, "srcref")
    functionLines <- .rs.deparseSrcref(srcref, FALSE)
    
    # Check if this matches the file contents.

--- a/src/cpp/session/modules/SessionBreakpoints.R
+++ b/src/cpp/session/modules/SessionBreakpoints.R
@@ -384,7 +384,10 @@
    srcref <- attr(funcDefn, "srcref")
    functionLines <- .rs.deparseSrcref(srcref, FALSE)
    
-   # Check if this matches the file contents.
+   # Check if this matches the file contents. Note that we intentionally
+   # use 'first_line' and 'last_line' below, as we're referencing against
+   # the "real" source file as opposed to an alias of copy (as might be
+   # used for e.g. package code).
    fileContents <- .rs.readLines(filePath)
    srcPos <- .rs.parseSrcref(srcref)
    srcLines <- seq(from = srcPos$first_line, to = srcPos$last_line)

--- a/src/cpp/session/modules/SessionBreakpoints.R
+++ b/src/cpp/session/modules/SessionBreakpoints.R
@@ -386,8 +386,9 @@
    
    # Check if this matches the file contents.
    fileContents <- .rs.readLines(filePath)
-   srcpos <- .rs.parseSrcref(srcref)
-   functionSrcLines <- fileContents[srcpos$first_parsed:srcpos$last_parsed]
+   srcPos <- .rs.parseSrcref(srcref)
+   srcLines <- seq(from = srcPos$first_line, to = srcPos$last_line)
+   functionSrcLines <- fileContents[srcLines]
    
    # Check if they match.
    identical(functionLines, functionSrcLines)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -287,7 +287,7 @@
    code <- if (is.character(lines))
    {
       srcpos <- .rs.parseSrcref(srcref)
-      range <- seq(from = srcpos$first_line, to = srcpos$last_line)
+      range <- seq(from = srcpos$first_parsed, to = srcpos$last_parsed)
       lines[range]
    }
    else

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -287,7 +287,7 @@
    code <- if (is.character(lines))
    {
       srcpos <- .rs.parseSrcref(srcref)
-      range <- seq(from = srcpos$first_parsed, to = srcpos$last_parsed)
+      range <- seq(from = srcpos$first_line, to = srcpos$last_line)
       lines[range]
    }
    else

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -287,7 +287,15 @@
    code <- if (is.character(lines))
    {
       srcpos <- .rs.parseSrcref(srcref)
-      range <- seq(from = srcpos$first_parsed, to = srcpos$last_parsed)
+      range <- if (inherits(srcfile, c("srcfilecopy", "srcfilealias")))
+      {
+         seq(from = srcpos$first_parsed, to = srcpos$last_parsed)
+      }
+      else
+      {
+         seq(from = srcpos$first_line, to = srcpos$last_line)
+      }
+
       lines[range]
    }
    else

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -347,8 +347,8 @@
   pos <- gregexpr(calltext, singleline, fixed = TRUE)[[1]]
   if (length(linepref) == 0L || linepref <= 0L)
   {
+     endpos <- pos[[1L]] + attr(pos, "match.length")[[1L]]
      pos <- pos[[1L]]
-     endpos <- pos + attr(pos, "match.length")
   }
   else if (length(pos) > 1)
   {
@@ -370,8 +370,8 @@
   }
   else
   {
+     endpos <- pos[[1L]] + attr(pos, "match.length")[[1L]]
      pos <- pos[[1L]]
-     endpos <- pos + attr(pos, "match.length")
   }
 
   # Return an empty source ref if we couldn't find a match

--- a/src/cpp/session/modules/automation/SessionAutomationRemote.R
+++ b/src/cpp/session/modules/automation/SessionAutomationRemote.R
@@ -228,7 +228,7 @@
    nodeIds
 })
 
-.rs.automation.addRemoteFunction("domClickElement", function(selector,
+.rs.automation.addRemoteFunction("domClickElement", function(selector = NULL,
                                                              objectId = NULL,
                                                              verticalOffset = 0L,
                                                              horizontalOffset = 0L,

--- a/src/cpp/tests/automation/testthat/test-automation-debugger.R
+++ b/src/cpp/tests/automation/testthat/test-automation-debugger.R
@@ -57,3 +57,109 @@ test_that("the debug position is correct in braced expressions", {
    remote$keyboardExecute("<Ctrl + L>")
    
 })
+
+# https://github.com/rstudio/rstudio/issues/15201
+test_that("package functions can be debugged after build and reload", {
+   
+   # Create an R package project.
+   projectPath <- tempfile("rstudio.automation.", tmpdir = dirname(tempdir()))
+   
+   remote$consoleExecuteExpr({
+      .rs.rpc.package_skeleton(
+         packageName = "rstudio.automation",
+         packageDirectory = !!projectPath,
+         sourceFiles = character(),
+         usingRcpp = FALSE
+      )
+   })
+   
+   # Open that project.
+   remote$consoleExecuteExpr(
+      .rs.api.openProject(!!projectPath)
+   )
+   
+   .rs.waitUntil("the new project is opened", function()
+   {
+      el <- remote$jsObjectViaSelector("#rstudio_project_menubutton_toolbar")
+      grepl("rstudio.automation", el$innerText, fixed = TRUE)
+   })
+   
+   # Add a source document.
+   remote$consoleExecuteExpr(
+      file.edit("R/example.R")
+   )
+   
+   code <- .rs.heredoc('
+      example <- function() {
+         1 + 1
+         2 + 2
+         3 + 3
+         4 + 4
+         5 + 5
+      }
+   ')
+   
+   editor <- remote$editorGetInstance()
+   editor$insert(code)
+   
+   # Save it, and build the package.
+   remote$commandExecute("saveSourceDoc")
+   remote$commandExecute("buildAll")
+   
+   .rs.waitUntil("build has completed", function()
+   {
+      output <- remote$consoleOutput()
+      any(output == "> library(rstudio.automation)")
+   })
+   
+   remote$consoleClear()
+   
+   # Try adding some breakpoints.
+   gutterEls <- remote$jsObjectsViaSelector(".ace_gutter-cell")
+   remote$domClickElement(objectId = gutterEls[[3]], horizontalOffset = -4L)
+   breakpointEls <- remote$jsObjectsViaSelector(".ace_breakpoint")
+   expect_equal(length(breakpointEls), 1L)
+   expect_equal(breakpointEls[[1]]$innerText, "3")
+   
+   remote$domClickElement(objectId = gutterEls[[4]], horizontalOffset = -4L)
+   breakpointEls <- remote$jsObjectsViaSelector(".ace_breakpoint")
+   expect_equal(length(breakpointEls), 2L)
+   expect_equal(breakpointEls[[2]]$innerText, "4")
+   
+   # Confirm that the object definition is in sync.
+   remote$consoleExecuteExpr({
+      .rs.isFunctionInSync("example", "R/example.R", "rstudio.automation")
+   })
+   
+   output <- remote$consoleOutput()
+   expect_contains(output, "[1] TRUE")
+   remote$consoleClear()
+   
+   # Try running the function, and checking the view.
+   remote$consoleExecuteExpr(example())
+   
+   activeLineEl <- remote$jsObjectViaSelector(".ace_executing-line")
+   expect_equal(activeLineEl$innerText, "3")
+   remote$commandExecute("activateConsole")
+   remote$keyboardExecute("c", "<Enter>")
+   
+   activeLineEl <- remote$jsObjectViaSelector(".ace_executing-line")
+   expect_equal(activeLineEl$innerText, "4")
+   remote$keyboardExecute("c", "<Enter>")
+   
+   # All done testing; close the project.
+   remote$commandExecute("closeProject")
+   
+   # If we received a modal, click "Don't Save".
+   hasDialog <- tryCatch(
+      { remote$domGetNodeId("#rstudio_dlg_no"); TRUE },
+      error = function(cnd) FALSE
+   )
+   
+   if (hasDialog)
+   {
+      noEl <- remote$jsObjectViaSelector("#rstudio_dlg_no")
+      remote$domClickElement(objectId = noEl)
+   }
+   
+})


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15201.

### Approach

- The 'match.length' attribute is set on the `pos` vector, not the individual elements, so we need to grab that from `pos` before subsetting when constructing `endpos`.
- Improve check for "fuzzy" matching of source references in a document. In particular, we first check all documents for an exact match before doing a more fuzzy match later.

### Automated Tests

TODO

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15201.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
