### PR TITLE
Add option to disable splash screen, close splash screen when clicked

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,8 @@
 
 #### RStudio
 
--
+- Added a user preference to disable showing the splash screen at startup (#15945)
+- The splash screen now closes when clicked with the mouse (#15614)
 
 #### Posit Workbench
 

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -332,6 +332,7 @@ namespace prefs {
 #define kRestoreProjectRVersion "restore_project_r_version"
 #define kClangVerbose "clang_verbose"
 #define kSubmitCrashReports "submit_crash_reports"
+#define kEnableSplashScreen "enable_splash_screen"
 #define kDefaultRVersion "default_r_version"
 #define kDefaultRVersionVersion "version"
 #define kDefaultRVersionRHome "r_home"
@@ -1641,6 +1642,12 @@ public:
     */
    bool submitCrashReports();
    core::Error setSubmitCrashReports(bool val);
+
+   /**
+    * Whether to show the splash screen when RStudio is starting.
+    */
+   bool enableSplashScreen();
+   core::Error setEnableSplashScreen(bool val);
 
    /**
     * The R version to use by default.

--- a/src/cpp/session/include/session/prefs/UserStateValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserStateValues.hpp
@@ -36,6 +36,7 @@ namespace prefs {
 #define kViewWindowBounds "windowBounds"
 #define kViewAccessibility "accessibility"
 #define kViewDisableRendererAccessibility "disableRendererAccessibility"
+#define kViewEnableSplashScreen "enableSplashScreen"
 #define kRemoteSession "remote_session"
 #define kRemoteSessionLastRemoteSessionUrl "lastRemoteSessionUrl"
 #define kRemoteSessionAuthCookies "authCookies"

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -1837,6 +1837,15 @@
    clear = function() { .rs.clearUserPref("submit_crash_reports") }
 )
 
+# Show splash screen when RStudio is starting
+#
+# Whether to show the splash screen when RStudio is starting.
+.rs.uiPrefs$enableSplashScreen <- list(
+   get = function() { .rs.getUserPref("enable_splash_screen") },
+   set = function(value) { .rs.setUserPref("enable_splash_screen", value) },
+   clear = function() { .rs.clearUserPref("enable_splash_screen") }
+)
+
 # 
 #
 # The R version to use by default.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2585,6 +2585,19 @@ core::Error UserPrefValues::setSubmitCrashReports(bool val)
 }
 
 /**
+ * Whether to show the splash screen when RStudio is starting.
+ */
+bool UserPrefValues::enableSplashScreen()
+{
+   return readPref<bool>("enable_splash_screen");
+}
+
+core::Error UserPrefValues::setEnableSplashScreen(bool val)
+{
+   return writePref("enable_splash_screen", val);
+}
+
+/**
  * The R version to use by default.
  */
 core::json::Object UserPrefValues::defaultRVersion()
@@ -3681,6 +3694,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kRestoreProjectRVersion,
       kClangVerbose,
       kSubmitCrashReports,
+      kEnableSplashScreen,
       kDefaultRVersion,
       kDataViewerMaxColumns,
       kDataViewerMaxCellSize,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1324,6 +1324,12 @@
             "title": "Submit crash reports to Posit",
             "description": "Whether to automatically submit crash reports to Posit."
         },
+        "enable_splash_screen": {
+            "type": "boolean",
+            "default": true,
+            "title": "Show splash screen when RStudio is starting",
+            "description": "Whether to show the splash screen when RStudio is starting."
+        },
         "default_r_version": {
             "type": "object",
             "properties": {

--- a/src/cpp/session/resources/schema/user-state-schema.json
+++ b/src/cpp/session/resources/schema/user-state-schema.json
@@ -63,13 +63,18 @@
                 "disableRendererAccessibility": {
                     "type": "boolean",
                     "description": "Disable Electron accessibility support"
+                },
+                "enableSplashScreen": {
+                    "type": "boolean",
+                    "description": "Whether to show the splash screen on startup"
                 }
              },
             "default": {
                 "zoomLevel": 1.0,
                 "windowBounds": { "width": 1200, "height": 900, "x": 0, "y": 0, "maximized": false },
                 "accessibility": false,
-                "disableRendererAccessibility": false
+                "disableRendererAccessibility": false,
+                "enableSplashScreen": true
             }
         },
         "remote_session": {

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -175,6 +175,8 @@ public interface DesktopFrame extends JavaScriptPassthrough
    void getEnableAccessibility(CommandWithArg<Boolean> callback);
    void setEnableAccessibility(boolean enable);
    void setDisableRendererAccessibility(boolean disable);
+   void getEnableSplashScreen(CommandWithArg<Boolean> callback);
+   void setEnableSplashScreen(boolean enable);
 
    void setAutohideMenubar(boolean enable);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
@@ -357,6 +357,13 @@ public class UserPrefs extends UserPrefsComputed
       });
    }
 
