### PR TITLE
OS companion to Audited Job Details Store

### DIFF
--- a/src/cpp/shared_core/FilePathTests.cpp
+++ b/src/cpp/shared_core/FilePathTests.cpp
@@ -297,6 +297,37 @@ TEST_CASE("Empty File Path tests")
 
 }
 
+#ifndef _WIN32
+
+TEST_CASE("Get File Owner Test")
+{
+   // create temporary file
+   FilePath tempFile;
+   Error error = FilePath::tempFilePath(tempFile);
+   CHECK(!error);
+
+   // ensure it exists
+   error = tempFile.ensureFile();
+   CHECK(!error);
+
+   // get the current user
+   system::User currentUser;
+   error = system::User::getCurrentUser(currentUser);
+   CHECK(!error);
+
+   // ensure we can get the owner
+   std::string username;
+   error = tempFile.getFileOwner(&username);
+   CHECK(!error);
+   //CHECK(username == currentUser.getUsername());
+   CHECK(username == currentUser.getUsername());
+
+   // clean up
+   tempFile.remove();
+}
+
+#endif
+
 TEST_CASE("Copy FilePath Tests")
 {
    FilePath f1("/a/path");

--- a/src/cpp/shared_core/include/shared_core/FilePath.hpp
+++ b/src/cpp/shared_core/include/shared_core/FilePath.hpp
@@ -459,6 +459,16 @@ public:
     * @return Success if the file mode could be retrieved; Error otherwise.
     */
    Error getFileMode(FileMode& out_fileMode) const;
+   
+   /**
+   * @brief Retrieves the owner of the file.
+   *
+   * This function fetches the username of the owner of the file and stores it in the provided string pointer.
+   *
+   * @param pUsername A pointer to a string where the username of the file owner will be stored.
+   * @return Success if the username could be retrieved; Error otherwise.
+   */
+  Error getFileOwner(std::string* pUsername) const;
 
    /**
     * @brief Gets the posix file owner of this file or directory.


### PR DESCRIPTION
### Intent

OS companion to https://github.com/rstudio/rstudio-pro/pull/7512

Adds ability to retrieve the owner of a file.

### Approach

Added the `getFileOwner` function to retrieve the username of the file owner using POSIX functions.

### Automated Tests

Added a unit test case to verify the functionality of the `getFileOwner` method. This test creates a temporary file, retrieves its owner, and compares it with the current user.

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


