### PR TITLE
Fix editor.openDocument

### DIFF
--- a/src/cpp/session/modules/automation/SessionAutomationTools.R
+++ b/src/cpp/session/modules/automation/SessionAutomationTools.R
@@ -367,7 +367,8 @@
 .rs.automation.addRemoteFunction("editor.openDocument", function(documentPath)
 {
    self$console.executeExpr({
-      file.create(!!documentPath, showWarnings = FALSE)
+      if (!file.exists(!!documentPath))
+         file.create(!!documentPath, showWarnings = FALSE)
       .rs.api.documentOpen(!!documentPath)
    })
    


### PR DESCRIPTION
### Intent

BRAT tests using the following pattern were failing because the editor was empty after the 

```R
   contents <- .rs.heredoc('
      ---
      title: R Markdown Document
      ---
      
      This is some prose.
      This is some more prose.
   ')
   
   remote$editor.openWithContents(ext = ".Rmd", contents = contents)
```

### Approach

Root cause: R's file.create() truncates files if they already exist.

How it broke: Commit d087cd76d2 refactored editor.openDocument into a separate function and added file.create() to ensure the file exists. When called from openWithContents, this truncated the file that had just been written.

### Automated Tests

Now they pass!


