### PR TITLE
fixups for server automation

### DIFF
--- a/src/cpp/rserver-automation.in
+++ b/src/cpp/rserver-automation.in
@@ -22,25 +22,28 @@ export RS_DB_MIGRATIONS_PATH="@CMAKE_CURRENT_SOURCE_DIR@/server/db"
 
 
 # use temporary directory for RStudio state
-ROOT=$(mktemp -d -p /tmp rstudio-automation-XXXXXX)
+: "${RSTUDIO_CONFIG_ROOT=$(mktemp -d -p /tmp rstudio-automation-XXXXXX)}"
+: "${RSTUDIO_CONFIG_HOME="${RSTUDIO_CONFIG_ROOT}/rstudio-config-home"}"
+: "${RSTUDIO_CONFIG_DIR="${RSTUDIO_CONFIG_ROOT}/rstudio-config-dir"}"
+: "${RSTUDIO_DATA_HOME="${RSTUDIO_CONFIG_ROOT}/rstudio-data-home"}"
 
-export RSTUDIO_CONFIG_HOME="${ROOT}/rstudio-config-home"
-export RSTUDIO_CONFIG_DIR="${ROOT}/rstudio-config-dir"
-export RSTUDIO_DATA_HOME="${ROOT}/rstudio-data-home"
+export RSTUDIO_CONFIG_HOME
+export RSTUDIO_CONFIG_DIR
+export RSTUDIO_DATA_HOME
 
 
 # use local database file
-cat <<- EOF > "${ROOT}/rserver-database.conf"
+cat <<- EOF > "${RSTUDIO_CONFIG_ROOT}/rserver-database.conf"
 provider=sqlite
-directory=${ROOT}
+directory=${RSTUDIO_CONFIG_ROOT}
 EOF
 
 
 # use the development rsession configuration file,
 # but make sure sessions run in automation mode
 RSESSION_CONFIG_FILE="@CMAKE_CURRENT_BINARY_DIR@/conf/rsession-dev.conf"
-cp "${RSESSION_CONFIG_FILE}" "${ROOT}/rsession.conf"
-cat <<- EOF >> "${ROOT}/rsession.conf"
+cp "${RSESSION_CONFIG_FILE}" "${RSTUDIO_CONFIG_ROOT}/rsession.conf"
+cat <<- EOF >> "${RSTUDIO_CONFIG_ROOT}/rsession.conf"
 # enable automation tools
 automation-agent=1
 EOF
@@ -52,8 +55,8 @@ server/rserver                                             \
 	--config-file="conf/rserver-dev.conf"                  \
 	--auth-none=1                                          \
 	--www-port=8788                                        \
-	--server-data-dir="${ROOT}"                            \
-	--database-config-file="${ROOT}/rserver-database.conf" \
-	--rsession-config-file="${ROOT}/rsession.conf"         \
+	--server-data-dir="${RSTUDIO_CONFIG_ROOT}"                            \
+	--database-config-file="${RSTUDIO_CONFIG_ROOT}/rserver-database.conf" \
+	--rsession-config-file="${RSTUDIO_CONFIG_ROOT}/rsession.conf"         \
 	"$@"
 

--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -258,14 +258,13 @@
    parentPwd <- parentEnv[["PWD"]]
    automationScript <- file.path(parentPwd, "rserver-automation")
    if (!file.exists(automationScript))
-      stop("rserver does not appear to be running on port 8788")
+      stop(automationScript, " does not exist.")
    
    message("-- Starting rserver-automation ...")
    withr::with_dir(parentPwd, system2(automationScript, wait = FALSE))
    
    # Kill the process on exit
    reg.finalizer(globalenv(), .rs.automation.killAutomationServer, onexit = TRUE)
-   
    
 })
 

--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -342,16 +342,6 @@
    # Avoid crashing on arm64 Linux.
    envVars[["RSTUDIO_QUERY_FONTS"]] <- "0"
    
-   # Make sure we have a running rserver-automation instance.
-   # Ensure that we have a running rserver instance.
-   if (mode == "server")
-   {
-      withr::with_envvar(envVars, {
-         .rs.automation.ensureRunningServerInstance()
-      })
-   }
-   
-   
    # Build argument list.
    # https://github.com/GoogleChrome/chrome-launcher/blob/main/docs/chrome-flags-for-tools.md
    
@@ -376,7 +366,15 @@
       )
    )
    
-   # Start up RStudio.
+   # Make sure we have a running rserver-automation instance.
+   if (mode == "server")
+   {
+      withr::with_envvar(envVars, {
+         .rs.automation.ensureRunningServerInstance()
+      })
+   }
+   
+   # Start up RStudio (or Chrome in "server" mode).
    process <- withr::with_envvar(envVars, {
       processx::process$new(appPath, args)
    })

--- a/src/cpp/session/modules/automation/SessionAutomationRemote.R
+++ b/src/cpp/session/modules/automation/SessionAutomationRemote.R
@@ -403,6 +403,16 @@
    }
 })
 
+.rs.automation.addRemoteFunction("modalClick", function(buttonName)
+{
+   .rs.tryCatch({
+      buttonSelector <- sprintf("#rstudio_dlg_%s", buttonName)
+      buttonId <- self$domGetNodeId(buttonSelector)
+      self$domClickElement(objectId = buttonId)
+      TRUE
+   })
+})
+
 .rs.automation.addRemoteFunction("quit", function()
 {
    # Close the websocket connection.


### PR DESCRIPTION
### Intent

Addresses some unit test failures in the debugger tests.

### Approach

- Make sure that environment variables set by the RStudio launcher are used by the `rserver-automation` script. This is necessary so that we can pre-populate the config file used by the automated instance of RStudio.
- Add some sleeps to help better sequence changes when tests are running.
