### PR TITLE
write project file before adding first run docs

### DIFF
--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -789,6 +789,15 @@ Error quartoCreateProject(const json::JsonRpcRequest& request,
       return error;
    }
 
+   // create the project file
+   using namespace projects;
+   error = r_util::writeProjectFile(
+            projectFilePath,
+            ProjectContext::buildDefaults(),
+            ProjectContext::defaultConfig());
+   if (error)
+      LOG_ERROR(error);
+
    // add some first run files
    using namespace module_context;
    std::vector<std::string> projFiles;
@@ -804,15 +813,6 @@ Error quartoCreateProject(const json::JsonRpcRequest& request,
       projFiles.push_back(projDir.getFilename() + ".qmd");
    }
    projects::addFirstRunDocs(projectFilePath, projFiles);
-
-   // create the project file
-   using namespace projects;
-   error = r_util::writeProjectFile(projectFilePath,
-                                    ProjectContext::buildDefaults(),
-                                    ProjectContext::defaultConfig());
-   if (error)
-      LOG_ERROR(error);
-
 
    // create-project command
    std::vector<std::string> args({

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -1257,6 +1257,12 @@ void addFirstRunDocs(const FilePath& projectFilePath, const std::vector<std::str
             projectFilePath,
             &scratchPath,
             &sharedScratchPath);
+   
+   if (error)
+   {
+      LOG_ERROR(error);
+      return;
+   }
 
    for (auto&& doc : docs)
    {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15222.

### Approach

Recent changes now require the project's `.Rproj` file to be created before the project scratch path can be computed. This PR resolves the issue by ensuring the project file is created before first run docs are added.

### Automated Tests

Captured by existing automation.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15222.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

