### PR TITLE
use portable R idiom in test-download.R

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -40,7 +40,7 @@ assign(".rs.platform.isLinux",   Sys.info()[["sysname"]] == "Linux",  envir = .r
 assign(".rs.platform.isMacos",   Sys.info()[["sysname"]] == "Darwin", envir = .rs.Env)
 
 #' Add a function to the 'tools:rstudio' environment.
-#' 
+#'
 #' This environment is placed on the search path, and so is accessible and
 #' readable during regular evaluation in an R session.
 #'
@@ -48,27 +48,27 @@ assign(".rs.platform.isMacos",   Sys.info()[["sysname"]] == "Darwin", envir = .r
 #'   to the supplied function name.
 #'
 #' @param FN The \R function to be added.
-#' 
+#'
 #' @param attrs An optional list of attributes, to be set on the function.
-#' 
+#'
 #' @param envir An optional environment, to be set as the enclosing environment
 #'   for the function `f`. By default, newly-defined functions use the
 #'   'tools:rstudio' environment as the parent function. For functions which
 #'   might be exposed to users (e.g. via options), you may want to instead use
 #'   the base environment to avoid issues with serialization.
 assign(".rs.addFunction", function(name, FN, attrs = list(), envir = .rs.toolsEnv())
-{ 
+{
    # add optional attributes
    for (attrib in names(attrs))
       attr(FN, attrib) <- attrs[[attrib]]
-   
+
    # ensure function evaluates in requested environment
    environment(FN) <- envir
-   
+
    # assign in tools env
    fullName <- paste(".rs.", name, sep = "")
    assign(fullName, FN, envir = .rs.toolsEnv())
-   
+
 }, envir = .rs.Env)
 
 # force helper function to also execute in tools environment
@@ -84,7 +84,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 
 # add a global (non-scoped) function to the tools:rstudio environment
 .rs.addFunction("addGlobalFunction", function(name, FN)
-{ 
+{
    envir <- .rs.toolsEnv()
    environment(FN) <- envir
    assign(name, FN, envir = envir)
@@ -112,11 +112,11 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 })
 
 .rs.addFunction("setVar", function(name, var)
-{ 
+{
    envir <- .rs.toolsEnv()
    if (!is.null(var))
       environment(var) <- envir
-   
+
    fullName <- paste(".rs.", name, sep = "")
    assign(fullName, var, envir = envir)
 })
@@ -126,14 +126,14 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    envir <- .rs.toolsEnv()
    if (!is.null(var))
       environment(var) <- envir
-   
+
    fullName <- paste(".rs.", name, sep = "")
    if (!exists(fullName, envir = envir, inherits = FALSE))
       assign(fullName, var, envir = envir)
 })
 
 .rs.addFunction("clearVar", function(name)
-{ 
+{
    envir <- .rs.toolsEnv()
    fullName <- paste(".rs.", name, sep = "")
    remove(list = fullName, pos = envir)
@@ -158,15 +158,15 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    # get reference to original function definition
    namespace <- getNamespace(package)
    original <- get(binding, envir = namespace)
-   
+
    # update our hook to match definition of original
    environment(hook) <- environment(original)
    formals(hook) <- formals(original)
-   
+
    # replace binding in search path environment
    envir <- as.environment(paste("package", package, sep = ":"))
    .rs.replaceBindingImpl(envir, binding, hook)
-   
+
    # also replace the binding in the package namespace if requested
    if (all)
    {
@@ -201,12 +201,12 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    # if the option is already set, nothing to do
    if (!is.null(getOption(name)))
       return(FALSE)
-   
+
    # otherwise, set it
    data <- list(value)
    names(data) <- name
    options(data)
-   
+
    TRUE
 })
 
@@ -224,22 +224,22 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 .rs.addFunction("restoreGlobalEnvFromFile", function(path)
 {
    Encoding(path) <- "UTF-8"
-   
+
    # avoid path encoding issues by moving to directory first
    if (!file.exists(path))
       return(paste(path, "does not exist"))
-   
+
    owd <- setwd(dirname(path))
    on.exit(setwd(owd), add = TRUE)
-   
+
    status <- try(
       load(basename(path), envir = .GlobalEnv),
       silent = TRUE
    )
-   
+
    if (!inherits(status, "try-error"))
       return("")
-   
+
    # older versions of R don't provide a 'condition' attribute
    # for 'try()' errors
    condition <- attr(status, "condition")
@@ -249,11 +249,11 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       else
          return("Unknown Error")
    }
-   
+
    # has condition, but no message? should not happen
    if (!"message" %in% names(condition))
       return("Unknown Error")
-   
+
    paste(condition$message, collapse = "\n")
 })
 
@@ -262,22 +262,22 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 {
    # get reference to current options
    opt <- options()
-   
+
    # don't attempt to serialize cpp11 preserve env as it may
    # contain recursive R objects which cause crashes when serialized
    #
    # https://github.com/rstudio/rstudio-pro/issues/2052
    opt$cpp11_preserve_env  <- NULL
    opt$cpp11_preserve_xptr <- NULL
-   
+
    # first write to sidecar file, and then rename that file
    # (don't let failed serialization leave behind broken workspace)
    sidecarFile <- paste(filename, "incomplete", sep = ".")
-   
+
    # remove an old sidecar file if any -- these would be leftover from
    # a previously-failed attempt to save the session
    unlink(sidecarFile)
-   
+
    status <- tryCatch(
       suppressWarnings(save(opt, file = sidecarFile)),
       error = identity
@@ -320,7 +320,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 
 # try to determine if devtools::dev_mode is on
 .rs.addFunction("devModeOn", function(){
-   
+
   # determine devmode path (devtools <= 0.6 hard-coded it)
   devToolsPath <- getOption("devtools.path")
   if (is.null(devToolsPath))
@@ -357,7 +357,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       .libPaths(c(lib, libPaths))
       on.exit(.libPaths(libPaths), add = TRUE)
    }
-   
+
    library(packageName, character.only = TRUE)
 })
 
@@ -370,9 +370,9 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 
 .rs.addFunction("getPackageVersion", function(packageName)
 {
-   v <- suppressWarnings(utils:::packageDescription(packageName, 
+   v <- suppressWarnings(utils:::packageDescription(packageName,
                                               fields="Version"))
-   package_version(v)   
+   package_version(v)
 })
 
 # save an environment to a file
@@ -385,7 +385,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
            file = filename,
            envir = env)
    )
-   
+
    invisible (NULL)
 })
 
@@ -397,12 +397,12 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 
 .rs.addFunction("attachDataFile", function(filename, name, pos = 2)
 {
-   if (!file.exists(filename)) 
+   if (!file.exists(filename))
       stop(gettextf("file '%s' not found", filename), domain = NA)
-   
+
    .Internal(attach(NULL, pos, name))
-   load(filename, envir = as.environment(pos)) 
-   
+   load(filename, envir = as.environment(pos))
+
    invisible (NULL)
 })
 
@@ -435,7 +435,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    else {
       warning("Unable to create a new graphics device ",
               "(RStudio device already active and only a ",
-              "single RStudio device is supported)", 
+              "single RStudio device is supported)",
               call. = FALSE)
    }
 })
@@ -448,7 +448,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    plot = snapshot
    attr(plot, "version") <- as.character(getRversion())
    class(plot) <- "recordedplot"
-   
+
    save(plot, file=filename)
 })
 
