### PR TITLE
stop using maxFactors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 
 #### RStudio
 
+- RStudio no longer displays factors with more than 64 levels as though they were character vectors (#14113)
 - Fixed an issue where the "Save As" dialog would not be visible when trying to save an older git revision of a file (#15955)
 - Fixed an issue where code indentation stopped working following code chunks containing only Quarto comments (#15879)
 - Fixed an issue where RStudio could hang when attempting to execute notebook chunks without a registered handler (#15979)

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -217,18 +217,16 @@
          col_type_r <- typeof(val)
          if (is.factor(val))
          {
+            # we previously used the 'maxFactors' variable to try and guess
+            # where a factor variable might have actually been intended to be
+            # used as a character vector. nowdays, with stringsAsFactors = FALSE
+            # being the default, this is no longer necessary and so we just
+            # ignore the 'maxFactors' parameter.
+            #
+            # https://github.com/rstudio/rstudio/issues/14113
             col_type <- "factor"
-            if (length(levels(val)) > maxFactors)
-            {
-               # if the number of factors exceeds the max, search the column as 
-               # though it were a character column
-               col_search_type <- "character"
-            }
-            else 
-            {
-               col_search_type <- "factor"
-               col_vals <- levels(val)
-            }
+            col_search_type <- "factor"
+            col_vals <- levels(val)
          }
          # for histograms, we support only the base R numeric class and its derivatives;
          # is.numeric can return true for values that can only be manipulated using


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14113.

### Approach

In older version of R (< 4.0.0), `stringsAsFactors = TRUE` was the default, and so data sets whose columns were logically character vectors were still read in as though they were factors. In practice, this meant you had character columns with a large number of unique "factors", even though it wasn't really intended to be used as a factor.

We tried to catch these scenarios by checking for factors which had more levels than might be typical, and treat those as though they were character vectors. Now that the default has changed, we can assume any existing factors are more intentional, and avoid "guessing" if they might have been intended to be character vectors.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14113.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
