### PR TITLE
always allow save when formatter is enabled

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -858,14 +858,16 @@ public class SourceColumn implements BeforeShowEvent.Handler,
       // ensure that save command state is synchronized with desktop.
       boolean saveEnabled = getNextActiveEditor() != null &&
             getNextActiveEditor().isSaveCommandActive();
+      
       getSourceCommand(commands_.saveSourceDoc()).setEnabled(
             active,
             active && saveEnabled,
             saveEnabled,
             Desktop.isDesktop());
 
-      boolean saveAsEnabled =  getNextActiveEditor() != null &&
+      boolean saveAsEnabled = getNextActiveEditor() != null &&
             getNextActiveEditor().getSupportedCommands().contains(commands_.saveSourceDocAs());
+      
       getSourceCommand(commands_.saveSourceDocAs()).setEnabled(
             active,
             active && saveAsEnabled,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3687,6 +3687,7 @@ public class TextEditingTarget implements
    public boolean isSaveCommandActive()
    {
       return
+            
          // force active?
          forceSaveCommandActive_ ||
 
@@ -3697,10 +3698,12 @@ public class TextEditingTarget implements
          ((getPath() == null) && docDisplay_.getCode().isEmpty()) ||
 
          // source on save is active
-         (isSourceOnSaveEnabled() && docUpdateSentinel_.sourceOnSave());
+         (isSourceOnSaveEnabled() && docUpdateSentinel_.sourceOnSave()) ||
+         
+         // format on save is active
+         (isFormatOnSaveEnabled());
    }
-
-
+   
    @Override
    public void forceSaveCommandActive()
    {
@@ -8285,7 +8288,7 @@ public class TextEditingTarget implements
             }
             
             // check for format on save
-            if (formatOnSave && formatOnSaveEnabled())
+            if (formatOnSave && isFormatOnSaveEnabled())
             {
                server_.formatDocument(
                      docUpdateSentinel_.getId(),
@@ -8315,7 +8318,7 @@ public class TextEditingTarget implements
       };
    }
    
-   private boolean formatOnSaveEnabled()
+   private boolean isFormatOnSaveEnabled()
    {
       // TODO: What should we do if a user tries to enable 'Reformat on Save' for a document
       // without actually setting the code formatter? Should we just opt them into using


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15734.

### Approach

If a formatter has been configured, and the document is configured to auto-format on save, then always allow the save command to run (since we don't know if the format-before-save action might mutate a "clean" document).

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15734.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
