### PR TITLE
fix files not opening when used to launch RDP

### DIFF
--- a/src/node/desktop/src/main/app-state.ts
+++ b/src/node/desktop/src/main/app-state.ts
@@ -26,6 +26,7 @@ import { WindowTracker } from './window-tracker';
 import { ModalDialogTracker } from './modal-dialog-tracker';
 import { EventBusTypes } from './event-bus-types';
 import { TypedEventEmitter } from './typed-event-emitter';
+import { ArgsManager } from './args-manager';
 
 /**
  * Global application state
@@ -54,6 +55,7 @@ export interface AppState {
   server?: Server;
   client?: Client;
   eventBus?: TypedEventEmitter<EventBusTypes>;
+  argsManager: ArgsManager;
 }
 
 let rstudio: AppState | null = null;

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -389,10 +389,6 @@ export class Application implements AppState {
     );
     this.sessionLauncher.launchFirstSession(installPath, !app.isPackaged);
 
-    this.gwtCallback?.once(GwtCallback.WORKBENCH_INITIALIZED, () => {
-      this.argsManager.handleAfterSessionLaunchCommands();
-    });
-
     this.setDockMenu();
 
     return run();

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -105,6 +105,9 @@ export class MainWindow extends GwtWindow {
     appState().gwtCallback?.on(GwtCallback.WORKBENCH_INITIALIZED, () => {
       this.onWorkbenchInitialized();
     });
+    appState().gwtCallback?.once(GwtCallback.WORKBENCH_INITIALIZED, () => {
+      appState().argsManager.handleAfterSessionLaunchCommands();
+    });
     appState().gwtCallback?.on(GwtCallback.SESSION_QUIT, () => {
       this.onSessionQuit();
     });

--- a/version/news/NEWS-2024.12.1-kousa-dogwood.md
+++ b/version/news/NEWS-2024.12.1-kousa-dogwood.md
@@ -11,7 +11,7 @@
 ### Fixed
 
 #### RStudio
-- Fixed an issue where double-clicking a source file to start RStudio didn't always open the file after starting. (#15536)
+- Fixed an issue where double-clicking a source file to start RStudio didn't always open the file after starting. (#15536, rstudio-pro#7259)
 - Fixed an issue where double-clicking a file to open it in running RStudio didn't work with zoomed plot windows. (#15457)
 - Fixed an issue where the RStudio UI stopped working if publishing was disabled in Global Options. (#15561)
 - Reverted support for `help.htmltoc` with R (>= 4.4); support will be re-evaluated in a future release. (#15531)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/7259

### Approach

The code that was setting a message handler on `gwtCallback` to deal with opening files after launch didn't work in Desktop Pro because `gwtCallback` wasn't set at the time it tried to use it.

In open-source, `gwtCallback` is already set when `this.sessionLauncher.launchFirstSession(...);` returns, but on Desktop Pro the licensing code delays creation of the main window (where `gwtCallback` is assigned) such that it **isn't** set when `launchFirstSession` returns.

This has never worked since we moved Desktop Pro to Electron.

Fixed by moving setting of the callback to the same place as other similar code (where the `gwtCallback` is guaranteed to be set for both open-source and pro).

### Automated Tests

None

### QA Notes

This change is entirely in open-source and impacts the scenario for both open-source and pro desktops. Recommend re-testing open-source in addition to testing pro.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


