### PR TITLE
avoid autosaving on blur if save in progress

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -68,6 +68,8 @@
 - Fixed an issue where ghost text could not be inserted in non-chunk parts of an R Markdown / Quarto document (#14507)
 - Fixed Mac Desktop Pro so it starts on an ARM (Mx) Mac that doesn't have Rosetta2 installed (rstudio-pro#3558)
 - Fixed Windows Desktop Pro so it starts up after using the Choose R dialog (rstudio-pro#6062)
+- Fixed an issue where RStudio could autosave files on blur even while a Save As... modal was active (#15303)
+
 
 #### Posit Workbench
 - Fixed an issue with Workbench login not respecting "Stay signed in when browser closes" when using Single Sign-On (rstudio-pro#5392)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15303.

### Approach

Set `isSaving_ = true` flag in more Save code paths; respect that when checking if we can autosave on blur.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15303.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

