### PR TITLE
handle new-style rmarkdown render error format

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 - RStudio now only writes the ProjectId field within a project's `.Rproj` file when required. Currently, this is for users who have configured a custom `.Rproj.user` location.
 - RStudio will now preserve unknown fields in `.Rproj` files that are added by future versions of RStudio. (#15524)
 - RStudio now sends an interrupt git processes when stopped via "Stop" during a git commit, rather than just terminating the processes. (#6471)
+- RStudio now properly displays R Markdown render errors with newer versions of the `rmarkdown` and `rlang` packages. (#15579)
 
 #### Posit Workbench
 - An SELinux policy module is now available, allowing Workbench to run when enforcement is enabled. (#4937, rstudio-pro/#4749)

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -924,8 +924,6 @@ private:
             auto lines = core::algorithm::split(output, "\n");
             for (int i = 0, n = lines.size(); i < n; i++)
             {
-               std::cerr << lines[i] << std::endl;
-
                if (lines[i] == "Error:" || boost::algorithm::starts_with(lines[i], "Error in "))
                {
                   errorLine = i;

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -73,6 +73,12 @@
 
 #define kAnsiEscapeRegex "(?:\033\\[\\d+m)*"
 
+#ifdef _WIN32
+# define kLineSep "\r\n"
+#else
+# define kLineSep "\n"
+#endif
+
 using namespace rstudio::core;
 using namespace boost::placeholders;
 
@@ -921,7 +927,7 @@ private:
             boost::regex reRenderError(kKnitrErrorRegex);
             boost::smatch match;
 
-            auto lines = core::algorithm::split(output, "\n");
+            auto lines = core::algorithm::split(output, kLineSep);
             for (int i = 0, n = lines.size(); i < n; i++)
             {
                if (lines[i] == "Error:" || boost::algorithm::starts_with(lines[i], "Error in "))

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -914,21 +914,61 @@ private:
          }
          else
          {
-            // check whether an error occurred while rendering the document and
-            // if knitr is about to exit. look for a specific quit marker and
-            // parse to to gather information for a source marker
-            const char* renderErrorPattern = "(?:.*?)" kKnitrErrorRegex "(.*)";
-            
-            boost::regex reRenderError(renderErrorPattern);
-            boost::smatch matches;
-            if (regex_utils::match(output, matches, reRenderError))
+            int errorLine        = -1;
+            int backtraceLine    = -1;
+            int quittingFromLine = -1;
+
+            boost::regex reRenderError(kKnitrErrorRegex);
+            boost::smatch match;
+
+            auto lines = core::algorithm::split(output, "\n");
+            for (int i = 0, n = lines.size(); i < n; i++)
             {
-               // looks like a knitr error; compose a compile error object and
-               // emit it to the client when the render is complete
-               int line = core::safe_convert::stringTo<int>(matches[1].str(), -1);
-               FilePath file = targetFile_.getParent().completePath(matches[3].str());
-               renderErrorMarker_ = SourceMarker(SourceMarker::Error, file, line, 1, {}, true);
-               renderErrorMessage_ << core::string_utils::trimWhitespace(matches[4].str());
+               std::cerr << lines[i] << std::endl;
+
+               if (lines[i] == "Error:" || boost::algorithm::starts_with(lines[i], "Error in "))
+               {
+                  errorLine = i;
+               }
+               else if (lines[i] == "Backtrace:")
+               {
+                  backtraceLine = i;
+               }
+               else if (regex_utils::match(lines[i], match, reRenderError))
+               {
+                  // looks like a knitr error; compose a compile error object and
+                  // emit it to the client when the render is complete
+                  quittingFromLine = i;
+                  int line = core::safe_convert::stringTo<int>(match[1].str(), -1);
+                  FilePath file = targetFile_.getParent().completePath(match[3].str());
+                  renderErrorMarker_ = SourceMarker(SourceMarker::Error, file, line, 1, {}, true);
+                  break;
+               }
+            }
+
+            if (quittingFromLine == -1)
+            {
+               // nothing to do; didn't see the expected knitr error line?
+            }
+            else if (errorLine == -1)
+            {
+               // didn't find an error line; assume error output
+               // follows the 'Quitting from:' line
+               std::string errorMessage = core::algorithm::join(
+                        lines.begin() + quittingFromLine,
+                        lines.end(),
+                        "\n");
+               renderErrorMessage_ << errorMessage;
+            }
+            else
+            {
+               // found an 'Error:' line; collect error from then
+               // to the 'Quitting from:' line
+               std::string errorMessage = core::algorithm::join(
+                        lines.begin() + errorLine,
+                        lines.begin() + (backtraceLine == -1 ? quittingFromLine : backtraceLine),
+                        "\n");
+               renderErrorMessage_ << errorMessage;
             }
          }
       }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15579.

### Approach

Redo the parsing of R Markdown render outputs, to handle alternate ways that an error might be presented.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15579.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
