### PR TITLE
Make accept NES command respect NES enabled setting

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetAssistantHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetAssistantHelper.java
@@ -1966,8 +1966,15 @@ public class TextEditingTargetAssistantHelper
       }
       else
       {
-         // No active suggestion, request one
-         requestNextEditSuggestions();
+         // No active suggestion, request one based on NES setting
+         if (prefs_.assistantNesEnabled().getGlobalValue())
+         {
+            requestNextEditSuggestions();
+         }
+         else
+         {
+            suggestionTimer_.schedule(0);
+         }
       }
    }
 


### PR DESCRIPTION
## Summary

- When no active suggestion is present and the user invokes the "Accept Next Edit Suggestion" command:
  - If NES is enabled → request NES suggestions (existing behavior)
  - If NES is disabled → request regular code suggestions instead

This is a follow-up to #16917.

## Test plan

- [ ] With NES enabled, verify "Accept Next Edit Suggestion" command requests NES suggestions
- [ ] With NES disabled, verify "Accept Next Edit Suggestion" command requests regular completions