### PR TITLE
use native browser APIs for RSA encryption where appropriate

### DIFF
--- a/src/cpp/core/include/core/system/Crypto.hpp
+++ b/src/cpp/core/include/core/system/Crypto.hpp
@@ -67,7 +67,7 @@ core::Error generateRsaCertAndKeyFiles(const std::string& in_certCommonName,
                                        const FilePath& in_certPath,
                                        const FilePath& in_certKeyPath);
 
-void rsaPublicKey(std::string* pExponent, std::string* pModulo);
+core::Error rsaPublicKey(std::string* pPublicKey);
 
 core::Error rsaPrivateDecrypt(const std::string& pCipherText, std::string* pPlainText);
          

--- a/src/cpp/core/system/Crypto.cpp
+++ b/src/cpp/core/system/Crypto.cpp
@@ -547,9 +547,21 @@ core::Error rsaPrivateDecrypt(const std::string& cipherText, std::string* pPlain
    status = EVP_PKEY_decrypt_init(ctx.get());
    if (status <= 0)
       return getLastCryptoError(ERROR_LOCATION);
+
+   status = EVP_PKEY_CTX_set_rsa_oaep_md(ctx.get(), EVP_sha256());
+   if (status <= 0)
+      return getLastCryptoError(ERROR_LOCATION);
+   
+   status = EVP_PKEY_CTX_set_rsa_padding(ctx.get(), RSA_PKCS1_OAEP_PADDING);
+   if (status <= 0)
+      return getLastCryptoError(ERROR_LOCATION);
    
    std::size_t size = 0;
-   status = EVP_PKEY_decrypt(ctx.get(), nullptr, &size, cipherTextBytes.data(), cipherTextBytes.size());
+   status = EVP_PKEY_decrypt(
+            ctx.get(),
+            nullptr, &size,
+            cipherTextBytes.data(), cipherTextBytes.size());
+   
    if (status <= 0)
       return getLastCryptoError(ERROR_LOCATION);
    

--- a/src/cpp/server/ServerPAMAuth.cpp
+++ b/src/cpp/server/ServerPAMAuth.cpp
@@ -104,10 +104,13 @@ void signIn(const http::Request& request,
 void publicKey(const http::Request&,
                http::Response* pResponse)
 {
-   std::string exp, mod;
-   core::system::crypto::rsaPublicKey(&exp, &mod);
+   std::string publicKey;
+   Error error = core::system::crypto::rsaPublicKey(&publicKey);
+   if (error)
+      LOG_ERROR(error);
+   
    pResponse->setNoCacheHeaders();
-   pResponse->setBody(exp + ":" + mod);
+   pResponse->setBody(publicKey);
    pResponse->setContentType("text/plain");
 }
 

--- a/src/cpp/session/modules/SessionCrypto.cpp
+++ b/src/cpp/session/modules/SessionCrypto.cpp
@@ -15,16 +15,13 @@
 
 #include "SessionCrypto.hpp"
 
-#include <string>
-
 #include <boost/bind/bind.hpp>
 
-#include <core/Log.hpp>
 #include <shared_core/Error.hpp>
+
+#include <core/Log.hpp>
 #include <core/Exec.hpp>
-
 #include <core/json/JsonRpc.hpp>
-
 #include <core/system/Crypto.hpp>
 
 #include <r/RSexp.hpp>
@@ -45,25 +42,19 @@ namespace {
 Error getPublicKey(const json::JsonRpcRequest& request,
                    json::JsonRpcResponse* pResponse)
 {
-   pResponse->setResult(publicKeyInfoJson());
-
+   std::string publicKey;
+   Error error = core::system::crypto::rsaPublicKey(&publicKey);
+   if (error)
+      return error;
+   
+   json::Object resultJson;
+   resultJson["key"] = publicKey;
+   pResponse->setResult(resultJson);
+   
    return Success();
 }
 
 } // anonymous namespace
-
-
-json::Object publicKeyInfoJson()
-{
-   std::string exponent;
-   std::string modulo;
-   core::system::crypto::rsaPublicKey(&exponent, &modulo);
-
-   json::Object result;
-   result["exponent"] = exponent;
-   result["modulo"] = modulo;
-   return result;
-}
 
 Error initialize()
 {

--- a/src/gwt/src/org/rstudio/studio/client/common/crypto/PublicKeyInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/crypto/PublicKeyInfo.java
@@ -20,11 +20,5 @@ public class PublicKeyInfo extends JavaScriptObject
 {
    protected PublicKeyInfo() {}
 
-   public native final String getExponent() /*-{
-      return this.exponent;
-   }-*/;
-
-   public native final String getModulo() /*-{
-      return this.modulo;
-   }-*/;
+   public native final String getKey() /*-{ return this.key; }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/crypto/RSAEncrypt.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/crypto/RSAEncrypt.java
@@ -15,8 +15,6 @@
 package org.rstudio.studio.client.common.crypto;
 
 import org.rstudio.core.client.CommandWithArg;
-import org.rstudio.core.client.ExternalJavaScriptLoader;
-import org.rstudio.core.client.ExternalJavaScriptLoader.Callback;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
@@ -48,28 +46,18 @@ public class RSAEncrypt
          callback.onSuccess("");
       }
 
-      loader_.addCallback(new Callback()
+      server.getPublicKey(new ServerRequestCallback<PublicKeyInfo>()
       {
          @Override
-         public void onLoaded()
-         { 
-            server.getPublicKey(new ServerRequestCallback<PublicKeyInfo>()
-            {
-               @Override
-               public void onResponseReceived(PublicKeyInfo response)
-               {
-   
-                  callback.onSuccess(encrypt(input,
-                                             response.getExponent(),
-                                             response.getModulo()));
-               }
-   
-               @Override
-               public void onError(ServerError error)
-               {
-                  callback.onFailure(error);
-               }
-            });
+         public void onResponseReceived(PublicKeyInfo response)
+         {
+            encrypt(input, response.getKey(), callback::onSuccess);
+         }
+
+         @Override
+         public void onError(ServerError error)
+         {
+            callback.onFailure(error);
          }
       });
    }
@@ -90,27 +78,64 @@ public class RSAEncrypt
          // fallback case for null input (see case 4375)
          callback.execute("");
       }
-
-      loader_.addCallback(new Callback()
-      {
-         @Override
-         public void onLoaded()
-         { 
-            callback.execute(encrypt(input, 
-                                     publicKeyInfo.getExponent(),
-                                     publicKeyInfo.getModulo()));
-           
-         }
-      });
+      
+      encrypt(input, publicKeyInfo.getKey(), callback::execute);
    }
    
   
-   private static native String encrypt(String value,
-                                        String exponent,
-                                        String modulo) /*-{
-      return $wnd.encrypt(value, exponent, modulo);
+   private static native void encrypt(String value,
+                                      String publicKey,
+                                      CommandWithArg<String> callback)
+   /*-{
+      
+      var subtle = $wnd.crypto.subtle;
+      
+      // The provided key is in PEM format; we need to extract the inner
+      // key contents and provide it as an array buffer.
+      var pemHeader = "-----BEGIN PRIVATE KEY-----";  // pragma: allowlist secret
+      var pemFooter = "-----END PRIVATE KEY-----";    // pragma: allowlist secret
+      var keyContents = publicKey
+         .replace(pemHeader, "")
+         .replace(pemFooter, "")
+         .replace(/\s+/g, "");
+      
+      var array = Uint8Array.from(
+         atob(pemContents),
+         function(ch) { return ch.charCodeAt(0); }
+      );
+      
+      // Finally, import the key.
+      var key = subtle.importKey(
+         "spki",
+         array.buffer,
+         { name: "RSA-OAEP", hash: "SHA-256" },
+         true,
+         ["encrypt"]
+      );
+      
+      key.then(function(key) {
+         
+         var encoder = new TextEncoder();
+         var message = subtle.encrypt(
+            { name: "RSA-OAEP" },
+            key,
+            encoder.encode(value)
+         );
+         
+         message.then(function(message) {
+            
+            var binaryString = "";
+            var byteArray = new Uint8Array(message);
+            for (var i = 0; i < byteArray.length; i++) {
+                binaryString += String.fromCharCode(byteArray[i]);
+            }
+            
+            var encryptedBase64 = btoa(binaryString);
+            console.log(encryptedBase64);
+            callback.@org.rstudio.core.client.CommandWithArg::execute(*)(message);
+         });
+      });
+      
    }-*/;
 
-   private static final ExternalJavaScriptLoader loader_ =
-         new ExternalJavaScriptLoader("js/encrypt.min.js");
 }


### PR DESCRIPTION
### Intent

Addresses open source side of https://github.com/rstudio/rstudio-pro/issues/5689.

### Approach

Remove usages of `rsa.js`, and instead rely on browser APIs for RSA encryption / decryption.

### Automated Tests

N/A; covered by existing automation.

### QA Notes

Test that tools which use encryption here work -- for example, on RStudio Server, check that `.rs.api.askForPassword()` returns the requested password correctly.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
