### PR TITLE
Add a news item for Positron Pro support on RHEL 8

### DIFF
--- a/version/news/NEWS-2025.09.1-cucumberleaf-sunflower.md
+++ b/version/news/NEWS-2025.09.1-cucumberleaf-sunflower.md
@@ -1,5 +1,11 @@
 ## RStudio 2025.09.1 "Cucumberleaf Sunflower" Release Notes
 
+### New
+
+#### Posit Workbench
+
+- Positron Pro sessions are now supported on RHEL 8
+
 ### Fixed
 
 #### RStudio


### PR DESCRIPTION
### Documentation

Simply adds a news item:
> - Positron Pro sessions are now supported on RHEL 8

