### PR TITLE
Begin implementing RuntimeService support in rsession

### DIFF
--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -339,8 +339,8 @@ void handleLoggerLog(const json::Object& params)
    }
 
    // Map backend log levels to RStudio logging macros
-   // Use "databot" prefix and include level to distinguish backend logs
-   std::string prefixedMessage = fmt::format("[databot] [{}] {}", level, message);
+   // Use "ai" prefix and include level to distinguish backend logs
+   std::string prefixedMessage = fmt::format("[ai] [{}] {}", level, message);
 
    if (level == "trace")
    {
@@ -370,7 +370,7 @@ void handleLoggerLog(const json::Object& params)
    {
       // Unknown levels are treated as high priority (see getLogLevelPriority),
       // so log them as errors to ensure visibility
-      ELOG("[databot] [{}] {}", level, message);
+      ELOG("[ai] [{}] {}", level, message);
    }
 }
 
@@ -567,7 +567,7 @@ std::string buildWebSocketUrl(int port)
    }
 #endif
 
-   // Desktop mode: include /ai-chat base path for DatabotServer routing
+   // Desktop mode: include /ai-chat base path for AIServer routing
    // The client will append /ws to get ws://127.0.0.1:{port}/ai-chat/ws
    std::string desktopUrl = "ws://127.0.0.1:" + boost::lexical_cast<std::string>(port) + "/ai-chat";
    DLOG("Desktop WebSocket URL: {}", desktopUrl);


### PR DESCRIPTION
# Add RuntimeService JSON-RPC Request/Response Infrastructure to rsession

## Summary

This PR implements the rsession side of the RuntimeService JSON-RPC API. It adds full bidirectional request/response communication capability between rsession and the backend, starting with the `runtime/getActiveSession` method.

**Key Additions:**
- Complete JSON-RPC 2.0 request/response infrastructure with proper error handling
- Implementation of `runtime/getActiveSession` handler returning real session data
- Configurable logging system with two environment variables for debugging
- Synchronous message processing architecture to handle ProcessOperations lifetime correctly

## Background

The backend communicates with rsession via JSON-RPC over stdin/stdout. Previously, SessionChat only handled notifications (one-way messages from backend to rsession). This PR adds support for requests (two-way messages requiring responses from rsession).

The initial use case is `runtime/getActiveSession`, which is called to understand the current execution context (language, version, sessionId, mode). Without this implementation, the backend would timeout waiting for responses, blocking basic functionality.

## Changes

### JSON-RPC Request/Response Infrastructure

**New Functions:**
- `sendJsonRpcResponse()`: Sends success responses with Content-Length framing and error handling
- `sendJsonRpcError()`: Sends JSON-RPC 2.0 error responses (e.g., -32601 for "Method not found")
- `handleRequest()`: Dispatches requests to appropriate handlers based on method name
- `handleGetActiveSession()`: Implements `runtime/getActiveSession` method

**Architecture Changes:**
- Modified `processBackendMessage()` to distinguish requests from notifications per JSON-RPC 2.0 spec:
  - **Request**: `id` field is present (value can be string, number, or null)
  - **Notification**: `id` field is absent entirely
- Changed to synchronous processing model: messages processed immediately in `onBackendStdout()` while `ProcessOperations&` reference is valid
- Removed deferred message queue (`s_pendingResponses`) to avoid dangling reference bugs

**Compliance with JSON-RPC 2.0:**
- Flexible request ID handling (supports string, number, or null)
- Error responses with standard error codes (-32601 for unknown methods)
- Proper Content-Length framing for all messages
- Correct request vs notification detection based on field presence, not value

### runtime/getActiveSession Implementation

Returns real session information:
```cpp
{
  "language": "R",                              // Currently hardcoded (Python detection TODO)
  "version": module_context::rVersion(),        // Actual R version (e.g., "4.3.2")
  "sessionId": module_context::activeSession().id(),  // Real session ID
  "mode": "console"                             // Currently hardcoded
}
```

### Logging Enhancements

#### Two Environment Variables:

