### PR TITLE
Notify copilot about completion acceptance

### DIFF
--- a/git_hooks/secrets/.secrets.baseline
+++ b/git_hooks/secrets/.secrets.baseline
@@ -517,7 +517,7 @@
         "filename": "src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java",
         "hashed_secret": "1c60262d3df7b0c6d2d5c52dd5014c985004219f",
         "is_verified": false,
-        "line_number": 7381,
+        "line_number": 7406,
         "is_secret": false
       },
       {
@@ -525,7 +525,7 @@
         "filename": "src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java",
         "hashed_secret": "12106b07b5b299b5e91117791ec7017f0820f84e",
         "is_verified": false,
-        "line_number": 7423,
+        "line_number": 7448,
         "is_secret": false
       }
     ],
@@ -616,5 +616,5 @@
       }
     ]
   },
-  "generated_at": "2025-05-20T20:56:10Z"
+  "generated_at": "2025-05-22T22:06:01Z"
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/NewRSConnectAuthPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/NewRSConnectAuthPage.java
@@ -1,4 +1,5 @@
-/* * NewRSConnectAuthPage.java
+/*
+ * NewRSConnectAuthPage.java
  *
  * Copyright (C) 2022 by Posit Software, PBC
  *

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/NewRSConnectAuthPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/NewRSConnectAuthPage.java
@@ -1,5 +1,4 @@
-/*
- * NewRSConnectAuthPage.java
+/* * NewRSConnectAuthPage.java
  *
  * Copyright (C) 2022 by Posit Software, PBC
  *

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -164,6 +164,7 @@ import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.Co
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotSignOutResponse;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotStatusResponse;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotTypes.CopilotCompletion;
+import org.rstudio.studio.client.workbench.copilot.model.CopilotTypes.CopilotCompletionCommand;
 import org.rstudio.studio.client.workbench.events.SessionInitEvent;
 import org.rstudio.studio.client.workbench.exportplot.model.SavePlotAsImageContext;
 import org.rstudio.studio.client.workbench.model.HTMLCapabilities;
@@ -759,6 +760,30 @@ public class RemoteServer implements Server
             .get();
       
       sendRequest(RPC_SCOPE, "copilot_generate_completions", params, requestCallback);
+   }
+   
+   @Override
+   public void copilotDidAcceptCompletion(CopilotCompletionCommand completionCommand,
+                                          ServerRequestCallback<Void> requestCallback) 
+   {
+      JSONArray params = new JSONArrayBuilder()
+            .add(completionCommand)
+            .get();
+      
+      sendRequest(RPC_SCOPE, "copilot_did_accept_completion", params, requestCallback);
+   }
+
+   @Override
+   public void copilotDidAcceptPartialCompletion(CopilotCompletion completion,
+                                                 int acceptedLength,
+                                                 ServerRequestCallback<Void> requestCallback)
+   {
+      JSONArray params = new JSONArrayBuilder()
+            .add(completion)
+            .add(acceptedLength)
+            .get();
+
+      sendRequest(RPC_SCOPE, "copilot_did_accept_partial_completion", params, requestCallback);
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/copilot/model/CopilotTypes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/copilot/model/CopilotTypes.java
@@ -55,10 +55,6 @@ public class CopilotTypes
       public String insertText;
       public CopilotRange range;
       public CopilotCompletionCommand command;
-
-      // The following is not part of the Copilot API, but is used internally
-      // to track ghost text for display.
-      public String displayText;
    }
    
    @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/copilot/server/CopilotServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/copilot/server/CopilotServerOperations.java
@@ -22,6 +22,7 @@ import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.Co
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotSignOutResponse;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotStatusResponse;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotTypes.CopilotCompletion;
+import org.rstudio.studio.client.workbench.copilot.model.CopilotTypes.CopilotCompletionCommand;
 
 public interface CopilotServerOperations
 {
@@ -48,4 +49,11 @@ public interface CopilotServerOperations
                                           int cursorRow,
                                           int cursorColumn,
                                           ServerRequestCallback<CopilotGenerateCompletionsResponse> requestCallback);
+
+   public void copilotDidAcceptCompletion(CopilotCompletionCommand completionCommand,
+                                          ServerRequestCallback<Void> requestCallback);
+
+   public void copilotDidAcceptPartialCompletion(CopilotCompletion completion,
+                                                 int acceptedLength,
+                                                 ServerRequestCallback<Void> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
@@ -88,7 +88,7 @@ public class TextEditingTargetCopilotHelper
       public int startCharacter;
       public int endLine;
       public int endCharacter;
-      private CopilotCompletion originalCompletion;
+      public CopilotCompletion originalCompletion;
    }
 
    public TextEditingTargetCopilotHelper(TextEditingTarget target)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
@@ -31,6 +31,7 @@ import org.rstudio.studio.client.common.Timers;
 import org.rstudio.studio.client.projects.ui.prefs.events.ProjectOptionsChangedEvent;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.copilot.Copilot;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotConstants;
@@ -64,6 +65,32 @@ public class TextEditingTargetCopilotHelper
    {
    }
    
+   class Completion
+   {
+      public Completion(CopilotCompletion originalCompletion, String displayText)
+      {
+         // Copilot includes trailing '```' for some reason in some cases,
+         // remove those if we're inserting in an R document.
+         this.insertText = postProcessCompletion(originalCompletion.insertText);
+         this.displayText = postProcessCompletion(displayText);
+
+         this.startLine = originalCompletion.range.start.line;
+         this.startCharacter = originalCompletion.range.start.character;
+         this.endLine = originalCompletion.range.end.line;
+         this.endCharacter = originalCompletion.range.end.character;
+
+         this.originalCompletion = originalCompletion;
+      }
+
+      public String insertText;
+      public String displayText;
+      public int startLine;
+      public int startCharacter;
+      public int endLine;
+      public int endCharacter;
+      private CopilotCompletion originalCompletion;
+   }
+
    public TextEditingTargetCopilotHelper(TextEditingTarget target)
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
@@ -185,18 +212,20 @@ public class TextEditingTargetCopilotHelper
                                     ? CopilotEventType.COMPLETION_RECEIVED_NONE
                                     : CopilotEventType.COMPLETION_RECEIVED_SOME));
                            
-                           for (int i = 0, n = completions.getLength(); i < n; i++)
+                           // TODO: If multiple completions are available we should provide a way for 
+                           // the user to view/select them. For now, use the last one.
+                           // https://github.com/rstudio/rstudio/issues/16055
+                           if (completions.getLength() > 0)
                            {
-                              CopilotCompletion completion = completions.getAt(i);
-                              
-                              completion.displayText = postProcessCompletion(computeGhostText(completion.insertText));
-                              
-                              // Copilot includes trailing '```' for some reason in some cases,
-                              // remove those if we're inserting in an R document.
-                              completion.insertText = postProcessCompletion(completion.insertText);
+                              CopilotCompletion completion = completions.getAt(completions.getLength() - 1);
 
-                              activeCompletion_ = completion;
+                              // The completion data gets modified when doing partial (word-by-word)
+                              // completions, so we need to use a copy and preserve the original
+                              // (which we need to send back to the server as-is in some language-server methods).
+                              activeCompletion_ = new Completion(completion, computeGhostText(completion.insertText));
+
                               display_.setGhostText(activeCompletion_.displayText);
+                              server_.copilotDidShowCompletion(completion, new VoidServerRequestCallback());
                            }
                         }
 
@@ -311,11 +340,13 @@ public class TextEditingTargetCopilotHelper
                         event.preventDefault();
 
                         Range aceRange = Range.create(
-                              activeCompletion_.range.start.line,
-                              activeCompletion_.range.start.character,
-                              activeCompletion_.range.end.line,
-                              activeCompletion_.range.end.character);
+                              activeCompletion_.startLine,
+                              activeCompletion_.startCharacter,
+                              activeCompletion_.endLine,
+                              activeCompletion_.endCharacter);
                         display_.replaceRange(aceRange, activeCompletion_.insertText);
+                        server_.copilotDidAcceptCompletion(activeCompletion_.originalCompletion.command,
+                                                           new VoidServerRequestCallback());
 
                         activeCompletion_ = null;
                      }
@@ -370,17 +401,19 @@ public class TextEditingTargetCopilotHelper
       String insertedWord = StringUtil.substring(text, 0, match.getIndex());
       String leftoverText = StringUtil.substring(text, match.getIndex());
       
+      int acceptedLength = insertedWord.length();
       int n = insertedWord.length();
       activeCompletion_.displayText = leftoverText;
       activeCompletion_.insertText = leftoverText;
-      activeCompletion_.range.start.character += n;
-      activeCompletion_.range.end.character += n;
+      activeCompletion_.startCharacter += n;
+      activeCompletion_.endCharacter += n;
       
       Timers.singleShot(() ->
       {
          suppressCursorChangeHandler_ = true;
          display_.insertCode(insertedWord, InsertionBehavior.EditorBehaviorsDisabled);
          display_.setGhostText(activeCompletion_.displayText);
+         server_.copilotDidAcceptPartialCompletion(activeCompletion_.originalCompletion, acceptedLength, new VoidServerRequestCallback());
          
          // Work around issue with ghost text not appearing after inserting
          // a code suggestion containing a new line
@@ -417,8 +450,8 @@ public class TextEditingTargetCopilotHelper
       int n = key.length();
       activeCompletion_.displayText = StringUtil.substring(activeCompletion_.displayText, n);
       activeCompletion_.insertText = StringUtil.substring(activeCompletion_.insertText, n);
-      activeCompletion_.range.start.character += n;
-      activeCompletion_.range.end.character += n;
+      activeCompletion_.startCharacter += n;
+      activeCompletion_.endCharacter += n;
       
       // Ace's ghost text uses a custom token appended to the current line,
       // and lines are eagerly re-tokenized when new text is inserted. To
@@ -490,7 +523,7 @@ public class TextEditingTargetCopilotHelper
    private boolean suppressCursorChangeHandler_;
    private boolean copilotDisabledInThisDocument_;
    
-   private CopilotCompletion activeCompletion_;
+   private Completion activeCompletion_;
    private boolean automaticCodeSuggestionsEnabled_ = true;
    
    


### PR DESCRIPTION
### Intent

Addresses #15903, and also puts back the change for https://github.com/rstudio/rstudio/pull/15900 (which I accidentally stomped when I reverted the Visual Mode copilot change).

### Approach

See https://github.com/github/copilot-language-server-release?tab=readme-ov-file#inline-completions for gory details.

- when user accepts entire completion (tab key), invoke `workspace/executeCommand` with the completion command that was received with the completion
- when user accepts part of the completion (word-by-word via Cmd+Right Arrow), invoke `textDocument/didPartiallyAcceptCompletion` with the original completion plus the length of text accepted so far
- when a completion suggestion is shown, invoke `textDocument/didShowCompletion` (this is the part that was unintentionally removed)

### Automated Tests

None

### QA Notes

Enable logging via `COPILOT_LOG_LEVEL=3` in ~./Renviron, and check that the above messages are being sent and follow the format shown in https://github.com/github/copilot-language-server-release?tab=readme-ov-file#inline-completions.

There is no user-visible impact of these, it's all for Copilot's use server-side (metrics, training, whatever it does with it).

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


