### PR TITLE
use did-finish-load instead of ready-to-show at Electron startup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,7 @@
 - Fixed issue where new R package projects did not inherit "Generate documentation with Roxygen" preference
 - Fixed an issue where large character vectors were shown with an NaN size in the environment pane (#15919)
 - Fixed an issue where hitting the Escape key to close the "Update Available" dialog would exit RStudio (#15444)
+- Fixed an issue where the splash screen would not close and the RStudio main window would not show when starting RStudio Desktop (#16191)
 
 #### Posit Workbench
 

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -229,7 +229,12 @@ export class SessionLauncher {
 
     // show the window (but don't if we are doing a --run-diagnostics)
     if (!appState().runDiagnostics) {
-      this.mainWindow.window.once('ready-to-show', async () => {
+      // Originally used 'ready-to-show' here, but we've been getting reports of the
+      // splash screen never closing and the main window never showing, and issues such
+      // as https://github.com/electron/electron/issues/40273 indicate that `ready-to-show`
+      // may not be reliable, especially if the user switches focus between different
+      // windows/apps while starting up.
+      this.mainWindow.window.webContents.once('did-finish-load', async () => {
         if (appState().startupDelayMs > 0) {
           await setTimeoutPromise(appState().startupDelayMs);
         }


### PR DESCRIPTION
### Intent

Addresses #16191 

### Approach

Per https://github.com/electron/electron/issues/40273 (and numerous other issues over the years) it appears Electron's `ready-to-show` message is not always fired, and we rely on that message to (1) show the main window and (2) hide the splash screen.

A common suggestion was to use `did-finish-load`, instead, so giving that a try.

### Automated Tests

None.

### QA Notes

I have never been able to repro this. It seems to be very machine and operating-system dependent.

So, if you are also unable to repro, at least do basic startup testing to ensure the main window appears and the splash screen goes away, even if you change focus to other windows (e.g. Alt+Tab on Windows) while RStudio is starting up.

Could also ask the person who opened the issue to try a daily build and see if it solves it, etc.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


