### PR TITLE
Create SELinux policy module

### DIFF
--- a/dependencies/linux/install-dependencies-bionic
+++ b/dependencies/linux/install-dependencies-bionic
@@ -65,6 +65,7 @@ sudo apt-get -y install \
   python3 \
   python3-venv \
   rrdtool \
+  selinux-policy-devel \
   software-properties-common \
   unzip \
   uuid-dev \
@@ -109,4 +110,4 @@ if [ -x "$(command -v python3)" ]; then
   python3 -m venv VENV
   ./VENV/bin/pip install --disable-pip-version-check -r commands.cmd.xml/requirements.txt
   popd
-fi 
+fi

--- a/dependencies/linux/install-dependencies-focal
+++ b/dependencies/linux/install-dependencies-focal
@@ -66,6 +66,7 @@ sudo apt-get -y install \
   python3 \
   python3-venv \
   rrdtool \
+  selinux-policy-devel \
   software-properties-common \
   unzip \
   uuid-dev \
@@ -114,4 +115,4 @@ if [ -x "$(command -v python3)" ]; then
   python3 -m venv VENV
   ./VENV/bin/pip install --disable-pip-version-check -r commands.cmd.xml/requirements.txt
   popd
-fi 
+fi

--- a/dependencies/linux/install-dependencies-jammy
+++ b/dependencies/linux/install-dependencies-jammy
@@ -67,6 +67,7 @@ sudo apt-get -y install \
   python3-venv \
   r-base-dev \
   rrdtool \
+  selinux-policy-devel \
   software-properties-common \
   unzip \
   uuid-dev \
@@ -100,4 +101,4 @@ if [ -x "$(command -v python3)" ]; then
   python3 -m venv VENV
   ./VENV/bin/pip install --disable-pip-version-check -r commands.cmd.xml/requirements.txt
   popd
-fi 
+fi

--- a/dependencies/linux/install-dependencies-noble
+++ b/dependencies/linux/install-dependencies-noble
@@ -66,6 +66,7 @@ sudo apt-get -y install \
   python3-venv \
   r-base-dev \
   rrdtool \
+  selinux-policy-devel \
   software-properties-common \
   unzip \
   uuid-dev \

--- a/dependencies/linux/install-dependencies-yum
+++ b/dependencies/linux/install-dependencies-yum
@@ -33,6 +33,7 @@ sudo yum install -y bzip2-devel
 sudo yum install -y zlib-devel
 sudo yum install -y pam-devel
 sudo yum install -y libuser-devel
+sudo yum install -y selinux-policy-devel
 
 # pandoc dependencies
 sudo yum install -y libffi

--- a/dependencies/linux/install-dependencies-zypper
+++ b/dependencies/linux/install-dependencies-zypper
@@ -33,6 +33,7 @@ sudo zypper --non-interactive in libopenssl-devel
 sudo zypper --non-interactive in libpq-devel
 sudo zypper --non-interactive in libsqlite-devel
 sudo zypper --non-interactive in pam-devel
+sudo zypper --non-interactive in selinux-policy-devel
 
 # boost
 sudo zypper --non-interactive in boost-devel

--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -10,7 +10,7 @@ ARG AWS_REGION=us-east-1
 RUN set -x \
     && sed -i "s/archive.ubuntu.com/$AWS_REGION.ec2.archive.ubuntu.com/" /etc/apt/sources.list \
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get update 
+    && apt-get update
 
 RUN apt-get update && \
     export DEBIAN_FRONTEND=noninteractive && \
@@ -54,6 +54,7 @@ RUN apt-get update && \
     pkg-config \
     python \
     r-base \
+    selinux-policy-dev \
     sudo \
     unzip \
     uuid-dev \

--- a/docker/jenkins/Dockerfile.focal
+++ b/docker/jenkins/Dockerfile.focal
@@ -10,7 +10,7 @@ ARG AWS_REGION=us-east-1
 RUN set -x \
     && sed -i "s/archive.ubuntu.com/$AWS_REGION.ec2.archive.ubuntu.com/" /etc/apt/sources.list \
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get update 
+    && apt-get update
 
 RUN apt-get update && \
     export DEBIAN_FRONTEND=noninteractive && \
@@ -53,6 +53,7 @@ RUN apt-get update && \
     pkg-config \
     python \
     r-base \
+    selinux-policy-dev \
     sudo \
     unzip \
     uuid-dev \

