### PR TITLE
synchronize concurrent accesses with mutex in more places

### DIFF
--- a/src/cpp/r/RExec.cpp
+++ b/src/cpp/r/RExec.cpp
@@ -55,12 +55,12 @@ namespace exec {
 namespace {
 
 // was the R session interrupted?
-bool s_wasInterrupted;
+std::atomic<bool> s_wasInterrupted(false);
 
 // are we currently executing R code? note that only one thread can ever
 // be executing code at a time, but we allow for an integer count so that
 // execution scope helpers can be nested
-int s_executionCount;
+std::atomic<int> s_executionCount(0);
 
 class CodeExecutingScope : boost::noncopyable
 {

--- a/src/cpp/r/session/RInit.cpp
+++ b/src/cpp/r/session/RInit.cpp
@@ -398,13 +398,14 @@ void ensureDeserialized()
       s_deferredDeserializationAction();
       s_deferredDeserializationAction.clear();
 
-      // mark session as deserialized
-      s_isSessionDeserialized = true;
-
       // run automation tests if configured to do so
       if (rCallbacks().runAutomation)
          rCallbacks().runAutomation();
    }
+
+   // mark session as deserialized
+   s_isSessionDeserialized = true;
+
 }
 
 bool isSessionRestored()

--- a/src/cpp/r/session/RInit.cpp
+++ b/src/cpp/r/session/RInit.cpp
@@ -57,6 +57,7 @@ boost::function<void()> s_beforeResumeCallback, s_afterResumeCallback;
 // the initialization process that are potentially highly latent. this allows
 // clients to bring their UI up and then receive an event indicating that the
 // latent deserialization actions are taking place
+std::atomic<bool> s_isSessionDeserialized(false);
 boost::function<void()> s_deferredDeserializationAction;
    
 void reportDeferredDeserializationError(const Error& error)
@@ -396,7 +397,10 @@ void ensureDeserialized()
       // do the deferred action
       s_deferredDeserializationAction();
       s_deferredDeserializationAction.clear();
-      
+
+      // mark session as deserialized
+      s_isSessionDeserialized = true;
+
       // run automation tests if configured to do so
       if (rCallbacks().runAutomation)
          rCallbacks().runAutomation();
@@ -405,7 +409,7 @@ void ensureDeserialized()
 
 bool isSessionRestored()
 {
-   return s_deferredDeserializationAction.empty();
+   return s_isSessionDeserialized;
 }
    
 FilePath rHistoryFilePath()

--- a/src/cpp/server/session/ServerSessionManager.cpp
+++ b/src/cpp/server/session/ServerSessionManager.cpp
@@ -404,6 +404,26 @@ Error SessionManager::launchAndTrackSession(
             rLibPath.getAbsolutePath());
 #endif
 
+#if defined(__has_feature)
+# if __has_feature(thread_sanitizer)
+
+   // the thread sanitizer will cause the session to hang if output
+   // if written to stdout or stderr, so redirect to a file instead
+   std::string tsanOptions = core::system::getenv("TSAN_OPTIONS");
+   if (tsanOptions.empty())
+   {
+      LOG_INFO_MESSAGE("Thread sanitizer is enabled. Reports will be logged to /tmp/rsession.tsan.log.");
+      tsanOptions = "log_path=/tmp/rsession.tsan.log";
+   }
+
+   core::system::setenv(
+       &config.environment,
+       "TSAN_OPTIONS",
+       tsanOptions);
+
+# endif
+#endif
+
    // launch the session
    PidType pid = 0;
    Error error = launchChildProcess(profile.executablePath,

--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -50,10 +50,10 @@ using ConsoleInputQueue = std::deque<rstudio::r::session::RConsoleInput>;
 ConsoleInputQueue s_consoleInputBuffer;
 
 // manage global state indicating whether R is processing input
-volatile sig_atomic_t s_rProcessingInput = 0;
+std::atomic<int> s_rProcessingInput(0);
 
 // the saved version of s_rProcessInput - the 'executing' property in the session metadata
-volatile sig_atomic_t s_sessionExecuting = 0;
+std::atomic<int> s_sessionExecuting(0);
 
 // Controls access to s_sessionExecuting and the file system
 boost::mutex s_sessionExecutingMutex;

--- a/src/cpp/session/SessionInit.cpp
+++ b/src/cpp/session/SessionInit.cpp
@@ -29,7 +29,7 @@ namespace {
 
 // have we fully initialized? used by rConsoleRead and clientInit to
 // tweak their behavior when the process is first starting
-bool s_sessionInitialized = false;
+std::atomic<bool> s_sessionInitialized(false);
 
 } // anonymous namespace
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -517,6 +517,7 @@ Error ensureLibRSoValid();
 void exitEarly(int status)
 {
    stopMonitorWorkerThread();
+   offlineService().stop();
    FileLock::cleanUp();
    FilePath(s_fallbackLibraryPath).removeIfExists();
    ::exit(status);

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1366,6 +1366,9 @@ void rCleanup(bool terminatedNormally)
       // stop the monitor thread
       stopMonitorWorkerThread();
 
+      // stop offline service thread
+      offlineService().stop();
+
       // cause graceful exit of clientEventService (ensures delivery
       // of any pending events prior to process termination). wait a
       // very brief interval first to allow the quit or other termination

--- a/src/cpp/session/http/SessionHttpConnectionListenerImpl.hpp
+++ b/src/cpp/session/http/SessionHttpConnectionListenerImpl.hpp
@@ -412,9 +412,10 @@ private:
    boost::thread listenerThread_;
 
    // flag indicating we've started
-   bool started_;
+   std::atomic<bool> started_;
+
    // Set when the first get_events request is received - ensure async rpc not used until client is ready to listen
-   bool eventsActive_;
+   std::atomic<bool> eventsActive_;
 
    boost::shared_ptr<boost::asio::ssl::context> sslContext_;
 };

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -355,6 +355,7 @@ struct firstNonEmpty
 // session events
 struct Events : boost::noncopyable
 {
+   // NOTE: The onConsoleOutput signal is potentially not fired from the main thread!!
    RSTUDIO_BOOST_SIGNAL<void()>                                       onBeforeClientInit;
    RSTUDIO_BOOST_SIGNAL<void(core::json::Object*)>                    onSessionInfo;
    RSTUDIO_BOOST_SIGNAL<void()>                                       onClientInit;

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "SessionRmdNotebook.hpp"
+
 #include "NotebookExec.hpp"
 #include "NotebookOutput.hpp"
 #include "NotebookPlots.hpp"
@@ -25,6 +26,7 @@
 #include "NotebookConditions.hpp"
 
 #include <shared_core/Error.hpp>
+
 #include <core/text/CsvParser.hpp>
 #include <core/FileSerializer.hpp>
 
@@ -47,6 +49,8 @@ namespace rmarkdown {
 namespace notebook {
 
 namespace {
+
+std::recursive_mutex s_consoleMutex;
 
 struct PendingChunkConsoleOutput
 {
@@ -93,8 +97,11 @@ FilePath getNextOutputFile(const std::string& docId, const std::string& chunkId,
 
 void flushPendingChunkConsoleOutputs(bool clear)
 {
+   std::lock_guard<std::recursive_mutex> guard(s_consoleMutex);
+
    for (auto&& entry : s_pendingChunkOutput)
       flushPendingChunkConsoleOutput(entry.first);
+
    if (clear)
       s_pendingChunkOutput.clear();
 }
@@ -462,6 +469,8 @@ void ChunkExecContext::onError(const core::json::Object& err)
 void ChunkExecContext::onConsoleText(int type, const std::string& output, 
       bool truncate, bool pending)
 {
+   std::lock_guard<std::recursive_mutex> guard(s_consoleMutex);
+
    // if we haven't received any actual output yet, don't push input into the
    // file yet
    if (type == kChunkConsoleInput && !hasOutput_) 

--- a/src/tools/clang-tsan-build
+++ b/src/tools/clang-tsan-build
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+read -r -d '' ASANFLAGS <<- EOF
+-fsanitize=thread
+EOF
+ASANFLAGS="$(echo "${ASANFLAGS}" | tr '\n' ' ')"
+
+: ${BUILD_DIR="clang-tsan-build"}
+: ${MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"}
+: ${R_HOME="$(R RHOME)"}
+
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+cmake ../cpp                                                \
+    -DLIBR_HOME="${R_HOME}"                                 \
+    -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang     \
+    -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
+    -DCMAKE_BUILD_TYPE="Debug"                              \
+    -DCMAKE_C_FLAGS="${ASANFLAGS}"                          \
+    -DCMAKE_CXX_FLAGS="${ASANFLAGS}"                        \
+    "$@"
+cd ..
+
+cmake --build "${BUILD_DIR}" -- "${MAKEFLAGS}"

--- a/version/news/NEWS-2024.12.1-kousa-dogwood.md
+++ b/version/news/NEWS-2024.12.1-kousa-dogwood.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 #### RStudio
+- Fixed an issue where executing Python code from an R Markdown chunk could cause a crash in rare cases. (#rstudio-pro/7322)
 - Fixed an issue where reformatting a document with unsaved changes when using `styler` for formatting could lose unsaved changes. (#15568)
 - Fixed an issue where double-clicking a source file to start RStudio didn't always open the file after starting. (#15536, rstudio-pro#7259)
 - Fixed an issue where double-clicking a file to open it in running RStudio didn't work with zoomed plot windows. (#15457)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/7322.

### Approach

The `onConsoleOutput` signal is actually emitted from a separate thread. The code wherein it's emitted even points this out:

https://github.com/rstudio/rstudio/blob/137c91db80581e808e9f7305245badc8b54178e9/src/cpp/session/SessionModuleContext.cpp#L2214-L2229

but unfortunately, it's easy to miss that implicit requirement. To handle this, I've added a recursive mutex to code paths which access shared data structures from an `onConsoleOutput` signal.

This PR also includes some switches from plain global variables to atomic versions where the thread sanitizer was able to "see" them being accessed by multiple threads.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio-pro/issues/7322. For what it's worth, I found the issue reproduced most readily if I selected some text within a Python code chunk, and then later executed it with Cmd + Enter.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
