### PR TITLE
Redo how memory limits are managed in RStudio

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,9 +6,10 @@
 - RStudio installation on Windows now registers icons for many supported file types. (#12730)
 - RStudio for Windows binaries now have digital signatures. (rstudio-pro#5772)
 - RStudio now only writes the ProjectId field within a project's `.Rproj` file when required. Currently, this is for users who have configured a custom `.Rproj.user` location.
+- Added memory limit monitoring to RStudio (linux only for now). If `ulimit -m` is set, this limit is displayed in the Memory Usage Report. As the limit is approached, a warning is displayed, then an error when the limit is reached. When the system is low on memory, the session can abort itself by shutting down in a controlled way with a dialog to the user, see the new `"allow-over-limit-sessions` option in rsession.conf. (rstudio-pro#5019).
 
 #### Posit Workbench
--
+- Changed memory limit enforcement of `/etc/rstudio/profiles` `max-memory-mb` setting from limiting virtual memory (`ulimit -v`) to resident memory (`ulimit -m`) for more accuracy. This allows a session to run quarto 1.6, that uses a lot of virtual memory due to its underlying virtual machine. Unfortunately resident memory is only enforceable at the kernel level in Linux versions that support cgroups. This change does add enforcement of resident memory with polling that will warn and stop over limit processes but could temporarily miss abrupt changes that could cause paging. For kernel enforcement, configure memory limits in the Job Launcher using cgroups (rstudio-pro#5019).
 
 ### Fixed
 #### RStudio

--- a/src/cpp/core/include/core/system/Resources.hpp
+++ b/src/cpp/core/include/core/system/Resources.hpp
@@ -67,6 +67,9 @@ Error getTotalMemoryUsed(long *pUsedKb, MemoryProvider *pProvider);
 // RAM) or a virtual one (e.g., a cgroup-imposed limit)
 Error getTotalMemory(long *pTotalKb, MemoryProvider *pProvider);
 
+// Returns 0 if there's no limit. cgroups memory limits if enabled, or ulimit -m
+Error getProcessMemoryLimit(long *pTotalKb, MemoryProvider *pProvider);
+
 } // namespace system
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/system/MacResources.cpp
+++ b/src/cpp/core/system/MacResources.cpp
@@ -93,6 +93,13 @@ Error getProcessMemoryUsed(long *pUsedKb, MemoryProvider *pProvider)
     return systemError(ret, "Failed to get memory resource usage from task_info", ERROR_LOCATION);
 }
 
+Error getProcessMemoryLimit(long *pLimitKb, MemoryProvider *pProvider)
+{
+   *pLimitKb = 0;
+   *pProvider = MemoryProviderUnknown;
+   return Success();
+}
+
 } // namespace system
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/system/Win32Resources.cpp
+++ b/src/cpp/core/system/Win32Resources.cpp
@@ -64,6 +64,11 @@ Error getTotalMemory(long *pTotalKb, MemoryProvider *pProvider)
    return Success();
 }
 
