### PR TITLE
Fix Chat pane race conditions and notification state after provider toggle

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPane.java
@@ -49,6 +49,17 @@ public class ChatPane
       URL
    }
 
+   private enum NotificationType
+   {
+      NONE,
+      UPDATE_AVAILABLE,
+      INSTALL_AVAILABLE,
+      UPDATING,
+      UPDATE_COMPLETE,
+      UPDATE_ERROR,
+      UPDATE_CHECK_FAILURE
+   }
+
    @Inject
    protected ChatPane(GlobalDisplay globalDisplay,
                       EventBus events,
@@ -333,6 +344,7 @@ public class ChatPane
             }
          });
 
+      currentNotificationType_ = NotificationType.UPDATE_AVAILABLE;
       updateNotificationPanel_.setVisible(true);
       updateFrameLayout();
    }
@@ -357,6 +369,7 @@ public class ChatPane
             }
          });
 
+      currentNotificationType_ = NotificationType.INSTALL_AVAILABLE;
       updateNotificationPanel_.setVisible(true);
       updateFrameLayout();
    }
@@ -369,6 +382,7 @@ public class ChatPane
       new NotificationBuilder(updateButtonPanel_, RES.styles().chatNotificationButton())
          .clear();
 
+      currentNotificationType_ = NotificationType.UPDATING;
       updateNotificationPanel_.setVisible(true);
       updateFrameLayout();
    }
@@ -381,6 +395,7 @@ public class ChatPane
       new NotificationBuilder(updateButtonPanel_, RES.styles().chatNotificationButton())
          .clear();
 
+      currentNotificationType_ = NotificationType.UPDATE_COMPLETE;
       updateNotificationPanel_.setVisible(true);
       updateFrameLayout();
    }
@@ -400,6 +415,7 @@ public class ChatPane
          })
          .addButton(constants_.chatDismiss(), () -> hideUpdateNotification());
 
+      currentNotificationType_ = NotificationType.UPDATE_ERROR;
       updateNotificationPanel_.setVisible(true);
       updateFrameLayout();
    }
@@ -407,8 +423,19 @@ public class ChatPane
    @Override
    public void hideUpdateNotification()
    {
+      currentNotificationType_ = NotificationType.NONE;
       updateNotificationPanel_.setVisible(false);
       updateFrameLayout();
+   }
+
+   @Override
+   public void hideErrorNotification()
+   {
+      if (currentNotificationType_ == NotificationType.UPDATE_ERROR ||
+          currentNotificationType_ == NotificationType.UPDATE_CHECK_FAILURE)
+      {
+         hideUpdateNotification();
+      }
    }
 
    @Override
@@ -420,6 +447,7 @@ public class ChatPane
          .clear()
          .addButton(constants_.chatDismiss(), () -> hideUpdateNotification());
 
+      currentNotificationType_ = NotificationType.UPDATE_CHECK_FAILURE;
       updateNotificationPanel_.setVisible(true);
       updateFrameLayout();
    }
@@ -764,6 +792,7 @@ public class ChatPane
    private ChatPresenter.Display.Observer observer_;
    private ChatPresenter.Display.UpdateObserver updateObserver_;
    private ChatPresenter.Display.Status currentStatus_ = null;
+   private NotificationType currentNotificationType_ = NotificationType.NONE;
 
    // Update notification UI components
    private FlowPanel updateNotificationPanel_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPresenter.java
@@ -77,6 +77,7 @@ public class ChatPresenter extends BasePresenter
       void showUpdateError(String errorMessage);
       void showUpdateCheckFailure();
       void hideUpdateNotification();
+      void hideErrorNotification();
       void showCrashedMessage(int exitCode);
       void showSuspendedMessage();
       void showIncompatibleVersion();
@@ -213,6 +214,7 @@ public class ChatPresenter extends BasePresenter
             // Posit AI was deselected as chat provider, stop backend and show not-selected message
             initializing_ = false;  // Cancel any ongoing initialization
             stopBackend();
+            display_.hideUpdateNotification();  // Clean up all notifications
             display_.setStatus(Display.Status.ASSISTANT_NOT_SELECTED);
          }
       });
@@ -570,12 +572,18 @@ public class ChatPresenter extends BasePresenter
       // Reset initialization flag - we're done
       initializing_ = false;
 
-      // Only hide notification if we're reloading after an install/update completion
-      // Otherwise, keep any "Update available" notification visible
+      // Handle notifications after successful load
       if (reloadingAfterUpdate_)
       {
+         // After update/install completion, hide all notifications
          display_.hideUpdateNotification();
-         reloadingAfterUpdate_ = false;  // Reset flag
+         reloadingAfterUpdate_ = false;
+      }
+      else
+      {
+         // Hide error notifications since backend started successfully
+         // Keep "Update available" notifications visible so user can update later
+         display_.hideErrorNotification();
       }
    }
 


### PR DESCRIPTION
## Summary
- Prevent concurrent initialization in ChatPresenter to avoid race conditions when multiple events trigger initialization simultaneously
- Fix update notification state persisting incorrectly after toggling the chat provider preference (Posit AI → None → Posit AI)

Addresses the issue where an error message "Unable to download update information, continuing with currently installed version" would appear at the top of the Chat pane after toggling the provider, even though the chat UI loaded successfully.

## Changes

### Race condition fixes (ChatPresenter.java)
- Added `initializing_` flag to guard against concurrent initialization from multiple event sources (session resume, preference change, pane ready)
- Added guards in `initializeChat()`, `restartBackend()`, preference change handler, and session resume handler
- Reset the flag appropriately on success, error, and timeout paths

### Notification state fixes
- Added `NotificationType` enum in ChatPane to track which type of notification is currently showing
- Added `hideErrorNotification()` method that only hides error-type notifications (UPDATE_ERROR, UPDATE_CHECK_FAILURE)
- When switching away from Posit AI: hide all notifications to clean up state
- After successful chat UI load: hide error notifications but preserve "Update available" notifications so users can still choose to update later

## Test plan
- [ ] Start RStudio with Posit AI as the chat provider
- [ ] Verify Chat pane loads successfully without error messages
- [ ] Go to Preferences → change Chat provider to "None"
- [ ] Verify Chat pane shows "Assistant not selected" message and no notification bar at top
- [ ] Change Chat provider back to "Posit AI"
- [ ] Verify Chat pane loads successfully without the "Unable to download update information" message
- [ ] Repeat steps 3-6 multiple times to verify no stale state accumulates
- [ ] (If update available) Verify "Update available" notification still appears and persists after UI load

## QA Notes
Testing should focus on toggling the chat provider preference multiple times and verifying no stale notification messages appear.

## Documentation
None

## Checklist
- [ ] I've read the [Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
- [ ] I've signed the [Contributor License Agreement](https://posit.co/individual-contributor-agreement/)
- [ ] I've read the [Contributor Guide](https://github.com/rstudio/rstudio/blob/main/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.ai/code)