### PR TITLE
fix scoping for function definition bound to argument name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@
 - Fixed an issue where opening multiple copies of RStudio Desktop installed in different locations would cause RStudio to try to open itself as a script. (#15554)
 - Fixed an issue where printing 0-row data.frames containing an 'hms' column from an R Markdown chunk could cause an unexpected error. (#15459)
 - Fixed an issue where the Resources page in the Help pane was not legible with dark themes. (#10855)
+- Fixed an issue where the RStudio diagnostics system incorrectly inferred the scope for functions defined and passed as named arguments. (#15629)
 
 #### Posit Workbench
 - Fixed an issue where uploading a file to a directory containing an '&' character could fail. (#6830)

--- a/src/cpp/core/include/core/r_util/RTokenizer.hpp
+++ b/src/cpp/core/include/core/r_util/RTokenizer.hpp
@@ -343,7 +343,8 @@ inline bool isLocalLeftAssign(const RToken& token)
 
 inline bool isLocalRightAssign(const RToken& token)
 {
-   return token.isType(RToken::OPER) && token.contentEquals(L"->");
+   return token.isType(RToken::OPER) &&
+          token.contentEquals(L"->");
 }
 
 inline bool isParentLeftAssign(const RToken& token)

--- a/src/cpp/session/modules/SessionDiagnosticsTests.cpp
+++ b/src/cpp/session/modules/SessionDiagnosticsTests.cpp
@@ -305,6 +305,8 @@ test_context("Diagnostics")
       
       EXPECT_NO_LINT("{ apple <- banana <- 42; apple + banana }");
       EXPECT_NO_LINT("{ .[apple, banana] <- c(1, 2); apple + banana }");
+
+      EXPECT_NO_ERRORS("c(warning = function() {}); warning(42)");
    }
    
    test_that("RStudio files can be successfully linted")

--- a/src/cpp/session/modules/SessionRParser.hpp
+++ b/src/cpp/session/modules/SessionRParser.hpp
@@ -27,8 +27,6 @@
 #include <vector>
 #include <map>
 #include <set>
-#include <iostream>
-#include <iomanip>
 #include <gsl/gsl>
 
 #include <core/Algorithm.hpp>


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15629.

### Approach

When the R parser finds a function definition, it tries to record the name + position of that function in the document. However, it was incorrectly treating usages of the form:

```r
list(example = function() {})
```

as though it were creating a function called `example` in the current scope, rather than binding the argument name `example` to an anonymous function definition. This PR checks for and fixes that.

### Automated Tests

Unit test included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15629.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
