### PR TITLE
Fix intermittent mouse selection failure in source editor

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -699,6 +699,15 @@ public class AceEditorWidget extends Composite
    {
       if (editor_ != null)
       {
+         // Check for and recover from corrupt mouse handler state.
+         // This can happen if an exception occurs during mouse event handling.
+         // See: https://github.com/rstudio/rstudio/issues/13436
+         if (editor_.isMouseHandlerStateCorrupt())
+         {
+            Debug.log("Recovering from corrupt Ace mouse handler state");
+            editor_.resetMouseHandlerState();
+         }
+
          if (BrowseCap.INSTANCE.aceVerticalScrollBarIssue())
             editor_.getRenderer().forceScrollbarUpdate();
          editor_.getRenderer().updateFontSize();


### PR DESCRIPTION
## Summary

- Adds automatic detection and recovery for corrupt Ace mouse handler state
- When an uncaught JavaScript exception occurs during mouse event handling, the MouseHandler can be left in an inconsistent state where mouse selection stops working for that editor tab
- Recovery is triggered when tabs are activated, so switching away and back to an affected tab will restore functionality

Addresses #13436

## Details

The root cause analysis suggests that Ace's MouseHandler can get stuck in a corrupt state when:
- An exception occurs during `onCaptureEnd` before cleanup code runs
- The `inVirtualSelectionMode` flag gets stuck `true` in multi-select scenarios
- The `state` property remains at a non-empty value like `"select"` or `"drag"`

This PR adds two methods to `AceEditorNative`:
- `isMouseHandlerStateCorrupt()` - detects suspicious state combinations (e.g., non-empty state when mouse is not pressed)
- `resetMouseHandlerState()` - resets all relevant state variables to their default values

The check runs in `AceEditorWidget.onActivate()`, so whenever a user switches to a tab with corrupt state, it will be automatically recovered.

## Test plan

- [ ] Verify normal mouse selection still works correctly
- [ ] Verify multi-cursor selection (Alt+click) still works
- [ ] Verify drag-and-drop text still works (if enabled)
- [ ] If the bug can be reproduced, verify that switching tabs recovers the editor


🤖 Generated with [Claude Code](https://claude.com/claude-code)