### PR TITLE
Companion to pro support for improvements to PAM auth

### DIFF
--- a/src/cpp/core/json/JsonRpc.cpp
+++ b/src/cpp/core/json/JsonRpc.cpp
@@ -457,7 +457,7 @@ std::string JsonRpcErrorCategory::message( int ev ) const
          return "The maximum amount of concurrent users for this license has been reached";
 
       case errc::LaunchParametersMissing:
-         return "Launch parameters for launcher session missing and should be resent";
+         return "Launch parameters for launcher session are missing";
 
       case errc::LimitSessionsReached:
          return "The maximum amount of concurrent session allowed for the user profile has been reached";

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -35,6 +35,7 @@
 #include <uuid/uuid.h>
 
 #include <shared_core/system/PosixSystem.hpp>
+#include <shared_core/system/SyslogDestination.hpp>
 
 #ifdef __APPLE__
 #include <gsl/gsl-lite.hpp>
@@ -2274,14 +2275,16 @@ Error launchChildProcess(std::string path,
       if (::setpgid(0,0) == -1)
       {
          Error error = systemError(errno, ERROR_LOCATION);
-         LOG_ERROR(error);
+         // Use safe logger in 'after fork before exec'
+         safeLogToSyslog(path, log::LogLevel::ERR, error.asString());
          ::exit(EXIT_FAILURE);
       }
 
       Error error = runProcess(path, runAsUser, config, configFilter);
       if (error)
       {
-         LOG_ERROR(error);
+         // Use safe logger in 'after fork before exec'
+         safeLogToSyslog(path, log::LogLevel::ERR, error.asString());
          ::exit(EXIT_FAILURE);
       }
    }

--- a/src/cpp/shared_core/include/shared_core/system/SyslogDestination.hpp
+++ b/src/cpp/shared_core/include/shared_core/system/SyslogDestination.hpp
@@ -32,6 +32,11 @@ namespace rstudio {
 namespace core {
 namespace system {
 
+void safeLogToSyslog(
+   const std::string& in_programId,
+   log::LogLevel in_logLevel,
+   const std::string& in_message);
+
 /**
  * @brief A class which logs messages to syslog.
  *

--- a/src/cpp/shared_core/system/SyslogDestination.cpp
+++ b/src/cpp/shared_core/system/SyslogDestination.cpp
@@ -127,6 +127,21 @@ void SyslogDestination::writeLog(
       std::cerr << in_message;
 }
 
+/*
+ * Safer logging that goes directly to syslog on unix. Use this api to log errors after fork,
+ * before exec when the main logging system is not reliable, or before logging has been
+ * initialized.
+ */
+void safeLogToSyslog(
+   const std::string& in_programId,
+   log::LogLevel in_logLevel,
+   const std::string& in_message)
+{
+   ::openlog(in_programId.c_str(), LOG_CONS | LOG_PID, LOG_USER);
+   ::syslog(logLevelToLogPriority(in_logLevel), "%s", in_message.c_str());
+   ::closelog();
+}
+
 } // namespace system
 } // namespace core
 } // namespace rstudio


### PR DESCRIPTION
Companion to: https://github.com/rstudio/rstudio-pro/pull/7456

Includes a "safeLogToSyslog" message for linux - used for situations you need to log an error when the logging system is not available, e.g. after the fork, before the exec, or before the log has been initialized.


