### PR TITLE
tweak when and how watchdog timer is invoked

### DIFF
--- a/src/cpp/session/SessionRpc.cpp
+++ b/src/cpp/session/SessionRpc.cpp
@@ -67,11 +67,10 @@ void endHandleRpcRequestDirect(boost::shared_ptr<HttpConnection> ptrConnection,
 
       // are there (or will there likely be) events pending?
       // (if not then notify the client)
-      if ( !clientEventQueue().eventAddedSince(executeStartTime) &&
-           !pJsonRpcResponse->hasAfterResponse() )
-      {
-         pJsonRpcResponse->setField(kEventsPending, "false");
-      }
+      bool eventsPending =
+          pJsonRpcResponse->hasAfterResponse() ||
+          clientEventQueue().eventAddedSince(executeStartTime);
+      pJsonRpcResponse->setField(kEventsPending, eventsPending ? "true" : "false");
 
       // send the response
       ptrConnection->sendJsonRpcResponse(*pJsonRpcResponse);

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -3823,11 +3823,16 @@ public class RemoteServer implements Server
 
    private boolean eventsPending(RpcResponse response)
    {
+      // NOTE: We previously treated the absence of the 'ep' field
+      // as an implicit sign that events were pending, but we have
+      // a number of custom methods and responses which fail to set
+      // this. We now require 'ep' to be explicitly set as "true"
+      // to signal if events are pending.
       String eventsPending = response.getField("ep");
       if (eventsPending == null)
-         return true; // default to true for json-rpc compactness
-      else
-         return Boolean.parseBoolean(eventsPending);
+         return false;
+      
+      return Boolean.parseBoolean(eventsPending);
    }
 
    private boolean resolveRpcErrorAndRetry(final String scope,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerEventListener.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerEventListener.java
@@ -207,8 +207,7 @@ class RemoteServerEventListener
         //   2) the user navigates Back within a Frame 
         //
         // can only imagine that it could happen in other scenarios!
-        if (!watchdog_.isRunning())
-           watchdog_.schedule(kWatchdogIntervalMs);
+        watchdog_.schedule(kWatchdogIntervalMs);
      }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerEventListener.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerEventListener.java
@@ -465,7 +465,7 @@ class RemoteServerEventListener
    // note: kSecondListenDelayMs must be less than kWatchdogIntervalMs
    // (by a reasonable margin) to void the watchdog getting involved 
    // unnecessarily during a listen delay
-   private final int kWatchdogIntervalMs = 1000;
+   private final int kWatchdogIntervalMs = 2000;
    private final int kSecondListenBounceMs = 250;
    private Timer listenTimer_;
        


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/6907.

### Approach

- Give the watchdog timer a longer timeout.
- Treat a missing 'ep' field within a response as "no events pending" rather than "events pending".
- Explicitly mark "ep" = "true" where appropriate, instead of leaving it blank.

### Automated Tests

N/A; unfortunately this is not easy to provide automated testing for.

### QA Notes

Unfortunately we'll have to rely on user feedback. 

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
