### PR TITLE
improve handling of inline comments

### DIFF
--- a/src/cpp/tests/automation/testthat/test-automation-reformat.R
+++ b/src/cpp/tests/automation/testthat/test-automation-reformat.R
@@ -21,3 +21,7 @@ withr::defer(.rs.automation.deleteRemote())
    expect_equal(contents, "1 + 1\n2 + 2\n")
    
 })
+
+.rs.test("https://github.com/rstudio/rstudio/issues/5425", {
+   
+})

--- a/src/cpp/tests/automation/testthat/test-automation-reformat.R
+++ b/src/cpp/tests/automation/testthat/test-automation-reformat.R
@@ -24,4 +24,12 @@ withr::defer(.rs.automation.deleteRemote())
 
 .rs.test("https://github.com/rstudio/rstudio/issues/5425", {
    
+   remote$editor.executeWithContents(".R", "c(1 #2\n)", function(editor) {
+      editor$selectAll()
+      Sys.sleep(0.1)
+      remote$commands.execute(.rs.appCommands$reformatCode)
+      contents <- editor$getValue()
+      expect_equal(contents, "c(\n  1 #2\n)\n")
+   })
+   
 })

--- a/version/news/NEWS-2024.12.1-kousa-dogwood.md
+++ b/version/news/NEWS-2024.12.1-kousa-dogwood.md
@@ -12,6 +12,7 @@
 - Fixed an issue where the Files pane could inadverently scroll back to top in some cases. (#15502)
 - Fixed an issue with non-ASCII characters in qmd files showing as "unexpected token." (#15316)
 - Fixed an issue where RStudio could emit a warning when attempting to retrieve help for R objects without a help page. (rstudio-pro#7063)
+- Fixed an issue where RStudio's code formatter could produce invalid code in some cases. (#5425)
 
 #### Posit Workbench
 - Fix images list in the launcher UI not updating immediately on cluster change for multi-cluster configurations with different image lists. (rstudio-pro#7169)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/5425.

### Approach

For a brief background, RStudio's code formatter acts upon a tokenized representation of the user's code. It performs two passes; one pass where it builds up metadata about the structure of the code being formatter, and another where it manipulates tokens to add whitespace and newlines where appropriate.

This PR resolves https://github.com/rstudio/rstudio/issues/5425 by forcing the formatter to use newlines after `,`, `(` and before `)`, to avoid scenarios where a closing bracket might incorrectly be collapsed onto the same line as a line comment.

### Automated Tests

A simple automated test was included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/5425.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

