### PR TITLE
use versioned name for postgresql formula

### DIFF
--- a/dependencies/osx/install-dependencies-osx-arch
+++ b/dependencies/osx/install-dependencies-osx-arch
@@ -47,7 +47,7 @@ FORMULAS=(
    openssl
    ninja
    pidof
-   postgresql
+   postgresql@14
    r
 )
 


### PR DESCRIPTION
For a 2+ years now, `brew` has given this message when installing dependencies:

```
Warning: Formula postgresql was renamed to postgresql@14.
```

Brew treats `postgresql` as `postgresql@14` so this is harmless, but might as well get rid of the warning message (and make it clear that we're installing v14).

Brew reference: https://github.com/Homebrew/homebrew-core/pull/107726