### PR TITLE
Allow project paths to match where ~/x = /home-dir/x

### DIFF
--- a/src/cpp/core/r_util/RSessionContext.cpp
+++ b/src/cpp/core/r_util/RSessionContext.cpp
@@ -353,6 +353,11 @@ SessionScopeState validateSessionScope(
             *pErrorMsg = "Project paths do not match:" + project + " and " + pSession->project() + " for session: " + scope.id();
             return ScopeInvalidProject;
          }
+         if (pSession->project().empty())
+         {
+            *pErrorMsg = "Session has no project recorded for session: " + scope.id();
+            return ScopeInvalidProject;
+         }
       }
 
       if (!projectDir.exists())


### PR DESCRIPTION
### Intent

Part of the fix for: https://github.com/rstudio/rstudio-pro/issues/9896

### Approach

Compare un-aliased paths before stopping the session start with "Invalid session scope" error.  With the other part of the fix, only aliased paths will get into the project-id-mappings file but if they do, don't abort the session start. 




