### PR TITLE
use project directory / home directory for new RStudio sessions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ### New
 #### RStudio
-- RStudio now uses the project directory / home directory for new RStudio sessions opened via the Dock menu's "Open in New Window" command. (#15409)
+- On macOS, RStudio now uses the project directory / home directory for new RStudio sessions opened via the Dock menu's "Open in New Window" command. (#15409)
 
 #### Posit Workbench
 -

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ### New
 #### RStudio
--
+- RStudio now uses the project directory / home directory for new RStudio sessions opened via the Dock menu's "Open in New Window" command. (#15409)
 
 #### Posit Workbench
 -

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -29,6 +29,7 @@ import org.rstudio.core.client.dom.Clipboard;
 import org.rstudio.core.client.dom.DocumentEx;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.WindowEx;
+import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.ModalDialogTracker;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -237,6 +238,14 @@ public class Application implements ApplicationEventHandlers
 
             // set session info
             session_.setSessionInfo(sessionInfo);
+            
+            // set project path for desktop
+            if (Desktop.isDesktop())
+            {
+               FileSystemItem projectDir = sessionInfo.getActiveProjectDir();
+               if (projectDir != null)
+                  Desktop.getFrame().setProjectDirectory(projectDir.getPath());
+            }
             
             if (sessionInfo.isAutomationHost())
             {

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -152,6 +152,7 @@ public interface DesktopFrame extends JavaScriptPassthrough
    
    void setPendingQuit(int pendingQuit, CommandWithArg<Void> callback);
    void setPendingProject(String projectFilePath);
+   void setProjectDirectory(String projectDirectory);
    void launchSession(boolean reload);
    
    void openProjectInNewWindow(String projectFilePath);

--- a/src/node/desktop/src/main/app-state.ts
+++ b/src/node/desktop/src/main/app-state.ts
@@ -56,6 +56,7 @@ export interface AppState {
   client?: Client;
   eventBus?: TypedEventEmitter<EventBusTypes>;
   argsManager: ArgsManager;
+  projectDirectory?: string;
 }
 
 let rstudio: AppState | null = null;

--- a/src/node/desktop/src/main/application-launch.ts
+++ b/src/node/desktop/src/main/application-launch.ts
@@ -70,7 +70,12 @@ export class ApplicationLaunch {
     const argv = app.isPackaged ? [] : [process.argv[1]];
 
     // resolve working directory
-    const workingDir = options.workingDirectory ?? path.dirname(options.projectFilePath || '');
+    let workingDir = app.getPath('home');
+    if (options.workingDirectory != null) {
+      workingDir = options.workingDirectory;
+    } else if (options.projectFilePath != null) {
+      workingDir = path.dirname(options.projectFilePath);
+    }
     setenv(kRStudioInitialWorkingDir, workingDir);
 
     // resolve project file, if any

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -486,7 +486,7 @@ export class Application implements AppState {
         {
           label: i18next.t('applicationTs.newRstudioWindow'),
           click: () => {
-            this.appLaunch?.launchRStudio({});
+            this.appLaunch?.launchRStudio({ workingDirectory: appState().projectDirectory });
           },
         },
       ]);

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -668,6 +668,10 @@ export class GwtCallback extends EventEmitter {
       this.pendingQuit = pendingQuit;
     });
 
+    ipcMain.on('desktop_set_project_directory', (event, projectDirectory) => {
+      appState().projectDirectory = resolveAliasedPath(projectDirectory);
+    });
+
     ipcMain.on('desktop_open_project_in_new_window', (event, projectFilePath) => {
       this.mainWindow.launchRStudio({
         projectFilePath: resolveAliasedPath(projectFilePath),

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -408,6 +408,10 @@ export function getDesktopBridge() {
         .catch((error) => reportIpcError('setPendingQuit', error));
     },
 
+    setProjectDirectory: (projectDirectory: string) => {
+      ipcRenderer.send('desktop_set_project_directory', projectDirectory);
+    },
+
     openFile: async (path: string) => {
       if (!path) {
         return;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15409.

### Approach

- After `client_init` has finished, forward the project directory to the desktop application.
- Use that project directory when launching new instances of RStudio via "Open in New Window".
- Fall back to home directory rather than root directory if no project is open.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15409.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

