### PR TITLE
fix crash on macOS with R files containing binary data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,10 +18,10 @@
 
 ### Fixed
 #### RStudio
-
 - Fixed an issue where execution of notebook chunks could fail if the `http_proxy` environment variable was set. (#15530)
 - Fixed an issue where RStudio could hang when attempting to stage large folders from the Git pane on Windows. (#13222)
 - Fixed an issue where RStudio could crash when attempting to clear plots while a new plot was being drawn. (#11856)
+- Fixed an issuew here RStudio could crash if a project contained `.R` files with binary data. (#15801)
 - Fixed an issue where the R startup banner was printed twice in rare cases. (#6907)
 - Fixed an issue where RStudio Server could hang when navigating the Open File dialog to a directory with many (> 100,000) files. (#15441)
 - Fixed an issue where the F1 shortcut would fail to retrieve documentation in packages. (#10869)

--- a/src/cpp/core/r_util/RTokenizer.cpp
+++ b/src/cpp/core/r_util/RTokenizer.cpp
@@ -122,18 +122,8 @@ bool isAlphanumeric(wchar_t ch)
    }
    else
    {
-      CFStringRef string = CFStringCreateWithBytes(
-               kCFAllocatorDefault,
-               (const UInt8*) &ch,
-               sizeof (wchar_t),
-               kCFStringEncodingUTF32LE,
-               false);
-
-      CFCharacterSetRef set = CFCharacterSetGetPredefined(kCFCharacterSetAlphaNumeric);
-      CFRange range = CFRangeMake(0, CFStringGetLength(string));
-      bool result = CFStringFindCharacterFromSet(string, set, range, 0, NULL);
-      CFRelease(string);
-      return result;
+      static CFCharacterSetRef set = CFCharacterSetGetPredefined(kCFCharacterSetAlphaNumeric);
+      return CFCharacterSetIsLongCharacterMember(set, ch);
    }
    
 #else

--- a/src/cpp/core/r_util/RTokenizer.cpp
+++ b/src/cpp/core/r_util/RTokenizer.cpp
@@ -113,19 +113,8 @@ Error tokenizeError(const std::string& reason, const ErrorLocation& location)
 bool isAlphanumeric(wchar_t ch)
 {
 #ifdef __APPLE__
-   
-   // if this appears to be an ASCII value, then use the standard library;
-   // otherwise, use core foundation
-   if (ch < static_cast<wchar_t>(128))
-   {
-      return iswalnum(ch);
-   }
-   else
-   {
-      static CFCharacterSetRef set = CFCharacterSetGetPredefined(kCFCharacterSetAlphaNumeric);
-      return CFCharacterSetIsLongCharacterMember(set, ch);
-   }
-   
+   static CFCharacterSetRef set = CFCharacterSetGetPredefined(kCFCharacterSetAlphaNumeric);
+   return CFCharacterSetIsLongCharacterMember(set, ch);
 #else
    return iswalnum(ch);
 #endif

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -21,38 +21,37 @@
 #include <string>
 #include <vector>
 
-#include <boost/algorithm/string.hpp>
-#include <boost/range/as_array.hpp>
-#include <boost/bind/bind.hpp>
-#include <boost/scope_exit.hpp>
-
-#include <signal.h>
 #include <fcntl.h>
-#include <syslog.h>
-#include <sys/resource.h>
-#include <sys/wait.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <pwd.h>
 #include <grp.h>
-#include <sys/types.h>
+#include <pwd.h>
+#include <signal.h>
+#include <sys/resource.h>
 #include <sys/socket.h>
-
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <syslog.h>
+#include <unistd.h>
 #include <uuid/uuid.h>
 
 #include <shared_core/system/PosixSystem.hpp>
 
 #ifdef __APPLE__
+#include <gsl/gsl-lite.hpp>
+#include <libproc.h>
 #include <mach-o/dyld.h>
 #include <sys/proc_info.h>
-#include <libproc.h>
-#include <gsl/gsl>
 #endif
 
 #ifdef __linux__
-#include <sys/prctl.h>
-#include <sys/sysinfo.h>
+
+#include <dirent.h>
 #include <linux/kernel.h>
+#include <stdarg.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <sys/sysinfo.h>
+
 // Some data structures here don't compile on rhel8 due to 'private' being used as a symbol???
 // so defining them again here
 //#include <linux/keyctl.h>
@@ -63,18 +62,18 @@
 #define KEY_SPEC_SESSION_KEYRING        -3      /* - key ID for session-specific keyring */
 #define KEY_SPEC_USER_KEYRING           -4      /* - key ID for UID-specific keyring */
 
-#include <dirent.h>
-#include <stdarg.h>
-#include <sys/syscall.h>
-
 #endif
 
-#include <boost/thread.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/range.hpp>
-#include <boost/algorithm/string/replace.hpp>
-#include <boost/algorithm/string/split.hpp>
+#include <boost/range/as_array.hpp>
+#include <boost/scope_exit.hpp>
+#include <boost/thread.hpp>
 
 #include <shared_core/SafeConvert.hpp>
 #include <shared_core/Error.hpp>

--- a/src/cpp/ext/CMakeLists.txt
+++ b/src/cpp/ext/CMakeLists.txt
@@ -16,6 +16,10 @@
 include(ExternalProject)
 include(FetchContent)
 
+cmake_policy(SET CMP0048 NEW)
+set(FETCHCONTENT_QUIET TRUE)
+set(CMAKE_WARN_DEPRECATED FALSE)
+
 #
 # Declare an external dependency.
 #
@@ -92,6 +96,8 @@ dependency(FMT
    REPOSITORY "https://github.com/fmtlib/fmt"
    REVISION   "123913715afeb8a437e6388b4473fcc4753e1c9a" # pragma: allowlist secret
 )
+
+set(FMT_INSTALL OFF)
 
 
 # gsl-lite
@@ -186,7 +192,9 @@ function(fetch)
       list(GET ARGV ${_INDEX1} _PREFIX)
 
       if(${_PREFIX}_ENABLED AND NOT RSTUDIO_USE_SYSTEM_${_PREFIX})
+         message(STATUS "Fetching dependency ${_NAME} ${${_PREFIX}_VERSION}")
          FetchContent_MakeAvailable("${_NAME}")
+         message(STATUS "Fetching dependency ${_NAME} ${${_PREFIX}_VERSION} - success")
          set("${_PREFIX}_SOURCE_DIR" "${CMAKE_BINARY_DIR}/_deps/${_NAME}-src" CACHE INTERNAL "")
          set("${_PREFIX}_BINARY_DIR" "${CMAKE_BINARY_DIR}/_deps/${_NAME}-build" CACHE INTERNAL "")
       endif()


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15801.

### Approach

Use an alternate, safer macOS API when testing if a `wchar_t` maps to an alphanumeric Unicode code point.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15801.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
