### PR TITLE
allow for chunk name when parsing knitr errors

### DIFF
--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -1379,7 +1379,16 @@ bool navigateToRenderPreviewError(const FilePath& previewFile,
    FilePath errFile = previewFile;
 
    // look for knitr error
-   const boost::regex knitrErr("Quitting from lines (\\d+)-(\\d+) \\(([^)]+)\\)");
+   const boost::regex knitrErr(
+      "Quitting from lines"    // prefix
+      "\\s*"                   // whitespace
+      "(\\d+)-(\\d+)"          // line numbers
+      "\\s*"                   // whitespace
+      "(?:\\[[^]]+\\])?"       // chunk name, in brackets
+      "\\s*"                   // whitespace
+      "\\(([^)]+)\\)"          // file name, in parens
+   );
+
    boost::smatch matches;
    if (regex_utils::search(output, matches, knitrErr))
    {

--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -23,32 +23,27 @@
 #include <shared_core/FilePath.hpp>
 #include <shared_core/json/Json.hpp>
 
-#include <r/RExec.hpp>
-#include <r/RRoutines.hpp>
-
 #include <core/Exec.hpp>
 #include <core/Version.hpp>
 #include <core/YamlUtil.hpp>
 #include <core/StringUtils.hpp>
 #include <core/FileSerializer.hpp>
-#include <core/text/AnsiCodeParser.hpp>
-
 #include <core/json/JsonRpc.hpp>
-
 #include <core/system/Process.hpp>
+#include <core/text/AnsiCodeParser.hpp>
 
 #include <r/RExec.hpp>
 #include <r/RUtil.hpp>
+#include <r/RRoutines.hpp>
 
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionSourceDatabase.hpp>
 #include <session/SessionConsoleProcess.hpp>
 #include <session/SessionQuarto.hpp>
 #include <session/projects/SessionProjects.hpp>
-
 #include <session/prefs/UserPrefs.hpp>
-#include <session/SessionQuarto.hpp>
 
+#include "../rmarkdown/SessionRMarkdown.hpp"
 #include "SessionQuartoPreview.hpp"
 #include "SessionQuartoXRefs.hpp"
 #include "SessionQuartoResources.hpp"
@@ -1379,16 +1374,7 @@ bool navigateToRenderPreviewError(const FilePath& previewFile,
    FilePath errFile = previewFile;
 
    // look for knitr error
-   const boost::regex knitrErr(
-      "Quitting from lines"    // prefix
-      "\\s*"                   // whitespace
-      "(\\d+)-(\\d+)"          // line numbers
-      "\\s*"                   // whitespace
-      "(?:\\[[^]]+\\])?"       // chunk name, in brackets
-      "\\s*"                   // whitespace
-      "\\(([^)]+)\\)"          // file name, in parens
-   );
-
+   boost::regex knitrErr(kKnitrErrorRegex);
    boost::smatch matches;
    if (regex_utils::search(output, matches, knitrErr))
    {

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -39,6 +39,7 @@
 #include <core/StringUtils.hpp>
 #include <core/Algorithm.hpp>
 #include <core/YamlUtil.hpp>
+#include <core/r_util/RProjectFile.hpp>
 
 #include <r/RExec.hpp>
 #include <r/RJson.hpp>
@@ -47,7 +48,6 @@
 #include <r/RRoutines.hpp>
 #include <r/RCntxtUtils.hpp>
 
-#include <core/r_util/RProjectFile.hpp>
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionConsoleProcess.hpp>
 #include <session/SessionAsyncRProcess.hpp>
@@ -919,8 +919,7 @@ private:
             // check whether an error occurred while rendering the document and
             // if knitr is about to exit. look for a specific quit marker and
             // parse to to gather information for a source marker
-            const char* renderErrorPattern =
-                  "(?:.*?)Quitting from lines (\\d+)-(\\d+) \\(([^)]+)\\)(.*)";
+            const char* renderErrorPattern = "(?:.*?)" kKnitrErrorRegex "(.*)";
             
             boost::regex reRenderError(renderErrorPattern);
             boost::smatch matches;
@@ -931,7 +930,7 @@ private:
                int line = core::safe_convert::stringTo<int>(matches[1].str(), -1);
                FilePath file = targetFile_.getParent().completePath(matches[3].str());
                renderErrorMarker_ = SourceMarker(SourceMarker::Error, file, line, 1, {}, true);
-               renderErrorMessage_ << matches[4].str();
+               renderErrorMessage_ << core::string_utils::trimWhitespace(matches[4].str());
             }
          }
       }

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.hpp
@@ -18,6 +18,13 @@
 
 #include <string>
 
+#define kKnitrErrorRegex                \
+    "Quitting from lines (\\d+)-(\\d+)" \
+    "\\s*"                              \
+    "(?:\\[.*?\\])?"                    \
+    "\\s*"                              \
+    "\\((.*?)\\)"
+
 #define kRenderTypeStatic   0
 #define kRenderTypeShiny    1
 #define kRenderTypeNotebook 2

--- a/src/cpp/session/modules/tex/SessionRnwWeave.cpp
+++ b/src/cpp/session/modules/tex/SessionRnwWeave.cpp
@@ -17,11 +17,9 @@
 
 #include <boost/utility.hpp>
 #include <boost/format.hpp>
-
 #include <boost/algorithm/string/split.hpp>
 
 #include <core/FileSerializer.hpp>
-
 #include <core/tex/TexLogParser.hpp>
 #include <core/tex/TexMagicComment.hpp>
 
@@ -32,9 +30,9 @@
 
 #include <session/projects/SessionProjects.hpp>
 #include <session/SessionModuleContext.hpp>
-
 #include <session/prefs/UserPrefs.hpp>
 
+#include "../rmarkdown/SessionRMarkdown.hpp"
 #include "SessionRnwConcordance.hpp"
 #include "SessionCompilePdfSupervisor.hpp"
 
@@ -292,9 +290,7 @@ public:
                           "([^\n]+)$");
 
       // new error style
-      boost::regex newErrRe("^\\s*Quitting from lines ([0-9]+)-([0-9]+) "
-                            "\\((.*?)\\)\\s*\\n(.*?)\\n");
-
+      boost::regex newErrRe("^\\s*" kKnitrErrorRegex "\\s*\\n(.*?)\\n");
       boost::smatch match;
       if (regex_utils::search(output, match, errRe))
       {


### PR DESCRIPTION
### Intent

Addresses part of https://github.com/rstudio/rstudio/issues/15562. Intentionally targeted to main; I don't think this meets the bar for the patch release + feels a bit risky.

### Approach

Update the regular expression used for parsing; in particular, allow an optional capture for the `[chunk name]`.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15562.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
