### PR TITLE
ensure envvars are plumbed when publishing from satellite

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
@@ -815,6 +815,7 @@ public class RSConnect implements SessionInitEvent.Handler,
          JsArrayString deployFiles,
          JsArrayString additionalFiles,
          JsArrayString ignoredFiles,
+         JsArrayString envVars,
          boolean isSelfContained,
          boolean isShiny,
          boolean asMultiple,
@@ -822,11 +823,12 @@ public class RSConnect implements SessionInitEvent.Handler,
          boolean isQuarto,
          boolean launch,
          JavaScriptObject record) /*-{
-      $wnd.opener.deployToRSConnect(sourceFile, deployDir, deployFile,
-                                    websiteDir, description, deployFiles,
-                                    additionalFiles, ignoredFiles, isSelfContained,
-                                    isShiny, asMultiple, asStatic, isQuarto, launch,
-                                    record);
+      $wnd.opener.deployToRSConnect(
+         sourceFile, deployDir, deployFile, websiteDir, description,
+         deployFiles, additionalFiles, ignoredFiles, envVars,
+         isSelfContained, isShiny, asMultiple, asStatic, isQuarto, launch,
+         record
+      );
    }-*/;
 
 
@@ -879,6 +881,8 @@ public class RSConnect implements SessionInitEvent.Handler,
                      result.getSettings().getAdditionalFiles()),
                JsArrayUtil.toJsArrayString(
                      result.getSettings().getIgnoredFiles()),
+               JsArrayUtil.toJsArrayString(
+                     result.getSettings().getEnvVars()),
                result.getSource().isSelfContained(),
                result.getSource().isShiny(),
                result.getSettings().getAsMultiple(),

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSettings.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSettings.java
@@ -59,6 +59,11 @@ public class RSConnectPublishSettings
       return ignoredFiles_;
    }
    
+   public List<String> getEnvVars()
+   {
+      return envVars_;
+   }
+   
    public boolean getAsMultiple()
    {
       return asMultiple_;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15289.

### Approach

We added support for environment variables in publishing, but failed to plumb those through when the deployment was initiated from a satellite window. This PR fixes that.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15289.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

