### PR TITLE
Avoid LOG_ERROR in code run after fork/before exec

### DIFF
--- a/src/cpp/server_core/system/Pam.cpp
+++ b/src/cpp/server_core/system/Pam.cpp
@@ -20,6 +20,7 @@
 
 #include <core/Log.hpp>
 #include <core/system/System.hpp>
+#include <shared_core/system/SyslogDestination.hpp>
 
 namespace rstudio {
 namespace core {
@@ -187,7 +188,7 @@ int PAM::login(const std::string& username,
                          &pamh_);
    if (status_ != PAM_SUCCESS)
    {
-      LOG_ERROR_MESSAGE("pam_start failed: " + lastError());
+      safeLogToSyslog("pam-login", log::LogLevel::ERR, "pam_start failed: " + lastError());
       return status_;
    }
 
@@ -195,14 +196,14 @@ int PAM::login(const std::string& username,
    if (status_ != PAM_SUCCESS)
    {
       if (status_ != PAM_AUTH_ERR)
-         LOG_ERROR_MESSAGE("pam_authenticate failed: " + lastError());
+         safeLogToSyslog("pam-login", log::LogLevel::ERR, "pam_authenticate failed: " + lastError());
       return status_;
    }
 
    status_ = ::pam_acct_mgmt(pamh_, defaultFlags_);
    if (status_ != PAM_SUCCESS)
    {
-      LOG_ERROR_MESSAGE("pam_acct_mgmt failed: " + lastError());
+      safeLogToSyslog("pam-login", log::LogLevel::ERR, "pam_acct_mgmt failed: " + lastError());
       return status_;
    }
 


### PR DESCRIPTION
Reviewed in: https://github.com/rstudio/rstudio-pro/pull/8041

### Intent

For pro issue: https://github.com/rstudio/rstudio-pro/issues/8039

### Approach

Avoid LOG_ERROR since it uses mutexes that can hang if running after-fork/before-exec when the child process is a clone of the parents.


