### PR TITLE
ensure menus reenable after reload

### DIFF
--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -144,6 +144,7 @@ export class MenuCallback extends EventEmitter {
     // GWT redefines and rebuilds the entire menu in some cases
     this.mainMenu = new Menu();
     this.mainMenuTemplate = new Array<MenuItemConstructorOptions>();
+    appState().modalTracker.resetGwtModals();
 
     if (process.platform === 'darwin') {
       const appMenu: MenuItemConstructorOptions = { role: 'appMenu', visible: true };


### PR DESCRIPTION
### Intent

If you change the setting for "Show Chat UI" via the command-palette, the main menu commands are disabled after the reload in Electron desktop (but okay in Server).

### Approach

When "Show Chat UI" setting changes via the command-palette (which is a modal) it issues a `Windows.Location.reload()`. The bug was that the Electron modal-dialog tracker still thought there was a modal after the reload, thus the main menu items were disabled.

Fixed by resetting the modal count when rebuilding the main menu.

### Automated Tests

None

### QA Notes

Test as described.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


