### PR TITLE
Suppress new frame prompt during AI code evaluation

### DIFF
--- a/src/cpp/r/include/r/session/RGraphics.hpp
+++ b/src/cpp/r/include/r/session/RGraphics.hpp
@@ -92,7 +92,25 @@ enum DeviceType
 
 DeviceType activeDeviceType();
 double devicePixelRatio();
-}
+
+// RAII scope to suppress new frame confirmation prompts
+// (e.g. during AI code evaluation)
+class SuppressNewFrameConfirmScope
+{
+public:
+   SuppressNewFrameConfirmScope() { s_count++; }
+   ~SuppressNewFrameConfirmScope() { s_count--; }
+
+   static bool isActive() { return s_count > 0; }
+
+   SuppressNewFrameConfirmScope(const SuppressNewFrameConfirmScope&) = delete;
+   SuppressNewFrameConfirmScope& operator=(const SuppressNewFrameConfirmScope&) = delete;
+
+private:
+   static int s_count;
+};
+
+} // namespace device
    
 struct DisplayState
 {

--- a/src/cpp/r/session/graphics/RGraphicsDevice.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevice.cpp
@@ -28,11 +28,11 @@
 #include <core/system/Environment.hpp>
 
 #include <r/RExec.hpp>
-#include <r/ROptions.hpp>
 #include <r/RRoutines.hpp>
 #include <r/RErrorCategory.hpp>
 #include <r/RUtil.hpp>
 
+#include <r/session/RGraphics.hpp>
 #include <r/session/RSessionUtils.hpp>
 
 #include "RGraphicsDevDesc.hpp"
@@ -62,6 +62,8 @@ namespace device {
 // intentionally not in anonymous namespace so that it can
 // be referenced and changed without explicit header export
 bool s_gdTracingEnabled = false;
+
+int SuppressNewFrameConfirmScope::s_count = 0;
 
 void GD_Trace(const std::string& func)
 {
@@ -112,9 +114,7 @@ Rboolean GD_NewFrameConfirm(pDevDesc dd)
 
    // suppress the new frame prompt when the AI assistant is running code,
    // so that execution isn't blocked waiting for user input
-   bool chatEvaluating = r::options::getOption<bool>(
-            "rstudio.chatEvaluating", false, false);
-   if (chatEvaluating)
+   if (SuppressNewFrameConfirmScope::isActive())
       return TRUE;
 
    // returning false causes the default implementation (printing a prompt
@@ -970,16 +970,14 @@ double devicePixelRatio()
 }
 
 void close()
-{     
+{
    if (s_pGEDevDesc != nullptr)
    {
       int deviceNumber = Rf_ndevNumber(s_pGEDevDesc->dev);
       Rf_killDevice(deviceNumber);
    }
 }
-   
 
- 
 } // namespace device
 
 // if we don't have pango cairo then provide a null definition

--- a/src/cpp/r/session/graphics/RGraphicsDevice.hpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevice.hpp
@@ -63,5 +63,5 @@ void close();
 } // namespace rstudio
 
 
-#endif // R_SESSION_GRAPHICS_DEVICE_HPP 
+#endif // R_SESSION_GRAPHICS_DEVICE_HPP
 

--- a/src/cpp/session/modules/SessionChat.R
+++ b/src/cpp/session/modules/SessionChat.R
@@ -620,11 +620,6 @@
       }, add = TRUE)
       .rs.chat.injectBindings()
 
-      # Suppress interactive prompts (e.g. "Hit <Return> to see next plot:")
-      # while AI-generated code is running
-      old <- options(rstudio.chatEvaluating = TRUE)
-      on.exit(options(old), add = TRUE)
-
       # Evaluate the provided code
       withVisible(eval(expr, envir = envir))
 

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -59,6 +59,7 @@
 #include <r/session/RConsoleActions.hpp>
 #include <r/session/RConsoleHistory.hpp>
 #include <r/session/REventLoop.hpp>
+#include <r/session/RGraphics.hpp>
 
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionOptions.hpp>
@@ -1397,6 +1398,10 @@ void executeCodeImpl(boost::shared_ptr<core::system::ProcessOperations> pOps,
       module_context::events().onConsoleInput(code);
 
       numExpressions = Rf_length(parsedSEXP);
+
+      // Suppress "Hit <Return> to see next plot:" prompts while
+      // AI-generated code is running
+      r::session::graphics::device::SuppressNewFrameConfirmScope suppressScope;
 
       // Evaluate each expression
       for (int i = 0; i < numExpressions && !error; i++)


### PR DESCRIPTION
## Intent

Addresses #17162.

## Summary

- When `par(ask = TRUE)` is set, R prompts "Hit <Return> to see next plot:" via `GD_NewFrameConfirm()`. This blocks AI-generated code execution waiting for interactive input.
- Adds a `SuppressNewFrameConfirmScope` RAII class (in `RGraphics.hpp`) with a static int counter that tracks nested suppression scopes.
- Constructs a scope instance in `executeCodeImpl()` before the expression evaluation loop, so the counter is active during AI code evaluation and automatically decremented when the scope exits.
- Checks `SuppressNewFrameConfirmScope::isActive()` in `GD_NewFrameConfirm()` to return `TRUE` (skip the prompt) while the AI assistant is evaluating code.

## Test plan

- [ ] Set `par(ask = TRUE)`, then ask the AI assistant to generate multiple plots — it should not block on the "Hit <Return>" prompt
- [ ] Verify that `par(ask = TRUE)` still works normally when plotting from the R console