### PR TITLE
Adjust database.

### DIFF
--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -667,7 +667,7 @@ core::Error Rowset::getMillisecondSinceEpochStrValue(RowsetIterator &row, const 
       return core::Success();
    }
 
-   auto timestampAsOptionalDouble = core::safe_convert::stringTo<int64_t>(timestampAsOptionalString.value());
+   auto timestampAsOptionalDouble = core::safe_convert::stringTo<double>(timestampAsOptionalString.value());
    if( timestampAsOptionalDouble.has_value() )
    {
       *result = core::date_time::timeFromMillisecondsSinceEpoch(timestampAsOptionalDouble.value());
@@ -720,7 +720,7 @@ core::Error Rowset::getISO8601StrValue(RowsetIterator & row, const std::string& 
    catch(const std::bad_cast & e)
    {
       return core::Error(boost::system::errc::invalid_argument,
-         "Could not convert field " + columnName + " from ISO 8601 string to ptime (" + e.what() + ")", ERROR_LOCATION);
+         "Could not convert field " + columnName + " from ISO 8601 string to ptime", ERROR_LOCATION);
    }
 
    if( result->value().is_not_a_date_time() )


### PR DESCRIPTION
### Intent

So this was adjusted in the gtest PR (https://github.com/rstudio/rstudio/pull/16389). I think it must have come in from a git operation because of how specific they are. There's a change lower in the file that I did add specifically add.

### Approach

Rolls it back to the original version.

### Automated Tests

Tests should run.

### QA Notes

> Ensure you have updated the QA Notes in the original issue.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


