### PR TITLE
Remove gpg1 installation from dependencies and add manual installatio…

### DIFF
--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -29,7 +29,6 @@ RUN dnf install -y \
     gcc-c++ \
     gettext \
     git \
-    gpg1 \
     gtk3 \
     java-17-openjdk \
     java-17-openjdk-devel \
@@ -102,6 +101,13 @@ ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common rhel9
 # panmirror needs to be able to build in this location
 RUN chmod -R 777 /opt/rstudio-tools/src
+
+# build and install gpg1.4 which we need to sign the builds in headless mode
+# this is unavailable in the official rhel9 repos
+RUN wget https://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.23.tar.bz2
+RUN tar xvf gnupg-1.4.23.tar.bz2
+RUN cd gnupg-1.4.23 && CFLAGS="-fcommon" ./configure --prefix=/gnupg1 && make && make install
+RUN ln -s /gnupg1/bin/gpg /usr/local/bin/gpg1
 
 # cachebust for Quarto release
 ADD https://quarto.org/docs/download/_download.json quarto_releases


### PR DESCRIPTION
The `gpg1` package has been retired from the RHEL9 EPEL:

https://www.mail-archive.com/devel@lists.fedoraproject.org/msg210858.html 

So building from source, instead (we already were doing this for RHEL8). Had to add `CFLAGS="-fcommon"` due to newer C++ compiler on RHEL9.

We use gpg1 for signing releases, not for anything in the product itself.