### PR TITLE
Optimize suggestion requests for Posit AI based on NES setting

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -759,11 +759,11 @@ public abstract class
    public abstract AppCommand assistantSignOut();
    public abstract AppCommand assistantStatus();
    public abstract AppCommand assistantRequestCompletions();
+   public abstract AppCommand assistantRequestSuggestions();
    public abstract AppCommand assistantAcceptNextWord();
    public abstract AppCommand assistantToggleAutomaticCompletions();
    public abstract AppCommand assistantAcceptNextEditSuggestion();
    public abstract AppCommand assistantDismissNextEditSuggestion();
-   public abstract AppCommand assistantRequestSuggestions();
 
    // Databricks
    public abstract AppCommand layoutZoomDatabricks();


### PR DESCRIPTION
## Summary

- For Posit AI with NES enabled, request NES directly instead of regular completions
- For Posit AI with NES disabled, request only regular completions (no NES fallback)
- Copilot behavior unchanged (regular completions with NES fallback if empty)

This ensures only 1 suggestion request is made after edits when using Posit AI.

## Test plan

- [ ] Verify Posit AI with NES enabled requests NES suggestions directly after edits
- [ ] Verify Posit AI with NES disabled requests only regular completions after edits
- [ ] Verify Copilot still falls back to NES when regular completions are empty