### PR TITLE
tweaks to proc_pidinfo return value handling

### DIFF
--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -669,7 +669,7 @@ Error getOpenFds(pid_t pid, std::vector<uint32_t>* pFds)
 Error getOpenFds(pid_t pid, std::vector<uint32_t> *pFds)
 {
    // get size of the buffer needed to hold the list of fds
-   int bufferSize = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, NULL, 0);
+   int bufferSize = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, nullptr, 0);
    if (bufferSize <= 0)
       return systemError(errno, ERROR_LOCATION);
 


### PR DESCRIPTION
### Intent

Follow up tweaks, inspired by https://github.com/rstudio/rstudio/pull/15361.

### Approach

Check our usages of `proc_pidinfo` and validate we're checking the return value correctly in each case. Much of this was gleaned by looking at usages within the xnu sources at https://github.com/apple-oss-distributions/xnu.

### Automated Tests

Covered by existing automation.

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
