### PR TITLE
notify copilot when we show a completion

### DIFF
--- a/git_hooks/secrets/.secrets.baseline
+++ b/git_hooks/secrets/.secrets.baseline
@@ -517,7 +517,7 @@
         "filename": "src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java",
         "hashed_secret": "1c60262d3df7b0c6d2d5c52dd5014c985004219f",
         "is_verified": false,
-        "line_number": 7363,
+        "line_number": 7375,
         "is_secret": false
       },
       {
@@ -525,7 +525,7 @@
         "filename": "src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java",
         "hashed_secret": "12106b07b5b299b5e91117791ec7017f0820f84e",
         "is_verified": false,
-        "line_number": 7405,
+        "line_number": 7417,
         "is_secret": false
       }
     ],
@@ -616,5 +616,5 @@
       }
     ]
   },
-  "generated_at": "2025-04-08T20:21:02Z"
+  "generated_at": "2025-04-10T17:03:23Z"
 }

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -1804,6 +1804,31 @@ Error copilotDocFocused(const json::JsonRpcRequest& request,
    return Success();
 }
 
+Error copilotDidShowCompletion(const json::JsonRpcRequest& request,
+                               json::JsonRpcResponse* pResponse)
+{
+   // Make sure copilot is running
+   if (!ensureAgentRunning())
+   {
+      // nothing to do if we can't connect to the agent
+      return Success();
+   }
+
+   // Read params
+   json::Object completionJson;
+   Error error = core::json::readParams(request.params, &completionJson);
+   if (error)
+   {
+      LOG_ERROR(error);
+      return error;
+   }
+
+   json::Object paramsJson;
+   paramsJson["item"] = completionJson;
+   sendNotification("textDocument/didShowCompletion", paramsJson);
+   return Success();
+}
+
 } // end anonymous namespace
 
 
@@ -1852,6 +1877,7 @@ Error initialize()
          (bind(registerAsyncRpcMethod, "copilot_sign_out", copilotSignOut))
          (bind(registerAsyncRpcMethod, "copilot_status", copilotStatus))
          (bind(registerRpcMethod, "copilot_doc_focused", copilotDocFocused))
+         (bind(registerRpcMethod, "copilot_did_show_completion", copilotDidShowCompletion))
          (bind(sourceModuleRFile, "SessionCopilot.R"))
          ;
    return initBlock.execute();

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -163,6 +163,7 @@ import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.Co
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotSignInResponse;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotSignOutResponse;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotStatusResponse;
+import org.rstudio.studio.client.workbench.copilot.model.CopilotTypes.CopilotCompletion;
 import org.rstudio.studio.client.workbench.events.SessionInitEvent;
 import org.rstudio.studio.client.workbench.exportplot.model.SavePlotAsImageContext;
 import org.rstudio.studio.client.workbench.model.HTMLCapabilities;
@@ -720,6 +721,17 @@ public class RemoteServer implements Server
             .get();
       
       sendRequest(RPC_SCOPE, "copilot_doc_focused", params, requestCallback);
+   };
+
+   @Override
+   public void copilotDidShowCompletion(CopilotCompletion completion,
+                                        ServerRequestCallback<Void> requestCallback) 
+   {
+      JSONArray params = new JSONArrayBuilder()
+            .add(completion)
+            .get();
+      
+      sendRequest(RPC_SCOPE, "copilot_did_show_completion", params, requestCallback);
    };
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/copilot/server/CopilotServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/copilot/server/CopilotServerOperations.java
@@ -21,6 +21,7 @@ import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.Co
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotSignInResponse;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotSignOutResponse;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotStatusResponse;
+import org.rstudio.studio.client.workbench.copilot.model.CopilotTypes.CopilotCompletion;
 
 public interface CopilotServerOperations
 {
@@ -34,6 +35,9 @@ public interface CopilotServerOperations
    
    public void copilotDocFocused(String documentId,
                                  ServerRequestCallback<Void> requestCallback);
+   
+   public void copilotDidShowCompletion(CopilotCompletion command,
+                                        ServerRequestCallback<Void> requestCallback);
 
    public void copilotGenerateCompletions(String documentId,
                                           String documentPath,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
@@ -31,6 +31,7 @@ import org.rstudio.studio.client.common.Timers;
 import org.rstudio.studio.client.projects.ui.prefs.events.ProjectOptionsChangedEvent;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.copilot.Copilot;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotConstants;
@@ -217,6 +218,9 @@ public class TextEditingTargetCopilotHelper
                      for (int i = 0, n = completions.getLength(); i < n; i++)
                      {
                         CopilotCompletion completion = completions.getAt(i);
+
+                        server_.copilotDidShowCompletion(completion,
+                                                         new VoidServerRequestCallback());
 
                         // fix up the copilot range; it's computed using the source document
                         // cursor position, but we want to convert this to the position


### PR DESCRIPTION
### Intent

Part of #15861 -- notify Copilot when we display a completion

### Approach

Send `textDocument/didShowCompletion` notification to Copilot when we display a completion (i.e. ghost text) that was returned to us by Copilot.

See https://github.com/github/copilot-language-server-release?tab=readme-ov-file#inline-completions for more details.

### Automated Tests

None

### QA Notes

Will add notes to issue once it is complete.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