+Error getProcessMemoryLimit(long *pUsedKb, MemoryProvider *pProvider)
+{
+   return 0;
+}
+
 } // namespace system
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1655,6 +1655,13 @@ void loadCranRepos(const std::string& repos,
 // provide definition methods for rsession::module_context
 namespace rstudio {
 namespace session {
+
+void controlledExit(int status)
+{
+   rCleanup(status == 0);
+   exitEarly(status);
+}
+
 namespace module_context {
 
 Error registerRBrowseUrlHandler(const RBrowseUrlHandler& handler)
@@ -1917,8 +1924,7 @@ void initMonitorClient()
 
 void beforeResume()
 {
-   LOG_DEBUG_MESSAGE("Setting activityState to resuming from: " + module_context::activeSession().activityState());
-   module_context::activeSession().setActivityState(r_util::kActivityStateResuming, true);
+   LOG_DEBUG_MESSAGE("Resuming session");
 }
 
 void afterResume()
@@ -2275,7 +2281,7 @@ int main(int argc, char * const argv[])
                                    ERROR_LOCATION);
          boost::format fmt("User '%1%' has id %2%, which is lower than the "
                            "minimum user id of %3% (this is controlled by "
-                           "the the auth-minimum-user-id rserver option)");
+                           "the auth-minimum-user-id rserver option)");
          std::string msg = boost::str(fmt % core::system::username()
                                           % core::system::effectiveUserId()
                                           % options.authMinimumUserId());

--- a/src/cpp/session/include/session/SessionMain.hpp
+++ b/src/cpp/session/include/session/SessionMain.hpp
@@ -21,6 +21,8 @@ namespace session {
 
 void terminateAllChildProcesses();
 
+void controlledExit(int statusCode);
+
 }
 }
 

--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -302,7 +302,13 @@ protected:
       "Indicates whether or not to allow full standalone UI mode.")
       ("allow-launcher-jobs",
       value<bool>(&allowLauncherJobs_)->default_value(true),
-      "Indicates whether or not to allow running jobs via the Launcher.");
+      "Indicates whether or not to allow running jobs via the Launcher.")
+      ("allow-over-limit-sessions",
+      value<bool>(&allowOverLimitSessions_)->default_value(false),
+      "Indicates whether or not to abort sessions that exceed their specified memory limit. Users will still see warnings and an error.")
+      ("abort-free-mem-percent",
+      value<int>(&abortFreeMemPercent_)->default_value(5),
+      "Sessions will be aborted if there is less than 100 MiB of free RAM or this configured percentage. Disable abort entirely by enabling allow-over-limit-sessions. Increase this value for easily reproducing this scenario in a test environment or to more strictly enforce memory limits on the system.");
 
    pR->add_options()
       ("r-core-source",
@@ -538,6 +544,8 @@ public:
    bool allowPresentationCommands() const { return allowPresentationCommands_ || allowOverlay(); }
    bool allowFullUI() const { return allowFullUI_ || allowOverlay(); }
    bool allowLauncherJobs() const { return allowLauncherJobs_ || allowOverlay(); }
+   bool allowOverLimitSessions() const { return allowOverLimitSessions_ || allowOverlay(); }
+   int abortFreeMemPercent() const { return abortFreeMemPercent_ || allowOverlay(); }
    core::FilePath coreRSourcePath() const { return core::FilePath(coreRSourcePath_); }
    core::FilePath modulesRSourcePath() const { return core::FilePath(modulesRSourcePath_); }
    core::FilePath sessionLibraryPath() const { return core::FilePath(sessionLibraryPath_); }
@@ -658,6 +666,8 @@ protected:
    bool allowPresentationCommands_;
    bool allowFullUI_;
    bool allowLauncherJobs_;
+   bool allowOverLimitSessions_;
+   int abortFreeMemPercent_;
    std::string coreRSourcePath_;
    std::string modulesRSourcePath_;
    std::string sessionLibraryPath_;

--- a/src/cpp/session/modules/SessionSystemResources.cpp
+++ b/src/cpp/session/modules/SessionSystemResources.cpp
@@ -17,10 +17,13 @@
 #include "../SessionMainProcess.hpp"
 #include <session/prefs/UserPrefs.hpp>
 #include <session/SessionModuleContext.hpp>
+#include <session/SessionMain.hpp>
+#include "../SessionConsoleInput.hpp"
 
 #include <chrono>
 
 #include <core/Exec.hpp>
+#include <core/system/Interrupts.hpp>
 
 #include <r/RExec.hpp>
 #include <r/RSexp.hpp>
@@ -208,6 +211,10 @@ json::Object MemoryUsage::toJson()
    usage["total"] = total.toJson();
    usage["used"] = used.toJson();
    usage["process"] = process.toJson();
+   usage["limit"] = limit.toJson();
+   usage["abort"] = abort;
+   usage["limitWarning"] = limitWarning;
+   usage["overLimit"] = overLimit;
    return usage;
 }
 
@@ -234,6 +241,50 @@ Error getMemoryUsage(boost::shared_ptr<MemoryUsage> *pMemUsage)
       return error;
    pStats->process = MemoryStat(kb, provider);
 
