### PR TITLE
remove unnecessary runAsync call

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -92,7 +92,6 @@ import org.rstudio.studio.client.workbench.prefs.model.WebDialogCookie;
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.core.client.RunAsyncCallback;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.FormElement;
@@ -596,27 +595,16 @@ public class Application implements ApplicationEventHandlers
    @Handler
    public void onShowRequestLog()
    {
-      GWT.runAsync(new RunAsyncCallback()
+      final RequestLogVisualization viz = new RequestLogVisualization();
+      final RootLayoutPanel root = RootLayoutPanel.get();
+      root.add(viz);
+      root.setWidgetTopBottom(viz, 10, Unit.PX, 10, Unit.PX);
+      root.setWidgetLeftRight(viz, 10, Unit.PX, 10, Unit.PX);
+      viz.addCloseHandler(new CloseHandler<RequestLogVisualization>()
       {
-         public void onFailure(Throwable reason)
+         public void onClose(CloseEvent<RequestLogVisualization> event)
          {
-            Window.alert(reason.toString());
-         }
-
-         public void onSuccess()
-         {
-            final RequestLogVisualization viz = new RequestLogVisualization();
-            final RootLayoutPanel root = RootLayoutPanel.get();
-            root.add(viz);
-            root.setWidgetTopBottom(viz, 10, Unit.PX, 10, Unit.PX);
-            root.setWidgetLeftRight(viz, 10, Unit.PX, 10, Unit.PX);
-            viz.addCloseHandler(new CloseHandler<RequestLogVisualization>()
-            {
-               public void onClose(CloseEvent<RequestLogVisualization> event)
-               {
-                  root.remove(viz);
-               }
-            });
+            root.remove(viz);
          }
       });
    }


### PR DESCRIPTION
Works around a sporadic GWT miscompilation where `GWT.runAsync()` could fail with JS exceptions like:

> 2024-10-28T21:20:02.457618Z [rserver] ERROR CLIENT EXCEPTION (rsession-kevin): (TypeError) : this.val$callback1_0_g$.onSuccess_150_g$ is not a function;|||rstudio-0.js@27#17290::execute|||rstudio-0.js@40#19468::executeScheduled|||rstudio-0.js@9#19130::runScheduledTasks|||rstudio-0.js@5#19236::flushPostEventPumpCommands|||rstudio-0.js@23#19405::execute|||rstudio-0.js@19#19094::execute|||rstudio-0.js@28#18727::apply|||rstudio-0.js@16#18789::entry0|||rstudio-0.js@14#18767::anonymous|||rstudio-0.js@45#19151::callback_0_g$|||Client-ID: 48315d4a-564a-420b-931e-f30fb68723c7|||User-Agent: Mozilla/5.0 (Macintosh  Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36
