### PR TITLE
Suppress INVALID_CLIENT_ID disconnect during R session restart

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -430,6 +430,7 @@ public class RemoteServer implements Server
    public void disconnect()
    {
       disconnected_ = true;
+      restartInProgress_ = false;
       serverEventListener_.stop();
       eventBus_.fireEvent(new ApplicationTutorialEvent(ApplicationTutorialEvent.SESSION_DISCONNECT));
    }
@@ -4059,7 +4060,11 @@ public class RemoteServer implements Server
          // disconnect so the ping loop in waitForSessionRestart continues
          // operating normally.
          if (restartInProgress_)
+         {
+            Debug.log("Suppressed INVALID_CLIENT_ID for '" + request.getMethod() + "' during restart");
+            serverEventListener_.stop();
             return true;
+         }
 
          // disconnect
          disconnect();


### PR DESCRIPTION
## Summary

During a deliberate restart, in-flight RPC requests (e.g. the event polling request from `RemoteServerEventListener`) may return `INVALID_CLIENT_ID` after the R session resets. Previously this triggered `disconnect()` and fired `ClientDisconnectedEvent`, which:

1. Set the `disconnected_` flag, silently breaking the ping loop in `waitForSessionRestart` that detects when the new session is ready.
2. Showed the "R Session Disconnected" dialog (a separate bug addressed in #17139 / #17140).

## Fix

Track restart state in `RemoteServer` by subscribing to `RestartStatusEvent`. When a restart is in progress, suppress the `disconnect()` call and `ClientDisconnectedEvent` for `INVALID_CLIENT_ID` errors, since they are expected and transient.

This is a root-cause fix that complements the handler-level guards in #17139 / #17140.

## Testing

- Restart R session and verify no spurious disconnect events are fired
- Verify `waitForSessionRestart` ping loop continues operating through the restart window
- Verify genuine `INVALID_CLIENT_ID` errors (outside of restart) still trigger disconnect as before