### PR TITLE
enable building with cmake 4.x

### DIFF
--- a/dependencies/common/install-soci
+++ b/dependencies/common/install-soci
@@ -95,6 +95,7 @@ fi
 "${CMAKE}" -G"${CMAKE_GENERATOR}"                      \
    -DCMAKE_POLICY_DEFAULT_CMP0063="NEW"                \
    -DCMAKE_POLICY_DEFAULT_CMP0074="NEW"                \
+   -DCMAKE_POLICY_VERSION_MINIMUM=3.5                  \
    -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true         \
    -DCMAKE_CXX_VISIBILITY_PRESET="$COMPILE_VISIBILITY" \
    -DSOCI_TESTS=OFF                                    \

--- a/src/cpp/ext/CMakeLists.txt
+++ b/src/cpp/ext/CMakeLists.txt
@@ -192,8 +192,19 @@ function(fetch)
       list(GET ARGV ${_INDEX1} _PREFIX)
 
       if(${_PREFIX}_ENABLED AND NOT RSTUDIO_USE_SYSTEM_${_PREFIX})
+         # Set yaml-cpp specific options before making it available
+         if("${_NAME}" STREQUAL "yaml-cpp")
+            set(CMAKE_POLICY_VERSION_MINIMUM "3.5" CACHE STRING "" FORCE)
+         endif()
+         
          message(STATUS "Fetching dependency ${_NAME} ${${_PREFIX}_VERSION}")
          FetchContent_MakeAvailable("${_NAME}")
+         
+         # Reset the policy version after yaml-cpp is configured
+         if("${_NAME}" STREQUAL "yaml-cpp")
+            unset(CMAKE_POLICY_VERSION_MINIMUM CACHE)
+         endif()
+         
          message(STATUS "Fetching dependency ${_NAME} ${${_PREFIX}_VERSION} - success")
          set("${_PREFIX}_SOURCE_DIR" "${CMAKE_BINARY_DIR}/_deps/${_NAME}-src" CACHE INTERNAL "")
          set("${_PREFIX}_BINARY_DIR" "${CMAKE_BINARY_DIR}/_deps/${_NAME}-build" CACHE INTERNAL "")


### PR DESCRIPTION
### Intent

`brew install cmake` is now installing cmake 4.0, which causes some build failures (soci during dependency step, and yaml-cpp during build step).

We should support building even with latest & greatest cmake.

### Approach

Add ` -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ` for SOCI and yaml-cpp, as suggested by cmake's error message.

### Automated Tests

Build-time

### QA Notes

Nothing to test.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