+   error = core::system::getProcessMemoryLimit(&kb, &provider);
+   if (error)
+      return error;
+   pStats->limit = MemoryStat(kb, provider);
+
+   if (pStats->limit.kb != 0)
+   {
+      uint64_t limit = pStats->limit.kb;
+      uint64_t process = pStats->process.kb;
+      long freeMem = pStats->total.kb - pStats->used.kb;
+      if (freeMem < 0)
+         freeMem = 0;
+      int freeMemPercent = freeMem * 100 / pStats->total.kb;
+
+      if (process > limit)
+      {
+	 int overBy = process - limit;
+	 int abortFreeMemPercent = options().abortFreeMemPercent();
+         pStats->overLimit = true;
+         // Treat memory limit as only an error unless instructed to abort the session:
+	 //  1. Let sys-admin's override abort
+	 //  2. Give a small grace limit, especially since RSS is fuzzy and memory gets reclaimed
+	 //  as you near the limit in cgroups.
+	 //  3. Don't kill sessions until the system needs memory: less than 100mb or 5% free (where 5 is configurable, useful especially for testing)
+         pStats->abort = !options().allowOverLimitSessions() && overBy > 50*1024 && (freeMem < 100*1024 || freeMemPercent < abortFreeMemPercent);
+         std::string statusMessage = "Session process using: " + std::to_string(process) + "kb over the limit of: " + std::to_string(limit) + "kb.";
+         std::string freeMessage = std::to_string(freeMem) + "kb free (" + std::to_string(freeMemPercent) + "%)";
+
+         if (pStats->abort)
+            LOG_ERROR_MESSAGE(statusMessage + " Stopping session due to low system memory (< 100mb or 5%): " + freeMessage);
+         else
+            LOG_ERROR_MESSAGE(statusMessage + " Showing user an error but not stopping session with sufficient free system memory (> 100mb and 5%): " + freeMessage);
+      }
+      // The client will produce a warning the first time but this will be nice to see how fast memory is increasing
+      else if (process + process * 0.15 > limit)
+      {
+         pStats->limitWarning = true;
+         LOG_WARNING_MESSAGE("Warning user: system memory usage: " + std::to_string(process) + " within 15% of the limit: " +
+                              std::to_string(limit) + " before session will be stopped");
+      }
+      else
+         LOG_DEBUG_MESSAGE("System memory limit check: " + std::to_string(process) + " / " + std::to_string(limit));
+   }
+
    *pMemUsage = pStats;
    return core::Success();
 }
@@ -259,6 +310,23 @@ Error initialize()
    return initBlock.execute();
 }
 
