### PR TITLE
Fix AceEditor command dispatch in Visual mode code chunks

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -496,13 +496,25 @@ public class AceEditor implements DocDisplay
       });
 
       addFocusHandler((FocusEvent event) -> s_lastFocusedEditor = this);
-      
+
       // https://github.com/rstudio/rstudio/issues/13118
       setColorPreview(userPrefs_.colorPreview().getValue());
+
+      // Register event listeners eagerly so that editors managed outside of
+      // the GWT widget hierarchy (e.g. Visual mode code chunks) can still
+      // receive events. See https://github.com/rstudio/rstudio/issues/17007
+      registerEditorEventListeners();
    }
 
    private void registerEditorEventListeners()
    {
+      // Clear any existing registrations so this method is safe to call
+      // multiple times (e.g. from both the constructor and on re-attach).
+      for (HandlerRegistration handler : editorEventListeners_)
+         if (handler != null)
+            handler.removeHandler();
+      editorEventListeners_.clear();
+
       editorEventListeners_.add(events_.addHandler(EditEvent.TYPE, new EditEvent.Handler()
       {
          @Override


### PR DESCRIPTION
## Intent

Addresses #17007.

## Summary

- `AceEditor` registers its event bus listeners (including the `AceEditorCommandEvent` handler used by `AceEditorCommandDispatcher`) in response to GWT's `AttachEvent`. In Visual mode, code chunk editors have their DOM elements managed by Panmirror rather than GWT's widget hierarchy, so `AttachEvent` never fires and the command handlers are never registered.
- Call `registerEditorEventListeners()` in the constructor so that listeners are registered eagerly, regardless of how the editor is attached to the DOM.
- Make `registerEditorEventListeners()` idempotent (clears existing registrations before re-registering) so it is safe to call from both the constructor and the attach handler. The attach handler call is still needed because pane layout changes can trigger widget detach/re-attach cycles via `BinarySplitLayoutPanel.setWidgets()`.

## Test plan

- [ ] Open an R Markdown or Quarto document in Visual mode
- [ ] Click into a code chunk
- [ ] Verify that AceEditor keyboard shortcuts work (e.g. insert assignment operator, insert pipe operator, move lines up/down, yank/paste)
- [ ] Switch to Source mode and verify the same shortcuts still work
- [ ] Verify no regressions with the Console editor
- [ ] Change the pane layout and verify shortcuts still work in all editors