### PR TITLE
use 'cell' when referring to Quarto docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@
 - Quarto documents now have a gear icon for editing cell (chunk) options (#11745)
 - Added "Copy RStudio Version" command to command palette for copying RStudio version, commit, and build date to the clipboard
 - RStudio now provides executed chunk code as a single multi-line entry in the Console history (#3520)
+- RStudio now refers to code blocks as "cells" instead of "chunks" for Quarto documents (#14596)
 
 #### Posit Workbench
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14596.

<img width="467" alt="Screenshot 2024-10-29 at 11 57 34 AM" src="https://github.com/user-attachments/assets/5dbe036d-ddc4-4a3f-98a1-f3afde25e87c">

### Approach

Dynamically update titles, aria-labels, and text nodes so that "chunk" is replaced with "cell" appropriately in Quarto document buttons and menus.

### Automated Tests

Not included.

### QA Notes

Test that "chunk" is used for R Markdown documents, and "cell" for Quarto documents.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
