### PR TITLE
provide extra UI for vulnerability information

### DIFF
--- a/src/cpp/session/modules/SessionPPM.R
+++ b/src/cpp/session/modules/SessionPPM.R
@@ -71,6 +71,14 @@
    as.list(matches)
 })
 
+# Get the active PPM repository, if any.
+.rs.addFunction("ppm.getActiveRepository", function()
+{
+   repos <- getOption("repos")[[1L]]
+   parts <- .rs.ppm.parseRepositoryUrl(repos)
+   .rs.scalar(parts[[1L]])
+})
+
 .rs.addFunction("markScalars", function(object)
 {
    if (is.recursive(object))

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -939,6 +939,26 @@
    
 })
 
+.rs.addJsonRpcHandler("get_repositories", function()
+{
+   # Figure out the PPM repository URL, if any
+   repos <- getOption("repos")
+   parts <- .rs.ppm.parseRepositoryUrl(repos[[1L]])
+   root <- parts[["root"]]
+   if (is.null(root))
+      return(list())
+   
+   # Ask it for the set of available repositories
+   endpoint <- file.path(root, "__api__/repos")
+   destfile <- tempfile("rstudio-ppm-repos", fileext = ".json")
+   status <- download.file(endpoint, destfile = destfile, quiet = TRUE)
+   contents <- readLines(destfile, warn = FALSE)
+   result <- .rs.fromJSON(contents)
+   
+   .rs.scalarListFromList(result)
+   
+})
+
 .rs.addJsonRpcHandler("get_secondary_repos", function(cran, custom)
 {
    .rs.getSecondaryRepos(cran, custom)

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -241,6 +241,12 @@ Error getPackageStateJson(json::Object* pJson)
    (*pJson)["packrat_context"] = packrat::contextAsJson(packratContext);
    (*pJson)["renv_context"] = renvContext;
 
+   std::string activeRepository;
+   error = r::exec::RFunction(".rs.ppm.getActiveRepository").call(&activeRepository);
+   if (error)
+      LOG_ERROR(error);
+   (*pJson)["active_repository"] = activeRepository;
+
    // collect vulnerability information as well
    SEXP vulnsSEXP = R_NilValue;
    error = r::exec::RFunction(".rs.ppm.getVulnerabilityInformation")

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -232,6 +232,7 @@
          <arg value="2"/>
          <arg value="-XdisableClassMetadata"/>
          <arg value="-XdisableCastChecking"/>
+         <arg line="-sourceLevel ${javac.version}"/>
          <arg line="-strict"/>
          <arg line="-gen gen"/>
          <!--<arg line="-style PRETTY"/>-->
@@ -298,6 +299,8 @@
             <path refid="project.class.path"/>
          </classpath>
          <jvmarg value="-Xmx2048M"/>
+         <arg value="-sourceLevel"/>
+         <arg value="${javac.version}"/>
          <arg value="-style"/>
          <arg value="PRETTY"/>
          <arg value="-XmethodNameDisplayMode"/>

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -40,13 +40,13 @@ import org.rstudio.core.client.jsonrpc.RpcResponse;
 import org.rstudio.core.client.jsonrpc.RpcResponseHandler;
 import org.rstudio.studio.client.application.ApplicationTutorialEvent;
 import org.rstudio.studio.client.application.Desktop;
+import org.rstudio.studio.client.application.events.AuthorizedEvent;
 import org.rstudio.studio.client.application.events.ClientDisconnectedEvent;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.InvalidClientVersionEvent;
 import org.rstudio.studio.client.application.events.InvalidSessionEvent;
 import org.rstudio.studio.client.application.events.ServerOfflineEvent;
 import org.rstudio.studio.client.application.events.SessionRelaunchEvent;
-import org.rstudio.studio.client.application.events.AuthorizedEvent;
 import org.rstudio.studio.client.application.events.UnauthorizedEvent;
 import org.rstudio.studio.client.application.model.ActiveSession;
 import org.rstudio.studio.client.application.model.InvalidSessionInfo;
@@ -210,6 +210,7 @@ import org.rstudio.studio.client.workbench.views.jobs.model.JobOutput;
 import org.rstudio.studio.client.workbench.views.output.lint.model.AceAnnotation;
 import org.rstudio.studio.client.workbench.views.output.lint.model.LintItem;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageInstallContext;
+import org.rstudio.studio.client.workbench.views.packages.model.PackageManagerRepository;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageState;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageUpdate;
 import org.rstudio.studio.client.workbench.views.packages.model.PackratActions;
@@ -1557,6 +1558,11 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, GET_PACKAGE_CITATIONS, params, requestCallback);
    }
    
