### PR TITLE
ensure current R version in UI respects defaults

### DIFF
--- a/git_hooks/secrets/.secrets.baseline
+++ b/git_hooks/secrets/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": "git_hooks/secrets/.secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -329,16 +325,6 @@
         "is_secret": false
       }
     ],
-    "src/cpp/server_core/DatabaseUtils.cpp": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/cpp/server_core/DatabaseUtils.cpp",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 62,
-        "is_secret": false
-      }
-    ],
     "src/cpp/server_core/UrlPortsTests.cpp": [
       {
         "type": "Hex High Entropy String",
@@ -347,6 +333,15 @@
         "is_verified": false,
         "line_number": 63,
         "is_secret": false
+      }
+    ],
+    "src/cpp/server_core/include/server_core/DatabaseConstants.hpp": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cpp/server_core/include/server_core/DatabaseConstants.hpp",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 40
       }
     ],
     "src/cpp/server_core/include/server_core/UrlPorts.hpp": [
@@ -616,5 +611,5 @@
       }
     ]
   },
-  "generated_at": "2025-07-08T20:21:55Z"
+  "generated_at": "2025-07-10T16:48:34Z"
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -112,9 +112,7 @@ public class GeneralPreferencesPane extends PreferencesPane
          rVersion_.setWidth("100%");
          rVersion_.setText(constants_.rVersionLoadingText());
          rVersion_.getElement().getStyle().setMarginLeft(2, Unit.PX);
-         Desktop.getFrame().getRVersion(version -> {
-            rVersion_.setText(version);
-         });
+         Desktop.getFrame().getRVersion(version -> rVersion_.setText(version));
          spaced(rVersion_);
          basic.add(rVersion_);
       }

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -43,7 +43,7 @@ import { resolveTemplateVar } from '../core/template-filter';
 import desktop from '../native/desktop.node';
 import { ChooseRModalWindow } from '../ui/widgets/choose-r';
 import { appState } from './app-state';
-import { findRInstallationsWin32 } from './detect-r';
+import { findDefault32Bit, findDefault64Bit, findRInstallationsWin32 } from './detect-r';
 import { GwtWindow } from './gwt-window';
 import { MainWindow } from './main-window';
 import { openMinimalWindow } from './minimal-window';
@@ -452,7 +452,23 @@ export class GwtCallback extends EventEmitter {
     });
 
     ipcMain.handle('desktop_get_r_version', () => {
-      const rBinDir = ElectronDesktopOptions().rBinDir();
+      const options = ElectronDesktopOptions();
+
+      if (options.useDefault32BitR()) {
+        const rHomeDir = findDefault32Bit();
+        if (rHomeDir) {
+          return `[32-bit] ${rHomeDir} [Default]`;
+        }
+      }
+
+      if (options.useDefault64BitR()) {
+        const rHomeDir = findDefault64Bit();
+        if (rHomeDir) {
+          return `[64-bit] ${rHomeDir} [Default]`;
+        }
+      }
+
+      const rBinDir = options.rBinDir();
       return formatSelectedVersionForUi(rBinDir);
     });
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/12545.

### Approach

We added new options indicating if the default version of 32-bit R, or 64-bit R, is in use. These options weren't being respected when showing the current version of R being used in the Global Options UI. Now we are.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
