### PR TITLE
Properly handle hitting ESC key in "Update Available" dialog box

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,7 +37,7 @@
 - Fixed an issue where RStudio would send multiple didOpen messages to GitHub Copilot for the same file (#16129)
 - Fixed issue where new R package projects did not inherit "Generate documentation with Roxygen" preference
 - Fixed an issue where large character vectors were shown with an NaN size in the environment pane (#15919)
-
+- Fixed an issue where hitting the Escape key to close the "Update Available" dialog would exit RStudio (#15444)
 
 #### Posit Workbench
 

--- a/src/cpp/session/modules/SessionUpdates.cpp
+++ b/src/cpp/session/modules/SessionUpdates.cpp
@@ -88,7 +88,15 @@ void beginUpdateCheck(bool manual,
    cmd.append("source('");
    cmd.append(string_utils::jsLiteralEscape(scriptPath));
    cmd.append("'); downloadUpdateInfo('");
-   cmd.append(http::util::urlEncode(RSTUDIO_VERSION));
+   
+   // Testing/debugging feature: set the RStudio version you want to impersonate for the 
+   // update check via the environment variable RSTUDIO_UPDATE_VERSION, e.g.
+   // RSTUDIO_UPDATE_VERSION=2022.07.2+576 (~/.Renviron is a good place to set this)
+   std::string versionOverride = core::system::getenv("RSTUDIO_UPDATE_VERSION");
+   if (!versionOverride.empty())
+      cmd.append(http::util::urlEncode(versionOverride));
+   else
+      cmd.append(http::util::urlEncode(RSTUDIO_VERSION));
    cmd.append("', '");
 #if defined(_WIN32)
    cmd.append("windows");

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -617,12 +617,16 @@ export class GwtCallback extends EventEmitter {
             type: this.convertMessageBoxType(type),
             message: caption,
             detail: message,
+            cancelId: _cancelButton,
+            defaultId: _defaultButton,
             buttons: this.convertButtons(buttons),
           };
         } else {
           openDialogOptions = {
             type: this.convertMessageBoxType(type),
             title: caption,
+            cancelId: _cancelButton,
+            defaultId: _defaultButton,
             message: message,
             buttons: this.convertButtons(buttons),
           };


### PR DESCRIPTION
### Intent

Addresses #15444

### Approach

Electron message box was ignoring the specified "cancel" and "default" button values we were passing, causing it to associate ESC with the wrong button.

The fix is to actually tell Electron about these.

### Automated Tests

None

### QA Notes

> [!NOTE]
> To aid in debugging / testing, you can now have RStudio impersonate a different version when performing the update check via the environment variable `RSTUDIO_UPDATE_VERSION`, e.g. `RSTUDIO_UPDATE_VERSION=2022.07.2+576`.
> `~/.Renviron` is a handy place to set this.

Electron may display the buttons in a different order than before as a result of this change, varying by platform conventions.
 
### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


