### PR TITLE
allow reinstallation of copilot even when running on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -74,9 +74,8 @@
 - Fixed an issue with Workbench login not respecting "Stay signed in when browser closes" when using Single Sign-On (rstudio-pro#5392)
 
 ### Dependencies
-
-- Updated GWT to version 2.10.1 (#15011)
 - Updated Electron to version 31.6.0 (#14982; Desktop)
+- Updated GWT to version 2.10.1 (#15011)
 
 ### Deprecated / Removed
 - Removed user preference for turning off focus indicator rectangles (#14352)

--- a/NEWS.md
+++ b/NEWS.md
@@ -68,6 +68,7 @@
 - Fixed an issue where ghost text could not be inserted in non-chunk parts of an R Markdown / Quarto document (#14507)
 - Fixed Mac Desktop Pro so it starts on an ARM (Mx) Mac that doesn't have Rosetta2 installed (rstudio-pro#3558)
 - Fixed Windows Desktop Pro so it starts up after using the Choose R dialog (rstudio-pro#6062)
+- Fixed an issue where updating the Copilot agent on Windows could fail if Copilot was already in use (#14850)
 
 #### Posit Workbench
 - Fixed an issue with Workbench login not respecting "Stay signed in when browser closes" when using Single Sign-On (rstudio-pro#5392)

--- a/src/cpp/session/modules/SessionCopilot.R
+++ b/src/cpp/session/modules/SessionCopilot.R
@@ -120,8 +120,20 @@
    # are loaded, we won't be able to remove them.
    .Call("rs_copilotStopAgent", PACKAGE = "(embedding)")
    
+   if (file.exists(targetDirectory))
+   {
+      # Rename the target directory, and then unlink it. We rename first as Windows
+      # will allow folders to be renamed, even if those folders contain locked files.
+      backupDirectory <- tempfile("copilot-agent-backup-", tmpdir = dirname(targetDirectory))
+      file.rename(targetDirectory, backupDirectory)
+      
+      # Register a finalizer that will clean up the backup directory on exit.
+      reg.finalizer(globalenv(), function(envir) {
+         unlink(backupDirectory, recursive = TRUE)
+      }, onexit = TRUE)
+   }
+   
    # Copy the directory recursively.
-   unlink(targetDirectory, recursive = TRUE)
    .rs.ensureDirectory(dirname(targetDirectory))
    file.copy(copilotAgentDirectory, dirname(targetDirectory), recursive = TRUE)
    

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -71,7 +71,7 @@
 # define kNodeExe "node.exe"
 #endif
 
-#define kCopilotAgentDefaultCommitHash ("1dcaf72099b436b5832d6117d9cd7a4a098a8d77") // pragma: allowlist secret
+#define kCopilotAgentDefaultCommitHash ("87038123804796ca7af20d1b71c3428d858a9124") // pragma: allowlist secret
 #define kCopilotDefaultDocumentVersion (0)
 #define kMaxIndexingFileSize (1048576)
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14850.

### Approach

Uses a 'rename and delete' strategy which allows us to reinstall Copilot even if it's already running / in use.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14850.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

