### PR TITLE
remove unused state from old RDP feature and regenerate AppCommands.R

### DIFF
--- a/git_hooks/secrets/.secrets.baseline
+++ b/git_hooks/secrets/.secrets.baseline
@@ -499,14 +499,14 @@
         "filename": "src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_en.properties",
         "hashed_secret": "adf045bed2348977abab6b6fe372f34905d94048",
         "is_verified": false,
-        "line_number": 132
+        "line_number": 128
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_en.properties",
         "hashed_secret": "c9a508aa5d76dc456c5cbdd9e4977088a5ef9b6b",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 129
       }
     ],
     "src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_fr.properties": [
@@ -515,14 +515,14 @@
         "filename": "src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_fr.properties",
         "hashed_secret": "cdc5ab1016e9a09e3f9316e3028db0e0f2c179e8",
         "is_verified": false,
-        "line_number": 127
+        "line_number": 123
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_fr.properties",
         "hashed_secret": "279a7d4638a178a68e9acb41850214992745569e",
         "is_verified": false,
-        "line_number": 128
+        "line_number": 124
       }
     ],
     "src/node/desktop/src/assets/locales/en.json": [
@@ -553,5 +553,5 @@
       }
     ]
   },
-  "generated_at": "2025-12-18T23:37:32Z"
+  "generated_at": "2026-01-05T21:36:47Z"
 }

--- a/src/cpp/r/R/AppCommands.R
+++ b/src/cpp/r/R/AppCommands.R
@@ -1,7 +1,7 @@
 #
 # AppCommands.R
 #
-# Copyright (C) 2025 by Posit Software, PBC
+# Copyright (C) 2026 by Posit Software, PBC
 #
 # Unless you have received this program directly from Posit Software pursuant
 # to the terms of a commercial license agreement with Posit Software, then
@@ -232,6 +232,7 @@
    projectSweaveOptions = "projectSweaveOptions",
    setWorkingDirToProjectDir = "setWorkingDirToProjectDir",
    consoleClear = "consoleClear",
+   consoleFind = "consoleFind",
    interruptR = "interruptR",
    restartR = "restartR",
    restartRClearOutput = "restartRClearOutput",
@@ -328,6 +329,8 @@
    showToolbar = "showToolbar",
    hideToolbar = "hideToolbar",
    toggleToolbar = "toggleToolbar",
+   toggleSidebar = "toggleSidebar",
+   toggleSidebarLocation = "toggleSidebarLocation",
    zoomActualSize = "zoomActualSize",
    zoomIn = "zoomIn",
    zoomOut = "zoomOut",
@@ -495,6 +498,8 @@
    tutorialRefresh = "tutorialRefresh",
    tutorialStop = "tutorialStop",
    tutorialHome = "tutorialHome",
+   activateChat = "activateChat",
+   layoutZoomChat = "layoutZoomChat",
    activateViewer = "activateViewer",
    layoutZoomViewer = "layoutZoomViewer",
    viewerPopout = "viewerPopout",
@@ -528,6 +533,7 @@
    signOut = "signOut",
    loadServerHome = "loadServerHome",
    clearBuild = "clearBuild",
+   findBuild = "findBuild",
    buildAll = "buildAll",
    buildIncremental = "buildIncremental",
    buildFull = "buildFull",
@@ -618,6 +624,8 @@
    layoutConsoleOnLeft = "layoutConsoleOnLeft",
    layoutConsoleOnRight = "layoutConsoleOnRight",
    paneLayout = "paneLayout",
+   restoreDefaultPaneAndTabLayout = "restoreDefaultPaneAndTabLayout",
+   restoreDefaultPaneAndTabLayoutNoPrompt = "restoreDefaultPaneAndTabLayoutNoPrompt",
    maximizeConsole = "maximizeConsole",
    maximizeSource = "maximizeSource",
    maximizeTabSet1 = "maximizeTabSet1",
@@ -625,10 +633,12 @@
    toggleEditorTokenInfo = "toggleEditorTokenInfo",
    layoutZoomLeftColumn = "layoutZoomLeftColumn",
    layoutZoomRightColumn = "layoutZoomRightColumn",
+   layoutZoomSidebar = "layoutZoomSidebar",
    focusLeftSeparator = "focusLeftSeparator",
    focusRightSeparator = "focusRightSeparator",
    focusCenterSeparator = "focusCenterSeparator",
    focusSourceColumnSeparator = "focusSourceColumnSeparator",
+   focusSidebarSeparator = "focusSidebarSeparator",
    showFileMenu = "showFileMenu",
    showEditMenu = "showEditMenu",
    showCodeMenu = "showCodeMenu",

