### PR TITLE
change Linux Desktop to use native dialogs by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,8 @@
 - ([#16485](https://github.com/rstudio/rstudio/issues/16485)): Removed inoperative min/max controls from Source Columns
 - ([#16516](https://github.com/rstudio/rstudio/issues/16516)): Fixed issue with extraneous space in object size for large objects in Environment pane
 - ([#16542](https://github.com/rstudio/rstudio/issues/16542)): Improved accessibility of column splitters by adding accessible labels for screen readers
+- ([#14683](https://github.com/rstudio/rstudio/issues/14683)): Changed RStudio Desktop on Linux to default to using native file and message dialog boxes
+- ([#15340](https://github.com/rstudio/rstudio/issues/15340)): Fixed issue where native file dialogs on RStudio Desktop on Linux wouldn't show .Rproj files
 
 #### Posit Workbench
 - (#rstudio-pro/8919): Fixed an issue where duplicate project entries within a user's recent project list could cause their home page to fail to load

--- a/src/cpp/session/prefs/UserPrefsComputedLayer.cpp
+++ b/src/cpp/session/prefs/UserPrefsComputedLayer.cpp
@@ -83,7 +83,8 @@ Error UserPrefsComputedLayer::readPrefs()
    layer[kDefaultRVersion] = defaultRVersionJson;
 
    #ifdef __linux__
-   layer[kNativeFileDialogs] = false;
+   // uncomment this to default to web-based file dialogs on Linux Desktop
+   // layer[kNativeFileDialogs] = false;
    #endif
 
    // Synctex viewer ----------------------------------------------------------


### PR DESCRIPTION
### Intent

Addresses #14683 and #15340

### Approach

Change back to native file and message dialogs on Linux desktop. All known issues have been resolved in Electron/Chromium (famous last words).

### Automated Tests

This is an area we are unable to automate with our current techniques.

### QA Notes

Note that the issue with .Rproj files has been fixed since 2025.05 (if using native desktop dialogs on Linux) but figured worth documenting in NEWS with the switch back to native dialogs by default.

If possible, test the native file dialogs on a few Linux distributions, especially with different desktop managers.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


