### PR TITLE
avoid marking template documents as dirty on creation

### DIFF
--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -329,9 +329,6 @@ Error newDocument(const json::JsonRpcRequest& request,
    if (json::isType<std::string>(jsonContents))
    {
       pDoc->setContents(jsonContents.getString());
-      // Mark as dirty if content is non-empty (unsaved content)
-      if (!jsonContents.getString().empty())
-         pDoc->setDirty(true);
    }
 
    pDoc->editProperties(properties);


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/16775.

### Approach

Avoid marking documents with template content as dirty on creation. Related to changes in https://github.com/rstudio/rstudio/commit/f1f1a222f4177cfe8178c3081500ab120c445e3a#diff-5978ad81c77f774b0c9dfac4e4b8b697da3e8bc38e808176cd340fccc4ba5052R273-R275.

### Automated Tests

Covered by existing automation.

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
