### PR TITLE
install aws cli; upload compressed archives of debug info

### DIFF
--- a/dependencies/common/install-aws-cli
+++ b/dependencies/common/install-aws-cli
@@ -15,8 +15,6 @@
 #
 #
 
-set -e
-
 source "$(dirname "${BASH_SOURCE[0]}")/../tools/rstudio-tools.sh"
 section "Installing AWS CLI"
 
@@ -55,4 +53,3 @@ Darwin)
 
 esac
 
-popd

--- a/dependencies/common/install-aws-cli
+++ b/dependencies/common/install-aws-cli
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+#
+# install-aws-cli
+#
+# Copyright (C) 2025 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+set -e
+
+source "$(dirname "${BASH_SOURCE[0]}")/../tools/rstudio-tools.sh"
+section "Installing AWS CLI"
+
+AWS_INSTDIR="${RSTUDIO_TOOLS_ROOT}/aws-cli"
+AWS_BINDIR="${AWS_INSTDIR}/bin"
+
+# First, check for aws-cli on the PATH
+AWS=$(command -v aws 2> /dev/null)
+if [ -n "${AWS}" ]; then
+	info "AWS CLI is already installed at ${AWS}"
+	exit 0
+fi
+
+# Next, check for aws-cli in the RStudio tools directory
+if command -v "${AWS_BINDIR}/aws" 2> /dev/null; then
+	info "AWS CLI is already installed at ${AWS_INSTDIR}"
+	exit 0
+fi
+
+sudo-if-necessary-for "${RSTUDIO_TOOLS_ROOT}" "$@"
+pushd "$(mktemp -d)"
+
+case "$(uname)" in
+
+Linux)
+	curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
+	unzip -q awscliv2.zip
+	./aws/install -i "${AWS_INSTDIR}" -b "${AWS_BINDIR}"
+	;;
+
+Darwin)
+	brew install awscli
+	;;
+
+esac
+
+popd

--- a/dependencies/common/install-aws-cli
+++ b/dependencies/common/install-aws-cli
@@ -47,11 +47,11 @@ Linux)
 	unzip -q awscliv2.zip
 	./aws/install -i "${AWS_INSTDIR}" -b "${AWS_BINDIR}"
 	popd
-	;;
+;;
 
 Darwin)
 	brew install awscli
-	;;
+;;
 
 esac
 

--- a/dependencies/common/install-aws-cli
+++ b/dependencies/common/install-aws-cli
@@ -31,20 +31,22 @@ if [ -n "${AWS}" ]; then
 fi
 
 # Next, check for aws-cli in the RStudio tools directory
-if command -v "${AWS_BINDIR}/aws" 2> /dev/null; then
+if command -v "${AWS_BINDIR}/aws" &> /dev/null; then
 	info "AWS CLI is already installed at ${AWS_INSTDIR}"
 	exit 0
 fi
 
-sudo-if-necessary-for "${RSTUDIO_TOOLS_ROOT}" "$@"
-pushd "$(mktemp -d)"
+# The AWS CLI is not installed; install it.
 
 case "$(uname)" in
 
 Linux)
+	sudo-if-necessary-for "${RSTUDIO_TOOLS_ROOT}" "$@"
+	pushd "$(mktemp -d)"
 	curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
 	unzip -q awscliv2.zip
 	./aws/install -i "${AWS_INSTDIR}" -b "${AWS_BINDIR}"
+	popd
 	;;
 
 Darwin)

--- a/dependencies/common/install-common
+++ b/dependencies/common/install-common
@@ -18,6 +18,7 @@
 set -e
 
 ./install-packages "$1"
+./install-aws-cli
 ./install-dictionaries
 ./install-mathjax
 ./install-boost

--- a/dependencies/tools/rstudio-tools.sh
+++ b/dependencies/tools/rstudio-tools.sh
@@ -33,10 +33,6 @@ fi
 export RSTUDIO_TOOLS_ROOT
 
 
-# version of go used for building
-export WORKBENCH_GO_VERSION="1.24.5"
-
-
 # RStudio dependency cache
 export RSTUDIO_BUILDTOOLS="https://rstudio-buildtools.s3.amazonaws.com"
 
@@ -50,6 +46,35 @@ export RSTUDIO_BUILDTOOLS="https://rstudio-buildtools.s3.amazonaws.com"
 # https://cmake.org/cmake/help/latest/envvar/MACOSX_DEPLOYMENT_TARGET.html
 #
 export MACOSX_DEPLOYMENT_TARGET="12.0"
+
+
+# version of node.js used for building
+#
+# When changing node version you must upload the corresponding archives to aws s3; use
+# rstudio/dependencies/tools/upload-node.sh
+#
+# In addition to updating the version here, search the entire repo for other instances of
+# RSTUDIO_NODE_VERSION and update to match.
+export RSTUDIO_NODE_VERSION="22.13.1"
+
+
+# actual directory name of the node installation used
+# mainly relevant for cases like macOS, where we have an -arm64 variant installed
+if [ "$(uname -sm)" = "Darwin arm64" ]; then
+	export RSTUDIO_NODE_DIR="${RSTUDIO_NODE_VERSION}-arm64"
+else
+	export RSTUDIO_NODE_DIR="${RSTUDIO_NODE_VERSION}"
+fi
+
+# version of go used for building
+export WORKBENCH_GO_VERSION="1.24.5"
+
+
+# Initialize ----
+
+# Make sure AWS CLI is available on the PATH
+PATH="${RSTUDIO_TOOLS_ROOT}/aws-cli/bin:${PATH}"
+hash -r
 
 
 # Generic Tools ----
