### PR TITLE
Handle case where getting proc info on MacOS fails

### DIFF
--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -2465,6 +2465,10 @@ Error getChildProcesses(
       int result = proc_pidinfo(pids[i], PROC_PIDT_SHORTBSDINFO, 0, &procInfo, sizeof(procInfo));
       if (result == -1)
          continue;
+      if (result != sizeof(procInfo)) {
+         // Something went wrong, skip this process (proc_pidinfo should return the size of the struct; anything else is an error)
+         continue;
+      }
       
       ProcessInfo info;
       info.pid = procInfo.pbsi_pid;


### PR DESCRIPTION
* Rarely proc_pidinfo() fails to get process info.
* Need to check for failure so as not to pass invalid data to a recursive call to getChildProcesses.

This issue manifested as unit test failures where we infinitely recursed getting the child processes of PID 0.


### Intent

Address unit test failures on MacOS that initially presented as seg faults. Further investigation revealed the cause to be an infinite recursion while getting information about child processes of a given process.

### Approach

Add an additional check when getting more detailed process info to ensure the operation succeeded. If not do not recurse for the process.

### Automated Tests

Covered by existing unit tests.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


