### PR TITLE
Update release notes for 2025.09.1+401.pro2

### DIFF
--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -29,12 +29,14 @@ This page provides the release notes associated with each release of RStudio and
 - ([#16346](https://github.com/rstudio/rstudio/issues/16436)): Fixed an issue where certain ALTREP objects could cause RStudio to crash while populating the Environment pane
 - ([#16446](https://github.com/rstudio/rstudio/issues/16446)): Fixed a regression that could cause file downloads to fail on Windows
 - ([#16449](https://github.com/rstudio/rstudio/issues/16449)): Fixed a regression that could cause package installation to fail when installing packages from local sources
-- ([#16463](https://github.com/rstudio/rstudio/issues/16463)): Fixed an issue where syntax highlighting was broken in certain Quarto documents
+- ([#16445](https://github.com/rstudio/rstudio/issues/16445)): Fixed an issue that cased an R session crashes when assigning the return value of HiResTEC::getMultipleBPC() to a variable
 
 #### Posit Workbench
 
 - (rstudio-pro#9163): Fixed the Open Project command to stop throwing an exception
 - (rstudio-pro#9219): Fixed a regression that caused the image selection dropdown in the new session dialog to display the wrong image
+- (rstudio-pro#9078): Fixed API error when username and posixuser do not match
+- (rstudio-pro#9107): Fixed config out of range error
 
 ## 2025.09.0 {#rstudio-2025.09.0}
 

--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -26,10 +26,9 @@ This page provides the release notes associated with each release of RStudio and
 
 - ([#16444](https://github.com/rstudio/rstudio/issues/16444)): Fixed an issue where the file extension of a new C++ source file was truncated to `.cp` on macOS
 - ([#16455](https://github.com/rstudio/rstudio/issues/16455)): Fixed an issue where file extensions for newly saved files were always lowercase on macOS
-- ([#16346](https://github.com/rstudio/rstudio/issues/16346)): Fixed an issue where certain ALTREP objects could cause RStudio to crash while populating the Environment pane
-- ([#16446](https://github.com/rstudio/rstudio/issues/16446)): Fixed a regression that could cause file downloads to fail on Windows
+- ([#16346](https://github.com/rstudio/rstudio/issues/16446)): Fixed an issue where certain ALTREP objects could cause RStudio to crash while populating the Environment pane. This fix also resolves duplicates [#16445](https://github.com/rstudio/rstudio/issues/16445) and [#16465](https://github.com/rstudio/rstudio/issues/16465)
 - ([#16449](https://github.com/rstudio/rstudio/issues/16449)): Fixed a regression that could cause package installation to fail when installing packages from local sources
-- ([#16445](https://github.com/rstudio/rstudio/issues/16445)): Fixed an issue that caused an R session crashes when assigning the return value of HiResTEC::getMultipleBPC() to a variable
+- ([#16463](https://github.com/rstudio/rstudio/issues/16463)): Fixed an issue where syntax highlighting was broken in certain Quarto documents
 
 #### Posit Workbench
 

--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -9,6 +9,34 @@ format:
 
 This page provides the release notes associated with each release of RStudio and Posit Workbench. Please contact customer support (<a href="mailto:support@posit.co">support@posit.co</a>) for questions about the described changes.
 
+## RStudio 2025.09.1
+
+**"Cucumberleaf Sunflower"**
+
+>Date: 2025-10-01
+
+### New
+
+#### Posit Workbench
+
+- Positron Pro sessions are now supported on RHEL 8
+
+### Fixed
+
+#### RStudio
+
+- ([#16444](https://github.com/rstudio/rstudio/issues/16444)): Fixed an issue where the file extension of a new C++ source file was truncated to `.cp` on macOS
+- ([#16455](https://github.com/rstudio/rstudio/issues/16455)): Fixed an issue where file extensions for newly saved files were always lowercase on macOS
+- ([#16346](https://github.com/rstudio/rstudio/issues/16436)): Fixed an issue where certain ALTREP objects could cause RStudio to crash while populating the Environment pane
+- ([#16446](https://github.com/rstudio/rstudio/issues/16446)): Fixed a regression that could cause file downloads to fail on Windows
+- ([#16449](https://github.com/rstudio/rstudio/issues/16449)): Fixed a regression that could cause package installation to fail when installing packages from local sources
+- ([#16463](https://github.com/rstudio/rstudio/issues/16463)): Fixed an issue where syntax highlighting was broken in certain Quarto documents
+
+#### Posit Workbench
+
+- (rstudio-pro#9163): Fixed the Open Project command to stop throwing an exception
+- (rstudio-pro#9219): Fixed a regression that caused the image selection dropdown in the new session dialog to display the wrong image
+
 ## 2025.09.0 {#rstudio-2025.09.0}
 
 | **"Cucumberleaf Sunflower"** | Date: 2025-09-12

--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -26,7 +26,7 @@ This page provides the release notes associated with each release of RStudio and
 
 - ([#16444](https://github.com/rstudio/rstudio/issues/16444)): Fixed an issue where the file extension of a new C++ source file was truncated to `.cp` on macOS
 - ([#16455](https://github.com/rstudio/rstudio/issues/16455)): Fixed an issue where file extensions for newly saved files were always lowercase on macOS
-- ([#16346](https://github.com/rstudio/rstudio/issues/16346)): Fixed an issue where certain ALTREP objects could cause RStudio to crash while populating the Environment pane. This fix also resolves duplicates [#16445](https://github.com/rstudio/rstudio/issues/16445) and [#16465](https://github.com/rstudio/rstudio/issues/16465)
+- ([#16436](https://github.com/rstudio/rstudio/issues/16436)): Fixed an issue where certain ALTREP objects could cause RStudio to crash while populating the Environment pane. This fix also resolves duplicates [#16445](https://github.com/rstudio/rstudio/issues/16445) and [#16465](https://github.com/rstudio/rstudio/issues/16465)
 - ([#16446](https://github.com/rstudio/rstudio/issues/16446)): Fixed a regression that could cause file downloads to fail on Windows
 - ([#16449](https://github.com/rstudio/rstudio/issues/16449)): Fixed a regression that could cause package installation to fail when installing packages from local sources
 - ([#16463](https://github.com/rstudio/rstudio/issues/16463)): Fixed an issue where syntax highlighting was broken in certain Quarto documents

--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -29,7 +29,7 @@ This page provides the release notes associated with each release of RStudio and
 - ([#16346](https://github.com/rstudio/rstudio/issues/16346)): Fixed an issue where certain ALTREP objects could cause RStudio to crash while populating the Environment pane
 - ([#16446](https://github.com/rstudio/rstudio/issues/16446)): Fixed a regression that could cause file downloads to fail on Windows
 - ([#16449](https://github.com/rstudio/rstudio/issues/16449)): Fixed a regression that could cause package installation to fail when installing packages from local sources
-- ([#16445](https://github.com/rstudio/rstudio/issues/16445)): Fixed an issue that cased an R session crashes when assigning the return value of HiResTEC::getMultipleBPC() to a variable
+- ([#16445](https://github.com/rstudio/rstudio/issues/16445)): Fixed an issue that caused an R session crashes when assigning the return value of HiResTEC::getMultipleBPC() to a variable
 
 #### Posit Workbench
 

--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -26,7 +26,7 @@ This page provides the release notes associated with each release of RStudio and
 
 - ([#16444](https://github.com/rstudio/rstudio/issues/16444)): Fixed an issue where the file extension of a new C++ source file was truncated to `.cp` on macOS
 - ([#16455](https://github.com/rstudio/rstudio/issues/16455)): Fixed an issue where file extensions for newly saved files were always lowercase on macOS
-- ([#16346](https://github.com/rstudio/rstudio/issues/16436)): Fixed an issue where certain ALTREP objects could cause RStudio to crash while populating the Environment pane
+- ([#16346](https://github.com/rstudio/rstudio/issues/16346)): Fixed an issue where certain ALTREP objects could cause RStudio to crash while populating the Environment pane
 - ([#16446](https://github.com/rstudio/rstudio/issues/16446)): Fixed a regression that could cause file downloads to fail on Windows
 - ([#16449](https://github.com/rstudio/rstudio/issues/16449)): Fixed a regression that could cause package installation to fail when installing packages from local sources
 - ([#16445](https://github.com/rstudio/rstudio/issues/16445)): Fixed an issue that cased an R session crashes when assigning the return value of HiResTEC::getMultipleBPC() to a variable

--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -9,11 +9,10 @@ format:
 
 This page provides the release notes associated with each release of RStudio and Posit Workbench. Please contact customer support (<a href="mailto:support@posit.co">support@posit.co</a>) for questions about the described changes.
 
-## RStudio 2025.09.1
 
-**"Cucumberleaf Sunflower"**
+## 2025.09.1 {#rstudio-2025.09.1}
 
->Date: 2025-10-01
+| **"Cucumberleaf Sunflower"** | Date: 2025-10-01
 
 ### New
 

--- a/version/news/NEWS-2025.09.1-cucumberleaf-sunflower.md
+++ b/version/news/NEWS-2025.09.1-cucumberleaf-sunflower.md
@@ -12,7 +12,7 @@
 
 - ([#16444](https://github.com/rstudio/rstudio/issues/16444)): Fixed an issue where the file extension of a new C++ source file was truncated to `.cp` on macOS
 - ([#16455](https://github.com/rstudio/rstudio/issues/16455)): Fixed an issue where file extensions for newly saved files were always lowercase on macOS
-- ([#16346](https://github.com/rstudio/rstudio/issues/16436)): Fixed an issue where certain ALTREP objects could cause RStudio to crash while populating the Environment pane
+- ([#16346](https://github.com/rstudio/rstudio/issues/16446)): Fixed an issue where certain ALTREP objects could cause RStudio to crash while populating the Environment pane
 - ([#16446](https://github.com/rstudio/rstudio/issues/16446)): Fixed a regression that could cause file downloads to fail on Windows
 - ([#16449](https://github.com/rstudio/rstudio/issues/16449)): Fixed a regression that could cause package installation to fail when installing packages from local sources
 - ([#16463](https://github.com/rstudio/rstudio/issues/16463)): Fixed an issue where syntax highlighting was broken in certain Quarto documents

--- a/version/news/NEWS-2025.09.1-cucumberleaf-sunflower.md
+++ b/version/news/NEWS-2025.09.1-cucumberleaf-sunflower.md
@@ -12,11 +12,9 @@
 
 - ([#16444](https://github.com/rstudio/rstudio/issues/16444)): Fixed an issue where the file extension of a new C++ source file was truncated to `.cp` on macOS
 - ([#16455](https://github.com/rstudio/rstudio/issues/16455)): Fixed an issue where file extensions for newly saved files were always lowercase on macOS
-- ([#16346](https://github.com/rstudio/rstudio/issues/16446)): Fixed an issue where certain ALTREP objects could cause RStudio to crash while populating the Environment pane
-- ([#16446](https://github.com/rstudio/rstudio/issues/16446)): Fixed a regression that could cause file downloads to fail on Windows
+- ([#16346](https://github.com/rstudio/rstudio/issues/16446)): Fixed an issue where certain ALTREP objects could cause RStudio to crash while populating the Environment pane. This fix also resolves duplicates [#16445](https://github.com/rstudio/rstudio/issues/16445) and [#16465](https://github.com/rstudio/rstudio/issues/16465)
 - ([#16449](https://github.com/rstudio/rstudio/issues/16449)): Fixed a regression that could cause package installation to fail when installing packages from local sources
 - ([#16463](https://github.com/rstudio/rstudio/issues/16463)): Fixed an issue where syntax highlighting was broken in certain Quarto documents
-- ([#16445](https://github.com/rstudio/rstudio/issues/16445)): Fixed an issue that caused an R session crashes when assigning the return value of HiResTEC::getMultipleBPC() to a variable
 
 #### Posit Workbench
 

--- a/version/news/NEWS-2025.09.1-cucumberleaf-sunflower.md
+++ b/version/news/NEWS-2025.09.1-cucumberleaf-sunflower.md
@@ -12,7 +12,7 @@
 
 - ([#16444](https://github.com/rstudio/rstudio/issues/16444)): Fixed an issue where the file extension of a new C++ source file was truncated to `.cp` on macOS
 - ([#16455](https://github.com/rstudio/rstudio/issues/16455)): Fixed an issue where file extensions for newly saved files were always lowercase on macOS
-- ([#16346](https://github.com/rstudio/rstudio/issues/16346)): Fixed an issue where certain ALTREP objects could cause RStudio to crash while populating the Environment pane. This fix also resolves duplicates [#16445](https://github.com/rstudio/rstudio/issues/16445) and [#16465](https://github.com/rstudio/rstudio/issues/16465)
+- ([#16436](https://github.com/rstudio/rstudio/issues/16436)): Fixed an issue where certain ALTREP objects could cause RStudio to crash while populating the Environment pane. This fix also resolves duplicates [#16445](https://github.com/rstudio/rstudio/issues/16445) and [#16465](https://github.com/rstudio/rstudio/issues/16465)
 - ([#16446](https://github.com/rstudio/rstudio/issues/16446)): Fixed a regression that could cause file downloads to fail on Windows
 - ([#16449](https://github.com/rstudio/rstudio/issues/16449)): Fixed a regression that could cause package installation to fail when installing packages from local sources
 - ([#16463](https://github.com/rstudio/rstudio/issues/16463)): Fixed an issue where syntax highlighting was broken in certain Quarto documents

--- a/version/news/NEWS-2025.09.1-cucumberleaf-sunflower.md
+++ b/version/news/NEWS-2025.09.1-cucumberleaf-sunflower.md
@@ -16,8 +16,11 @@
 - ([#16446](https://github.com/rstudio/rstudio/issues/16446)): Fixed a regression that could cause file downloads to fail on Windows
 - ([#16449](https://github.com/rstudio/rstudio/issues/16449)): Fixed a regression that could cause package installation to fail when installing packages from local sources
 - ([#16463](https://github.com/rstudio/rstudio/issues/16463)): Fixed an issue where syntax highlighting was broken in certain Quarto documents
+- ([#16445](https://github.com/rstudio/rstudio/issues/16445)): Fixed an issue that cased an R session crashes when assigning the return value of HiResTEC::getMultipleBPC() to a variable
 
 #### Posit Workbench
 
 - (rstudio-pro#9163): Fixed the Open Project command to stop throwing an exception
 - (rstudio-pro#9219): Fixed a regression that caused the image selection dropdown in the new session dialog to display the wrong image
+- (rstudio-pro#9078): Fixed API error when username and posixuser do not match
+- (rstudio-pro#9107): Fixed config out of range error

--- a/version/news/NEWS-2025.09.1-cucumberleaf-sunflower.md
+++ b/version/news/NEWS-2025.09.1-cucumberleaf-sunflower.md
@@ -16,7 +16,7 @@
 - ([#16446](https://github.com/rstudio/rstudio/issues/16446)): Fixed a regression that could cause file downloads to fail on Windows
 - ([#16449](https://github.com/rstudio/rstudio/issues/16449)): Fixed a regression that could cause package installation to fail when installing packages from local sources
 - ([#16463](https://github.com/rstudio/rstudio/issues/16463)): Fixed an issue where syntax highlighting was broken in certain Quarto documents
-- ([#16445](https://github.com/rstudio/rstudio/issues/16445)): Fixed an issue that cased an R session crashes when assigning the return value of HiResTEC::getMultipleBPC() to a variable
+- ([#16445](https://github.com/rstudio/rstudio/issues/16445)): Fixed an issue that caused an R session crashes when assigning the return value of HiResTEC::getMultipleBPC() to a variable
 
 #### Posit Workbench
 


### PR DESCRIPTION

Update release notes for IDE / Workbench 2025.09.1+401.pro2 release.

:warning: **Before converting from Draft PR:** :warning:

This change has been generated by the release script. Content is generated based on `version/news/NEWS-2025.09.1-cucumberleaf-sunflower.md`. If this file was not in sync with Pro or did not include items from other sources (i.e. the vscode extension), then some items may be missing.  Please verify content/formatting is correct and make changes if necessary.
