### PR TITLE
rename some clang files to avoid collisions

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -262,14 +262,14 @@ set(SESSION_SOURCE_FILES
    modules/build/SessionBuildErrors.cpp
    modules/build/SessionSourceCpp.cpp
    modules/automation/SessionAutomation.cpp
+   modules/clang/CompilationDatabase.cpp
    modules/clang/CodeCompletion.cpp
    modules/clang/DefinitionIndex.cpp
    modules/clang/Diagnostics.cpp
    modules/clang/FindReferences.cpp
    modules/clang/GoToDefinition.cpp
-   modules/clang/RCompilationDatabase.cpp
-   modules/clang/RSourceIndex.cpp
    modules/clang/SessionClang.cpp
+   modules/clang/SourceIndex.cpp
    modules/connections/ActiveConnections.cpp
    modules/connections/Connection.cpp
    modules/connections/ConnectionHistory.cpp

--- a/src/cpp/session/modules/clang/CodeCompletion.cpp
+++ b/src/cpp/session/modules/clang/CodeCompletion.cpp
@@ -28,9 +28,8 @@
 #include <session/projects/SessionProjects.hpp>
 #include <session/SessionModuleContext.hpp>
 
-#include "RCompilationDatabase.hpp"
-#include "RSourceIndex.hpp"
-#include "Diagnostics.hpp"
+#include "CompilationDatabase.hpp"
+#include "SourceIndex.hpp"
 
 using namespace rstudio::core;
 using namespace rstudio::core::libclang;
@@ -175,7 +174,7 @@ void discoverTranslationUnitIncludePaths(const FilePath& filePath,
                                          std::vector<std::string>* pIncludePaths)
 {
    std::vector<std::string> args =
-         rCompilationDatabase().compileArgsForTranslationUnit(
+         clangCompilationDatabase().compileArgsForTranslationUnit(
             filePath.getAbsolutePathNative(), false);
    
    for (const std::string& arg : args)
@@ -528,7 +527,7 @@ Error getCppCompletions(const core::json::JsonRpcRequest& request,
 
    // get the translation unit and do the code completion
    std::string filename = filePath.getAbsolutePath();
-   TranslationUnit tu = rSourceIndex().getTranslationUnit(filename);
+   TranslationUnit tu = sourceIndex().getTranslationUnit(filename);
 
    if (!tu.empty())
    {

--- a/src/cpp/session/modules/clang/CompilationDatabase.hpp
+++ b/src/cpp/session/modules/clang/CompilationDatabase.hpp
@@ -1,5 +1,5 @@
 /*
- * RCompilationDatabase.hpp
+ * ClangCompilationDatabase.hpp
  *
  * Copyright (C) 2022 by Posit Software, PBC
  *
@@ -13,8 +13,8 @@
  *
  */
 
-#ifndef SESSION_MODULES_CLANG_R_COMPILATION_DATABASE_HPP
-#define SESSION_MODULES_CLANG_R_COMPILATION_DATABASE_HPP
+#ifndef SESSION_MODULES_CLANG_COMPILATION_DATABASE_HPP
+#define SESSION_MODULES_CLANG_COMPILATION_DATABASE_HPP
 
 #include <map>
 #include <string>
@@ -46,11 +46,11 @@ namespace session {
 namespace modules {      
 namespace clang {
 
-class RCompilationDatabase : boost::noncopyable
+class ClangCompilationDatabase : boost::noncopyable
 {
 public:
-   RCompilationDatabase();
-   virtual ~RCompilationDatabase() {}
+   ClangCompilationDatabase();
+   virtual ~ClangCompilationDatabase() {}
 
    std::vector<std::string> compileArgsForTranslationUnit(
            const std::string& filename, bool usePrecompiledHeaders);
@@ -135,7 +135,7 @@ private:
    bool restoredCompilationConfig_;
 };
 
-core::libclang::CompilationDatabase rCompilationDatabase();
+core::libclang::CompilationDatabase clangCompilationDatabase();
 
 
 } // namespace clang
@@ -143,4 +143,4 @@ core::libclang::CompilationDatabase rCompilationDatabase();
 } // namespace session
 } // namespace rstudio
 
-#endif // SESSION_MODULES_CLANG_R_COMPILATION_DATABASE_HPP
+#endif // SESSION_MODULES_CLANG_COMPILATION_DATABASE_HPP

--- a/src/cpp/session/modules/clang/DefinitionIndex.cpp
+++ b/src/cpp/session/modules/clang/DefinitionIndex.cpp
@@ -29,8 +29,8 @@
 #include <session/SessionModuleContext.hpp>
 #include <session/projects/SessionProjects.hpp>
 
-#include "RSourceIndex.hpp"
-#include "RCompilationDatabase.hpp"
+#include "CompilationDatabase.hpp"
+#include "SourceIndex.hpp"
 
 using namespace rstudio::core;
 using namespace rstudio::core::libclang;
@@ -236,14 +236,14 @@ void fileChangeHandler(const core::system::FileChangeEvent& event)
       // get the compilation arguments for this file and use them to
       // create a translation unit
       std::vector<std::string> compileArgs =
-            rCompilationDatabase().compileArgsForTranslationUnit(file, true);
+            clangCompilationDatabase().compileArgsForTranslationUnit(file, true);
 
       if (!compileArgs.empty())
       {
          // create index
          CXIndex index = libclang::clang().createIndex(
                    1 /* Exclude PCH */,
-                   (rSourceIndex().verbose() > 0) ? 1 : 0);
+                   (sourceIndex().verbose() > 0) ? 1 : 0);
 
          // get args in form clang expects
          core::system::ProcessArgs argsArray(compileArgs);
@@ -367,7 +367,7 @@ FileLocation findDefinitionLocation(const FileLocation& location)
       return FileLocation();
 
    // get the definition cursor for this file location
-   Cursor cursor = rSourceIndex().referencedCursorForFileLocation(location);
+   Cursor cursor = sourceIndex().referencedCursorForFileLocation(location);
    if (cursor.isNull())
       return FileLocation();
 
@@ -376,7 +376,7 @@ FileLocation findDefinitionLocation(const FileLocation& location)
    if (!USR.empty())
    {
       // first inspect translation units we have an in-memory index for
-      TranslationUnits units = rSourceIndex().getIndexedTranslationUnits();
+      TranslationUnits units = sourceIndex().getIndexedTranslationUnits();
       for (const TranslationUnits::value_type& unit : units)
       {
          // search for the definition
@@ -631,7 +631,7 @@ void searchDefinitions(const std::string& term,
 
    // first search translation units we have an in-memory index for
    // (this will reflect unsaved changes in editor buffers)
-   TranslationUnits units = rSourceIndex().getIndexedTranslationUnits();
+   TranslationUnits units = sourceIndex().getIndexedTranslationUnits();
    for (TranslationUnits::iterator it = units.begin(); it != units.end(); ++it)
    {
       const TranslationUnit& unit = it->second;

--- a/src/cpp/session/modules/clang/Diagnostics.cpp
+++ b/src/cpp/session/modules/clang/Diagnostics.cpp
@@ -19,7 +19,7 @@
 
 #include <session/SessionModuleContext.hpp>
 
-#include "RSourceIndex.hpp"
+#include "SourceIndex.hpp"
 
 using namespace rstudio::core;
 using namespace rstudio::core::libclang;
@@ -143,7 +143,7 @@ json::Array getCppDiagnosticsJson(const FilePath& filePath)
    json::Array diagnosticsJson;
 
    // get diagnostics from translation unit
-   TranslationUnit tu = rSourceIndex().getTranslationUnit(
+   TranslationUnit tu = sourceIndex().getTranslationUnit(
       filePath.getAbsolutePath(),
                                              true);
    if (!tu.empty())

--- a/src/cpp/session/modules/clang/GoToDefinition.cpp
+++ b/src/cpp/session/modules/clang/GoToDefinition.cpp
@@ -20,8 +20,8 @@
 
 #include <session/SessionModuleContext.hpp>
 
-#include "RSourceIndex.hpp"
 #include "DefinitionIndex.hpp"
+#include "SourceIndex.hpp"
 
 using namespace rstudio::core;
 using namespace rstudio::core::libclang;

--- a/src/cpp/session/modules/clang/SessionClang.cpp
+++ b/src/cpp/session/modules/clang/SessionClang.cpp
@@ -31,13 +31,13 @@
 
 #include <core/libclang/LibClang.hpp>
 
-#include "Diagnostics.hpp"
+#include "CodeCompletion.hpp"
+#include "CompilationDatabase.hpp"
 #include "DefinitionIndex.hpp"
+#include "Diagnostics.hpp"
 #include "FindReferences.hpp"
 #include "GoToDefinition.hpp"
-#include "CodeCompletion.hpp"
-#include "RSourceIndex.hpp"
-#include "RCompilationDatabase.hpp"
+#include "SourceIndex.hpp"
 
 using namespace rstudio::core;
 using namespace rstudio::core::libclang;
@@ -93,7 +93,7 @@ void onSourceDocUpdated(boost::shared_ptr<source_database::SourceDocument> pDoc)
       return;
 
    // update unsaved files
-   rSourceIndex().unsavedFiles().update(filename,
+   sourceIndex().unsavedFiles().update(filename,
                                         pDoc->contents(),
                                         pDoc->dirty());
 
@@ -103,7 +103,7 @@ void onSourceDocUpdated(boost::shared_ptr<source_database::SourceDocument> pDoc)
       module_context::scheduleDelayedWork(
             boost::posix_time::milliseconds(100),
             boost::bind(&SourceIndex::primeEditorTranslationUnit,
-                        &(rSourceIndex()), filename),
+                        &(sourceIndex()), filename),
             true); // require idle
    }
 
@@ -117,7 +117,7 @@ void onSourceDocUpdated(boost::shared_ptr<source_database::SourceDocument> pDoc)
       module_context::scheduleDelayedWork(
             boost::posix_time::milliseconds(100),
             boost::bind(&SourceIndex::reprimeEditorTranslationUnit,
-                        &(rSourceIndex()), filename),
+                        &(sourceIndex()), filename),
             true); // require idle
    }
 }
@@ -129,21 +129,21 @@ void onSourceDocRemoved(const std::string& id, const std::string& path)
       module_context::resolveAliasedPath(path).getAbsolutePath();
 
    // remove from unsaved files
-   rSourceIndex().unsavedFiles().remove(resolvedPath);
+   sourceIndex().unsavedFiles().remove(resolvedPath);
 
    // remove the translation unit
-   rSourceIndex().removeTranslationUnit(resolvedPath);
+   sourceIndex().removeTranslationUnit(resolvedPath);
 }
 
 void onAllSourceDocsRemoved()
 {
-   rSourceIndex().unsavedFiles().removeAll();
-   rSourceIndex().removeAllTranslationUnits();
+   sourceIndex().unsavedFiles().removeAll();
+   sourceIndex().removeAllTranslationUnits();
 }
 
 void onPackageLibraryMutated()
 {
-   rCompilationDatabase().rebuildPackageCompilationDatabase();
+   clangCompilationDatabase().rebuildPackageCompilationDatabase();
 }
 
 bool cppIndexingDisabled()

--- a/src/cpp/session/modules/clang/SourceIndex.cpp
+++ b/src/cpp/session/modules/clang/SourceIndex.cpp
@@ -1,5 +1,5 @@
 /*
- * RSourceIndex.cpp
+ * ClangSourceIndex.cpp
  *
  * Copyright (C) 2022 by Posit Software, PBC
  *
@@ -13,7 +13,7 @@
  *
  */
 
-#include "RSourceIndex.hpp"
+#include "SourceIndex.hpp"
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/bind/bind.hpp>
@@ -25,7 +25,7 @@
 
 #include <core/libclang/LibClang.hpp>
 
-#include "RCompilationDatabase.hpp"
+#include "CompilationDatabase.hpp"
 
 using namespace rstudio::core;
 using namespace rstudio::core::libclang;
@@ -38,11 +38,11 @@ namespace clang {
 
 namespace {
 
-class RSourceIndex : public SourceIndex
+class ClangSourceIndex : public SourceIndex
 {
 public:
-   RSourceIndex()
-      : SourceIndex(rCompilationDatabase(), prefs::userPrefs().clangVerbose())
+   ClangSourceIndex()
+      : SourceIndex(clangCompilationDatabase(), prefs::userPrefs().clangVerbose())
    {
    }
 };
@@ -50,15 +50,15 @@ public:
 // store as a pointer so that it's never destructrued during shutdown
 // (we observed at least one instance of libclang crashing when calling
 // clang_disposeTranslationUnit during shutdown)
-RSourceIndex* s_pRSourceIndex = nullptr;
+ClangSourceIndex* s_pClangSourceIndex = nullptr;
 
 } // anonymous namespace
 
-SourceIndex& rSourceIndex()
+SourceIndex& sourceIndex()
 {
-   if (s_pRSourceIndex == nullptr)
-      s_pRSourceIndex = new RSourceIndex();
-   return *s_pRSourceIndex;
+   if (s_pClangSourceIndex == nullptr)
+      s_pClangSourceIndex = new ClangSourceIndex();
+   return *s_pClangSourceIndex;
 }
 
 bool isIndexableFile(const FileInfo& fileInfo,

--- a/src/cpp/session/modules/clang/SourceIndex.hpp
+++ b/src/cpp/session/modules/clang/SourceIndex.hpp
@@ -1,5 +1,5 @@
 /*
- * RSourceIndex.hpp
+ * SourceIndex.hpp
  *
  * Copyright (C) 2022 by Posit Software, PBC
  *
@@ -13,8 +13,8 @@
  *
  */
 
-#ifndef SESSION_MODULES_CLANG_R_SOURCE_INDEX_HPP
-#define SESSION_MODULES_CLANG_R_SOURCE_INDEX_HPP
+#ifndef SESSION_MODULES_CLANG_SOURCE_INDEX_HPP
+#define SESSION_MODULES_CLANG_SOURCE_INDEX_HPP
 
 #include <core/libclang/SourceIndex.hpp>
 
@@ -29,15 +29,15 @@ namespace session {
 namespace modules {      
 namespace clang {
 
-core::libclang::SourceIndex& rSourceIndex();
+core::libclang::SourceIndex& sourceIndex();
 
 bool isIndexableFile(const core::FileInfo& fileInfo,
                      const core::FilePath& pkgSrcDir,
                      const core::FilePath& pkgIncludeDir);
 
 } // namespace clang
-} // namespace handlers
+} // namespace modules
 } // namespace session
 } // namespace rstudio
 
-#endif // SESSION_MODULES_CLANG_R_SOURCE_INDEX_HPP
+#endif // SESSION_MODULES_CLANG_SOURCE_INDEX_HPP


### PR DESCRIPTION
Mostly to avoid having two files in the codebase called RSourceIndex, and the name RCompilationDatabase was a bit confusing IMHO.