### PR TITLE
Fix problem with launching multiple instances of RStudio installed in different locations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,9 +12,10 @@
 ### Fixed
 #### RStudio
 
-- Fixed an issue where the F1 shortcut would fail to retrieve documentation in packages (#10869)
-- Fixed an issue where some column names were not displayed following select() in pipe completions (#12501)
-- Fixed an issue where building with a newer version of Boost (e.g. Boost 1.86.0) would fail (no. 15625)
+- Fixed an issue where the F1 shortcut would fail to retrieve documentation in packages. (#10869)
+- Fixed an issue where some column names were not displayed following select() in pipe completions. (#12501)
+- Fixed an issue where building with a newer version of Boost (e.g. Boost 1.86.0) would fail. (#15625)
+- Fixed an issue where opening multiple copies of RStudio Desktop installed in different locations would cause RStudio to try to open itself as a script. (#15554)
 
 #### Posit Workbench
 -

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -143,7 +143,11 @@ export class Application implements AppState {
       logger().logDebug(`second-instance event: ARGS ${argv}`);
 
       // for files, open in the existing instance
-      this.argsManager.setUnswitchedArgs(argv);
+      //
+      // The slice(1) removes the RStudio executable argument; the attempt to detect
+      // and remove it inside setUnswitchedArgs() won't work if second instance of RStudio is in a
+      // different location than the first. https://github.com/rstudio/rstudio/issues/15554
+      this.argsManager.setUnswitchedArgs(argv.slice(1));
       if (this.argsManager.getProjectFileArg() === undefined) this.argsManager.handleAfterSessionLaunchCommands();
     });
   }


### PR DESCRIPTION
### Intent

Addresses #15554

### Approach

The problem here is that the code that tries to remove the "path to current executable" from the list of command-line arguments sent via the `second-instance` event didn't work if the second instance was in a different location than the first.

The fix is to remove the first entry from argv sent to `second-instance`, as it will always be the executable path.

### Automated Tests

None that I know of. Tricky to automate since it requires multiple versions of RStudio installed in different locations and running at the same time.

### QA Notes

Test as described in issue. The easier repro is to put two copies of RStudio on your system, such as RStudio1.app and RStudio2.app and:

- launch RStudio1.app and wait for it to load
- launch RStudio2.app (without this fix this will reproduce the issue)

NOTE: this is not specific to Mac; same problem on all Desktop platforms.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


