### PR TITLE
move existing zoomed plot window to foreground (desktop)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - Added a user preference to disable showing the splash screen at startup (#15945)
 - The splash screen now closes when clicked with the mouse (#15614)
 - The default console buffer size has been increased to 10000 lines (#16111)
+- The Zoom button in the plots pane on RStudio Desktop now brings an existing zoomed plot window to the foreground (#11661)
 
 #### Posit Workbench
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/Plots.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/Plots.java
@@ -14,17 +14,6 @@
  */
 package org.rstudio.studio.client.workbench.views.plots;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.event.logical.shared.HasResizeHandlers;
-import com.google.gwt.event.logical.shared.SelectionEvent;
-import com.google.gwt.event.logical.shared.SelectionHandler;
-import com.google.gwt.json.client.JSONObject;
-import com.google.gwt.user.client.ui.HasWidgets;
-import com.google.inject.Inject;
-import com.google.inject.Provider;
-
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Point;
 import org.rstudio.core.client.Size;
@@ -34,9 +23,9 @@ import org.rstudio.core.client.widget.HasCustomizableToolbar;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ProgressOperation;
+import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.DeferredInitCompletedEvent;
 import org.rstudio.studio.client.application.events.EventBus;
-import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.zoom.ZoomUtils;
@@ -63,6 +52,17 @@ import org.rstudio.studio.client.workbench.views.plots.model.SavePlotAsPdfOption
 import org.rstudio.studio.client.workbench.views.plots.ui.export.ExportPlot;
 import org.rstudio.studio.client.workbench.views.plots.ui.manipulator.ManipulatorChangedHandler;
 import org.rstudio.studio.client.workbench.views.plots.ui.manipulator.ManipulatorManager;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.logical.shared.HasResizeHandlers;
+import com.google.gwt.event.logical.shared.SelectionEvent;
+import com.google.gwt.event.logical.shared.SelectionHandler;
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.user.client.ui.HasWidgets;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 public class Plots extends BasePresenter implements PlotsChangedEvent.Handler,
                                                     LocatorEvent.Handler,
@@ -434,6 +434,7 @@ public class Plots extends BasePresenter implements PlotsChangedEvent.Handler,
             public void execute(WindowEx input)
             {
                zoomWindow_ = input;
+               zoomWindow_.focus();
             }
          }
       );


### PR DESCRIPTION
### Intent

Addresses #11661

### Approach

Move an existing zoomed plot window to the foreground when the Zoom button is clicked inthe plots pane. This makes desktop behaviour match long-standing Server behaviour.

### Automated Tests

None

### QA Notes

At a minimum recommend trying this on Mac and Windows (and Linux if you're feeling extra spicy). I only tested it on Mac during dev.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


