### PR TITLE
support multiple checkboxes for same pref

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CodePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CodePreferencesPane.java
@@ -256,6 +256,7 @@ public class CodePreferencesPane extends PreferencesPane
       stylerPanel.add(headerLabel("Format with styler"));
       stylerPanel.add(new Label("Use the styler R package to reformat code."));
       stylerPanel.add(extraSpacedBefore(checkboxPref(prefs_.codeFormatterStylerStrict())));
+      stylerPanel.add(checkboxPref(prefs_.reformatOnSave()));
       
       reformatOnSaveCommand_ = new FileChooserTextBox(
             "Reformat command:",
@@ -277,6 +278,7 @@ public class CodePreferencesPane extends PreferencesPane
       externalPanel.add(headerLabel("Format with an External Tool"));
       externalPanel.add(new Label("Use an external application to reformat code."));
       externalPanel.add(extraSpacedBefore(reformatOnSaveCommand_));
+      externalPanel.add(checkboxPref(prefs_.reformatOnSave()));
       
       SimplePanel formattingDetailsPanel = new SimplePanel();
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesPane.java
@@ -16,6 +16,9 @@ package org.rstudio.studio.client.workbench.prefs.views;
 
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.rstudio.core.client.prefs.PreferencesDialogPaneBase;
 import org.rstudio.core.client.prefs.RestartRequirement;
@@ -23,6 +26,8 @@ import org.rstudio.core.client.widget.NumericValueWidget;
 import org.rstudio.studio.client.workbench.prefs.model.Prefs.PrefValue;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.CheckBox;
 
@@ -142,9 +147,11 @@ public abstract class PreferencesPane extends PreferencesDialogPaneBase<UserPref
       final CheckBox checkBox = new CheckBox(label, asHtml);
       if (defaultSpaced)
          lessSpaced(checkBox);
+      
       checkBox.setValue(prefValue.getGlobalValue());
       if (title != null)
          checkBox.setTitle(title);
+      
       onApplyCommands_.add(new Command()
       {
          public void execute()
@@ -152,6 +159,27 @@ public abstract class PreferencesPane extends PreferencesDialogPaneBase<UserPref
             prefValue.setGlobalValue(checkBox.getValue());
          }
       });
+      
+      if (!cbMap_.containsKey(label))
+      {
+         cbMap_.put(label, new ArrayList<>());
+      }
+      
+      List<CheckBox> cbList = cbMap_.get(label);
+      cbList.add(checkBox);
+      
+      checkBox.addValueChangeHandler(new ValueChangeHandler<Boolean>()
+      {
+         @Override
+         public void onValueChange(ValueChangeEvent<Boolean> event)
+         {
+            for (CheckBox cb : cbMap_.get(label))
+            {
+               cb.setValue(checkBox.getValue(), false);
+            }
+         }
+      });
+      
       return checkBox;
    }
 
@@ -259,4 +287,5 @@ public abstract class PreferencesPane extends PreferencesDialogPaneBase<UserPref
    }
 
    protected final ArrayList<Command> onApplyCommands_ = new ArrayList<>();
+   protected final Map<String, List<CheckBox>> cbMap_ = new HashMap<>();
 }


### PR DESCRIPTION
A small change that adds the "format on save" preference to the Formatting page when specific formatters are enabled, since users<sup>1</sup> might not think to look there when checking if it's enabled.

<sup>1.</sup> By "users" I mean "me".

<img width="497" alt="Screenshot 2025-03-12 at 2 33 57 PM" src="https://github.com/user-attachments/assets/b6d192f1-01a2-4b8b-b210-8121b3d66d83" />
