### PR TITLE
Reduce Desktop build matrix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,3 +39,6 @@
 
 ### Dependencies
 - Updated Windows Desktop build to use Windows SDK 10.0.22621. (#15690)
+
+### Deprecated / Removed
+- No longer building RStudio Desktop or Desktop Pro for OpenSUSE 15, Ubuntu Focal, or RedHat 8. (rstudio-pro/#7445)

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -134,6 +134,17 @@ pipeline {
               values 'arm64'
             }
           }
+
+          exclude {
+            axis {
+              name 'OS'
+              values 'rhel8', 'opensuse15', 'focal'
+            }
+            axis {
+              name 'FLAVOR'
+              values 'Electron'
+            }
+          }
         }
 
         stages {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/7445

Keeping up-to-date with Electron is increasingly expensive on some Linux distros so we are reducing the platform matrix.

### Approach

Exclude desktop builds on opensuse15, focal, rhel8.

### Automated Tests

If we are running desktop tests on these platforms they will need to be disabled; I've pinged the appropriate person.

### QA Notes

> Ensure you have updated the QA Notes in the original issue.

### Documentation

https://github.com/rstudio/rstudio-pro/issues/7475

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


