### PR TITLE
keep app alive during startup on all platforms not just windows

### DIFF
--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -307,16 +307,16 @@ export class Application implements AppState {
     // provide logging capabiity to renderer and preload
     this.loggerCallback = new LoggerCallback();
 
-    // prevent app from terminating when last window closes during startup; this can cause
-    // app to exit after Choose R dialog closes but before the license dialog shows
+    // Prevent app from terminating when last window closes during startup; this can cause
+    // app to exit after Choose R dialog closes but before the license dialog shows. Also
+    // happens after the Manage License dialog (w/o Choose R being involved) if there is no
+    // splash screen to keep the app alive.
     // https://github.com/rstudio/rstudio-pro/issues/6062
 
     const windowAllClosedHandler = () => {
       // intentionally empty
     };
-    if (process.platform === 'win32') {
-      app.on('window-all-closed', windowAllClosedHandler);
-    }
+    app.on('window-all-closed', windowAllClosedHandler);
 
     // on Windows, ask the user what version of R they'd like to use
     let rPath;
@@ -385,7 +385,7 @@ export class Application implements AppState {
       confPath,
       new FilePath(),
       this.appLaunch,
-      process.platform === 'win32' ? windowAllClosedHandler : null,
+      windowAllClosedHandler,
     );
     this.sessionLauncher.launchFirstSession(installPath, !app.isPackaged);
 


### PR DESCRIPTION
### Intent

The new splash screen is dismissable via keyboard.

On RDP we [show the splash screen on top of the Manage License dialog](https://github.com/rstudio/rstudio-pro/issues/6962) at startup. It has been this way since RDP moved to Electron.

I plan to fix that, but noticed that if you close the splash screen in this scenario, then select a license, the app closes and you have to re-run it to startup. Essentially the same as https://github.com/rstudio/rstudio-pro/issues/6062 except not specific to Windows.

### Approach

Keep app alive during startup even if there are moments with no windows on all platforms, not just Windows.

### Automated Tests

None

### QA Notes

This bug has only been possible for a day (since adding the new splash screen) so don't have an issue for it. A fringe case, currently, but once I fix the issue with showing the splash screen at same time as license dialog, then this will become the normal case so fixing now.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


