### PR TITLE
use newer flag variant

### DIFF
--- a/src/node/desktop/src/main/main.ts
+++ b/src/node/desktop/src/main/main.ts
@@ -81,7 +81,7 @@ class RStudioMain {
     }
 
     if (!options.useGpuExclusionList()) {
-      app.commandLine.appendSwitch('ignore-gpu-blacklist');
+      app.commandLine.appendSwitch('ignore-gpu-blocklist');
     }
 
     // read rendering engine, if any


### PR DESCRIPTION
### Intent

Part of https://github.com/rstudio/rstudio-pro/issues/5914.

### Approach

Use newer flag, been in Chromium / Electron for several years.

### QA Notes

This flag is used when "Use GPU exclusion list" is unchecked:

<img width="655" height="661" alt="exclusion-list" src="https://github.com/user-attachments/assets/2dbf3700-2f5e-4f02-8f43-c32be39187dc" />

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


