### PR TITLE
refactoring and fixes for grouped outputs

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -130,6 +130,7 @@ set(SESSION_SOURCE_FILES
    SessionClientEventService.cpp
    SessionClientInit.cpp
    SessionConsoleInput.cpp
+   SessionConsoleOutput.cpp
    SessionConsoleProcess.cpp
    SessionConsoleProcessApi.cpp
    SessionConsoleProcessInfo.cpp

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -214,6 +214,8 @@ const int kSuspendBlocked = 196;
 const int kClipboardAction = 197;
 const int kDeploymentRecordsUpdated = 198;
 const int kRunAutomation = 199;
+const int kConsoleWritePendingError = 200;
+const int kConsoleWritePendingWarning = 201;
 
 }
 
@@ -598,6 +600,10 @@ std::string ClientEvent::typeName() const
          return "deployment_records_updated";
       case client_events::kRunAutomation:
          return "run_automation";
+      case client_events::kConsoleWritePendingError:
+         return "console_write_pending_error";
+      case client_events::kConsoleWritePendingWarning:
+         return "console_write_pending_warning";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/SessionClientEventQueue.hpp
+++ b/src/cpp/session/SessionClientEventQueue.hpp
@@ -43,26 +43,6 @@ private:
    ClientEventQueue();
    friend void initializeClientEventQueue();
    
-   class BufferedOutput : boost::noncopyable
-   {
-      
-   public:
-      BufferedOutput()
-      {
-      }
-      
-      int event() const { return event_; }
-      const std::string& output() const { return output_; }
-
-      void append(const std::string& data) { output_ += data; }
-      void clear() { output_.clear(); }
-      bool empty() const { return output_.empty(); }
-      
-   private:
-      int event_;
-      std::string output_;
-   };
-   
 public:
    // COPYING: boost::noncopyable
      
@@ -98,7 +78,7 @@ private:
 
    void flushAllBufferedOutput();
    void flushAllBufferedOutputExcept(int event);
-   void flushBufferedOutput(BufferedOutput* pOutput);
+   void flushBufferedOutput(int type, std::string* pOutput);
  
 private:
    // synchronization objects. heap based so they are never destructed
@@ -116,7 +96,7 @@ private:
 
    // buffered outputs (required for parts that might overflow)
    // maps event types to their collected outputs
-   std::map<int, BufferedOutput> bufferedOutputs_;
+   std::map<int, std::string> bufferedOutputs_;
 };
 
 } // namespace session

--- a/src/cpp/session/SessionClientEventQueue.hpp
+++ b/src/cpp/session/SessionClientEventQueue.hpp
@@ -32,7 +32,6 @@ namespace session {
    
 // initialization
 void initializeClientEventQueue();
-void finishInitializeClientEventQueue();
 
 // singleton
 class ClientEventQueue;
@@ -96,9 +95,6 @@ public:
    // annotate output
    void annotateOutput(int event, std::string* pOutput);
 
-   // inform the event queue that error output is pending
-   void setErrorOutputPending();
-
    // flush any buffered output
    void flush();
 
@@ -120,11 +116,12 @@ private:
    std::string activeConsole_;
    std::vector<ClientEvent> pendingEvents_;
    boost::posix_time::ptime lastEventAddTime_;
-   bool errorOutputPending_ = false;
 
    // buffered outputs (required for parts that might overflow)
-   BufferedOutput consoleOutput_;
-   BufferedOutput consoleErrors_;
+   BufferedOutput consoleStdout_;
+   BufferedOutput consoleStderr_;
+   BufferedOutput consolePendingErrors_;
+   BufferedOutput consolePendingWarnings_;
    BufferedOutput buildOutput_;
    
    // keep vector of pointers to buffered outputs, just to make

--- a/src/cpp/session/SessionClientEventQueue.hpp
+++ b/src/cpp/session/SessionClientEventQueue.hpp
@@ -47,15 +47,12 @@ private:
    {
       
    public:
-      BufferedOutput(int event, bool useConsoleActionLimit)
-         : event_(event),
-           useConsoleActionLimit_(useConsoleActionLimit)
+      BufferedOutput()
       {
       }
       
-      const std::string& output() const { return output_; }
       int event() const { return event_; }
-      bool useConsoleActionLimit() const { return useConsoleActionLimit_; }
+      const std::string& output() const { return output_; }
 
       void append(const std::string& data) { output_ += data; }
       void clear() { output_.clear(); }
@@ -64,7 +61,6 @@ private:
    private:
       int event_;
       std::string output_;
-      bool useConsoleActionLimit_;
    };
    
 public:
@@ -101,6 +97,7 @@ public:
 private:
 
    void flushAllBufferedOutput();
+   void flushAllBufferedOutputExcept(int event);
    void flushBufferedOutput(BufferedOutput* pOutput);
  
 private:
@@ -118,16 +115,8 @@ private:
    boost::posix_time::ptime lastEventAddTime_;
 
    // buffered outputs (required for parts that might overflow)
-   BufferedOutput consoleStdout_;
-   BufferedOutput consoleStderr_;
-   BufferedOutput consolePendingErrors_;
-   BufferedOutput consolePendingWarnings_;
-   BufferedOutput buildOutput_;
-   
-   // keep vector of pointers to buffered outputs, just to make
-   // iteration easier in places where we need to flush all buffers
-   std::vector<BufferedOutput*> bufferedOutputs_;
-
+   // maps event types to their collected outputs
+   std::map<int, BufferedOutput> bufferedOutputs_;
 };
 
 } // namespace session

