### PR TITLE
tweak parsing of incomplete CSI escapes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/AnsiCode.java
+++ b/src/gwt/src/org/rstudio/core/client/AnsiCode.java
@@ -728,7 +728,7 @@ public class AnsiCode
 
    // RegEx to match complete CSI codes (only a small subset)
    public static final String CSI_REGEX =
-         "[\u001b\u009b]\\[([0-9]*)([A-Z])";
+         "[\u001b\u009b]\\[([0-9]{1,4}(?:;[0-9]{0,4})*)?([a-zA-Z])";
    
    // Match ANSI SGR escape sequences
    public static final Pattern CSI_PATTERN = Pattern.create(CSI_REGEX);
@@ -740,13 +740,6 @@ public class AnsiCode
    // Match ANSI SGR escape sequences
    public static final Pattern CSI_PREFIX_PATTERN = Pattern.create(CSI_PREFIX_REGEX);
    
-   // RegEx to match complete SGR codes (colors, fonts, appearance)
-   public static final String SGR_REGEX =
-         "[\u001b\u009b]\\[(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[m]";
-
-   // Match ANSI SGR escape sequences
-   public static final Pattern SGR_ESCAPE_PATTERN = Pattern.create(SGR_REGEX);
-
    private Color currentColor_ = new Color();
    private Color currentBgColor_ = new Color();
    private boolean inverted_ = false;

--- a/src/gwt/src/org/rstudio/core/client/AnsiCode.java
+++ b/src/gwt/src/org/rstudio/core/client/AnsiCode.java
@@ -735,7 +735,7 @@ public class AnsiCode
    
    // RegEx to match incomplete CSI codes (only a small subset)
    public static final String CSI_PREFIX_REGEX =
-         "[\u001b\u009b]\\[";
+         "[\u001b\u009b]\\[(?:\\d|$)";
    
    // Match ANSI SGR escape sequences
    public static final Pattern CSI_PREFIX_PATTERN = Pattern.create(CSI_PREFIX_REGEX);

--- a/src/gwt/src/org/rstudio/core/client/AnsiCode.java
+++ b/src/gwt/src/org/rstudio/core/client/AnsiCode.java
@@ -733,19 +733,19 @@ public class AnsiCode
    // Match ANSI SGR escape sequences
    public static final Pattern CSI_PATTERN = Pattern.create(CSI_REGEX);
    
+   // RegEx to match incomplete CSI codes (only a small subset)
+   public static final String CSI_PREFIX_REGEX =
+         "[\u001b\u009b]\\[";
+   
+   // Match ANSI SGR escape sequences
+   public static final Pattern CSI_PREFIX_PATTERN = Pattern.create(CSI_PREFIX_REGEX);
+   
    // RegEx to match complete SGR codes (colors, fonts, appearance)
    public static final String SGR_REGEX =
          "[\u001b\u009b]\\[(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[m]";
 
    // Match ANSI SGR escape sequences
    public static final Pattern SGR_ESCAPE_PATTERN = Pattern.create(SGR_REGEX);
-
-   // RegEx to match partial SGR codes (don't have final "m" yet)
-   public static final String SGR_PARTIAL_REGEX =
-         "[\u001b\u009b]\\[(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9]";
-
-   // Match partial potential ANSI SGR escape sequences
-   public static final Pattern SGR_PARTIAL_ESCAPE_PATTERN = Pattern.create(SGR_PARTIAL_REGEX);
 
    private Color currentColor_ = new Color();
    private Color currentBgColor_ = new Color();

--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -697,7 +697,18 @@ public class VirtualConsole
                {
                   int n = StringUtil.parseInt(csiMatch.getGroup(1), 0);
                   String command = csiMatch.getGroup(2);
+ 
+                  // handle SGR codes up-front
+                  if (command == "m")
+                  {
+                     // process the SGR code
+                     ansiCodeStyles_ = ansi_.processCode(csiMatch.getValue());
+                     currentClazz = setCurrentClazz(ansiColorMode, clazz);
+                     tail = pos + csiMatch.getValue().length();
+                     break;
+                  }
                   
+                  // handle other supported commands
                   if (command == "C")
                   {
                      cursor_ = Math.min(output_.length(), cursor_ + n);
@@ -708,17 +719,6 @@ public class VirtualConsole
                   }
                   
                   tail = pos + csiMatch.getValue().length();
-                  break;
-               }
-               
-               // match complete SGR codes
-               Match sgrMatch = AnsiCode.SGR_ESCAPE_PATTERN.match(data, pos);
-               if (sgrMatch != null)
-               {
-                  // process the SGR code
-                  ansiCodeStyles_ = ansi_.processCode(sgrMatch.getValue());
-                  currentClazz = setCurrentClazz(ansiColorMode, clazz);
-                  tail = pos + sgrMatch.getValue().length();
                   break;
                }
                

--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -738,6 +738,8 @@ public class VirtualConsole
                   break;
                }
                
+               // if we get here, we didn't know what to do with the escape character
+               // just discard it and perform regular parsing from here on
                tail++;
                break;
                

--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -695,7 +695,6 @@ public class VirtualConsole
                Match csiMatch = AnsiCode.CSI_PATTERN.match(data, pos);
                if (csiMatch != null)
                {
-                  Debug.breakpoint();
                   int n = StringUtil.parseInt(csiMatch.getGroup(1), 0);
                   String command = csiMatch.getGroup(2);
                   

--- a/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
+++ b/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
@@ -1257,4 +1257,15 @@ public class VirtualConsoleTests extends GWTTestCase
       vc.submit("Hello world!\033[10DLL\033[4CRL");
       Assert.assertEquals(ele.getInnerText(), "HeLLo woRLd!");
    }
+   
+   public void testIncompleteAnsiCodes()
+   {
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = getVC(ele);
+      String text = "\u001b[34mhello\u001b[0m";
+      for (int i = 0, n = text.length(); i < n; i++)
+         vc.submit(text.substring(i, i + 1));
+      
+      Assert.assertEquals(ele.getInnerText(), "hello");
+   }
 }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15777.

### Approach

Tweak how we detect incomplete CSR escapes. In particular:

- Check for single `\033` escapes up-front, and buffer those.
- Parse SGR escapes as just a special case of a CSI escape.
- Check for an incomplete CSI escape before ANSI escapes, and continue parsing those.

### Automated Tests

Tests included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15777.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
