### PR TITLE
Fix mislabeling of empty tabset

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
@@ -79,7 +79,7 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
                           WorkbenchTab backgroundJobsTab,
                           WorkbenchTab workbenchJobsTab)
    {
-      super(owner, parentWindow, "ConsoleTabSet", null);
+      super(owner, parentWindow, "ConsoleTabSet", false, null);
       owner_ = owner;
       consolePane_ = consolePane;
       compilePdfTab_ = compilePdfTab;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -2407,7 +2407,7 @@ public class PaneManager
 
       // Only pass commands to sidebar for the empty state feature
       final WorkbenchTabPanel tabPanel = new WorkbenchTabPanel(frame, logicalWindow, persisterName,
-         isSidebar ? commands_ : null);
+         isSidebar, isSidebar ? commands_ : null);
 
       if (StringUtil.equals(persisterName, UserPrefsAccessor.Panes.QUADRANTS_TABSET1))
          tabs1_ = tabs;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchTabPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchTabPanel.java
@@ -59,7 +59,8 @@ class WorkbenchTabPanel
                  HasEnsureVisibleHandlers,
                  HasEnsureHeightHandlers
 {
-   public WorkbenchTabPanel(WindowFrame owner, LogicalWindow parentWindow, String tabListName, Commands commands)
+   public WorkbenchTabPanel(WindowFrame owner, LogicalWindow parentWindow, String tabListName,
+                            boolean showTitleWhenNoTabs, Commands commands)
    {
       final int UTILITY_AREA_SIZE = 52;
       panel_ = new LayoutPanel();
@@ -83,18 +84,21 @@ class WorkbenchTabPanel
                                  UTILITY_AREA_SIZE, Unit.PX);
       panel_.setWidgetTopHeight(utilPanel_, 0, Unit.PX, 22, Unit.PX);
 
-      // Create sidebar title for when there are no tabs
-      sidebarTitlePanel_ = new HTML(constants_.sidebarTitleText());
-      sidebarTitlePanel_.setStylePrimaryName(ThemeStyles.INSTANCE.multiPodUtilityArea());
-      sidebarTitlePanel_.addStyleName(ThemeStyles.INSTANCE.title());
-      Style titleStyle = sidebarTitlePanel_.getElement().getStyle();
-      titleStyle.setLineHeight(22, Unit.PX);
-      titleStyle.setPaddingLeft(8, Unit.PX);
-      titleStyle.setProperty("display", "flex");
-      titleStyle.setProperty("alignItems", "center");
-      panel_.add(sidebarTitlePanel_);
-      panel_.setWidgetLeftRight(sidebarTitlePanel_, 0, Unit.PX, UTILITY_AREA_SIZE, Unit.PX);
-      panel_.setWidgetTopHeight(sidebarTitlePanel_, 0, Unit.PX, 22, Unit.PX);
+      // Create title for when there are no tabs
+      if (showTitleWhenNoTabs)
+      {
+         sidebarTitlePanel_ = new HTML(constants_.sidebarTitleText());
+         sidebarTitlePanel_.setStylePrimaryName(ThemeStyles.INSTANCE.multiPodUtilityArea());
+         sidebarTitlePanel_.addStyleName(ThemeStyles.INSTANCE.title());
+         Style titleStyle = sidebarTitlePanel_.getElement().getStyle();
+         titleStyle.setLineHeight(22, Unit.PX);
+         titleStyle.setPaddingLeft(8, Unit.PX);
+         titleStyle.setProperty("display", "flex");
+         titleStyle.setProperty("alignItems", "center");
+         panel_.add(sidebarTitlePanel_);
+         panel_.setWidgetLeftRight(sidebarTitlePanel_, 0, Unit.PX, UTILITY_AREA_SIZE, Unit.PX);
+         panel_.setWidgetTopHeight(sidebarTitlePanel_, 0, Unit.PX, 22, Unit.PX);
+      }
 
       // Create empty state widget for when there are no tabs
       if (commands != null)


### PR DESCRIPTION
### Intent

Addresses #16732

### Approach

The "Sidebar" label was being created for any tab-free pane, not just the Sidebar as intended. It wasn't showing for TabSet2 due to this issue https://github.com/rstudio/rstudio/issues/16733.

Fixed by adding a `WorkbenchTabPanel` constructor argument `boolean showTitleWhenNoTabs` and only setting to true for the sidebar.

This won't work if set to true for other panes (they'll still show Sidebar) so if we decide later to show titles on other empty regions we'll need to make additional tweaks.

### Automated Tests

None

### QA Notes

Test per issue.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


