### PR TITLE
ensure Quarto documents can be accessed by Copilot

### DIFF
--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -108,7 +108,7 @@ std::map<std::string, std::string> s_extToLanguageIdMap = {
    { ".mjs",   "javascript" },
    { ".ps",    "powershell" },
    { ".py",    "python" },
-   { ".tex",   "latex" },
+   { ".qmd",   "quarto" },
    { ".r",     "r" },
    { ".rb",    "ruby" },
    { ".rmd",   "r" },

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -298,18 +298,19 @@ bool isIndexableDocument(const boost::shared_ptr<source_database::SourceDocument
    if (pDoc->contents().find('\0') != std::string::npos)
       return false;
    
+   // Our source database uses non-standard names for certain R file types,
+   // so explicitly check for those and allow them to be indexed.
+   if (pDoc->isRFile() || pDoc->isRMarkdownDocument())
+      return true;
+   
    // Allow indexing of Untitled documents if they have a known type.
    if (pDoc->isUntitled())
    {
-      // Our source database uses non-standard names for certain R file types,
-      // so explicitly check for those and allow them to be indexed.
-      if (pDoc->isRFile() || pDoc->isRMarkdownDocument())
-         return true;
-
       std::string type = pDoc->type();
       return languageIdToExtMap().count(type);
    }
    
+   // Otherwise, check for known files / extensions.
    FilePath docPath(pDoc->path());
    return isIndexableFile(docPath);
 }

--- a/version/news/NEWS-2024.12.1-kousa-dogwood.md
+++ b/version/news/NEWS-2024.12.1-kousa-dogwood.md
@@ -11,6 +11,7 @@
 
 #### RStudio
 - Reverted support for `help.htmltoc` with R (>= 4.4); support will be re-evaluated in a future release. (#15531)
+- Fixed an issue where Copilot completions were not provided in Quarto documents. (#15539)
 - Fixed an issue where very large character vectors in the R global environment could make RStudio initialize more slowly. (rstudio-pro#7226)
 - Fixed an issue where the `.Rproj.user` folder was not marked as hidden for new projects on Windows. (#15514)
 - Fixed an issue where the Files pane could inadverently scroll back to top in some cases. (#15502)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15539.

### Approach

Add Quarto to the known filetype list; also explicitly check the source document type even if the document is titled.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15539.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
