### PR TITLE
fix theoretical double-deletes and remove an unused constant

### DIFF
--- a/src/cpp/core/system/ChildProcessSubprocPollTests.cpp
+++ b/src/cpp/core/system/ChildProcessSubprocPollTests.cpp
@@ -37,7 +37,6 @@ const milliseconds kCheckSubprocDelay = milliseconds(25);
 const milliseconds kCheckSubprocDelayExpired = milliseconds(35);
 
 const milliseconds kCheckCwdDelay = milliseconds(35);
-const milliseconds kCheckCwdDelayExpired = milliseconds(45);
 
 void blockingwait(milliseconds ms)
 {

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -1538,6 +1538,7 @@ Error FilePath::openForRead(std::shared_ptr<std::istream>& out_stream) const
       if (!(*pResult))
       {
          delete pResult;
+         pResult = nullptr;
 
          Error error = systemError(boost::system::errc::no_such_file_or_directory, ERROR_LOCATION);
          error.addProperty("path", getAbsolutePath());
@@ -1548,6 +1549,7 @@ Error FilePath::openForRead(std::shared_ptr<std::istream>& out_stream) const
    catch(const std::exception& e)
    {
       delete pResult;
+      pResult = nullptr;
 
       Error error = systemError(boost::system::errc::io_error,
                                 ERROR_LOCATION);
@@ -1596,6 +1598,7 @@ Error FilePath::openForWrite(std::shared_ptr<std::ostream>& out_stream, bool in_
       if (!(*pResult))
       {
          delete pResult;
+         pResult = nullptr;
 
          Error error = systemError(boost::system::errc::no_such_file_or_directory, ERROR_LOCATION);
          error.addProperty("path", getAbsolutePath());
@@ -1607,6 +1610,7 @@ Error FilePath::openForWrite(std::shared_ptr<std::ostream>& out_stream, bool in_
    catch(const std::exception& e)
    {
       delete pResult;
+      pResult = nullptr;
       Error error = systemError(boost::system::errc::io_error,
                                 ERROR_LOCATION);
       error.addProperty("what", e.what());
@@ -1724,6 +1728,7 @@ Error FilePath::testWritePermissions() const
       if (!(*pStream))
       {
          delete pStream;
+         pStream = nullptr;
 
          Error error = systemError(boost::system::errc::no_such_file_or_directory, ERROR_LOCATION);
          error.addProperty("path", getAbsolutePath());
@@ -1733,6 +1738,7 @@ Error FilePath::testWritePermissions() const
    catch(const std::exception& e)
    {
       delete pStream;
+      pStream = nullptr;
 
       Error error = systemError(boost::system::errc::io_error,
                                 ERROR_LOCATION);


### PR DESCRIPTION
### Intent

Snyk flagged some theoretically possible double-deletes and also noticed an unused constant flagged at compile time.

### Approach

Null the pointers in question after deleting them (and remove the unused constant, which I confirmed is also not referenced in the pro repo code).

Near as I can tell, the only way there would be an actual problem is if an exception was thrown by some simple code (such as calling `systemError()` that runs after deleting the variables in question. Not a problem until it is, and less noise is good.

### Automated Tests

Ran the existing unit tests.

### QA Notes

Nothing to test here.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


