### PR TITLE
Tell Copilot about source files loaded in the IDE before Copilot has started up

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,7 +23,8 @@
 - Fixed an issue where code indentation stopped working following code chunks containing only Quarto comments (#15879)
 - Fixed an issue where RStudio could hang when attempting to execute notebook chunks without a registered handler (#15979)
 - (Windows) "Use default 32bit / 64bit version of R" now always uses the default version of R set in the registry (#12545)
-- Show an error message when the copilot language server is missing (#15923)
+- Show an error message when the GitHub Copilot language server is missing (#15923)
+- Fixed an issue where GitHub Copilot was unaware of files already loaded in the source editor before Copilot starts (#15895)
 
 #### Posit Workbench
 

--- a/git_hooks/secrets/.secrets.baseline
+++ b/git_hooks/secrets/.secrets.baseline
@@ -517,7 +517,7 @@
         "filename": "src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java",
         "hashed_secret": "1c60262d3df7b0c6d2d5c52dd5014c985004219f",
         "is_verified": false,
-        "line_number": 7406,
+        "line_number": 7417,
         "is_secret": false
       },
       {
@@ -525,7 +525,7 @@
         "filename": "src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java",
         "hashed_secret": "12106b07b5b299b5e91117791ec7017f0820f84e",
         "is_verified": false,
-        "line_number": 7448,
+        "line_number": 7459,
         "is_secret": false
       }
     ],
@@ -616,5 +616,5 @@
       }
     ]
   },
-  "generated_at": "2025-05-22T22:06:01Z"
+  "generated_at": "2025-05-28T21:58:18Z"
 }

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -216,6 +216,7 @@ const int kDeploymentRecordsUpdated = 198;
 const int kRunAutomation = 199;
 const int kConsoleWritePendingError = 200;
 const int kConsoleWritePendingWarning = 201;
+const int kCopilotStatusChanged = 202;
 
 }
 
@@ -604,6 +605,8 @@ std::string ClientEvent::typeName() const
          return "console_write_pending_error";
       case client_events::kConsoleWritePendingWarning:
          return "console_write_pending_warning";
+      case client_events::kCopilotStatusChanged:
+         return "copilot_status_changed";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -217,6 +217,7 @@ extern const int kDeploymentRecordsUpdated;
 extern const int kRunAutomation;
 extern const int kConsoleWritePendingError;
 extern const int kConsoleWritePendingWarning;
+extern const int kCopilotStatusChanged;
 
 }
    

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -1921,6 +1921,13 @@ Error copilotDidAcceptPartialCompletion(const json::JsonRpcRequest& request,
    return Success();
 }
 
+Error copilotRegisterOpenFiles(const json::JsonRpcRequest& request,
+                               json::JsonRpcResponse* pResponse)
+{
+   // TODO
+   return Success();
+}
+
 } // end anonymous namespace
 
 
@@ -1973,6 +1980,7 @@ Error initialize()
          (bind(registerRpcMethod, "copilot_did_show_completion", copilotDidShowCompletion))
          (bind(registerRpcMethod, "copilot_did_accept_completion", copilotDidAcceptCompletion))
          (bind(registerRpcMethod, "copilot_did_accept_partial_completion", copilotDidAcceptPartialCompletion))
+         (bind(registerRpcMethod, "copilot_register_open_files", copilotRegisterOpenFiles))
          (bind(sourceModuleRFile, "SessionCopilot.R"))
          ;
    return initBlock.execute();

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -206,6 +206,7 @@ class ClientEvent extends JavaScriptObject
    public static final String DeploymentRecordsUpdated = "deployment_records_updated";
    public static final String FormatDocumentCompleted = "format_document_completed";
    public static final String RunAutomation = "run_automation";
+   public static final String CopilotStatusChanged = "copilot_status_changed";
    
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -123,6 +123,7 @@ import org.rstudio.studio.client.tests.model.TestsResult;
 import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
 import org.rstudio.studio.client.workbench.addins.events.AddinRegistryUpdatedEvent;
 import org.rstudio.studio.client.workbench.codesearch.model.SearchPathFunctionDefinition;
+import org.rstudio.studio.client.workbench.copilot.model.CopilotStatusChangedEvent;
 import org.rstudio.studio.client.workbench.events.ActivatePaneEvent;
 import org.rstudio.studio.client.workbench.events.AdminNotificationEvent;
 import org.rstudio.studio.client.workbench.events.BrowseUrlEvent;
@@ -1181,6 +1182,11 @@ public class ClientEventDispatcher
          else if (type == ClientEvent.RunAutomation)
          {
             eventBus_.dispatchEvent(new RunAutomationEvent());
+         }
+         else if (type == ClientEvent.CopilotStatusChanged)
+         {
+            CopilotStatusChangedEvent.Data data = event.getData();
+            eventBus_.dispatchEvent(new CopilotStatusChangedEvent(data.getStatus()));
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -6907,14 +6907,14 @@ public class RemoteServer implements Server
    }
 
    @Override
