### PR TITLE
properly record package sources for local packages

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -28,8 +28,8 @@
    TYPE_DOCUMENT_OPEN        = 4L,
    TYPE_DOCUMENT_NEW         = 5L,
    TYPE_FILES_PANE_NAVIGATE  = 6L,
-   TYPE_SET_GHOST_TEXT       = 7L
-   
+   TYPE_SET_GHOST_TEXT       = 7L,
+   TYPE_ASK_FOR_RESTART      = 8L
 ))
 
 # list of potential event targets

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2425,21 +2425,6 @@
    .Call("rs_resolveAliasedPath", path, PACKAGE = "(embedding)")
 })
 
-.rs.addFunction("readPackageDescription", function(packagePath)
-{
-   # if this is an installed package with a package metafile,
-   # read from that location
-   metapath <- file.path(packagePath, "Meta/package.rds")
-   if (file.exists(metapath)) {
-      metadata <- readRDS(metapath)
-      return(as.list(metadata$DESCRIPTION))
-   }
-
-   # otherwise, attempt to read DESCRIPTION directly
-   descPath <- file.path(packagePath, "DESCRIPTION")
-   read.dcf(descPath, all = TRUE)
-})
-
 .rs.addFunction("readSourceDocument", function(id)
 {
    contents <- .Call("rs_readSourceDocument", as.character(id), PACKAGE = "(embedding)")

--- a/src/cpp/session/modules/SessionDependencies.R
+++ b/src/cpp/session/modules/SessionDependencies.R
@@ -214,6 +214,6 @@
    
    # For any packages which appear to have been updated,
    # tag their DESCRIPTION file with their installation source.
-   .rs.recordPackageSource(rows$path, local = FALSE)
+   .rs.recordPackageSource(rows$path)
 })
 

--- a/src/cpp/tests/testthat/test-install-packages.R
+++ b/src/cpp/tests/testthat/test-install-packages.R
@@ -1,0 +1,50 @@
+#
+# test-packages
+#
+# Copyright (C) 2022 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+expect_install <- function(pkgs, ...) {
+   
+   # create temporary library for installation
+   lib <- tempfile("library-")
+   dir.create(lib, recursive = TRUE)
+   on.exit(unlink(lib, recursive = TRUE), add = TRUE)
+   
+   # install the package
+   install.packages(pkgs, lib = lib, ...)
+   
+   # check that the package was installed
+   installedPkgs <- list.files(lib, full.names = TRUE)
+   expect_length(installedPkgs, 1L)
+   
+   # check that we can read the package DESCRIPTION file
+   pkgInfo <- .rs.readPackageDescription(installedPkgs)
+   expect_true(is.list(pkgInfo))
+   
+}
+
+test_that("packages can be installed", {
+   
+   expect_install("rlang", repos = "https://cloud.r-project.org")
+   expect_install("rlang", repos = "https://packagemanager.posit.co/cran/latest")
+   
+   info <- download.packages("rlang", destdir = tempdir(), type = "binary")
+   expect_install(info[1, 2], repos = NULL, type = "binary")
+
+   if (!.rs.platform.isWindows)
+   {
+      info <- download.packages("rlang", destdir = tempdir(), type = "source")
+      expect_install(info[1, 2], repos = NULL, type = "source")
+   }
+   
+})

--- a/src/gwt/src/org/rstudio/studio/client/events/RStudioApiRequestEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/RStudioApiRequestEvent.java
@@ -110,6 +110,7 @@ public class RStudioApiRequestEvent extends GwtEvent<RStudioApiRequestEvent.Hand
    public static final int TYPE_DOCUMENT_NEW         = 5;
    public static final int TYPE_FILES_PANE_NAVIGATE  = 6;
    public static final int TYPE_SET_GHOST_TEXT       = 7;
+   public static final int TYPE_ASK_FOR_RESTART      = 8;
    
    // list of potential event targets (keep in sync with Api.R)
    public static final int TARGET_UNKNOWN       = 0;
@@ -185,6 +186,17 @@ public class RStudioApiRequestEvent extends GwtEvent<RStudioApiRequestEvent.Hand
       }
       
       public final native String getText() /*-{ return this["text"]; }-*/;
+   }
+
+   public static class AskForRestartData extends JavaScriptObject
+   {
+      public static final String REASON_INSTALL_PACKAGES = "install.packages";
+
+      protected AskForRestartData()
+      {
+      }
+
+      public final native String getReason()  /*-{ return this["reason"]; }-*/;
    }
    
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -950,7 +950,7 @@ public class Packages
 
    public void onLoadedPackageUpdates(LoadedPackageUpdatesEvent event)
    {
-      restartForInstallWithConfirmation(event.getInstallCmd());
+      doRestartForInstall(event.getInstallCmd());
    }
 
    private class InstallCommand
@@ -1014,6 +1014,14 @@ public class Packages
       events_.fireEvent(event);
    }
 
+   private void doRestartForInstall(String installCmd)
+   {
+      // Use '@' prefix to signal this should be executed eagerly
+      String command = installCmd.startsWith("@") ? installCmd : "@" + installCmd;
+      SuspendOptions options = SuspendOptions.createSaveAll(true, command);
+      events_.fireEvent(new SuspendAndRestartEvent(options));
+   }
+
    private void restartForInstallWithConfirmation(final String installCmd)
    {
       String msg = constants_.restartForInstallWithConfirmation();
@@ -1027,10 +1035,7 @@ public class Packages
             true,
             () ->
             {
-               // Use '@' prefix to signal this should be executed eagerly
-               String command = installCmd.startsWith("@") ? installCmd : "@" + installCmd;
-               SuspendOptions options = SuspendOptions.createSaveAll(true, command);
-               events_.fireEvent(new SuspendAndRestartEvent(options));
+               doRestartForInstall(installCmd);
             },
             () ->
             {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16449.

### Approach

- Retool some of the "restart before installing package" code, primarily to make it possible to test our hooks now.
- Fix the logic around how local package sources are recorded.

### Automated Tests

Included in PR.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/16449.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
