### PR TITLE
don't show splash screen before RDP license dialog

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -76,6 +76,7 @@
 - Fixed an issue where some output from `uv` could be rendered blurry in the RStudio Console (#15282)
 - Fixed an issue where the IDE could hang when changing the file type of an R Markdown document (#15313)
 - Fixed the chunk options popup to work in Visual Mode for non-R chunks (#15312)
+- Fixed an issue with the splash screen appearing on top of the Desktop Pro Manage License dialog (rstudio-pro#6962)
 
 
 #### Posit Workbench

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -146,6 +146,7 @@ export class SessionLauncher {
   private nextSessionUrl?: string;
   private splash: BrowserWindow | undefined;
   private showSplash = process.env.NODE_ENV !== 'TEST';
+  private splashDelay: number;
 
   constructor(
     private sessionPath: FilePath,
@@ -154,7 +155,7 @@ export class SessionLauncher {
     private appLaunch: ApplicationLaunch,
     private windowAllClosedHandler: (() => void) | null,
   ) {
-    const splashDelay = process.env.RS_SPLASH_DELAY ? parseInt(process.env.RS_SPLASH_DELAY) : 150;
+    this.splashDelay = process.env.RS_SPLASH_DELAY ? parseInt(process.env.RS_SPLASH_DELAY) : 150;
     if (process.env.RS_NO_SPLASH) {
       this.showSplash = false;
     }
@@ -162,20 +163,6 @@ export class SessionLauncher {
     // don't show splash screen if started using --run-diagnostics
     if (appState().runDiagnostics) {
       this.showSplash = false;
-    }
-
-    // must check showSplash before and after the timeout
-    // before to determine if the timeout is required
-    // after to determine if the main window is ready to show
-    if (splashDelay > 0 && this.showSplash) {
-      setTimeoutPromise(splashDelay)
-        .then(() => {
-          if (this.showSplash) {
-            this.splash = createSplashScreen();
-            this.splash.show();
-          }
-        })
-        .catch((err) => logger().logError(err));
     }
   }
 
@@ -513,6 +500,21 @@ export class SessionLauncher {
   }
 
   private onLaunchFirstSession(): void {
+
+    // must check showSplash before and after the timeout
+    // before to determine if the timeout is required
+    // after to determine if the main window is ready to show
+    if (this.splashDelay > 0 && this.showSplash) {
+      setTimeoutPromise(this.splashDelay)
+        .then(() => {
+          if (this.showSplash) {
+            this.splash = createSplashScreen();
+            this.splash.show();
+          }
+        })
+        .catch((err) => logger().logError(err));
+    }
+
     const error = this.launchFirst();
     if (error) {
       logger().logError(error);


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/6962

(entire fix lives in open-source but only impacts desktop pro)

### Approach

Don't start the timer for splash screen until after we have (potentially) shown the Manage License dialog at startup.

### Automated Tests

None

### QA Notes

To test you'll need a system where the trial period has expired, remove your unexpired license file (if any), and start RStudio Desktop Pro. Shouldn't see the splash screen until after you have entered a license.

Also, confirm you still see the splash screen when starting another session via Session / New Session.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