+   @Override
+   public void getRepositories(ServerRequestCallback<JsArray<PackageManagerRepository>> requestCallback)
+   {
+      sendRequest(RPC_SCOPE, GET_REPOSITORIES, requestCallback);
+   }
 
    public void setCRANMirror(CRANMirror mirror,
                              ServerRequestCallback<Void> requestCallback)
@@ -7041,6 +7047,7 @@ public class RemoteServer implements Server
    private static final String PACKAGE_SKELETON = "package_skeleton";
    private static final String DISCOVER_PACKAGE_DEPENDENCIES = "discover_package_dependencies";
    private static final String GET_PACKAGE_CITATIONS = "get_package_citations";
+   private static final String GET_REPOSITORIES = "get_repositories";
 
    private static final String GET_HELP = "get_help";
    private static final String SHOW_HELP_TOPIC = "show_help_topic";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -106,7 +106,8 @@ public class Packages
    {
       void setPackageState(ProjectContext projectContext,
                            List<PackageInfo> packages,
-                           RepositoryPackageVulnerabilityListMap vulns);
+                           RepositoryPackageVulnerabilityListMap vulns,
+                           String activeRepository);
 
       void installPackage(PackageInstallContext installContext,
                           PackageInstallOptions defaultInstallOptions,
@@ -871,7 +872,7 @@ public class Packages
          packages = allPackages_;
       }
 
-      view_.setPackageState(projectContext_, packages, vulns_);
+      view_.setPackageState(projectContext_, packages, vulns_, activeRepository_);
    }
 
    private void checkPackageStatusOnNextConsolePrompt(
@@ -1208,6 +1209,7 @@ public class Packages
    {
       // sort the packages
       allPackages_ = new ArrayList<>();
+      activeRepository_ = newState.getActiveRepository();
       vulns_ = newState.getVulnerabilityInfo();
 
       JsArray<PackageInfo> serverPackages = newState.getPackageList();
@@ -1265,6 +1267,7 @@ public class Packages
    private final RenvServerOperations renvServer_;
    private ArrayList<PackageInfo> allPackages_ = new ArrayList<>();
    private RepositoryPackageVulnerabilityListMap vulns_;
+   private String activeRepository_;
    private ProjectContext projectContext_;
    private String packageFilter_ = new String();
    private HandlerRegistration consolePromptHandlerReg_ = null;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ElementIds;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.cellview.ImageButtonColumn;
 import org.rstudio.core.client.cellview.ImageButtonColumn.TitleProvider;
 import org.rstudio.core.client.dom.DomUtils;
@@ -37,6 +38,8 @@ import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.SuperDevMode;
 import org.rstudio.studio.client.packrat.model.PackratContext;
+import org.rstudio.studio.client.server.ServerError;
+import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.projects.ProjectContext;
@@ -47,6 +50,7 @@ import org.rstudio.studio.client.workbench.views.packages.model.PackageInstallCo
 import org.rstudio.studio.client.workbench.views.packages.model.PackageInstallOptions;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageInstallRequest;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageLibraryUtils;
+import org.rstudio.studio.client.workbench.views.packages.model.PackageManagerRepository;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageStatus;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageVulnerabilityTypes.RepositoryPackageVulnerabilityListMap;
 import org.rstudio.studio.client.workbench.views.packages.model.PackagesServerOperations;
@@ -57,6 +61,7 @@ import org.rstudio.studio.client.workbench.views.packages.ui.PackagesDataGridRes
 
 import com.google.gwt.cell.client.AbstractCell;
 import com.google.gwt.cell.client.Cell.Context;
+import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.shared.GWT;
 import com.google.gwt.dom.builder.shared.TableCellBuilder;
 import com.google.gwt.dom.builder.shared.TableRowBuilder;
@@ -66,8 +71,11 @@ import com.google.gwt.dom.client.EventTarget;
 import com.google.gwt.dom.client.InputElement;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.safehtml.client.SafeHtmlTemplates;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
@@ -79,6 +87,7 @@ import com.google.gwt.user.cellview.client.HasKeyboardSelectionPolicy.KeyboardSe
 import com.google.gwt.user.cellview.client.TextHeader;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.LayoutPanel;
+import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.user.client.ui.SuggestOracle;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.view.client.CellPreviewEvent;
@@ -109,12 +118,15 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
    public PackagesPane(Commands commands, 
                        Session session,
                        GlobalDisplay display,
-                       EventBus events)
+                       EventBus events,
+                       PackagesServerOperations server)
    {
       super(constants_.packagesTitle(), events);
+
       commands_ = commands;
       session_ = session;
       display_ = display;
+      server_ = server;
       
       dataGridRes_ = GWT.create(PackagesDataGridResources.class);
       ensureWidget();
@@ -129,13 +141,19 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
    @Override
    public void setPackageState(ProjectContext projectContext, 
                                List<PackageInfo> packages,
-                               RepositoryPackageVulnerabilityListMap vulns)
+                               RepositoryPackageVulnerabilityListMap vulns,
+                               String activeRepository)
    {
       projectContext_ = projectContext;
+      activeRepository_ = activeRepository;
       vulns_ = vulns;
 
       packagesDataProvider_.setList(packages);
       createPackagesTable();
+
+      // manage visibility of repository button
+      repositoryButton_.setText(StringUtil.notNull(activeRepository_));
+      repositoryButton_.setVisible(!StringUtil.isNullOrEmpty(activeRepository_));
 
       // manage visibility of Packrat / renv menu buttons
       PackratContext packratContext = projectContext_.getPackratContext();
@@ -232,6 +250,44 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
       }
       return row;
    }
