### PR TITLE
limit pai update checks to once per hour

### DIFF
--- a/src/cpp/session/include/session/prefs/UserStateValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserStateValues.hpp
@@ -111,6 +111,9 @@ namespace prefs {
 #define kZoteroApiKey "zotero_api_key"
 #define kZoteroDataDir "zotero_data_dir"
 #define kQuartoWebsiteSyncEditor "quarto_website_sync_editor"
+#define kPositAssistant "posit_assistant"
+#define kPositAssistantLastUpdateCheck "lastUpdateCheck"
+#define kPositAssistantRstudioVersionChecked "rstudioVersionChecked"
 
 class UserStateValues: public Preferences
 {
@@ -295,6 +298,12 @@ public:
     */
    bool quartoWebsiteSyncEditor();
    core::Error setQuartoWebsiteSyncEditor(bool val);
+
+   /**
+    * State related to the Posit Assistant feature.
+    */
+   core::json::Object positAssistant();
+   core::Error setPositAssistant(core::json::Object val);
 
 };
 

--- a/src/cpp/session/prefs/UserStateValues.cpp
+++ b/src/cpp/session/prefs/UserStateValues.cpp
@@ -413,6 +413,19 @@ core::Error UserStateValues::setQuartoWebsiteSyncEditor(bool val)
    return writePref("quarto_website_sync_editor", val);
 }
 
+/**
+ * State related to the Posit Assistant feature.
+ */
+core::json::Object UserStateValues::positAssistant()
+{
+   return readPref<core::json::Object>("posit_assistant");
+}
+
+core::Error UserStateValues::setPositAssistant(core::json::Object val)
+{
+   return writePref("posit_assistant", val);
+}
+
 std::vector<std::string> UserStateValues::allKeys()
 {
    return std::vector<std::string>({
@@ -446,6 +459,7 @@ std::vector<std::string> UserStateValues::allKeys()
       kZoteroApiKey,
       kZoteroDataDir,
       kQuartoWebsiteSyncEditor,
+      kPositAssistant,
    });
 }
    

--- a/src/cpp/session/resources/schema/user-state-schema.json
+++ b/src/cpp/session/resources/schema/user-state-schema.json
@@ -378,6 +378,23 @@
             "default": false,
             "title": "Quarto Website Sync Editor",
             "description": "Sync source editor to Quarto website preview navigation."
+        },
+        "posit_assistant": {
+            "type": "object",
+            "properties": {
+                "lastUpdateCheck": {
+                    "type": "string",
+                    "default": "",
+                    "description": "The timestamp of the last Posit Assistant update check."
+                },
+                "rstudioVersionChecked": {
+                    "type": "string",
+                    "default": "",
+                    "description": "The RStudio version that was last checked for Posit Assistant updates."
+                }
+            },
+            "title": "Posit Assistant State",
+            "description": "State related to the Posit Assistant feature."
         }
     }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
@@ -675,6 +675,32 @@ public class UserStateAccessor extends Prefs
          false);
    }
 
+   /**
+    * State related to the Posit Assistant feature.
+    */
+   public PrefValue<PositAssistant> positAssistant()
+   {
+      return object(
+         "posit_assistant",
+         _constants.positAssistantTitle(), 
+         _constants.positAssistantDescription(), 
+         null);
+   }
+
+   public static class PositAssistant extends JavaScriptObject
+   {
+      protected PositAssistant() {} 
+
+      public final native String getLastUpdateCheck() /*-{
+         return this && this.lastUpdateCheck || "";
+      }-*/;
+
+      public final native String getRstudioVersionChecked() /*-{
+         return this && this.rstudioVersionChecked || "";
+      }-*/;
+
+   }
+
    public void syncPrefs(String layer, JsObject source)
    {
       if (source.hasKey("general"))
@@ -737,6 +763,8 @@ public class UserStateAccessor extends Prefs
          zoteroDataDir().setValue(layer, source.getString("zotero_data_dir"));
       if (source.hasKey("quarto_website_sync_editor"))
          quartoWebsiteSyncEditor().setValue(layer, source.getBool("quarto_website_sync_editor"));
+      if (source.hasKey("posit_assistant"))
+         positAssistant().setValue(layer, source.getObject("posit_assistant"));
    }
    public List<PrefValue<?>> allPrefs()
    {
@@ -771,6 +799,7 @@ public class UserStateAccessor extends Prefs
       prefs.add(zoteroApiKey());
       prefs.add(zoteroDataDir());
       prefs.add(quartoWebsiteSyncEditor());
+      prefs.add(positAssistant());
       return prefs;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants.java
@@ -263,6 +263,14 @@ public interface UserStateAccessorConstants extends Constants {
    @DefaultStringValue("Sync source editor to Quarto website preview navigation.")
    String quartoWebsiteSyncEditorDescription();
 
+   /**
+    * State related to the Posit Assistant feature.
+    */
+   @DefaultStringValue("Posit Assistant State")
+   String positAssistantTitle();
+   @DefaultStringValue("State related to the Posit Assistant feature.")
+   String positAssistantDescription();
+
 
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_en.properties
@@ -136,4 +136,8 @@ zoteroDataDirDescription = Directory containing Zotero data files
 quartoWebsiteSyncEditorTitle = Quarto Website Sync Editor
 quartoWebsiteSyncEditorDescription = Sync source editor to Quarto website preview navigation.
 
+# State related to the Posit Assistant feature.
+positAssistantTitle = Posit Assistant State
+positAssistantDescription = State related to the Posit Assistant feature.
+
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_fr.properties
@@ -130,3 +130,7 @@ zoteroDataDirDescription= Répertoire contenant les fichiers de données Zotero
 # Sync source editor to Quarto website preview navigation.
 quartoWebsiteSyncEditorTitle= Éditeur de synchronisation du site web Quarto
 quartoWebsiteSyncEditorDescription= Synchronisation de l''éditeur source avec la navigation de l''aperçu du site web Quarto.
+
+# State related to the Posit Assistant feature.
+positAssistantTitle = État de l''assistant Posit
+positAssistantDescription = État lié à la fonctionnalité de l''assistant Posit.


### PR DESCRIPTION
Only download the pai manifest once-per hour, instead of at every session start. If no current pai installation or using a different version of RStudio than last time the check was made, the check will be done no matter how long it has been.