+void exitForMemoryLimit()
+{
+   controlledExit(37);
+}
+
+void startShutdownForMemoryLimit()
+{
+   bool busy = session::console_input::executing();
+   if (busy)
+   {
+      LOG_DEBUG_MESSAGE("Interrupting session for memory limit shutdown");
+      r::exec::setInterruptsPending(true);
+      core::system::interrupt();
+   }
+   // Give the interrupt a chance to finish, the event to get to the client and then exit cleanly with a failure status
+   module_context::scheduleDelayedWork(boost::posix_time::milliseconds(100), boost::bind(exitForMemoryLimit), false);
+}
 
 /**
  * Computes memory usage and emits it to the client as a client event.
@@ -277,8 +345,17 @@ void emitMemoryChangedEvent()
    }
    else
    {
-      ClientEvent event(client_events::kMemoryUsageChanged, pUsage->toJson());
+      json::Object usageJson = pUsage->toJson();
+      ClientEvent event(client_events::kMemoryUsageChanged, usageJson);
       module_context::enqueClientEvent(event);
+   }
+
+   if (pUsage && pUsage->overLimit && pUsage->abort)
+   {
+      // We've sent the event that the client will detect as memory limit exceeded so this will
+      // just exit after a pause to let the event get through, interrupt R cleanly, then exit as
+      // cleanly as possible but with an error status.
+      startShutdownForMemoryLimit();
    }
 }
 

--- a/src/cpp/session/modules/SessionSystemResources.hpp
+++ b/src/cpp/session/modules/SessionSystemResources.hpp
@@ -63,6 +63,11 @@ public:
    MemoryStat total;    // Total system memory
    MemoryStat used;     // System memory currently in use
    MemoryStat process;  // Memory used by the current process
+   MemoryStat limit;    // Memory limit for the current process
+
+   bool abort = false;        // True if over the limit and session will shutdown
+   bool overLimit = false;    // True if over the limit but enough free mem
+   bool limitWarning = false; // True if needs the limit warning
 };
 
 // Get information on current memory usage

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -563,6 +563,20 @@
             "memberName": "allowLauncherJobs_",
             "defaultValue": true,
             "description": "Indicates whether or not to allow running jobs via the Launcher."
+         },
+         {
+            "name": "allow-over-limit-sessions",
+            "type": "bool",
+            "memberName": "allowOverLimitSessions_",
+            "defaultValue": false,
+            "description": "Indicates whether or not to abort sessions that exceed their specified memory limit. Users will still see warnings and an error."
+         },
+         {
+            "name": "abort-free-mem-percent",
+            "type": "int",
+            "memberName": "abortFreeMemPercent_",
+            "defaultValue": 5,
+            "description": "Sessions will be aborted if there is less than 100 MiB of free RAM or this configured percentage. Disable abort entirely by enabling allow-over-limit-sessions. Increase this value for easily reproducing this scenario in a test environment or to more strictly enforce memory limits on the system."
          }
       ],
       "r": [

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationView.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationView.java
@@ -36,9 +36,11 @@ public interface ApplicationView extends AriaLiveStatusReporter
    void showApplicationDisconnected();
    void showApplicationOffline();
    void showApplicationUpdateRequired();
+   void showMemoryLimitExceeded(String status, boolean abort);
    
    // error messages
    void showSessionAbendWarning();
+   void showMemoryLimitWarning(String status, boolean updateOnly, boolean overLimit);
    
    // status or alert message for screen reader users,
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants.java
@@ -1492,4 +1492,49 @@ public interface StudioClientApplicationConstants extends com.google.gwt.i18n.cl
     @DefaultMessage("This will cause RStudio to immediately crash. You may lose work. Trigger crash?")
     @Key("reallyCrashMessage")
     String reallyCrashMessage();
+
+    /**
+     * Translated "Session memory limit exceeded. Restart required."
+     *
+     * @return translated "Session memory limit exceeded. Restart required."
+     */
+    @DefaultMessage("Session memory limit exceeded. Restart required.")
+    @Key("memoryLimitExceededCaption")
+    String memoryLimitExceededCaption();
+
+    /**
+     * Translated "Save files and restart session.\n\nSession will be stopped if there is less than 100 MiB or 5% free system memory."
+     *
+     * @return translated "Save files and restart session.\n\nSession will be stopped if there is less than 100 MiB or 5% free system memory."
+     */
+    @DefaultMessage("Save files and restart session.\n\nSession will be stopped if there is less than 100 MiB or 5% free system memory.")
+    @Key("memoryLimitExceededMessage")
+    String memoryLimitExceededMessage();
+
+    /**
+     * Translated "Memory limit has been exceeded. The IDE session has been terminated."
+     *
+     * @return translated "Memory limit has been exceeded. The IDE session has been terminated."
+     */
+    @DefaultMessage("Memory limit has been exceeded. The IDE session has been terminated.")
+    @Key("memoryLimitAbortedMessage")
+    String memoryLimitAbortedMessage();
+
+    /**
+     * Translated "Approaching session memory limit."
+     *
+     * @return translated "Approaching session memory limit."
+     */
+    @DefaultMessage("Approaching session memory limit.")
+    @Key("approachingMemoryLimit")
+    String approachingMemoryLimit();
+
+    /**
+     * Translated "Over session memory limit."
+     *
+     * @return translated "Over session memory limit."
+     */
+    @DefaultMessage("Over session memory limit.")
+    @Key("overMemoryLimit")
+    String overMemoryLimit();
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/events/ApplicationEventHandlers.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/ApplicationEventHandlers.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.application.events;
 
 import org.rstudio.studio.client.workbench.events.SessionInitEvent;
+import org.rstudio.studio.client.workbench.views.environment.events.MemoryUsageChangedEvent;
 
 public interface ApplicationEventHandlers extends LogoutRequestedEvent.Handler,
                                                   AuthorizedEvent.Handler,
@@ -37,6 +38,7 @@ public interface ApplicationEventHandlers extends LogoutRequestedEvent.Handler,
                                                   FileUploadEvent.Handler,
                                                   AriaLiveStatusEvent.Handler,
                                                   ClipboardActionEvent.Handler,
-                                                  RunAutomationEvent.Handler
+                                                  RunAutomationEvent.Handler,
+                                                  MemoryUsageChangedEvent.Handler
 {
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
@@ -155,6 +155,23 @@ public class ApplicationWindow extends Composite
    }
 
    @Override
