### PR TITLE
bugfix windows build shouldnt be linking pthread for gtests

### DIFF
--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -393,7 +393,6 @@ if (RSTUDIO_UNIT_TESTS_ENABLED)
    target_link_libraries(core_gtests PRIVATE
        rstudio-core
        rstudio-shared-core
-       pthread
        gtest_main
        ${Boost_LIBRARIES}
        ${CORE_SYSTEM_LIBRARIES}


### PR DESCRIPTION
### Intent

Windows build was failing due to recent addition of core gtest linking to pthread

### Approach

Remove linking of phread from the cmake. the ${CORE_SYSTEM_LIBRARIES} should include in its set the ${PTHREAD_LIBRARIES} which should only include pthread for linux OSes 

### Automated Tests

NA

### QA Notes

NA

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->