### PR TITLE
fix issue with copilot completions in unsaved documents

### DIFF
--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -128,6 +128,20 @@ std::map<std::string, std::string> s_extToLanguageIdMap = {
    { ".yml",   "yaml" },
 };
 
+std::map<std::string, std::string> makeLanguageIdToExtMap()
+{
+   std::map<std::string, std::string> map;
+   for (auto&& entry : s_extToLanguageIdMap)
+      map[entry.second] = entry.first;
+   return map;
+}
+
+std::map<std::string, std::string>& languageIdToExtMap()
+{
+   static auto instance = makeLanguageIdToExtMap();
+   return instance;
+}
+
 struct CopilotRequest
 {
    std::string method;
@@ -288,7 +302,7 @@ bool isIndexableDocument(const boost::shared_ptr<source_database::SourceDocument
    if (pDoc->isUntitled())
    {
       std::string type = pDoc->type();
-      return !type.empty();
+      return languageIdToExtMap().count(type);
    }
    
    FilePath docPath(pDoc->path());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -423,7 +423,10 @@ public class TextEditingTarget implements
             {
                fileTypeChanged = !StringUtil.equals(newFileType_.getTypeId(), fileType_.getTypeId());
             }
+            
             fileType_ = newFileType_;
+            if (fileTypeChanged)
+               copilotHelper_.onFileTypeChanged();
          }
 
          if (file_ != null)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
@@ -425,6 +425,11 @@ public class TextEditingTargetCopilotHelper
       return text;
    }
    
+   public void onFileTypeChanged()
+   {
+      copilotDisabledInThisDocument_ = false;
+   }
+   
    @Inject
    private void initialize(Copilot copilot,
                            EventBus events,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
@@ -152,8 +152,7 @@ public class TextEditingTargetCopilotHelper
                            Any result = response.result;
                            if (result == null)
                            {
-                              events_.fireEvent(
-                                    new CopilotEvent(CopilotEventType.COMPLETION_CANCELLED));
+                              events_.fireEvent(new CopilotEvent(CopilotEventType.COMPLETION_CANCELLED));
                               return;
                            }
                            


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15507.

### Approach

Untitled documents still normally have a file type. If the document has a recognized file type, then allow that file to be indexed (and provide completions for it).

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15507.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
