### PR TITLE
only generate project id if required

### DIFF
--- a/src/cpp/session/modules/automation/SessionAutomationRemote.R
+++ b/src/cpp/session/modules/automation/SessionAutomationRemote.R
@@ -346,6 +346,22 @@
    invisible(alive)
 })
 
+.rs.automation.addRemoteFunction("session.restart", function()
+{
+   # Invoke the restart command.
+   self$commands.execute("restartR")
+   
+   # Send a command to the console, and wait for it to be executed.
+   msg <- sprintf("Waiting for restart [token %s]", .rs.createUUID())
+   self$console.executeExpr({ writeLines(!!msg) })
+   
+   # Wait until we have console output.
+   .rs.waitUntil("session is ready", function()
+   {
+      any(self$console.getOutput() == msg)
+   })
+})
+
 .rs.automation.addRemoteFunction("session.reset", function()
 {
    # Clear any popups that might be visible.

--- a/src/cpp/session/modules/automation/SessionAutomationToolsProjects.R
+++ b/src/cpp/session/modules/automation/SessionAutomationToolsProjects.R
@@ -31,6 +31,9 @@
    
    projectPath <- file.path(tempdir(), projectName)
    
+   # If that path already exists, remove it.
+   unlink(projectPath, recursive = TRUE)
+   
    # Resolve the project type.
    type <- match.arg(type)
    

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -1008,6 +1008,13 @@ r_util::RProjectConfig ProjectContext::defaultConfig()
    defaultConfig.tutorialPath = std::string();
    defaultConfig.packageUseDevtools = prefs::userPrefs().useDevtools();
    defaultConfig.packageCleanBeforeInstall = prefs::userPrefs().cleanBeforeInstall();
+
+   // generate a project id if needed; currently this is only used for
+   // customizing the location of .Rproj.user directories
+   std::string userDir = prefs::userPrefs().projectUserDataDirectory();
+   if (!userDir.empty() && userDir != ".Rproj.user")
+      defaultConfig.projectId = core::system::generateUuid();
+
    return defaultConfig;
 }
 

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -101,6 +101,27 @@ Error validateScratchPath(const FilePath& scratchPath)
    
 }
 
+std::string getCustomUserDataDir()
+{
+   std::string userDataDir;
+
+   // check whether the user has configured a folder to host their project scratch path
+   // (and that the admin hasn't disallowed this)
+   if (session::options().sessionAllowProjectUserDataDirOverride())
+   {
+      userDataDir = prefs::userPrefs().projectUserDataDirectory();
+   }
+
+   // check whether the administrator has configured a default project scratch path
+   if (userDataDir.empty())
+   {
+      userDataDir = session::options().sessionProjectUserDataDir();
+   }
+
+   return userDataDir;
+
+}
+
 FilePath computeUserDir(const FilePath& projectFile,
                         const r_util::RProjectConfig& projectConfig)
 {
@@ -143,22 +164,9 @@ FilePath computeUserDir(const FilePath& projectFile,
       }
    }
 
-   std::string userDataDir;
-   
-   // check whether the user has configured a folder to host their project scratch path
-   // (and that the admin hasn't disallowed this)
-   if (session::options().sessionAllowProjectUserDataDirOverride())
-   {
-      userDataDir = prefs::userPrefs().projectUserDataDirectory();
-   }
-   
-   // check whether the administrator has configured a default project scratch path
-   if (userDataDir.empty())
-   {
-      userDataDir = session::options().sessionProjectUserDataDir();
-   }
    
    // if such a scratch path has been configured, use it if possible
+   std::string userDataDir = getCustomUserDataDir();
    if (!userDataDir.empty())
    {
       FilePath userDataPath = module_context::resolveAliasedPath(userDataDir);
@@ -1011,7 +1019,7 @@ r_util::RProjectConfig ProjectContext::defaultConfig()
 
    // generate a project id if needed; currently this is only used for
    // customizing the location of .Rproj.user directories
-   std::string userDir = prefs::userPrefs().projectUserDataDirectory();
+   std::string userDir = getCustomUserDataDir();
    if (!userDir.empty() && userDir != ".Rproj.user")
       defaultConfig.projectId = core::system::generateUuid();
 

--- a/version/news/NEWS-2024.12.1-kousa-dogwood.md
+++ b/version/news/NEWS-2024.12.1-kousa-dogwood.md
@@ -3,6 +3,7 @@
 ### New
 
 #### RStudio
+- RStudio now only adds a ProjectId field to a project's .Rproj file if it is explicitly required. Currently, this is only for projects where the .Rproj.user folder location has been customized.
 - The editor line height can now be customized (via Tools -> Global Options... -> Appearance) [Accessibility]. (#3372)
 - Noto Sans is now used as a fallback proportional font (for RStudio UI elements) on Linux systems. (#15547)
 

--- a/version/news/NEWS-2024.12.1-kousa-dogwood.md
+++ b/version/news/NEWS-2024.12.1-kousa-dogwood.md
@@ -3,7 +3,6 @@
 ### New
 
 #### RStudio
-- RStudio now only adds a ProjectId field to a project's .Rproj file if it is explicitly required. Currently, this is only for projects where the .Rproj.user folder location has been customized.
 - The editor line height can now be customized (via Tools -> Global Options... -> Appearance) [Accessibility]. (#3372)
 - Noto Sans is now used as a fallback proportional font (for RStudio UI elements) on Linux systems. (#15547)
 


### PR DESCRIPTION
### Intent

- Only add the ProjectId field to the .Rproj file if it is required.
- Preserve it, if it already exists within the file.

### Approach

Mostly straightforward changes; the main bit is adding a project id to the "default" project configuration, but only if it appears to be required (e.g. via user prefs or admin setting).

### Automated Tests

Included in the PR.

### QA Notes

- Create a new RStudio project. Check that the .Rproj file does not contain a ProjectId field (use a text editor).
- Use Tools -> Global Options..., and set a custom user data directory. The project should now contain a ProjectId entry.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
