### PR TITLE
don't elevate if quarto is already installed

### DIFF
--- a/dependencies/common/install-quarto
+++ b/dependencies/common/install-quarto
@@ -33,10 +33,6 @@ QUARTO_URL_BASE="https://github.com/quarto-dev/quarto-cli/releases/download/v${Q
 
 QUARTO_SUBDIR="quarto"
 
-# move to tools root
-sudo-if-necessary-for "${RSTUDIO_TOOLS_ROOT}" "$@"
-cd "${RSTUDIO_TOOLS_ROOT}"
-
 # check installed version
 QUARTO_BIN="${RSTUDIO_TOOLS_ROOT}/${QUARTO_SUBDIR}/bin/quarto"
 if test -f "${QUARTO_BIN}"; then
@@ -46,6 +42,10 @@ if test -f "${QUARTO_BIN}"; then
       exit 0
    fi
 fi
+
+# move to tools root
+sudo-if-necessary-for "${RSTUDIO_TOOLS_ROOT}" "$@"
+cd "${RSTUDIO_TOOLS_ROOT}"
 
 # reset quarto subdirectory
 rm -rf "${QUARTO_SUBDIR}"


### PR DESCRIPTION
When re-running dependency installation on a dev machine, the Quarto installation script always asks for elevation (possibly twice on a Mac, depending on sudo configuration), even if the correct version is already installed.

Fix by moving the elevation check after determining that quarto actually needs to be installed/upgraded.