### PR TITLE
interrupt R sessions before termination

### DIFF
--- a/src/cpp/core/include/core/system/Interrupts.hpp
+++ b/src/cpp/core/include/core/system/Interrupts.hpp
@@ -20,7 +20,7 @@ namespace system {
 #ifndef CORE_SYSTEM_INTERRUPTS_HPP
 #define CORE_SYSTEM_INTERRUPTS_HPP
 
-void interrupt();
+void interrupt(int pid = 0);
 
 #endif /* CORE_SYSTEM_INTERRUPTS_HPP */
 

--- a/src/cpp/core/system/PosixInterrupts.cpp
+++ b/src/cpp/core/system/PosixInterrupts.cpp
@@ -23,9 +23,9 @@ namespace rstudio {
 namespace core {
 namespace system {
 
-void interrupt()
+void interrupt(int pid)
 {
-   ::killpg(0, SIGINT);
+   ::killpg(pid, SIGINT);
 }
 
 } // end namespace system

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -514,18 +514,15 @@ Error ChildProcess::run()
       si.dwFlags |= STARTF_USESHOWWINDOW;
       si.wShowWindow = SW_HIDE;
    }
-   else if (options_.detachProcess || options_.terminateChildren)
+   else if (options_.detachProcess)
    {
-      if (options_.detachProcess)
-      {
-         dwFlags |= DETACHED_PROCESS;
-      }
-
-      if (options_.terminateChildren)
-      {
-         dwFlags |= CREATE_NEW_PROCESS_GROUP;
-      }
-
+      dwFlags |= DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP;
+      si.dwFlags |= STARTF_USESHOWWINDOW;
+      si.wShowWindow = SW_HIDE;
+   }
+   else if (options_.terminateChildren)
+   {
+      dwFlags |= CREATE_NEW_PROCESS_GROUP;
       si.dwFlags |= STARTF_USESHOWWINDOW;
       si.wShowWindow = SW_HIDE;
    }

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -516,7 +516,16 @@ Error ChildProcess::run()
    }
    else if (options_.detachProcess || options_.terminateChildren)
    {
-      dwFlags |= DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP;
+      if (options_.detachProcess)
+      {
+         dwFlags |= DETACHED_PROCESS;
+      }
+
+      if (options_.terminateChildren)
+      {
+         dwFlags |= CREATE_NEW_PROCESS_GROUP;
+      }
+
       si.dwFlags |= STARTF_USESHOWWINDOW;
       si.wShowWindow = SW_HIDE;
    }

--- a/src/cpp/core/system/Win32Interrupts.cpp
+++ b/src/cpp/core/system/Win32Interrupts.cpp
@@ -21,9 +21,16 @@ namespace rstudio {
 namespace core {
 namespace system {
 
-void interrupt(int pid)
+// NOTE: On Windows, the process group associated with a process is not
+// made available via any publicly-available Windows APIs. However, for
+// any process created with the CREATE_NEW_PROCESS_GROUP flag, the
+// process group id is the same as the process id of that new process.
+//
+// To wit, this API should only be used to terminate processes that are
+// known to be process group leaders.
+void interrupt(int processGroupId)
 {
-   ::GenerateConsoleCtrlEvent(CTRL_C_EVENT, pid);
+   ::GenerateConsoleCtrlEvent(CTRL_C_EVENT, processGroupId);
 }
 
 } // end namespace system

--- a/src/cpp/core/system/Win32Interrupts.cpp
+++ b/src/cpp/core/system/Win32Interrupts.cpp
@@ -27,10 +27,12 @@ namespace system {
 // process group id is the same as the process id of that new process.
 //
 // To wit, this API should only be used to terminate processes that are
-// known to be process group leaders.
+// known to be process group leaders. This normally implies that the
+// process was created with the 'terminateChildren' flag set, but
+// _NOT_ with 'detachProcess'.
 void interrupt(int processGroupId)
 {
-   ::GenerateConsoleCtrlEvent(CTRL_C_EVENT, processGroupId);
+   ::GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, processGroupId);
 }
 
 } // end namespace system

--- a/src/cpp/core/system/Win32Interrupts.cpp
+++ b/src/cpp/core/system/Win32Interrupts.cpp
@@ -21,9 +21,9 @@ namespace rstudio {
 namespace core {
 namespace system {
 
-void interrupt()
+void interrupt(int pid)
 {
-   ::GenerateConsoleCtrlEvent(CTRL_C_EVENT, 0);
+   ::GenerateConsoleCtrlEvent(CTRL_C_EVENT, pid);
 }
 
 } // end namespace system

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -633,15 +633,21 @@ FilePath tempFile(const std::string& prefix, const std::string& extension)
    return filePath;
 }
 
+namespace {
+
+FilePath tempDirImpl()
+{
+   return FilePath(
+       string_utils::systemToUtf8(
+           r::util::fixPath(R_TempDir)));
+}
+
+} // end anonymous namespace
+
 FilePath tempDir()
 {
-   std::string tempDir;
-   Error error = r::exec::RFunction("tempdir").call(&tempDir);
-   if (error)
-      LOG_ERROR(error);
-
-   FilePath filePath(string_utils::systemToUtf8(r::util::fixPath(tempDir)));
-   return filePath;
+   static FilePath instance = tempDirImpl();
+   return instance;
 }
 
 } // namespace utils

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -293,10 +293,10 @@ void AsyncRProcess::onProcessCompleted(int exitStatus)
    ipcRequests_.removeIfExists();
    ipcResponse_.removeIfExists();
 
+   onCompleted(exitStatus);
+
    terminationRequested_ = false;
    terminationRequestedTime_ = {};
-
-   onCompleted(exitStatus);
 }
 
 bool AsyncRProcess::isRunning()

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -293,11 +293,10 @@ void AsyncRProcess::onProcessCompleted(int exitStatus)
    ipcRequests_.removeIfExists();
    ipcResponse_.removeIfExists();
 
-   int status = terminationRequested_ ? 130 : exitStatus;
    terminationRequested_ = false;
    terminationRequestedTime_ = {};
 
-   onCompleted(status);
+   onCompleted(exitStatus);
 }
 
 bool AsyncRProcess::isRunning()

