### PR TITLE
Properly manage MathJax handler lifecycle on dismiss

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJax.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJax.java
@@ -101,19 +101,6 @@ public class MathJax
          }
       }));
 
-      handlers_.add(docDisplay_.addAttachHandler(new AttachEvent.Handler()
-      {
-         @Override
-         public void onAttachOrDetach(AttachEvent event)
-         {
-            if (!event.isAttached())
-            {
-               detachHandlers();
-               return;
-            }
-         }
-      }));
-
       handlers_.add(docDisplay_.addDocumentChangedHandler(new DocumentChangedEvent.Handler()
       {
          Timer bgRenderTimer_ = new Timer()
@@ -615,11 +602,21 @@ public class MathJax
       return text.matches("^\\$*\\s*\\$*$");
    }
 
-   private void detachHandlers()
+   public void detach()
    {
+      // end any ongoing render (cleans up anchor, cursor handler, popup)
+      endRender();
+
+      // remove registered event handlers
       for (HandlerRegistration handler : handlers_)
          handler.removeHandler();
       handlers_.clear();
+
+      // detach line widgets
+      for (PinnedLineWidget plw : cowToPlwMap_.values())
+         plw.detach();
+      cowToPlwMap_.clear();
+      lwToPlwMap_.clear();
    }
 
    public interface Styles extends CssResource

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3769,6 +3769,9 @@ public class TextEditingTarget implements
       if (inlinePreviewer_ != null)
          inlinePreviewer_.onDismiss();
 
+      if (mathjax_ != null)
+         mathjax_.detach();
+
       if (selectionChangedTimer_ != null)
          selectionChangedTimer_.cancel();
 


### PR DESCRIPTION
## Summary

- Remove self-managed `AttachEvent` handler from `MathJax` constructor — the parent now drives the lifecycle rather than MathJax reacting to DOM events internally.
- Replace private `detachHandlers()` with a public `detach()` method that performs full cleanup: ending active renders, removing event handlers, and detaching pinned line widgets.
- Call `mathjax_.detach()` from `TextEditingTarget.onDismiss()` to ensure proper cleanup when the editor is dismissed.