### PR TITLE
Fix LOG_TRACE_MESSAGE

### DIFF
--- a/src/cpp/shared_core/include/shared_core/Logger.hpp
+++ b/src/cpp/shared_core/include/shared_core/Logger.hpp
@@ -94,7 +94,8 @@ enum class LogLevel
    INFO = 3,       // Info, warning, and error messages will be logged.
    DEBUG = 4,      // All messages will be logged, except trace messages.
    DEBUG_LEVEL = 4,// Same as DEBUG. Preferred to avoid name conflict with core/Macros.hpp's DEBUG(..) macro used in rsession
-   TRACE = 5       // All messages will be logged, including trace messages.
+   TRACE = 5,      // All messages will be logged, including trace messages.
+   TRACE_LEVEL = 5,// Same as TRACE. Preferred to avoid name conflict with core/Macros.hpp's TRACE(..) macro used in rsession
 };
 
 /**


### PR DESCRIPTION
* Add missing TRACE_LEVEL enum in LogLevel class.


### Intent

The logging macro `LOG_TRACE_MESSAGE()` expanded out to use an enum value that didn't exist.

### Approach

Define the expected `TRACE_LEVEL` enum following the established pattern of `DEBUG_LEVEL` in the same enum.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Ensure you have updated the QA Notes in the original issue.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


