### PR TITLE
use smaller button label for repository

### DIFF
--- a/src/cpp/server_core/include/server_core/DatabaseUtils.hpp
+++ b/src/cpp/server_core/include/server_core/DatabaseUtils.hpp
@@ -94,9 +94,9 @@ struct ConnectionOptionsVisitor : boost::static_visitor<core::Error>
    core::Error operator()(const core::database::PostgresqlConnectionOptions& options) const;
    core::Error operator()(const core::database::ProviderNotSpecifiedConnectionOptions& options) const;
 
-   const boost::optional<core::system::User> databaseFileUser_;
-   const core::FilePath& databaseConfigFile_;
-   const std::string& defaultDatabaseName_;
+   boost::optional<core::system::User> databaseFileUser_;
+   core::FilePath databaseConfigFile_;
+   std::string defaultDatabaseName_;
 };
 
 } // namespace utils

--- a/src/cpp/session/modules/SessionPPM.R
+++ b/src/cpp/session/modules/SessionPPM.R
@@ -77,7 +77,10 @@
    
    m <- regexec(pattern, url, perl = TRUE)
    matches <- regmatches(url, m)[[1L]]
+   if (length(matches) == 0L)
+      return(NULL)
    
+   names(matches)[[1L]] <- "url"
    as.list(matches)
 })
 
@@ -101,10 +104,7 @@
 {
    repos <- getOption("repos")[[1L]]
    parts <- .rs.ppm.fromRepositoryUrl(repos)
-   if (length(parts) == 0L)
-      return(NULL)
-   
-   .rs.scalar(parts[[1L]])
+   .rs.scalarListFromList(parts)
 })
 
 .rs.addFunction("markScalars", function(object)

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -248,7 +248,7 @@ Error getPackageStateJson(json::Object* pJson)
    (*pJson)["packrat_context"] = packrat::contextAsJson(packratContext);
    (*pJson)["renv_context"] = renvContext;
 
-   std::string activeRepository;
+   json::Object activeRepository;
    error = r::exec::RFunction(".rs.ppm.getActiveRepository").call(&activeRepository);
    if (error)
       LOG_ERROR(error);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -107,7 +107,7 @@ public class Packages
       void setPackageState(ProjectContext projectContext,
                            List<PackageInfo> packages,
                            RepositoryPackageVulnerabilityListMap vulns,
-                           String activeRepository);
+                           JsObject activeRepository);
 
       void installPackage(PackageInstallContext installContext,
                           PackageInstallOptions defaultInstallOptions,
@@ -1267,7 +1267,7 @@ public class Packages
    private final RenvServerOperations renvServer_;
    private ArrayList<PackageInfo> allPackages_ = new ArrayList<>();
    private RepositoryPackageVulnerabilityListMap vulns_;
-   private String activeRepository_;
+   private JsObject activeRepository_;
    private ProjectContext projectContext_;
    private String packageFilter_ = new String();
    private HandlerRegistration consolePromptHandlerReg_ = null;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
@@ -144,7 +144,7 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
    public void setPackageState(ProjectContext projectContext, 
                                List<PackageInfo> packages,
                                RepositoryPackageVulnerabilityListMap vulns,
-                               String activeRepository)
+                               JsObject activeRepository)
    {
       projectContext_ = projectContext;
       activeRepository_ = activeRepository;
@@ -154,8 +154,11 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
       createPackagesTable();
 
       // manage visibility of repository button
-      repositoryButton_.setText(StringUtil.notNull(activeRepository_));
-      repositoryButton_.setVisible(!StringUtil.isNullOrEmpty(activeRepository_));
+      String reposLabel = getRepositoryButtonLabel();
+      String reposTitle = getRepositoryButtonTitle();
+      repositoryButton_.setText(StringUtil.notNull(reposLabel));
+      repositoryButton_.setTitle(reposTitle);
+      repositoryButton_.setVisible(!StringUtil.isNullOrEmpty(reposLabel));
 
       // manage visibility of Packrat / renv menu buttons
       PackratContext packratContext = projectContext_.getPackratContext();
@@ -938,6 +941,25 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
 
    }
 
