### PR TITLE
Improves session scope validation errors

### DIFF
--- a/src/cpp/core/include/core/r_util/RSessionContext.hpp
+++ b/src/cpp/core/include/core/r_util/RSessionContext.hpp
@@ -244,7 +244,8 @@ SessionScopeState validateSessionScope(
    const core::FilePath& userScratchPath,
    core::r_util::ProjectIdToFilePath projectIdToFilePath,
    bool projectSharingEnabled,
-   std::string* pProjectFilePath);
+   std::string* pProjectFilePath,
+   std::string* pErrorMsg);
 
 bool isSharedPath(const std::string& projectPath,
                   const core::FilePath& userHomePath);

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -212,6 +212,7 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
    // resolve scope
    scope_ = r_util::SessionScope::fromProjectId(projectId_, scopeId_);
    scopeState_ = core::r_util::ScopeValid;
+   scopeValidateError_ = "";
 
    sameSite_ = static_cast<rstudio::core::http::Cookie::SameSite>(sameSite);
 
@@ -407,7 +408,8 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
          FilePath(getOverlayOption(
                   kSessionSharedStoragePath))),
          projectSharingEnabled(),
-         &initialProjectPath_);
+         &initialProjectPath_,
+         &scopeValidateError_);
    }
    else
    {

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -192,6 +192,11 @@ public:
       return scopeState_;
    }
 
+   std::string scopeValidateError() const
+   {
+      return scopeValidateError_;
+   }
+
    std::string rCRANMultipleRepos() const
    {
       return rCRANMultipleRepos_;
@@ -252,6 +257,7 @@ private:
 
    core::r_util::SessionScope scope_;
    core::r_util::SessionScopeState scopeState_;
+   std::string scopeValidateError_;
 
    std::string userScratchPath_;
    std::string userHomePath_;


### PR DESCRIPTION
### Intent

Addresses: https://github.com/rstudio/rstudio-pro/issues/9879

### Approach

The scopeState and validateSession get called before logging is initialized so stash away not just the code but a detailed error was to why the validate failed so it can be logged before exiting.


