### PR TITLE
support older R in object.size impl

### DIFF
--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -742,6 +742,12 @@ bool isUserDefinedDatabase(SEXP object)
    return OBJECT(object) && Rf_inherits(object, "UserDefinedDatabase");
 }
 
+bool isAltrep(SEXP object)
+{
+   r::sxpinfo& info = *reinterpret_cast<r::sxpinfo*>(object);
+   return info.alt;
+}
+
 bool isNumeric(SEXP object)
 {
    return Rf_isNumeric(object);

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -115,6 +115,7 @@ bool isEnvironment(SEXP object);
 bool isPrimitiveEnvironment(SEXP object);
 bool isNumeric(SEXP object);
 bool isUserDefinedDatabase(SEXP object);
+bool isAltrep(SEXP object);
 
 // type coercions
 std::string asString(SEXP object);

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -1873,14 +1873,12 @@ double obj_size_tree(SEXP x,
    double size = 0;
 
    // Handle ALTREP objects
-   if (ALTREP(x))
+   if (r::sexp::isAltrep(x))
    {
-      SEXP klass = ALTREP_CLASS(x);
-
       size += 3 * sizeof(SEXP);
-      size += obj_size_tree(klass, base_env, sizeof_node, sizeof_vector, depth + 1);
-      size += obj_size_tree(R_altrep_data1(x), base_env, sizeof_node, sizeof_vector, depth + 1);
-      size += obj_size_tree(R_altrep_data2(x), base_env, sizeof_node, sizeof_vector, depth + 1);
+      size += obj_size_tree(TAG(x), base_env, sizeof_node, sizeof_vector, depth + 1);
+      size += obj_size_tree(CAR(x), base_env, sizeof_node, sizeof_vector, depth + 1);
+      size += obj_size_tree(CDR(x), base_env, sizeof_node, sizeof_vector, depth + 1);
       return size;
    }
 
@@ -2030,9 +2028,9 @@ double obj_size_tree(SEXP x,
    case EXTPTRSXP:
       size += sizeof_node;
       size += obj_size_tree(ATTRIB(x), base_env, sizeof_node, sizeof_vector, depth + 1);
-      size += sizeof(void*); // the actual pointer
-      size += obj_size_tree(EXTPTR_PROT(x), base_env, sizeof_node, sizeof_vector, depth + 1);
-      size += obj_size_tree(EXTPTR_TAG(x), base_env, sizeof_node, sizeof_vector, depth + 1);
+      size += obj_size_tree(TAG(x), base_env, sizeof_node, sizeof_vector, depth + 1);
+      size += sizeof(void*); // the actual pointer; lives in the CAR of the node
+      size += obj_size_tree(CDR(x), base_env, sizeof_node, sizeof_vector, depth + 1);
       break;
 
    case S4SXP:


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/8407.
Addresses https://github.com/rstudio/rstudio-pro/issues/8419.

### Approach

Instead of using the accessor macros / functions that might only be available in newer versions of R, use knowledge of these object's internals to directly access the members we care about.

### Automated Tests

Covered by existing automation.

### QA Notes

Test via notes in associated issues.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