+
+   private void selectRepository(PackageManagerRepository ppmRepo)
+   {
+      // TODO
+   }
+
+   private void showRepositoryMenu()
+   {
+      server_.getRepositories(new ServerRequestCallback<JsArray<PackageManagerRepository>>()
+      {
+         @Override
+         public void onResponseReceived(JsArray<PackageManagerRepository> response)
+         {
+            ToolbarPopupMenu menu = new ToolbarPopupMenu();
+            for (int i = 0, n = response.length(); i < n; i++)
+            {
+               PackageManagerRepository ppmRepo = response.get(i);
+               MenuItem menuItem = new MenuItem(ppmRepo.getName(), () ->
+               {
+                  selectRepository(ppmRepo);
+               });
+
+               String ppmDesc = ppmRepo.getDescription();
+               if (!StringUtil.isNullOrEmpty(ppmDesc))
+                  menuItem.getElement().setTitle(ppmDesc);
+
+               menu.addItem(menuItem);
+            }
+            menu.showRelativeTo(repositoryButton_);
+         }
+
+         @Override
+         public void onError(ServerError error)
+         {
+            Debug.logError(error);
+         }
+      });
+   }
    
    @Override
    protected Toolbar createMainToolbar()
@@ -300,6 +356,23 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
       helpButton_.setVisible(false);
       helpSeparator_ = toolbar.addRightSeparator();
       helpSeparator_.setVisible(false);
+
+      repositoryButton_ = new ToolbarButton(
+         "",
+         "",
+         (ImageResource) null,
+         new ClickHandler()
+         {
+            @Override
+            public void onClick(ClickEvent event)
+            {
+               showRepositoryMenu();
+            }
+         });
+
+      repositoryButton_.setVisible(false);
+      toolbar.addRightWidget(repositoryButton_);
+      toolbar.addRightSeparator();
 
       ElementIds.assignElementId(searchWidget_, ElementIds.SW_PACKAGES);
       toolbar.addRightWidget(searchWidget_);
@@ -833,6 +906,7 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
 
    private DataGrid<PackageInfo> packagesTable_;
    private ListDataProvider<PackageInfo> packagesDataProvider_;
+   private ToolbarButton repositoryButton_;
    private SearchWidget searchWidget_;
    private PackagesDisplayObserver observer_;
 
@@ -860,11 +934,14 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
    private LayoutPanel packagesTableContainer_;
    private int gridRenderRetryCount_;
    private ProjectContext projectContext_;
+   private String activeRepository_;
    private RepositoryPackageVulnerabilityListMap vulns_;
 
    private final Commands commands_;
    private final Session session_;
    private final GlobalDisplay display_;
