### PR TITLE
support copilot in visual editor code chunks

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -9443,6 +9443,11 @@ public class TextEditingTarget implements
    {
       return view_.isAttached();
    }
+   
+   public TextEditingTargetCopilotHelper getCopilotHelper()
+   {
+      return copilotHelper_;
+   }
 
    private StatusBar statusBar_;
    private final DocDisplay docDisplay_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
@@ -50,7 +50,6 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyDownEvent;
-import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.user.client.Timer;
 import com.google.inject.Inject;
 
@@ -64,16 +63,20 @@ public class TextEditingTargetCopilotHelper
    {
    }
    
+   private interface EditorCommand
+   {
+      public void invoke(DocDisplay editor);
+   }
+   
    public TextEditingTargetCopilotHelper(TextEditingTarget target)
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
       binder_.bind(commands_, this);
       
       target_ = target;
-      display_ = target.getDocDisplay();
-      
       registrations_ = new HandlerRegistrations();
       
+      srcEditor_ = target.getDocDisplay();
       completionTimer_ = new Timer()
       {
          @Override
@@ -82,119 +85,9 @@ public class TextEditingTargetCopilotHelper
             if (copilotDisabledInThisDocument_)
                return;
             
-            target_.withSavedDoc(() ->
+            withActiveEditor((editor) ->
             {
-               requestId_ += 1;
-               final int requestId = requestId_;
-               final Position savedCursorPosition = display_.getCursorPosition();
-               
-               events_.fireEvent(
-                     new CopilotEvent(CopilotEventType.COMPLETION_REQUESTED));
-               
-               server_.copilotGenerateCompletions(
-                     target_.getId(),
-                     StringUtil.notNull(target_.getPath()),
-                     StringUtil.isNullOrEmpty(target_.getPath()),
-                     display_.getCursorRow(),
-                     display_.getCursorColumn(),
-                     new ServerRequestCallback<CopilotGenerateCompletionsResponse>()
-                     {
-                        @Override
-                        public void onResponseReceived(CopilotGenerateCompletionsResponse response)
-                        {
-                           // Check for invalidated request.
-                           if (requestId_ != requestId)
-                              return;
-                           
-                           // Check for alternate cursor position.
-                           Position currentCursorPosition = display_.getCursorPosition();
-                           if (!currentCursorPosition.isEqualTo(savedCursorPosition))
-                              return;
-                           
-                           // Check for null completion results -- this may occur if the Copilot
-                           // agent couldn't be started for some reason.
-                           if (response == null)
-                              return;
-                           
-                           // Check whether completions are enabled in this document.
-                           if (Objects.equals(response.enabled, false))
-                           {
-                              copilotDisabledInThisDocument_ = true;
-                              events_.fireEvent(new CopilotEvent(CopilotEventType.COMPLETION_CANCELLED));
-                              return;
-                           }
-                           
-                           // Check for error.
-                           CopilotError error = response.error;
-                           if (error != null)
-                           {
-                              // Handle 'document could not be found' errors up-front. These errors
-                              // will normally self-resolve after the user starts editing the document,
-                              // so it should suffice just to indicate that no completions are available.
-                              int code = error.code;
-                              if (code == CopilotConstants.ErrorCodes.DOCUMENT_NOT_FOUND)
-                              {
-                                 events_.fireEvent(new CopilotEvent(CopilotEventType.COMPLETION_RECEIVED_NONE));
-                              }
-                              else
-                              {
-                                 String message = copilot_.messageForError(error);
-                                 events_.fireEvent(
-                                       new CopilotEvent(
-                                             CopilotEventType.COMPLETION_ERROR,
-                                             message));
-                                 return;
-                              }
-                           }
-                           
-                           // Check for null result. This might occur if the completion request
-                           // was cancelled by the copilot agent.
-                           Any result = response.result;
-                           if (result == null)
-                           {
-                              events_.fireEvent(new CopilotEvent(CopilotEventType.COMPLETION_CANCELLED));
-                              return;
-                           }
-                           
-                           // Check for a cancellation reason.
-                           Object reason = result.asPropertyMap().get("cancellationReason");
-                           if (reason != null)
-                           {
-                              events_.fireEvent(
-                                    new CopilotEvent(CopilotEventType.COMPLETION_CANCELLED));
-                              return;
-                           }
-                           
-                           // Otherwise, handle the response.
-                           JsArrayLike<CopilotCompletion> completions =
-                                 Js.cast(result.asPropertyMap().get("completions"));
-                           
-                           
-                           events_.fireEvent(new CopilotEvent(
-                                 completions.getLength() == 0
-                                    ? CopilotEventType.COMPLETION_RECEIVED_NONE
-                                    : CopilotEventType.COMPLETION_RECEIVED_SOME));
-                           
-                           for (int i = 0, n = completions.getLength(); i < n; i++)
-                           {
-                              CopilotCompletion completion = completions.getAt(i);
-                              
-                              // Copilot includes trailing '```' for some reason in some cases,
-                              // remove those if we're inserting in an R document.
-                              completion.text = postProcessCompletion(completion.text);
-                              completion.displayText = postProcessCompletion(completion.displayText);
-
-                              activeCompletion_ = completion;
-                              display_.setGhostText(activeCompletion_.displayText);
-                           }
-                        }
-
-                        @Override
-                        public void onError(ServerError error)
-                        {
-                           Debug.logError(error);
-                        }
-                     });
+               requestCompletions(editor);
             });
          }
       };
