### PR TITLE
ensure "use roxygen" setting is defaulted on when using devtools

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,7 @@
 - Fixed an issue where GitHub Copilot would not index project files when Copilot was started while the project is open (#16128)
 - Fixed an issue where the entire document was sent to GitHub Copilot after each edit instead of just the changes (#15901)
 - Fixed an issue where RStudio would send multiple didOpen messages to GitHub Copilot for the same file (#16129)
+- Fixed issue where new R package projects did not inherit "Generate documentation with Roxygen" preference
 - Fixed an issue where large character vectors were shown with an NaN size in the environment pane (#15919)
 
 

--- a/src/cpp/core/Settings.cpp
+++ b/src/cpp/core/Settings.cpp
@@ -15,9 +15,10 @@
 
 #include <core/Settings.hpp>
 
-#include <core/Log.hpp>
 #include <shared_core/FilePath.hpp>
 #include <shared_core/SafeConvert.hpp>
+
+#include <core/Log.hpp>
 #include <core/FileSerializer.hpp>
 
 namespace rstudio {
@@ -155,7 +156,5 @@ void Settings::writeSettings()
 }
 
 
-}
-}
-
-
+} // end namespace core
+} // end namespace rstudio

--- a/src/cpp/core/include/core/r_util/RProjectFile.hpp
+++ b/src/cpp/core/include/core/r_util/RProjectFile.hpp
@@ -65,10 +65,13 @@ std::ostream& operator << (std::ostream& stream, const YesNoAskValue& val);
 struct RProjectBuildDefaults
 {
    RProjectBuildDefaults()
-      : useDevtools(true),
+      : packageRoxygenize("rd,collate,namespace"),
+        useDevtools(true),
         cleanBeforeInstall(true)
    {
    }
+
+   std::string packageRoxygenize;
    bool useDevtools;
    bool cleanBeforeInstall;
 };

