### PR TITLE
Use workspace/didChangeConfiguration notification to set GitHub Copilot Proxy and auth server settings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 - RStudio for Windows binaries now have digital signatures. (rstudio-pro#5772)
 - RStudio now only writes the ProjectId field within a project's `.Rproj` file when required. Currently, this is for users who have configured a custom `.Rproj.user` location.
 - Added memory limit monitoring to RStudio (Linux only for now). If `ulimit -m` is set, this limit is displayed in the Memory Usage Report. As the limit is approached, a warning is displayed, then an error when the limit is reached. When the system is low on memory, the session can abort itself by shutting down in a controlled way with a dialog to the user. See the new `"allow-over-limit-sessions` option in rsession.conf. (rstudio-pro#5019).
+- RStudio now supports configuring a Kerberos Service Principal for the GitHub Copilot Language Server proxy settings. (#15823)
 - RStudio now supports installation of Rtools45 for the upcoming R 4.5.0 release on Windows.
 
 #### Posit Workbench

--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -456,6 +456,9 @@ protected:
       ("copilot-auth-provider",
       value<std::string>(&copilotAuthProvider_)->default_value(""),
       "The URL to the authentication provider to be used by GitHub Copilot.")
+      ("copilot-proxy-kerberos-service-principal",
+      value<std::string>(&copilotProxyKerberosPrincipal_)->default_value(""),
+      "The Kerberos service principal to use for authenticating GitHub Copilot with the proxy.")
       ("copilot-ssl-certificates-file",
       value<std::string>(&copilotSslCertificatesFile_)->default_value(""),
       "The path to a file containing one or more trusted certificates in PEM format.")
@@ -595,6 +598,7 @@ public:
    bool copilotEnabled() const { return copilotEnabled_; }
    std::string copilotProxyUrl() const { return copilotProxyUrl_; }
    std::string copilotAuthProvider() const { return copilotAuthProvider_; }
+   std::string copilotProxyKerberosPrincipal() const { return copilotProxyKerberosPrincipal_; }
    std::string copilotSslCertificatesFile() const { return copilotSslCertificatesFile_; }
    bool copilotProxyStrictSsl() const { return copilotProxyStrictSsl_; }
    core::FilePath deprecatedCopilotAgentHelper() const { return core::FilePath(deprecatedCopilotAgentHelper_); }
@@ -721,6 +725,7 @@ protected:
    bool copilotEnabled_;
    std::string copilotProxyUrl_;
    std::string copilotAuthProvider_;
+   std::string copilotProxyKerberosPrincipal_;
    std::string copilotSslCertificatesFile_;
    bool copilotProxyStrictSsl_;
    std::string deprecatedCopilotAgentHelper_;

--- a/src/cpp/session/modules/SessionCopilot.R
+++ b/src/cpp/session/modules/SessionCopilot.R
@@ -30,8 +30,31 @@
    if (is.null(proxy))
       return(NULL)
  
-   # return as scalar list  
+   # return as scalar list
    .rs.scalarListFromList(proxy)
+})
+
+.rs.addFunction("copilot.authProvider", function()
+{
+   # check for auth provider from option
+   authProvider <- getOption("rstudio.copilot.authProvider")
+   if (is.null(authProvider))
+      return(NULL)
+ 
+   # return as scalar list
+   .rs.scalarListFromList(authProvider)
+})
+
+
+.rs.addFunction("copilot.proxyKerberosServicePrincipal", function()
+{
+   # check for principal from option
+   principal <- getOption("rstudio.copilot.proxyKerberosServicePrincipal")
+   if (is.null(principal))
+      return(NULL)
+ 
+   # return as scalar list
+   .rs.scalarListFromList(principal)
 })
 
 .rs.addFunction("copilot.parseNetworkProxyUrl", function(url)

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -567,7 +567,6 @@ void setConfiguration()
    // if we now have a network proxy definition, log it
    if (!proxyUrl.empty())
    {
-      json::Value networkProxy;
       SEXP networkProxySEXP = R_NilValue;
 
       // parse the URL into its associated components for logging
@@ -578,6 +577,27 @@ void setConfiguration()
       {
          proxyUrl.clear();
          LOG_ERROR(error);
+      }
+      if (networkProxySEXP != R_NilValue)
+      {
+         json::Value networkProxy;
+         Error error = r::json::jsonValueFromObject(networkProxySEXP, &networkProxy);
+         if (error)
+            LOG_ERROR(error);
+         if (networkProxy.isObject())
+         {
+            json::Object networkProxyJson = networkProxy.getObject();
+
+            if (s_copilotLogLevel > 0)
+            {
+               json::Object networkProxyClone = networkProxyJson.clone().getObject();
+               if (networkProxyClone.hasMember("user"))
+                  networkProxyClone["user"] = "<user>";
+               if (networkProxyClone.hasMember("pass"))
+                  networkProxyClone["pass"] = "<pass>";
+               DLOG("Using network proxy: {}", networkProxyClone.writeFormatted());
+            }
+         }
       }
    }
    

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -530,20 +530,14 @@ json::Object sendSynchronousRequest(const std::string& method,
    return result;
 }
 
-void setEditorInfo()
+void setConfiguration()
 {
    json::Object paramsJson;
-   
-   json::Object editorInfoJson;
-   editorInfoJson["name"] = "RStudio";
-   editorInfoJson["version"] = RSTUDIO_VERSION;
-   paramsJson["editorInfo"] = editorInfoJson;
-   paramsJson["editorPluginInfo"] = editorInfoJson;
+   json::Object settingsJson;
    
    // network proxy settings 
    r::sexp::Protect protect;
-   SEXP networkProxySEXP = R_NilValue;
-      
+   
    // check strict ssl flag
    bool proxyStrictSsl = session::options().copilotProxyStrictSsl();
    
@@ -560,86 +554,92 @@ void setEditorInfo()
    if (!proxyUrlOverride.empty())
       proxyUrl = proxyUrlOverride;
    
-   // if we have one now, try to parse it
+   // if the network proxy isn't set, try reading a fallback from R
+   if (proxyUrl.empty())
+   {
+      SEXP networkProxySEXP = R_NilValue;
+      Error error = r::exec::RFunction(".rs.copilot.networkProxy").call(&networkProxySEXP, &protect);
+      if (error)
+         LOG_ERROR(error);
+      proxyUrl = networkProxySEXP == R_NilValue ? "" : r::sexp::asString(networkProxySEXP);
+   }
+
+   // if we now have a network proxy definition, log it
    if (!proxyUrl.empty())
    {
-      // parse the URL into its associated components
+      json::Value networkProxy;
+      SEXP networkProxySEXP = R_NilValue;
+
+      // parse the URL into its associated components for logging
       Error error = r::exec::RFunction(".rs.copilot.parseNetworkProxyUrl")
             .addUtf8Param(proxyUrl)
             .call(&networkProxySEXP, &protect);
       if (error)
+      {
+         proxyUrl.clear();
          LOG_ERROR(error);
+      }
    }
    
-   // if the network proxy isn't set, try reading a fallback from R
-   if (networkProxySEXP == R_NilValue)
+   // if we have a network proxy, add it to the configuration
+   if (!proxyUrl.empty())
    {
-      Error error = r::exec::RFunction(".rs.copilot.networkProxy").call(&networkProxySEXP, &protect);
-      if (error)
-         LOG_ERROR(error);
-   }
+      // check for proxy Kerberos service principal setting
+      std::string kerberosPrincipal = session::options().copilotProxyKerberosPrincipal();
 
-   // if we now have a network proxy definition, use it
-   if (networkProxySEXP != R_NilValue)
-   {
-      json::Value networkProxy;
-      Error error = r::json::jsonValueFromObject(networkProxySEXP, &networkProxy);
-      if (error)
-         LOG_ERROR(error);
+      // allow override from envvar
+      std::string kerberosPrincipalOverride = core::system::getenv("COPILOT_PROXY_KERBEROS_SERVICE_PRINCIPAL");
+      if (!kerberosPrincipalOverride.empty())
+         kerberosPrincipal = kerberosPrincipalOverride;
 
-      if (networkProxy.isObject())
+      // if the principal isn't set, try reading a fallback from R
+      if (kerberosPrincipal.empty())
       {
-         json::Object networkProxyJson = networkProxy.getObject();
-         
-         if (s_copilotLogLevel > 0)
-         {
-            json::Object networkProxyClone = networkProxyJson.clone().getObject();
-            if (networkProxyClone.hasMember("user"))
-               networkProxyClone["user"] = "<user>";
-            if (networkProxyClone.hasMember("pass"))
-               networkProxyClone["pass"] = "<pass>";
-            DLOG("Using network proxy: {}", networkProxyClone.writeFormatted());
-         }
-         
-         networkProxyJson["rejectUnauthorized"] = proxyStrictSsl;
-         paramsJson["networkProxy"] = networkProxyJson.getObject();
+         SEXP kerberosPrincipalSEXP = R_NilValue;
+         Error error = r::exec::RFunction(".rs.copilot.proxyKerberosServicePrincipal").call(&kerberosPrincipalSEXP, &protect);
+         if (error)
+            LOG_ERROR(error);
+         kerberosPrincipal = kerberosPrincipalSEXP == R_NilValue ? "" : r::sexp::asString(kerberosPrincipalSEXP);
       }
+      
+      json::Object httpParamsJson;
+      httpParamsJson["proxy"] = proxyUrl;
+      httpParamsJson["proxyStrictSSL"] = proxyStrictSsl;
+      if (!kerberosPrincipal.empty())
+         httpParamsJson["proxyKerberosServicePrincipal"] = kerberosPrincipal;
+      settingsJson["http"] = httpParamsJson;
    }
    
    // check for authentication provider
    std::string authProviderUrl = session::options().copilotAuthProvider();
+   
+   // allow override from envvar
+   std::string authProviderUrlOverride = core::system::getenv("COPILOT_AUTH_PROVIDER");
+   if (!authProviderUrlOverride.empty())
+      authProviderUrl = authProviderUrlOverride;
+   
    if (authProviderUrl.empty())
-      authProviderUrl = core::system::getenv("COPILOT_AUTH_PROVIDER");
+   {
+      // check for authentication provider configuration from R
+      SEXP authProviderSEXP = R_NilValue;
+      Error error = r::exec::RFunction(".rs.copilot.authProvider").call(&authProviderSEXP, &protect); 
+      if (error)
+         LOG_ERROR(error);
+      authProviderUrl = authProviderSEXP == R_NilValue ? "" : r::sexp::asString(authProviderSEXP);
+   }
    
    if (!authProviderUrl.empty())
    {
-      json::Object authProviderJson;
-      authProviderJson["url"] = authProviderUrl;
+      json::Object githubEnterpriseJson;
+      githubEnterpriseJson["uri"] = authProviderUrl;
       
-      DLOG("Using authentication provider: {}", authProviderJson.writeFormatted());
-      paramsJson["authProvider"] = authProviderJson;
+      DLOG("Using github-enterprise authentication provider: {}", githubEnterpriseJson.writeFormatted());
+      settingsJson["github-enterprise"] = githubEnterpriseJson;
    }
-   else
-   {
-      // check for authentication provider configuration from R
-      SEXP authProviderSEXP = r::options::getOption("rstudio.copilot.authProvider");
-      if (authProviderSEXP != R_NilValue)
-      {
-         json::Value authProviderJson;
-         Error error = r::json::jsonValueFromObject(authProviderSEXP, &authProviderJson);
-         if (error)
-            LOG_ERROR(error);
-
-         if (authProviderJson.isObject())
-         {
-            DLOG("Using authentication provider: {}", authProviderJson.writeFormatted());
-            paramsJson["authProvider"] = authProviderJson.getObject();
-         }
-      }
-   }
-   
+  
+   paramsJson["settings"] = settingsJson;
    std::string requestId = core::system::generateUuid();
-   sendRequest("setEditorInfo", requestId, paramsJson, CopilotContinuation());
+   sendNotification("workspace/didChangeConfiguration", paramsJson);
 }
 
 namespace agent {
@@ -685,7 +685,7 @@ bool onContinue(ProcessOperations& operations)
          bool isInitMethod =
                request.method == "initialize" ||
                request.method == "initialized" ||
-               request.method == "setEditorInfo";
+               request.method == "workspace/didChangeConfiguration";
          
          if (!isInitMethod)
             return false;
@@ -932,11 +932,15 @@ Error startAgent()
    json::Object clientInfoJson;
    clientInfoJson["name"] = "RStudio";
    clientInfoJson["version"] = RSTUDIO_VERSION;
-
+   
+   json::Object initializationOptionsJson;
+   initializationOptionsJson["editorInfo"] = clientInfoJson;
+   initializationOptionsJson["editorPluginInfo"] = clientInfoJson;
+   
    json::Object paramsJson;
    paramsJson["processId"] = ::getpid();
    paramsJson["locale"] = prefs::userPrefs().uiLanguage();
-   paramsJson["clientInfo"] = clientInfoJson;
+   paramsJson["initializationOptions"] = initializationOptionsJson;
    paramsJson["capabilities"] = json::Object();
    
    // set up continuation after we've finished initializing
@@ -951,7 +955,7 @@ Error startAgent()
       // newer versions of Copilot require an 'initialized' notification, which is
       // then used as a signal that they should start the agent process
       sendNotification("initialized", json::Object());
-      setEditorInfo();
+      setConfiguration();
    };
    
    std::string requestId = core::system::generateUuid();

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -930,6 +930,13 @@
             "description": "The URL to the authentication provider to be used by GitHub Copilot."
          },
          {
+            "name": "copilot-proxy-kerberos-service-principal",
+            "type": "string",
+            "memberName": "copilotProxyKerberosPrincipal_",
+            "defaultValue": "",
+            "description": "The Kerberos service principal to use for authenticating GitHub Copilot with the proxy."
+         },
+         {
             "name": "copilot-ssl-certificates-file",
             "type": "string",
             "memberName": "copilotSslCertificatesFile_",


### PR DESCRIPTION
### Intent

Addresses #15823

### Approach

Use the recommended approach (`workspace/didChangeConfiguration`) for setting proxy information (and github-enterprise server URL) instead of the deprecated `setEditorInfo` message. See the issue for details on what the new message (json) looks like.

As part of this change I added the option for setting a Kerberos Service Principal value for GitHub Copilot proxy settings. This defaults to blank, but a string value can be set with one of:

- `COPILOT_PROXY_KERBEROS_SERVICE_PRINCIPAL` (environment variable)
- `copilot-proxy-kerberos-service-principal` (rsession.conf setting)
- `rstudio.copilot.proxyKerberosServicePrincipal` (R option)

I also tweaked the Copilot logging macros to avoid name clashes with "message" and "formatted", and added debug-level logging of messages sent by Copilot via the `logMessage` callback.

### Automated Tests

No new tests added.

### QA Notes

See the issue.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


