### PR TITLE
enforce consistent ordering when presenting vulns

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageLinkColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageLinkColumn.java
@@ -14,13 +14,13 @@
  */
 package org.rstudio.studio.client.workbench.views.packages.ui;
 
+import java.util.Comparator;
 import java.util.List;
 
 import org.rstudio.core.client.Mutable;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageInfo;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageVulnerabilityTypes.PackageVulnerability;
-import org.rstudio.studio.client.workbench.views.packages.model.PackageVulnerabilityTypes.PackageVulnerabilityList;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageVulnerabilityTypes.PackageVulnerabilityListMap;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageVulnerabilityTypes.RepositoryPackageVulnerabilityListMap;
 
@@ -94,6 +94,15 @@ public abstract class PackageLinkColumn extends Column<PackageInfo, PackageInfo>
 
             String vulnText = "";
             List<PackageVulnerability> pvList = pvlMap.get(name).asList();
+            pvList.sort(new Comparator<PackageVulnerability>() 
+            {
+               @Override
+               public int compare(PackageVulnerability o1, PackageVulnerability o2)
+               {
+                  return o1.id.compareToIgnoreCase(o2.id);
+               }
+            });
+
             for (PackageVulnerability pvItem : pvList)
             {
                if (pvItem.versions.has(version))
@@ -172,7 +181,16 @@ public abstract class PackageLinkColumn extends Column<PackageInfo, PackageInfo>
                if (pvlMap == null || !pvlMap.has(name))
                   return;
 
-               PackageVulnerabilityList pvList = pvlMap.get(name);
+               List<PackageVulnerability> pvList = pvlMap.get(name).asList();
+               pvList.sort(new Comparator<PackageVulnerability>()
+               {
+                  @Override
+                  public int compare(PackageVulnerability o1, PackageVulnerability o2)
+                  {
+                     return o1.id.compareToIgnoreCase(o2.id);
+                  }
+               });
+
                PackageVulnerabilityModalDialog dialog = new PackageVulnerabilityModalDialog(info, pvList);
                dialog.showModal();
             });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageVulnerabilityModalDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageVulnerabilityModalDialog.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.studio.client.workbench.views.packages.ui;
 
+import java.util.List;
+
 import org.rstudio.core.client.widget.ModalDialogBase;
 import org.rstudio.core.client.widget.ThemedButton;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -24,7 +26,6 @@ import org.rstudio.studio.client.workbench.views.packages.model.PackageInfo;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageVulnerabilityTypes.PackageVulnerability;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageVulnerabilityTypes.PackageVulnerabilityEvent;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageVulnerabilityTypes.PackageVulnerabilityEventList;
-import org.rstudio.studio.client.workbench.views.packages.model.PackageVulnerabilityTypes.PackageVulnerabilityList;
 
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
@@ -41,7 +42,7 @@ import com.google.gwt.user.client.ui.Widget;
 public class PackageVulnerabilityModalDialog extends ModalDialogBase
 {
     public PackageVulnerabilityModalDialog(PackageInfo info,
-                                           PackageVulnerabilityList pvList)
+                                           List<PackageVulnerability> pvList)
     {
         super(Roles.getDialogRole());
 
@@ -95,7 +96,7 @@ public class PackageVulnerabilityModalDialog extends ModalDialogBase
             private final EventBus events_ = RStudioGinjector.INSTANCE.getEventBus();
         });
 
-        if (pvList_.getLength() > 1)
+        if (pvList_.size() > 1)
         {
             addLeftButton(prevButton_, "previous");
             addLeftButton(nextButton_, "next");
@@ -108,14 +109,14 @@ public class PackageVulnerabilityModalDialog extends ModalDialogBase
     private void refresh()
     {
         prevButton_.setEnabled(index_ > 0);
-        nextButton_.setEnabled(index_ < pvList_.getLength() - 1);
+        nextButton_.setEnabled(index_ < pvList_.size() - 1);
 
         panel_.getElement().getStyle().setMarginLeft(24, Unit.PX);
         panel_.getElement().getStyle().setMarginRight(24, Unit.PX);
 
         SafeHtmlBuilder sb = new SafeHtmlBuilder();
 
-        PackageVulnerability vuln = pvList_.getAt(index_);
+        PackageVulnerability vuln = pvList_.get(index_);
         sb.append(TEMPLATES.render(vuln.id, vuln.summary, vuln.details));
 
         if (vuln.ranges.getLength() > 0)
@@ -175,7 +176,7 @@ public class PackageVulnerabilityModalDialog extends ModalDialogBase
     }
 
     private final PackageInfo info_;
-    private final PackageVulnerabilityList pvList_;
+    private final List<PackageVulnerability> pvList_;
     private int index_;
 
     private final VerticalPanel container_;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16376.

### Approach

Straight-forward sorting of vulnerability list before display.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
