### PR TITLE
Reset GWT modal state on session reload to synchronize with Electron

### DIFF
--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -171,6 +171,12 @@ export class MainWindow extends GwtWindow {
     // (will get set again once the new session has initialized the workbench)
     this.workbenchInitialized = false;
 
+    // Reset GWT modal state when reloading the session to ensure modal dialog
+    // state is synchronized between GWT and Electron after session restart
+    if (reload) {
+      appState().modalTracker.resetGwtModals();
+    }
+
     const error = this.sessionLauncher?.launchNextSession(reload);
     if (error) {
       logger().logError(error);
@@ -269,18 +275,13 @@ export class MainWindow extends GwtWindow {
   }
 
   closeEvent(event: Electron.Event): void {
-
     if (!this.geometrySaved) {
       const bounds = this.window.getNormalBounds();
       ElectronDesktopOptions().saveWindowBounds({ ...bounds, maximized: this.window.isMaximized() });
       this.geometrySaved = true;
     }
 
-    if (
-      this.quitConfirmed ||
-      !this.sessionProcess ||
-      this.sessionProcess.exitCode !== null
-    ) {
+    if (this.quitConfirmed || !this.sessionProcess || this.sessionProcess.exitCode !== null) {
       closeAllSatellites(this.window);
       return;
     }

--- a/src/node/desktop/src/main/modal-dialog-tracker.ts
+++ b/src/node/desktop/src/main/modal-dialog-tracker.ts
@@ -76,6 +76,15 @@ export class ModalDialogTracker {
   }
 
   /**
+   * Resets the GWT modal count to 0. This should be called when the GWT
+   * application is reloaded (e.g., during session restart) to ensure the
+   * modal state is synchronized between GWT and Electron.
+   */
+  public resetGwtModals() {
+    this.gwtModalsShowing = 0;
+  }
+
+  /**
    * Tracks a modal dialog that is shown by Electron.dialog (async) to ensure that the
    * main menu is disabled while the dialog is open and re-enabled when the
    * dialog is closed.


### PR DESCRIPTION
### Intent

Addresses #16203

### Approach

The "session crashed" dialog disabled the menus (as it should) but this didn't get reset after the session restarted. Now it does.

### Automated Tests

We don't have the capability to automate this scenario, currently.

### QA Notes

You know what to do.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


