### PR TITLE
Update Electron from 39.5.1 to 39.6.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,7 +35,7 @@
 ### Dependencies
 - Ace 1.43.5
 - Copilot Language Server 1.425.0
-- Electron 39.5.1
+- Electron 39.6.0
 - Node.js 22.22.0 (copilot completions)
 - Quarto 1.8.26
 - xterm.js 6.0.0

--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -48,7 +48,7 @@
         "chai": "6.2.2",
         "copy-webpack-plugin": "13.0.1",
         "css-loader": "7.1.2",
-        "electron": "39.5.1",
+        "electron": "39.6.0",
         "electron-mocha": "13.1.0",
         "eslint": "9.39.2",
         "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -6390,9 +6390,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "39.5.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-39.5.1.tgz",
-      "integrity": "sha512-6s/sBQar+bbW59XSqohZj04MPic+kdVUAWjLbfQB/uLOeNw9jWX5FHaTxpHK29Xp3mKOHef7wErsjwMyCuWltg==",
+      "version": "39.6.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.6.0.tgz",
+      "integrity": "sha512-KQK3sJ6JCyymY3HQxV0N/bVBQwKQETRW0N/+OYcrL9H6tZhpmTSaZY3qSxcruWrPIuouvoiP3Vk/JKUpw05ZIw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -47,7 +47,7 @@
     "chai": "6.2.2",
     "copy-webpack-plugin": "13.0.1",
     "css-loader": "7.1.2",
-    "electron": "39.5.1",
+    "electron": "39.6.0",
     "electron-mocha": "13.1.0",
     "eslint": "9.39.2",
     "fork-ts-checker-webpack-plugin": "9.1.0",


### PR DESCRIPTION
## Summary
- Updates Electron from 39.5.1 to 39.6.0 in `package.json`, `package-lock.json`, and `NEWS.md`

## Test plan
- [ ] Verify the desktop application builds successfully with `cd src/node/desktop && npm run package`
- [ ] Smoke test the desktop application launches and basic functionality works