### PR TITLE
remove unnecessary matrix and stage lock

### DIFF
--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -96,196 +96,168 @@ pipeline {
       }
     }
 
-    stage("Build Matrix") {
+    stage('Build and Sign') {
 
       environment {
-        ENV = ""
+        AWS_ACCOUNT_ID = '749683154838'
+        KEYCHAIN_PASSPHRASE = credentials('ide-keychain-passphrase')
+        BUILD_AGENT_TEMP = "${env.HOME}/tmp"
+        MACOS_DEVELOPER_CERTIFICATE = credentials('MACOS_DEVELOPER_CERTIFICATE')
+        MACOS_DEVELOPER_CERTIFICATE_KEY = credentials('MACOS_DEVELOPER_CERTIFICATE_KEY')
       }
 
-      matrix {
+      steps {
+        script {
+          ENV = utils.getBuildEnv(!params.DAILY)
+        }
+        script {
+          // Create a keychain to hold the Developer ID certificate for signing
+          sh """
+            if [ ! -f "${BUILD_AGENT_TEMP}/buildagent.keychain" ]; then
+              security create-keychain -p ${KEYCHAIN_PASSPHRASE} ${BUILD_AGENT_TEMP}/buildagent.keychain
+            else
+              echo "Using keychain: ${BUILD_AGENT_TEMP}/buildagent.keychain"
+            fi
+          """
+        }
+        sh 'security default-keychain -s ${BUILD_AGENT_TEMP}/buildagent.keychain'
+        sh 'security unlock-keychain -p ${KEYCHAIN_PASSPHRASE} ${BUILD_AGENT_TEMP}/buildagent.keychain && security set-keychain-settings' // turn off timeout
+        // Import the Developer ID certificate from Jenkins Secrets.
+        sh 'security import \"${MACOS_DEVELOPER_CERTIFICATE}\" -k ${BUILD_AGENT_TEMP}/buildagent.keychain -P \"${MACOS_DEVELOPER_CERTIFICATE_KEY}\" -T /usr/bin/codesign'
+        // build rstudio
+        dir ("package/osx") {
+          withAWS(role: 'build', roleAccount: AWS_ACCOUNT_ID) {
+            sh "${ENV} ./make-package clean --rstudio-target=${FLAVOR}"
+          }
+        }
+      }
+    }
 
-        axes {
-          axis {
-            name 'FLAVOR'
-            values 'Electron'
+    stage('Test') {
+      environment {
+        PATH = "${env.HOME}/opt/bin:${env.PATH}"
+      }
+      steps {
+        dir("package/osx/build/src/cpp") {
+          // attempt to run cpp unit tests
+          // problems with rsession finding openssl, so those tests
+          // are disabled until we solve it (#6890)
+          sh "arch -x86_64 ./rstudio-tests"
+          
+          // electron tests not working in CI environment, under investigation
+          // if(FLAVOR == 'Electron') {
+          //   sh "cd ../../../../../src/node/desktop/ && $HOME/.yarn/bin/yarn && $HOME/.yarn/bin/yarn test"
+          // }
+          }
+        }
+      }
+
+    stage('Notarize and Upload') {
+      when { expression { return params.PUBLISH } }
+      
+      environment {
+        PATH = "${env.HOME}/opt/bin:${env.PATH}"
+        PACKAGE_FILE = """${sh (
+          script: "basename `ls package/osx/build/RStudio-*.dmg`",
+          returnStdout: true
+        ).trim()}"""
+        BUILD_TYPE = """${sh (
+          script: "cat version/BUILDTYPE",
+          returnStdout: true
+        ).trim().toLowerCase()}"""
+        PRODUCT = "${utils.getProductName()}"
+        AWS_PATH = "${FLAVOR.toLowerCase()}/macos"
+      }
+      
+      stages {
+
+        stage("Notarize") {
+          environment {
+            APPLE_ID = credentials('ide-apple-notarizer')
+          }
+
+          steps {
+            sh "docker/jenkins/notarize-release.sh package/osx/build/${PACKAGE_FILE}"
           }
         }
 
-        when { expression { return FLAVOR == 'Electron' } }
-
-        stages {
-          stage('Sequential Matrix') {
-            options {
-              lock('synchronous-matrix-ami')
+        stage("Upload Package") {
+          steps {
+            // this job is going to run on a macOS build agent, which cannot use an instance-profile
+            withAWS(role: 'ide-build', region: 'us-east-1') {
+              retry(5) {
+                script {
+                  utils.uploadPackageToS3 "package/osx/build/${PACKAGE_FILE}", "${AWS_PATH}/"
+                }
+              }
             }
-            stages{
-              stage('Build and Sign') {
+          }
+        }
+        
+        stage("Sentry Upload") {
+          when { expression { return params.DAILY } }
 
-                environment {
-                  AWS_ACCOUNT_ID = '749683154838'
-                  KEYCHAIN_PASSPHRASE = credentials('ide-keychain-passphrase')
-                  BUILD_AGENT_TEMP = "${env.HOME}/tmp"
-                  MACOS_DEVELOPER_CERTIFICATE = credentials('MACOS_DEVELOPER_CERTIFICATE')
-                  MACOS_DEVELOPER_CERTIFICATE_KEY = credentials('MACOS_DEVELOPER_CERTIFICATE_KEY')
+          environment {
+            SENTRY_API_KEY = credentials('ide-sentry-api-key')
+          }
+          
+          steps {
+            // upload debug symbols to Sentry
+            retry(5) {
+              // timeout sentry in 15 minutes
+              timeout(activity: true, time: 15) {
+                // upload Javascript source maps, but only once
+                dir ('package/osx/build/gwt') {
+                  script {
+                    if (FLAVOR == 'Electron') {
+                      utils.sentryUploadSourceMaps()
+                    }
+                  }
                 }
 
-                steps {
+                // upload C++ debug information
+                dir ('package/osx/build/src/cpp') {
                   script {
-                    ENV = utils.getBuildEnv(!params.DAILY)
-                  }
-                  script {
-                    // Create a keychain to hold the Developer ID certificate for signing
-                    sh """
-                      if [ ! -f "${BUILD_AGENT_TEMP}/buildagent.keychain" ]; then
-                        security create-keychain -p ${KEYCHAIN_PASSPHRASE} ${BUILD_AGENT_TEMP}/buildagent.keychain
-                      else
-                        echo "Using keychain: ${BUILD_AGENT_TEMP}/buildagent.keychain"
-                      fi
-                    """
-                  }
-                  sh 'security default-keychain -s ${BUILD_AGENT_TEMP}/buildagent.keychain'
-                  sh 'security unlock-keychain -p ${KEYCHAIN_PASSPHRASE} ${BUILD_AGENT_TEMP}/buildagent.keychain && security set-keychain-settings' // turn off timeout
-                  // Import the Developer ID certificate from Jenkins Secrets.
-                  sh 'security import \"${MACOS_DEVELOPER_CERTIFICATE}\" -k ${BUILD_AGENT_TEMP}/buildagent.keychain -P \"${MACOS_DEVELOPER_CERTIFICATE_KEY}\" -T /usr/bin/codesign'
-                  // build rstudio
-                  dir ("package/osx") {
-                    withAWS(role: 'build', roleAccount: AWS_ACCOUNT_ID) {
-                      sh "${ENV} ./make-package clean --rstudio-target=${FLAVOR}"
-                    }
+                    utils.sentryUpload 'dsym'
                   }
                 }
               }
+            }
+          }
+        }
+        
+        stage("Publish") {
+          environment {
+            GITHUB_LOGIN = credentials('posit-jenkins')
+            DAILIES_PATH = "${PRODUCT}/macos"
+          }
 
-              stage('Test') {
-                environment {
-                  PATH = "${env.HOME}/opt/bin:${env.PATH}"
-                }
-                steps {
-                  dir("package/osx/build/src/cpp") {
-                    // attempt to run cpp unit tests
-                    // problems with rsession finding openssl, so those tests
-                    // are disabled until we solve it (#6890)
-                    sh "arch -x86_64 ./rstudio-tests"
-                    
-                    // electron tests not working in CI environment, under investigation
-                    // if(FLAVOR == 'Electron') {
-                    //   sh "cd ../../../../../src/node/desktop/ && $HOME/.yarn/bin/yarn && $HOME/.yarn/bin/yarn test"
-                    // }
-                    }
-                  }
-                }
-
-              stage('Notarize and Upload') {
-                when { expression { return params.PUBLISH } }
-                
-                environment {
-                  PATH = "${env.HOME}/opt/bin:${env.PATH}"
-                  PACKAGE_FILE = """${sh (
-                    script: "basename `ls package/osx/build/RStudio-*.dmg`",
-                    returnStdout: true
-                  ).trim()}"""
-                  BUILD_TYPE = """${sh (
-                    script: "cat version/BUILDTYPE",
-                    returnStdout: true
-                  ).trim().toLowerCase()}"""
-                  PRODUCT = "${utils.getProductName()}"
-                  AWS_PATH = "${FLAVOR.toLowerCase()}/macos"
-                }
-                
-                stages {
-
-                  stage("Notarize") {
-                    environment {
-                      APPLE_ID = credentials('ide-apple-notarizer')
-                    }
-
-                    steps {
-                      sh "docker/jenkins/notarize-release.sh package/osx/build/${PACKAGE_FILE}"
-                    }
-                  }
-
-                  stage("Upload Package") {
-                    steps {
-                      // this job is going to run on a macOS build agent, which cannot use an instance-profile
-                      withAWS(role: 'ide-build', region: 'us-east-1') {
-                        retry(5) {
-                          script {
-                            utils.uploadPackageToS3 "package/osx/build/${PACKAGE_FILE}", "${AWS_PATH}/"
-                          }
-                        }
-                      }
-                    }
-                  }
-                  
-                  stage("Sentry Upload") {
-                    when { expression { return params.DAILY } }
-
-                    environment {
-                      SENTRY_API_KEY = credentials('ide-sentry-api-key')
-                    }
-                    
-                    steps {
-                      // upload debug symbols to Sentry
-                      retry(5) {
-                        // timeout sentry in 15 minutes
-                        timeout(activity: true, time: 15) {
-                          // upload Javascript source maps, but only once
-                          dir ('package/osx/build/gwt') {
-                            script {
-                              if (FLAVOR == 'Electron') {
-                                utils.sentryUploadSourceMaps()
-                              }
-                            }
-                          }
-
-                          // upload C++ debug information
-                          dir ('package/osx/build/src/cpp') {
-                            script {
-                              utils.sentryUpload 'dsym'
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                  
-                  stage("Publish") {
-                    environment {
-                      GITHUB_LOGIN = credentials('posit-jenkins')
-                      DAILIES_PATH = "${PRODUCT}/macos"
-                    }
-
-                    steps {
-                      dir("package/osx/build") {
-                        script {
-                          // publish build to dailies page
-                          utils.publishToDailiesSite PACKAGE_FILE, DAILIES_PATH, AWS_PATH
-                        }
-                      }
-                    }
-                  }
-
-                  stage("Update Daily Build Redirects") {
-                    environment {
-                      RSTUDIO_ORG_PEM = credentials('www-rstudio-org-pem')
-                    }
-
-                    when { 
-                      anyOf {
-                        expression { return params.PUBLISH && params.DAILY && FLAVOR == "Electron" }
-                        expression { return params.PUBLISH && params.DAILY && FLAVOR == "Server" }
-                      }
-                    }
-
-                    steps {
-                      script {
-                        // upload daily build redirects
-                        utils.updateDailyRedirects "${AWS_PATH}/${PACKAGE_FILE}"
-                      }
-                    }
-                  }
-                }
+          steps {
+            dir("package/osx/build") {
+              script {
+                // publish build to dailies page
+                utils.publishToDailiesSite PACKAGE_FILE, DAILIES_PATH, AWS_PATH
               }
+            }
+          }
+        }
+
+        stage("Update Daily Build Redirects") {
+          environment {
+            RSTUDIO_ORG_PEM = credentials('www-rstudio-org-pem')
+          }
+
+          when { 
+            anyOf {
+              expression { return params.PUBLISH && params.DAILY && FLAVOR == "Electron" }
+              expression { return params.PUBLISH && params.DAILY && FLAVOR == "Server" }
+            }
+          }
+
+          steps {
+            script {
+              // upload daily build redirects
+              utils.updateDailyRedirects "${AWS_PATH}/${PACKAGE_FILE}"
             }
           }
         }


### PR DESCRIPTION
### Intent

Simplify the Mac jenkinsfile by removing unnecessary `matrix`, and enable simultaneous builds of open-source and pro on different build agents (we now have two Mac agents for use by IDE builds).

### Approach

> [!NOTE]
> Most of this change is just un-indenting a bunch of lines without any other changes, plus a few deleted lines. Suggest the ignore whitespace option in github diff!

The primary change is to remove `lock('synchronous-matrix-ami')` as this will prevent builds from running simultaneously on different agents. As part of this I removed the `matrix` since we weren't actually using that (i.e. we had only a single axis).

We still have `disableConcurrentBuilds()` in the Jenkinsfile, so we won't be able to run (for example) two open-source builds simultanously on separate agents, but this change should enable open-source and pro to run at the same time on separate agents.

### Automated Tests

NA

### QA Notes

NA

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


