### PR TITLE
fixes to BRAT debugger automation

### DIFF
--- a/src/cpp/tests/automation/testthat/test-automation-debugger.R
+++ b/src/cpp/tests/automation/testthat/test-automation-debugger.R
@@ -18,7 +18,6 @@ test_that("the debug position is correct in braced expressions", {
    ')
    
    remote$documentOpen(".R", contents)
-   on.exit(remote$documentClose(), add = TRUE)
    
    # Click to set a breakpoint.
    gutterLayer <- remote$jsObjectViaSelector(".ace_gutter-layer")
@@ -89,6 +88,11 @@ test_that("package functions can be debugged after build and reload", {
       grepl("rstudio.automation", el$innerText, fixed = TRUE)
    })
    
+   # Close any open documents
+   remote$consoleExecuteExpr(
+      .rs.api.closeAllSourceBuffersWithoutSaving()
+   )
+   
    # Add a source document.
    remote$consoleExecuteExpr(file.edit("R/example.R"))
    remote$commandExecute("activateSource")
@@ -156,4 +160,11 @@ test_that("package functions can be debugged after build and reload", {
    Sys.sleep(1)
    remote$commandExecute("closeProject")
    
+   # Wait until the project has closed
+   .rs.waitFor("the project is closed", function()
+   {
+      el <- remote$jsObjectViaSelector("#rstudio_project_menubutton_toolbar")
+      grepl("Project: ", el$innerText, fixed = TRUE)
+   })
+    
 })


### PR DESCRIPTION
### Intent

These tests have been failing 100% of the time for me for a while, including a VERY long timeout making it painful to run all the automation.

### Approach

- Removed `on.exit(remote$documentClose(), add = TRUE)` from the first test; if I leave this in I get the following error

```
✔ | F W  S  OK | Context
✖ | 1        2 | automation-debugger [13.0s]                                    
───────────────────────────────────────────────────────────────────────────────────────
Error (test-automation-debugger.R:9:1): (code run outside of `test_that()`)
Error: invalid state
Backtrace:
    ▆
 1. └─remote$documentClose() at test-automation-debugger.R:9:1
 2.   └─self$consoleExecute("invisible(.rs.api.documentClose())") at modules/R/SessionAutomationRemote.R:207:4
 3.     └─self$client$DOM.getDocument() at modules/R/SessionAutomationRemote.R:137:4
 4.       └─.rs.automation.sendSynchronousRequest(...) at modules/R/SessionAutomationClient.R:212:5
 5.         └─.rs.automation.sendRequest(socket, method, params, callback) at modules/R/SessionAutomation.R:172:4
 6.           └─socket$send(json) at modules/R/SessionAutomation.R:151:4
 7.             └─websocket:::wsSend(private$wsObj, msg)
───────────────────────────────────────────────────────────────────────────────────────- 
```

- Close all documents after opening project; without that the test hangs until a timeout because there is a second document open and this confuses the attempt to act on an element

- Wait for project to close at end of test, otherwise I get an error very much like the first one above

### Automated Tests

Yes. Yes they are.

### QA Notes

NA

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


