### PR TITLE
ensure main window loaded before opening a file

### DIFF
--- a/src/node/desktop/src/main/event-bus-types.ts
+++ b/src/node/desktop/src/main/event-bus-types.ts
@@ -18,5 +18,6 @@
  */
 export type EventBusTypes = {
   'appmenu-set': [];
+  'main-window-loaded': [];
   'placeholder': [arg1: number, arg2: string]; // replace this with new events(s)
 }

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -21,7 +21,7 @@ import { logger } from '../core/logger';
 
 import i18next from 'i18next';
 import { setDockLabel } from '../native/dock.node';
-import { appState } from './app-state';
+import { appState, getEventBus } from './app-state';
 import { ApplicationLaunch, LaunchRStudioOptions } from './application-launch';
 import { DesktopBrowserWindow } from './desktop-browser-window';
 import { GwtCallback, PendingQuit } from './gwt-callback';
@@ -196,6 +196,7 @@ export class MainWindow extends GwtWindow {
     this.quitConfirmed = false;
     this.geometrySaved = false;
     this.workbenchInitialized = true;
+    getEventBus().emit('main-window-loaded');
 
     this.executeJavaScript('window.desktopHooks.getActiveProjectName()')
       .then((projectName) => {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/7259

### Approach

Another startup timing issue where, on some "faster" systems, Desktop Pro was still not loading the file that was double-clicked to launch RStudio.

The problem was that the main window may not have finished loading and initializing by the time the application got the 'load-file' message and entered the ready state, such that `gwtCallback` was still `null`. The old code then tried setting an event handler on `gwtCallback` to wait for things to be ready, but since `gwtCallback` was null, that was a no-op.

Fixed by checking if `gwtCallback` and `gwtCallback.initialized` are set when handling `open-file`, and if not, wait for a message from the main-window using the global event bus to open the file.

### Automated Tests

None

### QA Notes

As before, the change is entirely in open-source, so you'll want to re-check the scenario in both open-source and desktop pro. That's what you get when you find problems in the previous fix attempt. :-)

In addition to checking that you can launch RStudio by double-clicking a file and have the file open, also try double-clicking files when RStudio is already loaded (that uses the same code path as the first scenario).

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


