### PR TITLE
Remove a check for rsconnect 1.0.2 since we now require 1.3.1

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -238,27 +238,6 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       if (requiresRmarkdown)
          deps.addAll(getFeatureDependencies("rmarkdown"));
       
-      // update rsconnect version if necessary
-      // TODO: Remove after a future release when required 'rsconnect' version
-      // is updated globally.
-      if (isQuartoManuscript)
-      {
-         for (int i = 0, n = deps.size(); i < n; i++)
-         {
-            Dependency dep = deps.get(i);
-            if (StringUtil.equals(dep.getName(), "rsconnect"))
-            {
-               int compare = Version.compare(dep.getVersion(), "1.0.2");
-               if (compare < 0)
-               {
-                  deps.remove(i);
-                  deps.add(Dependency.cranPackage("rsconnect", "1.0.2"));
-                  break;
-               }
-            }
-         }
-      }
-
       withDependencies(
         constants_.publishingPaneHeader(),
         userAction,


### PR DESCRIPTION
### Intent

Clean up some old code. I personally stumbled on this when trying to investigate a Connect escalation and was confused at first that this was the operative version constraint and not the one in https://github.com/rstudio/rstudio/blob/dc0d85aaef0a15450202f9daec605b09c6ee0b99/src/cpp/session/resources/dependencies/r-packages.json#L253-L257

### Approach

␡

### Automated Tests

I don't think there were any tests for this, but if they are CI will catch it.

### QA Notes

Should be none, we already required a higher rsconnect.

### Documentation

None needed.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


