### PR TITLE
include Noto Sans in default font list

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/ThemeFonts.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ThemeFonts.java
@@ -29,7 +29,7 @@ public class ThemeFonts
 
    public static String getProportionalFont()
    {
-      return fontLoader.getProportionalFont() + ", serif";
+      return fontLoader.getProportionalFont() + ", sans-serif";
    }
 
    public static String getFixedWidthFont()
@@ -85,7 +85,7 @@ public class ThemeFonts
       public String getProportionalFont()
       {
          String font = BrowseCap.hasUbuntuFonts() ? "Ubuntu, " : "";
-         return font + "\"Lucida Sans\", \"DejaVu Sans\", \"Lucida Grande\", \"Segoe UI\", Verdana, Helvetica, sans-serif";
+         return font + "\"Lucida Sans\", \"DejaVu Sans\", \"Noto Sans\", \"Lucida Grande\", \"Segoe UI\", Verdana, Helvetica, sans-serif";
       }
 
       public String getFixedWidthFont()
@@ -116,7 +116,7 @@ public class ThemeFonts
          if (BrowseCap.isMacintosh())
             font += "Monaco, monospace";
          else if (BrowseCap.isLinux())
-            font += "\"Ubuntu Mono\", \"Droid Sans Mono\", \"DejaVu Sans Mono\", monospace";
+            font += "\"Ubuntu Mono\", \"Droid Sans Mono\", \"DejaVu Sans Mono\", \"Noto Sans Mono\", monospace";
          else
             font += "Consolas, \"Lucida Console\", monospace";
 

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -708,7 +708,7 @@ export class GwtCallback extends EventEmitter {
       } else if (process.platform === 'win32') {
         defaultFonts = ['Segoe UI', 'Verdana', 'Lucida Sans', 'DejaVu Sans', 'Lucida Grande', 'Helvetica'];
       } else {
-        defaultFonts = ['Lucida Sans', 'DejaVu Sans', 'Lucida Grande', 'Segoe UI', 'Verdana', 'Helvetica'];
+        defaultFonts = ['Lucida Sans', 'DejaVu Sans', 'Noto Sans', 'Lucida Grande', 'Segoe UI', 'Verdana', 'Helvetica'];
       }
 
       let proportionalFont = defaultFonts[0];

--- a/version/news/NEWS-2024.12.1-kousa-dogwood.md
+++ b/version/news/NEWS-2024.12.1-kousa-dogwood.md
@@ -4,6 +4,7 @@
 
 #### RStudio
 - The editor line height can now be customized (via Tools -> Global Options... -> Appearance) [Accessibility]. (#3372)
+- Noto Sans is now used as a fallback proportional font (for RStudio UI elements) on Linux systems. (#15547)
 
 #### Posit Workbench
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15547.

### Approach

- Add "Noto Sans" to the proportional font fallback list.
- Also use sans-serif as the default proportional fallback font on desktop. (We already were on server.)

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15547. (In particular, check that RStudio uses a sans-serif font for UI elements in a fresh Fedora 41 instance.)

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

