### PR TITLE
fix dependency scripts

### DIFF
--- a/dependencies/linux/install-dependencies-focal
+++ b/dependencies/linux/install-dependencies-focal
@@ -95,6 +95,7 @@ then
 fi
 
 # common
+cd ../common
 ./install-common focal
 cd ../linux
 

--- a/dependencies/linux/install-dependencies-jammy
+++ b/dependencies/linux/install-dependencies-jammy
@@ -86,6 +86,7 @@ if [ $arch = "amd64" ] ; then
 fi
 
 # common
+cd ../common
 ./install-common jammy
 cd ../linux
 

--- a/dependencies/linux/install-dependencies-noble
+++ b/dependencies/linux/install-dependencies-noble
@@ -85,6 +85,7 @@ if [ $arch = "amd64" ] ; then
 fi
 
 # common
+cd ../common
 ./install-common noble
 cd ../linux
 


### PR DESCRIPTION
### Intent

The debian dependency scripts were broken by https://github.com/rstudio/rstudio/pull/16336.

### Approach

Fix