### PR TITLE
Test whether or not FilPath will accept empty string

### DIFF
--- a/src/cpp/shared_core/FilePathTests.cpp
+++ b/src/cpp/shared_core/FilePathTests.cpp
@@ -71,7 +71,17 @@ TEST_CASE("Empty File Path tests")
    SECTION("Construction")
    {
       FilePath f;
+      CHECK(f.isEmpty());
       CHECK(f.getAbsolutePath().empty());
+   }
+
+   SECTION("Empty string constructor")
+   {
+      std::string empty;
+      FilePath filePath(empty);
+
+      CHECK(filePath.isEmpty());
+      CHECK(filePath.getAbsolutePath().empty());
    }
 
    SECTION("relative path construction")


### PR DESCRIPTION
### Intent

Looked for unit test to verify there wasn't an existing problem with constructing a `core::FilePath` using an empty string. Didn't see a test that explicitly covered that case, so adding one.

### Approach

Added a unit test to explicitly check for construction of `core::FilePath` using an empty string.

### Automated Tests

NA

### QA Notes

NA

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


