### PR TITLE
log messages from didChangeStatus at Debug level

### DIFF
--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -1376,10 +1376,10 @@ void onBackgroundProcessing(bool isIdle)
                if (kindJson.isString())
                   kind = kindJson.getString();
 
-                if (boost::iequals(kind, "Error"))
-                  ELOG("didChangeStatus: '{}'", message);
-                else if (boost::iequals(kind, "Warning") || boost::iequals(kind, "Inactive"))
-                  WLOG("didChangeStatus: '{}'", message);
+                // Log at debug level to avoid spamming the logs with things such as
+                // "You are not signed into GitHub."
+                // https://github.com/rstudio/rstudio/issues/15910
+                DLOG("didChangeStatus: '{}: {}'", kind, message);
             }
             continue;
          }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15910

### Approach

Log all messages from `didChangeStatus` at Debug level. Note that in prior releases we did not log this at all, so having it at Debug level gives us extra diagnostic possibilities without spamming the logs with non-helpful errors.

### Automated Tests

None

### QA Notes

See issue.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


