### PR TITLE
fix hang when invoking 'git' in some contexts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 ### Fixed
 #### RStudio
 
+- Fixed an issue where RStudio could hang when attempting to stage large folders from the Git pane on Windows. (#13222)
 - Fixed an issue where RStudio could crash when attempting to clear plots while a new plot was being drawn. (#11856)
 - Fixed an issue where the R startup banner was printed twice in rare cases. (#6907)
 - Fixed an issue where RStudio Server could hang when navigating the Open File dialog to a directory with many (> 100,000) files. (#15441)

--- a/src/cpp/core/include/core/Thread.hpp
+++ b/src/cpp/core/include/core/Thread.hpp
@@ -368,7 +368,7 @@ private:
 };
 
 template <typename F>
-std::thread run(F&& f)
+boost::thread run(F&& f)
 {
    try
    {
@@ -377,7 +377,7 @@ std::thread run(F&& f)
       if (error)
          LOG_ERROR(error);
 
-      return std::thread(std::forward<F>(f));
+      return boost::thread(std::forward<F>(f));
    }
    CATCH_UNEXPECTED_EXCEPTION;
 

--- a/src/cpp/core/include/core/Thread.hpp
+++ b/src/cpp/core/include/core/Thread.hpp
@@ -19,6 +19,7 @@
 #include <map>
 #include <queue>
 #include <set>
+#include <thread>
 
 #include <boost/utility.hpp>
 #include <boost/function.hpp>
@@ -27,7 +28,7 @@
 
 #include <core/BoostErrors.hpp>
 #include <core/BoostThread.hpp>
-#include <core/Log.hpp>
+#include <core/system/System.hpp>
 
 #define LOCK_MUTEX(m)                                                          \
    try                                                                         \
@@ -365,6 +366,23 @@ private:
    std::set<T, std::less<T>, std::allocator<T> > set_;
    mutable boost::mutex mutex_;
 };
+
+template <typename F>
+std::thread run(F&& f)
+{
+   try
+   {
+      system::SignalBlocker blocker;
+      Error error = blocker.blockAll();
+      if (error)
+         LOG_ERROR(error);
+
+      return std::thread(std::forward<F>(f));
+   }
+   CATCH_UNEXPECTED_EXCEPTION;
+
+   return {};
+}
 
 void safeLaunchThread(boost::function<void()> threadMain,
                       boost::thread* pThread = nullptr);

--- a/src/cpp/core/include/core/system/ChildProcess.hpp
+++ b/src/cpp/core/include/core/system/ChildProcess.hpp
@@ -190,10 +190,10 @@ public:
       }
 
       if (readStdoutThread.joinable())
-         readStdoutThread.join();
+         readStdoutThread.timed_join(boost::posix_time::seconds(1));
 
       if (readStderrThread.joinable())
-         readStderrThread.join();
+         readStderrThread.timed_join(boost::posix_time::seconds(1));
 
       // return error status
       return error;

--- a/src/cpp/core/include/core/system/ChildProcess.hpp
+++ b/src/cpp/core/include/core/system/ChildProcess.hpp
@@ -19,6 +19,7 @@
 #include <shared_core/Error.hpp>
 
 #include <core/Log.hpp>
+#include <core/Thread.hpp>
 #include <core/system/Process.hpp>
 
 namespace rstudio {
@@ -162,14 +163,14 @@ public:
          return Success();
 
       // read stdout, stderr
-      std::thread readStdoutThread([&]()
+      auto readStdoutThread = core::thread::run([&]()
       {
          Error error = readStdOut(&(pResult->stdOut));
          if (error)
             LOG_ERROR(error);
       });
 
-      std::thread readStderrThread([&]()
+      auto readStderrThread = core::thread::run([&]()
       {
          Error error = readStdErr(&(pResult->stdErr));
          if (error)
@@ -189,10 +190,10 @@ public:
       }
 
       if (readStdoutThread.joinable())
-         readStdoutThread.detach();
+         readStdoutThread.join();
 
       if (readStderrThread.joinable())
-         readStderrThread.detach();
+         readStderrThread.join();
 
       // return error status
       return error;

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -810,7 +810,7 @@ void AsyncChildProcess::poll()
       // from stdout and stderr can block
       std::string stdOut, stdErr;
 
-      std::thread readStdOutThread([&]()
+      auto readStdOutThread = core::thread::run([&]()
       {
          if (pImpl_->hStdOutRead)
          {
@@ -821,7 +821,7 @@ void AsyncChildProcess::poll()
          }
       });
 
-      std::thread readStdErrThread([&]()
+      auto readStdErrThread = core::thread::run([&]()
       {
          // read all remaining stderr
          if (pImpl_->hStdErrRead)

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -145,10 +145,17 @@ Error readPipeUntilDone(HANDLE hPipe, std::string* pOutput)
          {
             break;
          }
+
+         // If a named pipe is being read in message mode and the next message
+         // is longer than the nNumberOfBytesToRead parameter specifies,
+         // ReadFile returns FALSE and GetLastError returns ERROR_MORE_DATA.
+         // The remainder of the message can be read by a subsequent call to
+         // the ReadFile or PeekNamedPipe function.
          else if (error == ERROR_MORE_DATA)
          {
             continue;
          }
+
          else
          {
             return systemError(error, ERROR_LOCATION);


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13222.

### Approach

When reading output from a child process, do so in a child thread, since `::ReadFile()` can evidently hang in certain scenarios.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13222.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
