### PR TITLE
Fix SOCI build on Windows w/newer Cmake versions

### DIFF
--- a/dependencies/windows/install-soci/install-soci.R
+++ b/dependencies/windows/install-soci/install-soci.R
@@ -122,6 +122,7 @@ build <- function(arch, config) {
       -G "{CMAKE_GENERATOR}"
       -A {winarch}
       -DCMAKE_VERBOSE_MAKEFILE=ON
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
       -DCMAKE_CXX_FLAGS="/FS /EHsc"
       -DBOOST_INCLUDEDIR="{boost_include_dir}"
       -DBOOST_LIBRARYDIR="{boost_library_dir}"

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -26,7 +26,6 @@ RUN $env:chocolateyUseWindowsCompression = 'true'; `
 
 # install some deps via chocolatey
 RUN `
-  choco install -y vim; `
   choco install -y -i ant; `
   choco install -y 7zip; `
   choco install -y awscli; `


### PR DESCRIPTION
This is the Windows-specific fix for what I fixed on Mac and Linux here: https://github.com/rstudio/rstudio/pull/15844

The tweak to the Dockerfile was to remove a previous tweak I used to force an image rebuild (to again force an image rebuild).