### PR TITLE
use alternate style for SGR 2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -71,6 +71,7 @@
 - Fixed Windows Desktop Pro so it starts up after using the Choose R dialog (rstudio-pro#6062)
 - Fixed an issue where updating the Copilot agent on Windows could fail if Copilot was already in use (#14850)
 - Fixed an issue where RStudio could autosave files on blur even while a Save As... modal was active (#15303)
+- Fixed an issue where some output from `uv` could be rendered blurry in the RStudio Console (#15282)
 
 
 #### Posit Workbench

--- a/src/cpp/session/resources/themes/ambiance.rstheme
+++ b/src/cpp/session/resources/themes/ambiance.rstheme
@@ -237,7 +237,7 @@
 .xtermInvertColor { color: #202020; }
 .xtermInvertBgColor { background-color: #e6e1dc; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/chaos.rstheme
+++ b/src/cpp/session/resources/themes/chaos.rstheme
@@ -213,7 +213,7 @@
 .xtermInvertColor { color: #161616; }
 .xtermInvertBgColor { background-color: #e6e1dc; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/chrome.rstheme
+++ b/src/cpp/session/resources/themes/chrome.rstheme
@@ -186,7 +186,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: black; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/clouds.rstheme
+++ b/src/cpp/session/resources/themes/clouds.rstheme
@@ -161,7 +161,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: #000000; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/clouds_midnight.rstheme
+++ b/src/cpp/session/resources/themes/clouds_midnight.rstheme
@@ -159,7 +159,7 @@
 .xtermInvertColor { color: #191919; }
 .xtermInvertBgColor { background-color: #929292; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/cobalt.rstheme
+++ b/src/cpp/session/resources/themes/cobalt.rstheme
@@ -175,7 +175,7 @@
 .xtermInvertColor { color: #002240; }
 .xtermInvertBgColor { background-color: #ffffff; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/compile-themes.R
+++ b/src/cpp/session/resources/themes/compile-themes.R
@@ -719,7 +719,7 @@
          sprintf(".xtermInvertColor { color: %s; }", background),
          sprintf(".xtermInvertBgColor { background-color: %s; }", foreground),
          ".xtermBold { font-weight: bold; }",
-         ".xtermBlur { filter: blur(1px); }", 
+         ".xtermBlur { filter: brightness(75%); }", 
          ".xtermUnderline { text-decoration: underline; }",
          ".xtermBlink { text-decoration: blink; }",
          ".xtermHidden { visibility: hidden; }",

--- a/src/cpp/session/resources/themes/crimson_editor.rstheme
+++ b/src/cpp/session/resources/themes/crimson_editor.rstheme
@@ -177,7 +177,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: rgb(64, 64, 64); }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/dawn.rstheme
+++ b/src/cpp/session/resources/themes/dawn.rstheme
@@ -171,7 +171,7 @@
 .xtermInvertColor { color: #f9f9f9; }
 .xtermInvertBgColor { background-color: #080808; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/dracula.rstheme
+++ b/src/cpp/session/resources/themes/dracula.rstheme
@@ -197,7 +197,7 @@
 .xtermInvertColor { color: #282a36; }
 .xtermInvertBgColor { background-color: #f8f8f2; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/dreamweaver.rstheme
+++ b/src/cpp/session/resources/themes/dreamweaver.rstheme
@@ -202,7 +202,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: black; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/eclipse.rstheme
+++ b/src/cpp/session/resources/themes/eclipse.rstheme
@@ -161,7 +161,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: black; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/gob.rstheme
+++ b/src/cpp/session/resources/themes/gob.rstheme
@@ -171,7 +171,7 @@
 .xtermInvertColor { color: #0b0b0b; }
 .xtermInvertBgColor { background-color: #00ff00; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/idle_fingers.rstheme
+++ b/src/cpp/session/resources/themes/idle_fingers.rstheme
@@ -159,7 +159,7 @@
 .xtermInvertColor { color: #323232; }
 .xtermInvertBgColor { background-color: #ffffff; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/iplastic.rstheme
+++ b/src/cpp/session/resources/themes/iplastic.rstheme
@@ -180,7 +180,7 @@
 .xtermInvertColor { color: #eeeeee; }
 .xtermInvertBgColor { background-color: #333333; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/katzenmilch.rstheme
+++ b/src/cpp/session/resources/themes/katzenmilch.rstheme
@@ -185,7 +185,7 @@
 .xtermInvertColor { color: #f3f2f3; }
 .xtermInvertBgColor { background-color: rgba(15, 0, 9, 1.0); }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/kr_theme.rstheme
+++ b/src/cpp/session/resources/themes/kr_theme.rstheme
@@ -167,7 +167,7 @@
 .xtermInvertColor { color: #0b0a09; }
 .xtermInvertBgColor { background-color: #fcffe0; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/material.rstheme
+++ b/src/cpp/session/resources/themes/material.rstheme
@@ -201,7 +201,7 @@
 .xtermInvertColor { color: #263238; }
 .xtermInvertBgColor { background-color: #C5C8C6; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/merbivore.rstheme
+++ b/src/cpp/session/resources/themes/merbivore.rstheme
@@ -158,7 +158,7 @@
 .xtermInvertColor { color: #161616; }
 .xtermInvertBgColor { background-color: #e6e1dc; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/merbivore_soft.rstheme
+++ b/src/cpp/session/resources/themes/merbivore_soft.rstheme
@@ -159,7 +159,7 @@
 .xtermInvertColor { color: #1c1c1c; }
 .xtermInvertBgColor { background-color: #e6e1dc; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/mono_industrial.rstheme
+++ b/src/cpp/session/resources/themes/mono_industrial.rstheme
@@ -167,7 +167,7 @@
 .xtermInvertColor { color: #222c28; }
 .xtermInvertBgColor { background-color: #ffffff; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/monokai.rstheme
+++ b/src/cpp/session/resources/themes/monokai.rstheme
@@ -168,7 +168,7 @@
 .xtermInvertColor { color: #272822; }
 .xtermInvertBgColor { background-color: #f8f8f2; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/pastel_on_dark.rstheme
+++ b/src/cpp/session/resources/themes/pastel_on_dark.rstheme
@@ -171,7 +171,7 @@
 .xtermInvertColor { color: #2c2828; }
 .xtermInvertBgColor { background-color: #EAEAEA; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/solarized_dark.rstheme
+++ b/src/cpp/session/resources/themes/solarized_dark.rstheme
@@ -151,7 +151,7 @@
 .xtermInvertColor { color: #002b36; }
 .xtermInvertBgColor { background-color: #93a1a1; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/solarized_light.rstheme
+++ b/src/cpp/session/resources/themes/solarized_light.rstheme
@@ -154,7 +154,7 @@
 .xtermInvertColor { color: #fdf6e3; }
 .xtermInvertBgColor { background-color: #586e75; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/sqlserver.rstheme
+++ b/src/cpp/session/resources/themes/sqlserver.rstheme
@@ -196,7 +196,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: black; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/textmate.rstheme
+++ b/src/cpp/session/resources/themes/textmate.rstheme
@@ -188,7 +188,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: black; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/tomorrow.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow.rstheme
@@ -168,7 +168,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: #4d4d4c; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/tomorrow_night.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow_night.rstheme
@@ -168,7 +168,7 @@
 .xtermInvertColor { color: #1d1f21; }
 .xtermInvertBgColor { background-color: #c5c8c6; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/tomorrow_night_blue.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow_night_blue.rstheme
@@ -166,7 +166,7 @@
 .xtermInvertColor { color: #002451; }
 .xtermInvertBgColor { background-color: #ffffff; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/tomorrow_night_bright.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow_night_bright.rstheme
@@ -181,7 +181,7 @@
 .xtermInvertColor { color: #000000; }
 .xtermInvertBgColor { background-color: #dedede; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/tomorrow_night_eighties.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow_night_eighties.rstheme
@@ -168,7 +168,7 @@
 .xtermInvertColor { color: #2d2d2d; }
 .xtermInvertBgColor { background-color: #cccccc; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/twilight.rstheme
+++ b/src/cpp/session/resources/themes/twilight.rstheme
@@ -172,7 +172,7 @@
 .xtermInvertColor { color: #141414; }
 .xtermInvertBgColor { background-color: #f8f8f8; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/vibrant_ink.rstheme
+++ b/src/cpp/session/resources/themes/vibrant_ink.rstheme
@@ -157,7 +157,7 @@
 .xtermInvertColor { color: #0f0f0f; }
 .xtermInvertBgColor { background-color: #ffffff; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/session/resources/themes/xcode.rstheme
+++ b/src/cpp/session/resources/themes/xcode.rstheme
@@ -151,7 +151,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: #000000; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/DebugLine.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/DebugLine.rstheme
@@ -184,7 +184,7 @@
 .xtermInvertColor { color: #000000; }
 .xtermInvertBgColor { background-color: #ffffff; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/active4d.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/active4d.rstheme
@@ -212,7 +212,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: #3b3b3b; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/all_hallows_eve.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/all_hallows_eve.rstheme
@@ -182,7 +182,7 @@
 .xtermInvertColor { color: #000000; }
 .xtermInvertBgColor { background-color: #ffffff; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/amy.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/amy.rstheme
@@ -215,7 +215,7 @@
 .xtermInvertColor { color: #200020; }
 .xtermInvertBgColor { background-color: #d0d0ff; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/blackboard.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/blackboard.rstheme
@@ -189,7 +189,7 @@
 .xtermInvertColor { color: #0c1021; }
 .xtermInvertBgColor { background-color: #f8f8f8; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/brilliance_black.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/brilliance_black.rstheme
@@ -238,7 +238,7 @@
 .xtermInvertColor { color: rgba(13, 13, 13, 0.98); }
 .xtermInvertBgColor { background-color: #eeeeee; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/brilliance_dull.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/brilliance_dull.rstheme
@@ -246,7 +246,7 @@
 .xtermInvertColor { color: rgba(5, 5, 5, 0.98); }
 .xtermInvertBgColor { background-color: #cdcdcd; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/chrome_dev_tools.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/chrome_dev_tools.rstheme
@@ -209,7 +209,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: #000000; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/clouds.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/clouds.rstheme
@@ -207,7 +207,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: #000000; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/clouds_midnight.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/clouds_midnight.rstheme
@@ -208,7 +208,7 @@
 .xtermInvertColor { color: #191919; }
 .xtermInvertBgColor { background-color: #929292; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/cobalt.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/cobalt.rstheme
@@ -211,7 +211,7 @@
 .xtermInvertColor { color: #002240; }
 .xtermInvertBgColor { background-color: #ffffff; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/dawn.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/dawn.rstheme
@@ -217,7 +217,7 @@
 .xtermInvertColor { color: #f9f9f9; }
 .xtermInvertBgColor { background-color: #080808; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/dreamweaver.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/dreamweaver.rstheme
@@ -159,7 +159,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: #000000; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/eiffel.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/eiffel.rstheme
@@ -245,7 +245,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: #000000; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/espresso_libre.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/espresso_libre.rstheme
@@ -250,7 +250,7 @@
 .xtermInvertColor { color: #2a211c; }
 .xtermInvertBgColor { background-color: #bdae9d; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/git_hub.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/git_hub.rstheme
@@ -261,7 +261,7 @@
 .xtermInvertColor { color: #f8f8ff; }
 .xtermInvertBgColor { background-color: #000000; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/i_plastic.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/i_plastic.rstheme
@@ -226,7 +226,7 @@
 .xtermInvertColor { color: rgba(238, 238, 238, 0.92); }
 .xtermInvertBgColor { background-color: #000000; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/idle.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/idle.rstheme
@@ -193,7 +193,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: #000000; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/idle_fingers.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/idle_fingers.rstheme
@@ -205,7 +205,7 @@
 .xtermInvertColor { color: #323232; }
 .xtermInvertBgColor { background-color: #ffffff; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/katzenmilch.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/katzenmilch.rstheme
@@ -243,7 +243,7 @@
 .xtermInvertColor { color: #f3f2f3; }
 .xtermInvertBgColor { background-color: rgba(15, 0, 9, 1.00); }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/kr_theme.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/kr_theme.rstheme
@@ -209,7 +209,7 @@
 .xtermInvertColor { color: #0b0a09; }
 .xtermInvertBgColor { background-color: #fcffe0; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/kuroir_theme.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/kuroir_theme.rstheme
@@ -224,7 +224,7 @@
 .xtermInvertColor { color: #e8e9e8; }
 .xtermInvertBgColor { background-color: #363636; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/lazy.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/lazy.rstheme
@@ -189,7 +189,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: #000000; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/magic_wb_amiga.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/magic_wb_amiga.rstheme
@@ -243,7 +243,7 @@
 .xtermInvertColor { color: #969696; }
 .xtermInvertBgColor { background-color: #000000; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/merbivore.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/merbivore.rstheme
@@ -219,7 +219,7 @@
 .xtermInvertColor { color: #161616; }
 .xtermInvertBgColor { background-color: #e6e1dc; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/merbivore_soft.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/merbivore_soft.rstheme
@@ -226,7 +226,7 @@
 .xtermInvertColor { color: #1c1c1c; }
 .xtermInvertBgColor { background-color: #e6e1dc; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/mono_industrial.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/mono_industrial.rstheme
@@ -219,7 +219,7 @@
 .xtermInvertColor { color: #222c28; }
 .xtermInvertBgColor { background-color: #ffffff; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/monokai.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/monokai.rstheme
@@ -238,7 +238,7 @@
 .xtermInvertColor { color: #272822; }
 .xtermInvertBgColor { background-color: #f8f8f2; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/pastels_on_dark.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/pastels_on_dark.rstheme
@@ -219,7 +219,7 @@
 .xtermInvertColor { color: #2c2828; }
 .xtermInvertBgColor { background-color: #8f938f; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/slush_and_poppies.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/slush_and_poppies.rstheme
@@ -182,7 +182,7 @@
 .xtermInvertColor { color: #f1f1f1; }
 .xtermInvertBgColor { background-color: #000000; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/solarized_dark.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/solarized_dark.rstheme
@@ -220,7 +220,7 @@
 .xtermInvertColor { color: #002b36; }
 .xtermInvertBgColor { background-color: #93a1a1; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/solarized_light.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/solarized_light.rstheme
@@ -219,7 +219,7 @@
 .xtermInvertColor { color: #fdf6e3; }
 .xtermInvertBgColor { background-color: #586e75; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/sunburst.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/sunburst.rstheme
@@ -217,7 +217,7 @@
 .xtermInvertColor { color: #000000; }
 .xtermInvertBgColor { background-color: #f8f8f8; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/textmate.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/textmate.rstheme
@@ -261,7 +261,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: #000000; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/tomorrow.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/tomorrow.rstheme
@@ -254,7 +254,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: #4d4d4c; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/tomorrow_night.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/tomorrow_night.rstheme
@@ -254,7 +254,7 @@
 .xtermInvertColor { color: #1d1f21; }
 .xtermInvertBgColor { background-color: #c5c8c6; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/tomorrow_night_blue.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/tomorrow_night_blue.rstheme
@@ -254,7 +254,7 @@
 .xtermInvertColor { color: #002451; }
 .xtermInvertBgColor { background-color: #ffffff; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/tomorrow_night_bright.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/tomorrow_night_bright.rstheme
@@ -254,7 +254,7 @@
 .xtermInvertColor { color: #000000; }
 .xtermInvertBgColor { background-color: #dedede; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/tomorrow_night_eighties.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/tomorrow_night_eighties.rstheme
@@ -249,7 +249,7 @@
 .xtermInvertColor { color: #2d2d2d; }
 .xtermInvertBgColor { background-color: #cccccc; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/twilight.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/twilight.rstheme
@@ -227,7 +227,7 @@
 .xtermInvertColor { color: #141414; }
 .xtermInvertBgColor { background-color: #f8f8f8; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/vibrant_ink.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/vibrant_ink.rstheme
@@ -205,7 +205,7 @@
 .xtermInvertColor { color: #0f0f0f; }
 .xtermInvertBgColor { background-color: #ffffff; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/xcode_default.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/xcode_default.rstheme
@@ -212,7 +212,7 @@
 .xtermInvertColor { color: #ffffff; }
 .xtermInvertBgColor { background-color: #000000; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }

--- a/src/cpp/tests/testthat/themes/rsthemes/zenburnesque.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/zenburnesque.rstheme
@@ -180,7 +180,7 @@
 .xtermInvertColor { color: #404040; }
 .xtermInvertBgColor { background-color: #dedede; }
 .xtermBold { font-weight: bold; }
-.xtermBlur { filter: blur(1px); }
+.xtermBlur { filter: brightness(75%); }
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15282.

### Approach

Update the `.xtermBlur` styling for our bundled themes.

<img width="945" alt="Screenshot 2024-10-11 at 11 51 42 AM" src="https://github.com/user-attachments/assets/c849385a-abfd-4f77-8a9d-66474ecc71d4">

<img width="897" alt="Screenshot 2024-10-11 at 11 53 36 AM" src="https://github.com/user-attachments/assets/918fc012-aefc-4d14-9056-d63b69fbf27f">


### Automated Tests

N/A

### QA Notes

To be verified by community.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

