### PR TITLE
Prevent sending didOpen more than once, and suggest a restart if project indexing enabled and Copilot was started

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,8 @@
 - Show an error message when the GitHub Copilot language server is missing (#15923)
 - Fixed an issue where GitHub Copilot was unaware of files already loaded in the source editor before Copilot starts (#15895)
 - Fixed an issue where GitHub Copilot's status was incorrectly reported as an error in the Preferences dialog (#16119)
+- Fixed an issue where GitHub Copilot would not index project files when Copilot was started while the project is open (#16128)
+- Fixed an issue where RStudio would send multiple didOpen messages to GitHub Copilot for the same file (#16129)
 
 #### Posit Workbench
 

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -1244,9 +1244,6 @@ void didChangeNonIncremental(const std::string& uri,
                              int version,
                              const std::string& contents)
 {
-   if (!ensureAgentRunning())
-      return;
-
    if (s_knownDocuments.count(uri) == 0)
    {
       // unknown document, open it instead

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -1186,9 +1186,6 @@ void docOpened(const std::string& uri,
                int version,
                const std::string& contents)
 {
-   if (!ensureAgentRunning())
-      return;
-
    if (s_knownDocuments.count(uri) > 0)
    {
       // already told Copilot about this document, so just update it
@@ -1211,9 +1208,6 @@ void docOpened(const std::string& uri,
 
 void docClosed(const std::string& uri)
 {
-   if (!ensureAgentRunning())
-      return;
-
    if (s_knownDocuments.count(uri) == 0)
    {
       WLOG("Tried to close unknown document '{}'.", uri);
@@ -1349,6 +1343,9 @@ void onDocUpdated(boost::shared_ptr<source_database::SourceDocument> pDoc)
 
 void onDocRemoved(boost::shared_ptr<source_database::SourceDocument> pDoc)
 {
+   if (!ensureAgentRunning())
+      return;
+
    docClosed(uriFromDocument(pDoc));
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/ProjectCopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/ProjectCopilotPreferencesPane.java
@@ -41,6 +41,7 @@ import org.rstudio.studio.client.workbench.copilot.Copilot;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotConstants;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotStatusResponse;
+import org.rstudio.studio.client.workbench.copilot.model.CopilotStatusChangedEvent;
 import org.rstudio.studio.client.workbench.copilot.server.CopilotServerOperations;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.prefs.PrefsConstants;
@@ -57,6 +58,7 @@ import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.HorizontalPanel;
@@ -76,6 +78,12 @@ public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
       RestartRequirement requirement = new RestartRequirement();
       if (options_.getCopilotOptions().copilot_indexing_enabled != copilotIndexingEnabled_.getValue())
          requirement.setSessionRestartRequired(true);
+      
+      // If project indexing is enabled and Copilot was started while the dialog was open, suggest
+      // a session restart to ensure that Copilot indexes the project files.
+      if (copilotStarted_ && isIndexingEnabled())
+         requirement.setSessionRestartRequired(true); 
+
       return requirement;
    }
    
@@ -139,6 +147,21 @@ public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
       
       lblCopilotTos_ = new Label(constants_.copilotTermsOfServiceLabel());
       lblCopilotTos_.addStyleName(RES.styles().copilotTosLabel());
+
+      copilotStatusHandler_ = events_.addHandler(CopilotStatusChangedEvent.TYPE, (event) -> {
+         copilotStarted_ = event.getStatus() == CopilotStatusChangedEvent.RUNNING;
+      });
+   }
+
+   @Override
+   public void onUnload()
+   {
+      if (copilotStatusHandler_ != null)
+      {
+         copilotStatusHandler_.removeHandler();
+         copilotStatusHandler_ = null;
+      }
+      super.onUnload();
    }
    
    private void initDisplay(RProjectOptions options)
@@ -376,6 +399,16 @@ public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
       return constants_.copilotPaneName();
    }
 
+   private boolean isIndexingEnabled()
+   {
+      if (options_.getCopilotOptions().copilot_indexing_enabled == YesNoAskDefault.YES_VALUE)
+         return true;
+      else if (options_.getCopilotOptions().copilot_indexing_enabled == YesNoAskDefault.NO_VALUE)
+         return false;
+      else
+         return prefs_.copilotIndexingEnabled().getValue();
+   }
+
    private void hideButtons()
    {
       for (SmallButton button : statusButtons_)
@@ -396,7 +429,9 @@ public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
    
    // State
    private RProjectOptions options_;
-   
+   private HandlerRegistration copilotStatusHandler_;
+   private boolean copilotStarted_ = false; // did Copilot get started while the dialog was open?
+
    // UI
    private final YesNoAskDefault copilotEnabled_;
    private final YesNoAskDefault copilotIndexingEnabled_;


### PR DESCRIPTION
### Intent

Addresses #16128, #16129

### Approach

For #16128, mitigate by prompting to restart when Copilot was started (or restarted) while the preferences dialog was displayed AND a project is open AND project-indexing is enabled. This is simpler than handling re-indexing during the current session.

For #16129, send `textDocument/didChange` instead of `textDocument/didOpen` for all but the initial opening of the document. For now sending the full document text with didChange (as we were always doing with didOpen) instead of the incremental approach (that's covered in separate issue, not yet implemented, #15901).

### Automated Tests

None, but be a good idea. I'll look at writing some BRAT tests in this area, separately.

### QA Notes

Test per the issue descriptions.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


