### PR TITLE
Companion commit with some diagnostics improvements

### DIFF
--- a/src/cpp/core/http/Request.cpp
+++ b/src/cpp/core/http/Request.cpp
@@ -14,6 +14,7 @@
  */
 
 #include <core/http/Request.hpp>
+#include <core/http/Response.hpp>
 #include <core/http/URL.hpp>
 
 #include <gsl/gsl-lite.hpp>
@@ -293,6 +294,17 @@ void Request::addCookie(const std::string& name, const std::string& value)
    setHeader("Cookie", boost::algorithm::join(cookies, "; "));
 }
 
+void Request::removeCookie(const std::string& name)
+{
+   cookies_.erase(std::remove_if(cookies_.begin(), cookies_.end(), [&](Field pair){ return pair.first == name; }));
+   std::vector<std::string> cookies;
+   for (const auto& cookie : cookies_)
+   {
+      cookies.push_back(cookie.first + "=" + cookie.second);
+   }
+   setHeader("Cookie", boost::algorithm::join(cookies, "; "));
+}
+
 std::string Request::cookieValueFromHeader(const std::string& headerName) const
 {
    std::string value = headerValue(headerName);
@@ -430,6 +442,15 @@ std::ostream& operator << (std::ostream& stream, const Request& r)
    stream << m;
 
    return stream;
+}
+
+const std::string Request::debugInfoResponse(const Response& response) const
+{
+   std::string res = debugInfoFinal()  + " code: " + std::to_string(response.statusCode());
+   std::string apiError = response.apiError();
+   if (!apiError.empty())
+      res = res + " api error: " + apiError;
+   return res;
 }
 
 } // namespacce http

--- a/src/cpp/core/include/core/http/Request.hpp
+++ b/src/cpp/core/include/core/http/Request.hpp
@@ -138,6 +138,7 @@ public:
    std::string cookieValue(const std::string& name) const;
    std::string cookieValueFromHeader(const std::string& headerName) const;
    void addCookie(const std::string& name, const std::string& value);
+   void removeCookie(const std::string& name);
    
    const Fields& formFields() const;
    std::string formFieldValue(const std::string& name) const;
@@ -191,6 +192,8 @@ public:
       return debugInfo() + " in " + std::to_string(requestTime.total_seconds()) + "." +
                                     std::to_string(requestTime.total_milliseconds() % 1000) + "s";
    }
+
+   const std::string debugInfoResponse(const Response& response) const;
 
 private:
    // Use the internal URI when you need the "behind the proxy" URI

--- a/src/cpp/core/include/core/http/Response.hpp
+++ b/src/cpp/core/include/core/http/Response.hpp
@@ -59,6 +59,7 @@ enum Code {
    SwitchingProtocols = 101,
    Ok = 200,
    Created = 201,
+   NoContent = 204,
    PartialContent = 206,
    MovedPermanently = 301,
    MovedTemporarily = 302,
@@ -136,6 +137,7 @@ public:
       statusCodeStr_ = response.statusCodeStr_;
       statusMessage_ = response.statusMessage_;
       streamResponse_ = response.streamResponse_;
+      apiError_ = response.apiError_;
    }
 
 public:   
@@ -465,6 +467,10 @@ public:
       return streamResponse_;
    }
 
+   void setApiError(const std::string& apiError) { apiError_ = apiError; }
+   std::string apiError() const { return apiError_; }
+
+
 private:
    virtual void appendFirstLineBuffers(
          std::vector<boost::asio::const_buffer>& buffers) const;
@@ -492,6 +498,8 @@ private:
    NotFoundHandler notFoundHandler_;
 
    boost::shared_ptr<StreamResponse> streamResponse_;
+
+   std::string apiError_;
 };
 
 std::ostream& operator << (std::ostream& stream, const Response& r);

