### PR TITLE
acesupport watcher tool

### DIFF
--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -84,6 +84,9 @@
    <!-- Path where acesupport files should be generated -->
    <property name="ace.bin" value="${src.dir}/org/rstudio/studio/client/workbench/views/source/editors/text/ace"/>
 
+   <!-- For automatically re-generating acesupport on change -->
+   <property name="acesupport.watcher.dir" value="${tools.dir}/acesupport-watcher"/>
+
    <!-- Path to GWT libraries -->
    <set-if-exists property="lib.dir" value="../../dependencies/common/gwtproject"/>
    <set-if-exists property="lib.dir" value="/opt/rstudio-tools/dependencies/common/gwtproject"/>
@@ -148,6 +151,72 @@
          <fileset refid="acesupport.sources.fileset"/>
       </concat>
       <echo>Concatenated acesupport files to 'acesupport.js'</echo>
+   </target>
+
+   <!-- acesupport file watcher for development -->
+   <target name="acesupport-watch-install" description="Install acesupport watcher dependencies">
+      <exec executable="${yarn.bin}" dir="${acesupport.watcher.dir}" resolveexecutable="true" failonerror="true">
+         <arg value="install"/>
+         <arg value="--network-timeout"/>
+         <arg value="240000"/>
+      </exec>
+   </target>
+
+   <target name="acesupport-watch-check">
+      <available file="${acesupport.watcher.dir}/node_modules" type="dir" property="acesupport.watcher.installed"/>
+   </target>
+
+   <target name="acesupport-watch-install-if-needed" depends="acesupport-watch-check" unless="acesupport.watcher.installed">
+      <antcall target="acesupport-watch-install"/>
+   </target>
+
+   <!-- Kill any existing acesupport watcher using PID file -->
+   <property name="acesupport.watcher.pidfile" value="${acesupport.watcher.dir}/watcher.pid"/>
+
+   <target name="acesupport-watch-kill-windows" if="is.windows">
+      <exec executable="cmd" failonerror="false">
+         <arg value="/c"/>
+         <arg value="if exist &quot;${acesupport.watcher.pidfile}&quot; (for /f %p in (${acesupport.watcher.pidfile}) do taskkill /PID %p /F) 2>nul"/>
+      </exec>
+      <delete file="${acesupport.watcher.pidfile}" failonerror="false"/>
+   </target>
+
+   <target name="acesupport-watch-kill-unix" unless="is.windows">
+      <exec executable="sh" failonerror="false">
+         <arg value="-c"/>
+         <arg value="test -f '${acesupport.watcher.pidfile}' &amp;&amp; kill $(cat '${acesupport.watcher.pidfile}') 2>/dev/null; rm -f '${acesupport.watcher.pidfile}'"/>
+      </exec>
+   </target>
+
+   <target name="acesupport-watch-kill" description="Stop any running acesupport watcher">
+      <condition property="is.windows">
+         <os family="windows"/>
+      </condition>
+      <antcall target="acesupport-watch-kill-windows"/>
+      <antcall target="acesupport-watch-kill-unix"/>
+   </target>
+
+   <target name="acesupport-watch-windows" if="is.windows">
+      <exec executable="cmd" dir="${acesupport.watcher.dir}" spawn="true">
+         <arg value="/c"/>
+         <arg value="node"/>
+         <arg value="watch.js"/>
+      </exec>
+   </target>
+
+   <target name="acesupport-watch-unix" unless="is.windows">
+      <exec executable="node" dir="${acesupport.watcher.dir}" spawn="true">
+         <arg value="watch.js"/>
+      </exec>
+   </target>
+
+   <target name="acesupport-watch" depends="acesupport-watch-install-if-needed,acesupport-watch-kill" description="Start acesupport file watcher">
+      <condition property="is.windows">
+         <os family="windows"/>
+      </condition>
+      <antcall target="acesupport-watch-windows"/>
+      <antcall target="acesupport-watch-unix"/>
+      <echo>Started acesupport file watcher (background process)</echo>
    </target>
 
    <!-- panmirror typescript library -->
@@ -289,7 +358,7 @@
       </antcall>
    </target>
 
-   <target name="codeserver" depends="acesupport,javac" description="Run GWT devmode code server">
+   <target name="codeserver" depends="acesupport,acesupport-watch,javac" description="Run GWT devmode code server">
       <antcall target="panmirror">
          <param name="panmirror.target" value="${panmirror.target}"/>
       </antcall>

--- a/src/gwt/tools/acesupport-watcher/.gitignore
+++ b/src/gwt/tools/acesupport-watcher/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+watcher.pid
+watcher.log
+yarn.lock

--- a/src/gwt/tools/acesupport-watcher/package.json
+++ b/src/gwt/tools/acesupport-watcher/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "acesupport-watcher",
+  "version": "1.0.0",
+  "private": true,
+  "description": "File watcher for acesupport JavaScript files",
+  "main": "watch.js",
+  "scripts": {
+    "watch": "node watch.js"
+  },
+  "dependencies": {
+    "chokidar": "^4.0.0"
+  }
+}

