### PR TITLE
try harder when searching for groupError span elt

### DIFF
--- a/dependencies/tools/.gitignore
+++ b/dependencies/tools/.gitignore
@@ -1,3 +1,4 @@
+/copilot-language-server-*
 /quarto-*.tar.gz
 /quarto-*.zip
 hunspell_dictionaries/

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -491,29 +491,32 @@ public class ShellWidget extends Composite implements ShellDisplay,
    private void insertErrorWidgetElement(List<Element> errorEls,
                                          Element widgetEl)
    {
-      Element firstErrorEl = errorEls.get(0);
-      
       // If console groups are enabled, the error output might have been collected
       // into a single 'groupError' span element. Search the parent element, plus
       // all of that element's siblings.
-      Element parentEl = firstErrorEl.getParentElement();
-      for (Element el = parentEl.getParentElement().getFirstChildElement();
-           el != null;
-           el = el.getNextSiblingElement())
+      for (int i = 0, n = errorEls.size(); i < n; i++)
       {
-         if (el.hasClassName(VirtualConsole.RES.styles().groupError()))
+         Element errorEl = errorEls.get(n - i - 1);
+         Element parentEl = errorEl.getParentElement();
+         for (Element el = parentEl.getParentElement().getFirstChildElement();
+              el != null;
+              el = el.getNextSiblingElement())
          {
-            el.getParentElement().replaceChild(widgetEl, el);
-            return;
+            if (el.hasClassName(VirtualConsole.RES.styles().groupError()))
+            {
+               el.getParentElement().replaceChild(widgetEl, el);
+               return;
+            }
          }
       }
       
       // Otherwise, error output should be a sequence of DOM elements within
-      // some collection. Replace the first one with our error widget, and then
+      // some collection. Replace the last one with our error widget, and then
       // remove all the other error elements.
-      parentEl.replaceChild(widgetEl, firstErrorEl);
-      for (int i = 1; i < errorEls.size(); i++)
-         parentEl.removeChild(errorEls.get(i));
+      Element lastErrorEl = errorEls.get(errorEls.size() - 1);
+      lastErrorEl.getParentElement().replaceChild(widgetEl, lastErrorEl);
+      for (int i = 0, n = errorEls.size() - 1; i < n; i++)
+         errorEls.get(i).removeFromParent();
    }
 
    @Override


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16045.

### Approach

Try harder when searching for an error span element. (Sometimes the error elements are disjoint.)

Also, instead of trying to explicitly remove parent elements from a common parent, just remove them from their own parent (whatever that might be).

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/16045.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
