### PR TITLE
Add suspension blocking for chat backend in SessionChat module

### DIFF
--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -23,6 +23,7 @@
 #include "SessionHttpMethods.hpp"
 #include "SessionMainProcess.hpp"
 
+#include "modules/SessionChat.hpp"
 #include "modules/SessionConsole.hpp"
 #include "modules/SessionReticulate.hpp"
 
@@ -129,9 +130,10 @@ bool canSuspend(const std::string& prompt)
 #endif
    
    bool suspendIsBlocked = false;
-   
+
    suspendIsBlocked |= session::suspend::checkBlockingOp(main_process::haveDurableChildren(), suspend::kChildProcess);
    suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::jobs::isSuspendable(), suspend::kActiveJob);
+   suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::chat::isSuspendable(), "Chat is processing a request");
    suspendIsBlocked |= session::suspend::checkBlockingOp(!rstudio::r::session::isSuspendable(prompt), suspend::kCommandPrompt);
 
    if (session::options().sessionConnectionsBlockSuspend())

--- a/src/cpp/session/modules/SessionChat.hpp
+++ b/src/cpp/session/modules/SessionChat.hpp
@@ -29,6 +29,9 @@ namespace chat {
 
 core::Error initialize();
 
+// Returns true if session can suspend (i.e., chat backend is NOT busy)
+bool isSuspendable();
+
 } // end namespace chat
 } // end namespace modules
 } // end namespace session


### PR DESCRIPTION
# Implement `chat/setBusyStatus` Handler in rsession

## Summary

Implements handling of the `chat/setBusyStatus` JSON-RPC notification from the chat backend to prevent rsession from suspending while the backend is processing requests. This ensures that session suspension (which would kill the chat backend process) does not occur during active chat operations.

## Implementation Details

### Architecture

The implementation follows the established pattern used by other rsession modules (jobs, connections, etc.):

1. **Chat Backend → rsession**: Backend sends `chat/setBusyStatus` notification with `{ busy: true/false }`
2. **SessionChat.cpp**: Notification handler updates internal `s_chatBusy` flag
3. **SessionChat.hpp**: Exports `isSuspendable()` function that returns `!s_chatBusy`
4. **SessionConsoleInput.cpp**: `canSuspend()` function calls `modules::chat::isSuspendable()` to check if chat backend is busy
5. **Result**: When chat backend is busy, `canSuspend()` returns `false`, blocking suspension and showing user notification

**Critical point**: The actual suspension blocking happens in `canSuspend()` via the `isSuspendable()` check, NOT directly in the notification handler. This matches the established pattern for all other blocking conditions.

### Changes

**src/cpp/session/modules/SessionChat.hpp**
- Added `isSuspendable()` function declaration to expose busy state to suspension system
- Returns `true` when session can suspend (chat backend is idle)

**src/cpp/session/modules/SessionChat.cpp**
- Added `s_chatBusy` static boolean flag to track current busy status from chat backend (line 93)
- Implemented `handleSetBusyStatus()` notification handler (lines 382-397)
  - Parses `busy` boolean from JSON-RPC params
  - Updates `s_chatBusy` flag
  - Logs status changes using chat-specific `DLOG` macro
- Implemented `isSuspendable()` function (lines 1107-1111)
  - Returns `!s_chatBusy` to indicate if suspension is safe
  - Follows same naming and semantics as other modules
- Registered notification handler in `initialize()` (line 1138)
- Added cleanup in `onBackendExit()` (lines 717-722)
  - Clears `s_chatBusy` flag to prevent stuck suspension blocking if backend crashes
  - Logs cleanup action for debugging
- Added cleanup in `onShutdown()` (lines 1077-1081)
  - Ensures clean state during rsession shutdown

**src/cpp/session/SessionConsoleInput.cpp**
- Added `#include "modules/SessionChat.hpp"` (line 26) using relative path pattern
- Added suspension check in `canSuspend()` function (line 136)
  - Calls `modules::chat::isSuspendable()` to check chat backend busy state
  - Uses `checkBlockingOp()` to both block suspension AND track reason for user notification
  - User-visible message: "Chat is processing a request"
  - Integrates with existing suspension decision framework

### Behavior

**When Chat Backend is Busy:**
- rsession **cannot suspend** (automatic or signal-based)
- If suspension is attempted, user sees notification: "Session suspension is blocked by: Chat is processing a request"
- Debug logs show: "Chat backend busy status: busy"

**When Chat Backend is Idle:**
- rsession **can suspend** (if no other blocking conditions exist)
- Normal suspension behavior resumes
- Debug logs show: "Chat backend busy status: idle"

**When Chat Backend Process Exits:**
- Busy state is automatically cleared in `onBackendExit()`
- Suspension is no longer blocked (unless other conditions exist)
- Debug logs show: "Cleared chat backend busy state on process exit"
- No risk of "stuck busy" state beyond backend process lifetime

### Thread Safety

- All JSON-RPC notifications processed on main thread (`callbacksRequireMainThread = true`)
- No synchronization needed for `s_chatBusy` variable
- `suspend::checkBlockingOp()` is thread-safe internally

### Testing

**Build Status**: ✅ Successfully compiled with no errors or warnings (except expected linker warnings for library versions)

**Recommended Manual Testing:**
1. Send a chat message during active session
2. Verify suspension is blocked while backend processes request
3. Verify suspension allowed after request completes
4. Test crash recovery by killing backend process during operation
5. Verify busy state is cleared and suspension no longer blocked

## Integration

This implementation works alongside existing suspension blocking conditions:
- Child processes in terminals
- Active background jobs
- Incomplete R commands
- Database connections
- External pointers

The chat backend manages its own busy state using a reference counting system that sends:
- `{ busy: true }` on 0→1 transition (first operation starts)
- `{ busy: false }` on 1→0 transition (last operation completes)

## Files Modified

- `src/cpp/session/modules/SessionChat.hpp` - Added public API
- `src/cpp/session/modules/SessionChat.cpp` - Core implementation
- `src/cpp/session/SessionConsoleInput.cpp` - Suspension integration
