### PR TITLE
fixup for sync child process stdout, stderr read

### DIFF
--- a/src/cpp/core/include/core/system/ChildProcess.hpp
+++ b/src/cpp/core/include/core/system/ChildProcess.hpp
@@ -162,25 +162,10 @@ public:
       if (pResult == nullptr)
          return Success();
 
-      // read stdout, stderr
-      auto readStdoutThread = core::thread::run([&]()
-      {
-         Error error = readStdOut(&(pResult->stdOut));
-         if (error)
-            LOG_ERROR(error);
-      });
-
-      auto readStderrThread = core::thread::run([&]()
-      {
-         Error error = readStdErr(&(pResult->stdErr));
-         if (error)
-            LOG_ERROR(error);
-      });
-
       // wait on exit and get exit status. note we always need to do this
       // even if we called terminate due to an earlier error (so we always
       // reap the child)
-      Error waitError = waitForExit(&(pResult->exitStatus));
+      Error waitError = waitForExit(pResult);
       if (waitError)
       {
          if (!error)
@@ -189,12 +174,6 @@ public:
             LOG_ERROR(waitError);
       }
 
-      if (readStdoutThread.joinable())
-         readStdoutThread.timed_join(boost::posix_time::seconds(1));
-
-      if (readStderrThread.joinable())
-         readStderrThread.timed_join(boost::posix_time::seconds(1));
-
       // return error status
       return error;
    }
@@ -202,7 +181,7 @@ public:
 private:
    Error readStdOut(std::string* pOutput);
    Error readStdErr(std::string* pOutput);
-   Error waitForExit(int* pExitStatus);
+   Error waitForExit(ProcessResult* pResult);
 };
 
 

--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -919,7 +919,6 @@ Error SyncChildProcess::waitForExit(ProcessResult* pResult)
          LOG_ERROR(error);
    });
 
-   // create threads to consume stdout, stderr
    auto readStdErrThread = core::thread::run([&]()
    {
       Error error = readStdErr(&(pResult->stdErr));


### PR DESCRIPTION
### Intent

Fixes a failure in file locking tests; related to https://github.com/rstudio/rstudio/issues/13222.

### Approach

https://github.com/rstudio/rstudio/pull/15692 made a change that allowed us to read stdout + stderr in a non-blocking way, by using separate threads to read output on these threads. However, the POSIX side of this code could potentially close any open pipes (including those reading stdout / stderr) after seeing a process had exited.

This PR re-arranges that code so that we join the stdout + stderr read threads before attempting to close any open pipes.

### Automated Tests

Covered by existing automation.

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

