### PR TITLE
add a user preference to suppress Copilot message dialogs

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -436,6 +436,7 @@ namespace prefs {
 #define kCopilotTabKeyBehaviorSuggestion "suggestion"
 #define kCopilotTabKeyBehaviorCompletions "completions"
 #define kCopilotIndexingEnabled "copilot_indexing_enabled"
+#define kCopilotShowMessages "copilot_show_messages"
 #define kProjectName "project_name"
 #define kRunBackgroundJobDefaultWorkingDir "run_background_job_default_working_dir"
 #define kRunBackgroundJobDefaultWorkingDirProject "project"
@@ -1993,6 +1994,12 @@ public:
     */
    bool copilotIndexingEnabled();
    core::Error setCopilotIndexingEnabled(bool val);
+
+   /**
+    * When enabled, RStudio will show account and billing messages from GitHub Copilot in a message box.
+    */
+   bool copilotShowMessages();
+   core::Error setCopilotShowMessages(bool val);
 
    /**
     * User-provided name for the currently opened R project.

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -1302,8 +1302,10 @@ void onBackgroundProcessing(bool isIdle)
                 boost::iequals(type, "Warning") ||
                 boost::iequals(type, "Info"))
             {
-               std::string title = "GitHub Copilot";
-               module_context::showErrorMessage(title, message);
+               if (prefs::userPrefs().copilotShowMessages())
+                  module_context::showErrorMessage("GitHub Copilot", message);
+               else
+                  ELOG("showMessageRequest ({}): '{}'", type, message);
             }
             else // Log, Debug, or unknown
             {

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -2383,6 +2383,16 @@
    clear = function() { .rs.clearUserPref("copilot_indexing_enabled") }
 )
 
+# Display account and billing messages from GitHub Copilot
+#
+# When enabled, RStudio will show account and billing messages from GitHub
+# Copilot in a message box.
+.rs.uiPrefs$copilotShowMessages <- list(
+   get = function() { .rs.getUserPref("copilot_show_messages") },
+   set = function(value) { .rs.setUserPref("copilot_show_messages", value) },
+   clear = function() { .rs.clearUserPref("copilot_show_messages") }
+)
+
 # 
 #
 # User-provided name for the currently opened R project.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -3352,6 +3352,19 @@ core::Error UserPrefValues::setCopilotIndexingEnabled(bool val)
 }
 
 /**
+ * When enabled, RStudio will show account and billing messages from GitHub Copilot in a message box.
+ */
+bool UserPrefValues::copilotShowMessages()
+{
+   return readPref<bool>("copilot_show_messages");
+}
+
+core::Error UserPrefValues::setCopilotShowMessages(bool val)
+{
+   return writePref("copilot_show_messages", val);
+}
+
+/**
  * User-provided name for the currently opened R project.
  */
 std::string UserPrefValues::projectName()
@@ -3714,6 +3727,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kCopilotCompletionsDelay,
       kCopilotTabKeyBehavior,
       kCopilotIndexingEnabled,
+      kCopilotShowMessages,
       kProjectName,
       kRunBackgroundJobDefaultWorkingDir,
       kCodeFormatter,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1741,6 +1741,12 @@
             "title": "Index project files with GitHub Copilot",
             "description": "When enabled, RStudio will index project files with GitHub Copilot."
         },
