### PR TITLE
ensure "use default" options read current registry value on startup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 - Fixed an issue where the "Save As" dialog would not be visible when trying to save an older git revision of a file (#15955)
 - Fixed an issue where code indentation stopped working following code chunks containing only Quarto comments (#15879)
 - Fixed an issue where RStudio could hang when attempting to execute notebook chunks without a registered handler (#15979)
+- (Windows) "Use default 32bit / 64bit version of R" now always uses the default version of R set in the registry (#12545)
 
 #### Posit Workbench
 

--- a/src/cpp/session/resources/schema/user-state-schema.json
+++ b/src/cpp/session/resources/schema/user-state-schema.json
@@ -58,7 +58,7 @@
                 },
                 "accessibility": {
                     "type": "boolean",
-                    "description": "Screen reader support" 
+                    "description": "Screen reader support"
                 },
                 "disableRendererAccessibility": {
                     "type": "boolean",
@@ -145,6 +145,8 @@
             },
             "default": {
                 "windows": {
+                    "useDefault32BitR": false,
+                    "useDefault64BitR": true,
                     "rBinDir": "",
                     "preferR64": true,
                     "rExecutablePath": ""
@@ -388,13 +390,13 @@
             "type": "string",
             "default": "",
             "title": "Zotero API Key",
-            "description": "Key for making Zotero API calls"  
+            "description": "Key for making Zotero API calls"
         },
         "zotero_data_dir": {
             "type": "string",
             "default": "",
             "title": "Zotero Data Directory",
-            "description": "Directory containing Zotero data files" 
+            "description": "Directory containing Zotero data files"
         },
         "quarto_website_sync_editor": {
             "type": "boolean",

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -47,6 +47,8 @@ const kRendererEngine = 'renderer.engine';
 const kRendererUseGpuExclusionList = 'renderer.useGpuExclusionList';
 const kRendererUseGpuDriverBugWorkarounds = 'renderer.useGpuDriverBugWorkarounds';
 
+const kUseDefault32BitR = 'platform.windows.useDefault32BitR';
+const kUseDefault64BitR = 'platform.windows.useDefault64BitR';
 const kRExecutablePath = 'platform.windows.rExecutablePath';
 const kPreferR64 = 'platform.windows.preferR64';
 
@@ -299,6 +301,24 @@ export class DesktopOptionsImpl implements DesktopOptions {
     }
 
     return rBinDir;
+  }
+
+  // Windows-only options
+  public useDefault32BitR() {
+    return this.config.get(kUseDefault32BitR, false);
+  }
+
+  public setUseDefault32BitR(useDefault: boolean) {
+    this.config.set(kUseDefault32BitR, useDefault);
+  }
+
+  // Windows-only option
+  public useDefault64BitR() {
+    return this.config.get(kUseDefault64BitR, false);
+  }
+
+  public setUseDefault64BitR(useDefault: boolean) {
+    this.config.set(kUseDefault64BitR, useDefault);
   }
 
   // Windows-only option

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -215,7 +215,6 @@ function findBuildRootImpl(rootDir: string): string {
       for (const buildFile of ['.ninja_log', 'CMakeFiles']) {
         const buildPath = `${buildDirParent}/${buildFile}`;
         if (fs.existsSync(buildPath)) {
-          console.log(buildDirParent);
           const stat = fs.statSync(buildPath);
           buildDirs.push({ path: buildDirParent, stat: stat });
         }

--- a/src/node/desktop/src/ui/widgets/choose-r.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r.ts
@@ -118,6 +118,7 @@ export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
 
       this.addIpcHandler('use-default-32bit', async (event, data: CallbackData) => {
         const installPath = initData.default32bitPath;
+        data.useDefault32BitR = true;
         data.binaryPath = `${installPath}/bin/i386/${kWindowsRExe}`;
         logger().logDebug(`Using default 32-bit version of R (${data.binaryPath})`);
         return this.maybeResolve(resolve, data);
@@ -125,6 +126,7 @@ export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
 
       this.addIpcHandler('use-default-64bit', async (event, data: CallbackData) => {
         const installPath = initData.default64bitPath;
+        data.useDefault64BitR = true;
         data.binaryPath = `${installPath}/bin/x64/${kWindowsRExe}`;
         logger().logDebug(`Using default 64-bit version of R (${data.binaryPath})`);
         return this.maybeResolve(resolve, data);

--- a/src/node/desktop/src/ui/widgets/choose-r/preload.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/preload.ts
@@ -17,6 +17,8 @@ import { getDesktopLoggerBridge } from '../../../renderer/logger-bridge';
 import { normalizeSeparatorsNative, kWindowsRExe } from '../../utils';
 
 export interface CallbackData {
+  useDefault32BitR?: boolean;
+  useDefault64BitR?: boolean;
   binaryPath?: string;
   renderingEngine?: string;
 }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/12545.

### Approach

- When the user selects "use default 32bit / 64bit version of R", save that in the Electron desktop options.
- On startup, consult those options; if set, then attempt to use the default versions of R.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/12545.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
