### PR TITLE
use separate build library path when installing package

### DIFF
--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -253,6 +253,7 @@ struct RSuspendOptions
    bool excludePackages = false;
    std::string ephemeralEnvVars;
    std::string afterRestartCommand;
+   std::string buildLibraryPath;
 };
 
 void suspendForRestart(const RSuspendOptions& options);

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -253,7 +253,7 @@ struct RSuspendOptions
    bool excludePackages = false;
    std::string ephemeralEnvVars;
    std::string afterRestartCommand;
-   std::string buildLibraryPath;
+   std::string builtPackagePath;
 };
 
 void suspendForRestart(const RSuspendOptions& options);

--- a/src/cpp/r/include/r/session/RSessionState.hpp
+++ b/src/cpp/r/include/r/session/RSessionState.hpp
@@ -49,7 +49,7 @@ void initialize(SessionStateCallbacks callbacks);
 
 bool save(const core::FilePath& statePath,
           const std::string& afterRestartCommand,
-          const std::string& buildLibraryPath,
+          const std::string& builtPackagePath,
           bool serverMode,
           bool excludePackages,
           bool disableSaveCompression,

--- a/src/cpp/r/include/r/session/RSessionState.hpp
+++ b/src/cpp/r/include/r/session/RSessionState.hpp
@@ -49,6 +49,7 @@ void initialize(SessionStateCallbacks callbacks);
 
 bool save(const core::FilePath& statePath,
           const std::string& afterRestartCommand,
+          const std::string& buildLibraryPath,
           bool serverMode,
           bool excludePackages,
           bool disableSaveCompression,

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -709,13 +709,14 @@ void useBuildLibraryPath(const FilePath& srcPath)
    }
 
    FilePath homePath = core::system::userHomePath("R_USER|HOME");
-   REprintf("[!] %s\n", homePath.getAbsolutePath().c_str());
    std::string aliasedPath = FilePath::createAliasedPath(srcPath.getParent(), homePath);
    REprintf(
             "\n"
             "- RStudio was unable to move '%s' into your package library.\n"
-            "- %s has been added to the library paths for this session.\n"
+            "- '%s' will be loaded from the following library path for this session:\n"
+            "- \"%s\"\n"
             "\n",
+            srcPath.getFilename().c_str(),
             srcPath.getFilename().c_str(),
             aliasedPath.c_str());
 }

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -738,11 +738,11 @@ Error deferredRestore(const FilePath& statePath, bool serverMode)
             else
             {
                REprintf(
-                        "RStudio was unable to move the installed package \"%s\" from %s to %s.\n"
-                        "%s has been added to the library paths for this session.",
+                        "\n"
+                        "- RStudio was unable to move \"%s\" into your package library.\n"
+                        "- %s has been added to the library paths for this session.\n"
+                        "\n",
                         srcPath.getFilename().c_str(),
-                        srcPath.getAbsolutePath().c_str(),
-                        tgtPath.getAbsolutePath().c_str(),
                         srcPath.getParent().getAbsolutePath().c_str());
             }
          }

