### PR TITLE
bump hardcoded copyright 2024 -> 2025

### DIFF
--- a/docs/news/_quarto.yml
+++ b/docs/news/_quarto.yml
@@ -36,7 +36,7 @@ website:
 
   page-footer:
     left: |
-      Copyright © 2011-2024 Posit Software, PBC, formerly RStudio, PBC. All Rights Reserved.
+      Copyright © 2011-2025 Posit Software, PBC, formerly RStudio, PBC. All Rights Reserved.
     center: |
        RStudio & Posit Workbench Release Notes
     right:

--- a/docs/user/rstudio/_quarto.yml
+++ b/docs/user/rstudio/_quarto.yml
@@ -117,7 +117,7 @@ website:
           
   page-footer:
     left: |
-      Copyright © 2009-2024 Posit Software, PBC. All Rights Reserved.
+      Copyright © 2009-2025 Posit Software, PBC. All Rights Reserved.
     center: |
       RStudio {{< var buildType >}} {{< var version >}}
     right:

--- a/src/cpp/tools/generate-cdp-client.R
+++ b/src/cpp/tools/generate-cdp-client.R
@@ -48,7 +48,7 @@ template <- .rs.heredoc('
    #
    # SessionAutomationClient.R
    #
-   # Copyright (C) 2024 by Posit Software, PBC
+   # Copyright (C) 2025 by Posit Software, PBC
    #
    # Unless you have received this program directly from Posit Software pursuant
    # to the terms of a commercial license agreement with Posit Software, then

--- a/src/gwt/tools/generate-prefs.R
+++ b/src/gwt/tools/generate-prefs.R
@@ -97,7 +97,7 @@ generate <- function(schemaPath, className) {
       #
       # SessionUserPrefValues.R
       #
-      # Copyright (C) 2024 by Posit Software, PBC
+      # Copyright (C) 2025 by Posit Software, PBC
       #
       # Unless you have received this program directly from Posit Software pursuant
       # to the terms of a commercial license agreement with Posit Software, then

--- a/src/node/desktop/src/ui/splash/splash.html
+++ b/src/node/desktop/src/ui/splash/splash.html
@@ -85,7 +85,7 @@
     <g id="Layer_5">
       <text class="cls-5" transform="translate(262.07 285.47)">
         <tspan x="0" y="0">Development Build</tspan>
-        <tspan x="0" y="24">Copyright (C) 2024 Posit Software, PBC</tspan>
+        <tspan x="0" y="24">Copyright (C) 2025 Posit Software, PBC</tspan>
       </text>
     </g>
     <g id="Layer_6">


### PR DESCRIPTION
### Intent

Addresses open-source side of #15580; I'll make a separate PR for any pro-only instances I find.

### Approach

Most displayed copyright years are dynamically generated at build time, these are the ones I found that are not.

- release notes
- user guide
- the comment block header for some source files generated at build time
- the splash screen (dev builds; set automatically in real builds)

### Automated Tests

NA

### QA Notes

If you find any other places in the UI or docs that use 2024 as an upper bound, please add to this issue.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


