### PR TITLE
use CF APIs when checking alnum characters

### DIFF
--- a/src/cpp/core/r_util/RTokenizer.cpp
+++ b/src/cpp/core/r_util/RTokenizer.cpp
@@ -27,6 +27,10 @@
 // correctly in the presence of the assertion (with the annoying side effect
 // of logging an assertion every time the product starts up)
 
+#ifdef __APPLE__
+# include <CoreFoundation/CoreFoundation.h>
+#endif
+
 #include <core/r_util/RTokenizer.hpp>
 
 #include <boost/regex.hpp>
@@ -35,9 +39,9 @@
 #include <sstream>
 
 #include <shared_core/Error.hpp>
+
 #include <core/Log.hpp>
 #include <core/StringUtils.hpp>
-
 
 namespace rstudio {
 namespace core {
@@ -100,6 +104,39 @@ Error tokenizeError(const std::string& reason, const ErrorLocation& location)
    Error error(boost::system::errc::invalid_argument, location);
    error.addProperty("reason", reason);
    return error;
+}
+
+// on macOS, std::iswalnum() and other variants don't seem to handle certain
+// unicode character categories?
+//
+// https://github.com/rstudio/rstudio/issues/15316
+bool isAlphanumeric(wchar_t ch)
+{
+#ifdef __APPLE__
+   
+   // if this appears to be an ASCII value, then use the standard library;
+   // otherwise, use CF APIs
+   if (ch < static_cast<wchar_t>(128))
+   {
+      return iswalnum(ch);
+   }
+   else
+   {
+      CFStringRef string = CFStringCreateWithBytes(
+               kCFAllocatorDefault,
+               (const UInt8*) &ch,
+               sizeof (wchar_t),
+               kCFStringEncodingUTF32LE,
+               false);
+
+      CFCharacterSetRef set = CFCharacterSetGetPredefined(kCFCharacterSetAlphaNumeric);
+      CFRange range = CFRangeMake(0, CFStringGetLength(string));
+      return CFStringFindCharacterFromSet(string, set, range, 0, NULL);
+   }
+   
+#else
+   return iswalnum(ch);
+#endif
 }
 
 } // anonymous namespace
@@ -213,7 +250,7 @@ RToken RTokenizer::nextToken()
         return numberToken;
   }
 
-  if (iswalnum(c) || c == L'.')
+  if (isAlphanumeric(c) || c == L'.')
   {
      // From Section 10.3.2, identifiers must not start with
      // a digit, nor may they start with a period followed by
@@ -418,7 +455,7 @@ RToken RTokenizer::matchIdentifier()
       eat();
     
       wchar_t ch = peek();
-      match = iswalnum(ch) || ch == L'.' || ch == L'_';
+      match = isAlphanumeric(ch) || ch == L'.' || ch == L'_';
    }
    
    std::size_t row = row_;

--- a/src/cpp/core/r_util/RTokenizer.cpp
+++ b/src/cpp/core/r_util/RTokenizer.cpp
@@ -115,7 +115,7 @@ bool isAlphanumeric(wchar_t ch)
 #ifdef __APPLE__
    
    // if this appears to be an ASCII value, then use the standard library;
-   // otherwise, use CF APIs
+   // otherwise, use core foundation
    if (ch < static_cast<wchar_t>(128))
    {
       return iswalnum(ch);
@@ -131,7 +131,9 @@ bool isAlphanumeric(wchar_t ch)
 
       CFCharacterSetRef set = CFCharacterSetGetPredefined(kCFCharacterSetAlphaNumeric);
       CFRange range = CFRangeMake(0, CFStringGetLength(string));
-      return CFStringFindCharacterFromSet(string, set, range, 0, NULL);
+      bool result = CFStringFindCharacterFromSet(string, set, range, 0, NULL);
+      CFRelease(string);
+      return result;
    }
    
 #else

--- a/src/cpp/core/r_util/RTokenizerTests.cpp
+++ b/src/cpp/core/r_util/RTokenizerTests.cpp
@@ -330,6 +330,17 @@ test_context("RTokenizer")
       expect_true(rTokens.size() == 1);
    }
    
+   test_that("unicode letters are identified properly")
+   {
+      RTokens rTokens(L"区 <- 42");
+      expect_true(rTokens.size() == 5);
+      expect_true(rTokens.at(0).isType(RToken::ID));
+      expect_true(rTokens.at(1).isType(RToken::WHITESPACE));
+      expect_true(rTokens.at(2).isType(RToken::OPER));
+      expect_true(rTokens.at(3).isType(RToken::WHITESPACE));
+      expect_true(rTokens.at(4).isType(RToken::NUMBER));
+   }
+   
 }
 
 } // namespace r_util


### PR DESCRIPTION
NOTE: We can probably hold this for next release.

### Intent

Addresses https://github.com/rstudio/rstudio/issues/15316.

### Approach

The `std::isw*` functions on macOS don't appear to work as expected. Fall back to the Core Foundation APIs, which apparently do.

### Automated Tests

Unit tests included.

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

