### PR TITLE
fix issue with scroll position being reset on scroll

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -77,6 +77,13 @@ public class DomUtils
    public static native Element getActiveElement() /*-{
       return $doc.activeElement;
    }-*/;
+   
+   public static native void setFocus(Element el, boolean preventScroll)
+   /*-{
+      el.focus({
+         preventScroll: preventScroll
+      });
+   }-*/;
 
    /**
     * In IE8, focusing the history table (which is larger than the scroll

--- a/src/gwt/src/org/rstudio/core/client/widget/VirtualizedDataGrid.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/VirtualizedDataGrid.java
@@ -179,7 +179,7 @@ public abstract class VirtualizedDataGrid<T> extends RStudioDataGrid<T>
       
       if (changed)
       {
-         redraw();
+         super.redraw();
          Scheduler.get().scheduleDeferred(new ScheduledCommand()
          {
             @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesList.java
@@ -98,12 +98,6 @@ public class FilesList extends Composite
          {
             return "transparent";
          }
-         
-         @Override
-         protected boolean resetFocusOnCell()
-         {
-            return false;
-         }
       };
             
       selectionModel_ = new MultiSelectionModel<>(KEY_PROVIDER);

--- a/version/news/NEWS-2024.12.1-kousa-dogwood.md
+++ b/version/news/NEWS-2024.12.1-kousa-dogwood.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 #### RStudio
+- Fixed an issue where the Files pane could inadverently scroll back to top in some cases. (#15502)
 - Fixed an issue with non-ASCII characters in qmd files showing as "unexpected token." (#15316)
 - Fixed an issue where RStudio could emit a warning when attempting to retrieve help for R objects without a help page. (rstudio-pro#7063)
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15502.

### Approach

GWT will attempt to reset focus on a cell after scrolling, as per:

https://github.com/gwtproject/gwt/blob/c2229e7557450cd2842269f5fe9cb8586e90b50c/user/src/com/google/gwt/user/cellview/client/AbstractHasData.java#L320-L325

We want to avoid this behavior, so we implement our own `resetScrollOnFocus()` method here which handles that behavior but just does nothing.

https://github.com/rstudio/rstudio/blob/e8d795d0098578eb696aa105124dd2213b388b2c/src/gwt/src/org/rstudio/core/client/widget/VirtualizedDataGrid.java#L152-L160

Unfortunately, we were further overriding that override in the constructor for the Files list, so we need to remove the (unnecessary, incorrect) override.

The name + return value for this method confused me at first  -- it doesn't mark whether we want the "reset focus on scroll" behavior, it represents whether our handler is taking control of the intended action for "reset focus on scroll" , and so should return `true` if we've implemented the behavior we want therein (even if that behavior is no-op).

The downside with this PR is that the currently-selected cell loses focus on scroll, which would prevent the pane from being keyboard accessible -- so perhaps we should restore focus, but preserve the scroll position when we do so?

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15502.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