@@ -482,58 +482,58 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    envir <- new.env(parent = emptyenv())
    load(filename, envir = envir)
    plot <- envir$plot
-   
+
    # restore native symbols
    dlls <- getLoadedDLLs()
    rVersion <- getRversion()
    wasPairlist <- is.pairlist(plot[[1]])
-   
+
    # convert to list (iterating large pairlist in R is slow; especially
    # since we need to update the data structure as we read through)
    items <- as.list(plot[[1]])
-   
+
    # iterate through and update native symbols (this is necessary as the
    # saved object will contain native routines with incorrect or null
    # addresses; we need to re-discover the correct address for the routines
    # required in generating the plot)
    restored <- lapply(items, function(item) {
-      
+
       # extract saved symbol
       symbol <- item[[2]][[1]]
       if (!inherits(symbol, "NativeSymbolInfo"))
          return(item)
-      
+
       # extract associated package name
       name <- if (is.null(symbol$package))
          symbol$dll[["name"]]
       else
          symbol$package[["name"]]
-      
+
       # re-construct the required symbol
       nativeSymbol <- getNativeSymbolInfo(
          name    = symbol$name,
          PACKAGE = dlls[[name]]
       )
-      
+
       # replace the old symbol
       item[[2]][[1]] <- nativeSymbol
       item
-      
+
    })
-   
+
    # turn back into pairlist after
    if (wasPairlist)
       restored <- as.pairlist(restored)
-   
+
    # update plot items
    if (!is.null(restored))
       plot[[1]] <- restored
-   
+
    # tag plot with process pid
    plotPid <- attr(plot, "pid")
    if (is.null(plotPid) || (plotPid != Sys.getpid()))
       attr(plot, "pid") <- Sys.getpid()
-   
+
    # if this plot depends on the grid package, and we don't have a graphics
    # device open, then we'll have to create a new one
    # https://github.com/rstudio/rstudio/issues/2919
@@ -545,12 +545,12 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
          break
       }
    }
-   
+
    # we suppressWarnings so that R doesn't print a warning if we restore
-   # a plot saved from a previous version of R (which will occur if we 
+   # a plot saved from a previous version of R (which will occur if we
    # do a resume after upgrading the version of R on the server)
    suppressWarnings(grDevices::replayPlot(plot))
-   
+
 })
 
 # generate a uuid
@@ -625,7 +625,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
          unlockBinding(binding, envir)
          on.exit(lockBinding(binding, envir), add = TRUE)
       }
-   
+
       assign(binding, value, envir = envir)
    }
 })
@@ -635,18 +635,18 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    # override in namespace
    if (!requireNamespace(package, quietly = TRUE))
       stop(sprintf("Failed to load namespace for package '%s'", package))
-   
+
    namespace <- asNamespace(package)
-   
+
    # get reference to original binding
    original <- get(binding, envir = namespace)
-   
+
    # replace the binding
    if (is.function(override))
       environment(override) <- namespace
-   
+
    .rs.replaceBindingImpl(namespace, binding, override)
-   
+
    # if package is attached, override there as well
    searchPathName <- paste("package", package, sep = ":")
    if (searchPathName %in% search()) {
@@ -654,7 +654,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       if (exists(binding, envir = env))
          .rs.replaceBindingImpl(env, binding, override)
    }
-   
+
    # return original
    original
 })
@@ -668,7 +668,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    # replace in environment on search path
    envir <- as.environment(paste("package", package, sep = ":"))
    .rs.replaceBindingImpl(envir, name, hook)
-   
+
    # remap in function namespace if requested as well
    if (namespace)
    {
@@ -685,10 +685,10 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    # ensure the package is loaded and attached (since we need to modify
    # the version of the function normally placed on the search path)
    library(package, character.only = TRUE, quietly = TRUE)
-   
+
    # construct search path environment name for package
    packageName <- paste("package", package, sep = ":")
-   
+
    # get original version of function (bail if it doesn't exist)
    original <- base::get(name, packageName, mode = "function")
    if (is.null(original)) {
@@ -696,10 +696,10 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       msg <- sprintf(fmt, shQuote(name))
       stop(msg, call. = FALSE)
    }
-   
+
    # new function definition
    new <- hookFactory(original)
-   
+
    # replace the bindings
    .rs.replacePackageBinding(name, package, new, namespace)
 })
