### PR TITLE
Preserve unknown fields in .Rproj files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - RStudio installation on Windows now registers icons for many supported file types. (#12730)
 - RStudio for Windows binaries now have digital signatures. (rstudio-pro#5772)
 - RStudio now only writes the ProjectId field within a project's `.Rproj` file when required. Currently, this is for users who have configured a custom `.Rproj.user` location.
+- RStudio will now preserve unknown fields in `.Rproj` files that are added by future versions of RStudio. (#15524)
 
 #### Posit Workbench
 -

--- a/src/cpp/core/include/core/r_util/RProjectFile.hpp
+++ b/src/cpp/core/include/core/r_util/RProjectFile.hpp
@@ -72,6 +72,14 @@ struct RProjectBuildDefaults
    bool cleanBeforeInstall;
 };
 
+struct ProjectConfigEntry
+{
+   std::string name;
+   std::string value;
+
+   ProjectConfigEntry(const std::string& name, const std::string& value) : name(name), value(value) {}
+};
+
 struct RProjectConfig
 {
    RProjectConfig()
@@ -120,7 +128,8 @@ struct RProjectConfig
         spellingDictionary(),
         copilotEnabled(DefaultValue),
         copilotIndexingEnabled(DefaultValue),
-        projectName()
+        projectName(),
+        unknownFields()
    {
    }
 
@@ -170,6 +179,20 @@ struct RProjectConfig
    int copilotEnabled;
    int copilotIndexingEnabled;
    std::string projectName;
+
+   // Unknown items, presumably written by a newer version of RStudio.
+   //
+   // On save, these are written after the known fields, in ascending alphabetical order.
+   // 
+   // IMPORTANT! To avoid unnecessary changes to project files created by newer versions of RStudio
+   //            (when being rewritten by older versions of RStudio) always add new fields to the final
+   //            section of the file, in alphabetical order and add them to the "knownFields" set
+   //            in RProjectFile.cpp.
+   //
+   //            This mechanism was introduced in the 2025.04 release of RStudio; earlier versions 
+   //            did not preserve unknown fields.
+   //
+   std::vector<ProjectConfigEntry> unknownFields;
 };
 
 Error findProjectFile(FilePath filePath,

--- a/src/cpp/core/include/core/r_util/RProjectFile.hpp
+++ b/src/cpp/core/include/core/r_util/RProjectFile.hpp
@@ -129,7 +129,7 @@ struct RProjectConfig
         copilotEnabled(DefaultValue),
         copilotIndexingEnabled(DefaultValue),
         projectName(),
-        unknownFields()
+        sortedFields()
    {
    }
 
@@ -192,7 +192,7 @@ struct RProjectConfig
    //            This mechanism was introduced in the 2025.04 release of RStudio; earlier versions 
    //            did not preserve unknown fields.
    //
-   std::vector<ProjectConfigEntry> unknownFields;
+   std::vector<ProjectConfigEntry> sortedFields;
 };
 
 Error findProjectFile(FilePath filePath,

--- a/src/cpp/core/include/core/r_util/RProjectFile.hpp
+++ b/src/cpp/core/include/core/r_util/RProjectFile.hpp
@@ -122,6 +122,13 @@ struct RProjectConfig
         copilotEnabled(DefaultValue),
         copilotIndexingEnabled(DefaultValue),
         projectName(),
+
+        // new fields following the convention of being stored in the final section of the file in 
+        // sorted order start here
+
+        // firstSortedExample(), // EXAMPLE: remove once a new field has actually been added
+
+        // internal storage for sorted fields
         sortedFields()
    {
    }
@@ -173,10 +180,12 @@ struct RProjectConfig
    int copilotIndexingEnabled;
    std::string projectName;
 
-   // Sorted fields, which can be a mixture of known fields and unknown fields written
-   // by a newer version of RStudio.
-   //
-   // On save, these are written in the final section of the file, in alphabetical order by name.
+   // fields living in the sorted section at end of file start here
+
+   // EXAMPLE: (search for firstSortedExample in RProjectFile.cpp to see usage)
+   // Remove this when adding an actual new field.
+   // std::string firstSortedExample;
+
    std::map<std::string, std::string> sortedFields;
 };
 

--- a/src/cpp/core/include/core/r_util/RProjectFile.hpp
+++ b/src/cpp/core/include/core/r_util/RProjectFile.hpp
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <iosfwd>
+#include <map>
 
 #include <core/r_util/RVersionInfo.hpp>
 
@@ -70,14 +71,6 @@ struct RProjectBuildDefaults
    }
    bool useDevtools;
    bool cleanBeforeInstall;
-};
-
-struct ProjectConfigEntry
-{
-   std::string name;
-   std::string value;
-
-   ProjectConfigEntry(const std::string& name, const std::string& value) : name(name), value(value) {}
 };
 
 struct RProjectConfig
@@ -180,19 +173,11 @@ struct RProjectConfig
    int copilotIndexingEnabled;
    std::string projectName;
 
-   // Unknown items, presumably written by a newer version of RStudio.
+   // Sorted fields, which can be a mixture of known fields and unknown fields written
+   // by a newer version of RStudio.
    //
