### PR TITLE
use '.rs.test' for automation test cases

### DIFF
--- a/src/cpp/session/modules/automation/SessionAutomationRemote.R
+++ b/src/cpp/session/modules/automation/SessionAutomationRemote.R
@@ -26,7 +26,7 @@
 .rs.defineVar("automation.remote", new.env(parent = emptyenv()))
 .rs.defineVar("automation.remoteInstance", NULL)
 
-.rs.addFunction("automation.runTest", function(desc, code)
+.rs.addFunction("test", function(desc, code)
 {
    # Check test markers.
    currentMarkers <- .rs.getVar("automation.currentMarkers")
@@ -60,11 +60,6 @@
    assign("self", .rs.automation.remote, envir = .rs.automation.remotePrivateEnv)
    .rs.setVar("automation.remoteInstance", .rs.automation.remote)
    remote <- .rs.automation.remoteInstance
-   
-   # Load testthat, and provide a 'test_that' override which automatically cleans
-   # up various state when a test is run.
-   library(testthat)
-   assign("test_that", .rs.automation.runTest, envir = globalenv())
    
    # Return the remote instance.
    remote

--- a/src/cpp/tests/automation/testthat/test-automation-build-pane.R
+++ b/src/cpp/tests/automation/testthat/test-automation-build-pane.R
@@ -5,7 +5,7 @@ self <- remote <- .rs.automation.newRemote()
 withr::defer(.rs.automation.deleteRemote())
 
 
-test_that("we can test a file in the build pane", {
+.rs.test("we can test a file in the build pane", {
    
    # Create a project.
    remote$projectCreate(type = "package")

--- a/src/cpp/tests/automation/testthat/test-automation-completions.R
+++ b/src/cpp/tests/automation/testthat/test-automation-completions.R
@@ -6,7 +6,7 @@ withr::defer(.rs.automation.deleteRemote())
 
 
 # https://github.com/rstudio/rstudio/issues/14784
-test_that("autocompletion doesn't trigger active bindings", {
+.rs.test("autocompletion doesn't trigger active bindings", {
    
    code <- .rs.heredoc('
       Test <- R6::R6Class("Test",
@@ -29,7 +29,7 @@ test_that("autocompletion doesn't trigger active bindings", {
    
 })
 
-test_that("autocompletion in console produces the expected completion list for new variables", {
+.rs.test("autocompletion in console produces the expected completion list for new variables", {
    
    remote$consoleExecute('
       foobar <- 42
@@ -42,7 +42,7 @@ test_that("autocompletion in console produces the expected completion list for n
 })
 
 # https://github.com/rstudio/rstudio/issues/13196
-test_that("autocompletion in console produces the expected completion list in an existing base function", {
+.rs.test("autocompletion in console produces the expected completion list in an existing base function", {
    
    completions <- remote$completionsRequest("cat(")
    expect_equal(completions, c("... =", "file =", "sep =", "fill =", "labels =", "append ="))
@@ -50,7 +50,7 @@ test_that("autocompletion in console produces the expected completion list in an
 })
 
 # https://github.com/rstudio/rstudio/issues/13196
-test_that("autocompletion in console produces the expected completion list in an existing non-base function", {
+.rs.test("autocompletion in console produces the expected completion list in an existing non-base function", {
    
    completions <- remote$completionsRequest("stats::rnorm(")
    expect_equal(completions, c("n =", "mean =", "sd ="))
@@ -58,7 +58,7 @@ test_that("autocompletion in console produces the expected completion list in an
 })
 
 # https://github.com/rstudio/rstudio/issues/13196
-test_that("autocompletion in console produces the expected completion list when using a new function", {
+.rs.test("autocompletion in console produces the expected completion list when using a new function", {
    
    # Define a function accepting some parameters.
    remote$keyboardExecute("a <- function(x, y, z) { print(x + y) }", "<Enter>")
@@ -70,7 +70,7 @@ test_that("autocompletion in console produces the expected completion list when 
 })
 
 # https://github.com/rstudio/rstudio/issues/13291
-test_that("list names are provided as completions following '$'", {
+.rs.test("list names are provided as completions following '$'", {
    
    code <- .rs.heredoc('
       test_df <- data.frame(
@@ -93,7 +93,7 @@ test_that("list names are provided as completions following '$'", {
 })
 
 # https://github.com/rstudio/rstudio/issues/12678
-test_that("autocompletion in console shows local variables first.", {
+.rs.test("autocompletion in console shows local variables first.", {
    
    code <- .rs.heredoc('
       library(dplyr)
@@ -108,7 +108,7 @@ test_that("autocompletion in console shows local variables first.", {
 })
 
 # https://github.com/rstudio/rstudio/issues/13611
-test_that("autocompletions within piped expressions work at start of document", {
+.rs.test("autocompletions within piped expressions work at start of document", {
    
    code <- .rs.heredoc('
       
@@ -125,7 +125,7 @@ test_that("autocompletions within piped expressions work at start of document", 
 })
 
 # https://github.com/rstudio/rstudio/issues/15115
-test_that(".DollarNames completions still produce types", {
+.rs.test(".DollarNames completions still produce types", {
    
    remote$consoleExecuteExpr({
    
@@ -154,7 +154,7 @@ test_that(".DollarNames completions still produce types", {
 })
 
 # https://github.com/rstudio/rstudio/issues/15046
-test_that("Tab keypresses indent multi-line selections", {
+.rs.test("Tab keypresses indent multi-line selections", {
    
    contents <- .rs.heredoc('
       ---
@@ -177,7 +177,7 @@ test_that("Tab keypresses indent multi-line selections", {
 })
 
 # https://github.com/rstudio/rstudio/issues/13065
-test_that("code_completion_include_already_used works as expected", {
+.rs.test("code_completion_include_already_used works as expected", {
    
    contents <- .rs.heredoc('
       mtcars |> write()
@@ -206,7 +206,7 @@ test_that("code_completion_include_already_used works as expected", {
 })
 
 # https://github.com/rstudio/rstudio/issues/15161
-test_that("dplyr piped variable names are properly quoted / unquoted", {
+.rs.test("dplyr piped variable names are properly quoted / unquoted", {
    
    contents <- .rs.heredoc('
       library(dplyr)
@@ -223,7 +223,7 @@ test_that("dplyr piped variable names are properly quoted / unquoted", {
 })
 
 # https://github.com/rstudio/rstudio/issues/13290
-test_that("column names are quoted appropriately", {
+.rs.test("column names are quoted appropriately", {
    
    remote$consoleExecuteExpr({
       data <- list(apple = "apple", "2024" = "2024")

--- a/src/cpp/tests/automation/testthat/test-automation-data-viewer.R
+++ b/src/cpp/tests/automation/testthat/test-automation-data-viewer.R
@@ -6,14 +6,14 @@ withr::defer(.rs.automation.deleteRemote())
 
 
 # https://github.com/rstudio/rstudio/pull/14657
-test_that("we can use the data viewer with temporary R expressions", {
+.rs.test("we can use the data viewer with temporary R expressions", {
    remote$consoleExecute("View(subset(mtcars, mpg >= 30))")
    viewerFrame <- remote$jsObjectViaSelector("#rstudio_data_viewer_frame")
    expect_true(grepl("gridviewer.html", viewerFrame$src))
    remote$commandExecute("closeSourceDoc")
 })
 
-test_that("viewer filters function as expected", {
+.rs.test("viewer filters function as expected", {
    
    # Start viewing a data.frame with a list column.
    remote$consoleExecuteExpr({

--- a/src/cpp/tests/automation/testthat/test-automation-debugger.R
+++ b/src/cpp/tests/automation/testthat/test-automation-debugger.R
@@ -6,7 +6,7 @@ withr::defer(.rs.automation.deleteRemote())
 
 
 # https://github.com/rstudio/rstudio/issues/15072
-test_that("the debug position is correct in braced expressions", {
+.rs.test("the debug position is correct in braced expressions", {
 
    contents <- .rs.heredoc('
       f <- function() {
@@ -59,7 +59,7 @@ test_that("the debug position is correct in braced expressions", {
 })
 
 # https://github.com/rstudio/rstudio/issues/15201
-test_that("package functions can be debugged after build and reload", {
+.rs.test("package functions can be debugged after build and reload", {
    
    # Create an R package project.
    projectPath <- tempfile("rstudio.automation.", tmpdir = dirname(tempdir()))

--- a/src/cpp/tests/automation/testthat/test-automation-editor.R
+++ b/src/cpp/tests/automation/testthat/test-automation-editor.R
@@ -4,7 +4,7 @@ library(testthat)
 self <- remote <- .rs.automation.newRemote()
 withr::defer(.rs.automation.deleteRemote())
 
-test_that("whitespace is trimmed on save appropriately", {
+.rs.test("whitespace is trimmed on save appropriately", {
    
    # strip trailing whitespace in this scope
    remote$consoleExecuteExpr({

--- a/src/cpp/tests/automation/testthat/test-automation-history.R
+++ b/src/cpp/tests/automation/testthat/test-automation-history.R
@@ -4,7 +4,7 @@ library(testthat)
 self <- remote <- .rs.automation.newRemote()
 withr::defer(.rs.automation.deleteRemote())
 
-test_that("timestamp() adds to console history", {
+.rs.test("timestamp() adds to console history", {
    
    remote$consoleExecuteExpr(timestamp(quiet = TRUE))
    remote$keyboardExecute("<Up>")

--- a/src/cpp/tests/automation/testthat/test-automation-python.R
+++ b/src/cpp/tests/automation/testthat/test-automation-python.R
@@ -5,7 +5,7 @@ self <- remote <- .rs.automation.newRemote()
 withr::defer(.rs.automation.deleteRemote())
 
 # https://github.com/rstudio/rstudio/issues/14560
-test_that("attributes like __foo__ are not quoted when inserted via completions", {
+.rs.test("attributes like __foo__ are not quoted when inserted via completions", {
    remote$skipIfNotInstalled("reticulate")
    remote$consoleExecute("reticulate::repl_python()")
    remote$consoleExecute("import sys")

--- a/src/cpp/tests/automation/testthat/test-automation-quarto.R
+++ b/src/cpp/tests/automation/testthat/test-automation-quarto.R
@@ -4,7 +4,7 @@ library(testthat)
 self <- remote <- .rs.automation.newRemote()
 withr::defer(.rs.automation.deleteRemote())
 
-test_that("the warn option is preserved when running chunks", {
+.rs.test("the warn option is preserved when running chunks", {
    
    contents <- .rs.heredoc('
       ---
@@ -35,7 +35,7 @@ test_that("the warn option is preserved when running chunks", {
 })
 
 # https://github.com/rstudio/rstudio/issues/11745
-test_that("the expected chunk widgets show for multiple chunks", {
+.rs.test("the expected chunk widgets show for multiple chunks", {
    contents <- .rs.heredoc('
       ---
       title: "Chunk widgets"
@@ -89,7 +89,7 @@ test_that("the expected chunk widgets show for multiple chunks", {
 
 })
 
-test_that("can cancel switching to visual editor", {
+.rs.test("can cancel switching to visual editor", {
    contents <- .rs.heredoc('
       ---
       title: "Visual Mode Denied"
@@ -129,7 +129,7 @@ test_that("can cancel switching to visual editor", {
    
 })
 
-test_that("can switch to visual editor and back to source editor", {
+.rs.test("can switch to visual editor and back to source editor", {
    contents <- .rs.heredoc('
       ---
       title: "Visual Mode"
@@ -183,7 +183,7 @@ test_that("can switch to visual editor and back to source editor", {
    
 })
 
-test_that("visual editor welcome dialog displays again if don't show again is unchecked", {
+.rs.test("visual editor welcome dialog displays again if don't show again is unchecked", {
    contents <- .rs.heredoc('
       ---
       title: "Visual Mode"
@@ -236,7 +236,7 @@ test_that("visual editor welcome dialog displays again if don't show again is un
    
 })
 
-test_that("displaying and closing chunk options popup doesn't modify already-sorted settings", {
+.rs.test("displaying and closing chunk options popup doesn't modify already-sorted settings", {
    contents <- .rs.heredoc('
       ---
       title: "The Title"
@@ -298,7 +298,7 @@ test_that("displaying and closing chunk options popup doesn't modify already-sor
 
 })
 
-test_that("displaying and closing chunk options popup sorts the settings", {
+.rs.test("displaying and closing chunk options popup sorts the settings", {
    contents <- .rs.heredoc('
       ---
       title: "The Title"
@@ -354,7 +354,7 @@ test_that("displaying and closing chunk options popup sorts the settings", {
 
 
 # https://github.com/rstudio/rstudio/issues/14552
-test_that("empty header labels are permitted in document outline", {
+.rs.test("empty header labels are permitted in document outline", {
    
    contents <- .rs.heredoc('
       ---
@@ -403,7 +403,7 @@ test_that("empty header labels are permitted in document outline", {
 })
 
 # https://github.com/rstudio/rstudio/issues/15191
-test_that("variable-width nested chunks can be folded", {
+.rs.test("variable-width nested chunks can be folded", {
    
    contents <- .rs.heredoc('
       ---
@@ -450,7 +450,7 @@ test_that("variable-width nested chunks can be folded", {
 })
 
 # https://github.com/rstudio/rstudio/issues/15189
-test_that("raw html blocks are preserved by visual editor", {
+.rs.test("raw html blocks are preserved by visual editor", {
    
    contents <- .rs.heredoc('
       ---
@@ -499,7 +499,7 @@ test_that("raw html blocks are preserved by visual editor", {
 })
 
 # https://github.com/rstudio/rstudio/issues/15253
-test_that("raw latex blocks are preserved by visual editor", {
+.rs.test("raw latex blocks are preserved by visual editor", {
    
    contents <- .rs.heredoc('
       ---

--- a/src/cpp/tests/automation/testthat/test-automation-refactoring.R
+++ b/src/cpp/tests/automation/testthat/test-automation-refactoring.R
@@ -5,7 +5,7 @@ self <- remote <- .rs.automation.newRemote()
 withr::defer(.rs.automation.deleteRemote())
 
 # https://github.com/rstudio/rstudio/issues/4961
-test_that("rename in scope operates across chunks", {
+.rs.test("rename in scope operates across chunks", {
    
    contents <- .rs.heredoc('
       ---

--- a/src/cpp/tests/automation/testthat/test-automation-reformat.R
+++ b/src/cpp/tests/automation/testthat/test-automation-reformat.R
@@ -5,7 +5,7 @@ self <- remote <- .rs.automation.newRemote()
 withr::defer(.rs.automation.deleteRemote())
 
 
-test_that("Documents can be reformatted on save", {
+.rs.test("Documents can be reformatted on save", {
    
    remote$consoleExecute(".rs.writeUserPref(\"reformat_on_save\", TRUE)")
    remote$consoleExecute(".rs.writeUserPref(\"code_formatter\", \"styler\")")

--- a/src/cpp/tests/automation/testthat/test-automation-restart.R
+++ b/src/cpp/tests/automation/testthat/test-automation-restart.R
@@ -6,7 +6,7 @@ withr::defer(.rs.automation.deleteRemote())
 
 
 # https://github.com/rstudio/rstudio/issues/14636
-test_that("variables can be referenced after restart", {
+.rs.test("variables can be referenced after restart", {
    
    remote$consoleExecute("x <- 1; y <- 2")
    remote$consoleExecute(".rs.api.restartSession('print(x + y)')")

--- a/src/cpp/tests/automation/testthat/test-automation-rmarkdown.R
+++ b/src/cpp/tests/automation/testthat/test-automation-rmarkdown.R
@@ -4,7 +4,7 @@ library(testthat)
 self <- remote <- .rs.automation.newRemote()
 withr::defer(.rs.automation.deleteRemote())
 
-test_that("the warn option is preserved when running chunks", {
+.rs.test("the warn option is preserved when running chunks", {
    
    contents <- .rs.heredoc('
       ---
@@ -35,7 +35,7 @@ test_that("the warn option is preserved when running chunks", {
    
 })
 
-test_that("the expected chunk widgets show for multiple chunks", {
+.rs.test("the expected chunk widgets show for multiple chunks", {
 
    contents <- .rs.heredoc('
       ---
@@ -90,7 +90,7 @@ test_that("the expected chunk widgets show for multiple chunks", {
    
 })
 
-test_that("can cancel switching to visual editor", {
+.rs.test("can cancel switching to visual editor", {
    
    contents <- .rs.heredoc('
       ---
@@ -131,7 +131,7 @@ test_that("can cancel switching to visual editor", {
    
 })
 
-test_that("can switch to visual editor and back to source editor", {
+.rs.test("can switch to visual editor and back to source editor", {
    
    contents <- .rs.heredoc('
       ---
@@ -187,7 +187,7 @@ test_that("can switch to visual editor and back to source editor", {
    
 })
 
-test_that("visual editor welcome dialog displays again if don't show again is unchecked", {
+.rs.test("visual editor welcome dialog displays again if don't show again is unchecked", {
    contents <- .rs.heredoc('
       ---
       title: "Visual Mode"
@@ -240,7 +240,7 @@ test_that("visual editor welcome dialog displays again if don't show again is un
 
 })
 
-test_that("displaying and closing chunk options popup doesn't modify settings", {
+.rs.test("displaying and closing chunk options popup doesn't modify settings", {
    
    contents <- .rs.heredoc('
       ---
@@ -287,7 +287,7 @@ test_that("displaying and closing chunk options popup doesn't modify settings", 
    
 })
 
-test_that("displaying chunk options popup and applying without making changes doesn't modify settings", {
+.rs.test("displaying chunk options popup and applying without making changes doesn't modify settings", {
    
    contents <- .rs.heredoc('
       ---
@@ -339,7 +339,7 @@ test_that("displaying chunk options popup and applying without making changes do
 })
 
 
-test_that("reverting chunk option changes restores original options ", {
+.rs.test("reverting chunk option changes restores original options ", {
    
    contents <- .rs.heredoc('
       ---
@@ -386,7 +386,7 @@ test_that("reverting chunk option changes restores original options ", {
 })
 
 # https://github.com/rstudio/rstudio/issues/6829
-test_that("modifying chunk options via UI doesn't mess up other options", {
+.rs.test("modifying chunk options via UI doesn't mess up other options", {
    
    contents <- .rs.heredoc('
       ---
@@ -412,7 +412,7 @@ test_that("modifying chunk options via UI doesn't mess up other options", {
 
 })
 
-test_that("setup chunk starting with no options works with chunk options UI", {
+.rs.test("setup chunk starting with no options works with chunk options UI", {
    contents <- .rs.heredoc('
       ---
       title: "Chunk widgets"
@@ -450,7 +450,7 @@ test_that("setup chunk starting with no options works with chunk options UI", {
 
 })
 
-test_that("setup chunk with three options displays on multiple lines", {
+.rs.test("setup chunk with three options displays on multiple lines", {
    contents <- .rs.heredoc('
       ---
       title: "Chunk widgets"

--- a/src/cpp/tests/automation/testthat/test-automation-suspend.R
+++ b/src/cpp/tests/automation/testthat/test-automation-suspend.R
@@ -4,7 +4,7 @@ library(testthat)
 self <- remote <- .rs.automation.newRemote()
 withr::defer(.rs.automation.deleteRemote())
 
-test_that("loaded packages are preserved on suspend + resume", {
+.rs.test("loaded packages are preserved on suspend + resume", {
    
    remote$commandExecute("consoleClear")
    remote$consoleExecuteExpr({
@@ -40,7 +40,7 @@ test_that("loaded packages are preserved on suspend + resume", {
    
 })
 
-test_that("attached datasets are preserved on suspend + resume", {
+.rs.test("attached datasets are preserved on suspend + resume", {
    
    remote$consoleExecuteExpr({
       data <- list(apple = 1, banana = 2, cherry = 3)

--- a/src/cpp/tests/automation/testthat/test-automation-sweave.R
+++ b/src/cpp/tests/automation/testthat/test-automation-sweave.R
@@ -5,7 +5,7 @@ self <- remote <- .rs.automation.newRemote()
 withr::defer(.rs.automation.deleteRemote())
 
 
-test_that("Braces are inserted and highlighted correctly in Sweave documents", {
+.rs.test("Braces are inserted and highlighted correctly in Sweave documents", {
    
    documentContents <- .rs.heredoc('
       This is a Sweave document.

--- a/src/cpp/tests/automation/testthat/test-automation-syntax-highlighting.R
+++ b/src/cpp/tests/automation/testthat/test-automation-syntax-highlighting.R
@@ -5,7 +5,7 @@ self <- remote <- .rs.automation.newRemote()
 withr::defer(.rs.automation.deleteRemote())
 
 
-test_that("Quarto Documents are highlighted as expected", {
+.rs.test("Quarto Documents are highlighted as expected", {
    
    documentContents <- .rs.heredoc('
       ---
@@ -29,7 +29,7 @@ test_that("Quarto Documents are highlighted as expected", {
 })
 
 # https://github.com/rstudio/rstudio/issues/14652
-test_that("Quarto callout divs are tokenized correctly", {
+.rs.test("Quarto callout divs are tokenized correctly", {
    
    documentContents <- .rs.heredoc('
       ::: {.callout 0}
@@ -66,7 +66,7 @@ test_that("Quarto callout divs are tokenized correctly", {
 })
 
 # https://github.com/rstudio/rstudio/issues/14699
-test_that("Quarto chunks receive chunk begin / end markers as expected", {
+.rs.test("Quarto chunks receive chunk begin / end markers as expected", {
    
    documentContents <- .rs.heredoc('
       ---
@@ -89,7 +89,7 @@ test_that("Quarto chunks receive chunk begin / end markers as expected", {
 })
 
 # https://github.com/rstudio/rstudio/issues/14592
-test_that("The sequence '# |' is not tokenized as a Quarto comment prefix", {
+.rs.test("The sequence '# |' is not tokenized as a Quarto comment prefix", {
   
    documentContents <- .rs.heredoc('
       #|  yaml: true
@@ -117,7 +117,7 @@ test_that("The sequence '# |' is not tokenized as a Quarto comment prefix", {
 })
 
 # https://github.com/rstudio/rstudio/issues/15019
-test_that("tikz chunks are properly highlighted", {
+.rs.test("tikz chunks are properly highlighted", {
    
    documentContents <- .rs.heredoc('
       ---
@@ -153,7 +153,7 @@ test_that("tikz chunks are properly highlighted", {
 })
 
 # https://github.com/rstudio/rstudio/issues/12161
-test_that("nested GitHub chunks are highlighted appropriately", {
+.rs.test("nested GitHub chunks are highlighted appropriately", {
    
    contents <- .rs.heredoc('
       ---


### PR DESCRIPTION
- We're doing some stuff that's not typical for the regular `test_that()` workflow.
- It's shorter.