### PR TITLE
Update release notes for 2024.09.1+394.pro7

### DIFF
--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -21,26 +21,26 @@ This page provides the release notes associated with each release of RStudio and
 
 #### Posit Workbench
 
-- Add support for conditional regex replacement strings in proxied auth (rstudio-pro#6753)
+- Add support for conditional regex replacement strings in proxied auth. (rstudio-pro#6753)
 
 ### Fixed
 
 #### RStudio
 
-- Fixed an issue where the R session could crash on connect while generating console output (#15330)
-- Fixed Visual Editor losing raw HTML code blocks (#15189)
-- Fixed Visual Editor losing raw LaTeX code blocks (#15253)
-- Fixed opening and saving files on UNC paths (Windows Desktop, #15280)
-- Fixed package builds failing when set to generate documents on build (#15236)
+- Fixed an issue where the R session could crash on connect while generating console output. (#15330)
+- Fixed Visual Editor losing raw HTML code blocks. (#15189)
+- Fixed Visual Editor losing raw LaTeX code blocks. (#15253)
+- Fixed opening and saving files on UNC paths. (Windows Desktop, #15280)
+- Fixed package builds failing when set to generate documents on build. (#15236)
 
 #### Posit Workbench
 
-- Fixed OAuth failure for Snowflake roles that must be double-quoted (rstudio-pro#6881)
-- Fixed a bug in the Homepage launcher UI where limits and constraints could be copied to the Local cluster launch spec from a different cluster resulting in a launch failure (rstudio-pro#6913)
+- Fixed OAuth failure for Snowflake roles that must be double-quoted. (rstudio-pro#6881)
+- Fixed a bug in the Homepage launcher UI where limits and constraints could be copied to the Local cluster launch spec from a different cluster resulting in a launch failure. (rstudio-pro#6913)
 
 ### Deprecated / Removed
 
-- Removed msys-ssh client from Windows Desktop install and stopped setting RSTUDIO_MSYS_SSH environment variable (rstudio-pro#6880)
+- Removed msys-ssh client from Windows Desktop install and stopped setting RSTUDIO_MSYS_SSH environment variable. (rstudio-pro#6880)
 
 ### Dependencies
 

--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -38,12 +38,6 @@ This page provides the release notes associated with each release of RStudio and
 - Fixed OAuth failure for Snowflake roles that must be double-quoted (rstudio-pro#6881)
 - Fixed a bug in the Homepage launcher UI where limits and constraints could be copied to the Local cluster launch spec from a different cluster resulting in a launch failure (rstudio-pro#6913)
 
-### Upgrade Instructions
-
-#### Posit Workbench
-
-If upgrading from Workbench 2024.04.x with automatic user provisioning enabled, to fix a performance and reliability issue, the `server-address` setting in `workbench-nss.conf` should be updated to `unix:/var/run/rstudio-server/rstudio-rserver/user-service.socket`. See [User Provisioning Configuration](https://docs.posit.co/ide/server-pro/user_provisioning/configuration.html) in the Workbench Admin Guide for more information. (rstudio-pro#6591)
-
 ### Deprecated / Removed
 
 - Removed msys-ssh client from Windows Desktop install and stopped setting RSTUDIO_MSYS_SSH environment variable (rstudio-pro#6880)

--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -36,7 +36,6 @@ This page provides the release notes associated with each release of RStudio and
 #### Posit Workbench
 
 - Fixed OAuth failure for Snowflake roles that must be double-quoted (rstudio-pro#6881)
-- Fixed a bug where no supplied default images from config would result in no image passed to launcher, but the UI would show an image as if it was selected (rstudio-pro#6910)
 - Fixed a bug in the Homepage launcher UI where limits and constraints could be copied to the Local cluster launch spec from a different cluster resulting in a launch failure (rstudio-pro#6913)
 
 ### Upgrade Instructions

--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -9,6 +9,48 @@ format:
 
 This page provides the release notes associated with each release of RStudio and Posit Workbench. Please contact customer support (<a href="mailto:support@posit.co">support@posit.co</a>) for questions about the described changes.
 
+## RStudio 2024.09.1
+
+**"Cranberry Hibiscus"**
+
+>Date: 2024-11-04
+
+### New
+
+#### RStudio
+
+#### Posit Workbench
+
+- Add support for conditional regex replacement strings in proxied auth (rstudio-pro#6753)
+
+### Fixed
+
+#### RStudio
+
+- Fixed an issue where the R session could crash on connect while generating console output (#15330)
+- Fixed Visual Editor losing raw HTML code blocks (#15189)
+- Fixed Visual Editor losing raw LaTeX code blocks (#15253)
+- Fixed opening and saving files on UNC paths (Windows Desktop, #15280)
+- Fixed package builds failing when set to generate documents on build (#15236)
+
+#### Posit Workbench
+
+- Fixed OAuth failure for Snowflake roles that must be double-quoted (rstudio-pro#6881)
+- Fixed a bug where no supplied default images from config would result in no image passed to launcher, but the UI would show an image as if it was selected (rstudio-pro#6910)
+- Fixed a bug in the Homepage launcher UI where limits and constraints could be copied to the Local cluster launch spec from a different cluster resulting in a launch failure (rstudio-pro#6913)
+
+### Upgrade Instructions
+
+#### Posit Workbench
+
+If upgrading from Workbench 2024.04.x with automatic user provisioning enabled, to fix a performance and reliability issue, the `server-address` setting in `workbench-nss.conf` should be updated to `unix:/var/run/rstudio-server/rstudio-rserver/user-service.socket`. See [User Provisioning Configuration](https://docs.posit.co/ide/server-pro/user_provisioning/configuration.html) in the Workbench Admin Guide for more information. (rstudio-pro#6591)
+
+### Deprecated / Removed
+
+- Removed msys-ssh client from Windows Desktop install and stopped setting RSTUDIO_MSYS_SSH environment variable (rstudio-pro#6880)
+
+### Dependencies
+
 ## RStudio 2024.09.0
 
 **"Cranberry Hibiscus"**

--- a/version/news/NEWS-2024.09.1-cranberry-hibiscus.md
+++ b/version/news/NEWS-2024.09.1-cranberry-hibiscus.md
@@ -21,7 +21,6 @@
 #### Posit Workbench
 
 - Fixed OAuth failure for Snowflake roles that must be double-quoted (rstudio-pro#6881)
-- Fixed a bug where no supplied default images from config would result in no image passed to launcher, but the UI would show an image as if it was selected (rstudio-pro#6910)
 - Fixed a bug in the Homepage launcher UI where limits and constraints could be copied to the Local cluster launch spec from a different cluster resulting in a launch failure (rstudio-pro#6913)
 
 ### Upgrade Instructions

--- a/version/news/NEWS-2024.09.1-cranberry-hibiscus.md
+++ b/version/news/NEWS-2024.09.1-cranberry-hibiscus.md
@@ -23,12 +23,6 @@
 - Fixed OAuth failure for Snowflake roles that must be double-quoted (rstudio-pro#6881)
 - Fixed a bug in the Homepage launcher UI where limits and constraints could be copied to the Local cluster launch spec from a different cluster resulting in a launch failure (rstudio-pro#6913)
 
-### Upgrade Instructions
-
-#### Posit Workbench
-
-If upgrading from Workbench 2024.04.x with automatic user provisioning enabled, to fix a performance and reliability issue, the `server-address` setting in `workbench-nss.conf` should be updated to `unix:/var/run/rstudio-server/rstudio-rserver/user-service.socket`. See [User Provisioning Configuration](https://docs.posit.co/ide/server-pro/user_provisioning/configuration.html) in the Workbench Admin Guide for more information. (rstudio-pro#6591)
-
 ### Deprecated / Removed
 
 - Removed msys-ssh client from Windows Desktop install and stopped setting RSTUDIO_MSYS_SSH environment variable (rstudio-pro#6880)


### PR DESCRIPTION

Update release notes for IDE / Workbench 2024.09.1+394.pro7 release.

:warning: **Before converting from Draft PR:** :warning:

This change has been generated by the release script. Content is generated based on `version/news/NEWS-2024.09.1-cranberry-hibiscus.md`. If this file was not in sync with Pro or did not include items from other sources (i.e. the vscode extension), then some items may be missing.  Please verify content/formatting is correct and make changes if necessary.