+   public void showMemoryLimitExceeded(String status, boolean abort)
+   {
+      if (abort)
+         ApplicationEndedPopupPanel.showMemoryLimitExceeded(status);
+      else
+         globalDisplay_.showErrorMessage(constants_.memoryLimitExceededCaption(),
+                                         constants_.memoryLimitExceededMessage() + "\n\n" + status);
+   }
+
+   @Override
+   public void showMemoryLimitWarning(String status, boolean updateOnly, boolean overLimit)
+   {
+      if (!updateOnly || warningBar_ != null)
+        showWarning(true, (overLimit ? constants_.overMemoryLimit() : constants_.approachingMemoryLimit()) + " " + status);
+   }
+
+   @Override
    public void showApplicationUpdateRequired()
    {
       globalDisplay_.showMessage(

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/appended/ApplicationEndedPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/appended/ApplicationEndedPopupPanel.java
@@ -82,6 +82,13 @@ public class ApplicationEndedPopupPanel extends PopupPanel
       asyncShow(OFFLINE, description, null);
    }
 
+   public static void showMemoryLimitExceeded(String status)
+   {
+      String description = constants_.memoryLimitAbortedMessage() + "\n\n" + status;
+
+      asyncShow(MEMORY_LIMIT, description, null);
+   }
+
    public static void prefetch(Command continuation)
    {
       asyncShow(PREFETCH, null, continuation);
@@ -119,6 +126,7 @@ public class ApplicationEndedPopupPanel extends PopupPanel
    private static final int DISCONNECTED = 3;
    private static final int OFFLINE = 4;
    private static final int QUIT_MULTI = 5;
+   private static final int MEMORY_LIMIT = 6;
 
    private ApplicationEndedPopupPanel(int mode, String description)
    {
@@ -170,6 +178,12 @@ public class ApplicationEndedPopupPanel extends PopupPanel
       case QUIT_MULTI:
          image = new DecorativeImage(new ImageResource2x(RESOURCES.applicationQuit2x()));
          captionLabel.setText(constants_.rSessionEndedCaption());
+         button.setText(constants_.reconnectButtonText());
+         break;
+
+      case MEMORY_LIMIT:
+         image = new DecorativeImage(new ImageResource2x(RESOURCES.applicationSuicide2x()));
+         captionLabel.setText(constants_.rSessionAbortedCaption());
          button.setText(constants_.reconnectButtonText());
          break;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/ViewEnvironmentConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/ViewEnvironmentConstants.java
@@ -1231,7 +1231,85 @@ public interface ViewEnvironmentConstants extends com.google.gwt.i18n.client.Mes
     @Key("preparingDataImportText")
     String preparingDataImportText();
 
+    /**
+     * Translated "Session memory used"
+     * 
+     * @return translated "Session memory used"
+     */
+    @DefaultMessage("Session memory used")
+    @Key("sessionMemoryUsed")
+    String sessionMemoryUsed();
 
+    /**
+     * Translated "Session memory limit"
+     * 
+     * @return translated "Session memory limit"
+     */
+    @DefaultMessage("Session memory limit")
+    @Key("sessionMemoryLimit")
+    String sessionMemoryLimit();
 
+    /**
+     * Translated "System memory used"
+     *
+     * @return translated "System memory used"
+     */
+    @DefaultMessage("System memory used")
+    @Key("systemMemoryUsed")
+    String systemMemoryUsed();
+
+    /**
+     * Translated "unlimited"
+     *
+     * @return translated "unlimited"
+     */
+    @DefaultMessage("unlimited")
+    @Key("unlimited")
+    String unlimited();
+
+    /**
+     * Translated "limit"
+     *
+     * @return translated "limit"
+     */
+    @DefaultMessage("limit")
+    @Key("limit")
+    String limit();
+
+    /**
+     * Translated "free"
+     *
+     * @return translated "free"
+     */
+    @DefaultMessage("free")
+    @Key("freeMemory")
+    String freeMemory();
+
+    /**
+     * Translated "out of"
+     *
+     * @return translated "out of"
+     */
+    @DefaultMessage("out of")
+    @Key("outOf")
+    String outOf();
+
+    /**
+     * Translated "MiB"
+     *
+     * @return translated "MiB"
+     */
+    @DefaultMessage("MiB")
+    @Key("megabytes")
+    String megabytes();
+
+    /**
+     * Translated "Workbench limit"
+     *
+     * @return translated "Workbench limit"
+     */
+    @DefaultMessage("Workbench limit")
+    @Key("workbenchLimit")
+    String workbenchLimit();
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/model/MemoryStat.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/model/MemoryStat.java
@@ -44,7 +44,7 @@ public class MemoryStat extends JavaScriptObject
          case MEMORY_PROVIDER_LINUX_CGROUPS:
             return "cgroup";
          case MEMORY_PROVIDER_LINUX_ULIMIT:
-            return "ulimit";
+            return constants_.workbenchLimit();
          case MEMORY_PROVIDER_LINUX_PROCFS:
             return "/proc filesystem";
          case MEMORY_PROVIDER_LINUX_PROCMEMINFO:

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/MemoryUsageSummary.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/MemoryUsageSummary.java
@@ -126,26 +126,37 @@ public class MemoryUsageSummary extends Composite
          constants_.usedBySession(),
          report.getSystemUsage().getProcess()));
 
+      boolean useProcessLimit = usage.useProcessLimit();
+      if (useProcessLimit)
+      {
+         // Show the process limit if there is one and it's not already being used for total memory
+         statsBody.appendChild(buildStatsRow(
+            MemUsageWidget.MEMORY_PIE_UNUSED_COLOR,
+            constants_.sessionMemoryLimit(),
+            usage.getLimit().getKb(),
+            usage.getLimit().getProviderName()));
+      }
+
       // The memory used by the system that isn't already accounted for in the process
       statsBody.appendChild(buildStatsRow(
-         MemoryUsagePieChart.getSystemColorCode(
-            report.getSystemUsage().getPercentUsed()),
+         useProcessLimit ?  null :
+            MemoryUsagePieChart.getSystemColorCode(usage.getPercentUsed()),
          constants_.usedBySystem(),
-         report.getSystemUsage().getUsed().getKb() - report.getSystemUsage().getProcess().getKb(),
-         report.getSystemUsage().getUsed().getProviderName()));
+         usage.getUsed().getKb() - usage.getProcess().getKb(),
+         usage.getUsed().getProviderName()));
 
       // The memory left on the system (the total less the used)
       statsBody.appendChild(buildStatsRow(
-         MemUsageWidget.MEMORY_PIE_UNUSED_COLOR,
+         useProcessLimit ? null : MemUsageWidget.MEMORY_PIE_UNUSED_COLOR,
          constants_.freeSystemMemory(),
-         report.getSystemUsage().getTotal().getKb() - report.getSystemUsage().getUsed().getKb(),
-         report.getSystemUsage().getUsed().getProviderName()));
+         usage.getTotal().getKb() - usage.getUsed().getKb(),
+         usage.getUsed().getProviderName()));
 
       // Total system memory
       statsBody.appendChild(buildStatsRow(
          null,
          constants_.totalSystemMemory(),
-         report.getSystemUsage().getTotal()));
+         usage.getTotal()));
 
       stats_.getElement().appendChild(statsTable);
       Roles.getDialogRole().setAriaLabelledbyProperty(statsTable, Id.of(header));


