### PR TITLE
improve legibility of debug-highlighted text

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 #### RStudio
 
 - RStudio now highlights all keywords from the SQL 2023 standard in SQL documents (#15841)
+- Improved legibility of highlighted code when RStudio debugger is active
 - Added a user preference to disable showing the splash screen at startup (#15945)
 - The splash screen now closes when clicked with the mouse (#15614)
 

--- a/src/cpp/session/resources/themes/ambiance.rstheme
+++ b/src/cpp/session/resources/themes/ambiance.rstheme
@@ -193,7 +193,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #907F2C;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/chaos.rstheme
+++ b/src/cpp/session/resources/themes/chaos.rstheme
@@ -169,7 +169,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #8B7A27;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/chrome.rstheme
+++ b/src/cpp/session/resources/themes/chrome.rstheme
@@ -142,7 +142,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #FFEF9C;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/clouds.rstheme
+++ b/src/cpp/session/resources/themes/clouds.rstheme
@@ -111,7 +111,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #FFEF9C;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/clouds_midnight.rstheme
+++ b/src/cpp/session/resources/themes/clouds_midnight.rstheme
@@ -112,7 +112,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #8C7C29;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/cobalt.rstheme
+++ b/src/cpp/session/resources/themes/cobalt.rstheme
@@ -128,7 +128,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #80803C;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/compile-themes.R
+++ b/src/cpp/session/resources/themes/compile-themes.R
@@ -573,10 +573,6 @@
    .rs.updateSetting(content, color, "ace_print-margin", "background")
 })
 
-.rs.addFunction("setActiveDebugLineColor", function(content, color) {
-   .rs.updateSetting(content, color, "ace_active_debug_line", "background-color")
-})
-
 .rs.addFunction("setSelectionStartBorderRadius", function(content) {
    .rs.updateSetting(content, "2px", "ace_selection.ace_start", "border-radius")
 })

--- a/src/cpp/session/resources/themes/crimson_editor.rstheme
+++ b/src/cpp/session/resources/themes/crimson_editor.rstheme
@@ -133,7 +133,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #FFEF9C;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/dawn.rstheme
+++ b/src/cpp/session/resources/themes/dawn.rstheme
@@ -124,7 +124,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #FCEC99;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/dracula.rstheme
+++ b/src/cpp/session/resources/themes/dracula.rstheme
@@ -153,7 +153,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #948437;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/dreamweaver.rstheme
+++ b/src/cpp/session/resources/themes/dreamweaver.rstheme
@@ -158,7 +158,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #FFEF9C;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/eclipse.rstheme
+++ b/src/cpp/session/resources/themes/eclipse.rstheme
@@ -111,7 +111,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #FFEF9C;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/gob.rstheme
+++ b/src/cpp/session/resources/themes/gob.rstheme
@@ -127,7 +127,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #857522;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/idle_fingers.rstheme
+++ b/src/cpp/session/resources/themes/idle_fingers.rstheme
@@ -112,7 +112,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #998835;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/iplastic.rstheme
+++ b/src/cpp/session/resources/themes/iplastic.rstheme
@@ -136,7 +136,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #F7E693;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/katzenmilch.rstheme
+++ b/src/cpp/session/resources/themes/katzenmilch.rstheme
@@ -138,7 +138,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #F9E896;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/kr_theme.rstheme
+++ b/src/cpp/session/resources/themes/kr_theme.rstheme
@@ -120,7 +120,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #857421;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/material.rstheme
+++ b/src/cpp/session/resources/themes/material.rstheme
@@ -122,7 +122,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #7F8437;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;
@@ -154,7 +153,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #928838;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/merbivore.rstheme
+++ b/src/cpp/session/resources/themes/merbivore.rstheme
@@ -111,7 +111,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #8B7A27;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/merbivore_soft.rstheme
+++ b/src/cpp/session/resources/themes/merbivore_soft.rstheme
@@ -112,7 +112,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #8E7D2A;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/mono_industrial.rstheme
+++ b/src/cpp/session/resources/themes/mono_industrial.rstheme
@@ -123,7 +123,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #918530;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/monokai.rstheme
+++ b/src/cpp/session/resources/themes/monokai.rstheme
@@ -121,7 +121,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #93832D;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/pastel_on_dark.rstheme
+++ b/src/cpp/session/resources/themes/pastel_on_dark.rstheme
@@ -124,7 +124,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #968330;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/solarized_dark.rstheme
+++ b/src/cpp/session/resources/themes/solarized_dark.rstheme
@@ -104,7 +104,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #585b2c;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/solarized_light.rstheme
+++ b/src/cpp/session/resources/themes/solarized_light.rstheme
@@ -107,7 +107,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #FEEA8E;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/sqlserver.rstheme
+++ b/src/cpp/session/resources/themes/sqlserver.rstheme
@@ -152,7 +152,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #FFEF9C;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/textmate.rstheme
+++ b/src/cpp/session/resources/themes/textmate.rstheme
@@ -144,7 +144,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #FFEF9C;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/tomorrow.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow.rstheme
@@ -124,7 +124,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #FFEF9C;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/tomorrow_night.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow_night.rstheme
@@ -124,7 +124,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #8E7F2D;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/tomorrow_night_blue.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow_night_blue.rstheme
@@ -122,7 +122,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #808145;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/tomorrow_night_bright.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow_night_bright.rstheme
@@ -137,10 +137,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  margin-left: -1px;
-  margin-top: -1px;
-  padding: 1px;
-  background-color: #323000;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/tomorrow_night_bright.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow_night_bright.rstheme
@@ -137,7 +137,10 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #806F1C;
+  margin-left: -1px;
+  margin-top: -1px;
+  padding: 1px;
+  background-color: #323000;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/tomorrow_night_eighties.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow_night_eighties.rstheme
@@ -124,7 +124,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #968633;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/twilight.rstheme
+++ b/src/cpp/session/resources/themes/twilight.rstheme
@@ -125,7 +125,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #8A7926;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/vibrant_ink.rstheme
+++ b/src/cpp/session/resources/themes/vibrant_ink.rstheme
@@ -110,7 +110,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #877724;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/xcode.rstheme
+++ b/src/cpp/session/resources/themes/xcode.rstheme
@@ -104,7 +104,6 @@
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: #FFEF9C;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -352,9 +352,10 @@ pre {
 }
 
 .ace_active_debug_line {
-   margin-left: -1px;
+   margin-left: -2px;
    margin-top: -1px;
-   padding: 1px;
+   padding-right: 2px;
+   padding-bottom: 2px;
 }
 
 .editor_light .ace_active_debug_line {
@@ -362,7 +363,7 @@ pre {
 }
 
 .editor_dark .ace_active_debug_line {
-   background-color: rgb(50, 46, 8);
+   background-color: rgb(54, 50, 8);
 }
 
 .ace_tooltip {

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -6,6 +6,7 @@
 @external ace_info, ace_warning, ace_error;
 @external ace_breakpoint, ace_inactive-breakpoint, ace_pending-breakpoint, ace_executing-line;
 @external ace_chunk-queued-line, ace_chunk-executed-line, ace_chunk-resting-line, ace_chunk-error-line;
+@external ace_active_debug_line;
 @external visual_chunk-queued-line, visual_chunk-executed-line, visual_chunk-resting-line, visual_chunk-error-line;
 @external ace_sb;
 @external cueText;
@@ -29,7 +30,7 @@
 @external gwt-TabLayoutPanel-Workbench;
 @external gwt-TabLayoutPanelTabs;
 @external gwt-DecoratedPopupPanel;
-@external editor_dark;
+@external editor_light, editor_dark;
 @external gwt-TextBox-readonly;
 @external gwt-TextBox;
 @external gwt-ListBox;
@@ -348,6 +349,20 @@ pre {
 
 .ace_editor, .ace_text-layer {
    font-family: fixedWidthFont !important;
+}
+
+.ace_active_debug_line {
+   margin-left: -1px;
+   margin-top: -1px;
+   padding: 1px;
+}
+
+.editor_light .ace_active_debug_line {
+   background-color: rgb(255, 240, 180);
+}
+
+.editor_dark .ace_active_debug_line {
+   background-color: rgb(50, 46, 8);
 }
 
 .ace_tooltip {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
@@ -130,10 +130,16 @@ public class AceThemes
          document.getBody().appendChild(currentStyleEl);
       }
       
-      if(theme.isDark())
+      if (theme.isDark())
+      {
+         document.getBody().removeClassName("editor_light");
          document.getBody().addClassName("editor_dark");
+      }
       else
+      {
          document.getBody().removeClassName("editor_dark");
+         document.getBody().addClassName("editor_light");
+      }
       
       // Deferred so that the browser can render the styles.
       new Timer()

--- a/src/gwt/tools/compile-themes.R
+++ b/src/gwt/tools/compile-themes.R
@@ -213,10 +213,6 @@ applyFixups.pastel_on_dark <- function(content, parsed)
    content
 }
 
-applyFixups.solarized_dark <- function(content, parsed) {
-   content <- .rs.setActiveDebugLineColor(content, "#585b2c")
-}
-
 applyFixups.tomorrow_night_blue <- applyFixups.kr_theme
 applyFixups.tomorrow_night_bright <- applyFixups.kr_theme
 


### PR DESCRIPTION
### Intent

Improve the contrast for the background highlight used for currently-debugged code.

For light themes, the background highlight is just slightly more pale. For dark themes, the background highlight is much darker, more closely matching the typical background of dark themes.

#### Before (Light)

<img width="756" alt="Screenshot 2025-05-19 at 3 50 14 PM" src="https://github.com/user-attachments/assets/2477a51e-9727-48df-afc9-19ed6f19dddf" />

#### After (Light)

<img width="750" alt="Screenshot 2025-05-19 at 3 49 57 PM" src="https://github.com/user-attachments/assets/86d35f63-0b79-4fd9-ba64-33febd75f2bd" />


#### Before (Dark)


<img width="759" alt="image" src="https://github.com/user-attachments/assets/ab9610cf-08c7-4ab8-82c4-4bced07c6d35" />


#### After (Dark)

<img width="755" alt="Screenshot 2025-05-19 at 3 46 19 PM" src="https://github.com/user-attachments/assets/9c8f4a9c-e5b3-4644-a255-a303958ccdc2" />

### Approach

- Remove the theme-specific highlights, and instead just use a default highlight for light vs. dark themes. (User-defined themes will still override these.)

### Automated Tests

N/A

### QA Notes

Test that code remains legible in different themes when the debugger is active. A way to get into this state for testing:

```R
debugonce(data.frame)
data.frame(x = 1)
```

Then, the RStudio debugger should open. Press 'n' to step forward one step, and you should see something like the images above.



### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
