### PR TITLE
Mention Posit AI in update notification wording

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants_en.properties
@@ -31,8 +31,8 @@ chatNotInstalledWithVersionMessage=Posit AI ({0}) is available to install.
 chatNotInstalledDescription=Posit AI includes Posit Assistant for collaborative chat and Next-Edit Suggestions that predict your next code change.
 chatLearnMore=Learn More
 chatInstallButton=Install Posit AI
-chatUpdateAvailableTitle=Update Available
-chatUpdateAvailableWithVersionsMessage=You have version {0} installed. Version {1} is available.
+chatUpdateAvailableTitle=Posit AI Update Available
+chatUpdateAvailableWithVersionsMessage=You have Posit AI version {0} installed. Version {1} is available.
 chatUpdateButton=Update Posit AI
 
 # Button labels

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants_fr.properties
@@ -31,8 +31,8 @@ chatNotInstalledWithVersionMessage=Posit AI ({0}) est disponible pour installati
 chatNotInstalledDescription=Posit AI comprend Posit Assistant pour le chat collaboratif et les suggestions de modification suivante qui prédisent votre prochain changement de code.
 chatLearnMore=En savoir plus
 chatInstallButton=Installer Posit AI
-chatUpdateAvailableTitle=Mise à jour disponible
-chatUpdateAvailableWithVersionsMessage=Vous avez la version {0} installée. La version {1} est disponible.
+chatUpdateAvailableTitle=Mise à jour de Posit AI disponible
+chatUpdateAvailableWithVersionsMessage=Vous avez la version {0} de Posit AI installée. La version {1} est disponible.
 chatUpdateButton=Mettre à jour Posit AI
 
 # Étiquettes de boutons


### PR DESCRIPTION
## Summary

- Prefixes the update-available title with "Posit AI" so users know what the update is for
- Adds "Posit AI" to the version message for additional clarity
- Updates both English and French localization strings

## Intent

Addresses #17088.

## Test plan

- [ ] Trigger the Posit AI update-available notification and verify the title reads "Posit AI Update Available"
- [ ] Verify the version message reads "You have Posit AI version X installed. Version Y is available."
- [ ] Check the French locale renders the equivalent translated strings