### PR TITLE
Fix the isShared function for k8s cgroups

### DIFF
--- a/src/cpp/core/system/LinuxResources.cpp
+++ b/src/cpp/core/system/LinuxResources.cpp
@@ -744,6 +744,10 @@ bool isSharedCgroup(const std::string& path, uid_t uid)
       return false;
    }
 
+   // Kubernetes pod - this is the cgroup
+   if (path == "0://")
+      return false;
+
    LOG_DEBUG_MESSAGE("Unrecognized cgroup pattern, assuming a shared group and using /proc/meminfo for memory usage: " + path);
 
    // By default, assume it's a shared cgroup and don't use it


### PR DESCRIPTION

### Intent

Addresses: https://github.com/rstudio/rstudio-pro/issues/9178


### Approach

This pattern indicates it's a per-pod cgroup so we should use it for memory usage, not the /proc/meminfo that's the node




