### PR TITLE
Changes to rserver's shutdown sequence

### DIFF
--- a/src/cpp/server/ServerMainOverlay.cpp
+++ b/src/cpp/server/ServerMainOverlay.cpp
@@ -16,6 +16,8 @@
 #include <shared_core/Error.hpp>
 #include <set>
 
+#include <core/system/System.hpp>
+
 using namespace rstudio::core;
 
 namespace rstudio {
@@ -44,6 +46,10 @@ void startShutdown()
 std::set<std::string> interruptProcs()
 {
    return std::set<std::string>();
+}
+
+void addProcsToShutdown(std::vector<core::system::ProcessInfo> *pChildren)
+{
 }
 
 void shutdown()


### PR DESCRIPTION
A couple of changes in how the server stop process works:

  - first stop restarting monitored processes
  - get all of the children before we start stopping processes because some may get re-parented to root
  - provide a hook for deciding which children get stopped

Reviewed in: https://github.com/rstudio/rstudio-pro/pull/9752

