### PR TITLE
support Quarto YAML completions in '_brand.yml'

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/yaml/YamlEditorToolsProviderQuarto.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/yaml/YamlEditorToolsProviderQuarto.java
@@ -32,9 +32,9 @@ import com.google.inject.Inject;
 
 import elemental2.core.JsObject;
 import elemental2.promise.IThenable;
-import elemental2.promise.Promise;
 import elemental2.promise.IThenable.ThenOnFulfilledCallbackFn;
 import elemental2.promise.IThenable.ThenOnRejectedCallbackFn;
+import elemental2.promise.Promise;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
@@ -62,7 +62,9 @@ public class YamlEditorToolsProviderQuarto implements YamlEditorToolsProvider
       {
          String filename = FileSystemItem.getNameFromPath(StringUtil.notNull(path));
          return SourceDocument.XT_QUARTO_DOCUMENT.equals(extendedType) ||
-                isQuartoProjectYaml(filename) ||  isQuartoExtensionYaml(filename) ||
+                isQuartoProjectYaml(filename) || 
+                isQuartoExtensionYaml(filename) ||
+                isQuartoBrandYaml(filename) ||
                 isQuartoMetadataYaml(path);
       }
       else
@@ -80,6 +82,12 @@ public class YamlEditorToolsProviderQuarto implements YamlEditorToolsProvider
    {
       return filename.equals("_extension.yml") ||
              filename.equals("_extension.yaml");
+   }
+   
+   private boolean isQuartoBrandYaml(String filename)
+   {
+      return filename.equals("_brand.yml") ||
+             filename.equals("_brand.yaml");
    }
    
    private boolean isQuartoMetadataYaml(String path)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/yaml/YamlEditorToolsProviderQuarto.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/yaml/YamlEditorToolsProviderQuarto.java
@@ -19,6 +19,7 @@ import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ExternalJavaScriptLoader;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.Version;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.model.ApplicationServerOperations;
@@ -86,6 +87,10 @@ public class YamlEditorToolsProviderQuarto implements YamlEditorToolsProvider
    
    private boolean isQuartoBrandYaml(String filename)
    {
+      // only supported with recent quarto releases
+      if (Version.compare(config_.version, "1.6.24") < 0)
+         return false;
+      
       return filename.equals("_brand.yml") ||
              filename.equals("_brand.yaml");
    }


### PR DESCRIPTION
This allows the Quarto completions provider to give completions within `_brand.ya?ml` files.

<img width="624" alt="Screenshot 2024-10-08 at 10 53 17 AM" src="https://github.com/user-attachments/assets/07b477e5-454a-48d8-8b1a-0b9a0b727afa">

@cscheid is there any other sort of sanity checking I should do here?