### PR TITLE
Prevent exception in OpenFileDialog

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/OpenFileDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/OpenFileDialog.java
@@ -14,11 +14,11 @@
  */
 package org.rstudio.core.client.files.filedialog;
 
-import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.files.FileSystemContext;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.ProgressOperationWithInput;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 
 public class OpenFileDialog extends FileDialog
@@ -87,7 +87,8 @@ public class OpenFileDialog extends FileDialog
       // 'fresh' from 'stale' user input; ie, tell whether
       // the user is navigating in the widget or typing in
       // the file name textbox
-      if (event.getSelectedItem().isDirectory())
+      FileSystemItem item = event.getSelectedItem();
+      if (item != null && item.isDirectory())
          browser_.setFilename("");
    }
 


### PR DESCRIPTION
### Intent

File Open dialog (web version) is throwing an exception when loading.

### Approach

Null check

### Automated Tests

I'll look at adding a BRAT test for this (desktop also has this bug when using web-based file dialogs).

### QA Notes

Make sure File Open dialog loads correctly on Server/Workbench.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


