### PR TITLE
hide run-automation server option

### DIFF
--- a/src/cpp/server/include/server/ServerOptions.gen.hpp
+++ b/src/cpp/server/include/server/ServerOptions.gen.hpp
@@ -64,7 +64,7 @@ protected:
 
    pAutomation->add_options()
       ("run-automation",
-      value<bool>(&runAutomation_)->default_value(false),
+      value<bool>(&runAutomation_)->default_value(false)->implicit_value(true),
       "Run RStudio's built-in automation tests. Requires a Google Chrome installation.");
 
    pVerify->add_options()

--- a/src/cpp/server/server-options.json
+++ b/src/cpp/server/server-options.json
@@ -25,6 +25,8 @@
             "memberName": "runAutomation_",
             "type": "bool",
             "defaultValue": false,
+            "implicitValue": true,
+            "isHidden": true,
             "description": "Run RStudio's built-in automation tests. Requires a Google Chrome installation."
          }
       ],


### PR DESCRIPTION
So that we don't generate documentation for this option.

Also allow an implicit 'true' value, so that `./rserver-dev --run-automation` works without giving an explicit value.