### PR TITLE
Close the /proc dir when getting child process memory

### DIFF
--- a/src/cpp/core/system/LinuxResources.cpp
+++ b/src/cpp/core/system/LinuxResources.cpp
@@ -208,9 +208,13 @@ long getProcessSizeOfChildren(PidType parentPid, UidType userId)
             statusFile.close();
          }
       }
+      ::closedir(pDir);
+      pDir = nullptr;
    }
    catch (...)
    {
+      if (pDir != nullptr)
+         ::closedir(pDir);
       return 0;
    }
    int numChildren = 0;


### PR DESCRIPTION

### Intent

Addresses: https://github.com/rstudio/rstudio-pro/issues/8319



