### PR TITLE
Update open file maximum with child processes

### DIFF
--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -807,7 +807,8 @@ Error ChildProcess::run()
          // the child from clobbering the parent's FDs
          // and actually prevents potential missed child exits caused by
          // clobbering of FDs affecting epoll calls
-         signal_safe::closeFileDescriptorsFromParent(fdCloseFd[READ], STDERR_FILENO+1, hard);
+         // Use the soft limit as the upper bound since that's the effective limit.
+         signal_safe::closeFileDescriptorsFromParent(fdCloseFd[READ], STDERR_FILENO+1, soft);
          ::close(fdCloseFd[READ]);
       }
 


### PR DESCRIPTION
* Switch to using the soft limit when closing file descriptors in a child process.
* Establish a reasonable upper limit of maximum files when closing file descriptors in a child process.

In recent Linux/Docker systems the hard limit for open files is set to nearly 1 billion. This causes issues with our slow close fallback mechanism which tries to brute-force close every file descriptor up to that limit. The limit of 1M included in this change was taken from an Ubuntu 22.04 system.


### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Ensure you have updated the QA Notes in the original issue.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


