### PR TITLE
use alternate strategy for ensuring stacked modals are visible

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -612,7 +612,7 @@ pre {
 }
 
 .gwt-DialogBox-ModalDialog, .gwt-DecoratedPopupPanel {
-   z-index: 1002;
+   z-index: 1000;
 }
 
 .gwt-SuggestBoxPopup {

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogTracker.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogTracker.java
@@ -18,26 +18,34 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ElementIds;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.command.impl.DesktopMenuCallback;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity;
 
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.ui.Panel;
 import com.google.gwt.user.client.ui.PopupPanel;
 
 public class ModalDialogTracker
 {
    public static void onShow(PopupPanel panel)
    {
+      ensureVisible(panel);
       dialogStack_.add(panel);
+
       if (Desktop.hasDesktopFrame()) {
          if (BrowseCap.isElectron())
             Desktop.getFrame().setNumGwtModalsShowing(numModalsShowing());
          DesktopMenuCallback.setMainMenuEnabled(false);
       }
+
       updateInert(true);
    }
 
@@ -132,6 +140,25 @@ public class ModalDialogTracker
          A11y.setInert(ideFrame, inert);
       if (satWrapper != null)
          A11y.setInert(satWrapper, inert);
+   }
+
+   private static void ensureVisible(Panel panel)
+   {
+      try
+      {
+         ensureVisibleImpl(panel);
+      }
+      catch (Exception e)
+      {
+         Debug.logException(e);
+      }
+   }
+
+   private static void ensureVisibleImpl(Panel panel)
+   {
+      Style styles = DomUtils.getComputedStyles(panel.getElement());
+      Integer zIndex = StringUtil.parseInt(styles.getZIndex(), 1000);
+      panel.getElement().getStyle().setZIndex(zIndex + dialogStack_.size());
    }
 
    private static final List<PopupPanel> dialogStack_ = new ArrayList<>();


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16042.
Addresses https://github.com/rstudio/rstudio/issues/15992.

### Approach

Use the modal dialog tracker to manually adjust the z-index of any displayed modal dialogs, so that newly-presented ones are always on top.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15992, and confirm also that https://github.com/rstudio/rstudio/issues/15955 did not regress.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