+        "copilot_show_messages": {
+            "type": "boolean",
+            "default": true,
+            "title": "Display account and billing messages from GitHub Copilot",
+            "description": "When enabled, RStudio will show account and billing messages from GitHub Copilot in a message box."
+        },
         "project_name": {
             "description": "User-provided name for the currently opened R project.",
             "type": "string",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -3665,6 +3665,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * When enabled, RStudio will show account and billing messages from GitHub Copilot in a message box.
+    */
+   public PrefValue<Boolean> copilotShowMessages()
+   {
+      return bool(
+         "copilot_show_messages",
+         _constants.copilotShowMessagesTitle(), 
+         _constants.copilotShowMessagesDescription(), 
+         true);
+   }
+
+   /**
     * User-provided name for the currently opened R project.
     */
    public PrefValue<String> projectName()
@@ -4316,6 +4328,8 @@ public class UserPrefsAccessor extends Prefs
          copilotTabKeyBehavior().setValue(layer, source.getString("copilot_tab_key_behavior"));
       if (source.hasKey("copilot_indexing_enabled"))
          copilotIndexingEnabled().setValue(layer, source.getBool("copilot_indexing_enabled"));
+      if (source.hasKey("copilot_show_messages"))
+         copilotShowMessages().setValue(layer, source.getBool("copilot_show_messages"));
       if (source.hasKey("project_name"))
          projectName().setValue(layer, source.getString("project_name"));
       if (source.hasKey("run_background_job_default_working_dir"))
@@ -4592,6 +4606,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(copilotCompletionsDelay());
       prefs.add(copilotTabKeyBehavior());
       prefs.add(copilotIndexingEnabled());
+      prefs.add(copilotShowMessages());
       prefs.add(projectName());
       prefs.add(runBackgroundJobDefaultWorkingDir());
       prefs.add(codeFormatter());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -2142,6 +2142,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String copilotIndexingEnabledDescription();
 
    /**
+    * When enabled, RStudio will show account and billing messages from GitHub Copilot in a message box.
+    */
+   @DefaultStringValue("Display account and billing messages from GitHub Copilot")
+   String copilotShowMessagesTitle();
+   @DefaultStringValue("When enabled, RStudio will show account and billing messages from GitHub Copilot in a message box.")
+   String copilotShowMessagesDescription();
+
+   /**
     * User-provided name for the currently opened R project.
     */
    @DefaultStringValue("")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -1076,6 +1076,10 @@ copilotTabKeyBehaviorEnum_completions=Code Completion
 copilotIndexingEnabledTitle = Index project files with GitHub Copilot
 copilotIndexingEnabledDescription = When enabled, RStudio will index project files with GitHub Copilot.
 
+# When enabled, RStudio will show account and billing messages from GitHub Copilot in a message box.
+copilotShowMessagesTitle = Display account and billing messages from GitHub Copilot
+copilotShowMessagesDescription = When enabled, RStudio will show account and billing messages from GitHub Copilot in a message box.
+
 # User-provided name for the currently opened R project.
 projectNameTitle = 
 projectNameDescription = User-provided name for the currently opened R project.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
@@ -1079,6 +1079,10 @@ copilotTabKeyBehaviorEnum_completions = Achèvement du code
 copilotIndexingEnabledTitle = Indexer les fichiers de projet avec GitHub Copilot
 copilotIndexingEnabledDescription = Lorsqu''il est activé, RStudio indexera les fichiers de projet avec GitHub Copilot.
 
+# When enabled, RStudio will show account and billing messages from GitHub Copilot in a message box.
+copilotShowMessagesTitle = Afficher les messages de compte et de facturation de GitHub Copilot
+copilotShowMessagesDescription = Lorsqu''il est activé, RStudio affichera les messages de compte et de facturation de GitHub Copilot dans une boîte de dialogue.
+
 # User-provided name for the currently opened R project.
 projectNameTitle = 
 projectNameDescription = Nom fourni par l''utilisateur pour le projet R actuellement ouvert.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
@@ -141,7 +141,8 @@ public class CopilotPreferencesPane extends PreferencesPane
       
       cbCopilotEnabled_ = checkboxPref(prefs_.copilotEnabled(), true);
       cbCopilotIndexingEnabled_ = checkboxPref(prefs_.copilotIndexingEnabled(), true);
-      
+      cbCopilotShowMessages_ = checkboxPref(prefs_.copilotShowMessages(), true);
+
       selCopilotTabKeyBehavior_ = new SelectWidget(
             prefsConstants_.copilotTabKeyBehaviorTitle(),
             new String[] {
@@ -209,6 +210,9 @@ public class CopilotPreferencesPane extends PreferencesPane
          add(spacedBefore(headerLabel(constants_.copilotCompletionsHeader())));
          add(selCopilotCompletionsTrigger_);
          add(nvwCopilotCompletionsDelay_);
+
+         add(spacedBefore(headerLabel(constants_.otherCaption())));
+         add(cbCopilotShowMessages_);
 
          // add(checkboxPref(prefs_.copilotAllowAutomaticCompletions()));
          // add(selCopilotTabKeyBehavior_);
@@ -528,6 +532,7 @@ public class CopilotPreferencesPane extends PreferencesPane
    private final Label lblCopilotStatus_;
    private final CheckBox cbCopilotEnabled_;
    private final CheckBox cbCopilotIndexingEnabled_;
+   private final CheckBox cbCopilotShowMessages_;
    private final List<SmallButton> statusButtons_;
    private final SmallButton btnShowError_;
    private final SmallButton btnSignIn_;


### PR DESCRIPTION
### Intent

Add-on to #15848

### Approach

Added a user preference to control whether Copilot messages (sent by Copilot) are shown or not. These are shown in a modal dialog, so this serves as an escape hatch if Copilot starts spamming us with a bunch of messages.

Currently the only known message is the one shown when you've used up all 200 free completions for the month with a free Copilot account.

<img width="675" alt="copilot-prefs" src="https://github.com/user-attachments/assets/8a5d994d-f545-4612-8004-009aadabbc36" />

### Automated Tests

None

### QA Notes

See notes in issue.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


