### PR TITLE
tweak to vscode launch and task scripts

### DIFF
--- a/.vscode/open-source/launch.json
+++ b/.vscode/open-source/launch.json
@@ -23,9 +23,8 @@
       "name": "Start RStudio Server",
       "type": "node",
       "request": "launch",
-      "runtimeExecutable": "npx",
+      "runtimeExecutable": "bash",
       "runtimeArgs": [
-        "bash",
         "rserver-dev"
       ],
       "cwd": "${workspaceFolder}/build/src/cpp",

--- a/.vscode/open-source/tasks.json
+++ b/.vscode/open-source/tasks.json
@@ -143,13 +143,13 @@
         }
       },
       "osx": {
-        "command": "install-dependencies-osx",
+        "command": "./install-dependencies-osx",
         "options": {
           "cwd": "dependencies/osx"
         }
       },
       "linux": {
-        "command": "install-dependencies-linux",
+        "command": "./install-dependencies-linux",
         "options": {
           "cwd": "dependencies/linux"
         }


### PR DESCRIPTION
### Intent

Fix dependency installation tasks to work even if `.` isn't in the path, and fix "Start RStudio Server" launch config (failed for me the way it was).
