### PR TITLE
handle potential exceptions when invoking stat

### DIFF
--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -672,11 +672,12 @@ export class FilePath {
    * Checks whether this file path is a directory.
    */
   isDirectory(): boolean {
-    const stat = fs.lstatSync(this.path, {
-      throwIfNoEntry: false,
-    });
-
-    return stat != null && stat.isDirectory();
+    try {
+      const stats = fs.statSync(this.path);
+      return stats.isDirectory();
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -16,7 +16,7 @@
 
 import { BrowserWindow } from 'electron';
 import Store from 'electron-store';
-import { existsSync, lstatSync } from 'fs';
+import { statSync } from 'fs';
 import { basename, dirname, join } from 'path';
 import { properties } from '../../../../../cpp/session/resources/schema/user-state-schema.json';
 import { normalizeSeparatorsNative } from '../../ui/utils';
@@ -366,8 +366,19 @@ if (process.platform === 'darwin') {
  * @returns Full path to Rterm.exe including arch folder
  */
 export function fixWindowsRExecutablePath(rExePath: string): string {
-  if (process.platform !== 'win32' || !existsSync(rExePath) || lstatSync(rExePath).isDirectory()) {
-    // unexpected situation: just leave it as-is
+  // skip on other platforms
+  if (process.platform !== 'win32') {
+    return rExePath;
+  }
+
+  // if we were given the path to a directory, or a non-existent file,
+  // then just return the path as-is (unexpected)
+  try {
+    const info = statSync(rExePath);
+    if (info.isDirectory()) {
+      return rExePath;
+    }
+  } catch {
     return rExePath;
   }
 

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -120,7 +120,7 @@ export function augmentCommandLineArguments(): void {
  * an error only when a stale lockfile exists, but
  * we could not successfully remove it
  */
-export function removeStaleOptionsLockfile(): void {
+function removeStaleOptionsLockfileImpl(): void {
   if (process.platform !== 'win32') {
     return;
   }
@@ -141,6 +141,14 @@ export function removeStaleOptionsLockfile(): void {
   }
 
   fs.unlinkSync(lockFilePath);
+}
+
+export function removeStaleOptionsLockfile(): void {
+  try {
+    removeStaleOptionsLockfileImpl();
+  } catch (err: unknown) {
+    logger().logError(err);
+  }
 }
 
 export function rsessionExeName(): string {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15516.

### Approach

In the places where we're invoking `statSync`, make sure we have an exception handle active just in case.

### Automated Tests

N/A

### QA Notes

To be verified by community.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

