### PR TITLE
sync minor SectionChooser.java change from pro back to open-source

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/prefs/SectionChooser.java
+++ b/src/gwt/src/org/rstudio/core/client/prefs/SectionChooser.java
@@ -92,7 +92,9 @@ class SectionChooser extends SimplePanel implements
    {
       DecorativeImage img = new DecorativeImage(icon.getSafeUri());
       nudgeDown(img);
-      img.setSize("29px", "20px");
+      img.setHeight("20px");
+      img.setWidth("29px");
+      img.getElement().getStyle().setProperty("objectFit", "contain");
       Label label = new Label(name, false);
       final ClickableVerticalPanel panel = new ClickableVerticalPanel();
       panel.setHorizontalAlignment(VerticalPanel.ALIGN_LEFT);
@@ -101,6 +103,7 @@ class SectionChooser extends SimplePanel implements
       innerPanel.setHorizontalAlignment(HorizontalPanel.ALIGN_CENTER);
       innerPanel.setVerticalAlignment(HorizontalPanel.ALIGN_MIDDLE);
       innerPanel.add(img);
+
       innerPanel.add(nudgeRightPlus(label));
       panel.add(innerPanel);
       panel.setStyleName(res_.styles().section());


### PR DESCRIPTION
Bring over a change made only on the pro-side to open-source side, getting this file back in sync. The change was made 2 years ago thus has shipped many times in Workbench and Desktop Pro without ending the universe.