### PR TITLE
Move disabling Quarto and Crashpad for AL2 check into cmake files

### DIFF
--- a/cmake/globals.cmake
+++ b/cmake/globals.cmake
@@ -233,13 +233,26 @@ set(RSTUDIO_NODE_VERSION "20.15.1" CACHE INTERNAL "Node version for building")
 # node version installed with the product
 set(RSTUDIO_INSTALLED_NODE_VERSION "20.15.1" CACHE INTERNAL "Node version installed with product")
 
+# Check if we're running on Amazon Linux 2
+set(IS_AL2 FALSE)
+if(LINUX AND OS_RELEASE_PRETTY_NAME STREQUAL "Amazon Linux 2")
+   set(IS_AL2 TRUE)
+   message(STATUS "Running on Amazon Linux 2: ${IS_AL2}")
+endif()
+
 # quarto support
 
-# Note that Quarto support is now always enabled.
+# Note that Quarto support is now always enabled, except on Amazon Linux 2.
 #
 #   Set QUARTO_ENABLED = TRUE to have RStudio bundle an embedded copy of Quarto (default).
 #   Set QUARTO_ENABLED = FALSE to force the use of an external Quarto installation.
 #
+
+if (IS_AL2)
+   set(QUARTO_ENABLED FALSE CACHE INTERNAL "Internal Quarto enabled")
+   message(STATUS "Quarto disabled on Amazon Linux 2")
+endif()
+
 if(NOT DEFINED QUARTO_ENABLED)
    set(QUARTO_ENABLED TRUE CACHE INTERNAL "")
 endif()

--- a/docker/jenkins/Dockerfile.al2
+++ b/docker/jenkins/Dockerfile.al2
@@ -2,10 +2,6 @@ ARG ARCH=amd64
 FROM --platform=linux/$ARCH amazonlinux:2
 ARG ARCH
 
-# Disable Quarto and Crashpad builds for AL2
-ARG QUARTO_ENABLED=0
-ARG RSTUDIO_CRASHPAD_ENABLED=0
-
 ENV OPERATING_SYSTEM=centos_7
 
 RUN set -x \

--- a/jenkins/utils.groovy
+++ b/jenkins/utils.groovy
@@ -208,11 +208,6 @@ def getBuildEnv(boolean isHourly) {
   if (isHourly) {
     env = "${env} SCCACHE_ENABLED=1"
   }
-  if (binding.hasVariable('OS') && OS == "al2")
-  {
-    // disable software that can't be built on AL2
-    env = "${env} RSTUDIO_CRASHPAD_ENABLED=0 QUARTO_ENABLED=0"
-  }
 
   return env
 }

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -356,6 +356,11 @@ if(NOT DEFINED RSTUDIO_CRASHPAD_ENABLED)
       set(RSTUDIO_CRASHPAD_ENABLED FALSE)
    endif()
 
+   if (LINUX AND IS_AL2)
+      message(STATUS "Crashpad not enabled on Amazon Linux 2; disabling Crashpad")
+      set(RSTUDIO_CRASHPAD_ENABLED FALSE)
+   endif()
+
 endif()
 
 # Crashpad


### PR DESCRIPTION
### Intent

Putting the check for enabling Quarto and Crashpad in the `make-*` package scripts accidentally broke several other builds. Moving the check for AL2 into cmake should fix the builds

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


