### PR TITLE
save before renaming source files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@
 ### Fixed
 #### RStudio
 - "Run All" now only executes R chunks when "Chunk Output in Console" is set (#11995)
+- Fixed an issue where the Rename File command did not write unsaved changes before performing the rename (#15242)
 - Fixed an issue where the chunk options popup didn't recognize chunk labels preceded by a comma (#15156)
 - Fixed an issue where the chunk options popup was confused by quoted strings containing spaces (#6829)
 - Fixed an issue where the chunk options popup was confused by spaces around equals signs (#2673)

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/RenameFileInitiatedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/RenameFileInitiatedEvent.java
@@ -1,5 +1,5 @@
 /*
- * RenameSourceFileEvent.java
+ * RenameFileInitiatedEvent.java
  *
  * Copyright (C) 2022 by Posit Software, PBC
  *
@@ -20,19 +20,19 @@ import org.rstudio.studio.client.application.events.CrossWindowEvent;
 import com.google.gwt.event.shared.EventHandler;
 
 @JavaScriptSerializable
-public class RenameSourceFileEvent extends CrossWindowEvent<RenameSourceFileEvent.Handler>
+public class RenameFileInitiatedEvent extends CrossWindowEvent<RenameFileInitiatedEvent.Handler>
 {
    public interface Handler extends EventHandler
    {
-      void onRenameSourceFile(RenameSourceFileEvent event);
+      void onRenameFileInitiated(RenameFileInitiatedEvent event);
    }
 
-   public RenameSourceFileEvent(String path)
+   public RenameFileInitiatedEvent(String path)
    {
       path_ = path;
    }
 
-   public RenameSourceFileEvent()
+   public RenameFileInitiatedEvent()
    {
    }
 
@@ -44,7 +44,7 @@ public class RenameSourceFileEvent extends CrossWindowEvent<RenameSourceFileEven
    @Override
    protected void dispatch(Handler handler)
    {
-      handler.onRenameSourceFile(this);
+      handler.onRenameFileInitiated(this);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -85,6 +85,7 @@ import org.rstudio.studio.client.common.filetypes.SweaveFileType;
 import org.rstudio.studio.client.common.filetypes.TexFileType;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.common.filetypes.events.CopySourcePathEvent;
+import org.rstudio.studio.client.common.filetypes.events.RenameFileInitiatedEvent;
 import org.rstudio.studio.client.common.filetypes.events.RenameSourceFileEvent;
 import org.rstudio.studio.client.common.mathjax.MathJax;
 import org.rstudio.studio.client.common.presentation2.model.PresentationEditorLocation;
@@ -845,6 +846,19 @@ public class TextEditingTarget implements
                autoSaveTimer_.cancel();
             }
          }));
+      
+      releaseOnDismiss_.add(
+            events_.addHandler(RenameFileInitiatedEvent.TYPE, new RenameFileInitiatedEvent.Handler()
+            {
+               @Override
+               public void onRenameFileInitiated(RenameFileInitiatedEvent event)
+               {
+                  if (StringUtil.equals(event.getPath(), docUpdateSentinel_.getPath()))
+                  {
+                     save();
+                  }
+               }
+            }));
    }
 
    static {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15242.

### Approach

When a "renameFile" action is initiated, fire an event first to allow any available text editing targets to attempt a save first.

### Automated Tests

TODO

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15242. Note that the save happens as soon as the "Rename" command is initiated.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
