### PR TITLE
cast to bool (fix current boost)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 
 - Fixed an issue where the F1 shortcut would fail to retrieve documentation in packages (#10869)
 - Fixed an issue where some column names were not displayed following select() in pipe completions (#12501)
+- Fixed an issue where building with a newer version of Boost (e.g. Boost 1.86.0) would fail (no. 15625)
 
 #### Posit Workbench
 -

--- a/src/cpp/core/json/JsonRpc.cpp
+++ b/src/cpp/core/json/JsonRpc.cpp
@@ -193,7 +193,7 @@ void JsonRpcResponse::setAfterResponse(
    
 bool JsonRpcResponse::hasAfterResponse() const
 {
-   return afterResponse_;
+   return static_cast<bool>(afterResponse_);
 }
    
    


### PR DESCRIPTION
### Intent

With a current boost version (tested with 1.86.0) rstudio does not build because of
```
rstudio-2024.12.0-467/src/cpp/core/json/JsonRpc.cpp: In member function bool rstudio::core::json::JsonRpcResponse::hasAfterResponse() const:
rstudio-2024.12.0-467/src/cpp/core/json/JsonRpc.cpp:196:11: error: cannot convert const boost::function<void()> to bool in return
  196 |    return afterResponse_;
      |           ^~~~~~~~~~~~~~
      |           |
      |           const boost::function<void()>
```

### Approach

Function returning a `bool` requires an explicit cast in newer boost versions.
This has been added.

### Automated Tests
> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

none

### QA Notes
> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

none

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

none

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->

contributor agreement has been signed for PR https://github.com/rstudio/rstudio/pull/14938 already


