### PR TITLE
Add overlay methods to handle session CRAN repo defaults

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@
 - Posit Workbench Administration Guide & User Guide and Posit Workbench Licenses guide now includes release version in navigation bar reference URLs. (rstudio-pro#6826)
 - Restrict Positron and VS Code sessions for insecure (non-SSL) contexts. These editors do not work properly otherwise. (rstudio-pro#3741)
 - Added support for HTTP Proxy variables in rserver and rsession to enable managed credentials features in Workbench environments behind a proxy server. (rstudio-pro#5893)
+- Set Public Package Manager (P3M) as the default for R libraries in RStudio Pro sessions, if no other repository is specified. Package Manager will deliver pre-built binary packages when available, which are faster to install than source packages and don't require most additional build dependencies. (rstudio-pro#5066)
 
 ### Fixed
 #### RStudio

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -131,6 +131,7 @@ set(SESSION_SOURCE_FILES
    SessionConsoleProcessSocketPacket.cpp
    SessionConsoleProcessTable.cpp
    SessionContentUrls.cpp
+   SessionCRANOverlay.cpp
    SessionDirs.cpp
    SessionRpc.cpp
    SessionHttpMethods.cpp

--- a/src/cpp/session/SessionCRANOverlay.cpp
+++ b/src/cpp/session/SessionCRANOverlay.cpp
@@ -1,0 +1,37 @@
+/*
+ * SessionCRANOverlay.cpp
+ *
+ * Copyright (C) 2024 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "SessionCRANOverlay.hpp"
+
+namespace rstudio {
+namespace session {
+namespace overlay {
+
+static constexpr const char* kDefaultCRANMirror = "https://cran.rstudio.com/";
+
+std::string getDefaultCRANMirror()
+{
+   return kDefaultCRANMirror;
+}
+
+std::string mapCRANMirrorUrl(const std::string& cranMirror)
+{
+   // No mapping required
+   return cranMirror;
+}
+
+} // namespace overlay
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/session/SessionCRANOverlay.hpp
+++ b/src/cpp/session/SessionCRANOverlay.hpp
@@ -1,0 +1,40 @@
+/*
+ * SessionCRANOverlay.hpp
+ *
+ * Copyright (C) 2024 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SESSION_CRAN_OVERLAY
+#define SESSION_CRAN_OVERLAY
+
+#include <string>
+
+namespace rstudio {
+namespace session {
+namespace overlay {
+
+/**
+ * @breif Returns the default CRAN mirror URL. For use when no other mirror is specified.
+ */
+std::string getDefaultCRANMirror();
+
+/**
+ * @brief Determines if the provided cranMirror URL requires further processing, and if so,
+ * returns the processed URL.
+ */
+std::string mapCRANMirrorUrl(const std::string& cranMirror);
+
+} // namespace overlay
+} // namespace session
+} // namespace rstudio
+
+#endif // SESSION_CRAN_OVERLAY

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -121,6 +121,7 @@
 #include "SessionClientEventQueue.hpp"
 #include "SessionClientInit.hpp"
 #include "SessionConsoleInput.hpp"
+#include "SessionCRANOverlay.hpp"
 #include "SessionDirs.hpp"
 #include "SessionHttpMethods.hpp"
 #include "SessionInit.hpp"
@@ -2470,16 +2471,16 @@ int main(int argc, char * const argv[])
       }
       else if (val && layerName == kUserPrefsDefaultLayer)
       {
-         // If we found defaults in the prefs schema, use them.
-         rOptions.rCRANUrl = prefs::userPrefs().getCRANMirror().url;
+         // If we found defaults in the prefs schema, let the overlay determine
+         // if further processing of the default URL is needed
+         rOptions.rCRANUrl = overlay::mapCRANMirrorUrl(prefs::userPrefs().getCRANMirror().url);
          rOptions.rCRANSecondary = prefs::userPrefs().getCRANMirror().secondary;
          source = "preference defaults";
       }
       else
       {
-         // Hard-coded repo of last resort so we don't wind up without a repo setting (users will
-         // not be able to install packages without one)
-         rOptions.rCRANUrl = "https://cran.rstudio.com/";
+         // If all else fails, use the default
+         rOptions.rCRANUrl = overlay::getDefaultCRANMirror();
          source = "hard-coded default";
       }
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2426,7 +2426,7 @@ int main(int argc, char * const argv[])
       // 4. The session's repo settings (in rsession.conf/repos.conf)
       // 5. The server's repo settings
       // 6. The default repo settings from the preferences schema (user-prefs-schema.json)
-      // 7. If all else fails, cran.rstudio.com
+      // 7. If all else fails, fallback to the default in the overlay
       std::string layerName;
       auto val = prefs::userPrefs().readValue(kCranMirror, &layerName);
       if (val && ((options.allowCRANReposEdit() && layerName == kUserPrefsUserLayer) ||
@@ -2471,15 +2471,16 @@ int main(int argc, char * const argv[])
       }
       else if (val && layerName == kUserPrefsDefaultLayer)
       {
-         // If we found defaults in the prefs schema, let the overlay determine
-         // if further processing of the default URL is needed
+         // If we found defaults in the prefs schema, use them but let the overlay
+         // determine if further processing of the default URL is needed
          rOptions.rCRANUrl = overlay::mapCRANMirrorUrl(prefs::userPrefs().getCRANMirror().url);
          rOptions.rCRANSecondary = prefs::userPrefs().getCRANMirror().secondary;
          source = "preference defaults";
       }
       else
       {
-         // If all else fails, use the default
+         // Hard-coded repo of last resort so we don't wind up without a repo setting (users will
+         // not be able to install packages without one)
          rOptions.rCRANUrl = overlay::getDefaultCRANMirror();
          source = "hard-coded default";
       }


### PR DESCRIPTION
### Intent

OS companion to https://github.com/rstudio/rstudio-pro/pull/6973.

We need to handle session CRAN repo default settings a bit differently in the Pro code. This PR attempt to address that by introducing an overlay that will allow Pro to do it's extra processing when required.

Once both these PRs are approved, I will merge this one and sync to Pro, and then handle any conflicts before merging the Pro PR.

### Approach

Adds the new ServerCRANOverlay.cpp and header files, with the open source implementation doing no extra mapping of the user prefs default, and returning the existing default of `https://cran.rstudio.com/` in the fallback scenario.

### Automated Tests

We shouldn't need changes to any existing tests here, as the behaviour should be the same.

### QA Notes

We'll want to make sure that `https://cran.rstudio.com/` is still used as the default. 

### Documentation

N/A, no changes to behaviour

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


