### PR TITLE
more MSVC tweaks

### DIFF
--- a/dependencies/tools/rstudio-tools.cmd
+++ b/dependencies/tools/rstudio-tools.cmd
@@ -392,7 +392,7 @@ exit /b 0
 :add-vstools-to-path
 
 for %%Q in ("BuildTools" "Community") do (
-  for %%P in ("%ProgramFiles(x86)%" "%ProgramFiles%") do (
+  for %%P in ("%ProgramFiles%" "%ProgramFiles(x86)%") do (
     call :add-vstools-to-path-impl "%%~P\Microsoft Visual Studio\2022\%%~Q"
     if defined _VCTOOLSDIR (
       goto :add-vstools-to-path-done

--- a/dependencies/tools/rstudio-tools.cmd
+++ b/dependencies/tools/rstudio-tools.cmd
@@ -48,7 +48,7 @@ call :find-project-root
 call :add-vstools-to-path
 
 :: The version of the Windows SDK to use when building.
-set WIN32_SDK_VERSION=1.0.19041.0
+set WIN32_SDK_VERSION=1.0.20348.0
 
 :: Node version used when building the product
 set RSTUDIO_NODE_VERSION=22.13.1

--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -83,17 +83,18 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
 # Download the Build Tools bootstrapper.
 Invoke-DownloadFile https://aka.ms/vs/17/release/vs_buildtools.exe vs_buildtools.exe
 
-# Install Build Tools with the Microsoft.VisualStudio.Workload.AzureBuildTools workload.
-# Exclude workloads and components with known issues.
-cmd.exe /C start /w vs_buildtools.exe --wait --norestart --nocache `
-    --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
+# Install Build Tools. For whatever reason, this fails when we try to install
+# into C:/Program Files (x86), so just use the "regular" C:/Program Files.
+RUN start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
+    --installPath "C:/Program Files/Microsoft Visual Studio/2022/BuildTools" `
+    --add Microsoft.VisualStudio.Workload.CoreEditor `
     --add Microsoft.VisualStudio.Workload.NativeDesktop `
-    --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64	`
-    --add Microsoft.VisualStudio.Component.Windows10SDK.19041 `
-    --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 `
-    --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 `
-    --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 `
-    --remove Microsoft.VisualStudio.Component.Windows81SDK
+    --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core `
+    --add Microsoft.VisualStudio.Component.VC.CoreIde `
+    --add Microsoft.VisualStudio.Component.VC.Redist.14.Latest `
+    --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+    --add Microsoft.VisualStudio.Component.Windows10SDK `
+    --add Microsoft.VisualStudio.Component.Windows10SDK.20348
 
 # Clean up.
 Remove-Item vs_buildtools.exe

--- a/dependencies/windows/tools.R
+++ b/dependencies/windows/tools.R
@@ -206,18 +206,18 @@ initialize <- function() {
 
    # Make sure MSVC tools are available
    msvcCandidates <- c(
-      "C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Auxiliary/Build",
       "C:/Program Files/Microsoft Visual Studio/2022/BuildTools/VC/Auxiliary/Build",
-      "C:/Program Files (x86)/Microsoft Visual Studio/2022/Community/VC/Auxiliary/Build",
-      "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Auxiliary/Build"
+      "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Auxiliary/Build",
+      "C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Auxiliary/Build",
+      "C:/Program Files (x86)/Microsoft Visual Studio/2022/Community/VC/Auxiliary/Build"
    )
 
    msvc <- Filter(file.exists, msvcCandidates)
    if (length(msvc) == 0L) {
       message <- paste(
          "No MSVC 2022 installation detected.",
-         "Install build tools using 'Install-RStudio-Prereqs.ps1'.
-      ")
+         "Install build tools using 'Install-RStudio-Prereqs.ps1'."
+      )
       fatal(message)
    }
    PATH$prepend(msvc[[1L]])

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -1,14 +1,19 @@
 # escape=`
 
-# Use the latest Windows Server Core (LTSC - Long Term Service Channel) image with .NET Framework 4.8.
-# https://docs.microsoft.com/en-us/visualstudio/install/build-tools-container?view=vs-2019
+# https://hub.docker.com/r/microsoft/windows-servercore
 FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
 
-# If building the docker image locally uncomment this line
-# ENV JENKINS_URL=something
-
-# Restore the default Windows shell for correct batch processing.
+# Use plain cmd shell for initial setup.
 SHELL ["cmd", "/S", "/C"]
+
+# Set JENKINS_URL if it's not currently set.
+RUN if not defined JENKINS_URL ( setx /M JENKINS_URL jenkins-docker-build )
+
+# Tell test scripts what operating system we are.
+ENV OPERATING_SYSTEM=windows_10
+
+# Work within build tools directory.
+WORKDIR "C:/BuildTools"
 
 #
 # Installation instructions borrowed from:
@@ -24,28 +29,26 @@ SHELL ["cmd", "/S", "/C"]
 # Note that we use this tool to install Visual Studio's build tools, as well as the
 # required Windows 10 SDK, as chocolatey doesn't seem to provide the versions we need.
 #
-RUN `
-    # Download the Build Tools bootstrapper.
-    curl -SL --output vs_buildtools.exe https://aka.ms/vs/17/release/vs_buildtools.exe `
-    `
-    # Install Build Tools with the Microsoft.VisualStudio.Workload.AzureBuildTools workload, excluding workloads and components with known issues.
-    && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
-        --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
-        --add Microsoft.VisualStudio.Workload.NativeDesktop `
-        --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64	`
-        --add Microsoft.VisualStudio.Component.Windows10SDK.19041 `
-        --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 `
-        --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 `
-        --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 `
-        --remove Microsoft.VisualStudio.Component.Windows81SDK `
-        || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
-    `
-    # Cleanup
-    && del /q vs_buildtools.exe
 
-ENV OPERATING_SYSTEM=windows_10
+# Download the Build Tools bootstrapper.
+RUN curl -SL --output vs_buildtools.exe https://aka.ms/vs/17/release/vs_buildtools.exe
 
-# set RUN commands to use powershell
+# Install Build Tools. For whatever reason, this fails when we try to install
+# into C:/Program Files (x86), so just use the "regular" C:/Program Files.
+RUN start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
+    --installPath "C:/Program Files/Microsoft Visual Studio/2022/BuildTools" `
+    --add Microsoft.VisualStudio.Workload.CoreEditor `
+    --add Microsoft.VisualStudio.Workload.NativeDesktop `
+    --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core `
+    --add Microsoft.VisualStudio.Component.VC.CoreIde `
+    --add Microsoft.VisualStudio.Component.VC.Redist.14.Latest `
+    --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+    --add Microsoft.VisualStudio.Component.Windows10SDK.19041
+
+# Clean up.
+RUN del /q vs_buildtools.exe
+
+# Use Powershell for the rest of the script.
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue'; "]
 
 # Note: keep installed dependencies in-sync with Install-RStudio-Prereqs.ps1 for consistency

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -43,7 +43,9 @@ RUN start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
     --add Microsoft.VisualStudio.Component.VC.CoreIde `
     --add Microsoft.VisualStudio.Component.VC.Redist.14.Latest `
     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
-    --add Microsoft.VisualStudio.Component.Windows10SDK.19041
+    --add Microsoft.VisualStudio.Component.Windows10SDK `
+    --add Microsoft.VisualStudio.Component.Windows10SDK.20348
+
 
 # Clean up.
 RUN del /q vs_buildtools.exe

--- a/docker/win-docker-build-image.cmd
+++ b/docker/win-docker-build-image.cmd
@@ -19,6 +19,7 @@ REM rebuild the image if necessary
     --tag %REPO%:%IMAGE% ^
     --file docker\jenkins\Dockerfile.%IMAGE% ^
     --memory 16GB ^
+    --build-arg JENKINS_URL=development-build ^
     --build-arg GITHUB_LOGIN=%DOCKER_GITHUB_LOGIN% ^
     .
 

--- a/docker/win-docker-build-image.cmd
+++ b/docker/win-docker-build-image.cmd
@@ -5,20 +5,28 @@ setlocal EnableDelayedExpansion
 :: Script to build docker image for building RStudio Desktop for Windows
 ::
 
+for %%A in (%*) do (
+    if /I "%%A" == "clean" (
+        set "NO_CACHE=--no-cache"
+    )
+)
+
 set IMAGE=windows
 
 REM move to the repo root (script's parent directory)
 cd %~dp0\..
 call dependencies\tools\rstudio-tools.cmd
 
-REM determine repo name
+REM Determine the repository name.
+REM Used to differentiate 'rstudio' from 'rstudio-pro' when tagging the image.
 for /F "delims=" %%i in ("%CD%") do set REPO=%%~nxi
 
-REM rebuild the image if necessary
+REM Build the image.
 %RUN% with-echo docker build ^
-    --tag %REPO%:%IMAGE% ^
     --file docker\jenkins\Dockerfile.%IMAGE% ^
+    --tag %REPO%:%IMAGE% ^
     --memory 16GB ^
+    %NO_CACHE% ^
     --build-arg JENKINS_URL=development-build ^
     --build-arg GITHUB_LOGIN=%DOCKER_GITHUB_LOGIN% ^
     .

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -2,7 +2,7 @@
 def utils
 
 // Some constants.
-def WIN32_SDK_VERSION = "10.0.19041.0"
+def WIN32_SDK_VERSION = "10.0.20348.0"
 def WIN32_SDK_BINDIR  = "C:/Program Files (x86)/Windows Kits/10/bin/${WIN32_SDK_VERSION}/x64"
 
 pipeline {


### PR DESCRIPTION
### Intent

Fixes the Windows Docker builds.

### Approach

For whatever reason, the `vs_buildtools.exe` tool fails to install Visual Studio tools in C:/Program Files (86)/, but succeeds in other locations. So, put our installation in C:/Program Files instead.

Confirmed that a local win-docker-compile works.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