-   public void copilotRegisterOpenFiles(String[] paths,
+   public void copilotRegisterOpenFiles(ArrayList<String> filePaths,
                                         ServerRequestCallback<Void> requestCallback) 
    {
-      // JSONArray params = new JSONArrayBuilder()
-      //       .add(documentId)
-      //       .get();
+      JSONArray jsonPaths = JSONUtils.toJSONStringArray(filePaths);
+      JSONArray params = new JSONArray();
+      params.set(0, jsonPaths);
       
-      // sendRequest(RPC_SCOPE, "copilot_doc_focused", params, requestCallback);
+      sendRequest(RPC_SCOPE, "copilot_register_open_files", params, requestCallback);
    };
 
    private boolean isAuthStatusRequest(RpcRequest request)

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -6906,6 +6906,17 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, "record_command_execution", params, callback);
    }
 
+   @Override
+   public void copilotRegisterOpenFiles(String[] paths,
+                                        ServerRequestCallback<Void> requestCallback) 
+   {
+      // JSONArray params = new JSONArrayBuilder()
+      //       .add(documentId)
+      //       .get();
+      
+      // sendRequest(RPC_SCOPE, "copilot_doc_focused", params, requestCallback);
+   };
+
    private boolean isAuthStatusRequest(RpcRequest request)
    {
       return request.getMethod().equals(AUTH_STATUS);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/copilot/model/CopilotStatusChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/copilot/model/CopilotStatusChangedEvent.java
@@ -1,0 +1,72 @@
+/*
+ * CopilotStatusChangedEvent.java
+ *
+ * Copyright (C) 2025 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.copilot.model;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class CopilotStatusChangedEvent extends GwtEvent<CopilotStatusChangedEvent.Handler>
+{
+   // keep in sync with CopilotAgentRuntimeStatus in SessionCopilot.cpp
+   public static final int UNKNOWN = 0;
+   public static final int PREPARING = 1;
+   public static final int STARTING = 2;
+   public static final int RUNNING = 3;
+   public static final int STOPPING = 4;
+   public static final int STOPPED = 5;
+
+   public interface Handler extends EventHandler
+   {
+      void onCopilotStatusChangedEvent(CopilotStatusChangedEvent event);
+   }
+
+   public static class Data extends JavaScriptObject
+   {
+      protected Data()
+      {
+      }
+
+      public native final int getStatus() /*-{
+         return this.status;
+      }-*/;
+   }
+
+   public CopilotStatusChangedEvent(int status)
+   {
+      status_ = status;
+   }
+
+   public int getStatus()
+   {
+      return status_;
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onCopilotStatusChangedEvent(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<>();
+
+   private final int status_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/copilot/server/CopilotServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/copilot/server/CopilotServerOperations.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.studio.client.workbench.copilot.server;
 
+import java.util.ArrayList;
+
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotDiagnosticsResponse;
@@ -57,6 +59,6 @@ public interface CopilotServerOperations
                                                  int acceptedLength,
                                                  ServerRequestCallback<Void> requestCallback);
 
-   public void copilotRegisterOpenFiles(String[] paths,
+   public void copilotRegisterOpenFiles(ArrayList<String> filePaths,
                                         ServerRequestCallback<Void> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/copilot/server/CopilotServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/copilot/server/CopilotServerOperations.java
@@ -56,4 +56,7 @@ public interface CopilotServerOperations
    public void copilotDidAcceptPartialCompletion(CopilotCompletion completion,
                                                  int acceptedLength,
                                                  ServerRequestCallback<Void> requestCallback);
+
+   public void copilotRegisterOpenFiles(String[] paths,
+                                        ServerRequestCallback<Void> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1288,23 +1288,24 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    {
       int status = event.getStatus();
 
-      // When copilot first starts let it know about documents that were loaded before
-      // it started (i.e. files loaded from a previous session or before enabling Copilot).
+      // After Copilot first starts let it know about documents that were loaded before
+      // it started (i.e. files loaded from a previous session).
       if (status == CopilotStatusChangedEvent.RUNNING && !copilotNotifiedAboutOpenFiles_)
       {
+         server_.copilotRegisterOpenFiles(getOpenFilePaths(), new VoidServerRequestCallback());
          copilotNotifiedAboutOpenFiles_ = true;
 
       }
       else if (status == CopilotStatusChangedEvent.STOPPING ||
                status == CopilotStatusChangedEvent.STOPPED)
       {
-         // Prepare for case where Copilot is turned back on during the current session
+         // In case Copilot gets turned back on during the current session...
          copilotNotifiedAboutOpenFiles_ = false;
       }
    }
 
    // return an array of strings containing file paths of all open files
-   public String[] getOpenFilePaths()
+   public ArrayList<String> getOpenFilePaths()
    {
       ArrayList<String> paths = new ArrayList<>();
       for (SourceColumn column : columnList_)
@@ -1316,7 +1317,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
                paths.add(path);
          }
       }
-      return paths.toArray(new String[0]);
+      return paths;
    }
 
    public void nextTabWithWrap()


### PR DESCRIPTION
> [!NOTE]
> Marked as draft; it is "done" but I want to do some more testing and need to write up test notes.

### Intent

Addresses #15895

### Approach

When Copilot starts up tell the front-end UI to register any open documents with Copilot (one time). This ultimately uses the same code as the "project file indexing" feature.

This will typically be files that were left opened when the session closed, and thus get reloaded early in startup before Copilot has started up.

### Automated Tests

None

### QA Notes

TODO - describe how to test this

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


