### PR TITLE
Fix `rpostback askpass`

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/crypto/RSAEncrypt.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/crypto/RSAEncrypt.java
@@ -76,7 +76,10 @@ public class RSAEncrypt
                                         String exponent,
                                         String modulo,
                                         ResponseCallback callback) /*-{
-      $wnd.encrypt(value, exponent, modulo).then(callback.onSuccess, callback.onFailure);
+      $wnd.encrypt(value, exponent, modulo).then(
+         function(data) { callback.@org.rstudio.studio.client.common.crypto.RSAEncrypt.ResponseCallback::onSuccess(Ljava/lang/String;)(data); },
+         function(error) { callback.@org.rstudio.studio.client.common.crypto.RSAEncrypt.ResponseCallback::onFailure(Lorg/rstudio/studio/client/server/ServerError;)(error); }
+      );
    }-*/;
 
    private static final ExternalJavaScriptLoader loader_ =


### PR DESCRIPTION
### Intent

Addresses #16656

(rpostback askpass modal not closing)

### Summary

Fixes a regression introduced in #16636 where the `rpostback askpass` modal dialog would not close when clicking OK, and the entered passphrase would not be captured.

Fixes #16656

### Root Cause

PR #16636 converted the RSA encryption from synchronous to asynchronous by having the JavaScript `window.encrypt()` function return a Promise. The Java/GWT code was updated to handle this by calling `.then()` on the Promise:

```java
$wnd.encrypt(value, exponent, modulo).then(callback.onSuccess, callback.onFailure);
```

However, this approach doesn't work correctly in GWT's JavaScript interop. When Java method references are passed directly to JavaScript code as callbacks, they lose their proper binding context. As a result:

1. The Promise resolves successfully in JavaScript
2. The `.then()` handler attempts to call `callback.onSuccess`
3. The callback fails to execute due to improper binding
4. The Java code never receives notification that encryption completed
5. The modal dialog never closes

No errors were logged because from JavaScript's perspective, the Promise resolved successfully. From Java's perspective, it was simply waiting for a callback that never came.

### Solution

Wrap the callback method invocations using GWT's JSNI (JavaScript Native Interface) syntax, which properly binds the Java methods when calling them from JavaScript:

```java
$wnd.encrypt(value, exponent, modulo).then(
   function(data) { callback.@org.rstudio.studio.client.common.crypto.RSAEncrypt.ResponseCallback::onSuccess(Ljava/lang/String;)(data); },
   function(error) { callback.@org.rstudio.studio.client.common.crypto.RSAEncrypt.ResponseCallback::onFailure(Lorg/rstudio/studio/client/server/ServerError;)(error); }
);
```

This ensures that when the Promise resolves or rejects, the Java callback methods are invoked with the correct context.

### Testing

1. Start RStudio Server
2. Open a terminal in RStudio
3. Run: `/usr/lib/rstudio-server/bin/rpostback askpass "Enter test passphrase"`
4. A modal dialog should appear
5. Enter a passphrase and click OK
6. The dialog should close immediately
7. The passphrase should appear in the terminal output

Alternatively, trigger the askpass dialog through a git operation requiring authentication (e.g., `git push` to a repository with SSH key passphrase protection).

### Files Changed

- `src/gwt/src/org/rstudio/studio/client/common/crypto/RSAEncrypt.java`