### PR TITLE
remove the unused setting for automatically submitting crash report

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -331,7 +331,6 @@ namespace prefs {
 #define kLatexShellEscape "latex_shell_escape"
 #define kRestoreProjectRVersion "restore_project_r_version"
 #define kClangVerbose "clang_verbose"
-#define kSubmitCrashReports "submit_crash_reports"
 #define kEnableSplashScreen "enable_splash_screen"
 #define kDefaultRVersion "default_r_version"
 #define kDefaultRVersionVersion "version"
@@ -1637,12 +1636,6 @@ public:
     */
    int clangVerbose();
    core::Error setClangVerbose(int val);
-
-   /**
-    * Whether to automatically submit crash reports to Posit.
-    */
-   bool submitCrashReports();
-   core::Error setSubmitCrashReports(bool val);
 
    /**
     * Whether to show the splash screen when RStudio is starting.

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -1830,15 +1830,6 @@
    clear = function() { .rs.clearUserPref("clang_verbose") }
 )
 
-# Submit crash reports to Posit
-#
-# Whether to automatically submit crash reports to Posit.
-.rs.uiPrefs$submitCrashReports <- list(
-   get = function() { .rs.getUserPref("submit_crash_reports") },
-   set = function(value) { .rs.setUserPref("submit_crash_reports", value) },
-   clear = function() { .rs.clearUserPref("submit_crash_reports") }
-)
-
 # Show splash screen when RStudio is starting
 #
 # Whether to show the splash screen when RStudio is starting.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2572,19 +2572,6 @@ core::Error UserPrefValues::setClangVerbose(int val)
 }
 
 /**
- * Whether to automatically submit crash reports to Posit.
- */
-bool UserPrefValues::submitCrashReports()
-{
-   return readPref<bool>("submit_crash_reports");
-}
-
-core::Error UserPrefValues::setSubmitCrashReports(bool val)
-{
-   return writePref("submit_crash_reports", val);
-}
-
-/**
  * Whether to show the splash screen when RStudio is starting.
  */
 bool UserPrefValues::enableSplashScreen()
@@ -3706,7 +3693,6 @@ std::vector<std::string> UserPrefValues::allKeys()
       kLatexShellEscape,
       kRestoreProjectRVersion,
       kClangVerbose,
-      kSubmitCrashReports,
       kEnableSplashScreen,
       kDefaultRVersion,
       kDataViewerMaxColumns,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1319,12 +1319,6 @@
             "title": "Clang verbosity level (0 - 2)",
             "description": "The verbosity level to use with Clang (0 - 2)"
         },
-        "submit_crash_reports": {
-            "type": "boolean",
-            "default": true,
-            "title": "Submit crash reports to Posit",
-            "description": "Whether to automatically submit crash reports to Posit."
-        },
         "enable_splash_screen": {
             "type": "boolean",
             "default": true,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -2789,18 +2789,6 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * Whether to automatically submit crash reports to Posit.
-    */
-   public PrefValue<Boolean> submitCrashReports()
-   {
-      return bool(
-         "submit_crash_reports",
-         _constants.submitCrashReportsTitle(), 
-         _constants.submitCrashReportsDescription(), 
-         true);
-   }
-
-   /**
     * Whether to show the splash screen when RStudio is starting.
     */
    public PrefValue<Boolean> enableSplashScreen()
@@ -4244,8 +4232,6 @@ public class UserPrefsAccessor extends Prefs
          restoreProjectRVersion().setValue(layer, source.getBool("restore_project_r_version"));
       if (source.hasKey("clang_verbose"))
          clangVerbose().setValue(layer, source.getInteger("clang_verbose"));
-      if (source.hasKey("submit_crash_reports"))
-         submitCrashReports().setValue(layer, source.getBool("submit_crash_reports"));
       if (source.hasKey("enable_splash_screen"))
          enableSplashScreen().setValue(layer, source.getBool("enable_splash_screen"));
       if (source.hasKey("default_r_version"))
@@ -4588,7 +4574,6 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(latexShellEscape());
       prefs.add(restoreProjectRVersion());
       prefs.add(clangVerbose());
-      prefs.add(submitCrashReports());
       prefs.add(enableSplashScreen());
       prefs.add(defaultRVersion());
       prefs.add(dataViewerMaxColumns());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -1648,14 +1648,6 @@ public interface UserPrefsAccessorConstants extends Constants {
    String clangVerboseDescription();
 
    /**
-    * Whether to automatically submit crash reports to Posit.
-    */
-   @DefaultStringValue("Submit crash reports to Posit")
-   String submitCrashReportsTitle();
-   @DefaultStringValue("Whether to automatically submit crash reports to Posit.")
-   String submitCrashReportsDescription();
-
-   /**
     * Whether to show the splash screen when RStudio is starting.
     */
    @DefaultStringValue("Show splash screen when RStudio is starting")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -829,10 +829,6 @@ restoreProjectRVersionDescription = Whether to restore the last version of R use
 clangVerboseTitle = Clang verbosity level (0 - 2)
 clangVerboseDescription = The verbosity level to use with Clang (0 - 2)
 
-# Whether to automatically submit crash reports to Posit.
-submitCrashReportsTitle = Submit crash reports to Posit
-submitCrashReportsDescription = Whether to automatically submit crash reports to Posit.
-
 # Whether to show the splash screen when RStudio is starting.
 enableSplashScreenTitle = Show splash screen when RStudio is starting
 enableSplashScreenDescription = Whether to show the splash screen when RStudio is starting.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
@@ -808,10 +808,6 @@ restoreProjectRVersionDescription= Indiquer ou non, si la dernière version de R
 clangVerboseTitle= Niveau de verbosité de Clang (0 - 2)
 clangVerboseDescription= Le niveau de verbosité à utiliser avec Clang (0 - 2).
 
-# Whether to automatically submit crash reports to Posit.
-submitCrashReportsTitle= Soumettre les rapports d'erreur à Posit
-submitCrashReportsDescription= Si on doit souhaitez soumettre automatiquement les rapports de panne à Posit.
-
 # Whether to show the splash screen when RStudio is starting.
 enableSplashScreenTitle= Afficher l'écran de démarrage lors du lancement de RStudio
 enableSplashScreenDescription= Si on doit afficher l'écran de démarrage lors du lancement de RStudio.


### PR DESCRIPTION
### Intent

Noticed we still have a setting related to crash reporting. It is unused.

Shows up in the command palette:

<img width="950" height="160" alt="screenshot of command palette with results of searching for 'crash'" src="https://github.com/user-attachments/assets/fb38bfea-a409-483b-b8f1-a3bf2bbba5f1" />

### Approach

Remove it

### Automated Tests

NA

### QA Notes

Confirm the "Submit crash reports for Posit" setting no longer shows up in the command palette.

### Documentation

NA