### PR TITLE
improve performance when reading number of source documents

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,7 @@
 - Fixed a WCAG 1.1.1 violation (unlabeled image in the Console toolbar) by marking it as cosmetic. [Accessibility] (#15757)
 - Fixed Material theme's colors for selected word or text highlighting so they are more visible. [Accessibility] (#15753)
 - Fixed an issue where .bib files with extra commas could be treated as binary files on RHEL9. (rstudio-pro/7521)
+- Fixed an issue where documents could open very slowly when many tabs were already open. (#15767)
 
 #### Posit Workbench
 - Fixed an issue where uploading a file to a directory containing an '&' character could fail. (#6830)

--- a/src/cpp/session/SessionSourceDatabase.cpp
+++ b/src/cpp/session/SessionSourceDatabase.cpp
@@ -23,18 +23,17 @@
 #include <boost/bind/bind.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
-#include <core/Log.hpp>
-#include <core/Exec.hpp>
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
 #include <shared_core/Hash.hpp>
+
+#include <core/Log.hpp>
+#include <core/Exec.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/FileUtils.hpp>
 #include <core/RegexUtils.hpp>
 #include <core/DateTime.hpp>
-
 #include <core/system/System.hpp>
-
 #include <core/http/Util.hpp>
 
 #include <r/RUtil.hpp>
@@ -870,14 +869,15 @@ Error list(std::vector<boost::shared_ptr<SourceDocument>>* pDocs)
          // get the source doc
          boost::shared_ptr<SourceDocument> pDoc(new SourceDocument());
          Error error = source_database::get(filePath.getFilename(), pDoc);
-         if (!error)
+         if (error)
          {
-            // safety filter
-            if (isSafeSourceDocument(filePath, pDoc))
-               pDocs->push_back(pDoc);
-         }
-         else
             LOG_ERROR(error);
+            continue;
+         }
+
+         // safety filter
+         if (isSafeSourceDocument(filePath, pDoc))
+            pDocs->push_back(pDoc);
       }
    }
    


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15767.

### Approach

When checking how many documents are in the source database, instead of attempting to _read_ each source document, just list the document paths themselves, and take that length.

### Automated Tests

Covered by existing automation.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15767.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