--- a/docker/jenkins/Dockerfile.jammy
+++ b/docker/jenkins/Dockerfile.jammy
@@ -40,7 +40,7 @@ RUN apt-get update && \
     libfuse2 \
     libgl1-mesa-dev \
     libgtk-3-0 \
-    libjpeg-dev \ 
+    libjpeg-dev \
     libpam-dev \
     libpango1.0-dev \
     libpng-dev\
@@ -60,6 +60,7 @@ RUN apt-get update && \
     python3-dev \
     python-is-python3 \
     r-base \
+    selinux-policy-dev \
     sudo \
     unzip \
     uuid-dev \

--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -49,6 +49,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     R \
     rpm-build \
     sqlite3-devel \
+    selinux-policy-devel \
     sudo \
     tar \
     unzip \

--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -6,7 +6,7 @@ ENV OPERATING_SYSTEM=rockylinux_8
 
 RUN set -x \
       && yum install epel-release -y \
-      && yum install dnf-plugins-core -y \ 
+      && yum install dnf-plugins-core -y \
       && yum config-manager --set-enabled powertools \
       && yum update -y
 
@@ -31,13 +31,13 @@ RUN yum install -y \
     libXcursor-devel \
     libXrandr-devel \
     libacl-devel \
-    libcap-devel \ 
+    libcap-devel \
     libcurl-devel \
     libpq-devel \
     libuuid-devel \
     libxml2-devel \
     llvm-devel \
-    libjpeg-turbo-devel \ 
+    libjpeg-turbo-devel \
     libpng-devel \
     libtiff-devel \
     lsof \
@@ -56,6 +56,7 @@ RUN yum install -y \
     R \
     rpmdevtools \
     rpm-sign \
+    selinux-policy-devel \
     sqlite-devel \
     sudo \
     valgrind \
@@ -109,14 +110,14 @@ RUN chmod -R 777 /opt/rstudio-tools/src
 RUN wget https://pagure.io/libuser/archive/libuser-0.62/libuser-libuser-0.62.tar.gz
 RUN tar zxvf libuser-libuser-0.62.tar.gz
 RUN mkdir -p /usr/include/libuser