@@ -707,7 +707,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 .rs.addFunction("callAs", function(name, f, ...)
 {
    # TODO: figure out how to print the args (...) as part of the message
-   
+
    # run the original function (f). setup condition handlers solely so that
    # we can correctly print the name of the function called in error
    # and warning messages -- otherwise R prints "original(...)"
@@ -738,11 +738,11 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 # notification that an internal R function was called
 .rs.addFunction("registerNotifyHook", function(name, package, hook, namespace = FALSE)
 {
-   hookFactory <- function(original) function(...) 
-   { 
+   hookFactory <- function(original) function(...)
+   {
       # call hook after original is executed
       on.exit(hook(...))
-      
+
       # call original
       .rs.callAs(name, original, ...)
    }
@@ -752,15 +752,15 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 # marking functions in R packages as unsupported
 .rs.addFunction("registerUnsupported", function(name, package, alternative = "")
 {
-   unsupported <- function(...) 
-   {  
+   unsupported <- function(...)
+   {
       msg <- "function not supported in RStudio"
       if (nzchar(alternative))
         msg <- paste(msg, "(try", alternative, "instead)")
       msg <- paste(msg, "\n", sep = "")
       stop(msg)
    }
-                                              
+
    .rs.registerReplaceHook(name, package, unsupported)
 })
 
@@ -783,7 +783,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
         list(CRAN = cran),
         .rs.parseCRANReposList(secondary)
       )
-      
+
       # ensure repos is character (many packages assume the
       # repos option will be a character vector)
       n <- names(r)
@@ -842,22 +842,22 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    # that directory
    file <- tempfile(pattern = ".rstudio-", tmpdir = lib)
    status <- tryCatch(file.create(file), condition = identity)
-   
+
    # treat any conditions as errors, since R will emit a
    # warning (rather than error) if file creation fails
    if (inherits(status, "condition"))
       return(FALSE)
-   
+
    # now, try to remove the temporary file (it would stink
    # if we could create files but not remove them ...)
    status <- tryCatch(file.remove(file), condition = identity)
    if (inherits(status, "condition"))
       return(FALSE)
-   
+
    # we successfully created and removed a file in the library
    # directory; treat it as writable
    TRUE
-   
+
 })
 
 .rs.addFunction("defaultLibPathIsWriteable", function()
@@ -866,18 +866,18 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 })
 
 # Support for implementing json-rpc methods directly in R:
-# 
-# - json-rpc method endpoints can be installed by calling the 
+#
+# - json-rpc method endpoints can be installed by calling the
 #   .rs.addJsonRpcHandler function (all R files within the handlers directory
 #   are sourced so that they can install handlers)
 #
-# - these endpoints are installed within the tools:rstudio environment, 
-#   therefore if common helper methods are required they should be added to 
+# - these endpoints are installed within the tools:rstudio environment,
+#   therefore if common helper methods are required they should be added to
 #   the same environment using .rs.addFunction
 #
 # - Json <-> R marshalling is implemented within RJsonRpc.cpp
 #   details on how this works can be found in the comments therin
-#  
+#
 
 # add an rpc handler to the tools:rstudio environment
 .rs.addFunction("addJsonRpcHandler", function(name, FN)
@@ -890,7 +890,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 .rs.addFunction("listJsonRpcHandlers", function()
 {
    objects(
-      name      = "tools:rstudio", 
+      name      = "tools:rstudio",
       pattern   = utils:::glob2rx(".rs.rpc.*"),
       all.names = TRUE
    )
@@ -930,14 +930,14 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
                                       quiet = FALSE)
 {
    stamps <- paste(prefix, stamp, suffix, sep = "")
-   
+
    lapply(stamps, function(stamp) {
       invisible(.Call("rs_timestamp", stamp, PACKAGE = "(embedding)"))
    })
-   
+
    if (!quiet)
       cat(stamps, sep = "\n")
-   
+
    invisible(stamps)
 })
 
@@ -952,16 +952,16 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 
 
 .rs.addFunction("parseQuitArguments", function(command) {
-  
+
    # parse the command
    expr <- parse(text = command)
    if (length(expr) == 0)
       stop("Not a fully formed command: ", command)
-   
+
    # match args
    call <- as.call(expr[[1]])
    call <- match.call(quit, call)
-   
+
    # return as list without the function name
    as.list(call)[-1]
 })
@@ -973,7 +973,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 # when a function is traced, some data about the function (such as its original
 # body and source references) exist only on the untraced copy
 .rs.addFunction("untraced", function(fun) {
-   if (.rs.isTraced(fun)) 
+   if (.rs.isTraced(fun))
       fun@original
    else
       fun
@@ -1014,31 +1014,31 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 {
    pattern <- if (nzchar(token))
       paste("^", .rs.asCaseInsensitiveRegex(.rs.escapeForRegex(token)), sep = "")
-   
+
    # Manually construct a call to `list.files` which should work across
    # versions of R >= 2.11.
    formals <- as.list(formals(base::list.files))
-   
+
    formals$path <- directory
    formals$pattern <- pattern
    formals$all.files <- TRUE
    formals$full.names <- TRUE
-   
+
    # NOTE: not available in older versions of R, but defaults to FALSE
    # with newer versions.
    if ("include.dirs" %in% names(formals))
       formals[["include.dirs"]] <- TRUE
-   
+
    # NOTE: not available with older versions of R, but defaults to FALSE
    if ("no.." %in% names(formals))
       formals[["no.."]] <- TRUE
-   
+
    # Generate the call, and evaluate it.
    result <- do.call(base::list.files, formals)
-   
+
    # Clean up duplicated '/'.
    absolutePaths <- gsub("/+", "/", result)
-   
+
    # Remove un-needed `.` paths. These paths will look like
    #
    #     <path>/.
@@ -1052,7 +1052,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
                             invert = TRUE,
                             value = TRUE)
    }
-   
+
    absolutePaths
 })
 
@@ -1088,7 +1088,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       indent_ <- "  "
       indentSize_ <- 0
       data_ <- character()
-      
+
       indented_ <- function(data) {
          indent <- paste(character(indentSize_ + 1), collapse = indent_)
          for (i in seq_along(data))
@@ -1098,29 +1098,29 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
                data[[i]] <- paste(indent, data[[i]], sep = "")
             data
       }
-      
+
       list(
-         
+
          append = function(...) {
             data_ <<- c(data_, indented_(list(...)))
          },
-         
+
          appendf = function(...) {
             data_ <<- c(data_, indented_(sprintf(...)))
          },
-         
+
          indent = function() {
             indentSize_ <<- indentSize_ + 1
          },
-         
+
          unindent = function() {
             indentSize_ <<- max(0, indentSize_ - 1)
          },
-         
+
          data = function() unlist(data_)
-         
+
       )
-      
+
    })()
 })
 
@@ -1130,52 +1130,52 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       capacity_ <- 1024
       index_ <- 0
       data_ <- vector("list", capacity_)
-      
+
       append <- function(data) {
-         
+
          # increment index and check capacity
          index_ <<- index_ + 1
          if (index_ > capacity_) {
             capacity_ <<- capacity_ * 2
             data_[capacity_] <<- list(NULL)
          }
-         
+
          # append data
          if (is.null(data))
             data_[index_] <<- list(NULL)
          else
             data_[[index_]] <<- data
       }
