### PR TITLE
use queue + batch for processing file changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -88,6 +88,7 @@
 - Fixed an issue where column names starting with numbers were not properly quoted when inserted as a completion (#13290)
 - Fixed an issue where right-clicking on the console history did not present Paste as an option (#14538)
 - Fixed a performance regression that occurred when requesting completions for very large R objects (#15422)
+- Fixed an issue where RStudio could hang on startup with projects containing a very large number of files (#15434)
 
 #### Posit Workbench
 

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -1325,18 +1325,12 @@ void onBackgroundProcessing(bool isIdle)
       }
    }
    
-   // index files in the queue (maximum 1 second)
+   // index files in the queue
    if (isIdle && !s_indexQueue.empty())
    {
       auto start = boost::chrono::steady_clock::now();
       while (true)
       {
-         // check for finished
-         auto now = boost::chrono::steady_clock::now();
-         auto elapsed = boost::chrono::duration_cast<boost::chrono::seconds>(now - start);
-         if (elapsed.count() > 0)
-            break;
-
          // run on batch of files
          auto n = std::min(s_indexQueue.size(), std::size_t(s_indexBatchSize));
          for (std::size_t i = 0; i < n; i++)
@@ -1345,6 +1339,12 @@ void onBackgroundProcessing(bool isIdle)
          // remove those files
          s_indexQueue.erase(s_indexQueue.begin(), s_indexQueue.begin() + n);
          if (s_indexQueue.empty())
+            break;
+         
+         // check for finished
+         auto now = boost::chrono::steady_clock::now();
+         auto elapsed = boost::chrono::duration_cast<boost::chrono::milliseconds>(now - start);
+         if (elapsed.count() >= 100)
             break;
       }
    }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15434.

### Approach

- Use a queue when processing Copilot file changes, to avoid potentially swamping the R session on startup.
- Avoid using `module_context::isTextFile()`, as the fallback involves invoking `/usr/bin/file`, which is much too slow.

The main downside with this change is that we're no longer indexing some files that the user might have expected (e.g. `.csv` files?). I'm not sure if we should allow indexing of those files in any case, though -- feels like it should be opt-in?

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15434.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
