### PR TITLE
fix news entry for 8840

### DIFF
--- a/version/news/NEWS-2026.01.0-apple-blossom.md
+++ b/version/news/NEWS-2026.01.0-apple-blossom.md
@@ -1,6 +1,7 @@
 ## RStudio 2026.01.0 "Apple Blossom" Release Notes
 
 ### New
+
 #### RStudio
 
 - ([#10567](https://github.com/rstudio/rstudio/issues/10567)): Added tools for searching within Console output and Build output
@@ -22,6 +23,7 @@
 - (rstudio-pro#6377): Added CSRF protection to the export file API
 
 #### Posit Workbench
+
 - (rstudio-pro#9506): Added `auth-openid-aws-role-claim` and `auth-openid-aws-session-name-claim` settings to allow mapping custom OIDC claim names for AWS credentials
 - (rstudio-pro#9088): Added support for admin-enforced settings in Positron
 - (rstudio-pro#9106): Added support for managing R and Python interpreters for Workbench Jobs in Positron and VS Code
@@ -33,12 +35,12 @@
 - (rstudio-pro#9585): Added revocation logic for Session RPC cookies when a session ends (exit, suspension, or halt) or when the related user account is locked, ensuring immediate invalidation of credentials
 - (rstudio-pro#9169): Added `use-legacy-homepage` option to allow Admins to set the legacy home page as the default during the deprecation window
 - (rstudio-pro#9065, rstudio-pro#9074): Added support for Custom OAuth Managed Credentials
-- (rstudio-pro#8840): Added support for launching sessions with projects that the Workbench node cannot find, in case the project exists on the session node
 - (rstudio-pro#5913): Added support for Managed Credentials in Workbench Jobs
 - (rstudio-pro#9224): Added support for projects in `get_session` and `launch_session` Workbench APIs
 - (rstudio-pro#6426): Added long-polling support to `get_session` Workbench API
 
 ### Fixed
+
 #### RStudio
 
 - ([#16398](https://github.com/rstudio/rstudio/issues/16398)): Fixed an issue where ANSI codes were rendered incorrectly in warning messages captured while rendering plots
@@ -96,6 +98,7 @@
 - (rstudio-pro#8046): Fixed an issue where `rstudio-server` and `root` users were incorrectly added to Workbench's internal database
 - (rstudio-pro#6489): Fixed excessive logging when too many files are open in RStudio Pro
 - (rstudio-pro#4901): Fixed an issue where sessions were not terminated when `rsession.conf` contained `session-timeout-minutes=0` and `session-timeout-kill-hours=1`
+- (rstudio-pro#8840): Fixed an issue where RStudio Pro `.Rproj` files were not directly checked for existence, which caused errors when launching RStudio Pro sessions for nonexistent projects
 - (rstudio-workbench-vscode-ext#289): Fixed links to User Guide documentation in Positron
 
 ### Deprecated / Removed
@@ -109,6 +112,7 @@
 - ([#16218](https://github.com/rstudio/rstudio/issues/16218)) Removed Crashpad for collecting crash dumps
 
 ### Dependencies
+
 - Copilot Language Server 1.399.0
 - Electron 38.7.2
 - Node.js 22.21.1 (Copilot completions)


### PR DESCRIPTION
### Intent

Fix a misworded release note about what #rstudio-pro/8840 does.
