### PR TITLE
refine truncation behavior

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1149,6 +1149,53 @@ public class StringUtil
       return StringUtil.substring(string, 0, truncatedSize) + suffix;
    }
 
+   public static String truncateLines(String output, int maxLineLength)
+   {
+      // If truncation isn't enabled, do nothing.
+      if (maxLineLength == 0)
+         return output;
+
+      // If the size of the output we've received is already below the limit, return early.
+      int n = output.length();
+      if (n <= maxLineLength)
+         return output;
+
+      // Check for the first newline. If we don't find anything,
+      // we can just substring the string itself.
+      int rhs = output.indexOf("\n");
+      if (rhs == -1)
+         return output.substring(0, maxLineLength) + " ... <truncated>";
+
+      // Iterate over all of the newlines within the output text.
+      // For each string, pull out the relevant substring, and then
+      // truncate it if appropriate. Build the result as an array
+      // of strings which we'll later join into a final string.
+      JsVectorString result = JsVectorString.createVector();
+
+      int lhs = 0;
+      while (rhs != -1)
+      {
+         // Grab the (possibly truncated) substring within.
+         String value = (rhs - lhs > maxLineLength)
+            ? output.substring(lhs, lhs + maxLineLength) + " ... <truncated>"
+            : output.substring(lhs, rhs);
+         result.push(value);
+
+         // Look for the next newline.
+         lhs = rhs + 1;
+         rhs = output.indexOf("\n", lhs);
+      }
+
+      // Add the final bit of text following the last newline found in the line.
+      String value = (n - lhs > maxLineLength)
+         ? output.substring(lhs, lhs + maxLineLength) + " ... <truncated>"
+         : output.substring(lhs);
+      result.push(value);
+
+      // Finally, join it all back together.
+      return result.join("\n");
+   }
+
    public static boolean isOneOf(String string, String... candidates)
    {
       for (String candidate : candidates)

--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -335,54 +335,7 @@ public class VirtualConsole
    @Override
    public String toString()
    {
-      return truncate(output_.toString());
-   }
-
-   private String truncate(String output)
-   {
-      // If truncation isn't enabled, do nothing.
-      if (maxLineLength_ == 0)
-         return output;
-
-      // If the size of the output we've received is already below the limit, return early.
-      int n = output.length();
-      if (n <= maxLineLength_)
-         return output;
-
-      // Check for the first newline. If we don't find anything,
-      // we can just substring the string itself.
-      int rhs = output.indexOf("\n");
-      if (rhs == -1)
-         return output.substring(0, maxLineLength_) + " ... <truncated>";
-
-      // Iterate over all of the newlines within the output text.
-      // For each string, pull out the relevant substring, and then
-      // truncate it if appropriate. Build the result as an array
-      // of strings which we'll later join into a final string.
-      JsVectorString result = JsVectorString.createVector();
-
-      int lhs = 0;
-      while (rhs != -1)
-      {
-         // Grab the (possibly truncated) substring within.
-         String value = (rhs - lhs > maxLineLength_)
-            ? output.substring(lhs, lhs + maxLineLength_) + " ... <truncated>"
-            : output.substring(lhs, rhs);
-         result.push(value);
-
-         // Look for the next newline.
-         lhs = rhs + 1;
-         rhs = output.indexOf("\n", lhs);
-      }
-
-      // Add the final bit of text following the last newline found in the line.
-      String value = (n - lhs > maxLineLength_)
-         ? output.substring(lhs, lhs + maxLineLength_) + " ... <truncated>"
-         : output.substring(lhs);
-      result.push(value);
-
-      // Finally, join it all back together.
-      return result.join("\n");
+      return StringUtil.truncateLines(output_.toString(), maxLineLength_);
    }
 
    public int getLength()
@@ -649,6 +602,8 @@ public class VirtualConsole
     */
    private void text(String text, String clazz, boolean forceNewRange)
    {
+      text = StringUtil.truncateLines(text, maxLineLength_);
+
       if (newText_ != null)
          newText_.append(text);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/ConsoleAction.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/ConsoleAction.java
@@ -20,6 +20,14 @@ public class ConsoleAction extends JavaScriptObject
 {
    protected ConsoleAction() {}
 
+   public static final native ConsoleAction create(int type, String data)
+   /*-{
+      return {
+         type: type,
+         data: data
+      };
+   }-*/;
+
    public static final int PROMPT = 0;
    public static final int INPUT = 1;
    public static final int OUTPUT = 2;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16111.

### Approach

- Truncate text in VirtualConsole when it's submitted.
- In addition, when replaying console actions from the client, ensure those actions are truncated appropriately.

We could also consider truncating text when adding them to the R console action buffer, but that seemed messier to unravel.

### Automated Tests

TODO

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
