### PR TITLE
Switch from posit-jenkins credentials to the new posit-jenkins-rstudi…

### DIFF
--- a/jenkins/Jenkinsfile.build
+++ b/jenkins/Jenkinsfile.build
@@ -132,7 +132,7 @@ pipeline {
             }
 
             environment {
-              GITHUB_LOGIN = credentials('posit-jenkins')
+              GITHUB_LOGIN = credentials('posit-jenkins-rstudio')
               DOCKER_TAG = utils.getDockerTag()
               DOCKER_FILE = "docker/jenkins/Dockerfile.${env.os}"
             }

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -77,7 +77,7 @@ pipeline {
             checkout([$class: 'GitSCM',
                       branches: [[name: "${params.COMMIT_HASH}"]],
                       extensions: [],
-                      userRemoteConfigs: [[credentialsId: 'posit-jenkins', url: GIT_URL ]]])
+                      userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL ]]])
           }
         }
 
@@ -189,7 +189,7 @@ pipeline {
                   checkout([$class: 'GitSCM',
                             branches: [[name: "${params.COMMIT_HASH}"]],
                             extensions: [],
-                            userRemoteConfigs: [[credentialsId: 'posit-jenkins', url: GIT_URL ]]])
+                            userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL ]]])
                 }
               }
 
@@ -358,7 +358,7 @@ pipeline {
                   
                   stage("Publish") {
                     environment {
-                      GITHUB_LOGIN = credentials('posit-jenkins')
+                      GITHUB_LOGIN = credentials('posit-jenkins-rstudio')
                       DAILIES_PATH = "${PRODUCT}/${OS}-${utils.getArchForOs(OS, ARCH)}"
                     }
 

--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -63,7 +63,7 @@ pipeline {
           checkout([$class: 'GitSCM',
                     branches: [[name: "${params.COMMIT_HASH}"]],
                     extensions: [],
-                    userRemoteConfigs: [[credentialsId: 'posit-jenkins', url: "${GIT_URL}"]]])
+                    userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: "${GIT_URL}"]]])
         }
       }
     }
@@ -90,7 +90,7 @@ pipeline {
         // boost won't compile without the brew version of openssl.
         // only add it to the dep resolve step though, or the ide build will compile against the wrong openssl
         PATH = '/usr/local/opt/openssl/bin:/usr/local/opt/openssl/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
-        GITHUB_LOGIN = credentials('posit-jenkins')
+        GITHUB_LOGIN = credentials('posit-jenkins-rstudio')
       }
       steps {
         sh 'cd dependencies/osx && RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN ./install-dependencies-osx && cd ../..'
@@ -234,7 +234,7 @@ pipeline {
         
         stage("Publish") {
           environment {
-            GITHUB_LOGIN = credentials('posit-jenkins')
+            GITHUB_LOGIN = credentials('posit-jenkins-rstudio')
             DAILIES_PATH = "${PRODUCT}/macos"
           }
 

--- a/jenkins/Jenkinsfile.pull-request
+++ b/jenkins/Jenkinsfile.pull-request
@@ -12,7 +12,7 @@ pipeline {
   }
 
   environment {
-    GITHUB_LOGIN = credentials('posit-jenkins')
+    GITHUB_LOGIN = credentials('posit-jenkins-rstudio')
     JENKINS_CREDENTIALS = credentials('jenkins-api-creds')
     OS = 'jammy'
     ARCH = 'x86_64'

--- a/jenkins/Jenkinsfile.pull-request-build
+++ b/jenkins/Jenkinsfile.pull-request-build
@@ -6,7 +6,7 @@ pipeline {
   }
 
   environment {
-    GITHUB_LOGIN = credentials('posit-jenkins')
+    GITHUB_LOGIN = credentials('posit-jenkins-rstudio')
     JENKINS_CREDENTIALS = credentials('jenkins-api-creds')
     OS = 'jammy'
     ARCH = 'x86_64'

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -51,7 +51,7 @@ pipeline {
             checkout([$class: 'GitSCM',
               branches: [[name: params.COMMIT_HASH]],
               extensions: [],
-              userRemoteConfigs: [[credentialsId: 'posit-jenkins', url: GIT_URL]]])
+              userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL]]])
           }
         }
 
@@ -123,7 +123,7 @@ pipeline {
             checkout([$class: 'GitSCM',
               branches: [[name: params.COMMIT_HASH]],
               extensions: [],
-              userRemoteConfigs: [[credentialsId: 'posit-jenkins', url: GIT_URL]]])
+              userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL]]])
           }
         }
 
@@ -224,7 +224,7 @@ pipeline {
 
             stage ('Publish') {
               environment {
-                GITHUB_LOGIN = credentials('posit-jenkins')
+                GITHUB_LOGIN = credentials('posit-jenkins-rstudio')
                 PRODUCT = "${utils.getProductName()}"
                 // This is being done to make the variables visible to the powershell call
                 VERSION = "${RSTUDIO_VERSION}"

--- a/jenkins/utils.groovy
+++ b/jenkins/utils.groovy
@@ -21,7 +21,7 @@ boolean hasChangesIn(String module, boolean invertMatch = false, boolean useRege
   * Adds a remote reference to the specified branch.
   */
 void addRemoteRef(String branchName) {
-  withCredentials([gitUsernamePassword(credentialsId: 'posit-jenkins', gitToolName: 'Default')]) {
+  withCredentials([gitUsernamePassword(credentialsId: 'posit-jenkins-rstudio', gitToolName: 'Default')]) {
     sh "git config --add remote.origin.fetch +refs/heads/${branchName}:refs/remotes/origin/${branchName}"
     sh "git fetch --no-tags --force --progress ${GIT_URL} refs/heads/${branchName}:refs/remotes/origin/${branchName}"
   }
@@ -382,7 +382,7 @@ def checkRunsRequestWithRetry(String method, String payload = "", String url = p
   def response = checkRunsRequest(method, payload, url)
   if (response.status == 401) {
     echo "Received 401 response. Retrying with new token."
-    GITHUB_LOGIN = credentials('posit-jenkins')
+    GITHUB_LOGIN = credentials('posit-jenkins-rstudio')
     response = checkRunsRequest(method, payload, url)
   }
   return response


### PR DESCRIPTION
…o credentials.

Not sure who the proper people are for this PR, please let me know who should review it, if not one of you three!

### Intent

We are in the process of deprecating the old `posit-jenkins` credentials.  It is replaced by `posit-jenkins-rstudio`.  The credentials have the exact same permissions, and have been in use for a few weeks in a couple of locations, and since monday across all the jenkins jobs on the jenkins server.  

Changing the references to the credentials in all the various Jenkinsfiles in across many repos in the company is the next step!

This PR accomplishes that goal for the `rstudio` repo.


Connected to issue https://github.com/rstudio/cloudops/issues/543

