### PR TITLE
tweak to readline completions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,7 @@
 - Clicking in the editor gutter to toggle a breakpoint no longer also selects the associated line (#15226)
 - RStudio no longer logs warning / error messages related to disabled R actions (e.g. ReadConsole) in forked sessions (#15221)
 - RStudio Desktop now forwards `LD_LIBRARY_PATH` when detecting available R installations (#15044)
+- Fixed an issue with incorrect completions provided in `readline()` context (#15238)
 
 #### Posit Workbench
 - Fixed an issue with Workbench login not respecting "Stay signed in when browser closes" when using Single Sign-On (rstudio-pro#5392)

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2361,9 +2361,14 @@ assign(x = ".rs.acCompletionTypes",
       if (length(results) == 1L)
          return(.rs.emptyCompletions(excludeOtherCompletions = TRUE))
       
+      # remove whitespace around options
+      results <- .rs.trimWhitespace(results)
+      
       # capitalized first as this is likely to be the default
       cap <- grepl("^[A-Z]", results)
       results <- c(results[cap], results[!cap])
+      
+      # return completions
       completions <- .rs.makeCompletions(
          token = token,
          results = results,


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15238.

### Approach

When we detect that `readline()` is active, we try to provide completions based on options within an `(a/b/c)` string. This PR adjusts that so that we only provide completions if more than one alternative is provided, to guard against things like `readline("Do you want to do the thing? (You can't undo this).")`.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15238.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
