### PR TITLE
automatically publish DATABRICKS_HOST, SNOWFLAKE_ACCOUNT env vars

### DIFF
--- a/git_hooks/secrets/.secrets.baseline
+++ b/git_hooks/secrets/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": "git_hooks/secrets/.secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -526,7 +530,7 @@
         "filename": "src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java",
         "hashed_secret": "1c60262d3df7b0c6d2d5c52dd5014c985004219f",
         "is_verified": false,
-        "line_number": 7438,
+        "line_number": 7439,
         "is_secret": false
       },
       {
@@ -534,7 +538,7 @@
         "filename": "src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java",
         "hashed_secret": "12106b07b5b299b5e91117791ec7017f0820f84e",
         "is_verified": false,
-        "line_number": 7480,
+        "line_number": 7481,
         "is_secret": false
       }
     ],
@@ -625,5 +629,5 @@
       }
     ]
   },
-  "generated_at": "2025-07-25T16:45:08Z"
+  "generated_at": "2025-07-31T17:06:44Z"
 }

--- a/src/cpp/session/modules/SessionRSConnect.R
+++ b/src/cpp/session/modules/SessionRSConnect.R
@@ -20,11 +20,22 @@
   if (!nzchar(environFile) || !file.exists(environFile))
     return(character())
 
