### PR TITLE
increase click target size in Files / Packages pane links

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/cellview/LinkColumn.java
+++ b/src/gwt/src/org/rstudio/core/client/cellview/LinkColumn.java
@@ -98,7 +98,7 @@ public abstract class LinkColumn<T> extends Column<T, String>
 
    interface NameTemplate extends SafeHtmlTemplates
    {
-      @Template("<span class=\"{0}\" title=\"{1}\">{1}</span>")
+      @Template("<div class=\"{0}\" title=\"{1}\">{1}</div>")
       SafeHtml render(String className, String title);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageLinkColumn.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageLinkColumn.css
@@ -2,7 +2,6 @@
 @external editor_dark, ace_editor_theme;
 
 .icon {
-   display: inline-block;
    width: 16px;
    height: 16px;
    margin-right: 4px;
@@ -14,7 +13,6 @@
 }
 
 .iconPlaceholder {
-   display: inline-block;
    width: 16px;
    height: 16px;
    margin-right: 4px;
@@ -25,6 +23,7 @@
 }
 
 .link {
+   flex: 1;
    overflow: hidden;
    text-overflow: ellipsis;
    color: #0000AA;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageLinkColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageLinkColumn.java
@@ -215,7 +215,7 @@ public abstract class PackageLinkColumn extends Column<PackageInfo, PackageInfo>
 
    interface Templates extends SafeHtmlTemplates
    {
-      @Template("<span class=\"{0}\" title=\"{1}\">{1}</span>")
+      @Template("<div class=\"{0}\" title=\"{1}\">{1}</div>")
       SafeHtml renderPackageName(String className, String title);
 
       @Template("<img class=\"rstudio_vulnerability_icon {0}\" title=\"{1}\" src=\"{2}\"></img>")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGrid.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGrid.css
@@ -8,7 +8,7 @@
 @eval THEME_ALTERNATE_BACKGROUND org.rstudio.core.client.theme.ThemeColors.alternateBackground;
 
 .packageColumn {
-   display: block;
+   display: flex;
    white-space: nowrap;
    text-overflow: ellipsis;
    overflow: hidden;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16484.

### Approach

- Use space-filling divs in the Files pane.
- Use flexbox in the Packages pane to size packages appropriately.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/16484.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
