### PR TITLE
restore old names for list packages API

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1378,11 +1378,15 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       # Keep only fields of interest.
       pkgInfo <- pkgDesc[c("Package", "Title", "Version")]
       
+      # Re-map names. Note that these names are also used and expected by
+      # panmirror / Quarto.
+      names(pkgInfo) <- c("name", "desc", "version")
+      
       # Also record metadata about the library where it was found.
       libraryPath <- dirname(pkgPath)
-      pkgInfo[["Library"]] <- .rs.createAliasedPath(libraryPath)
-      pkgInfo[["LibraryAbsolute"]] <- libraryPath
-      pkgInfo[["LibraryIndex"]] <- match(libraryPath, .libPaths(), nomatch = 0L)
+      pkgInfo[["library"]] <- .rs.createAliasedPath(libraryPath)
+      pkgInfo[["library_absolute"]] <- libraryPath
+      pkgInfo[["library_index"]] <- match(libraryPath, .libPaths(), nomatch = 0L)
       
       # Also note which packages appear to be loaded or attached.
       isLoaded <- FALSE
@@ -1397,20 +1401,20 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
          isLoaded &&
          paste("package", pkgName, sep = ":") %in% search()
       
-      pkgInfo[["Loaded"]] <- isLoaded
-      pkgInfo[["Attached"]] <- isAttached
+      pkgInfo[["loaded"]] <- isLoaded
+      pkgInfo[["attached"]] <- isAttached
       
-      pkgInfo[["Source"]] <- tryCatch(
+      pkgInfo[["source"]] <- tryCatch(
          .rs.inferPackageSource(pkgDesc),
          error = function(cnd) "[Unknown]"
       )
       
-      pkgInfo[["BrowseUrl"]] <- tryCatch(
+      pkgInfo[["browse_url"]] <- tryCatch(
          .rs.inferPackageBrowseUrl(pkgDesc),
          error = function(cnd) ""
       )
       
-      pkgInfo[["PackageUrl"]] <- tryCatch(
+      pkgInfo[["package_url"]] <- tryCatch(
          .rs.inferPackageDocumentationUrl(pkgDesc),
          error = function(cnd) ""
       )
@@ -1421,7 +1425,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    })
    
    # Sort based on the package name.
-   pkgOrder <- order(.rs.mapChr(pkgInfos, `[[`, "Package"))
+   pkgOrder <- order(.rs.mapChr(pkgInfos, `[[`, "name"))
    pkgInfos <- pkgInfos[pkgOrder]
    
    # And we're done.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageInfo.java
@@ -24,51 +24,51 @@ public class PackageInfo extends JavaScriptObject
    }
    
    public final native String getName() /*-{
-      return this["Package"];
+      return this["name"];
    }-*/;
    
    public final native String getDesc() /*-{
-      return this["Title"] || "";
+      return this["desc"] || "";
    }-*/;
    
    public final native String getVersion() /*-{
-      return this["Version"] || "";
+      return this["version"] || "";
    }-*/;
 
    public final native String getPackageSource() /*-{
-      return this["Source"] || "";
+      return this["source"] || "";
    }-*/;
    
    public final native String getLibrary() /*-{
-      return this["Library"] || "";
+      return this["library"] || "";
    }-*/;
    
    public final native String getLibraryAbsolute() /*-{
-      return this["LibraryAbsolute"] || "";
+      return this["library_absolute"] || "";
    }-*/;
    
    public final native int getLibraryIndex() /*-{
-      return this["LibraryIndex"] || 0;
+      return this["library_index"] || 0;
    }-*/;
 
    public final native String getHelpUrl() /*-{
-      return "help/library/" + this["Package"] + "/html/00Index.html";
+      return "help/library/" + this["name"] + "/html/00Index.html";
    }-*/;
 
    public final native String getPackageUrl() /*-{
-      return this["PackageUrl"] || "";
+      return this["package_url"] || "";
    }-*/;
 
    public final native String getBrowseUrl() /*-{
-      return this["BrowseUrl"] || "";
+      return this["browse_url"] || "";
    }-*/;
 
    public final native boolean isAttached() /*-{
-      return this["Attached"] || false;
+      return this["attached"] || false;
    }-*/;
 
    public final native void setAttached(boolean attached) /*-{
-      this["Attached"] = attached;
+      this["attached"] = attached;
    }-*/;
    
    public final native boolean isFirstInLibrary() /*-{
@@ -80,17 +80,11 @@ public class PackageInfo extends JavaScriptObject
    }-*/;
    
    public final native String getPackratStringField(String name) /*-{
-      if (typeof this[name] === "undefined" || this[name] === null)
-         return "";
-      else
-         return this[name];
+      return this[name] || "";
    }-*/;
    
    public final native boolean getPackratBoolField(String name) /*-{
-      if (typeof this[name] === "undefined" || this[name] === null)
-         return false;
-      else
-         return this[name];
+      return this[name] || false;
    }-*/;
    
    public final String getPackratVersion() 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16149.

### Approach

A recent PR had renamed some of the fields from the RPC used to list installed packages. Unfortunately, I overlooked that this RPC is also used by the Insert Citation API, to figure out what packages (and what citations) are available. Revert those name changes.

