### PR TITLE
Fix race condition causing Chat pane to get stuck on "Starting Posit Assistant..."

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPane.java
@@ -282,11 +282,24 @@ public class ChatPane
    @Override
    public void loadUrl(String url)
    {
+      // Cancel any pending load handler from updateFrameContent() to prevent
+      // it from overwriting the URL content when it fires
+      cancelPendingLoadHandler(frame_);
+
       contentType_ = ContentType.URL;
       currentUrl_ = url;
       currentContent_ = null;
       frame_.setUrl(url);
    }
+
+   private native void cancelPendingLoadHandler(RStudioThemedFrame frame) /*-{
+      var iframe = frame.@org.rstudio.core.client.widget.RStudioFrame::getElement()();
+      if (iframe._rstudioPendingLoadHandler) {
+         iframe.removeEventListener('load', iframe._rstudioPendingLoadHandler);
+         iframe._rstudioPendingLoadHandler = null;
+         console.log("ChatPane: Cancelled pending load handler before loading URL");
+      }
+   }-*/;
 
    @Override
    public void setObserver(ChatPresenter.Display.Observer observer)


### PR DESCRIPTION
## Summary

- Fixes a race condition where the Chat pane gets stuck displaying "Starting Posit Assistant..." after browser reload
- The issue occurred when a pending load handler from `updateFrameContent()` fired after `loadUrl()` had already loaded the Chat UI, overwriting it with the status message
- Adds `cancelPendingLoadHandler()` to cancel stale handlers when loading the Chat UI URL

## Test plan

- [ ] Reload browser multiple times with Chat pane visible
- [ ] Verify Chat pane loads successfully without getting stuck on "Starting Posit Assistant..."
- [ ] Check console for "ChatPane: Cancelled pending load handler before loading URL" message when fix activates