### PR TITLE
ensure that code execution stops upon error in R Markdown chunks

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -100,7 +100,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 })
 
 # for functions which might act as error handlers
-.rs.addFunction("addErrorHandlerFunction", function(name, type, fn)
+.rs.addFunction("addErrorHandlerFunction", function(name, type, handler)
 {
    attrs <- list(
       rstudioErrorHandler = TRUE,
@@ -108,7 +108,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       errorHandlerType    = type
    )
 
-   .rs.addFunction(name, fn, attrs, envir = .rs.toolsEnv())
+   .rs.addFunction(name, handler, attrs, envir = .rs.toolsEnv())
 })
 
 .rs.addFunction("setVar", function(name, var)

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -99,6 +99,18 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    .rs.addFunction(fullName, FN, envir = envir)
 })
 
+# for functions which might act as error handlers
+.rs.addFunction("addErrorHandlerFunction", function(name, type, fn)
+{
+   attrs <- list(
+      rstudioErrorHandler = TRUE,
+      hideFromDebugger    = TRUE,
+      errorHandlerType    = type
+   )
+
+   .rs.addFunction(name, fn, attrs, envir = .rs.toolsEnv())
+})
+
 .rs.addFunction("setVar", function(name, var)
 { 
    envir <- .rs.toolsEnv()

--- a/src/cpp/r/RCntxt.cpp
+++ b/src/cpp/r/RCntxt.cpp
@@ -102,7 +102,7 @@ bool RCntxt::isDebugHidden() const
 bool RCntxt::isErrorHandler() const
 {
    SEXP errFlag = r::sexp::getAttrib(callfun(), "errorHandlerType");
-   return TYPEOF(errFlag) == INTSXP;
+   return errFlag != R_NilValue;
 }
 
 bool RCntxt::hasSourceRefs() const

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1060,8 +1060,8 @@ void rConsoleWrite(const std::string& output, int otype)
 
    // notify listeners
    auto type = (otype == 1)
-         ? module_context::ConsoleOutputNormal
-         : module_context::ConsoleOutputError;
+         ? module_context::ConsoleOutputError
+         : module_context::ConsoleOutputNormal;
    module_context::events().onConsoleOutput(type, output);
 
    // add to event queue

--- a/src/cpp/session/modules/NotebookErrors.R
+++ b/src/cpp/session/modules/NotebookErrors.R
@@ -16,7 +16,7 @@
 .rs.addErrorHandlerFunction("handleNotebookError", "notebook", function()
 {
    .rs.recordTraceback(FALSE, function(err) {
-      .Call("rs_recordNotebookError", err)
+      .Call("rs_recordNotebookError", err, PACKAGE = "(embedding)")
    })
 })
 

--- a/src/cpp/session/modules/NotebookErrors.R
+++ b/src/cpp/session/modules/NotebookErrors.R
@@ -13,7 +13,7 @@
 #
 #
 
-.rs.addErrorHandlerFunction("handleNotebookError", "traceback", function()
+.rs.addErrorHandlerFunction("handleNotebookError", "notebook", function()
 {
    .rs.recordTraceback(FALSE, function(err) {
       .Call("rs_recordNotebookError", err)

--- a/src/cpp/session/modules/NotebookErrors.R
+++ b/src/cpp/session/modules/NotebookErrors.R
@@ -13,14 +13,14 @@
 #
 #
 
-.rs.addFunction("handleNotebookError", function() {
-  .rs.recordTraceback(FALSE, function(err) {
-    .Call("rs_recordNotebookError", err)
-  })
-},
-attrs = list(hideFromDebugger = TRUE,
-             errorHandlerType = 4L))
+.rs.addErrorHandlerFunction("handleNotebookError", "traceback", function()
+{
+   .rs.recordTraceback(FALSE, function(err) {
+      .Call("rs_recordNotebookError", err)
+   })
+})
 
-.rs.addFunction("registerNotebookErrHandler", function() {
-  options(error = .rs.handleNotebookError)
+.rs.addFunction("registerNotebookErrorHandler", function()
+{
+   options(error = .rs.handleNotebookError)
 })

--- a/src/cpp/session/modules/SessionErrors.R
+++ b/src/cpp/session/modules/SessionErrors.R
@@ -248,37 +248,25 @@ attrs = list(hideFromDebugger = TRUE))
   .rs.enqueClientEvent("unhandled_error", err)
 })
 
-.rs.addFunction("recordAnyTraceback", function()
+.rs.addErrorHandlerFunction("recordAnyTraceback", "traceback", function()
 {
    .rs.recordTraceback(FALSE, .rs.enqueueError)
-},
-attrs = list(rstudioErrorHandler = TRUE,
-             hideFromDebugger = TRUE,
-             errorHandlerType = "traceback"))
+})
 
-.rs.addFunction("recordUserTraceback", function()
+.rs.addErrorHandlerFunction("recordUserTraceback", "traceback", function()
 {
    .rs.recordTraceback(TRUE, .rs.enqueueError)
-},
-attrs = list(rstudioErrorHandler = TRUE,
-             hideFromDebugger = TRUE,
-             errorHandlerType = "traceback"))
+})
 
-.rs.addFunction("breakOnAnyError", function()
+.rs.addErrorHandlerFunction("breakOnAnyError", "break", function()
 {
    .rs.breakOnError(FALSE)
-},
-attrs = list(rstudioErrorHandler = TRUE,
-             hideFromDebugger = TRUE, 
-             errorHandlerType = "break"))
+})
 
-.rs.addFunction("breakOnUserError", function()
+.rs.addErrorHandlerFunction("breakOnUserError", "break", function()
 {
    .rs.breakOnError(TRUE)
-},
-attrs = list(rstudioErrorHandler = TRUE,
-             hideFromDebugger = TRUE,
-             errorHandlerType = "break"))
+})
 
 .rs.addFunction("setErrorManagementType", function(type, userOnly)
 {

--- a/src/cpp/session/modules/rmarkdown/NotebookErrors.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookErrors.cpp
@@ -39,8 +39,7 @@ void ErrorCapture::connect()
    sexpErrHandler_.set(r::options::getOption("error"));
 
    // set new handler
-   Error error = r::exec::RFunction(".rs.registerNotebookErrHandler")
-                                  .callUnsafe();
+   Error error = r::exec::RFunction(".rs.registerNotebookErrorHandler").callUnsafe();
    if (error)
       LOG_ERROR(error);
 

--- a/src/cpp/tests/automation/testthat/test-automation-rmarkdown.R
+++ b/src/cpp/tests/automation/testthat/test-automation-rmarkdown.R
@@ -490,3 +490,25 @@ withr::defer(.rs.automation.deleteRemote())
 
 })
 
+.rs.test("errors in notebook chunks halt execution", {
+   
+   contents <- .rs.heredoc('
+      ---
+      title: Stop on Error
+      ---
+      
+      ```{r}
+      stop("An error occurred here.")
+      stop("This line of code should not be executed.")
+      ```
+   ')
+   
+   remote$editor.executeWithContents(".Rmd", contents, function(editor) {
+      editor$gotoLine(6L)
+      remote$commands.execute(.rs.appCommands$executeCurrentChunk)
+      output <- remote$console.getOutput()
+      expect_true("Error: An error occurred here." %in% output)
+      expect_false("This line of code should not be executed." %in% output)
+   })
+   
+})

--- a/src/cpp/tests/debugger/debugging-14276.R
+++ b/src/cpp/tests/debugger/debugging-14276.R
@@ -6,6 +6,7 @@
 #
 
 # trace(.rs.simulateSourceRefs, quote(str(var)))
+fn <- NULL
 eval(parse(text = "fn <- function() {
   x <- 1
   1 + 1

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationInterrupt.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationInterrupt.java
@@ -139,13 +139,16 @@ public class ApplicationInterrupt implements ConsoleBusyEvent.Handler
 
    public void interruptR(final InterruptHandler handler,
                           List<String> errorHandlerTypes,
-                          String replacedWithHandlerType) {
+                          String replacedWithHandlerType)
+   {
       final String originalDebugType = errorManager_.getErrorHandlerType();
       
-      if (!errorHandlerTypes.contains(originalDebugType)) {
+      if (!errorHandlerTypes.contains(originalDebugType))
+      {
          interruptR(handler);
       }
-      else {
+      else
+      {
          errorManager_.setDebugSessionHandlerType(
             replacedWithHandlerType,
             new ServerRequestCallback<Void>()

--- a/version/news/NEWS-2025.05.1-mariposa-orchid.md
+++ b/version/news/NEWS-2025.05.1-mariposa-orchid.md
@@ -11,6 +11,7 @@
 #### RStudio
 
 - Fixed an issue where RStudio could hang when attempting to execute notebook chunks without a registered handler (#15979)
+- Fixed an issue where RStudio continued executing code within R Markdown chunks after an error occurred (#16000, #16002)
 
 #### Posit Workbench
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16000.
Addresses https://github.com/rstudio/rstudio/issues/16002.

### Approach

I had made some changes to error handling in RStudio that had caused us to skip running the error reporter if it appeared we did not have any stack frames. This change in behavior unfortunately also meant that R Markdown chunk execution was never notified when an error occurred, so it didn't know to stop execution following an error.

### Automated Tests

Automated tests included.

### QA Notes

Test via notes in issues.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
