### PR TITLE
Export getProcessSize function

### DIFF
--- a/src/cpp/core/include/core/system/Resources.hpp
+++ b/src/cpp/core/include/core/system/Resources.hpp
@@ -70,6 +70,7 @@ Error getTotalMemory(long *pTotalKb, MemoryProvider *pProvider);
 // Returns 0 if there's no limit. cgroups memory limits if enabled, or ulimit -m
 Error getProcessMemoryLimit(long *pTotalKb, MemoryProvider *pProvider);
 
+// Returns the RSS + swap for the current process.
 // The goal here is to choose values that are specific to a given process,
 // that are using real resources on the system. Including swap so that processes
 // that overflow main memory continue are measured based on their complete size.

--- a/src/cpp/core/include/core/system/Resources.hpp
+++ b/src/cpp/core/include/core/system/Resources.hpp
@@ -70,6 +70,11 @@ Error getTotalMemory(long *pTotalKb, MemoryProvider *pProvider);
 // Returns 0 if there's no limit. cgroups memory limits if enabled, or ulimit -m
 Error getProcessMemoryLimit(long *pTotalKb, MemoryProvider *pProvider);
 
+// The goal here is to choose values that are specific to a given process,
+// that are using real resources on the system. Including swap so that processes
+// that overflow main memory continue are measured based on their complete size.
+long getProcessSize();
+
 } // namespace system
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/system/LinuxResources.cpp
+++ b/src/cpp/core/system/LinuxResources.cpp
@@ -718,6 +718,11 @@ Error getProcessMemoryLimit(long *pTotalKb, MemoryProvider *pProvider)
    return Success();
 }
 
+long getProcessSize()
+{
+   return getProcessSize(::getpid());
+}
+
 } // namespace system
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/system/MacResources.cpp
+++ b/src/cpp/core/system/MacResources.cpp
@@ -100,6 +100,19 @@ Error getProcessMemoryLimit(long *pLimitKb, MemoryProvider *pProvider)
    return Success();
 }
 
+long getProcessSize()
+{
+    long processMemoryUsedKb = 0;
+    MemoryProvider memoryProvider = MemoryProvider::MemoryProviderUnknown;
+    Error error = getProcessMemoryUsed(&processMemoryUsedKb, &memoryProvider);
+    if (error)
+    {
+       return 0;
+    }
+
+    return processMemoryUsedKb;
+}
+
 } // namespace system
 } // namespace core
 } // namespace rstudio


### PR DESCRIPTION
* Export getProcessSize() so library client processes can get their memory footprint.

* On Linux it's a simple wrapper around the preexisting version that takes a PID as an argument.
* On MacOS it's a wrapper but around the more full-featured getProcessMemoryUsed().


### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Ensure you have updated the QA Notes in the original issue.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


