### PR TITLE
notify copilot when a document gets focused

### DIFF
--- a/git_hooks/secrets/.secrets.baseline
+++ b/git_hooks/secrets/.secrets.baseline
@@ -517,7 +517,7 @@
         "filename": "src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java",
         "hashed_secret": "1c60262d3df7b0c6d2d5c52dd5014c985004219f",
         "is_verified": false,
-        "line_number": 7356,
+        "line_number": 7362,
         "is_secret": false
       },
       {
@@ -525,7 +525,7 @@
         "filename": "src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java",
         "hashed_secret": "12106b07b5b299b5e91117791ec7017f0820f84e",
         "is_verified": false,
-        "line_number": 7398,
+        "line_number": 7404,
         "is_secret": false
       }
     ],
@@ -616,5 +616,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-05T18:16:37Z"
+  "generated_at": "2025-04-07T20:15:00Z"
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -712,6 +712,18 @@ public class RemoteServer implements Server
    }
    
    @Override
+   public void copilotDocFocused(String documentId,
+                                 ServerRequestCallback<Void> requestCallback) 
+   {
+      JSONArray params = new JSONArrayBuilder()
+            .add(documentId)
+            .get();
+      
+      sendRequest(RPC_SCOPE, "copilot_doc_focused", params, requestCallback);
+
+   };
+
+   @Override
    public void copilotGenerateCompletions(String documentId,
                                           String documentPath,
                                           boolean isUntitled,
@@ -7425,6 +7437,6 @@ public class RemoteServer implements Server
       public RpcRequest request;
       public RpcResponseHandler responseHandler;
       public RetryHandler retryHandler;
-   };
+   }
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/copilot/server/CopilotServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/copilot/server/CopilotServerOperations.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.copilot.server;
 
 import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotDiagnosticsResponse;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotGenerateCompletionsResponse;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotSignInResponse;
@@ -31,6 +32,9 @@ public interface CopilotServerOperations
    
    public void copilotStatus(ServerRequestCallback<CopilotStatusResponse> requestCallback);
    
+   public void copilotDocFocused(String documentId,
+                                 ServerRequestCallback<Void> requestCallback);
+
    public void copilotGenerateCompletions(String documentId,
                                           String documentPath,
                                           boolean isUntitled,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
@@ -864,6 +864,12 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
          @Override
          public void execute()
          {
+            // notify Copilot of the focused document
+            if (event.getId() != null)
+            {
+               server_.copilotDocFocused(event.getId(), new VoidServerRequestCallback());
+            }
+
             // ignore this event if it's from main window but the main window
             // doesn't have focus
             if (!mainWindowFocused_ && event.isFromMainWindow())


### PR DESCRIPTION
### Intent

Addresses #15876

### Approach

Implement notification as described here: https://github.com/github/copilot-language-server-release?tab=readme-ov-file#text-document-focusing

### Automated Tests

None

### QA Notes

See issue.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


