### PR TITLE
avoid recursion in event handlers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 
 - Fixed an issue where the "Save As" dialog would not be visible when trying to save an older git revision of a file (#15955)
 - Fixed an issue where code indentation stopped working following code chunks containing only Quarto comments (#15879)
+- Fixed an issue where RStudio could hang when attempting to execute notebook chunks without a registered handler (#15979)
 
 #### Posit Workbench
 

--- a/cmake/globals.cmake
+++ b/cmake/globals.cmake
@@ -70,6 +70,12 @@ if (NOT DEFINED RSTUDIO_DEFAULT_LOG_PATH)
    set(RSTUDIO_DEFAULT_LOG_PATH "/var/log/rstudio/rstudio-server")
 endif()
 
+# if we're running within vscode, force color diagnostics
+if(DEFINED ENV{VSCODE_PID})
+   set(CMAKE_COLOR_MAKEFILE TRUE)
+   set(CMAKE_COLOR_DIAGNOSTICS TRUE)
+endif()
+
 # detect architecture
 if(UNIX)
 

--- a/src/cpp/session/SessionClientEventQueue.cpp
+++ b/src/cpp/session/SessionClientEventQueue.cpp
@@ -420,18 +420,10 @@ void ClientEventQueue::flushBufferedOutput(int event, std::string* pOutput)
 
    if (isConsoleOutputEvent(event))
    {
-      if (event == client_events::kConsoleWriteOutput)
-      {
-         auto type = module_context::ConsoleOutputNormal;
-         module_context::events().onConsoleOutput(type, *pOutput);
-         r::session::consoleActions().add(kConsoleActionOutput, *pOutput);
-      }
-      else
-      {
-         auto type = module_context::ConsoleOutputError;
-         module_context::events().onConsoleOutput(type, *pOutput);
-         r::session::consoleActions().add(kConsoleActionOutputError, *pOutput);
-      }
+      auto actionType = (event == client_events::kConsoleWriteOutput)
+         ? kConsoleActionOutput
+         : kConsoleActionOutputError;
+      r::session::consoleActions().add(actionType, *pOutput);
 
       // send client event
       json::Object payload;

--- a/src/cpp/session/SessionConsoleOutput.cpp
+++ b/src/cpp/session/SessionConsoleOutput.cpp
@@ -95,8 +95,8 @@ void onBusy(bool busy)
    setPendingOutputType(PendingOutputTypeUnknown);
 }
 
-void onConsoleOutputReceived(module_context::ConsoleOutputType type,
-                             const std::string& output)
+void onConsoleOutput(module_context::ConsoleOutputType type,
+                     const std::string& output)
 {
    if (s_pendingOutputType == PendingOutputTypeUnknown)
    {
@@ -204,7 +204,7 @@ Error initialize()
 #endif
 
    events().onBusy.connect(onBusy);
-   events().onConsoleOutputReceived.connect(onConsoleOutputReceived);
+   events().onConsoleOutput.connect(onConsoleOutput);
    events().onPreferencesSaved.connect(onPreferencesSaved);
 
    RS_REGISTER_CALL_METHOD(rs_errorOutputPending);

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1062,7 +1062,7 @@ void rConsoleWrite(const std::string& output, int otype)
    auto type = (otype == 1)
          ? module_context::ConsoleOutputNormal
          : module_context::ConsoleOutputError;
-   module_context::events().onConsoleOutputReceived(type, output);
+   module_context::events().onConsoleOutput(type, output);
 
    // add to event queue
    int event;

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -358,7 +358,6 @@ struct Events : boost::noncopyable
    RSTUDIO_BOOST_SIGNAL<void(const std::string&)>                     onConsoleInput;
    RSTUDIO_BOOST_SIGNAL<void(bool)>                                   onBusy;
    RSTUDIO_BOOST_SIGNAL<void(const std::string&, const std::string&)> onActiveConsoleChanged;
-   RSTUDIO_BOOST_SIGNAL<void(ConsoleOutputType, const std::string&)>  onConsoleOutputReceived;
    RSTUDIO_BOOST_SIGNAL<void(ConsoleOutputType, const std::string&)>  onConsoleOutput;
    RSTUDIO_BOOST_SIGNAL<void()>                                       onUserInterrupt;
    RSTUDIO_BOOST_SIGNAL<void(ChangeSource)>                           onDetectChanges;

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
@@ -377,12 +377,10 @@ bool ChunkExecContext::onCondition(Condition condition,
          return true;
    }
 
-   // add to event queue
+   // add to event queue -- we use 'output' rather than 'error' here
+   // just so that the output doesn't get buffered on the client side
    session::clientEventQueue().add(
-      ClientEvent(client_events::kConsoleWriteError, message));
-
-   // force events to be flushed, so output is displayed
-   session::clientEventQueue().flush();
+      ClientEvent(client_events::kConsoleWriteOutput, message));
 
    return true;
 }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15979.

### Approach

We use events (signals) to notify other modules when console output of different types is received. As part of the work to support annotated console outputs, I moved some the event firing into the console output queue. However, this can cause an issue:

- Events are flushed from the queue (lock acquired here),
- If a console event is flushed, we signal to other modules that console output was emitted,
- Those receivers might themselves try to add other client events,
- We then attempt to acquire the same aforementioned lock again. Deadlock!

The fix here is to signal console output as it's emitted, not as its processed.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15979.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