-      
+
       data <- function() {
          data_[seq_len(index_)]
       }
-      
+
       clear <- function() {
          capacity_ <<- 1024
          index_ <<- 0
          data_ <<- vector("list", capacity_)
       }
-      
+
       empty <- function() {
          index_ == 0
       }
-      
+
       list(append = append, clear = clear, empty = empty, data = data)
-      
+
    })()
 })
 
 .rs.addFunction("regexMatches", function(pattern, x) {
-   
+
    matches <- gregexpr(pattern, x, perl = TRUE)[[1]]
    starts <- attr(matches, "capture.start")
    ends <- starts + attr(matches, "capture.length") - 1
    strings <- substring(x, starts, ends)
-   
+
    names(strings) <- attr(matches, "capture.names")
    strings
-   
+
 })
 
 .rs.addFunction("withChangedExtension", function(path, ext)
@@ -1201,11 +1201,11 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
          stop("file at path '", path, "' exists but is not a directory")
       return(TRUE)
    }
-   
+
    success <- dir.create(path, recursive = TRUE)
    if (!success)
       stop("failed to create directory at path '", path, "'")
-   
+
    TRUE
 })
 
@@ -1273,19 +1273,19 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       format(R.version$arch),
       format(R.version$os)
    )
-   
+
    sprintf("R (%s)", paste(fields, collapse = " "))
 })
 
 .rs.addFunction("initHttpUserAgent", function()
 {
    utils <- asNamespace("utils")
-   
+
    defaultAgent <- if (is.function(utils$defaultUserAgent))
       utils$defaultUserAgent()
    else
       .rs.defaultHttpUserAgent()
-   
+
    if (identical(defaultAgent, getOption("HTTPUserAgent")))
    {
       info <- .rs.api.versionInfo()
@@ -1295,7 +1295,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
          if (!is.null(info$edition)) "Pro",
          paste("(", format(info$version), ")", sep = "")
       )
-      
+
       rstudioAgent <- paste(fields, collapse = " ")
       newAgent <- paste(rstudioAgent, defaultAgent, sep = "; ")
       options(HTTPUserAgent = newAgent)
@@ -1314,7 +1314,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 {
    if (package %in% loadedNamespaces())
       return(hook())
-   
+
    setHook(
       hookName = packageEvent(package, "onLoad"),
       value    = hook,
@@ -1328,7 +1328,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    searchPathName <- paste("package", package, sep = ":")
    if (searchPathName %in% search())
       return(hook())
-   
+
    setHook(
       hookName = packageEvent(package, "attach"),
       value    = hook,
@@ -1340,13 +1340,13 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 {
    # Make sure we use native separators, and expand tildes.
    entry <- normalizePath(entry, mustWork = FALSE)
-   
+
    # Get the current PATH.
    oldPath <- strsplit(Sys.getenv("PATH"), .Platform$path.sep, fixed = TRUE)[[1L]]
-   
+
    # Prepend the new entry, removing it from the old PATH if is already exists.
    newPath <- c(entry, setdiff(oldPath, entry))
-   
+
    # Update the PATH.
    Sys.setenv(PATH = paste(newPath, collapse = .Platform$path.sep))
 })
@@ -1378,7 +1378,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    pos <- which(search() == ".conflicts")
    if (length(pos) == 0)
       return(NULL)
-   
+
    # empty out the .conflicts environment
    envirs <- lapply(pos, as.environment)
    for (envir in envirs)
@@ -1386,7 +1386,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       symbols <- ls(envir = envir, all.names = TRUE)
       rm(list = symbols, envir = envir)
    }
-   
+
    # return the environments
    envirs
 })
@@ -1395,22 +1395,22 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 {
    # remove leading, trailing whitespace
    trimmed <- gsub("^[^\\S\\r\\n]*\\n|\\n[^\\S\\r\\n]*$", "", text, perl = TRUE)
-   
+
    # split into lines
    lines <- strsplit(trimmed, "\n", fixed = TRUE)[[1L]]
-   
+
    # compute common indent
    indent <- regexpr("[^[:space:]]", lines)
    common <- min(setdiff(indent, -1L))
-   
+
    # put it together
    rendered <- paste(substring(lines, common), collapse = "\n")
-   
+
    # if any dots were supplied, assume they're sprintf format arguments
    dots <- eval(substitute(alist(...)))
    if (length(dots))
       rendered <- sprintf(rendered, ...)
-   
+
    # return rendered text
    rendered
 })
@@ -1426,7 +1426,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       later::run_now
    else
       function() {}
-   
+
    callback <- if (swallowErrors)
    {
       function()
@@ -1436,18 +1436,18 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    {
       predicate
    }
-   
+
    for (i in seq_len(retryCount))
    {
       pollForEvents()
-      
+
       result <- callback()
       if (!identical(result, FALSE))
          return(result)
-      
+
       Sys.sleep(waitTimeSecs)
    }
-   
+
    stop(sprintf("timed out waiting until '%s'", reason))
 })
 
@@ -1456,24 +1456,24 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    # collect information about the running version of R / RStudio
    rstudioInfo <- .rs.api.versionInfo()
    rstudioVersion <- format(rstudioInfo$long_version)
-   
+
    rstudioEdition <- sprintf(
       "%s [%s]",
       if (rstudioInfo$mode == "desktop") "Desktop" else "Server",
       if (is.null(rstudioInfo$edition)) "Open Source" else toupper(rstudioInfo$edition)
    )
-   
+
    rInfo <- utils::sessionInfo()
    rVersion <- rInfo$R.version$version.string
    rVersion <- sub("^R version", "", rVersion, fixed = TRUE)
    osVersion <- rInfo$running
-   
+
    rInfoText <- local({
       op <- options(width = 78)
       on.exit(options(op), add = TRUE)
       paste(capture.output(print(rInfo)), collapse = "\n")
    })
