### PR TITLE
fix quarto syntax highlight issues

### DIFF
--- a/src/cpp/tests/automation/testthat/test-automation-quarto.R
+++ b/src/cpp/tests/automation/testthat/test-automation-quarto.R
@@ -554,3 +554,35 @@ withr::defer(.rs.automation.deleteRemote())
       expect_equal(editor$session$getLine(4), "```{=latex}")
    })
 })
+
+# https://github.com/rstudio/rstudio/issues/16463
+.rs.test("empty quarto blocks don't break highlight in chunk", {
+   
+   contents <- .rs.heredoc('
+      ---
+      title: Chunk Syntax Highlighting
+      ---
+      
+      ```{r}
+      #| echo: true
+      2 * 2
+      ```
+   ')
+   
+   remote$editor.executeWithContents(".qmd", contents, function(editor) {
+      
+      editor$gotoLine(6, 13)
+      remote$keyboard.sendKeys("<Enter>")
+      remote$keyboard.sendKeys("<Enter>")
+      Sys.sleep(0.1)
+      tokens <- as.vector(editor$session$getTokens(8))
+
+      expect_equal(tokens[[1L]]$value, "2")
+      expect_equal(tokens[[2L]]$value, " ")
+      expect_equal(tokens[[3L]]$value, "*")
+      expect_equal(tokens[[4L]]$value, " ")
+      expect_equal(tokens[[5L]]$value, "2")
+
+   })
+   
+})

--- a/src/gwt/acesupport/acemode/utils.js
+++ b/src/gwt/acesupport/acemode/utils.js
@@ -327,7 +327,6 @@ var YamlHighlightRules = require("mode/yaml_highlight_rules").YamlHighlightRules
                regex: "^\\s*(?!#)",
                onMatch: function(value, state, stack, line, context) {
                   this.next = context.quarto.state;
-                  delete context.quarto.state;
                   return this.token;
                }
             });
@@ -340,7 +339,6 @@ var YamlHighlightRules = require("mode/yaml_highlight_rules").YamlHighlightRules
             regex: "^\\s*(?!#)",
             onMatch: function(value, state, stack, line, context) {
                this.next = context.quarto.state;
-               delete context.quarto.state;
                return this.token;
             }
          });

--- a/version/news/NEWS-2025.09.1-cucumberleaf-sunflower.md
+++ b/version/news/NEWS-2025.09.1-cucumberleaf-sunflower.md
@@ -8,6 +8,7 @@
 - ([#16346](https://github.com/rstudio/rstudio/issues/16436)): Fixed an issue where certain ALTREP objects could cause RStudio to crash while populating the Environment pane
 - ([#16446](https://github.com/rstudio/rstudio/issues/16446)): Fixed a regression that could cause file downloads to fail on Windows
 - ([#16449](https://github.com/rstudio/rstudio/issues/16449)): Fixed a regression that could cause package installation to fail when installing packages from local sources
+- ([#16463](https://github.com/rstudio/rstudio/issues/16463)): Fixed an issue where syntax highlighting was broken in certain Quarto documents
 
 #### Posit Workbench
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16463.

NEWS will be added to the patch release after backporting.

### Approach

The saved state used in Quarto highlights might need to be re-used as a rule is applied multiple times against a single line. Avoid deleting the context information in this scenario.

### Automated Tests

Included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/16463.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
