### PR TITLE
fix up diagnostics for unevaluated code chunks in visual mode

### DIFF
--- a/version/news/NEWS-2024.12.1-kousa-dogwood.md
+++ b/version/news/NEWS-2024.12.1-kousa-dogwood.md
@@ -22,6 +22,7 @@
 - Fixed an issue where the Files pane could inadverently scroll back to top in some cases. (#15502)
 - Fixed an issue with non-ASCII characters in qmd files showing as "unexpected token." (#15316)
 - Fixed an issue where chunk highlighting in Sweave documents was incorrect. (#15574)
+- Fixed an issue where code diagnostics were incorrectly applied to un-evaluated R code chunks in visual mode. (#15592)
 - Fixed an issue where RStudio could emit a warning when attempting to retrieve help for R objects without a help page. (rstudio-pro#7063)
 
 #### Posit Workbench


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15592.

### Approach

In Visual Mode, code diagnostics are applied by supplying the contents of that chunk to the diagnostics system directly. However, we weren't accounting for the (optional) chunk header displayed for evaluated versus unevaluated / verbatim code chunks. This PR rectifies that by removing the chunk header if it exists.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15592.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

