### PR TITLE
Don't tell copilot when closing a file we didn't tell it about in the first place

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@
 - ([#14510](https://github.com/rstudio/rstudio/issues/14510)): Fixed issue where gutter icons were incorrectly presented for spellcheck issues
 - ([#16474](https://github.com/rstudio/rstudio/issues/16474)): Adjusted Pane Layout options UI to improve space utilization
 - ([#16471](https://github.com/rstudio/rstudio/issues/16471)): Fixed issue where Copilot status messages appeared below editor when Copilot was disabled
+- ([#16423](https://github.com/rstudio/rstudio/issues/16423)): Fixed issue where Copilot gave a warning when closing a document it was told to ignore
 
 #### Posit Workbench
 - (#rstudio-pro/8919): Fixed an issue where duplicate project entries within a user's recent project list could cause their home page to fail to load

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -1487,6 +1487,10 @@ void onDocRemoved(boost::shared_ptr<source_database::SourceDocument> pDoc)
    if (!ensureAgentRunning())
       return;
 
+   // we didn't tell Copilot about this document, so skip this
+   if (!isIndexableDocument(pDoc))
+      return;
+
    docClosed(uriFromDocument(pDoc));
 }
 


### PR DESCRIPTION
### Intent

Addresses #16423

### Intent

We don't notify Copilot about following files when opened in RStudio, but we were telling it when they closed and it gave an error about closing a file it didn't know about.

- binary files
- hidden files (e.g. `.Renviron`)
- `Renviron.site`
- files in hidden folders (`.foo/...`)
- `.Rproj` files

### Approach

If a closing file isn’t indexable, don’t report it as closed to Copilot.

### Automated Tests

None

### QA Notes

Test per issue.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


