### PR TITLE
avoid proxy when sending session requests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 ### Fixed
 #### RStudio
 
+- Fixed an issue where execution of notebook chunks could fail if the `http_proxy` environment variable was set. (#15530)
 - Fixed an issue where RStudio could crash when attempting to clear plots while a new plot was being drawn. (#11856)
 - Fixed an issue where the R startup banner was printed twice in rare cases. (#6907)
 - Fixed an issue where RStudio Server could hang when navigating the Open File dialog to a directory with many (> 100,000) files. (#15441)

--- a/src/cpp/core/http/ProxyUtils.cpp
+++ b/src/cpp/core/http/ProxyUtils.cpp
@@ -100,13 +100,6 @@ bool ProxyUtils::shouldProxy(const std::string& address,
    return true;
 }
 
-void ProxyUtils::addNoProxyRule(const std::string& address,
-                                const std::string& port)
-{
-   auto rule = createNoProxyRule(address + ":" + port);
-   noProxyRules_.emplace_back(std::move(rule));
-}
-
 ProxyUtils& proxyUtils()
 {
    static ProxyUtils proxyUtils;

--- a/src/cpp/core/http/ProxyUtils.cpp
+++ b/src/cpp/core/http/ProxyUtils.cpp
@@ -28,6 +28,13 @@ namespace rstudio {
 namespace core {
 namespace http {
 
+namespace {
+
+// URLs which we can contact directly, without using proxy
+std::vector<std::pair<std::string, std::string>> s_noProxyUrls;
+
+} // end anonymous namespace
+
 ProxyUtils::ProxyUtils()
 {
    auto http_proxy = system::getenv("http_proxy");
@@ -89,7 +96,15 @@ bool ProxyUtils::shouldProxy(const std::string& address,
    if (address.empty() && port.empty())
       return true;
 
-   for(const auto& rule : noProxyRules_)
+   for (auto&& url : s_noProxyUrls)
+   {
+      if (address == url.first && port == url.second)
+      {
+         return false;
+      }
+   }
+
+   for (const auto& rule : noProxyRules_)
    {
       if (rule->match(address, port))
       {
@@ -98,6 +113,11 @@ bool ProxyUtils::shouldProxy(const std::string& address,
       }
    }
    return true;
+}
+
+void addNoProxyUrl(const std::string& address, const std::string& port)
+{
+   s_noProxyUrls.push_back({address, port});
 }
 
 const ProxyUtils& proxyUtils()

--- a/src/cpp/core/http/ProxyUtilsTests.cpp
+++ b/src/cpp/core/http/ProxyUtilsTests.cpp
@@ -114,11 +114,20 @@ test_context("ProxyUtilsTests")
       auto rule = core::http::createNoProxyRule("127.0.0.1", "8787");
       utils.addNoProxyRule(std::move(rule));
 
-      auto proxyUrl = utils.httpProxyUrl("http://www.example.com");
-      REQUIRE(proxyUrl.has_value());
+      // proxy other URLs
+      REQUIRE(utils.httpProxyUrl("other.example.com", "443").has_value());
+      REQUIRE(utils.httpProxyUrl("other.example.com").has_value());
 
-      auto localUrl = utils.httpProxyUrl("127.0.0.1", "8787");
-      REQUIRE_FALSE(localUrl.has_value());
+      // proxy requests to localhost targeted at other ports
+      REQUIRE(utils.httpProxyUrl("127.0.0.1", "8788").has_value());
+      REQUIRE(utils.httpProxyUrl("127.0.0.1").has_value());
+
+      // don't proxy for example.com directly
+      REQUIRE_FALSE(utils.httpProxyUrl("example.com", "443").has_value());
+
+      // don't proxy localhost on this port
+      REQUIRE_FALSE(utils.httpProxyUrl("127.0.0.1", "8787").has_value());
+
    }
 }
 

--- a/src/cpp/core/http/ProxyUtilsTests.cpp
+++ b/src/cpp/core/http/ProxyUtilsTests.cpp
@@ -100,8 +100,25 @@ test_context("ProxyUtilsTests")
       system::setenv("no_proxy", "example.com");
 
       ProxyUtils utils;
-      auto url =  utils.httpProxyUrl("example.com", "443");
+      auto url = utils.httpProxyUrl("example.com", "443");
       REQUIRE_FALSE(url.has_value());
+   }
+
+   test_that("noProxyRules can be added")
+   {
+      ProxyUtils utils;
+
+      system::setenv("http_proxy", "http://proxy.example.com:8080");
+      system::setenv("no_proxy", "example.com");
+
+      auto rule = core::http::createNoProxyRule("127.0.0.1", "8787");
+      utils.addNoProxyRule(std::move(rule));
+
+      auto proxyUrl = utils.httpProxyUrl("http://www.example.com");
+      REQUIRE(proxyUrl.has_value());
+
+      auto localUrl = utils.httpProxyUrl("127.0.0.1", "8787");
+      REQUIRE_FALSE(localUrl.has_value());
    }
 }
 

--- a/src/cpp/core/include/core/http/NoProxyRules.hpp
+++ b/src/cpp/core/include/core/http/NoProxyRules.hpp
@@ -152,6 +152,13 @@ class NoProxyRuleCidrBlock : public NoProxyRule
 
 std::unique_ptr<NoProxyRule> createNoProxyRule(const std::string& rule);
 
+inline std::unique_ptr<NoProxyRule> createNoProxyRule(
+    const std::string& address,
+    const std::string& port)
+{
+   return createNoProxyRule(address + ":" + port);
+}
+
 } // namespace http
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/include/core/http/ProxyUtils.hpp
+++ b/src/cpp/core/include/core/http/ProxyUtils.hpp
@@ -30,15 +30,21 @@ class ProxyUtils
 {
 public:
    ProxyUtils();
-   boost::optional<URL>
-   httpProxyUrl(const std::string& address = std::string(),
-                const std::string& port = std::string()) const;
 
-   boost::optional<URL>
-   httpsProxyUrl(const std::string& address = std::string(),
-                 const std::string& port = std::string()) const;
+   boost::optional<URL> httpProxyUrl(
+         const std::string& address = std::string(),
+         const std::string& port = std::string()) const;
+
+   boost::optional<URL> httpsProxyUrl(
+         const std::string& address = std::string(),
+         const std::string& port = std::string()) const;
+
+   void addNoProxyRule(
+         const std::string& address,
+         const std::string& port = std::string());
 
    const NoProxyRules& noProxyRules() const { return noProxyRules_; }
+
 private:
    bool shouldProxy(const std::string& address, const std::string& port) const;
    std::string httpProxyVar_;
@@ -46,8 +52,7 @@ private:
    NoProxyRules noProxyRules_;
 };
 
-void addNoProxyUrl(const std::string& address, const std::string& port);
-const ProxyUtils& proxyUtils();
+ProxyUtils& proxyUtils();
 
 } // namespace http
 } // namespace core

--- a/src/cpp/core/include/core/http/ProxyUtils.hpp
+++ b/src/cpp/core/include/core/http/ProxyUtils.hpp
@@ -39,9 +39,10 @@ public:
          const std::string& address = std::string(),
          const std::string& port = std::string()) const;
 
-   void addNoProxyRule(
-         const std::string& address,
-         const std::string& port = std::string());
+   void addNoProxyRule(std::unique_ptr<NoProxyRule> rule)
+   {
+      noProxyRules_.emplace_back(std::move(rule));
+   }
 
    const NoProxyRules& noProxyRules() const { return noProxyRules_; }
 

--- a/src/cpp/core/include/core/http/ProxyUtils.hpp
+++ b/src/cpp/core/include/core/http/ProxyUtils.hpp
@@ -38,7 +38,7 @@ public:
    httpsProxyUrl(const std::string& address = std::string(),
                  const std::string& port = std::string()) const;
 
-   const NoProxyRules& noProxyRules() const { return noProxyRules_; }      
+   const NoProxyRules& noProxyRules() const { return noProxyRules_; }
 private:
    bool shouldProxy(const std::string& address, const std::string& port) const;
    std::string httpProxyVar_;
@@ -46,6 +46,7 @@ private:
    NoProxyRules noProxyRules_;
 };
 
+void addNoProxyUrl(const std::string& address, const std::string& port);
 const ProxyUtils& proxyUtils();
 
 } // namespace http

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -218,7 +218,7 @@ Error startHttpConnectionListener()
       // set the standalone port so rpostback and others know how to
       // connect back into the session process
       std::string port = safe_convert::numberToString(endpoint.port());