--- a/src/cpp/session/include/session/prefs/UserStateValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserStateValues.hpp
@@ -37,10 +37,6 @@ namespace prefs {
 #define kViewAccessibility "accessibility"
 #define kViewDisableRendererAccessibility "disableRendererAccessibility"
 #define kViewEnableSplashScreen "enableSplashScreen"
-#define kRemoteSession "remote_session"
-#define kRemoteSessionLastRemoteSessionUrl "lastRemoteSessionUrl"
-#define kRemoteSessionAuthCookies "authCookies"
-#define kRemoteSessionTempAuthCookies "tempAuthCookies"
 #define kRenderer "renderer"
 #define kRendererEngine "engine"
 #define kRendererUseGpuExclusionList "useGpuExclusionList"
@@ -137,12 +133,6 @@ public:
     */
    core::json::Object view();
    core::Error setView(core::json::Object val);
-
-   /**
-    * 
-    */
-   core::json::Object remoteSession();
-   core::Error setRemoteSession(core::json::Object val);
 
    /**
     * 

--- a/src/cpp/session/prefs/UserStateValues.cpp
+++ b/src/cpp/session/prefs/UserStateValues.cpp
@@ -65,19 +65,6 @@ core::Error UserStateValues::setView(core::json::Object val)
 /**
  * 
  */
-core::json::Object UserStateValues::remoteSession()
-{
-   return readPref<core::json::Object>("remote_session");
-}
-
-core::Error UserStateValues::setRemoteSession(core::json::Object val)
-{
-   return writePref("remote_session", val);
-}
-
-/**
- * 
- */
 core::json::Object UserStateValues::renderer()
 {
    return readPref<core::json::Object>("renderer");
@@ -432,7 +419,6 @@ std::vector<std::string> UserStateValues::allKeys()
       kGeneral,
       kFont,
       kView,
-      kRemoteSession,
       kRenderer,
       kPlatform,
       kContextId,

--- a/src/cpp/session/resources/schema/user-state-schema.json
+++ b/src/cpp/session/resources/schema/user-state-schema.json
@@ -77,31 +77,6 @@
                 "enableSplashScreen": true
             }
         },
