### PR TITLE
avoid setting empty Authorization header in requests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 - ([#16402](https://github.com/rstudio/rstudio/issues/16402)): Fixed an issue where the wrong Python installation was chosen during Quarto render in some cases
 - ([#16532](https://github.com/rstudio/rstudio/issues/16352)): Fixed an issue where ongoing R Markdown render output was lost when after a browser refresh
 - ([#16346](https://github.com/rstudio/rstudio/issues/16436)): Fixed an issue where certain ALTREP objects could cause RStudio to crash while populating the Environment pane
+- ([#16446](https://github.com/rstudio/rstudio/issues/16446)): Fixed a regression that could cause file downloads to fail on Windows
 
 #### Posit Workbench
 - (#rstudio-pro/8919): Fixed an issue where duplicate project entries within a user's recent project list could cause their home page to fail to load

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -2282,10 +2282,16 @@ assign(".rs.downloadFile", utils::download.file, envir = .rs.toolsEnv())
       # Handle the simpler length-one URL case up front.
       if (length(url) == 1L)
       {
+         # Build relevant headers for the call.
+         callHeaders <- headers
          authHeader <- .rs.computeAuthorizationHeader(url)
+         if (length(authHeader) && nzchar(authHeader))
+            callHeaders <- c(callHeaders, Authorization = authHeader)
+
+         # Build a call to invoke the base R downloader.
          call <- match.call(expand.dots = TRUE)
          call[[1L]] <- quote(.rs.downloadFile)
-         call["headers"] <- list(c(headers, Authorization = authHeader))
+         call["headers"] <- if (length(callHeaders)) list(callHeaders)
          status <- eval(call, envir = parent.frame())
          return(invisible(status))
       }
@@ -2298,12 +2304,17 @@ assign(".rs.downloadFile", utils::download.file, envir = .rs.toolsEnv())
          # Figure out which URLs are associated with the current header.
          idx <- which(authHeaders == authHeader)
 
+         # Build relevant headers for the call.
+         callHeaders <- headers
+         if (length(authHeader) && nzchar(authHeader))
+            callHeaders <- c(callHeaders, Authorization = authHeader)
+
          # Build a call to download these files all in one go.
          call <- match.call(expand.dots = TRUE)
          call[[1L]] <- quote(.rs.downloadFile)
          call["url"] <- list(url[idx])
          call["destfile"] <- list(destfile[idx])
-         call["headers"] <- list(c(headers, Authorization = authHeader))
+         call["headers"] <- if (length(callHeaders)) list(callHeaders)
          retvals[idx] <- eval(call, envir = parent.frame())
       }
 

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -2291,7 +2291,8 @@ assign(".rs.downloadFile", utils::download.file, envir = .rs.toolsEnv())
          # Build a call to invoke the base R downloader.
          call <- match.call(expand.dots = TRUE)
          call[[1L]] <- quote(.rs.downloadFile)
-         call["headers"] <- if (length(callHeaders)) list(callHeaders)
+         if (length(callHeaders))
+            call["headers"] <- list(callHeaders)
          status <- eval(call, envir = parent.frame())
          return(invisible(status))
       }
@@ -2314,7 +2315,8 @@ assign(".rs.downloadFile", utils::download.file, envir = .rs.toolsEnv())
          call[[1L]] <- quote(.rs.downloadFile)
          call["url"] <- list(url[idx])
          call["destfile"] <- list(destfile[idx])
-         call["headers"] <- if (length(callHeaders)) list(callHeaders)
+         if (length(callHeaders))
+            call["headers"] <- list(callHeaders)
          retvals[idx] <- eval(call, envir = parent.frame())
       }
 

--- a/src/cpp/tests/testthat/test-download.R
+++ b/src/cpp/tests/testthat/test-download.R
@@ -57,10 +57,13 @@ test_that("download hooks don't set an empty authorization header", {
    
    trace(.rs.downloadFile, quote({
       expect_identical(headers, NULL)
-      invokeRestart("abort")
+      stop("exiting early")
    }), print = FALSE)
    on.exit(untrace(.rs.downloadFile))
    
-   download.file(url, tempfile())
+   tryCatch(
+      download.file(url, tempfile()),
+      error = function(cnd) NULL
+   )
    
 })

--- a/src/cpp/tests/testthat/test-download.R
+++ b/src/cpp/tests/testthat/test-download.R
@@ -67,3 +67,29 @@ test_that("download hooks don't set an empty authorization header", {
    )
    
 })
+
+test_that("we can download packages from repositories", {
+   
+   info <- download.packages(
+      pkgs    = "rlang",
+      destdir = tempdir(),
+      repos   = "https://cloud.r-project.org"
+   )
+   
+   path <- info[1, 2]
+   expect_true(file.exists(path))
+   files <- untar(path, list = TRUE)
+   expect_true("rlang/DESCRIPTION" %in% files)
+   
+   info <- download.packages(
+      pkgs    = "rlang",
+      destdir = tempdir(),
+      repos   = "https://packagemanager.posit.co/cran/latest"
+   )
+   
+   path <- info[1, 2]
+   expect_true(file.exists(path))
+   files <- untar(path, list = TRUE)
+   expect_true("rlang/DESCRIPTION" %in% files)
+   
+})

--- a/src/cpp/tests/testthat/test-download.R
+++ b/src/cpp/tests/testthat/test-download.R
@@ -47,3 +47,20 @@ test_that("download.file hooks work as expected", {
    expect_download(c(url, url))
 
 })
+
+# https://github.com/rstudio/rstudio/issues/16446
+test_that("download hooks don't set an empty authorization header", {
+
+   skip_if(!"headers" %in% names(formals(utils::download.file)))   
+   
+   url <- "https://cran.rstudio.com"
+   
+   trace(.rs.downloadFile, quote({
+      expect_identical(headers, NULL)
+      invokeRestart("abort")
+   }), print = FALSE)
+   on.exit(untrace(.rs.downloadFile))
+   
+   download.file(url, tempfile())
+   
+})


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16446.

### Approach

Fixed an issue wherein we could set an empty Authorization header, which can cause downloads to fail in certain contexts.

### Automated Tests

Added a test.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/16446.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
