### PR TITLE
remove unneeded polyfill for text encoding

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -34,7 +34,6 @@ used by these components are included below):
 - RapidJSON
 - msinttypes
 - gsl-lite
-- fast-text-encoding
 - SOCI
 - PostgreSQL
 - elemental2
@@ -3506,23 +3505,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-fast-text-encoding
-----------------------------------------------------------------------
-
-Copyright 2020 Sam Thorogood
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
 
 SOCI License
 ----------------------------------------------------------------------

--- a/src/gwt/www/index.htm
+++ b/src/gwt/www/index.htm
@@ -26,7 +26,6 @@
   <title>RStudio</title>
   #!head_tags#
   <link type="text/css" rel="stylesheet" href="css/icons.css" />
-  <script src="js/text.min.js"></script>
   <script src="js/js-yaml.min.js"></script>
   <script src="#!gwt_prefix#rstudio/rstudio.nocache.js"></script>
 </head>


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/16268.

See https://github.com/rstudio/rstudio/commit/20657df92de834377fa3ec20ed345a4a6c92b0b5 for the commit where this was added.