### PR TITLE
wait for code execution to finish in automation APIs

### DIFF
--- a/src/cpp/session/modules/automation/SessionAutomationRemote.R
+++ b/src/cpp/session/modules/automation/SessionAutomationRemote.R
@@ -153,6 +153,15 @@
    
    # Send an Enter key to force execution.
    self$client$Input.dispatchKeyEvent(type = "rawKeyDown", windowsVirtualKeyCode = 13L)
+   
+   # Wait until the code has finished execution.
+   Sys.sleep(0.1)
+   editorEl <- self$jsObjectViaSelector("#rstudio_console_input")
+   .rs.waitUntil("console is no longer busy", function()
+   {
+      !grepl("rstudio-console-busy", editorEl$className)
+   })
+   
 })
 
 .rs.automation.addRemoteFunction("consoleOutput", function()

--- a/src/cpp/tests/automation/testthat/test-automation-suspend.R
+++ b/src/cpp/tests/automation/testthat/test-automation-suspend.R
@@ -6,37 +6,22 @@ withr::defer(.rs.automation.deleteRemote())
 
 .rs.test("loaded packages are preserved on suspend + resume", {
    
-   remote$commandExecute("consoleClear")
+   # Load the 'tools' package.
    remote$consoleExecuteExpr({
       library(tools)
-      writeLines(search())
    })
    
-   .rs.waitUntil("the tools package is loaded", function()
-   {
-      remote$keyboardExecute("<Enter>")
-      ".GlobalEnv" %in% remote$consoleOutput()
-   })
-   
-   beforeSuspend <- setdiff(remote$consoleOutput(), "local:rprofile")
-   expect_contains(beforeSuspend, "package:tools")
-   
+   # Suspend the session.
    remote$commandExecute("suspendSession")
-   remote$commandExecute("consoleClear")
+   Sys.sleep(1)
    
+   # Check and see if 'tools' was loaded on resume.
    remote$consoleExecuteExpr({
-      library(tools)
-      writeLines(search())
+      "tools" %in% loadedNamespaces()
    })
    
-   .rs.waitUntil("the tools package is loaded", function()
-   {
-      remote$keyboardExecute("<Enter>")
-      ".GlobalEnv" %in% remote$consoleOutput()
-   })
-   
-   afterSuspend <- setdiff(remote$consoleOutput(), "local:rprofile")
-   expect_contains(afterSuspend, "package:tools")
+   output <- remote$consoleOutput()
+   expect_contains(output, "[1] TRUE")
    
 })
 
@@ -48,15 +33,10 @@ withr::defer(.rs.automation.deleteRemote())
    })
    
    remote$commandExecute("suspendSession")
+   Sys.sleep(1)
    
    remote$consoleExecuteExpr({
       writeLines(search())
-   })
-   
-   .rs.waitUntil("the session has been restored", function()
-   {
-      remote$keyboardExecute("<Enter>")
-      ".GlobalEnv" %in% remote$consoleOutput()
    })
    
    output <- remote$consoleOutput()
@@ -65,5 +45,9 @@ withr::defer(.rs.automation.deleteRemote())
    remote$consoleExecuteExpr(apple + banana + cherry)
    output <- remote$consoleOutput()
    expect_true("[1] 6" %in% output)
+   
+   remote$consoleExecuteExpr({
+      detach("my-attached-dataset")
+   })
    
 })

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellDisplay.java
@@ -43,6 +43,7 @@ public interface ShellDisplay extends ShellOutputWriter,
    boolean isPromptEmpty();
    String getPromptText();
    
+   void setBusy(boolean busy);
    void setReadOnly(boolean readOnly);
    void setSuppressPendingInput(boolean suppressPendingInput);
 

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -372,6 +372,20 @@ public class ShellWidget extends Composite implements ShellDisplay,
       // moves to it scrolling ensues.
       input_.forceCursorChange();
    }
+   
+   @Override
+   public void setBusy(boolean busy)
+   {
+      Element el = input_.getWidget().getElement();
+      if (busy)
+      {
+         el.addClassName(RSTUDIO_CONSOLE_BUSY);
+      }
+      else
+      {
+         el.removeClassName(RSTUDIO_CONSOLE_BUSY);
+      }
+   }
 
    @Override
    public void setSuppressPendingInput(boolean suppressPendingInput)
@@ -493,6 +507,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
          prompt = consolify(prompt);
 
       prompt_.getElement().setInnerText(prompt);
+      prompt_.getElement().removeClassName("rstudio-console-busy");
       ensureInputVisible();
 
       // Deal gracefully with multi-line prompts
@@ -1104,4 +1119,5 @@ public class ShellWidget extends Composite implements ShellDisplay,
    private boolean clearErrors_ = false;
 
    private static final String KEYWORD_CLASS_NAME = ConsoleResources.KEYWORD_CLASS_NAME;
+   private static final String RSTUDIO_CONSOLE_BUSY = "rstudio-console-busy";
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -507,7 +507,6 @@ public class ShellWidget extends Composite implements ShellDisplay,
          prompt = consolify(prompt);
 
       prompt_.getElement().setInnerText(prompt);
-      prompt_.getElement().removeClassName("rstudio-console-busy");
       ensureInputVisible();
 
       // Deal gracefully with multi-line prompts

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -330,6 +330,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
 
    public void onConsoleInput(final ConsoleInputEvent event)
    {
+      view_.setBusy(true);
       view_.clearLiveRegion();
       server_.consoleInput(event.getInput(),
                            event.getConsole(),
@@ -398,6 +399,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    // so not explicitly entered by the user)
    private void consolePrompt(String prompt, boolean addToHistory)
    {
+      view_.setBusy(false);
       view_.consolePrompt(prompt, true);
 
       if (lastPromptText_ == null
@@ -489,7 +491,8 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       final String previousInput = StringUtil.notNull(display.getText());
 
       // define code block we execute at finish
-      Command finishSendToConsole = new Command() {
+      Command finishSendToConsole = new Command()
+      {
          @Override
          public void execute()
          {
@@ -497,7 +500,6 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
             {
                String commandText = event.shouldEcho() ? view_.processCommandEntry() : event.getCode();
                processCommandEntry(commandText, event.shouldEcho());
-
                display.setText(previousInput);
             }
 


### PR DESCRIPTION
### Intent

This ensures that `consoleExecute()` and `consoleExecuteExpr()` do not return until the code submitted has actually finished executing.

### Approach

The Shell widget now sets an `rstudio-console-busy` CSS class when busy, and unsets it when waiting for input in the prompt.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
