### PR TITLE
more robust newline trimming implementation

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
+++ b/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
@@ -164,11 +164,19 @@ public class ConsoleOutputWriter
          return virtualConsole_.getNewElements();
    }
 
+   public void normalizePreviousOutput()
+   {
+      if (virtualConsole_ != null)
+      {
+         virtualConsole_.normalizePreviousOutput();
+      }
+   }
+   
    public void ensureStartingOnNewLine()
    {
       if (virtualConsole_ != null)
       {
-          virtualConsole_.ensureStartingOnNewLine();
+         virtualConsole_.ensureStartingOnNewLine();
 
          // clear the virtual console so we start with a fresh slate
          virtualConsole_ = null;

--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -408,6 +408,21 @@ public class VirtualConsole
       
       if (forceNewRange)
       {
+         // normalize previous bit of output if it was a chunk
+         if (parent_ != null)
+         {
+            Node lastChildNode = parent_.getLastChild();
+            if (Element.is(lastChildNode))
+            {
+               Element lastChildEl = Element.as(lastChildNode);
+               if (lastChildEl.hasClassName(RES.styles().group()))
+               {
+                  trimLeadingNewlines(lastChildEl);
+                  trimTrailingNewlines(lastChildEl);
+               }
+            }
+         }
+         
          // create a new output range with this class
          final ClassRange newRange = new ClassRange(cursor_, clazz, text, preserveHTML_, hyperlink_);
          appendChild(newRange.element);
@@ -987,6 +1002,55 @@ public class VirtualConsole
       return (ansiColorMode_ == UserPrefs.ANSI_CONSOLE_MODE_OFF)
          ? CONTROL.match(data, offset)
          : AnsiCode.CONTROL_PATTERN.match(data, offset);
+   }
+   
+   public void normalizePreviousOutput()
+   {
+      if (parent_ == null)
+         return;
+      
+      Node childNode = parent_.getLastChild();
+      if (!Element.is(childNode))
+         return;
+      
+      Element childEl = Element.as(childNode);
+      if (!childEl.hasClassName(RES.styles().group()))
+         return;
+      
+      trimLeadingNewlines(childEl);
+      trimTrailingNewlines(childEl);
+   }
+   
+   private void trimLeadingNewlines(Element childEl)
+   {
+      Node firstChildNode = childEl.getFirstChild();
+      while (firstChildNode.getNodeType() != Node.TEXT_NODE)
+      {
+         firstChildNode = firstChildNode.getFirstChild();
+         if (firstChildNode == null)
+         {
+            return;
+         }
+      }
+ 
+      firstChildNode.setNodeValue(
+            firstChildNode.getNodeValue().replaceFirst("^\\n+", ""));
+   }
+   
+   private void trimTrailingNewlines(Element childEl)
+   {
+      Node lastChildNode = childEl.getLastChild();
+      while (lastChildNode.getNodeType() != Node.TEXT_NODE)
+      {
+         lastChildNode = lastChildNode.getLastChild();
+         if (lastChildNode == null)
+         {
+            return;
+         }
+      }
+ 
+      lastChildNode.setNodeValue(
+            lastChildNode.getNodeValue().replaceFirst("\\n+$", ""));
    }
 
    // Elements added by last submit call; only captured if forceNewRange was true

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -23,13 +23,11 @@ import org.rstudio.core.client.ConsoleOutputWriter;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.TimeBufferedCommand;
-import org.rstudio.core.client.Version;
 import org.rstudio.core.client.VirtualConsole;
 import org.rstudio.core.client.dom.DOMRect;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.jsonrpc.RpcObjectList;
-import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.core.client.widget.BottomScrollPanel;
 import org.rstudio.core.client.widget.FontSizer;
 import org.rstudio.core.client.widget.PreWidget;
@@ -40,12 +38,9 @@ import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.debugging.model.UnhandledError;
 import org.rstudio.studio.client.common.debugging.ui.ConsoleError;
-import org.rstudio.studio.client.workbench.events.SessionInitEvent;
 import org.rstudio.studio.client.workbench.model.ConsoleAction;
 import org.rstudio.studio.client.workbench.model.Session;
-import org.rstudio.studio.client.workbench.model.SessionInfo;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
-import org.rstudio.studio.client.workbench.prefs.model.UserPrefsAccessor;
 import org.rstudio.studio.client.workbench.prefs.model.UserState;
 import org.rstudio.studio.client.workbench.views.console.ConsoleResources;
 import org.rstudio.studio.client.workbench.views.console.events.RunCommandWithDebugEvent;
@@ -54,17 +49,14 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor;
 import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor.NewLineMode;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Renderer;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.CursorChangedEvent;
-import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorThemeChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.PasteEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.RenderFinishedEvent;
-import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceTheme;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.RepeatingCommand;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
-import com.google.gwt.dom.client.Node;
 import com.google.gwt.dom.client.SpanElement;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.BlurEvent;
@@ -570,6 +562,8 @@ public class ShellWidget extends Composite implements ShellDisplay,
 
       input_.setPasswordMode(!showInput);
       clearErrors_ = true;
+      
+      output_.normalizePreviousOutput();
       output_.ensureStartingOnNewLine();
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/ShellPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/ShellPane.java
@@ -19,8 +19,10 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.ui.*;
 import com.google.inject.Inject;
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.Debug;
 import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.common.console.ConsolePromptEvent;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.shell.ShellWidget;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
@@ -37,6 +39,7 @@ public class ShellPane extends ShellWidget implements Shell.Display
       editor.setDisableOverwrite(true);
 
       editor.setFileType(FileTypeRegistry.R, true);
+      
       // Setting file type to R changes the wrap mode to false. We want it to
       // be true so that the console input can wrap.
       editor.setUseWrapMode(true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -384,8 +384,10 @@ public class ChunkOutputStream extends FlowPanel
    public void clearOutput()
    {
       clear();
+      
       if (vconsole_ != null)
          vconsole_.clear();
+      
       lastOutputType_ = RmdChunkOutputUnit.TYPE_NONE;
    }
 
@@ -394,6 +396,11 @@ public class ChunkOutputStream extends FlowPanel
    {
       // flush any remaining queued errors
       flushQueuedErrors();
+      
+      // normalize outputs
+      vconsole_.normalizePreviousOutput();
+      
+      // reset last output types
       lastOutputType_ = RmdChunkOutputUnit.TYPE_NONE;
    }
    
@@ -794,6 +801,11 @@ public class ChunkOutputStream extends FlowPanel
          }
       }
       return 0;
+   }
+   
+   private void normalizeOutput()
+   {
+      vconsole_.normalizePreviousOutput();
    }
    
    private final ChunkOutputPresenter.Host host_;


### PR DESCRIPTION
### Intent

In R, users will often emit leading and trailing newlines for certain outputs (e.g. messages) to help make them visually distinct from other pieces of output. Because we're now managing that sort of display ourselves via sections for output in the console, we can trim those leading + trailing newlines.

### Approach

We now clean up newlines within a section when:

- A new type of console output is started;
- Execution is finished (e.g. for an R Markdown chunk),
- The console prompt is displayed.

Each of the above signals that the previous section is "complete" and cannot be re-opened, and so it's an opportunity for us to normalize its output.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
