### PR TITLE
Binary regex fix.

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -2111,7 +2111,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       pkgSource <- gsub("/(src|bin)/.*", "", pkgEntry$Repository, perl = TRUE)
       
       # Also remove a potential binary component.
-      pkgSource <- sub("/__[^_]+__/[^/]+/", "", pkgSource)
+      pkgSource <- sub("/__[^_]+__/[^/]+/", "/", pkgSource)
       
       c(
          RemoteType   = "standard",


### PR DESCRIPTION
### Intent

So I think this is at least part of the fix for the repo display issue.

In furtherance of https://github.com/rstudio/rstudio-pro/issues/8802

### Approach

Idea here is to adjust the regex to leave a `/` when it pulls out the `/__linux__/jammy/` section of the url. I think this requires re-installation of the package to fixup the `DESCRIPTION` file.

### Automated Tests

None.

### QA Notes

None.

### Documentation

None.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


