### PR TITLE
fix menubar focus issue with multiple cursors in RStudio Desktop on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@
 - ([#15444](https://github.com/rstudio/rstudio/issues/15444)): Fixed an issue where hitting the Escape key to close the "Update Available" dialog would exit RStudio
 - ([#16191](https://github.com/rstudio/rstudio/issues/16191)): Fixed an issue where the splash screen would not close and the RStudio main window would not show when starting RStudio Desktop
 - ([#16198](https://github.com/rstudio/rstudio/issues/16198)): Fixed an issue where the "Switch Focus between Source/Console" command would not work when the Visual Editor was active
+- ([#12470](https://github.com/rstudio/rstudio/issues/12470)): Fixed an issue in RStudio Desktop on Windows where creating multiple cursors using Alt + the mouse would move focus to the menu bar
 
 #### Posit Workbench
 

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -948,6 +948,20 @@ export class GwtCallback extends EventEmitter {
       process.crash();
     });
 
+    // Handle Alt+mouse down notification for Windows multi-cursor fix
+    ipcMain.on('desktop_alt_mouse_down', (event) => {
+      const window = BrowserWindow.fromWebContents(event.sender);
+      if (window) {
+        // Find the GwtWindow that owns this BrowserWindow
+        for (const owner of this.owners) {
+          if (owner.window === window && 'notifyAltMouseDown' in owner) {
+            (owner as any).notifyAltMouseDown();
+            break;
+          }
+        }
+      }
+    });
+
     ipcMain.handle('desktop_get_session_server', () => {
       GwtCallback.unimpl('desktop_get_session_server');
       return {};

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -524,6 +524,10 @@ export function getDesktopBridge() {
       ipcRenderer.send('desktop_set_disable_renderer_accessibility', disable);
     },
 
+    notifyAltMouseDown: () => {
+      ipcRenderer.send('desktop_alt_mouse_down');
+    },
+
     getIgnoreGpuExclusionList: (callback: VoidCallback<boolean>) => {
       ipcRenderer
         .invoke('desktop_get_ignore_gpu_exclusion_list')


### PR DESCRIPTION
> [!IMPORTANT]
> Marked as draft while I do additional testing.

### Intent

Addresses #12470

### Approach

Inject a global mousedown listener that detects when the mouse is clicked while <kbd>Alt</kbd> is held, then suppresses the Alt keyUp event that would normally activate the menu bar.

### Automated Tests

None, we don't have the capability to automate testing this.

### QA Notes

The change is scoped to Windows Desktop only, and only Electron-specific coded was modified, so should be no risk to Server/Workbench, or Desktop on Mac and Linux.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