-   // On save, these are written after the known fields, in ascending alphabetical order.
-   // 
-   // IMPORTANT! To avoid unnecessary changes to project files created by newer versions of RStudio
-   //            (when being rewritten by older versions of RStudio) always add new fields to the final
-   //            section of the file, in alphabetical order and add them to the "knownFields" set
-   //            in RProjectFile.cpp.
-   //
-   //            This mechanism was introduced in the 2025.04 release of RStudio; earlier versions 
-   //            did not preserve unknown fields.
-   //
-   std::vector<ProjectConfigEntry> sortedFields;
+   // On save, these are written in the final section of the file, in alphabetical order by name.
+   std::map<std::string, std::string> sortedFields;
 };
 
 Error findProjectFile(FilePath filePath,

--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -1084,6 +1084,13 @@ Error readProjectFile(const FilePath& projectFilePath,
       pConfig->projectName = it->second;
    }
 
+   // EXAMPLE: adding a new field; this can be removed once we've actually added new fields
+   // it = dcfFields.find("FirstSortedExample");
+   // if (it != dcfFields.end())
+   // {
+   //    pConfig->firstSortedExample = it->second;
+   // }
+
    return Success();
 }
 
@@ -1398,11 +1405,23 @@ Error writeProjectFile(const FilePath& projectFilePath,
       contents.append(boost::str(fmt % config.projectName));
    }
 
-   // write the sorted fields to end of file
-   if (!config.sortedFields.empty())
+   auto sortedFields = config.sortedFields; // create writable copy
+
+   // Newer field scheme (sorted fields in final section) processing starts here.
+   // Unlike the "legacy" fields above, do not add these directly to "contents"; instead
+   // add (or remove) from sortedFields.
+
+   // EXAMPLE: adding/updating a new field; remove example after actually adding a new field
+   // if (!config.firstSortedExample.empty())
+   //    sortedFields["FirstSortedExample"] = config.firstSortedExample;
+   // else
+   //    sortedFields.erase("FirstSortedExample");
+
+   // add the sorted fields
+   if (!sortedFields.empty())
    {
       contents.append("\n");
-      for (const auto& field : config.sortedFields)
+      for (const auto& field : sortedFields)
       {
          boost::format fmt("%1%: %2%\n");
          contents.append(boost::str(fmt % field.first % field.second));

--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -556,7 +556,7 @@ Error readProjectFile(const FilePath& projectFilePath,
    {
       if (knownFields.find(field.first) == knownFields.end())
       {
-         pConfig->unknownFields.emplace_back(field.first, field.second);
+         pConfig->sortedFields.emplace_back(field.first, field.second);
       }
    }
 
@@ -1404,9 +1404,9 @@ Error writeProjectFile(const FilePath& projectFilePath,
    }
 
    // sort and write unknown fields
-   if (!config.unknownFields.empty())
+   if (!config.sortedFields.empty())
    {
-      std::vector<ProjectConfigEntry> sortedFields = config.unknownFields;
+      std::vector<ProjectConfigEntry> sortedFields = config.sortedFields;
       std::sort(sortedFields.begin(), sortedFields.end(),
                 [](const ProjectConfigEntry& a, const ProjectConfigEntry& b) {
                    return a.name < b.name;

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -706,6 +706,7 @@ Error writeProjectConfig(const json::Object& configJson)
    }
    else
    {
+      config.unknownFields = existingConfig.unknownFields;
       if (!existingConfig.defaultOpenDocs.empty())
       {
          config.defaultOpenDocs = existingConfig.defaultOpenDocs;

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -706,7 +706,7 @@ Error writeProjectConfig(const json::Object& configJson)
    }
    else
    {
-      config.unknownFields = existingConfig.unknownFields;
+      config.sortedFields = existingConfig.sortedFields;
       if (!existingConfig.defaultOpenDocs.empty())
       {
          config.defaultOpenDocs = existingConfig.defaultOpenDocs;


### PR DESCRIPTION
### Intent

Addresses #15524

### Approach

If and when future versions of RStudio add new fields to the .Rproj file, this version of RStudio will now preserve those fields when rewriting the file.

This places a new constraint on the .Rproj file: all new fields added in the future **must** be added to the final section of the file (i.e. after all currently-known fields, separated by a blank line).

For example, "Great" and "Super" were added to this .Rproj file in the correct location:

```
Version: 1.0
ProjectId: cc66b902-21c6-48a1-8759-90d1f47ffe97

RestoreWorkspace: Yes
SaveWorkspace: No
AlwaysSaveHistory: No

EnableCodeIndexing: No
UseSpacesForTab: Yes
NumSpacesForTab: 4
Encoding: GB2312

RnwWeave: knitr
LaTeX: XeLaTeX
RootDocument: NAMESPACE

LineEndingConversion: Native

BuildType: Package
PackageCleanBeforeInstall: No
PackagePath: man
PackageInstallArgs: --no-multiarch --with-keep.source --foo
PackageBuildArgs: --source
PackageBuildBinaryArgs: --binary
PackageCheckArgs: --check

UseNativePipeOperator: Yes

QuitChildProcessesOnExit: Yes
DisableExecuteRprofile: Yes

MarkdownWrap: Column
MarkdownWrapAtColumn: 72
MarkdownReferences: Block
MarkdownCanonical: No

ZoteroLibraries: "My Library"

PythonType: system
PythonVersion: 3.12.8
PythonPath: /opt/python/3.12.8/bin/python

SpellingDictionary: en_CA

Great: stuff
Super: duper
```

### Automated Tests

None

### QA Notes

Test by adding new fields to the end of the file, as shown in the example earlier. The new fields must be sorted in ascending alphabetical order, with a single blank line separating them from all the previous (known) fields.

Test things such as opening and closing the project, and editing project preferences.

Recommend having the project under source control, then you can use git diff to see what's changing.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


