### PR TITLE
Revert Copilot support in Visual Mode code chunks

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -9450,11 +9450,6 @@ public class TextEditingTarget implements
    {
       return view_.isAttached();
    }
-   
-   public TextEditingTargetCopilotHelper getCopilotHelper()
-   {
-      return copilotHelper_;
-   }
 
    private StatusBar statusBar_;
    private final DocDisplay docDisplay_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -797,6 +797,7 @@ public class VisualMode implements VisualModeEditorSync,
               panmirror_.getEditingOutlineLocation());
    }
 
+   
    public DocDisplay getActiveEditor()
    {
       return activeEditor_;
@@ -817,16 +818,6 @@ public class VisualMode implements VisualModeEditorSync,
          // A code chunk has focus; enable code commands
          setCodeCommandsEnabled(true);
       }
-   }
-   
-   public VisualModeChunk getActiveEditorChunk()
-   {
-      return activeEditorChunk_;
-   }
-   
-   public void setActiveEditorChunk(VisualModeChunk activeEditorChunk)
-   {
-      activeEditorChunk_ = activeEditorChunk;
    }
    
    /**
@@ -1946,7 +1937,6 @@ public class VisualMode implements VisualModeEditorSync,
    private UserPrefs prefs_;
    private SourceServerOperations source_;
    private DocDisplay activeEditor_;  // the current embedded editor
-   private VisualModeChunk activeEditorChunk_;
    
    private final TextEditingTarget target_;
    private final TextEditingTarget.Display view_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
@@ -56,7 +56,6 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEdit
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
 import org.rstudio.studio.client.workbench.views.source.editors.text.assist.RChunkHeaderParser;
-import org.rstudio.studio.client.workbench.views.source.editors.text.events.CursorChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditingTargetSelectedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkContextPanmirrorUi;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkDefinition;
@@ -191,24 +190,6 @@ public class VisualModeChunk
       // editors)
       editor_.setUseWrapMode(true);
       
-      releaseOnDismiss_.add(editor_.addCapturingKeyDownHandler(new KeyDownHandler()
-      {
-         @Override
-         public void onKeyDown(KeyDownEvent event)
-         {
-            target_.getCopilotHelper().onKeyDown(editor_, event);
-         }
-      }));
-      
-      releaseOnDismiss_.add(editor_.addCursorChangedHandler(new CursorChangedEvent.Handler()
-      {
-         @Override
-         public void onCursorChanged(CursorChangedEvent event)
-         {
-            target_.getCopilotHelper().onCursorChanged(editor_);
-         }
-      }));
-      
       // Special comment continuation
       releaseOnDismiss_.add(editor_.addKeyDownHandler(new KeyDownHandler()
       {
@@ -217,14 +198,14 @@ public class VisualModeChunk
             NativeEvent ne = event.getNativeEvent();
             TextEditingTargetQuartoHelper.continueSpecialCommentOnNewline(editor_, ne);
          }
-      }));
+      }
+      ));
       
       // Track activation state and notify visual mode
       releaseOnDismiss_.add(editor_.addFocusHandler((evt) ->
       { 
          active_ = true; 
          target_.getVisualMode().setActiveEditor(editor_);
-         target_.getVisualMode().setActiveEditorChunk(VisualModeChunk.this);
 
          // Ensure keyboard shortcut commands (e.g. Save File) route here when using multiple source columns
          events_.fireEvent(new EditingTargetSelectedEvent(target_));
@@ -232,12 +213,10 @@ public class VisualModeChunk
          // Route commands properly when editor is in a secondary window
          events_.fireEvent(new DocFocusedEvent(target_.getPath(), target_.getId()));
       }));
-      
       releaseOnDismiss_.add(editor_.addBlurHandler((evt) ->
       {
          active_ = false;
          target_.getVisualMode().setActiveEditor(null);
-         target_.getVisualMode().setActiveEditorChunk(null);
       }));
 
       // Track UI pref for tab behavior. Note that this can't be a lambda because Ace has trouble with lambda bindings.


### PR DESCRIPTION
### Intent

Addresses #15912

### Approach

Revert commit 734b74870aebaeda04382c74b00e9c39406679bd and re-add the overlapping changes from https://github.com/rstudio/rstudio/pull/15885.

Reopened https://github.com/rstudio/rstudio/issues/13427 and assigned to backlog.

### Automated Tests

NA

### QA Notes

Ensure completions not showing up in Visual Mode code chunks, sanity checking of completions in source mode.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


