### PR TITLE
Add Trace log level support

### DIFF
--- a/src/cpp/core/LogOptions.cpp
+++ b/src/cpp/core/LogOptions.cpp
@@ -58,6 +58,7 @@ namespace log {
 #define kLogMessageFormatPretty  "pretty"
 #define kLogMessageFormatJson    "json"
 
+#define kLoggingLevelTrace "trace"
 #define kLoggingLevelDebug "debug"
 #define kLoggingLevelInfo  "info"
 #define kLoggingLevelWarn  "warn"
@@ -107,6 +108,8 @@ std::string logLevelToString(LogLevel logLevel)
 {
    switch (logLevel)
    {
+      case LogLevel::TRACE:
+         return kLoggingLevelTrace;
       case LogLevel::DEBUG:
          return kLoggingLevelDebug;
       case LogLevel::INFO:
@@ -158,6 +161,8 @@ LogLevel strToLogLevel(const std::string& logLevelStr)
        return LogLevel::INFO;
    else if (boost::iequals(logLevelStr, kLoggingLevelDebug))
        return LogLevel::DEBUG;
+   else if (boost::iequals(logLevelStr, kLoggingLevelTrace))
+       return LogLevel::TRACE;
    else
        return LogLevel::WARN;
 }

--- a/src/cpp/core/LoggingTests.cpp
+++ b/src/cpp/core/LoggingTests.cpp
@@ -249,7 +249,9 @@ test_context("Logging")
             "[Bob]\n"
             "log-level=error\n\n"
             "[Jill]\n"
-            "log-level=info";
+            "log-level=info\n\n"
+            "[Emma]\n"
+            "log-level=trace\n\n";
 
       REQUIRE_FALSE(core::writeStringToFile(tmpConfPath, confFileContents));
 
@@ -260,20 +262,29 @@ test_context("Logging")
       REQUIRE_FALSE(core::system::initializeStderrLog("logging-tests-" + id, log::LogLevel::WARN, true));
       REQUIRE_FALSE(core::system::reinitLog());
 
+      LOG_TRACE_MESSAGE_NAMED("Bob", "This is Bob trace");
       LOG_DEBUG_MESSAGE_NAMED("Bob", "This is Bob debug");
       LOG_INFO_MESSAGE_NAMED("Bob", "This is Bob info");
       LOG_WARNING_MESSAGE_NAMED("Bob", "This is Bob warning");
       LOG_ERROR_MESSAGE_NAMED("Bob", "This is Bob error");
 
+      LOG_TRACE_MESSAGE_NAMED("Jill", "This is Jill trace");
       LOG_DEBUG_MESSAGE_NAMED("Jill", "This is Jill debug");
       LOG_INFO_MESSAGE_NAMED("Jill", "This is Jill info");
       LOG_WARNING_MESSAGE_NAMED("Jill", "This is Jill warning");
       LOG_ERROR_MESSAGE_NAMED("Jill", "This is Jill error");
 
+      LOG_TRACE_MESSAGE_NAMED("Sampson", "This is Sampson trace");
       LOG_DEBUG_MESSAGE_NAMED("Sampson", "This is Sampson debug");
       LOG_INFO_MESSAGE_NAMED("Sampson", "This is Sampson info");
       LOG_WARNING_MESSAGE_NAMED("Sampson", "This is Sampson warning");
       LOG_ERROR_MESSAGE_NAMED("Sampson", "This is Sampson error");
+
+      LOG_TRACE_MESSAGE_NAMED("Emma", "This is Emma trace");
+      LOG_DEBUG_MESSAGE_NAMED("Emma", "This is Emma debug");
+      LOG_INFO_MESSAGE_NAMED("Emma", "This is Emma info");
+      LOG_WARNING_MESSAGE_NAMED("Emma", "This is Emma warning");
+      LOG_ERROR_MESSAGE_NAMED("Emma", "This is Emma error");
 
       FilePath logFile = tmpConfPath.getParent().completeChildPath("logging-tests-" + id + ".log");
       REQUIRE(logFile.exists());
@@ -281,20 +292,29 @@ test_context("Logging")
       std::string logFileContents;
       REQUIRE_FALSE(core::readStringFromFile(logFile, &logFileContents));
 
+      REQUIRE(logFileContents.find("This is Bob trace") == std::string::npos);
       REQUIRE(logFileContents.find("This is Bob debug") == std::string::npos);
       REQUIRE(logFileContents.find("This is Bob info") == std::string::npos);
       REQUIRE(logFileContents.find("This is Bob warning") == std::string::npos);
       REQUIRE(logFileContents.find("This is Bob error") != std::string::npos);
 
+      REQUIRE(logFileContents.find("This is Jill trace") == std::string::npos);
       REQUIRE(logFileContents.find("This is Jill debug") == std::string::npos);
       REQUIRE(logFileContents.find("This is Jill info") != std::string::npos);
       REQUIRE(logFileContents.find("This is Jill warning") != std::string::npos);
       REQUIRE(logFileContents.find("This is Jill error") != std::string::npos);
 
+      REQUIRE(logFileContents.find("This is Sampson trace") == std::string::npos);
       REQUIRE(logFileContents.find("This is Sampson debug") == std::string::npos);
       REQUIRE(logFileContents.find("This is Sampson info") == std::string::npos);
       REQUIRE(logFileContents.find("This is Sampson warning") != std::string::npos);
       REQUIRE(logFileContents.find("This is Sampson error") != std::string::npos);
+
+      REQUIRE(logFileContents.find("This is Emma trace") != std::string::npos);
+      REQUIRE(logFileContents.find("This is Emma debug") != std::string::npos);
+      REQUIRE(logFileContents.find("This is Emma info") != std::string::npos);
+      REQUIRE(logFileContents.find("This is Emma warning") != std::string::npos);
+      REQUIRE(logFileContents.find("This is Emma error") != std::string::npos);
    }
 
    test_that("File logs can rotate")

--- a/src/cpp/core/include/core/Log.hpp
+++ b/src/cpp/core/include/core/Log.hpp
@@ -97,7 +97,26 @@ std::string errorAsLogEntry(const Error& error);
 #define LOG_DEBUG_ACTION_NAMED(logSection, action) rstudio::core::log::logDebugAction(logSection, \
                                                                                       action)
 
