### PR TITLE
use alternate message when restoring R

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -646,8 +646,9 @@ public class Application implements ApplicationEventHandlers
    @Override
    public void onSessionSerialization(SessionSerializationEvent event)
    {
-      switch(event.getAction().getType())
+      switch (event.getAction().getType())
       {
+      
       case SessionSerializationAction.LOAD_DEFAULT_WORKSPACE:
          view_.showSerializationProgress(
                          constants_.loadingWorkspaceMessage() + getSuffix(event),
@@ -656,6 +657,7 @@ public class Application implements ApplicationEventHandlers
                                 // this will always be at workbench startup
                          0);    // no timeout
          break;
+         
       case SessionSerializationAction.SAVE_DEFAULT_WORKSPACE:
          view_.showSerializationProgress(
                           constants_.savingWorkspaceImageMessage() + getSuffix(event),
@@ -663,30 +665,34 @@ public class Application implements ApplicationEventHandlers
                           0,    // show immediately
                           0);   // no timeout
          break;
+         
       case SessionSerializationAction.SUSPEND_SESSION:
          events_.fireEvent(new ApplicationTutorialEvent(ApplicationTutorialEvent.SESSION_SUSPEND));
          view_.showSerializationProgress(
                           constants_.backingUpRSessionMessage(),
                           true,    // modal, inputs will fall dead anyway
-                          0,       // show immediately
+                          2000,    // delay a bit
                           60000);  // timeout after 60 seconds. this is done
                                    // in case the user suspends or loses
                                    // connectivity during the backup (in which
                                    // case the 'completed' event dies with
                                    // server and is never received by the client
          break;
+         
       case SessionSerializationAction.RESUME_SESSION:
          view_.showSerializationProgress(
-                          constants_.backingUpRSessionMessage(),
+                          constants_.restoringRSessionMessage(),
                           false, // non-modal, appears to user as std latency
                           2000,  // don't show this for reasonable restore time
                                  // (happens inline while using a running
                                  // workbench so be more conservative)
                           0);    // no timeout
          break;
+         
       case SessionSerializationAction.COMPLETED:
          view_.hideSerializationProgress();
          break;
+         
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -649,6 +649,14 @@ public class Application implements ApplicationEventHandlers
       switch (event.getAction().getType())
       {
       
+      case SessionSerializationAction.SAVE_DEFAULT_WORKSPACE:
+         view_.showSerializationProgress(
+                          constants_.savingWorkspaceImageMessage() + getSuffix(event),
+                          true, // modal, inputs will fall dead anyway
+                          0,    // show immediately
+                          0);   // no timeout
+         break;
+         
       case SessionSerializationAction.LOAD_DEFAULT_WORKSPACE:
          view_.showSerializationProgress(
                          constants_.loadingWorkspaceMessage() + getSuffix(event),
@@ -658,20 +666,12 @@ public class Application implements ApplicationEventHandlers
                          0);    // no timeout
          break;
          
-      case SessionSerializationAction.SAVE_DEFAULT_WORKSPACE:
-         view_.showSerializationProgress(
-                          constants_.savingWorkspaceImageMessage() + getSuffix(event),
-                          true, // modal, inputs will fall dead anyway
-                          0,    // show immediately
-                          0);   // no timeout
-         break;
-         
       case SessionSerializationAction.SUSPEND_SESSION:
          events_.fireEvent(new ApplicationTutorialEvent(ApplicationTutorialEvent.SESSION_SUSPEND));
          view_.showSerializationProgress(
                           constants_.backingUpRSessionMessage(),
                           true,    // modal, inputs will fall dead anyway
-                          2000,    // delay a bit
+                          2000,    // don't show for quick suspends
                           60000);  // timeout after 60 seconds. this is done
                                    // in case the user suspends or loses
                                    // connectivity during the backup (in which

--- a/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants.java
@@ -162,6 +162,15 @@ public interface StudioClientApplicationConstants extends com.google.gwt.i18n.cl
     String backingUpRSessionMessage();
 
     /**
+     * Translated "Restoring R session...".
+     *
+     * @return translated "Restoring R session..."
+     */
+    @DefaultMessage("Restoring R session...")
+    @Key("restoringRSessionMessage")
+    String restoringRSessionMessage();
+    
+    /**
      * Translated "Switch R Version".
      *
      * @return translated "Switch R Version"

--- a/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_en.properties
@@ -14,6 +14,7 @@ focusedElementLabel=Focused Element:
 loadingWorkspaceMessage=Loading workspace
 savingWorkspaceImageMessage=Saving workspace image
 backingUpRSessionMessage=Backing up R session...
+restoringRSessionMessage=Restoring R session...
 switchRVersionCaption=Switch R Version
 workspaceNotRestoredMessage=The workspace was not restored
 startupScriptsNotExecutedMessage=, and startup scripts were not executed

--- a/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_fr.properties
@@ -14,6 +14,7 @@ focusedElementLabel=Élément ciblé:
 loadingWorkspaceMessage=Chargement de l''espace de travail
 savingWorkspaceImageMessage=Sauvegarde de l''image de l''espace de travail
 backingUpRSessionMessage=Sauvegarde de la session R...
+restoringRSessionMessage=Restaurer de la session R...
 switchRVersionCaption=Changer de version R
 workspaceNotRestoredMessage=L''espace de travail n''a pas été restauré
 startupScriptsNotExecutedMessage=, et les scripts de démarrage n''ont pas été exécutés.

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
@@ -318,7 +318,10 @@ public class ApplicationWindow extends Composite
          @Override
          public void run()
          {
-            activeSerializationProgress_.showProgress();
+            if (activeSerializationProgress_ != null)
+            {
+               activeSerializationProgress_.showProgress();
+            }
          }
       };
       
@@ -327,7 +330,10 @@ public class ApplicationWindow extends Composite
          @Override
          public void run()
          {
-            activeSerializationProgress_.hide();
+            if (activeSerializationProgress_ != null)
+            {
+               activeSerializationProgress_.hide();
+            }
          }
       };
 

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
@@ -304,40 +304,62 @@ public class ApplicationWindow extends Composite
                                          int delayMs,
                                          int timeoutMs)
    {
-      // hide any existing progress
-      hideSerializationProgress();
+      // reset / cancel a previous serialization operation
+      resetState();
 
       // create and show progress
       activeSerializationProgress_ =
                     new ApplicationSerializationProgress(msg, modal, delayMs,
                           !ariaLive_.isDisabled(AriaLiveService.SESSION_STATE));
-
-      // implement timeout for *this* serialization progress instance if
-      // requested (check to ensure the same instance because another
-      // serialization progress could occur in the meantime and we don't
-      // want to hide it)
-      if (timeoutMs > 0)
+      
+      // create timers for showing, hiding output
+      showTimer_ = new Timer()
       {
-         final ApplicationSerializationProgress timeoutSerializationProgress =
-                                                   activeSerializationProgress_;
-         new Timer() {
-            @Override
-            public void run()
-            {
-               if (timeoutSerializationProgress == activeSerializationProgress_)
-                  hideSerializationProgress();
-            }
-         }.schedule(timeoutMs);
-      }
+         @Override
+         public void run()
+         {
+            activeSerializationProgress_.showProgress();
+         }
+      };
+      
+      hideTimer_ = new Timer()
+      {
+         @Override
+         public void run()
+         {
+            activeSerializationProgress_.hide();
+         }
+      };
+
+      // start the timers
+      showTimer_.schedule(delayMs);
+      hideTimer_.schedule(timeoutMs);
    }
 
    @Override
    public void hideSerializationProgress()
    {
+      resetState();
+   }
+   
+   private void resetState()
+   {
       if (activeSerializationProgress_ != null)
       {
          activeSerializationProgress_.hide();
          activeSerializationProgress_ = null;
+      }
+      
+      if (showTimer_ != null)
+      {
+         showTimer_.cancel();
+         showTimer_ = null;
+      }
+      
+      if (hideTimer_ != null)
+      {
+         hideTimer_.cancel();
+         hideTimer_ = null;
       }
    }
 
@@ -353,6 +375,8 @@ public class ApplicationWindow extends Composite
 
    // active serialization progress message
    private ApplicationSerializationProgress activeSerializationProgress_;
+   private Timer showTimer_;
+   private Timer hideTimer_;
 
    private static final int COMPONENT_SPACING = 6;
    private Widget workbenchScreen_;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/serializationprogress/ApplicationSerializationProgress.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/serializationprogress/ApplicationSerializationProgress.java
@@ -49,33 +49,11 @@ public class ApplicationSerializationProgress extends PopupPanel
 
       // set widget
       setWidget(label);
-      
-      // show (after specified delay so long as we were not already hidden)
-      if (delayMs > 0)
-      {
-         new Timer() { public void run()
-         {
-            if (!wasHidden_)
-               showProgress();
-            
-         }}.schedule(delayMs);
-      }
-      else
-      {
-         showProgress();
-      }
    } 
    
-   @Override
-   public void hide()
+   public void showProgress()
    {
-      super.hide();
-      wasHidden_ = true;
-   }
-   
-   private void showProgress()
-   {
-      setPopupPositionAndShow( new PopupPanel.PositionCallback() 
+      setPopupPositionAndShow(new PopupPanel.PositionCallback() 
       {
          public void setPosition(int width, int height) 
          {
@@ -84,7 +62,7 @@ public class ApplicationSerializationProgress extends PopupPanel
       });
    }
    
-   private boolean wasHidden_ = false;
+   // Boilerplate ----
    
    public interface Styles extends CssResource
    {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14511.

### Approach

- Use an alternate message when restoring R.
- Try to be more careful about how we handle and dismiss serialization messages.
- Try to be more careful in how we manage the suspend UI state.

This PR doesn't actually change anything around how suspend / resume is performed; it just changes how it's reported to the user. In particular, we now properly report "Restoring R session..." while the session is being restored, instead of "Backing up R session...", which surely caused some confusion.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14511.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
