### PR TITLE
set SPARK_CONNECT_USER_AGENT on startup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 - Added memory limit monitoring to RStudio (Linux only for now). If `ulimit -m` is set, this limit is displayed in the Memory Usage Report. As the limit is approached, a warning is displayed, then an error when the limit is reached. When the system is low on memory, the session can abort itself by shutting down in a controlled way with a dialog to the user. See the new `"allow-over-limit-sessions` option in rsession.conf. (rstudio-pro#5019).
 - RStudio now supports configuring a Kerberos Service Principal for the GitHub Copilot Language Server proxy settings. (#15823)
 - RStudio now supports installation of Rtools45 for the upcoming R 4.5.0 release on Windows.
+- RStudio now sets the environment variable `SPARK_CONNECT_USER_AGENT = posit-rstudio` in R sessions. (rstudio-pro#7732)
 
 #### Posit Workbench
 - Changed memory limit enforcement of `/etc/rstudio/profiles` `max-memory-mb` setting from limiting virtual memory (`ulimit -v`) to resident memory (`ulimit -m`) for more accuracy. This allows a session to run quarto 1.6, which uses a lot of virtual memory due to its underlying virtual machine. Unfortunately, resident memory is only enforceable at the kernel level in Linux versions that support cgroups. To make up for the loss of kernel enforcement, RStudio warns the user and stops over limit sessions. For more robust kernel enforcement, configure memory limits in the Job Launcher using cgroups (rstudio-pro#5019).

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -845,6 +845,11 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       rsession::persistentState().setAbend(true);
    }
 
+   // set spark user agent if unset
+   std::string sparkUserAgent = core::system::getenv("SPARK_CONNECT_USER_AGENT");
+   if (sparkUserAgent.empty())
+      core::system::setenv("SPARK_CONNECT_USER_AGENT", "posit-rstudio");
+
    // begin session
    using namespace module_context;
    activeSession().beginSession(rVersion(), rHomeDir(), rVersionLabel());


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/7732.

### Approach

Straightforward setting of environment variable.

### Automated Tests

N/A

### QA Notes

N/A; I believe this will be verified externally?

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
