### PR TITLE
Suppress 'R Session Disconnected' dialog on Desktop

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -943,7 +943,13 @@ public class Application implements ApplicationEventHandlers
    public void onClientDisconnected(ClientDisconnectedEvent event)
    {
       cleanupWorkbench();
-      view_.showApplicationDisconnected();
+
+      // only show the disconnected state in server mode (desktop mode has its
+      // own handling triggered by process exit)
+      if (!Desktop.isDesktop())
+      {
+         view_.showApplicationDisconnected();
+      }
    }
 
    @Override


### PR DESCRIPTION
## Summary

The `onClientDisconnected` handler in `Application.java` was showing the "R Session Disconnected" popup unconditionally, including on Desktop where it should never appear. Desktop has its own session recovery mechanism triggered by process exit.

## Fix

Add a `Desktop.isDesktop()` guard, mirroring the existing pattern in `onQuit()` which already suppresses the quit popup on Desktop.

## Testing

- On Desktop, trigger a scenario where `INVALID_CLIENT_ID` is returned during session restart
- Verify the "R Session Disconnected" dialog no longer appears
- On Server, verify the dialog still appears for genuine disconnections