### PR TITLE
save file before formatting document

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3883,7 +3883,7 @@ public class TextEditingTarget implements
          {
             withReformatDependencies(() ->
             {
-               withSavedDoc(() ->
+               save(() ->
                {
                   server_.formatDocument(
                         docUpdateSentinel_.getId(),

--- a/version/news/NEWS-2024.12.1-kousa-dogwood.md
+++ b/version/news/NEWS-2024.12.1-kousa-dogwood.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 #### RStudio
+- Fixed an issue where reformatting a document with unsaved changes when using `styler` for formatting could lose unsaved changes. (#15568)
 - Fixed an issue where double-clicking a source file to start RStudio didn't always open the file after starting. (#15536, rstudio-pro#7259)
 - Fixed an issue where double-clicking a file to open it in running RStudio didn't work with zoomed plot windows. (#15457)
 - Fixed an issue where the RStudio UI stopped working if publishing was disabled in Global Options. (#15561)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15568.

### Approach

`withSavedDoc()` only saves the document to RStudio's source database; it does not update the actual file on disk being edited by the user. Use `save()` instead here so that we do indeed update the document before formatting here.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15568. 

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

