### PR TITLE
issue-16640: Fix ls command on wrong directory 'build-Server-RPM/*.rpm'

### DIFF
--- a/docker/docker-compile.sh
+++ b/docker/docker-compile.sh
@@ -155,9 +155,9 @@ if [ -n "$CMAKE_BUILD_TYPE" ]; then
     ENV="$ENV CMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE"
 fi
 
-# adjust folder path when building debug
-if [ "$CMAKE_BUILD_TYPE" = "Debug" ]; then
-    FLAVOR_SUFFIX="-Debug"
+# adjust folder path when building with explicit build type
+if [ -n "$CMAKE_BUILD_TYPE" ]; then
+    FLAVOR_SUFFIX="-${CMAKE_BUILD_TYPE}"
 fi
 
 # remove previous image if it exists


### PR DESCRIPTION
### Intent
Fix the ls command on wrong directory name

### Approach

Checkout from tag: 2025.09.2-418, got error below while trying to build rpm for RHEL9.

CMAKE_BUILD_TYPE=Release CONTAINER_ARCH=amd64 ./docker/docker-compile.sh rhel9 server 2025.09.2-418 .... CPack: /cmake-3.25.2/Source/CPack/cmCPackGenerator.cxx:1179 - package: /package/build-Server-RPM-Release/rstudio-server-rhel-2025.09.2-418-x86_64.rpm generated. build-Server-RPM/*.rpm ls: cannot access 'build-Server-RPM/*.rpm': No such file or directory 


### Automated Tests

Run this command, should build RPM successfully.

CMAKE_BUILD_TYPE=Release CONTAINER_ARCH=amd64 ./docker/docker-compile.sh rhel9 server 2025.09.2-418

### QA Notes

Ensure you have updated the QA Notes in the original issue.


### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


