### PR TITLE
dependency installer tweaks

### DIFF
--- a/dependencies/common/install-gwt
+++ b/dependencies/common/install-gwt
@@ -25,8 +25,14 @@ section "Installing GWT ${GWT_VERSION}"
 
 mkdir -p gwtproject
 cd gwtproject
+if [ -e "gwt-${GWT_VERSION}" ]; then
+	echo "GWT ${GWT_VERSION} is already installed."
+	exit 0
+fi
+
 download "https://rstudio-buildtools.s3.us-east-1.amazonaws.com/gwt/gwt-${GWT_VERSION}.tar.gz"
 extract "gwt-${GWT_VERSION}.tar.gz"
 rm "gwt-${GWT_VERSION}.tar.gz"
+touch "gwt-${GWT_VERSION}"
 yay "GWT ${GWT_VERSION} installed to $(pwd)"
 cd ..

--- a/dependencies/linux/install-dependencies-yum
+++ b/dependencies/linux/install-dependencies-yum
@@ -17,48 +17,40 @@
 
 set -e
 
-# build/development tools
-sudo yum install -y make
-sudo yum install -y gcc
-sudo yum install -y gcc-c++
-sudo yum install -y rpmdevtools
-sudo yum install -y wget
-sudo yum install -y jq
-sudo yum install -y whois
+PACKAGES=(
+	ant
+	boost-devel
+	bzip2-devel
+	cmake
+	fakeroot
+	gcc
+	gcc-c++
+	java
+	java-devel
+	jq
+	libffi
+	libuser-devel
+	libuuid-devel
+	libXScrnSaver-devel
+	libxslt-devel
+	make
+	mesa-libGL-devel
+	openssl-devel
+	pam-devel
+	pango-devel
+	postgresql-devel
+	rpmdevtools
+	sqlite-devel
+	wget
+	whois
+	xml-commons-apis
+	zlib-devel
+)
 
-# core system libraries
-sudo yum install -y libuuid-devel
-sudo yum install -y openssl-devel
-sudo yum install -y bzip2-devel
-sudo yum install -y zlib-devel
-sudo yum install -y pam-devel
-sudo yum install -y libuser-devel
-
-# pandoc dependencies
-sudo yum install -y libffi
-
-# boost
-sudo yum install -y boost-devel
-
-# pango cairo
-sudo yum install -y pango-devel
-
-# gwt prereqs
-sudo yum install -y java
-sudo yum install -y java-devel
-sudo yum install -y ant
-sudo yum install -y xml-commons-apis
-
-# required for Qt
-sudo yum install -y libxslt-devel
-sudo yum install -y mesa-libGL-devel
-sudo yum install -y libXScrnSaver-devel
-sudo yum install -y fakeroot
-sudo yum install -y postgresql-devel
+sudo yum install -y "${PACKAGES[@]}"
 
 # overlay
-if [ -e install-overlay-yum ]
-then
+if [ -e install-overlay-yum ]; then
   ./install-overlay-yum
 fi
 

--- a/src/cpp/ext/CMakeLists.txt
+++ b/src/cpp/ext/CMakeLists.txt
@@ -45,13 +45,14 @@ set(CMAKE_WARN_DEPRECATED FALSE)
 function(dependency)
 
    set(_NAME "${ARGV0}")
-   cmake_parse_arguments(PARSE_ARGV 1 "" "" "COMMENT;CUSTOM;VERSION;REPOSITORY;REVISION" "PLATFORMS")
+   cmake_parse_arguments(PARSE_ARGV 1 "" "" "COMMENT;CUSTOM;VERSION;REPOSITORY;REVISION;CXXFLAGS" "PLATFORMS")
 
    set(${_NAME}_VERSION    "${_VERSION}"    CACHE INTERNAL "")
    set(${_NAME}_REPOSITORY "${_REPOSITORY}" CACHE INTERNAL "")
    set(${_NAME}_REVISION   "${_REVISION}"   CACHE INTERNAL "")
    set(${_NAME}_CUSTOM     "${_CUSTOM}"     CACHE INTERNAL "")
    set(${_NAME}_PLATFORMS  "${_PLATFORMS}"  CACHE INTERNAL "")
+   set(${_NAME}_CXXFLAGS   "${_CXXFLAGS}"   CACHE INTERNAL "")
 
    if(_PLATFORMS)
       foreach(_PLATFORM IN LISTS _PLATFORMS)
@@ -144,11 +145,16 @@ dependency(WEBSOCKETPP
 
 
 # yaml-cpp
+
+# help yaml-cpp 0.8.0 find <cstdint> during compilation
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/yaml-cpp.h" "#include <cstdint>")
+
 dependency(YAML_CPP
    COMMENT    "yaml-cpp is a YAML parser and emitter in C++ matching the YAML 1.2 spec."
    VERSION    "0.8.0"
    REPOSITORY "https://github.com/jbeder/yaml-cpp"
    REVISION   "f7320141120f720aecc4c32be25586e7da9eb978" # pragma: allowlist secret
+   CXXFLAGS   "-include ${CMAKE_CURRENT_BINARY_DIR}/yaml-cpp.h"
 )
 
 
@@ -160,7 +166,6 @@ dependency(ZLIB
    REVISION   "51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf" # pragma: allowlist secret
    PLATFORMS  WIN32
 )
-
 
 function(fetch)
 
@@ -213,7 +218,10 @@ function(fetch)
 
       if(${_PREFIX}_FETCHED)
          message(STATUS "Fetching dependency ${_NAME} ${${_PREFIX}_VERSION}")
+         set(_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+         set(CMAKE_CXX_FLAGS "${${_PREFIX}_CXXFLAGS} ${CMAKE_CXX_FLAGS}")
          FetchContent_MakeAvailable("${_NAME}")
+         set(CMAKE_CXX_FLAGS "${_CMAKE_CXX_FLAGS}")
          message(STATUS "Fetching dependency ${_NAME} ${${_PREFIX}_VERSION} - success")
          set("${_PREFIX}_SOURCE_DIR" "${CMAKE_BINARY_DIR}/_deps/${_NAME}-src" CACHE INTERNAL "")
          set("${_PREFIX}_BINARY_DIR" "${CMAKE_BINARY_DIR}/_deps/${_NAME}-build" CACHE INTERNAL "")


### PR DESCRIPTION
- Make the GWT installer idempotent.
- Install our RHEL dependencies in one invocation, to speed the whole process up.
- Also add cmake and sqlite-devel so that SOCI builds succeed.