### PR TITLE
Fix signing rpm packages non-interactively

### DIFF
--- a/docker/jenkins/sign-release.sh
+++ b/docker/jenkins/sign-release.sh
@@ -64,7 +64,7 @@ gpg --version
 
 # import signing key
 echo "Installing signing key from $KEYFILE..."
-gpg --no-default-keyring --keyring=$TMP_PUB_KEYRING --secret-keyring=$TMP_SEC_KEYRING --import $KEYFILE
+gpg --batch --pinentry-mode loopback --passphrase-file $PASSFILE --no-default-keyring --keyring=$TMP_PUB_KEYRING --secret-keyring=$TMP_SEC_KEYRING --import $KEYFILE
 PASSPHRASE=$(cat $PASSFILE)
 
 # scrape out the signing key ID


### PR DESCRIPTION
### Intent

The current gpg command was giving errors when signing rpm packages in Jenkins. To enable non-interactive signing to work with gpg, I added some extra flags. This is working in the Jenkins CI associated with pro-drivers repo.

https://github.com/rstudio/pro-drivers/pull/523#issuecomment-3761569146

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Ensure you have updated the QA Notes in the original issue.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


