### PR TITLE
fix issue with missing completion after select

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 #### RStudio
 
 - Fixed an issue where the F1 shortcut would fail to retrieve documentation in packages (#10869)
+- Fixed an issue where some column names were not displayed following select() in pipe completions (#12501)
 
 #### Posit Workbench
 -

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -416,7 +416,11 @@ var RCodeModel = function(session, tokenizer,
                      data.excludeArgs.push(value);
                   }
                }
-
+            }
+            else
+            {
+               if (!cursor.moveToPreviousToken())
+                  return false;
             }
          }
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/12501.

### Approach

Discovery of column names in dplyr pipe completions is done on the client side. The code doing this was inadvertently skipping an extra token, due to the need to check for an `=` following an identifier name.

This PR resolves the issue by moving the cursor back following a missing `=`.

### Automated Tests

TODO

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/12501.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
