### PR TITLE
avoid groovy string interpolation

### DIFF
--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -129,7 +129,7 @@ pipeline {
             # Turn off timeout
             security set-keychain-settings
 
-            # Import the developer ID from JEnkins secrets
+            # Import the developer ID from Jenkins secrets
             security import "${MACOS_DEVELOPER_CERTIFICATE}" -k ${BUILD_AGENT_TEMP}/buildagent.keychain -P "${MACOS_DEVELOPER_CERTIFICATE_KEY}" -T /usr/bin/codesign
           '''
         }

--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -112,19 +112,28 @@ pipeline {
           ENV = utils.getBuildEnv(!params.DAILY)
         }
         script {
-          // Create a keychain to hold the Developer ID certificate for signing
-          sh """
+          sh '''
+            set -e
+
+            # Create a keychain to hold the Developer ID certificate for signing
             if [ ! -f "${BUILD_AGENT_TEMP}/buildagent.keychain" ]; then
               security create-keychain -p ${KEYCHAIN_PASSPHRASE} ${BUILD_AGENT_TEMP}/buildagent.keychain
             else
               echo "Using keychain: ${BUILD_AGENT_TEMP}/buildagent.keychain"
             fi
-          """
+
+            # Set a default keychain, and unlock it
+            security default-keychain -s ${BUILD_AGENT_TEMP}/buildagent.keychain
+            security unlock-keychain -p ${KEYCHAIN_PASSPHRASE} ${BUILD_AGENT_TEMP}/buildagent.keychain
+
+            # Turn off timeout
+            security set-keychain-settings
+
+            # Import the developer ID from JEnkins secrets
+            security import "${MACOS_DEVELOPER_CERTIFICATE}" -k ${BUILD_AGENT_TEMP}/buildagent.keychain -P "${MACOS_DEVELOPER_CERTIFICATE_KEY}" -T /usr/bin/codesign
+          '''
         }
-        sh 'security default-keychain -s ${BUILD_AGENT_TEMP}/buildagent.keychain'
-        sh 'security unlock-keychain -p ${KEYCHAIN_PASSPHRASE} ${BUILD_AGENT_TEMP}/buildagent.keychain && security set-keychain-settings' // turn off timeout
         // Import the Developer ID certificate from Jenkins Secrets.
-        sh 'security import \"${MACOS_DEVELOPER_CERTIFICATE}\" -k ${BUILD_AGENT_TEMP}/buildagent.keychain -P \"${MACOS_DEVELOPER_CERTIFICATE_KEY}\" -T /usr/bin/codesign'
         // build rstudio
         dir ("package/osx") {
           withAWS(role: 'build', roleAccount: AWS_ACCOUNT_ID) {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/7286.

### Approach

Use single-quoted strings, so that Groovy string interpolation doesn't expand keys in the string itself (let that expansion happen in the shell instead).

### Automated Tests

The build system is the automated test.

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

