### PR TITLE
fix terminal selection highlight not visible

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermTheme.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermTheme.java
@@ -36,7 +36,7 @@ public class XTermTheme
    public String background;
    public String cursor;
    public String cursorAccent;
-   public String selection;
+   public String selectionBackground;
    public String black;
    public String red;
    public String green;
@@ -198,7 +198,7 @@ public class XTermTheme
       theme.green = green;
       theme.magenta = magenta;
       theme.red = red;
-      theme.selection = selection;
+      theme.selectionBackground = selection;
       theme.white = white;
       theme.yellow = yellow;
 


### PR DESCRIPTION
## Intent

Addresses #16965.

## Summary

- Rename xterm.js theme property from `selection` to `selectionBackground` to match the xterm.js 5.0+ API

The `ITheme.selection` property was renamed to `selectionBackground` in xterm.js 5.0 for consistency with other background color properties. After the xterm.js 6.0 update (#16820), the selection highlight was invisible because the old property name was being used.

## Test plan

- [ ] Open terminal, generate some output (e.g., `ls -l`)
- [ ] Select text with the mouse
- [ ] Verify selection highlight is visible