### PR TITLE
tweak copy of notebook chunk defns

### DIFF
--- a/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
@@ -210,8 +210,7 @@ void onDocPendingRemove(boost::shared_ptr<source_database::SourceDocument> pDoc)
       return;
 
    // check for a contextual (uncommitted) chunk definitions file
-   FilePath chunkDefsFile = chunkDefinitionsPath(pDoc->path(), pDoc->id(),
-         notebookCtxId());
+   FilePath chunkDefsFile = chunkDefinitionsPath(pDoc->path(), pDoc->id(), notebookCtxId());
    if (!chunkDefsFile.exists())
       return;
 
@@ -221,36 +220,21 @@ void onDocPendingRemove(boost::shared_ptr<source_database::SourceDocument> pDoc)
    Error error = pDoc->contentsMatchDisk(&matches);
    if (error)
       LOG_ERROR(error);
+   
    if (matches)
    {
-      FilePath target = chunkDefinitionsPath(
-               pDoc->path(), pDoc->id(), kSavedCtx);
+      FilePath target = chunkDefinitionsPath(pDoc->path(), pDoc->id(), kSavedCtx);
+      error = target.getParent().ensureDirectory();
+      if (error)
+         LOG_ERROR(error);
 
-      // only perform the copy if the saved branch is stale (older than the
-      // uncommitted branch)
+      // only perform the copy if the saved branch is stale
+      // (older than the uncommitted branch)
       if (target.getLastWriteTime() < chunkDefsFile.getLastWriteTime())
       {
-         // remove the old chunk definition file to make way for the new one 
-         error = target.remove();
-         if (error)
-         {
-            // can't remove the old definition file, so leave it alone
+         error = chunkDefsFile.copy(target, true);
+         if (error && !isFileNotFoundError(error))
             LOG_ERROR(error);
-         }
-         else
-         {
-            error = chunkDefsFile.copy(target);
-            if (error)
-            {
-               // removed the old file, but could not copy the new one; this
-               // should never happen. ideally we'd back up the old file and
-               // restore it if we can't copy the new one, but since restoring
-               // the backup and copying the new file are effectively the same
-               // operation it's unlikely to offer any true improvements in
-               // robustness.
-               LOG_ERROR(error);
-            }
-         }
       }
    }
 }


### PR DESCRIPTION
### Intent

This PR addresses an intermittent issue that popped up when running automation tests, seemingly related to a failure to copy notebook chunk definitions.

For reference, the error:

> 2024-11-14T18:43:25.742005Z [rsession-kevin] ERROR system error 2 (No such file or directory) [path: /tmp/RtmpLqA3oL/rstudio-automation-state-e2d33db9a6ca/data-home/notebooks/7DF203A4-document-e2d3283e6349/1/9DA86720a9cea511/chunks.json, target-path: /tmp/RtmpLqA3oL/rstudio-automation-state-e2d33db9a6ca/data-home/notebooks/7DF203A4-document-e2d3283e6349/1/s/chunks.json]; OCCURRED AT Error rstudio::core::FilePath::copy(const FilePath &, bool) const src/cpp/shared_core/FilePath.cpp:819; LOGGED FROM: void rstudio::session::modules::rmarkdown::notebook::(anonymous namespace)::onDocPendingRemove(boost::shared_ptr<source_database::SourceDocument>) src/cpp/session/modules/rmarkdown/NotebookCache.cpp:251

### Approach

The prior implementation used two separate steps wherein (1) the old chunks definition file was removed, and (2) the new chunk definitions were then copied over. Instead of doing two separate steps, just copy with overwrite.

This PR also ensures that the parent directory for the chunk definitions file exists, just to be defensive.

### Automated Tests

Covered by existing automation.

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
