### PR TITLE
fix misused condition variable

### DIFF
--- a/src/cpp/core/include/core/Thread.hpp
+++ b/src/cpp/core/include/core/Thread.hpp
@@ -275,8 +275,11 @@ public:
       }
       else if (waitDuration.is_not_a_date_time())
       {
-         pWaitCondition_->wait(lock);
-         
+         while (queue_.empty()) 
+         {
+            pWaitCondition_->wait(lock);
+         }
+
          // We are locked when wait returns
          *pVal = queue_.front();
          queue_.pop();
@@ -287,10 +290,13 @@ public:
       {
          boost::system_time timeoutTime = boost::get_system_time() + waitDuration;
 
-         bool notified = false;
+         bool notified = true;
          try
          {
-             notified = pWaitCondition_->timed_wait(lock, timeoutTime);
+            while (queue_.empty())
+            {
+               notified = pWaitCondition_->timed_wait(lock, timeoutTime);
+            }
          }
          catch(const boost::thread_resource_error& e)
          {

--- a/src/cpp/core/include/core/Thread.hpp
+++ b/src/cpp/core/include/core/Thread.hpp
@@ -276,9 +276,7 @@ public:
       else if (waitDuration.is_not_a_date_time())
       {
          while (queue_.empty()) 
-         {
             pWaitCondition_->wait(lock);
-         }
 
          // We are locked when wait returns
          *pVal = queue_.front();

--- a/src/cpp/core/include/core/Thread.hpp
+++ b/src/cpp/core/include/core/Thread.hpp
@@ -294,9 +294,7 @@ public:
          try
          {
             while (queue_.empty())
-            {
                notified = pWaitCondition_->timed_wait(lock, timeoutTime);
-            }
          }
          catch(const boost::thread_resource_error& e)
          {


### PR DESCRIPTION
Intent
Addresses: https://github.com/rstudio/rstudio-pro/issues/8922

Approach
The condition variable ensures the mutex is locked, but when it is separated out into its own method, the mutex unlocks letting someone else grab the connection.