### PR TITLE
apply theme-aware styles to empty sidebar text

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchTabPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchTabPanel.java
@@ -86,6 +86,7 @@ class WorkbenchTabPanel
       // Create sidebar title for when there are no tabs
       sidebarTitlePanel_ = new HTML(constants_.sidebarTitleText());
       sidebarTitlePanel_.setStylePrimaryName(ThemeStyles.INSTANCE.multiPodUtilityArea());
+      sidebarTitlePanel_.addStyleName(ThemeStyles.INSTANCE.title());
       Style titleStyle = sidebarTitlePanel_.getElement().getStyle();
       titleStyle.setLineHeight(22, Unit.PX);
       titleStyle.setPaddingLeft(8, Unit.PX);
@@ -112,6 +113,7 @@ class WorkbenchTabPanel
          // Add explanatory text
          HTML noTabsText = new HTML(constants_.noTabsAssignedText());
          noTabsText.getElement().getStyle().setMarginBottom(12, Unit.PX);
+         noTabsText.addStyleName(ThemeStyles.INSTANCE.subtitle());
          emptyStateContent.add(noTabsText);
 
          ThemedButton configureButton = new ThemedButton(constants_.configurePanesButtonText(), event -> {


### PR DESCRIPTION
### Intent

Addresses #16599

### Approach

Use title and subtitle theme-aware styles for the sidebar

<img width="297" height="432" alt="sidebar-dark" src="https://github.com/user-attachments/assets/b8d79399-01b7-4001-bea2-25ceb7f03f37" />

### Automated Tests

None

### QA Notes

Test as described in issue.

### Documentation

NA