### PR TITLE
fix crash when querying object size for ALTREP objects

### DIFF
--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -1980,7 +1980,12 @@ double obj_size_tree(SEXP x,
    case LISTSXP:
    case LANGSXP:
    case DOTSXP:
-      for (; x != R_NilValue; x = CDR(x))
+      // NOTE: Certain R objects (seemingly, ALTREP objects?) may also place non-node
+      // R objects within the CDR of a node here, so we need to validate we do indeed
+      // still have a node while looping here.
+      //
+      // https://github.com/rstudio/rstudio/issues/16202
+      for (; is_linked_list(x); x = CDR(x))
       {
          size += sizeof_node;
          size += obj_size_tree(ATTRIB(x), base_env, sizeof_node, sizeof_vector, depth + 1);

--- a/src/cpp/tests/testthat/test-environment.R
+++ b/src/cpp/tests/testthat/test-environment.R
@@ -380,4 +380,8 @@ test_that("object size computations are correct", {
    expect_equal_size(list("a", "a", "a"))
    expect_equal_size(list("a", "b", "c"))
    
+   # https://github.com/rstudio/rstudio/issues/16202
+   x <- as.character(42)
+   expect_true(.rs.objectSize(x) > 0)
+   
 })


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16202.

### Approach

Validate we still have a pairlist-like object while iterating through pairlists when computing an object's size.

### Automated Tests

Added.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/16202.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
