### PR TITLE
Fix focus switching issue with Visual Editor and Console

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@
 - Fixed an issue where large character vectors were shown with an NaN size in the environment pane (#15919)
 - Fixed an issue where hitting the Escape key to close the "Update Available" dialog would exit RStudio (#15444)
 - Fixed an issue where the splash screen would not close and the RStudio main window would not show when starting RStudio Desktop (#16191)
+- Fixed an issue where the "Switch Focus between Source/Console" command would not work when the Visual Editor was active (#16198)
 
 #### Posit Workbench
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -960,7 +960,13 @@ public class TextEditingTarget implements
    @Handler
    void onSwitchFocusSourceConsole()
    {
-      if (docDisplay_.isFocused())
+      // Check if either the regular source editor (docDisplay) has focus
+      // or if the visual editor has focus (either ProseMirror or a code chunk)
+      boolean sourceHasFocus = docDisplay_.isFocused() || 
+                              visualEditorHasFocus_ || 
+                              (visualMode_.isActivated() && visualMode_.getActiveEditor() != null);
+      
+      if (sourceHasFocus)
          commands_.activateConsole().execute();
       else
          commands_.activateSource().execute();
@@ -1080,7 +1086,13 @@ public class TextEditingTarget implements
 
    public void onVisualEditorBlur()
    {
+      visualEditorHasFocus_ = false;
       maybeAutoSaveOnBlur();
+   }
+   
+   public void onVisualEditorFocus()
+   {
+      visualEditorHasFocus_ = true;
    }
 
    public void navigateToXRef(String xref)
@@ -9493,6 +9505,7 @@ public class TextEditingTarget implements
    private TextEditingTargetThemeHelper themeHelper_;
    private boolean ignoreDeletes_;
    private boolean forceSaveCommandActive_ = false;
+   private boolean visualEditorHasFocus_ = false;
    private final TextEditingTargetScopeHelper scopeHelper_;
    private final TextEditingTargetCopilotHelper copilotHelper_;
    private TextEditingTargetPackageDependencyHelper packageDependencyHelper_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -1639,6 +1639,7 @@ public class VisualMode implements VisualModeEditorSync,
                @Override
                public void onPanmirrorFocus(PanmirrorFocusEvent event)
                {
+                  target_.onVisualEditorFocus();
                   target_.checkForExternalEdit(100);
                   
                   // Disable code-related commands, on the presumption that we


### PR DESCRIPTION
### Intent

Addresses  #16198

### Approach

Fix logic to detect when focus is in visual mode (prosemirror) or a code chunk (ace) in a visual mode document.

### Automated Tests

None

### QA Notes

Test per issue.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


