### PR TITLE
fix unlabeled image in console toolbar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,7 @@
 - Fixed an issue where locator points were not drawn on click. (#10025, #11103)
 - Fixed an issue where RStudio would crash when using the MySQL ODBC Connector on Microsoft Windows. (#15674)
 - Fixed an issue where autocompletion of R6 object names could fail with R6 2.6.0. (#15706)
+- Fixed a WCAG 1.1.1 violation (unlabeled image in the Console toolbar) by marking it as cosmetic. [Accessibility] (#15757)
 - Fixed an issue where .bib files with extra commas could be treated as binary files on RHEL9. (rstudio-pro/7521)
 
 #### Posit Workbench

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleInterpreterVersion.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleInterpreterVersion.java
@@ -183,6 +183,10 @@ public class ConsoleInterpreterVersion
       Image downArrow = new Image(new ImageResource2x(ThemeResources.INSTANCE.menuDownArrow2x()));
       downArrow.getElement().addClassName("rstudio-themes-inverts");
       downArrow.addStyleName(RES.styles().iconDownArrow());
+      
+      // this control is not operable via keyboard or screen reader, so for now we'll just hide it
+      // from screen readers altogether instead of having an unlabeled image
+      downArrow.setAltText("");
       panel.add(downArrow);
       
       return panel;


### PR DESCRIPTION
### Intent

Addresses #15757 

### Approach

The UI widget that uses this image is not implemented to support keyboard or screen reader use. Marking the image as cosmetic so it doesn't show up in screen readers.

### Automated Tests

None currently.

### QA Notes

Added notes to the issue.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


