### PR TITLE
Store chat history per-workspace instead of globally

### DIFF
--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -183,13 +183,6 @@ bool isChatProviderPosit()
    return getConfiguredChatProvider() == kChatProviderPosit;
 }
 
-// Returns true if chat is disabled (provider set to "none")
-// Checks project-level setting first, then falls back to global preference
-bool isChatProviderNone()
-{
-   return getConfiguredChatProvider() == kChatProviderNone;
-}
-
 // Returns true if the user wants Posit AI for either chat or completions
 // Used to determine if install/update operations should be allowed
 bool isPositAiWanted()
@@ -3536,21 +3529,7 @@ Error startChatBackend(bool resumeConversation)
    args.push_back("--workspace");
    args.push_back(workspacePath.getAbsolutePath());
 
-   // Create storage base path: {XDG_DATA_HOME}/pai/
-   FilePath storagePath = xdg::userDataDir().completePath("pai");
-   error = storagePath.ensureDirectory();
-   if (error)
-      return(error);
-
-   args.push_back("--storage");
-   args.push_back(storagePath.getAbsolutePath());
-
-   // Pass config file path (config is in pai/, but working dir is pai/bin/)
-   FilePath configPath = storagePath.completePath("paconfig.json");
-   args.push_back("--config");
-   args.push_back(configPath.getAbsolutePath());
-
-   // Generate a persistent ID for this workspace directory
+   // Generate workspace ID first (needed for storage path)
    std::string workspacePathStr = workspacePath.getAbsolutePath();
    std::string workspaceId = session::projectToProjectId(
        module_context::userScratchPath(),
@@ -3560,6 +3539,26 @@ Error startChatBackend(bool resumeConversation)
 
    args.push_back("--workspace-id");
    args.push_back(workspaceId);
+
+   // Create base path for shared config: {XDG_DATA_HOME}/pai/
+   FilePath basePath = xdg::userDataDir().completePath("pai");
+   error = basePath.ensureDirectory();
+   if (error)
+      return(error);
+
+   // Pass config file path (shared across all workspaces)
+   FilePath configPath = basePath.completePath("paconfig.json");
+   args.push_back("--config");
+   args.push_back(configPath.getAbsolutePath());
+
+   // Create workspace-specific storage path: {XDG_DATA_HOME}/pai/workspaces/{workspaceId}/
+   FilePath storagePath = basePath.completePath("workspaces").completePath(workspaceId);
+   error = storagePath.ensureDirectory();
+   if (error)
+      return(error);
+
+   args.push_back("--storage");
+   args.push_back(storagePath.getAbsolutePath());
 
    // Add resume-conversation flag if resuming after suspend/restart
    if (resumeConversation)


### PR DESCRIPTION
## Summary
- Changes chat storage path from `{XDG_DATA_HOME}/pai/` to `{XDG_DATA_HOME}/pai/workspaces/{workspaceId}/` so each workspace has its own chat history
- Keeps config file (`paconfig.json`) shared across all workspaces at the base path
- Removes unused `isChatProviderNone()` function

## Test plan
- [ ] Open RStudio in workspace A, start a chat conversation
- [ ] Open RStudio in workspace B, verify chat history from workspace A is not visible
- [ ] Return to workspace A, verify chat history is preserved
- [ ] Verify config settings are still shared across workspaces

## QA Notes
Note: Existing chat history from before this change will not be migrated to the new per-workspace location.

## Documentation
None