-      core::http::addNoProxyUrl("127.0.0.1", port);
+      core::http::proxyUtils().addNoProxyRule("127.0.0.1", port);
       core::system::setenv(kRSessionStandalonePortNumber, port);
 
       // save the standalone port for possible session relaunches - launcher sessions

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -218,7 +218,7 @@ Error startHttpConnectionListener()
       // set the standalone port so rpostback and others know how to
       // connect back into the session process
       std::string port = safe_convert::numberToString(endpoint.port());
-      core::http::proxyUtils().addNoProxyRule("127.0.0.1", port);
+      auto rule = core::http::createNoProxyRule("127.0.0.1", port);
       core::system::setenv(kRSessionStandalonePortNumber, port);
 
       // save the standalone port for possible session relaunches - launcher sessions

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -30,20 +30,17 @@
 
 #include <boost/algorithm/string.hpp>
 
-#include <core/Thread.hpp>
-
-#include <core/gwt/GwtLogHandler.hpp>
-#include <core/gwt/GwtFileHandler.hpp>
-
 #include <shared_core/json/Json.hpp>
 #include <shared_core/Logger.hpp>
-#include <core/json/JsonRpc.hpp>
 
-#include <core/system/Crypto.hpp>
-
-#include <core/text/TemplateFilter.hpp>
-
+#include <core/Thread.hpp>
+#include <core/gwt/GwtFileHandler.hpp>
+#include <core/gwt/GwtLogHandler.hpp>
 #include <core/http/CSRFToken.hpp>