--- a/src/cpp/r/session/RSuspend.cpp
+++ b/src/cpp/r/session/RSuspend.cpp
@@ -89,6 +89,7 @@ bool saveSessionState(const RSuspendOptions& options,
       return r::session::state::save(
                suspendedSessionPath,
                options.afterRestartCommand,
+               options.buildLibraryPath,
                utils::isServerMode(),
                options.excludePackages,
                disableSaveCompression,

--- a/src/cpp/r/session/RSuspend.cpp
+++ b/src/cpp/r/session/RSuspend.cpp
@@ -89,7 +89,7 @@ bool saveSessionState(const RSuspendOptions& options,
       return r::session::state::save(
                suspendedSessionPath,
                options.afterRestartCommand,
-               options.buildLibraryPath,
+               options.builtPackagePath,
                utils::isServerMode(),
                options.excludePackages,
                disableSaveCompression,

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -374,9 +374,9 @@ Error suspendForRestart(const core::json::JsonRpcRequest& request,
    // when launcher sessions restart, they need to set a special exit code
    // to ensure that the rsession-run script restarts the rsession process
    // instead of having to submit an entirely new launcher session
-   int exitStatus = options().getBoolOverlayOption(kLauncherSessionOption) ?
-            EX_SUSPEND_RESTART_LAUNCHER_SESSION :
-            EX_CONTINUE;
+   int exitStatus = options().getBoolOverlayOption(kLauncherSessionOption)
+         ? EX_SUSPEND_RESTART_LAUNCHER_SESSION
+         : EX_CONTINUE;
 
    rstudio::r::session::RSuspendOptions options(exitStatus);
    Error error = json::readObjectParam(
@@ -387,6 +387,11 @@ Error suspendForRestart(const core::json::JsonRpcRequest& request,
             "after_restart", &(options.afterRestartCommand));
    if (error)
       return error;
+   
+   // read optional build library path (ignore errors)
+   json::readObjectParam(
+            request.params, 0,
+            "build_library_path", &(options.buildLibraryPath));
 
    pResponse->setAfterResponse(boost::bind(doSuspendForRestart, options));
    return Success();

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -391,7 +391,7 @@ Error suspendForRestart(const core::json::JsonRpcRequest& request,
    // read optional build library path (ignore errors)
    json::readObjectParam(
             request.params, 0,
-            "build_library_path", &(options.buildLibraryPath));
+            "built_package_path", &(options.builtPackagePath));
 
    pResponse->setAfterResponse(boost::bind(doSuspendForRestart, options));
    return Success();

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -318,6 +318,7 @@ namespace prefs {
 #define kSshKeyTypeRsa "rsa"
 #define kUseDevtools "use_devtools"
 #define kCleanBeforeInstall "clean_before_install"
+#define kUseBuildSubdirectory "use_build_subdirectory"
 #define kUseSecureDownload "use_secure_download"
 #define kCleanupAfterRCmdCheck "cleanup_after_r_cmd_check"
 #define kViewDirAfterRCmdCheck "view_dir_after_r_cmd_check"
@@ -1548,6 +1549,12 @@ public:
     */
    bool cleanBeforeInstall();
    core::Error setCleanBeforeInstall(bool val);
+
+   /**
+    * Whether to use a `_build` sub-directory in the current library paths when developing an R package.
+    */
+   bool useBuildSubdirectory();
+   core::Error setUseBuildSubdirectory(bool val);
 
    /**
     * Whether to use secure downloads when fetching R packages.

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -1551,7 +1551,7 @@ public:
    core::Error setCleanBeforeInstall(bool val);
 
    /**
-    * Whether to use a `_build` sub-directory in the current library paths when developing an R package.
+    * When set, RStudio will build your package in a '_build' sub-directory of your current library paths.
     */
    bool useBuildSubdirectory();
    core::Error setUseBuildSubdirectory(bool val);

--- a/src/cpp/session/modules/SessionBuild.R
+++ b/src/cpp/session/modules/SessionBuild.R
@@ -128,3 +128,21 @@ options(buildtools.with = function(code)
    
    scriptPath
 })
+
+.rs.addFunction("prependLibraryPath", function(libPath)
+{
+   .libPaths(c(libPath, .libPaths()))
+})
+
+.rs.addFunction("makeBuildLibraryPath", function()
+{
+   for (libPath in .libPaths())
+   {
+      if (.rs.isLibraryWriteable(libPath))
+      {
+         buildLibPath <- tempfile("build-", tmpdir = libPath)
+         if (dir.create(buildLibPath, recursive = TRUE, showWarnings = FALSE))
+            return(buildLibPath)
+      }
+   }
+})

--- a/src/cpp/session/modules/SessionBuild.R
+++ b/src/cpp/session/modules/SessionBuild.R
@@ -134,7 +134,7 @@ options(buildtools.with = function(code)
    .libPaths(c(libPath, .libPaths()))
 })
 
-.rs.addFunction("makeBuildLibraryPath", function(packageName)
+.rs.addFunction("makeBuildLibraryPath", function()
 {
    for (libPath in .libPaths())
    {

--- a/src/cpp/session/modules/SessionBuild.R
+++ b/src/cpp/session/modules/SessionBuild.R
@@ -134,15 +134,17 @@ options(buildtools.with = function(code)
    .libPaths(c(libPath, .libPaths()))
 })
 
-.rs.addFunction("makeBuildLibraryPath", function()
+.rs.addFunction("makeBuildLibraryPath", function(packageName)
 {
    for (libPath in .libPaths())
    {
-      if (.rs.isLibraryWriteable(libPath))
-      {
-         buildLibPath <- tempfile("build-", tmpdir = libPath)
-         if (dir.create(buildLibPath, recursive = TRUE, showWarnings = FALSE))
-            return(buildLibPath)
-      }
+      buildLibPath <- file.path(libPath, "_build")
+      if (dir.exists(buildLibPath) || dir.create(buildLibPath, showWarnings = FALSE))
+         return(buildLibPath)
    }
+})
+
+.rs.addFunction("removeBuildLibraryPath", function(buildLibraryPath)
+{
+   .libPaths(setdiff(.libPaths(), buildLibraryPath))
 })

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -1708,10 +1708,10 @@
    clear = function() { .rs.clearUserPref("clean_before_install") }
 )
 
-# Build packages in sub-directory
+# Use alternate library path when building package
 #
-# Whether to use a `_build` sub-directory in the current library paths when
-# developing an R package.
+# When set, RStudio will build your package in a '_build' sub-directory of your
+# current library paths.
 .rs.uiPrefs$useBuildSubdirectory <- list(
    get = function() { .rs.getUserPref("use_build_subdirectory") },
    set = function(value) { .rs.setUserPref("use_build_subdirectory", value) },

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -1708,6 +1708,16 @@
    clear = function() { .rs.clearUserPref("clean_before_install") }
 )
 
+# Build packages in sub-directory
+#
+# Whether to use a `_build` sub-directory in the current library paths when
+# developing an R package.
+.rs.uiPrefs$useBuildSubdirectory <- list(
+   get = function() { .rs.getUserPref("use_build_subdirectory") },
+   set = function(value) { .rs.setUserPref("use_build_subdirectory", value) },
+   clear = function() { .rs.clearUserPref("use_build_subdirectory") }
+)
+
 # Download R packages securely
 #
 # Whether to use secure downloads when fetching R packages.

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -675,19 +675,18 @@ private:
          core::system::environment(&childEnv);
 
       // get library paths for build
-      std::string buildLibPath;
+      std::string buildLibraryPath;
       Error libError = r::exec::RFunction(".rs.makeBuildLibraryPath")
-            .addUtf8Param(pkgInfo_.name())
-            .call(&buildLibPath);
+            .call(&buildLibraryPath);
       if (libError)
          LOG_ERROR(libError);
       
       // prepend build library path if its available
       std::string libPaths = module_context::libPathsString();
-      if (!buildLibPath.empty())
+      if (!buildLibraryPath.empty())
       {
-         builtPackagePath_ = fmt::format("{}/{}", buildLibPath, pkgInfo_.name());
-         libPaths = fmt::format("{}{}{}", buildLibPath, kPathSep, libPaths);
+         builtPackagePath_ = fmt::format("{}/{}", buildLibraryPath, pkgInfo_.name());
+         libPaths = fmt::format("{}{}{}", buildLibraryPath, kPathSep, libPaths);
       }
       
       // set this for the child process

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -675,18 +675,24 @@ private:
          core::system::environment(&childEnv);
 
       // get library paths for build
-      std::string buildLibraryPath;
-      Error libError = r::exec::RFunction(".rs.makeBuildLibraryPath")
-            .call(&buildLibraryPath);
-      if (libError)
-         LOG_ERROR(libError);
-      
-      // prepend build library path if its available
       std::string libPaths = module_context::libPathsString();
-      if (!buildLibraryPath.empty())
+      
+      // use a sub-directory for build if configured to do so
+      if (prefs::userPrefs().useBuildSubdirectory())
       {
-         builtPackagePath_ = fmt::format("{}/{}", buildLibraryPath, pkgInfo_.name());
-         libPaths = fmt::format("{}{}{}", buildLibraryPath, kPathSep, libPaths);
+         
+         std::string buildLibraryPath;
+         Error libError = r::exec::RFunction(".rs.makeBuildLibraryPath")
+               .call(&buildLibraryPath);
+         if (libError)
+            LOG_ERROR(libError);
+
+         // prepend build library path if its available
+         if (!buildLibraryPath.empty())
+         {
+            builtPackagePath_ = fmt::format("{}/{}", buildLibraryPath, pkgInfo_.name());
+            libPaths = fmt::format("{}{}{}", buildLibraryPath, kPathSep, libPaths);
+         }
       }
       
       // set this for the child process

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -686,7 +686,7 @@ private:
       std::string libPaths = module_context::libPathsString();
       if (!buildLibPath.empty())
       {
-         buildLibPath_ = fmt::format("{}/{}", buildLibPath, pkgInfo_.name());
+         builtPackagePath_ = fmt::format("{}/{}", buildLibPath, pkgInfo_.name());
          libPaths = fmt::format("{}{}{}", buildLibPath, kPathSep, libPaths);
       }
       
@@ -1892,7 +1892,7 @@ private:
       json::Object dataJson;
       dataJson["restart_r"] = restartR_;
       dataJson["after_restart_command"] = afterRestartCommand;
-      dataJson["build_library_path"] = buildLibPath_;
+      dataJson["built_package_path"] = builtPackagePath_;
       ClientEvent event(client_events::kBuildCompleted, dataJson);
       module_context::enqueClientEvent(event);
    }
@@ -1937,7 +1937,7 @@ private:
    json::Array errorsJson_;
    r_util::RPackageInfo pkgInfo_;
    projects::RProjectBuildOptions options_;
-   std::string buildLibPath_;
+   std::string builtPackagePath_;
    std::vector<FilePath> libPaths_;
    std::string successMessage_;
    std::string buildToolsWarning_;

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -676,7 +676,9 @@ private:
 
       // get library paths for build
       std::string buildLibPath;
-      Error libError = r::exec::RFunction(".rs.makeBuildLibraryPath").call(&buildLibPath);
+      Error libError = r::exec::RFunction(".rs.makeBuildLibraryPath")
+            .addUtf8Param(pkgInfo_.name())
+            .call(&buildLibPath);
       if (libError)
          LOG_ERROR(libError);
       

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -59,6 +59,12 @@
 #include "SessionSourceCpp.hpp"
 #include "SessionInstallRtools.hpp"
 
+#ifdef _WIN32
+# define kPathSep ";"
+#else
+# define kPathSep ":"
+#endif
+
 using namespace rstudio::core;
 using namespace boost::placeholders;
 
@@ -631,19 +637,6 @@ private:
                      const core::system::ProcessCallbacks& cb)
    {
 
-      // if this action is going to INSTALL the package then on
-      // windows we need to unload the library first
-#ifdef _WIN32
-      if (packagePath.completeChildPath("src").exists() &&
-         (type == kBuildAndReload || type == kBuildIncremental || type == kBuildFull || type == kBuildBinaryPackage))
-      {
-         std::string pkg = pkgInfo_.name();
-         Error error = r::exec::RFunction(".rs.forceUnloadPackage", pkg).call();
-         if (error)
-            LOG_ERROR(error);
-      }
-#endif
-
       // use both the R and gcc error parsers
       CompileErrorParsers parsers;
       parsers.add(rErrorParser(packagePath.completePath("R")));
@@ -681,10 +674,22 @@ private:
       else
          core::system::environment(&childEnv);
 
-      // allow child process to inherit our R_LIBS
+      // get library paths for build
+      std::string buildLibPath;
+      Error libError = r::exec::RFunction(".rs.makeBuildLibraryPath").call(&buildLibPath);
+      if (libError)
+         LOG_ERROR(libError);
+      
+      // prepend build library path if its available
       std::string libPaths = module_context::libPathsString();
-      if (!libPaths.empty())
-         core::system::setenv(&childEnv, "R_LIBS", libPaths);
+      if (!buildLibPath.empty())
+      {
+         buildLibPath_ = fmt::format("{}/{}", buildLibPath, pkgInfo_.name());
+         libPaths = fmt::format("{}{}{}", buildLibPath, kPathSep, libPaths);
+      }
+      
+      // set this for the child process
+      core::system::setenv(&childEnv, "R_LIBS", libPaths);
       
       // record the library paths used when this build was kicked off
       libPaths_ = module_context::getLibPaths();
@@ -1885,6 +1890,7 @@ private:
       json::Object dataJson;
       dataJson["restart_r"] = restartR_;
       dataJson["after_restart_command"] = afterRestartCommand;
+      dataJson["build_library_path"] = buildLibPath_;
       ClientEvent event(client_events::kBuildCompleted, dataJson);
       module_context::enqueClientEvent(event);
    }
@@ -1929,6 +1935,7 @@ private:
    json::Array errorsJson_;
    r_util::RPackageInfo pkgInfo_;
    projects::RProjectBuildOptions options_;
+   std::string buildLibPath_;
    std::vector<FilePath> libPaths_;
    std::string successMessage_;
    std::string buildToolsWarning_;

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -522,7 +522,7 @@ private:
 
       std::string documentCall = useDevtools()
             ? fmt::format("devtools::document(roclets = c({}))", roclets)
-            : fmt::format("roxygen2::roxygenize('.', roclets = c({})", roclets);
+            : fmt::format("roxygen2::roxygenize('.', roclets = c({}))", roclets);
       
       // show the user the call to document
       enqueCommandString(documentCall);

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2403,6 +2403,19 @@ core::Error UserPrefValues::setCleanBeforeInstall(bool val)
 }
 
 /**
+ * Whether to use a `_build` sub-directory in the current library paths when developing an R package.
+ */
+bool UserPrefValues::useBuildSubdirectory()
+{
+   return readPref<bool>("use_build_subdirectory");
+}
+
+core::Error UserPrefValues::setUseBuildSubdirectory(bool val)
+{
+   return writePref("use_build_subdirectory", val);
+}
+
+/**
  * Whether to use secure downloads when fetching R packages.
  */
 bool UserPrefValues::useSecureDownload()
@@ -3602,6 +3615,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kSshKeyType,
       kUseDevtools,
       kCleanBeforeInstall,
+      kUseBuildSubdirectory,
       kUseSecureDownload,
       kCleanupAfterRCmdCheck,
       kViewDirAfterRCmdCheck,

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2403,7 +2403,7 @@ core::Error UserPrefValues::setCleanBeforeInstall(bool val)
 }
 
 /**
- * Whether to use a `_build` sub-directory in the current library paths when developing an R package.
+ * When set, RStudio will build your package in a '_build' sub-directory of your current library paths.
  */
 bool UserPrefValues::useBuildSubdirectory()
 {

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1241,8 +1241,8 @@
         "use_build_subdirectory": {
             "type": "boolean",
             "default": true,
-            "title": "Build packages in sub-directory",
-            "description": "Whether to use a `_build` sub-directory in the current library paths when developing an R package."
+            "title": "Use alternate library path when building package",
+            "description": "When set, RStudio will build your package in a '_build' sub-directory of your current library paths."
         },
         "use_secure_download": {
             "type": "boolean",

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1238,6 +1238,12 @@
             "title": "Always use --preclean when installing package",
             "description": "Always use --preclean when installing package."
         },
+        "use_build_subdirectory": {
+            "type": "boolean",
+            "default": true,
+            "title": "Build packages in sub-directory",
+            "description": "Whether to use a `_build` sub-directory in the current library paths when developing an R package."
+        },
         "use_secure_download": {
             "type": "boolean",
             "default": true,

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -1330,17 +1330,8 @@ bool FilePath::isWithin(const FilePath& in_scopePath) const
       return true;
 
    // Make the paths lexically normal so that e.g. foo/../bar isn't considered a child of foo.
-   std::string childPathString = getLexicallyNormalPath();
-   std::string parentPathString = in_scopePath.getLexicallyNormalPath();
-
-   // Normalize separators
-#ifdef _WIN32
-   std::replace(childPathString.begin(), childPathString.end(), '\\', '/');
-   std::replace(parentPathString.begin(), parentPathString.end(), '\\', '/');
-#endif
-
-   FilePath child(childPathString);
-   FilePath parent(parentPathString);
+   FilePath child(getLexicallyNormalPath());
+   FilePath parent(in_scopePath.getLexicallyNormalPath());
 
    // Easy test: We can't possibly be in this scope path if it has more components than we do
    if (parent.m_impl->Path.size() > child.m_impl->Path.size())
@@ -1348,7 +1339,8 @@ bool FilePath::isWithin(const FilePath& in_scopePath) const
 
    // Find the first path element that differs. Stop when we reach the end of the parent
    // path, or a "." path component, which signifies the end of a directory (/foo/bar/.)
-   for (auto childIt = child.m_impl->Path.begin(), parentIt = parent.m_impl->Path.begin();
+   for (boost::filesystem::path::iterator childIt = child.m_impl->Path.begin(),
+                                          parentIt = parent.m_impl->Path.begin();
         parentIt != parent.m_impl->Path.end() && *parentIt != ".";
         parentIt++, childIt++)
    {

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -1330,8 +1330,17 @@ bool FilePath::isWithin(const FilePath& in_scopePath) const
       return true;
 
    // Make the paths lexically normal so that e.g. foo/../bar isn't considered a child of foo.
-   FilePath child(getLexicallyNormalPath());
-   FilePath parent(in_scopePath.getLexicallyNormalPath());
+   std::string childPathString = getLexicallyNormalPath();
+   std::string parentPathString = in_scopePath.getLexicallyNormalPath();
+
+   // Normalize separators
+#ifdef _WIN32
+   std::replace(childPathString.begin(), childPathString.end(), '\\', '/');
+   std::replace(parentPathString.begin(), parentPathString.end(), '\\', '/');
+#endif
+
+   FilePath child(childPathString);
+   FilePath parent(parentPathString);
 
    // Easy test: We can't possibly be in this scope path if it has more components than we do
    if (parent.m_impl->Path.size() > child.m_impl->Path.size())
@@ -1339,8 +1348,7 @@ bool FilePath::isWithin(const FilePath& in_scopePath) const
 
    // Find the first path element that differs. Stop when we reach the end of the parent
    // path, or a "." path component, which signifies the end of a directory (/foo/bar/.)
-   for (boost::filesystem::path::iterator childIt = child.m_impl->Path.begin(),
-                                          parentIt = parent.m_impl->Path.begin();
+   for (auto childIt = child.m_impl->Path.begin(), parentIt = parent.m_impl->Path.begin();
         parentIt != parent.m_impl->Path.end() && *parentIt != ".";
         parentIt++, childIt++)
    {

--- a/src/cpp/shared_core/FilePathTests.cpp
+++ b/src/cpp/shared_core/FilePathTests.cpp
@@ -310,12 +310,17 @@ TEST_CASE("Copy FilePath Tests")
    CHECK(f2.getAbsolutePath() == "/a/path");
 }
 
-TEST_CASE("within")
+#ifdef _WIN32
+
+TEST_CASE("Windows: FilePath.isWithin")
 {
-   FilePath f1("C:/tmp/example");
-   FilePath f2("C:\\tmp\\example\\subdir");
-   CHECK(f2.isWithin(f1));
+   CHECK(FilePath("C:/tmp/dir").isWithin(FilePath("C:/tmp")));
+   CHECK(FilePath("C:\\tmp\\dir").isWithin(FilePath("C:/tmp")));
+   CHECK(FilePath("C:/tmp/dir").isWithin(FilePath("C:\\tmp")));
+   CHECK(FilePath("C:\\tmp\\dir").isWithin(FilePath("C:\\tmp")));
 }
+
+#endif
 
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/shared_core/FilePathTests.cpp
+++ b/src/cpp/shared_core/FilePathTests.cpp
@@ -310,5 +310,12 @@ TEST_CASE("Copy FilePath Tests")
    CHECK(f2.getAbsolutePath() == "/a/path");
 }
 
+TEST_CASE("within")
+{
+   FilePath f1("C:/tmp/example");
+   FilePath f2("C:\\tmp\\example\\subdir");
+   CHECK(f2.isWithin(f1));
+}
+
 } // namespace core
 } // namespace rstudio

--- a/src/gwt/src/org/rstudio/studio/client/application/model/SuspendOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/model/SuspendOptions.java
@@ -53,7 +53,7 @@ public class SuspendOptions extends JavaScriptObject
          save_minimal: saveMinimal,
          save_workspace: saveWorkspace,
          exclude_packages: excludePackages,
-         after_restart: afterRestart || ""
+         after_restart: afterRestart || "",
       };
    }-*/;
    
@@ -83,6 +83,14 @@ public class SuspendOptions extends JavaScriptObject
     */
    public native final boolean getExcludePackages() /*-{
       return this.exclude_packages;
+   }-*/;
+   
+   public native final void setBuildLibraryPath(String buildLibraryPath) /*-{
+      this.build_library_path = buildLibraryPath;
+   }-*/;
+   
+   public native final String getBuildLibraryPath() /*-{
+      return this.build_library_path;
    }-*/;
    
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/model/SuspendOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/model/SuspendOptions.java
@@ -85,12 +85,12 @@ public class SuspendOptions extends JavaScriptObject
       return this.exclude_packages;
    }-*/;
    
-   public native final void setBuildLibraryPath(String buildLibraryPath) /*-{
-      this.build_library_path = buildLibraryPath;
+   public native final void setBuiltPackagePath(String path) /*-{
+      this.built_package_path = path;
    }-*/;
    
-   public native final String getBuildLibraryPath() /*-{
-      return this.build_library_path;
+   public native final String getBuiltPackagePath() /*-{
+      return this.built_package_path;
    }-*/;
    
 }

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/BuildToolsPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/BuildToolsPanel.java
@@ -15,7 +15,6 @@
 
 package org.rstudio.studio.client.projects.ui.prefs.buildtools;
 
-import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
@@ -29,12 +28,12 @@ import org.rstudio.studio.client.projects.StudioClientProjectConstants;
 import org.rstudio.studio.client.projects.model.RProjectOptions;
 import org.rstudio.studio.client.projects.ui.prefs.ProjectPreferencesDialogResources;
 
-import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.TextBox;

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/BuildToolsPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/BuildToolsPanel.java
@@ -28,6 +28,7 @@ import org.rstudio.studio.client.projects.StudioClientProjectConstants;
 import org.rstudio.studio.client.projects.model.RProjectOptions;
 import org.rstudio.studio.client.projects.ui.prefs.ProjectPreferencesDialogResources;
 
+import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.ClickEvent;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -2628,6 +2628,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Whether to use a `_build` sub-directory in the current library paths when developing an R package.
+    */
+   public PrefValue<Boolean> useBuildSubdirectory()
+   {
+      return bool(
+         "use_build_subdirectory",
+         _constants.useBuildSubdirectoryTitle(), 
+         _constants.useBuildSubdirectoryDescription(), 
+         true);
+   }
+
+   /**
     * Whether to use secure downloads when fetching R packages.
     */
    public PrefValue<Boolean> useSecureDownload()
@@ -4112,6 +4124,8 @@ public class UserPrefsAccessor extends Prefs
          useDevtools().setValue(layer, source.getBool("use_devtools"));
       if (source.hasKey("clean_before_install"))
          cleanBeforeInstall().setValue(layer, source.getBool("clean_before_install"));
+      if (source.hasKey("use_build_subdirectory"))
+         useBuildSubdirectory().setValue(layer, source.getBool("use_build_subdirectory"));
       if (source.hasKey("use_secure_download"))
          useSecureDownload().setValue(layer, source.getBool("use_secure_download"));
       if (source.hasKey("cleanup_after_r_cmd_check"))
@@ -4455,6 +4469,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(sshKeyType());
       prefs.add(useDevtools());
       prefs.add(cleanBeforeInstall());
+      prefs.add(useBuildSubdirectory());
       prefs.add(useSecureDownload());
       prefs.add(cleanupAfterRCmdCheck());
       prefs.add(viewDirAfterRCmdCheck());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -2628,7 +2628,7 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * Whether to use a `_build` sub-directory in the current library paths when developing an R package.
+    * When set, RStudio will build your package in a '_build' sub-directory of your current library paths.
     */
    public PrefValue<Boolean> useBuildSubdirectory()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -1538,11 +1538,11 @@ public interface UserPrefsAccessorConstants extends Constants {
    String cleanBeforeInstallDescription();
 
    /**
-    * Whether to use a `_build` sub-directory in the current library paths when developing an R package.
+    * When set, RStudio will build your package in a '_build' sub-directory of your current library paths.
     */
-   @DefaultStringValue("Build packages in sub-directory")
+   @DefaultStringValue("Use alternate library path when building package")
    String useBuildSubdirectoryTitle();
-   @DefaultStringValue("Whether to use a `_build` sub-directory in the current library paths when developing an R package.")
+   @DefaultStringValue("When set, RStudio will build your package in a '_build' sub-directory of your current library paths.")
    String useBuildSubdirectoryDescription();
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -1538,6 +1538,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String cleanBeforeInstallDescription();
 
    /**
+    * Whether to use a `_build` sub-directory in the current library paths when developing an R package.
+    */
+   @DefaultStringValue("Build packages in sub-directory")
+   String useBuildSubdirectoryTitle();
+   @DefaultStringValue("Whether to use a `_build` sub-directory in the current library paths when developing an R package.")
+   String useBuildSubdirectoryDescription();
+
+   /**
     * Whether to use secure downloads when fetching R packages.
     */
    @DefaultStringValue("Download R packages securely")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -774,9 +774,9 @@ useDevtoolsDescription = Whether to use the devtools R package.
 cleanBeforeInstallTitle = Always use --preclean when installing package
 cleanBeforeInstallDescription = Always use --preclean when installing package.
 
-# Whether to use a `_build` sub-directory in the current library paths when developing an R package.
-useBuildSubdirectoryTitle = Build packages in sub-directory
-useBuildSubdirectoryDescription = Whether to use a `_build` sub-directory in the current library paths when developing an R package.
+# When set, RStudio will build your package in a '_build' sub-directory of your current library paths.
+useBuildSubdirectoryTitle = Use alternate library path when building package
+useBuildSubdirectoryDescription = When set, RStudio will build your package in a '_build' sub-directory of your current library paths.
 
 # Whether to use secure downloads when fetching R packages.
 useSecureDownloadTitle = Download R packages securely

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -774,6 +774,10 @@ useDevtoolsDescription = Whether to use the devtools R package.
 cleanBeforeInstallTitle = Always use --preclean when installing package
 cleanBeforeInstallDescription = Always use --preclean when installing package.
 
+# Whether to use a `_build` sub-directory in the current library paths when developing an R package.
+useBuildSubdirectoryTitle = Build packages in sub-directory
+useBuildSubdirectoryDescription = Whether to use a `_build` sub-directory in the current library paths when developing an R package.
+
 # Whether to use secure downloads when fetching R packages.
 useSecureDownloadTitle = Download R packages securely
 useSecureDownloadDescription = Whether to use secure downloads when fetching R packages.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
@@ -61,6 +61,7 @@ public class PackagesPreferencesPane extends PreferencesPane
                                   MirrorsServerOperations server)
    {
       res_ = res;
+      prefs_ = uiPrefs;
       server_ = server;
 
       secondaryReposWidget_ = new SecondaryReposWidget();
@@ -160,6 +161,7 @@ public class PackagesPreferencesPane extends PreferencesPane
       lessSpaced(useDevtools_);
       development.add(useDevtools_);
 
+      development.add(checkboxPref(uiPrefs.useBuildSubdirectory()));
       development.add(checkboxPref(uiPrefs.saveAndReloadWorkspaceOnBuild()));
       development.add(checkboxPref(constants_.developmentSaveLabel(), uiPrefs.saveFilesBeforeBuild()));
       development.add(checkboxPref(constants_.developmentNavigateLabel(), uiPrefs.navigateToBuildError()));
@@ -399,6 +401,7 @@ public class PackagesPreferencesPane extends PreferencesPane
    }
 
    private final PreferencesDialogResources res_;
+   private final UserPrefs prefs_;
    private final MirrorsServerOperations server_;
    private final InfoBar infoBar_;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
@@ -204,7 +204,7 @@ public class BuildPresenter extends BasePresenter
                SuspendOptions options = userPrefs_.saveAndReloadWorkspaceOnBuild().getValue()
                      ? SuspendOptions.createSaveAll(false, afterRestartCommand)
                      : SuspendOptions.createSaveMinimal(false, afterRestartCommand);
-               options.setBuildLibraryPath(event.getBuildLibraryPath());
+               options.setBuiltPackagePath(event.getBuiltPackagePath());
                eventBus_.fireEvent(new SuspendAndRestartEvent(options));
             }
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
@@ -204,6 +204,7 @@ public class BuildPresenter extends BasePresenter
                SuspendOptions options = userPrefs_.saveAndReloadWorkspaceOnBuild().getValue()
                      ? SuspendOptions.createSaveAll(false, afterRestartCommand)
                      : SuspendOptions.createSaveMinimal(false, afterRestartCommand);
+               options.setBuildLibraryPath(event.getBuildLibraryPath());
                eventBus_.fireEvent(new SuspendAndRestartEvent(options));
             }
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/events/BuildCompletedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/events/BuildCompletedEvent.java
@@ -35,6 +35,10 @@ public class BuildCompletedEvent extends GwtEvent<BuildCompletedEvent.Handler>
       public native final String getAfterRestartCommand() /*-{
          return this.after_restart_command;
       }-*/;
