### PR TITLE
avoid empty path in Find in Files dialog

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
@@ -14,19 +14,9 @@
  */
 package org.rstudio.studio.client.workbench.views.output.find;
 
-import com.google.gwt.aria.client.Roles;
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.core.client.JavaScriptObject;
-import com.google.gwt.core.client.JsArrayString;
-import com.google.gwt.dom.client.DivElement;
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.SpanElement;
-import com.google.gwt.dom.client.Style;
-import com.google.gwt.uibinder.client.UiBinder;
-import com.google.gwt.uibinder.client.UiField;
-import com.google.gwt.user.client.ui.CheckBox;
-import com.google.gwt.user.client.ui.TextBox;
-import com.google.gwt.user.client.ui.Widget;
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemItem;
@@ -41,8 +31,19 @@ import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.workbench.views.output.OutputConstants;
 
-import java.util.ArrayList;
-import java.util.Arrays;
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.dom.client.DivElement;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.SpanElement;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.CheckBox;
+import com.google.gwt.user.client.ui.TextBox;
+import com.google.gwt.user.client.ui.Widget;
 
 public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
 {
@@ -261,7 +262,7 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
 
    private void manageExcludeFilePattern()
    {
-      // disable custom exclude text box when 'Exclude these files:' is unchecked
+      // disable custom exclude text box when 'Exclude files' is unchecked
       showDivIf(divExcludeCustomFilter_, checkboxExcludeCustom_.getValue());
       
       // disable 'Files matched by .gitignore' when directory is not a git repository or git is not installed
@@ -364,7 +365,22 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
       checkboxCaseSensitive_.setValue(dialogState.isCaseSensitive());
       checkboxWholeWord_.setValue(dialogState.isWholeWord());
       checkboxRegex_.setValue(dialogState.isRegex());
-      dirChooser_.setText(dialogState.getPath());
+
+      String path = dialogState.getPath();
+      if (StringUtil.isNullOrEmpty(path))
+      {
+         FileSystemItem projectDir =
+            RStudioGinjector.INSTANCE.getSession().getSessionInfo().getActiveProjectDir();
+         if (projectDir != null)
+         {
+            path = projectDir.getPath();
+         }
+         else
+         {
+            path = "~";
+         }
+      }
+      dirChooser_.setText(path);
 
       String includeFilePatterns = StringUtil.join(
             Arrays.asList(dialogState.getFilePatterns()), ", ");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
@@ -83,7 +83,7 @@
          </rw:FormCheckBox>
       </div>
 
-      <rw:FormCheckBox elementId="{ElementIds.getExcludeCustom}" ui:field="checkboxExcludeCustom_" text="Exclude these files:">
+      <rw:FormCheckBox elementId="{ElementIds.getExcludeCustom}" ui:field="checkboxExcludeCustom_" text="Exclude files matching pattern">
             <ui:attribute name="text" key="customExclusionsText"/>
       </rw:FormCheckBox>
       <div ui:field="divExcludeCustomFilter_">

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialogBinderImplGenMessages_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialogBinderImplGenMessages_en.properties
@@ -11,11 +11,11 @@ customFilter=Custom Filter
 
 exampleText=Example\: *.R, *.r, *.csv. Separate multiple types with commas.
 
-excludeFiles=Exclude these files\:
+excludeFiles=Exclude files
 
 gitExclusionsText=Exclude files matched by .gitignore
 
-customExclusionsText=Exclude these files\:
+customExclusionsText=Exclude files matching pattern
 
 packageSources=Package Sources (R/ , src/)
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialogBinderImplGenMessages_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialogBinderImplGenMessages_fr.properties
@@ -11,11 +11,11 @@ customFilter=Filtre personnalisé
 
 exampleText=Exemple\: *.R, *.r, *.csv. Séparez les différents types par des virgules.
 
-excludeFiles=Exclure ces fichiers\:
+excludeFiles=Exclure fichiers
 
 gitExclusionsText=Exclure les fichiers identifiés par .gitignore
 
-customExclusionsText=Exclure ces fichiers\:
+customExclusionsText=Exclure fichiers
 
 packageSources=Sources des paquets (R/ , src/)
 


### PR DESCRIPTION
### Intent

Addresses a small issue that could prevent Find in Files from working when an empty directory was set for the search directory, and instead defaults to the project directory (or home directory if none is known).

Also tweaks the UI labels, since using a trailing colon for a checkbox label here is a bit odd.

Addresses https://github.com/rstudio/rstudio/issues/16555.

### Approach

Straightforward UI changes.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

