### PR TITLE
Fix suggestion display when copilot suggestion matches some existing text at the start of the suggestion

### DIFF
--- a/version/news/NEWS-2025.05.1-mariposa-orchid.md
+++ b/version/news/NEWS-2025.05.1-mariposa-orchid.md
@@ -10,6 +10,7 @@
 
 #### RStudio
 
+- Fixed an issue where GitHub Copilot suggestions could be missing some text (#16023)
 - Fixed an issue where warnings were not treated as errors when options(warn = 2) was set (#16031)
 - Fixed an issue where RStudio could hang when attempting to execute notebook chunks without a registered handler (#15979)
 - Fixed an issue where RStudio continued executing code within R Markdown chunks after an error occurred (#16000, #16002)


### PR DESCRIPTION
### Intent

Addresses #16023 

### Approach

Fix how we compute the ghost text; namely, use the suggestion text minus any common prefix matching existing text in the document.

The old way was flat-out busted. Who wrote that? Oh right, it was me.

### Automated Tests

Ron has added some tests around this (currently failing).

### QA Notes

Try every possible combination of text throughout space and time. Twice.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


