### PR TITLE
defer setting height on chunk output

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -48,6 +48,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkOu
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Overflow;
@@ -429,9 +430,7 @@ public class ChunkOutputWidget extends Composite
       
       if (state_ != CHUNK_PRE_OUTPUT)
       {
-         // if we got some output, synchronize the chunk's height to accommodate
-         // it
-         syncHeight(true, ensureVisible);
+         Scheduler.get().scheduleDeferred(() -> syncHeight(true, ensureVisible));
       }
       else if (execScope == NotebookQueueUnit.EXEC_SCOPE_CHUNK)
       {


### PR DESCRIPTION
### Intent

Speculatively addresses https://github.com/rstudio/rstudio/issues/16157.

### Approach

We have some code that tries to manually resize the chunk output widget after code execution has finished. My hypothesis is that, in some rare cases, the chunk output finished event might be received before we have finished rendering all error text into the chunk output widget, thereby causing us to resize the widget before we know the actual intended size.

As a band-aid, defer sync-ing the height after execution has finished, to give other machinery a chance to finish updating the chunk output.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
