### PR TITLE
trailing comma so pro build doesn't have a syntax error

### DIFF
--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -749,8 +749,10 @@ export function getDesktopBridge() {
 
     getPathForFile: (file: any) => {
       return webUtils.getPathForFile(file);
-    }
+    },
 
+    // Important: be sure last item above has a trailing commma since the pro
+    // branch will add additional items below.
     // pro-only start
 
     // pro-only end


### PR DESCRIPTION
### Intent

Fix build break in desktop pro (i.e. after this gets merged to pro).

