### PR TITLE
change RStudio to Posit in command

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -1630,7 +1630,7 @@ public:
    core::Error setClangVerbose(int val);
 
    /**
-    * Whether to automatically submit crash reports to RStudio.
+    * Whether to automatically submit crash reports to Posit.
     */
    bool submitCrashReports();
    core::Error setSubmitCrashReports(bool val);

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -1828,9 +1828,9 @@
    clear = function() { .rs.clearUserPref("clang_verbose") }
 )
 
-# Submit crash reports to RStudio
+# Submit crash reports to Posit
 #
-# Whether to automatically submit crash reports to RStudio.
+# Whether to automatically submit crash reports to Posit.
 .rs.uiPrefs$submitCrashReports <- list(
    get = function() { .rs.getUserPref("submit_crash_reports") },
    set = function(value) { .rs.setUserPref("submit_crash_reports", value) },

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2572,7 +2572,7 @@ core::Error UserPrefValues::setClangVerbose(int val)
 }
 
 /**
- * Whether to automatically submit crash reports to RStudio.
+ * Whether to automatically submit crash reports to Posit.
  */
 bool UserPrefValues::submitCrashReports()
 {

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1320,8 +1320,8 @@
         "submit_crash_reports": {
             "type": "boolean",
             "default": true,
-            "title": "Submit crash reports to RStudio",
-            "description": "Whether to automatically submit crash reports to RStudio."
+            "title": "Submit crash reports to Posit",
+            "description": "Whether to automatically submit crash reports to Posit."
         },
         "default_r_version": {
             "type": "object",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -2784,7 +2784,7 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * Whether to automatically submit crash reports to RStudio.
+    * Whether to automatically submit crash reports to Posit.
     */
    public PrefValue<Boolean> submitCrashReports()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -1642,11 +1642,11 @@ public interface UserPrefsAccessorConstants extends Constants {
    String clangVerboseDescription();
 
    /**
-    * Whether to automatically submit crash reports to RStudio.
+    * Whether to automatically submit crash reports to Posit.
     */
-   @DefaultStringValue("Submit crash reports to RStudio")
+   @DefaultStringValue("Submit crash reports to Posit")
    String submitCrashReportsTitle();
-   @DefaultStringValue("Whether to automatically submit crash reports to RStudio.")
+   @DefaultStringValue("Whether to automatically submit crash reports to Posit.")
    String submitCrashReportsDescription();
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -826,9 +826,9 @@ restoreProjectRVersionDescription = Whether to restore the last version of R use
 clangVerboseTitle = Clang verbosity level (0 - 2)
 clangVerboseDescription = The verbosity level to use with Clang (0 - 2)
 
-# Whether to automatically submit crash reports to RStudio.
-submitCrashReportsTitle = Submit crash reports to RStudio
-submitCrashReportsDescription = Whether to automatically submit crash reports to RStudio.
+# Whether to automatically submit crash reports to Posit.
+submitCrashReportsTitle = Submit crash reports to Posit
+submitCrashReportsDescription = Whether to automatically submit crash reports to Posit.
 
 # The R version to use by default.
 defaultRVersionTitle = 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
@@ -806,9 +806,9 @@ restoreProjectRVersionDescription= Indiquer ou non, si la dernière version de R
 clangVerboseTitle= Niveau de verbosité de Clang (0 - 2)
 clangVerboseDescription= Le niveau de verbosité à utiliser avec Clang (0 - 2).
 
-# Whether to automatically submit crash reports to RStudio.
-submitCrashReportsTitle= Soumettre les rapports d''erreur à RStudio
-submitCrashReportsDescription= Si on doit souhaitez soumettre automatiquement les rapports de panne à RStudio.
+# Whether to automatically submit crash reports to Posit.
+submitCrashReportsTitle= Soumettre les rapports d''erreur à Posit
+submitCrashReportsDescription= Si on doit souhaitez soumettre automatiquement les rapports de panne à Posit.
 
 # The R version to use by default.
 defaultRVersionTitle=


### PR DESCRIPTION
### Intent

Related to #15571

### Approach

Change preference text from "Submit crash reports to RStudio" to "Submit crash reports to Posit".

### Automated Tests

NA

### QA Notes

NA

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


