### PR TITLE
Stop http server before shutting down, make processes to send interrupt to pluggable in the overlay

### DIFF
--- a/src/cpp/server/ServerMainOverlay.cpp
+++ b/src/cpp/server/ServerMainOverlay.cpp
@@ -14,6 +14,7 @@
  */
 
 #include <shared_core/Error.hpp>
+#include <set>
 
 using namespace rstudio::core;
 
@@ -34,6 +35,15 @@ Error startup()
 Error reloadConfiguration()
 {
    return Success();
+}
+
+void startShutdown()
+{
+}
+
+std::set<std::string> interruptProcs()
+{
+   return std::set<std::string>();
 }
 
 void shutdown()


### PR DESCRIPTION

### Intent

Addresses workbench issue: https://github.com/rstudio/rstudio-pro/issues/7173
companion to: 

### Approach

- stop the http server before killing sub-processes
- provide a startShutdown hook for the overlay
- additional debug messages for the stop process

### QA Notes

This should only affect the OS server configuration. The only real change there is that the http server gets stopped before we start terminating sessions so it could change the behavior, particularly what errors are logged while the server is shutting down.  Additional debug messages exist to provide more diagnostics.