### PR TITLE
Unzoom columns when starting RStudio

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
@@ -834,7 +834,6 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
 
    /**
     * Check if the saved state represents a zoomed column layout.
-    * A zoomed state is when one column takes up (almost) the entire panel width.
     * We detect this to avoid restoring broken zoom state on restart (issue #16688).
     */
    private boolean isZoomedColumnState(State state)
@@ -849,12 +848,31 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
          return false;
 
       // Check if any single column takes up almost the entire panel width
-      // (within 50px to account for splitters and small rounding)
+      // This catches sidebar zoom and right column zoom
       for (int width : widths)
       {
          if (width > panelWidth - 50)
             return true;
       }
+
+      // Check for left column zoom: right-side columns are collapsed
+      // Right widget is always the last stored width
+      int rightWidth = widths[widths.length - 1];
+      boolean rightCollapsed = rightWidth < 20;
+
+      // If sidebar is on the right, it's the second-to-last width
+      boolean sidebarOnRight = sidebar_ != null && !"left".equals(sidebarLocation_);
+      boolean sidebarCollapsed = true; // Default true if no sidebar on right
+
+      if (sidebarOnRight && widths.length >= 2)
+      {
+         int sidebarWidth = widths[widths.length - 2];
+         sidebarCollapsed = sidebarWidth < 20;
+      }
+
+      // If right (and sidebar if on right) are collapsed, left column is zoomed
+      if (rightCollapsed && sidebarCollapsed)
+         return true;
 
       return false;
    }


### PR DESCRIPTION
### Intent

Addresses #16688

### Approach

If you exit RStudio with a column zoomed (left column, middle column, or sidebar), and restart, it should now unzoom the column and go back to regular layout.

I tried making it handle starting up in a zoomed state but that proved much more complex than it was worth, and introduced exciting new problems.

### Automated Tests

None, don't currently have a way to test this scenario via automation.

### QA Notes

Zoom the left column via View > Panes > Zoom Left/Center Column and right via View > Panes > Zoom Right Column. There is no zoom widget for these columns (unlike the sidebar).

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


