### PR TITLE
handle paste requests / attempts outside of console input line

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -81,6 +81,7 @@
 - Fixed the chunk options popup to work in Visual Mode for non-R chunks (#15312)
 - Fixed an issue with the splash screen appearing on top of the Desktop Pro Manage License dialog (rstudio-pro#6962)
 - Fixed an issue where column names starting with numbers were not properly quoted when inserted as a completion (#13290)
+- Fixed an issue where right-clicking on the console history did not present Paste as an option (#14538)
 
 #### Posit Workbench
 

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -53,6 +53,7 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.RepeatingCommand;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.dom.client.SpanElement;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.BlurEvent;
@@ -272,8 +273,11 @@ public class ShellWidget extends Composite implements ShellDisplay,
       };
 
       initWidget(scrollPanel_);
-
+      addDomHandler(secondaryInputHandler, ClickEvent.getType());
+      getElement().setAttribute("contenteditable", "true");
+      
       addCopyHook(getElement());
+      addPasteHook(getElement());
    }
 
    private native void addCopyHook(Element element) /*-{
@@ -287,6 +291,26 @@ public class ShellWidget extends Composite implements ShellDisplay,
          element.addEventListener("cut", clean, true);
       }
    }-*/;
+   
+   private native final void addPasteHook(Element el) /*-{
+   
+      var self = this;
+      
+      el.addEventListener("paste", function(event) {
+         var text = event.clipboardData.getData("text/plain");
+         self.@org.rstudio.studio.client.common.shell.ShellWidget::onPaste(*)(event, text);
+      }, true);
+   
+   }-*/;
+   
+   private void onPaste(NativeEvent event, String text)
+   {
+      event.stopPropagation();
+      event.preventDefault();
+      
+      input_.focus();
+      input_.insertCode(text);
+   }
 
 
    public void scrollToBottom()

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -274,7 +274,6 @@ public class ShellWidget extends Composite implements ShellDisplay,
 
       initWidget(scrollPanel_);
       addDomHandler(secondaryInputHandler, ClickEvent.getType());
-      getElement().setAttribute("contenteditable", "true");
       
       addCopyHook(getElement());
       addPasteHook(getElement());
@@ -296,6 +295,14 @@ public class ShellWidget extends Composite implements ShellDisplay,
    
       var self = this;
       
+      // when showing a context menu, make the content briefly editable so that
+      // paste is enabled as an option
+      el.addEventListener("contextmenu", function(event) {
+         el.setAttribute("contenteditable", "true");
+         setTimeout(function() { el.setAttribute("contenteditable", "false"); }, 0);
+      }, true);
+      
+      // implement a paste handler that routes pastes into the console input
       el.addEventListener("paste", function(event) {
          var text = event.clipboardData.getData("text/plain");
          self.@org.rstudio.studio.client.common.shell.ShellWidget::onPaste(*)(event, text);


### PR DESCRIPTION
### Intent

Addresses #14538.

### Approach

- Mark the whole container of console inputs + outputs as 'contenteditable', so that the right click context menu includes "Paste" as an option.

- Implement a paste handler that drives paste attempts to the Console.

I am a bit worried about potential side effects of marking the whole element as 'contenteditable' here, but I'm hoping they're limited since we're doing this only briefly.

One downside is that "cut" is also erroneously set as enabled in this scenario, but the pro's of having paste work as the user expects probably outweighs the con's.

### Automated Tests

N/A

### QA Notes

Test via notes in #14538.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

