### PR TITLE
include vscode launch / tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,6 @@ CONTRIBUTING.html
 CMakeLists.txt.user
 .idea/
 
-.vscode/*
-!.vscode/extensions.json
-
 **/\.tern-port
 .#*
 *.autosave

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "type": "lldb",
+        "request": "attach",
+        "name": "RStudio: Attach to rsession",
+        "program": "rsession"
+      }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build RStudio",
+            "type": "shell",
+            "command": "cmake --build . --target all",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "options": {
+                "cwd": "build",
+            },
+            "problemMatcher": "$gcc",
+        }
+    ]
+}

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -25,6 +25,12 @@ set(CMAKE_POSITION_INDEPENDENT_CODE Yes)
 # use C++17
 set(CMAKE_CXX_STANDARD 17)
 
+# use colored output in VSCode
+if(DEFINED ENV{VSCODE_PID})
+  set(CMAKE_COLOR_MAKEFILE TRUE)
+  set(CMAKE_COLOR_DIAGNOSTICS TRUE)
+endif()
+
 # use clang on osx
 if(APPLE)
 


### PR DESCRIPTION
Mainly so that we get default build + debug tasks to use in VSCode, when opening the repository from the root.