### PR TITLE
Fix NES gutter icon persisting across file close/open cycles

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetAssistantHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetAssistantHelper.java
@@ -2030,6 +2030,9 @@ public class TextEditingTargetAssistantHelper
 
       Timers.singleShot(() ->
       {
+         if (dismissed_ || editSuggestion_ == null)
+            return;
+
          ignoreNextDocumentChangeEvents();
 
          // Use anchored position to insert at the ghost text location,
@@ -2515,6 +2518,13 @@ public class TextEditingTargetAssistantHelper
    {
       dismissed_ = true;
 
+      // Invalidate any in-flight async RPC requests so their callbacks
+      // are rejected when they arrive. Without this, a stale completion
+      // response can reschedule nesTimer_ and render a gutter icon on a
+      // dismissed editor. (https://github.com/rstudio/rstudio/issues/17108)
+      requestId_ += 1;
+      nesId_ += 1;
+
       // Cancel all timers and reset suggestion state
       suspendTimer_.cancel();
       nesTimer_.cancel();
@@ -2522,13 +2532,6 @@ public class TextEditingTargetAssistantHelper
 
       // Clear diff view state
       clearDiffState();
-
-      // Invalidate any in-flight async RPC requests so their callbacks
-      // are rejected when they arrive. Without this, a stale completion
-      // response can reschedule nesTimer_ and render a gutter icon on a
-      // dismissed editor. (https://github.com/rstudio/rstudio/issues/17108)
-      requestId_ += 1;
-      nesId_ += 1;
 
       // Remove handler registrations
       registrations_.removeHandler();


### PR DESCRIPTION
## Intent

Addresses #17108.

## Summary

- Invalidate in-flight async RPC request IDs (`requestId_`, `nesId_`) in `onDismiss()` so that stale completion callbacks are rejected when they arrive after a file is closed
- Add a `dismissed_` guard flag checked at key async entry points (`showEditSuggestionImpl`, `requestNextEditSuggestions`, `suggestionTimer_`) to prevent any suggestion rendering or request scheduling on a dismissed editor

The root cause is a race condition specific to the Copilot NES fallback path: when a regular completion request is in-flight at the time a file is closed, the response callback can pass the staleness check (since `onDismiss()` did not previously invalidate the request IDs), then reschedule `nesTimer_` via the empty-result fallback, ultimately rendering a stale NES gutter icon.

## Test plan

- [ ] Open a file, trigger an NES suggestion with Copilot, accept it, then close the file without saving
- [ ] Open a new file and verify no stale NES gutter icon appears
- [ ] Verify NES suggestions still work normally after the fix (accept, dismiss, auto-trigger)