### PR TITLE
Fix GH token acquisition for GH PR checks #8844

### DIFF
--- a/git_hooks/secrets/.secrets.baseline
+++ b/git_hooks/secrets/.secrets.baseline
@@ -223,6 +223,16 @@
         "is_secret": false
       }
     ],
+    "jenkins/utils.groovy": [
+      {
+        "type": "Secret Keyword",
+        "filename": "jenkins/utils.groovy",
+        "hashed_secret": "c267b646441a206d44803d8cb20896c4a166cac2",
+        "is_verified": false,
+        "line_number": 405,
+        "is_secret": false
+      }
+    ],
     "src/cpp/core/Base64.cpp": [
       {
         "type": "Base64 High Entropy String",
@@ -625,5 +635,5 @@
       }
     ]
   },
-  "generated_at": "2025-07-25T16:45:08Z"
+  "generated_at": "2025-08-08T20:33:31Z"
 }


### PR DESCRIPTION
Tries to address some of the authentication errors we are seeing on long-running jenkins jobs by acquiring the GH token every time we push a check. I don't think the retry logic was correctly updating the global GITHUB_LOGIN environment variable before. This approach is more straightforward.