### PR TITLE
avoid shared_ptr in exec context

### DIFF
--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -49,6 +49,20 @@ using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {
+
+// make_unique is not available in C++11, so we provide
+// a definition here just in case
+template <class T, class... Args>
+std::unique_ptr<T> make_unique(Args&&... args)
+{
+   return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+} // end namespace core
+} // end namespace rstudio
+
+namespace rstudio {
+namespace core {
    class DistributedEvent;
    class Error;
    class Success;

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.hpp
@@ -120,8 +120,8 @@ private:
    bool hasOutput_;
    bool hasErrors_;
 
-   std::vector<boost::shared_ptr<NotebookCapture> > captures_;
-   std::vector<boost::shared_ptr<core::ScopedFileLock> > locks_;
+   std::vector<std::unique_ptr<NotebookCapture>> captures_;
+   std::vector<std::unique_ptr<core::ScopedFileLock>> locks_;
    std::vector<RSTUDIO_BOOST_CONNECTION> connections_;
 };
 


### PR DESCRIPTION
### Intent

A potential fix for https://github.com/rstudio/rstudio-pro/issues/7322.

### Approach

Instead of using shared pointers, use unique pointers. ExecContext is already non-copyable, so it makes sense to let it "own" the pointers created here.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio-pro/issues/7322.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
