### PR TITLE
Fix typo in properties directory name

### DIFF
--- a/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
@@ -61,9 +61,9 @@ private:
    // This contains the properties directory, as well as susspended session data, session-persistence-state etc
    // Baked into this path is the session id
 
-   // Properties Path Example : ~/.local/share/rstudio/sessions/active/session-6d0bdd18/properites
+   // Properties Path Example : ~/.local/share/rstudio/sessions/active/session-6d0bdd18/properties
    FilePath scratchPath_;
-   const std::string propertiesDirName_ = "properites";
+   const std::string propertiesDirName_ = "properties";
 
    Error ensurePropertyDir() const;
 

--- a/src/cpp/core/r_util/RActiveSessionsStorage.cpp
+++ b/src/cpp/core/r_util/RActiveSessionsStorage.cpp
@@ -305,7 +305,7 @@ void RpcActiveSessionsStorage::migrateSessions() const
 {
 #ifndef _WIN32
    static const std::string migratedFileName = ".migrated";
-   static const std::string properites = "properites";
+   static const std::string properties = "properties";
 
    FilePath rootMigratedFile = storagePath_.completeChildPath(migratedFileName);
    if (!rootMigratedFile.exists())
@@ -327,7 +327,7 @@ void RpcActiveSessionsStorage::migrateSessions() const
          FilePath migratedFile = child.completeChildPath(migratedFileName);
          if (!migratedFile.exists())
          {
-            if (child.completeChildPath(properites).exists())
+            if (child.completeChildPath(properties).exists())
             {
                std::string sessionId;
                Error error = sessionIdFromFolder(child, &sessionId);


### PR DESCRIPTION
### Intent

Fix name typo in properties directory under the user session folder.
![Screenshot 2025-07-04 at 12 32 26 PM](https://github.com/user-attachments/assets/02c52053-b1d9-4efc-98b7-3e2a8430a809)

### Approach

N/A

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