+   private final PackagesServerOperations server_;
+
    private final PackagesDataGridResources dataGridRes_;
 
    private static final PackagesConstants constants_ = com.google.gwt.core.client.GWT.create(PackagesConstants.class);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageManagerRepository.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageManagerRepository.java
@@ -1,0 +1,34 @@
+/*
+ * PackageManagerRepository.java
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.packages.model;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+public class PackageManagerRepository extends JavaScriptObject
+{
+    public static final String TYPE_R      = "R";
+    public static final String TYPE_PYTHON = "Python";
+
+    protected PackageManagerRepository()
+    {
+    }
+
+    public final native int getId()             /*-{ return this.id || -1; }-*/;
+    public final native String getName()        /*-{ return this.name || ""; }-*/;
+    public final native String getCreated()     /*-{ return this.created || ""; }-*/;
+    public final native String getDescription() /*-{ return this.description || ""; }-*/;
+    public final native String getType()        /*-{ return this.type || ""; }-*/;
+    public final native boolean isHidden()      /*-{ return this.hidden || false; }-*/;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageState.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageState.java
@@ -40,4 +40,8 @@ public class PackageState extends JavaScriptObject
    public final native RepositoryPackageVulnerabilityListMap getVulnerabilityInfo() /*-{
       return this.vulns;
    }-*/;
