### PR TITLE
Fix Chat pane preference checks and loading flow

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/PaiUtil.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/PaiUtil.java
@@ -47,4 +47,18 @@ public class PaiUtil
       return userPrefs.assistant().getGlobalValue()
             .equals(UserPrefsAccessor.ASSISTANT_POSIT);
    }
+
+   /**
+    * Returns true if the user has selected Posit AI as their chat provider.
+    * Use this to gate chat features that should only be active when Posit AI
+    * is selected as the chat provider.
+    *
+    * @param userPrefs The user preferences
+    * @return true if user has selected Posit AI for chat, false otherwise
+    */
+   public static boolean isChatProviderPosit(UserPrefs userPrefs)
+   {
+      return userPrefs.chatProvider().getGlobalValue()
+            .equals(UserPrefsAccessor.CHAT_PROVIDER_POSIT);
+   }
 }


### PR DESCRIPTION
## Summary

- Fix Chat pane to check `chatProvider` preference instead of `assistant` preference
- Add status tracking to prevent race conditions in `onSelected()` refresh logic
- Add preference change listener to react when chat provider selection changes
- Simplify initialization flag to only guard message listener setup

## Background

The Chat pane had two issues:

1. **Wrong preference being checked**: The code was checking the `assistant` preference (which controls code completions) instead of the `chatProvider` preference (which controls the Chat pane). This caused the "Unable to download update information" warning even when Posit AI was correctly selected as the chat provider.

2. **Race condition in `onSelected()`**: When the pane became visible, it would refresh HTML content which could interfere with pending load handlers from `updateFrameContent()`, causing blank panes.

## Changes

### PaiUtil.java
- Added `isChatProviderPosit()` method to check the `chatProvider` preference

### ChatPresenter.java
- Updated all preference checks to use `isChatProviderPosit()` instead of `isPaiSelected()`
- Added `UserPrefsChangedEvent` handler to listen for `chat_provider` preference changes
- Chat pane now reacts dynamically when the user changes their chat provider setting

### ChatPane.java
- Added `currentStatus_` field to track pane status
- Fixed `onSelected()` to only refresh URL content when status is READY (avoids race conditions with HTML status messages)
- Renamed `initialized_` to `listenerSetup_` to clarify its purpose

### SessionChat.cpp
- Added `isChatProviderPosit()` function to check the `chatProvider` preference
- Updated `checkForUpdatesOnStartup()`, `chatCheckForUpdates()`, `chatInstallUpdate()`, and `chatGetUpdateStatus()` to use `isChatProviderPosit()`
- Added validation to reset `chatProvider` to "none" if PAI becomes unavailable

## QA Notes

1. **Test blank pane bug fix**:
   - Set chat provider preference to "None"
   - Open the Chat pane
   - Verify "Chat is not available..." message displays
   - Hide and re-show the sidebar
   - Verify message still displays (not blank)

2. **Test preference change handling**:
   - With Chat pane visible and chat provider set to "None", verify "not available" message
   - Change chat provider preference to "Posit"
   - Verify Chat pane starts initializing (shows "Starting..." or loads UI)
   - Change preference back to "None"
   - Verify "not available" message reappears

3. **Test normal chat flow**:
   - With Posit selected as chat provider, open Chat pane
   - Verify it loads the chat UI correctly without any update warning
   - Hide and re-show sidebar
   - Verify chat UI is still functional

## Documentation

None

## Checklist

- [ ] Code review done
- [ ] Integration testing completed
- [ ] Unit tests updated/added

🤖 Generated with [Claude Code](https://claude.ai/code)