@@ -216,11 +109,129 @@ public class TextEditingTargetCopilotHelper
       
    }
    
+   private void requestCompletions(DocDisplay editor)
+   {
+      target_.withSavedDoc(() ->
+      {
+         requestId_ += 1;
+         final int requestId = requestId_;
+         final Position cursorPosition = getSourceEditorCursorPosition();
+
+         events_.fireEvent(
+               new CopilotEvent(CopilotEventType.COMPLETION_REQUESTED));
+
+         server_.copilotGenerateCompletions(
+               target_.getId(),
+               StringUtil.notNull(target_.getPath()),
+               StringUtil.isNullOrEmpty(target_.getPath()),
+               cursorPosition.getRow(),
+               cursorPosition.getColumn(),
+               new ServerRequestCallback<CopilotGenerateCompletionsResponse>()
+               {
+                  @Override
+                  public void onResponseReceived(CopilotGenerateCompletionsResponse response)
+                  {
+                     // Check for invalidated request.
+                     if (requestId_ != requestId)
+                        return;
+
+                     // Check for alternate cursor position.
+                     if (!cursorPosition.isEqualTo(getSourceEditorCursorPosition()))
+                        return;
+
+                     // Check for null completion results -- this may occur if the Copilot
+                     // agent couldn't be started for some reason.
+                     if (response == null)
+                        return;
+
+                     // Check whether completions are enabled in this document.
+                     if (Objects.equals(response.enabled, false))
+                     {
+                        copilotDisabledInThisDocument_ = true;
+                        events_.fireEvent(new CopilotEvent(CopilotEventType.COMPLETION_CANCELLED));
+                        return;
+                     }
+
+                     // Check for error.
+                     CopilotError error = response.error;
+                     if (error != null)
+                     {
+                        // Handle 'document could not be found' errors up-front. These errors
+                        // will normally self-resolve after the user starts editing the document,
+                        // so it should suffice just to indicate that no completions are available.
+                        int code = error.code;
+                        if (code == CopilotConstants.ErrorCodes.DOCUMENT_NOT_FOUND)
+                        {
+                           events_.fireEvent(new CopilotEvent(CopilotEventType.COMPLETION_RECEIVED_NONE));
+                        }
+                        else
+                        {
+                           String message = copilot_.messageForError(error);
+                           events_.fireEvent(
+                                 new CopilotEvent(
+                                       CopilotEventType.COMPLETION_ERROR,
+                                       message));
+                           return;
+                        }
+                     }
+
+                     // Check for null result. This might occur if the completion request
+                     // was cancelled by the copilot agent.
+                     Any result = response.result;
+                     if (result == null)
+                     {
+                        events_.fireEvent(new CopilotEvent(CopilotEventType.COMPLETION_CANCELLED));
+                        return;
+                     }
+
+                     // Check for a cancellation reason.
+                     Object reason = result.asPropertyMap().get("cancellationReason");
+                     if (reason != null)
+                     {
+                        events_.fireEvent(
+                              new CopilotEvent(CopilotEventType.COMPLETION_CANCELLED));
+                        return;
+                     }
+
+                     // Otherwise, handle the response.
+                     JsArrayLike<CopilotCompletion> completions =
+                           Js.cast(result.asPropertyMap().get("completions"));
+
+
+                     events_.fireEvent(new CopilotEvent(
+                           completions.getLength() == 0
+                           ? CopilotEventType.COMPLETION_RECEIVED_NONE
+                              : CopilotEventType.COMPLETION_RECEIVED_SOME));
+
+                     for (int i = 0, n = completions.getLength(); i < n; i++)
+                     {
+                        CopilotCompletion completion = completions.getAt(i);
+
+                        // Copilot includes trailing '```' for some reason in some cases,
+                        // remove those if we're inserting in an R document.
+                        completion.text = postProcessCompletion(completion.text);
+                        completion.displayText = postProcessCompletion(completion.displayText);
+
+                        activeCompletion_ = completion;
+                        editor.setGhostText(activeCompletion_.displayText);
+                     }
+                  }
+
+                  @Override
+                  public void onError(ServerError error)
+                  {
+                     Debug.logError(error);
+                  }
+               });
+      });
+   }
+
+   
    private void manageHandlers()
    {
       if (!copilot_.isEnabled())
       {
-         display_.removeGhostText();
+         srcEditor_.removeGhostText();
          registrations_.removeHandler();
          requestId_ = 0;
          completionTimer_.cancel();
@@ -230,98 +241,15 @@ public class TextEditingTargetCopilotHelper
       {
          registrations_.addAll(
 
-               display_.addCursorChangedHandler((event) ->
+               srcEditor_.addCursorChangedHandler((event) ->
                {
-                  // Check if we've been toggled off
-                  if (!automaticCodeSuggestionsEnabled_)
-                     return;
-                  
-                  // Check preference value
-                  String trigger = prefs_.copilotCompletionsTrigger().getGlobalValue();
-                  if (trigger != UserPrefsAccessor.COPILOT_COMPLETIONS_TRIGGER_AUTO)
-                     return;
-                           
-                  // Allow one-time suppression of cursor change handler
-                  if (suppressCursorChangeHandler_)
-                  {
-                     suppressCursorChangeHandler_ = false;
-                     return;
-                  }
-                  
-                  // Don't do anything if we have a selection.
-                  if (display_.hasSelection())
-                  {
-                     completionTimer_.cancel();
-                     return;
-                  }
-                  
-                  // Request completions on cursor navigation.
-                  int delayMs = MathUtil.clamp(prefs_.copilotCompletionsDelay().getValue(), 10, 5000);
-                  completionTimer_.schedule(delayMs);
-
-                  // Delay handler so we can handle a Tab keypress
-                  Timers.singleShot(0, () -> {
-                     activeCompletion_ = null;
-                     display_.removeGhostText();
-                  });
+                  onCursorChanged(srcEditor_);
                }),
 
-               display_.addCapturingKeyDownHandler(new KeyDownHandler()
+               srcEditor_.addCapturingKeyDownHandler((event) ->
                {
-                  @Override
-                  public void onKeyDown(KeyDownEvent keyEvent)
-                  {
-                     // If ghost text is being displayed, accept it on a Tab key press.
-                     // TODO: Let user choose keybinding for accepting ghost text?
-                     if (activeCompletion_ == null)
-                        return;
-
-                     // TODO: If we have a completion popup, should that take precedence?
-                     if (display_.isPopupVisible())
-                        return;
-                     
-                     // Check if the user just inserted some text matching the current
-                     // ghost text. If so, we'll suppress the next cursor change handler,
-                     // so we can continue presenting the current ghost text.
-                     String key = EventProperty.key(keyEvent.getNativeEvent());
-                     if (activeCompletion_.displayText.startsWith(key))
-                     {
-                        updateCompletion(key);
-                        suppressCursorChangeHandler_ = true;
-                        return;
-                     }
-
-                     NativeEvent event = keyEvent.getNativeEvent();
-                     if (event.getKeyCode() == KeyCodes.KEY_TAB)
-                     {
-                        event.stopPropagation();
-                        event.preventDefault();
-
-                        Range aceRange = Range.create(
-                              activeCompletion_.range.start.line,
-                              activeCompletion_.range.start.character,
-                              activeCompletion_.range.end.line,
-                              activeCompletion_.range.end.character);
-                        display_.replaceRange(aceRange, activeCompletion_.text);
-
-                        activeCompletion_ = null;
-                     }
-                     else if (event.getKeyCode() == KeyCodes.KEY_BACKSPACE)
-                     {
-                        display_.removeGhostText();
-                     }
-                     else if (event.getKeyCode() == KeyCodes.KEY_RIGHT &&
-                              (event.getCtrlKey() || event.getMetaKey()))
-                     {
-                        event.stopPropagation();
-                        event.preventDefault();
-
-                        commands_.copilotAcceptNextWord().execute();
-                     }
-                     
-                  }
+                  onKeyDown(srcEditor_, event);
                })
-
          );
 
       }
@@ -331,17 +259,25 @@ public class TextEditingTargetCopilotHelper
    @Handler
    public void onCopilotRequestCompletions()
    {
-      if (copilot_.isEnabled() && display_.isFocused())
+      if (copilot_.isEnabled())
          completionTimer_.schedule(0);
    }
    
    @Handler
    public void onCopilotAcceptNextWord()
    {
-      if (!display_.isFocused())
+      withActiveEditor((editor) ->
+      {
+         onCopilotAcceptNextWordImpl(editor);
+      });
+   }
+   
+   private void onCopilotAcceptNextWordImpl(DocDisplay editor)
+   {
+      if (!editor.isFocused())
          return;
          
-      boolean hasActiveSuggestion = display_.hasGhostText() && activeCompletion_ != null;
+      boolean hasActiveSuggestion = editor.hasGhostText() && activeCompletion_ != null;
       if (!hasActiveSuggestion)
          return;
       
@@ -364,8 +300,8 @@ public class TextEditingTargetCopilotHelper
       Timers.singleShot(() ->
       {
          suppressCursorChangeHandler_ = true;
-         display_.insertCode(insertedWord, InsertionBehavior.EditorBehaviorsDisabled);
-         display_.setGhostText(activeCompletion_.displayText);
+         editor.insertCode(insertedWord, InsertionBehavior.EditorBehaviorsDisabled);
+         editor.setGhostText(activeCompletion_.displayText);
          
          // Work around issue with ghost text not appearing after inserting
          // a code suggestion containing a new line
@@ -373,7 +309,7 @@ public class TextEditingTargetCopilotHelper
          {
             Timers.singleShot(20, () ->
             {
-               display_.setGhostText(activeCompletion_.displayText);
+               editor.setGhostText(activeCompletion_.displayText);
             });
          }
       });
@@ -382,7 +318,7 @@ public class TextEditingTargetCopilotHelper
    @Handler
    public void onCopilotToggleAutomaticCompletions()
    {
-      if (display_.isFocused())
+      if (srcEditor_.isFocused())
       {
          automaticCodeSuggestionsEnabled_ = !automaticCodeSuggestionsEnabled_;
          
@@ -397,7 +333,7 @@ public class TextEditingTargetCopilotHelper
       }
    }
    
-   private void updateCompletion(String key)
+   private void updateCompletion(DocDisplay editor, String key)
    {
       int n = key.length();
       activeCompletion_.displayText = StringUtil.substring(activeCompletion_.displayText, n);
@@ -411,7 +347,7 @@ public class TextEditingTargetCopilotHelper
       // dodge this effect, we reset the ghost text at the end of the event loop.
       Timers.singleShot(() ->
       {
-         display_.setGhostText(activeCompletion_.displayText);
+         editor.setGhostText(activeCompletion_.displayText);
       });
    }
    
@@ -430,6 +366,140 @@ public class TextEditingTargetCopilotHelper
       copilotDisabledInThisDocument_ = false;
    }
    
+   private void withActiveEditor(EditorCommand command)
+   {
+      if (target_.isVisualModeActivated())
+      {
+         DocDisplay visEditor = target_.getVisualMode().getActiveEditor();
+         if (visEditor != null)
+         {
+            command.invoke(visEditor);
+         }
+      }
+      else
+      {
+         command.invoke(srcEditor_);
+      }
+   }
+   
+   private Position getSourceEditorCursorPosition()
+   {
+      if (target_.isVisualModeActivated())
+      {
+         DocDisplay visEditor = target_.getVisualMode().getActiveEditor();
+         if (visEditor != null)
+         {
+            Position chunkPos =
+                  target_.getVisualMode().getActiveEditorChunk().getScope().getPreamble();
+            
+            Position visPos = visEditor.getCursorPosition();
+            
+            return Position.create(
+                  chunkPos.getRow() + visPos.getRow(),
+                  visPos.getColumn());
+         }
+         else
+         {
+            return null;
+         }
+      }
+      else
+      {
+         return srcEditor_.getCursorPosition();
+      }
+   }
+   
+   public void onCursorChanged(DocDisplay editor)
+   {
+      // Check if we've been toggled off
+      if (!automaticCodeSuggestionsEnabled_)
+         return;
+
+      // Check preference value
+      String trigger = prefs_.copilotCompletionsTrigger().getGlobalValue();
+      if (trigger != UserPrefsAccessor.COPILOT_COMPLETIONS_TRIGGER_AUTO)
+         return;
+
+      // Allow one-time suppression of cursor change handler
+      if (suppressCursorChangeHandler_)
+      {
+         suppressCursorChangeHandler_ = false;
+         return;
+      }
+
+      // Don't do anything if we have a selection.
+      if (editor.hasSelection())
+      {
+         completionTimer_.cancel();
+         return;
+      }
+
+      // Request completions on cursor navigation.
+      int delayMs = MathUtil.clamp(prefs_.copilotCompletionsDelay().getValue(), 10, 5000);
+      completionTimer_.schedule(delayMs);
+
+      // Delay handler so we can handle a Tab keypress
+      Timers.singleShot(0, () -> {
+         activeCompletion_ = null;
+         editor.removeGhostText();
+      });
+   }
+   
+   public void onKeyDown(DocDisplay editor, KeyDownEvent keyEvent)
+   {
+      if (!editor.isFocused())
+         return;
+      
+      // If ghost text is being displayed, accept it on a Tab key press.
+      // TODO: Let user choose keybinding for accepting ghost text?
+      if (activeCompletion_ == null)
+         return;
+
+      // TODO: If we have a completion popup, should that take precedence?
+      if (editor.isPopupVisible())
+         return;
+
+      // Check if the user just inserted some text matching the current
+      // ghost text. If so, we'll suppress the next cursor change handler,
+      // so we can continue presenting the current ghost text.
+      String key = EventProperty.key(keyEvent.getNativeEvent());
+      if (activeCompletion_.displayText.startsWith(key))
+      {
+         updateCompletion(editor, key);
+         suppressCursorChangeHandler_ = true;
+         return;
+      }
+
+      NativeEvent event = keyEvent.getNativeEvent();
+      if (event.getKeyCode() == KeyCodes.KEY_TAB)
+      {
+         event.stopPropagation();
+         event.preventDefault();
+
+         Range aceRange = Range.create(
+               activeCompletion_.range.start.line,
+               activeCompletion_.range.start.character,
+               activeCompletion_.range.end.line,
+               activeCompletion_.range.end.character);
+         editor.replaceRange(aceRange, activeCompletion_.text);
+
+         activeCompletion_ = null;
+      }
+      else if (event.getKeyCode() == KeyCodes.KEY_BACKSPACE)
+      {
+         editor.removeGhostText();
+      }
+      else if (event.getKeyCode() == KeyCodes.KEY_RIGHT &&
+            (event.getCtrlKey() || event.getMetaKey()))
+      {
+         event.stopPropagation();
+         event.preventDefault();
+
+         commands_.copilotAcceptNextWord().execute();
+      }
+   }
+
+   
    @Inject
    private void initialize(Copilot copilot,
                            EventBus events,
@@ -447,7 +517,7 @@ public class TextEditingTargetCopilotHelper
    }
    
    private final TextEditingTarget target_;
-   private final DocDisplay display_;
+   private final DocDisplay srcEditor_;
    private final Timer completionTimer_;
    private final HandlerRegistrations registrations_;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -797,7 +797,6 @@ public class VisualMode implements VisualModeEditorSync,
               panmirror_.getEditingOutlineLocation());
    }
 
-   
    public DocDisplay getActiveEditor()
    {
       return activeEditor_;
@@ -818,6 +817,16 @@ public class VisualMode implements VisualModeEditorSync,
          // A code chunk has focus; enable code commands
          setCodeCommandsEnabled(true);
       }
+   }
+   
+   public VisualModeChunk getActiveEditorChunk()
+   {
+      return activeEditorChunk_;
+   }
+   
+   public void setActiveEditorChunk(VisualModeChunk activeEditorChunk)
+   {
+      activeEditorChunk_ = activeEditorChunk;
    }
    
    /**
@@ -1937,6 +1946,7 @@ public class VisualMode implements VisualModeEditorSync,
    private UserPrefs prefs_;
    private SourceServerOperations source_;
    private DocDisplay activeEditor_;  // the current embedded editor
+   private VisualModeChunk activeEditorChunk_;
    
    private final TextEditingTarget target_;
    private final TextEditingTarget.Display view_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
@@ -56,6 +56,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEdit
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
 import org.rstudio.studio.client.workbench.views.source.editors.text.assist.RChunkHeaderParser;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.CursorChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditingTargetSelectedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkContextPanmirrorUi;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkDefinition;
@@ -190,6 +191,24 @@ public class VisualModeChunk
       // editors)
       editor_.setUseWrapMode(true);
       
+      releaseOnDismiss_.add(editor_.addCapturingKeyDownHandler(new KeyDownHandler()
+      {
+         @Override
+         public void onKeyDown(KeyDownEvent event)
+         {
+            target_.getCopilotHelper().onKeyDown(editor_, event);
+         }
+      }));
+      
+      releaseOnDismiss_.add(editor_.addCursorChangedHandler(new CursorChangedEvent.Handler()
+      {
+         @Override
+         public void onCursorChanged(CursorChangedEvent event)
+         {
+            target_.getCopilotHelper().onCursorChanged(editor_);
+         }
+      }));
+      
       // Special comment continuation
       releaseOnDismiss_.add(editor_.addKeyDownHandler(new KeyDownHandler()
       {
@@ -198,14 +217,14 @@ public class VisualModeChunk
             NativeEvent ne = event.getNativeEvent();
             TextEditingTargetQuartoHelper.continueSpecialCommentOnNewline(editor_, ne);
          }
-      }
-      ));
+      }));
       
       // Track activation state and notify visual mode
       releaseOnDismiss_.add(editor_.addFocusHandler((evt) ->
       { 
          active_ = true; 
          target_.getVisualMode().setActiveEditor(editor_);
+         target_.getVisualMode().setActiveEditorChunk(VisualModeChunk.this);
 
          // Ensure keyboard shortcut commands (e.g. Save File) route here when using multiple source columns
          events_.fireEvent(new EditingTargetSelectedEvent(target_));
@@ -213,10 +232,12 @@ public class VisualModeChunk
          // Route commands properly when editor is in a secondary window
          events_.fireEvent(new DocFocusedEvent(target_.getPath(), target_.getId()));
       }));
+      
       releaseOnDismiss_.add(editor_.addBlurHandler((evt) ->
       {
          active_ = false;
          target_.getVisualMode().setActiveEditor(null);
+         target_.getVisualMode().setActiveEditorChunk(null);
       }));
 
       // Track UI pref for tab behavior. Note that this can't be a lambda because Ace has trouble with lambda bindings.


### PR DESCRIPTION
### Intent

Addresses part of https://github.com/rstudio/rstudio/issues/13427.

### Approach

Extend the existing Copilot integration to visual editor code chunks; mostly by checking for visual mode + an active visual editor in the TextEditingTargetCopilotHelper, and doing some magic to compute the equivalent source editor cursor position when requesting Copilot completions.

### Automated Tests

N/A

### QA Notes

Test that Copilot completions are offered within R code chunks of the visual editor.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
