### PR TITLE
ensure options(warn = 2) is handled properly

### DIFF
--- a/src/cpp/r/R/GlobalCallingHandlers.R
+++ b/src/cpp/r/R/GlobalCallingHandlers.R
@@ -115,7 +115,7 @@
    # disabled entirely (via a negative value for the option).
    #
    # Similarly, this handler will be invoked for warnings even when warn >= 2,
-   # but in this scenario we want treate warnings as errors, and so we should
+   # but in this scenario we want treat warnings as errors, and so we should
    # avoid invoking the handler here.
    warn <- getOption("warn", default = 0L)
    if (warn <= 0L || warn >= 2L)

--- a/src/cpp/r/R/GlobalCallingHandlers.R
+++ b/src/cpp/r/R/GlobalCallingHandlers.R
@@ -113,8 +113,12 @@
    # If the user is opting into bundling warnings, just let the default
    # R warning handler take over. We also need to ignore if warnings are
    # disabled entirely (via a negative value for the option).
+   #
+   # Similarly, this handler will be invoked for warnings even when warn >= 2,
+   # but in this scenario we want treate warnings as errors, and so we should
+   # avoid invoking the handler here.
    warn <- getOption("warn", default = 0L)
-   if (warn <= 0L)
+   if (warn <= 0L || warn >= 2L)
       return(FALSE)
    
    # I can't imagine anyone is actually using this in the wild, but...

--- a/src/cpp/session/modules/automation/SessionAutomationToolsConsole.R
+++ b/src/cpp/session/modules/automation/SessionAutomationToolsConsole.R
@@ -69,8 +69,9 @@
    
 })
 
-.rs.automation.addRemoteFunction("console.getOutput", function()
+.rs.automation.addRemoteFunction("console.getOutput", function(n = NULL)
 {
    output <- self$js.querySelector("#rstudio_console_output")
-   strsplit(output$innerText, split = "\n", fixed = TRUE)[[1L]]
+   lines <- strsplit(output$innerText, split = "\n", fixed = TRUE)[[1L]]
+   tail(lines, n = .rs.nullCoalesce(n, length(lines)))
 })

--- a/src/cpp/tests/automation/testthat/test-automation-console.R
+++ b/src/cpp/tests/automation/testthat/test-automation-console.R
@@ -125,3 +125,25 @@ withr::defer(.rs.automation.deleteRemote())
    expect_true(foundWarningSpan)
    
 })
+
+# https://github.com/rstudio/rstudio/issues/16031
+.rs.test("warnings are treated as errors when options(warn = 2)", {
+   
+   remote$console.executeExpr({
+      
+      options(warn = 2)
+      
+      x <- tryCatch(
+         as.numeric("oops"),
+         error = identity
+      )
+      
+      options(warn = 0)
+      inherits(x, "error")
+      
+   })
+   
+   output <- remote$console.getOutput(n = 1L)
+   expect_equal(output, "[1] TRUE")
+   
+})

--- a/src/gwt/.gitignore
+++ b/src/gwt/.gitignore
@@ -14,3 +14,9 @@ javac.*
 
 # ignore local VSCode settings
 .vscode/
+
+# ignore stuff that java dumps on crash
+/snap.*.trc
+/core.*.dmp
+/heapdump.*.phd
+/javacore.*.txt

--- a/version/news/NEWS-2025.05.1-mariposa-orchid.md
+++ b/version/news/NEWS-2025.05.1-mariposa-orchid.md
@@ -10,6 +10,7 @@
 
 #### RStudio
 
+- Fixed an issue where warnings were not treated as errors when options(warn = 2) was set (#16031)
 - Fixed an issue where RStudio could hang when attempting to execute notebook chunks without a registered handler (#15979)
 - Fixed an issue where RStudio continued executing code within R Markdown chunks after an error occurred (#16000, #16002)
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16031,

### Approach

The new global warning handler we added was incorrectly handling warnings when `options(warn = 2)` was set. Don't do that.

### Automated Tests

Included in PR.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/16031.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
