### PR TITLE
Mousewheel zoom feature for RStudio desktop

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 - ([#16009](https://github.com/rstudio/rstudio/issues/16009)): When manually checking for updates (after previously ignoring an update), an option to stop ignoring updates prompts
 - ([#15988](https://github.com/rstudio/rstudio/issues/15988)): Posit Product Documentation theme v7.0.0; adds cookie consent, several style updates, accessibility fixes, dark theme improvements
 - ([#16214](https://github.com/rstudio/rstudio/issues/16214)): Introduces a new structure for release note entries
+- ([#16226](https://github.com/rstudio/rstudio/issues/16226)): Added option (off by default) to zoom RStudio Desktop UI with Ctrl/Cmd+mouse wheel
 
 #### Posit Workbench
 

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -1010,8 +1010,8 @@ public:
    /**
     * A delay in milliseconds to wait before applying the zoom level after a mouse wheel event.
     */
-   double mousewheelZoomDebounceMs();
-   core::Error setMousewheelZoomDebounceMs(double val);
+   int mousewheelZoomDebounceMs();
+   core::Error setMousewheelZoomDebounceMs(int val);
 
    /**
     * The name of the color theme to apply to the text editor in RStudio.

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -174,6 +174,7 @@ namespace prefs {
 #define kEditorLineHeight "editor_line_height"
 #define kHelpFontSizePoints "help_font_size_points"
 #define kEnableMousewheelZoom "enable_mousewheel_zoom"
+#define kMousewheelZoomDebounceMs "mousewheel_zoom_debounce_ms"
 #define kEditorTheme "editor_theme"
 #define kServerEditorFontEnabled "server_editor_font_enabled"
 #define kServerEditorFont "server_editor_font"
@@ -1005,6 +1006,12 @@ public:
     */
    bool enableMousewheelZoom();
    core::Error setEnableMousewheelZoom(bool val);
+
+   /**
+    * A delay in milliseconds to wait before applying the zoom level after a mouse wheel event.
+    */
+   double mousewheelZoomDebounceMs();
+   core::Error setMousewheelZoomDebounceMs(double val);
 
    /**
     * The name of the color theme to apply to the text editor in RStudio.

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -173,6 +173,7 @@ namespace prefs {
 #define kFontSizePoints "font_size_points"
 #define kEditorLineHeight "editor_line_height"
 #define kHelpFontSizePoints "help_font_size_points"
+#define kEnableMousewheelZoom "enable_mousewheel_zoom"
 #define kEditorTheme "editor_theme"
 #define kServerEditorFontEnabled "server_editor_font_enabled"
 #define kServerEditorFont "server_editor_font"
@@ -998,6 +999,12 @@ public:
     */
    double helpFontSizePoints();
    core::Error setHelpFontSizePoints(double val);
+
+   /**
+    * Use Ctrl+mousewheel (Cmd+mousewheel on macOS) to zoom the interface in and out.
+    */
+   bool enableMousewheelZoom();
+   core::Error setEnableMousewheelZoom(bool val);
 
    /**
     * The name of the color theme to apply to the text editor in RStudio.

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -1001,7 +1001,7 @@ public:
    core::Error setHelpFontSizePoints(double val);
 
    /**
-    * Use Ctrl+mousewheel (Cmd+mousewheel on macOS) to zoom the interface in and out.
+    * Use Ctrl+Mouse Wheel (Cmd+mMusew hWel on macOS) to zoom the interface in and out.
     */
    bool enableMousewheelZoom();
    core::Error setEnableMousewheelZoom(bool val);

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -1001,7 +1001,7 @@ public:
    core::Error setHelpFontSizePoints(double val);
 
    /**
-    * Use Ctrl+Mouse Wheel (Cmd+mMusew hWel on macOS) to zoom the interface in and out.
+    * Use Ctrl+Mouse Wheel (Cmd+Mouse Wheel on macOS) to zoom the interface in and out.
     */
    bool enableMousewheelZoom();
    core::Error setEnableMousewheelZoom(bool val);

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -852,7 +852,7 @@
 
 # Zoom with mouse wheel when holding Ctrl (Cmd on macOS)
 #
-# Use Ctrl+Mouse Wheel (Cmd+mMusew hWel on macOS) to zoom the interface in and
+# Use Ctrl+Mouse Wheel (Cmd+Mouse Wheel on macOS) to zoom the interface in and
 # out.
 .rs.uiPrefs$enableMousewheelZoom <- list(
    get = function() { .rs.getUserPref("enable_mousewheel_zoom") },

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -850,9 +850,10 @@
    clear = function() { .rs.clearUserPref("help_font_size_points") }
 )
 
-# Enable mousewheel zoom
+# Zoom with mouse wheel when holding Ctrl (Cmd on macOS)
 #
-# Use Ctrl+mousewheel (Cmd+mousewheel on macOS) to zoom the interface in and out.
+# Use Ctrl+Mouse Wheel (Cmd+mMusew hWel on macOS) to zoom the interface in and
+# out.
 .rs.uiPrefs$enableMousewheelZoom <- list(
    get = function() { .rs.getUserPref("enable_mousewheel_zoom") },
    set = function(value) { .rs.setUserPref("enable_mousewheel_zoom", value) },

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -850,6 +850,15 @@
    clear = function() { .rs.clearUserPref("help_font_size_points") }
 )
 
+# Enable mousewheel zoom
+#
+# Use Ctrl+mousewheel (Cmd+mousewheel on macOS) to zoom the interface in and out.
+.rs.uiPrefs$enableMousewheelZoom <- list(
+   get = function() { .rs.getUserPref("enable_mousewheel_zoom") },
+   set = function(value) { .rs.setUserPref("enable_mousewheel_zoom", value) },
+   clear = function() { .rs.clearUserPref("enable_mousewheel_zoom") }
+)
+
 # Theme
 #
 # The name of the color theme to apply to the text editor in RStudio.

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -860,6 +860,16 @@
    clear = function() { .rs.clearUserPref("enable_mousewheel_zoom") }
 )
 
+# Mouse wheel zoom debounce delay (ms)
+#
+# A delay in milliseconds to wait before applying the zoom level after a mouse
+# wheel event.
+.rs.uiPrefs$mousewheelZoomDebounceMs <- list(
+   get = function() { .rs.getUserPref("mousewheel_zoom_debounce_ms") },
+   set = function(value) { .rs.setUserPref("mousewheel_zoom_debounce_ms", value) },
+   clear = function() { .rs.clearUserPref("mousewheel_zoom_debounce_ms") }
+)
+
 # Theme
 #
 # The name of the color theme to apply to the text editor in RStudio.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -1194,7 +1194,7 @@ core::Error UserPrefValues::setHelpFontSizePoints(double val)
 }
 
 /**
- * Use Ctrl+mousewheel (Cmd+mousewheel on macOS) to zoom the interface in and out.
+ * Use Ctrl+Mouse Wheel (Cmd+mMusew hWel on macOS) to zoom the interface in and out.
  */
 bool UserPrefValues::enableMousewheelZoom()
 {

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -1194,6 +1194,19 @@ core::Error UserPrefValues::setHelpFontSizePoints(double val)
 }
 
 /**
+ * Use Ctrl+mousewheel (Cmd+mousewheel on macOS) to zoom the interface in and out.
+ */
+bool UserPrefValues::enableMousewheelZoom()
+{
+   return readPref<bool>("enable_mousewheel_zoom");
+}
+
+core::Error UserPrefValues::setEnableMousewheelZoom(bool val)
+{
+   return writePref("enable_mousewheel_zoom", val);
+}
+
+/**
  * The name of the color theme to apply to the text editor in RStudio.
  */
 std::string UserPrefValues::editorTheme()
@@ -3561,6 +3574,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kFontSizePoints,
       kEditorLineHeight,
       kHelpFontSizePoints,
+      kEnableMousewheelZoom,
       kEditorTheme,
       kServerEditorFontEnabled,
       kServerEditorFont,

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -1207,6 +1207,19 @@ core::Error UserPrefValues::setEnableMousewheelZoom(bool val)
 }
 
 /**
+ * A delay in milliseconds to wait before applying the zoom level after a mouse wheel event.
+ */
+double UserPrefValues::mousewheelZoomDebounceMs()
+{
+   return readPref<double>("mousewheel_zoom_debounce_ms");
+}
+
+core::Error UserPrefValues::setMousewheelZoomDebounceMs(double val)
+{
+   return writePref("mousewheel_zoom_debounce_ms", val);
+}
+
+/**
  * The name of the color theme to apply to the text editor in RStudio.
  */
 std::string UserPrefValues::editorTheme()
@@ -3575,6 +3588,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kEditorLineHeight,
       kHelpFontSizePoints,
       kEnableMousewheelZoom,
+      kMousewheelZoomDebounceMs,
       kEditorTheme,
       kServerEditorFontEnabled,
       kServerEditorFont,

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -1209,12 +1209,12 @@ core::Error UserPrefValues::setEnableMousewheelZoom(bool val)
 /**
  * A delay in milliseconds to wait before applying the zoom level after a mouse wheel event.
  */
-double UserPrefValues::mousewheelZoomDebounceMs()
+int UserPrefValues::mousewheelZoomDebounceMs()
 {
-   return readPref<double>("mousewheel_zoom_debounce_ms");
+   return readPref<int>("mousewheel_zoom_debounce_ms");
 }
 
-core::Error UserPrefValues::setMousewheelZoomDebounceMs(double val)
+core::Error UserPrefValues::setMousewheelZoomDebounceMs(int val)
 {
    return writePref("mousewheel_zoom_debounce_ms", val);
 }

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -1194,7 +1194,7 @@ core::Error UserPrefValues::setHelpFontSizePoints(double val)
 }
 
 /**
- * Use Ctrl+Mouse Wheel (Cmd+mMusew hWel on macOS) to zoom the interface in and out.
+ * Use Ctrl+Mouse Wheel (Cmd+Mouse Wheel on macOS) to zoom the interface in and out.
  */
 bool UserPrefValues::enableMousewheelZoom()
 {

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -647,8 +647,8 @@
         "enable_mousewheel_zoom": {
             "type": "boolean",
             "default": false,
-            "title": "Enable mousewheel zoom",
-            "description": "Use Ctrl+mousewheel (Cmd+mousewheel on macOS) to zoom the interface in and out."
+            "title": "Zoom with mouse wheel when holding Ctrl (Cmd on macOS)",
+            "description": "Use Ctrl+Mouse Wheel (Cmd+mMusew hWel on macOS) to zoom the interface in and out."
         },
         "editor_theme": {
             "type": "string",

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -644,6 +644,12 @@
             "title": "Help panel font size (points)",
             "description": "The help panel font size, in points."
         },
+        "enable_mousewheel_zoom": {
+            "type": "boolean",
+            "default": false,
+            "title": "Enable mousewheel zoom",
+            "description": "Use Ctrl+mousewheel (Cmd+mousewheel on macOS) to zoom the interface in and out."
+        },
         "editor_theme": {
             "type": "string",
             "default": "Textmate (default)",

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -648,7 +648,7 @@
             "type": "boolean",
             "default": false,
             "title": "Zoom with mouse wheel when holding Ctrl (Cmd on macOS)",
-            "description": "Use Ctrl+Mouse Wheel (Cmd+mMusew hWel on macOS) to zoom the interface in and out."
+            "description": "Use Ctrl+Mouse Wheel (Cmd+Mouse Wheel on macOS) to zoom the interface in and out."
         },
         "editor_theme": {
             "type": "string",

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -650,6 +650,12 @@
             "title": "Zoom with mouse wheel when holding Ctrl (Cmd on macOS)",
             "description": "Use Ctrl+Mouse Wheel (Cmd+Mouse Wheel on macOS) to zoom the interface in and out."
         },
+        "mousewheel_zoom_debounce_ms": {
+            "type": "number",
+            "default": 100,
+            "title": "Mouse wheel zoom debounce delay (ms)",
+            "description": "A delay in milliseconds to wait before applying the zoom level after a mouse wheel event."
+        },
         "editor_theme": {
             "type": "string",
             "default": "Textmate (default)",

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -651,7 +651,7 @@
             "description": "Use Ctrl+Mouse Wheel (Cmd+Mouse Wheel on macOS) to zoom the interface in and out."
         },
         "mousewheel_zoom_debounce_ms": {
-            "type": "number",
+            "type": "integer",
             "default": 100,
             "title": "Mouse wheel zoom debounce delay (ms)",
             "description": "A delay in milliseconds to wait before applying the zoom level after a mouse wheel event."

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -171,6 +171,7 @@ public interface DesktopFrame extends JavaScriptPassthrough
    void setBackgroundColor(JsArrayInteger rgbColor);
    void changeTitleBarColor(int r, int g, int b);
    void syncToEditorTheme(boolean isDark);
+   void setMousewheelZoomEnabled(boolean enabled);
    
    void getEnableAccessibility(CommandWithArg<Boolean> callback);
    void setEnableAccessibility(boolean enable);

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -172,6 +172,7 @@ public interface DesktopFrame extends JavaScriptPassthrough
    void changeTitleBarColor(int r, int g, int b);
    void syncToEditorTheme(boolean isDark);
    void setMousewheelZoomEnabled(boolean enabled);
+   void setMousewheelZoomDebounce(double debounceMs);
    
    void getEnableAccessibility(CommandWithArg<Boolean> callback);
    void setEnableAccessibility(boolean enable);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
@@ -236,10 +236,11 @@ public class UserPrefs extends UserPrefsComputed
       announceScreenReaderState();
       syncToggleTabKeyMovesFocusState();
       
-      // Send initial mousewheel zoom preference to desktop
+      // Send initial mousewheel zoom preferences to desktop
       if (BrowseCap.isElectron())
       {
          Desktop.getFrame().setMousewheelZoomEnabled(enableMousewheelZoom().getValue());
+         Desktop.getFrame().setMousewheelZoomDebounce(mousewheelZoomDebounceMs().getValue());
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
@@ -98,6 +98,7 @@ public class UserPrefs extends UserPrefsComputed
          enableSplashScreen().addValueChangeHandler(enabled -> Desktop.getFrame().setEnableSplashScreen(enabled.getValue()));
          enableScreenReader().addValueChangeHandler(enabled -> Desktop.getFrame().setEnableAccessibility(enabled.getValue()));
          enableMousewheelZoom().addValueChangeHandler(enabled -> Desktop.getFrame().setMousewheelZoomEnabled(enabled.getValue()));
+         mousewheelZoomDebounceMs().addValueChangeHandler(debounceMs -> Desktop.getFrame().setMousewheelZoomDebounce(debounceMs.getValue()));
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
@@ -97,6 +97,7 @@ public class UserPrefs extends UserPrefsComputed
          autohideMenubar().addValueChangeHandler(enabled -> Desktop.getFrame().setAutohideMenubar(enabled.getValue()));
          enableSplashScreen().addValueChangeHandler(enabled -> Desktop.getFrame().setEnableSplashScreen(enabled.getValue()));
          enableScreenReader().addValueChangeHandler(enabled -> Desktop.getFrame().setEnableAccessibility(enabled.getValue()));
+         enableMousewheelZoom().addValueChangeHandler(enabled -> Desktop.getFrame().setMousewheelZoomEnabled(enabled.getValue()));
       }
    }
 
@@ -233,6 +234,12 @@ public class UserPrefs extends UserPrefsComputed
       origScreenReaderLabel_ = commands_.toggleScreenReaderSupport().getMenuLabel(false);
       announceScreenReaderState();
       syncToggleTabKeyMovesFocusState();
+      
+      // Send initial mousewheel zoom preference to desktop
+      if (BrowseCap.isElectron())
+      {
+         Desktop.getFrame().setMousewheelZoomEnabled(enableMousewheelZoom().getValue());
+      }
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1353,7 +1353,7 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * Use Ctrl+Mouse Wheel (Cmd+mMusew hWel on macOS) to zoom the interface in and out.
+    * Use Ctrl+Mouse Wheel (Cmd+Mouse Wheel on macOS) to zoom the interface in and out.
     */
    public PrefValue<Boolean> enableMousewheelZoom()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1367,13 +1367,13 @@ public class UserPrefsAccessor extends Prefs
    /**
     * A delay in milliseconds to wait before applying the zoom level after a mouse wheel event.
     */
-   public PrefValue<Double> mousewheelZoomDebounceMs()
+   public PrefValue<Integer> mousewheelZoomDebounceMs()
    {
-      return dbl(
+      return integer(
          "mousewheel_zoom_debounce_ms",
          _constants.mousewheelZoomDebounceMsTitle(), 
          _constants.mousewheelZoomDebounceMsDescription(), 
-         100.0);
+         100);
    }
 
    /**
@@ -4023,7 +4023,7 @@ public class UserPrefsAccessor extends Prefs
       if (source.hasKey("enable_mousewheel_zoom"))
          enableMousewheelZoom().setValue(layer, source.getBool("enable_mousewheel_zoom"));
       if (source.hasKey("mousewheel_zoom_debounce_ms"))
-         mousewheelZoomDebounceMs().setValue(layer, source.getDbl("mousewheel_zoom_debounce_ms"));
+         mousewheelZoomDebounceMs().setValue(layer, source.getInteger("mousewheel_zoom_debounce_ms"));
       if (source.hasKey("editor_theme"))
          editorTheme().setValue(layer, source.getString("editor_theme"));
       if (source.hasKey("server_editor_font_enabled"))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1353,6 +1353,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Use Ctrl+mousewheel (Cmd+mousewheel on macOS) to zoom the interface in and out.
+    */
+   public PrefValue<Boolean> enableMousewheelZoom()
+   {
+      return bool(
+         "enable_mousewheel_zoom",
+         _constants.enableMousewheelZoomTitle(), 
+         _constants.enableMousewheelZoomDescription(), 
+         false);
+   }
+
+   /**
     * The name of the color theme to apply to the text editor in RStudio.
     */
    public PrefValue<String> editorTheme()
@@ -3996,6 +4008,8 @@ public class UserPrefsAccessor extends Prefs
          editorLineHeight().setValue(layer, source.getDbl("editor_line_height"));
       if (source.hasKey("help_font_size_points"))
          helpFontSizePoints().setValue(layer, source.getDbl("help_font_size_points"));
+      if (source.hasKey("enable_mousewheel_zoom"))
+         enableMousewheelZoom().setValue(layer, source.getBool("enable_mousewheel_zoom"));
       if (source.hasKey("editor_theme"))
          editorTheme().setValue(layer, source.getString("editor_theme"));
       if (source.hasKey("server_editor_font_enabled"))
@@ -4440,6 +4454,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(fontSizePoints());
       prefs.add(editorLineHeight());
       prefs.add(helpFontSizePoints());
+      prefs.add(enableMousewheelZoom());
       prefs.add(editorTheme());
       prefs.add(serverEditorFontEnabled());
       prefs.add(serverEditorFont());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1353,7 +1353,7 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * Use Ctrl+mousewheel (Cmd+mousewheel on macOS) to zoom the interface in and out.
+    * Use Ctrl+Mouse Wheel (Cmd+mMusew hWel on macOS) to zoom the interface in and out.
     */
    public PrefValue<Boolean> enableMousewheelZoom()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1365,6 +1365,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * A delay in milliseconds to wait before applying the zoom level after a mouse wheel event.
+    */
+   public PrefValue<Double> mousewheelZoomDebounceMs()
+   {
+      return dbl(
+         "mousewheel_zoom_debounce_ms",
+         _constants.mousewheelZoomDebounceMsTitle(), 
+         _constants.mousewheelZoomDebounceMsDescription(), 
+         100.0);
+   }
+
+   /**
     * The name of the color theme to apply to the text editor in RStudio.
     */
    public PrefValue<String> editorTheme()
@@ -4010,6 +4022,8 @@ public class UserPrefsAccessor extends Prefs
          helpFontSizePoints().setValue(layer, source.getDbl("help_font_size_points"));
       if (source.hasKey("enable_mousewheel_zoom"))
          enableMousewheelZoom().setValue(layer, source.getBool("enable_mousewheel_zoom"));
+      if (source.hasKey("mousewheel_zoom_debounce_ms"))
+         mousewheelZoomDebounceMs().setValue(layer, source.getDbl("mousewheel_zoom_debounce_ms"));
       if (source.hasKey("editor_theme"))
          editorTheme().setValue(layer, source.getString("editor_theme"));
       if (source.hasKey("server_editor_font_enabled"))
@@ -4455,6 +4469,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(editorLineHeight());
       prefs.add(helpFontSizePoints());
       prefs.add(enableMousewheelZoom());
+      prefs.add(mousewheelZoomDebounceMs());
       prefs.add(editorTheme());
       prefs.add(serverEditorFontEnabled());
       prefs.add(serverEditorFont());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -790,6 +790,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String helpFontSizePointsDescription();
 
    /**
+    * Use Ctrl+mousewheel (Cmd+mousewheel on macOS) to zoom the interface in and out.
+    */
+   @DefaultStringValue("Enable mousewheel zoom")
+   String enableMousewheelZoomTitle();
+   @DefaultStringValue("Use Ctrl+mousewheel (Cmd+mousewheel on macOS) to zoom the interface in and out.")
+   String enableMousewheelZoomDescription();
+
+   /**
     * The name of the color theme to apply to the text editor in RStudio.
     */
    @DefaultStringValue("Theme")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -790,11 +790,11 @@ public interface UserPrefsAccessorConstants extends Constants {
    String helpFontSizePointsDescription();
 
    /**
-    * Use Ctrl+Mouse Wheel (Cmd+mMusew hWel on macOS) to zoom the interface in and out.
+    * Use Ctrl+Mouse Wheel (Cmd+Mouse Wheel on macOS) to zoom the interface in and out.
     */
    @DefaultStringValue("Zoom with mouse wheel when holding Ctrl (Cmd on macOS)")
    String enableMousewheelZoomTitle();
-   @DefaultStringValue("Use Ctrl+Mouse Wheel (Cmd+mMusew hWel on macOS) to zoom the interface in and out.")
+   @DefaultStringValue("Use Ctrl+Mouse Wheel (Cmd+Mouse Wheel on macOS) to zoom the interface in and out.")
    String enableMousewheelZoomDescription();
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -790,11 +790,11 @@ public interface UserPrefsAccessorConstants extends Constants {
    String helpFontSizePointsDescription();
 
    /**
-    * Use Ctrl+mousewheel (Cmd+mousewheel on macOS) to zoom the interface in and out.
+    * Use Ctrl+Mouse Wheel (Cmd+mMusew hWel on macOS) to zoom the interface in and out.
     */
-   @DefaultStringValue("Enable mousewheel zoom")
+   @DefaultStringValue("Zoom with mouse wheel when holding Ctrl (Cmd on macOS)")
    String enableMousewheelZoomTitle();
-   @DefaultStringValue("Use Ctrl+mousewheel (Cmd+mousewheel on macOS) to zoom the interface in and out.")
+   @DefaultStringValue("Use Ctrl+Mouse Wheel (Cmd+mMusew hWel on macOS) to zoom the interface in and out.")
    String enableMousewheelZoomDescription();
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -798,6 +798,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String enableMousewheelZoomDescription();
 
    /**
+    * A delay in milliseconds to wait before applying the zoom level after a mouse wheel event.
+    */
+   @DefaultStringValue("Mouse wheel zoom debounce delay (ms)")
+   String mousewheelZoomDebounceMsTitle();
+   @DefaultStringValue("A delay in milliseconds to wait before applying the zoom level after a mouse wheel event.")
+   String mousewheelZoomDebounceMsDescription();
+
+   /**
     * The name of the color theme to apply to the text editor in RStudio.
     */
    @DefaultStringValue("Theme")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -404,6 +404,10 @@ helpFontSizePointsDescription = The help panel font size, in points.
 enableMousewheelZoomTitle = Zoom with mouse wheel when holding Ctrl (Cmd on macOS)
 enableMousewheelZoomDescription = Use Ctrl+Mouse Wheel (Cmd+Mouse Wheel on macOS) to zoom the interface in and out.
 
+# A delay in milliseconds to wait before applying the zoom level after a mouse wheel event.
+mousewheelZoomDebounceMsTitle = Mouse wheel zoom debounce delay (ms)
+mousewheelZoomDebounceMsDescription = A delay in milliseconds to wait before applying the zoom level after a mouse wheel event.
+
 # The name of the color theme to apply to the text editor in RStudio.
 editorThemeTitle = Theme
 editorThemeDescription = The name of the color theme to apply to the text editor in RStudio.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -400,9 +400,9 @@ editorLineHeightDescription = The editor line height, as a percentage of the fon
 helpFontSizePointsTitle = Help panel font size (points)
 helpFontSizePointsDescription = The help panel font size, in points.
 
-# Use Ctrl+Mouse Wheel (Cmd+mMusew hWel on macOS) to zoom the interface in and out.
+# Use Ctrl+Mouse Wheel (Cmd+Mouse Wheel on macOS) to zoom the interface in and out.
 enableMousewheelZoomTitle = Zoom with mouse wheel when holding Ctrl (Cmd on macOS)
-enableMousewheelZoomDescription = Use Ctrl+Mouse Wheel (Cmd+mMusew hWel on macOS) to zoom the interface in and out.
+enableMousewheelZoomDescription = Use Ctrl+Mouse Wheel (Cmd+Mouse Wheel on macOS) to zoom the interface in and out.
 
 # The name of the color theme to apply to the text editor in RStudio.
 editorThemeTitle = Theme

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -400,6 +400,10 @@ editorLineHeightDescription = The editor line height, as a percentage of the fon
 helpFontSizePointsTitle = Help panel font size (points)
 helpFontSizePointsDescription = The help panel font size, in points.
 
+# Use Ctrl+mousewheel (Cmd+mousewheel on macOS) to zoom the interface in and out.
+enableMousewheelZoomTitle = Enable mousewheel zoom
+enableMousewheelZoomDescription = Use Ctrl+mousewheel (Cmd+mousewheel on macOS) to zoom the interface in and out.
+
 # The name of the color theme to apply to the text editor in RStudio.
 editorThemeTitle = Theme
 editorThemeDescription = The name of the color theme to apply to the text editor in RStudio.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -400,9 +400,9 @@ editorLineHeightDescription = The editor line height, as a percentage of the fon
 helpFontSizePointsTitle = Help panel font size (points)
 helpFontSizePointsDescription = The help panel font size, in points.
 
-# Use Ctrl+mousewheel (Cmd+mousewheel on macOS) to zoom the interface in and out.
-enableMousewheelZoomTitle = Enable mousewheel zoom
-enableMousewheelZoomDescription = Use Ctrl+mousewheel (Cmd+mousewheel on macOS) to zoom the interface in and out.
+# Use Ctrl+Mouse Wheel (Cmd+mMusew hWel on macOS) to zoom the interface in and out.
+enableMousewheelZoomTitle = Zoom with mouse wheel when holding Ctrl (Cmd on macOS)
+enableMousewheelZoomDescription = Use Ctrl+Mouse Wheel (Cmd+mMusew hWel on macOS) to zoom the interface in and out.
 
 # The name of the color theme to apply to the text editor in RStudio.
 editorThemeTitle = Theme

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
@@ -387,6 +387,10 @@ fontSizePointsDescription= La taille de la police par défaut de l''éditeur, en
 helpFontSizePointsTitle= Taille de la police du panneau d''aide (points)
 helpFontSizePointsDescription= La taille de la police du panneau d''aide, en points.
 
+# Use Ctrl+Mouse Wheel (Cmd+Mouse Wheel on macOS) to zoom the interface in and out.
+enableMousewheelZoomTitle = Zoom avec la molette de la souris en maintenant Ctrl (Cmd sur macOS)
+enableMousewheelZoomDescription = Utilisez Ctrl+molette de la souris (Cmd+molette de la souris sur macOS) pour agrandir et réduire l''interface.
+
 # The name of the color theme to apply to the text editor in RStudio.
 editorThemeTitle= Thème
 editorThemeDescription= Le nom du thème de couleur à appliquer à l''éditeur de texte dans RStudio.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
@@ -391,6 +391,10 @@ helpFontSizePointsDescription= La taille de la police du panneau d''aide, en poi
 enableMousewheelZoomTitle = Zoom avec la molette de la souris en maintenant Ctrl (Cmd sur macOS)
 enableMousewheelZoomDescription = Utilisez Ctrl+molette de la souris (Cmd+molette de la souris sur macOS) pour agrandir et réduire l''interface.
 
+# A delay in milliseconds to wait before applying the zoom level after a mouse wheel event.
+mousewheelZoomDebounceMsTitle = Délai d''anti-rebond du zoom de la molette de la souris (ms)
+mousewheelZoomDebounceMsDescription = Un délai en millisecondes à attendre avant d''appliquer le niveau de zoom après un événement de molette de souris.
+
 # The name of the color theme to apply to the text editor in RStudio.
 editorThemeTitle= Thème
 editorThemeDescription= Le nom du thème de couleur à appliquer à l''éditeur de texte dans RStudio.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -221,9 +221,11 @@ public class GeneralPreferencesPane extends PreferencesPane
       }
 
       CheckBox enableSplashScreen = checkboxPref(prefs_.enableSplashScreen());
+      CheckBox enableMouseWheelZoom = checkboxPref(prefs_.enableMousewheelZoom());
       if (BrowseCap.isElectron())
       {
          basic.add(enableSplashScreen);
+         basic.add(enableMouseWheelZoom);
       }
 
       VerticalTabPanel graphics = new VerticalTabPanel(ElementIds.GENERAL_GRAPHICS_PREFS);

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -785,6 +785,13 @@ export class GwtCallback extends EventEmitter {
       nativeTheme.themeSource = isDark ? 'dark' : 'light';
     });
 
+    ipcMain.on('desktop_set_mousewheel_zoom_enabled', (_event, enabled: boolean) => {
+      // Broadcast to all windows
+      for (const window of BrowserWindow.getAllWindows()) {
+        window.webContents.send('desktop_set_mousewheel_zoom_enabled', enabled);
+      }
+    });
+
     ipcMain.handle('desktop_get_enable_accessibility', () => {
       return ElectronDesktopOptions().accessibility();
     });

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -792,6 +792,13 @@ export class GwtCallback extends EventEmitter {
       }
     });
 
+    ipcMain.on('desktop_set_mousewheel_zoom_debounce', (_event, zoomDebounceMs: number) => {
+      // Broadcast to all windows
+      for (const window of BrowserWindow.getAllWindows()) {
+        window.webContents.send('desktop_set_mousewheel_zoom_debounce', zoomDebounceMs);
+      }
+    });
+
     ipcMain.handle('desktop_get_enable_accessibility', () => {
       return ElectronDesktopOptions().accessibility();
     });

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -494,6 +494,10 @@ export function getDesktopBridge() {
       ipcRenderer.send('desktop_sync_to_editor_theme', isDark);
     },
 
+    setMousewheelZoomEnabled: (enabled: boolean) => {
+      ipcRenderer.send('desktop_set_mousewheel_zoom_enabled', enabled);
+    },
+
     getEnableAccessibility: (callback: VoidCallback<boolean>) => {
       ipcRenderer
         .invoke('desktop_get_enable_accessibility')

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -498,6 +498,10 @@ export function getDesktopBridge() {
       ipcRenderer.send('desktop_set_mousewheel_zoom_enabled', enabled);
     },
 
+    setMousewheelZoomDebounce: (debounceMs: number) => {
+      ipcRenderer.send('desktop_set_mousewheel_zoom_debounce', debounceMs);
+    },
+
     getEnableAccessibility: (callback: VoidCallback<boolean>) => {
       ipcRenderer
         .invoke('desktop_get_enable_accessibility')

--- a/src/node/desktop/src/renderer/preload.ts
+++ b/src/node/desktop/src/renderer/preload.ts
@@ -63,13 +63,17 @@ for (const apiKey of apiKeys) {
 // Set up Ctrl/Cmd+Mousewheel zoom support
 if (desktopApiConnected) {
   let lastZoomTime = 0;
-  const ZOOM_THROTTLE_MS = 100; // Throttle zoom events to prevent excessive changes
   let mousewheelZoomEnabled = false; // Default to disabled
+  let zoomThrottleMs = 100; // Default debounce time
 
   // Listen for preference updates from the main process
   ipcRenderer.on('desktop_set_mousewheel_zoom_enabled', (_event, enabled: boolean) => {
     mousewheelZoomEnabled = enabled;
     logString('debug', `[preload] mousewheel zoom ${enabled ? 'enabled' : 'disabled'}`);
+  });
+  ipcRenderer.on('desktop_set_mousewheel_zoom_debounce', (_event, zoomDebounceMs: number) => {
+    zoomThrottleMs = zoomDebounceMs;
+    logString('debug', `[preload] mousewheel zoom debounce ${zoomThrottleMs} ms`);
   });
 
   window.addEventListener('DOMContentLoaded', () => {
@@ -92,7 +96,7 @@ if (desktopApiConnected) {
 
           // Throttle zoom events
           const currentTime = Date.now();
-          if (currentTime - lastZoomTime < ZOOM_THROTTLE_MS) {
+          if (currentTime - lastZoomTime < zoomThrottleMs) {
             return;
           }
           lastZoomTime = currentTime;

--- a/src/node/desktop/src/renderer/preload.ts
+++ b/src/node/desktop/src/renderer/preload.ts
@@ -64,7 +64,7 @@ for (const apiKey of apiKeys) {
 if (desktopApiConnected) {
   let lastZoomTime = 0;
   let mousewheelZoomEnabled = false; // Default to disabled
-  let zoomThrottleMs = 100; // Default debounce time
+  let zoomDebounceDurationMs = 100; // Default debounce time
 
   // Listen for preference updates from the main process
   ipcRenderer.on('desktop_set_mousewheel_zoom_enabled', (_event, enabled: boolean) => {
@@ -72,8 +72,8 @@ if (desktopApiConnected) {
     logString('debug', `[preload] mousewheel zoom ${enabled ? 'enabled' : 'disabled'}`);
   });
   ipcRenderer.on('desktop_set_mousewheel_zoom_debounce', (_event, zoomDebounceMs: number) => {
-    zoomThrottleMs = zoomDebounceMs;
-    logString('debug', `[preload] mousewheel zoom debounce ${zoomThrottleMs} ms`);
+    zoomDebounceDurationMs = zoomDebounceMs;
+    logString('debug', `[preload] mousewheel zoom debounce ${zoomDebounceDurationMs} ms`);
   });
 
   window.addEventListener('DOMContentLoaded', () => {
@@ -96,7 +96,7 @@ if (desktopApiConnected) {
 
           // Throttle zoom events
           const currentTime = Date.now();
-          if (currentTime - lastZoomTime < zoomThrottleMs) {
+          if (currentTime - lastZoomTime < zoomDebounceDurationMs) {
             return;
           }
           lastZoomTime = currentTime;


### PR DESCRIPTION
### Intent

Addresses #16226 (also previously closed issue #11595)

### Approach

- Added a "Zoom with Mouse Wheel" user preference to Global Options / General (off by default), only in Desktop

<img width="701" height="712" alt="screenshot showing global options with new mousewheel preference highlighted" src="https://github.com/user-attachments/assets/555ae811-d2df-4c81-9560-07035099adb7" />

- Added a numeric preference "Mouse wheel zoom debounce delay" to control the speed of the zoom (this preference is only editable via the command-palette; default is 100ms, a higher number slows the scrolling, lower number will speed it up)

<img width="607" height="91" alt="screenshot showing command palette w/debounce delay" src="https://github.com/user-attachments/assets/205a1c11-07e0-48df-a25c-66a30502af40" />

- When enabled, Ctrl (Linux/Windows) / Cmd (macOS) plus mouse-wheel fires existing Zoom In / Zoom Out events

### Automated Tests

None specifically for mouse-wheel

### QA Notes

Test that the feature is off by default, and works as described when enabled. Ultimately the Ctrl/Cmd+Mouse Wheel action is firing the same zoom in / zoom out commands as the keyboard shortcuts.

This is a desktop-only feature.

### Documentation

None (but user preference docs will be updated automatically)

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


