### PR TITLE
escape '&' in file upload response

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,5 +24,5 @@
 - Fixed an issue where printing 0-row data.frames containing an 'hms' column from an R Markdown chunk could cause an unexpected error. (#15459)
 
 #### Posit Workbench
--
+- Fixed an issue where uploading a file to a directory containing an '&' character could fail. (#6830)
 

--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -503,11 +503,12 @@ std::string jsonLiteralEscape(const std::string& str)
 // the JSON could be misconstrued by the browser as HTML.
 std::string jsonHtmlEscape(const std::string& str)
 {
-   std::string escapes = "<>";
+   std::string escapes = "<>&";
    std::map<char, std::string> subs;
 
    subs['<'] = "\\u003c"; // JSON unicode character encoding
    subs['>'] = "\\u003e"; // JSON unicode character encoding
+   subs['&'] = "\\u0026"; // JSON unicode character encoding
 
    return escape(escapes, subs, str);
 }


### PR DESCRIPTION
### Intent

Addresses #6830.

### Approach

Replace '&' with its unicode-escaped equivalent, so it doesn't get encoded as `&amp;` somewhere in the processing pipeline.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio-pro/issues/7412.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
