### PR TITLE
fix raw latex block roundtripping in Visual Editor

### DIFF
--- a/version/news/NEWS-2024.09.1-cranberry-hibiscus.md
+++ b/version/news/NEWS-2024.09.1-cranberry-hibiscus.md
@@ -9,8 +9,9 @@
 ### Fixed
 
 #### RStudio
- 
+
 - Fixed Visual Editor losing raw HTML code blocks (#15189)
+- Fixed Visual Editor losing raw LaTeX code blocks (#15253)
 
 #### Posit Workbench
 
@@ -21,4 +22,3 @@
 If upgrading from Workbench 2024.04.x with automatic user provisioning enabled, to fix a performance and reliability issue, the `server-address` setting in `workbench-nss.conf` should be updated to `unix:/var/run/rstudio-server/rstudio-rserver/user-service.socket`. See [User Provisioning Configuration](https://docs.posit.co/ide/server-pro/user_provisioning/configuration.html) in the Workbench Admin Guide for more information. (rstudio-pro#6591)
 
 ### Dependencies
-


### PR DESCRIPTION
### Intent

Fixes #15253 

### Approach

Update the NEWS and hope some random AI will code the fix. One of these days...

The actual fix comes from the panmirror repo (`quarto-dev/quarto`) via: https://github.com/quarto-dev/quarto/pull/559

Once the quarto PR is merged into `main` I will backport it to the `release/rstudio-cranberry-hibiscus` branch, which is what gets pulled via the dependency scripts. The build dockerfiles watch for changes to this branch and should pull down the updated bits.

### Automated Tests

I'll author a test once this is merged and pulled forward to `main`.

### QA Notes

See issue for repro steps.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


