### PR TITLE
Change Workbench to RStudio Server in logged-out dialog title

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@
 - Fixed an issue where opening multiple copies of RStudio Desktop installed in different locations would cause RStudio to try to open itself as a script. (#15554)
 - Fixed an issue where printing 0-row data.frames containing an 'hms' column from an R Markdown chunk could cause an unexpected error. (#15459)
 - Fixed an issue where the Resources page in the Help pane was not legible with dark themes. (#10855)
+- Fixed an issue where "Posit Workbench" was used instead of "RStudio Server" in a message shown when the user was signed out during a session. (#15698)
 
 #### Posit Workbench
 - Fixed an issue where uploading a file to a directory containing an '&' character could fail. (#6830)

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -34,6 +34,7 @@ import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.application.Application;
 import org.rstudio.studio.client.application.ApplicationInterrupt;
 import org.rstudio.studio.client.application.AriaLiveService;
+import org.rstudio.studio.client.application.LoggedOutDialog;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.ui.AboutDialog;
 import org.rstudio.studio.client.application.ui.ProjectPopupMenu;
@@ -356,7 +357,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(YamlEditorToolsProviderQuarto yamlCompletionSourceQuarto);
    void injectMembers(TextEditingTargetCopilotHelper copilotHelper);
    void injectMembers(DocUpdateSentinel sentinel);
-
+   void injectMembers(LoggedOutDialog loggedOutDialog);
 
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/application/LoggedOutDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/LoggedOutDialog.java
@@ -20,14 +20,20 @@ import org.rstudio.core.client.widget.ModalDialogBase;
 import org.rstudio.core.client.widget.MultiLineLabel;
 import org.rstudio.core.client.widget.ThemedButton;
 import org.rstudio.core.client.widget.images.MessageDialogImages;
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.model.ProductEditionInfo;
 
 import com.google.gwt.aria.client.Roles;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
 
 public class LoggedOutDialog extends ModalDialogBase 
 {
@@ -48,9 +54,22 @@ public class LoggedOutDialog extends ModalDialogBase
    {
       super(Roles.getAlertdialogRole());
 
-      setText("Posit Workbench Login Required");
+      RStudioGinjector.INSTANCE.injectMembers(this);
+
+      setText(isWorkbench() ? constants_.workbenchLoginRequired() : constants_.serverLoginRequired());
       addActionButton(createLoginButton());
       setGlassEnabled(true);
+   }
+
+   @Inject
+   private void initialize(Provider<ProductEditionInfo> pEdition)
+   {
+      pEdition_ = pEdition;
+   }
+
+   private boolean isWorkbench()
+   {
+      return pEdition_.get() != null && pEdition_.get().proLicense();
    }
 
    @Override
@@ -70,7 +89,7 @@ public class LoggedOutDialog extends ModalDialogBase
          image.setAltText(imageText);
 
 
-      Label label = new MultiLineLabel("Login expired or signed out from another window.\nSelect 'Login' for a new login tab. Return here to resume session.");
+      Label label = new MultiLineLabel(constants_.serverLoginRequiredMessage());
       label.setStylePrimaryName(ThemeResources.INSTANCE.themeStyles().dialogMessage());
       horizontalPanel.add(label);
 
@@ -79,7 +98,7 @@ public class LoggedOutDialog extends ModalDialogBase
 
    private ThemedButton createLoginButton() 
    {
-      ThemedButton loginButton = new ThemedButton("Login", clickEvent -> 
+      ThemedButton loginButton = new ThemedButton(constants_.loginButton(), clickEvent -> 
       {
          String url = ApplicationUtils.getHostPageBaseURLWithoutContext(true) + "auth-sign-in";
          Window.open(url, "_blank", "");
@@ -104,4 +123,6 @@ public class LoggedOutDialog extends ModalDialogBase
    }
 
    private boolean visible_;
+   private static final StudioClientApplicationConstants constants_ = GWT.create(StudioClientApplicationConstants.class);
+   private Provider<ProductEditionInfo> pEdition_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/LoggedOutDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/LoggedOutDialog.java
@@ -56,8 +56,6 @@ public class LoggedOutDialog extends ModalDialogBase
 
       RStudioGinjector.INSTANCE.injectMembers(this);
 
-      setText(isWorkbench() ? constants_.workbenchLoginRequired() : constants_.serverLoginRequired());
-      addActionButton(createLoginButton());
       setGlassEnabled(true);
    }
 
@@ -75,6 +73,9 @@ public class LoggedOutDialog extends ModalDialogBase
    @Override
    protected Widget createMainWidget() 
    {
+      setText(isWorkbench() ? constants_.workbenchLoginRequired() : constants_.serverLoginRequired());
+      addActionButton(createLoginButton());
+
       HorizontalPanel horizontalPanel = new HorizontalPanel();
       horizontalPanel.setVerticalAlignment(HasVerticalAlignment.ALIGN_TOP);
 
@@ -89,7 +90,8 @@ public class LoggedOutDialog extends ModalDialogBase
          image.setAltText(imageText);
 
 
-      Label label = new MultiLineLabel(constants_.serverLoginRequiredMessage());
+      Label label = new MultiLineLabel(
+         isWorkbench() ? constants_.workbenchLoginRequiredMessage() : constants_.serverLoginRequiredMessage());
       label.setStylePrimaryName(ThemeResources.INSTANCE.themeStyles().dialogMessage());
       horizontalPanel.add(label);
 

--- a/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants.java
@@ -1517,6 +1517,15 @@ public interface StudioClientApplicationConstants extends com.google.gwt.i18n.cl
      * @return translated "Login expired or signed out from another window.\nSelect 'Login' for a new login tab. Return here to resume session."
      */
     @DefaultMessage("Login expired or signed out from another window.\nSelect ''Login'' for a new login tab. Return here to resume session.")
+    @Key("workbenchLoginRequiredMessage")
+    String workbenchLoginRequiredMessage();
+
+    /**
+     * Translated "Login expired or signed out from another window.\nSelect 'Login' for a new login tab.".
+     *
+     * @return translated "Login expired or signed out from another window.\nSelect 'Login' for a new login tab."
+     */
+    @DefaultMessage("Login expired or signed out from another window.\nSelect ''Login'' for a new login tab.")
     @Key("serverLoginRequiredMessage")
     String serverLoginRequiredMessage();
 

--- a/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants.java
@@ -1492,4 +1492,40 @@ public interface StudioClientApplicationConstants extends com.google.gwt.i18n.cl
     @DefaultMessage("This will cause RStudio to immediately crash. You may lose work. Trigger crash?")
     @Key("reallyCrashMessage")
     String reallyCrashMessage();
+
+    /**
+     * Translated "Posit Workbench Login Required".
+     *
+     * @return translated "Posit Workbench Login Required"
+     */
+    @DefaultMessage("Posit Workbench Login Required")
+    @Key("workbenchLoginRequired")
+    String workbenchLoginRequired();
+
+    /**
+     * Translated "RStudio Server Login Required".
+     *
+     * @return translated "RStudio Server Login Required"
+     */
+    @DefaultMessage("RStudio Server Login Required")
+    @Key("serverLoginRequired")
+    String serverLoginRequired();
+
+    /**
+     * Translated "Login expired or signed out from another window.\nSelect 'Login' for a new login tab. Return here to resume session.".
+     *
+     * @return translated "Login expired or signed out from another window.\nSelect 'Login' for a new login tab. Return here to resume session."
+     */
+    @DefaultMessage("Login expired or signed out from another window.\nSelect ''Login'' for a new login tab. Return here to resume session.")
+    @Key("serverLoginRequiredMessage")
+    String serverLoginRequiredMessage();
+
+    /**
+     * Translated "Login".
+     *
+     * @return translated "Login"
+     */
+    @DefaultMessage("Login")
+    @Key("loginButton")
+    String loginButton();
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_en.properties
@@ -164,5 +164,6 @@ reallyCrashCaption=Danger!
 reallyCrashMessage=This will cause RStudio to immediately crash. You may lose work. Trigger crash?
 workbenchLoginRequired=Posit Workbench Login Required
 serverLoginRequired=RStudio Server Login Required
-serverLoginRequiredMessage=Login expired or signed out from another window.\nSelect ''Login'' for a new login tab. Return here to resume session.
+workbenchLoginRequiredMessage=Login expired or signed out from another window.\nSelect ''Login'' for a new login tab. Return here to resume session.
+serverLoginRequiredMessage=Login expired or signed out from another window.\nSelect ''Login'' for a new login tab.
 loginButton=Login

--- a/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_en.properties
@@ -162,3 +162,7 @@ visitWebsiteForNewVersionText=Please visit https://posit.co/download/rstudio-des
 updateDisabledForVersionText=Automatic update notifications were disabled for {0}.
 reallyCrashCaption=Danger!
 reallyCrashMessage=This will cause RStudio to immediately crash. You may lose work. Trigger crash?
+workbenchLoginRequired=Posit Workbench Login Required
+serverLoginRequired=RStudio Server Login Required
+serverLoginRequiredMessage=Login expired or signed out from another window.\nSelect ''Login'' for a new login tab. Return here to resume session.
+loginButton=Login

--- a/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_fr.properties
@@ -162,3 +162,7 @@ visitWebsiteForNewVersionText=Veuillez visiter https://posit.co/download/rstudio
 updateDisabledForVersionText=Les notifications de mise à jour automatique ont été désactivées pour {0}.
 reallyCrashCaption=Danger!
 reallyCrashMessage=Vous êtes sur le point de forcer RStudio à planter. Cela peut entraîner la perte de données. Voulez-vous vraiment continuer?
+workbenchLoginRequired=Connexion requise pour Posit Workbench
+serverLoginRequired=Connexion requise pour RStudio Server
+serverLoginRequiredMessage=La connexion a expiré ou vous vous êtes déconnecté depuis une autre fenêtre.\nSélectionnez ''Connexion'' pour ouvrir un nouvel onglet de connexion. Revenez ici pour reprendre la session.
+loginButton=Connexion

--- a/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_fr.properties
@@ -164,5 +164,6 @@ reallyCrashCaption=Danger!
 reallyCrashMessage=Vous êtes sur le point de forcer RStudio à planter. Cela peut entraîner la perte de données. Voulez-vous vraiment continuer?
 workbenchLoginRequired=Connexion requise pour Posit Workbench
 serverLoginRequired=Connexion requise pour RStudio Server
-serverLoginRequiredMessage=La connexion a expiré ou vous vous êtes déconnecté depuis une autre fenêtre.\nSélectionnez ''Connexion'' pour ouvrir un nouvel onglet de connexion. Revenez ici pour reprendre la session.
+workbenchLoginRequiredMessage=La connexion a expiré ou vous vous êtes déconnecté depuis une autre fenêtre.\nSélectionnez ''Connexion'' pour ouvrir un nouvel onglet de connexion. Revenez ici pour reprendre la session.
+serverLoginRequiredMessage=La connexion a expiré ou vous vous êtes déconnecté depuis une autre fenêtre.\nSélectionnez ''Connexion'' pour ouvrir un nouvel onglet de connexion.
 loginButton=Connexion


### PR DESCRIPTION
### Intent

Addresses #15698

### Approach

It was originally assumed that this dialog would only appear in Posit Workbench so the strings were hardcoded and mentioned "Posit Workbench".

It can display in open-source Server as well, so made the strings localizable and show slightly different message in open-source vs. Workbench.

#### Open Source (new)

<img width="430" alt="open-source-server" src="https://github.com/user-attachments/assets/4ae563dd-36b6-4191-bb30-dccfe0c64e22" />

#### Workbench (unchanged)

<img width="430" alt="workbench" src="https://github.com/user-attachments/assets/39117247-76f9-4005-b93f-10c88ce82fdb" />

### Automated Tests

NA

### QA Notes

Test as described in issue on open-source Server. Should also do a sanity check of the dialog on Workbench, so I've marked this for both projects.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