+   public void setEnableSplashScreen(boolean enabled)
+   {
+      if (Desktop.hasDesktopFrame())
+         Desktop.getFrame().setEnableSplashScreen(enabled);
+      enableSplashScreen().setGlobalValue(enabled);
+   }
+
    public static final int LAYER_DEFAULT  = 0;
    public static final int LAYER_SYSTEM   = 1;
    public static final int LAYER_COMPUTED = 2;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -2801,6 +2801,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Whether to show the splash screen when RStudio is starting.
+    */
+   public PrefValue<Boolean> enableSplashScreen()
+   {
+      return bool(
+         "enable_splash_screen",
+         _constants.enableSplashScreenTitle(), 
+         _constants.enableSplashScreenDescription(), 
+         true);
+   }
+
+   /**
     * The R version to use by default.
     */
    public PrefValue<DefaultRVersion> defaultRVersion()
@@ -4222,6 +4234,8 @@ public class UserPrefsAccessor extends Prefs
          clangVerbose().setValue(layer, source.getInteger("clang_verbose"));
       if (source.hasKey("submit_crash_reports"))
          submitCrashReports().setValue(layer, source.getBool("submit_crash_reports"));
+      if (source.hasKey("enable_splash_screen"))
+         enableSplashScreen().setValue(layer, source.getBool("enable_splash_screen"));
       if (source.hasKey("default_r_version"))
          defaultRVersion().setValue(layer, source.getObject("default_r_version"));
       if (source.hasKey("data_viewer_max_columns"))
@@ -4561,6 +4575,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(restoreProjectRVersion());
       prefs.add(clangVerbose());
       prefs.add(submitCrashReports());
+      prefs.add(enableSplashScreen());
       prefs.add(defaultRVersion());
       prefs.add(dataViewerMaxColumns());
       prefs.add(dataViewerMaxCellSize());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -1656,6 +1656,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String submitCrashReportsDescription();
 
    /**
+    * Whether to show the splash screen when RStudio is starting.
+    */
+   @DefaultStringValue("Show splash screen when RStudio is starting")
+   String enableSplashScreenTitle();
+   @DefaultStringValue("Whether to show the splash screen when RStudio is starting.")
+   String enableSplashScreenDescription();
+
+   /**
     * The R version to use by default.
     */
    @DefaultStringValue("")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -833,6 +833,10 @@ clangVerboseDescription = The verbosity level to use with Clang (0 - 2)
 submitCrashReportsTitle = Submit crash reports to Posit
 submitCrashReportsDescription = Whether to automatically submit crash reports to Posit.
 
+# Whether to show the splash screen when RStudio is starting.
+enableSplashScreenTitle = Show splash screen when RStudio is starting
+enableSplashScreenDescription = Whether to show the splash screen when RStudio is starting.
+
 # The R version to use by default.
 defaultRVersionTitle = 
 defaultRVersionDescription = The R version to use by default.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
@@ -810,6 +810,10 @@ clangVerboseDescription= Le niveau de verbosité à utiliser avec Clang (0 - 2).
 submitCrashReportsTitle= Soumettre les rapports d''erreur à Posit
 submitCrashReportsDescription= Si on doit souhaitez soumettre automatiquement les rapports de panne à Posit.
 
