### PR TITLE
improve contrast for colors

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.css
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.css
@@ -10,8 +10,8 @@
 /* Light themes */
 
 @def LIGHT_BACKGROUND_COLOR rgba(0, 0, 0, 0.08);
-@def LIGHT_ERROR_COLOR      #FF0000;
-@def LIGHT_WARNING_COLOR    #E04F00;
+@def LIGHT_ERROR_COLOR      #BB0000;
+@def LIGHT_WARNING_COLOR    #8B4513;
 @def LIGHT_MESSAGE_COLOR    #7AA8D7;
 
 .rstudio-themes-default .ace_console_error .group {
@@ -58,7 +58,7 @@
 
 @def DARK_BACKGROUND_COLOR rgba(255, 255, 255, 0.1);
 @def DARK_ERROR_COLOR      #FF8000;
-@def DARK_WARNING_COLOR    #FFDD22;
+@def DARK_WARNING_COLOR    #E5C515;
 @def DARK_MESSAGE_COLOR    #7AA8D7;
 
 .rstudio-themes-dark .ace_console_error .group {


### PR DESCRIPTION
## Before

<img width="555" alt="Screenshot 2025-04-03 at 1 10 23 PM" src="https://github.com/user-attachments/assets/f511b940-5e21-4c65-964b-4c0ac26048c1" />

## After

<img width="570" alt="Screenshot 2025-04-03 at 1 10 20 PM" src="https://github.com/user-attachments/assets/c15496fe-5cb7-498e-bfa4-4bb36c0c9eb9" />

This also ensures that the contrast for the colours used meet the WCAG AA requirements.