### PR TITLE
Update release notes for 2026.01.0+392.pro5

### DIFF
--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -44,7 +44,7 @@ This page provides the release notes associated with each release of RStudio and
 - (rstudio-pro#8920): Added option to remove recent projects from Workbench home page
 - (rstudio-pro#9550): Added `POSIT_PRODUCT` environment variable with value "WORKBENCH" to all Sessions and jobs
 - (rstudio-pro#9585): Added revocation logic for Session RPC cookies when a session ends (exit, suspension, or halt) or when the related user account is locked, ensuring immediate invalidation of credentials
-- (rstudio-pro#9169): Added `use-legacy-homepage` option to allow Admins to set the legacy home page as the default during the deprecation window
+- (rstudio-pro#9169): Added `use-legacy-homepage` option to allow admins to set the legacy home page as the default during the deprecation window
 - (rstudio-pro#9065, rstudio-pro#9074): Added support for custom OAuth managed credentials
 - (rstudio-pro#8840): Added support for launching sessions with projects that the Workbench node cannot find, in case the project exists on the session node
 - (rstudio-pro#5913): Added support for managed credentials in Workbench Jobs


### PR DESCRIPTION

Update release notes for IDE / Workbench 2026.01.0+392.pro5 release.

:warning: **Before converting from Draft PR:** :warning:

This change has been generated by the release script. Content is generated based on `version/news/NEWS-2026.01.0-apple-blossom.md`. If this file was not in sync with Pro or did not include items from other sources (i.e. the vscode extension), then some items may be missing.  Please verify content/formatting is correct and make changes if necessary.
