### PR TITLE
Support F1 if leading `?`

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -791,7 +791,8 @@
    token <- .rs.guessToken(line, cursorPos)
    if (token == '')
       return()
-
+   # strip leading `?`
+   token <- sub("^\\?", "", token)
    pieces <- strsplit(token, ':{2,3}')[[1]]
 
    # use devtools shim for help if available (old devtools version)


### PR DESCRIPTION
### Intent

Address a edge case of #10869 

### Approach

Remove leading `?` from `token` and we are able to press F1 and it works if function is fully typed out.


### Automated Tests

NA

### QA Notes

NA

### Documentation

NA

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


Signed contributor agreement