### PR TITLE
allow snippets in function calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@
 - Added "Copy RStudio Version" command to command palette for copying RStudio version, commit, and build date to the clipboard
 - RStudio User Guide and RStudio & Posit Workbench Release Notes now include versioned URLs in the Guides drop-down menu in the navigation bar(rstudio-pro#6151)
 - RStudio now provides executed chunk code as a single multi-line entry in the Console history (#3520)
+- RStudio now provides snippet completions within function calls and subset calls (#13441)
 
 #### Posit Workbench
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -286,7 +286,7 @@ public class CompletionRequester
 
    }
 
-   private static final Pattern RE_EXTRACTION = Pattern.create("[$@:\\[\\(=]", "");
+   private static final Pattern RE_EXTRACTION = Pattern.create("[$@:]", "");
    private boolean isTopLevelCompletionRequest()
    {
       String line = docDisplay_.getCurrentLineUpToCursor();
@@ -408,9 +408,7 @@ public class CompletionRequester
                }
             }
          
-            // Get snippet completions. Bail if this isn't a top-level
-            // completion -- TODO is to add some more context that allows us
-            // to properly ascertain this.
+            // Get snippet completions. Bail if this isn't a top-level completion
             if (isTopLevelCompletionRequest())
             {
                // disable snippets if Python REPL is active for now
@@ -420,7 +418,12 @@ public class CompletionRequester
 
                if (!noSnippets)
                {
-                  addSnippetCompletions(token, newComp);
+                  // de-emphasize snippet completions in function calls
+                  String line = docDisplay_.getCurrentLineUpToCursor();
+                  Pattern pattern = Pattern.create("[\\(\\[]", "");
+                  boolean back = pattern.test(line);
+                     
+                  addSnippetCompletions(token, back, newComp);
                }
             }
 
@@ -622,6 +625,7 @@ public class CompletionRequester
 
    private void addSnippetCompletions(
          String token,
+         boolean back,
          ArrayList<QualifiedName> completions)
    {
       if (StringUtil.isNullOrEmpty(token))
@@ -632,8 +636,19 @@ public class CompletionRequester
          ArrayList<String> snippets = snippets_.getAvailableSnippets();
          String tokenLower = token.toLowerCase();
          for (String snippet : snippets)
+         {
             if (snippet.toLowerCase().startsWith(tokenLower))
-               completions.add(0, QualifiedName.createSnippet(snippet));
+            {
+               if (back)
+               {
+                  completions.add(QualifiedName.createSnippet(snippet));
+               }
+               else
+               {
+                  completions.add(0, QualifiedName.createSnippet(snippet));
+               }
+            }
+         }
       }
    }
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13441.

### Approach

Tweak the regular expression used to decide whether snippet completions are appropriate in the current context.

De-emphasize snippet completions in function + subset contexts, but still make them available.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13441.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

