### PR TITLE
fix issue with duplicated restart message

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -41,6 +41,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/join.hpp>
 
+#include <core/AnsiEscapes.hpp>
 #include <core/CrashHandler.hpp>
 #include <core/BoostSignals.hpp>
 #include <core/BoostThread.hpp>
@@ -360,7 +361,17 @@ Error bufferConsoleInput(const core::json::JsonRpcRequest& request,
 
 void doSuspendForRestart(const rstudio::r::session::RSuspendOptions& options)
 {
-   module_context::consoleWriteOutput("\nRestarting R session...\n\n");
+   std::string message;
+   if (prefs::userPrefs().consoleHighlightConditions() == kConsoleHighlightConditionsErrorsWarningsMessages)
+   {
+      message = kAnsiEscapeGroupStartMessage "Restarting R session..." kAnsiEscapeGroupEnd;
+   }
+   else
+   {
+      message = "\nRestarting R session...\n\n";
+   }
+
+   module_context::consoleWriteOutput(message);
    rstudio::r::session::suspendForRestart(options);
 }
 

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2215,34 +2215,18 @@ void consoleWriteOutput(const std::string& output)
 {
    // NOTE: all actions herein must be threadsafe! (see comment above)
 
-   // add console action
-   r::session::consoleActions().add(kConsoleActionOutput, output);
-
    // enque write output (same as session::rConsoleWrite)
    ClientEvent event(client_events::kConsoleWriteOutput, output);
    enqueClientEvent(event);
-
-   // fire event
-   module_context::events().onConsoleOutput(
-                                    module_context::ConsoleOutputNormal,
-                                    output);
 }
 
 void consoleWriteError(const std::string& message)
 {
    // NOTE: all actions herein must be threadsafe! (see comment above)
 
-   // add console action
-   r::session::consoleActions().add(kConsoleActionOutputError, message);
-
    // enque write error (same as session::rConsoleWrite)
    ClientEvent event(client_events::kConsoleWriteError, message);
    enqueClientEvent(event);
-
-   // fire event
-   module_context::events().onConsoleOutput(
-                                    module_context::ConsoleOutputError,
-                                    message);
 }
 
 void showErrorMessage(const std::string& title, const std::string& message)


### PR DESCRIPTION
Fixes an issue from the recent condition highlight work. Now that console actions and events are emitted when output is processed in the event queue, we no longer need to fire those events here.

https://github.com/rstudio/rstudio/blob/04820b29de92c83dcb3a863b4dcd37ae0395bee9/src/cpp/session/SessionClientEventQueue.cpp#L438-L453

Also, using this to give a banner to the "Restarting R session..." message.

<img width="282" alt="Screenshot 2025-03-31 at 2 03 44 PM" src="https://github.com/user-attachments/assets/34c8e3a7-20f3-453b-870b-ccafd35c02c0" />