### PR TITLE
Companion for session-use-file-storage=0 PR

### DIFF
--- a/src/cpp/core/r_util/RActiveSessionsStorage.cpp
+++ b/src/cpp/core/r_util/RActiveSessionsStorage.cpp
@@ -93,7 +93,15 @@ std::vector<std::string> FileActiveSessionsStorage::listSessionIds() const
       if (boost::algorithm::starts_with(child.getFilename(), prefix))
       {
          std::string id = child.getFilename().substr(prefix.length());
-         sessions.push_back(id);
+
+         const std::string propertiesDirName = "properites";
+
+         FilePath propsDir = child.completeChildPath(propertiesDirName);
+         // Only include sessions with a properites dir as file based sessions.
+         if (propsDir.isDirectory())
+         {
+            sessions.push_back(id);
+         }
       }
 
    }

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -143,8 +143,13 @@ bool parseAndValidateJsonRpcConnection(
       return false;
    }
 
-   // check for invalid client id
-   if (pJsonRpcRequest->clientId != persistentState().activeClientId())
+   // check for invalid client id - must match, unless it's rserver using quit session from the homepage (no client id in that case)
+#ifdef RSTUDIO_SERVER
+   bool rserverQuitSession = pJsonRpcRequest->clientId == "" && pJsonRpcRequest->method == kQuitSession;
+#else
+   bool rserverQuitSession = false;
+#endif
+   if (pJsonRpcRequest->clientId != persistentState().activeClientId() && !rserverQuitSession)
    {
       Error error(json::errc::InvalidClientId, ERROR_LOCATION);
       ptrConnection->sendJsonRpcError(error);

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1427,9 +1427,9 @@ void rCleanup(bool terminatedNormally)
       // destroy session if requested
       if (s_destroySession)
       {
-         // If the launcher is enabled, keeping the activeSession around until the job shows an exit status
-         // at which point it will be removed by rworkspaces
-         if (options().getBoolOverlayOption(kLauncherSessionOption))
+         // If the launcher is enabled with rworkspaces, keep the activeSession around until the job shows an exit status
+         // at which point it will be removed by rworkspaces. Otherwise, just remove the session at this point.
+         if (options().getBoolOverlayOption(kLauncherSessionOption) && options().sessionUseFileStorage())
             module_context::activeSession().setActivityState(r_util::kActivityStateDestroyPending, true);
          else
          {


### PR DESCRIPTION
### Intent

Reviewed in  https://github.com/rstudio/rstudio-pro/pull/9905/

### Approach

- only recognize active sessions with 'properites' subdir
- hook for rserver to use quit_session for clean session exit
- fix for session-use-file-storage exit - remove the active/sessions dir



