### PR TITLE
Ignore mouse events on splash screen to avoid Electron teardown crash

### DIFF
--- a/src/node/desktop/src/main/splash-screen.ts
+++ b/src/node/desktop/src/main/splash-screen.ts
@@ -32,6 +32,12 @@ export function createSplashScreen(): BrowserWindow {
     hasShadow: false,
   });
 
+  // Workaround for Electron crash on Windows when the mouse is over a
+  // transparent frameless window during teardown. Ignoring mouse events
+  // prevents hit tests from triggering during window destruction.
+  // https://github.com/electron/electron/pull/49929
+  splash.setIgnoreMouseEvents(true);
+
   splash.loadURL(SPLASH_WEBPACK_ENTRY).catch((err: unknown) => logger().logError(err));
   return splash;
 }


### PR DESCRIPTION
## Intent

Addresses #17135.

## Summary

- Call `setIgnoreMouseEvents(true)` on the splash screen BrowserWindow to prevent Chromium from processing mouse events, avoiding the hit test code path that crashes during window teardown

Electron 39.7.0 introduced a regression where hit tests on transparent frameless windows during teardown dereference freed memory. On Windows this causes a startup crash when the mouse pointer is over the splash screen while it closes. The upstream fix is [electron/electron#49929](https://github.com/electron/electron/pull/49929) but hasn't shipped in a release yet.

This temporarily disables click-to-dismiss and keypress-to-dismiss on the splash screen. The event handlers in `splash.html` are retained so they can be re-enabled once the Electron fix is available.

## Test plan

- [ ] Build desktop app on Windows
- [ ] Launch RStudio with mouse pointer over the splash screen area
- [ ] Confirm no crash occurs
- [ ] Confirm splash screen displays and auto-closes after main window loads