### PR TITLE
check for npm packages during precommit

### DIFF
--- a/git_hooks/hooks/pre-commit
+++ b/git_hooks/hooks/pre-commit
@@ -55,18 +55,20 @@ detect_secrets_installed() {
 }
 
 # Linting and formatting on RStudio Desktop IDE files
-if test -f ./src/node/desktop/.lintstagedrc
+if git diff --staged --name-only | grep -qE '^src/node/desktop/.*'
 then
-    hook_setup
-    if git diff --staged --name-only | grep -qE '^src/node/desktop/.*'
-    then
+    if ! test -f ./src/node/desktop/.lintstagedrc; then
+        echo -e >&2 "${color_highlight}Note: src/node/desktop linting pre-commit hook is not being run because ${color_none}.lintstagedrc${color_highlight} was not found.${color_none}"
+    elif ! test -x ./src/node/desktop/node_modules/.bin/prettier || ! test -x ./src/node/desktop/node_modules/.bin/eslint; then
+        echo -e >&2 "${color_highlight}Note: src/node/desktop linting pre-commit hook is not being run because the npm packages are not installed.${color_none}"
+        echo -e >&2 "\tInstall the npm dependencies by moving to ${color_highlight}src/node/desktop${color_none} and running ${color_highlight}npm install${color_none}."
+    else
+        hook_setup
         cd ./src/node/desktop && npx lint-staged
         if [ $? -ne 0 ]; then
             fail_precommit=true
         fi
     fi
-else
-    echo -e >&2 "${color_highlight}Note: src/node/desktop linting pre-commit hook is not being run because ${color_none}.lintstagedrc${color_highlight} was not found.${color_none}"
 fi
 
 # Secret scanning on staged files


### PR DESCRIPTION
### Intent

Linting for the Desktop code was recently added, but the pre-commit hook fails if there are files modified in `src/node/desktop` but the dependencies haven't been installed because `prettier` and `eslint` aren't present.

Since these files can be modified in merge commits by people not working on Desktop, this results in people using `--no-verify`, which also bypasses the detect-secrets check.

### Approach

The detect-secrets check looks to see if `detect-secrets` is installed before running it. If it isn't installed, the hook outputs a non-error informational message.

This PR follows that precedent by checking for `prettier` and `eslint` before running the JS lint checks. If they aren't installed, it outputs an informational message directing the user to run `npm install` in the appropriate path.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


