### PR TITLE
use timestamp when signing Windows binaries

### DIFF
--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -157,7 +157,7 @@ pipeline {
             bat 'type smtools-windows-x64.log'
             bat 'C:\\Windows\\System32\\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user'
             bat '"C:\\Program Files\\DigiCert\\DigiCert One Signing Manager Tools\\smksp_cert_sync"'
-            bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x64\\signtool" sign /sha1 %DIGICERT_CERTIFICATE_FINGERPRINT% /td SHA256 /fd SHA256 ' + EXECUTABLES
+            bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x64\\signtool" sign /tr http://timestamp.digicert.com /sha1 %DIGICERT_CERTIFICATE_FINGERPRINT% /td SHA256 /fd SHA256 ' + EXECUTABLES
             bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x64\\signtool\" verify /v /pa ' + EXECUTABLES
           }
         }
@@ -197,7 +197,7 @@ pipeline {
               steps {
                 bat 'C:\\Windows\\System32\\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user'
                 bat '"C:\\Program Files\\DigiCert\\DigiCert One Signing Manager Tools\\smksp_cert_sync"'
-                bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x64\\signtool" sign /sha1 %DIGICERT_CERTIFICATE_FINGERPRINT% /td SHA256 /fd SHA256 package\\win32\\build\\' + LONG_PACKAGE_NAME + '.exe'
+                bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x64\\signtool" sign /tr http://timestamp.digicert.com /sha1 %DIGICERT_CERTIFICATE_FINGERPRINT% /td SHA256 /fd SHA256 package\\win32\\build\\' + LONG_PACKAGE_NAME + '.exe'
                 bat "\"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x64\\signtool\" verify /v /pa package\\win32\\build\\${LONG_PACKAGE_NAME}.exe"
               }
             }


### PR DESCRIPTION
### Intent

Followup to https://github.com/rstudio/rstudio/pull/15647.

### Approach

I noticed we are not timestamping our signatures on Windows. Without this Windows can't be sure the app was signed while the signature was still valid.

![sig-time](https://github.com/user-attachments/assets/bc8d4813-dd81-453c-8a7b-9bb93ef78a92)

Fix by adding the switch to apply a timestamp.

### Automated Tests

NA

### QA Notes

Test via Digital Signatures in file properties and see if there's a timestamp.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


