### PR TITLE
Fix return type from env-var detection

### DIFF
--- a/src/cpp/session/modules/SessionRSConnect.R
+++ b/src/cpp/session/modules/SessionRSConnect.R
@@ -24,9 +24,7 @@
     contents <- readLines(environFile, warn = FALSE)
     pattern <- "^\\s*([\\w_]+)\\s*="
     matchedLines <- grep(pattern, contents, perl = TRUE, value = TRUE)
-    envVars <- gsub("\\s*=.*", "", matchedLines)
-    
-    as.character(names(envVars))
+    gsub("\\s*=.*", "", matchedLines)
 })
 
 .rs.addJsonRpcHandler("forget_rsconnect_deployments", function(sourcePath, outputPath)


### PR DESCRIPTION
### Intent

Fix for the fix for #15883

### Approach

Method was not returning a vector as the caller expects. Now it does.

### Automated Tests

None

### QA Notes

Rinse and repeat.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


