### PR TITLE
retroactively mark Workbench API as out of preview

### DIFF
--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -252,7 +252,7 @@ Since Positron Pro is now enabled by default, the following default configuratio
 - Fixed an issue where audited jobs would fail if the user's Workbench username differs from their posix username (rstudio-pro#8129)
 - Fixed an issue where the session init container was being added to containerized sessions and jobs on clusters that did not support them (rstudio-pro#8009)
 - Fixed an issue where Shiny for Python and other applications would reguarly experience websocket failures in VS Code and Positron sessions (rstudio-pro#7368)
-- Fixed an issue where the positron-settings.json example in the Admin guide had an extra comma (rstudio-pro#8853) 
+- Fixed an issue where the positron-settings.json example in the Admin guide had an extra comma (rstudio-pro#8853)
 
 ### Dependencies
 
@@ -472,6 +472,7 @@ Since Positron Pro is now enabled by default, the following default configuratio
 - Added support for reloading the Launcher through systemd (rstudio-pro#3749)
 - Added support for a configurable auth (SAML/OpenID) username re-write rule (rstudio-pro#6987)
 - Migrated Snowflake Native App documentation from Posit Workbench Administration Guide to the [Posit Partnerships](https://docs.posit.co/partnerships/snowflake/) site.
+- Made Workbench API generally available and removed Preview status
 
 ### Fixed
 #### RStudio


### PR DESCRIPTION
### Intent

We forgot to announce when the Workbench API came out of preview. Oops.

### Documentation

News docs

### NEWS PR

This is the news PR.

### Checklist

- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


