### PR TITLE
Fix child process exit

### DIFF
--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -2327,7 +2327,7 @@ Error launchChildProcess(std::string path,
          Error error = systemError(errno, ERROR_LOCATION);
          // Use safe logger in 'after fork before exec'
          safeLogToSyslog(path, log::LogLevel::ERR, error.asString());
-         ::exit(EXIT_FAILURE);
+         ::_exit(EXIT_FAILURE);
       }
 
       Error error = runProcess(path, runAsUser, config, configFilter);
@@ -2335,7 +2335,7 @@ Error launchChildProcess(std::string path,
       {
          // Use safe logger in 'after fork before exec'
          safeLogToSyslog(path, log::LogLevel::ERR, error.asString());
-         ::exit(EXIT_FAILURE);
+         ::_exit(EXIT_FAILURE);
       }
    }
 


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 

When the PAM login failed in the child process, it was shutting down the child using ::exit() , which causes atexit hooks to run, which includes C++ destructors for static objects. ::_exit() is what you're SUPPOSED to use in that context, which just kills the process right-here-right-now.

Presumably, one of those static destructors was modifying a file descriptor that the parent process depended on, making the event loop's internals fall into an inconsistent state.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

When PAM session initialization failed in a forked child process (before exec), rserver-launcher would enter an unresponsive state and stop processing new session launch requests. This required manually restarting rserver-launcher to recover.

The issue manifested as:
- PAM errors logged successfully (e.g., "pam_open_session failed: Cannot make/remove an entry
 for the specified session")
- Child process exiting
- But `onSessionExit` callback never being called in parent
- rserver-launcher appearing to run normally but not responding to new launch requests


After fork (but before exec), calling `exit()` is dangerous because:
- Running destructors can modify shared state (like file descriptors) that the parent process
 depends on
- This can corrupt the parent's event loop state, causing it to become unresponsive
- The behavior is non-deterministic depending on what static destructors do

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Ensure you have updated the QA Notes in the original issue.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