--- a/src/cpp/core/r_util/REnvironmentPosix.cpp
+++ b/src/cpp/core/r_util/REnvironmentPosix.cpp
@@ -928,6 +928,10 @@ Error rVersion(const FilePath& rHomePath,
    if (error)
    {
       error.addProperty("r-script", rScriptPath);
+      error.addProperty("command", fullCommand);
+      if (!module.empty())
+         error.addProperty("module", module);
+      error.addProperty("modules-bin-path", moduleBinaryPath.getAbsolutePath());
       return error;
    }
    else
@@ -938,6 +942,7 @@ Error rVersion(const FilePath& rHomePath,
       if (regex_utils::search(versionInfo, match, re))
       {
          *pVersion = match[1];
+         LOG_DEBUG_MESSAGE("Found R version: " + *pVersion + " with: " + fullCommand);
          return Success();
       }
       else
@@ -951,6 +956,10 @@ Error rVersion(const FilePath& rHomePath,
 
          // log any errors emitted by R
          error.addProperty("r-error", result.stdErr);
+         error.addProperty("command", fullCommand);
+         if (!module.empty())
+            error.addProperty("module", module);
+         error.addProperty("modules-bin-path", moduleBinaryPath.getAbsolutePath());
          return error;
       }
    }

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -731,10 +731,7 @@ Error closeChildFileDescriptorsFrom(pid_t childPid, int pipeFd, uint32_t fdStart
    }
    else
    {
-      // we simply log the error instead of returning it because this is generally benign and can
-      // happen in certain normal scenarios, such as if /proc/x/fd is only readable by root
-      // (if core dumps are turned off)
-      core::log::logErrorAsDebug(error);
+      // this happens in normal scenarios, such as if /proc/x/fd is only readable by root
    }
 
    // write message close (-1) even if we failed to retrieve pids above

--- a/src/cpp/server/include/server/auth/ServerAuthHandler.hpp
+++ b/src/cpp/server/include/server/auth/ServerAuthHandler.hpp
@@ -212,7 +212,7 @@ void invalidateAuthCookie(const std::string& cookie,
 
 core::Error initialize();
 
-bool isCookieRevoked(const std::string& cookie);
+bool isCookieRevoked(const std::string& cookie, std::string* pDebugInfo);
 
 // User functions
 core::Error addUser(boost::asio::io_context& ioContext, const std::string& username, bool isAdmin = false);

--- a/src/cpp/server_core/include/server_core/http/SecureCookie.hpp
+++ b/src/cpp/server_core/include/server_core/http/SecureCookie.hpp
@@ -53,9 +53,10 @@ http::Cookie createSecureCookie(const std::string& name,
                                 http::Cookie::SameSite sameSite = http::Cookie::SameSite::Undefined);
 
 std::string readSecureCookie(const core::http::Request& request,
-                             const std::string& name);
+                             const std::string& name,
+                             std::string* pDebugInfo = nullptr);
 
-std::string readSecureCookie(const std::string& signedCookieValue);
+std::string readSecureCookie(const std::string& signedCookieValue, std::string* pDebugInfo = nullptr);
 
 // Reads the secure cookie. If reading fails or the cookie is invalid
 // pValue will be set to an empty string and pExpires and pLoginExpiry
@@ -64,7 +65,8 @@ void readSecureCookie(
    const std::string& signedCookieValue,
    std::string* pValue,
    boost::posix_time::ptime* pExpires,
-   boost::optional<boost::posix_time::ptime>* pLoginExpiry);
+   boost::optional<boost::posix_time::ptime>* pLoginExpiry,
+   std::string* pDebugInfo = nullptr);
 
 core::Error hashWithSecureKey(const std::string& value, std::string* pHMAC);
 


### PR DESCRIPTION
Note: some internal JSON RPC error messages have more detail. Now instead of just "Protocol error" or "Invalid request", it will include the error summary that includes error properties.

1) Improve request/response debugging info so JSON RPC errors are displayed if present

2) Expose more info in JSON RPC errors to make it easier for API developers to identify problems.

3) Debug info to troubleshoot logout failures

4) More info around reading config files

5) Diagnostics around automatic detection of R versions (r-versions file)

(reviewed in PR: https://github.com/rstudio/rstudio-pro/pull/8119)

### Intent

Improve diagnostics for debug messages and api errors. 

### QA Notes

Should be covered by automation. Some internal debug logs and api errors will have changed but hopefully no tests are checking for specific "message" values. 


