### PR TITLE
remove extra logging and speculative fix from previous debugging of pane layout prefs issue

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PaneLayoutPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PaneLayoutPreferencesPane.java
@@ -206,14 +206,6 @@ public class PaneLayoutPreferencesPane extends PreferencesPane
 
       PaneConfig paneConfig = userPrefs.panes().getGlobalValue().cast();
 
-      Debug.log("Pane Layout Dialog opening - config null: " + (paneConfig == null) +
-         ", quadrants: " + (paneConfig != null ? paneConfig.getQuadrants().length() : "null") +
-         ", tabSet1: " + (paneConfig != null ? paneConfig.getTabSet1().length() : "null") +
-         ", tabSet2: " + (paneConfig != null ? paneConfig.getTabSet2().length() : "null") +
-         ", hiddenTabSet: " + (paneConfig != null ? paneConfig.getHiddenTabSet().length() : "null") +
-         ", sidebar: " + (paneConfig != null ? paneConfig.getSidebar().length() : "null") +
-         ", sidebar_visible: " + (paneConfig != null ? paneConfig.getSidebarVisible() : "null"));
-
       additionalColumnCount_ = paneConfig.getAdditionalSourceColumns();
 
       add(new Label(constants_.paneLayoutText(),
@@ -304,9 +296,6 @@ public class PaneLayoutPreferencesPane extends PreferencesPane
          for (String value : visiblePanes)
             lb.addItem(value);
       }
-
-      boolean isValid = paneConfig != null && paneConfig.validateAndAutoCorrect();
-      Debug.log("Pane Layout DialogConfig validation: " + isValid + ", was null: " + (paneConfig == null));
 
       if (paneConfig == null || !paneConfig.validateAndAutoCorrect())
          userPrefs.panes().setGlobalValue(PaneConfig.createDefault(), false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneConfig.java
@@ -40,16 +40,15 @@ public class PaneConfig extends UserPrefsAccessor.Panes
                                           JsArrayString sidebarTabs,
                                           boolean sidebarVisible,
                                           String sidebarLocation) /*-{
-      // Make defensive copies of all arrays to prevent shared reference issues
       return {
-         quadrants: panes.slice(),
-         tabSet1: tabSet1.slice(),
-         tabSet2: tabSet2.slice(),
-         hiddenTabSet: hiddenTabSet.slice(),
+         quadrants: panes,
+         tabSet1: tabSet1,
+         tabSet2: tabSet2,
+         hiddenTabSet: hiddenTabSet,
          console_left_on_top: consoleLeftOnTop,
          console_right_on_top: consoleRightOnTop,
          additional_source_columns: additionalSources,
-         sidebar: sidebarTabs.slice(),
+         sidebar: sidebarTabs,
          sidebar_visible: sidebarVisible,
          sidebar_location: sidebarLocation
       };
@@ -224,10 +223,7 @@ public class PaneConfig extends UserPrefsAccessor.Panes
    {
       JsArrayString panes = getQuadrants();
       if (panes == null)
-      {
-         Debug.log("validateAndAutoCorrect: PaneConfig is null");
          return false;
-      }
 
       JsArrayString ts1 = getTabSet1();
       JsArrayString ts2 = getTabSet2();
@@ -267,10 +263,21 @@ public class PaneConfig extends UserPrefsAccessor.Panes
 
       // Check for any unknown tabs
       Set<String> allTabs = makeSet(getAllTabs());
-      if (!(isSubset(allTabs, JsUtil.asIterable(ts1)) &&
-            isSubset(allTabs, JsUtil.asIterable(ts2))))
+      ArrayList<String> unknownTabs = new ArrayList<>();
+      for (String tab : JsUtil.asIterable(ts1))
       {
-         Debug.log("validateAndAutoCorrect: Invalid tabset config (Unknown tabs)");
+         if (!allTabs.contains(tab))
+            unknownTabs.add(tab);
+      }
+      for (String tab : JsUtil.asIterable(ts2))
+      {
+         if (!allTabs.contains(tab))
+            unknownTabs.add(tab);
+      }
+      if (!unknownTabs.isEmpty())
+      {
+         Debug.log("validateAndAutoCorrect: Invalid tabset config (Unknown tabs: " + 
+                   StringUtil.joinStrings(unknownTabs, ", ") + ")");
          return false;
       }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -403,11 +403,7 @@ public class PaneManager
       
       userPrefs.panes().addValueChangeHandler(evt ->
       {
-         PaneConfig newConfig = evt.getValue().cast();
-         Debug.log("ValueChangeHandler: Panes preference changed - sidebar_visible=" +
-            newConfig.getSidebarVisible());
-
-         ArrayList<LogicalWindow> newPanes = createPanes(validateConfig(newConfig));
+         ArrayList<LogicalWindow> newPanes = createPanes(validateConfig(evt.getValue().cast()));
          panes_ = newPanes;
          center_.replaceWindows(newPanes.get(0), newPanes.get(1));
          right_.replaceWindows(newPanes.get(2), newPanes.get(3));
@@ -1011,28 +1007,8 @@ public class PaneManager
    {
       PaneConfig paneConfig = getCurrentConfig();
 
-      Debug.log("setSidebarPref called: showSidebar=" + showSidebar +
-         ", current config sidebar_visible=" + paneConfig.getSidebarVisible());
-
       if (showSidebar == paneConfig.getSidebarVisible())
-      {
-         Debug.log("setSidebarPref: Early return - value unchanged");
          return;
-      }
-
-      // Capture array lengths before creating new config to detect corruption
-      int quadLen = paneConfig.getQuadrants().length();
-      int ts1Len = paneConfig.getTabSet1().length();
-      int ts2Len = paneConfig.getTabSet2().length();
-      int hiddenLen = paneConfig.getHiddenTabSet().length();
-      int sidebarLen = paneConfig.getSidebar().length();
-
-      Debug.log("setSidebarPref: Config before create - quadrants: " + quadLen +
-         ", tabSet1: " + ts1Len +
-         ", tabSet2: " + ts2Len +
-         ", hiddenTabSet: " + hiddenLen +
-         ", sidebar: " + sidebarLen +
-         ", setting sidebar_visible to: " + showSidebar);
 
       // Update the preference
       userPrefs_.panes().setGlobalValue(PaneConfig.create(
@@ -1046,26 +1022,6 @@ public class PaneManager
          paneConfig.getSidebar(),
          showSidebar,
          paneConfig.getSidebarLocation()));
-
-      // Verify the original config's arrays weren't corrupted by shared references
-      if (paneConfig.getQuadrants().length() != quadLen ||
-          paneConfig.getTabSet1().length() != ts1Len ||
-          paneConfig.getTabSet2().length() != ts2Len ||
-          paneConfig.getHiddenTabSet().length() != hiddenLen ||
-          paneConfig.getSidebar().length() != sidebarLen)
-      {
-         Debug.log("ERROR: setSidebarPref: Array corruption detected! Original config modified. " +
-            "Before: q=" + quadLen + " ts1=" + ts1Len + " ts2=" + ts2Len + " h=" + hiddenLen + " s=" + sidebarLen +
-            " After: q=" + paneConfig.getQuadrants().length() +
-            " ts1=" + paneConfig.getTabSet1().length() +
-            " ts2=" + paneConfig.getTabSet2().length() +
-            " h=" + paneConfig.getHiddenTabSet().length() +
-            " s=" + paneConfig.getSidebar().length());
-      }
-      else
-      {
-         Debug.log("setSidebarPref: Config arrays verified - no corruption detected");
-      }
 
       userPrefs_.writeUserPrefs();
    }
@@ -1113,12 +1069,8 @@ public class PaneManager
 
    public void showSidebar(boolean showSidebar)
    {
-      Debug.log("showSidebar called: showSidebar=" + showSidebar + ", sidebar_=" +
-         (sidebar_ == null ? "null" : "not null"));
-
       if (showSidebar && sidebar_ == null)
       {
-         Debug.log("showSidebar: Creating and showing sidebar");
          // Create sidebar configuration
          PaneConfig config = getCurrentConfig();
          JsArrayString sidebarTabs = config.getSidebar();
@@ -1148,7 +1100,6 @@ public class PaneManager
       }
       else if (!showSidebar && sidebar_ != null)
       {
-         Debug.log("showSidebar: Hiding sidebar");
          panel_.removeSidebarWidget();
          sidebar_ = null;
       }
@@ -1910,18 +1861,9 @@ public class PaneManager
 
    public void activateTab(Tab tab)
    {
-      Debug.log("activateTab called for tab: " + tab);
-
       lastSelectedTab_ = tab;
       WorkbenchTabPanel panel = getOwnerTabPanel(tab);
       LogicalWindow parent = panel.getParentWindow();
-
-      Debug.log("activateTab: tab=" + tab + ", parent=" +
-         (parent == panesByName_.get(UserPrefsAccessor.Panes.QUADRANTS_SIDEBAR) ? "SIDEBAR" :
-          parent == panesByName_.get(UserPrefsAccessor.Panes.QUADRANTS_TABSET1) ? "TABSET1" :
-          parent == panesByName_.get(UserPrefsAccessor.Panes.QUADRANTS_TABSET2) ? "TABSET2" :
-          parent == panesByName_.get(UserPrefsAccessor.Panes.QUADRANTS_HIDDENTABSET) ? "HIDDEN" : "OTHER") +
-         ", sidebar_=" + (sidebar_ == null ? "null" : "not null"));
 
       // If the tab belongs to the hidden tabset, add it to one being displayed
       if (parent == panesByName_.get(UserPrefsAccessor.Panes.QUADRANTS_HIDDENTABSET))


### PR DESCRIPTION
Gets rid of the extra logging and remove a scary speculative fix that was not actually related to the problem (which ended up being an RDP thing).

Left in logging when an unknown tab is found and includes the name in the message.