+
+   public final native String getActiveRepository() /*-{
+      return this.active_repository;
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackagesServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackagesServerOperations.java
@@ -65,5 +65,10 @@ public interface PackagesServerOperations extends PackratServerOperations
                         String libraryPath,
                         ServerRequestCallback<String> requestCallback);
    
-   void getPackageCitations(String packageName, ServerRequestCallback<JavaScriptObject> requestCallback);
+   void getPackageCitations(
+      String packageName,
+      ServerRequestCallback<JavaScriptObject> requestCallback);
+
+   void getRepositories(
+      ServerRequestCallback<JsArray<PackageManagerRepository>> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageLinkColumn.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageLinkColumn.css
@@ -9,6 +9,18 @@
    vertical-align: middle;
    margin-top: 0 !important;
    margin-left: 4px;
+   cursor: pointer;
+   user-select: none;
+}
+
+.iconPlaceholder {
+   display: inline-block;
+   width: 16px;
+   height: 16px;
+   margin-right: 4px;
+   vertical-align: middle;
+   margin-top: 0 !important;
+   margin-left: 4px;
    user-select: none;
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageVulnerabilityModalDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageVulnerabilityModalDialog.java
@@ -1,0 +1,191 @@
+/*
+ * PackageVulnerabilityModalDialog.java
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.packages.ui;
+
+import org.rstudio.core.client.widget.ModalDialogBase;
+import org.rstudio.core.client.widget.ThemedButton;
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.common.HelpLink;
+import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
+import org.rstudio.studio.client.workbench.views.packages.model.PackageInfo;
+import org.rstudio.studio.client.workbench.views.packages.model.PackageVulnerabilityTypes.PackageVulnerability;
+import org.rstudio.studio.client.workbench.views.packages.model.PackageVulnerabilityTypes.PackageVulnerabilityEvent;
+import org.rstudio.studio.client.workbench.views.packages.model.PackageVulnerabilityTypes.PackageVulnerabilityEventList;
+import org.rstudio.studio.client.workbench.views.packages.model.PackageVulnerabilityTypes.PackageVulnerabilityList;
+
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.safehtml.client.SafeHtmlTemplates;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.user.client.ui.Widget;
+
+public class PackageVulnerabilityModalDialog extends ModalDialogBase
+{
+    public PackageVulnerabilityModalDialog(PackageInfo info,
+                                           PackageVulnerabilityList pvList)
+    {
+        super(Roles.getDialogRole());
+
+        setText(info.getName() + " " + info.getVersion() + ": Known Vulnerabilities");
+
+        info_ = info;
+        pvList_ = pvList;
+        index_ = 0;
+
+        container_ = new VerticalPanel();
+
+        panel_ = new HTML();
+        panel_.setSize("500px", "400px");
+        panel_.getElement().getStyle().setProperty("userSelect", "text");
+        container_.add(panel_);
+
+        moreInfoLink_ = new HelpLink();
+        container_.add(moreInfoLink_);
+
+        prevButton_ = new ThemedButton("Previous", new ClickHandler()
+        {
+            @Override
+            public void onClick(ClickEvent event)
+            {
+                index_ = index_ - 1;
+                refresh();
+            }
+        });
+
+        nextButton_ = new ThemedButton("Next", new ClickHandler() 
+        {
+            @Override
+            public void onClick(ClickEvent event)
+            {
+                index_ = index_ + 1;
+                refresh();
+            }
+        });
+
+        updateButton_ = new ThemedButton("Update", new ClickHandler()
+        {
+            @Override
+            public void onClick(ClickEvent event)
+            {
+                events_.fireEvent(new SendToConsoleEvent(
+                    "install.packages(\"" + info_.getName() + "\")",
+                    true));
+                closeDialog();
+            }
+
+            private final EventBus events_ = RStudioGinjector.INSTANCE.getEventBus();
+        });
+
+        if (pvList_.getLength() > 1)
+        {
+            addLeftButton(prevButton_, "previous");
+            addLeftButton(nextButton_, "next");
+        }
+
+        addOkButton(updateButton_);
+        addCancelButton();
+    }
+
+    private void refresh()
+    {
+        prevButton_.setEnabled(index_ > 0);
+        nextButton_.setEnabled(index_ < pvList_.getLength() - 1);
+
+        panel_.getElement().getStyle().setMarginLeft(24, Unit.PX);
+        panel_.getElement().getStyle().setMarginRight(24, Unit.PX);
+
+        SafeHtmlBuilder sb = new SafeHtmlBuilder();
+
+        PackageVulnerability vuln = pvList_.getAt(index_);
+        sb.append(TEMPLATES.render(vuln.id, vuln.summary, vuln.details));
+
+        if (vuln.ranges.getLength() > 0)
+        {
+            sb.appendHtmlConstant("<h3>Events</h3>");
+
+            sb.appendHtmlConstant("<ul>");
+            for (PackageVulnerabilityEventList eventList : vuln.ranges.asList())
+            {
+                for (PackageVulnerabilityEvent event : eventList.events.asList())
+                {
+                    if (event.introduced != null)
+                    {
+                        sb.append(TEMPLATES.renderEvent("Introduced", info_.getName(), event.introduced));
+                    }
+
+                    if (event.fixed != null)
+                    {
+                        sb.append(TEMPLATES.renderEvent("Fixed", info_.getName(), event.fixed));
+                    }
+                }
+            }
+            sb.appendHtmlConstant("</ul>");
+        }
+
+        panel_.setHTML(sb.toSafeHtml());
+
+        moreInfoLink_.setCaption(vuln.id);
+        moreInfoLink_.setLink("https://osv.dev/vulnerability/" + vuln.id, false);
+    }
+
+    @Override
+    protected Widget createMainWidget()
+    {
+        return container_;
+    }
+
+    @Override
+    public void showModal()
+    {
+        super.showModal();
+        refresh();
+    }
+
+    interface Templates extends SafeHtmlTemplates
+    {
+        @Template("""
+           <h1>{0}</h1>
+           <h2>{1}</h2>
+           <h3>Details</h3>
+           <p>{2}</p>
+        """)
+        SafeHtml render(String id, String summary, String details);
+
+        @Template("<li>{0} in {1} {2}.</li>")
+        SafeHtml renderEvent(String eventType, String packageName, String packageVersion);
+    }
+
+    PackageInfo info_;
+    PackageVulnerabilityList pvList_;
+    private int index_;
+
+    VerticalPanel container_;
+    HTML panel_;
+    HTML events_;
+
+    ThemedButton prevButton_;
+    ThemedButton nextButton_;
+    ThemedButton updateButton_;
+    HelpLink moreInfoLink_;
+
+    private static final Templates TEMPLATES = GWT.create(Templates.class);
+}


### PR DESCRIPTION
### Intent

This PR bundles two changes:

- We now display the active repository in the Packages pane;
- We now provide a dedicated piece of UI for presenting vulnerability information.

<img width="281" alt="Screenshot 2025-06-30 at 4 48 01 PM" src="https://github.com/user-attachments/assets/fd2267c7-df81-4ed4-b955-3baa528f726c" />

<img width="579" alt="image" src="https://github.com/user-attachments/assets/b6831eee-31be-4eee-977b-09a42c977d73" />

### Approach

Mostly straightforward GWT UI + session RPC stuff.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
