### PR TITLE
Add note about legacy homepage deprecation

### DIFF
--- a/version/news/NEWS-2025.08.0-cucumberleaf-sunflower.md
+++ b/version/news/NEWS-2025.08.0-cucumberleaf-sunflower.md
@@ -43,6 +43,7 @@
 - (rstudio-pro#8504): Displays Positron version information in Positron Pro session output
 - (vscode-server#202): Adds GitHub Device Login url as a default trusted domain for VS Code and Positron Pro sessions
 - (rstudio-pro#6867): Image selection in the launcher dialog has been enhanced to more clearly display and classify various images to the user
+- (rstudio-pro#8776): Add a switch in both Workbench homepages to switch to either the new or legacy versions, remember user choice locally (see deprecation notice)
 
 ### Fixed
 

--- a/version/news/NEWS-2025.08.0-cucumberleaf-sunflower.md
+++ b/version/news/NEWS-2025.08.0-cucumberleaf-sunflower.md
@@ -118,3 +118,4 @@ After completing the package upgrade, carefully review the backed up files and t
 - ([#16104](https://github.com/rstudio/rstudio/issues/16104)): Removed the "Limit visible console output" feature
 - (rstudio-pro#8257): Removed publishing to Posit Cloud
 - ([#16233](https://github.com/rstudio/rstudio/issues/16233)): Removed the "Send automated crash reports" feature from RStudio Desktop
+- (rstudio-pro#8776): With the release of the new Workbench homepage, the legacy Workbench homepage is now considered deprecated and will be removed in a later release


### PR DESCRIPTION
NEWS PR regarding the deprecation of the legacy Workbench homepage.