### PR TITLE
fix regression with Sweave background highlight

### DIFF
--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -1026,21 +1026,18 @@
 
 .rs.addFunction("estimatedObjectSize", function(x)
 {
-   n <- length(x)
-   if (n < 1E5)
+   if (is.character(x))
    {
-      .rs.objectSize(x)
+      n <- length(x)
+      if (n < 1E5)
+      {
+         result <- n * .Machine$sizeof.pointer
+         class(result) <- "object_size"
+         attr(result, "estimate") <- TRUE
+         return(result)
+      }
    }
-   else if (is.character(x))
-   {
-      result <- n * .Machine$sizeof.pointer
-      class(result) <- "object_size"
-      attr(result, "estimate") <- TRUE
-      return(result)
-   }
-   else
-   {
-      .rs.objectSize(x)
-   }
+   
+   .rs.objectSize(x)
 })
 

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -1029,7 +1029,7 @@
    if (is.character(x))
    {
       n <- length(x)
-      if (n < 1E5)
+      if (!is.na(n) && n >= 1E5)
       {
          result <- n * .Machine$sizeof.pointer
          class(result) <- "object_size"

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -1026,16 +1026,14 @@
 
 .rs.addFunction("estimatedObjectSize", function(x)
 {
-   if (is.character(x))
+   # avoid invoking object.size() on large character vectors,
+   # as this can be slow
+   if (is.character(x) && length(unclass(x)) >= 1E5)
    {
-      n <- length(x)
-      if (!is.na(n) && n >= 1E5)
-      {
-         result <- n * .Machine$sizeof.pointer
-         class(result) <- "object_size"
-         attr(result, "estimate") <- TRUE
-         return(result)
-      }
+      result <- n * .Machine$sizeof.pointer
+      class(result) <- "object_size"
+      attr(result, "estimate") <- TRUE
+      return(result)
    }
    
    .rs.objectSize(x)

--- a/src/cpp/tests/automation/testthat/test-automation-sweave.R
+++ b/src/cpp/tests/automation/testthat/test-automation-sweave.R
@@ -26,3 +26,36 @@ withr::defer(.rs.automation.deleteRemote())
    })
    
 })
+
+# https://github.com/rstudio/rstudio/issues/15574
+.rs.test("Background chunk highlight in Sweave documents is correct", {
+   
+   contents <- .rs.heredoc('
+      \\begin{document}
+      
+      This is some text.
+      
+      <<chunk>>=
+      print(1 + 1)
+      @
+      
+      This is some more text.
+      
+      \\end{document}
+   ')
+   
+   remote$editor.executeWithContents(".Rnw", contents, function(editor) {
+      
+      markers <- as.vector(editor$session$getMarkers(0L))
+      highlightMarkers <- Filter(function(marker) {
+         grepl("background_highlight", marker$clazz)
+      }, markers)
+      
+      expect_equal(length(highlightMarkers), 3L)
+      expect_equal(highlightMarkers[[1L]]$range$start$row, 4L)
+      expect_equal(highlightMarkers[[2L]]$range$start$row, 5L)
+      expect_equal(highlightMarkers[[3L]]$range$start$row, 6L)
+      
+   })
+   
+})

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceBackgroundHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceBackgroundHighlighter.java
@@ -445,7 +445,7 @@ public class AceBackgroundHighlighter
    {
       return ListUtil.create(
             new HighlightPattern(
-                  "<<(.*?)>>",
+                  "^\\s*<<.*>>=\\s*$",
                   "^\\s*@\\s*$")
       );
    }

--- a/version/news/NEWS-2024.12.1-kousa-dogwood.md
+++ b/version/news/NEWS-2024.12.1-kousa-dogwood.md
@@ -21,6 +21,7 @@
 - Fixed an issue where the `.Rproj.user` folder was not marked as hidden for new projects on Windows. (#15514)
 - Fixed an issue where the Files pane could inadverently scroll back to top in some cases. (#15502)
 - Fixed an issue with non-ASCII characters in qmd files showing as "unexpected token." (#15316)
+- Fixed an issue where chunk highlighting in Sweave documents was incorrect. (#15574)
 - Fixed an issue where RStudio could emit a warning when attempting to retrieve help for R objects without a help page. (rstudio-pro#7063)
 
 #### Posit Workbench


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15574.

### Approach

A recent PR added support for variable-width chunks, intended primarily for R Markdown and Quarto documents. This change relied on the capture length for the highlighter regular expressions, under the assumption that the start and end chunk would use an equal-length prefix.

This, of course, is not true for Sweave documents. Fortunately, the fix is simple -- don't use a capturing regular expression in that scenario.

This PR also brings a brown-bag fix -- some objects might report a missing value for `length()`, so we only try to compute that for character vectors (which should never do that).

### Automated Tests

Included in this PR.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15574.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
