### PR TITLE
Prevent "illegal value for lineNumber" from Copilot

### DIFF
--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -1105,26 +1105,6 @@ bool ensureAgentRunning(Error* pAgentLaunchError = nullptr)
    return error == Success();
 }
 
-void onDocAdded(boost::shared_ptr<source_database::SourceDocument> pDoc)
-{
-   if (!ensureAgentRunning())
-      return;
-   
-   if (!isIndexableDocument(pDoc))
-      return;
-   
-   json::Object textDocumentJson;
-   textDocumentJson["uri"] = uriFromDocument(pDoc);
-   textDocumentJson["languageId"] = languageIdFromDocument(pDoc);
-   textDocumentJson["version"] = kCopilotDefaultDocumentVersion;
-   textDocumentJson["text"] = "";
-
-   json::Object paramsJson;
-   paramsJson["textDocument"] = textDocumentJson;
-
-   sendNotification("textDocument/didOpen", paramsJson);
-}
-
 std::string contentsFromDocument(boost::shared_ptr<source_database::SourceDocument> pDoc)
 {
    std::string contents = pDoc->contents();
@@ -1139,6 +1119,26 @@ std::string contentsFromDocument(boost::shared_ptr<source_database::SourceDocume
    }
    
    return contents;
+}
+
+void onDocAdded(boost::shared_ptr<source_database::SourceDocument> pDoc)
+{
+   if (!ensureAgentRunning())
+      return;
+   
+   if (!isIndexableDocument(pDoc))
+      return;
+   
+   json::Object textDocumentJson;
+   textDocumentJson["uri"] = uriFromDocument(pDoc);
+   textDocumentJson["languageId"] = languageIdFromDocument(pDoc);
+   textDocumentJson["version"] = kCopilotDefaultDocumentVersion;
+   textDocumentJson["text"] = contentsFromDocument(pDoc);
+
+   json::Object paramsJson;
+   paramsJson["textDocument"] = textDocumentJson;
+
+   sendNotification("textDocument/didOpen", paramsJson);
 }
 
 namespace file_monitor {


### PR DESCRIPTION
### Intent

With the newer `copilot-language-server`, was often getting an error after opening a source file in RStudio, saying "Copilot: Request getCompletions failed with message: Illegal value for lineNumber".

<img width="489" alt="copilot-error" src="https://github.com/user-attachments/assets/f135504f-f635-42d6-8ffb-4e4237b367ba" />

### Approach

We were not passing the text of the document via `textDocument/didOpen` in response to `onDocAdded`, but we were via `onDocUpdated`. So when Copilot thinks the file is empty it complains about the current line number being out of range.

Fixed by passing the document contents in both cases.

### Automated Tests

None

### QA Notes

Routine usage.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


