### PR TITLE
Migration of IDE Troubleshooting from Support Articles to central doc…

### DIFF
--- a/docs/user/rstudio/_quarto.yml
+++ b/docs/user/rstudio/_quarto.yml
@@ -109,6 +109,12 @@ website:
               - ide/guide/environments/r/packages.qmd
               - ide/guide/environments/r/renv.qmd
               - ide/guide/environments/py/python.qmd
+          - section: "Troubleshooting"
+            contents: 
+              - ide/guide/troubleshooting/desktop-will-not-start.qmd
+              - ide/guide/troubleshooting/resetting-state.qmd
+              - ide/guide/troubleshooting/logs.qmd
+              - ide/guide/troubleshooting/diagnostic-report.qmd
       - section: "Reference"
         collapse-level: 1
         contents:

--- a/docs/user/rstudio/ide/guide/troubleshooting/desktop-will-not-start.qmd
+++ b/docs/user/rstudio/ide/guide/troubleshooting/desktop-will-not-start.qmd
@@ -1,0 +1,63 @@
+---
+pagetitle: "Desktop will not start"
+date-meta: 2025-01-07
+---
+
+# RStudio will not start
+
+Below is a list of common start-up problems. If one of the following does not describe your problem, see the information at the bottom to start a new support discussion.
+
+## Check the version of R
+
+RStudio requires R version 3.6.0 or higher to run. Make sure your current installation meets this requirement, if not, please download and install R from [https://cran.r-project.org](https://cran.r-project.org).
+
+::: {.callout-note}
+On Windows, if you have multiple versions of R installed, you can press and hold Ctrl when starting RStudio to select your version of R.
+:::
+
+## Check for Startup files
+
+Try removing all startup files such as `.Rprofile`, `.Renviron`, and `.RData` from your initial working directory. The R code within these files may be causing an error. If RStudio successfully starts after removing these files, try to pinpoint which file resulted in the error. If you are able to determine the source of the problem, please notify us with the details. Be sure to include the steps to reproduce this error (including necessary code) and we'll investigate.
+
+## RStudio cannot find R
+
+If you installed R to a non-default location, it is possible RStudio cannot find R on your machine. Open a standard console session (RGui, R.app, Terminal, etc) and type the following command at the console:
+
+```R
+> Sys.which("R")
+```
+
+The displayed location must be in your search path for RStudio to successfully bind to your R installation.
+
+::: {.callout-note}
+On Windows, you can force RStudio to bind to a specific version of R by pressing and holding Ctrl when starting RStudio.
+:::
+
+## Check firewall, proxy settings, and antimalware
+
+Although RStudio does not require internet access, it does use a localhost connection to link your R session with the RStudio IDE. As a result, it is possible a (software-based) firewall, network setting, or antimalware program is blocking access to RStudio. If you have a firewall, HTTP or HTTPS proxy configured, add `localhost` and `127.0.0.1` to the list of approved Hosts and Domains. After this, try restarting RStudio. If you have antimalware software configured that may be blocking RStudio, please check its settings and allow-list RStudio if necessary.
+
+## Check the permissions on the ~/.rstudio-desktop directory
+
+RStudio saves some session files in the `~/.rstudio-desktop` directory - if this directory has its permissions changed, RStudio may not be able to read and write to that folder and may fail to start. Check the permissions and make sure that you have read, write, and execute permissions to this folder - if not, change the permissions or reset RStudio's state as described below.
+
+## Reset RStudio's state
+
+In some cases, it is necessary to reset RStudio's state analogous to a fresh installation. To do this, see the section [Resetting RStudio's State](resetting-state.qmd).
+
+# Other Start-Up Problems
+
+If you are still unable to start RStudio and you are using the open-source version, please open a new topic in [https://forum.posit.co](https://forum.posit.co) and provide any relevant details as noted below.
+
+## System information
+
+Upload a [diagnostic report](diagnostic-report.qmd) and the output from the associated terminal session to a service like Gist and include the link.
+
+## Error information
+
+- General description
+- The version of RStudio you are trying to launch
+- Error messages
+- [Log files](logs.qmd)
+- Attempted steps taken to fix
+- Have you successfully launched RStudio in the past?

--- a/docs/user/rstudio/ide/guide/troubleshooting/desktop-will-not-start.qmd
+++ b/docs/user/rstudio/ide/guide/troubleshooting/desktop-will-not-start.qmd
@@ -1,5 +1,5 @@
 ---
-pagetitle: "Desktop will not start"
+title: "RStudio Desktop will not start"
 date-meta: 2025-01-07
 ---
 

--- a/docs/user/rstudio/ide/guide/troubleshooting/diagnostic-report.qmd
+++ b/docs/user/rstudio/ide/guide/troubleshooting/diagnostic-report.qmd
@@ -1,0 +1,48 @@
+---
+pagetitle: "Creating a Diagnostic Report"
+date-meta: 2025-01-07
+---
+
+# Creating a diagnostic report
+
+Diagnostic reports can be created within a working session, or from outside a session on a terminal.
+
+## In an RStudio session
+
+Select from the menu **Help > Diagnostics > Write Diagnostics Report**
+
+## Outside of an RStudio session
+
+If RStudio is not starting, you can use the following method to run a diagnostics report. Note that you need to also show us the contents of the terminal session that is started.
+
+### Windows
+
+You can run a diagnostics report by typing the following command into **Start > Run**:
+
+```powershell
+"C:\Program Files\RStudio\rstudio.exe" --run-diagnostics
+```
+
+The diagnostics report will be placed in your user's Documents folder in a folder called `rstudio-diagnostics`, for example `C:\Users\Username\Documents\rstudio-diagnostics\diagnostics-report.txt`
+
+Note If you installed RStudio to a different location than `C:\Program Files` make sure to specify this location in the command.
+
+### Mac OS X
+
+You can run a diagnostics report by typing the following command at the Terminal:
+
+```zsh
+/Applications/RStudio.app/Contents/MacOS/RStudio --run-diagnostics
+```
+
+The diagnostics report will be placed in your user home directory, for example `~/rstudio-diagnostics/diagnostics-report.txt`.
+
+### Linux
+
+You can run a diagnostics report by typing the following command at the Terminal:
+
+```bash
+rstudio --run-diagnostics
+```
+
+The diagnostics report will be placed in your user home directory, for example `~/rstudio-diagnostics/diagnostics-report.txt`.

--- a/docs/user/rstudio/ide/guide/troubleshooting/logs.qmd
+++ b/docs/user/rstudio/ide/guide/troubleshooting/logs.qmd
@@ -1,0 +1,42 @@
+---
+title: "Log files and crash reports"
+date-meta: 2025-01-07
+---
+
+# Log Files
+
+If you are experiencing difficulties with the RStudio Desktop IDE, then finding your RStudio application logs may help you get to the bottom of your problem. To browse the directory containing the logs from within RStudio Desktop IDE by opening **Help Menu > Diagnostics > Show Log Files**.
+
+## If RStudio Desktop IDE is not starting
+
+### Windows
+
+You can open an Explorer window to the log file directory by typing the following command into **Start > Run**:
+
+```powershell
+%LOCALAPPDATA%\RStudio\log
+```
+
+### macOS
+
+You can open a Finder window to the log file directory by typing the following command at a terminal:
+
+```zsh
+open ~/.local/share/rstudio/log
+```
+
+### Linux
+
+The log file can be found in this directory: 
+
+```bash
+~/.local/share/rstudio/log
+```
+
+You can open the log files directly from the file browser or with the text editor of your choice.
+
+# Crash Reports
+
+Crash Reports can be enabled by your administrator. See [Automated Crash Reporting](https://docs.posit.co/ide/server-pro/server_management/automated_crash_reporting.html) in the Admin Guide for more information.
+
+

--- a/docs/user/rstudio/ide/guide/troubleshooting/resetting-state.qmd
+++ b/docs/user/rstudio/ide/guide/troubleshooting/resetting-state.qmd
@@ -1,0 +1,98 @@
+---
+title: "Resetting RStudio's State"
+date-meta: 2025-01-08
+---
+
+# Overview
+
+RStudio Desktop stores its internal state in a hidden directory. If this directory does not exist, RStudio will create it on start up. This directory includes information about open documents, log files, and other state information. Removing (or renaming) this directory will reset RStudio's state. 
+
+We recommend renaming this directory to create a backup version instead of completely deleting it. If you experience a crash or RStudio fails to start, this directory may contain vital information for determining the source of the error. In this case, we recommend renaming this directory and sending it along if asked by Posit's support team.
+
+User preferences are stored in a separate folder from internal state. This lets you perform a state reset without losing your settings, and also allows for preferences to be sync'ed between machines - for example in `%AppData%` on Windows - while internal state is machine specific. 
+
+Some versions of RStudio Desktop store additional preferences (such as the size and location of the window and the rendering mode) in a separate location. To fully reset state, this must also be deleted or renamed, as described below in "Resetting Other Preferences".
+
+If you are using RStudio Projects, we'd also recommend resetting the project-specific state if you're having issues - you can do this by navigating to the Project's folder in your file browser, and renaming the `.Rproj.user` directory there.
+
+# Accessing the RStudio-Desktop Directory (Internal State)
+
+## Windows
+
+You can open an Explorer window into the RStudio-Desktop directory by typing the following command into **Start > Run**:
+
+```powershell
+%localappdata%\RStudio
+```
+
+You can then rename this directory and send it with your support request.
+
+## macOS
+
+You can easily create a backup by running the following command from the terminal. Then you can send this backup with your support request:
+
+```zsh
+mv ~/.local/share/rstudio ~/.local/share/rstudio-backup
+```
+
+Alternatively, you can open a Finder window into the RStudio directory by typing the following command at the Terminal:
+
+```zsh
+open ~/.local/share/rstudio
+```
+
+## Linux
+
+You can easily create a backup by running the following command from the terminal. Then you can send this backup with your support request:
+
+```bash
+mv ~/.local/share/rstudio ~/.local/share/rstudio-backup
+```
+
+Alternatively, you can open a File Browser into the RStudio directory by typing the following command at the Terminal:
+
+```bash
+xdg-open ~/.local/share/rstudio
+```
+
+# The RStudio Configuration Directory
+
+Most problems do not require clearing preferences to resolve, but you will need to rename or remove this folder if you wish to perform a full factory reset. 
+
+## Windows
+
+You can open an Explorer window into the RStudio preferences directory by typing the following command into **Start > Run**:
+
+```powershell
+%appdata%\RStudio
+```
+
+You can then rename this directory to backup-rstudio and send it with your support request.
+
+## macOS
+
+To create a backup, run the following command from the terminal. You can then include the file `~/backup-rstudio-prefs` with your support request:
+
+```zsh
+defaults read com.rstudio.desktop > ~/backup-rstudio-prefs
+```
+
+To delete these settings, run the following command from the terminal. Use caution; this cannot be undone unless you have created the backup file, and deleting anything other than `com.rstudio.desktop` could create serious problems with your system.
+
+```zsh
+defaults delete com.rstudio.desktop
+```
+
+## Linux
+
+You can easily create a backup by running the following command from the terminal. Then you can send this backup with your support request:
+
+```bash
+mv ~/.config/rstudio ~/backup-rstudio
+```
+
+Alternatively, you can open a File Browser into the RStudio preferences directory by typing the following command at the Terminal:
+
+```bash
+xdg-open ~/.config/rstudio
+```


### PR DESCRIPTION
…umentation.


### Intent

Addresses Jira ticket https://positpbc.atlassian.net/browse/DOCS-134

Moves IDE related troubleshooting information out of Support Articles in ZenDesk, and into the main documentation for the IDE.

### Approach

Copy and paste, with some minor editing, migration to qmd format, and updating of content and re-ordering as required.

### QA Notes

I ran `quarto preview`

### Documentation

This is user guide, a new section at the bottom called "Troubleshooting".

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

