### PR TITLE
avoid value sharing in JSON move

### DIFF
--- a/src/cpp/shared_core/json/Json.cpp
+++ b/src/cpp/shared_core/json/Json.cpp
@@ -847,11 +847,7 @@ void Value::writeFormatted(std::ostream& os) const
 
 void Value::move(Value&& in_other)
 {
-   // rapidjson copy is a move operation
-   // only move the underlying value (and none of the document members)
-   // because we do not want to move the allocators (as they are the same and rapidjson cannot
-   // handle this)
-   static_cast<JsonValue&>(*m_impl->Document) = static_cast<JsonValue&>(*in_other.m_impl->Document);
+   m_impl->Document->Swap(in_other.m_impl->Document->Move());
 }
 
 // Object Member =======================================================================================================

--- a/src/cpp/shared_core/json/JsonTests.cpp
+++ b/src/cpp/shared_core/json/JsonTests.cpp
@@ -1081,6 +1081,21 @@ TEST_CASE("Json")
       CHECK((json::readObject(obj, "intArr", badIntSet) && badIntSet.empty()));
       CHECK((json::readObject(obj, "intArr", badOptIntSet) && !!(badOptIntSet == boost::none)));
    }
+
+   SECTION("Objects and shared values")
+   {
+      json::Object object;
+      object["apple"] = "apple";
+      object["banana"] = "banana";
+      {
+         object["apple"] = object["banana"];
+         CHECK(object["apple"].isString());
+         CHECK(object["banana"].isString());
+         object["apple"] = object["banana"];
+         CHECK(object["apple"].isString());
+         CHECK(object["banana"].isString());
+      }
+   }
 }
 
 } // end namespace tests


### PR DESCRIPTION
### Intent

Addresses root cause of https://github.com/rstudio/rstudio-pro/issues/8918.

### Approach

The previous move implementation was effectively causing two objects to share the underlying JSON document. When one of those objects went out-of-scope, it would destruct its shared document, thereby leading to the assigned-to document unexpectedly now having a null value.

### Automated Tests

Included in PR.

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
