### PR TITLE
Suppress spurious assistant errors logged on restart

### DIFF
--- a/src/cpp/session/modules/SessionAssistant.cpp
+++ b/src/cpp/session/modules/SessionAssistant.cpp
@@ -1625,10 +1625,7 @@ void didOpen(lsp::DidOpenTextDocumentParams params)
    boost::shared_ptr<source_database::SourceDocument> pDoc(new source_database::SourceDocument);
    Error error = lsp::sourceDocumentFromUri(params.textDocument.uri, pDoc);
    if (error)
-   {
-      LOG_ERROR(error);
       return;
-   }
 
    if (!isIndexableDocument(pDoc))
       return;
@@ -1653,10 +1650,7 @@ void didChange(lsp::DidChangeTextDocumentParams params)
    boost::shared_ptr<source_database::SourceDocument> pDoc(new source_database::SourceDocument);
    Error error = lsp::sourceDocumentFromUri(params.textDocument.uri, pDoc);
    if (error)
-   {
-      LOG_ERROR(error);
       return;
-   }
 
    if (!isIndexableDocument(pDoc))
       return;
@@ -1684,10 +1678,7 @@ void didClose(lsp::DidCloseTextDocumentParams params)
    boost::shared_ptr<source_database::SourceDocument> pDoc(new source_database::SourceDocument);
    Error error = lsp::sourceDocumentFromUri(params.textDocument.uri, pDoc);
    if (error)
-   {
-      LOG_ERROR(error);
       return;
-   }
 
    if (!isIndexableDocument(pDoc))
       return;
@@ -1732,10 +1723,7 @@ void onBackgroundProcessing(bool isIdle)
       json::Object responseJson;
       Error error = responseJson.parse(response);
       if (error)
-      {
-         LOG_ERROR(error);
          continue;
-      }
 
       // Handle various notifications
       json::Value methodJson = responseJson["method"];


### PR DESCRIPTION
## Intent

Addresses #16983.

## Summary

- Remove `LOG_ERROR` calls in `didOpen`, `didChange`, and `didClose` when `sourceDocumentFromUri` fails. During restart, these events fire for documents from the previous session that aren't yet in the source database. The errors are benign since we never sent a corresponding notification to the agent.
- Remove `LOG_ERROR` in `onBackgroundProcessing` when agent output fails to parse as JSON. Non-JSON output from the agent is expected and should be silently dropped.

## Test plan

- [ ] Enable Posit AI (or Copilot) for completions
- [ ] Open several source files in RStudio
- [ ] Close and restart RStudio
- [ ] Verify no errors are logged in `rsession-user.log` related to `SessionAssistant.cpp`