### PR TITLE
add newline to rlang messages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@
 - Fixed an issue where Copilot support on Apple Silicon Macs was running via Rosetta2 instead of natively. (#14156)
 - Fixed an issue where documents could open very slowly when many tabs were already open. (#15767)
 - Fixed an issue where the download of Rtools44 could fail when using Posit Package Manager as the default R package repository. (#15803)
+- Fixed an issue where messages produced by `rlang::inform()` were not separated by newlines.
 
 #### Posit Workbench
 - Fixed an issue where uploading a file to a directory containing an '&' character could fail. (#6830)


### PR DESCRIPTION
Fixes an issue where no newline was printed between messages emitted by `rlang::inform()` when executed as part of a Notebook chunk.

## Before

<img width="342" alt="Screenshot 2025-03-21 at 11 12 47 AM" src="https://github.com/user-attachments/assets/6577ccea-3ba2-4733-9291-de7ecf0d3aca" />

## After

<img width="352" alt="Screenshot 2025-03-21 at 11 13 05 AM" src="https://github.com/user-attachments/assets/d1ba8601-19a3-4bb8-a8c8-8e9ab7f8ccac" />
