### PR TITLE
include executed chunk code as single multi-line console history entry

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
 - RStudio now includes `.env` files in the fuzzy finder, and also displays these files in the Files pane
 - Quarto documents now have a gear icon for editing cell (chunk) options (#11745)
 - Added "Copy RStudio Version" command to command palette for copying RStudio version, commit, and build date to the clipboard
+- RStudio now provides executed chunk code as a single multi-line entry in the Console history (#3520)
 
 #### Posit Workbench
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -610,10 +610,12 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    
    private void flush(boolean resetPosition)
    {
+      // extract all buffered code
       String code = StringUtil.join(buffer_, "\n");
       buffer_.clear();
-      historyManager_.addToHistory(code);
       
+      // add to history, and reset history position if requested
+      historyManager_.addToHistory(code);
       if (resetPosition)
          historyManager_.resetPosition();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -16,6 +16,7 @@
 package org.rstudio.studio.client.workbench.views.console.shell;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.CommandWithArg;
@@ -38,6 +39,8 @@ import org.rstudio.studio.client.common.debugging.ErrorManager;
 import org.rstudio.studio.client.common.debugging.events.UnhandledErrorEvent;
 import org.rstudio.studio.client.common.dependencies.DependencyManager;
 import org.rstudio.studio.client.common.shell.ShellDisplay;
+import org.rstudio.studio.client.rmarkdown.events.ChunkExecStateChangedEvent;
+import org.rstudio.studio.client.rmarkdown.model.NotebookDocQueue;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
@@ -106,6 +109,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
                               ConsoleResetHistoryEvent.Handler,
                               ConsoleRestartRCompletedEvent.Handler,
                               ConsoleExecutePendingInputEvent.Handler,
+                              ChunkExecStateChangedEvent.Handler,
                               SendToConsoleEvent.Handler,
                               DebugModeChangedEvent.Handler,
                               RunCommandWithDebugEvent.Handler,
@@ -196,6 +200,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       eventBus.addHandler(ConsoleResetHistoryEvent.TYPE, this);
       eventBus.addHandler(ConsoleRestartRCompletedEvent.TYPE, this);
       eventBus.addHandler(ConsoleExecutePendingInputEvent.TYPE, this);
+      eventBus.addHandler(ChunkExecStateChangedEvent.TYPE, this);
       eventBus.addHandler(SendToConsoleEvent.TYPE, this);
       eventBus.addHandler(DebugModeChangedEvent.TYPE, this);
       eventBus.addHandler(RunCommandWithDebugEvent.TYPE, this);
@@ -591,9 +596,49 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    public void onConsoleHistoryAdded(ConsoleHistoryAddedEvent event)
    {
       if (isBrowsePrompt())
+      {
          browseHistoryManager_.addToHistory(event.getCode());
-      else
-         historyManager_.addToHistory(event.getCode());
+         return;
+      }
+      
+      buffer_.add(event.getCode());
+      if (bufferingInput_)
+         return;
+      
+      flush(false);
+   }
+   
+   private void flush(boolean resetPosition)
+   {
+      String code = StringUtil.join(buffer_, "\n");
+      buffer_.clear();
+      historyManager_.addToHistory(code);
+      
+      if (resetPosition)
+         historyManager_.resetPosition();
+   }
+   
+   @Override
+   public void onChunkExecStateChanged(ChunkExecStateChangedEvent event)
+   {
+      switch (event.getExecState())
+      {
+      
+      case NotebookDocQueue.CHUNK_EXEC_STARTED:
+      {
+         bufferingInput_ = true;
+         break;
+      }
+      
+      case NotebookDocQueue.CHUNK_EXEC_FINISHED:
+      case NotebookDocQueue.CHUNK_EXEC_CANCELLED:
+      {
+         bufferingInput_ = false;
+         flush(true);
+         break;
+      }
+      
+      }
    }
 
    private final class InputKeyHandler implements KeyDownHandler,
@@ -908,6 +953,8 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    private static final String GROUP_CONSOLE = "console";
    private static final String STATE_INPUT = "input";
 
+   private List<String> buffer_ = new ArrayList<String>();
+   private boolean bufferingInput_ = false;
    private boolean restoreFocus_ = true;
    private boolean debugging_ = false;
    private static final ConsoleConstants constants_ = GWT.create(ConsoleConstants.class);


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/3520.

### Approach

The changes here are entirely on the front-end, and the idea is:

- When chunk execution begins, we start buffering any console input;
- When chunk execution ends, we collect any received console input, and submit it as a single entry.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/3520. It would be worth checking the sanity of the console history with:

- Execution of a single chunk's contents (via the Run button),
- Execution of a subset of code in a chunk (via Cmd + Enter),
- Execution of all chunks in a document (via Run All or similar)

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
