### PR TITLE
Add posit-assistant-test-manifest session option

### DIFF
--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -488,7 +488,10 @@ protected:
       "The path to a file containing one or more trusted certificates in PEM format.")
       ("posit-assistant-helper",
       value<std::string>(&positAssistantHelper_)->default_value(std::string()),
-      "The path to an optional shell script, which when invoked, should start the Posit Next Edit Suggestions Language Server.");
+      "The path to an optional shell script, which when invoked, should start the Posit Next Edit Suggestions Language Server.")
+      ("posit-assistant-test-manifest",
+      value<bool>(&positAssistantTestManifest_)->default_value(false)->implicit_value(true),
+      "Use the test manifest URL for Posit AI package updates.");
 
    pMisc->add_options();
 
@@ -626,6 +629,7 @@ public:
    bool positAssistantEnabled() const { return positAssistantEnabled_; }
    std::string positAssistantSslCertificatesFile() const { return positAssistantSslCertificatesFile_; }
    core::FilePath positAssistantHelper() const { return core::FilePath(positAssistantHelper_); }
+   bool positAssistantTestManifest() const { return positAssistantTestManifest_; }
 
 
 protected:
@@ -758,6 +762,7 @@ protected:
    bool positAssistantEnabled_;
    std::string positAssistantSslCertificatesFile_;
    std::string positAssistantHelper_;
+   bool positAssistantTestManifest_;
    virtual bool allowOverlay() const { return false; };
 };
 

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -3403,8 +3403,10 @@ Error downloadManifest(json::Object* pManifest)
    }
 #endif
 
-   // Get download URI via redirector
-   std::string downloadUri = "https://www.rstudio.org/links/posit-assistant-manifest";
+   // Get download URI via redirector; use test manifest when opted in
+   std::string downloadUri = options().positAssistantTestManifest()
+      ? "https://www.rstudio.org/links/posit-assistant-manifest-test"
+      : "https://www.rstudio.org/links/posit-assistant-manifest";
 
    DLOG("Downloading manifest from: {}", downloadUri);
 

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -997,6 +997,15 @@
             "type": "core::FilePath",
             "memberName": "positAssistantHelper_",
             "description": "The path to an optional shell script, which when invoked, should start the Posit Next Edit Suggestions Language Server."
+         },
+         {
+            "name": "posit-assistant-test-manifest",
+            "type": "bool",
+            "memberName": "positAssistantTestManifest_",
+            "defaultValue": false,
+            "implicitValue": true,
+            "isHidden": true,
+            "description": "Use the test manifest URL for Posit AI package updates."
          }
       ],
       "misc": [

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -612,6 +612,11 @@ export class SessionLauncher {
       argList.push('--automation-agent');
     }
 
+    // if we're using the test manifest, forward that to the R session
+    if (app.commandLine.hasSwitch('posit-assistant-test-manifest')) {
+      argList.push('--posit-assistant-test-manifest');
+    }
+
     // In Windows development builds, move the session executable
     // to a separate location, so we can more easily build and restart
     // with an "active" rsession executable.


### PR DESCRIPTION
## Summary

This is to aid in testing of https://github.com/rstudio/rstudio/pull/17142.

- Adds a hidden `posit-assistant-test-manifest` bool session option that switches `downloadManifest()` to fetch from a test redirector URL instead of the production one
- Forwards the `--posit-assistant-test-manifest` CLI switch from the Electron desktop app to rsession, following the same pattern as `--automation-agent`
- Enables QA testing of manifest-dependent features against release builds without modifying the production manifest

## Test plan

- [ ] Build backend (`cd build && cmake --build . --target rsession`)
- [ ] Launch with `--posit-assistant-test-manifest`, confirm rsession log shows the test redirector URL
- [ ] Launch without the flag, confirm the production URL is used
- [ ] Confirm `rsession --help` does not list the new option (hidden)
- [ ] Build Electron app, launch with `open RStudio.app --args --posit-assistant-test-manifest`, confirm the flag is forwarded to rsession