### PR TITLE
only upload debug symbols for daily builds

### DIFF
--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -1,6 +1,6 @@
 def utils
 
-def ext_map = 
+def ext_map =
 [
   'jammy':      'deb',
   'rhel8':      'rpm',
@@ -90,7 +90,7 @@ pipeline {
               RSTUDIO_VERSION_FLOWER = utils.getFlower()
               IS_PRO = RSTUDIO_VERSION_SUFFIX.contains('pro')
               RSTUDIO_VERSION_FILENAME = utils.getVersionFilename(RSTUDIO_VERSION) // Define here for use later in utils.rebuildCheck()
-              
+
               // Set up environment for builds.
               ENV = utils.getBuildEnv(!params.DAILY)
             }
@@ -202,14 +202,12 @@ pipeline {
                   dir('package/linux') {
                     if (params.DAILY) {
                       sh "PACKAGE_OS='${package_os[env.OS]}' ${ENV} ./make-${FLAVOR.toLowerCase()}-package ${ext_map[env.OS].toUpperCase()} clean"
+                      withAWS(role: 'build', roleAccount: AWS_ACCOUNT_ID) {
+                        sh "PACKAGE_OS='${package_os[env.OS]}' ${ENV} ./scripts/upload-debug-symbols ${FLAVOR.toLowerCase()} ${ext_map[env.OS].toUpperCase()} ${ARCH}"
+                      }
                     } else {
                       withAWS(role: 'build', roleAccount: AWS_ACCOUNT_ID) {
                         sh "PACKAGE_OS='${package_os[env.OS]}' ${ENV} ./make-${FLAVOR.toLowerCase()}-package ${ext_map[env.OS].toUpperCase()} clean"
-                      }
-                    }
-                    if (env.WORKSPACE != "pull-requests") {
-                      withAWS(role: 'build', roleAccount: AWS_ACCOUNT_ID) {
-                        sh "PACKAGE_OS='${package_os[env.OS]}' ${ENV} ./scripts/upload-debug-symbols ${FLAVOR.toLowerCase()} ${ext_map[env.OS].toUpperCase()} ${ARCH}"
                       }
                     }
                     sh '../../docker/jenkins/sign-release.sh ${BUILD_LOCATION}/rstudio-*.${PKG_EXTENSION} ${CODESIGN_KEY} ${CODESIGN_PASS}'
@@ -355,10 +353,10 @@ pipeline {
 
                   stage ("Update Daily Build Redirects") {
                     environment {
-                      RSTUDIO_ORG_PEM = credentials('www-rstudio-org-pem') 
+                      RSTUDIO_ORG_PEM = credentials('www-rstudio-org-pem')
                     }
 
-                    when { 
+                    when {
                       anyOf {
                         expression { return params.PUBLISH && params.DAILY && FLAVOR == "Electron" }
                         expression { return params.PUBLISH && params.DAILY && FLAVOR == "Server" }
@@ -387,7 +385,7 @@ pipeline {
     stage('Trigger Testing Jobs') {
       agent { label 'linux' }
 
-      // Skip for hourly builds, non-published builds, and branches that don't 
+      // Skip for hourly builds, non-published builds, and branches that don't
       // have corresponding automation branches
       when {
         allOf {


### PR DESCRIPTION
### Intent

Discussion: https://github.com/rstudio/rstudio/pull/16410#discussion_r2334655115

If we don't care about the debug symbols for hourly builds, we could move the code to upload them into the conditional for daily builds.

The big question is: Do we care about debug symbols for daily builds? PR presented for discussion.

### Checklist

- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


