### PR TITLE
The "new" url will have the version number before "licenses"

### DIFF
--- a/docs/user/rstudio/_quarto.yml
+++ b/docs/user/rstudio/_quarto.yml
@@ -31,7 +31,7 @@ website:
           - text: "Posit Workbench Documentation"
             url: 'https://docs.posit.co/ide/server-pro/{{< var version >}}'
           - text: Licenses
-            url: 'https://docs.posit.co/ide/server-pro/licenses/{{< var version >}}'   
+            url: 'https://docs.posit.co/ide/server-pro/{{< var version >}}/licenses/'   
       - icon: "list"
         aria-label: 'Drop-down menu for additional Posit resources'
         menu:


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 

Related to #16075

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.


Updates the Licenses URL to the new "path". The version number now comes before /licenses since we've moved that content into the server "docs" directory / repo.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Ensure you have updated the QA Notes in the original issue.


I manually added `2025.09.0` in place of `{{< var version >}}` and the URL worked. Switched it back and hopeful that once we build the docs, it will insert the variable version and the URL will work as expected.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