-   
+
    # create issue template and fill in the pieces
    template <- .rs.heredoc("
       ### System details
@@ -1482,43 +1482,43 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
           RStudio Version : %s
           OS Version      : %s
           R Version       : %s
-  
+
       ### Steps to reproduce the problem
-      
+
       ### Describe the problem in detail
-      
+
       ### Describe the behavior you expected
-      
+
       ---
-      
+
       <details>
-      
+
       <summary>Session Info</summary>
-      
+
       ``` r
       %s
       ```
-      
+
       </details>
    ")
-   
+
    rendered <- sprintf(template, rstudioVersion, rstudioEdition, osVersion, rVersion, rInfoText)
-   
+
    if (rstudioInfo$mode == "desktop") {
-      
+
       # on desktop, we copy the text directly to the clipboard
       text <- paste(rendered, collapse = "\n")
       .Call("rs_clipboardSetText", text, PACKAGE = "(embedding)")
-      
+
       writeLines(.rs.heredoc("
          * The bug report template has been written to the clipboard.
          * Please paste the clipboard contents into the issue comment section,
          * and then fill out the rest of the issue details.
          *
       "))
-      
+
    } else {
-      
+
       # on server, we ask the user to copy the text to the clipboard
       header <- .rs.heredoc("
          <!--
@@ -1526,7 +1526,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
          and then click 'Cancel' to close the dialog.
          -->
       ")
-      
+
       # write generated text to file, then open it in an editor
       text <- c(header, "", rendered)
       file <- tempfile("rstudio-bug-report-", fileext = ".html")
@@ -1535,24 +1535,24 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       utils::file.edit(file)
 
    }
-   
+
    # if 'pro' wasn't supplied, then try to guess based on the running edition
    if (is.null(pro))
       pro <- !is.null(rstudioInfo$edition)
-   
+
    # tell the user we're about to navigate away
    url <- if (pro) {
       "https://github.com/rstudio/rstudio-pro/issues/new"
    } else {
       "https://github.com/rstudio/rstudio/issues/new"
    }
-   
+
    # notify the user
    fmt <- " * Navigating to '%s' in 3 seconds ... "
    msg <- sprintf(fmt, url)
    writeLines(msg)
    Sys.sleep(3)
-   
+
    # perform navigation
    utils::browseURL(url)
 })
@@ -1616,19 +1616,19 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
                                               environmentDataDir)
 {
    tryCatch(
-      
+
       .rs.restoreSearchPathImpl(
          searchPathsFile,
          packagePathsFile,
          environmentDataDir
       ),
-      
+
       error = function(cnd) {
          header <- "Error restoring search paths:"
          message <- paste(c(header, conditionMessage(cnd)), collapse = "\n\t")
          writeLines(message, con = stderr())
       }
-      
+
    )
 })
 
@@ -1643,22 +1643,22 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       dequote = TRUE,
       trim = TRUE
    )
-   
+
    # Exclude 'base' if it was serialized, since that's always loaded.
    packagePaths[["base"]] <- NULL
-   
+
    # Restore the packages.
    .rs.restorePackages(packagePaths)
-   
+
    # Read the search paths file.
    searchPaths <- readLines(searchPathsFile, warn = FALSE)
-   
+
    # Detach anything that's on the search path right now, but not in the search path list.
    currentSearchPaths <- setdiff(
       search(),
       c(".GlobalEnv", "tools:rstudio", "package:base", "package:tools", "package:utils")
    )
-   
+
    for (entry in currentSearchPaths)
    {
       if (!entry %in% searchPaths)
@@ -1666,7 +1666,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
          detach(entry, character.only = TRUE)
       }
    }
-   
+
    # Build our iteration indices.
    # - Iterate in reverse order, since 'library()' always attaches entries to the front of the search path.
    # - Iterate by index, since we use those to map certain search path elements to data files.
@@ -1675,7 +1675,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       to = 2L,
       by = -1L
    )
-   
+
    # Using our index from above, iterate and attach packages.
    for (index in indices)
    {
@@ -1693,18 +1693,18 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
             .rs.attachDataFile(dataFilePath, searchPathEl)
       }
    }
-   
+
 })
 
 .rs.addFunction("restorePackages", function(packagePaths)
 {
    # Use environment to track visited packages.
    visitedPackages <- new.env(parent = emptyenv())
-   
+
    # Treat 'R' as already visited, so that we skip it.
    # (Some packages include R version requirements in their DESCRIPTION files.)
    visitedPackages[["R"]] <- TRUE
-   
+
    # Start loading.
    for (package in names(packagePaths))
       .rs.restorePackagesImpl(package, packagePaths, visitedPackages)
@@ -1717,10 +1717,10 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    # Check if we've already visited this package.
    if (exists(package, envir = visitedPackages))
       return()
-   
+
    # Mark this package as visited.
    visitedPackages[[package]] <- TRUE
-   
+
    # If we don't have a known namespace path for this package, skip it.
    # This can occur for packages which import a package in their DESCRIPTION file,
    # but don't explicitly import it in their NAMESPACE.
@@ -1731,10 +1731,10 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    packagePath <- packagePaths[[package]]
    if (is.null(packagePath))
       return()
-   
+
    libLoc <- dirname(packagePath)
    packageDesc <- as.list(utils::packageDescription(package, lib.loc = libLoc))
-   
+
    # Load any of its dependencies first.
    fields <- c("Depends", "Imports", "LinkingTo")
    for (field in fields)
@@ -1762,7 +1762,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
          )
       }
    }
-   
+
    value
 })
 
@@ -1775,40 +1775,40 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    # disable warnings in this scope
    op <- options(warn = -1L)
    on.exit(options(op), add = TRUE)
-   
+
    # read file
    text <- .rs.nullCoalesce(text, readLines(path, warn = FALSE))
    contents <- paste(text, collapse = "\n")
-   
+
    # split on newlines; allow spaces to continue a value
    parts <- strsplit(contents, "\\n(?=\\S)", perl = TRUE)[[1L]]
-   
+
    # remove comments and blank lines
    parts <- grep("^\\s*(?:#|$)", parts, perl = TRUE, value = TRUE, invert = TRUE)
-   
+
    # split into key / value pairs
    index <- regexpr(delimiter, parts, fixed = TRUE)
    keys <- substring(parts, 1L, index - 1L)
    vals <- substring(parts, index + 1L)
-   
+
    # trim whitespace when requested
    if (trim)
    {
       keys <- .rs.trimWhitespace(keys)
       vals <- gsub("\n\\s*", " ", .rs.trimWhitespace(vals), perl = TRUE)
    }
