### PR TITLE
Remove this mutex for the rsaSign and rsaVerify functions

### DIFF
--- a/src/cpp/core/system/Crypto.cpp
+++ b/src/cpp/core/system/Crypto.cpp
@@ -56,8 +56,6 @@ namespace crypto {
 
 namespace {
 
-std::recursive_mutex s_openssl_mutex;
-
 template <typename T, typename Deleter>
 std::unique_ptr<T, Deleter> make_unique_ptr(T* ptr, Deleter deleter) {
     return std::unique_ptr<T, Deleter>(ptr, deleter);
@@ -191,8 +189,6 @@ Error rsaSign(const std::string& message,
               const std::string& pemPrivateKey,
               std::string* pOutSignature)
 {
-   std::lock_guard<std::recursive_mutex> guard(s_openssl_mutex);
-
    // create a sha256 hash of the message first which is what we will sign
    // this prevents attackers from being able to back into creating a valid message
    std::string hash;
@@ -252,8 +248,6 @@ Error rsaVerify(const std::string& message,
                 const std::string& signature,
                 const std::string& pemPublicKey)
 {
-   std::lock_guard<std::recursive_mutex> guard(s_openssl_mutex);
-
    // create a sha256 hash of the message first which is what we will verify
    // this prevents attackers from being able to back into creating a valid message
    std::string hash;


### PR DESCRIPTION

### Intent

Addresses: https://github.com/rstudio/rstudio-pro/issues/9702

### Approach

We lived for a long time without them, I added them for the job verify bug which we found was somewhere else.  It turns out rsaSign gets used for each job launcher request. This may be causing a bottleneck with workbench that shows up in the load tests.




