### PR TITLE
fix: avoid hardcoding path to `xdg-open`

### DIFF
--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -84,7 +84,7 @@
 #include "ServerLogVars.hpp"
 
 #if defined(__linux__)
-# define kOpenProgram "/usr/bin/xdg-open"
+# define kOpenProgram "xdg-open"
 #elif defined(__APPLE__)
 # define kOpenProgram "/usr/bin/open"
 #elif defined(_WIN32)


### PR DESCRIPTION
### Intent

Makes the `viewer` RStudio API function work in Linux environments where `xdg-open` is found under a non-default location like e.g. in [Distrobox](https://distrobox.it)es (cf. https://github.com/89luca89/distrobox/issues/645#issuecomment-1462560668 and https://github.com/89luca89/distrobox/commit/e15cec7e3264878075ad8ee6161a06f7a53b6749). Also relevant for [`rstudioapi::viewer()`](https://rstudio.github.io/rstudioapi/reference/viewer.html) which calls the RStudio API function under the hood.

### Approach

Simply avoid hardcoding the path and instead expect `xdg-open` to be on `PATH` on Linux (which is usually the case).

### Automated Tests

Untested.

### QA Notes

### Documentation

None.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


