### PR TITLE
Works around boost bug in 1.87

### DIFF
--- a/src/cpp/core/include/core/http/SocketAcceptorService.hpp
+++ b/src/cpp/core/include/core/http/SocketAcceptorService.hpp
@@ -32,6 +32,16 @@ namespace rstudio {
 namespace core {
 namespace http {
 
+namespace {
+
+   inline boost::asio::io_context* newContext()
+   {
+       errno = 0; // Workaround boost::asio bug 1588 - when this is 34 - it throws "config out of range"
+       return new boost::asio::io_context();
+   }
+
+}
+
 typedef boost::function<void(const boost::system::error_code& ec)> 
                                                                AcceptHandler;
 
@@ -40,7 +50,7 @@ class SocketAcceptorService : boost::noncopyable
 {
 public:
    SocketAcceptorService()
-      : pInternalIOService_(new boost::asio::io_context()),
+      : pInternalIOService_(newContext()),
         ioContext_(*pInternalIOService_),
         acceptor_(ioContext_)
    {


### PR DESCRIPTION
Where if errno is set to 34 this exception is thrown: "config out of range"

### Intent

Addresses: https://github.com/rstudio/rstudio-pro/issues/9107 

(boost issue: https://github.com/chriskohlhoff/asio/issues/1588)

### Approach

This might come up randomly for our customers in 2025.05 and 2025.09 - Boost 1.87... if something the process does before initializing the http server gets a ERANGE error, that process throws this unexpected exception.

I tested this code and if you set errno = 34 -  it gets that error.  So setting it to 0 should avoid the problem. 


