### PR TITLE
Add capability negotiation to protocol handshake

### DIFF
--- a/src/cpp/session/modules/chat/ChatConstants.cpp
+++ b/src/cpp/session/modules/chat/ChatConstants.cpp
@@ -48,22 +48,6 @@ const std::vector<std::string>& rstudioCapabilities()
    return s_capabilities;
 }
 
-// Baseline peer capabilities assumed for protocol 8.0 when the peer
-// does not include a capabilities field in the handshake.
-const std::set<std::string>& baselinePeerCapabilities()
-{
-   static const std::set<std::string> s_baseline = {
-      "logger/log",
-      "ui/showMessage",
-      "chat/setBusyStatus",
-      "runtime/cancelExecution",
-      "lifecycle/requestShutdown",
-      "runtime/sessionChanged",
-      "runtime/executionOutput",
-   };
-   return s_baseline;
-}
-
 } // namespace constants
 } // namespace chat
 } // namespace modules

--- a/src/cpp/session/modules/chat/ChatConstants.hpp
+++ b/src/cpp/session/modules/chat/ChatConstants.hpp
@@ -17,7 +17,6 @@
 #define SESSION_CHAT_CONSTANTS_HPP
 
 #include <chrono>
-#include <set>
 #include <string>
 #include <vector>
 
@@ -63,10 +62,6 @@ constexpr std::chrono::milliseconds kMaxDelay{100};
 // Returns the set of JSON-RPC methods that RStudio can handle
 // (i.e., requests/notifications that the peer may send to RStudio).
 const std::vector<std::string>& rstudioCapabilities();
-
-// Returns the baseline capabilities assumed for a peer that does not
-// send a capabilities field during the handshake (protocol 8.0).
-const std::set<std::string>& baselinePeerCapabilities();
 
 // ============================================================================
 // Restart limits


### PR DESCRIPTION
## Intent

Add capability negotiation to the `protocol/getVersion` handshake between rsession and the databot backend.

## Summary

- Define the list of JSON-RPC methods RStudio handles in `ChatConstants.cpp` (`rstudioCapabilities()`)
- Define the baseline peer capabilities assumed for protocol 8.0 (`baselinePeerCapabilities()`)
- Extend `handleGetProtocolVersion()` to read an optional `capabilities` array from the request and include RStudio's capabilities in the response
- Add `peerHasCapability()` query function for runtime checks
- Guard `requestBackendShutdown()` and `sendStreamingOutput()` with capability checks

Both sides exchange capability lists during the handshake. When a peer omits the field (older build), the baseline set for protocol 8.0 is assumed. This is additive within the current protocol version — no version bump needed.

Companion PR: https://github.com/posit-dev/databot/pull/604

## Test plan

- [ ] New RStudio + new databot: verify capabilities appear in handshake logs, `lifecycle/requestShutdown` sent only when peer advertises it
- [ ] New RStudio + old databot (no capabilities in request): verify baseline assumed, all notifications sent as before
- [ ] Old RStudio + new databot (no capabilities in response): verify databot assumes baseline