### PR TITLE
Need the work guard to keep run() from returning

### DIFF
--- a/src/cpp/session/SessionServerRpc.cpp
+++ b/src/cpp/session/SessionServerRpc.cpp
@@ -101,6 +101,7 @@ boost::asio::io_context s_ioContext;
 
 void rpcWorkerThreadFunc()
 {
+   auto work = boost::asio::make_work_guard(s_ioContext);
    s_ioContext.run();
 }
 


### PR DESCRIPTION
By default run will exit if there's no work but the guard will keep that from happening.





