### PR TITLE
Implement JSON-RPC over stdio for Chat Backend Communication

### DIFF
--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -123,7 +123,8 @@ std::string s_backendOutputBuffer;
 std::vector<json::Value> s_pendingResponses;
 
 // Regex for parsing Content-Length header (case-insensitive per HTTP spec)
-boost::regex s_contentLengthRegex("Content-Length:\\s*(\\d+)", boost::regex::icase);
+// Matches only at start of line to avoid false matches in log output
+boost::regex s_contentLengthRegex("(?:^|\r\n)Content-Length:\\s*(\\d+)", boost::regex::icase);
 
 // Map of notification method names to handler functions
 using NotificationHandler = std::function<void(const json::Object&)>;


### PR DESCRIPTION
## Summary

Implements JSON-RPC over stdio protocol in SessionChat.cpp to communicate with the databot backend, following the proven patterns from SessionCopilot.cpp. This enables the backend to send logging notifications to RStudio's logging system, with infrastructure in place for future Request/Response and Events patterns.

## Background

The Chat pane's databot backend (Node.js) is launched with the --json flag, which enables JSON-RPC over stdio mode. Previously, SessionChat.cpp only logged stdout/stderr as plain text. This PR implements proper JSON-RPC message parsing and routing, starting with support for logging notifications from the backend.

##  Changes

Core Infrastructure (SessionChat.cpp)

Message Parsing:
- Added s_backendOutputBuffer for accumulating partial messages
- Added s_pendingResponses queue for parsed JSON-RPC messages
- Added case-insensitive Content-Length header regex (follows HTTP spec)
- Added s_notificationHandlers map for method routing

Notification Handling:
- registerNotificationHandler() - Register handlers for notification methods
- handleNotification() - Dispatch notifications to registered handlers
- processBackendMessage() - Route incoming messages (notifications vs responses)
- handleLoggerLog() - Handle logger/log notifications with direct level mapping:
    - trace → TLOG
    - debug → DLOG
    - info → ILOG
    - warn → WLOG
    - error → ELOG
- processPendingMessages() - Process queued messages
- onBackgroundProcessing() - Main-thread callback for safe message processing

Content-Length Message Parser:
- Replaced simple stdout logging with proper JSON-RPC message parser
- Parses Content-Length headers (case-insensitive per HTTP spec)
- Try to handle malformed message by only looking for Content-Length in complete header blocks
- Handles multiple messages in single read
- Buffers partial messages until complete
- Extracts body based on byte count (UTF-8 safe)
- Verbose logging at chatLogLevel >= 2

Thread Safety:
- Messages queued in onBackendStdout() on stdout thread
- Processing deferred to onBackgroundProcessing() on main thread
- Follows SessionCopilot pattern: separation of buffering from processing
- Infrastructure ready for future timeout handling

State Cleanup:
- Clear buffers on backend exit
- Clear buffers on shutdown

Design Decisions

1. Minimal Implementation Scope

- Only implements notification (fire-and-forget) pattern for current logging use case
- Request/Response and Events infrastructure deferred to future PR
- Keeps this PR focused and reviewable

2. Case-Insensitive Header Matching

boost::regex s_contentLengthRegex("Content-Length:\\s*(\\d+)", boost::regex::icase);
- Follows HTTP/JSON-RPC spec (headers are case-insensitive)
- Backend's connection.ts uses /i flag
- Prevents silent failure if backend emits different casing

3. Background Processing Pattern

- Follows SessionCopilot architecture: onStdout buffers, background processor handles
- Ensures main-thread execution for handlers
- callbacksRequireMainThread = true provides thread-safety guarantee
- No mutex needed (verified against SessionCopilot pattern)

## Testing

1. Set log level (optional):
  export CHAT_LOG_LEVEL=2  # 0=off, 1=errors, 2=verbose
2. Launch RStudio and start Chat backend
3. Verify backend logs appear in rsession logs with [databot] prefix
4. Check level mapping:
    - Backend logger.trace() → RStudio TLOG
    - Backend logger.debug() → RStudio DLOG
    - Backend logger.info() → RStudio ILOG
    - Backend logger.warn() → RStudio WLOG
    - Backend logger.error() → RStudio ELOG
5. Verbose mode (CHAT_LOG_LEVEL=2):
    - Should see "Received message from backend: {...}" for each JSON-RPC message

## Architecture

Message Flow
```
  Backend (Node.js)                    RStudio Session (C++)
        |                                     |
        | --[stdout]-->                       |
        | Content-Length: 123\r\n\r\n         |
        | {"jsonrpc":"2.0",...}               |
        |                                     |
        |                  [onBackendStdout - Any Thread]
        |                  - Accumulate in buffer
        |                  - Parse Content-Length header
        |                  - Extract message body (byte-based)
        |                  - Parse JSON
        |                  - Queue in s_pendingResponses
        |                                     |
        |              [onBackgroundProcessing - Main Thread]
        |                  - processPendingMessages()
        |                  - processBackendMessage()
        |                  - handleNotification()
        |                  - handleLoggerLog()
        |                  - DLOG/WLOG/ELOG/etc.
```
##  Thread Safety

  - callbacksRequireMainThread = true ensures callbacks run on main thread
  - poll() skips callbacks when not on main thread (PosixChildProcess.cpp:1063)
  - Background processor provides explicit main-thread execution
  - Matches SessionCopilot's battle-tested pattern (no mutex needed)

