### PR TITLE
Add NEWS entry for launcher version bump

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,3 +66,4 @@
 - Electron 38.5.0
 - Node.js 22.18.0
 - Quarto 1.8.25
+- Launcher 2.21.0


### PR DESCRIPTION
For rstudio/rstudio-pro#9491.

I don't think we've historically put launcher versions in the Dependencies list like this but I think it makes sense?