--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -287,6 +287,7 @@ void setBuildPackageDefaults(const std::string& packagePath,
 {
    pConfig->buildType = kBuildTypePackage;
    pConfig->packageUseDevtools = buildDefaults.useDevtools;
+   pConfig->packageRoxygenize = buildDefaults.packageRoxygenize;
    pConfig->packageCleanBeforeInstall = buildDefaults.cleanBeforeInstall;
    pConfig->packagePath = packagePath;
    pConfig->packageInstallArgs = kPackageInstallArgsDefault;
@@ -299,7 +300,7 @@ std::string detectBuildType(const FilePath& projectFilePath,
    FilePath projectDir = projectFilePath.getParent();
    if (r_util::isPackageDirectory(projectDir))
    {
-      setBuildPackageDefaults("", buildDefaults ,pConfig);
+      setBuildPackageDefaults("", buildDefaults, pConfig);
    }
    else if (projectDir.completeChildPath("pkg/DESCRIPTION").exists())
    {

--- a/src/cpp/session/include/session/projects/SessionProjects.hpp
+++ b/src/cpp/session/include/session/projects/SessionProjects.hpp
@@ -75,7 +75,7 @@ struct RProjectBuildOptions
       websiteOutputFormat(),
       autoRoxygenizeForCheck(true),
       autoRoxygenizeForBuildPackage(true),
-      autoRoxygenizeForBuildAndReload(false)
+      autoRoxygenizeForBuildAndReload(true)
    {
    }
 

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -1087,15 +1087,9 @@ Error ProjectContext::readBuildOptions(RProjectBuildOptions* pOptions)
    pOptions->previewWebsite = optionsFile.getBool("preview_website", true);
    pOptions->livePreviewWebsite = optionsFile.getBool("live_preview_website", false);
    pOptions->websiteOutputFormat = optionsFile.get("website_output_format", "all");
-   pOptions->autoRoxygenizeForCheck = optionsFile.getBool(
-                                       "auto_roxygenize_for_check",
-                                       true);
-   pOptions->autoRoxygenizeForBuildPackage = optionsFile.getBool(
-                                       "auto_roxygenize_for_build_package",
-                                       true);
-   pOptions->autoRoxygenizeForBuildAndReload = optionsFile.getBool(
-                                       "auto_roxygenize_for_build_and_reload",
-                                       false);
+   pOptions->autoRoxygenizeForCheck = optionsFile.getBool("auto_roxygenize_for_check", true);
+   pOptions->autoRoxygenizeForBuildPackage = optionsFile.getBool("auto_roxygenize_for_build_package", true);
+   pOptions->autoRoxygenizeForBuildAndReload = optionsFile.getBool("auto_roxygenize_for_build_and_reload", true);
 
    // opportunistically sync in-memory representation to what we read from disk
    buildOptions_ = *pOptions;
@@ -1115,12 +1109,9 @@ Error ProjectContext::writeBuildOptions(const RProjectBuildOptions& options)
    optionsFile.set("preview_website", options.previewWebsite);
    optionsFile.set("live_preview_website", options.livePreviewWebsite);
    optionsFile.set("website_output_format", options.websiteOutputFormat);
-   optionsFile.set("auto_roxygenize_for_check",
-                   options.autoRoxygenizeForCheck);
-   optionsFile.set("auto_roxygenize_for_build_package",
-                   options.autoRoxygenizeForBuildPackage);
-   optionsFile.set("auto_roxygenize_for_build_and_reload",
-                   options.autoRoxygenizeForBuildAndReload);
+   optionsFile.set("auto_roxygenize_for_check", options.autoRoxygenizeForCheck);
+   optionsFile.set("auto_roxygenize_for_build_package", options.autoRoxygenizeForBuildPackage);
+   optionsFile.set("auto_roxygenize_for_build_and_reload", options.autoRoxygenizeForBuildAndReload);
    optionsFile.endUpdate();
 
    // opportunistically sync in-memory representation to what we wrote to disk

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -483,18 +483,19 @@ json::Object projectBuildOptionsJson()
    Error error = s_projectContext.readBuildOptions(&buildOptions);
    if (error)
       LOG_ERROR(error);
+
    json::Object buildOptionsJson;
    buildOptionsJson["makefile_args"] = buildOptions.makefileArgs;
    buildOptionsJson["preview_website"] = buildOptions.previewWebsite;
    buildOptionsJson["live_preview_website"] = buildOptions.livePreviewWebsite;
    buildOptionsJson["website_output_format"] = buildOptions.websiteOutputFormat;
+
    json::Object autoRoxJson;
    autoRoxJson["run_on_check"] = buildOptions.autoRoxygenizeForCheck;
-   autoRoxJson["run_on_package_builds"] =
-                              buildOptions.autoRoxygenizeForBuildPackage;
-   autoRoxJson["run_on_build_and_reload"] =
-                              buildOptions.autoRoxygenizeForBuildAndReload;
+   autoRoxJson["run_on_package_builds"] = buildOptions.autoRoxygenizeForBuildPackage;
+   autoRoxJson["run_on_build_and_reload"] = buildOptions.autoRoxygenizeForBuildAndReload;
    buildOptionsJson["auto_roxygenize_options"] = autoRoxJson;
+
    return buildOptionsJson;
 }
 


### PR DESCRIPTION
### Intent

Related to https://github.com/rstudio/rstudio/issues/2900, but doesn't directly address that issue.

### Approach

- Build documentation by default on Install and Restart
- Set the packageRoxygenize project option appropriately

### Automated Tests

Not included.

### QA Notes

Create a new R package project, and check that you get these settings.

<img width="569" alt="Screenshot 2025-06-18 at 1 01 51 PM" src="https://github.com/user-attachments/assets/06ad15b7-d13e-4316-91c0-ca09bb95ed96" />

<img width="333" alt="Screenshot 2025-06-18 at 1 01 56 PM" src="https://github.com/user-attachments/assets/6dcf40bf-66bf-4b67-af81-b7192844a1f6" />


### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
