### PR TITLE
Adjusted the width of the standalone Accessibility Dialog

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,10 +3,10 @@
 ### New
 #### RStudio
 - ([#15928](https://github.com/rstudio/rstudio/issues/15928)): RStudio now uses Air for formatting R code in projects configured to use Air
-- ([#16127](https://github.com/rstudio/rstudio/issues/16127)) ESC key now dismisses Copilot ghost text in source editor
+- ([#16127](https://github.com/rstudio/rstudio/issues/16127)): ESC key now dismisses Copilot ghost text in source editor
 - ([#16415](https://github.com/rstudio/rstudio/issues/16415)): RStudio now provides completions for the `_` placeholer in piped expressions
 - ([#16281](https://github.com/rstudio/rstudio/issues/16281)): RStudio will no longer perform type inference on the completion results provided by .DollarNames methods for values where `attr(*, "suppressTypeInference")` is `TRUE`
-- ([#16375](https://github.com/rstudio/rstudio/issues/16375)) Copilot Language Server (completions) is now launched via node.js instead of as a standalone binary
+- ([#16375](https://github.com/rstudio/rstudio/issues/16375)): Copilot Language Server (completions) is now launched via node.js instead of as a standalone binary
 - ([#16427](https://github.com/rstudio/rstudio/issues/16427)): RStudio now provided a diagnostic warning for invocations of `paste()` with unexpected named arguments
 
 #### Posit Workbench
@@ -21,6 +21,7 @@
 - ([#16337](https://github.com/rstudio/rstudio/issues/16337)): Fixed an issue where R error output was not displayed in rare cases
 - ([#15963](https://github.com/rstudio/rstudio/issues/15963)): Fixed an issue where an unsaved R Markdown document could erroneously be marked as saved after executing a chunk
 - ([#16402](https://github.com/rstudio/rstudio/issues/16402)): Fixed an issue where the wrong Python installation was chosen during Quarto render in some cases
+- ([#16457](https://github.com/rstudio/rstudio/issues/16457)): Adjusted width of the standalone Accessibility Options dialog to fully display the pane
 - ([#16532](https://github.com/rstudio/rstudio/issues/16352)): Fixed an issue where ongoing R Markdown render output was lost when after a browser refresh
 
 #### Posit Workbench

--- a/src/gwt/src/org/rstudio/core/client/prefs/SectionChooser.java
+++ b/src/gwt/src/org/rstudio/core/client/prefs/SectionChooser.java
@@ -14,16 +14,22 @@
  */
 package org.rstudio.core.client.prefs;
 
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.rstudio.core.client.ElementIds;
+import org.rstudio.core.client.a11y.A11y;
+import org.rstudio.core.client.widget.DecorativeImage;
+import org.rstudio.studio.client.workbench.prefs.views.PreferencesDialogConstants;
+
 import com.google.gwt.aria.client.Id;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.aria.client.SelectedValue;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.KeyDownHandler;
-import org.rstudio.core.client.ElementIds;
-
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.logical.shared.HasSelectionHandlers;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
@@ -34,11 +40,6 @@ import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
-import org.rstudio.core.client.a11y.A11y;
-import org.rstudio.core.client.widget.DecorativeImage;
-
-import java.util.LinkedHashSet;
-import java.util.Set;
 
 /**
  * Vertical tab control used by Preferences dialogs. Follows the ARIA tab pattern.
@@ -248,7 +249,7 @@ class SectionChooser extends SimplePanel implements
 
    public int getDesiredWidth()
    {
-      return 132;
+      return PreferencesDialogConstants.SECTION_CHOOSER_WIDTH;
    }
 
    public void focus()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.css
@@ -3,6 +3,7 @@
 
 @eval PANEL_CONTAINER_WIDTH org.rstudio.studio.client.workbench.prefs.views.PreferencesDialogConstants.panelContainerWidth();
 @eval PANEL_CONTAINER_HEIGHT org.rstudio.studio.client.workbench.prefs.views.PreferencesDialogConstants.panelContainerHeight();
+@eval PANEL_CONTAINER_WIDTH_NO_CHOOSER org.rstudio.studio.client.workbench.prefs.views.PreferencesDialogConstants.panelContainerWidthNoChooser();
 
 .panelContainer {
    width: PANEL_CONTAINER_WIDTH;
@@ -10,7 +11,7 @@
 }
 
 .panelContainerNoChooser {
-   width: 468px;
+   width: PANEL_CONTAINER_WIDTH_NO_CHOOSER;
    height: PANEL_CONTAINER_HEIGHT;
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialogConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialogConstants.java
@@ -24,7 +24,12 @@ public class PreferencesDialogConstants
 {
    public static final int PANEL_CONTAINER_WIDTH  = 640;
    public static final int PANEL_CONTAINER_HEIGHT = 580;
-   
+   public static final int SECTION_CHOOSER_WIDTH = 132;
+
+   // Width of the panel container when the section chooser is not shown, e.g.
+   // Help / Accessibility / Acccessibility Options...
+   public static final int PANEL_CONTAINER_WIDTH_NO_CHOOSER = 516;
+
    public static final String panelContainerWidth()
    {
       return PANEL_CONTAINER_WIDTH + "px";
@@ -35,4 +40,8 @@ public class PreferencesDialogConstants
       return PANEL_CONTAINER_HEIGHT + "px";
    }
    
+   public static final String panelContainerWidthNoChooser()
+   {
+      return PANEL_CONTAINER_WIDTH_NO_CHOOSER + "px";
+   }
 }


### PR DESCRIPTION
### Intent

Addresses #16457

### Approach

At some point we made the options panes a bit wider but didn't adjust the width of the standalone accessibility options dialog (which doesn't show the section chooser).

Added a constant for that and adjusted the value, and also added a constant for the section chooser's width.

Now looks like this:

<img width="570" height="698" alt="fixed" src="https://github.com/user-attachments/assets/c8cea39e-56e4-40a5-bc24-2378f1c96928" />

### Automated Tests

None

### QA Notes

Test per issue.

### Documentation

NA