### PR TITLE
Don't show copilot status messages when disabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@
 - ([#16532](https://github.com/rstudio/rstudio/issues/16352)): Fixed an issue where ongoing R Markdown render output was lost when after a browser refresh
 - ([#14510](https://github.com/rstudio/rstudio/issues/14510)): Fixed issue where gutter icons were incorrectly presented for spellcheck issues
 - ([#16474](https://github.com/rstudio/rstudio/issues/16474)): Adjusted Pane Layout options UI to improve space utilization
+- ([#16471](https://github.com/rstudio/rstudio/issues/16471)): Fixed issue where Copilot status messages appeared below editor when Copilot was disabled
 
 #### Posit Workbench
 - (#rstudio-pro/8919): Fixed an issue where duplicate project entries within a user's recent project list could cause their home page to fail to load

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1897,6 +1897,15 @@ public class TextEditingTarget implements
                @Override
                public void onCopilot(CopilotEvent event)
                {
+                  // If copilot is disabled, hide the status message as a catch-all for
+                  // this report of messages appearing when they shouldn't:
+                  // https://github.com/rstudio/rstudio/issues/16471
+                  if (!copilotHelper_.isCopilotEnabled())
+                  {
+                     view_.getStatusBar().hideStatus();
+                     return;
+                  }
+
                   switch (event.getType())
                   {
                   

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
@@ -495,6 +495,11 @@ public class TextEditingTargetCopilotHelper
    {
       copilotDisabledInThisDocument_ = false;
    }
+
+   public boolean isCopilotEnabled()
+   {
+      return copilot_.isEnabled();
+   }
    
    private String computeGhostText(String completionText)
    {


### PR DESCRIPTION
### Intent

Addresses #16471

### Approach

Before showing a Copilot message in the editor status bar, check if copilot is enabled and if not, hide all copilot messages.

### Automated Tests

None

### QA Notes

I was not able to repro this issue, but this should handle whatever scenario caused it to happen.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


