### PR TITLE
allow visibility of Source column to be controlled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 - ([#16427](https://github.com/rstudio/rstudio/issues/16427)): RStudio now provided a diagnostic warning for invocations of `paste()` with unexpected named arguments
 - ([#16483](https://github.com/rstudio/rstudio/issues/16483)): In R Markdown / Quarto documents, RStudio now only used a paged-table view for auto-printed data objects; explicit invocations of `print()` will use the existing print method
 - ([#16480](https://github.com/rstudio/rstudio/issues/16480)): RStudio now has a full-height "Sidebar" pane
+- ([#16435](https://github.com/rstudio/rstudio/issues/16435)): The visibility of the Source column in the Packages pane can now be toggled via user preference
 
 #### Posit Workbench
 - ([#16218](https://github.com/rstudio/rstudio/issues/16218)) Workbench no longer uses Crashpad for collecting crash dumps

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -207,6 +207,7 @@ namespace prefs {
 #define kRealTimeSpellchecking "real_time_spellchecking"
 #define kNavigateToBuildError "navigate_to_build_error"
 #define kPackagesPaneEnabled "packages_pane_enabled"
+#define kPackagesSourceColumnEnabled "packages_source_column_enabled"
 #define kCppTemplate "cpp_template"
 #define kRestoreSourceDocuments "restore_source_documents"
 #define kHandleErrorsInUserCodeOnly "handle_errors_in_user_code_only"
@@ -1160,6 +1161,12 @@ public:
     */
    bool packagesPaneEnabled();
    core::Error setPackagesPaneEnabled(bool val);
+
+   /**
+    * Whether to display the Source column in the Package's pane.
+    */
+   bool packagesSourceColumnEnabled();
+   core::Error setPackagesSourceColumnEnabled(bool val);
 
    /**
     * C++ template.

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -1087,6 +1087,15 @@
    clear = function() { .rs.clearUserPref("packages_pane_enabled") }
 )
 
+# Display the Source column in the Packages pane
+#
+# Whether to display the Source column in the Package's pane.
+.rs.uiPrefs$packagesSourceColumnEnabled <- list(
+   get = function() { .rs.getUserPref("packages_source_column_enabled") },
+   set = function(value) { .rs.setUserPref("packages_source_column_enabled", value) },
+   clear = function() { .rs.clearUserPref("packages_source_column_enabled") }
+)
+
 # C++ template
 #
 # C++ template.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -1532,6 +1532,19 @@ core::Error UserPrefValues::setPackagesPaneEnabled(bool val)
 }
 
 /**
+ * Whether to display the Source column in the Package's pane.
+ */
+bool UserPrefValues::packagesSourceColumnEnabled()
+{
+   return readPref<bool>("packages_source_column_enabled");
+}
+
+core::Error UserPrefValues::setPackagesSourceColumnEnabled(bool val)
+{
+   return writePref("packages_source_column_enabled", val);
+}
+
+/**
  * C++ template.
  */
 std::string UserPrefValues::cppTemplate()
@@ -3626,6 +3639,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kRealTimeSpellchecking,
       kNavigateToBuildError,
       kPackagesPaneEnabled,
+      kPackagesSourceColumnEnabled,
       kCppTemplate,
       kRestoreSourceDocuments,
       kHandleErrorsInUserCodeOnly,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -822,6 +822,12 @@
             "title": "Enable the Packages pane",
             "description": "Whether to enable RStudio's Packages pane."
         },
+        "packages_source_column_enabled": {
+            "type": "boolean",
+            "default": true,
+            "title": "Display Source column",
+            "description": "Whether to display the Source column in the Package's pane."
+        },
         "cpp_template": {
             "type": "string",
             "default": "Rcpp",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1691,6 +1691,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Whether to display the Source column in the Package's pane.
+    */
+   public PrefValue<Boolean> packagesSourceColumnEnabled()
+   {
+      return bool(
+         "packages_source_column_enabled",
+         _constants.packagesSourceColumnEnabledTitle(), 
+         _constants.packagesSourceColumnEnabledDescription(), 
+         true);
+   }
+
+   /**
     * C++ template.
     */
    public PrefValue<String> cppTemplate()
@@ -4097,6 +4109,8 @@ public class UserPrefsAccessor extends Prefs
          navigateToBuildError().setValue(layer, source.getBool("navigate_to_build_error"));
       if (source.hasKey("packages_pane_enabled"))
          packagesPaneEnabled().setValue(layer, source.getBool("packages_pane_enabled"));
+      if (source.hasKey("packages_source_column_enabled"))
+         packagesSourceColumnEnabled().setValue(layer, source.getBool("packages_source_column_enabled"));
       if (source.hasKey("cpp_template"))
          cppTemplate().setValue(layer, source.getString("cpp_template"));
       if (source.hasKey("restore_source_documents"))
@@ -4521,6 +4535,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(realTimeSpellchecking());
       prefs.add(navigateToBuildError());
       prefs.add(packagesPaneEnabled());
+      prefs.add(packagesSourceColumnEnabled());
       prefs.add(cppTemplate());
       prefs.add(restoreSourceDocuments());
       prefs.add(handleErrorsInUserCodeOnly());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -998,6 +998,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String packagesPaneEnabledDescription();
 
    /**
+    * Whether to display the Source column in the Package's pane.
+    */
+   @DefaultStringValue("Display the Source column in the Packages pane")
+   String packagesSourceColumnEnabledTitle();
+   @DefaultStringValue("Whether to display the Source column in the Package's pane.")
+   String packagesSourceColumnEnabledDescription();
+
+   /**
     * C++ template.
     */
    @DefaultStringValue("C++ template")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -504,6 +504,10 @@ navigateToBuildErrorDescription = Whether to navigate to build errors.
 packagesPaneEnabledTitle = Enable the Packages pane
 packagesPaneEnabledDescription = Whether to enable RStudio's Packages pane.
 
+# Whether to display the Source column in the Package's pane.
+packagesSourceColumnEnabledTitle = Display the Source column in the Packages pane
+packagesSourceColumnEnabledDescription = Whether to display the Source column in the Package's pane.
+
 # C++ template.
 cppTemplateTitle = C++ template
 cppTemplateDescription = C++ template.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesConstants.java
@@ -91,4 +91,5 @@ public interface PackagesConstants extends com.google.gwt.i18n.client.Messages {
     String selectPackageArchiveCaption();
     String selectAllLabel();
     String selectNoneLabel();
+    String displaySourceColumn();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesConstants_en.properties
@@ -74,3 +74,4 @@ selectPackageArchiveCaption=Select Package Archive
 selectAllLabel=Select All
 selectNoneLabel=Select None
 browsePackageOn=Browse package on {0} [{1}]
+displaySourceColumn=Display Source column

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesConstants_fr.properties
@@ -74,3 +74,4 @@ selectPackageArchiveCaption=Sélectionner l''archive des paquets
 selectAllLabel=Sélectionner tout
 selectNoneLabel=Sélectionner Aucun
 browsePackageOn=Parcourir le paquet sur {0} [{1}]
+displaySourceColumn=Afficher la colonne source


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16435.

### Approach

- Add a new preference used to toggle visibility of the source column.
- Also introduce a small dropdown menu item next to the Refresh button to control its visibility.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/16435.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
