### PR TITLE
Update websocketpp revision to latest

### DIFF
--- a/src/cpp/ext/CMakeLists.txt
+++ b/src/cpp/ext/CMakeLists.txt
@@ -138,7 +138,7 @@ dependency(WEBSOCKETPP
    COMMENT    "WebSocket++ is a header only C++ library that implements RFC6455 The WebSocket Protocol."
    VERSION    "0.8.3"
    REPOSITORY "https://github.com/amini-allight/websocketpp"
-   REVISION   "a11fa6fe4937ca251753e90b1836a68bf57768a9" # pragma: allowlist secret
+   REVISION   "ee8cf4257e001d939839cff5b1766a835b749cd6" # pragma: allowlist secret
    CUSTOM     TRUE
 )
 


### PR DESCRIPTION
All Builds are currently broken with the error:

```
[2025-04-09T13:55:28.228Z] [1/9] Creating directories for 'websocketpp-populate'

[2025-04-09T13:55:28.228Z] [1/9] Performing download step (git clone) for 'websocketpp-populate'

[2025-04-09T13:55:28.228Z] Cloning into 'websocketpp-src'...

[2025-04-09T13:55:28.228Z] fatal: reference is not a tree: a11fa6fe4937ca251753e90b1836a68bf57768a9

[2025-04-09T13:55:28.228Z] CMake Error at websocketpp-subbuild/websocketpp-populate-prefix/tmp/websocketpp-populate-gitclone.cmake:49 (message):

[2025-04-09T13:55:28.228Z]   Failed to checkout tag: 'a11fa6fe4937ca251753e90b1836a68bf57768a9'

[2025-04-09T13:55:28.228Z] 

[2025-04-09T13:55:28.228Z] 

[2025-04-09T13:55:28.228Z] FAILED: websocketpp-populate-prefix/src/websocketpp-populate-stamp/websocketpp-populate-download /var/lib/jenkins/workspace/IDE/Pro-Builds/Platforms/session-pipeline/main/package/linux/build-Session-jammy/_deps/websocketpp-subbuild/websocketpp-populate-prefix/src/websocketpp-populate-stamp/websocketpp-populate-download 

[2025-04-09T13:55:28.228Z] cd /var/lib/jenkins/workspace/IDE/Pro-Builds/Platforms/session-pipeline/main/package/linux/build-Session-jammy/_deps && /usr/local/bin/cmake -P /var/lib/jenkins/workspace/IDE/Pro-Builds/Platforms/session-pipeline/main/package/linux/build-Session-jammy/_deps/websocketpp-subbuild/websocketpp-populate-prefix/tmp/websocketpp-populate-gitclone.cmake && /usr/local/bin/cmake -E touch /var/lib/jenkins/workspace/IDE/Pro-Builds/Platforms/session-pipeline/main/package/linux/build-Session-jammy/_deps/websocketpp-subbuild/websocketpp-populate-prefix/src/websocketpp-populate-stamp/websocketpp-populate-download

[2025-04-09T13:55:28.228Z] ninja: build stopped: subcommand failed.

[2025-04-09T13:55:28.228Z] 

[2025-04-09T13:55:28.228Z] CMake Error at /usr/local/share/cmake-3.25/Modules/FetchContent.cmake:1624 (message):

[2025-04-09T13:55:28.228Z]   Build step for websocketpp failed: 1
```

I don't know if this is the reason for the failure, but `a11fa6fe4937ca251753e90b1836a68bf57768a9` used to be the HEAD commit on the `develop` branch for this repo, but a [new commit was pushed 8 hours ago](https://github.com/amini-allight/websocketpp/commits/develop/) (at the time of writing this). 

So, in an attempt to fix this, this PR updates the revision we are using to the latest commit on the branch. Long term, if this is the actual issue, we'll need a better solution, but all of our builds are broken right now.