### PR TITLE
use lobstr for object size when available

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@
 - RStudio now provides executed chunk code as a single multi-line entry in the Console history (#3520)
 - RStudio now provides snippet completions within function calls and subset calls (#13441)
 - RStudio now supports zooming the IDE via Meta + NumpadAdd and Meta + NumpadSubtract (#12242)
+- RStudio now uses `lobstr::obj_size()` when computing object sizes for display in the Environment pane (#15369)
 
 #### Posit Workbench
 

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -711,7 +711,7 @@
 
       # some objects (e.g. ALTREP) have compact representations that are forced to materialize if
       # an attempt is made to compute their metrics exactly; avoid computing the size for these
-      size <- if (computeSize) object.size(obj) else 0
+      size <- if (computeSize) .rs.objectSize(obj) else 0
       len <- length(obj)
    }
 
@@ -1009,4 +1009,12 @@
 
    # Assume that other kinds of objects can be restored.
    TRUE
+})
+
+.rs.addFunction("objectSize", function(x)
+{
+   if ("lobstr" %in% loadedNamespaces())
+      lobstr::obj_size(x)
+   else
+      utils::object.size(x)
 })

--- a/src/cpp/session/modules/SessionObjectExplorer.R
+++ b/src/cpp/session/modules/SessionObjectExplorer.R
@@ -1198,7 +1198,7 @@
 
 .rs.addFunction("explorer.objectSize", function(object)
 {
-   format(object.size(object), units = "auto")
+   format(.rs.objectSize(object), units = "auto")
 })
 
 .rs.addFunction("explorer.isPythonObjectExpandable", function(object)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15369.

### Approach

Use `lobstr::obj_size()` if available; and `utils::object.size()` if not, when computing the size of an R object.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15369.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
