### PR TITLE
allow rename in scope to work across chunks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,8 @@
 - Improved support for variable-width chunk headers and footers in R Markdown / Quarto documents (#15191)
 - The "Include all function arguments in completion list" user preference can be used to control whether RStudio includes function arguments which appear to have already been used in the current context (#13065)
 - Available environment variables are now provided as completion suggestions within `Sys.unsetenv()` (#15215)
-- RStudio IDE User Guide and RStudio & Posit Workbench Release Notes now includes release version in navigation bar reference URLs. (#15223)
+- RStudio IDE User Guide and RStudio & Posit Workbench Release Notes now includes release version in navigation bar reference URLs (#15223)
+- Rename in Scope now operates across chunks within R Markdown and Quarto documents (#4961)
 
 #### Posit Workbench
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/4961.

### Approach

The rename in scope helper currently isolated its changes to the currently-active chunk, for top-level variables within an R code chunk. This PR changes the behavior so that, if the user wants to refactor a variable in a chunk, that refactor happens across all R code chunks.

### Automated Tests

TODO

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/4961.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
