### PR TITLE
reenable a unit test that was incorrectly disabled

### DIFF
--- a/src/cpp/tests/testthat/test-rsconnect.R
+++ b/src/cpp/tests/testthat/test-rsconnect.R
@@ -51,8 +51,6 @@ test_that("setting UI prefs updates options", {
 })
 
 test_that(".rs.rsconnectDeployList() includes _quarto.yml and _metadata.yml files (#10995 )", {
-   skip_if_not(Sys.getenv("QUARTO_ENABLED") == "TRUE", "Not run when Quarto disabled")
-
    dir.create(tf <- tempfile()); on.exit(unlink(tf, TRUE, TRUE))
    dir.create(file.path(tf, "sub"))
 


### PR DESCRIPTION
### Intent

Noticed this when running the cpp unit tests:

```
── Skipped tests (3) ───────────────────────────────────────────────────────────
• Not run when Quarto disabled (1): test-rsconnect.R:54:4
```

### Approach

This was broken with some re-jiggering of the `QUARTO_ENABLED` value, which is no longer set as an environment variable by the test script. AFAIK we include Quarto in all our builds now, so shouldn't need to be disabled.

### Automated Tests

Confirmed it passes locally on MacOS. Hopefully passes everywhere.

### QA Notes

NA

### Documentation
NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


