### PR TITLE
Add .positai and .claude to ignore files for user projects

### DIFF
--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -1787,19 +1787,26 @@ Error augmentSvnIgnore()
       svnIgnore += ".Rhistory\n";
       svnIgnore += ".RData\n";
       svnIgnore += ".Ruserdata\n";
+      svnIgnore += ".positai\n";
    }
    else
    {
-      // If svn:ignore exists, add .Rproj.user unless it's already there
-      if (regex_utils::search(svnIgnore, boost::regex("^\\.Rproj\\.user$")))
-         return Success();
-
       bool addExtraNewline = svnIgnore.size() > 0
                              && svnIgnore[svnIgnore.size() - 1] != '\n';
       if (addExtraNewline)
          svnIgnore += "\n";
 
-      svnIgnore += ".Rproj.user\n";
+      // Add .Rproj.user and .positai unless they're already there
+      std::string additions;
+      if (!regex_utils::search(svnIgnore, boost::regex("^\\.Rproj\\.user$")))
+         additions += ".Rproj.user\n";
+      if (!regex_utils::search(svnIgnore, boost::regex("^\\.positai$")))
+         additions += ".positai\n";
+
+      if (additions.empty())
+         return Success();
+
+      svnIgnore += additions;
    }
 
    // write back svn:ignore

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -418,8 +418,13 @@ void ProjectContext::augmentRbuildignore()
       const char * const kIgnorePkgTgz = R"(.*\.tgz$)";
       const std::string newLine = "\n";
 
+      const char * const kIgnorePositai = R"(^\.positai$)";
+      const char * const kIgnoreClaude = R"(^\.claude$)";
+
       std::string ignoreLines = kIgnoreRproj + newLine +
-                                kIgnoreRprojUser + newLine;
+                                kIgnoreRprojUser + newLine +
+                                kIgnorePositai + newLine +
+                                kIgnoreClaude + newLine;
 
       if (session::options().packageOutputInPackageFolder())
       {
@@ -465,6 +470,8 @@ void ProjectContext::augmentRbuildignore()
          // for previous less precisely specified .Rproj entries
          bool hasRProj = strIgnore.find(R"(\.Rproj$)") != std::string::npos;
          bool hasRProjUser = strIgnore.find(kIgnoreRprojUser) != std::string::npos;
+         bool hasPositai = strIgnore.find(kIgnorePositai) != std::string::npos;
+         bool hasClaude = strIgnore.find(kIgnoreClaude) != std::string::npos;
          bool hasAllPackageExclusions = true;
 
          bool addExtraNewline = strIgnore.size() > 0
@@ -476,6 +483,10 @@ void ProjectContext::augmentRbuildignore()
             strIgnore += kIgnoreRproj + newLine;
          if (!hasRProjUser)
             strIgnore += kIgnoreRprojUser + newLine;
+         if (!hasPositai)
+            strIgnore += kIgnorePositai + newLine;
+         if (!hasClaude)
+            strIgnore += kIgnoreClaude + newLine;
 
          if (session::options().packageOutputInPackageFolder())
          {
@@ -504,7 +515,7 @@ void ProjectContext::augmentRbuildignore()
             }
          }
 
-         if (hasRProj && hasRProjUser && hasAllPackageExclusions)
+         if (hasRProj && hasRProjUser && hasPositai && hasClaude && hasAllPackageExclusions)
             return;
 
          error = core::writeStringToFile(rbuildIgnorePath,


### PR DESCRIPTION
## Summary

- Add `^\.positai$` and `^\.claude$` to `.Rbuildignore` when RStudio augments package projects (both new and existing files).
- Add `.positai` to `svn:ignore` for SVN projects (both new and existing ignores).

`.positai` is fully local state and should always be ignored. `.claude` is excluded from `.Rbuildignore` since it shouldn't end up in package tarballs, but is intentionally *not* added to `.gitignore` — users may want to share some `.claude` config (e.g. `CLAUDE.md`, `settings.json`) with their team.

## Test plan

- [ ] Open a new R package project with Git — verify `.Rbuildignore` includes `^\.positai$` and `^\.claude$`
- [ ] Open an existing R package project with Git — verify the entries are augmented into `.Rbuildignore`
- [ ] Open a new project with SVN — verify `svn:ignore` includes `.positai`
- [ ] Open an existing SVN project — verify `.positai` is augmented into `svn:ignore`