### PR TITLE
stop builds for Ubuntu Focal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,3 +28,7 @@
 - Copilot Language Server 1.310.0 (#15935)
 - Electron 35.2.1 (#15933)
 - Quarto 1.7.29 (#15934)
+
+### Deprecated / Removed
+
+- RStudio Server and Posit Workbench are no longer supported on Ubuntu Focal (#15940)

--- a/jenkins/Jenkinsfile.build
+++ b/jenkins/Jenkinsfile.build
@@ -1,7 +1,6 @@
 def utils
 
 def labelForOS = [
-  'focal':     'linux',
   'jammy':      'linux',
   'rhel8':      'linux',
   'rhel9':      'linux',
@@ -104,7 +103,7 @@ pipeline {
         axes {
           axis {
             name 'os'
-            values 'focal', 'jammy', 'rhel8', 'rhel9', 'opensuse15', 'windows'
+            values 'jammy', 'rhel8', 'rhel9', 'opensuse15', 'windows'
           }
           axis {
             name 'arch'

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -2,7 +2,6 @@ def utils
 
 def ext_map = 
 [
-  'focal':      'deb',
   'jammy':      'deb',
   'rhel8':      'rpm',
   'rhel9':      'rpm',
@@ -11,7 +10,6 @@ def ext_map =
 
 def package_os =
 [
-  'focal':      'Ubuntu Focal',
   'jammy':      'Ubuntu Jammy',
   'rhel8':      'RHEL 8',
   'rhel9':      'RHEL 9',
@@ -111,7 +109,7 @@ pipeline {
         axes {
           axis {
             name 'OS'
-            values 'focal', 'jammy', 'rhel8', 'rhel9', 'opensuse15'
+            values 'jammy', 'rhel8', 'rhel9', 'opensuse15'
           }
           axis {
             name 'ARCH'
@@ -138,7 +136,7 @@ pipeline {
           exclude {
             axis {
               name 'OS'
-              values 'rhel8', 'opensuse15', 'focal'
+              values 'rhel8', 'opensuse15'
             }
             axis {
               name 'FLAVOR'
@@ -249,11 +247,6 @@ pipeline {
                         }
                       }
                       stage("rsession Tests") {
-                        when {
-                          allOf {
-                            expression { return !(OS == "focal" &&  FLAVOR == "Electron" && IS_PRO == false) } // See https://github.com/rstudio/rstudio-pro/issues/4681  
-                          }
-                        }
                         steps {
                           dir ( 'package/linux/' ) {
                             sh "cd ${BUILD_LOCATION}/src/cpp && ./rstudio-tests --scope rsession"
@@ -261,11 +254,6 @@ pipeline {
                         }
                       }
                       stage("rserver Tests") {
-                        when {
-                          allOf {
-                            expression { return !(OS == "focal" &&  FLAVOR == "Electron" && IS_PRO == false) } // See https://github.com/rstudio/rstudio-pro/issues/4681  
-                          }
-                        }
                         steps {
                           dir ( 'package/linux/' ) {
                             sh "cd ${BUILD_LOCATION}/src/cpp && ./rstudio-tests --scope rserver"
@@ -273,11 +261,6 @@ pipeline {
                         }
                       }
                       stage("r Tests") {
-                        when {
-                          allOf {
-                            expression { return OS != "focal"} // See https://github.com/rstudio/rstudio-pro/issues/4681  
-                          }
-                        }
                         steps {
                           dir ( 'package/linux/' ) {
                             sh "cd ${BUILD_LOCATION}/src/cpp && ./rstudio-tests --scope r"

--- a/jenkins/utils.groovy
+++ b/jenkins/utils.groovy
@@ -330,16 +330,13 @@ def shouldBuild(boolean isDaily, boolean isPro) {
         (env.OS == 'jammy' && env.ARCH == 'x86_64' && isFlavorAProServerProduct()) ||
         (env.OS == 'jammy' && env.ARCH == 'arm64' && env.FLAVOR == 'Electron'))
     } else {
-      // build an arm64 rhel9 Electron and an x86_64 focal Server
+      // build an arm64 rhel9 Electron and an x86_64 jammy Server
       inHourlySubset = ((env.OS == 'rhel9' && env.ARCH == 'arm64' && env.FLAVOR == 'Electron') ||
-        (env.OS == 'focal' && env.ARCH == 'x86_64' && env.FLAVOR == 'Server'))
+        (env.OS == 'jammy' && env.ARCH == 'x86_64' && env.FLAVOR == 'Server'))
     }
   }
 
-  // The focal builds are being build on bionic, hence the name confusion here
-  def bionicProArm = (env.OS == 'focal' && env.ARCH == 'arm64' && isPro)
-
-  return matchesFilter && inHourlySubset && !bionicProArm
+  return matchesFilter && inHourlySubset
 }
 
 /**


### PR DESCRIPTION
### Intent

Addresses #15940

### Approach

Remove focal from lists of things to build. For hourly builds, do an x86_64 Server build on jammy instead of focal.

Pro-specific changes will be made when I merge this to pro, tracked with https://github.com/rstudio/rstudio-pro/issues/8042.

Once this is in, I will remove already-created focal builds so they don't show up on the dailies site. Tracked with https://github.com/rstudio/latest-builds/issues/190.

### Automated Tests

NA

### QA Notes

NA

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


