### PR TITLE
avoid expensive status call when autorefresh is false

### DIFF
--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -1847,13 +1847,21 @@ Error vcsFullStatus(const json::JsonRpcRequest&,
 Error vcsAllStatus(const json::JsonRpcRequest& request,
                    json::JsonRpcResponse* pResponse)
 {
+   bool minimal = false;
+   Error error = json::readParams(request.params, &minimal);
+   if (error)
+      LOG_ERROR(error);
+
    json::Object result;
    json::JsonRpcResponse tmp;
 
-   Error error = vcsFullStatus(request, &tmp);
-   if (error)
-      return error;
-   result["status"] = tmp.result();
+   if (!minimal)
+   {
+      error = vcsFullStatus(request, &tmp);
+      if (error)
+         return error;
+      result["status"] = tmp.result();
+   }
 
    error = vcsListBranches(request, &tmp);
    if (error)

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/GitServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/GitServerOperations.java
@@ -58,8 +58,8 @@ public interface GitServerOperations extends VCSServerOperations
    void gitUnstage(ArrayList<String> paths,
                    ServerRequestCallback<Void> requestCallback);
 
-   void gitAllStatus(
-         ServerRequestCallback<AllStatus> requestCallback);
+   void gitAllStatus(boolean minimal,
+                     ServerRequestCallback<AllStatus> requestCallback);
 
    void gitFullStatus(
          ServerRequestCallback<JsArray<StatusAndPathInfo>> requestCallback);

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -2911,9 +2911,12 @@ public class RemoteServer implements Server
    }
 
    @Override
-   public void gitAllStatus(ServerRequestCallback<AllStatus> requestCallback)
+   public void gitAllStatus(boolean minimal,
+                            ServerRequestCallback<AllStatus> requestCallback)
    {
-      sendRequest(RPC_SCOPE, GIT_ALL_STATUS, requestCallback);
+      JSONArray params = new JSONArray();
+      params.set(0, JSONBoolean.getInstance(minimal));
+      sendRequest(RPC_SCOPE, GIT_ALL_STATUS, params, requestCallback);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ChangelistTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ChangelistTable.java
@@ -151,13 +151,11 @@ public abstract class ChangelistTable extends Composite
       layout_.setWidgetTopBottom(scrollPanel_, 0, Unit.PX, 0, Unit.PX);
       layout_.setWidgetLeftRight(scrollPanel_, 0, Unit.PX, 0, Unit.PX);
       progressPanel_ = new ProgressPanel();
-      progressPanel_.getElement().getStyle().setBackgroundColor("white");
+      progressPanel_.getElement().getStyle().setBackgroundColor("transparent");
+      progressPanel_.setVisible(false);
       layout_.add(progressPanel_);
       layout_.setWidgetTopBottom(progressPanel_, 0, Unit.PX, 0, Unit.PX);
       layout_.setWidgetLeftRight(progressPanel_, 0, Unit.PX, 0, Unit.PX);
-
-      setProgress(true);
-
       initWidget(layout_);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/model/VcsState.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/model/VcsState.java
@@ -80,6 +80,7 @@ public abstract class VcsState
             }
          }
       }));
+      
       registrations.add(eventBus_.addHandler(FileChangeEvent.TYPE, new FileChangeEvent.Handler()
       {
          @Override
@@ -124,15 +125,6 @@ public abstract class VcsState
             }
          }
       }));
-
-      Scheduler.get().scheduleDeferred(new ScheduledCommand()
-      {
-         @Override
-         public void execute()
-         {
-            refresh(false);
-         }
-      });
    }
 
    public void bindRefreshHandler(Widget owner,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitChangelistTablePresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitChangelistTablePresenter.java
@@ -97,6 +97,18 @@ public class GitChangelistTablePresenter
    {
       return view_;
    }
+   
+   public void refresh(boolean minimal)
+   {
+      if (minimal)
+      {
+         gitState_.refreshMinimal();
+      }
+      else
+      {
+         gitState_.refresh(false);
+      }
+   }
 
    private final GitServerOperations server_;
    private final GitChangelistTable view_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
@@ -78,6 +78,8 @@ public class GitPane extends WorkbenchPane implements Display, BranchCaptionChan
 
       table_ = changelistTablePresenter.getView();
       table_.addStyleName("ace_editor_theme");
+      
+      presenter_ = changelistTablePresenter;
 
       if (Desktop.isDesktop())
       {
@@ -192,12 +194,19 @@ public class GitPane extends WorkbenchPane implements Display, BranchCaptionChan
 
       return toolbar;
    }
+   
+   @Override
+   public void onBeforeSelected()
+   {
+      boolean minimal = !prefs_.vcsAutorefresh().getValue();
+      presenter_.refresh(minimal);
+   }
 
    @Override
    public void onSelected()
    {
-      Scheduler.get().scheduleDeferred(new ScheduledCommand() {
-
+      Scheduler.get().scheduleDeferred(new ScheduledCommand()
+      {
          @Override
          public void execute()
          {
@@ -309,15 +318,16 @@ public class GitPane extends WorkbenchPane implements Display, BranchCaptionChan
    private ToolbarButton pushButton_;
    private ToolbarButton refreshButton_;
 
-   @SuppressWarnings("unused")
    private final GitServerOperations server_;
    private final Commands commands_;
    @SuppressWarnings("unused")
    private final GlobalDisplay display_;
    private final UserPrefs prefs_;
 
+   private final GitChangelistTable table_;
+   private final GitChangelistTablePresenter presenter_;
    private final CheckoutBranchToolbarButton switchBranchToolbarButton_;
    private final CreateBranchToolbarButton createBranchToolbarButton_;
-   private final GitChangelistTable table_;
+   
    private static final ViewVcsConstants constants_ = GWT.create(ViewVcsConstants.class);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/model/GitState.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/model/GitState.java
@@ -84,7 +84,7 @@ public class GitState extends VcsState
 
    public void refresh(final boolean showError, final Command onCompleted)
    {
-      server_.gitAllStatus(new ServerRequestCallback<AllStatus>()
+      server_.gitAllStatus(false, new ServerRequestCallback<AllStatus>()
       {
          @Override
          public void onResponseReceived(AllStatus response)
@@ -104,6 +104,26 @@ public class GitState extends VcsState
             if (showError)
                globalDisplay_.showErrorMessage(constants_.errorCapitalized(),
                                                error.getUserMessage());
+         }
+      });
+   }
+   
+   public void refreshMinimal()
+   {
+      server_.gitAllStatus(true, new ServerRequestCallback<AllStatus>()
+      {
+         @Override
+         public void onResponseReceived(AllStatus response)
+         {
+            branches_ = response.getBranches();
+            remoteBranchInfo_ = response.getRemoteBranchInfo();
+            handlers_.fireEvent(new VcsRefreshEvent(Reason.VcsOperation));
+         }
+
+         @Override
+         public void onError(ServerError error)
+         {
+            Debug.logError(error);
          }
       });
    }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15492.

### Approach

When `vcs_autorefresh = false` is set, only perform a "minimal" refresh when the Git pane is activated -- that is, just list remote branches; avoid calling `git status`. This provides us the information needed to populate the Git toolbar buttons, without needing to populate information on changed files.

Also tweaks the background color of the Git pane to avoid white flashing during refresh (just use a transparent background).

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15492.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
