### PR TITLE
Followup test and misc. fixes for default sidebar on left and Posit Assistant visible by default

### DIFF
--- a/src/cpp/tests/automation/testthat/test-automation-pane-layout.R
+++ b/src/cpp/tests/automation/testthat/test-automation-pane-layout.R
@@ -53,7 +53,7 @@ withr::defer(.rs.automation.deleteRemote())
    .rs.verifyQuadrantTabs(remote, PANE_LAYOUT_RIGHT_BOTTOM, expectedTabSet2Tabs)
 
    # Check that Sidebar dropdown shows correct text
-   expectedSidebarTabs <- c("Sidebar on Right")
+   expectedSidebarTabs <- c("Sidebar on Left")
    .rs.verifyQuadrantTabs(remote, PANE_LAYOUT_SIDEBAR, expectedSidebarTabs)
 
    # Check that Sidebar visible checkbox is unchecked
@@ -76,7 +76,7 @@ withr::defer(.rs.automation.deleteRemote())
    
    # Test sidebar dropdown
    expectedTexts <- c("Sidebar on Left", "Sidebar on Right")
-   .rs.verifyQuadrantDropdownOptions(remote, PANE_LAYOUT_SIDEBAR_SELECT, expectedTexts, 2)
+   .rs.verifyQuadrantDropdownOptions(remote, PANE_LAYOUT_SIDEBAR_SELECT, expectedTexts, 1)
 
    # Close dialog
    remote$keyboard.insertText("<Escape>")
@@ -414,10 +414,10 @@ withr::defer(.rs.automation.deleteRemote())
    expect_true(remote$dom.isChecked(remote$dom.querySelector(PANE_LAYOUT_SIDEBAR_VISIBLE)),
                info = "Sidebar should now be checked")
 
-   # Move sidebar to left
-   .rs.selectDropdownOption(remote, PANE_LAYOUT_SIDEBAR, "Sidebar on Left")
+   # Move sidebar to right (away from the default of left)
+   .rs.selectDropdownOption(remote, PANE_LAYOUT_SIDEBAR, "Sidebar on Right")
    sidebarPosition <- .rs.getQuadrantDropdownText(remote, PANE_LAYOUT_SIDEBAR)
-   expect_equal(sidebarPosition, "Sidebar on Left", info = "Sidebar should be on left")
+   expect_equal(sidebarPosition, "Sidebar on Right", info = "Sidebar should be on right")
 
    # Add some tabs to the sidebar (Files, Environment, History)
    expect_true(.rs.toggleTab(remote, PANE_LAYOUT_SIDEBAR, "Files"))
@@ -441,14 +441,14 @@ withr::defer(.rs.automation.deleteRemote())
 
    # Verify all settings are back to defaults
 
-   # 1. Sidebar should be unchecked
+   # 1. Sidebar should be unchecked (hidden by default, even though Posit Assistant is in sidebar)
    expect_false(remote$dom.isChecked(remote$dom.querySelector(PANE_LAYOUT_SIDEBAR_VISIBLE)),
                 info = "Sidebar visible checkbox should be unchecked after reset")
 
-   # 2. Sidebar should be on right
+   # 2. Sidebar should be on left (the default)
    sidebarPositionAfter <- .rs.getQuadrantDropdownText(remote, PANE_LAYOUT_SIDEBAR)
