### PR TITLE
use getCurrentConfig instead of raw value access

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -320,7 +320,7 @@ public class PaneManager
          else
          {
             sourceColumnManager_.consolidateColumns(0);
-            PaneConfig paneConfig = userPrefs_.panes().getValue().cast();
+            PaneConfig paneConfig = getCurrentConfig();
             userPrefs_.panes().setGlobalValue(PaneConfig.create(
                JsArrayUtil.copy(paneConfig.getQuadrants()),
                paneConfig.getTabSet1(),
@@ -1006,7 +1006,7 @@ public class PaneManager
    
    private void setSidebarPref(boolean showSidebar)
    {
-      PaneConfig paneConfig = userPrefs_.panes().getValue().cast();
+      PaneConfig paneConfig = getCurrentConfig();
       if (showSidebar == paneConfig.getSidebarVisible())
          return;
 
@@ -1042,7 +1042,7 @@ public class PaneManager
    public void onToggleSidebar()
    {
       // Toggle the preference value and update UI
-      PaneConfig paneConfig = userPrefs_.panes().getValue().cast();
+      PaneConfig paneConfig = getCurrentConfig();
       boolean newVisibility = !paneConfig.getSidebarVisible();
      
       setSidebarPref(newVisibility);
@@ -1063,7 +1063,7 @@ public class PaneManager
    public void toggleSidebarLocation()
    {
       // Toggle the sidebar location between left and right
-      PaneConfig paneConfig = userPrefs_.panes().getValue().cast();
+      PaneConfig paneConfig = getCurrentConfig();
       String currentLocation = paneConfig.getSidebarLocation();
       String newLocation = "left".equals(currentLocation) ? "right" : "left";
       
@@ -1095,7 +1095,7 @@ public class PaneManager
       if (showSidebar && sidebar_ == null)
       {
          // Create sidebar configuration
-         PaneConfig config = userPrefs_.panes().getValue().cast();
+         PaneConfig config = getCurrentConfig();
          JsArrayString sidebarTabs = config.getSidebar();
          
          // Create sidebar tabset if not already created
@@ -1170,8 +1170,8 @@ public class PaneManager
    public void setSidebarLocation(String location)
    {
       // Update preference and refresh the sidebar if visible
-      PaneConfig paneConfig = userPrefs_.panes().getValue().cast();
-      
+      PaneConfig paneConfig = getCurrentConfig();
+
       // Only update if location has changed
       if (!location.equals(paneConfig.getSidebarLocation()))
       {


### PR DESCRIPTION
### Intent

Speculative fix for #16618

### Approach

I couldn't reproduce so asked AI to examine the scenario. It thinks the problem could be related to the way we were reading these prefs (using a lower-level technique) that could result in nulls in some cases. The change is to use `getCurrentConfig()` instead which handles the null case and returns a valid config.

### Automated Tests

Existing BRAT tests passed, but that was true before this change so not actually testing the scenario. If we can get a repro then can add a test.

### QA Notes

Give it a shot. Maybe record your screen while attempting to do this so you can look back and see what sequence led to the problem (or do that with a build prior to this change first). If you do manage to reproduce please take a look in the javascript console (dev tools) and see if anything interesting shows up (e.g. an exception).

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


