### PR TITLE
Sidebar tweaks (when no tabs are assigned to it)

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/UIConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/UIConstants.java
@@ -27,4 +27,6 @@ public interface UIConstants extends com.google.gwt.i18n.client.Messages {
     String cannotAddMoreColumnsText(int maxColumnCount);
     String closeText();
     String configurePanesButtonText();
+    String noTabsAssignedText();
+    String sidebarTitleText();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/UIConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/UIConstants_en.properties
@@ -10,3 +10,5 @@ cannotAddColumnText=Cannot Add Column
 cannotAddMoreColumnsText=You can''t add more than {0} columns.
 closeText=Close
 configurePanesButtonText=Configure Panes...
+noTabsAssignedText=The Sidebar has no tabs assigned to it.
+sidebarTitleText=Sidebar

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/UIConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/UIConstants_fr.properties
@@ -10,3 +10,5 @@ cannotAddColumnText=Impossible d''ajouter une colonne
 cannotAddMoreColumnsText=Vous ne pouvez pas ajouter plus de {0} colonnes.
 closeText=Fermer
 configurePanesButtonText=Configurer les panneaux...
+noTabsAssignedText=La barre latérale n''a pas d''onglets assignés.
+sidebarTitleText=Barre latérale

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchTabPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchTabPanel.java
@@ -83,19 +83,36 @@ class WorkbenchTabPanel
                                  UTILITY_AREA_SIZE, Unit.PX);
       panel_.setWidgetTopHeight(utilPanel_, 0, Unit.PX, 22, Unit.PX);
 
+      // Create sidebar title for when there are no tabs
+      sidebarTitlePanel_ = new HTML(constants_.sidebarTitleText());
+      sidebarTitlePanel_.setStylePrimaryName(ThemeStyles.INSTANCE.multiPodUtilityArea());
+      Style titleStyle = sidebarTitlePanel_.getElement().getStyle();
+      titleStyle.setLineHeight(22, Unit.PX);
+      titleStyle.setPaddingLeft(8, Unit.PX);
+      titleStyle.setProperty("display", "flex");
+      titleStyle.setProperty("alignItems", "center");
+      panel_.add(sidebarTitlePanel_);
+      panel_.setWidgetLeftRight(sidebarTitlePanel_, 0, Unit.PX, UTILITY_AREA_SIZE, Unit.PX);
+      panel_.setWidgetTopHeight(sidebarTitlePanel_, 0, Unit.PX, 22, Unit.PX);
+
       // Create empty state widget for when there are no tabs
       if (commands != null)
       {
          // Outer container that fills the entire space
          FlowPanel emptyStateContainer = new FlowPanel();
 
-         // Inner content with just the button
+         // Inner content with text and button
          FlowPanel emptyStateContent = new FlowPanel();
          Style contentStyle = emptyStateContent.getElement().getStyle();
          contentStyle.setProperty("display", "flex");
          contentStyle.setProperty("flexDirection", "column");
          contentStyle.setProperty("alignItems", "center");
          contentStyle.setTextAlign(Style.TextAlign.CENTER);
+
+         // Add explanatory text
+         HTML noTabsText = new HTML(constants_.noTabsAssignedText());
+         noTabsText.getElement().getStyle().setMarginBottom(12, Unit.PX);
+         emptyStateContent.add(noTabsText);
 
          ThemedButton configureButton = new ThemedButton(constants_.configurePanesButtonText(), event -> {
             commands.paneLayout().execute();
@@ -391,6 +408,12 @@ class WorkbenchTabPanel
 
    private void updateEmptyStateVisibility()
    {
+      // Control visibility of sidebar title
+      if (sidebarTitlePanel_ != null)
+      {
+         sidebarTitlePanel_.setVisible(tabs_.isEmpty());
+      }
+
       if (emptyStatePanel_ != null)
       {
          // Get the wrapper element created by LayoutPanel
@@ -439,6 +462,7 @@ class WorkbenchTabPanel
    private boolean neverVisible_ = false;
    private LayoutPanel panel_;
    private HTML utilPanel_;
+   private HTML sidebarTitlePanel_;
    private Widget emptyStatePanel_;
    private static final UIConstants constants_ = GWT.create(UIConstants.class);
 }


### PR DESCRIPTION
### Intent

Added a title to the Sidebar and some text above the "Configure Panes..." button. These are only visible when no tabs are assigned to the Sidebar.

<img width="1392" height="1479" alt="screenshot of sidebar on left with no tabs assigned" src="https://github.com/user-attachments/assets/5d351045-7c82-4ff7-b27e-87739980f7d3" />


### Approach

See code

### Automated Tests

Existing BRAT tests still pass.

### QA Notes

Verify text and title shown when there are no tabs, not shown when there are tabs.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


