### PR TITLE
don't try to create keychain if it already exists

### DIFF
--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -122,12 +122,14 @@ pipeline {
                     ENV = utils.getBuildEnv(!params.DAILY)
                   }
                   script {
-                    try {
-                      // Create a keychain to hold the Developer ID certificate for signing
-                      sh 'security create-keychain -p ${KEYCHAIN_PASSPHRASE} ${BUILD_AGENT_TEMP}/buildagent.keychain'
-                    } catch (Exception e) {
-                      echo "Warning: create-keychain failed (expected if it already existed): ${e.getMessage()}"
-                    }
+                    // Create a keychain to hold the Developer ID certificate for signing
+                    sh """
+                      if [ ! -f "${BUILD_AGENT_TEMP}/buildagent.keychain" ]; then
+                        security create-keychain -p ${KEYCHAIN_PASSPHRASE} ${BUILD_AGENT_TEMP}/buildagent.keychain
+                      else
+                        echo "Keychain already exists: ${BUILD_AGENT_TEMP}/buildagent.keychain"
+                      fi
+                    """
                   }
                   sh 'security default-keychain -s ${BUILD_AGENT_TEMP}/buildagent.keychain'
                   sh 'security unlock-keychain -p ${KEYCHAIN_PASSPHRASE} ${BUILD_AGENT_TEMP}/buildagent.keychain && security set-keychain-settings' // turn off timeout


### PR DESCRIPTION
### Intent

Currently each Mac build will show an error like this. It is "expected" and caught via try/catch, but a successful build really shouldn't show errors, will lead to confusion.

<img width="1247" alt="jenkins-error" src="https://github.com/user-attachments/assets/3e22da4a-1d99-448a-a5e5-afdfe4d822c4" />

### Approach

Instead of using try/catch, test for existence of keychain and don't try to create it if already present.

### Automated Tests

NA

### QA Notes

NA

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


