### PR TITLE
Fix FindFirstFileW handle leak in isDirectoryLockedWin32

### DIFF
--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -145,6 +145,7 @@ bool isDirectoryLockedWin32(const std::wstring& filePath)
          if (dwError == ERROR_SHARING_VIOLATION)
          {
             // REprintf("[!] %s is locked.\n", string_utils::wideToUtf8(childPath).c_str());
+            FindClose(hFind);
             return true;
          }
       }
@@ -158,6 +159,7 @@ bool isDirectoryLockedWin32(const std::wstring& filePath)
          if (isDirectoryLockedWin32(childPath))
          {
             // REprintf("[!] %s is locked.\n", string_utils::wideToUtf8(childPath).c_str());
+            FindClose(hFind);
             return true;
          }
       }


### PR DESCRIPTION
## Summary
- Fix Windows handle leak in `isDirectoryLockedWin32()` function where early returns did not close the `FindFirstFileW` handle
- Added `FindClose(hFind)` before returning `true` when a locked file or subdirectory is detected

## Test plan
- [ ] Verify on Windows that directory lock detection still works correctly
- [ ] Confirm no handle leaks occur when locked files are found

## Documentation
None

---

- [ ] I have tested this locally  
- [ ] I have added automated tests as necessary
- [ ] My PR title uses [conventional commit style](https://www.conventionalcommits.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)