### PR TITLE
Fix roxygen parentheses interfering with Ctrl+Enter execution

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -4275,6 +4275,15 @@ public class AceEditor implements DocDisplay
 
       while (endRow <= endRowLimit)
       {
+         // skip comment and empty lines without counting their bracket tokens;
+         // this is necessary since roxygen comments can contain bracket tokens
+         // (e.g. #' [foo()]) that would otherwise interfere with bracket balancing
+         if (rowIsEmptyOrComment(endRow))
+         {
+            endRow++;
+            continue;
+         }
+
          // update bracket token counts
          JsArray<Token> tokens = getTokens(endRow);
          for (Token token : JsUtil.asIterable(tokens))
@@ -4292,7 +4301,7 @@ public class AceEditor implements DocDisplay
          }
 
          // continue search if line ends with binary operator
-         if (rowEndsInBinaryOperatorOrOpenParen(endRow) || rowIsEmptyOrComment(endRow))
+         if (rowEndsInBinaryOperatorOrOpenParen(endRow))
          {
             endRow++;
             continue;

--- a/src/gwt/test/test-multiline-expr.R
+++ b/src/gwt/test/test-multiline-expr.R
@@ -134,5 +134,16 @@ c("a
 b"
 )
 
+# 21: roxygen with function link and single-line function
+#' similar to [foo()]
+#' @return NULL
+f <- function() {}
+
+# 22: roxygen with function link and multi-line function
+#' similar to [foo()]
+#' @return NULL
+f <- function() {
+}
+
 # cursor should end here after executing all lines
 EOF


### PR DESCRIPTION
## Intent

Addresses #15631.

## Summary

- Move the `rowIsEmptyOrComment()` check in `rMultiLineExpr` to the top of the end-row discovery loop, before bracket token counting. Roxygen markdown links like `#' [foo()]` produce bracket/paren tokens that were being counted, causing the multi-line expression finder to compute incorrect expression boundaries.
- Add test cases (#21, #22) to `test-multiline-expr.R` covering roxygen function links followed by single-line and multi-line function definitions.

## Test plan

- [ ] Open `src/gwt/test/test-multiline-expr.R` in RStudio and press Ctrl/Cmd+Enter repeatedly from line 1. Cursor should step through each numbered block correctly, including new tests #21 and #22, without skipping lines or producing errors.
- [ ] Verify the `# cursor should end here` marker is reached at the end.
- [ ] Confirm existing multi-line expression behavior (pipes, brackets, multi-line strings) is unaffected.