### PR TITLE
avoid copilot requests when shutting down

### DIFF
--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -1892,10 +1892,10 @@ SEXP rs_copilotVersion()
 SEXP rs_copilotStopAgent()
 {
    // stop the copilot agent
-   stopAgentSync();
+   bool stopped = stopAgentSync();
  
    // return status
-   return Rf_ScalarLogical(true);
+   return Rf_ScalarLogical(stopped);
 }
 
 Error copilotVerifyInstalled(const json::JsonRpcRequest& request,


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16623.

### Approach

When RStudio is shutting down, there may still be Copilot requests being processed. This PR ensures that any pending requests or responses are dropped once a shutdown is triggered.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/16623.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
