### PR TITLE
Use a different method of syncing certs on windows

### DIFF
--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -156,7 +156,7 @@ pipeline {
             bat 'msiexec /i smtools-windows-x64.msi /quiet /qn /L*V smtools-windows-x64.log'
             bat 'type smtools-windows-x64.log'
             bat 'C:\\Windows\\System32\\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user'
-            bat '"C:\\Program Files\\DigiCert\\DigiCert One Signing Manager Tools\\smksp_cert_sync"'
+            bat '"C:\\Program Files\\DigiCert\\DigiCert One Signing Manager Tools\\smctl.exe" windows certsync'
             bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x64\\signtool" sign /tr http://timestamp.digicert.com /sha1 %DIGICERT_CERTIFICATE_FINGERPRINT% /td SHA256 /fd SHA256 ' + EXECUTABLES
             bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x64\\signtool\" verify /v /pa ' + EXECUTABLES
           }
@@ -196,7 +196,7 @@ pipeline {
             stage('Sign Installer') {
               steps {
                 bat 'C:\\Windows\\System32\\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user'
-                bat '"C:\\Program Files\\DigiCert\\DigiCert One Signing Manager Tools\\smksp_cert_sync"'
+                bat '"C:\\Program Files\\DigiCert\\DigiCert One Signing Manager Tools\\smctl.exe" windows certsync'
                 bat '"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x64\\signtool" sign /tr http://timestamp.digicert.com /sha1 %DIGICERT_CERTIFICATE_FINGERPRINT% /td SHA256 /fd SHA256 package\\win32\\build\\' + LONG_PACKAGE_NAME + '.exe'
                 bat "\"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x64\\signtool\" verify /v /pa package\\win32\\build\\${LONG_PACKAGE_NAME}.exe"
               }


### PR DESCRIPTION
The smksp_cert_sync.exe tool stopped working on the latest update of Windows. An alternate method to achieve the same is to use smctl.exe directly.

### Intent

Attempt to fix the Windows builds.

### Approach

Use a different method to sync signing certs during build signing.

### Automated Tests

Normal tests for Windows installers, assuming this addresses the build issue.
