### PR TITLE
upload debug symbols to S3

### DIFF
--- a/dependencies/tools/rstudio-tools.sh
+++ b/dependencies/tools/rstudio-tools.sh
@@ -54,6 +54,18 @@ export MACOSX_DEPLOYMENT_TARGET="12.0"
 
 # Generic Tools ----
 
+all-defined () {
+	
+	for VAR in "$@"; do
+		if [ -z "${!VAR}" ]; then
+			return 1
+		fi
+	done
+
+	return 0
+
+}
+
 section () {
 	echo -e "\033[1m\033[36m==>\033[39m $*\033[0m"
 }

--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -310,12 +310,6 @@ fi
 # For Jenkins builds, upload debug symbols to S3.
 upload-debug-symbols () {
 
-   # Validate that the 'aws' cli is available
-   if ! command -v aws 2> /dev/null; then
-      echo "-- skipping debug symbol upload; aws cli is not available"
-      return 0
-   fi
-
    # Validate that the requisite environment variables are defined.
    if ! all-defined JENKINS_URL PRODUCT OS ARCH; then
       echo "-- skipping debug symbol upload; non-production build"
@@ -326,6 +320,15 @@ upload-debug-symbols () {
    if [[ "${WORKSPACE}" =~ "pull-requests" ]]; then
       echo "-- skipping debug symbol upload; build triggered via pull request"
       return 0
+   fi
+
+   # Validate that the 'aws' cli is available
+   if ! command -v aws 2> /dev/null; then
+      pushd "$(mktemp -d)"
+      curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
+      unzip awscliv2.zip
+      ./aws/install -i ~/aws-cli -b ~/aws-cli/bin
+      popd
    fi
 
    # Preflight checks passed; upload debug symbols.

--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -307,5 +307,12 @@ if [ "${RSTUDIO_BUILD_PACKAGE:-1}" = "1" ]; then
    cpack --verbose --debug -G "$PACKAGE_TARGET"
 fi
 
+# For Jenkins builds, upload debug symbols to S3
+if [ -n "${JENKINS_URL}" ]; then
+   "${PKG_DIR}/scripts/upload-debug-symbols" \
+      "${RSTUDIO_VERSION_FULL}"              \
+      "${BUILD_DIR}"
+fi
+
 cd "$PREV_WD"
 

--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -310,15 +310,23 @@ fi
 # For Jenkins builds, upload debug symbols to S3.
 upload-debug-symbols () {
 
+   # Validate that the 'aws' cli is available
+   if ! command -v aws 2> /dev/null; then
+      echo "-- aws cli is not available; debug symbols will not be uploaded"
+      return 1
+   fi
+
    # Validate that the requisite environment variables are defined.
    if ! all-defined JENKINS_URL PRODUCT OS ARCH; then
+      echo "-- skipping debug symbol upload for non-production build"
       return 1
    fi
 
    # Don't upload debug symbols for builds triggered by pull requests.
-   case "${WORKSPACE}" in
-   *pull-requests*) return 1 ;;
-   esac
+   if [[ "${WORKSPACE}" =~ "pull-requests" ]]; then
+      echo "-- skipping debug symbol upload; build triggered via pull request"
+      return 1
+   fi
 
    # Preflight checks passed; upload debug symbols.
    "${PKG_DIR}/scripts/upload-debug-symbols" \

--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -307,11 +307,16 @@ if [ "${RSTUDIO_BUILD_PACKAGE:-1}" = "1" ]; then
    cpack --verbose --debug -G "$PACKAGE_TARGET"
 fi
 
-# For Jenkins builds, upload debug symbols to S3
-if [ -n "${JENKINS_URL}" ]; then
+# For Jenkins builds, upload debug symbols to S3.
+# It's expected that PRODUCT, OS, and ARCH are set
+# by the Jenkins job executing this script.
+if all-defined JENKINS_URL PRODUCT OS ARCH; then
    "${PKG_DIR}/scripts/upload-debug-symbols" \
-      "${RSTUDIO_VERSION_FULL}"              \
-      "${BUILD_DIR}"
+      "${BUILD_DIR}" \
+      "${PRODUCT}" \
+      "${OS}" \
+      "${ARCH}" \
+      "${RSTUDIO_VERSION_FULL}"
 fi
 
 cd "$PREV_WD"

--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -308,16 +308,29 @@ if [ "${RSTUDIO_BUILD_PACKAGE:-1}" = "1" ]; then
 fi
 
 # For Jenkins builds, upload debug symbols to S3.
-# It's expected that PRODUCT, OS, and ARCH are set
-# by the Jenkins job executing this script.
-if all-defined JENKINS_URL PRODUCT OS ARCH; then
+upload-debug-symbols () {
+
+   # Validate that the requisite environment variables are defined.
+   if ! all-defined JENKINS_URL PRODUCT OS ARCH; then
+      return 1
+   fi
+
+   # Don't upload debug symbols for builds triggered by pull requests.
+   case "${WORKSPACE}" in
+   *pull-requests*) return 1 ;;
+   esac
+
+   # Preflight checks passed; upload debug symbols.
    "${PKG_DIR}/scripts/upload-debug-symbols" \
       "${BUILD_DIR}" \
       "${PRODUCT}" \
       "${OS}" \
       "${ARCH}" \
       "${RSTUDIO_VERSION_FULL}"
-fi
+
+}
+
+upload-debug-symbols
 
 cd "$PREV_WD"
 

--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -312,13 +312,13 @@ upload-debug-symbols () {
 
    # Validate that the 'aws' cli is available
    if ! command -v aws 2> /dev/null; then
-      echo "-- aws cli is not available; debug symbols will not be uploaded"
+      echo "-- skipping debug symbol upload; aws cli is not available"
       return 1
    fi
 
    # Validate that the requisite environment variables are defined.
    if ! all-defined JENKINS_URL PRODUCT OS ARCH; then
-      echo "-- skipping debug symbol upload for non-production build"
+      echo "-- skipping debug symbol upload; non-production build"
       return 1
    fi
 

--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -313,19 +313,19 @@ upload-debug-symbols () {
    # Validate that the 'aws' cli is available
    if ! command -v aws 2> /dev/null; then
       echo "-- skipping debug symbol upload; aws cli is not available"
-      return 1
+      return 0
    fi
 
    # Validate that the requisite environment variables are defined.
    if ! all-defined JENKINS_URL PRODUCT OS ARCH; then
       echo "-- skipping debug symbol upload; non-production build"
-      return 1
+      return 0
    fi
 
    # Don't upload debug symbols for builds triggered by pull requests.
    if [[ "${WORKSPACE}" =~ "pull-requests" ]]; then
       echo "-- skipping debug symbol upload; build triggered via pull request"
-      return 1
+      return 0
    fi
 
    # Preflight checks passed; upload debug symbols.

--- a/package/linux/scripts/upload-debug-symbols
+++ b/package/linux/scripts/upload-debug-symbols
@@ -14,8 +14,7 @@
 # AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
 #
 
-# TODO: Find a more appropriate bucket?
-AWS_BUCKET="s3://rstudio-buildtools"
+AWS_BUCKET="s3://rstudio-dbgsym"
 
 usage () {
 

--- a/package/linux/scripts/upload-debug-symbols
+++ b/package/linux/scripts/upload-debug-symbols
@@ -33,21 +33,16 @@ if [ "$1" = "" ] || [ "$1" = "--help" ]; then
 fi
 
 # TODO: Find a more appropriate bucket?
-AWS_BUCKET="s3://rstudio-buildtools"
+AWS_BUCKET="s3://rstudio-buildtools/debug-symbols"
 
 RSTUDIO_VERSION="$1"
 BUILD_DIRECTORY="$2"
-
-case "$(uname)" in
-	Darwin) suffix="dSYM" ;;
-	Linux)  suffix="debug" ;;
-esac
 
 # Find debug symbols in the build directory provided
 cd "${BUILD_DIRECTORY}"
 while IFS= read -r -d '' sym; do
 	src="${sym}"
-	tgt="${AWS_BUCKET}/debug-symbols/${RSTUDIO_VERSION}/$(basename "${sym}")"
+	tgt="${AWS_BUCKET}/${RSTUDIO_VERSION}/$(basename "${sym}")"
 	aws s3 cp --recursive "${src}" "${tgt}"
-done < <(find . -name "*.${suffix}" -print0)
+done < <(find . -name "*.debug" -print0)
 

--- a/package/linux/scripts/upload-debug-symbols
+++ b/package/linux/scripts/upload-debug-symbols
@@ -14,15 +14,18 @@
 # AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
 #
 
+# TODO: Find a more appropriate bucket?
+AWS_BUCKET="s3://rstudio-buildtools"
+
 usage () {
 
 	cat <<- EOF
 
-	Usage: $0 [rstudio-version] [build-directory]
+	Usage: $0 [build-directory] [product] [os] [arch] [version]
 
 	Automatically discover all debug symbols within a particular
 	build directory, and then upload those symbols to AWS S3.
-	
+
 	EOF
 
 }
@@ -32,17 +35,22 @@ if [ "$1" = "" ] || [ "$1" = "--help" ]; then
 	exit 1
 fi
 
-# TODO: Find a more appropriate bucket?
-AWS_BUCKET="s3://rstudio-buildtools/debug-symbols"
+# Read params into named variables
+builddir="$1"
+product="$2"
+os="$3"
+arch="$4"
+version="$5"
 
-RSTUDIO_VERSION="$1"
-BUILD_DIRECTORY="$2"
+
+# Construct the folder to use for hosting these debug symbols.
+aws_folder="${AWS_BUCKET}/${version}/${product}/${os}/${arch}"
 
 # Find debug symbols in the build directory provided
-cd "${BUILD_DIRECTORY}"
+cd "${builddir}"
 while IFS= read -r -d '' sym; do
 	src="${sym}"
-	tgt="${AWS_BUCKET}/${RSTUDIO_VERSION}/$(basename "${sym}")"
-	aws s3 cp --recursive "${src}" "${tgt}"
+	tgt="${aws_folder}/$(basename "${sym}")"
+	aws s3 cp "${src}" "${tgt}"
 done < <(find . -name "*.debug" -print0)
 

--- a/package/linux/scripts/upload-debug-symbols
+++ b/package/linux/scripts/upload-debug-symbols
@@ -44,7 +44,7 @@ version="$5"
 
 
 # Construct the folder to use for hosting these debug symbols.
-aws_folder="${AWS_BUCKET}/${version}/${product}/${os}/${arch}"
+aws_folder="${AWS_BUCKET}/${version}/${product}-${os}-${arch}"
 
 # Find debug symbols in the build directory provided
 cd "${builddir}"

--- a/package/linux/scripts/upload-debug-symbols
+++ b/package/linux/scripts/upload-debug-symbols
@@ -42,6 +42,13 @@ arch="$4"
 version="$5"
 
 
+# Find the aws command-line tool
+PATH="$HOME/aws-cli/bin;$PATH"
+if ! command -v aws 2> /dev/null; then
+	echo ERROR: aws-cli is not available
+	exit 1
+fi
+
 # Construct the folder to use for hosting these debug symbols.
 aws_folder="${AWS_BUCKET}/${version}/${product}-${os}-${arch}"
 

--- a/scripts/upload-debug-symbols
+++ b/scripts/upload-debug-symbols
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+#
+# upload-debug-symbols
+#
+# Copyright (C) 2025 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+
+usage () {
+
+	cat <<- EOF
+
+	Usage: $0 [rstudio-version] [build-directory]
+
+	Automatically discover all debug symbols within a particular
+	build directory, and then upload those symbols to AWS S3.
+	
+	EOF
+
+}
+
+if [ "$1" = "" ] || [ "$1" = "--help" ]; then
+	usage
+	exit 1
+fi
+
+# TODO: Find a more appropriate bucket?
+AWS_BUCKET="s3://rstudio-buildtools"
+
+RSTUDIO_VERSION="$1"
+BUILD_DIRECTORY="$2"
+
+case "$(uname)" in
+	Darwin) suffix="dSYM" ;;
+	Linux)  suffix="debug" ;;
+esac
+
+# Find debug symbols in the build directory provided
+cd "${BUILD_DIRECTORY}"
+while IFS= read -r -d '' sym; do
+	src="${sym}"
+	tgt="${AWS_BUCKET}/debug-symbols/${RSTUDIO_VERSION}/$(basename "${sym}")"
+	aws s3 cp --recursive "${src}" "${tgt}"
+done < <(find . -name "*.${suffix}" -print0)
+


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/8889.

### Approach

- Create a new script that automatically finds debug symbol files (suffixed with `.debug`) in a build directory, then uploads those to S3.
- Use the various parameter names we get from Jenkins when computing the destination path for uploads.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