+   private String getRepositoryButtonLabel()
+   {
+      if (activeRepository_ == null)
+         return null;
+      
+      String repos = activeRepository_.getString("repos");
+      String snapshot = activeRepository_.getString("snapshot");
+      return repos + "/" + snapshot;
+   }
+
+   private String getRepositoryButtonTitle()
+   {
+      if (activeRepository_ == null)
+         return null;
+
+      String url = activeRepository_.getString("url");
+      return url;
+   }
+
    private final SafeHtml renderText(String text)
    {
       String className = dataGridRes_.dataGridStyle().packageColumn();
@@ -989,7 +1011,7 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
    private LayoutPanel packagesTableContainer_;
    private int gridRenderRetryCount_;
    private ProjectContext projectContext_;
-   private String activeRepository_;
+   private JsObject activeRepository_;
    private RepositoryPackageVulnerabilityListMap vulns_;
 
    private final Commands commands_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageState.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageState.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.packages.model;
 
+import org.rstudio.core.client.js.JsObject;
 import org.rstudio.studio.client.workbench.projects.ProjectContext;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageVulnerabilityTypes.RepositoryPackageVulnerabilityListMap;
 
@@ -41,7 +42,7 @@ public class PackageState extends JavaScriptObject
       return this.vulns;
    }-*/;
 
-   public final native String getActiveRepository() /*-{
+   public final native JsObject getActiveRepository() /*-{
       return this.active_repository;
    }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageManagerSelectRepositoryModalDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageManagerSelectRepositoryModalDialog.java
@@ -29,6 +29,7 @@ import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style.Display;
 import com.google.gwt.dom.client.Style.FontStyle;
+import com.google.gwt.dom.client.Style.TextOverflow;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.dom.client.TableCellElement;
 import com.google.gwt.dom.client.TableRowElement;
@@ -79,8 +80,13 @@ public class PackageManagerSelectRepositoryModalDialog extends ModalDialog<Packa
             cellEl = Document.get().createTDElement();
             rowEl.appendChild(cellEl);
 
+            Element cellContentsEl = Document.get().createElement("span");
+            cellContentsEl.getStyle().setDisplay(Display.BLOCK);
+            cellContentsEl.getStyle().setTextOverflow(TextOverflow.ELLIPSIS);
+            cellContentsEl.setInnerText(object.getName());
+
             cellEl = Document.get().createTDElement();
-            cellEl.setInnerText(object.getName());
+            cellEl.appendChild(cellContentsEl);
             rowEl.appendChild(cellEl);
 
             String description = object.getDescription();
@@ -88,8 +94,9 @@ public class PackageManagerSelectRepositoryModalDialog extends ModalDialog<Packa
             {
                rowEl.setTitle(description);
 
-               Element cellContentsEl = Document.get().createElement("span");
+               cellContentsEl = Document.get().createElement("span");
                cellContentsEl.getStyle().setDisplay(Display.BLOCK);
+               cellContentsEl.getStyle().setTextOverflow(TextOverflow.ELLIPSIS);
                cellContentsEl.setInnerText(description);
 
                cellEl = Document.get().createTDElement();
@@ -101,7 +108,7 @@ public class PackageManagerSelectRepositoryModalDialog extends ModalDialog<Packa
                description = "(No description available)";
                rowEl.setTitle(description);
 
-               Element cellContentsEl = Document.get().createElement("span");
+               cellContentsEl = Document.get().createElement("span");
                cellContentsEl.getStyle().setFontStyle(FontStyle.ITALIC);
                cellContentsEl.setInnerText(description);
 
@@ -120,7 +127,7 @@ public class PackageManagerSelectRepositoryModalDialog extends ModalDialog<Packa
          @Override
          public int[] getColumnWidths()
          {
-            return new int[] { 10, 80, 400 };
+            return new int[] { 10, 100, 370 };
          }
 
          @Override


### PR DESCRIPTION
Addresses a unit test failure (large repository URL pushing buttons off screen).

<img width="289" height="72" alt="image" src="https://github.com/user-attachments/assets/fcfe6bf9-a4f7-4f53-a88e-2625c84621e8" />