+# Whether to show the splash screen when RStudio is starting.
+enableSplashScreenTitle= Afficher l''écran de démarrage lors du lancement de RStudio
+enableSplashScreenDescription= Si on doit afficher l''écran de démarrage lors du lancement de RStudio.
+
 # The R version to use by default.
 defaultRVersionTitle=
 defaultRVersionDescription= La version de R à utiliser par défaut.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
@@ -123,6 +123,10 @@ public class UserStateAccessor extends Prefs
          return this && this.disableRendererAccessibility || false;
       }-*/;
 
+      public final native boolean getEnableSplashScreen() /*-{
+         return this && this.enableSplashScreen || true;
+      }-*/;
+
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -222,6 +222,12 @@ public class GeneralPreferencesPane extends PreferencesPane
          basic.add(autohideMenubar);
       }
 
+      enableSplashScreen_ = new CheckBox(prefs_.enableSplashScreen().getTitle());
+      if (BrowseCap.isElectron())
+      {
+         basic.add(enableSplashScreen_);
+      }
+
       VerticalTabPanel graphics = new VerticalTabPanel(ElementIds.GENERAL_GRAPHICS_PREFS);
 
       initializeGraphicsBackendWidget();
@@ -528,6 +534,8 @@ public class GeneralPreferencesPane extends PreferencesPane
       initialUiLanguage_ = prefs_.uiLanguage().getValue();
       initialNativeFileDialogs_ = prefs_.nativeFileDialogs().getValue();
       initialDisableRendererAccessibility_ = prefs_.disableRendererAccessibility().getValue();
+      initialEnableSplashScreen_ = prefs.enableSplashScreen().getValue();
+      enableSplashScreen_.setValue(initialEnableSplashScreen_);
    }
 
    @Override
@@ -653,6 +661,13 @@ public class GeneralPreferencesPane extends PreferencesPane
             WebDialogCookie.setUseWebDialogs(useWebDialogsPrefValue);
             restartRequirement.setUiReloadRequired(true);
          }
+
+         boolean enableSplashScreenSetting = enableSplashScreen_.getValue();
+         if (enableSplashScreenSetting != initialEnableSplashScreen_)
+         {
+            initialEnableSplashScreen_ = enableSplashScreenSetting;
+            prefs.setEnableSplashScreen(enableSplashScreenSetting);
+         }
       }
 
       // Pro specific
@@ -756,6 +771,7 @@ public class GeneralPreferencesPane extends PreferencesPane
    private CheckBox disableRendererAccessibility_ = null;
    private CheckBox useGpuExclusions_ = null;
    private CheckBox useGpuDriverBugWorkarounds_ = null;
+   private CheckBox enableSplashScreen_ = null;
    private SelectWidget renderingEngineWidget_ = null;
    private String renderingEngine_ = null;
 
@@ -781,4 +797,5 @@ public class GeneralPreferencesPane extends PreferencesPane
    private String initialUiLanguage_;
    private boolean initialNativeFileDialogs_;
    private boolean initialDisableRendererAccessibility_;
+   private boolean initialEnableSplashScreen_;
 }

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -773,6 +773,14 @@ export class GwtCallback extends EventEmitter {
       ElectronDesktopOptions().setAccessibility(enable);
     });
 
