### PR TITLE
avoid duplicate entries in safe.directory config

### DIFF
--- a/git_hooks/secrets/run-detect-secrets
+++ b/git_hooks/secrets/run-detect-secrets
@@ -36,7 +36,20 @@ then
     exit 1
 fi
 
-git config --global --add safe.directory "$(pwd)"
+add-safe-directory () {
+
+    safe_directory=$(git config --global --get-all safe.directory)
+    for var in ${safe_directory}; do
+        if [ "${var}" = "*" ] || [ "${var}" = "$(pwd)" ]; then
+            return 0
+        fi
+    done
+
+    git config --global --add safe.directory "$(pwd)"
+
+}
+
+add-safe-directory
 
 baseline_file="git_hooks/secrets/.secrets.baseline"
 baseline_file_pattern="${baseline_file}.*"


### PR DESCRIPTION
I noticed today that our git hooks are adding the RStudio directory as a "safe" directory on every git hook invocation, and that these entries are being duplicated. This means you end up with something like:

```
$ git config --get-all safe.directory
/home/kevin/rstudio
/home/kevin/rstudio
/home/kevin/rstudio
/home/kevin/rstudio
/home/kevin/rstudio
/home/kevin/rstudio
/home/kevin/rstudio
/home/kevin/rstudio
```

This PR prevents that from happening.