### PR TITLE
don't show min/max buttons for full-height source columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 - ([#16474](https://github.com/rstudio/rstudio/issues/16474)): Adjusted Pane Layout options UI to improve space utilization
 - ([#16471](https://github.com/rstudio/rstudio/issues/16471)): Fixed issue where Copilot status messages appeared below editor when Copilot was disabled
 - ([#16423](https://github.com/rstudio/rstudio/issues/16423)): Fixed issue where Copilot gave a warning when closing a document it was told to ignore
+- ([#16485](https://github.com/rstudio/rstudio/issues/16485)): Removed inoperative min/max controls from Source Columns
 
 #### Posit Workbench
 - (#rstudio-pro/8919): Fixed an issue where duplicate project entries within a user's recent project list could cause their home page to fail to load

--- a/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
@@ -44,6 +44,11 @@ public class WindowFrame extends Composite
 {
    public WindowFrame(String name, String accessibleName)
    {
+      this(name, accessibleName, true);
+   }
+
+   public WindowFrame(String name, String accessibleName, boolean showMinMaxButtons)
+   {
       name_ = name;
 
       RStudioGinjector.INSTANCE.injectMembers(this);
@@ -66,21 +71,24 @@ public class WindowFrame extends Composite
       frame_.setStylePrimaryName(styles.windowframe());
       frame_.addStyleName(styles.windowFrameObject());
 
-      frame_.add(minimizeButton_);
-      frame_.setWidgetTopHeight(minimizeButton_,
-            TOP_SHADOW_WIDTH + 4, Style.Unit.PX,
-            14, Style.Unit.PX);
-      frame_.setWidgetRightWidth(minimizeButton_,
-            RIGHT_SHADOW_WIDTH + 25, Style.Unit.PX,
-            14, Style.Unit.PX);
+      if (showMinMaxButtons)
+      {
+         frame_.add(minimizeButton_);
+         frame_.setWidgetTopHeight(minimizeButton_,
+               TOP_SHADOW_WIDTH + 4, Style.Unit.PX,
+               14, Style.Unit.PX);
+         frame_.setWidgetRightWidth(minimizeButton_,
+               RIGHT_SHADOW_WIDTH + 25, Style.Unit.PX,
+               14, Style.Unit.PX);
 
-      frame_.add(maximizeButton_);
-      frame_.setWidgetTopHeight(maximizeButton_,
-                                TOP_SHADOW_WIDTH + 4, Style.Unit.PX,
-                                14, Style.Unit.PX);
-      frame_.setWidgetRightWidth(maximizeButton_,
-                                 RIGHT_SHADOW_WIDTH + 7, Style.Unit.PX,
-                                 14, Style.Unit.PX);
+         frame_.add(maximizeButton_);
+         frame_.setWidgetTopHeight(maximizeButton_,
+                                   TOP_SHADOW_WIDTH + 4, Style.Unit.PX,
+                                   14, Style.Unit.PX);
+         frame_.setWidgetRightWidth(maximizeButton_,
+                                    RIGHT_SHADOW_WIDTH + 7, Style.Unit.PX,
+                                    14, Style.Unit.PX);
+      }
 
       buttonsArea_ = new FlowPanel();
       frame_.add(buttonsArea_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -1786,7 +1786,8 @@ public class PaneManager
 
    private LogicalWindow createSource(String frameName, String accessibleName, Widget display)
    {
-      WindowFrame sourceFrame = new WindowFrame(frameName, accessibleName);
+      boolean showMinMaxButtons = StringUtil.equals(frameName, SourceColumnManager.MAIN_SOURCE_NAME);
+      WindowFrame sourceFrame = new WindowFrame(frameName, accessibleName, showMinMaxButtons);
       sourceFrame.setFillWidget(display);
       LogicalWindow sourceWindow = new LogicalWindow(
             sourceFrame,


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16485

### Approach

Only show min/max widgets in the regular source pane, not in source columns.

<img width="1166" height="743" alt="source-column-no-min-max" src="https://github.com/user-attachments/assets/b55be34b-99f5-4316-8699-1d5162efb092" />

### Automated Tests

None

### QA Notes

Verify widgets don't show in source columns but continue to show in the main source pane.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