-    # Read environment variable names from the file
-    contents <- readLines(environFile, warn = FALSE)
-    pattern <- "^\\s*([\\w_]+)\\s*="
-    matchedLines <- grep(pattern, contents, perl = TRUE, value = TRUE)
-    gsub("\\s*=.*", "", matchedLines)
+  # Read environment variable names from the file
+  contents <- readLines(environFile, warn = FALSE)
+  pattern <- "^\\s*([\\w_]+)\\s*="
+  matchedLines <- grep(pattern, contents, perl = TRUE, value = TRUE)
+  variables <- gsub("\\s*=.*", "", matchedLines)
+  
+  # Auto-select certain special environment variables
+  selected <- getOption(
+     "rstudio.deployments.autoselectEnvVars",
+     default = c("DATABRICKS_HOST", "SNOWFLAKE_ACCOUNT")
+  )
+
+  list(
+   variables = variables,
+   selected  = intersect(variables, selected)
+  )
 })
 
 .rs.addJsonRpcHandler("forget_rsconnect_deployments", function(sourcePath, outputPath)

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectDeploymentEnvVars.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectDeploymentEnvVars.java
@@ -1,0 +1,33 @@
+/*
+ * RSConnectDeploymentEnvVars.java
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.rsconnect.model;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
+
+public class RSConnectDeploymentEnvVars extends JavaScriptObject
+{
+   protected RSConnectDeploymentEnvVars()
+   {
+   }
+
+   public final native JsArrayString getVariables() /*-{
+      return this.variables || [];
+   }-*/;
+
+   public final native JsArrayString getSelected() /*-{
+      return this.selected || [];
+   }-*/;
+}

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectDeploymentEnvVars.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectDeploymentEnvVars.java
@@ -1,7 +1,7 @@
 /*
  * RSConnectDeploymentEnvVars.java
  *
- * Copyright (C) 2022 by Posit Software, PBC
+ * Copyright (C) 2025 by Posit Software, PBC
  *
  * Unless you have received this program directly from Posit Software pursuant
  * to the terms of a commercial license agreement with Posit Software, then

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectServerOperations.java
@@ -50,7 +50,8 @@ public interface RSConnectServerOperations extends QuartoServerOperations
                String quartoSrcFile,
                ServerRequestCallback<RSConnectDeploymentFiles> requestCallback);
    
-   void getDeploymentEnvVars(ServerRequestCallback<JsArrayString> resultCallback);
+   void getDeploymentEnvVars(
+               ServerRequestCallback<RSConnectDeploymentEnvVars> resultCallback);
    
    void publishContent(RSConnectPublishSource source, 
                String account, String server, String appName, String appTitle, String appId,

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.css
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.css
@@ -29,6 +29,9 @@
 
 .envVarsList
 {
+   white-space: nowrap;
+   overflow: hidden;
+   text-overflow: ellipsis;
 	margin-top: 6px;
 	margin-bottom: 6px;
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.css
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.css
@@ -27,6 +27,12 @@
 	font-style: oblique;
 }
 
+.envVarsList
+{
+	margin-top: 6px;
+	margin-bottom: 6px;
+}
+
 .sourceDestLabels
 {
    color: #808080;
@@ -82,17 +88,17 @@
    background-color: #ffffff;
    border: 1px solid #999999;
    height: 205px;
-   width: 250px;
+   width: 264px;
    padding: 7px;
    margin-top: 5px;
    margin-bottom: 10px;
-   margin-right: 30px;
+   margin-right: 16px;
    overflow: hidden;
 }
 
 .wizard .fileList
 {
-   height: 126px;
+   height: 105px;
 }
 
 .fileList .gwt-CheckBox,

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -1475,22 +1475,10 @@ public class RSConnectDeploy extends Composite
          envVarsLabel_.setText(constants_.envVarsPublishMessage(selectedEnvVars_.size(), appContentType()));
          envVarsLabel_.setVisible(true);
 
-         if (selectedEnvVars_.size() > 3)
-         {
-            String label =
-               selectedEnvVars_.get(0) + ", " +
-               selectedEnvVars_.get(1) + ", " +
-               selectedEnvVars_.get(2) + ", " +
-               "...";
-            envVarsList_.setText(label);
-            envVarsList_.setVisible(true);
-         }
-         else
-         {
-            String label = StringUtil.join(selectedEnvVars_, ", ");
-            envVarsList_.setText(label);
-            envVarsList_.setVisible(true);
-         }
+         String label = StringUtil.join(selectedEnvVars_, ", ");
+         envVarsList_.setText(label);
+         envVarsList_.setTitle(label);
+         envVarsList_.setVisible(true);
       }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
@@ -135,7 +135,7 @@
      </rw:customCell>
    </rw:row>
    </rw:LayoutGrid>
-   <g:Label styleName="{res.style.envVarsLabel}" ui:field="envVarsLabel_" visible="true">
-   </g:Label>
+   <g:Label styleName="{res.style.envVarsLabel}" ui:field="envVarsLabel_" visible="true"/>
+   <g:Label styleName="{res.style.envVarsList}" ui:field="envVarsList_" visible="true"/>
    </g:HTMLPanel>
 </ui:UiBinder> 

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -136,6 +136,7 @@ import org.rstudio.studio.client.rsconnect.model.RSConnectAppName;
 import org.rstudio.studio.client.rsconnect.model.RSConnectApplicationInfo;
 import org.rstudio.studio.client.rsconnect.model.RSConnectApplicationResult;
 import org.rstudio.studio.client.rsconnect.model.RSConnectAuthUser;
+import org.rstudio.studio.client.rsconnect.model.RSConnectDeploymentEnvVars;
 import org.rstudio.studio.client.rsconnect.model.RSConnectDeploymentFiles;
 import org.rstudio.studio.client.rsconnect.model.RSConnectDeploymentRecord;
 import org.rstudio.studio.client.rsconnect.model.RSConnectLintResults;
@@ -5648,7 +5649,7 @@ public class RemoteServer implements Server
    }
    
    @Override
-   public void getDeploymentEnvVars(ServerRequestCallback<JsArrayString> resultCallback)
+   public void getDeploymentEnvVars(ServerRequestCallback<RSConnectDeploymentEnvVars> resultCallback)
    {
       sendRequest(RPC_SCOPE, "get_deployment_env_vars", resultCallback);
    }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/7155.

### Approach

- During deployment, automatically select and upload the DATABRICKS_HOST and SNOWFLAKE_ACCOUNT environment variables if they are set.
- Let this be configured via the `rstudio.deployment.autoselectEnvVars` R option; mainly for internal use if required. We can think of a more publicly-facing configuration if appropriate.
- Amend the publication UI to also display a subset of what environment variables will be published.


<img width="593" height="393" alt="Screenshot 2025-07-31 at 10 06 28 AM" src="https://github.com/user-attachments/assets/2c331fa3-c6e1-4059-a563-42dd1a695005" />


### Automated Tests

N/A

### QA Notes

- Try setting the DATABRICKS_HOST and / or SNOWFLAKE_ACCOUNT environment variables.
- Check that they're automatically selected when publishing an application.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
