### PR TITLE
Fix Files pane not showing all new files after git pull

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - ([#16942](https://github.com/rstudio/rstudio/issues/16942)): Enforce a minimum width for the Sidebar pane
 
 ### Fixed
+- ([#16632](https://github.com/rstudio/rstudio/issues/16632)): Fixed an issue where not all new files would appear in the Files pane after a git pull
 - ([#16714](https://github.com/rstudio/rstudio/issues/16714)): Fixed an issue where formatting edits with air did not behave well with the editor undo stack
 - ([#16732](https://github.com/rstudio/rstudio/issues/16732)): Fixed an issue where TabSet1 with no tabs assigned would show the Sidebar title
 - ([#16733](https://github.com/rstudio/rstudio/issues/16733)): Fixed an issue where a Presentation tab would be added to TabSet2 when it was assigned to the Sidebar


### PR DESCRIPTION
## Intent

Addresses #16632.

## Summary

- When multiple files were added via git pull, only some would appear in the Files pane until switching to another pane and back
- This was caused by the `VirtualizedDataGrid` not properly redrawing when files were added incrementally via `FileChange` events
- The fix adds a debounced redraw (100ms) after file additions, batching rapid-fire events into a single redraw

## Test plan

- [ ] Create a small repository with a few files
- [ ] Create a project in RStudio using this repository
- [ ] Outside RStudio, add several files to the repository and push
- [ ] In the RStudio Git pane, click Pull
- [ ] Verify all new files appear in the Files pane without needing to switch panes