### PR TITLE
Prevent Copilot process from starting multiple times

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,7 @@
 - Fixed an issue where .bib files with extra commas could be treated as binary files on RHEL9. (rstudio-pro/7521)
 - Update NO_PROXY domain filter to be less restrictive and allow for expressions like `.local` and `.sub.example.local` (#15607)
 - Fixed an issue where Copilot support on Apple Silicon Macs was running via Rosetta2 instead of natively. (#14156)
+- Fixed an issue where the Copilot process was being started twice per RStudio session. (#15858))
 - Fixed an issue where documents could open very slowly when many tabs were already open. (#15767)
 - Fixed an issue where the download of Rtools44 could fail when using Posit Package Manager as the default R package repository. (#15803)
 - Fixed an issue where messages produced by `rlang::inform()` were not separated by newlines.

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -891,6 +891,7 @@ void stopAgent()
    if (s_agentPid == -1)
    {
       //DLOG("No agent running; nothing to do.");
+      s_agentRuntimeStatus = CopilotAgentRuntimeStatus::Stopped;
       return;
    }
 

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -978,7 +978,10 @@ Error startAgent()
    }
    
    if (error)
+   {
+      s_agentRuntimeStatus = CopilotAgentRuntimeStatus::Unknown;
       return error;
+   }
    
 
    // Wait for the process to start.
@@ -989,7 +992,10 @@ Error startAgent()
    s_agentStartupError = std::string();
    waitFor([]() { return s_agentPid != -1; });
    if (s_agentPid == -1)
+   {
+      s_agentRuntimeStatus = CopilotAgentRuntimeStatus::Unknown;
       return Error(boost::system::errc::no_such_process, ERROR_LOCATION);
+   }
    
    // Send an initialize request to the agent.
    json::Object clientInfoJson;
@@ -1011,6 +1017,7 @@ Error startAgent()
    {
       if (error)
       {
+         s_agentRuntimeStatus = CopilotAgentRuntimeStatus::Unknown;
          LOG_ERROR(error);
          return;
       }

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -230,6 +230,7 @@ enum class CopilotAgentNotRunningReason {
 
 enum class CopilotAgentRuntimeStatus {
    Unknown,
+   Preparing,
    Starting,
    Running,
    Stopping,
@@ -900,6 +901,14 @@ void stopAgent()
 
 Error startAgent()
 {
+   if (s_agentRuntimeStatus != CopilotAgentRuntimeStatus::Unknown &&
+       s_agentRuntimeStatus != CopilotAgentRuntimeStatus::Stopped)
+   {
+      return Success();
+   }
+
+   s_agentRuntimeStatus = CopilotAgentRuntimeStatus::Preparing;
+
    Error error;
 
    // Create environment for agent process
@@ -974,13 +983,9 @@ Error startAgent()
 
    // Wait for the process to start.
    //
-   // TODO: This is kind of a hack. We should probably instead use something like a
-   // status flag that tracks if the agent is stopped, starting, or already running.
-   //
    // We include this because all requests will fail if we haven't yet called
    // initialized, so maybe the right approach is to have some sort of 'ensureInitialized'
    // method?
-   s_agentRuntimeStatus = CopilotAgentRuntimeStatus::Unknown;
    s_agentStartupError = std::string();
    waitFor([]() { return s_agentPid != -1; });
    if (s_agentPid == -1)


### PR DESCRIPTION
### Intent

Addresses #15858

### Approach

Prevent `startAgent()` (which we call at least twice on startup) from starting multiple copilot processes.

### Automated Tests

None

### QA Notes

Test per issue description.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