-RUN cp libuser-libuser-0.62/lib/*.h /usr/include/libuser 
+RUN cp libuser-libuser-0.62/lib/*.h /usr/include/libuser
 
 # build and install gpg1.4 which we need to sign the builds in headless mode
 # this is unavailable in the official rhel8 repos
 RUN wget https://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.23.tar.bz2
 RUN tar xvf gnupg-1.4.23.tar.bz2
 RUN cd gnupg-1.4.23 && ./configure --prefix=/gnupg1 && make && make install
-RUN ln -s /gnupg1/bin/gpg /usr/local/bin/gpg1 
+RUN ln -s /gnupg1/bin/gpg /usr/local/bin/gpg1
 
 # cachebust for Quarto release
 ADD https://quarto.org/docs/download/_download.json quarto_releases

--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -8,7 +8,7 @@ ARG AWS_REGION=us-east-1
 
 RUN set -x \
       && yum install epel-release -y \
-      && yum install dnf-plugins-core -y \ 
+      && yum install dnf-plugins-core -y \
       && yum config-manager --set-enabled crb \
       && yum update -y
 
@@ -35,7 +35,7 @@ RUN dnf install -y \
     libXcursor-devel \
     libXrandr-devel \
     libacl-devel \
-    libcap-devel \ 
+    libcap-devel \
     libcurl-devel \
     libffi \
     libjpeg-turbo-devel \
@@ -58,6 +58,7 @@ RUN dnf install -y \
     python3 \
     rpm-sign \
     rpmdevtools \
+    selinux-policy-devel \
     sqlite-devel \
     sudo \
     valgrind \
@@ -68,7 +69,7 @@ RUN dnf install -y \
     zlib-devel
 
 # The latest redhat build of java-11-openjdk (11.0.20.0.8-2.el9) is missing a dependency on tzdata-java
-# https://bugzilla.redhat.com/show_bug.cgi?id=2225018 
+# https://bugzilla.redhat.com/show_bug.cgi?id=2225018
 # use the workaround until they resolve the issue
 RUN dnf install -y tzdata-java
 
@@ -123,6 +124,11 @@ ENV RUSTUP_HOME="/opt/rstudio-tools/dependencies/common/overlay/rust"
 RUN if [ -d "/opt/rstudio-tools/dependencies/common/overlay/rust" ]; then \
     chmod -R 777 /opt/rstudio-tools/dependencies/common/overlay/rust \
     ; fi
+
+# prepare SELinux policy module
+COPY package/linux/selinux/ /opt/rstudio-tools/selinux/
+ENV SELINUX_MAKEFILE=/usr/share/selinux/devel/Makefile
+RUN /bin/bash /opt/rstudio-tools/selinux/build_selinux_policy.sh --rpm
 
 # remove any previous users with conflicting IDs
 ARG JENKINS_GID=999

--- a/package/linux/CMakeLists.txt
+++ b/package/linux/CMakeLists.txt
@@ -279,8 +279,3 @@ set(CPACK_RPM_PACKAGE_AUTOREQPROV " no")
 
 # build package
 include(CPack)
-
-
-
-
-

--- a/package/linux/debian-control/postinst.in
+++ b/package/linux/debian-control/postinst.in
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # errors shouldn't cause script to exit
-set +e 
+set +e
 
 # add rserver user account
 useradd -r -U rstudio-server
@@ -90,7 +90,7 @@ if test "$INIT_SYSTEM" = "systemd"
 then
    systemctl stop rstudio-server.service 2>/dev/null
    systemctl disable rstudio-server.service 2>/dev/null
-  
+
    if test -e /lib/systemd
    then
       SYSTEMD_PREFIX="/lib/systemd"
@@ -99,7 +99,7 @@ then
    fi
 
    cp ${CMAKE_INSTALL_PREFIX}/extras/systemd/rstudio-server.service $${EMPTY}{SYSTEMD_PREFIX}/system/rstudio-server.service
-  
+
    systemctl daemon-reload
    systemctl enable rstudio-server.service
    $RSERVER_ADMIN_SCRIPT start

--- a/package/linux/debian-control/postrm.in
+++ b/package/linux/debian-control/postrm.in
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 # errors shouldn't cause script to exit
-set +e 
+set +e
 
-# remove softlink to admin script 
+# remove softlink to admin script
 rm -f /usr/sbin/rstudio-server
 
 # remove temporary streams

--- a/package/linux/selinux/.gitignore
+++ b/package/linux/selinux/.gitignore
@@ -1,0 +1,14 @@
+rstudio.pp
+rstudio.fc
+tmp
+CMakeCache.txt
+CMakeFiles
+CPack*Config.cmake
+Makefile
+_CPack_Packages
+install_manifest.txt
+debian-control
+postinst
+postrm
+*.deb
+*.rpm

--- a/package/linux/selinux/CMakeLists.txt
+++ b/package/linux/selinux/CMakeLists.txt
@@ -1,0 +1,177 @@
+#
+# CMakeLists.txt
+#
+# Copyright (C) 2022 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+cmake_minimum_required(VERSION 3.10)
+project(selinux)
+
+# configure cpack install location
+set(CPACK_SET_DESTDIR "ON")
+set(CPACK_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
+
+# package metadata
+set(CPACK_PACKAGE_NAME "rstudio-server-selinux")
+set(CPACK_PACKAGE_DESCRIPTION "SELinux policy module for rstudio-server")
+set(CPACK_PACKAGE_VENDOR "Posit Software")
+set(CPACK_PACKAGE_CONTACT "RStudio <info@posit.co>")
+
+# read distro information from standard location
+set(IS_RHEL "OFF")
+set(DISTRO_NAME "generic Linux")
+set(DISTRO_PRETTY_NAME "")
+set(DISTRO_ID "")
+set(DISTRO_VERSION "")
+set(DISTRO_CODENAME "")
+if(EXISTS "/etc/os-release")
+  file(STRINGS "/etc/os-release" OS_RELEASE_LINES)
+  foreach(LINE ${OS_RELEASE_LINES})
+    string(REGEX MATCH "^[^=]+" KEY ${LINE})
+    string(REPLACE "${KEY}=" "" VAL ${LINE})
+    string(REPLACE "\"" "" VAL ${VAL})
+    if(KEY STREQUAL "ID")
+      set(DISTRO_ID ${VAL})
+    elseif(KEY STREQUAL "ID_LIKE")
+      string(FIND ${VAL} "rhel" FOUND)
+      if(FOUND GREATER_EQUAL 0)
+        set(IS_RHEL "ON")
+      endif()
+    elseif(KEY STREQUAL "VERSION_ID")
+      string(REGEX MATCH "^[0-9]+" DISTRO_VERSION)
+    elseif(KEY STREQUAL "VERSION_CODENAME")
+      set(DISTRO_CODENAME ${VAL})
+    elseif(KEY STREQUAL "NAME")
+      set(DISTRO_NAME ${VAL})
+    elseif(KEY STREQUAL "PRETTY_NAME")
+      set(DISTRO_PRETTY_NAME ${VAL})
+    endif()
+  endforeach()
+endif()
+if(DISTRO_PRETTY_NAME STREQUAL "")
+  set(DISTRO_PRETTY_NAME ${DISTRO_NAME})
+endif()
+if(IS_RHEL)
+  set(PACKAGE_SUFFIX "-rhel${DISTRO_VERSION}")
+elseif(NOT DISTRO_CODENAME STREQUAL "")
+  set(PACKAGE_SUFFIX "-${DISTRO_CODENAME}")
+elseif(NOT DISTRO_ID STREQUAL "")
+  set(PACKAGE_SUFFIX "-${DISTRO_ID}${DISTRO_VERSION}")
+else()
+  set(PACKAGE_SUFFIX "")
+endif()
+
+message(STATUS "Packaging SELinux policy for ${DISTRO_PRETTY_NAME}")
+
+# find the Makefile provided by the selinux policy
+if(NOT DEFINED SELINUX_MAKEFILE)
+  if(EXISTS "/usr/share/selinux/devel/Makefile")
+    set(SELINUX_MAKEFILE "/usr/share/selinux/devel/Makefile")
+  elseif(EXISTS "/usr/share/selinux/devel/include/Makefile")
+    set(SELINUX_MAKEFILE "/usr/share/selinux/devel/include/Makefile")
+  else()
+    # Some distros use different paths, so search for the file
+    file(GLOB_RECURSE SELINUX_MAKEFILE FOLLOW_SYMLINKS "/usr/share/selinux/*/Makefile")
+    list(GET SELINUX_MAKEFILE 0 SELINUX_MAKEFILE)
+  endif()
+endif()
+
+# Find where the distro stores its .pp files
+if(NOT DEFINED SELINUX_PACKAGE_PATH)
+  if(EXISTS "/usr/share/selinux/packages/")
+    set(SELINUX_PACKAGE_PATH "/usr/share/selinux/packages/")
+  elseif(EXISTS "/usr/share/selinux/default/")
+    set(SELINUX_PACKAGE_PATH "/usr/share/selinux/default/")
+  else()
+    # Some distros use different paths, so search for an existing policy file and imitate it
+    file(GLOB_RECURSE SELINUX_PACKAGE_PATH FOLLOW_SYMLINKS "/usr/share/selinux/*.pp*")
+    list(GET SELINUX_PACKAGE_PATH 0 SELINUX_PACKAGE_PATH)
+    get_filename_component(SELINUX_PACKAGE_PATH ${SELINUX_PACKAGE_PATH} DIRECTORY)
+  endif()
+endif()
+
+# configure the paths in the file context list
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/rstudio.fc.in
+               ${CMAKE_CURRENT_SOURCE_DIR}/rstudio.fc)
+
+# compile the policy module using the selinux Makefile
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/rstudio.pp
+                   COMMAND make ARGS -C ${CMAKE_CURRENT_SOURCE_DIR} -f ${SELINUX_MAKEFILE} rstudio.pp
+                   COMMAND mv ARGS ${CMAKE_CURRENT_SOURCE_DIR}/rstudio.pp ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/rstudio.pp
+                   MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/rstudio.te
+                   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/rstudio.fc
+                           ${CMAKE_CURRENT_SOURCE_DIR}/rstudio.te)
+
+# generate the man pages
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/rstudio_selinux.8
+                          ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/rstudio_server_selinux.8
+                   COMMAND sepolicy ARGS ${SEPOLICY_ARGS} manpage -p ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY} -d rstudio_t rstudio_server_t
+                   MAIN_DEPENDENCY ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/rstudio.pp)
+
+# install the module and the man pages to the appropriate paths
+add_custom_target(selinux ALL
+                  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/rstudio.pp
+                          ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/rstudio_selinux.8
+                          ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/rstudio_server_selinux.8)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/rstudio.pp
+        DESTINATION ${SELINUX_PACKAGE_PATH})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/rstudio_selinux.8
+              ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/rstudio_server_selinux.8
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/man/man8)
+
+# prepare the installation/uninstallation scripts
+if(IS_RHEL)
+  set(CHECK_UNINSTALL_CONDITION "[ $1 -eq 0 ]")
+else()
+  set(CHECK_UNINSTALL_CONDITION "/bin/true")
+endif()
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/postinst.in
+               ${CMAKE_CURRENT_BINARY_DIR}/postinst)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/postrm.in
+               ${CMAKE_CURRENT_BINARY_DIR}/postrm)
+
+set(PACKAGE_ATOM "${CPACK_PACKAGE_NAME}${PACKAGE_SUFFIX}${CPACK_PACKAGE_VERSION}")
+
+  # rpm-specific
+set(CPACK_RPM_SPEC_INSTALL_POST "/bin/true")
+set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/postinst")
+set(CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/postrm")
+
+set(CPACK_RPM_FILE_NAME "${PACKAGE_ATOM}-noarch")
+set(CPACK_RPM_PACKAGE_SUMMARY "${CPACK_PACKAGE_DESCRIPTION}")
+set(CPACK_RPM_PACKAGE_LICENSE "AGPL v.3.0")
+set(CPACK_RPM_PACKAGE_GROUP "Development/Tools")
+set(CPACK_RPM_PACKAGE_ARCHITECTURE "noarch")
+set(CPACK_RPM_PACKAGE_REQUIRES "policycoreutils-python-utils, libselinux-utils")
+set(CPACK_RPM_PACKAGE_REQUIRES_POST "selinux-policy-base, policycoreutils-python-utils")
+set(CPACK_RPM_PACKAGE_REQUIRES_POSTUN "policycoreutils-python-utils")
+set(CPACK_RPM_PACKAGE_SUGGESTS "rstudio-server")
+set(CPACK_RPM_PACKAGE_AUTOREQPROV " no")
+
+# debian-specific
+file(COPY ${CMAKE_CURRENT_BINARY_DIR}/postinst
+          ${CMAKE_CURRENT_BINARY_DIR}/postrm
+          DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/debian-control
+          FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ
+          GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_BINARY_DIR}/debian-control/postinst;${CMAKE_CURRENT_BINARY_DIR}/debian-control/postrm")
+
+set(CPACK_PACKAGE_FILE_NAME "${PACKAGE_ATOM}-all")
+set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "${CPACK_PACKAGE_DESCRIPTION}")
+set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "all")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "selinux-policy-default, policycoreutils, selinux-utils")
+set(CPACK_DEBIAN_PACKAGE_SUGGESTS "rstudio-server")
+set(CPACK_DEBIAN_PACKAGE_CONTROL_STRICT_PERMISSION TRUE)
+set(CPACK_DEBIAN_COMPRESSION_TYPE "xz")
+
+# build package
+include(CPack)

