### PR TITLE
Respect user-configured R download method for Posit AI package downloads

### DIFF
--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -3413,12 +3413,15 @@ Error downloadManifest(json::Object* pManifest)
    // Create temp file for download
    FilePath tempFile = module_context::tempFile("manifest", "json");
 
-   // Use R's download.file() function with timeout protection
+   // Use R's download.file() function with timeout protection.
+   // Do not hardcode the download method -- let R use whatever method the
+   // user/admin has configured via options(download.file.method).  Corporate
+   // proxy environments typically set method = "curl" with a --cacert option
+   // in download.file.extra to trust the proxy's CA certificate.
    r::exec::RFunction downloadFunc("download.file");
    downloadFunc.addParam("url", downloadUri);
    downloadFunc.addParam("destfile", tempFile.getAbsolutePath());
    downloadFunc.addParam("quiet", true);
-   downloadFunc.addParam("method", "libcurl");  // Use libcurl for HTTPS support
    downloadFunc.addParam("timeout", 30);  // 30 second timeout
 
    Error error = downloadFunc.call();
@@ -3844,12 +3847,12 @@ Error downloadPackage(const std::string& url, const FilePath& destPath)
 
    DLOG("Downloading package from: {} to: {}", url, destPath.getAbsolutePath());
 
-   // Use R's download.file() function with timeout protection
+   // Use R's download.file() function with timeout protection.
+   // Do not hardcode the download method -- see downloadManifest() comment.
    r::exec::RFunction downloadFunc("download.file");
    downloadFunc.addParam("url", url);
    downloadFunc.addParam("destfile", destPath.getAbsolutePath());
    downloadFunc.addParam("quiet", false);  // Show progress for user feedback
-   downloadFunc.addParam("method", "libcurl");
    downloadFunc.addParam("mode", "wb");  // Binary mode for zip files
    downloadFunc.addParam("timeout", 60);  // 60 second timeout for larger package
 
@@ -4664,6 +4667,12 @@ Error startChatBackend(bool resumeConversation)
    // Set up environment
    core::system::Options environment;
    core::system::environment(&environment);
+
+   // Set NODE_EXTRA_CA_CERTS if a custom certificates file is provided.
+   std::string certificatesFile =
+      session::options().positAssistantSslCertificatesFile();
+   if (!certificatesFile.empty())
+      core::system::setenv(&environment, "NODE_EXTRA_CA_CERTS", certificatesFile);
 
    // Enable Node.js proxy support for fetch().
    // When HTTP_PROXY / HTTPS_PROXY env vars are set (e.g. via ~/.Renviron),


### PR DESCRIPTION
## Intent

Addresses #17052.

## Summary

- Remove hardcoded `method = "libcurl"` from the manifest and package `download.file()` calls in `SessionChat.cpp`, so R uses whatever download method the user/admin has configured via `options(download.file.method)` and `options(download.file.extra)`.
- Set `NODE_EXTRA_CA_CERTS` from `--posit-assistant-ssl-certificates-file` in `startChatBackend()`, mirroring what `SessionAssistant.cpp` already does for Copilot/NES.

PR #17059 fixed proxy support for the Node.js chat backend (`fetch()` calls) by setting `NODE_USE_ENV_PROXY=1`. However, the R-side manifest and package downloads still failed behind SSL-intercepting proxies because `download.file(method = "libcurl")` was hardcoded, overriding any user/admin R configuration.

Corporate proxy environments typically configure R with `options(download.file.method = "curl")` and `options(download.file.extra = "--cacert /path/to/proxy-ca.pem")`. With the hardcoded `"libcurl"`, this configuration was ignored.

## Test plan

See https://github.com/rstudio/rstudio/pull/17059 for more detailed testing instructions. This new change adds an additional requirement, putting following in ~/.Rprofile:

```R
options(
   download.file.method = "curl",
   download.file.extra = paste(
      "-L -f --cacert",
      "/Users/username-here/.mitmproxy/mitmproxy-ca-cert.pem"
   )
)
```

- [ ] **Proxy test**: Configure mitmproxy (`mitmdump -p 8888`), set `https_proxy=http://127.0.0.1:8888` and `NODE_EXTRA_CA_CERTS=~/.mitmproxy/mitmproxy-ca-cert.pem` in `~/.Renviron`, set `options(download.file.method = "curl", download.file.extra = "-L -f --cacert ~/.mitmproxy/mitmproxy-ca-cert.pem")` in `~/.Rprofile`. Verify manifest and package download succeed through the proxy.
- [ ] **Regression test**: Remove all proxy configuration. Verify Posit Assistant downloads work normally with no proxy.
- [ ] **Windows test**: Verify default `"wininet"` method works (uses Windows certificate store).