### PR TITLE
Adjust font used in splash screen

### DIFF
--- a/src/node/desktop/src/ui/splash/splash.html
+++ b/src/node/desktop/src/ui/splash/splash.html
@@ -15,7 +15,7 @@
     <defs>
       <style>
         .cls-1 {
-          font-family: OpenSans-Medium, 'Open Sans';
+          font-family: Arial, Helvetica, sans-serif;
           font-size: 18.7px;
           font-weight: 500;
         }
@@ -34,7 +34,7 @@
         }
 
         .cls-5 {
-          font-family: OpenSans-Regular, 'Open Sans';
+          font-family: Arial, Helvetica, sans-serif;
           font-size: 20px;
           font-variation-settings: 'wght' 400, 'wdth' 100;
         }

--- a/src/node/desktop/src/ui/splash/splash.html
+++ b/src/node/desktop/src/ui/splash/splash.html
@@ -16,7 +16,7 @@
       <style>
         .cls-1 {
           font-family: Arial, Helvetica, sans-serif;
-          font-size: 18.7px;
+          font-size: 18px;
           font-weight: 500;
         }
 
@@ -35,7 +35,7 @@
 
         .cls-5 {
           font-family: Arial, Helvetica, sans-serif;
-          font-size: 20px;
+          font-size: 19px;
           font-variation-settings: 'wght' 400, 'wdth' 100;
         }
 

--- a/src/node/desktop/src/ui/splash/splash_unversioned.html.in
+++ b/src/node/desktop/src/ui/splash/splash_unversioned.html.in
@@ -15,7 +15,7 @@
     <defs>
       <style>
         .cls-1 {
-          font-family: OpenSans-Medium, 'Open Sans';
+          font-family: Arial, Helvetica, sans-serif;
           font-size: 18.7px;
           font-weight: 500;
         }
@@ -34,7 +34,7 @@
         }
 
         .cls-5 {
-          font-family: OpenSans-Regular, 'Open Sans';
+          font-family: Arial, Helvetica, sans-serif;
           font-size: 20px;
           font-variation-settings: 'wght' 400, 'wdth' 100;
         }

--- a/src/node/desktop/src/ui/splash/splash_unversioned.html.in
+++ b/src/node/desktop/src/ui/splash/splash_unversioned.html.in
@@ -16,7 +16,7 @@
       <style>
         .cls-1 {
           font-family: Arial, Helvetica, sans-serif;
-          font-size: 18.7px;
+          font-size: 18px;
           font-weight: 500;
         }
 
@@ -35,7 +35,7 @@
 
         .cls-5 {
           font-family: Arial, Helvetica, sans-serif;
-          font-size: 20px;
+          font-size: 19px;
           font-variation-settings: 'wght' 400, 'wdth' 100;
         }
 


### PR DESCRIPTION
### Intent

Adjustment to #6876

### Approach

The splash screen SVG was using an unavailable font, and a serif font was being substituted.

Changed font specification to `font-family: Arial, Helvetica, sans-serif;` and slightly reduced size. Here's how it looks:

#### macOS

<img width="655" alt="mac-new-font" src="https://github.com/user-attachments/assets/47068bcd-e191-47f8-8984-dd810492a338">

#### Windows-11

![windows-new-font](https://github.com/user-attachments/assets/863f92db-1e07-4009-9127-39aaacf29861)


#### Ubuntu 24

<img width="691" alt="ubuntu-new-font" src="https://github.com/user-attachments/assets/91f49eda-9761-4b95-8fda-12dce319987f">

### Automated Tests

None

### QA Notes

Stare at it for at least 25 minutes.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


