### PR TITLE
only annotate error output when we know an error has occurred

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 #### RStudio
 - ([#16320](https://github.com/rstudio/rstudio/issues/16320)): Fixed message shown when ssh keyphrases don't match
 - ([#16331](https://github.com/rstudio/rstudio/issues/16331)): RStudio no longer removes previously-registered global calling handlers on startup
+- ([#16337](https://github.com/rstudio/rstudio/issues/16337)): Fixed an issue where R error output was not displayed in rare cases
 
 #### Posit Workbench
 - (#rstudio-pro/8919): Fixed an issue where duplicate project entries within a user's recent project list could cause their home page to fail to load

--- a/src/cpp/session/SessionClientEventQueue.cpp
+++ b/src/cpp/session/SessionClientEventQueue.cpp
@@ -198,10 +198,6 @@ void ClientEventQueue::annotateOutput(int event,
       {
          annotateError(pOutput, true);
       }
-      else
-      {
-         annotateError(pOutput, false);
-      }
    }
 
    if (isWarningAnnotationEnabled())

--- a/src/cpp/session/SessionConsoleOutput.cpp
+++ b/src/cpp/session/SessionConsoleOutput.cpp
@@ -100,15 +100,6 @@ void onConsoleOutput(module_context::ConsoleOutputType type,
 {
    if (s_pendingOutputType == PendingOutputTypeUnknown)
    {
-      // Detect error output.
-      if (s_isErrorAnnotationEnabled)
-      {
-         if (boost::regex_search(output, s_reErrorPrefix))
-         {
-            setPendingOutputType(PendingOutputTypeError);
-         }
-      }
-
       // When 'options(warn = 0)' is set, warning output will be printed
       // if any uncaught warnings were emitted during code execution.
       if (s_isWarningAnnotationEnabled)

--- a/src/cpp/tests/automation/testthat/test-automation-console.R
+++ b/src/cpp/tests/automation/testthat/test-automation-console.R
@@ -210,3 +210,25 @@ withr::defer(.rs.automation.deleteRemote())
    })
    
 })
+
+# https://github.com/rstudio/rstudio/issues/16337
+.rs.test("error output is not lost following caught error", {
+   
+   code <- quote({
+      foo <- function() {
+         writeLines("Some output.")
+         try(stop("try(silent = FALSE)"), silent = FALSE)
+         writeLines("Some more output.")
+         stop("Error.")
+      }
+   })
+   
+   remote$editor.openWithContents(".R", deparse(code))
+   remote$commands.execute(.rs.appCommands$sourceActiveDocument)
+   remote$console.executeExpr(foo())
+   
+   output <- remote$console.getOutput()
+   expect_true("Some output." %in% output)
+   expect_true("Some more output." %in% output)
+   
+})

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -58,6 +58,7 @@ import com.google.gwt.core.client.Scheduler.RepeatingCommand;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.dom.client.Node;
 import com.google.gwt.dom.client.SpanElement;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.BlurEvent;
@@ -495,14 +496,18 @@ public class ShellWidget extends Composite implements ShellDisplay,
       {
          Element errorEl = errorEls.get(n - i - 1);
          Element parentEl = errorEl.getParentElement();
-         for (Element el = parentEl.getParentElement().getFirstChildElement();
-              el != null;
-              el = el.getNextSiblingElement())
+         for (Node node = parentEl.getParentElement().getLastChild();
+              node != null;
+              node = node.getPreviousSibling())
          {
-            if (el.hasClassName(VirtualConsole.RES.styles().groupError()))
+            if (Element.is(node))
             {
-               el.getParentElement().replaceChild(widgetEl, el);
-               return;
+               Element el = Element.as(node);
+               if (el.hasClassName(VirtualConsole.RES.styles().groupError()))
+               {
+                  el.getParentElement().replaceChild(widgetEl, el);
+                  return;
+               }
             }
          }
       }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16337.

### Approach

Previously, we tried to annotate error output in all kinds of output, even if an error hadn't already been signaled by R. This PR pulls that behavior back, so that we only highlight error output when an uncaught R error has occurred.

### Automated Tests

Included in PR.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/16337.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
