### PR TITLE
make sure front-end is notified on chunk error

### DIFF
--- a/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
@@ -125,7 +125,14 @@ public:
             // circumstances we should stop right away
             if (!execContext_->options().getOverlayOption("error", false))
             {
+               // notify client
+               enqueueExecStateChanged(
+                   ChunkExecFinished,
+                   execContext_ ? execContext_->options().chunkOptions() : json::Object());
+
+               // clear execution state
                clear();
+
                return Success();
             }
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -875,7 +875,9 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    private void navigateHistory(int offset)
    {
       if (isBrowsePrompt())
+      {
          browseHistoryManager_.navigateHistory(offset);
+      }
       else
       {
          if (input_.isCursorAtEnd())

--- a/version/news/NEWS-2025.05.1-mariposa-orchid.md
+++ b/version/news/NEWS-2025.05.1-mariposa-orchid.md
@@ -15,6 +15,7 @@
 - Fixed an issue where RStudio could hang when attempting to execute notebook chunks without a registered handler (#15979)
 - Fixed an issue where RStudio continued executing code within R Markdown chunks after an error occurred (#16000, #16002)
 - Fixed an issue where no more console output was produced after a '\r' character input in some cases (#16038)
+- Fixed an issue where console history could not be retrieved if an error occurred while executing a notebook chunk (#16006)
 
 #### Posit Workbench
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16006.

### Approach

When RStudio is executing a chunk, it will buffer any input submitted as part of that chunk execution, as per
https://github.com/rstudio/rstudio/blob/4295bb47c5568d901550232abb043fc6b837b8ba/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java#L625-L646. The intention here is to collect all chunk input into a single "block" of command line history, so that it can all be recalled at once.

Unfortunately, it appears that RStudio was not sending a "chunk finished" event when an error occurred that halted chunk execution. This PR alleviates that.

### Automated Tests

Included with PR.

### QA Notes

Test via notes in issue.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