+      
+      public native final String getBuildLibraryPath() /*-{
+         return this.build_library_path;
+      }-*/;
    }
 
    public interface Handler extends EventHandler
@@ -55,6 +59,11 @@ public class BuildCompletedEvent extends GwtEvent<BuildCompletedEvent.Handler>
    public String getAfterRestartCommand()
    {
       return data_.getAfterRestartCommand();
+   }
+   
+   public String getBuildLibraryPath()
+   {
+      return data_.getBuildLibraryPath();
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/events/BuildCompletedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/events/BuildCompletedEvent.java
@@ -36,8 +36,8 @@ public class BuildCompletedEvent extends GwtEvent<BuildCompletedEvent.Handler>
          return this.after_restart_command;
       }-*/;
       
-      public native final String getBuildLibraryPath() /*-{
-         return this.build_library_path;
+      public native final String getBuiltPackagePath() /*-{
+         return this.built_package_path;
       }-*/;
    }
 
@@ -61,9 +61,9 @@ public class BuildCompletedEvent extends GwtEvent<BuildCompletedEvent.Handler>
       return data_.getAfterRestartCommand();
    }
    
-   public String getBuildLibraryPath()
+   public String getBuiltPackagePath()
    {
-      return data_.getBuildLibraryPath();
+      return data_.getBuiltPackagePath();
    }
 
    @Override


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13399.

### Approach

On Windows, it's common for package installation to fail with errors of the form:

> ERROR: cannot remove earlier installation, is it in use?

typically because (as the error message states) the package is currently loaded; possibly in a totally separate R session. This PR seeks to alleviate the issue by:

- Installing the package into its own unique build library path,
- Performing the regular suspend + restart,
- On restart, we attempt to move the installed package to the intended install location,
- If that fails, we just add that directory to the library paths, and notify the user.

This way, even if the package is already in use by a separate R process, the user will still be able to install and test the package.

I'd like to add an option to enable / disable this behavior just in case.

### Automated Tests

N/A

### QA Notes

The simplest way to test on Windows would be to do something like the following:

1. In one RStudio session, run `library(rlang)` to load `rlang`;
2. In another RStudio session, create a new project from Git, and use https://github.com/r-lib/rlang as the repository location;
3. After the project is opened, try to Install the package.

You should see something like:

```
- RStudio was unable to move "rlang" into your package library.
- C:/Users/kevin/AppData/Local/R/win-library/4.4/build-fdbc1ec921b9 has been added to the library paths for this session.
> library(rlang)
```

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