+    ipcMain.handle('desktop_get_enable_splash_screen', () => {
+      return ElectronDesktopOptions().enableSplashScreen();
+    });
+
+    ipcMain.on('desktop_set_enable_splash_screen', (_event, enable) => {
+      ElectronDesktopOptions().setEnableSplashScreen(enable);
+    });
+
     ipcMain.on('desktop_set_autohide_menubar', (_event, autohide: boolean) => {
       this.mainWindow.window.setAutoHideMenuBar(autohide);
       this.mainWindow.window.setMenuBarVisibility(!autohide);

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -34,6 +34,7 @@ const kFixedWidthFont = 'font.fixedWidthFont';
 const kZoomLevel = 'view.zoomLevel';
 const kWindowBounds = 'view.windowBounds';
 const kAccessibility = 'view.accessibility';
+const kEnableSplashScreen = 'view.enableSplashScreen';
 const kDisableRendererAccessibility = 'view.disableRendererAccessibility';
 
 const kLastRemoteSessionUrl = 'session.lastRemoteSessionUrl';
@@ -187,6 +188,14 @@ export class DesktopOptionsImpl implements DesktopOptions {
 
   public accessibility(): boolean {
     return this.config.get(kAccessibility, properties.view.default.accessibility);
+  }
+
+  public setEnableSplashScreen(enabled: boolean): void {
+    this.config.set(kEnableSplashScreen, enabled);
+  }
+
+  public enableSplashScreen(): boolean {
+    return this.config.get(kEnableSplashScreen, properties.view.default.enableSplashScreen);
   }
 
   public setDisableRendererAccessibility(accessibility: boolean): void {

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -503,7 +503,7 @@ export class SessionLauncher {
     // must check showSplash before and after the timeout
     // before to determine if the timeout is required
     // after to determine if the main window is ready to show
-    if (this.splashDelay > 0 && this.showSplash) {
+    if (this.splashDelay > 0 && this.showSplash && ElectronDesktopOptions().enableSplashScreen()) {
       setTimeoutPromise(this.splashDelay)
         .then(() => {
           if (this.showSplash) {

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -506,6 +506,17 @@ export function getDesktopBridge() {
       ipcRenderer.send('desktop_set_enable_accessibility', enable);
     },
 
+    getEnableSplashScreen: (callback: VoidCallback<boolean>) => {
+      ipcRenderer
+        .invoke('desktop_get_enable_splash_screen')
+        .then((enabled) => callback(enabled))
+        .catch((error) => reportIpcError('getEnableSplashScreen', error));
+    },
+
+    setEnableSplashScreen: (enable: boolean) => {
+      ipcRenderer.send('desktop_set_enable_splash_screen', enable);
+    },
+
     setAutohideMenubar: (enable: boolean) => {
       ipcRenderer.send('desktop_set_autohide_menubar', enable);
     },

--- a/src/node/desktop/src/ui/splash/splash.html
+++ b/src/node/desktop/src/ui/splash/splash.html
@@ -9,7 +9,7 @@
       }
     </style>
 </head>
-<body style="-webkit-app-region:drag">
+<body style="-webkit-app-region:no-drag">
   <?xml version="1.0" encoding="utf-8"?>
   <svg xmlns="http://www.w3.org/1999/svg" xmlns:xlink="http://www.w3.org/2000/xlink" viewBox="0 0 766 434">
     <defs>
@@ -120,6 +120,9 @@
   </svg>
   <script>
     document.addEventListener('keydown', function(event) {
+        window.close();
+    });
+    document.addEventListener('mousedown', function(event) {
         window.close();
     });
   </script>

--- a/src/node/desktop/src/ui/splash/splash_unversioned.html.in
+++ b/src/node/desktop/src/ui/splash/splash_unversioned.html.in
@@ -9,7 +9,7 @@
       }
     </style>
 </head>
-<body style="-webkit-app-region:drag">
+<body style="-webkit-app-region:no-drag">
   <?xml version="1.0" encoding="utf-8"?>
   <svg xmlns="http://www.w3.org/1999/svg" xmlns:xlink="http://www.w3.org/2000/xlink" viewBox="0 0 766 434">
     <defs>
@@ -120,6 +120,9 @@
   </svg>
   <script>
     document.addEventListener('keydown', function(event) {
+        window.close();
+    });
+    document.addEventListener('mousedown', function(event) {
         window.close();
     });
   </script>


### PR DESCRIPTION
### Intent

Addresses #15945 and #15614

### Approach

Added a user preference for disabling the splash screen (i.e. so it doesn't display at all). Also made the splash screen close when clicked with the mouse.

<img width="683" alt="splash-screen-pref" src="https://github.com/user-attachments/assets/173d654d-74c2-43b9-ae7f-bcfe893dc113" />

### Automated Tests

None added

### QA Notes

See original issues for details.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


