### PR TITLE
tweak identification of syntactic r identifiers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -78,6 +78,7 @@
 - Fixed an issue where the IDE could hang when changing the file type of an R Markdown document (#15313)
 - Fixed the chunk options popup to work in Visual Mode for non-R chunks (#15312)
 - Fixed an issue with the splash screen appearing on top of the Desktop Pro Manage License dialog (rstudio-pro#6962)
+- Fixed an issue where column names starting with numbers were not properly quoted when inserted as a completion (#13290)
 
 
 #### Posit Workbench

--- a/src/cpp/tests/automation/testthat/test-automation-completions.R
+++ b/src/cpp/tests/automation/testthat/test-automation-completions.R
@@ -224,3 +224,19 @@ test_that("dplyr piped variable names are properly quoted / unquoted", {
    expect_equal(completions, c("zzz A", "zzz B"))
    
 })
+
+# https://github.com/rstudio/rstudio/issues/13290
+test_that("column names are quoted appropriately", {
+   
+   remote$consoleExecuteExpr({
+      data <- list(apple = "apple", "2024" = "2024")
+   })
+   
+   remote$keyboardExecute("data$", "<Tab>")
+   Sys.sleep(1)
+   remote$keyboardExecute("<Down>", "<Enter>", "<Enter>")
+   
+   output <- remote$consoleOutput()
+   expect_equal(tail(output, n = 1L), "[1] \"2024\"")
+   
+})

--- a/src/gwt/src/org/rstudio/core/client/RegexUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/RegexUtil.java
@@ -33,8 +33,7 @@ public class RegexUtil
    {
       String regex =
             "^" +
-            "(?!_+[" + WORD_CHARACTER +"])" +
-            "[" + WORD_CHARACTER + ".]" +
+            "(?![_0-9])" +
             "[" + WORD_CHARACTER +  "._]*" +
             "$";
       


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13290.

### Approach

Tweak the way we detect syntactic identifiers. Roughly speaking, they should not start with `_` or a number, but should consist of 1 or more word characters there-on (including `.` and `_`).

### Automated Tests

Automation included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13290.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
