### PR TITLE
support detection of '.air.toml' in project

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -175,6 +175,7 @@ set(SESSION_SOURCE_FILES
    http/SessionHttpConnectionUtils.cpp
    modules/RStudioAPI.cpp
    modules/SessionAbout.cpp
+   modules/SessionAir.cpp
    modules/SessionApiPrefs.cpp
    modules/SessionAskPass.cpp
    modules/SessionAskSecret.cpp

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -23,6 +23,7 @@
 #include "modules/rmarkdown/SessionBlogdown.hpp"
 #include "modules/rmarkdown/SessionBookdown.hpp"
 #include "modules/connections/SessionConnections.hpp"
+#include "modules/SessionAir.hpp"
 #include "modules/SessionBreakpoints.hpp"
 #include "modules/SessionDependencyList.hpp"
 #include "modules/SessionRAddins.hpp"
@@ -682,8 +683,8 @@ void handleClientInit(const boost::function<void()>& initFunction,
 
    if (projects::projectContext().hasProject())
    {
-      FilePath airTomlPath = projects::projectContext().directory().completePath("air.toml");
-      sessionInfo["has_air_toml"] = airTomlPath.exists();
+      using namespace modules::air;
+      sessionInfo["has_air_toml"] = hasAirToml(projects::projectContext().directory());
    }
 
    module_context::events().onSessionInfo(&sessionInfo);

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -133,6 +133,7 @@
 
 #include "modules/RStudioAPI.hpp"
 #include "modules/SessionAbout.hpp"
+#include "modules/SessionAir.hpp"
 #include "modules/SessionAskPass.hpp"
 #include "modules/SessionAskSecret.hpp"
 #include "modules/SessionAuthoring.hpp"
@@ -736,12 +737,12 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       (modules::system_resources::initialize)
       (modules::copilot::initialize)
       (modules::automation::initialize)
+      (modules::air::initialize)
 
       // workers
       (workers::web_request::initialize)
 
       // R code
-      (bind(sourceModuleRFile, "SessionAir.R"))
       (bind(sourceModuleRFile, "SessionCodeTools.R"))
       (bind(sourceModuleRFile, "SessionPatches.R"))
 

--- a/src/cpp/session/modules/SessionAir.cpp
+++ b/src/cpp/session/modules/SessionAir.cpp
@@ -1,0 +1,57 @@
+/*
+ * SessionAir.cpp
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "SessionAir.hpp"
+
+#include <boost/bind.hpp>
+
+#include <core/Exec.hpp>
+
+#include <session/SessionModuleContext.hpp>
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace air {
+
+bool hasAirToml(const FilePath& projectPath)
+{
+   for (auto&& suffix : { "air.toml", ".air.toml" })
+   {
+      FilePath airPath = projectPath.completePath(suffix);
+      if (airPath.exists())
+         return true;
+   }
+
+   return false;
+}
+
+core::Error initialize()
+{
+   using boost::bind;
+   using namespace module_context;
+
+   ExecBlock initBlock;
+   initBlock.addFunctions()
+      (bind(sourceModuleRFile, "SessionAir.R"));
+   return initBlock.execute();
+}
+
+} // end namespace air
+} // end namespace modules
+} // end namespace session
+} // end namespace rstudio

--- a/src/cpp/session/modules/SessionAir.hpp
+++ b/src/cpp/session/modules/SessionAir.hpp
@@ -1,0 +1,40 @@
+/*
+ * SessionAir.hpp
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef RSTUDIO_SESSION_MODULES_AIR
+#define RSTUDIO_SESSION_MODULES_AIR
+
+namespace rstudio {
+namespace core {
+class Error;
+class FilePath;
+} // end namespace core
+} // end namespace rstudio
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace air {
+
+bool hasAirToml(const core::FilePath& projectDir);
+
+core::Error initialize();
+
+} // end namespace air
+} // end namespace modules
+} // end namespace session
+} // end namespace rstudio
+
+#endif /* RSTUDIO_SESSION_MODULES_AIR */

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -59,6 +59,8 @@ extern "C" const char *locale2charset(const char *);
 #include <session/prefs/UserPrefs.hpp>
 #include <session/prefs/Preferences.hpp>
 
+#include "SessionAir.hpp"
+
 using namespace rstudio::core;
 using namespace boost::placeholders;
 
@@ -696,10 +698,8 @@ bool canUseAirFormatter(int context, const FilePath& documentPath)
       {
          if (projects::projectContext().hasProject())
          {
-            FilePath airTomlPath = projects::projectContext()
-               .directory()
-               .completePath("air.toml");
-            return airTomlPath.exists();
+            using namespace modules::air;
+            return hasAirToml(projects::projectContext().directory());
          }
          else
          {


### PR DESCRIPTION
### Intent

Air supports `air.toml` and `.air.toml` within a project directory, as per https://github.com/posit-dev/air/blob/e11b43d57cdc3b037b0ef6128fb9b7b191a97e42/docs/configuration.qmd#L87-L88.

### Approach

Create the proper infrastructure for a C++ module for Air, and use it.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/16420.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

