### PR TITLE
Improve RStudio version check for Posit AI beta

### DIFF
--- a/src/cpp/core/include/core/Version.hpp
+++ b/src/cpp/core/include/core/Version.hpp
@@ -42,7 +42,7 @@ public:
       try
       {
          // split version into components
-         static boost::regex reVersion("[._-]+");
+         static boost::regex reVersion("[._+-]+");
          version = core::string_utils::trimWhitespace(version);
          boost::sregex_token_iterator it(version.begin(), version.end(), reVersion, -1);
          boost::sregex_token_iterator end;

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -3381,22 +3381,24 @@ Error checkForUpdatesOnStartup()
       }
       else
       {
-         // Dev builds use 999 as patch version
-         bool isDevBuild = current.versionPatch() == 999;
-         bool forceDevCheck = !core::system::getenv("RSTUDIO_FORCE_DEV_UPDATE_CHECK").empty();
+         std::string versionStr(RSTUDIO_VERSION);
+         bool isDailyBuild = versionStr.find("-daily") != std::string::npos;
+         bool isHourlyBuild = versionStr.find("-hourly") != std::string::npos;
+         bool isPrereleaseBuild = isDailyBuild || isHourlyBuild;
+         bool forceCheck = !core::system::getenv("RSTUDIO_FORCE_DEV_UPDATE_CHECK").empty();
 
-         DLOG("RStudio version check: current={}, recommended={}, isDevBuild={}",
-              RSTUDIO_VERSION, recommendedVersion, isDevBuild);
+         DLOG("RStudio version check: current={}, recommended={}, isPrerelease={}",
+              RSTUDIO_VERSION, recommendedVersion, isPrereleaseBuild);
 
          // Skip if Posit Assistant not installed (user hasn't completed beta signup)
          if (installedVersion == "0.0.0")
          {
             DLOG("  Skipping version warning (Posit Assistant not installed)");
          }
-         // Skip for dev builds unless overridden
-         else if (isDevBuild && !forceDevCheck)
+         // Only check for prerelease builds (daily/hourly) unless overridden
+         else if (!isPrereleaseBuild && !forceCheck)
          {
-            DLOG("  Skipping version warning (dev build)");
+            DLOG("  Skipping version warning (release build)");
          }
          else if (current < recommended)
          {

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialog.java
@@ -128,8 +128,8 @@ public class AboutDialog extends ModalDialogBase
 
    private void fetchPositAssistantVersion()
    {
-      // Only fetch if user has selected Posit AI as their assistant
-      if (!paiUtil_.isPaiSelected())
+      // Only fetch if user has selected Posit AI as their assistant or chat provider
+      if (!paiUtil_.isPaiSelected() && !paiUtil_.isChatProviderPosit())
          return;
 
       chatServer_.chatGetVersion(new ServerRequestCallback<String>()


### PR DESCRIPTION
## Summary
- Fix version parsing to handle `+` delimiter in RStudio version strings (e.g., `2026.04.0-daily+194`)
- Restrict RStudio update check to daily/hourly builds only (skip for release builds)
- Fix About dialog to fetch Posit Assistant version when Posit is selected as chat provider