### PR TITLE
ensure all loaded namespaces are serialized on suspend / resume

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -1282,3 +1282,4 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
    .rs.api.sendRequest(request)
    invisible(text)
 })
+

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1613,11 +1613,10 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       }
       else
       {
-         dataFilePath <- file.path(environmentDataDir, index)
+         # NOTE: Use '-1' to accommodate 0-based versus 1-based indexing.
+         dataFilePath <- file.path(environmentDataDir, index - 1L)
          if (file.exists(dataFilePath))
-         {
             .rs.attachDataFile(dataFilePath, searchPathEl)
-         }
       }
    }
    

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1595,8 +1595,6 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       if (grepl("^package:", searchPathEl))
       {
          packageName <- substring(searchPathEl, 9L)
-         message <- paste("Attaching package:", packageName)
-         .rs.logErrorMessage(message)
          library(packageName, character.only = TRUE)
       }
       else
@@ -1661,9 +1659,6 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       }
    }
 
-   message <- paste("Loading namespace:", file.path(.rs.nullCoalesce(libLoc, "<?>"), package))
-   .rs.logErrorMessage(message)
-   
    # Load the package.   
    loadNamespace(package, lib.loc = libLoc)
 })

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1580,6 +1580,20 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    # Read the search paths file.
    searchPaths <- readLines(searchPathsFile, warn = FALSE)
    
+   # Detach anything that's on the search path right now, but not in the search path list.
+   currentSearchPaths <- setdiff(
+      search(),
+      c(".GlobalEnv", "tools:rstudio", "package:base", "package:tools", "package:utils")
+   )
+   
+   for (entry in currentSearchPaths)
+   {
+      if (!entry %in% searchPaths)
+      {
+         detach(entry, character.only = TRUE)
+      }
+   }
+   
    # Build our iteration indices.
    # - Iterate in reverse order, since 'library()' always attaches entries to the front of the search path.
    # - Iterate by index, since we use those to map certain search path elements to data files.
@@ -1659,7 +1673,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       }
    }
 
-   # Load the package.   
+   # Load the package.
    loadNamespace(package, lib.loc = libLoc)
 })
 
@@ -1723,7 +1737,6 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    names(vals) <- keys
    
    vals
-   
 })
 
 .rs.addFunction("packagePaths", function()

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1614,7 +1614,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       }
       else
       {
-         # NOTE: Use '-1' to accommodate 0-based versus 1-based indexing.
+         # NOTE: Subtract by 1 to accommodate 0-based versus 1-based indexing.
          dataFilePath <- file.path(environmentDataDir, index - 1L)
          if (file.exists(dataFilePath))
             .rs.attachDataFile(dataFilePath, searchPathEl)

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1604,6 +1604,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       by = -1L
    )
    
+   # Using our index from above, iterate and attach packages.
    for (index in indices)
    {
       searchPathEl <- searchPaths[[index]]

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1552,7 +1552,8 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       ),
       
       error = function(cnd) {
-         message <- paste("Error restoring search paths:", conditionMessage(cnd))
+         header <- "Error restoring search paths:"
+         message <- paste(c(header, conditionMessage(cnd)), collapse = "\n\t")
          writeLines(message, con = stderr())
       }
       

--- a/src/cpp/tests/automation/testthat/test-automation-suspend.R
+++ b/src/cpp/tests/automation/testthat/test-automation-suspend.R
@@ -6,12 +6,19 @@ withr::defer(.rs.automation.deleteRemote())
 
 test_that("loaded packages are preserved on suspend + resume", {
    
+   remote$commandExecute("consoleClear")
    remote$consoleExecuteExpr({
       library(tools)
       writeLines(search())
    })
    
-   beforeSuspend <- remote$consoleOutput()
+   .rs.waitUntil("the tools package is loaded", function()
+   {
+      remote$keyboardExecute("<Enter>")
+      ".GlobalEnv" %in% remote$consoleOutput()
+   })
+   
+   beforeSuspend <- setdiff(remote$consoleOutput(), "local:rprofile")
    expect_contains(beforeSuspend, "package:tools")
    
    remote$commandExecute("suspendSession")
@@ -22,8 +29,41 @@ test_that("loaded packages are preserved on suspend + resume", {
       writeLines(search())
    })
    
-   afterSuspend <- remote$consoleOutput()
+   .rs.waitUntil("the tools package is loaded", function()
+   {
+      remote$keyboardExecute("<Enter>")
+      ".GlobalEnv" %in% remote$consoleOutput()
+   })
+   
+   afterSuspend <- setdiff(remote$consoleOutput(), "local:rprofile")
    expect_contains(afterSuspend, "package:tools")
-   expect_equal(beforeSuspend, afterSuspend)
+   
+})
+
+test_that("attached datasets are preserved on suspend + resume", {
+   
+   remote$consoleExecuteExpr({
+      data <- list(apple = 1, banana = 2, cherry = 3)
+      attach(data, name = "my-attached-dataset")
+   })
+   
+   remote$commandExecute("suspendSession")
+   
+   remote$consoleExecuteExpr({
+      writeLines(search())
+   })
+   
+   .rs.waitUntil("the session has been restored", function()
+   {
+      remote$keyboardExecute("<Enter>")
+      ".GlobalEnv" %in% remote$consoleOutput()
+   })
+   
+   output <- remote$consoleOutput()
+   expect_contains(output, "my-attached-dataset")
+   
+   remote$consoleExecuteExpr(apple + banana + cherry)
+   output <- remote$consoleOutput()
+   expect_true("[1] 6" %in% output)
    
 })

--- a/src/cpp/tests/automation/testthat/test-automation-suspend.R
+++ b/src/cpp/tests/automation/testthat/test-automation-suspend.R
@@ -1,0 +1,29 @@
+
+library(testthat)
+
+self <- remote <- .rs.automation.newRemote()
+withr::defer(.rs.automation.deleteRemote())
+
+test_that("loaded packages are preserved on suspend + resume", {
+   
+   remote$consoleExecuteExpr({
+      library(tools)
+      writeLines(search())
+   })
+   
+   beforeSuspend <- remote$consoleOutput()
+   expect_contains(beforeSuspend, "package:tools")
+   
+   remote$commandExecute("suspendSession")
+   remote$commandExecute("consoleClear")
+   
+   remote$consoleExecuteExpr({
+      library(tools)
+      writeLines(search())
+   })
+   
+   afterSuspend <- remote$consoleOutput()
+   expect_contains(afterSuspend, "package:tools")
+   expect_equal(beforeSuspend, afterSuspend)
+   
+})


### PR DESCRIPTION

### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/3074.

### Approach

- Re-write the session suspend / resume code in R, so that it can be more readily debugged and tested.
- Ensure that all loaded namespaces, not just attached packages, are included in the 'package_paths' file we generate.

We now use a two-pass approach when loading and attaching packages:

- First, use `loadNamespace()` to load all the package namespaces from the previous session, with leaf packages being loaded first.
- Then, use `library()` to attach packages, preserving the order of the search path as it was before suspend.


### Automated Tests

TODO

### QA Notes

Test via notes in https://github.com/rstudio/rstudio-pro/issues/3074.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
