### PR TITLE
allow view of files within 'allowed-directories'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 
 #### RStudio
 
+- Fixed an issue where pkgdown websites built outside of the user directory could not be viewed from RStudio Server (#15133)
 - Fixed an issue where the "Save As" dialog would not be visible when trying to save an older git revision of a file (#15955)
 - Fixed an issue where code indentation stopped working following code chunks containing only Quarto comments (#15879)
 - Fixed an issue where RStudio could hang when attempting to execute notebook chunks without a registered handler (#15979)

--- a/src/cpp/conf/rsession-dev.conf
+++ b/src/cpp/conf/rsession-dev.conf
@@ -33,7 +33,8 @@ r-session-package-archives=${RSTUDIO_DEPENDENCIES_DIR}/common
 # execute rpostback from build tree
 external-rpostback-path=session/postback/rpostback
 
-# allow directories
+# allow content in /usr/local/dev for testing
+restrict-directory-view=1
 directory-view-allow-list=/usr/local/dev
 
 # common dependencies

--- a/src/cpp/conf/rsession-dev.conf
+++ b/src/cpp/conf/rsession-dev.conf
@@ -33,6 +33,9 @@ r-session-package-archives=${RSTUDIO_DEPENDENCIES_DIR}/common
 # execute rpostback from build tree
 external-rpostback-path=session/postback/rpostback
 
+# allow directories
+directory-view-allow-list=/usr/local/dev
+
 # common dependencies
 external-hunspell-dictionaries-path=${RSTUDIO_DEPENDENCIES_DICTIONARIES_DIR}
 external-mathjax-path=${RSTUDIO_DEPENDENCIES_MATHJAX_DIR}

--- a/src/cpp/conf/rsession-dev.conf
+++ b/src/cpp/conf/rsession-dev.conf
@@ -33,10 +33,6 @@ r-session-package-archives=${RSTUDIO_DEPENDENCIES_DIR}/common
 # execute rpostback from build tree
 external-rpostback-path=session/postback/rpostback
 
-# allow content in /usr/local/dev for testing
-restrict-directory-view=1
-directory-view-allow-list=/usr/local/dev
-
 # common dependencies
 external-hunspell-dictionaries-path=${RSTUDIO_DEPENDENCIES_DICTIONARIES_DIR}
 external-mathjax-path=${RSTUDIO_DEPENDENCIES_MATHJAX_DIR}

--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -283,6 +283,7 @@ void httpServerAddHandlers()
    // workbench get secure + authentication when required
    uri_handlers::add("/help", secureAsyncHttpHandler(proxyContentRequest, true));
    uri_handlers::add("/files", secureAsyncHttpHandler(proxyContentRequest, true));
+   uri_handlers::add("/show", secureAsyncHttpHandler(proxyContentRequest, true));
    uri_handlers::add("/custom", secureAsyncHttpHandler(proxyContentRequest, true));
    uri_handlers::add("/session", secureAsyncHttpHandler(proxyContentRequest, true));
    uri_handlers::add("/docs", secureAsyncHttpHandler(secureAsyncFileHandler(), true));

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2279,20 +2279,24 @@ void showFile(const FilePath& filePath, const std::string& window)
 
 std::string createFileUrl(const core::FilePath& filePath)
 {
-    // determine url based on whether this is in ~ or not
-    std::string url;
-    if (isVisibleUserFile(filePath))
-    {
-       std::string relPath = filePath.getRelativePath(
-          module_context::userHomePath());
-       url = "files/" + relPath;
-    }
-    else
-    {
-       url = "file_show?path=" + core::http::util::urlEncode(
-          filePath.getAbsolutePath(), true);
-    }
-    return url;
+   // determine url based on whether this is in ~ or not
+   std::string url;
+   if (isVisibleUserFile(filePath))
+   {
+      auto home = module_context::userHomePath();
+      auto path = filePath.getRelativePath(home);
+      url = "files/" + path;
+   }
+   else if (isPathViewAllowed(filePath))
+   {
+      url = "show" + filePath.getAbsolutePath();
+   }
+   else
+   {
+      auto path = core::http::util::urlEncode(filePath.getAbsolutePath(), true);
+      url = "file_show?path=" + path;
+   }
+   return url;
 }
 
 
@@ -2633,6 +2637,7 @@ bool isPathViewAllowed(const FilePath& filePath)
 
    // Check session option for explicitly allowed directories
    std::string allowDirs = session::options().directoryViewAllowList();
+   std::cerr << "-- " << allowDirs << std::endl;
    if (!allowDirs.empty())
    {
       std::vector<std::string> dirs = core::algorithm::split(allowDirs, ":");

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2627,23 +2627,22 @@ bool isPathViewAllowed(const FilePath& filePath)
 
    // Viewing content in R libraries is always allowed
    std::vector<FilePath> libPaths = getLibPaths();
-   for (const auto& dir: libPaths)
+   for (auto&& libPath : libPaths)
    {
-      if (filePath.isWithin(dir))
+      if (filePath.isWithin(libPath))
       {
          return true;
       }
    }
 
    // Check session option for explicitly allowed directories
-   std::string allowDirs = session::options().directoryViewAllowList();
-   std::cerr << "-- " << allowDirs << std::endl;
-   if (!allowDirs.empty())
+   std::string allowDirsPref = session::options().directoryViewAllowList();
+   if (!allowDirsPref.empty())
    {
-      std::vector<std::string> dirs = core::algorithm::split(allowDirs, ":");
-      for (const auto& dir: dirs)
+      auto allowDirs = core::algorithm::split(allowDirsPref, ":");
+      for (auto&& allowDir : allowDirs)
       {
-         if (filePath.isWithin(FilePath(dir)))
+         if (filePath.isWithin(FilePath(allowDir)))
          {
             return true;
          }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15133.

### Approach

Introduces a new `/show` endpoint, which allows a user to view files located at arbitrary file paths on the filesystem, as long as that path is considered "viewable". See `isPathViewAllowed()` for more details. Note that file access is still restricted based on the filesystem permissions vs. the session's user.

If we wanted to make this more intentional, we could further restrict this endpoint -- any strong feelings?

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15133.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
