### PR TITLE
Update default AI assistant preference to Posit and change log level for language-server not found

### DIFF
--- a/src/cpp/session/modules/SessionAssistant.cpp
+++ b/src/cpp/session/modules/SessionAssistant.cpp
@@ -350,7 +350,7 @@ FilePath paiLanguageServerPath()
       }
    }
    
-   ELOG("Posit AI Language Server not found in '{}'.", languageServerDir.getAbsolutePath());
+   WLOG("Posit AI Language Server not found in '{}'.", languageServerDir.getAbsolutePath());
    return FilePath();
 }
 

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1772,7 +1772,7 @@
             "type": "string",
             "enum": ["none", "posit", "copilot"],
             "enumReadable": ["(None)", "Posit Assistant", "GitHub Copilot"],
-            "default": "none",
+            "default": "posit",
             "title": "AI Assistant",
             "description": "Select which AI assistant to use for code suggestions and assistance."
         },

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -3692,7 +3692,7 @@ public class UserPrefsAccessor extends Prefs
             ASSISTANT_POSIT,
             ASSISTANT_COPILOT
          },
-         "none",
+         "posit",
          new String[] {
             _constants.assistantEnum_none(),
             _constants.assistantEnum_posit(),


### PR DESCRIPTION
Addresses #16940

### Intent

For the beta we want Posit AI selected as the default completions provider.

### Approach

Change the default from None to Posit.

When starting up without Posit AI installed, this was logging several errors about the language server not being found. I changed that to a warning, since it is something happening in normal usage.

### Automated Tests

None

### QA Notes

Test that completions is now defaulting to Posit instead of None, and completions are working after installing and logging into Posit AI.

### Documentation

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


