### PR TITLE
Fix RStudio Chat WebSocket connection for remote access

### DIFF
--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -3470,6 +3470,9 @@ Error allocatePort(int* pPort)
 // WebSocket URL Construction
 // ============================================================================
 
+// Returns either:
+// - Server mode: relative path (e.g., "/p/58fab3e4/ai-chat")
+// - Desktop mode: absolute URL (e.g., "ws://127.0.0.1:1234/ai-chat")
 std::string buildWebSocketUrl(int port)
 {
 #ifdef RSTUDIO_SERVER


### PR DESCRIPTION
Addresses https://github.com/rstudio/rstudio/issues/16933

## Summary

- Return relative WebSocket paths in server mode instead of absolute URLs
- This ensures the WebSocket connection uses the same hostname as the page, guaranteeing the `port-token` cookie is sent with the upgrade request

## Problem

RStudio Chat works when accessing RStudio Server via `localhost:8787` but fails when accessed via IP address from a remote machine. The root cause is a cookie domain scoping issue where the `port-token` cookie is not sent with WebSocket requests when the hostname differs.

## Solution

Changed `buildWebSocketUrl()` to return a relative path (e.g., `/p/xxxxxxxx/ai-chat`) instead of an absolute URL in server mode. The client then constructs the full WebSocket URL using `window.location`, ensuring the hostname matches and the cookie is sent.

## Test plan

- [ ] Access RStudio Server via localhost - verify Chat works
- [ ] Access RStudio Server via IP address - verify Chat works
- [ ] Access RStudio Server via domain name with HTTPS - verify Chat works
- [ ] Test RStudio Desktop - verify no regression

**Note:** Requires corresponding change in Posit AI client.