### PR TITLE
Single-thread proxy connections for openssl

### DIFF
--- a/src/cpp/core/include/core/http/AsyncConnection.hpp
+++ b/src/cpp/core/include/core/http/AsyncConnection.hpp
@@ -90,6 +90,8 @@ public:
    virtual const std::string& handlerPrefix() const = 0;
 
    virtual void setHandlerPrefix(const std::string& prefix) = 0;
+
+   virtual boost::asio::io_context::strand& getStrand() = 0;
 };
 
 } // namespace http

--- a/src/cpp/core/include/core/http/TcpIpAsyncClient.hpp
+++ b/src/cpp/core/include/core/http/TcpIpAsyncClient.hpp
@@ -80,10 +80,10 @@ private:
       pAsyncConnector->connect(
             connectAddress,
             connectPort,
-            boost::asio::bind_executor(strand_,
+            boost::asio::bind_executor(*pStrand_,
                  boost::bind(&TcpIpAsyncClient::writeRequest,
                              TcpIpAsyncClient::sharedFromThis())),
-            boost::asio::bind_executor(strand_,
+            boost::asio::bind_executor(*pStrand_,
                  boost::bind(&TcpIpAsyncClient::handleConnectionError,
                              TcpIpAsyncClient::sharedFromThis(), _1)),
             connectionTimeout_);

--- a/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
+++ b/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
@@ -93,10 +93,10 @@ protected:
       pAsyncConnector->connect(
             connectAddress,
             connectPort,
-            boost::asio::bind_executor(strand_, boost::bind(&TcpIpAsyncClientSsl::handleConnect,
+            boost::asio::bind_executor(*pStrand_, boost::bind(&TcpIpAsyncClientSsl::handleConnect,
                                                             TcpIpAsyncClientSsl::sharedFromThis(),
                                                             proxyUrl)),
-            boost::asio::bind_executor(strand_, boost::bind(&TcpIpAsyncClientSsl::handleConnectionError,
+            boost::asio::bind_executor(*pStrand_, boost::bind(&TcpIpAsyncClientSsl::handleConnectionError,
                                                             TcpIpAsyncClientSsl::sharedFromThis(),
                                                             _1)),
             connectionTimeout_);
@@ -131,7 +131,7 @@ private:
             socket().next_layer(),
             connectRequest.toBuffers(),
             boost::asio::bind_executor(
-                strand_,
+                *pStrand_,
                 boost::bind(&TcpIpAsyncClientSsl::handleProxyConnectWrite,
                             sharedFromThis(),
                             boost::asio::placeholders::error)));
@@ -154,7 +154,7 @@ private:
             connectResponseBuffer_,
             "\r\n",
             boost::asio::bind_executor(
-                strand_,
+                *pStrand_,
                 boost::bind(&TcpIpAsyncClientSsl::handleProxyConnectRead,
                             sharedFromThis(),
                             boost::asio::placeholders::error)));
@@ -211,7 +211,7 @@ private:
      ptrSslStream_->async_handshake(
          boost::asio::ssl::stream_base::client,
          boost::asio::bind_executor(
-             strand_,
+             *pStrand_,
              boost::bind(&TcpIpAsyncClientSsl::handleHandshake,
                          sharedFromThis(),
                          boost::asio::placeholders::error)));

--- a/src/cpp/server/session/ServerSessionProxy.cpp
+++ b/src/cpp/server/session/ServerSessionProxy.cpp
@@ -1219,6 +1219,8 @@ void proxyLocalhostRequest(
    // create async tcp/ip client and assign request
    boost::shared_ptr<http::IAsyncClient> pClient(
       new server_core::http::LocalhostAsyncClient(ptrConnection->ioService(), address, port));
+   // Ensure async operations on both the browser->rserver and rserver->backend run on the same thread. 
+   pClient->setStrand(&ptrConnection->getStrand());
    pClient->request().assign(request);
 
    // execute request


### PR DESCRIPTION
### Intent

Addresses: https://github.com/rstudio/rstudio-pro/issues/7264


### Approach

Need to ensure the client to rserver connection, i.e. AsyncConnectionImpl uses the same strand as the AsyncClient for rserver to backend for websocket connections that are "full duplex", i.e. emit traffic at the same time on both sides. When using openssl, boost::asio requires that handlers run on a single thread. Previously AsyncClient itself got a strand to fix part of the problem but this fixes the other side.

I did not start out using a pointer for the setStrand method in AsyncClient but ended up there because:

1) The strand class is not copyable and requires an io_service as a constructor arg that's also a constructor param.
2) The AsyncClient is extended by several other classes with default params 
3) Most callers don't need the strand
4) We don't need the strand to be in place until the 'execute' 
5) The AsyncConnection and AsyncClient are destroyed at the same time

### Automated Tests

I have some automation for testing this that will come as a separate PR that verifies this fixes the problem. 


