### PR TITLE
Update version-control.qmd

### DIFF
--- a/docs/user/rstudio/ide/guide/tools/version-control.qmd
+++ b/docs/user/rstudio/ide/guide/tools/version-control.qmd
@@ -192,3 +192,13 @@ To add an exception for this directory, call:
 ```
 
 You can mark the offending directory as safe by following the suggested action above and then closing and re-opening the project in RStudio.
+
+Additionally, the Git pane will not appear if Git is not activated for the current project in the project options. To enable Git for the project:
+
+1.  Open the Tools menu and select Project Options.
+
+2.  Navigate to the Git/SVN tab.
+
+3.  In the dropdown field labeled Version control system, change the selection from (None) to Git.
+
+4.  Restart RStudio and check if the Git pane appears.


### PR DESCRIPTION
The Git pane does not appear, if Git is not activated in the R project. This is obvious, but not for someone new to R and Git.


### Intent

> I have added another scenario which can be the cause why the Git pane is not appearing. This added documentation is pointing users to check, if they have activated Git on their R projects. 

### Approach

> Added a textual description as documentation of another possible reason why the Git pane doesn't show up.

### Automated Tests

> N/A

### QA Notes

> N/A.

### Documentation
> The documentation was enhanced in this section: Troubleshooting
Subsection: Git is installed, but the Git pane doesn’t appear.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md. I have signed the individual contributor agreement on 20-JAN-2025 and sent it to the appropriate email address (contribute@posit.co). -->