-   expect_equal(sidebarPositionAfter, "Sidebar on Right",
-                info = "Sidebar should be on right after reset")
+   expect_equal(sidebarPositionAfter, "Sidebar on Left",
+                info = "Sidebar should be on left after reset")
 
    # 3. Only Posit Assistant should be checked in Sidebar
    expect_true(.rs.isTabChecked(remote, PANE_LAYOUT_SIDEBAR, "Posit Assistant"),
@@ -526,10 +526,15 @@ withr::defer(.rs.automation.deleteRemote())
    expect_true(remote$dom.isChecked(remote$dom.querySelector(PANE_LAYOUT_SIDEBAR_VISIBLE)),
                info = "Sidebar visibility should remain checked when tabs remain")
 
-   # Uncheck the last visible tab (Environment)
+   # Uncheck Environment
    expect_true(.rs.toggleTab(remote, PANE_LAYOUT_SIDEBAR, "Environment"))
    expect_false(.rs.isTabChecked(remote, PANE_LAYOUT_SIDEBAR, "Environment"),
                 info = "Environment should no longer be checked in sidebar")
+
+   # Also uncheck Posit Assistant (which is checked by default) to truly empty the sidebar
+   expect_true(.rs.toggleTab(remote, PANE_LAYOUT_SIDEBAR, "Posit Assistant"))
+   expect_false(.rs.isTabChecked(remote, PANE_LAYOUT_SIDEBAR, "Posit Assistant"),
+                info = "Posit Assistant should no longer be checked in sidebar")
 
    # Verify sidebar visibility checkbox was automatically unchecked
    expect_false(remote$dom.isChecked(remote$dom.querySelector(PANE_LAYOUT_SIDEBAR_VISIBLE)),

--- a/src/cpp/tests/automation/testthat/test-automation-tabs.R
+++ b/src/cpp/tests/automation/testthat/test-automation-tabs.R
@@ -173,10 +173,12 @@ isElementSelected <- function(selector) {
    expect_false(.rs.isTabChecked(remote, PANE_LAYOUT_SIDEBAR, "Files"),
                "Files should be unchecked in sidebar after toggling")
 
-   # Keep the sidebar visible despite having no tabs
-   remote$dom.clickElement(PANE_LAYOUT_SIDEBAR_VISIBLE)
+   # Keep the sidebar visible (Posit Assistant is still in sidebar by default, so it may already be checked)
+   if (!remote$dom.isChecked(remote$dom.querySelector(PANE_LAYOUT_SIDEBAR_VISIBLE))) {
+      remote$dom.clickElement(PANE_LAYOUT_SIDEBAR_VISIBLE)
+   }
    expect_true(remote$dom.isChecked(remote$dom.querySelector(PANE_LAYOUT_SIDEBAR_VISIBLE)),
-               info = "Sidebar should now be checked")
+               info = "Sidebar should be checked")
 
    # Apply changes by clicking OK button
    remote$dom.clickElement(selector = "#rstudio_preferences_confirm")
@@ -282,14 +284,16 @@ isElementSelected <- function(selector) {
    expect_true(.rs.toggleTab(remote, PANE_LAYOUT_SIDEBAR, "Environment"),
                "Should successfully toggle Environment off sidebar")
 
-   # Verify Files is now unchecked in the sidebar
+   # Verify Environment is now unchecked in the sidebar
    expect_false(.rs.isTabChecked(remote, PANE_LAYOUT_SIDEBAR, "Environment"),
                "Environment should be unchecked in sidebar after toggling")
 
-   # Keep the sidebar visible despite having no tabs
-   remote$dom.clickElement(PANE_LAYOUT_SIDEBAR_VISIBLE)
+   # Keep the sidebar visible (Posit Assistant is still in sidebar by default, so it may already be checked)
+   if (!remote$dom.isChecked(remote$dom.querySelector(PANE_LAYOUT_SIDEBAR_VISIBLE))) {
+      remote$dom.clickElement(PANE_LAYOUT_SIDEBAR_VISIBLE)
+   }
    expect_true(remote$dom.isChecked(remote$dom.querySelector(PANE_LAYOUT_SIDEBAR_VISIBLE)),
-               info = "Sidebar should now be checked")
+               info = "Sidebar should be checked")
 
    # Apply changes by clicking OK button
    remote$dom.clickElement(selector = "#rstudio_preferences_confirm")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PaneLayoutPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PaneLayoutPreferencesPane.java
@@ -367,10 +367,10 @@ public class PaneLayoutPreferencesPane extends PreferencesPane
 
       // Set initial selection based on current preference
       String currentLocation = currentConfig.getSidebarLocation();
-      if ("left".equals(currentLocation))
-         sidebarLocation_.setSelectedIndex(0);
+      if ("right".equals(currentLocation))
+         sidebarLocation_.setSelectedIndex(1);
       else
-         sidebarLocation_.setSelectedIndex(1); // default to right
+         sidebarLocation_.setSelectedIndex(0); // default to left
 
       // Add change handler to track changes and rebuild grid
       sidebarLocation_.addChangeHandler(event -> {
@@ -498,6 +498,9 @@ public class PaneLayoutPreferencesPane extends PreferencesPane
 
    private void resetToDefaults()
    {
+      // Suppress auto-check behavior during reset
+      isResetting_ = true;
+
       // Get default configuration
       PaneConfig defaultConfig = PaneConfig.createDefault();
 
@@ -540,6 +543,9 @@ public class PaneLayoutPreferencesPane extends PreferencesPane
 
       // Mark as dirty so changes apply on OK/Apply
       dirty_ = true;
+
+      // Re-enable auto-check behavior
+      isResetting_ = false;
    }
 
    private String updateTable(int newCount)
@@ -894,7 +900,7 @@ public class PaneLayoutPreferencesPane extends PreferencesPane
          boolean sidebarVisible = sidebarVisibleCheckbox_.getValue();
 
          // Get the selected sidebar location from dropdown
-         String sidebarLocation = "right"; // default
+         String sidebarLocation = "left"; // default
          if (sidebarLocation_ != null)
          {
             int selectedIndex = sidebarLocation_.getSelectedIndex();
@@ -959,6 +965,10 @@ public class PaneLayoutPreferencesPane extends PreferencesPane
 
    private void updateSidebarVisibilityCheckbox()
    {
+      // Don't auto-update during reset - reset sets visibility explicitly
+      if (isResetting_)
+         return;
+
       boolean hasTabs = hasSidebarTabs();
       boolean currentlyVisible = sidebarVisibleCheckbox_.getValue();
 
@@ -1000,6 +1010,7 @@ public class PaneLayoutPreferencesPane extends PreferencesPane
    private final CheckBox sidebarVisibleCheckbox_;
    private final PaneManager paneManager_;
    private boolean dirty_ = false;
+   private boolean isResetting_ = false;
    private Toolbar columnToolbar_;
 
    private VerticalPanel leftTopPanel_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
@@ -889,7 +889,7 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
    private Widget center_;
    private Widget right_;
    private Widget sidebar_;
-   private String sidebarLocation_ = "right";
+   private String sidebarLocation_ = "left";
    private static final String GROUP_WORKBENCH = "workbenchp";
    private static final String KEY_RIGHTPANESIZE = "rightpanesize";
    private Command layoutCommand_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneConfig.java
@@ -91,7 +91,7 @@ public class PaneConfig extends UserPrefsAccessor.Panes
 
       JsArrayString sidebarTabs = createArray().cast();
       sidebarTabs.push(PaneManager.CHAT_PANE);
-      String sidebarLocation = "right";
+      String sidebarLocation = "left";
       boolean sidebarVisible = false;
       boolean consoleLeftOnTop = false;
       boolean consoleRightOnTop = true;


### PR DESCRIPTION
Fixes to BRAT tests for pane layout and tabs to adjust for sidebar being on left by default, and for the Posit Assistant tab being enabled and checked by default.

Also fixed product code to handle resetting the default layout correctly after these changes.

Related to https://github.com/rstudio/rstudio/issues/16903 and https://github.com/rstudio/rstudio/pull/16851, 