### PR TITLE
Ensure Save As dialog is visible when invoked from a popup panel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 
 #### RStudio
 
+- Fixed an issue where the "Save As" dialog would not be visible when trying to save an older git revision of a file (#15955)
 - Fixed an issue where code indentation stopped working following code chunks containing only Quarto comments (#15879)
 
 #### Posit Workbench

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -612,7 +612,7 @@ pre {
 }
 
 .gwt-DialogBox-ModalDialog, .gwt-DecoratedPopupPanel {
-   z-index: 1000;
+   z-index: 1002;
 }
 
 .gwt-SuggestBoxPopup {


### PR DESCRIPTION
### Intent

Addresses #15955

### Approach

This is an issue with the web-based file dialogs, so RStudio Server and Workbench, and Desktop when not using native file dialogs (the default on Linux desktop).

The "Save As" popup had a z-index of 1000, but it was being invoked from a popup with a z-index of 1001, thus was hidden from view. The 1001 value is set here: https://github.com/rstudio/rstudio/blob/f31e2b74eacb2d55eb544d529fe56375ca92f9d1/src/gwt/src/org/rstudio/core/client/widget/FullscreenPopupPanel.java#L60

Fixed by increasing the dialog to use 1002.

### Automated Tests

None

### QA Notes

Test per scenario in issue.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


