### PR TITLE
revert default use of native file and message dialogs on Linux desktop

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,6 @@
 - RStudio now supports new features from the R graphics engine (groups, glyphs) when supported by the underlying device (#14613)
 - The .Rproj.user folder location can now be customized globally both by users and administrators (#15098)
 - RStudio now supports code formatting using the 'styler' R package, as well via other external applications (#2563)
-- Use native file and message dialogs by default on Linux desktop (#14683; Linux Desktop)
 - Added www-socket option to rserver.conf to enable server to listen on a Unix domain socket (#14938; Open-Source Server)
 - RStudio now supports syntax highlighting for Fortran source files (#10403)
 - Display label "Publish" next to the publish icon on editor toolbar (#13604)

--- a/src/cpp/session/prefs/UserPrefsComputedLayer.cpp
+++ b/src/cpp/session/prefs/UserPrefsComputedLayer.cpp
@@ -86,6 +86,10 @@ Error UserPrefsComputedLayer::readPrefs()
    defaultRVersionJson["label"] = versionSettings.defaultRVersionLabel();
    layer[kDefaultRVersion] = defaultRVersionJson;
 
+   #ifdef __linux__
+   layer[kNativeFileDialogs] = false;
+   #endif
+
    // Synctex viewer ----------------------------------------------------------
 #ifdef __APPLE__
 # define kDefaultDesktopPdfPreviewer kPdfPreviewerRstudio


### PR DESCRIPTION
### Intent

Addresses #15372

### Approach

Undo the change made earlier in the Kousa Dogwood release. The original PR was: https://github.com/rstudio/rstudio/pull/14976

### Automated Tests

NA

### QA Notes

Verify that web-based dialogs are once again the default on Linux desktop.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


