### PR TITLE
Fix desktop build for RHEL8

### DIFF
--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -59,7 +59,7 @@ exit 1
 is_rhel8() {
    if [ -f /etc/os-release ]; then
       . /etc/os-release
-      [[ "$ID" == "rhel" && "${VERSION_ID%%.*}" == "8" ]] && return 0
+      [[ "$ID" == "rhel" || "$ID" == "rocky" ]] && [[ "${VERSION_ID%%.*}" == "8" ]] && return 0
    fi
    return 1
 }

--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -55,11 +55,23 @@ Options
 EOF
 exit 1
 }
+# Add detection function near top of file
+is_rhel8() {
+   if [ -f /etc/os-release ]; then
+      . /etc/os-release
+      [[ "$ID" == "rhel" && "${VERSION_ID%%.*}" == "8" ]] && return 0
+   fi
+   return 1
+}
 
 NPM_INSTALLED=0
 install-npm-packages() {
    if [ "${NPM_INSTALLED}" = "0" ]; then
-      MAKEFLAGS="" ${NPM} ci
+      if is_rhel8; then
+         MAKEFLAGS="" scl enable gcc-toolset-13 "${NPM} ci"
+      else
+         MAKEFLAGS="" ${NPM} ci
+      fi
       NPM_INSTALLED=1
    fi
 }

--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -55,7 +55,7 @@ Options
 EOF
 exit 1
 }
-# Add detection function near top of file
+
 is_rhel8() {
    if [ -f /etc/os-release ]; then
       . /etc/os-release

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "ts-node scripts/clean.ts",
     "lint": "eslint ./src ./test",
-    "package": "electron-forge package",
+    "package": "node scripts/packaging.mjs",
     "start": "electron-forge start -- --no-sandbox",
     "debug": "electron-forge start --inspect-electron",
     "fullstart": "npm install && electron-forge start",

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "ts-node scripts/clean.ts",
     "lint": "eslint ./src ./test",
-    "package": "npm ci && electron-forge package",
+    "package": "electron-forge package",
     "start": "electron-forge start -- --no-sandbox",
     "debug": "electron-forge start --inspect-electron",
     "fullstart": "npm install && electron-forge start",

--- a/src/node/desktop/scripts/packaging.mjs
+++ b/src/node/desktop/scripts/packaging.mjs
@@ -1,0 +1,35 @@
+/*
+ * packaging.mjs
+ *
+ * Copyright (C) 2025 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { execSync } from 'child_process';
+
+function isRHEL8OrRocky8() {
+  try {
+    const osRelease = execSync('cat /etc/os-release').toString();
+    return (
+      (osRelease.includes('RHEL') || osRelease.includes('Rocky')) &&
+      osRelease.includes('VERSION_ID="8')
+    );
+  } catch {
+    return false;
+  }
+}
+
+const baseCommand = 'npm ci && electron-forge package';
+const command = isRHEL8OrRocky8()
+  ? `scl enable gcc-toolset-13 "${baseCommand}"`
+  : baseCommand;
+
+execSync(command, { stdio: 'inherit' });

--- a/src/node/desktop/src/main/gwt-window.ts
+++ b/src/node/desktop/src/main/gwt-window.ts
@@ -33,7 +33,7 @@ export abstract class GwtWindow extends DesktopBrowserWindow {
     //
     // https://github.com/rstudio/rstudio/issues/11016
     this.window.webContents.on('did-navigate', (_event, _params) => {
-      this.window.webContents.clearHistory();
+      this.window.webContents.navigationHistory.clear();
     });
   }
 


### PR DESCRIPTION
### Intent

Follow-up change for: #15450

### Approach

On RHEL8 (Rocky 8 in our case), newer compilers are already installed, but need to be accessed via this `scl` (software collections) command. Only using the newer compiler for building Electron's native node modules, all other C++ will continue using the same compiler as before.

All my attempts to use the alternatives system as I did on other platforms ultimately failed with problems ranging from not finding compiler plugins, to the compiler crashing.

### Automated Tests

NA

### QA Notes

NA

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


