### PR TITLE
guard against 0-length vectors when formatting for paged table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 - Fixed an issue where some column names were not displayed following select() in pipe completions. (#12501)
 - Fixed an issue where building with a newer version of Boost (e.g. Boost 1.86.0) would fail. (#15625)
 - Fixed an issue where opening multiple copies of RStudio Desktop installed in different locations would cause RStudio to try to open itself as a script. (#15554)
+- Fixed an issue where printing 0-row data.frames containing an 'hms' column from an R Markdown chunk could cause an unexpected error. (#15459)
 
 #### Posit Workbench
 -

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -315,6 +315,14 @@
       data,
       function (y) {
         
+        # some objects, e.g. 'hms', might produce an unexpected
+        # value when an empty vector of that class is formatted,
+        # so only format non-empty vectors
+        #
+        # https://github.com/rstudio/rstudio/issues/15459
+        if (length(y) == 0)
+          return(character())
+         
         # escape NAs from character columns
         if (typeof(y) == "character") {
           y[y == "NA"] <- "__NA__"


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15459.

### Approach

RStudio assumes that `length(x) == length(format(x))`, but unfortunately that assumption is not always true for user-defined classes. This PR handles the specific case for 'hms' objects, where formatting an empty 'hms' vector produces a length-one vector with the string "hms()" rather than an empty character vector.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15459.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
