### PR TITLE
Use built-in C++ implementation of base64enc to avoid package dependency

### DIFF
--- a/src/cpp/session/modules/SessionChat.R
+++ b/src/cpp/session/modules/SessionChat.R
@@ -46,18 +46,8 @@
       replayPlot(recordedPlot)
       dev.off()
 
-      # Read and encode the PNG file
-      pngData <- readBin(tmpFile, "raw", file.info(tmpFile)$size)
-
-      # Base64 encode using available package
-      if (requireNamespace("base64enc", quietly = TRUE)) {
-         encoded <- base64enc::base64encode(pngData)
-      } else if (requireNamespace("jsonlite", quietly = TRUE)) {
-         encoded <- jsonlite::base64_enc(pngData)
-      } else {
-         warning("Neither base64enc nor jsonlite available for plot encoding")
-         return(NULL)
-      }
+      # Base64 encode the PNG file using built-in C++ implementation
+      encoded <- .rs.base64encodeFile(tmpFile)
 
       list(
          data = encoded,


### PR DESCRIPTION
### Intent

Addresses #16926 and #16927

### Approach

Break dependency on jsonlite and base64enc packages and use built-in method.

### Automated Tests

None

### QA Notes

Test as described in issues.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


