### PR TITLE
make sure project IDs are not lost when writing project options

### DIFF
--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -1024,6 +1024,16 @@ Error readProjectFile(const FilePath& projectFilePath,
    {
       pConfig->projectName = it->second;
    }
+   
+   it = dcfFields.find("ProjectId");
+   if (it != dcfFields.end())
+   {
+      pConfig->projectId = it->second;
+   }
+   else
+   {
+      pConfig->projectId = defaultConfig.projectId;
+   }
 
    return Success();
 }

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -798,7 +798,10 @@ Error writeProjectConfig(const json::Object& configJson)
                             "project_name", config.projectName);
    if (error)
       return error;
-  
+   
+   // project id
+   config.projectId = existingConfig.projectId;
+   
    // write the config
    error = r_util::writeProjectFile(s_projectContext.file(),
                                     ProjectContext::buildDefaults(),


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15405.

### Approach

Make sure we bring along a previously-existing project ID when writing project options.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15405.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
