### PR TITLE
Avoiding set_default_verify_paths with a custom CA

### DIFF
--- a/src/cpp/core/http/Ssl.cpp
+++ b/src/cpp/core/http/Ssl.cpp
@@ -288,14 +288,16 @@ void initializeSslContext(boost::asio::ssl::context* pContext,
          ec.clear();
       }
 
-      pContext->set_default_verify_paths(ec);
-      if (ec)
+      if (certificateAuthority.empty())
       {
-         LOG_ERROR(Error(ec, "Could not set default certificate verification paths on SSL context", ERROR_LOCATION));
-         ec.clear();
+         pContext->set_default_verify_paths(ec);
+         if (ec)
+         {
+            LOG_ERROR(Error(ec, "Could not set default certificate verification paths on SSL context", ERROR_LOCATION));
+            ec.clear();
+         }
       }
-
-      if (!certificateAuthority.empty())
+      else
       {
          boost::asio::const_buffer buff(certificateAuthority.data(), certificateAuthority.size());
          pContext->add_certificate_authority(buff, ec);


### PR DESCRIPTION
### Intent

Fix performance problems seen in load test 

### Approach

Don't call the very expensive set_default_verify_paths call if we have a custom CA.  