### PR TITLE
fix regression where .Rproj.user folder not marked hidden

### DIFF
--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -183,23 +183,21 @@ Error computeScratchPaths(const FilePath& projectFile,
                           FilePath* pScratchPath,
                           FilePath* pSharedScratchPath)
 {
-   // ensure project user dir
+   // compute project directory
    FilePath projectUserDir = computeUserDir(projectFile, projectConfig);
-   if (!projectUserDir.exists())
-   {
-      // create
-      Error error = projectUserDir.ensureDirectory();
-      if (error)
-         return error;
+   
+   // make sure it exists
+   Error error = projectUserDir.ensureDirectory();
+   if (error)
+      return error;
 
-      // mark hidden if we are on win32
+   // mark hidden if we are on win32
 #ifdef _WIN32
-      error = core::system::makeFileHidden(projectUserDir);
-      if (error)
-         return error;
+   error = core::system::makeFileHidden(projectUserDir);
+   if (error)
+      LOG_ERROR(error);
 #endif
-   }
-
+   
    // now add context id to form scratch path
    if (pScratchPath)
    {

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -183,7 +183,7 @@ Error computeScratchPaths(const FilePath& projectFile,
                           FilePath* pScratchPath,
                           FilePath* pSharedScratchPath)
 {
-   // compute project directory
+   // compute project user dir
    FilePath projectUserDir = computeUserDir(projectFile, projectConfig);
    
    // make sure it exists

--- a/version/news/NEWS-2024.12.1-kousa-dogwood.md
+++ b/version/news/NEWS-2024.12.1-kousa-dogwood.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 #### RStudio
+- Fixed an issue where the `.Rproj.user` folder was not marked as hidden for new projects on Windows. (#15514)
 - Fixed an issue where the Files pane could inadverently scroll back to top in some cases. (#15502)
 - Fixed an issue with non-ASCII characters in qmd files showing as "unexpected token." (#15316)
 - Fixed an issue where RStudio could emit a warning when attempting to retrieve help for R objects without a help page. (rstudio-pro#7063)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15514.

### Approach

The `computeUserDirectory()` now also creates the default project directory, which causes us to avoid an older code path where we also would have marked the project directory as hidden. This PR ensures we unconditionally mark the `.Rproj.user` directory as hidden on Windows, even if it was already created before.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15514. Windows only.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

