### PR TITLE
use fc-list when querying fonts on Linux

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -111,13 +111,21 @@ export class GwtCallback extends EventEmitter {
 
       const result = execSync(command, { encoding: 'utf-8' });
       return result.trim().split('\n');
+
     } else {
+      
       const result = findFontsSync({ monospace: monospace }).map((fd) => {
-        return process.platform === 'darwin' ? fd.postscriptName : fd.family;
+        if (process.platform === 'darwin') {
+          return monospace ? fd.postscriptName : fd.family;
+        } else {
+          return fd.family;
+        }
       });
+      
       const fontList = [...new Set<string>(result)];
       fontList.sort((lhs, rhs) => { return lhs.localeCompare(rhs); });
       return fontList;
+      
     }
   
   }

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -101,9 +101,16 @@ export class GwtCallback extends EventEmitter {
   getFonts(monospace: boolean) {
 
     if (this.hasFontConfig) {
-      const spacing = monospace ? 'mono' : 'proportional';
-      const result = execSync(`fc-list :spacing=${spacing} family`, { encoding: 'utf-8' });
-      return result.split('\n');
+      
+      let command: string = '';
+      if (monospace) {
+        command = 'fc-list :spacing=mono family | sort';
+      } else {
+        command = 'fc-list :lang=en family | grep -i sans | grep -iv mono | sort';
+      }
+
+      const result = execSync(command, { encoding: 'utf-8' });
+      return result.trim().split('\n');
     } else {
       const result = findFontsSync({ monospace: monospace }).map((fd) => {
         return process.platform === 'darwin' ? fd.postscriptName : fd.family;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15396.

### Approach

The node native module we use for querying fonts appears to be buggy on Linux. Avoid using it there when possible.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15396.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
