### PR TITLE
check that publishing UI exists before trying to operate on it

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -1134,7 +1134,8 @@ public class TextEditingTargetWidget
       previewHTMLButton_.setText(width >= 560, previewCommandText_);
       knitDocumentButton_.setText(width >= 560, knitCommandText_);
       quartoRenderButton_.setText(width >= 560, quartoCommandText_);
-      publishButton_.setShowCaption(width >= 530);
+      if (publishButton_ != null)
+         publishButton_.setShowCaption(width >= 530);
 
       String action = getSourceOnSaveAction();
       srcOnSaveLabel_.setText(width < 490 ? action : constants_.actionOnSave(action));

--- a/version/news/NEWS-2024.12.1-kousa-dogwood.md
+++ b/version/news/NEWS-2024.12.1-kousa-dogwood.md
@@ -12,7 +12,8 @@
 
 #### RStudio
 - Fixed an issue where double-clicking a source file to start RStudio didn't always open the file after starting. (#15536)
-- Fixed an issue where double-clicking a file to open it in running RStudio didn't work with zoomed plot windows. (#15457) 
+- Fixed an issue where double-clicking a file to open it in running RStudio didn't work with zoomed plot windows. (#15457)
+- Fixed an issue where the RStudio UI stopped working if publishing was disabled in Global Options. (#15561)
 - Reverted support for `help.htmltoc` with R (>= 4.4); support will be re-evaluated in a future release. (#15531)
 - Fixed an issue where Copilot completions were not provided in Quarto documents. (#15539)
 - Fixed an issue where very large character vectors in the R global environment could make RStudio initialize more slowly. (rstudio-pro#7226)


### PR DESCRIPTION
### Intent

Addresses #15561 (regression in Kousa Dogwood initial release)

### Approach

Check that the publishing button exists before referencing it. 

### Automated Tests

Pending; will work on that separately

### QA Notes

Test as described in the issue.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->