### PR TITLE
Prevent child processes from inheriting parent-side handles in Win32ChildProcess

### DIFF
--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -418,6 +418,13 @@ Error ChildProcess::run()
    {
       return LAST_SYSTEM_ERROR();
    }
+   // Ensure parent-side handle is not inheritable to prevent child processes from inheriting it
+   if (!::SetHandleInformation(pImpl_->hStdInWrite,
+                               HANDLE_FLAG_INHERIT,
+                               0))
+   {
+      return LAST_SYSTEM_ERROR();
+   }
 
    // Standard output pipe
    // Use 256KB buffer to prevent backend from blocking on stdout writes
@@ -434,6 +441,13 @@ Error ChildProcess::run()
    {
       return LAST_SYSTEM_ERROR();
    }
+   // Ensure parent-side handle is not inheritable to prevent child processes from inheriting it
+   if (!::SetHandleInformation(pImpl_->hStdOutRead,
+                               HANDLE_FLAG_INHERIT,
+                               0))
+   {
+      return LAST_SYSTEM_ERROR();
+   }
 
    // Standard error pipe
    // Use 256KB buffer to prevent backend from blocking on stderr writes
@@ -447,6 +461,13 @@ Error ChildProcess::run()
    if (!::SetHandleInformation(hStdErrWrite,
                                HANDLE_FLAG_INHERIT,
                                HANDLE_FLAG_INHERIT))
+   {
+      return LAST_SYSTEM_ERROR();
+   }
+   // Ensure parent-side handle is not inheritable to prevent child processes from inheriting it
+   if (!::SetHandleInformation(pImpl_->hStdErrRead,
+                               HANDLE_FLAG_INHERIT,
+                               0))
    {
       return LAST_SYSTEM_ERROR();
    }


### PR DESCRIPTION
### Intent

Addresses #16799

### Summary

Fixes a Windows-only bug where switching RMarkdown or Quarto documents into Visual Mode would show an infinite spinner and never complete. The issue was introduced in #16727 (commit d03d216b27514da3e5f7b23f1c06cba87970a549).

### Root Cause

The problematic commit increased pipe buffer sizes by passing `SECURITY_ATTRIBUTES` with `bInheritHandle = TRUE` to `CreatePipe()`. This made **both** ends of each pipe inheritable by child processes, not just the child-side handles.

Before:
- `CreatePipe(..., nullptr, 0)` created non-inheritable handles by default
- Only child-side handles (stdin read, stdout/stderr write) were explicitly made inheritable via `SetHandleInformation`

After the change:
- `CreatePipe(..., &sa, 256 * 1024)` with `sa.bInheritHandle = TRUE` made **both** ends inheritable
- Child processes inherited parent-side handles (stdin write, stdout/stderr read)
- Pipes never properly closed because child processes held copies of parent handles
- Panmirror hung during initialization waiting for input that never completed

### The Fix

After creating each pipe with the increased buffer size, explicitly set the parent-side handles to non-inheritable:

- `pImpl_->hStdInWrite` - parent writes to child's stdin
- `pImpl_->hStdOutRead` - parent reads from child's stdout
- `pImpl_->hStdErrRead` - parent reads from child's stderr

This restores the correct handle inheritance behavior while maintaining the increased 256KB buffer size that prevents pipe saturation.

### Testing

1. Create a new RMarkdown or Quarto document in RStudio on Windows
2. Click the "Visual" button to switch to Visual Mode
3. Verify that Visual Mode loads successfully without an infinite spinner
4. Verify that Visual Mode functionality works correctly (editing, saving, etc.)

### Files Changed

- `src/cpp/core/system/Win32ChildProcess.cpp` - Added `SetHandleInformation` calls to clear `HANDLE_FLAG_INHERIT` on parent-side pipe handles
