### PR TITLE
fix gwt build warning "Plural form 'one' unknown..."

### DIFF
--- a/src/gwt/src/org/rstudio/studio/RStudio.gwt.xml
+++ b/src/gwt/src/org/rstudio/studio/RStudio.gwt.xml
@@ -139,6 +139,9 @@
    <!-- Specify supported locales -->
    <extend-property name="locale" values="en,fr"/>
 
+   <!-- remove the 'default' locale permutation as it does not support plurals -->
+   <set-property name="locale" value="en,fr"/>
+
    <!-- Set default locale to en -->
    <set-property-fallback name="locale" value="en"/>
 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RsconnectConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RsconnectConstants_en.properties
@@ -163,3 +163,5 @@ publishOptions=Publish options
 reconnectAccount=Reconnect Account
 publishingContentLabel=Publishing content
 publishWizardLabel=Publish Wizard
+envVarsPublishMessage={0,number} environment variables will be published with this {1}.
+envVarsPublishMessage[one]=1 environment variable will be published with this {1}.

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RsconnectConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RsconnectConstants_fr.properties
@@ -163,3 +163,5 @@ reconnectAccount=Reconnecter le compte
 documentsLowercasePlural=documents
 publishingContentLabel=Publication du contenu
 publishWizardLabel=Assistant de publication
+envVarsPublishMessage={0,number} variables d''environnement seront publiées avec ce {1}.
+envVarsPublishMessage[one]={0,number} variable d''environnement sera publiée avec ce {1}.


### PR DESCRIPTION
### Intent

During GWT builds there is a warning:

``` 
[WARN] Plural form 'one' unknown in com.google.gwt.i18n.client.impl.plurals.DefaultRule: ignoring
```

### Approach

Fixed by removing the `default` locale as it does not support plurals. We define `en` as the fallback so don't need/want `default`. This is described under "The Default Locale" section of this page: https://www.gwtproject.org/doc/latest/DevGuideI18nLocale.html.

The clue that this was the problem came from https://code.google.com/archive/p/google-web-toolkit/issues/5979.

Also added FR localizations for this string. Sanity tested as follow (other non-French in French UI, and layout issues, are preexisting problems):

<img width="583" alt="english-one" src="https://github.com/user-attachments/assets/6d4e535e-5b83-4ccf-bbed-03aa8337f4f0" />
<img width="584" alt="english-two" src="https://github.com/user-attachments/assets/e3e466c9-c9c5-4811-9ea6-1ef542f67f79" />
<img width="581" alt="français-deux" src="https://github.com/user-attachments/assets/2eb17ec5-34b7-47cd-963e-98504980075c" />
<img width="581" alt="français-un" src="https://github.com/user-attachments/assets/51f8e1de-2258-454d-9608-1a884174c81d" />

### Automated Tests

None

### QA Notes

Screenshots show what you'd want to test, if you want to test it.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
