### PR TITLE
fix handling of extended errors w/virtualized console

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -852,6 +852,13 @@ public class VirtualConsole
                   Match groupStartMatch = groupStartPattern.match(data.substring(head), 0);
                   if (groupStartMatch != null)
                   {
+                     // skip escapes if we're virtualized
+                     if (isVirtualized())
+                     {
+                        tail += groupStartMatch.getValue().length() - 1;
+                        break;
+                     }
+                     
                      String type = groupStartMatch.getGroup(1);
                      String groupClazz = groupTypeToClazz(type);
                      
@@ -886,6 +893,13 @@ public class VirtualConsole
                   Match groupEndMatch = groupEndPattern.match(data.substring(head), 0);
                   if (groupEndMatch != null)
                   {
+                     // skip escapes if we're virtualized
+                     if (isVirtualized())
+                     {
+                        tail += groupEndMatch.getValue().length() - 1;
+                        break;
+                     }
+                     
                      if (parent_.hasClassName(RES.styles().group()))
                      {
                         forceNewRange = forceNewRange_ = true;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ChangelistTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ChangelistTable.java
@@ -292,11 +292,11 @@ public abstract class ChangelistTable extends Composite
    public void setItems(ArrayList<StatusAndPath> items)
    {
       setProgress(false);
+      items = (items == null) ? new ArrayList<>() : items;
       table_.setPageSize(items.size());
       dataProvider_.getList().clear();
       dataProvider_.getList().addAll(items);
-      ColumnSortEvent.fire(table_,
-                           table_.getColumnSortList());
+      ColumnSortEvent.fire(table_, table_.getColumnSortList());
 
       if (selectFirstItemByDefault_)
       {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15877.

### Approach

The DOM structure of the console output history will differ depending on whether console virtualization is enabled or not. This affects how the extended error widget should be inserted. Accommodate those differences.

### Automated Tests

Covered by existing automation.

### QA Notes

See https://github.com/rstudio/rstudio/issues/15877.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
