### PR TITLE
use flag when updating console history from added history entries

### DIFF
--- a/src/cpp/r/include/r/session/RConsoleHistory.hpp
+++ b/src/cpp/r/include/r/session/RConsoleHistory.hpp
@@ -44,7 +44,7 @@ class ConsoleHistory : boost::noncopyable
 public:
    typedef boost::circular_buffer<std::string>::value_type value_type;
    typedef boost::circular_buffer<std::string>::const_iterator const_iterator;
-   typedef RSTUDIO_BOOST_SIGNAL<void (const std::string&)> AddSignal;
+   typedef RSTUDIO_BOOST_SIGNAL<void (const std::string&, bool)> AddSignal;
 
 private:
    ConsoleHistory();
@@ -63,7 +63,7 @@ public:
 
    void setRemoveDuplicates(bool removeDuplicates);
    
-   void add(const std::string& command);
+   void add(const std::string& command, bool update);
    
    const_iterator begin() const { return historyBuffer_.begin(); }
    const_iterator end() const { return historyBuffer_.end(); }

--- a/src/cpp/r/session/RConsoleHistory.cpp
+++ b/src/cpp/r/session/RConsoleHistory.cpp
@@ -65,7 +65,7 @@ void ConsoleHistory::setRemoveDuplicates(bool removeDuplicates)
    removeDuplicates_ = removeDuplicates;
 }
 
-void ConsoleHistory::add(const std::string& command)
+void ConsoleHistory::add(const std::string& command, bool update)
 {
    if (!command.empty())
    {
@@ -92,7 +92,7 @@ void ConsoleHistory::add(const std::string& command)
             historyBuffer_.push_back(line);
          
             // notify listeners
-            onAdd_(line);
+            onAdd_(line, update);
          }
       }
    }

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -370,7 +370,7 @@ int RReadConsole(const char *pmt,
             // created as a result of a shell escape
             consoleActions().add(kConsoleActionInput, consoleInput.text);
             if (addToHistory && !isInjectedBrowserCommand(consoleInput.text))
-               consoleHistory().add(consoleInput.text);
+               consoleHistory().add(consoleInput.text, false);
 
             // call console input hook and interrupt if the hook tells us to
             if (!consoleInputHook(prompt, consoleInput.text))
@@ -636,9 +636,9 @@ void Raddhistory(SEXP call, SEXP op, SEXP args, SEXP env)
       ConsoleHistory& history = consoleHistory();
       std::for_each(commands.begin(), 
                     commands.end(),
-                    boost::bind(&ConsoleHistory::add, &history, _1));
+                    boost::bind(&ConsoleHistory::add, &history, _1, true));
    }
-   catch(r::exec::RErrorException& e)
+   catch (r::exec::RErrorException& e)
    {
       r::exec::errorCall(call, e.message());
    }

