### PR TITLE
Pin RHEL packages to 9.4

### DIFF
--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -6,11 +6,16 @@ ENV OPERATING_SYSTEM=rockylinux_9
 
 ARG AWS_REGION=us-east-1
 
+# echo 9.4 into releasever so that yum update doesn't update us higher than 9.4
+# RHEL 9.4 is required to get openssl 3.0. Later versions have openssl 3.2+
 RUN set -x \
-      && yum install epel-release -y \
-      && yum install dnf-plugins-core -y \ 
-      && yum config-manager --set-enabled crb \
-      && yum update -y
+    && echo 9.4 > /etc/yum/vars/releasever \
+    && echo vault/rocky > /etc/yum/vars/contentdir \
+    && sed -i -e 's|^mirrorlist=|#mirrorlist=|g' -e 's|^#baseurl=|baseurl=|g' /etc/yum.repos.d/rocky*.repo \
+    && yum install epel-release -y \
+    && sed -i -e 's/$releasever/9/g' -e 's/${releasever}/9/g' /etc/yum.repos.d/epel*.repo \
+    && yum config-manager --set-enabled crb \
+    && yum update -y
 
 RUN dnf install -y \
     R \


### PR DESCRIPTION
### Intent

Pin the packages to 9.4 so that install/update commands don't update the RHEL install to 9.7.

Confirmed that after a build with this image that we're still using openssl 3.0:

### Approach

This is fairly straightforward to do in actual RHEL (`yum --releasever=9.4 update -y --allowerasing`). 

Since we're using Rocky Linux, we have to manually work with the config files this way instead.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Ensure you have updated the QA Notes in the original issue.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


