### PR TITLE
Bump the Go compiler version

### DIFF
--- a/dependencies/tools/rstudio-tools.sh
+++ b/dependencies/tools/rstudio-tools.sh
@@ -34,7 +34,7 @@ export RSTUDIO_TOOLS_ROOT
 
 
 # version of go used for building
-export WORKBENCH_GO_VERSION="1.22.3"
+export WORKBENCH_GO_VERSION="1.24.5"
 
 
 # RStudio dependency cache


### PR DESCRIPTION
### Intent

This commit bumps the Go toolchain used in RStudio and downstream Workbench components to address vulnerability scanning issues.

Go 1.24.5 is the latest at time of writing.

Part of https://github.com/rstudio/rstudio-pro/issues/8732.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
