### PR TITLE
Fix Windows handle leaks in terminateProcess and getProcesses

### DIFF
--- a/src/cpp/core/system/Win32System.cpp
+++ b/src/cpp/core/system/Win32System.cpp
@@ -848,6 +848,7 @@ Error terminateProcess(PidType pid)
    {
       return LAST_SYSTEM_ERROR();
    }
+   CloseHandleOnExitScope closeHandle(&hProc, ERROR_LOCATION);
    if (!::TerminateProcess(hProc, 1))
    {
       return LAST_SYSTEM_ERROR();
@@ -954,6 +955,7 @@ Error getProcesses(std::vector<ProcessInfo> *pOutProcesses)
    {
       return LAST_SYSTEM_ERROR();
    }
+   CloseHandleOnExitScope closeSnap(&hSnap, ERROR_LOCATION);
 
    if (Process32First(hSnap, &processEntry))
    {


### PR DESCRIPTION
## Summary
- Fix handle leak in `terminateProcess()` where the process handle from `OpenProcess()` was never closed
- Fix handle leak in `getProcesses()` where the snapshot handle from `CreateToolhelp32Snapshot()` was never closed

Both fixes use the existing `CloseHandleOnExitScope` RAII helper class, following the same pattern already used elsewhere in this file.