### PR TITLE
use global pref value as default for magic wand menu

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -793,7 +793,7 @@ public class TextEditingTargetWidget
          DocPropMenuItem reformatOnSaveMenuItem = new DocPropMenuItem(
                constants_.reformatDocumentOnSave(),
                docUpdateSentinel_,
-               false,
+               userPrefs_.reformatOnSave().getValue(),
                TextEditingTarget.REFORMAT_ON_SAVE,
                DocUpdateSentinel.PROPERTY_TRUE);
          


### PR DESCRIPTION
Related to https://github.com/rstudio/rstudio/issues/2563.

This PR makes sure that the Code Transform menu uses the current preference value as the default for formatting a document. Adjusting this option here still only modifies the preference for that specific document.

<img width="323" alt="Screenshot 2024-10-09 at 3 28 46 PM" src="https://github.com/user-attachments/assets/642f5513-0667-4909-a6f0-5acda2b78440">
