### PR TITLE
use estimate of object size for large character vectors

### DIFF
--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -711,7 +711,7 @@
 
       # some objects (e.g. ALTREP) have compact representations that are forced to materialize if
       # an attempt is made to compute their metrics exactly; avoid computing the size for these
-      size <- if (computeSize) .rs.objectSize(obj) else 0
+      size <- if (computeSize) .rs.estimatedObjectSize(obj) else 0
       len <- length(obj)
    }
 
@@ -737,7 +737,7 @@
       {
          len_desc <- if (len > 1)
          {
-            paste(len, " elements, ", sep = "")
+            paste(len, " elements,", sep = "")
          }
          else
          {
@@ -752,8 +752,13 @@
          }
          else
          {
+            is_size_estimated <- identical(attr(size, "estimate"), TRUE)
+            size <- format(size, units = "auto", standard = "SI")
+            if (is_size_estimated)
+               size <- paste(">", size)
+            
             fmt <- "Large %s (%s %s)"
-            val <- sprintf(fmt, class, len_desc, format(size, units = "auto", standard = "SI"))
+            val <- sprintf(fmt, class, len_desc, size)
          }
          contents_deferred <- TRUE
       }
@@ -1018,3 +1023,24 @@
    else
       utils::object.size(x)
 })
+
+.rs.addFunction("estimatedObjectSize", function(x)
+{
+   n <- length(x)
+   if (n < 1E5)
+   {
+      .rs.objectSize(x)
+   }
+   else if (is.character(x))
+   {
+      result <- n * .Machine$sizeof.pointer
+      class(result) <- "object_size"
+      attr(result, "estimate") <- TRUE
+      return(result)
+   }
+   else
+   {
+      .rs.objectSize(x)
+   }
+})
+

--- a/version/news/NEWS-2024.12.1-kousa-dogwood.md
+++ b/version/news/NEWS-2024.12.1-kousa-dogwood.md
@@ -16,6 +16,7 @@
 - Fixed an issue where RStudio could emit a warning when attempting to retrieve help for R objects without a help page. (rstudio-pro#7063)
 
 #### Posit Workbench
+- Fixed an issue where very large character vectors in the R global environment could make RStudio initialize more slowly. (rstudio-pro#7226)
 - Fix images list in the launcher UI not updating immediately on cluster change for multi-cluster configurations with different image lists. (rstudio-pro#7169)
 - Fix a regression where editors configured with both a default cluster of "Local" and a default image cause a misconfiguration on session launch. (rstudio-pro#7172, rstudio-pro#7178)
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/7226.

### Approach

R performs some expensive computations when computing the size of character vectors. Avoid this computation for large vectors, and instead provide an estimate based on the minimum-possible size for that vector.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio-pro/issues/7226.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
