### PR TITLE
use rstudio-localhost for dev server

### DIFF
--- a/dependencies/common/install-hosts
+++ b/dependencies/common/install-hosts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# install-common
+# install-hosts
 #
 # Copyright (C) 2022 by Posit Software, PBC
 #
@@ -17,21 +17,17 @@
 
 set -e
 
-./install-packages "$1"
-./install-dictionaries
-./install-mathjax
-./install-boost
-./install-pandoc
-./install-quarto
-./install-sentry-cli
-./install-npm-dependencies
-./install-soci
-./install-crashpad
-./install-panmirror
-./install-sccache
-./install-hosts
+source "$(dirname "${BASH_SOURCE[0]}")/../tools/rstudio-tools.sh"
+section "Updating /etc/hosts"
 
-if [ -e install-overlay ]
-then
-   ./install-overlay "$1"
+ENTRY="127.0.0.1  rstudio-localhost"
+if grep -q "${ENTRY}" /etc/hosts; then
+   info "/etc/hosts is already up-to-date."
+   exit 0
 fi
+
+# re-run as root if necessary
+sudo-if-necessary-for /etc/hosts "$@"
+info "Adding ${ENTRY} to /etc/hosts."
+echo "${ENTRY}" >> /etc/hosts
+

--- a/src/cpp/rserver-dev.in
+++ b/src/cpp/rserver-dev.in
@@ -32,6 +32,7 @@ cleanup()
 }
 trap cleanup SIGINT
 
+echo "[i] Starting RStudio Server. Please connect at http://rstudio-localhost:8787."
 RS_CRASH_HANDLER_PATH="$(pwd)/server/crash-handler-proxy/crash-handler-proxy" \
    RS_CRASHPAD_HANDLER_PATH="${RSTUDIO_TOOLS_ROOT}/crashpad/crashpad/out/Default/crashpad_handler" \
    RS_DB_MIGRATIONS_PATH="${CMAKE_CURRENT_SOURCE_DIR}/server/db" \


### PR DESCRIPTION
Primarily for development scenarios where we want to simulate http connections from a non-localhost domain, since browsers might apply different security restrictions in this scenario.