### PR TITLE
resolve netrc path consistently

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1849,14 +1849,19 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    strings[.rs.endsWith(strings, string)]
 })
 
+.rs.addFunction("netrcPath", function(overridePath = NULL)
+{
+   .rs.nullCoalesce(
+      overridePath,
+      getOption("netrc", default = Sys.getenv("NETRC", unset = "~/.netrc"))
+   )
+})
+
 .rs.addFunction("readNetrc", function(netrcPath = NULL)
 {
    # Resolve the path to the .netrc file.
-   netrcPath <- .rs.nullCoalesce(netrcPath,
-   {
-      Sys.getenv("NETRC", unset = "~/.netrc")
-   })
-
+   netrcPath <- .rs.netrcPath(netrcPath)
+   
    info <- file.info(netrcPath, extra_cols = FALSE)
    if (is.na(info$mode))
       return(NULL)

--- a/src/cpp/session/modules/SessionPPM.R
+++ b/src/cpp/session/modules/SessionPPM.R
@@ -183,7 +183,7 @@
    )
    
    # use netrc if available
-   netrcFile <- getOption("netrc", default = Sys.getenv("NETRC", unset = "~/.netrc"))
+   netrcFile <- .rs.netrcPath()
    if (file.exists(netrcFile))
    {
       curl::handle_setopt(


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16227.

### Approach

Find out where we're trying to compute the `.netrc` path, and make sure we're respecting the R `netrc` option consistently.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