**1. CHAT_LOG_LEVEL** (controls rsession verbosity):
- `0`: No console output (default)
- `1`: rsession logs only (no JSON-RPC message bodies)
- `2`: rsession logs + JSON-RPC bodies for all messages except `logger/log` (formatted version shown instead)
- `3`: rsession logs + JSON-RPC bodies for ALL messages including `logger/log` (for debugging logging mechanism)

**2. CHAT_BACKEND_MIN_LEVEL** (filters backend logs by severity):
- Valid values: `trace`, `debug`, `info`, `warn`, `error`, `fatal` (case-insensitive)
- Default: `error` (only show error and fatal logs from backend)
- Example: `CHAT_BACKEND_MIN_LEVEL=info` shows info, warn, error, and fatal logs

#### Log Level Handling:

Added `getLogLevelPriority()` function with conservative filtering:
- Known levels: `trace` (0), `debug` (1), `info` (2), `warn` (3), `error` (4), `fatal` (5)
- **Unknown levels**: priority 999 (treated as highest severity to ensure critical messages never filtered)

Updated `handleLoggerLog()` to:
- Apply level filtering based on `CHAT_BACKEND_MIN_LEVEL`
- Include level in formatted output
- Route `fatal` logs to `ELOG` (not `DLOG`)
- Route unknown levels to `ELOG` (conservative approach for potentially critical issues)

Added `shouldLogBackendMessage()` to eliminate duplicate output:
- At level 2: Hide raw JSON for `logger/log` notifications (formatted version sufficient)
- At level 3+: Show raw JSON for all messages including `logger/log` (for debugging logging itself)

## Technical Details

### ProcessOperations Lifetime Management

The original implementation attempted to store a `ProcessOperations` reference globally to send responses later. This caused dangling reference bugs because `ProcessOperations` is an abstract class passed as a reference parameter.

**Solution**: Changed to synchronous processing. Messages are parsed and processed immediately in `onBackendStdout()` while the `ProcessOperations&` reference is valid. This is safe because `callbacksRequireMainThread=true` ensures we're already on the main thread.

### Error Handling

All `writeToStdin()` calls now check for errors and log failures via `ELOG`. Unknown request methods receive proper JSON-RPC error responses instead of being silently ignored.

### Removed Code

- Removed `s_pendingResponses` queue (no longer needed with synchronous processing)
- Removed `processPendingMessages()` function (no longer needed)
- Cleaned up `onBackendProcessing()` and `onBackgroundExit()` to remove references to message queue

## Testing

### Manual Testing

Set environment variables and observe logging:

```bash
# Minimal logging (errors only from backend)
CHAT_LOG_LEVEL=1 CHAT_BACKEND_MIN_LEVEL=error ./rsession

# Verbose logging for debugging (show all backend logs, raw JSON for non-logger messages)
CHAT_LOG_LEVEL=2 CHAT_BACKEND_MIN_LEVEL=trace ./rsession

# Maximum verbosity (show everything including logger/log raw JSON)
CHAT_LOG_LEVEL=3 CHAT_BACKEND_MIN_LEVEL=trace ./rsession

# Only show critical backend failures
CHAT_LOG_LEVEL=1 CHAT_BACKEND_MIN_LEVEL=fatal ./rsession
```

### Verification

With backend running:
- Send `runtime/getActiveSession` request → Verify response received with correct session data
- Send unknown method request → Verify error -32601 response returned
- Send request with `{"id": null}` → Verify response sent with `"id": null`
- Check backend logs filtered correctly by level
- Verify fatal logs always visible regardless of filter setting
- Confirm no duplicate output for logger/log messages

## Future Work

- **Python REPL detection**: Currently `language` is hardcoded to "R"
- **Additional RuntimeService methods**: `getWorkingDirectory`, `executeCode`, etc.
- **Mode detection**: Currently `mode` is hardcoded to "console"
- **Request timeouts**: Add timeout handling for request/response pattern (similar to SessionCopilot.cpp)

## Related Issues

Unblocks basic functionality by implementing the first RuntimeService API method that the backend requires to understand the execution context.