### PR TITLE
let dirty flag be 'sticky' across background saves

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 - ([#16331](https://github.com/rstudio/rstudio/issues/16331)): RStudio no longer removes previously-registered global calling handlers on startup
 - ([#13470](https://github.com/rstudio/rstudio/issues/13470)): Avoid printing positioning data when creating patchwork objects in R Markdown chunks
 - ([#16337](https://github.com/rstudio/rstudio/issues/16337)): Fixed an issue where R error output was not displayed in rare cases
+- ([#15963](https://github.com/rstudio/rstudio/issues/15963)): Fixed an issue where an unsaved R Markdown document could erroneously be marked as saved after executing a chunk
 
 #### Posit Workbench
 - (#rstudio-pro/8919): Fixed an issue where duplicate project entries within a user's recent project list could cause their home page to fail to load

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -507,8 +507,8 @@ Error saveDocumentCore(const std::string& contents,
       // note that document saves are also invoked to only update document
       // properties, not necessarily document contents, so we let the dirty
       // flag be 'sticky' across sequential autosave invocations.
-      bool dirty = contents != pDoc->contents();
-      pDoc->setDirty(pDoc->dirty() || dirty);
+      bool hasChanges = contents != pDoc->contents();
+      pDoc->setDirty(pDoc->dirty() || hasChanges);
    }
 
    // always update the contents so it holds the original UTF-8 data

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -389,6 +389,8 @@ Error saveDocumentCore(const std::string& contents,
                        boost::shared_ptr<SourceDocument> pDoc,
                        bool retryWrite)
 {
+   Error error;
+
    // check whether we have a path and if we do get/resolve its value
    std::string oldPath, path;
    FilePath fullDocPath;
@@ -400,18 +402,11 @@ Error saveDocumentCore(const std::string& contents,
       fullDocPath = module_context::resolveAliasedPath(path);
    }
 
-   // update dirty state: dirty if there was no path AND the new contents
-   // are different from the old contents (and was thus a content autosave
-   // as distinct from a fold-spec or scroll-position/selection autosave)
-   pDoc->setDirty(!hasPath && (contents != pDoc->contents()));
-   
    bool hasType = json::isType<std::string>(jsonType);
    if (hasType)
    {
       pDoc->setType(jsonType.getString());
    }
-   
-   Error error;
    
    bool hasEncoding = json::isType<std::string>(jsonEncoding);
    if (hasEncoding)
@@ -481,6 +476,9 @@ Error saveDocumentCore(const std::string& contents,
       if (error)
          return error;
 
+      // we've successfully saved and updated the document; update its dirty state
+      pDoc->setDirty(false);
+
       // enque file changed event if we need to
       if (!module_context::isDirectoryMonitored(fullDocPath.getParent()))
       {
@@ -502,6 +500,15 @@ Error saveDocumentCore(const std::string& contents,
       {
          source_database::events().onDocRenamed(oldPath, pDoc);
       }
+   }
+   else
+   {
+      // if an autosave has been performed, then update the dirty flag.
+      // note that document saves are also invoked to only update document
+      // properties, not necessarily document contents, so we let the dirty
+      // flag be 'sticky' across sequential autosave invocations.
+      bool dirty = contents != pDoc->contents();
+      pDoc->setDirty(pDoc->dirty() || dirty);
    }
 
    // always update the contents so it holds the original UTF-8 data


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/15963.

### Approach

Allow the dirty flag on a document to be 'sticky' across background saves.

Note that a background save might be triggered not by changes in the in-editor buffer, but instead by changes in document properties -- for example, the chunk outputs associated with an R Markdown document. In this scenario, the save might be performed with no document changes, but this does not imply that the document on-disk will now be in-sync with our source database.

With this change, once a document is 'dirty', it will remain dirty until the user explicitly saves the document, which would tell RStudio to write the document's contents out to disk. This will cause us to incorrectly consider a document as 'dirty' after e.g. inserting a character, waiting for autosave, deleting a character, and then waiting for autosave again, but this seems better than the alternative.

This PR also changes some of the sequencing around when a document's dirty state is changed. In particular, we now only mark a document as "clean" following a successful save, whereas previously we were marking a document's dirty flag prior to the (successful or failed) save attempt.

### Automated Tests

TODO

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/15963.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
