### PR TITLE
send SIGINT when first stopping console processes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - RStudio for Windows binaries now have digital signatures. (rstudio-pro#5772)
 - RStudio now only writes the ProjectId field within a project's `.Rproj` file when required. Currently, this is for users who have configured a custom `.Rproj.user` location.
 - RStudio will now preserve unknown fields in `.Rproj` files that are added by future versions of RStudio. (#15524)
+- RStudio now sends an interrupt git processes when stopped via "Stop" during a git commit, rather than just terminating the processes. (#6471)
 
 #### Posit Workbench
 -

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -243,8 +243,8 @@ private:
    core::system::ProcessOptions options_;
    boost::shared_ptr<ConsoleProcessInfo> procInfo_;
 
-   // Whether the process should be stopped
-   bool interrupt_ = false;
+   // The number of times we've tried to interrupt / stop this process
+   int interruptCount_ = 0;
 
    // Whether to send pty interrupt
    bool interruptChild_ = false;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressDialog.java
@@ -245,16 +245,15 @@ public class ConsoleProgressDialog extends ProgressDialog
       if (isShowing())
       {
          display_.setReadOnly(true);
-         stopButton().setFocus(true);
       
          // when a shell exits we close the dialog
          if (getInteractionMode() == ConsoleProcessInfo.INTERACTION_ALWAYS)
-            stopButton().click();
+            closeDialog();
          
          // when we were showOnOutput and the process succeeded then
          // we also auto-close
          else if (showOnOutput_ && (event.getExitCode() == 0))
-            stopButton().click();
+            closeDialog();
       }
       
       // the dialog was showOnOutput_ but was never shown so just tear
@@ -287,26 +286,22 @@ public class ConsoleProgressDialog extends ProgressDialog
             @Override
             public void onResponseReceived(Void response)
             {
-               closeDialog();
+               // Don't immediately close; wait for the process itself
+               // to exit before closing since the interrupt might not
+               // immediately stop the underlying process.
             }
 
             @Override
             public void onError(ServerError error)
             {
-               stopButton().setEnabled(true);
                super.onError(error);
             }
          });
-         
-         stopButton().setEnabled(false);
       }
       else
       {
          closeDialog();
       }
-
-      // Whether success or failure, we don't want to interrupt again
-      running_ = false;
    }
    
    private CommandWithArg<ShellInput> inputHandler_ = 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/6471.

### Approach

When stopping a console process (e.g. git) via the Stop button in UI, we now send a proper interrupt to the process rather than just directly terminating the process with SIGTERM. We still ensure that a SIGTERM is later sent if the user clicks the Stop button 3 or more times.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/6471.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
