### PR TITLE
Fix chunk options in Visual Editor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -72,6 +72,7 @@
 - Fixed an issue where updating the Copilot agent on Windows could fail if Copilot was already in use (#14850)
 - Fixed an issue where RStudio could autosave files on blur even while a Save As... modal was active (#15303)
 - Fixed an issue where some output from `uv` could be rendered blurry in the RStudio Console (#15282)
+- Fixed the chunk options popup to work in Visual Mode for non-R chunks (#15312)
 
 
 #### Posit Workbench

--- a/src/cpp/tests/automation/testthat/test-automation-rmarkdown.R
+++ b/src/cpp/tests/automation/testthat/test-automation-rmarkdown.R
@@ -439,3 +439,76 @@ test_that("modifying chunk options via UI doesn't mess up other options", {
    remote$documentClose()
    remote$keyboardExecute("<Ctrl + L>")
 })
+
+test_that("setup chunk starting with no options works with chunk options UI", {
+   contents <- .rs.heredoc('
+      ---
+      title: "Chunk widgets"
+      ---
+
+      ```{r setup, include=FALSE}
+      ```
+
+      This is an R Markdown document.
+   ')
+   id <- remote$documentOpen(".Rmd", contents)
+   editor <- remote$editorGetInstance()
+   
+   remote$domClickElement(".rstudio_modify_chunk")
+   Sys.sleep(1)
+   remote$domClickElement("#rstudio_chunk_opt_warnings")
+   remote$domClickElement("#rstudio_chunk_opt_messages")
+   remote$keyboardExecute("<Escape>")
+   expect_equal('```{r setup, include=FALSE}', editor$session$getLine(4))
+   expect_equal('knitr::opts_chunk$set(warning = TRUE, message = TRUE)', editor$session$getLine(5))
+   remote$domClickElement(".rstudio_modify_chunk")
+   Sys.sleep(1)
+   remote$domClickElement("#rstudio_chunk_opt_warnings")
+   remote$domClickElement("#rstudio_chunk_opt_messages")
+   remote$keyboardExecute("<Escape>")
+   expect_equal('```{r setup, include=FALSE}', editor$session$getLine(4))
+   expect_equal('knitr::opts_chunk$set(warning = FALSE, message = FALSE)', editor$session$getLine(5))
+   remote$domClickElement(".rstudio_modify_chunk")
+   Sys.sleep(1)
+   remote$domClickElement("#rstudio_chunk_opt_warnings")
+   remote$domClickElement("#rstudio_chunk_opt_messages")
+   remote$keyboardExecute("<Escape>")
+   expect_equal('```{r setup, include=FALSE}', editor$session$getLine(4))
+   expect_equal('```', editor$session$getLine(5))
+   
+   remote$documentClose()
+   remote$keyboardExecute("<Ctrl + L>")
+})
+
+test_that("setup chunk with three options displays on multiple lines", {
+   contents <- .rs.heredoc('
+      ---
+      title: "Chunk widgets"
+      ---
+   
+      ```{r setup, include=FALSE}
+      knitr::opts_chunk$set(eval = FALSE, include = FALSE)
+      ```
+
+      This is an R Markdown document.
+   ')
+   id <- remote$documentOpen(".Rmd", contents)
+   editor <- remote$editorGetInstance()
+   
+   remote$domClickElement(".rstudio_modify_chunk")
+   Sys.sleep(1)
+   remote$domClickElement("#rstudio_chunk_opt_warnings")
+   remote$domClickElement("#rstudio_chunk_opt_messages")
+   remote$keyboardExecute("<Escape>")
+   expect_equal('```{r setup, include=FALSE}', editor$session$getLine(4))
+   expect_equal('knitr::opts_chunk$set(', editor$session$getLine(5))
+   expect_equal('\teval = FALSE,', editor$session$getLine(6))
+   expect_equal('\tmessage = TRUE,', editor$session$getLine(7))
+   expect_equal('\twarning = TRUE,', editor$session$getLine(8))
+   expect_equal('\tinclude = FALSE', editor$session$getLine(9))
+   expect_equal(')', editor$session$getLine(10))
+   
+   remote$documentClose()
+   remote$keyboardExecute("<Ctrl + L>")
+})
+

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUi.java
@@ -364,16 +364,17 @@ public abstract class ChunkContextUi implements ChunkContextToolbar.Host
 
    private ChunkOptionsPopupPanel createPopupPanel()
    {
+      boolean isVisualEditor = outerEditor_.isVisualEditorActive();
       int row = getRow();
       if (isSetupChunk(row))
-         return new SetupChunkOptionsPopupPanel();
+         return new SetupChunkOptionsPopupPanel(isVisualEditor);
       
       String engine = getEngine(row);
       if (!engine.toLowerCase().equals("r") &&
           !engine.toLowerCase().equals("d3"))
-         return new CustomEngineChunkOptionsPopupPanel(engine_);
+         return new CustomEngineChunkOptionsPopupPanel(engine_, isVisualEditor);
       
-      return new DefaultChunkOptionsPopupPanel(engine_);
+      return new DefaultChunkOptionsPopupPanel(engine_, isVisualEditor);
    }
 
    protected ChunkContextToolbar toolbar_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
@@ -92,13 +92,14 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
       rfsContext_ = rfsContext;
    }
    
-   public ChunkOptionsPopupPanel(boolean includeChunkNameUI)
+   public ChunkOptionsPopupPanel(boolean includeChunkNameUI, boolean isVisualEditor)
    {
       super(true);
       setVisible(false);
       
       RStudioGinjector.INSTANCE.injectMembers(this);
       
+      isVisualEditor_ = isVisualEditor;
       chunkOptions_ = new HashMap<>();
       originalChunkOptions_ = new HashMap<>();
       
@@ -655,6 +656,7 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
    
    protected String originalLine_;
    protected String chunkPreamble_;
+   protected final boolean isVisualEditor_;
    
    protected HashMap<String, String> chunkOptions_;
    protected HashMap<String, String> originalChunkOptions_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/CustomEngineChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/CustomEngineChunkOptionsPopupPanel.java
@@ -16,9 +16,9 @@ package org.rstudio.studio.client.workbench.views.source.editors.text.rmd.displa
 
 public class CustomEngineChunkOptionsPopupPanel extends DefaultChunkOptionsPopupPanel
 {
-   public CustomEngineChunkOptionsPopupPanel(String engine)
+   public CustomEngineChunkOptionsPopupPanel(String engine, boolean isVisualEditor)
    {
-      super(engine);
+      super(engine, isVisualEditor);
       
       showWarningsInOutputCb_.setVisible(false);
       showMessagesInOutputCb_.setVisible(false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/DefaultChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/DefaultChunkOptionsPopupPanel.java
@@ -32,9 +32,9 @@ import java.util.Map;
 
 public class DefaultChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
 {
-   public DefaultChunkOptionsPopupPanel(String engine)
+   public DefaultChunkOptionsPopupPanel(String engine, boolean isVisualEditor)
    {
-      super(true);
+      super(true, isVisualEditor);
 
       engine_ = engine;
       enginePanel_.setVisible(false);
@@ -45,7 +45,8 @@ public class DefaultChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
    {
       originalLine_ = display_.getLine(position_.getRow());
       ChunkHeaderInfo extraInfo = new ChunkHeaderInfo();
-      parseChunkHeader(originalLine_, display_.getModeId(), originalChunkOptions_, extraInfo);
+      parseChunkHeader(originalLine_, isVisualEditor_ ? "mode/r" : display_.getModeId(),
+                       originalChunkOptions_, extraInfo);
       chunkPreamble_ = extraInfo.chunkPreamble;
       if (!StringUtil.isNullOrEmpty(extraInfo.chunkLabel))
          tbChunkLabel_.setText(extraInfo.chunkLabel);
@@ -115,7 +116,12 @@ public class DefaultChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
 
    private Pair<String, String> getChunkHeaderBounds(String modeId)
    {
-      if (modeId == "mode/rmarkdown")
+      // When using Visual Editor the mode is the chunk's mode, not the document's
+      // mode. Leverage fact the Visual Editor only supports markdown-like formats
+      // using a modified form of the rmarkdown-style boundaries.
+      if (isVisualEditor_)
+         return new Pair<>("{", "}");
+      else if (modeId == "mode/rmarkdown")
          return new Pair<>("```{", "}");
       else if (modeId == "mode/sweave")
          return new Pair<>("<<", ">>=");
@@ -123,8 +129,6 @@ public class DefaultChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
          return new Pair<>("<!--", "");
       else if (modeId == "mode/c_cpp")
          return new Pair<>("/***", "");
-      else if (modeId == "mode/r")  // Used in visual mode for embedded chunk editor
-         return new Pair<>("{", "}");
 
       return null;
    }


### PR DESCRIPTION
### Intent

Addresses #15312

### Approach

Adjusted chunk parsing code to handle the visual editor differences. Two main issues were:

- the "mode" given in visual editor mode was for the individual chunk, not the overall document, and the code only recognized the R scenario
- the setup chunk parsing code relied on the trailing "```" but that isn't present in visual mode, so temporarily added it during parsing (rather than mucking with all the parsing code)

### Automated Tests

Partial: still need to add visual editor tests, but will do as part of a separate PR I've got in flight.

### QA Notes

Verify as documented in issue.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


