### PR TITLE
paste workarounds from Windows

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/JavaScriptEventHistory.java
+++ b/src/gwt/src/org/rstudio/studio/client/JavaScriptEventHistory.java
@@ -76,7 +76,7 @@ public class JavaScriptEventHistory
       
       // define our handler (we can just use a single one)
       var handler = $entry(function(event) {
-         self.@org.rstudio.studio.client.JavaScriptEventHistory::onEvent(Lcom/google/gwt/dom/client/NativeEvent;)(event);
+         self.@org.rstudio.studio.client.JavaScriptEventHistory::onEvent(*)(event);
       });
       
       // define the events that we want to listen to

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -318,6 +318,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
             var text = event.clipboardData.getData("text/plain");
             self.@org.rstudio.studio.client.common.shell.ShellWidget::onPaste(*)(event, text);
          }
+         eventTarget = null;
       }, true);
    
    }-*/;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14538.

### Approach

The 'paste' event generated after clicking Paste in the context menu seems to have an unexpected event target;

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14538.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