+#include <core/http/ProxyUtils.hpp>
+#include <core/json/JsonRpc.hpp>
+#include <core/system/Crypto.hpp>
+#include <core/text/TemplateFilter.hpp>
 
 #include <r/RExec.hpp>
 #include <r/session/RSession.hpp>
@@ -221,6 +218,7 @@ Error startHttpConnectionListener()
       // set the standalone port so rpostback and others know how to
       // connect back into the session process
       std::string port = safe_convert::numberToString(endpoint.port());
+      core::http::addNoProxyUrl("127.0.0.1", port);
       core::system::setenv(kRSessionStandalonePortNumber, port);
 
       // save the standalone port for possible session relaunches - launcher sessions
@@ -967,8 +965,7 @@ void onUserPrefsChanged(const std::string& layer, const std::string& pref)
    }
 }
 
-
-}
+} // end anonymous namespace
 
 core::Error initialize()
 {

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -218,7 +218,6 @@ Error startHttpConnectionListener()
       // set the standalone port so rpostback and others know how to
       // connect back into the session process
       std::string port = safe_convert::numberToString(endpoint.port());
-      auto rule = core::http::createNoProxyRule("127.0.0.1", port);
       core::system::setenv(kRSessionStandalonePortNumber, port);
 
       // save the standalone port for possible session relaunches - launcher sessions

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2264,7 +2264,7 @@ int main(int argc, char * const argv[])
       // set the standalone port if we are running in standalone mode
       if (options.standalone())
       {
-         core::http::addNoProxyUrl("127.0.0.1", options.wwwPort());
+         core::http::proxyUtils().addNoProxyRule("127.0.0.1", options.wwwPort());
          core::system::setenv(kRSessionStandalonePortNumber, options.wwwPort());
       }
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -59,6 +59,7 @@
 #include <core/ProgramStatus.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/http/URL.hpp>
+#include <core/http/ProxyUtils.hpp>
 #include <core/http/Request.hpp>
 #include <core/http/Response.hpp>
 #include <core/http/UriHandler.hpp>
@@ -2263,6 +2264,7 @@ int main(int argc, char * const argv[])
       // set the standalone port if we are running in standalone mode
       if (options.standalone())
       {
+         core::http::addNoProxyUrl("127.0.0.1", options.wwwPort());
          core::system::setenv(kRSessionStandalonePortNumber, options.wwwPort());
       }
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2264,7 +2264,8 @@ int main(int argc, char * const argv[])
       // set the standalone port if we are running in standalone mode
       if (options.standalone())
       {
-         core::http::proxyUtils().addNoProxyRule("127.0.0.1", options.wwwPort());
+         auto rule = core::http::createNoProxyRule("127.0.0.1", options.wwwPort());
+         core::http::proxyUtils().addNoProxyRule(std::move(rule));
          core::system::setenv(kRSessionStandalonePortNumber, options.wwwPort());
       }
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2250,7 +2250,10 @@ int main(int argc, char * const argv[])
       if (desktopMode)
       {
          // do the same for port number, for rpostback in rdesktop configs
-         core::system::setenv(kRSessionPortNumber, options.wwwPort());
+         std::string port = options.wwwPort();
+         auto rule = core::http::createNoProxyRule("127.0.0.1", port);
+         core::http::proxyUtils().addNoProxyRule(std::move(rule));
+         core::system::setenv(kRSessionPortNumber, port);
       }
 
       // provide session stream for postback in server mode
@@ -2264,7 +2267,10 @@ int main(int argc, char * const argv[])
       // set the standalone port if we are running in standalone mode
       if (options.standalone())
       {
-         core::system::setenv(kRSessionStandalonePortNumber, options.wwwPort());
+         std::string port = options.wwwPort();
+         auto rule = core::http::createNoProxyRule("127.0.0.1", port);
+         core::http::proxyUtils().addNoProxyRule(std::move(rule));
+         core::system::setenv(kRSessionStandalonePortNumber, port);
       }
 
       // ensure we aren't being started as a low (privileged) account

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2264,8 +2264,6 @@ int main(int argc, char * const argv[])
       // set the standalone port if we are running in standalone mode
       if (options.standalone())
       {
-         auto rule = core::http::createNoProxyRule("127.0.0.1", options.wwwPort());
-         core::http::proxyUtils().addNoProxyRule(std::move(rule));
          core::system::setenv(kRSessionStandalonePortNumber, options.wwwPort());
       }
 

--- a/src/cpp/session/include/session/http/SessionRequest.hpp
+++ b/src/cpp/session/include/session/http/SessionRequest.hpp
@@ -19,8 +19,6 @@
 #include <shared_core/Error.hpp>
 #include <core/system/Environment.hpp>
 
-#include <session/http/SessionRequest.hpp>
-
 #include <core/http/TcpIpBlockingClient.hpp>
 #include <core/http/TcpIpBlockingClientSsl.hpp>
 #include <core/http/ConnectionRetryProfile.hpp>
@@ -101,6 +99,15 @@ inline core::Error sendSessionRequest(const std::string& uri,
 
       }
 #endif
+
+      // Ensure a no-proxy rule is set up, to allow the loopback request
+      static std::once_flag s_noProxyOnce;
+      std::call_once(s_noProxyOnce, [=]()
+      {
+         auto rule = core::http::createNoProxyRule("127.0.0.1", tcpipPort);
+         core::http::proxyUtils().addNoProxyRule(std::move(rule));
+      });
+
       // Need to turn verify off here because we don't know the address used in the cert. Because we are listening on 127.0.0.1, 
       // and the tcp stack forces that to be a local connection, there's no ambiguity about who we are connecting to so I don't
       // think verification adds anything here.

--- a/src/cpp/session/include/session/http/SessionRequest.hpp
+++ b/src/cpp/session/include/session/http/SessionRequest.hpp
@@ -100,14 +100,6 @@ inline core::Error sendSessionRequest(const std::string& uri,
       }
 #endif
 
-      // Ensure a no-proxy rule is set up, to allow the loopback request
-      static std::once_flag s_noProxyOnce;
-      std::call_once(s_noProxyOnce, [=]()
-      {
-         auto rule = core::http::createNoProxyRule("127.0.0.1", tcpipPort);
-         core::http::proxyUtils().addNoProxyRule(std::move(rule));
-      });
-
       // Need to turn verify off here because we don't know the address used in the cert. Because we are listening on 127.0.0.1, 
       // and the tcp stack forces that to be a local connection, there's no ambiguity about who we are connecting to so I don't
       // think verification adds anything here.


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15530.

### Approach

There is some functionality within RStudio that relies on the session being able to send session requests to itself. This can fail in scenarios where the session has also been configured with an `http_proxy` that doesn't handle this, or if that proxy doesn't even exist.

### Automated Tests

Included in the PR.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15530. Note that (I suspect) this issue only affects RStudio Desktop, since RStudio Server will typically use a domain socket instead for requests.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
