### PR TITLE
[DOC] Backport - Updating release notes with previous configuration values

### DIFF
--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -195,7 +195,7 @@ If running Workbench behind a proxy server, you may need to update your `NO_PROX
 - HTTP Proxy variables are now supported in rserver and rsession, so it's important to include local addresses to Job Launcher sessions and other internal services in your `NO_PROXY` list.
 - See the [Outgoing Proxies](https://docs.posit.co/ide/server-pro/access_and_security/outgoing_proxies.html) section of the Posit Workbench Administration Guide for more information. (rstudio-pro#5893)
 
-You may also want to update the following configuration entries, as the default values have changed: <i class="bi bi-info-circle-fill" title="Documentation change since last release/patch."></i>
+You may also want to update the following configuration entries, as the default values have changed:
 
    | Configuration entry | Previous default value | New default value | Reference |
    |-------------------- | ---------------------- | ------------------ | -----------|

--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -121,7 +121,6 @@ This page provides the release notes associated with each release of RStudio and
 - Re-designed the user experience for configuring managed credentials (rstudio-pro#6748)
 - Added support for using Azure delegated credentials to access DevOps repositories (rstudio-pro#6734)
 - Improved the database migration experience with additional feedback to the admin, logging, and potential error handling (rstudio-pro#6674)
-- Increased default values for `rsession-proxy-max-wait-secs` and `www-thread-pool-size` (rstudio-pro#6149)
 - Improved diagnostics for the license manager (rstudio-pro#5932)
 - Added support for reloading the Launcher through systemd (rstudio-pro#3749)
 - Added support for a configurable auth (SAML/OpenID) username re-write rule (rstudio-pro#6987)
@@ -195,6 +194,13 @@ If running Workbench behind a proxy server, you may need to update your `NO_PROX
 
 - HTTP Proxy variables are now supported in rserver and rsession, so it's important to include local addresses to Job Launcher sessions and other internal services in your `NO_PROXY` list.
 - See the [Outgoing Proxies](https://docs.posit.co/ide/server-pro/access_and_security/outgoing_proxies.html) section of the Posit Workbench Administration Guide for more information. (rstudio-pro#5893)
+
+You may also want to update the following configuration entries, as the default values have changed: <i class="bi bi-info-circle-fill" title="Documentation change since last release/patch."></i>
+
+   | Configuration entry | Previous default value | New default value | Reference |
+   |-------------------- | ---------------------- | ------------------ | -----------|
+   | `rsession-proxy-max-wait-secs` | 10 | 30| (rstudio-pro#6149) |
+   | `www-thread-pool-size` | 2 | 6 | (rstudio-pro#6149) |
 
 ### Dependencies
 - Updated GWT to version 2.10.1. (#15011)

--- a/version/news/NEWS-2024.12.0-kousa-dogwood.md
+++ b/version/news/NEWS-2024.12.0-kousa-dogwood.md
@@ -123,7 +123,7 @@ If running Workbench behind a proxy server, you may need to update your `NO_PROX
 - HTTP Proxy variables are now supported in rserver and rsession, so it's important to include local addresses to Job Launcher sessions and other internal services in your `NO_PROXY` list.
 - See the [Outgoing Proxies](https://docs.posit.co/ide/server-pro/access_and_security/outgoing_proxies.html) section of the Posit Workbench Administration Guide for more information. (rstudio-pro#5893)
 
-You may also want to update the following configuration entries, as the default values have changed: <i class="bi bi-info-circle-fill" title="Documentation change since last release/patch."></i>
+You may also want to update the following configuration entries, as the default values have changed: 
 
    | Configuration entry | Previous default value | New default value | Reference |
    |-------------------- | ---------------------- | ------------------ | -----------|

--- a/version/news/NEWS-2024.12.0-kousa-dogwood.md
+++ b/version/news/NEWS-2024.12.0-kousa-dogwood.md
@@ -49,7 +49,6 @@
 - Re-designed the user experience for configuring managed credentials (rstudio-pro#6748)
 - Added support for using Azure delegated credentials to access DevOps repositories (rstudio-pro#6734)
 - Improved the database migration experience with additional feedback to the admin, logging, and potential error handling (rstudio-pro#6674)
-- Increased default values for `rsession-proxy-max-wait-secs` and `www-thread-pool-size` (rstudio-pro#6149)
 - Improved diagnostics for the license manager (rstudio-pro#5932)
 - Added support for reloading the Launcher through systemd (rstudio-pro#3749)
 - Added support for a configurable auth (SAML/OpenID) username re-write rule (rstudio-pro#6987)
@@ -123,6 +122,13 @@ If running Workbench behind a proxy server, you may need to update your `NO_PROX
 
 - HTTP Proxy variables are now supported in rserver and rsession, so it's important to include local addresses to Job Launcher sessions and other internal services in your `NO_PROXY` list.
 - See the [Outgoing Proxies](https://docs.posit.co/ide/server-pro/access_and_security/outgoing_proxies.html) section of the Posit Workbench Administration Guide for more information. (rstudio-pro#5893)
+
+You may also want to update the following configuration entries, as the default values have changed: <i class="bi bi-info-circle-fill" title="Documentation change since last release/patch."></i>
+
+   | Configuration entry | Previous default value | New default value | Reference |
+   |-------------------- | ---------------------- | ------------------ | -----------|
+   | `rsession-proxy-max-wait-secs` | 10 | 30| (rstudio-pro#6149) |
+   | `www-thread-pool-size` | 2 | 6 | (rstudio-pro#6149) |
 
 ### Dependencies
 - Updated GWT to version 2.10.1. (#15011)


### PR DESCRIPTION
### Intent

Related to: [`rstudio-pro` #7709](https://github.com/rstudio/rstudio-pro/issues/7709)

- adds table to show previous configuration values
- moves information on configuration values into Upgrade section

### Approach

Can move the content (back) to the New - Workbench section if deemed more appropriate. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

Built locally

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