@@ -547,21 +572,3 @@ check_env_vars() {
 	done
 	return $all_set
 }
-
-# version of node.js used for building
-#
-# When changing node version you must upload the corresponding archives to aws s3; use
-# rstudio/dependencies/tools/upload-node.sh
-#
-# In addition to updating the version here, search the entire repo for other instances of
-# RSTUDIO_NODE_VERSION and update to match.
-export RSTUDIO_NODE_VERSION="22.13.1"
-
-
-# actual directory name of the node installation used
-# mainly relevant for cases like macOS, where we have an -arm64 variant installed
-if [ "$(uname -sm)" = "Darwin arm64" ]; then
-	export RSTUDIO_NODE_DIR="${RSTUDIO_NODE_VERSION}-arm64"
-else
-	export RSTUDIO_NODE_DIR="${RSTUDIO_NODE_VERSION}"
-fi

--- a/dependencies/tools/rstudio-tools.sh
+++ b/dependencies/tools/rstudio-tools.sh
@@ -73,8 +73,10 @@ export WORKBENCH_GO_VERSION="1.24.5"
 # Initialize ----
 
 # Make sure AWS CLI is available on the PATH
-PATH="${RSTUDIO_TOOLS_ROOT}/aws-cli/bin:${PATH}"
-hash -r
+if ! command -v aws &> /dev/null; then
+	PATH="${RSTUDIO_TOOLS_ROOT}/aws-cli/bin:${PATH}"
+	hash -r
+fi
 
 
 # Generic Tools ----

--- a/package/linux/scripts/upload-debug-symbols
+++ b/package/linux/scripts/upload-debug-symbols
@@ -44,7 +44,7 @@ version="$5"
 ensure-aws-cli () {
 
 	# Check and see if aws-cli is already on the PATH.
-	if command -v aws 2> /dev/null; then
+	if command -v aws &> /dev/null; then
 		return 0
 	fi
 
@@ -52,7 +52,7 @@ ensure-aws-cli () {
    PATH="${HOME}/aws-cli/bin:${PATH}"
    hash -r
 
-	if command -v aws 2> /dev/null; then
+	if command -v aws &> /dev/null; then
 		return 0
 	fi
 
@@ -65,7 +65,7 @@ ensure-aws-cli () {
 
 	# Check once more for the aws-cli.
 	hash -r
-	command -v aws 2> /dev/null
+	command -v aws &> /dev/null
 
 }
 
@@ -74,15 +74,35 @@ ensure-aws-cli || {
 	exit 1
 }
 
-# Construct the folder to use for hosting these debug symbols.
-aws_folder="${AWS_BUCKET}/${version}/${product}-${os}-${arch}"
-
-# Find debug symbols in the build directory provided
+# Move to build directory
 cd "${builddir}"
+
+# Build path to archive we'll generate
+prefix="${product}-${os}-${arch}"
+tar="$(pwd)/${prefix}.tar"
+
+# Find debug symbols in the build directory provided,
+# and collect them into an archive. 
 while IFS= read -r -d '' symfile; do
-	xz -k "${symfile}"
-	src="${symfile}.xz"
-	tgt="${aws_folder}/$(basename "${sym}").xz"
-	aws s3 cp "${src}" "${tgt}"
+
+	# Move to directory containing the debug info
+	dirname="$(dirname "${symfile}")"
+	pushd "${dirname}"
+
+	# Add it to the archive
+	basename="$(basename "${symfile}")"
+	tar rf "${tar}" "${basename}"
+
+	# Return to original directory
+	popd
+
 done < <(find . -name "*.debug" -print0)
+
+# Compress the archive
+xz "${tar}"
+
+# Upload to S3
+src="${tar}.xz"
+tgt="${AWS_BUCKET}/${version}/${src}"
+aws s3 cp "${src}" "${tgt}"
 

--- a/package/linux/scripts/upload-debug-symbols
+++ b/package/linux/scripts/upload-debug-symbols
@@ -79,9 +79,10 @@ aws_folder="${AWS_BUCKET}/${version}/${product}-${os}-${arch}"
 
 # Find debug symbols in the build directory provided
 cd "${builddir}"
-while IFS= read -r -d '' sym; do
-	src="${sym}"
-	tgt="${aws_folder}/$(basename "${sym}")"
+while IFS= read -r -d '' symfile; do
+	xz -k "${symfile}"
+	src="${symfile}.xz"
+	tgt="${aws_folder}/$(basename "${sym}").xz"
 	aws s3 cp "${src}" "${tgt}"
 done < <(find . -name "*.debug" -print0)
 


### PR DESCRIPTION
- Install the AWS CLI tools in our Docker images, so we can use them from shell scripts for interacting with AWS where required. (It's a lot easier to do this in our shell scripts than in Jenkins.)
- Instead of uploading symbols all separately, collect them into an archive. We can save a lot of space given the large amount of duplication in shared code between different executables.