--- a/src/cpp/session/include/session/SessionAsyncRProcess.hpp
+++ b/src/cpp/session/include/session/SessionAsyncRProcess.hpp
@@ -94,6 +94,7 @@ private:
    void onProcessCompleted(int exitStatus);
    bool isRunning_;
    bool terminationRequested_;
+   std::chrono::steady_clock::time_point terminationRequestedTime_;
    PidType pid_;
    std::string input_;
    core::FilePath ipcRequests_;

--- a/src/cpp/session/include/session/SessionAsyncRProcess.hpp
+++ b/src/cpp/session/include/session/SessionAsyncRProcess.hpp
@@ -93,6 +93,7 @@ protected:
 private:
    void onProcessCompleted(int exitStatus);
    bool isRunning_;
+   bool isQuarto_;
    bool terminationRequested_;
    std::chrono::steady_clock::time_point terminationRequestedTime_;
    PidType pid_;

--- a/src/cpp/session/include/session/SessionAsyncRProcess.hpp
+++ b/src/cpp/session/include/session/SessionAsyncRProcess.hpp
@@ -93,9 +93,7 @@ protected:
 private:
    void onProcessCompleted(int exitStatus);
    bool isRunning_;
-   bool isQuarto_;
-   bool terminationRequested_;
-   std::chrono::steady_clock::time_point terminationRequestedTime_;
+   int terminationRequestedCount_;
    PidType pid_;
    std::string input_;
    core::FilePath ipcRequests_;

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -777,12 +777,13 @@ private:
          outputFile_ = outputFile;
       }
 
-
       // the process may be terminated normally by the IDE (e.g. to stop the
       // Shiny server); alternately, a termination is considered normal if
       // the process succeeded and produced output.
-      terminate(terminateType_ == renderTerminateNormal ||
-                (exitStatus == 0 && outputFile_.exists()));
+      terminate(
+          terminateType_ == renderTerminateNormal ||
+          exitStatus == 130 ||
+          (exitStatus == 0 && outputFile_.exists()));
    }
 
    void terminateWithError(const Error& error)

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -768,21 +768,18 @@ private:
 
    void onCompleted(int exitStatus)
    {
+      using namespace module_context;
+
       // see if we can determine the output file
-      FilePath outputFile = module_context::extractOutputFileCreated
-                                                   (targetFile_.getParent(), allOutput_);
+      FilePath outputFile = extractOutputFileCreated(targetFile_.getParent(), allOutput_);
       if (!outputFile.isEmpty())
-      {
-         // record output file
          outputFile_ = outputFile;
-      }
 
       // the process may be terminated normally by the IDE (e.g. to stop the
       // Shiny server); alternately, a termination is considered normal if
       // the process succeeded and produced output.
       terminate(
           terminateType_ == renderTerminateNormal ||
-          exitStatus == 130 ||
           (exitStatus == 0 && outputFile_.exists()));
    }
 
@@ -826,7 +823,7 @@ private:
       resultJson["output_file"] = outputFile;
       
       std::vector<SourceMarker> knitrErrors;
-      if (renderErrorMarker_)
+      if (!terminationRequested() && renderErrorMarker_)
       {
          renderErrorMarker_.message = core::html_utils::HTML(renderErrorMessage_.str());
          knitrErrors.push_back(renderErrorMarker_);

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/RmdOutput.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/RmdOutput.java
@@ -545,8 +545,11 @@ public class RmdOutput implements RmdRenderStartedEvent.Handler,
           result.getViewerType() == UserPrefs.RMD_VIEWER_TYPE_NONE)
          return;
 
-      String extension = FileSystemItem.getExtensionFromPath(
-                                                result.getOutputFile());
+      String outputFile = result.getOutputFile();
+      if (StringUtil.isNullOrEmpty(outputFile))
+         return;
+      
+      String extension = FileSystemItem.getExtensionFromPath(outputFile);
       if (".pdf".equals(extension))
       {
          String previewer = prefs_.pdfPreviewer().getValue();


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/12109.

### Approach

For the classes we use to handle child processes, we often signal a process should be terminated via returning `false` in the `onContinue()` handler. This termination is done by sending a `SIGTERM` signal to the process (or equivalent on Windows).

Unfortunately, terminating an R process in this way implies that exit handlers won't get executed, which is problematic for code which needs to perform cleanup tasks on quit. This PR attempts to remedy the issue by first sending an interrupt when termination is requested, and then later forcefully terminating if the interrupt is not respected.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/12109.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
