### PR TITLE
[DOC] Back port - updates NEWS with Positron Pro `enabled` default value change

### DIFF
--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -177,7 +177,7 @@ During package upgrade, the following files will be backed up if they exist:
 
 After completing the package upgrade, carefully review the backed up files and the new default configuration files and merge any customizations as needed.
 
-Since Positron Pro is now enabled by default, the following default configuration value has changed in the `positron.conf` configuration file:<i class="bi bi-info-circle-fill" title="Documentation change since last release/patch."></i>
+Since Positron Pro is now enabled by default, the following default configuration value has changed in the `positron.conf` configuration file:<i class="bi bi-info-circle-fill" title="Documentation change since last release."></i>
 
    | Configuration entry | Previous default value | New default value | Reference |
    |-------------------- | ---------------------- | ------------------ | -----------|

--- a/version/news/NEWS-2025.09.0-cucumberleaf-sunflower.md
+++ b/version/news/NEWS-2025.09.0-cucumberleaf-sunflower.md
@@ -135,7 +135,7 @@ During package upgrade, the following files will be backed up if they exist:
 
 After completing the package upgrade, carefully review the backed up files and the new default configuration files and merge any customizations as needed.
 
-Since Positron Pro sessions are now enabled by default, the following default configuration value has changed in the `positron.conf` configuration file:   <i class="bi bi-info-circle-fill" title="Documentation change since last release/patch."></i>
+Since Positron Pro sessions are now enabled by default, the following default configuration value has changed in the `positron.conf` configuration file:   <i class="bi bi-info-circle-fill" title="Documentation change since last release."></i>
 
    | Configuration entry | Previous default value | New default value | Reference |
    |-------------------- | ---------------------- | ------------------ | -----------|


### PR DESCRIPTION
### Intent

Related to [rstudio-pro 9376](https://github.com/rstudio/rstudio-pro/issues/9376)

### Approach

Adds table that shows new default value for Positron Pro sessions `enabled` config option as well as the previous default value. 

This needs to be back-ported so that changes take effect for the `2025.09.0` docs and later

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Ensure you have updated the QA Notes in the original issue.

### Documentation

NEWS only, back port to `2025.09.0`

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


