### PR TITLE
communicate server vs. desktop and allowed-origin to posit ai backend

### DIFF
--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -4344,13 +4344,17 @@ Error startChatBackend(bool resumeConversation)
       args.push_back("--server-mode");
    }
 
-   // Allow the chat UI (served by rsession on a different port) to
-   // connect to the databot WebSocket in embedded mode.
-   std::string wwwPort = options().wwwPort();
-   if (!wwwPort.empty())
+   // In desktop mode, allow the chat UI (served by rsession on a different
+   // port) to connect to the databot WebSocket through the origin check.
+   // Not needed in server mode where embedded origin lockdown is disabled.
+   if (options().programMode() == kSessionProgramModeDesktop)
    {
-      args.push_back("--allowed-origin");
-      args.push_back("http://127.0.0.1:" + wwwPort);
+      std::string wwwPort = options().wwwPort();
+      if (!wwwPort.empty())
+      {
+         args.push_back("--allowed-origin");
+         args.push_back("http://127.0.0.1:" + wwwPort);
+      }
    }
 
    // Add resume-conversation flag if resuming after suspend/restart

--- a/src/cpp/session/modules/chat/ChatConstants.cpp
+++ b/src/cpp/session/modules/chat/ChatConstants.cpp
@@ -29,7 +29,7 @@ const char* const kIndexFileName = "index.html";
 const char* const kCspConfigPath = "dist/csp.json";
 
 // Protocol Version (SUPPORTED_PROTOCOL_VERSION)
-const char* const kProtocolVersion = "8.0";
+const char* const kProtocolVersion = "9.0";
 
 // Capabilities: JSON-RPC methods that RStudio handles
 const std::vector<std::string>& rstudioCapabilities()


### PR DESCRIPTION
### Intent

Notify Posit AI when it is hosted in RStudio Server, and pass the websocket URL for communication between UI and backend when in Desktop mode.

Increase protocol version.