### PR TITLE
fix issue with update of cached frame

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 
 #### RStudio
 
+- Fixed an issue where RStudio would display a "Cannot reinitialise DataTable" error when viewing data sets. (#15482)
 - Fixed an issue where pkgdown websites built outside of the user directory could not be viewed from RStudio Server (#15133)
 - RStudio no longer displays factors with more than 64 levels as though they were character vectors (#14113)
 - Fixed an issue where the "Save As" dialog would not be visible when trying to save an older git revision of a file (#15955)

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -1647,46 +1647,6 @@ SEXP createList(const std::vector<std::string>& names, Protect* pProtect)
    return listSEXP;
 }
    
-PreservedSEXP::PreservedSEXP(SEXP sexp)
-   : sexp_(R_NilValue)
-{
-   set(sexp);
-}
-
-PreservedSEXP::PreservedSEXP(PreservedSEXP&& original)
-   : sexp_(original.sexp_)
-{
-   original.sexp_ = R_NilValue;
-}
-
-void PreservedSEXP::set(SEXP sexp)
-{
-   releaseNow();
-   sexp_ = sexp;
-   if (sexp_ != R_NilValue)
-      ::R_PreserveObject(sexp_);
-}
-
-PreservedSEXP::~PreservedSEXP()
-{
-   try
-   {
-      releaseNow();
-   }
-   catch(...)
-   {
-   }
-}
-
-void PreservedSEXP::releaseNow()
-{
-   if (sexp_ != R_NilValue)
-   {
-      ::R_ReleaseObject(sexp_);
-      sexp_ = R_NilValue;
-   }
-}
-
 SEXP SEXPPreserver::add(SEXP dataSEXP)
 {
    if (dataSEXP != R_NilValue)

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -15,16 +15,18 @@
 
 #include "DataViewer.hpp"
 
+#include <gsl/gsl-lite.hpp>
+
 #include <string>
 #include <vector>
 #include <sstream>
-#include <gsl/gsl-lite.hpp>
 
 #include <boost/format.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
+#include <shared_core/Noncopyable.hpp>
 #include <shared_core/SafeConvert.hpp>
 
 #include <core/Log.hpp>
@@ -225,12 +227,12 @@ int safeDim(SEXP data, DimType dimType)
 }
 
 // CachedFrame represents an object that's currently active in a data viewer window.
-struct CachedFrame
+struct CachedFrame : noncopyable
 {
-   CachedFrame(const std::string& env, const std::string& obj, SEXP sexp):
-      envName(env),
-      objName(obj),
-      observedSEXP(sexp)
+   CachedFrame(const std::string& env, const std::string& obj, SEXP sexp)
+      : envName(env),
+        objName(obj),
+        observedSEXP(sexp)
    {
       if (sexp == nullptr)
          return;
@@ -254,10 +256,6 @@ struct CachedFrame
       ncol = safeDim(sexp, DIM_COLS);
    };
    
-   // Class is movable but not copyable
-   CachedFrame(CachedFrame&&) = default;
-   CachedFrame(const CachedFrame&) = delete;
-
    // The location of the frame (if we know it)
    std::string envName;
    std::string objName;
@@ -1137,7 +1135,7 @@ void onDetectChanges(module_context::ChangeSource source)
          module_context::enqueClientEvent(event);
 
          // replace old frame with new
-         s_cachedFrames.emplace(i->first, std::move(newFrame));
+         i->second = std::move(newFrame);
       }
    }
 }

--- a/src/cpp/shared_core/include/shared_core/Noncopyable.hpp
+++ b/src/cpp/shared_core/include/shared_core/Noncopyable.hpp
@@ -1,0 +1,39 @@
+/*
+ * Noncopyable.hpp
+ * 
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant to the terms of a commercial license agreement
+ * with Posit, then this program is licensed to you under the following terms:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef RSTUDIO_NONCOPYABLE_HPP
+#define RSTUDIO_NONCOPYABLE_HPP
+
+namespace rstudio {
+
+// Like boost::noncopyable, but allows a type to remain movable.
+struct noncopyable
+{
+    noncopyable() = default;
+    noncopyable(noncopyable&&) = default;
+    noncopyable& operator=(noncopyable&&) = default;
+};
+ 
+} // end namespace rstudio
+
+#endif /* RSTUDIO_NONCOPYABLE_HPP */


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15482.

### Approach

- Make `CachedFrame` a proper move-only type.
- Make sure we _actually_ update the cached frame when the underlying SEXP changes.
- I have learned the hard way that `map.insert(key, value)` _does nothing_ if the `map` already contains a value for `key`.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15482.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
