### PR TITLE
Suppress 'R Session Disconnected' dialog on Desktop and during restart

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -942,13 +942,19 @@ public class Application implements ApplicationEventHandlers
    @Override
    public void onClientDisconnected(ClientDisconnectedEvent event)
    {
+      // During a deliberate restart, in-flight RPCs may return
+      // INVALID_CLIENT_ID which triggers this event spuriously.
+      // Early-return to avoid cleanupWorkbench() calling disconnect(),
+      // which would poison the RPC layer and break the ping loop in
+      // waitForSessionRestart.
+      if (pApplicationQuit_.get().isSuspendingAndRestarting())
+         return;
+
       cleanupWorkbench();
 
       // only show the disconnected state in server mode (desktop mode has its
-      // own handling triggered by process exit), and not when we are
-      // deliberately restarting (in-flight RPCs may return INVALID_CLIENT_ID
-      // during the restart window, which triggers this event spuriously)
-      if (!Desktop.isDesktop() && !pApplicationQuit_.get().isSuspendingAndRestarting())
+      // own handling triggered by process exit)
+      if (!Desktop.isDesktop())
       {
          view_.showApplicationDisconnected();
       }


### PR DESCRIPTION
## Summary

The `onClientDisconnected` handler in `Application.java` was showing the "R Session Disconnected" popup unconditionally. This is wrong in two cases:

1. **On Desktop**, where the dialog should never appear (Desktop has its own session recovery mechanism triggered by process exit).
2. **During a deliberate restart**, where in-flight RPC requests may return `INVALID_CLIENT_ID` as the session resets, spuriously triggering the disconnect event.

## Fix

Add guards for both cases in `onClientDisconnected()`:
- `Desktop.isDesktop()` check, mirroring the existing pattern in `onQuit()`
- `pApplicationQuit_.get().isSuspendingAndRestarting()` check, using the existing accessor on `ApplicationQuit`

## Testing

- On Desktop, verify the "R Session Disconnected" dialog no longer appears during restart
- On Server, verify the dialog no longer appears during a deliberate restart
- On Server, verify the dialog still appears for genuine disconnections (e.g. network loss)