### PR TITLE
Update "Positron" to "Positron Pro" in Workbench context

### DIFF
--- a/version/news/NEWS-2024.12.0-kousa-dogwood.md
+++ b/version/news/NEWS-2024.12.0-kousa-dogwood.md
@@ -31,12 +31,12 @@
 
 
 #### Posit Workbench
-- Added preview support for Positron sessions to RHEL9 and Ubuntu 22/24 packages. Positron sessions must be manually configured by an admin. (rstudio-pro#6861)
-- Added new database tables to support saving Positron state across user logout. (rstudio-pro#6820)
-- Restricted Positron and VS Code sessions for insecure (non-SSL) contexts. These editors do not work properly otherwise. (rstudio-pro#3741)
-- Added a countdown on the homepage for VS Code and Positron sessions to reflect the `session-timeout-kill-hours` setting and indicate when a session may be terminated if the user doesn't interact with it. (rstudio-pro#6743)
-- The most recently opened folder is saved for Positron sessions. (rstudio-pro#6874).
-- Added a `session-timeout-kill-hours` setting to VS Code and Positron sessions, which terminates sessions after being idle for a set number of hours. (rstudio-pro#5746)
+- Added preview support for Positron Pro sessions to RHEL9 and Ubuntu 22/24 packages. Positron Pro sessions must be manually configured by an admin. (rstudio-pro#6861)
+- Added new database tables to support saving Positron Pro state across user logout. (rstudio-pro#6820)
+- Restricted Positron Pro and VS Code sessions for insecure (non-SSL) contexts. These editors do not work properly otherwise. (rstudio-pro#3741)
+- Added a countdown on the homepage for VS Code and Positron Pro sessions to reflect the `session-timeout-kill-hours` setting and indicate when a session may be terminated if the user doesn't interact with it. (rstudio-pro#6743)
+- The most recently opened folder is saved for Positron Pro sessions. (rstudio-pro#6874).
+- Added a `session-timeout-kill-hours` setting to VS Code and Positron Pro sessions, which terminates sessions after being idle for a set number of hours. (rstudio-pro#5746)
 - Added the Quarto, Posit Shiny, and Posit Publisher extensions to the default `vscode.extensions.conf` file for fresh installs. These extensions will be installed automatically for users upon VS Code session launch. (rstudio-pro#6388)
 - Added preview support for setting an active timeout, which logs out users after a period of time, regardless of activity. (rstudio-pro#5815)
 - Introduced a new session init container that copies session components to the session container, allowing updates to components independent of the session image. The session init container can be enabled in Kubernetes sessions by setting `launcher-sessions-init-container-enabled=1` in `rserver.conf`. Additionally, the init container uses a new multi-platform Linux session components package to support session images across different Linux distributions. (rstudio-pro#6821)


### PR DESCRIPTION
OS PR for https://github.com/rstudio/rstudio-pro/pull/7148