### PR DESCRIPTION

### Intent

This addresses the pro issue: https://github.com/rstudio/rstudio-pro/issues/5019 where quarto 1.6 is incompatible with the virtual memory limit logic in the RStudio core libraries.

### Approach

- Warn the user as they approach the limit, providing an error dialog, and (optionally) aborting the session when it's low on memory

- Changes core library setResourceLimit(MemoryLimit,..) from using virtual memory (ulimit -v) to Resident memory (ulimit -m). Virtual memory is inaccurate but resident memory is only enforceable with more modern linux kernels that support cgroups, and extra logic to manage the groups. 

- Enforces memory limit in RStudio itself, by using the existing memory usage widget polling, adding a few fields to the memory changed event.

- Added options to rsession.conf so an admin can turn on/off the 'abort' session feature and adjust the limit of system memory that triggers an abort. This is especially useful for testing, so you can trigger an abort without getting too close to the system limit.

- Currently mac/windows return 0 for the process limit but if it would be useful we could return OS specific limits as appropriate.

### QA Notes

Since there isn't a way to set memory limits for an rsession in open source, it will be easier to test this once it gets merged into rstudio-pro. In the meantime, we shouldn't see any regressions. 

On a linux machine, if you set ulimit -m before launching the desktop, it should show that as the process memory limit and give you warnings, errors, and abort if the system is out running out of free memory. 

### Documentation

I don't think there's much to document about the OS side other than the release notes since it shouldn't affect any system behavior when there's no limit set.