-   
+
    # strip quotes if requested
    if (dequote)
    {
       keys <- .rs.dequote(keys)
       vals <- .rs.dequote(vals)
    }
-   
+
    # return as named list
    storage.mode(vals) <- "list"
    names(vals) <- keys
-   
+
    vals
 })
 
@@ -1823,7 +1823,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 {
    if (!length(string))
       string <- ""
-   
+
    n <- nchar(string)
    (nchar(strings) >= n) & (substring(strings, 1, n) == string)
 })
@@ -1837,7 +1837,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 {
    if (!length(string))
       string <- ""
-   
+
    nstrings <- nchar(strings)
    nstring <- nchar(string)
    (nstrings >= nstring) &
@@ -1856,14 +1856,14 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    {
       Sys.getenv("NETRC", unset = "~/.netrc")
    })
-   
+
    info <- file.info(netrcPath, extra_cols = FALSE)
    if (is.na(info$mode))
       return(NULL)
-   
+
    # Read the contents of the file.
    contents <- readLines(netrcPath, warn = FALSE)
-   
+
    # Remove any 'macdef' entries within the file.
    macdefLines <- rev(grep("^\\s*macdef\\b", contents, perl = TRUE))
    if (length(macdefLines))
@@ -1879,7 +1879,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
          )
       }
    }
-   
+
    # Read the tokens within the file.
    tokens <- scan(
       text         = paste(contents, collapse = "\n"),
@@ -1888,28 +1888,28 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       comment.char = "#",
       quiet        = TRUE
    )
-   
+
    # Add some blank tokens at end, to support lookahead.
    tokens <- c(tokens, "", "")
-   
+
    # Make a simple token walker.
    i <- 0L; n <- length(tokens)
    pop <- function() {
       i <<- i + 1L
       tokens[[i]]
    }
-   
+
    # netrc can have machine, login, password, and account fields.
    machine <- ""
-   
+
    # Start parsing the .netrc entries within the file.
    stack <- .rs.stack(mode = "list")
-   
+
    token <- pop()
    while (nzchar(token))
    {
       entry <- list()
-      
+
       # Get the machine definition. Handle 'default' here as well.
       entry[["machine"]] <- if (token == "default")
          ""
@@ -1917,7 +1917,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
          pop()
       else
          stop("unexpected token '", token, "'; expected 'machine' or 'default'")
-      
+
       # Handle the optional fields.
       token <- pop()
       while (token %in% c("login", "password", "account"))
@@ -1925,15 +1925,15 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
          entry[[token]] <- pop()
          token <- pop()
       }
-      
+
       # Add it to the result stack.
       stack$push(entry)
    }
-   
+
    # Return result as named list.
    result <- stack$data()
    names(result) <- .rs.mapChr(result, `[[`, "machine")
-   
+
    result
 })
 
@@ -1942,33 +1942,33 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    ni <- as.integer(length(input))
    if (ni < 3L)
       return(integer())
-   
+
    no <- ni %/% 3L * 4L
    output <- integer(no)
-   
+
    i0 <- seq.int(1L, ni - 2L, by = 3L)
    i1 <- seq.int(2L, ni - 1L, by = 3L)
    i2 <- seq.int(3L, ni - 0L, by = 3L)
-   
+
    o0 <- seq.int(1L, no - 3L, by = 4L)
    o1 <- seq.int(2L, no - 2L, by = 4L)
    o2 <- seq.int(3L, no - 1L, by = 4L)
    o3 <- seq.int(4L, no - 0L, by = 4L)
-   
+
    output[o0] <- table[1L + bitwShiftR(input[i0], 2L)]
-   
+
    output[o1] <- table[1L + bitwOr(
       bitwShiftL(bitwAnd(input[i0], 0x03L), 4L),
       bitwShiftR(bitwAnd(input[i1], 0xF0L), 4L)
    )]
-   
+
    output[o2] <- table[1L + bitwOr(
       bitwShiftL(bitwAnd(input[i1], 0x0FL), 2L),
       bitwShiftR(bitwAnd(input[i2], 0xC0L), 6L)
    )]
-   
+
    output[o3] <- table[1L + bitwAnd(input[i2], 0x3FL)]
-   
+
    output
 })
 
@@ -1978,12 +1978,12 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    remaining <- ni %% 3L
    if (remaining == 0L)
       return(integer())
-   
+
    output <- rep.int(61L, 4L)
    i <- ni - remaining + 1
-   
+
    output[1L] <- table[1L + bitwShiftR(input[i + 0L], 2L)]
-   
+
    if (remaining == 1L)
    {
       output[2L] <- table[1L + bitwShiftL(bitwAnd(input[i + 0L], 0x03L), 4L)]
@@ -1994,10 +1994,10 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
          bitwShiftL(bitwAnd(input[i + 0L], 0x03L), 4L),
          bitwShiftR(bitwAnd(input[i + 1L], 0xF0L), 4L)
       )]
-      
+
       output[3L] <- table[1L + bitwShiftL(bitwAnd(input[i + 1L], 0x0FL), 2L)]
    }
-   
+
    output
 })
 
@@ -2010,11 +2010,11 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       as.integer(text)
    else
       stop("unexpected input type ", typeof(text))
-   
+
    # build base64 table
    chars <- "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="  # pragma: allowlist secret
    table <- as.integer(charToRaw(chars))
-   
+
    # encode the data
    encoded <- c(
       .rs.rBase64EncodeMain(input, table),
@@ -2031,7 +2031,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    netrcEntries <- .rs.readNetrc()
    if (is.null(netrcEntries))
       return("")
-   
+
    # Parse the URL into its component parts.
    pattern <- paste0(
       "^",
@@ -2044,10 +2044,10 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       "(?:#(?<fragment>.*))?",                             # Fragment
       "$"
    )
-   
+
    matches <- .rs.regexMatches(pattern, url)
    parts <- as.list(matches)
-   
+
    # Look for valid credentials for the provided URLs.
    for (netrcEntry in netrcEntries)
    {
@@ -2058,7 +2058,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
          return(result)
       }
    }
-   
+
    ""
 })
 
@@ -2069,7 +2069,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       utils::available.packages(),
       stringsAsFactors = FALSE
    )
-   
+
    # Record sources for each package.
    for (pkgPath in pkgPaths)
       .rs.recordPackageSourceImpl(pkgPath, db, local)
@@ -2079,16 +2079,16 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 {
    # Infer package name from installed path.
    pkgName <- basename(pkgPath)
-   
+
    # Read the package's DESCRIPTION file.
    pkgDesc <- packageDescription(pkgName, lib.loc = dirname(pkgPath))
-   
+
    # If the package already has some remote fields recorded, then skip.
    # Currently, this is relevant for packages installed from R-universe.
    remotes <- grep("^Remote", names(pkgDesc), value = TRUE)
    if (length(remotes))
       return()
-   
+
    remoteFields <- if (local)
    {
       c(
@@ -2103,16 +2103,16 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       pkgEntry <- subset(db, Package == pkgName)
       if (nrow(pkgEntry) == 0L)
          return()
-      
+
       # Grab the package version.
       pkgVersion <- pkgDesc[["Version"]]
-      
+
       # Normalize the repository path, removing source / binary suffixes.
       pkgSource <- gsub("/(src|bin)/.*", "", pkgEntry$Repository, perl = TRUE)
-      
+
       # Also remove a potential binary component.
       pkgSource <- sub("/__[^_]+__/[^/]+/", "/", pkgSource)
-      
+
       c(
          RemoteType   = "standard",
          RemotePkgRef = pkgName,
@@ -2121,13 +2121,13 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
          RemoteSha    = pkgVersion
       )
    }
-      
+
    remoteText <- sprintf(
       "%s: %s",
       names(remoteFields),
       unlist(remoteFields)
    )
-   
+
    # Update the DESCRIPTION file. We read and write the DESCRIPTION file
    # just to avoid issues with potential trailing lines.
    descPath <- file.path(pkgPath, "DESCRIPTION")
@@ -2135,7 +2135,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    descContents <- descContents[nzchar(descContents)]
    descContents <- c(descContents, remoteText)
    writeLines(descContents, con = descPath, useBytes = TRUE)
-   
+
    # Update `Meta/package.rds`.
    metaPackagePath <- file.path(pkgPath, "Meta/package.rds")
    if (file.exists(metaPackagePath))
@@ -2154,7 +2154,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       if (identical(fn, base::readline))
          return(TRUE)
    }
-   
+
    FALSE
 })
 
@@ -2163,7 +2163,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    if (is.recursive(object))
       for (i in seq_along(object))
          object[[i]] <- .rs.markScalars(object[[i]])
-   
+
    if (is.atomic(object) && length(object) == 1L)
       .rs.scalar(object)
    else
@@ -2182,13 +2182,13 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 .rs.addFunction("installedPackagesFileInfoDiff", function(before, after)
 {
    result <- merge(before, after, by = "path", all = TRUE)
-   
+
    diffs <-
       (is.na(result$ctime.x) & !is.na(result$ctime.y)) |
       (is.na(result$mtime.x) & !is.na(result$mtime.y)) |
       (result$ctime.x != result$ctime.y) |
       (result$mtime.x != result$mtime.y)
-   
+
    result[which(diffs), ]
 })
 
@@ -2196,9 +2196,9 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 {
    .data <- list()
    storage.mode(.data) <- mode
-   
+
    list(
-      
+
       push = function(...) {
          dots <- list(...)
          for (data in dots) {
@@ -2208,43 +2208,43 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
                .data[[length(.data) + 1]] <<- data
          }
       },
-      
+
       pop = function() {
          item <- .data[[length(.data)]]
          length(.data) <<- length(.data) - 1
          item
       },
-      
+
       peek = function() {
          .data[[length(.data)]]
       },
-      
+
       contains = function(data) {
          data %in% .data
       },
-      
+
       empty = function() {
          length(.data) == 0
       },
-      
+
       get = function(index) {
          if (index <= length(.data)) .data[[index]]
       },
-      
+
       set = function(index, value) {
          .data[[index]] <<- value
       },
-      
+
       clear = function() {
          .data <<- list()
       },
-      
+
       data = function() {
          .data
       }
-      
+
    )
-   
+
 })
 
 .rs.addFunction("isAbsolutePath", function(path)
@@ -2267,7 +2267,7 @@ assign(".rs.downloadFile", utils::download.file, envir = .rs.toolsEnv())
       "This is an RStudio hook."
       "Use `.rs.downloadFile` to bypass this hook if necessary."
       ""
-      
+
       # Note that R also supports downloading multiple files in parallel,
       # so the 'url' parameter may be a vector of URLs.
       #
@@ -2275,10 +2275,10 @@ assign(".rs.downloadFile", utils::download.file, envir = .rs.toolsEnv())
       # so we try to handle this appropriately here.
       if (missing(method))
          method <- getOption("download.file.method", default = "auto")
-      
+
       # Silence diagnostic warnings.
       headers <- get("headers", envir = environment(), inherits = FALSE)
-      
+
       # Handle the simpler length-one URL case up front.
       if (length(url) == 1L)
       {
@@ -2289,7 +2289,7 @@ assign(".rs.downloadFile", utils::download.file, envir = .rs.toolsEnv())
          status <- eval(call, envir = parent.frame())
          return(invisible(status))
       }
-      
+
       # Otherwise, do some more work to map headers to URLs as appropriate.
       retvals <- vector("integer", length = length(url))
       authHeaders <- .rs.mapChr(url, .rs.computeAuthorizationHeader)
@@ -2297,7 +2297,7 @@ assign(".rs.downloadFile", utils::download.file, envir = .rs.toolsEnv())
       {
          # Figure out which URLs are associated with the current header.
          idx <- which(authHeaders == authHeader)
-         
+
          # Build a call to download these files all in one go.
          call <- match.call(expand.dots = TRUE)
          call[[1L]] <- quote(.rs.downloadFile)
@@ -2306,13 +2306,14 @@ assign(".rs.downloadFile", utils::download.file, envir = .rs.toolsEnv())
          call["headers"] <- list(c(headers, Authorization = authHeader))
          retvals[idx] <- eval(call, envir = parent.frame())
       }
-      
+
       # Note that even if multiple files are downloaded, R only reports
       # a single status code, with 0 implying that all downloads succeeded.
       status <- if (all(retvals == 0L)) 0L else 1L
-      attr(status, "retvals") <- retvals
+      if (getRversion() >= "4.5.0")
+         attr(status, "retvals") <- retvals
       invisible(status)
-      
+
    })
 
 .rs.defineHook(
@@ -2324,7 +2325,7 @@ assign(".rs.downloadFile", utils::download.file, envir = .rs.toolsEnv())
       "This is an RStudio hook."
       "Use `utils::install.packages()` to bypass this hook if necessary."
       ""
-      
+
       if (interactive())
       {
          # Check if package installation was disabled in this version of RStudio.
@@ -2334,7 +2335,7 @@ assign(".rs.downloadFile", utils::download.file, envir = .rs.toolsEnv())
             msg <- "Package installation is disabled in this version of RStudio."
             stop(msg, call. = FALSE)
          }
-         
+
          # Notify if we're about to update an already-loaded package.
          # Skip this within renv and packrat projects.
          if (.rs.installPackagesRequiresRestart(pkgs))
@@ -2342,31 +2343,31 @@ assign(".rs.downloadFile", utils::download.file, envir = .rs.toolsEnv())
             call <- sys.call()
             call[[1L]] <- quote(install.packages)
             command <- .rs.deparseCall(call)
-            
+
             .rs.enqueLoadedPackageUpdates(command)
             invokeRestart("abort")
          }
-         
+
          # Make sure Rtools is on the PATH for Windows.
          .rs.addRToolsToPath()
          on.exit(.rs.restorePreviousPath(), add = TRUE)
       }
-      
+
       # Resolve library path.
       if (missing(lib) || is.null(lib))
          lib <- .libPaths()[1L]
-      
+
       # Check if we're installing a package from the filesystem,
       # versus installing a package from CRAN.
       isLocal <- is.null(repos) || any(grepl("/", pkgs, fixed = TRUE))
-      
+
       if (isLocal)
       {
          # Invoke the original function.
          call <- sys.call()
          call[[1L]] <- quote(utils::install.packages)
          result <- eval(call, envir = parent.frame())
-         
+
          # Record the package source.
          shouldRecord <- is.character(pkgs) && length(pkgs) == 1L
          if (shouldRecord)
@@ -2377,30 +2378,30 @@ assign(".rs.downloadFile", utils::download.file, envir = .rs.toolsEnv())
          # Get paths to DESCRIPTION files, so we can see what packages
          # were updated before and after installation.
          before <- .rs.installedPackagesFileInfo(lib)
-         
+
          # Invoke the original function.
          call <- sys.call()
          call[[1L]] <- quote(utils::install.packages)
          result <- eval(call, envir = parent.frame())
-         
+
          # Check and see what packages were updated.
          after <- .rs.installedPackagesFileInfo(lib)
-         
+
          # Figure out which packages were changed.
          rows <- .rs.installedPackagesFileInfoDiff(before, after)
-         
+
          # For any packages which appear to have been updated,
          # tag their DESCRIPTION file with their installation source.
          .rs.recordPackageSource(rows$path, local = FALSE)
       }
-      
+
       # Notify the front-end that we've made some updates.
       if (interactive())
       {
          .rs.updatePackageEvents()
          .Call("rs_packageLibraryMutated", PACKAGE = "(embedding)")
       }
-      
+
       # Return installation result, invisibly.
       invisible(result)
    })
@@ -2414,16 +2415,16 @@ assign(".rs.downloadFile", utils::download.file, envir = .rs.toolsEnv())
       "This is an RStudio hook."
       "Use `utils::remove.packages()` to bypass this hook if necessary."
       ""
-      
+
       # Invoke original.
       result <- utils::remove.packages(pkgs, lib)
-      
+
       # Notify front-end that the package library was mutated.
       if (interactive())
       {
          .Call("rs_packageLibraryMutated", PACKAGE = "(embedding)")
       }
-      
+
       # Return original result.
       invisible(result)
    })

--- a/src/cpp/tests/testthat/test-download.R
+++ b/src/cpp/tests/testthat/test-download.R
@@ -16,34 +16,34 @@
 context("download")
 
 expect_download <- function(url, destfile = NULL, method = "libcurl") {
-   
-   destfile <- destfile %||% {
-      .rs.mapChr(seq_along(url), function(i) tempfile())
-   }
-   
+
+   destfile <- .rs.nullCoalesce(destfile, {
+       .rs.mapChr(seq_along(url), function(i) tempfile())
+   })
+
    lhs <- .rs.downloadFile(
       url      = url,
       destfile = destfile,
       method   = method,
       quiet    = TRUE
    )
-   
+
    rhs <- utils::download.file(
       url      = url,
       destfile = destfile,
       method   = method,
       quiet    = TRUE
    )
-   
+
    expect_equal(lhs, rhs)
-   
+
 }
 
 test_that("download.file hooks work as expected", {
-   
+
    url <- "https://cran.rstudio.com"
-   
+
    expect_download(url)
    expect_download(c(url, url))
-   
+
 })


### PR DESCRIPTION
### Intent

There are inconsistent build failures that look like this:
```
2025-09-09 07:26:54  Error (ine = 46:col = 4;test-download.R:46:4ile:///tmp/jenkins-ad98536b/workspace/IDE/Pro-Builds/Platforms/linux-pipeline/rel-cucumberleaf-sunflower/src/cpp/tests/testthat/test-download.Rtest-download.R:46:4>): download.file hooks work as expected
2025-09-09 07:26:54  Error in `destfile %||% {
2025-09-09 07:26:54      .rs.mapChr(seq_along(url), function(i) tempfile())
2025-09-09 07:26:54  }`: could not find function "%||%"
2025-09-09 07:26:54  Backtrace:
2025-09-09 07:26:54      ▆
2025-09-09 07:26:54   1. └─expect_download(url) at ine = 46:col = 4;39m">file:///tmp/jenkins-ad98536b/workspace/IDE/Pro-Builds/Platforms/linux-pipeline/rel-cucumberleaf-sunflower/src/cpp/tests/testthat/test-download.Rtest-download.R:46:439m
```

### Approach

It seems that `%||%` is an R idiom that wasn't available in some of the R versions that we run our tests against. Some libraries define it but that means that our tests are subject to loading order.

Kevin already switched to this more portable function on `main` so this copies the fix from there.

### Automated Tests

This is a fix for an automated test.

### Documentation

Test fix, N/A

### NEWS PR

Test fix, N/A

### Checklist

- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


