### PR TITLE
Use RStudio project folder as GitHub Copilot Workspace Folder

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 #### RStudio
 - RStudio now uses an alternate display for R errors, warnings, and messages. In addition, output on stderr (e.g. R messages) are colored the same as regular output on stdout. (#2574)
 - RStudio now displays a message when the GitHub Copilot completion limit has been reached (typically on a free Copilot account). (#15848)
+- RStudio now uses the RStudio project folder as the GitHub Copilot workspace root, providing more relevant completions. (#15816)
 - On macOS, RStudio now uses the project directory / home directory for new RStudio sessions opened via the Dock menu's "Open in New Window" command. (#15409)
 - RStudio Desktop now supports opening files via drag and drop. (#4037)
 - RStudio installation on Windows now registers icons for many supported file types. (#12730)

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -437,6 +437,7 @@ namespace prefs {
 #define kCopilotTabKeyBehaviorCompletions "completions"
 #define kCopilotIndexingEnabled "copilot_indexing_enabled"
 #define kCopilotShowMessages "copilot_show_messages"
+#define kCopilotProjectWorkspace "copilot_project_workspace"
 #define kProjectName "project_name"
 #define kRunBackgroundJobDefaultWorkingDir "run_background_job_default_working_dir"
 #define kRunBackgroundJobDefaultWorkingDirProject "project"
@@ -2000,6 +2001,12 @@ public:
     */
    bool copilotShowMessages();
    core::Error setCopilotShowMessages(bool val);
+
+   /**
+    * When enabled, RStudio will tell Copilot to use the current RStudio project's folder as a workspace.
+    */
+   bool copilotProjectWorkspace();
+   core::Error setCopilotProjectWorkspace(bool val);
 
    /**
     * User-provided name for the currently opened R project.

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -1011,7 +1011,27 @@ Error startAgent()
    paramsJson["processId"] = ::getpid();
    paramsJson["locale"] = prefs::userPrefs().uiLanguage();
    paramsJson["initializationOptions"] = initializationOptionsJson;
-   paramsJson["capabilities"] = json::Object();
+
+   std::string workspaceFolderURI;
+   if (prefs::userPrefs().copilotProjectWorkspace() && projects::projectContext().hasProject())
+   {
+      workspaceFolderURI = uriFromDocumentPath(projects::projectContext().directory().getAbsolutePath());
+   }
+
+   json::Object workspaceJson;
+   workspaceJson["workspaceFolders"] = !workspaceFolderURI.empty();
+   json::Object capabilitiesJson;
+   capabilitiesJson["workspace"] = workspaceJson;
+   paramsJson["capabilities"] = capabilitiesJson;
+
+   if (!workspaceFolderURI.empty())
+   {
+      json::Object workspaceFolderJson;
+      workspaceFolderJson["uri"] = workspaceFolderURI;
+      json::Array workspaceFoldersJsonArray;
+      workspaceFoldersJsonArray.push_back(workspaceFolderJson);
+      paramsJson["workspaceFolders"] = workspaceFoldersJsonArray;
+   }
    
    // set up continuation after we've finished initializing
    auto initializedCallback = [=](const Error& error, json::JsonRpcResponse* pResponse)

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -2393,6 +2393,16 @@
    clear = function() { .rs.clearUserPref("copilot_show_messages") }
 )
 
+# Use RStudio project folder as a Copilot workspace
+#
+# When enabled, RStudio will tell Copilot to use the current RStudio project's
+# folder as a workspace.
+.rs.uiPrefs$copilotProjectWorkspace <- list(
+   get = function() { .rs.getUserPref("copilot_project_workspace") },
+   set = function(value) { .rs.setUserPref("copilot_project_workspace", value) },
+   clear = function() { .rs.clearUserPref("copilot_project_workspace") }
+)
+
 # 
 #
 # User-provided name for the currently opened R project.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -3365,6 +3365,19 @@ core::Error UserPrefValues::setCopilotShowMessages(bool val)
 }
 
 /**
+ * When enabled, RStudio will tell Copilot to use the current RStudio project's folder as a workspace.
+ */
+bool UserPrefValues::copilotProjectWorkspace()
+{
+   return readPref<bool>("copilot_project_workspace");
+}
+
+core::Error UserPrefValues::setCopilotProjectWorkspace(bool val)
+{
+   return writePref("copilot_project_workspace", val);
+}
+
+/**
  * User-provided name for the currently opened R project.
  */
 std::string UserPrefValues::projectName()
@@ -3728,6 +3741,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kCopilotTabKeyBehavior,
       kCopilotIndexingEnabled,
       kCopilotShowMessages,
+      kCopilotProjectWorkspace,
       kProjectName,
       kRunBackgroundJobDefaultWorkingDir,
       kCodeFormatter,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1747,6 +1747,12 @@
             "title": "Display account and billing messages from GitHub Copilot",
             "description": "When enabled, RStudio will show account and billing messages from GitHub Copilot in a message box."
         },
+        "copilot_project_workspace": {
+            "type": "boolean",
+            "default": true,
+            "title": "Use RStudio project folder as a Copilot workspace",
+            "description": "When enabled, RStudio will tell Copilot to use the current RStudio project's folder as a workspace."
+        },
         "project_name": {
             "description": "User-provided name for the currently opened R project.",
             "type": "string",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -3677,6 +3677,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * When enabled, RStudio will tell Copilot to use the current RStudio project's folder as a workspace.
+    */
+   public PrefValue<Boolean> copilotProjectWorkspace()
+   {
+      return bool(
+         "copilot_project_workspace",
+         _constants.copilotProjectWorkspaceTitle(), 
+         _constants.copilotProjectWorkspaceDescription(), 
+         true);
+   }
+
+   /**
     * User-provided name for the currently opened R project.
     */
    public PrefValue<String> projectName()
@@ -4330,6 +4342,8 @@ public class UserPrefsAccessor extends Prefs
          copilotIndexingEnabled().setValue(layer, source.getBool("copilot_indexing_enabled"));
       if (source.hasKey("copilot_show_messages"))
          copilotShowMessages().setValue(layer, source.getBool("copilot_show_messages"));
+      if (source.hasKey("copilot_project_workspace"))
+         copilotProjectWorkspace().setValue(layer, source.getBool("copilot_project_workspace"));
       if (source.hasKey("project_name"))
          projectName().setValue(layer, source.getString("project_name"));
       if (source.hasKey("run_background_job_default_working_dir"))
@@ -4607,6 +4621,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(copilotTabKeyBehavior());
       prefs.add(copilotIndexingEnabled());
       prefs.add(copilotShowMessages());
+      prefs.add(copilotProjectWorkspace());
       prefs.add(projectName());
       prefs.add(runBackgroundJobDefaultWorkingDir());
       prefs.add(codeFormatter());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -2150,6 +2150,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String copilotShowMessagesDescription();
 
    /**
+    * When enabled, RStudio will tell Copilot to use the current RStudio project's folder as a workspace.
+    */
+   @DefaultStringValue("Use RStudio project folder as a Copilot workspace")
+   String copilotProjectWorkspaceTitle();
+   @DefaultStringValue("When enabled, RStudio will tell Copilot to use the current RStudio project's folder as a workspace.")
+   String copilotProjectWorkspaceDescription();
+
+   /**
     * User-provided name for the currently opened R project.
     */
    @DefaultStringValue("")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -1080,6 +1080,10 @@ copilotIndexingEnabledDescription = When enabled, RStudio will index project fil
 copilotShowMessagesTitle = Display account and billing messages from GitHub Copilot
 copilotShowMessagesDescription = When enabled, RStudio will show account and billing messages from GitHub Copilot in a message box.
 
+# When enabled, RStudio will tell Copilot to use the current RStudio project's folder as a workspace.
+copilotProjectWorkspaceTitle = Use RStudio project folder as a Copilot workspace
+copilotProjectWorkspaceDescription = When enabled, RStudio will tell Copilot to use the current RStudio project's folder as a workspace.
+
 # User-provided name for the currently opened R project.
 projectNameTitle = 
 projectNameDescription = User-provided name for the currently opened R project.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
@@ -1083,6 +1083,10 @@ copilotIndexingEnabledDescription = Lorsqu''il est activé, RStudio indexera les
 copilotShowMessagesTitle = Afficher les messages de compte et de facturation de GitHub Copilot
 copilotShowMessagesDescription = Lorsqu''il est activé, RStudio affichera les messages de compte et de facturation de GitHub Copilot dans une boîte de dialogue.
 
+# When enabled, RStudio will tell Copilot to use the current RStudio project's folder as a workspace.
+copilotProjectWorkspaceTitle = Utiliser le dossier du projet RStudio comme espace de travail Copilot
+copilotProjectWorkspaceDescription = Lorsqu''il est activé, RStudio indiquera à Copilot d''utiliser le dossier du projet RStudio actuel comme espace de travail.
+
 # User-provided name for the currently opened R project.
 projectNameTitle = 
 projectNameDescription = Nom fourni par l''utilisateur pour le projet R actuellement ouvert.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
@@ -142,7 +142,7 @@ public class CopilotPreferencesPane extends PreferencesPane
       cbCopilotEnabled_ = checkboxPref(prefs_.copilotEnabled(), true);
       cbCopilotIndexingEnabled_ = checkboxPref(prefs_.copilotIndexingEnabled(), true);
       cbCopilotShowMessages_ = checkboxPref(prefs_.copilotShowMessages(), true);
-
+      cbCopilotProjectWorkspace_ = checkboxPref(prefs_.copilotProjectWorkspace(), true);
       selCopilotTabKeyBehavior_ = new SelectWidget(
             prefsConstants_.copilotTabKeyBehaviorTitle(),
             new String[] {
@@ -213,6 +213,7 @@ public class CopilotPreferencesPane extends PreferencesPane
 
          add(spacedBefore(headerLabel(constants_.otherCaption())));
          add(cbCopilotShowMessages_);
+         add(cbCopilotProjectWorkspace_);
 
          // add(checkboxPref(prefs_.copilotAllowAutomaticCompletions()));
          // add(selCopilotTabKeyBehavior_);
@@ -533,6 +534,7 @@ public class CopilotPreferencesPane extends PreferencesPane
    private final CheckBox cbCopilotEnabled_;
    private final CheckBox cbCopilotIndexingEnabled_;
    private final CheckBox cbCopilotShowMessages_;
+   private final CheckBox cbCopilotProjectWorkspace_;
    private final List<SmallButton> statusButtons_;
    private final SmallButton btnShowError_;
    private final SmallButton btnSignIn_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
@@ -82,7 +82,8 @@ public class CopilotPreferencesPane extends PreferencesPane
       RestartRequirement requirement = super.onApply(prefs);
       if (initialCopilotIndexingEnabled_ != prefs.copilotIndexingEnabled().getGlobalValue())
          requirement.setSessionRestartRequired(true);
-      
+      if (initialCopilotWorkspaceEnabled_ != prefs.copilotProjectWorkspace().getGlobalValue())
+         requirement.setSessionRestartRequired(true); 
       return requirement;
    }
    
@@ -454,7 +455,7 @@ public class CopilotPreferencesPane extends PreferencesPane
    protected void initialize(UserPrefs prefs)
    {
       initialCopilotIndexingEnabled_ = prefs.copilotIndexingEnabled().getGlobalValue();
-      
+      initialCopilotWorkspaceEnabled_ = prefs.copilotProjectWorkspace().getGlobalValue();
       projectServer_.readProjectOptions(new ServerRequestCallback<RProjectOptions>()
       {
          @Override
@@ -527,6 +528,7 @@ public class CopilotPreferencesPane extends PreferencesPane
    // State
    private String copilotStartupError_;
    private boolean initialCopilotIndexingEnabled_;
+   private boolean initialCopilotWorkspaceEnabled_;
    private RProjectOptions projectOptions_;
  
    // UI


### PR DESCRIPTION
### Intent

Addresses #15816

### Approach

If RStudio has a project open, and the new user preference ("Use RStudio project folder as a Copilot workspace") is set to true (the default), pass the project folder to Copilot as the "workspace folder" when initializing Copilot.

<img width="662" alt="copilot-prefs" src="https://github.com/user-attachments/assets/cda3a4f7-b051-44d7-8f3d-b2e81c370541" />

### Automated Tests

None

### QA Notes

[The documention](https://github.com/github/copilot-language-server-release?tab=readme-ov-file#workspace-folders-synchronization) says "Workspace folders are optional but highly recommended as they greatly improve the quality of suggestions." Otherwise, no information on what, exactly, this does.

Good luck testing that.

You can turn on logging by adding `COPILOT_LOG_LEVEL=3` to `~/.Renviron` then check that we pass the correct information to Copilot when initializing it.

For example, with no project folder, and/or the feature is off, should see "workspaceFolders: false":

```json
{
  "jsonrpc": "2.0",
  "method": "initialize",
  "params": {
    "processId": 18584,
    "locale": "en",
    "initializationOptions": {
      "editorInfo": {
        "name": "RStudio",
        "version": "2025.04.999-dev+999"
      },
      "editorPluginInfo": {
        "name": "RStudio",
        "version": "2025.04.999-dev+999"
      }
    },
    "capabilities": {
      "workspace": {
        "workspaceFolders": false
      }
    }
  },
  "id": "83f2bc6a-5034-4e75-ab1c-884082a57349"
}
```

With the feature on and a project open, should be "true" along with the folder being passed:


```json
{
  "jsonrpc": "2.0",
  "method": "initialize",
  "params": {
    "processId": 18785,
    "locale": "en",
    "initializationOptions": {
      "editorInfo": {
        "name": "RStudio",
        "version": "2025.04.999-dev+999"
      },
      "editorPluginInfo": {
        "name": "RStudio",
        "version": "2025.04.999-dev+999"
      }
    },
    "capabilities": {
      "workspace": {
        "workspaceFolders": true
      }
    },
    "workspaceFolders": [
      {
        "uri": "file:///Users/zippy/myproject"
      }
    ]
  },
  "id": "c0377475-962d-45c3-9999-bb3393645624"
}
```

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


