### PR TITLE
always remap Windows history functions

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -799,10 +799,11 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 # list all rpc handlers in the tools:rstudio environment
 .rs.addFunction("listJsonRpcHandlers", function()
 {
-   rpcHandlers <- objects("tools:rstudio", 
-                          all.names=TRUE, 
-                          pattern=utils:::glob2rx(".rs.rpc.*"))
-   return (rpcHandlers)
+   objects(
+      name      = "tools:rstudio", 
+      pattern   = utils:::glob2rx(".rs.rpc.*"),
+      all.names = TRUE
+   )
 })
 
 

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -33,6 +33,12 @@ assign(".rs.symbolLookupEnv", function()
    new.env(parent = .rs.toolsEnv())
 }, envir = .rs.Env)
 
+# platform detection
+assign(".rs.platform.isUnix",    .Platform$OS.type == "unix",         envir = .rs.Env)
+assign(".rs.platform.isWindows", .Platform$OS.type == "windows",      envir = .rs.Env)
+assign(".rs.platform.isLinux",   Sys.info()[["sysname"]] == "Linux",  envir = .rs.Env)
+assign(".rs.platform.isMacos",   Sys.info()[["sysname"]] == "Darwin", envir = .rs.Env)
+
 #' Add a function to the 'tools:rstudio' environment.
 #' 
 #' This environment is placed on the search path, and so is accessible and
@@ -827,7 +833,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
   })
   
   # savehistory
-  .rs.registerReplaceHook("savehistory", "utils", function(original, 
+  .rs.registerReplaceHook("savehistory", "utils", function(original,
                                                            file = ".Rhistory")
   {
     invisible(.Call("rs_saveHistory", file))
@@ -1522,18 +1528,3 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
          return(value)
    }
 })
-
-.rs.addFunction("initTools", function()
-{
-   ostype <- .Platform$OS.type
-   info <- Sys.info()
-   envir <- .rs.toolsEnv()
-   
-   assign(".rs.platform.isUnix",    ostype == "unix",              envir = envir)
-   assign(".rs.platform.isWindows", ostype == "windows",           envir = envir)
-   assign(".rs.platform.isLinux",   info[["sysname"]] == "Linux",  envir = envir)
-   assign(".rs.platform.isMacos",   info[["sysname"]] == "Darwin", envir = envir)
-   
-})
-
-.rs.initTools()

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -827,42 +827,45 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
     system(paste("nautilus", diagPath))
 })
 
-
-.rs.replacePackageBinding("history", "utils", function(...) {
+.rs.addFunction("history", function(max.show = 25, reverse = FALSE, pattern, ...)
+{
    invisible(.Call("rs_activatePane", "history", PACKAGE = "(embedding)"))
 })
 
-.rs.addFunction("registerHistoryFunctions", function() {
-  
-   # loadhistory
-   .rs.replacePackageBinding("loadhistory", "utils", function(file = ".Rhistory")
-   {
-      invisible(.Call("rs_loadHistory", file, PACKAGE = "(embedding)"))
-   }, namespace = TRUE)
+.rs.addFunction("savehistory", function(file = ".Rhistory")
+{
+   invisible(.Call("rs_saveHistory", file, PACKAGE = "(embedding)"))
+})
+
+.rs.addFunction("loadhistory", function(file = ".Rhistory")
+{
+   invisible(.Call("rs_loadHistory", file, PACKAGE = "(embedding)"))
+})
+
+.rs.addFunction("timestamp", function(stamp = date(),
+                                      prefix = "##------ ",
+                                      suffix = " ------##",
+                                      quiet = FALSE)
+{
+   stamps <- paste(prefix, stamp, suffix, sep = "")
    
-   # savehistory
-   .rs.replacePackageBinding("savehistory", "utils", function(file = ".Rhistory")
-   {
-      invisible(.Call("rs_saveHistory", file, PACKAGE = "(embedding)"))
-   }, namespace = TRUE)
+   lapply(stamps, function(stamp) {
+      invisible(.Call("rs_timestamp", stamp, PACKAGE = "(embedding)"))
+   })
    
-   # timestamp
-   .rs.replacePackageBinding("timestamp", "utils", function(stamp = date(),
-                                                            prefix = "##------ ",
-                                                            suffix = " ------##",
-                                                            quiet = FALSE)
-   {
-      stamps <- paste(prefix, stamp, suffix, sep = "")
-      
-      lapply(stamps, function(stamp) {
-         invisible(.Call("rs_timestamp", stamp, PACKAGE = "(embedding)"))
-      })
-      
-      if (!quiet)
-         cat(stamps, sep = "\n")
-      
-      invisible(stamps)
-   }, namespace = TRUE)
+   if (!quiet)
+      cat(stamps, sep = "\n")
+   
+   invisible(stamps)
+})
+
+.rs.replacePackageBinding("history", "utils", .rs.history)
+
+.rs.addFunction("registerHistoryFunctions", function()
+{
+   .rs.replacePackageBinding("savehistory", "utils", .rs.savehistory, namespace = TRUE)
+   .rs.replacePackageBinding("loadhistory", "utils", .rs.loadhistory, namespace = TRUE)
+   .rs.replacePackageBinding("timestamp", "utils", .rs.timestamp, namespace = TRUE)
 })
 
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15292.

### Approach

When overriding the relevant history-related functions, do so in both the package namespace as well as the exported environment.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15292.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