--- a/src/cpp/session/SessionConsoleOutput.cpp
+++ b/src/cpp/session/SessionConsoleOutput.cpp
@@ -35,6 +35,10 @@ namespace console_output {
 
 namespace {
 
+#ifndef RSTUDIO_PACKAGE_BUILD
+bool s_simulateLatency;
+#endif
+
 PendingOutputType s_pendingOutputType;
 
 std::atomic<bool> s_isErrorAnnotationEnabled;
@@ -141,6 +145,15 @@ SEXP rs_errorOutputPending()
 
 } // end anonymous namespace
 
+void simulateLatency()
+{
+#ifndef RSTUDIO_PACKAGE_BUILD
+   if (s_simulateLatency)
+   {
+      boost::this_thread::sleep_for(boost::chrono::milliseconds(200));
+   }
+#endif
+}
 
 PendingOutputType getPendingOutputType()
 {
@@ -182,6 +195,11 @@ bool isWarningAnnotationEnabled()
 Error initialize()
 {
    using namespace module_context;
+
+#ifndef RSTUDIO_PACKAGE_BUILD
+   std::string simulateLatency = core::system::getenv("RS_SIMULATE_CONSOLE_LATENCY");
+   s_simulateLatency = core::string_utils::isTruthy(simulateLatency);
+#endif
 
    events().onBusy.connect(onBusy);
    events().onConsoleOutputReceived.connect(onConsoleOutputReceived);

--- a/src/cpp/session/SessionConsoleOutput.cpp
+++ b/src/cpp/session/SessionConsoleOutput.cpp
@@ -1,0 +1,199 @@
+/*
+ * SessionConsoleOutput.cpp
+ *
+ * Copyright (C) 2025 by Posit Software, PBC
+ *
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <boost/regex.hpp>
+
+#include <r/RExec.hpp>
+#include <r/RRoutines.hpp>
+
+#include <session/prefs/UserPrefs.hpp>
+#include <session/SessionConsoleOutput.hpp>
+#include <session/SessionModuleContext.hpp>
+
+
+#define kNeverMatch "^(?!)$"
+
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace session {
+namespace console_output {
+
+namespace {
+
+PendingOutputType s_pendingOutputType;
+
+std::atomic<bool> s_isErrorAnnotationEnabled;
+std::atomic<bool> s_isWarningAnnotationEnabled;
+
+boost::regex s_reErrorPrefix(kNeverMatch);
+boost::regex s_reWarningPrefix(kNeverMatch);
+boost::regex s_reInAdditionPrefix(kNeverMatch);
+
+void synchronize()
+{
+   std::string highlightConditionsPref = prefs::userPrefs().consoleHighlightConditions();
+   if (highlightConditionsPref != kConsoleHighlightConditionsNone)
+   {
+      Error error;
+
+      std::string reErrorPrefix;
+      error = r::exec::RFunction(".rs.reErrorPrefix")
+            .call(&reErrorPrefix);
+      if (error)
+         LOG_ERROR(error);
+
+      std::string reWarningPrefix;
+      error = r::exec::RFunction(".rs.reWarningPrefix")
+            .call(&reWarningPrefix);
+      if (error)
+         LOG_ERROR(error);
+
+      std::string reInAdditionPrefix;
+      error = r::exec::RFunction(".rs.reInAdditionPrefix")
+            .call(&reInAdditionPrefix);
+      if (error)
+         LOG_ERROR(error);
+
+      s_isErrorAnnotationEnabled =
+            highlightConditionsPref == kConsoleHighlightConditionsErrorsWarningsMessages ||
+            highlightConditionsPref == kConsoleHighlightConditionsErrorsWarnings ||
+            highlightConditionsPref == kConsoleHighlightConditionsErrors;
+
+      s_isWarningAnnotationEnabled =
+            highlightConditionsPref == kConsoleHighlightConditionsErrorsWarningsMessages ||
+            highlightConditionsPref == kConsoleHighlightConditionsErrorsWarnings;
+
+      s_reErrorPrefix      = boost::regex(reErrorPrefix, boost::regex::icase);
+      s_reWarningPrefix    = boost::regex(reWarningPrefix, boost::regex::icase);
+      s_reInAdditionPrefix = boost::regex(reInAdditionPrefix, boost::regex::icase);
+   }
+}
+
+void onBusy(bool busy)
+{
+   setPendingOutputType(PendingOutputTypeUnknown);
+}
+
+void onConsoleOutputReceived(module_context::ConsoleOutputType type,
+                             const std::string& output)
+{
+   if (s_pendingOutputType == PendingOutputTypeUnknown)
+   {
+      // Detect error output.
+      if (s_isErrorAnnotationEnabled)
+      {
+         if (boost::regex_search(output, s_reErrorPrefix))
+         {
+            setPendingOutputType(PendingOutputTypeError);
+         }
+      }
+
+      // When 'options(warn = 0)' is set, warning output will be printed
+      // if any uncaught warnings were emitted during code execution.
+      if (s_isWarningAnnotationEnabled)
+      {
+         if (boost::regex_search(output, s_reWarningPrefix))
+         {
+            setPendingOutputType(PendingOutputTypeWarning);
+         }
+      }
+   }
+   else if (s_pendingOutputType == PendingOutputTypeError)
+   {
+      // If we're currently processing error output, R may also
+      // print warning output as part of the error.
+      if (s_pendingOutputType == PendingOutputTypeError)
+      {
+         if (boost::regex_search(output, s_reInAdditionPrefix))
+         {
+            setPendingOutputType(PendingOutputTypeWarning);
+         }
+      }
+   }
+}
+
+void onPreferencesSaved()
+{
+   synchronize();
+}
+
+SEXP rs_errorOutputPending()
+{
+   clientEventQueue().flush();
+   setPendingOutputType(PendingOutputTypeError);
+   return Rf_ScalarLogical(1);
+}
+
+} // end anonymous namespace
+
+
+PendingOutputType getPendingOutputType()
+{
+   return s_pendingOutputType;
+}
+
+void setPendingOutputType(PendingOutputType type)
+{
+   s_pendingOutputType = type;
+}
+
+const boost::regex& reErrorPrefix()
+{
+   return s_reErrorPrefix;
+}
+
+const boost::regex& reWarningPrefix()
+{
+   return s_reWarningPrefix;
+}
+
+const boost::regex& reInAdditionPrefix()
+{
+   return s_reInAdditionPrefix;
+}
+
+
+bool isErrorAnnotationEnabled()
+{
+   return s_isErrorAnnotationEnabled;
+}
+
+bool isWarningAnnotationEnabled()
+{
+   return s_isWarningAnnotationEnabled;
+}
+
+
+Error initialize()
+{
+   using namespace module_context;
+
+   events().onBusy.connect(onBusy);
+   events().onConsoleOutputReceived.connect(onConsoleOutputReceived);
+   events().onPreferencesSaved.connect(onPreferencesSaved);
+
+   RS_REGISTER_CALL_METHOD(rs_errorOutputPending);
+
+   synchronize();
+
+   return Success();
+}
+
+} // end namespace console_output
+} // end namespace session
+} // end namespace rstudio

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1029,8 +1029,10 @@ void rConsoleWrite(const std::string& output, int otype)
 
    using namespace console_output;
 
-   // DEBUG: simulate latency
-   boost::this_thread::sleep_for(boost::chrono::milliseconds(200));
+   // simulate latency for development builds
+#ifndef RSTUDIO_PACKAGE_BUILD
+   console_output::simulateLatency();
+#endif
 
    // notify listeners
    auto type = (otype == 1)

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -619,6 +619,9 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       // r utils
       (r_utils::initialize)
 
+      // console output
+      (console_output::initialize)
+
       // suspend timeout
       (suspend::initialize)
 
@@ -850,9 +853,6 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
    // setup fork handlers
    main_process::setupForkHandlers();
 
-   // setup extra handlers for client event queue
-   rsession::finishInitializeClientEventQueue();
-
    // success!
    return Success();
 }
@@ -1016,6 +1016,8 @@ void rBusy(bool busy)
    if (busy && !console_input::executing())
       return;
 
+   module_context::events().onBusy(busy);
+
    ClientEvent busyEvent(kBusy, busy);
    rsession::clientEventQueue().add(busyEvent);
 }
@@ -1025,7 +1027,37 @@ void rConsoleWrite(const std::string& output, int otype)
    if (main_process::wasForked())
       return;
 
-   int event = otype == 1 ? kConsoleWriteError : kConsoleWriteOutput;
+   using namespace console_output;
+
+   // DEBUG: simulate latency
+   boost::this_thread::sleep_for(boost::chrono::milliseconds(200));
+
+   // notify listeners
+   auto type = (otype == 1)
+         ? module_context::ConsoleOutputNormal
+         : module_context::ConsoleOutputError;
+   module_context::events().onConsoleOutputReceived(type, output);
+
+   // add to event queue
+   int event;
+
+   switch (getPendingOutputType())
+   {
+
+   case rstudio::session::console_output::PendingOutputTypeError:
+      event = kConsoleWritePendingError;
+      break;
+
+   case rstudio::session::console_output::PendingOutputTypeWarning:
+      event = kConsoleWritePendingWarning;
+      break;
+
+   default:
+      event = (otype == 1) ? kConsoleWriteError : kConsoleWriteOutput;
+      break;
+
+   }
+
    ClientEvent writeEvent(event, output);
    rsession::clientEventQueue().add(writeEvent);
 }

--- a/src/cpp/session/include/session/SessionConsoleOutput.hpp
+++ b/src/cpp/session/include/session/SessionConsoleOutput.hpp
@@ -1,0 +1,50 @@
+/*
+ * SessionConsoleOutput.hpp
+ *
+ * Copyright (C) 2025 by Posit Software, PBC
+ *
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef RSTUDIO_SESSION_CONSOLE_OUTPUT_HPP
+#define RSTUDIO_SESSION_CONSOLE_OUTPUT_HPP
+
+#include <boost/regex_fwd.hpp>
+
+#include <shared_core/Error.hpp>
+
+namespace rstudio {
+namespace session {
+namespace console_output {
+
+enum PendingOutputType {
+   PendingOutputTypeUnknown,
+   PendingOutputTypeError,
+   PendingOutputTypeWarning,
+};
+
+PendingOutputType getPendingOutputType();
+void setPendingOutputType(PendingOutputType type);
+
+const boost::regex& reErrorPrefix();
+const boost::regex& reWarningPrefix();
+const boost::regex& reInAdditionPrefix();
+
+bool isErrorAnnotationEnabled();
+bool isWarningAnnotationEnabled();
+
+core::Error initialize();
+
+} // end namespace console_output
+} // end namespace session
+} // end namespace rstudio
+
+#endif /* RSTUDIO_SESSION_CONSOLE_OUTPUT_HPP */

--- a/src/cpp/session/include/session/SessionConsoleOutput.hpp
+++ b/src/cpp/session/include/session/SessionConsoleOutput.hpp
@@ -25,6 +25,8 @@ namespace rstudio {
 namespace session {
 namespace console_output {
 
+void simulateLatency();
+
 enum PendingOutputType {
    PendingOutputTypeUnknown,
    PendingOutputTypeError,

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -41,8 +41,9 @@
 #include <core/system/ShellUtils.hpp>
 #include <core/system/System.hpp>
 
-#include <session/SessionOptions.hpp>
 #include <session/SessionClientEvent.hpp>
+#include <session/SessionConsoleOutput.hpp>
+#include <session/SessionOptions.hpp>
 #include <session/SessionSourceDatabase.hpp>
 
 #include "../SessionClientEventQueue.hpp"
@@ -355,7 +356,9 @@ struct Events : boost::noncopyable
    RSTUDIO_BOOST_SIGNAL<void()>                                       onBeforeExecute;
    RSTUDIO_BOOST_SIGNAL<void(const std::string&)>                     onConsolePrompt;
    RSTUDIO_BOOST_SIGNAL<void(const std::string&)>                     onConsoleInput;
+   RSTUDIO_BOOST_SIGNAL<void(bool)>                                   onBusy;
    RSTUDIO_BOOST_SIGNAL<void(const std::string&, const std::string&)> onActiveConsoleChanged;
+   RSTUDIO_BOOST_SIGNAL<void(ConsoleOutputType, const std::string&)>  onConsoleOutputReceived;
    RSTUDIO_BOOST_SIGNAL<void(ConsoleOutputType, const std::string&)>  onConsoleOutput;
    RSTUDIO_BOOST_SIGNAL<void()>                                       onUserInterrupt;
    RSTUDIO_BOOST_SIGNAL<void(ChangeSource)>                           onDetectChanges;

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -215,6 +215,8 @@ extern const int kSuspendBlocked;
 extern const int kClipboardAction;
 extern const int kDeploymentRecordsUpdated;
 extern const int kRunAutomation;
+extern const int kConsoleWritePendingError;
+extern const int kConsoleWritePendingWarning;
 
 }
    

--- a/src/cpp/session/modules/SessionErrors.cpp
+++ b/src/cpp/session/modules/SessionErrors.cpp
@@ -180,12 +180,6 @@ void onUserSettingsChanged(const std::string& pref,
    *pHandleUserErrorsOnly = handleUserErrorsOnly;
 }
 
-SEXP rs_errorOutputPending()
-{
-   clientEventQueue().setErrorOutputPending();
-   return Rf_ScalarLogical(1);
-}
-
 } // anonymous namespace
 
 json::Value errorStateAsJson()
@@ -205,8 +199,6 @@ Error initialize()
 
    using boost::bind;
    using namespace module_context;
-
-   RS_REGISTER_CALL_METHOD(rs_errorOutputPending);
 
    // Check to see whether the error handler has changed immediately after init
    // (to find changes from e.g. .Rprofile) and after every console prompt.

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -480,16 +480,24 @@ public class ShellWidget extends Composite implements ShellDisplay,
          errorWidget.setTracebackVisible(true);
 
       Element parentEl = errorNodes.get(0).getParentElement();
-      if (parentEl.hasClassName(VirtualConsole.RES.styles().group()))
+      while (true)
       {
-         Element replaceEl = parentEl;
-         parentEl = parentEl.getParentElement();
-         parentEl.replaceChild(errorWidget.getElement(), replaceEl);
-      }
-      else
-      {
-         parentEl.removeAllChildren();
-         parentEl.appendChild(errorWidget.getElement());
+         if (parentEl.hasClassName(VirtualConsole.RES.styles().groupError()))
+         {
+            Element replaceEl = parentEl;
+            parentEl = parentEl.getParentElement();
+            parentEl.replaceChild(errorWidget.getElement(), replaceEl);
+            break;
+         }
+         
+         parentEl = parentEl.getPreviousSiblingElement();
+         if (parentEl == null)
+         {
+            parentEl = errorNodes.get(0).getParentElement();
+            parentEl.removeAllChildren();
+            parentEl.appendChild(errorWidget.getElement());
+            break;
+         }
       }
       
       scrollPanel_.onContentSizeChanged();


### PR DESCRIPTION
### Intent

The main problem being solved in this PR relates to the fact that (1) R doesn't provide any APIs to let us know if output is being printed while errors or warnings are being processed, and (2) error / warning output might be processed in pieces, or batches, so we do need to try and maintain our own state about whether we're currently expecting output to be errors or warnings.

### Approach

- Try to undo some of the coupling I had introduced in the first PR. Now, most of the "console output" state management is done in a separate file.

- Improve handling of "delayed" warning / error outputs. Unfortunately, because R doesn't actually provide any indication as to whether output is being printed as part of processing an error or a warning, we need to manually track that state as output is processed. This introduces some complexity into output + error event handling, but I think I've got the right approach.

- Introduce two new client event types, which are used for pending error output + pending warning outputs. The primary reason we use these is so we can know a-priori whether a snippet of text should be grouped as error or warning output. 

- Use a single map, mapping event types to buffered outputs, rather than a collection of different members / vectors.

### Automated Tests

N/A; for a follow-up PR.

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
