### PR TITLE
don't process RPCs while rendering plots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 ### Fixed
 #### RStudio
 
+- Fixed an issue where RStudio could crash when attempting to clear plots while a new plot was being drawn. (#11856)
 - Fixed an issue where RStudio Server could hang when navigating the Open File dialog to a directory with many (> 100,000) files. (#15441)
 - Fixed an issue where the F1 shortcut would fail to retrieve documentation in packages. (#10869)
 - Fixed an issue where some column names were not displayed following select() in pipe completions. (#12501)

--- a/src/cpp/r/include/r/session/REventLoop.hpp
+++ b/src/cpp/r/include/r/session/REventLoop.hpp
@@ -16,6 +16,7 @@
 #ifndef R_EVENT_LOOP_HPP
 #define R_EVENT_LOOP_HPP
 
+#include <boost/noncopyable.hpp>
 #include <boost/date_time/posix_time/posix_time_duration.hpp>
 
 namespace rstudio {
@@ -57,7 +58,12 @@ bool polledEventHandlerInitialized();
 // device to remain responsive)
 void processEvents();
 
-
+class DisablePolledEventHandlerScope : boost::noncopyable
+{
+public:
+   DisablePolledEventHandlerScope();
+   ~DisablePolledEventHandlerScope();
+};
 
 } // namespace event_loop
 } // namespace session

--- a/src/cpp/r/session/REmbeddedWin32.cpp
+++ b/src/cpp/r/session/REmbeddedWin32.cpp
@@ -140,9 +140,14 @@ namespace session {
 
 namespace {
 
+int s_disablePolledEventHandler = 0;
+
 void (*s_polledEventHandler)(void) = nullptr;
 void rPolledEventCallback()
 {
+   if (s_disablePolledEventHandler != 0)
+       return;
+
    if (s_polledEventHandler != nullptr)
       s_polledEventHandler();
 }
@@ -370,6 +375,17 @@ void processEvents()
 {
    R_ProcessEvents();
 }
+
+DisablePolledEventHandlerScope::DisablePolledEventHandlerScope()
+{
+   s_disablePolledEventHandler += 1;
+}
+
+DisablePolledEventHandlerScope::~DisablePolledEventHandlerScope()
+{
+   s_disablePolledEventHandler -= 1;
+}
+
 
 } // namespace event_loop
 } // namespace session

--- a/src/cpp/r/session/graphics/RGraphicsPlot.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsPlot.cpp
@@ -15,18 +15,17 @@
 
 #include "RGraphicsPlot.hpp"
 
-#include <iostream>
-
 #include <boost/format.hpp>
 
 #include <shared_core/Error.hpp>
-#include <core/Log.hpp>
 
+#include <core/Log.hpp>
 #include <core/system/System.hpp>
 #include <core/StringUtils.hpp>
 
 #include <r/RExec.hpp>
 #include <r/session/RGraphics.hpp>
+#include <r/session/REventLoop.hpp>
 
 using namespace rstudio::core;
 
@@ -128,7 +127,10 @@ Error Plot::renderFromDisplay()
    {
       return Success();
    }
-   
+
+   // disable polled events in this scope
+   r::session::event_loop::DisablePolledEventHandlerScope scope;
+
    // generate a new storage uuid
    std::string storageUuid = core::system::generateUuid();
    

--- a/src/cpp/r/session/graphics/RShadowPngGraphicsHandler.cpp
+++ b/src/cpp/r/session/graphics/RShadowPngGraphicsHandler.cpp
@@ -27,6 +27,7 @@
 #include <r/ROptions.hpp>
 #include <r/session/RSessionUtils.hpp>
 #include <r/session/RGraphics.hpp>
+#include <r/session/REventLoop.hpp>
 
 #undef TRUE
 #undef FALSE
@@ -430,6 +431,10 @@ void onAfterAddDevice(DeviceContext* pDC)
 
 Error writeToPNG(const FilePath& targetPath, DeviceContext* pDC)
 {
+   // disable polled events -- we don't want to manipulate
+   // the graphics device (or destroy it!) while we're using it
+   r::session::event_loop::DisablePolledEventHandlerScope scope;
+
    // sync the shadow device to ensure we have the full playlist,
    shadowDevSync(pDC);
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11856.

### Approach

RStudio processes RPCs via its polled event handler, which gets called whenever R tries to process events via R_ProcessEvents. However, this can be called recursively in some cases, and so we can end up in situations where RPCs get handled while a different RPC is currently being handled.

This can lead to issues when those RPCs manipulate the same data structures; e.g. if we delete the graphics device while another one is in the middle of generating plots. Hence the crash in https://github.com/rstudio/rstudio/issues/11856.

This PR resolves the issue in a narrow way, specifically by disabling the polled event handler temporarily while writing plots to disk.

### Automated Tests

N/A; not easily amenable to automated testing.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/11856.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
