### PR TITLE
Changes release note entry structure

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,11 +13,13 @@
 - ([#16111](https://github.com/rstudio/rstudio/issues/16111)): Increases the default console buffer size to 10000 lines
 - ([#11661](https://github.com/rstudio/rstudio/issues/11661)): The Zoom button in the RStudio Desktop plots pane now brings an existing zoomed plot window to the foreground 
 - ([#16009](https://github.com/rstudio/rstudio/issues/16009)): When manually checking for updates (after previously ignoring an update), an option to stop ignoring updates prompts
+- ([#15988](https://github.com/rstudio/rstudio/issues/15988)): Posit Product Documentation theme v7.0.0; adds cookie consent, several style updates, accessibility fixes, dark theme improvements
 
 #### Posit Workbench
 
 - ([#14083](https://github.com/rstudio/rstudio/issues/14083)): Allows for custom certificate bundles for GitHub Copilot
 - (rstudio-pro#5357): Allows strict enforcement of the user limit specified by the Posit Workbench product license
+- (rstudio-pro#7533): Posit Product Documentation theme v7.0.1; adds cookie consent, several style updates, accessibility fixes, dark theme improvements
 
 ### Fixed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,60 +4,60 @@
 
 #### RStudio
 
-- RStudio now highlights all keywords from the SQL 2023 standard in SQL documents (#15841)
-- RStudio now uses lobstr when computing object sizes (#15919)
-- RStudio now supports version 17 of the R graphics engine (#16138)
-- Improved legibility of highlighted code when RStudio debugger is active
-- Added a user preference to disable showing the splash screen at startup (#15945)
-- The splash screen now closes when clicked with the mouse (#15614)
-- The default console buffer size has been increased to 10000 lines (#16111)
-- The Zoom button in the plots pane on RStudio Desktop now brings an existing zoomed plot window to the foreground (#11661)
-- When manually checking for updates (after previously ignoring an update) an option is provided to stop ignoring updates (#16009)
+- (#15841): RStudio now highlights all keywords from the SQL 2023 standard in SQL documents 
+- (#15919): RStudio now uses lobstr when computing object sizes
+- (#16138): RStudio now supports version 17 of the R graphics engine
+- (#16213): Improves legibility of highlighted code when RStudio debugger is active
+- (#15945): Adds a user preference to disable showing the splash screen at startup
+- (#15614): The splash screen closes when clicked with the mouse
+- (#16111): Increases the default console buffer size to 10000 lines
+- (#11661): The Zoom button in the RStudio Desktop plots pane now brings an existing zoomed plot window to the foreground 
+- (#16009): When manually checking for updates (after previously ignoring an update), an option to stop ignoring updates prompts
 
 #### Posit Workbench
 
-- Allow for custom certificate bundles for GitHub Copilot (#14083)
-- Allow strict enforcement of the user limit specified by the Posit Workbench product license (rstudio-pro#5357)
+- (#14083): Allows for custom certificate bundles for GitHub Copilot
+- (rstudio-pro#5357): Allows strict enforcement of the user limit specified by the Posit Workbench product license
 
 ### Fixed
 
 #### RStudio
 
-- Fixed an issue where RStudio would display a "Cannot reinitialise DataTable" error when viewing data sets. (#15482)
-- Fixed an issue where pkgdown websites built outside of the user directory could not be viewed from RStudio Server (#15133)
-- RStudio no longer displays factors with more than 64 levels as though they were character vectors (#14113)
-- Fixed an issue where the "Save As" dialog would not be visible when trying to save an older git revision of a file (#15955)
-- Fixed an issue where code indentation stopped working following code chunks containing only Quarto comments (#15879)
-- Fixed an issue where RStudio could hang when attempting to execute notebook chunks without a registered handler (#15979)
-- (Windows) "Use default 32bit / 64bit version of R" now always uses the default version of R set in the registry (#12545)
-- Show an error message when the GitHub Copilot language server is missing (#15923)
-- Fixed an issue where GitHub Copilot was unaware of files already loaded in the source editor before Copilot starts (#15895)
-- Fixed an issue where RStudio's Update Packages dialog could report packages were out-of-date for packages installed into multiple library paths (#16133)
+- (#15482): Fixed an issue where RStudio would display a "Cannot reinitialise DataTable" error when viewing data sets 
+- (#15133): Fixed an issue where pkgdown websites built outside of the user directory could not be viewed from RStudio Server
+- (#14113): RStudio no longer displays factors with more than 64 levels as though they were character vectors
+- (#15955): Fixed an issue where the "Save As" dialog would not be visible when trying to save an older git revision of a file
+- (#15879): Fixed an issue where code indentation stopped working following code chunks containing only Quarto comments
+- (#15979): Fixed an issue where RStudio could hang when attempting to execute notebook chunks without a registered handler
+- (#12545): (Windows) "Use default 32bit / 64bit version of R" now always uses the default version of R set in the registry
+- (#15923): Show an error message when the GitHub Copilot language server is missing
+- (#15895): Fixed an issue where GitHub Copilot was unaware of files already loaded in the source editor before Copilot starts
+- (#16133): Fixed an issue where RStudio's Update Packages dialog could report packages were out-of-date for packages installed into multiple library paths
 - Fixed an issue where attempting to attach or detach a package using the Packages pane could cause UI to become out-of-sync with actual package state
-- Fixed an issue where GitHub Copilot's status was incorrectly reported as an error in the Preferences dialog (#16119)
-- Fixed an issue where GitHub Copilot would not index project files when Copilot was started while the project is open (#16128)
-- Fixed an issue where the entire document was sent to GitHub Copilot after each edit instead of just the changes (#15901)
-- Fixed an issue where RStudio would send multiple didOpen messages to GitHub Copilot for the same file (#16129)
-- Fixed issue where new R package projects did not inherit "Generate documentation with Roxygen" preference
-- Fixed an issue where large character vectors were shown with an NaN size in the environment pane (#15919)
-- Fixed an issue where hitting the Escape key to close the "Update Available" dialog would exit RStudio (#15444)
-- Fixed an issue where the splash screen would not close and the RStudio main window would not show when starting RStudio Desktop (#16191)
-- Fixed an issue where the "Switch Focus between Source/Console" command would not work when the Visual Editor was active (#16198)
+- (#16119): Fixed an issue where GitHub Copilot's status was incorrectly reported as an error in the Preferences dialog
+- (#16128): Fixed an issue where GitHub Copilot would not index project files when Copilot was started while the project is open
+- (#15901): Fixed an issue where the entire document was sent to GitHub Copilot after each edit instead of just the changes
+- (#16129): Fixed an issue where RStudio would send multiple didOpen messages to GitHub Copilot for the same file
+- (#2900): Fixed issue where new R package projects did not inherit "Generate documentation with Roxygen" preference
+- (#15919): Fixed an issue where large character vectors were shown with an NaN size in the environment pane
+- (#15444): Fixed an issue where hitting the Escape key to close the "Update Available" dialog would exit RStudio
+- (#16191): Fixed an issue where the splash screen would not close and the RStudio main window would not show when starting RStudio Desktop
+- (#16198): Fixed an issue where the "Switch Focus between Source/Console" command would not work when the Visual Editor was active
 
 #### Posit Workbench
 
-- Fixed an issue where Positron State wasn't being loaded on login (rstudio-pro#8144)
-- Fixed an issue where Shiny for Python and other applications would reguarly experience websocket failures in VS Code and Positron sessions (rstudio-pro#7368)
+- (rstudio-pro#8144): Fixed an issue where Positron State wasn't being loaded on login
+- (rstudio-pro#7368): Fixed an issue where Shiny for Python and other applications would reguarly experience websocket failures in VS Code and Positron sessions
 
 ### Dependencies
 
-- Copilot Language Server 1.342.0 (#15935)
-- Electron 37.2.0 (#15933)
-- GWT 2.12.2 (#16062)
-- Quarto 1.7.32 (#15934)
+- (#15935): Copilot Language Server 1.342.0
+- (#15933): Electron 37.2.0
+- (#16062): GWT 2.12.2
+- (#15934): Quarto 1.7.32
 
 ### Deprecated / Removed
 
-- RStudio Server and Posit Workbench are no longer supported on Ubuntu Focal (#15940)
-- Publishing to Posit Cloud has been removed (rstudio-pro#8257)
-- The "Limit visible console output" feature has been removed (#16104)
+- (#15940): RStudio Server and Posit Workbench are no longer supported on Ubuntu Focal
+- (#16104): Removed the "Limit visible console output" feature
+- (rstudio-pro#8257): Removed publishing to Posit Cloud

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,45 +4,45 @@
 
 #### RStudio
 
-- (#15841): RStudio now highlights all keywords from the SQL 2023 standard in SQL documents 
-- (#15919): RStudio now uses lobstr when computing object sizes
-- (#16138): RStudio now supports version 17 of the R graphics engine
-- (#16213): Improves legibility of highlighted code when RStudio debugger is active
-- (#15945): Adds a user preference to disable showing the splash screen at startup
-- (#15614): The splash screen closes when clicked with the mouse
-- (#16111): Increases the default console buffer size to 10000 lines
-- (#11661): The Zoom button in the RStudio Desktop plots pane now brings an existing zoomed plot window to the foreground 
-- (#16009): When manually checking for updates (after previously ignoring an update), an option to stop ignoring updates prompts
+- ([#15841](https://github.com/rstudio/rstudio/issues/15841)): RStudio now highlights all keywords from the SQL 2023 standard in SQL documents 
+- ([#15919](https://github.com/rstudio/rstudio/issues/15919)): RStudio now uses lobstr when computing object sizes
+- ([#16138](https://github.com/rstudio/rstudio/issues/16138)): RStudio now supports version 17 of the R graphics engine
+- ([#16213](https://github.com/rstudio/rstudio/issues/16213)): Improves legibility of highlighted code when RStudio debugger is active
+- ([#15945](https://github.com/rstudio/rstudio/issues/15945)): Adds a user preference to disable showing the splash screen at startup
+- ([#15614](https://github.com/rstudio/rstudio/issues/15614)): The splash screen closes when clicked with the mouse
+- ([#16111](https://github.com/rstudio/rstudio/issues/16111)): Increases the default console buffer size to 10000 lines
+- ([#11661](https://github.com/rstudio/rstudio/issues/11661)): The Zoom button in the RStudio Desktop plots pane now brings an existing zoomed plot window to the foreground 
+- ([#16009](https://github.com/rstudio/rstudio/issues/16009)): When manually checking for updates (after previously ignoring an update), an option to stop ignoring updates prompts
 
 #### Posit Workbench
 
-- (#14083): Allows for custom certificate bundles for GitHub Copilot
+- ([#14083](https://github.com/rstudio/rstudio/issues/14083)): Allows for custom certificate bundles for GitHub Copilot
 - (rstudio-pro#5357): Allows strict enforcement of the user limit specified by the Posit Workbench product license
 
 ### Fixed
 
 #### RStudio
 
-- (#15482): Fixed an issue where RStudio would display a "Cannot reinitialise DataTable" error when viewing data sets 
-- (#15133): Fixed an issue where pkgdown websites built outside of the user directory could not be viewed from RStudio Server
-- (#14113): RStudio no longer displays factors with more than 64 levels as though they were character vectors
-- (#15955): Fixed an issue where the "Save As" dialog would not be visible when trying to save an older git revision of a file
-- (#15879): Fixed an issue where code indentation stopped working following code chunks containing only Quarto comments
-- (#15979): Fixed an issue where RStudio could hang when attempting to execute notebook chunks without a registered handler
-- (#12545): (Windows) "Use default 32bit / 64bit version of R" now always uses the default version of R set in the registry
-- (#15923): Show an error message when the GitHub Copilot language server is missing
-- (#15895): Fixed an issue where GitHub Copilot was unaware of files already loaded in the source editor before Copilot starts
-- (#16133): Fixed an issue where RStudio's Update Packages dialog could report packages were out-of-date for packages installed into multiple library paths
+- ([#15482](https://github.com/rstudio/rstudio/issues/15482)): Fixed an issue where RStudio would display a "Cannot reinitialise DataTable" error when viewing data sets 
+- ([#15133](https://github.com/rstudio/rstudio/issues/15133)): Fixed an issue where pkgdown websites built outside of the user directory could not be viewed from RStudio Server
+- ([#14113](https://github.com/rstudio/rstudio/issues/14113)): RStudio no longer displays factors with more than 64 levels as though they were character vectors
+- ([#15955](https://github.com/rstudio/rstudio/issues/15955)): Fixed an issue where the "Save As" dialog would not be visible when trying to save an older git revision of a file
+- ([#15879](https://github.com/rstudio/rstudio/issues/15879)): Fixed an issue where code indentation stopped working following code chunks containing only Quarto comments
+- ([#15979](https://github.com/rstudio/rstudio/issues/15979)): Fixed an issue where RStudio could hang when attempting to execute notebook chunks without a registered handler
+- ([#12545](https://github.com/rstudio/rstudio/issues/12545)): (Windows) "Use default 32bit / 64bit version of R" now always uses the default version of R set in the registry
+- ([#15923](https://github.com/rstudio/rstudio/issues/15923)): Show an error message when the GitHub Copilot language server is missing
+- ([#15895](https://github.com/rstudio/rstudio/issues/15895)): Fixed an issue where GitHub Copilot was unaware of files already loaded in the source editor before Copilot starts
+- ([#16133](https://github.com/rstudio/rstudio/issues/16133)): Fixed an issue where RStudio's Update Packages dialog could report packages were out-of-date for packages installed into multiple library paths
 - Fixed an issue where attempting to attach or detach a package using the Packages pane could cause UI to become out-of-sync with actual package state
-- (#16119): Fixed an issue where GitHub Copilot's status was incorrectly reported as an error in the Preferences dialog
-- (#16128): Fixed an issue where GitHub Copilot would not index project files when Copilot was started while the project is open
-- (#15901): Fixed an issue where the entire document was sent to GitHub Copilot after each edit instead of just the changes
-- (#16129): Fixed an issue where RStudio would send multiple didOpen messages to GitHub Copilot for the same file
-- (#2900): Fixed issue where new R package projects did not inherit "Generate documentation with Roxygen" preference
-- (#15919): Fixed an issue where large character vectors were shown with an NaN size in the environment pane
-- (#15444): Fixed an issue where hitting the Escape key to close the "Update Available" dialog would exit RStudio
-- (#16191): Fixed an issue where the splash screen would not close and the RStudio main window would not show when starting RStudio Desktop
-- (#16198): Fixed an issue where the "Switch Focus between Source/Console" command would not work when the Visual Editor was active
+- ([#16119](https://github.com/rstudio/rstudio/issues/16119)): Fixed an issue where GitHub Copilot's status was incorrectly reported as an error in the Preferences dialog
+- ([#16128](https://github.com/rstudio/rstudio/issues/16128)): Fixed an issue where GitHub Copilot would not index project files when Copilot was started while the project is open
+- ([#15901](https://github.com/rstudio/rstudio/issues/15901)): Fixed an issue where the entire document was sent to GitHub Copilot after each edit instead of just the changes
+- ([#16129](https://github.com/rstudio/rstudio/issues/16129)): Fixed an issue where RStudio would send multiple didOpen messages to GitHub Copilot for the same file
+- Fixed issue where new R package projects did not inherit "Generate documentation with Roxygen" preference
+- ([#15919](https://github.com/rstudio/rstudio/issues/15919)): Fixed an issue where large character vectors were shown with an NaN size in the environment pane
+- ([#15444](https://github.com/rstudio/rstudio/issues/15444)): Fixed an issue where hitting the Escape key to close the "Update Available" dialog would exit RStudio
+- ([#16191](https://github.com/rstudio/rstudio/issues/16191)): Fixed an issue where the splash screen would not close and the RStudio main window would not show when starting RStudio Desktop
+- ([#16198](https://github.com/rstudio/rstudio/issues/16198)): Fixed an issue where the "Switch Focus between Source/Console" command would not work when the Visual Editor was active
 
 #### Posit Workbench
 
@@ -51,13 +51,13 @@
 
 ### Dependencies
 
-- (#15935): Copilot Language Server 1.342.0
-- (#15933): Electron 37.2.0
-- (#16062): GWT 2.12.2
-- (#15934): Quarto 1.7.32
+- ([#15935](https://github.com/rstudio/rstudio/issues/15935)): Copilot Language Server 1.342.0
+- ([#15933](https://github.com/rstudio/rstudio/issues/15933)): Electron 37.2.0
+- ([#16062](https://github.com/rstudio/rstudio/issues/13924)): GWT 2.12.2
+- ([#15934](https://github.com/rstudio/rstudio/issues/15934)): Quarto 1.7.32
 
 ### Deprecated / Removed
 
-- (#15940): RStudio Server and Posit Workbench are no longer supported on Ubuntu Focal
-- (#16104): Removed the "Limit visible console output" feature
+- ([#15940](https://github.com/rstudio/rstudio/issues/15940)): RStudio Server and Posit Workbench are no longer supported on Ubuntu Focal
+- ([#16104](https://github.com/rstudio/rstudio/issues/16104)): Removed the "Limit visible console output" feature
 - (rstudio-pro#8257): Removed publishing to Posit Cloud

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 - ([#11661](https://github.com/rstudio/rstudio/issues/11661)): The Zoom button in the RStudio Desktop plots pane now brings an existing zoomed plot window to the foreground 
 - ([#16009](https://github.com/rstudio/rstudio/issues/16009)): When manually checking for updates (after previously ignoring an update), an option to stop ignoring updates prompts
 - ([#15988](https://github.com/rstudio/rstudio/issues/15988)): Posit Product Documentation theme v7.0.0; adds cookie consent, several style updates, accessibility fixes, dark theme improvements
+- ([#16214](https://github.com/rstudio/rstudio/issues/16214)): Introduces a new structure for release note entries
+
 
 #### Posit Workbench
 


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 


Relates to #16214 

To improve scalability and readability, following the same structure as Quarto and Positron for release note entries.

Also adds an entry for this change and two missed theme-related entries. 
### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Ensure you have updated the QA Notes in the original issue.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

This is a preview of what the update will look like:

<img width="443" height="753" alt="2025-07-10_16-41-12" src="https://github.com/user-attachments/assets/4358aad2-0824-41dc-ad16-ff614d656357" />

- I disabled the `link-external-icon` for this site since it was really distracting in the entries now that I have links to the open source issues and also - essentially every link in this site is an external link... so it seems almost odd to include it.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


