### PR TITLE
strip ANSI codes from warning labels in plots

### DIFF
--- a/src/cpp/session/modules/NotebookConditions.R
+++ b/src/cpp/session/modules/NotebookConditions.R
@@ -21,8 +21,7 @@
    }
    else
    {
-      prefix <- gettext("Warning :", domain = "R")
-      paste0(prefix, paste(conditionMessage(cnd), collapse = "\n"))
+      paste(as.character(cnd), collapse = "\n")
    }
    
    .Call("rs_signalNotebookCondition", 1L, msg, PACKAGE = "(embedding)")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkConditionBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkConditionBar.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.text;
 
+import org.rstudio.core.client.AnsiCode;
 import org.rstudio.core.client.ColorUtil;
 import org.rstudio.core.client.js.JsArrayEx;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkOutputUi;
@@ -69,7 +70,9 @@ public class ChunkConditionBar extends Composite
             continue;
          }
          bar.setVisible(true);
-         Label entry = new Label(conditions.get(i).getString(1));
+
+         String condition = conditions.get(i).getString(1);
+         Label entry = new Label(AnsiCode.strip(condition));
          entry.addStyleName(style.contents());
          contents.add(entry);
       }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16398.

<img width="562" height="273" alt="Screenshot 2025-09-04 at 3 23 12 PM" src="https://github.com/user-attachments/assets/b922062a-9481-4d11-84f0-c0b8a1d41158" />

This PR fixes that.

<img width="996" height="998" alt="image" src="https://github.com/user-attachments/assets/129fbe6f-59ba-4636-8aef-6017d489cdfc" />

### Approach

- Use the existing `as.character()` generic when formatting conditions.
- Strip ANSI codes before label generation.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
