### PR TITLE
Fix blurry inline notebook plots on HiDPI displays

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@
 - ([#17026](https://github.com/rstudio/rstudio/pull/17026)): Fixed an issue where roxygen parentheses interfered with Ctrl+Enter execution
 - ([#14626](https://github.com/rstudio/rstudio/issues/14626)): Fixed an issue where RStudio-specific file type icons (e.g. .Rmd, .qmd, .Rpres) were not shown in file managers on Linux
 - ([#15609](https://github.com/rstudio/rstudio/issues/15609)): Fixed an issue where RStudio startup on Windows was delayed by several seconds on systems with endpoint security software
+- ([#16838](https://github.com/rstudio/rstudio/issues/16838)): Fixed an issue where inline notebook and Quarto plots were blurry on HiDPI displays when custom figure dimensions were specified
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/cpp/session/modules/NotebookPlots.R
+++ b/src/cpp/session/modules/NotebookPlots.R
@@ -26,12 +26,12 @@
 {
    dpi <- if (dpi <= 0) .rs.notebooks.defaultPlotDpi else dpi
    
-   if (units == "px") # px = automatic size behavior 
+   if (units == "px") # px = automatic size behavior
    {
       height <- height * pixelRatio
       width <- width * pixelRatio
-      dpi <- dpi * pixelRatio
    }
+   dpi <- dpi * pixelRatio
 
    # form the arguments to the graphics device creator
    args <- list(


### PR DESCRIPTION
## Intent

Addresses #16838.

## Summary

- Fixes a regression where inline notebook/Quarto plots rendered with custom figure dimensions (`fig-width`, `fig-height`, `fig-asp`) were blurry on HiDPI/Retina displays
- The device pixel ratio was only being applied to DPI when using automatic (pixel-based) sizing, not when using manual (inch-based) sizing
- Moves the `dpi * pixelRatio` scaling outside the `units == "px"` conditional so it applies to both sizing modes

## Details

Commit `98bc0203b5` ("support custom DPI in chunk plots") refactored `NotebookPlots.R` and inadvertently moved the DPI pixel-ratio scaling inside a conditional block that only executes for automatic sizing. Previously, DPI was unconditionally scaled via `res = 96 * pixelRatio`.

When a user specifies custom figure dimensions, the sizing mode is set to `PlotSizeManual` with `units = "in"`, which skipped the pixel ratio multiplication on DPI. This produced images at 96 DPI instead of 192 DPI on 2x Retina displays (e.g., 672x480 instead of 1344x960 for a 7x5 inch plot).

## Test plan

- [ ] Open a Quarto or R Notebook document on a HiDPI/Retina display
- [ ] Run a chunk with default figure settings — verify the plot is crisp
- [ ] Run a chunk with custom `fig-width`/`fig-height` — verify the plot is equally crisp
- [ ] Run a chunk with `fig-asp` set — verify the plot is crisp
- [ ] Verify plots are also crisp on a non-HiDPI display (pixel ratio = 1)