### PR TITLE
fix \r handling with annotation of messages

### DIFF
--- a/src/cpp/tests/automation/testthat/test-automation-console.R
+++ b/src/cpp/tests/automation/testthat/test-automation-console.R
@@ -181,4 +181,12 @@ withr::defer(.rs.automation.deleteRemote())
    output <- remote$console.getOutput(n = 1L)
    expect_equal(output, "This is some more output.")
    
+   remote$console.clear()
+   remote$console.executeExpr({
+      message("M1", appendLF = FALSE); message("\b", appendLF = FALSE); message("2")
+   })
+   
+   output <- remote$console.getOutput(n = 1L)
+   expect_equal(output, "M2")
+   
 })

--- a/src/cpp/tests/automation/testthat/test-automation-console.R
+++ b/src/cpp/tests/automation/testthat/test-automation-console.R
@@ -147,3 +147,38 @@ withr::defer(.rs.automation.deleteRemote())
    expect_equal(output, "[1] TRUE")
    
 })
+
+# https://github.com/rstudio/rstudio/issues/16038
+.rs.test("carriage returns don't break output annotation", {
+   
+   remote$console.clear()
+   remote$console.executeExpr({
+      message("M1"); cat("O1\r"); message("M2")
+   })
+   
+   spanOutputs <- list()
+   spanEls <- consoleOutputEl$querySelectorAll("span")
+   for (i in seq_len(spanEls$length))
+   {
+      spanEl <- spanEls[[i - 1L]]
+      spanOutputs[[spanEl$innerText]] <- TRUE
+   }
+   
+   spanOutputs <- names(spanOutputs)
+   
+   expect_true("M1" %in% spanOutputs)
+   expect_true("M2" %in% spanOutputs)
+   expect_false("O1" %in% spanOutputs)
+   
+   m1idx <- which(spanOutputs == "M1")
+   m2idx <- which(spanOutputs == "M2")
+   expect_equal(m2idx - m1idx, 1L)
+   
+   remote$console.executeExpr({
+      writeLines("This is some more output.")
+   })
+   
+   output <- remote$console.getOutput(n = 1L)
+   expect_equal(output, "This is some more output.")
+   
+})

--- a/version/news/NEWS-2025.05.1-mariposa-orchid.md
+++ b/version/news/NEWS-2025.05.1-mariposa-orchid.md
@@ -14,6 +14,7 @@
 - Fixed an issue where warnings were not treated as errors when options(warn = 2) was set (#16031)
 - Fixed an issue where RStudio could hang when attempting to execute notebook chunks without a registered handler (#15979)
 - Fixed an issue where RStudio continued executing code within R Markdown chunks after an error occurred (#16000, #16002)
+- Fixed an issue where no more console output was produced after a '\r' character input in some cases (#16038)
 
 #### Posit Workbench
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16038.

### Approach

- Null check for an element which might be `null`.
- Handle the scenario where we're starting a new output group when the cursor isn't located at the end of the line. In this scenario, trim the relevant parts of output.

### Automated Tests

Included in PR.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/16038.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
