### PR TITLE
pass keychain path through to codesign

### DIFF
--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -102,7 +102,7 @@ pipeline {
       environment {
         AWS_ACCOUNT_ID = '749683154838'
         KEYCHAIN_PASSPHRASE = credentials('ide-keychain-passphrase')
-        BUILD_AGENT_TEMP = "${env.HOME}/tmp"
+        KEYCHAIN_PATH = "${pwd()}/buildagent.keychain"
         MACOS_DEVELOPER_CERTIFICATE = credentials('MACOS_DEVELOPER_CERTIFICATE')
         MACOS_DEVELOPER_CERTIFICATE_KEY = credentials('MACOS_DEVELOPER_CERTIFICATE_KEY')
       }
@@ -116,21 +116,25 @@ pipeline {
             set -e
 
             # Create a keychain to hold the Developer ID certificate for signing
-            if [ ! -f "${BUILD_AGENT_TEMP}/buildagent.keychain" ]; then
-              security create-keychain -p ${KEYCHAIN_PASSPHRASE} ${BUILD_AGENT_TEMP}/buildagent.keychain
+            if [ ! -f "${KEYCHAIN_PATH}" ]; then
+              echo "Creating new keychain: ${KEYCHAIN_PATH}"
+              security create-keychain -p "${KEYCHAIN_PASSPHRASE}" "${KEYCHAIN_PATH}"
             else
-              echo "Using keychain: ${BUILD_AGENT_TEMP}/buildagent.keychain"
+              echo "Using existing keychain: ${KEYCHAIN_PATH}"
             fi
 
             # Set a default keychain, and unlock it
-            security default-keychain -s ${BUILD_AGENT_TEMP}/buildagent.keychain
-            security unlock-keychain -p ${KEYCHAIN_PASSPHRASE} ${BUILD_AGENT_TEMP}/buildagent.keychain
+            security default-keychain -s "${KEYCHAIN_PATH}"
+            security unlock-keychain -p "${KEYCHAIN_PASSPHRASE}" "${KEYCHAIN_PATH}"
 
             # Turn off timeout
-            security set-keychain-settings
+            security set-keychain-settings "${KEYCHAIN_PATH}"
 
             # Import the developer ID from Jenkins secrets
-            security import "${MACOS_DEVELOPER_CERTIFICATE}" -k ${BUILD_AGENT_TEMP}/buildagent.keychain -P "${MACOS_DEVELOPER_CERTIFICATE_KEY}" -T /usr/bin/codesign
+            security import "${MACOS_DEVELOPER_CERTIFICATE}" \
+              -k "${KEYCHAIN_PATH}"                          \
+              -P "${MACOS_DEVELOPER_CERTIFICATE_KEY}"        \
+              -T /usr/bin/codesign
           '''
         }
         // Import the Developer ID certificate from Jenkins Secrets.

--- a/package/osx/cmake/codesign-package.cmake
+++ b/package/osx/cmake/codesign-package.cmake
@@ -27,6 +27,11 @@ set(CODESIGN_FLAGS
    --force
    --deep)
 
+# include keychain path if provided
+if(ENV{KEYCHAIN_PATH})
+   list(APPEND CODESIGN_FLAGS --keychain "$ENV{KEYCHAIN_PATH}")
+endif()
+
 # NOTE: we always attempt to sign a package build of RStudio
 # (even if it's just a development build) as our usages of
 # install_name_tool will invalidate existing signatures on


### PR DESCRIPTION
Attempting to fix build / signing issues with the macos-test instance we're using to build RStudio.