+#define LOG_TRACE_MESSAGE(message) (rstudio::core::log::isLogLevel(rstudio::core::log::LogLevel::TRACE_LEVEL) ? rstudio::core::log::logTraceMessageReturn(message) : false)
+
+#define LOG_TRACE_MESSAGE_WITH_PROPS(message, props) rstudio::core::log::logTraceMessage(message, \
+                                                                                         std::string(), \
+                                                                                         props, \
+                                                                                         ErrorLocation())
+
+#define LOG_TRACE_MESSAGE_NAMED(logSection, message) rstudio::core::log::logTraceMessage(message, \
+                                                                                         logSection)
+
+#define LOG_TRACE_ACTION_NAMED(logSection, action) rstudio::core::log::logTraceAction(logSection, \
+                                                                                      action)
+
 #define LOG_PASSTHROUGH_MESSAGE(source, message) rstudio::core::log::logPassthroughMessage(source, message)
+
+#define TLOGF(__FMT__, ...)                                                                                            \
+   do {                                                                                                                \
+      std::string message = fmt::format(FMT_STRING(__FMT__), ##__VA_ARGS__);                                           \
+      ::rstudio::core::log::logTraceMessage(message);                                                                  \
+   } while (0)
 
 #define DLOGF(__FMT__, ...)                                                    \
   do {                                                                         \

--- a/src/cpp/shared_core/Logger.cpp
+++ b/src/cpp/shared_core/Logger.cpp
@@ -57,6 +57,8 @@ LogLevel logLevelFromStr(const std::string& in_str)
       return LogLevel::INFO;
    else if (in_str == "OFF")
       return LogLevel::OFF;
+   else if (in_str == "TRACE")
+      return LogLevel::TRACE;
    else
       return LogLevel::DEBUG;
 }
@@ -84,6 +86,10 @@ std::string logLevelName(log::LogLevel in_logLevel)
       case LogLevel::OFF:
       {
          return "OFF";
+      }
+      case LogLevel::TRACE:
+      {
+         return "TRACE";
       }
       default:
       {
@@ -119,6 +125,11 @@ std::ostream& operator<<(std::ostream& io_ostream, LogLevel in_logLevel)
       case LogLevel::INFO:
       {
          io_ostream << "INFO";
+         break;
+      }
+      case LogLevel::TRACE:
+      {
+         io_ostream << "TRACE";
          break;
       }
       case LogLevel::OFF:
@@ -670,6 +681,12 @@ void logErrorAsDebug(const Error& in_error)
       logger().writeMessageToDestinations(LogLevel::DEBUG, std::string(), "", boost::none, ErrorLocation(), in_error);
 }
 
+void logErrorAsTrace(const Error& in_error)
+{
+   if (!in_error.isExpected())
+      logger().writeMessageToDestinations(LogLevel::TRACE, std::string(), "", boost::none, ErrorLocation(), in_error);
+}
+
 void logErrorMessage(const std::string& in_message, const std::string& in_section)
 {
    logErrorMessage(in_message, in_section, boost::none, ErrorLocation());
@@ -740,6 +757,38 @@ void logDebugAction(const boost::function<std::string(boost::optional<LogMessage
                      const std::string& in_section)
 {
    logger().writeMessageToDestinations(LogLevel::DEBUG, in_action, in_section, ErrorLocation());
+}
+
+// Exists for the LOG_TRACE_MESSAGE macro that needs a dummy value here so we can use a ? statement
+// to hide the evaluation of the arguments.
+bool logTraceMessageReturn(const std::string& in_message)
+{
+   logTraceMessage(in_message, std::string());
+   return true;
+}
+
+void logTraceMessage(const std::string& in_message, const std::string& in_section)
+{
+   logTraceMessage(in_message, in_section, boost::none, ErrorLocation());
+}
+
+void logTraceMessage(const std::string& in_message, const ErrorLocation& in_loggedFrom)
+{
+   logTraceMessage(in_message, "", boost::none, in_loggedFrom);
+}
+
+void logTraceMessage(const std::string& in_message,
+                     const std::string& in_section,
+                     const boost::optional<LogMessageProperties>& in_properties,
+                     const ErrorLocation& in_loggedFrom)
+{
+   logger().writeMessageToDestinations(LogLevel::TRACE, in_message, in_section, in_properties, in_loggedFrom);
+}
+
+void logTraceAction(const boost::function<std::string(boost::optional<LogMessageProperties>*)>& in_action,
+                    const std::string& in_section)
+{
+   logger().writeMessageToDestinations(LogLevel::TRACE, in_action, in_section, ErrorLocation());
 }
 
 void logInfoMessage(const std::string& in_message, const std::string& in_section)

--- a/src/cpp/shared_core/include/shared_core/Logger.hpp
+++ b/src/cpp/shared_core/include/shared_core/Logger.hpp
@@ -88,12 +88,13 @@ constexpr char s_delim = ';';
  */
 enum class LogLevel
 {
-   OFF = 0,       // No messages will be logged.
-   ERR = 1,       // Error messages will be logged.
-   WARN = 2,      // Warning and error messages will be logged.
-   INFO = 3,      // Info, warning, and error messages will be logged.
-   DEBUG = 4,     // All messages will be logged.
-   DEBUG_LEVEL = 4// Same as DEBUG. Preferred to avoid name conflict with core/Macros.hpp's DEBUG(..) macro used in rsession
+   OFF = 0,        // No messages will be logged.
+   ERR = 1,        // Error messages will be logged.
+   WARN = 2,       // Warning and error messages will be logged.
+   INFO = 3,       // Info, warning, and error messages will be logged.
+   DEBUG = 4,      // All messages will be logged, except trace messages.
+   DEBUG_LEVEL = 4,// Same as DEBUG. Preferred to avoid name conflict with core/Macros.hpp's DEBUG(..) macro used in rsession
+   TRACE = 5       // All messages will be logged, including trace messages.
 };
 
 /**
@@ -274,6 +275,16 @@ void logErrorAsInfo(const Error& in_error);
 void logErrorAsDebug(const Error& in_error);
 
 /**
+ * @brief Logs an error as a trace message to all registered destinations.
+ *
+ * If no destinations are registered, no log will be written.
+ * If the configured log level is below LogLevel::TRACE, no log will be written.
+ *
+ * @param in_error      The error to log as a trace message.
+ */
+void logErrorAsTrace(const Error& in_error);
+
+/**
  * @brief Logs an error to all registered destinations.
  *
  * If no destinations are registered, no log will be written.
@@ -400,6 +411,59 @@ void logDebugMessage(const std::string& in_message,
  * @param in_section      The section of the log that the message belongs in.
  */
 void logDebugAction(const boost::function<std::string(boost::optional<LogMessageProperties>*)>& in_action,
+                    const std::string& in_section = std::string());
+
+/**
+ * @brief Logs a trace message to all registered destinations.
+ *
+ * If no destinations are registered, no log will be written.
+ * If the configured log level is below LogLevel::TRACE, no log will be written.
+ *
+ * @param in_message      The message to log as a trace message.
+ * @param in_section      The section of the log that the message belongs in. Default: no section.
+ */
+void logTraceMessage(const std::string& in_message, const std::string& in_section = std::string());
+
+/* Like the above but used for macros that need a value return */
+bool logTraceMessageReturn(const std::string& in_message);
+
+/**
+ * @brief Logs a trace message to all registered destinations.
+ *
+ * If no destinations are registered, no log will be written.
+ * If the configured log level is below LogLevel::TRACE, no log will be written.
+ *
+ * @param in_message      The message to log as a trace message.
+ * @param in_location     The location from which the error message was logged.
+ */
+void logTraceMessage(const std::string& in_message, const ErrorLocation& in_loggedFrom);
+
+/**
+ * @brief Logs a trace message to all registered destinations.
+ *
+ * If no destinations are registered, no log will be written.
+ * If the configured log level is below LogLevel::TRACE, no log will be written.
+ *
+ * @param in_message      The message to log as a trace message.
+ * @param in_section      The section of the log that the message belongs in.
+ * @param in_properties   The log message properties to log.
+ * @param in_location     The location from which the message was logged.
+ */
+void logTraceMessage(const std::string& in_message,
+                     const std::string& in_section,
+                     const boost::optional<LogMessageProperties>& in_properties,
+                     const ErrorLocation& in_loggedFrom);
+
+/**
+ * @brief Logs a trace message to all registered destinations by invoking an action.
+ *
+ * If no destinations are registered, no log will be written.
+ * If the configured log level is below LogLevel::TRACE, no log will be written.
+ *
+ * @param in_action       The action that will construct the log message if a logger is configured with trace level.
+ * @param in_section      The section of the log that the message belongs in.
+ */
+void logTraceAction(const boost::function<std::string(boost::optional<LogMessageProperties>*)>& in_action,
                     const std::string& in_section = std::string());
 
 /**


### PR DESCRIPTION
* Add new "trace" log level that's a superset of "debug" level.
* Add appropriate logger methods and macros.


### Intent

To better separate debug messages from messages meant to trace the internal execution of a process, add a new log level "Trace".

### Approach

Approach is straightforward: replicate what we do for debug logging, but call it trace logging. The new `TRACE` level is one above `DEBUG` so that it captures all log messages.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


