### PR TITLE
avoid issue with S3 dispatch by calling .DollarNames generic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@
 - Fixed an issue where the Resources page in the Help pane was not legible with dark themes. (#10855)
 - Fixed an issue where "Posit Workbench" was used instead of "RStudio Server" in a message shown when the user was signed out during a session. (#15698)
 - Fixed an issue where the RStudio diagnostics system incorrectly inferred the scope for functions defined and passed as named arguments. (#15629)
+- Fixed an issue where autocompletion of R6 object names could fail with R6 2.6.0. (#15706)
 
 #### Posit Workbench
 - Fixed an issue where uploading a file to a directory containing an '&' character could fail. (#6830)

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1615,7 +1615,14 @@ assign(x = ".rs.acCompletionTypes",
       dollarNamesMethod <- .rs.getDollarNamesMethod(object, TRUE, envir = envir)
       if (is.function(dollarNamesMethod))
       {
-         allNames <- dollarNamesMethod(object, "")
+         # An invocation of something like NextMethod() can fail if we try
+         # to invoke the underlying method directly, so in this scenario
+         # we still just allow the default S3 dispatch to take place.
+         expr <- substitute(
+            .DollarNames(object, ""),
+            list(object = object)
+         )
+         allNames <- eval(expr, envir = envir)
          
          # check for custom helpHandler
          helpHandler <- attr(allNames, "helpHandler", exact = TRUE)

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1619,7 +1619,7 @@ assign(x = ".rs.acCompletionTypes",
          # to invoke the underlying method directly, so in this scenario
          # we still just allow the default S3 dispatch to take place.
          expr <- substitute(
-            .DollarNames(object, ""),
+            utils::.DollarNames(object, pattern = ""),
             list(object = object)
          )
          allNames <- eval(expr, envir = envir)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15706.

### Approach

Invoking an S3 method directly can interfere with dispatch done by `NextMethod()`; to avoid this, invoke the `.DollarNames` generic instead of the method we discover. (We still use the presence of such a method as an indication that we should use `.DollarNames` for requesting object names.)

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15706. Note that the issue will only reproduce with R6 2.6.0.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

