### PR TITLE
avoid presenting overlapping / spurious completions

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
@@ -343,14 +343,14 @@ public class TextEditingTargetCopilotHelper
                            }
 
                            events_.fireEvent(new CopilotEvent(
-                                 completions.size() == 0
+                                 completions.isEmpty()
                                     ? CopilotEventType.COMPLETION_RECEIVED_NONE
                                     : CopilotEventType.COMPLETION_RECEIVED_SOME));
                            
                            // TODO: If multiple completions are available we should provide a way for 
                            // the user to view/select them. For now, use the last one.
                            // https://github.com/rstudio/rstudio/issues/16055
-                           if (completions.size() > 0)
+                           if (!completions.isEmpty())
                            {
                               CopilotCompletion completion = completions.get(completions.size() - 1);
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16757.

### Approach

In some cases, Copilot will provide completions which are identical to what already exists in the current document. Detect those completions, and discard them as irrelevant.

In addition, fix a logic bug where we might "over-trim" a completion. (Properly check offsets when trimming and subsetting a completion's insertText during normalization.)

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/16757.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
