### PR TITLE
Fix Windows HOME for assistant and chat backend processes

### DIFF
--- a/src/cpp/session/modules/SessionAssistant.cpp
+++ b/src/cpp/session/modules/SessionAssistant.cpp
@@ -1208,6 +1208,13 @@ Error startAgent(const std::string& assistantType = "")
    // See: https://github.com/nodejs/node/pull/57165
    core::system::setenv(&environment, "NODE_USE_ENV_PROXY", "1");
 
+#ifdef _WIN32
+   // On Windows, R sets HOME to the user's Documents directory rather than
+   // %USERPROFILE%. Correct it so child processes (e.g. git) find their
+   // expected config files.
+   core::system::setHomeToUserProfile(&environment);
+#endif
+
    // Find node.js
    FilePath nodePath;
    error = node_tools::findNode(&nodePath, "rstudio.copilot.nodeBinaryPath");

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -3926,6 +3926,13 @@ Error startChatBackend(bool resumeConversation)
    // See: https://github.com/nodejs/node/pull/57165
    core::system::setenv(&environment, "NODE_USE_ENV_PROXY", "1");
 
+#ifdef _WIN32
+   // On Windows, R sets HOME to the user's Documents directory rather than
+   // %USERPROFILE%. Correct it so child processes (e.g. git) find their
+   // expected config files.
+   core::system::setHomeToUserProfile(&environment);
+#endif
+
    // Set up callbacks
    core::system::ProcessCallbacks callbacks;
    callbacks.onStarted = [](core::system::ProcessOperations& ops) {


### PR DESCRIPTION
## Intent

Addresses #17056.

## Summary

- On Windows, R sets `HOME` to the user's Documents directory instead of `%USERPROFILE%`. The assistant and chat backend child processes inherited this incorrect `HOME`, causing tools like `git` to fail to find `~/.gitconfig` and other user config files.
- Call `setHomeToUserProfile()` when building the child process environment in both `SessionAssistant.cpp` and `SessionChat.cpp`, matching the existing pattern used by `SessionGit`, `SessionSVN`, and `SessionWorkbench`.

## Test plan

- [ ] On Windows, open Posit Assistant and ask it to run a git command (e.g. `git log --oneline -3`) — verify it finds `~/.gitconfig` and completes successfully
- [ ] Verify R code execution from the assistant is unaffected (R's own `HOME` is unchanged)