--- a/src/gwt/tools/acesupport-watcher/watch.js
+++ b/src/gwt/tools/acesupport-watcher/watch.js
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+
+/**
+ * Acesupport File Watcher
+ *
+ * Watches for changes in src/gwt/acesupport and automatically
+ * concatenates JavaScript files into acesupport.js.
+ *
+ * This provides automatic rebuilding during development without
+ * needing to manually run `ant acesupport`.
+ */
+
+const chokidar = require('chokidar');
+const fs = require('fs');
+const path = require('path');
+
+// Resolve paths relative to this script's location
+const scriptDir = __dirname;
+const gwtDir = path.resolve(scriptDir, '../..');
+const acesupportSourceDir = path.resolve(gwtDir, 'acesupport');
+const acesupportOutputFile = path.resolve(
+   gwtDir,
+   'src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/acesupport.js'
+);
+const pidFile = path.join(scriptDir, 'watcher.pid');
+const logFile = path.join(scriptDir, 'watcher.log');
+
+// Debounce delay in milliseconds
+const DEBOUNCE_DELAY = 200;
+
+// Set up logging to file
+const logStream = fs.createWriteStream(logFile, { flags: 'a' });
+
+function log(message) {
+   const timestamp = new Date().toISOString();
+   const line = `[${timestamp}] ${message}`;
+   console.log(line);
+   logStream.write(line + '\n');
+}
+
+// Write PID file for process management
+fs.writeFileSync(pidFile, process.pid.toString(), 'utf8');
+log(`Started with PID ${process.pid}`);
+
+/**
+ * Check if a file path is a JavaScript file we care about
+ */
+function isWatchedJsFile(filePath) {
+   const fileName = path.basename(filePath);
+   return filePath.endsWith('.js') && fileName !== 'extern.js';
+}
+
+/**
+ * Recursively get all .js files in a directory, sorted for consistent output
+ */
+function getJsFiles(dir) {
+   const files = [];
+
+   function walk(currentDir) {
+      const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+      for (const entry of entries) {
+         const fullPath = path.join(currentDir, entry.name);
+         if (entry.isDirectory()) {
+            walk(fullPath);
+         } else if (entry.isFile() && isWatchedJsFile(fullPath)) {
+            files.push(fullPath);
+         }
+      }
+   }
+
+   walk(dir);
+   return files.sort();
+}
+
+/**
+ * Concatenate all acesupport JS files into a single output file
+ */
+function concatenateFiles() {
+   const startTime = Date.now();
+
+   try {
+      const files = getJsFiles(acesupportSourceDir);
+      const contents = files.map((file) => fs.readFileSync(file, 'utf8'));
+      const concatenated = contents.join('\n');
+
+      fs.writeFileSync(acesupportOutputFile, concatenated, 'utf8');
+
+      const elapsed = Date.now() - startTime;
+      log(`Rebuilt acesupport.js (${files.length} files, ${elapsed}ms)`);
+   } catch (err) {
+      log(`Error: ${err.message}`);
+   }
+}
+
+/**
+ * Debounced rebuild - batches rapid file changes
+ */
+let debounceTimer = null;
+let pendingChanges = [];
+
+function scheduleRebuild(event, filePath) {
+   const relativePath = path.relative(acesupportSourceDir, filePath);
+   pendingChanges.push(`${event}: ${relativePath}`);
+
+   if (debounceTimer) {
+      clearTimeout(debounceTimer);
+   }
+
+   debounceTimer = setTimeout(() => {
+      log(`Files changed: ${pendingChanges.join(', ')}`);
+      pendingChanges = [];
+      debounceTimer = null;
+      concatenateFiles();
+   }, DEBOUNCE_DELAY);
+}
+
+/**
+ * Handle a file change event
+ */
+function handleFileChange(event, filePath) {
+   if (!isWatchedJsFile(filePath)) {
+      return;
+   }
+   scheduleRebuild(event, filePath);
+}
+
+log('Starting...');
+log(`Watching: ${acesupportSourceDir}`);
+log(`Output: ${acesupportOutputFile}`);
+log(`Log file: ${logFile}`);
+
+// Watch the entire acesupport directory (chokidar v4 doesn't support globs)
+const watcher = chokidar.watch(acesupportSourceDir, {
+   persistent: true,
+   ignoreInitial: true,
+   recursive: true,
+});
+
+watcher
+   .on('add', (filePath) => handleFileChange('added', filePath))
+   .on('change', (filePath) => handleFileChange('changed', filePath))
+   .on('unlink', (filePath) => handleFileChange('removed', filePath))
+   .on('error', (error) => {
+      log(`Error: ${error.message}`);
+   })
+   .on('ready', () => {
+      log('Ready and watching for changes');
+   });
+
+// Clean up PID file on shutdown
+function cleanup() {
+   try {
+      fs.unlinkSync(pidFile);
+   } catch (e) {
+      // Ignore errors removing PID file
+   }
+   logStream.end();
+}
+
+// Handle graceful shutdown
+process.on('SIGINT', () => {
+   log('Shutting down (SIGINT)...');
+   cleanup();
+   watcher.close().then(() => process.exit(0));
+});
+
+process.on('SIGTERM', () => {
+   log('Shutting down (SIGTERM)...');
+   cleanup();
+   watcher.close().then(() => process.exit(0));
+});


### PR DESCRIPTION
When working on the acesupport code, one normally has to manually run `ant acesupport` to rebuild the associated `.js` files. This PR lets us create a watcher process that automatically rebuilds the acesupport tools whenever one of the associated `.js` files change, making the process faster.