--- a/src/cpp/session/modules/SessionHistory.cpp
+++ b/src/cpp/session/modules/SessionHistory.cpp
@@ -262,7 +262,7 @@ Error searchHistory(const json::JsonRpcRequest& request,
 {
    // get the query
    std::string query;
-   int maxEntries;
+   int maxEntries = 0;
    Error error = json::readParams(request.params, &query, &maxEntries);
    if (error)
       return error;
@@ -389,7 +389,7 @@ Error searchHistoryArchiveByPrefix(const json::JsonRpcRequest& request,
    return Success();
 }
 
-void onHistoryAdd(const std::string& command)
+void onHistoryAdd(const std::string& command, bool update)
 {   
    // add command to history archive
    Error error = historyArchive().add(command);
@@ -402,14 +402,18 @@ void onHistoryAdd(const std::string& command)
    entries.push_back(HistoryEntry(entryIndex, 0, command));
    json::Object entriesJson;
    historyEntriesAsJson(entries, &entriesJson);
-   ClientEvent event(client_events::kHistoryEntriesAdded, entriesJson);
+   
+   json::Object eventJson;
+   eventJson["entries"] = entriesJson;
+   eventJson["update"] = update;
+   ClientEvent event(client_events::kHistoryEntriesAdded, eventJson);
    module_context::enqueClientEvent(event);
 }
 
 SEXP rs_timestamp(SEXP stampSEXP)
 {
    std::string stamp = r::sexp::safeAsString(stampSEXP);
-   r::session::consoleHistory().add(stamp);
+   r::session::consoleHistory().add(stamp, true);
    return R_NilValue;
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -23,7 +23,6 @@ import org.rstudio.core.client.events.HighlightEvent;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.files.filedialog.events.OpenFileDialogEvent;
 import org.rstudio.core.client.js.JsObject;
-import org.rstudio.core.client.jsonrpc.RpcObjectList;
 import org.rstudio.studio.client.application.events.ClipboardActionEvent;
 import org.rstudio.studio.client.application.events.ComputeThemeColorsEvent;
 import org.rstudio.studio.client.application.events.DeferredInitCompletedEvent;
@@ -189,7 +188,6 @@ import org.rstudio.studio.client.workbench.views.files.events.FileChangeEvent;
 import org.rstudio.studio.client.workbench.views.files.model.FileChange;
 import org.rstudio.studio.client.workbench.views.help.events.ShowHelpEvent;
 import org.rstudio.studio.client.workbench.views.history.events.HistoryEntriesAddedEvent;
-import org.rstudio.studio.client.workbench.views.history.model.HistoryEntry;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobOutputEvent;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobRefreshEvent;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobUpdatedEvent;
@@ -394,8 +392,8 @@ public class ClientEventDispatcher
          }
          else if (type == ClientEvent.HistoryEntriesAdded)
          {
-            RpcObjectList<HistoryEntry> entries = event.getData();
-            eventBus_.dispatchEvent(new HistoryEntriesAddedEvent(entries));
+            HistoryEntriesAddedEvent.Data data = event.getData();
+            eventBus_.dispatchEvent(new HistoryEntriesAddedEvent(data));
          }
          else if (type == ClientEvent.QuotaStatus)
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -435,8 +435,9 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
 
    private void processCommandEntry(String commandText, boolean echo)
    {
-      if (addToHistory_ && (commandText.length() > 0))
-      eventBus_.fireEvent(new ConsoleHistoryAddedEvent(commandText));
+      // add to console history
+      if (addToHistory_ && commandText.length() > 0)
+         eventBus_.fireEvent(new ConsoleHistoryAddedEvent(commandText));
 
       // fire event
       eventBus_.fireEvent(new ConsoleInputEvent(commandText, "", echo ? 0 : ConsoleInputEvent.FLAG_NO_ECHO));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -792,19 +792,21 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       }
    }
    
-   @Override
-   public void onHistoryEntriesAdded(HistoryEntriesAddedEvent event)
-   {
-      RpcObjectList<HistoryEntry> entries = event.getEntries();
-      for (HistoryEntry entry : entries.toArrayList())
-      {
-         historyManager_.addToHistory(entry.getCommand());
-      }
-   }
-
    private boolean isBrowsePrompt()
    {
       return lastPromptText_ != null && (lastPromptText_.startsWith("Browse"));
+   }
+   
+   public void onHistoryEntriesAdded(HistoryEntriesAddedEvent event)
+   {
+      if (event.update())
+      {
+         RpcObjectList<HistoryEntry> entries = event.getEntries();
+         for (HistoryEntry entry : entries.toArrayList())
+         {
+            historyManager_.addToHistory(entry.getCommand());
+         }
+      }
    }
 
    private void resetHistoryPosition()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/history/events/HistoryEntriesAddedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/history/events/HistoryEntriesAddedEvent.java
@@ -14,34 +14,47 @@
  */
 package org.rstudio.studio.client.workbench.views.history.events;
 
-import com.google.gwt.event.shared.EventHandler;
-import com.google.gwt.event.shared.GwtEvent;
 import org.rstudio.core.client.jsonrpc.RpcObjectList;
 import org.rstudio.studio.client.workbench.views.history.model.HistoryEntry;
 
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
 public class HistoryEntriesAddedEvent extends GwtEvent<HistoryEntriesAddedEvent.Handler>
 {
-   public static final GwtEvent.Type<HistoryEntriesAddedEvent.Handler> TYPE = new GwtEvent.Type<>();
-
-   public interface Handler extends EventHandler
+   public static class Data extends JavaScriptObject
    {
-      void onHistoryEntriesAdded(HistoryEntriesAddedEvent event);
+      protected Data()
+      {
+      }
+      
+      public native final RpcObjectList<HistoryEntry> entries() /*-{ return this["entries"] }-*/;
+      public native final boolean update() /*-{ return this["update"]; }-*/;
    }
-
-   public HistoryEntriesAddedEvent(RpcObjectList<HistoryEntry> entries)
+   
+   public HistoryEntriesAddedEvent(Data data)
    {
-      entries_ = entries;
+      data_ = data;
    }
 
    public RpcObjectList<HistoryEntry> getEntries()
    {
-      return entries_;
+      return data_.entries();
    }
-
-   @Override
-   protected void dispatch(Handler handler)
+   
+   public boolean update()
    {
-      handler.onHistoryEntriesAdded(this);
+      return data_.update();
+   }
+   
+   private final Data data_;
+
+   // Boilerplate ----
+   
+   public interface Handler extends EventHandler
+   {
+      void onHistoryEntriesAdded(HistoryEntriesAddedEvent event);
    }
 
    @Override
@@ -50,5 +63,12 @@ public class HistoryEntriesAddedEvent extends GwtEvent<HistoryEntriesAddedEvent.
       return TYPE;
    }
 
-   private final RpcObjectList<HistoryEntry> entries_;
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onHistoryEntriesAdded(this);
+   }
+
+   public static final GwtEvent.Type<HistoryEntriesAddedEvent.Handler> TYPE = new GwtEvent.Type<>();
+
 }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15345. NEWS not required since this was only ever broken in the development builds.

### Approach

The console history maintained in the RStudio front-end, and the history file `.Rhistory` used by R, are handled differently in a few places. In particular, in a live session, we keep the "complete" submitted command, to allow for multi-line commands in the console history.

This means that things in the console history could be coming from different sources:

1. Added by us, when a command is executed;
2. Added by R, when the "addhistory" C callback is invoked.

This PR tries to ensure that versions of (2) which might also necessitate updating the console history maintained in the front-end do also happen.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15345.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
