### PR TITLE
Fix incorrect Copilot status shown in preference dialog after disabling and reenabling Copilot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@
 - (Windows) "Use default 32bit / 64bit version of R" now always uses the default version of R set in the registry (#12545)
 - Show an error message when the GitHub Copilot language server is missing (#15923)
 - Fixed an issue where GitHub Copilot was unaware of files already loaded in the source editor before Copilot starts (#15895)
+- Fixed an issue where GitHub Copilot's status was incorrectly reported as an error in the Preferences dialog (#16119)
 
 #### Posit Workbench
 

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/ProjectCopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/ProjectCopilotPreferencesPane.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.JSON;
+import org.rstudio.core.client.SingleShotTimer;
 import org.rstudio.core.client.prefs.RestartRequirement;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.FormLabel;
@@ -297,7 +298,14 @@ public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
             }
             else if (response.result == null)
             {
-               if (response.error != null && response.error.getCode() != CopilotConstants.ErrorCodes.AGENT_SHUT_DOWN)
+               if (response.error != null && response.error.getCode() == CopilotConstants.ErrorCodes.AGENT_NOT_INITIALIZED)
+               {
+                  // Copilot still starting up, so wait a second and refresh again
+                  SingleShotTimer.fire(1000, () -> {
+                     refresh();
+                  });
+               }
+               else if (response.error != null && response.error.getCode() != CopilotConstants.ErrorCodes.AGENT_SHUT_DOWN)
                {
                   lblCopilotStatus_.setText(constants_.copilotStartupError());
                }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/copilot/model/CopilotConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/copilot/model/CopilotConstants.java
@@ -24,6 +24,7 @@ public class CopilotConstants
    
    public static class ErrorCodes
    {
+      public static final int AGENT_NOT_INITIALIZED = -32002;
       public static final int AGENT_SHUT_DOWN = -32600;
       public static final int DOCUMENT_NOT_FOUND = -32602;
       public static final int UNABLE_TO_GET_LOCAL_ISSUER_CERTIFICATE = -32603;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.DialogOptions;
 import org.rstudio.core.client.JSON;
+import org.rstudio.core.client.SingleShotTimer;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.prefs.RestartRequirement;
 import org.rstudio.core.client.resources.ImageResource2x;
@@ -413,7 +414,14 @@ public class CopilotPreferencesPane extends PreferencesPane
             }
             else if (response.result == null)
             {
-               if (response.error != null && response.error.getCode() != CopilotConstants.ErrorCodes.AGENT_SHUT_DOWN)
+               if (response.error != null && response.error.getCode() == CopilotConstants.ErrorCodes.AGENT_NOT_INITIALIZED)
+               {
+                  // Copilot still starting up, so wait a second and refresh again
+                  SingleShotTimer.fire(1000, () -> {
+                     refresh();
+                  });
+               }
+               else if (response.error != null && response.error.getCode() != CopilotConstants.ErrorCodes.AGENT_SHUT_DOWN)
                {
                   lblCopilotStatus_.setText(constants_.copilotStartupError());
                   if (!StringUtil.isNullOrEmpty(response.output))


### PR DESCRIPTION
### Intent

Addresses #16119

### Approach

The `copilot-language-server` has a two stage initialization that the older agent did not, and the refresh code in the preferences dialog wasn't aware of this. Now it waits a second if it gets the status that indicates the second initialization step has not yet happened, and tries again to fetch the status (and repeats, if necessary).

### Automated Tests

None

### QA Notes

Test per steps in issue.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


