### PR TITLE
use Windows APIs for enumerating fonts

### DIFF
--- a/src/node/desktop/.vscode/settings.json
+++ b/src/node/desktop/.vscode/settings.json
@@ -69,7 +69,11 @@
     "xstring": "cpp",
     "xtr1common": "cpp",
     "xtree": "cpp",
-    "xutility": "cpp"
+    "xutility": "cpp",
+    "cstdarg": "cpp",
+    "deque": "cpp",
+    "queue": "cpp",
+    "unordered_set": "cpp"
   },
 
   // Help Windows find node, npm

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -109,6 +109,8 @@ export class GwtCallback extends EventEmitter {
 
       const result = execSync(command, { encoding: 'utf-8' });
       return result.trim().split('\n');
+    } else if (platform() === 'win32') {
+      return desktop.win32ListMonospaceFonts();
     } else {
       const result = findFontsSync({ monospace: monospace }).map((fd) => {
         if (process.platform === 'darwin') {

--- a/src/node/desktop/src/native/desktop.node.d.ts
+++ b/src/node/desktop/src/native/desktop.node.d.ts
@@ -61,3 +61,12 @@ export declare function searchRegistryForDefaultInstallationOfR(registryVersionK
  * @param path The path to an existing file.
  */
 export declare function openExternal(path: string): void;
+
+/**
+ * (Windows only)
+ *
+ * List monospace fonts available on the system.
+ *
+ */
+export declare function win32ListMonospaceFonts(): string[];
+

--- a/src/node/desktop/src/native/desktop/desktop.cc
+++ b/src/node/desktop/src/native/desktop/desktop.cc
@@ -771,6 +771,7 @@ std::vector<std::string> win32ListMonospaceFontsImpl()
     logFont.lfCharSet = DEFAULT_CHARSET;
     EnumFontFamiliesEx(hdc, &logFont, (FONTENUMPROC) win32ListMonospaceFontsProc, (LPARAM) &fontSet, 0);
     ReleaseDC(NULL, hdc);
+    fontSet.erase("8514oem");
     fontList = std::vector<std::string>(fontSet.begin(), fontSet.end());
 #endif
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13007.

### Approach

Instead of using node-system-fonts to enumerate fonts on Windows, just use Windows APIs directly. We still keep node-system-fonts around for macOS, but we're pretty close to removing our dependence on it.

### Automated Tests

N/A

### QA Notes

Test that installed fixed-width fonts are still listed and available in the Tools -> Appearance -> Editor Font list. It's also worth comparing the fonts that get displayed in that list for older RStudio installations versus this one.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
