### PR TITLE
backport fix for issue #16444 (truncated .cpp extension on macOS)

### DIFF
--- a/version/news/NEWS-2025.09.1-cucumberleaf-sunflower.md
+++ b/version/news/NEWS-2025.09.1-cucumberleaf-sunflower.md
@@ -1,0 +1,9 @@
+## RStudio 2025.09.0 "Cucumberleaf Sunflower" Release Notes
+
+### Fixed
+
+#### RStudio
+
+- ([#16444](https://github.com/rstudio/rstudio/issues/16444)): Fixed an issue where the file extension of a new C++ source file was truncated to `.cp` on macOS
+
+#### Posit Workbench


### PR DESCRIPTION
### Intent

Backport fix for #16444 from `main`.