### PR TITLE
upgrade to Electron 37.2.5

### DIFF
--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -48,7 +48,7 @@
         "chai": "5.2.0",
         "copy-webpack-plugin": "13.0.0",
         "css-loader": "7.1.2",
-        "electron": "37.2.4",
+        "electron": "37.2.5",
         "electron-mocha": "13.1.0",
         "eslint": "9.27.0",
         "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -3677,9 +3677,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "version": "1.0.30001731",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
+      "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
       "dev": true,
       "funding": [
         {
@@ -4961,9 +4961,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "37.2.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-37.2.4.tgz",
-      "integrity": "sha512-F1WDDvY60TpFwGyW+evNB5q0Em8PamcDTVIKB2NaiaKEbNC2Fabn8Wyxy5g+Anirr1K40eKGjfSJhWEUbI1TOw==",
+      "version": "37.2.5",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.2.5.tgz",
+      "integrity": "sha512-719ZqEp43rj6xDJMICm4CIXl8keFFgvVNO9Ix6OtjNjrh9HtYlP/1WiYeRohnXj06aLyGx5NCzrHbG7j3BxO9w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5042,9 +5042,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.191",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.191.tgz",
-      "integrity": "sha512-xcwe9ELcuxYLUFqZZxL19Z6HVKcvNkIwhbHUz7L3us6u12yR+7uY89dSl570f/IqNthx8dAw3tojG7i4Ni4tDA==",
+      "version": "1.5.194",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.194.tgz",
+      "integrity": "sha512-SdnWJwSUot04UR51I2oPD8kuP2VI37/CADR1OHsFOUzZIvfWJBO6q11k5P/uKNyTT3cdOsnyjkrZ+DDShqYqJA==",
       "dev": true,
       "license": "ISC"
     },
@@ -6019,9 +6019,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "dev": true,
       "funding": [
         {

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -46,7 +46,7 @@
     "chai": "5.2.0",
     "copy-webpack-plugin": "13.0.0",
     "css-loader": "7.1.2",
-    "electron": "37.2.4",
+    "electron": "37.2.5",
     "electron-mocha": "13.1.0",
     "eslint": "9.27.0",
     "fork-ts-checker-webpack-plugin": "9.1.0",

--- a/version/news/NEWS-2025.08.0-cucumberleaf-sunflower
+++ b/version/news/NEWS-2025.08.0-cucumberleaf-sunflower
@@ -107,7 +107,7 @@ After completing the package upgrade, carefully review the backed up files and t
 ### Dependencies
 
 - ([#15935](https://github.com/rstudio/rstudio/issues/15935)): Copilot Language Server 1.352.0
-- ([#15933](https://github.com/rstudio/rstudio/issues/15933)): Electron 37.2.4
+- ([#15933](https://github.com/rstudio/rstudio/issues/15933)): Electron 37.2.5
 - ([#16062](https://github.com/rstudio/rstudio/issues/13924)): GWT 2.12.2
 - ([#15934](https://github.com/rstudio/rstudio/issues/15934)): Quarto 1.7.32
 


### PR DESCRIPTION
### Intent

Upgrade from electron 37.2.4 to 37.2.5:

https://releases.electronjs.org/release/compare/v37.2.4/v37.2.5
