### PR TITLE
Fix Cmd+W in secondary windows also closing source tab in main window

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@
 - ([#15863](https://github.com/rstudio/rstudio/issues/15863)): Fixed an issue where "Use Selection for Find" (Cmd+E) incorrectly jumped to the next match instead of only populating the find bar
 - ([#16838](https://github.com/rstudio/rstudio/issues/16838)): Fixed an issue where inline notebook and Quarto plots were blurry on HiDPI displays when custom figure dimensions were specified
 - ([#17095](https://github.com/rstudio/rstudio/issues/17095)): Fixed an issue where declining to save a file with an unexpected extension would disable saving for that file
+- ([#17115](https://github.com/rstudio/rstudio/issues/17115)): Fixed an issue on macOS Desktop where the "Close" keyboard shortcut in secondary windows (e.g. Shiny app, Help pop-out) were also processed by the main window
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -532,7 +532,11 @@ export class DesktopBrowserWindow extends EventEmitter {
   keyPressEvent(event: Electron.Event, input: Electron.Input): void {
     if (process.platform === 'darwin') {
       if (input.meta && input.key.toLowerCase() === 'w') {
-        // on macOS, intercept Cmd+W and emit the window close signal
+        // On macOS, intercept Cmd+W and emit the window close signal.
+        // preventDefault() stops the global application menu accelerator
+        // from also firing, which would route 'closeSourceDoc' to the
+        // main window and close a source tab there (rstudio#17115).
+        event.preventDefault();
         this.emit(DesktopBrowserWindow.CLOSE_WINDOW_SHORTCUT);
       }
     } else if (process.platform === 'win32') {


### PR DESCRIPTION
## Intent

Addresses #17115.

## Summary

On macOS, pressing Cmd+W in a secondary window (e.g. Shiny app running in a window, popped-out Help pane) would close the secondary window **and** close a source tab in the main window. This regression began with the Electron 38.7.0 update (#16665), which changed how macOS application menu accelerators interact with child windows.

The root cause: Electron's `Menu.setApplicationMenu()` registers accelerators globally on macOS. When Cmd+W was pressed in a secondary window, the `before-input-event` handler correctly closed the secondary window, but the global `closeSourceDoc` accelerator also fired and routed the command to the main window. `BrowserWindow.removeMenu()` (called via `ensureNoMenu()`) is a no-op on macOS since the application menu is application-wide.

The fix:

- Call `event.preventDefault()` in the `before-input-event` handler when intercepting Cmd+W. Per the Electron docs, this suppresses both page key events and menu shortcuts.
- In `GwtWindow.onCloseWindowShortcut()`, explicitly invoke `closeSourceDoc` (with `$RStudio.last_focused_window` routing) instead of relying on the now-suppressed menu accelerator.

## Test plan

- [ ] macOS: Open a Shiny app in a window, press Cmd+W — only the Shiny window closes, source tabs in main window are unaffected
- [ ] macOS: Pop out the Help pane, press Cmd+W — only the Help window closes
- [ ] macOS: With a source tab focused in the main window, press Cmd+W — the source tab closes as expected
- [ ] macOS: Open a separate source window (pop out a source tab), press Cmd+W — closes a source tab in that window, not in the main window
- [ ] macOS: Other shortcuts (Cmd+N, Cmd+O, etc.) still work from secondary windows and route to the main window
- [ ] Windows/Linux: No behavioral changes (the fix is macOS-only)