### PR TITLE
fix files not always opening when launching RStudio via double-clicking a source file

### DIFF
--- a/src/node/desktop/src/main/args-manager.ts
+++ b/src/node/desktop/src/main/args-manager.ts
@@ -44,11 +44,6 @@ export const kSessionExit = 'session-exit';
 export const kHelp = '--help';
 export const kStartupDelay = 'startup-delay';
 
-// RStudio Pro Only
-// export const kSessionServerOption = '--session-server';
-// export const kSessionServerUrlOption = '--session-url';
-// export const kTempCookiesOption = '--use-temp-cookies';
-
 const defaultStartupDelaySeconds = 5;
 
 export interface Option {

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -147,6 +147,7 @@ export class SessionLauncher {
   private splash: BrowserWindow | undefined;
   private showSplash = process.env.NODE_ENV !== 'TEST';
   private splashDelay: number;
+  private splashLinger: number;
 
   constructor(
     private sessionPath: FilePath,
@@ -156,6 +157,7 @@ export class SessionLauncher {
     private windowAllClosedHandler: (() => void) | null,
   ) {
     this.splashDelay = process.env.RS_SPLASH_DELAY ? parseInt(process.env.RS_SPLASH_DELAY) : 100;
+    this.splashLinger = process.env.RS_SPLASH_LINGER ? parseInt(process.env.RS_SPLASH_LINGER) : 1300;
     if (process.env.RS_NO_SPLASH) {
       this.showSplash = false;
     }
@@ -244,7 +246,7 @@ export class SessionLauncher {
         // if the splash screen displayed, keep it visible for another brief period to
         // reduce cases where it flashes and hides without being readable
         if (this.splash) {
-          setTimeoutPromise(1300)
+          setTimeoutPromise(this.splashLinger)
             .then(() => {
               this.splash?.close();
             })

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -408,7 +408,7 @@ export function getDesktopBridge() {
         .catch((error) => reportIpcError('setPendingQuit', error));
     },
 
-    openFile: (path: string) => {
+    openFile: async (path: string) => {
       if (!path) {
         return;
       }
@@ -417,22 +417,17 @@ export function getDesktopBridge() {
       if (webcontents.length) {
         path = path.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('\n', '\\n');
 
-        // be sure window has the desktop hooks (the splash screen, for example, does NOT have them)
+        // use first window that has the desktop hooks (the splash screen, for example, does NOT have them)
         for (const webcontent of webcontents) {
-          webcontent.executeJavaScript('!!window.desktopHooks').then((hasHooks: boolean) => {
-            if (hasHooks) {
-              webcontent.executeJavaScript(`window.desktopHooks.openFile("${path}")`)
-                .then(() => {
-                  // Successfully executed the script, break out of the loop
-                  return;
-                })
-                .catch((error: unknown) => {
-                  logString('err', safeError(error).message);
-                });
+          const hasHooks: boolean = await webcontent.executeJavaScript('!!window.desktopHooks');
+          if (hasHooks) {
+            try {
+              await webcontent.executeJavaScript(`window.desktopHooks.openFile("${path}")`);
+            } catch (error: unknown) {
+              logString('err', safeError(error).message);
             }
-          }).catch((error: unknown) => {
-            logString('err', safeError(error).message);
-          });
+            break;
+          }
         }
       }
     },

--- a/version/news/NEWS-2024.12.1-kousa-dogwood.md
+++ b/version/news/NEWS-2024.12.1-kousa-dogwood.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 #### RStudio
+- Fixed an issue where double-clicking a source file to start RStudio didn't always open the file after starting. (#15536)
 - Reverted support for `help.htmltoc` with R (>= 4.4); support will be re-evaluated in a future release. (#15531)
 - Fixed an issue where Copilot completions were not provided in Quarto documents. (#15539)
 - Fixed an issue where very large character vectors in the R global environment could make RStudio initialize more slowly. (rstudio-pro#7226)


### PR DESCRIPTION
### Intent

Addresses #15536

### Approach

Instead of telling the first available window to open a file, ensure the window used is capable of opening files by checking for desktop hooks.

The problem was the splash screen was the first window opened, so if the "open file" message arrived while the splash screen was still showing, the splash screen could receive the "open file" message, and this would fail to do anything.

I also added an environment variable, `RS_SPLASH_LINGER` for overriding the minimum length of time the splash screen stays visible. The default is `1300` (1.3 seconds). For testing this issue, recommend setting a longer time, e.g. `RS_SPLASH_LINGER=8000` for 8 seconds.

### Automated Tests

Tough to automate.

### QA Notes

Test various combinations, starting RStudio via double-clicking a source file 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


