### PR TITLE
allow skipping cpack step

### DIFF
--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -272,6 +272,9 @@ if [ -n "$SCCACHE_ENABLED" ]; then
    sccache --show-stats
 fi
 
-cpack --verbose --debug -G "$PACKAGE_TARGET"
+if [ "${RSTUDIO_BUILD_PACKAGE:-1}" = "1" ]; then
+   cpack --verbose --debug -G "$PACKAGE_TARGET"
+fi
+
 cd "$PREV_WD"
 


### PR DESCRIPTION
This is primarily to help support faster development builds with RStudio Workbench.

We can set `RSTUDIO_BUILD_PACKAGE=0` to build RStudio Workbench without actually building the `.deb` installer (which is very slow), and instead manually install components ourselves (much faster).