### PR TITLE
Add mime type for .bib files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,7 @@
 - Fixed an issue where locator points were not drawn on click. (#10025, #11103)
 - Fixed an issue where RStudio would crash when using the MySQL ODBC Connector on Microsoft Windows. (#15674)
 - Fixed an issue where autocompletion of R6 object names could fail with R6 2.6.0. (#15706)
+- Fixed an issue where .bib files with extra commas could be treated as binary files on RHEL9. (rstudio-pro/7521)
 
 #### Posit Workbench
 - Fixed an issue where uploading a file to a directory containing an '&' character could fail. (#6830)

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -166,6 +166,7 @@ MimeType s_mimeTypes[] =
       { "Renviron",     "text/x-shell" },
       { "rprofvis",     "text/x-r-profile" },
       { "vcxproj",      "text/xml" },
+      { "bib",          "text/plain" },
 
       { "tif",          "image/tiff" },
       { "tiff",         "image/tiff" },


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/7521 by setting an explicit type for `.bib` files.

### Approach

I think it's worth hard coding it since the number of commas in the file shouldn't determine if the file can be opened by RStudio if the file still contains ascii

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Ensure you have updated the QA Notes in the original issue.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


