### PR TITLE
only use paged tables for auto-printed data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 - ([#16281](https://github.com/rstudio/rstudio/issues/16281)): RStudio will no longer perform type inference on the completion results provided by .DollarNames methods for values where `attr(*, "suppressTypeInference")` is `TRUE`
 - ([#16375](https://github.com/rstudio/rstudio/issues/16375)): Copilot Language Server (completions) is now launched via node.js instead of as a standalone binary
 - ([#16427](https://github.com/rstudio/rstudio/issues/16427)): RStudio now provided a diagnostic warning for invocations of `paste()` with unexpected named arguments
+- ([#16483](https://github.com/rstudio/rstudio/issues/16483)): In R Markdown / Quarto documents, RStudio now only used a paged-table view for auto-printed data objects; explicit invocations of `print()` will use the existing print method
 
 #### Posit Workbench
 - ([#16218](https://github.com/rstudio/rstudio/issues/16218)) Workbench no longer uses Crashpad for collecting crash dumps

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -123,15 +123,11 @@
           overridePrint(o$x, o$options, o$className, o$nRow, o$nCol)
       } else {
         # appears to be an explicit invocation of 'print';
-        # use the saved print method if available, or the next
-        # method if not
+        # use the saved print method if available, or the next method if not
         methods <- paste("print", class(x), sep = ".")
-        for (method in methods) {
-           if (exists(method, envir = .rs.S3Originals)) {
+        for (method in methods)
+           if (exists(method, envir = .rs.S3Originals))
               return(.rs.S3Originals[[method]](x, ...))
-           }
-        }
-        
         NextMethod()
       }
       

--- a/src/cpp/tests/automation/testthat/test-automation-rmarkdown.R
+++ b/src/cpp/tests/automation/testthat/test-automation-rmarkdown.R
@@ -631,3 +631,42 @@ withr::defer(.rs.automation.deleteRemote())
    })
    
 })
+
+# https://github.com/rstudio/rstudio/issues/16483
+.rs.test("paged-table representation only used for auto-printed objects", {
+   
+   contents <- .rs.heredoc('
+      ---
+      title: Paged Table; Auto-Printing
+      ---
+      
+      ```{r}
+      mtcars
+      ```
+   ')
+   
+   remote$editor.executeWithContents(".Rmd", contents, function(editor) {
+      editor$gotoLine(6)
+      remote$commands.execute(.rs.appCommands$executeCurrentChunk)
+      Sys.sleep(1)
+      expect_no_error(remote$dom.querySelector(".pagedtable"))
+   })
+   
+   contents <- .rs.heredoc('
+      ---
+      title: Paged Table; Explicit Printing
+      ---
+      
+      ```{r}
+      print(mtcars)
+      ```
+   ')
+   
+   remote$editor.executeWithContents(".Rmd", contents, function(editor) {
+      editor$gotoLine(6)
+      remote$commands.execute(.rs.appCommands$executeCurrentChunk)
+      Sys.sleep(1)
+      expect_error(remote$dom.querySelector(".pagedtable"))
+   })
+   
+})


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16483.

### Approach

Our paged table print tooling relies on us injecting S3 method overrides for various classes. This PR gives us a mechanism for delegating back to the original method, in cases where `print()` appears to have been explicitly invoked by the user, as opposed to being synthesized by R for an auto-printed object.

### Automated Tests

Included with PR.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/16483.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