--- a/package/linux/selinux/postinst.in
+++ b/package/linux/selinux/postinst.in
@@ -1,0 +1,8 @@
+#!/bin/sh
+semodule -n -i ${SELINUX_PACKAGE_PATH}/rstudio.pp
+
+if /usr/sbin/selinuxenabled; then
+    /usr/sbin/load_policy
+    restorecon -R ${CMAKE_INSTALL_PREFIX}/bin/*
+fi
+

--- a/package/linux/selinux/postrm.in
+++ b/package/linux/selinux/postrm.in
@@ -1,0 +1,9 @@
+#!/bin/sh
+if ${CHECK_UNINSTALL_CONDITION}; then
+   semodule -n -r rstudio
+
+   if /usr/sbin/selinuxenabled; then
+     /usr/sbin/load_policy
+     restorecon -R ${CMAKE_INSTALL_PREFIX}/bin/*
+   fi
+fi

--- a/package/linux/selinux/rstudio.fc.in
+++ b/package/linux/selinux/rstudio.fc.in
@@ -1,0 +1,7 @@
+@CMAKE_INSTALL_PREFIX@/bin/rstudio-launcher        -- gen_context(system_u:object_r:rstudio_exec_t,s0)
+@CMAKE_INSTALL_PREFIX@/bin/rstudio-local-launcher  -- gen_context(system_u:object_r:rstudio_exec_t,s0)
+@CMAKE_INSTALL_PREFIX@/bin/rworkspaces             -- gen_context(system_u:object_r:rstudio_exec_t,s0)
+@CMAKE_INSTALL_PREFIX@/bin/rserver                 -- gen_context(system_u:object_r:rstudio_server_exec_t,s0)
+@CMAKE_INSTALL_PREFIX@/bin/rserver-launcher        -- gen_context(system_u:object_r:rstudio_server_exec_t,s0)
+@CMAKE_INSTALL_PREFIX@/bin/rstudio-server          -- gen_context(system_u:object_r:rstudio_server_exec_t,s0)
+

--- a/package/linux/selinux/rstudio.if
+++ b/package/linux/selinux/rstudio.if
@@ -1,0 +1,77 @@
+## <summary>policy for rstudio</summary>
+
+########################################
+## <summary>
+##	Execute rstudio_exec_t in the rstudio domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`rstudio_domtrans',`
+	gen_require(`
+		type rstudio_t, rstudio_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, rstudio_exec_t, rstudio_t)
+')
+
+########################################
+## <summary>
+##	Execute rstudio_server_exec_t in the rstudio_server domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`rstudio_server_domtrans',`
+	gen_require(`
+		type rstudio_server_t, rstudio_server_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, rstudio_server_exec_t, rstudio_server_t)
+')
+
+######################################
+## <summary>
+##	Execute rstudio in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`rstudio_exec',`
+	gen_require(`
+		type rstudio_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, rstudio_exec_t)
+')
+
+######################################
+## <summary>
+##	Execute rstudio_server in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`rstudio_server_exec',`
+	gen_require(`
+		type rstudio_server_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, rstudio_server_exec_t)
+')

--- a/package/linux/selinux/rstudio.te
+++ b/package/linux/selinux/rstudio.te
@@ -1,0 +1,59 @@
+policy_module(rstudio, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+require {
+	type unreserved_port_t;
+	class tcp_socket name_connect;
+	class passwd rootok;
+}
+
+type rstudio_t;
+type rstudio_exec_t;
+type rstudio_server_t;
+type rstudio_server_exec_t;
+init_daemon_domain(rstudio_t, rstudio_exec_t)
+init_daemon_domain(rstudio_server_t, rstudio_server_exec_t)
+
+permissive rstudio_t;
+permissive rstudio_server_t;
+
+########################################
+#
+# local policies
+#
+
+allow rstudio_t self:capability { chown setgid setuid };
+allow rstudio_t self:process { fork getpgid setpgid setrlimit signal_perms };
+allow rstudio_t self:fifo_file rw_fifo_file_perms;
+allow rstudio_t self:unix_stream_socket { create_stream_socket_perms connectto };
+allow rstudio_t self:passwd rootok;
+
+allow rstudio_server_t self:fifo_file rw_fifo_file_perms;
+allow rstudio_server_t self:unix_stream_socket { create_stream_socket_perms connectto };
+allow rstudio_server_t self:passwd rootok;
+allow rstudio_server_t self:process setpgid;
+allow rstudio_server_t unreserved_port_t:tcp_socket name_connect;
+
+# TODO: This doesn't seem right -- is it necessary?
+# allow init_t self:process setpgid;
+
+domain_use_interactive_fds(rstudio_t)
+domain_use_interactive_fds(rstudio_server_t)
+
+auth_use_nsswitch(rstudio_t)
+
+logging_send_syslog_msg(rstudio_t)
+logging_send_syslog_msg(rstudio_server_t)
+logging_send_audit_msgs(rstudio_server_t)
+
+files_read_etc_files(rstudio_t)
+files_read_etc_files(rstudio_server_t)
+
+miscfiles_read_localization(rstudio_t)
+miscfiles_read_localization(rstudio_server_t)
+
+sysnet_dns_name_resolve(rstudio_t)


### PR DESCRIPTION
### Intent

Adds an SELinux policy module in order to allow Workbench to run on SELinux-enabled systems without disabling enforcement. 

Addresses https://github.com/rstudio/rstudio/issues/4937

### Approach

The SELinux userspace includes tools for tracking what actions were denied to running applications and translating them into policy configuration. This output was used to indicate which rules would be necessary, and I wrote a specific policy based on those.

### Automated Tests

It's not possible to build unit tests for this functionality, as it is external to the application itself. (It might be possible to create an end-to-end test in a VM, but that depends on a lot of infrastructure.)

### QA Notes

This potentially touches every part of the system. We need to validate the entire workflow:
* Verify that installing the .rpm and .deb packages on both non-SELinux and SELinux systems works without errors
* Verify that all services start up successfully with SELinux in enforcing mode
* Verify that all workspace types function as expected, paying special attention to any functionality that might require access to system resources
* Verify that uninstalling the .rpm/.deb packages cleans up the SELinux policy

### Documentation

TODO: This is scheduled to be released after 2024.12.0, so adding a news entry will need to wait.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests
