### PR TITLE
populate env vars for publishing from .Renviron instead of passing entire environment

### DIFF
--- a/src/cpp/session/modules/SessionRSConnect.R
+++ b/src/cpp/session/modules/SessionRSConnect.R
@@ -15,7 +15,18 @@
 
 .rs.addJsonRpcHandler("get_deployment_env_vars", function()
 {
-   as.character(names(Sys.getenv()))
+  # Find active .Renviron file
+  environFile <- .rs.findEnvironFile()
+  if (!nzchar(environFile) || !file.exists(environFile))
+    return(character())
+
+    # Read environment variable names from the file
+    contents <- readLines(environFile, warn = FALSE)
+    pattern <- "^\\s*([\\w_]+)\\s*="
+    matchedLines <- grep(pattern, contents, perl = TRUE, value = TRUE)
+    envVars <- gsub("\\s*=.*", "", matchedLines)
+    
+    as.character(names(envVars))
 })
 
 .rs.addJsonRpcHandler("forget_rsconnect_deployments", function(sourcePath, outputPath)


### PR DESCRIPTION
### Intent

Addresses #15883

### Approach

Instead of passing along all env-vars from the current environment, only pass those found in the .Renviron file (with no additional filtering).

### Automated Tests

None added

### QA Notes

See issue

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


