### PR TITLE
Migration of IDE Troubleshooting from Support Articles to central doc…

### DIFF
--- a/docs/user/rstudio/_quarto.yml
+++ b/docs/user/rstudio/_quarto.yml
@@ -109,6 +109,12 @@ website:
               - ide/guide/environments/r/packages.qmd
               - ide/guide/environments/r/renv.qmd
               - ide/guide/environments/py/python.qmd
+          - section: "Troubleshooting"
+            contents: 
+              - ide/guide/troubleshooting/desktop-will-not-start.qmd
+              - ide/guide/troubleshooting/resetting-state.qmd
+              - ide/guide/troubleshooting/logs.qmd
+              - ide/guide/troubleshooting/diagnostic-report.qmd
       - section: "Reference"
         collapse-level: 1
         contents:

--- a/docs/user/rstudio/ide/guide/troubleshooting/desktop-will-not-start.qmd
+++ b/docs/user/rstudio/ide/guide/troubleshooting/desktop-will-not-start.qmd
@@ -1,0 +1,57 @@
+---
+title: "RStudio Desktop will not start"
+date-meta: 2025-01-07
+---
+
+Below is a list of common start-up problems. If one of the following does not describe your problem, see [Other start-up issues] for next steps.
+
+## Check the version of R
+
+RStudio requires R version 3.6.0, or higher, to run. Ensure your current installation meets this requirement. If not, please download and install R from [https://cran.r-project.org](https://cran.r-project.org).
+
+On Windows, if you have multiple versions of R installed, you can press and hold Ctrl when starting RStudio to select your version of R.
+
+## Check for Startup files
+
+The R code within these files may be causing an error. So, try removing all startup files such as `.Rprofile`, `.Renviron`, and `.RData` from your initial working directory. If RStudio successfully starts after removing these files, try to pinpoint which file resulted in the error. If you are able to determine the source of the problem, please notify Support with the details. Be sure to include the steps to reproduce this error (including necessary code).
+
+## RStudio cannot find R
+
+If you installed R to a non-default location, it is possible RStudio cannot find R on your machine. Open a standard console session and type the following command at the console:
+
+```R
+> Sys.which("R")
+```
+
+The displayed location must be in your search path for RStudio to successfully bind to your R installation.
+
+On Windows, you can force RStudio to bind to a specific version of R by pressing and holding Ctrl when starting RStudio.
+
+## Check firewall, proxy settings, and antimalware
+
+Although RStudio does not require internet access, it does use a localhost connection to link your R session with the RStudio IDE. As a result, it is possible a (software-based) firewall, network setting, or antimalware program is blocking access to RStudio. If you have a firewall, HTTP or HTTPS proxy configured, add `localhost` and `127.0.0.1` to the list of approved hosts and domains. Then, restart RStudio. If you have antimalware software configured that may be blocking RStudio, please check its settings and allow-list RStudio, if necessary.
+
+## Check the permissions on the ~/.rstudio-desktop directory
+
+RStudio saves some session files in the `~/.rstudio-desktop` directory. If this directory has its permissions changed, RStudio may not have read and write access for that folder and may fail to start. Check the permissions and make sure the folder has read, write, and execute permissions. If not, change the permissions or reset RStudio's state as described below.
+
+## Reset RStudio's state
+
+In some cases, it is necessary to reset RStudio's state analogous to a fresh installation. To do this, see the [Resetting RStudio's State](resetting-state.qmd).
+
+# Other start-up issues
+
+If you are unable to start RStudio and are using the open-source version, please open a new topic in [https://forum.posit.co](https://forum.posit.co) and provide any relevant details as noted below.
+
+## System information
+
+Upload a [diagnostic report](diagnostic-report.qmd) and the output from the associated terminal session to a service like Gist and include the link.
+
+## Error information
+
+- General description
+- The version of RStudio you are trying to launch
+- Error messages
+- [Log files](logs.qmd)
+- Attempted steps taken to fix
+- Have you successfully launched RStudio in the past?

--- a/docs/user/rstudio/ide/guide/troubleshooting/diagnostic-report.qmd
+++ b/docs/user/rstudio/ide/guide/troubleshooting/diagnostic-report.qmd
@@ -1,0 +1,46 @@
+---
+title: "Creating a Diagnostic Report"
+date-meta: 2025-01-07
+---
+
+Diagnostic reports can be created within a working session, or from outside a session on a terminal.
+
+## In an RStudio session
+
+From the menu, click **Help** > **Diagnostics** > **Write Diagnostics Report**.
+
+## Outside of an RStudio session
+
+If RStudio is not starting, run a diagnostics report using the following method. Additionally, you need to provide the contents of the started terminal session.
+
+### Windows
+
+Run a diagnostics report by typing the following command into **Start** > **Run**:
+
+```powershell
+"C:\Program Files\RStudio\rstudio.exe" --run-diagnostics
+```
+
+The diagnostics report is placed in your user's Documents directory in a directory called `rstudio-diagnostics`. For example: `C:\Users\Username\Documents\rstudio-diagnostics\diagnostics-report.txt`
+
+If you installed RStudio to a location other than `C:\Program Files`, specify this unique location in the command.
+
+### macOS
+
+Run a diagnostics report by typing the following command at the Terminal:
+
+```zsh
+/Applications/RStudio.app/Contents/MacOS/RStudio --run-diagnostics
+```
+
+The diagnostics report is placed in your user home directory For example: `~/rstudio-diagnostics/diagnostics-report.txt`.
+
+### Linux
+
+Run a diagnostics report by typing the following command at the Terminal:
+
+```bash
+rstudio --run-diagnostics
+```
+
+The diagnostics report is placed in your user home directory. For example: `~/rstudio-diagnostics/diagnostics-report.txt`.

--- a/docs/user/rstudio/ide/guide/troubleshooting/logs.qmd
+++ b/docs/user/rstudio/ide/guide/troubleshooting/logs.qmd
@@ -1,0 +1,40 @@
+---
+title: "Log files and crash reports"
+date-meta: 2025-01-07
+---
+
+If you are experiencing difficulties with the RStudio Desktop IDE, then finding your RStudio application logs could expose the issue. To browse the directory containing the logs from within RStudio Desktop IDEi, open **Help Menu** > **Diagnostics** > **Show Log Files**.
+
+## RStudio Desktop IDE is not starting
+
+### Windows
+
+Open an Explorer window to the log file directory by typing the following command into **Start** > **Run**:
+
+```powershell
+%LOCALAPPDATA%\RStudio\log
+```
+
+### macOS
+
+Open a Finder window to the log file directory by typing the following command at a terminal:
+
+```zsh
+open ~/.local/share/rstudio/log
+```
+
+### Linux
+
+The log file is located in this directory: 
+
+```bash
+~/.local/share/rstudio/log
+```
+
+Open the log files directly from the file browser or with the text editor of your choice.
+
+# Crash reports
+
+An administrator can enable crash reports. For more information, see the [Automated Crash Reporting](https://docs.posit.co/ide/server-pro/server_management/automated_crash_reporting.html) section in the Posit Workbench Administrator Guide.
+
+

--- a/docs/user/rstudio/ide/guide/troubleshooting/resetting-state.qmd
+++ b/docs/user/rstudio/ide/guide/troubleshooting/resetting-state.qmd
@@ -1,0 +1,102 @@
+---
+title: "Resetting RStudio's State"
+date-meta: 2025-01-08
+---
+
+## Overview
+
+RStudio Desktop stores its internal state in a hidden directory. If this directory does not exist, RStudio creates it on start-up. This directory includes information about open documents, log files, and other state information. Removing (or renaming) this directory resets RStudio's state. 
+
+Instead of deleting the directory, we recommend renaming this directory to create a backup version. If you experience a crash or RStudio fails to start, this directory contains vital information for determining the source of the error. In this case, we recommend renaming this directory and forwarding it to Posit's support team.
+
+User preferences are stored in a separate folder from internal state. This allows you to perform a state reset without losing your settings. Additionally, it allows for preferences to be synced between machines without including machine-specific internal state information.
+
+Some versions of RStudio Desktop store additional preferences (such as the size and location of the window and the rendering mode) in a separate location. To fully reset state, this must also be deleted or renamed. Learn more in the [Resetting other preferences] section below.
+
+If you are using RStudio Projects, and you are having issues, reset the project-specific state by navigating to the Project's folder in your file browser and renaming the `.Rproj.user` directory.
+
+# Accessing the RStudio Desktop directory (internal state)
+
+## Windows
+
+Open an Explorer window in the RStudio Desktop directory by typing the following command into **Start** > **Run**:
+
+```powershell
+%localappdata%\RStudio
+```
+
+Then, rename this directory and send it with your support request.
+
+## macOS
+
+Create a backup by running the following command from the terminal. Then, send this backup with your support request:
+
+```zsh
+mv ~/.local/share/rstudio ~/.local/share/rstudio-backup
+```
+
+Alternatively, open a Finder window in the RStudio directory by typing the following command at the Terminal:
+
+```zsh
+open ~/.local/share/rstudio
+```
+
+## Linux
+
+Create a backup by running the following command from the terminal. Then, send this backup with your support request:
+
+```bash
+mv ~/.local/share/rstudio ~/.local/share/rstudio-backup
+```
+
+Alternatively, open a File Browser in the RStudio directory by typing the following command at the Terminal:
+
+```bash
+xdg-open ~/.local/share/rstudio
+```
+
+# Resetting other preferences
+
+Most problems do not require clearing preferences to resolve. However, you need to rename or remove this folder if to perform a full factory reset. 
+
+## Windows
+
+Open an Explorer window in the RStudio preferences directory by typing the following command into **Start** > **Run**:
+
+```powershell
+%appdata%\RStudio
+```
+
+Then, rename this directory to backup-RStudio and send it with your support request.
+
+## macOS
+
+To create a backup, run the following command from the terminal. Then include the file `~/backup-rstudio-prefs` with your support request:
+
+```zsh
+defaults read com.rstudio.desktop > ~/backup-rstudio-prefs
+```
+
+To delete these settings, run the following command from the terminal. 
+
+:::{.callout-warning}
+This action cannot be undone unless you have created the backup file. Deleting anything other than `com.rstudio.desktop` could create serious problems with your system.
+:::
+
+```zsh
+defaults delete com.rstudio.desktop
+```
+
+## Linux
+
+Create a backup by running the following command from the terminal. Then, send this backup with your support request:
+
+```bash
+mv ~/.config/rstudio ~/backup-rstudio
+```
+
+Alternatively, open a File Browser in the RStudio preferences directory by typing the following command at the Terminal:
+
+```bash
+xdg-open ~/.config/rstudio
+```


### PR DESCRIPTION
…umentation - try two


### Intent

Replaces PR #15582 - there were a lot of changes to make and I wanted to do it locally rather than using the GH UI.

Addresses Jira ticket https://positpbc.atlassian.net/browse/DOCS-134

Moves IDE related troubleshooting information out of Support Articles in ZenDesk, and into the main documentation for the IDE.

### Approach

Copy and paste, with some minor editing, migration to qmd format, and updating of content and re-ordering as required.
Much advice from @AshleyHenry15 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

I ran `quarto preview`

### Documentation

This is user guide, a new section at the bottom called "Troubleshooting".

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests



