### PR TITLE
Upload debug symbols separately to refresh the AWS token

### DIFF
--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -1,6 +1,6 @@
 def utils
 
-def ext_map = 
+def ext_map =
 [
   'jammy':      'deb',
   'rhel8':      'rpm',
@@ -90,7 +90,7 @@ pipeline {
               RSTUDIO_VERSION_FLOWER = utils.getFlower()
               IS_PRO = RSTUDIO_VERSION_SUFFIX.contains('pro')
               RSTUDIO_VERSION_FILENAME = utils.getVersionFilename(RSTUDIO_VERSION) // Define here for use later in utils.rebuildCheck()
-              
+
               // Set up environment for builds.
               ENV = utils.getBuildEnv(!params.DAILY)
             }
@@ -207,7 +207,7 @@ pipeline {
                         sh "PACKAGE_OS='${package_os[env.OS]}' ${ENV} ./make-${FLAVOR.toLowerCase()}-package ${ext_map[env.OS].toUpperCase()} clean"
                       }
                     }
-                    if (WORKSPACE == "pull-requests") {
+                    if (env.WORKSPACE != "pull-requests") {
                       withAWS(role: 'build', roleAccount: AWS_ACCOUNT_ID) {
                         sh "PACKAGE_OS='${package_os[env.OS]}' ${ENV} ./scripts/upload-debug-symbols ${FLAVOR.toLowerCase()} ${ext_map[env.OS].toUpperCase()} ${ARCH}"
                       }
@@ -355,10 +355,10 @@ pipeline {
 
                   stage ("Update Daily Build Redirects") {
                     environment {
-                      RSTUDIO_ORG_PEM = credentials('www-rstudio-org-pem') 
+                      RSTUDIO_ORG_PEM = credentials('www-rstudio-org-pem')
                     }
 
-                    when { 
+                    when {
                       anyOf {
                         expression { return params.PUBLISH && params.DAILY && FLAVOR == "Electron" }
                         expression { return params.PUBLISH && params.DAILY && FLAVOR == "Server" }
@@ -387,7 +387,7 @@ pipeline {
     stage('Trigger Testing Jobs') {
       agent { label 'linux' }
 
-      // Skip for hourly builds, non-published builds, and branches that don't 
+      // Skip for hourly builds, non-published builds, and branches that don't
       // have corresponding automation branches
       when {
         allOf {

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -1,6 +1,6 @@
 def utils
 
-def ext_map =
+def ext_map = 
 [
   'jammy':      'deb',
   'rhel8':      'rpm',
@@ -90,7 +90,7 @@ pipeline {
               RSTUDIO_VERSION_FLOWER = utils.getFlower()
               IS_PRO = RSTUDIO_VERSION_SUFFIX.contains('pro')
               RSTUDIO_VERSION_FILENAME = utils.getVersionFilename(RSTUDIO_VERSION) // Define here for use later in utils.rebuildCheck()
-
+              
               // Set up environment for builds.
               ENV = utils.getBuildEnv(!params.DAILY)
             }
@@ -355,10 +355,10 @@ pipeline {
 
                   stage ("Update Daily Build Redirects") {
                     environment {
-                      RSTUDIO_ORG_PEM = credentials('www-rstudio-org-pem')
+                      RSTUDIO_ORG_PEM = credentials('www-rstudio-org-pem') 
                     }
 
-                    when {
+                    when { 
                       anyOf {
                         expression { return params.PUBLISH && params.DAILY && FLAVOR == "Electron" }
                         expression { return params.PUBLISH && params.DAILY && FLAVOR == "Server" }
@@ -387,7 +387,7 @@ pipeline {
     stage('Trigger Testing Jobs') {
       agent { label 'linux' }
 
-      // Skip for hourly builds, non-published builds, and branches that don't
+      // Skip for hourly builds, non-published builds, and branches that don't 
       // have corresponding automation branches
       when {
         allOf {

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -200,8 +200,17 @@ pipeline {
 
                 steps {
                   dir('package/linux') {
-                    withAWS(role: 'build', roleAccount: AWS_ACCOUNT_ID) {
+                    if (params.DAILY) {
                       sh "PACKAGE_OS='${package_os[env.OS]}' ${ENV} ./make-${FLAVOR.toLowerCase()}-package ${ext_map[env.OS].toUpperCase()} clean"
+                    } else {
+                      withAWS(role: 'build', roleAccount: AWS_ACCOUNT_ID) {
+                        sh "PACKAGE_OS='${package_os[env.OS]}' ${ENV} ./make-${FLAVOR.toLowerCase()}-package ${ext_map[env.OS].toUpperCase()} clean"
+                      }
+                    }
+                    if (WORKSPACE == "pull-requests") {
+                      withAWS(role: 'build', roleAccount: AWS_ACCOUNT_ID) {
+                        sh "PACKAGE_OS='${package_os[env.OS]}' ${ENV} ./scripts/upload-debug-symbols ${FLAVOR.toLowerCase()} ${ext_map[env.OS].toUpperCase()} ${ARCH}"
+                      }
                     }
                     sh '../../docker/jenkins/sign-release.sh ${BUILD_LOCATION}/rstudio-*.${PKG_EXTENSION} ${CODESIGN_KEY} ${CODESIGN_PASS}'
                   }

--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -31,6 +31,8 @@ PREV_WD=$(pwd)
 # raise the limit on number of open files
 ulimit -n 2048
 
+HELP_TARGETS='One of "Electron" or "Server"'
+
 function help() {
     cat <<EOF
 usage: make-package target package [clean]
@@ -44,7 +46,7 @@ Examples
 
 Positional Arguments
   target -- build target
-    One of "Electron" or "Server"
+    $HELP_TARGETS
 
   package
     One of "DEB" or "RPM"
@@ -64,10 +66,10 @@ install-npm-packages() {
    fi
 }
 
-# For a full package build the package.json file gets modified with the 
-# desired build version and product name, and the build-info.ts source 
+# For a full package build the package.json file gets modified with the
+# desired build version and product name, and the build-info.ts source
 # file gets modified with details on the build (date, git-commit, etc).
-# We try to put these back to their original state at the end of the 
+# We try to put these back to their original state at the end of the
 # package build.
 PACKAGE_VERSION_SET=0
 set-version () {
@@ -75,7 +77,7 @@ set-version () {
       pushd ${ELECTRON_SOURCE_DIR}
       echo "ensure node-gyp installed for node ${RSTUDIO_NODE_VERSION}"
       ${NPX} node-gyp install ${RSTUDIO_NODE_VERSION}
-      
+
       install-npm-packages
 
       # Set package.json info
@@ -113,6 +115,12 @@ RSTUDIO_TARGET=$1
 PACKAGE_TARGET=$2
 CLEAN=$3
 
+source "${PKG_DIR}/scripts/vars.sh"
+
+if [ -f "${PKG_DIR}/scripts/overlay.sh" ]; then
+  source "${PKG_DIR}/scripts/overlay.sh"
+fi
+
 if [ "$RSTUDIO_TARGET" != "Desktop" ] && [ "$RSTUDIO_TARGET" != "Electron" ] && [ "$RSTUDIO_TARGET" != "Server" ]
 then
    help
@@ -138,21 +146,6 @@ else
    GWT_MAIN_MODULE=RStudioServer
 fi
 export GWT_MAIN_MODULE
-
-if test -z "$BUILD_DIR"
-then
-   # set build type( if necessary) and build dir
-   if test -z "$CMAKE_BUILD_TYPE"
-   then
-      CMAKE_BUILD_TYPE=RelWithDebInfo
-      BUILD_DIR=build-$RSTUDIO_TARGET-$PACKAGE_TARGET
-   else
-      BUILD_DIR=build-$RSTUDIO_TARGET-$PACKAGE_TARGET-$CMAKE_BUILD_TYPE
-   fi
-fi
-
-# make build directory absolute
-BUILD_DIR=$(readlink -f "$BUILD_DIR")
 
 # clean if requested
 if [ "$CLEAN" == "clean" ]
@@ -274,7 +267,7 @@ fi
 # if SCCACHE_ENABLED environment variable is set, use sccache
 if [ -n "$SCCACHE_ENABLED" ]; then
     echo "Using sccache"
-   
+
     if [ -n "$AWS_ACCESS_KEY_ID" ] || [ $(aws sts get-caller-identity --query "Account" --profile ${AWS_PROFILE:-sso}) -eq 14 ]; then
         echo "AWS credentials valid, using S3 build cache"
         export SCCACHE_BUCKET="rstudio-build-cache"
@@ -314,33 +307,6 @@ fi
 if [ "${RSTUDIO_BUILD_PACKAGE:-1}" = "1" ]; then
    cpack --verbose --debug -G "$PACKAGE_TARGET"
 fi
-
-# For Jenkins builds, upload debug symbols to S3.
-upload-debug-symbols () {
-
-   # Validate that the requisite environment variables are defined.
-   if ! all-defined JENKINS_URL PRODUCT OS ARCH; then
-      echo "-- skipping debug symbol upload; non-production build"
-      return 0
-   fi
-
-   # Don't upload debug symbols for builds triggered by pull requests.
-   if [[ "${WORKSPACE}" =~ "pull-requests" ]]; then
-      echo "-- skipping debug symbol upload; build triggered via pull request"
-      return 0
-   fi
-
-   # Preflight checks passed; upload debug symbols.
-   "${PKG_DIR}/scripts/upload-debug-symbols" \
-      "${BUILD_DIR}" \
-      "${PRODUCT}" \
-      "${OS}" \
-      "${ARCH}" \
-      "${RSTUDIO_VERSION_FULL}"
-
-}
-
-upload-debug-symbols
 
 cd "$PREV_WD"
 

--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -66,10 +66,10 @@ install-npm-packages() {
    fi
 }
 
-# For a full package build the package.json file gets modified with the
-# desired build version and product name, and the build-info.ts source
+# For a full package build the package.json file gets modified with the 
+# desired build version and product name, and the build-info.ts source 
 # file gets modified with details on the build (date, git-commit, etc).
-# We try to put these back to their original state at the end of the
+# We try to put these back to their original state at the end of the 
 # package build.
 PACKAGE_VERSION_SET=0
 set-version () {
@@ -77,7 +77,7 @@ set-version () {
       pushd ${ELECTRON_SOURCE_DIR}
       echo "ensure node-gyp installed for node ${RSTUDIO_NODE_VERSION}"
       ${NPX} node-gyp install ${RSTUDIO_NODE_VERSION}
-
+      
       install-npm-packages
 
       # Set package.json info
@@ -115,6 +115,9 @@ RSTUDIO_TARGET=$1
 PACKAGE_TARGET=$2
 CLEAN=$3
 
+# This script populates BUILD_DIR, CMAKE_BUILD_TYPE, and RSTUDIO_VERSION_FULL,
+# as well as filling in RSTUDIO_VERSION_MAJOR/MINOR/PATCH with defaults if not
+# specified.
 source "${PKG_DIR}/scripts/vars.sh"
 
 if [ -f "${PKG_DIR}/scripts/overlay.sh" ]; then
@@ -267,7 +270,7 @@ fi
 # if SCCACHE_ENABLED environment variable is set, use sccache
 if [ -n "$SCCACHE_ENABLED" ]; then
     echo "Using sccache"
-
+   
     if [ -n "$AWS_ACCESS_KEY_ID" ] || [ $(aws sts get-caller-identity --query "Account" --profile ${AWS_PROFILE:-sso}) -eq 14 ]; then
         echo "AWS credentials valid, using S3 build cache"
         export SCCACHE_BUCKET="rstudio-build-cache"

--- a/package/linux/scripts/upload-debug-symbols
+++ b/package/linux/scripts/upload-debug-symbols
@@ -23,7 +23,7 @@ AWS_BUCKET="s3://rstudio-debug-symbols"
 
 usage () {
 
-  cat <<- EOF
+	cat <<- EOF
 
 	Usage: $0 <product> <os> <arch>
 
@@ -51,47 +51,49 @@ fi
 product="$1"
 os="$2"
 arch="$3"
-version="$RSTUDIO_VERSION_FULL"
 
 PACKAGE_DIR=`pwd`
 RSTUDIO_TARGET="$product"
 PACKAGE_TARGET="$os"
+
+# This script populates BUILD_DIR and RSTUDIO_VERSION_FULL
 source "${PKG_DIR}/scripts/vars.sh"
 
 builddir="$BUILD_DIR"
+version="$RSTUDIO_VERSION_FULL"
 
 
 ensure-aws-cli () {
 
-  # Check and see if aws-cli is already on the PATH.
-  if command -v aws &> /dev/null; then
-    return 0
-  fi
+	# Check and see if aws-cli is already on the PATH.
+	if command -v aws &> /dev/null; then
+		return 0
+	fi
 
-  # Try to look for an aws-cli installation in the home directory.
-  PATH="${HOME}/aws-cli/bin:${PATH}"
-  hash -r
+	# Try to look for an aws-cli installation in the home directory.
+	PATH="${HOME}/aws-cli/bin:${PATH}"
+	hash -r
 
-  if command -v aws &> /dev/null; then
-    return 0
-  fi
+	if command -v aws &> /dev/null; then
+		return 0
+	fi
 
-  # The aws-cli is not installed; try to install it now.
-  pushd "$(mktemp -d)"
-  curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
-  unzip -q awscliv2.zip
-  ./aws/install -i ~/aws-cli -b ~/aws-cli/bin
-  popd
+	# The aws-cli is not installed; try to install it now.
+	pushd "$(mktemp -d)"
+	curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
+	unzip -q awscliv2.zip
+	./aws/install -i ~/aws-cli -b ~/aws-cli/bin
+	popd
 
-  # Check once more for the aws-cli.
-  hash -r
-  command -v aws &> /dev/null
+	# Check once more for the aws-cli.
+	hash -r
+	command -v aws &> /dev/null
 
 }
 
 ensure-aws-cli || {
-  echo "ERROR: aws-cli is not available"
-  exit 1
+	echo "ERROR: aws-cli is not available"
+	exit 1
 }
 
 # Move to build directory
@@ -101,11 +103,11 @@ cd "${builddir}"
 prefix="${product}-${os}-${arch}"
 
 # Find debug symbols in the build directory provided,
-# and collect them into an archive.
+# and collect them into an archive. 
 while IFS= read -r -d '' symfile; do
-  bname="$(basename "${symfile}")"
-  dname="$(dirname "${symfile}")"
-  tar -r -f "${prefix}.tar" -C "${dname}" "${bname}"
+	bname="$(basename "${symfile}")"
+	dname="$(dirname "${symfile}")"
+	tar -r -f "${prefix}.tar" -C "${dname}" "${bname}"
 done < <(find . -name "*.debug" -print0)
 
 # Compress the archive
@@ -115,3 +117,4 @@ xz "${prefix}.tar"
 src="${prefix}.tar.xz"
 tgt="${AWS_BUCKET}/${version}/${prefix}.tar.xz"
 aws s3 cp "${src}" "${tgt}"
+

--- a/package/linux/scripts/upload-debug-symbols
+++ b/package/linux/scripts/upload-debug-symbols
@@ -14,64 +14,84 @@
 # AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
 #
 
+set -e
+
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${PKG_DIR}/../../dependencies/tools/rstudio-tools.sh"
+
 AWS_BUCKET="s3://rstudio-debug-symbols"
 
 usage () {
 
-	cat <<- EOF
+  cat <<- EOF
 
-	Usage: $0 [build-directory] [product] [os] [arch] [version]
+	Usage: $0 <product> <os> <arch>
 
 	Automatically discover all debug symbols within a particular
 	build directory, and then upload those symbols to AWS S3.
+
+	Required environment variables:
+		RSTUDIO_VERSION_MAJOR
+		RSTUDIO_VERSION_MINOR
+		RSTUDIO_VERSION_PATCH
+
+	Optional environment variables:
+		RSTUDIO_VERSION_SUFFIX
 
 	EOF
 
 }
 
-if [ "$1" = "" ] || [ "$1" = "--help" ]; then
+if [ "$3" = "" ] || [ "$1" = "--help" ] || [[ -z "$RSTUDIO_VERSION_MAJOR" ]] || [[ -z "$RSTUDIO_VERSION_MINOR" ]] || [[ -z "$RSTUDIO_VERSION_PATCH" ]]; then
 	usage
 	exit 1
 fi
 
 # Read params into named variables
-builddir="$1"
-product="$2"
-os="$3"
-arch="$4"
-version="$5"
+product="$1"
+os="$2"
+arch="$3"
+version="$RSTUDIO_VERSION_FULL"
+
+PACKAGE_DIR=`pwd`
+RSTUDIO_TARGET="$product"
+PACKAGE_TARGET="$os"
+source "${PKG_DIR}/scripts/vars.sh"
+
+builddir="$BUILD_DIR"
+
 
 ensure-aws-cli () {
 
-	# Check and see if aws-cli is already on the PATH.
-	if command -v aws &> /dev/null; then
-		return 0
-	fi
+  # Check and see if aws-cli is already on the PATH.
+  if command -v aws &> /dev/null; then
+    return 0
+  fi
 
-	# Try to look for an aws-cli installation in the home directory.
-   PATH="${HOME}/aws-cli/bin:${PATH}"
-   hash -r
+  # Try to look for an aws-cli installation in the home directory.
+  PATH="${HOME}/aws-cli/bin:${PATH}"
+  hash -r
 
-	if command -v aws &> /dev/null; then
-		return 0
-	fi
+  if command -v aws &> /dev/null; then
+    return 0
+  fi
 
-	# The aws-cli is not installed; try to install it now.
-   pushd "$(mktemp -d)"
-   curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
-   unzip -q awscliv2.zip
-   ./aws/install -i ~/aws-cli -b ~/aws-cli/bin
-   popd
+  # The aws-cli is not installed; try to install it now.
+  pushd "$(mktemp -d)"
+  curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
+  unzip -q awscliv2.zip
+  ./aws/install -i ~/aws-cli -b ~/aws-cli/bin
+  popd
 
-	# Check once more for the aws-cli.
-	hash -r
-	command -v aws &> /dev/null
+  # Check once more for the aws-cli.
+  hash -r
+  command -v aws &> /dev/null
 
 }
 
 ensure-aws-cli || {
-	echo "ERROR: aws-cli is not available"
-	exit 1
+  echo "ERROR: aws-cli is not available"
+  exit 1
 }
 
 # Move to build directory
@@ -81,11 +101,11 @@ cd "${builddir}"
 prefix="${product}-${os}-${arch}"
 
 # Find debug symbols in the build directory provided,
-# and collect them into an archive. 
+# and collect them into an archive.
 while IFS= read -r -d '' symfile; do
-	bname="$(basename "${symfile}")"
-	dname="$(dirname "${symfile}")"
-	tar -r -f "${prefix}.tar" -C "${dname}" "${bname}"
+  bname="$(basename "${symfile}")"
+  dname="$(dirname "${symfile}")"
+  tar -r -f "${prefix}.tar" -C "${dname}" "${bname}"
 done < <(find . -name "*.debug" -print0)
 
 # Compress the archive
@@ -95,4 +115,3 @@ xz "${prefix}.tar"
 src="${prefix}.tar.xz"
 tgt="${AWS_BUCKET}/${version}/${prefix}.tar.xz"
 aws s3 cp "${src}" "${tgt}"
-

--- a/package/linux/scripts/vars.sh
+++ b/package/linux/scripts/vars.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+#
+# vars.sh -- shared code to define environment variables for Linux builds
+#
+# Copyright (C) 2025 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+if test -z "$BUILD_DIR"
+then
+   # set build type (if necessary) and build dir
+   if test -z "$CMAKE_BUILD_TYPE"
+   then
+      CMAKE_BUILD_TYPE=RelWithDebInfo
+      BUILD_DIR=build-$RSTUDIO_TARGET-$PACKAGE_TARGET
+   else
+      BUILD_DIR=build-$RSTUDIO_TARGET-$PACKAGE_TARGET-$CMAKE_BUILD_TYPE
+   fi
+fi
+
+# make build directory absolute
+BUILD_DIR=$(readlink -f "$BUILD_DIR")
+
+# build RStudio version suffix
+RSTUDIO_VERSION_ARRAY=(
+   "${RSTUDIO_VERSION_MAJOR-99}"
+   "${RSTUDIO_VERSION_MINOR-9}"
+   "${RSTUDIO_VERSION_PATCH-9}"
+)
+
+RSTUDIO_VERSION_FULL=$(IFS="."; echo "${RSTUDIO_VERSION_ARRAY[*]}")"${RSTUDIO_VERSION_SUFFIX}"
+


### PR DESCRIPTION
### Intent

We're getting some build failures based on AWS token expiration:

https://build.posit.it/job/IDE/job/Pro-Builds/job/Platforms/job/linux-pipeline/job/main/2568/pipeline-overview/?start-byte=11062074&selected-node=378#log-378-412

This seems flaky because it depends on how long the build took.

### Approach

Ideally we shouldn't be using `withAWS` around a build process because tokens are hard-limited to a single hour. But since we're using S3 for sccache, we sort of have to. However, it doesn't seem to be a problem for the token to expire during the build, so that's not a problem in and of itself.

The debug symbols need to be uploaded after the build is completed, so we should refresh the token when we do that.

### Automated Tests

There's not really a good way to test this other than running it in Jenkins.

### Checklist

- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests
