### PR TITLE
use download hook and add auth headers

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1790,7 +1790,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
          fmt <- "netrc file %s has 0%s permissions; it will be ignored"
          msg <- sprintf(fmt, shQuote(netrcPath), as.character(info$mode))
          warning(msg, call. = FALSE)
-         warning(".netrc files should accessible to only your own user account")
+         warning(".netrc files should accessible to only your own user account", call. = FALSE)
       }
       
       return(NULL)

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1278,7 +1278,20 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       value    = hook,
       action   = "append"
    )
-      
+
+})
+
+.rs.addFunction("registerPackageAttachedHook", function(package, hook)
+{
+   searchPathName <- paste("package", package, sep = ":")
+   if (searchPathName %in% search())
+      return(hook())
+   
+   setHook(
+      hookName = packageEvent(package, "attach"),
+      value    = hook,
+      action   = "append"
+   )
 })
 
 .rs.addFunction("prependToPath", function(entry)
@@ -1766,6 +1779,23 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    if (is.na(info$mode))
       return(NULL)
    
+   # Require that the netrc file be accessible only to the current user.
+   if ((info$mode & "077") != 0L)
+   {
+      warned <- getOption("rstudio.netrc.warnedAboutPermissions", default = FALSE)
+      options(rstudio.netrc.warnedAboutPermissions = TRUE)
+      
+      if (!warned)
+      {
+         fmt <- "netrc file %s has 0%s permissions; it will be ignored"
+         msg <- sprintf(fmt, shQuote(netrcPath), as.character(info$mode))
+         warning(msg, call. = FALSE)
+         warning(".netrc files should accessible to only your own user account")
+      }
+      
+      return(NULL)
+   }
+   
    # Read the contents of the file.
    contents <- readLines(netrcPath, warn = FALSE)
    
@@ -1840,4 +1870,40 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    names(result) <- .rs.mapChr(result, `[[`, "machine")
    
    result
+})
+
+.rs.addFunction("computeAuthorizationHeader", function(url)
+{
+   # Parse the URL into its component parts.
+   pattern <- paste0(
+      "^(?:(?<scheme>[a-z][a-z0-9+\\-.]*)://)?",           # Scheme
+      "(?:(?<user>[^:@/?#]+)(?::(?<pass>[^@/?#]*))?@)?",   # User, Password
+      "(?<host>\\[[^\\]]+\\]|[^:/?#]+)",                   # Host (IPv6 in [])
+      "(?::(?<port>\\d+))?",                               # Port
+      "(?<path>/[^?#]*)?",                                 # Path
+      "(?:\\?(?<query>[^#]*))?",                           # Query
+      "(?:#(?<fragment>.*))?",                             # Fragment
+      "$"
+   )
+   
+   match <- regexec(pattern, url, perl = TRUE)
+   parts <- as.list(regmatches(url, match)[[1L]])
+   
+   # Read user's .netrc file (if any)
+   netrcEntries <- .rs.readNetrc()
+   if (is.null(netrcEntries))
+      return("")
+   
+   # Look for valid credentials for the provided URLs.
+   for (netrcEntry in netrcEntries)
+   {
+      if (.rs.startsWith(parts$host, netrcEntry$machine))
+      {
+         userPass <- paste(netrcEntry$login, netrcEntry$password, sep = ":")
+         result <- paste("Basic", .rs.base64encode(userPass))
+         return(result)
+      }
+   }
+   
+   ""
 })

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1876,7 +1876,8 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 {
    # Parse the URL into its component parts.
    pattern <- paste0(
-      "^(?:(?<scheme>[a-z][a-z0-9+\\-.]*)://)?",           # Scheme
+      "^",
+      "(?:(?<scheme>[a-z][a-z0-9+\\-.]*)://)?",            # Scheme
       "(?:(?<user>[^:@/?#]+)(?::(?<pass>[^@/?#]*))?@)?",   # User, Password
       "(?<host>\\[[^\\]]+\\]|[^:/?#]+)",                   # Host (IPv6 in [])
       "(?::(?<port>\\d+))?",                               # Port

--- a/src/cpp/session/modules/SessionRUtil.cpp
+++ b/src/cpp/session/modules/SessionRUtil.cpp
@@ -13,11 +13,18 @@
  *
  */
 
-#include <yaml-cpp/yaml.h>
-
 #include <session/SessionRUtil.hpp>
 
+#include <string>
+#include <yaml-cpp/yaml.h>
+
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/ini_parser.hpp>
+#include <boost/regex.hpp>
+#include <boost/url.hpp>
+
 #include <shared_core/Error.hpp>
+
 #include <core/Log.hpp>
 #include <core/Exec.hpp>
 #include <core/FileSerializer.hpp>
@@ -33,10 +40,7 @@
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionSuspend.hpp>
 
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/ini_parser.hpp>
-#include <boost/regex.hpp>
-
+#include "core/http/URL.hpp"
 #include "shiny/SessionShiny.hpp"
 
 namespace rstudio {

--- a/src/cpp/tests/testthat/test-download.R
+++ b/src/cpp/tests/testthat/test-download.R
@@ -1,0 +1,49 @@
+#
+# test-download.R
+#
+# Copyright (C) 2022 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+context("download")
+
+expect_download <- function(url, destfile = NULL, method = "libcurl") {
+   
+   destfile <- destfile %||% {
+      .rs.mapChr(seq_along(url), function(i) tempfile())
+   }
+   
+   lhs <- .rs.downloadFile(
+      url      = url,
+      destfile = destfile,
+      method   = method,
+      quiet    = TRUE
+   )
+   
+   rhs <- utils::download.file(
+      url      = url,
+      destfile = destfile,
+      method   = method,
+      quiet    = TRUE
+   )
+   
+   expect_equal(lhs, rhs)
+   
+}
+
+test_that("download.file hooks work as expected", {
+   
+   url <- "https://cran.rstudio.com"
+   
+   expect_download(url)
+   expect_download(c(url, url))
+   
+})


### PR DESCRIPTION
### Intent

Part of https://github.com/rstudio/rstudio-pro/issues/8155.

### Approach

- Create our own `download.file` hook, that eventually calls the original `download.file` implementation.
- Use that hook to read login + password information from a user's `.netrc`, and pass those as headers.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio-pro/issues/8155.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
