### PR TITLE
8933 bugfix regression with file pane refreshing on file changes

### DIFF
--- a/src/cpp/core/include/core/Thread.hpp
+++ b/src/cpp/core/include/core/Thread.hpp
@@ -301,7 +301,14 @@ public:
          try
          {
             while (queue_.empty())
+            {
                notified = pWaitCondition_->timed_wait(lock, timeoutTime);
+               if (!notified)
+               {
+                  // Timed out
+                  return false;
+               }
+            }
          }
          catch(const boost::thread_resource_error& e)
          {
@@ -310,14 +317,11 @@ public:
             return false;
          }
 
-         if (notified)
-         {
-            // We are locked when wait returns and we are notified
-            *pVal = queue_.front();
-            queue_.pop();
-         }
+         // We are locked when wait returns and we are notified
+         *pVal = queue_.front();
+         queue_.pop();
 
-         return notified;
+         return true;
       }
    }
 

--- a/src/cpp/core/include/core/Thread.hpp
+++ b/src/cpp/core/include/core/Thread.hpp
@@ -297,16 +297,20 @@ public:
       {
          boost::system_time timeoutTime = boost::get_system_time() + waitDuration;
 
-         bool notified = true;
          try
          {
+            // Handle spurious wakeups by looping
             while (queue_.empty())
             {
-               notified = pWaitCondition_->timed_wait(lock, timeoutTime);
-               if (!notified)
+               boost::system_time now = boost::get_system_time();
+               if (now >= timeoutTime)
                {
-                  // Timed out
-                  return false;
+                  return false; // Already timed out
+               }
+
+               if( !pWaitCondition_->timed_wait(lock, timeoutTime))
+               {
+                  return false; // Timed out
                }
             }
          }


### PR DESCRIPTION
### Intent

Changes to threadsafequeue had caused a regression with the file pane refreshing on file changes

### Approach

Found that we did not return properly from timed out dequeue, so return on timeout added

### Automated Tests

NA

### QA Notes

NA

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->