### PR TITLE
use Leap 15.6 (up from 15.5) on build image

### DIFF
--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -1,5 +1,5 @@
 ARG ARCH=amd64
-FROM --platform=linux/$ARCH opensuse/leap:15.5
+FROM --platform=linux/$ARCH opensuse/leap:15.6
 ARG ARCH
 
 ENV OPERATING_SYSTEM=opensuse_leap15


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/7342

### Approach

Changed `5` to `6`.

I did test builds using the Dockerfile of both Workbench and Desktop Pro, and confirmed they built and were installable and runnable on OpenSUSE Leap/15.6.

### Automated Tests

NA

### QA Notes

General coverage on OpenSUSE will suffice. Nothing to specifically test.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


