### PR TITLE
no need for RSTUDIO_AUTOMATION_EXE

### DIFF
--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -411,8 +411,7 @@
    
    # No existing session; start a new one and attach to it.
    appPath <- .rs.nullCoalesce(appPath, {
-      defaultAppPath <- .rs.automation.applicationPath(mode)
-      Sys.getenv("RSTUDIO_AUTOMATION_EXE", unset = defaultAppPath)
+      .rs.automation.applicationPath(mode)
    })
    
    # Build argument list.

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -604,7 +604,6 @@ export class SessionLauncher {
       }
 
       // set up environment variables to help find automation tests
-      setenv('RSTUDIO_AUTOMATION_EXE', process.argv0);
       if (!app.isPackaged) {
         const projectRoot = findRepoRoot();
         setenv('RSTUDIO_AUTOMATION_ROOT', projectRoot);


### PR DESCRIPTION
We can rely on `.rs.automation.applicationPath(mode)` to return the correct path for us.