### PR TITLE
tweaks for rtools installation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 - RStudio for Windows binaries now have digital signatures. (rstudio-pro#5772)
 - RStudio now only writes the ProjectId field within a project's `.Rproj` file when required. Currently, this is for users who have configured a custom `.Rproj.user` location.
 - Added memory limit monitoring to RStudio (Linux only for now). If `ulimit -m` is set, this limit is displayed in the Memory Usage Report. As the limit is approached, a warning is displayed, then an error when the limit is reached. When the system is low on memory, the session can abort itself by shutting down in a controlled way with a dialog to the user. See the new `"allow-over-limit-sessions` option in rsession.conf. (rstudio-pro#5019).
+- RStudio now supports installation of Rtools45 for the upcoming R 4.5.0 release on Windows.
 
 #### Posit Workbench
 - Changed memory limit enforcement of `/etc/rstudio/profiles` `max-memory-mb` setting from limiting virtual memory (`ulimit -v`) to resident memory (`ulimit -m`) for more accuracy. This allows a session to run quarto 1.6, which uses a lot of virtual memory due to its underlying virtual machine. Unfortunately, resident memory is only enforceable at the kernel level in Linux versions that support cgroups. To make up for the loss of kernel enforcement, RStudio warns the user and stops over limit sessions. For more robust kernel enforcement, configure memory limits in the Job Launcher using cgroups (rstudio-pro#5019).
@@ -44,6 +45,7 @@
 - Update NO_PROXY domain filter to be less restrictive and allow for expressions like `.local` and `.sub.example.local` (#15607)
 - Fixed an issue where Copilot support on Apple Silicon Macs was running via Rosetta2 instead of natively. (#14156)
 - Fixed an issue where documents could open very slowly when many tabs were already open. (#15767)
+- Fixed an issue where the download of Rtools44 could fail when using Posit Package Manager as the default R package repository. (#15803)
 
 #### Posit Workbench
 - Fixed an issue where uploading a file to a directory containing an '&' character could fail. (#6830)

--- a/src/cpp/session/modules/build/SessionInstallRtools.R
+++ b/src/cpp/session/modules/build/SessionInstallRtools.R
@@ -16,15 +16,28 @@
 .rs.addFunction("findRtoolsInstaller", function(version, url)
 {
    tryCatch(
-      .rs.findRtoolsInstallerImpl(url),
+      .rs.findRtoolsInstallerImpl(url, version),
       error = function(cnd) {
          .rs.findRtoolsInstallerFallback(version)
       }
    )
 })
 
-.rs.addFunction("findRtoolsInstallerImpl", function(url)
+.rs.addFunction("findRtoolsInstallerImpl", function(url, version)
 {
+   # check whether the URL selected is associated with a CRAN mirror;
+   # if not, select a "real" CRAN mirror instead
+   mirrors <- utils::getCRANmirrors(local.only = TRUE)$URL
+   matches <- vapply(mirrors, function(mirror) {
+      .rs.startsWith(url, mirror)
+   }, FUN.VALUE = logical(1))
+   
+   if (!any(matches)) {
+      fmt <- "https://cloud.r-project.org/bin/windows/Rtools/rtools%s/rtools.html"
+      shortVersion <- gsub(".", "", version, fixed = TRUE)
+      url <- sprintf(fmt, shortVersion)
+   }
+   
    # download contents of home page
    destfile <- tempfile("rtools-home-", fileext = ".html")
    download.file(url, destfile, mode = "wb", quiet = TRUE)
@@ -49,7 +62,11 @@
 
 .rs.addFunction("findRtoolsInstallerFallback", function(version)
 {
-   if (version == "4.4")
+   if (version == "4.5")
+   {
+      "https://rstudio.org/links/rtools45"
+   }
+   else if (version == "4.4")
    {
       "https://rstudio.org/links/rtools44"
    }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15803.

### Approach

- If the current repository doesn't appear to be an actual CRAN mirror, then fall back to the default cloud mirror.
- Add links for rtools44 and rtools45 installers. Those have been uploaded.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15803.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
