### PR TITLE
Companion to feature to generalize session metadata

### DIFF
--- a/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
@@ -19,8 +19,10 @@
 #include <set>
 
 #include <core/json/JsonRpc.hpp>
+#include <core/r_util/RSessionContext.hpp>
 
 #include <shared_core/FilePath.hpp>
+
 
 namespace rstudio {
 namespace core {
@@ -46,7 +48,7 @@ protected:
 class FileActiveSessionStorage : public IActiveSessionStorage
 {
 public:
-   explicit FileActiveSessionStorage(const FilePath& location);
+   explicit FileActiveSessionStorage(const FilePath& location, const core::r_util::FilePathToProjectId& projectToIdFunction = {});
    ~FileActiveSessionStorage() override = default;
    Error readProperty(const std::string& name, std::string* pValue) override;   
    Error readProperties(const std::set<std::string>& names, std::map<std::string, std::string>* pValues) override;
@@ -56,6 +58,8 @@ public:
    Error destroy() override;
    Error isValid(bool* pValue) override;
 
+   uintmax_t getSuspendSize();
+
 private:
    // Scratch Path Example : ~/.local/share/rstudio/sessions/active/session-6d0bdd18
    // This contains the properties directory, as well as susspended session data, session-persistence-state etc
@@ -63,6 +67,8 @@ private:
 
    // Properties Path Example : ~/.local/share/rstudio/sessions/active/session-6d0bdd18/properites
    FilePath scratchPath_;
+   const core::r_util::FilePathToProjectId& projectToIdFunction_;
+
    const std::string propertiesDirName_ = "properites";
 
    Error ensurePropertyDir() const;

--- a/src/cpp/core/include/core/r_util/RActiveSessions.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessions.hpp
@@ -33,6 +33,7 @@
 #include <shared_core/FilePath.hpp>
 #include <shared_core/SafeConvert.hpp>
 #include <shared_core/json/Json.hpp>
+#include <shared_core/system/SyslogDestination.hpp>
 
 namespace rstudio {
 namespace core {
@@ -100,6 +101,12 @@ private:
    friend class RpcActiveSessionsStorage;
 
    explicit ActiveSession(const std::string& id) : id_(id) 
+   {
+   }
+
+   explicit ActiveSession(
+      const std::string& id,
+      std::shared_ptr<IActiveSessionStorage> storage) : id_(id), storage_(storage)
    {
    }
 
@@ -712,7 +719,7 @@ public:
 
 private:
    std::string id_;
-   FilePath scratchPath_;
+   FilePath scratchPath_;                    // Use isEmpty() for for processes not owned by the session user (i.e. not file storage)
    std::shared_ptr<IActiveSessionStorage> storage_;
    SortConditions sortConditions_;
 };
@@ -722,6 +729,8 @@ class IActiveSessionsStorage;
 class ActiveSessions : boost::noncopyable
 {
 public:
+   explicit ActiveSessions(std::shared_ptr<IActiveSessionsStorage> storage);
+
    explicit ActiveSessions(std::shared_ptr<IActiveSessionsStorage> storage, const FilePath& rootStoragePath);
 
    static FilePath storagePath(const FilePath& path)
@@ -754,7 +763,7 @@ public:
    boost::shared_ptr<ActiveSession> emptySession(const std::string& id) const;
 
 private:
-   FilePath storagePath_;
+   FilePath storagePath_;  // Only set for file based session storage
    std::shared_ptr<IActiveSessionsStorage> storage_;
 };
 

--- a/src/cpp/core/include/core/r_util/RActiveSessionsStorage.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessionsStorage.hpp
@@ -43,7 +43,7 @@ namespace r_util {
    class FileActiveSessionsStorage : public IActiveSessionsStorage
    {
    public:
-      explicit FileActiveSessionsStorage(const FilePath& rootStoragePath);
+      explicit FileActiveSessionsStorage(const FilePath& rootStoragePath, const core::r_util::FilePathToProjectId& projectToIdFunction = {});
       ~FileActiveSessionsStorage() = default;
       std::vector< std::string > listSessionIds() const override;
       size_t getSessionCount() const override;
@@ -52,6 +52,7 @@ namespace r_util {
       
    private:
       FilePath storagePath_;
+      const core::r_util::FilePathToProjectId& projectToIdFunction_;
    };
 
    class RpcActiveSessionsStorage : public core::r_util::IActiveSessionsStorage

--- a/src/cpp/core/include/core/r_util/RSessionContext.hpp
+++ b/src/cpp/core/include/core/r_util/RSessionContext.hpp
@@ -175,7 +175,19 @@ public:
 
    static SessionScope positronSession(const std::string& id);
 
+   static SessionScope projectNone(const std::string& id, uid_t uid);
+
+   static SessionScope jupyterLabSession(const std::string& id, uid_t uid);
+   static SessionScope jupyterNotebookSession(const std::string& id, uid_t uid);
+
+   static SessionScope vscodeSession(const std::string& id, uid_t uid);
+
+   static SessionScope positronSession(const std::string& id, uid_t uid);
+
+   // Only use this if you are in the session user's process as it uses the effective uid
    static SessionScope fromSessionId(const std::string &id, const std::string& editor);
+
+   static SessionScope fromSessionId(const std::string &id, const std::string& editor, uid_t uid);
 
    SessionScope()
    {
@@ -291,6 +303,9 @@ std::string sessionContextFile(const SessionContext& context);
 std::string generateScopeId();
 std::string generateScopeId(const std::vector<std::string>& reserved);
 
+r_util::SessionScope getSessionScope(const std::string& workbench, const std::string& sessionId, const std::string& projectId, const uid_t uid);
+
+std::string getSessionUrlForScope(const r_util::SessionScope& scope, const std::string& hostPageUrl);
 
 } // namespace r_util
 } // namespace core 

--- a/src/cpp/core/r_util/RActiveSessions.cpp
+++ b/src/cpp/core/r_util/RActiveSessions.cpp
@@ -62,6 +62,11 @@ ActiveSessions::ActiveSessions(std::shared_ptr<IActiveSessionsStorage> storage, 
    storagePath_ = storagePath(rootStoragePath);
 }
 
+ActiveSessions::ActiveSessions(std::shared_ptr<IActiveSessionsStorage> storage) :
+   storage_(storage)
+{
+}
+
 Error ActiveSessions::create(const std::string& project,
                              const std::string& workingDir,
                              bool initial,
@@ -177,7 +182,12 @@ boost::shared_ptr<ActiveSession> ActiveSessions::get(const std::string& id) cons
 {
    std::shared_ptr<IActiveSessionStorage> candidateStorage = storage_->getSessionStorage(id);
    if (candidateStorage != nullptr)
-      return boost::shared_ptr<ActiveSession>(new ActiveSession(id, storagePath_.completeChildPath(kSessionDirPrefix + id), candidateStorage));
+   {
+      if (storagePath_.isEmpty()) // rpc or db storage
+         return boost::shared_ptr<ActiveSession>(new ActiveSession(id, candidateStorage));
+      else // file storage
+         return boost::shared_ptr<ActiveSession>(new ActiveSession(id, storagePath_.completeChildPath(kSessionDirPrefix + id), candidateStorage));
+   }
    else
       return boost::shared_ptr<ActiveSession>(new ActiveSession(id));
 }

--- a/src/cpp/core/r_util/RActiveSessionsStorage.cpp
+++ b/src/cpp/core/r_util/RActiveSessionsStorage.cpp
@@ -58,7 +58,7 @@ FilePath getSessionDirPath(const FilePath& storagePath, const std::string& sessi
 
 } // anonymous namespace
 
-FileActiveSessionsStorage::FileActiveSessionsStorage(const FilePath& rootStoragePath)
+FileActiveSessionsStorage::FileActiveSessionsStorage(const FilePath& rootStoragePath, const FilePathToProjectId& projectToIdFunction) : projectToIdFunction_ (projectToIdFunction)
 {
    storagePath_ = ActiveSessions::storagePath(rootStoragePath);
    Error error = storagePath_.ensureDirectory();
@@ -111,7 +111,7 @@ size_t FileActiveSessionsStorage::getSessionCount() const
 std::shared_ptr<IActiveSessionStorage> FileActiveSessionsStorage::getSessionStorage(const std::string& id) const
 {
    FilePath scratchPath = storagePath_.completeChildPath(kSessionDirPrefix + id);
-   return std::make_shared<FileActiveSessionStorage>(scratchPath);
+   return std::make_shared<FileActiveSessionStorage>(scratchPath, projectToIdFunction_);
 }
 
 


### PR DESCRIPTION
### Intent

Reviewed in: https://github.com/rstudio/rstudio-pro/pull/9857

### Approach

Rpc and db session metadata implementations should not depend on the file system. Separate out the project id lookup function so we can expose a project id property. 


