### PR TITLE
fix computation of language id for untitled docs

### DIFF
--- a/src/cpp/session/SessionSourceDatabase.cpp
+++ b/src/cpp/session/SessionSourceDatabase.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 #include <algorithm>
 
+#include <boost/algorithm/string.hpp>
 #include <boost/regex.hpp>
 #include <boost/bind/bind.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
@@ -337,6 +338,43 @@ std::string SourceDocument::getProperty(const std::string& name) const
 bool SourceDocument::isUntitled() const
 {
    return path().empty() && !getProperty("tempName").empty();
+}
+
+std::string SourceDocument::languageId() const
+{
+   // Map internal document types to LSP language identifiers.
+   // See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem
+   if (type_ == kSourceDocumentTypeRSource ||
+       type_ == kSourceDocumentTypeRMarkdown ||
+       type_ == kSourceDocumentTypeRHTML ||
+       type_ == kSourceDocumentTypeSweave)
+   {
+      return "r";
+   }
+   else if (type_ == kSourceDocumentTypeQuartoMarkdown)
+   {
+      return "quarto";
+   }
+   else if (type_ == kSourceDocumentTypeJS)
+   {
+      return "javascript";
+   }
+   else if (type_ == kSourceDocumentTypeShell)
+   {
+      return "shellscript";
+   }
+   else if (type_ == kSourceDocumentTypeCpp ||
+            type_ == kSourceDocumentTypePython ||
+            type_ == kSourceDocumentTypeSQL)
+   {
+      // These types already match LSP language IDs
+      return type_;
+   }
+   else
+   {
+      // For unknown types, return the type as-is (lowercase)
+      return boost::algorithm::to_lower_copy(type_);
+   }
 }
 
 // set contents from string

--- a/src/cpp/session/include/session/SessionSourceDatabase.hpp
+++ b/src/cpp/session/include/session/SessionSourceDatabase.hpp
@@ -163,6 +163,8 @@ public:
       return type_.size() > 0 && type_ == kSourceDocumentTypeRSource;
    }
 
+   std::string languageId() const;
+
    core::Error readFromJson(core::json::Object* pDocJson);
    void writeToJson(core::json::Object* pDocJson, bool includeContents = true) const;
 

--- a/src/cpp/session/modules/SessionAssistant.cpp
+++ b/src/cpp/session/modules/SessionAssistant.cpp
@@ -325,7 +325,7 @@ bool isIndexableDocument(const boost::shared_ptr<source_database::SourceDocument
    // Allow indexing of Untitled documents if they have a known type.
    if (pDoc->isUntitled())
    {
-      std::string type = pDoc->type();
+      std::string type = pDoc->languageId();
       std::string ext = lsp::extensionFromLanguageId(type);
       return !ext.empty();
    }
@@ -1352,7 +1352,7 @@ void syncOpenDocuments()
       std::string languageId;
       if (pDoc->isUntitled())
       {
-         languageId = pDoc->type();
+         languageId = pDoc->languageId();
       }
       else
       {


### PR DESCRIPTION
Since we need to use the LSP-expected language ID, not the internal type identifier that RStudio uses.