### PR TITLE
Fix C++ file extension truncation on macOS in save dialog

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 - ([#16402](https://github.com/rstudio/rstudio/issues/16402)): Fixed an issue where the wrong Python installation was chosen during Quarto render in some cases
 - ([#16532](https://github.com/rstudio/rstudio/issues/16352)): Fixed an issue where ongoing R Markdown render output was lost when after a browser refresh
 - ([#16346](https://github.com/rstudio/rstudio/issues/16436)): Fixed an issue where certain ALTREP objects could cause RStudio to crash while populating the Environment pane
+- ([#16444](https://github.com/rstudio/rstudio/issues/16444)): Fixed an issue where the file extension of a new C++ source file was truncated to `.cp` on macOS
 
 #### Posit Workbench
 - (#rstudio-pro/8919): Fixed an issue where duplicate project entries within a user's recent project list could cause their home page to fail to load

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -29,7 +29,7 @@ import {
 } from 'electron';
 import { IpcMainEvent, MessageBoxOptions, OpenDialogOptions, SaveDialogOptions } from 'electron/main';
 import EventEmitter from 'events';
-import { existsSync, lstatSync, writeFileSync } from 'fs';
+import { existsSync, statSync, writeFileSync } from 'fs';
 import { platform, release } from 'os';
 import i18next from 'i18next';
 import { findFontsSync } from 'node-system-fonts';
@@ -232,12 +232,12 @@ export class GwtCallback extends EventEmitter {
 
         // On macOS with Electron 36+, when defaultPath is just a directory and we have a defaultExtension,
         // provide a complete filename to avoid extension truncation issues (e.g., ".cpp" becoming ".cp")
-        // https://github.com/rstudio/rstudio/issues/16444
+        // https://github.com/rstudio/rstudio/issues/16444, https://github.com/electron/electron/issues/48332
         if (defaultExtension && process.platform === 'darwin') {
           const endsWithSeparator = defaultPath.endsWith('/');
           const parsedPath = path.parse(defaultPath);
-          const hasNoFilename = !parsedPath.base || parsedPath.base === '.';
-          const isExistingDir = existsSync(defaultPath) && lstatSync(defaultPath).isDirectory();
+          const hasNoFilename = !parsedPath.base || parsedPath.base === '.' || parsedPath.base === '..';
+          const isExistingDir = existsSync(defaultPath) && statSync(defaultPath).isDirectory();
 
           if (endsWithSeparator || hasNoFilename || isExistingDir) {
             // Append a default filename with the extension

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -29,7 +29,7 @@ import {
 } from 'electron';
 import { IpcMainEvent, MessageBoxOptions, OpenDialogOptions, SaveDialogOptions } from 'electron/main';
 import EventEmitter from 'events';
-import { existsSync, writeFileSync } from 'fs';
+import { existsSync, lstatSync, writeFileSync } from 'fs';
 import { platform, release } from 'os';
 import i18next from 'i18next';
 import { findFontsSync } from 'node-system-fonts';
@@ -228,9 +228,26 @@ export class GwtCallback extends EventEmitter {
         forceDefaultExtension: boolean,
         focusOwner: boolean,
       ) => {
+        let defaultPath = normalizeSeparatorsNative(resolveAliasedPath(dir));
+
+        // On macOS with Electron 36+, when defaultPath is just a directory and we have a defaultExtension,
+        // provide a complete filename to avoid extension truncation issues (e.g., ".cpp" becoming ".cp")
+        // https://github.com/rstudio/rstudio/issues/16444
+        if (defaultExtension && process.platform === 'darwin') {
+          const endsWithSeparator = defaultPath.endsWith('/');
+          const parsedPath = path.parse(defaultPath);
+          const hasNoFilename = !parsedPath.base || parsedPath.base === '.';
+          const isExistingDir = existsSync(defaultPath) && lstatSync(defaultPath).isDirectory();
+
+          if (endsWithSeparator || hasNoFilename || isExistingDir) {
+            // Append a default filename with the extension
+            defaultPath = path.join(defaultPath, `Untitled${defaultExtension}`);
+          }
+        }
+
         const saveDialogOptions: SaveDialogOptions = {
           title: caption,
-          defaultPath: normalizeSeparatorsNative(resolveAliasedPath(dir)),
+          defaultPath: defaultPath,
           buttonLabel: label,
         };
         logger().logDebug(`Using path: ${saveDialogOptions.defaultPath}`);


### PR DESCRIPTION
### Intent

Addresses #16444

### Approach

Work around electron issue on macOS by setting the extension directly when saving a new file.

### Automated Tests

NA - we don't have ability to automate file dialogs.

### QA Notes

Check the issue's scenario, and also test other cases where we prompt for a filename, including "save as".

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


