### PR TITLE
8937-pro adds a oneshot command that can be scheduled with asyncserver

### DIFF
--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -40,6 +40,7 @@ set(CORE_SOURCE_FILES
    HtmlUtils.cpp
    Log.cpp
    LogOptions.cpp
+   OneShotCommand.cpp
    PerformanceTimer.cpp
    ProgramOptions.cpp
    RegexUtils.cpp

--- a/src/cpp/core/OneShotCommand.cpp
+++ b/src/cpp/core/OneShotCommand.cpp
@@ -1,0 +1,48 @@
+/*
+ * OneShotCommand.cpp
+ *
+ * Copyright (C) 2025 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+#include <core/OneShotCommand.hpp>
+
+
+namespace rstudio {
+namespace core {
+
+
+OneShotCommand::OneShotCommand(const boost::function<bool()>& execute,
+                  const boost::posix_time::time_duration& waitFor)
+   : ScheduledCommand(execute),
+   waitFor_(waitFor)
+{
+   if (waitFor == boost::posix_time::not_a_date_time)
+      executionTime_ = now();
+   else
+      executionTime_ = now() + waitFor_;
+}
+
+void OneShotCommand::execute()
+{
+   if (now() > executionTime_)
+   {
+      execute_();
+      finished_ = true;
+   }
+}
+
+boost::posix_time::time_duration OneShotCommand::period()
+{
+   return waitFor_;
+}
+
+} // namespace core
+} // namespace rstudio

--- a/src/cpp/core/include/core/IncrementalCommand.hpp
+++ b/src/cpp/core/include/core/IncrementalCommand.hpp
@@ -26,6 +26,9 @@ namespace core {
 class IncrementalCommand : public ScheduledCommand
 {
 public:
+   /*
+   * @param execute - function should return true if it has more work to do or false to indicate all work is completed
+   */
    IncrementalCommand(
          const boost::posix_time::time_duration& incrementalDuration,
          const boost::function<bool()>& execute)

--- a/src/cpp/core/include/core/OneShotCommand.hpp
+++ b/src/cpp/core/include/core/OneShotCommand.hpp
@@ -1,0 +1,47 @@
+/*
+ * OneShotCommand.hpp
+ *
+ * Copyright (C) 2025 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+#ifndef CORE_ONESHOT_COMMAND_HPP
+#define CORE_ONESHOT_COMMAND_HPP
+
+#include <core/ScheduledCommand.hpp>
+
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/utility.hpp>
+
+namespace rstudio {
+namespace core {
+
+class OneShotCommand : public ScheduledCommand
+{
+public:
+
+   OneShotCommand(const boost::function<bool()>& execute,
+                  const boost::posix_time::time_duration& waitFor);
+
+   ~OneShotCommand() override = default;
+
+public:
+   void execute() override;
+   virtual boost::posix_time::time_duration period();
+
+protected:
+   const boost::posix_time::time_duration waitFor_;
+   boost::posix_time::ptime executionTime_;
+};
+
+} // namespace core
+} // namespace rstudio
+
+#endif // CORE_ONESHOT_COMMAND_HPP

--- a/src/cpp/core/include/core/PeriodicCommand.hpp
+++ b/src/cpp/core/include/core/PeriodicCommand.hpp
@@ -25,6 +25,9 @@ namespace core {
 class PeriodicCommand : public ScheduledCommand
 {
 public:
+   /*
+   * @param execute - function should return true if it has more work to do or false to indicate all work is completed
+   */
    PeriodicCommand(const boost::posix_time::time_duration& period,
                    const boost::function<bool()>& execute,
                    bool immediate = true)

--- a/src/cpp/core/include/core/ScheduledCommand.hpp
+++ b/src/cpp/core/include/core/ScheduledCommand.hpp
@@ -25,9 +25,10 @@
 namespace rstudio {
 namespace core {
 
-// NOTE: execute function should return true if it has more work to do
-// or false to indicate all work is completed
-
+/*
+* @brief Command that can be queued to run fom the async server
+* @details See child classes for scheduling options
+*/
 class ScheduledCommand : boost::noncopyable
 {
 public:


### PR DESCRIPTION
### Intent

Open source implementation for pro 8937

### Approach

Adds a one shot command that can be scheduled with the asyncserver


### Automated Tests

NA

### QA Notes

See ticket

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->