### PR TITLE
update to electron 31.7.5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -104,7 +104,7 @@ If running Workbench behind a proxy server, you may need to update your `NO_PROX
 
 ### Dependencies
 - Updated GWT to version 2.10.1 (#15011)
-- Updated Electron to version 31.7.4 (#14982; Desktop)
+- Updated Electron to version 31.7.5 (#14982; Desktop)
 
 ### Deprecated / Removed
 - Removed user preference for turning off focus indicator rectangles (#14352)

--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -48,7 +48,7 @@
         "chai": "4.5.0",
         "copy-webpack-plugin": "12.0.2",
         "css-loader": "7.1.2",
-        "electron": "31.7.4",
+        "electron": "31.7.5",
         "electron-mocha": "13.0.1",
         "eslint": "8.57",
         "fork-ts-checker-webpack-plugin": "9.0.2",
@@ -5030,9 +5030,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "31.7.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-31.7.4.tgz",
-      "integrity": "sha512-uvSxcYq349bbCp60vmsTJGviI0pBfrvZK+YQHs3L0nzhZeBin0+o7bC1j3vmK+CeTxAZlWWjtgtc3z7XYrHm5w==",
+      "version": "31.7.5",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-31.7.5.tgz",
+      "integrity": "sha512-8zFzVJdhxTRmoPcRiKkEmPW0bJHAUsTQJwEX2YJ8X0BVFIJLwSvHkSlpCjEExVbNCAk+gHnkIYX+2OyCXrRwHQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5108,9 +5108,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.57",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.57.tgz",
-      "integrity": "sha512-xS65H/tqgOwUBa5UmOuNSLuslDo7zho0y/lgQw35pnrqiZh7UOWHCeL/Bt6noJATbA6tpQJGCifsFsIRZj1Fqg==",
+      "version": "1.5.60",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.60.tgz",
+      "integrity": "sha512-HcraRUkTKJ+8yA3b10i9qvhUlPBRDlKjn1XGek1zDGVfAKcvi8TsUnImGqLiEm9j6ZulxXIWWIo9BmbkbCTGgA==",
       "dev": true,
       "license": "ISC"
     },

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -46,7 +46,7 @@
     "chai": "4.5.0",
     "copy-webpack-plugin": "12.0.2",
     "css-loader": "7.1.2",
-    "electron": "31.7.4",
+    "electron": "31.7.5",
     "electron-mocha": "13.0.1",
     "eslint": "8.57",
     "fork-ts-checker-webpack-plugin": "9.0.2",


### PR DESCRIPTION
### Intent

Another day, another Electron update. This goes from 31.7.4 to 31.7.5 and picks up a couple bug fixes and CVE fixes: https://github.com/electron/electron/releases/tag/v31.7.5

### Approach

Rinse and repeat.

### Automated Tests

Successfully ran Electron unit tests and BRAT automation.

### QA Notes

Test via routine usage and automation.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


