### PR TITLE
provide diagnostic for unexpected arguments to paste

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,8 +5,9 @@
 - ([#15928](https://github.com/rstudio/rstudio/issues/15928)): RStudio now uses Air for formatting R code in projects configured to use Air
 - ([#16127](https://github.com/rstudio/rstudio/issues/16127)) ESC key now dismisses Copilot ghost text in source editor
 - ([#16415](https://github.com/rstudio/rstudio/issues/16415)): RStudio now provides completions for the `_` placeholer in piped expressions
-- ([#16281](https://github.com/rstudio/rstudio/issues/16281)): RStudio will no longer perform type inference on the completion results provided by .DollarNames methods for values where `attr(*, "suppressTypeInference")` is `TRUE`.
+- ([#16281](https://github.com/rstudio/rstudio/issues/16281)): RStudio will no longer perform type inference on the completion results provided by .DollarNames methods for values where `attr(*, "suppressTypeInference")` is `TRUE`
 - ([#16375](https://github.com/rstudio/rstudio/issues/16375)) Copilot Language Server (completions) is now launched via node.js instead of as a standalone binary
+- ([#16427](https://github.com/rstudio/rstudio/issues/16427)): RStudio now provided a diagnostic warning for invocations of `paste()` with unexpected named arguments
 
 #### Posit Workbench
 - ([#16218](https://github.com/rstudio/rstudio/issues/16218)) Workbench no longer uses Crashpad for collecting crash dumps

--- a/src/cpp/core/include/core/collection/Position.hpp
+++ b/src/cpp/core/include/core/collection/Position.hpp
@@ -16,6 +16,7 @@
 #define CORE_COLLECTION_POSITION_HPP
 
 #include <iostream>
+#include <sstream>
 
 namespace rstudio {
 namespace core {


### PR DESCRIPTION
### Intent

Normally, invocations of `paste()` in code will expect unnamed arguments, unless the name directly matches one of the known formal parameters (e.g. `collapse` or `sep`). If a user misspells an argument name, the code will silently execute without error, even though the code will likely not do what the user intended.

Addresses https://github.com/rstudio/rstudio/issues/16427.

### Approach

Added diagnostic code that handles this specific case.

<img width="397" height="81" alt="Screenshot 2025-09-17 at 11 05 06 AM" src="https://github.com/user-attachments/assets/a0a800a2-3aac-47fc-8ae2-6ead9d54f0e3" />

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

