### PR TITLE
Remove Sentry from Jenkins

### DIFF
--- a/jenkins/Jenkinsfile.build
+++ b/jenkins/Jenkinsfile.build
@@ -25,7 +25,7 @@ pipeline {
   
   parameters {
     booleanParam name: 'DAILY', defaultValue: true, description: 'Builds daily/nightly builds if true; builds hourly builds if false.'
-    booleanParam name: 'PUBLISH', defaultValue: true, description: 'Publish the build to S3 and sentry.'
+    booleanParam name: 'PUBLISH', defaultValue: true, description: 'Publish the build to S3.'
     booleanParam name: 'FORCE_BUILD_BINARIES', defaultValue: false, description: 'Force build binaries even if there are no changes, and even if they have already been built previously'
     booleanParam name: 'FORCE_BUILD_DOCKER', defaultValue: false, description: 'Force build docker images even if there are no dockerfile changes'
     string name: 'OS_FILTER', defaultValue: 'all', description: 'Pattern to limit builds by matching OS'
@@ -168,37 +168,6 @@ pipeline {
       }
 
       stages {
-        stage ("Create a Sentry Release") {
-          agent {
-            dockerfile {
-              filename 'Dockerfile.dispatcher'
-              label 'linux'
-            }
-          }
-          
-          environment {
-            SENTRY_API_KEY = credentials('ide-sentry-api-key')
-          }
-
-          when { expression { return params.PUBLISH && params.DAILY } }
-
-          steps { 
-            echo "Creating a sentry release for version ${RSTUDIO_VERSION}"
-
-            // Install sentry
-            sh "HOME=`pwd` ./dependencies/common/install-sentry-cli"
-
-            // create new release on Sentry
-            sh 'sentry-cli --auth-token ${SENTRY_API_KEY} releases --org rstudio --project ide-backend new ' + RSTUDIO_VERSION
-
-            // associate commits
-            sh 'sentry-cli --auth-token ${SENTRY_API_KEY} releases --org rstudio --project ide-backend set-commits --auto ' + RSTUDIO_VERSION
-
-            // finalize release
-            sh 'sentry-cli --auth-token ${SENTRY_API_KEY} releases --org rstudio --project ide-backend finalize ' + RSTUDIO_VERSION
-          }
-        }
-
         stage ("Build Windows") {
           when {
             anyOf {

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -323,27 +323,6 @@ pipeline {
                       }
                     }
                   }
-
-                  stage("Sentry Upload") {
-                    when { expression { return params.DAILY } }
-
-                    environment {
-                      SENTRY_API_KEY = credentials('ide-sentry-api-key')
-                    }
-                    
-                    steps {
-                      // Upload Sentry
-                      dir("package/linux/${BUILD_LOCATION}/src/cpp") {
-                        retry(5) {
-                          timeout(activity: true, time: 15) {
-                            script {
-                              utils.sentryUpload 'elf'
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
                   
                   stage("Publish") {
                     environment {

--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -217,38 +217,6 @@ pipeline {
                     }
                   }
                   
-                  stage("Sentry Upload") {
-                    when { expression { return params.DAILY } }
-
-                    environment {
-                      SENTRY_API_KEY = credentials('ide-sentry-api-key')
-                    }
-                    
-                    steps {
-                      // upload debug symbols to Sentry
-                      retry(5) {
-                        // timeout sentry in 15 minutes
-                        timeout(activity: true, time: 15) {
-                          // upload Javascript source maps, but only once
-                          dir ('package/osx/build/gwt') {
-                            script {
-                              if (FLAVOR == 'Electron') {
-                                utils.sentryUploadSourceMaps()
-                              }
-                            }
-                          }
-
-                          // upload C++ debug information
-                          dir ('package/osx/build/src/cpp') {
-                            script {
-                              utils.sentryUpload 'dsym'
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                  
                   stage("Publish") {
                     environment {
                       GITHUB_LOGIN = credentials('posit-jenkins')


### PR DESCRIPTION
### Intent

https://github.com/rstudio/rstudio/issues/16221 in Apple Blossom has caused Cucumberleaf Sunflower builds to fail on the sentry parts. This PR starts back porting the removal of sentry from Jenkins. I'll be merging it forward into all supported branches on approval.

I'm skipping Chocolate Cosmos because it's about to go out of support and going all the way back to cranberry hibiscus is already probably overkill

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Ensure you have updated the QA Notes in the original issue.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