-        "remote_session": {
-            "type": "object",
-            "properties": {
-                "lastRemoteSessionUrl": {
-                    "type": "string"
-                },
-                "authCookies": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "tempAuthCookies": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            },
-            "default": {
-                "lastRemoteSessionUrl": "",
-                "authCookies": [],
-                "tempAuthCookies": []
-            }
-        },
         "renderer": {
             "type": "object",
             "properties": {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
@@ -132,36 +132,6 @@ public class UserStateAccessor extends Prefs
    /**
     * 
     */
-   public PrefValue<RemoteSession> remoteSession()
-   {
-      return object(
-         "remote_session",
-         _constants.remoteSessionTitle(), 
-         _constants.remoteSessionDescription(), 
-         null);
-   }
-
-   public static class RemoteSession extends JavaScriptObject
-   {
-      protected RemoteSession() {} 
-
-      public final native String getLastRemoteSessionUrl() /*-{
-         return this && this.lastRemoteSessionUrl || "";
-      }-*/;
-
-      public final native JsArrayString getAuthCookies() /*-{
-         return this && this.authCookies || [];
-      }-*/;
-
-      public final native JsArrayString getTempAuthCookies() /*-{
-         return this && this.tempAuthCookies || [];
-      }-*/;
-
-   }
-
-   /**
-    * 
-    */
    public PrefValue<Renderer> renderer()
    {
       return object(
@@ -713,8 +683,6 @@ public class UserStateAccessor extends Prefs
          font().setValue(layer, source.getObject("font"));
       if (source.hasKey("view"))
          view().setValue(layer, source.getObject("view"));
-      if (source.hasKey("remote_session"))
-         remoteSession().setValue(layer, source.getObject("remote_session"));
       if (source.hasKey("renderer"))
          renderer().setValue(layer, source.getObject("renderer"));
       if (source.hasKey("platform"))
@@ -776,7 +744,6 @@ public class UserStateAccessor extends Prefs
       prefs.add(general());
       prefs.add(font());
       prefs.add(view());
-      prefs.add(remoteSession());
       prefs.add(renderer());
       prefs.add(platform());
       prefs.add(contextId());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants.java
@@ -51,14 +51,6 @@ public interface UserStateAccessorConstants extends Constants {
     * 
     */
    @DefaultStringValue("")
-   String remoteSessionTitle();
-   @DefaultStringValue("")
-   String remoteSessionDescription();
-
-   /**
-    * 
-    */
-   @DefaultStringValue("")
    String rendererTitle();
    @DefaultStringValue("")
    String rendererDescription();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_en.properties
@@ -29,10 +29,6 @@ viewTitle =
 viewDescription = 
 
 # 
-remoteSessionTitle = 
-remoteSessionDescription = 
-
-# 
 rendererTitle = 
 rendererDescription = 
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_fr.properties
@@ -24,10 +24,6 @@ viewTitle =
 viewDescription = 
 
 # 
-remoteSessionTitle = 
-remoteSessionDescription = 
-
-# 
 rendererTitle = 
 rendererDescription = 
 

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -49,10 +49,6 @@ const kAccessibility = 'view.accessibility';
 const kEnableSplashScreen = 'view.enableSplashScreen';
 const kDisableRendererAccessibility = 'view.disableRendererAccessibility';
 
-const kLastRemoteSessionUrl = 'session.lastRemoteSessionUrl';
-const kAuthCookies = 'session.authCookies';
-const kTempAuthCookies = 'session.tempAuthCookies';
-
 const kIgnoredUpdateVersions = 'general.ignoredUpdateVersions';
 
 const kRendererEngine = 'renderer.engine';
@@ -223,30 +219,6 @@ export class DesktopOptionsImpl implements DesktopOptions {
 
   public disableRendererAccessibility(): boolean {
     return this.config.get(kDisableRendererAccessibility, properties.view.default.disableRendererAccessibility);
-  }
-
-  public setLastRemoteSessionUrl(lastRemoteSessionUrl: string): void {
-    this.config.set(kLastRemoteSessionUrl, lastRemoteSessionUrl);
-  }
-
-  public lastRemoteSessionUrl(): string {
-    return this.config.get(kLastRemoteSessionUrl, properties.remote_session.default.lastRemoteSessionUrl);
-  }
-
-  public setAuthCookies(authCookies: string[]): void {
-    this.config.set(kAuthCookies, authCookies);
-  }
-
-  public authCookies(): string[] {
-    return this.config.get(kAuthCookies, properties.remote_session.default.authCookies);
-  }
-
-  public setTempAuthCookies(tempAuthCookies: string[]): void {
-    this.config.set(kTempAuthCookies, tempAuthCookies);
-  }
-
-  public tempAuthCookies(): string[] {
-    return this.config.get(kTempAuthCookies, properties.remote_session.default.tempAuthCookies);
   }
 
   public setIgnoredUpdateVersions(ignoredUpdateVersions: string[]): void {

--- a/src/node/desktop/test/unit/main/desktop-options.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-options.test.ts
@@ -70,9 +70,6 @@ describe('DesktopOptions', () => {
     assert.equal(options.zoomLevel(), properties.view.default.zoomLevel);
     assert.deepEqual(options.windowBounds(), properties.view.default.windowBounds);
     assert.equal(options.accessibility(), properties.view.default.accessibility);
-    assert.equal(options.lastRemoteSessionUrl(), properties.remote_session.default.lastRemoteSessionUrl);
-    assert.deepEqual(options.authCookies(), properties.remote_session.default.authCookies);
-    assert.deepEqual(options.tempAuthCookies(), properties.remote_session.default.tempAuthCookies);
     assert.deepEqual(options.ignoredUpdateVersions(), properties.general.default.ignoredUpdateVersions);
     if (process.platform === 'win32') {
       assert.equal(options.rBinDir(), properties.platform.default.windows.rBinDir);
@@ -94,9 +91,6 @@ describe('DesktopOptions', () => {
     const newWindowBounds = { width: 123, height: 321, x: 0, y: 0, maximized: false };
     const newAccessibility = !(properties.view.default.accessibility as boolean);
     const newDisableRendererAccessibility = !(properties.view.default.disableRendererAccessibility as boolean);
-    const newLastRemoteSessionUrl = 'testLastRemoteSessionUrl';
-    const newAuthCookies = ['test', 'Autht', 'Cookies'];
-    const newTempAuthCookies = ['test', 'Temp', 'Auth', 'Cookies'];
     const newIgnoredUpdateVersions = ['test', 'Ignored', 'Update', 'Versions'];
 
     const newRBinDir = 'C:/R/bin/x64';
@@ -113,9 +107,6 @@ describe('DesktopOptions', () => {
     options.saveWindowBounds(newWindowBounds);
     options.setAccessibility(newAccessibility);
     options.setDisableRendererAccessibility(newDisableRendererAccessibility);
-    options.setLastRemoteSessionUrl(newLastRemoteSessionUrl);
-    options.setAuthCookies(newAuthCookies);
-    options.setTempAuthCookies(newTempAuthCookies);
     options.setIgnoredUpdateVersions(newIgnoredUpdateVersions);
     options.setPeferR64(newPeferR64);
     options.setRExecutablePath(newRExecPath);
@@ -126,9 +117,6 @@ describe('DesktopOptions', () => {
     assert.deepEqual(options.windowBounds(), newWindowBounds);
     assert.equal(options.accessibility(), newAccessibility);
     assert.equal(options.disableRendererAccessibility(), newDisableRendererAccessibility);
-    assert.equal(options.lastRemoteSessionUrl(), newLastRemoteSessionUrl);
-    assert.deepEqual(options.authCookies(), newAuthCookies);
-    assert.deepEqual(options.tempAuthCookies(), newTempAuthCookies);
     assert.deepEqual(options.ignoredUpdateVersions(), newIgnoredUpdateVersions);
     if (process.platform === 'win32') {
       assert.equal(options.rBinDir(), normalizeSeparatorsNative(newRBinDir));


### PR DESCRIPTION
Remove following state entries that were used by the removed RDP feature:

- lastRemoteSessionUrl
- authCookies
- tempAuthCookies

The state code handles loading and saving unknown values, so this shouldn't break anything if somebody actually has any of these sitting in their state file.

Unrelated: re-ran `generate-commands-accessor.R` to pick up recently added commands.