### PR TITLE
Fix segfault with use-after-free of Error object

### DIFF
--- a/src/cpp/session/modules/SessionDependencies.cpp
+++ b/src/cpp/session/modules/SessionDependencies.cpp
@@ -626,10 +626,10 @@ Error installDependencies(const json::JsonRpcRequest& request,
       LOG_ERROR(error);
 
    std::string jobId;
-   error = jobs::startScriptJob(installJob, [&]()
+   error = jobs::startScriptJob(installJob, []()
    {
       // Call R script job callback
-      error = r::exec::RFunction(".rs.onInstallScriptJobFinished").call();
+      Error error = r::exec::RFunction(".rs.onInstallScriptJobFinished").call();
       if (error)
          LOG_ERROR(error);
 


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 

Fixes #16169.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

Debugging `rsession` revealed the issue:

```
Thread 1 "rsession" received signal SIGSEGV, Segmentation fault.
0x0000aaaae8eaa420 in rstudio::core::Error::operator= (this=0xffffcf743650) at /workspace/rstudio-pro/src/cpp/shared_core/include/shared_core/Error.hpp:178
178 class Error : public virtual ErrorLock
```

Which happened in the following code:

https://github.com/rstudio/rstudio-pro/blob/7ec3029abb4f14a72796757db86a4a37692f0c8d/src/cpp/session/modules/SessionDependencies.cpp#L629-L638

If the lambda is called after the `installDependencies` script returns, the local Error object we are capturing by reference will be destroyed by the time we attempt to reassign it inside the lambda.

Let's just not capture any variables and create a new Error object to use inside the lambda.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Ensure you have updated the QA Notes in the original issue.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


