### PR TITLE
fix issue with icons darkening when hovered

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGrid.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGrid.css
@@ -40,7 +40,7 @@
    filter: brightness(0.80);
 }
 
-.rstudio-themes-default img:hover {
+.rstudio-themes-default .dataGridCell img:hover {
    filter: brightness(0.50) !important;
 }
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/8658.

### Approach

Tweak the css selector to make it more specific.

### Automated Tests

No tests for this currently.

### QA Notes

The "R" icon can only be tested with Server, but the others such as toolbar icons can be tested in desktop or server.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


