### PR TITLE
fix formatting for object size for large character vectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,7 @@
 - Fixed an issue where GitHub Copilot's status was incorrectly reported as an error in the Preferences dialog (#16119)
 - Fixed an issue where GitHub Copilot would not index project files when Copilot was started while the project is open (#16128)
 - Fixed an issue where RStudio would send multiple didOpen messages to GitHub Copilot for the same file (#16129)
+- Fixed an issue where large character vectors were shown with an NaN size in the environment pane (#15919)
 
 
 #### Posit Workbench

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -718,6 +718,7 @@
    class <- .rs.getSingleClass(obj)
    contents <- list()
    contents_deferred <- FALSE
+   is_size_estimated <- FALSE
 
    # for language objects, don't evaluate, just show the expression
    if (is.symbol(obj))
@@ -753,12 +754,12 @@
          else
          {
             is_size_estimated <- identical(attr(size, "estimate"), TRUE)
-            size <- format(size, units = "auto", standard = "SI")
+            size_formatted <- format(size, units = "auto", standard = "SI")
             if (is_size_estimated)
-               size <- paste(">", size)
+               size_formatted <- paste(">", size_formatted)
             
             fmt <- "Large %s (%s %s)"
-            val <- sprintf(fmt, class, len_desc, size)
+            val <- sprintf(fmt, class, len_desc, size_formatted)
          }
          contents_deferred <- TRUE
       }
@@ -794,6 +795,7 @@
       value             = .rs.scalar(val),
       description       = .rs.scalar(desc),
       size              = .rs.scalar(size),
+      is_size_estimated = .rs.scalar(is_size_estimated),
       length            = .rs.scalar(len),
       contents          = contents,
       contents_deferred = .rs.scalar(contents_deferred)

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -186,11 +186,16 @@ public class StringUtil
    // than that.
    public static String formatFileSize(int size)
    {
+      return formatFileSize(size, 1024);
+   }
+
+   public static String formatFileSize(int size, int bytesPerKilo)
+   {
       int i = 0, divisor = 1;
 
-      for (; nativeDivide(size, divisor) > 1024 && i < LABELS.length; i++)
+      for (; nativeDivide(size, divisor) > bytesPerKilo && i < LABELS.length; i++)
       {
-         divisor *= 1024;
+         divisor *= bytesPerKilo;
       }
 
       return FORMAT.format((double)size / divisor) + " " + LABELS[i];

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/model/RObject.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/model/RObject.java
@@ -59,6 +59,10 @@ public class RObject extends JavaScriptObject
    public final native int getSize() /*-{
       return this.size;
    }-*/;
+
+   public final native boolean isSizeEstimated() /*-{
+      return this.is_size_estimated || false;
+   }-*/;
    
    public final native boolean getContentsDeferred() /*-{
       return this.contents_deferred;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectGrid.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectGrid.java
@@ -209,8 +209,17 @@ public class EnvironmentObjectGrid extends EnvironmentObjectDisplay
                   {
                      int size = object.rObject.getSize();
                      if (size < 0)
+                     {
                         return "<NA>";
-                     return StringUtil.formatFileSize(size);
+                     }
+                     else if (object.rObject.isSizeEstimated())
+                     {
+                        return "> " + StringUtil.formatFileSize(size, 1000);
+                     }
+                     else
+                     {
+                        return StringUtil.formatFileSize(size);
+                     }
                   }
               });
       columns_.add(new ObjectGridColumn(


### PR DESCRIPTION
### Intent

Addresses part of https://github.com/rstudio/rstudio/issues/15919.

### Approach

We were inadvertently converting the session-computed "size" variable into a string from a numeric value. Fix that, but also report if the computed size is an estimate, and use that when rendering the UI.

### Automated Tests

Included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15919.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
