### PR TITLE
allow ghost text insertion in all parts of rmd doc

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -60,6 +60,7 @@
 - RStudio no longer logs warning / error messages related to disabled R actions (e.g. ReadConsole) in forked sessions (#15221)
 - RStudio Desktop now forwards `LD_LIBRARY_PATH` when detecting available R installations (#15044)
 - Fixed an issue with incorrect completions provided in `readline()` context (#15238)
+- Fixed an issue where ghost text could not be inserted in non-chunk parts of an R Markdown / Quarto document (#14507)
 
 #### Posit Workbench
 - Fixed an issue with Workbench login not respecting "Stay signed in when browser closes" when using Single Sign-On (rstudio-pro#5392)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
@@ -924,6 +924,14 @@ public abstract class CompletionManagerBase
       // Don't auto complete if tab auto completion was disabled
       if (!userPrefs_.tabCompletion().getValue() || userPrefs_.tabKeyMoveFocus().getValue())
          return false;
+      
+      // If this line has ghost text available, insert that.
+      if (docDisplay_.hasGhostText())
+      {
+         docDisplay_.applyGhostText();
+         docDisplay_.scrollCursorIntoViewIfNecessary();
+         return true;
+      }
 
       // if the line is blank, don't request completions unless
       // the user has explicitly opted in

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -415,11 +415,7 @@ public class RCompletionManager implements CompletionManager
          if (keycode == KeyCodes.KEY_TAB && modifier == KeyboardShortcut.NONE)
          {
             invalidatePendingRequests();
-            AceGhostText ghostText = docDisplay_.getGhostText();
-            docDisplay_.replaceRange(
-                  Range.fromPoints(ghostText.position, ghostText.position),
-                  ghostText.text);
-            docDisplay_.removeGhostText();
+            docDisplay_.applyGhostText();
             docDisplay_.scrollCursorIntoViewIfNecessary();
             return true;
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -502,5 +502,6 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    AceGhostText getGhostText();
    void setGhostText(String text);
    boolean hasGhostText();
+   void applyGhostText();
    void removeGhostText();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -722,10 +722,14 @@ public class AceEditorNative extends JavaScriptObject
       this.setGhostText(text);
    }-*/;
    
-   public final native void applyGhostText() /*-{
-      var ghostText = this.renderer.$ghostText;
-      
-   }-*/;
+   public final void applyGhostText()
+   {
+      AceGhostText ghostText = getGhostText();
+      getSession().replace(
+            Range.fromPoints(ghostText.position, ghostText.position),
+            ghostText.text);
+      removeGhostText();
+   }
    
    public final native boolean hasGhostText() /*-{
       return this.renderer.$ghostText != null;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14507.

### Approach

Allow the base completion manager (which is used for all completions except for plain R mode documents) to handle Tab, and use that to insert ghost text when any is available.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14507.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
