### PR TITLE
Fix pane layout not persisting when moving tabs out of sidebar

### DIFF
--- a/src/cpp/tests/automation/testthat/test-automation-panes.R
+++ b/src/cpp/tests/automation/testthat/test-automation-panes.R
@@ -1799,3 +1799,135 @@ withr::defer(.rs.automation.deleteRemote())
 
    .rs.resetUILayout(remote)
 })
+
+.rs.test("Moving Posit Assistant from visible sidebar to TabSet1 persists across UI reload", {
+   skip_on_ci()
+
+   # Pane layout dialog selectors (defined in test-automation-pane-layout.R)
+   PL_RIGHT_TOP <- "#rstudio_pane_layout_right_top"
+   PL_SIDEBAR <- "#rstudio_pane_layout_sidebar"
+   PL_SIDEBAR_VISIBLE <- "#rstudio_pane_layout_sidebar_visible"
+
+   # 0. Show the sidebar
+   remote$commands.execute("toggleSidebar")
+
+   # Wait for the sidebar to be created
+   .rs.waitUntil("sidebar created", function() {
+      remote$dom.elementExists("#rstudio_Sidebar_pane")
+   })
+
+   # 1. Verify default state: Posit Assistant is in the sidebar, not in TabSet1
+   .rs.openPaneLayoutOptions(remote)
+
+   expect_true(.rs.isTabChecked(remote, PL_SIDEBAR, "Posit Assistant"),
+               info = "Posit Assistant should be in sidebar by default")
+   expect_false(.rs.isTabChecked(remote, PL_RIGHT_TOP, "Posit Assistant"),
+                info = "Posit Assistant should not be in TabSet1 by default")
+
+   # 2. Move Posit Assistant to TabSet1 by checking it there
+   expect_true(.rs.toggleTab(remote, PL_RIGHT_TOP, "Posit Assistant"))
+
+   # 3. Verify it moved: checked in TabSet1, unchecked in sidebar
+   expect_true(.rs.isTabChecked(remote, PL_RIGHT_TOP, "Posit Assistant"),
+               info = "Posit Assistant should now be checked in TabSet1")
+   expect_false(.rs.isTabChecked(remote, PL_SIDEBAR, "Posit Assistant"),
+                info = "Posit Assistant should no longer be in sidebar")
+
+   # Sidebar visibility should have auto-unchecked (last tab removed)
+   expect_false(remote$dom.isChecked(remote$dom.querySelector(PL_SIDEBAR_VISIBLE)),
+                info = "Sidebar visibility should auto-uncheck when last tab removed")
+
+   # 4. Apply changes by clicking OK
+   remote$dom.clickElement(selector = "#rstudio_preferences_confirm")
+   .rs.waitUntil("dialog closed", function() {
+      !remote$dom.elementExists(".gwt-DialogBox")
+   })
+   Sys.sleep(0.5)
+
+   # 5. Reload the UI to test persistence
+   remote$js.eval("window.location.reload()")
+
+   # 6. Wait for page to reload (TabSet1 should reappear)
+   .rs.waitUntil("page reloaded", function() {
+      remote$dom.elementExists("#rstudio_TabSet1_pane")
+   })
+   Sys.sleep(0.5)
+
+   # 7. Re-open the Pane Layout dialog and verify the change persisted
+   .rs.openPaneLayoutOptions(remote)
+
+   expect_true(.rs.isTabChecked(remote, PL_RIGHT_TOP, "Posit Assistant"),
+               info = "Posit Assistant should still be in TabSet1 after reload")
+   expect_false(.rs.isTabChecked(remote, PL_SIDEBAR, "Posit Assistant"),
+                info = "Posit Assistant should not be in sidebar after reload")
+   expect_false(remote$dom.isChecked(remote$dom.querySelector(PL_SIDEBAR_VISIBLE)),
+                info = "Sidebar visibility should still be unchecked after reload")
+
+   # Close dialog
+   remote$keyboard.insertText("<Escape>")
+
+   # 8. Reset layout
+   .rs.resetUILayout(remote)
+})
+
+.rs.test("Moving Posit Assistant from hidden sidebar to TabSet1 persists across UI reload", {
+   skip_on_ci()
+
+   # Pane layout dialog selectors (defined in test-automation-pane-layout.R)
+   PL_RIGHT_TOP <- "#rstudio_pane_layout_right_top"
+   PL_SIDEBAR <- "#rstudio_pane_layout_sidebar"
+   PL_SIDEBAR_VISIBLE <- "#rstudio_pane_layout_sidebar_visible"
+
+   # 1. Verify default state: Posit Assistant is in the sidebar, not in TabSet1
+   .rs.openPaneLayoutOptions(remote)
+
+   expect_true(.rs.isTabChecked(remote, PL_SIDEBAR, "Posit Assistant"),
+               info = "Posit Assistant should be in sidebar by default")
+   expect_false(.rs.isTabChecked(remote, PL_RIGHT_TOP, "Posit Assistant"),
+                info = "Posit Assistant should not be in TabSet1 by default")
+
+   # 2. Move Posit Assistant to TabSet1 by checking it there
+   expect_true(.rs.toggleTab(remote, PL_RIGHT_TOP, "Posit Assistant"))
+
+   # 3. Verify it moved: checked in TabSet1, unchecked in sidebar
+   expect_true(.rs.isTabChecked(remote, PL_RIGHT_TOP, "Posit Assistant"),
+               info = "Posit Assistant should now be checked in TabSet1")
+   expect_false(.rs.isTabChecked(remote, PL_SIDEBAR, "Posit Assistant"),
+                info = "Posit Assistant should no longer be in sidebar")
+
+   # Sidebar visibility should have auto-unchecked (last tab removed)
+   expect_false(remote$dom.isChecked(remote$dom.querySelector(PL_SIDEBAR_VISIBLE)),
+                info = "Sidebar visibility should auto-uncheck when last tab removed")
+
+   # 4. Apply changes by clicking OK
+   remote$dom.clickElement(selector = "#rstudio_preferences_confirm")
+   .rs.waitUntil("dialog closed", function() {
+      !remote$dom.elementExists(".gwt-DialogBox")
+   })
+   Sys.sleep(0.5)
+
+   # 5. Reload the UI to test persistence
+   remote$js.eval("window.location.reload()")
+
+   # 6. Wait for page to reload (TabSet1 should reappear)
+   .rs.waitUntil("page reloaded", function() {
+      remote$dom.elementExists("#rstudio_TabSet1_pane")
+   })
+   Sys.sleep(0.5)
+
+   # 7. Re-open the Pane Layout dialog and verify the change persisted
+   .rs.openPaneLayoutOptions(remote)
+
+   expect_true(.rs.isTabChecked(remote, PL_RIGHT_TOP, "Posit Assistant"),
+               info = "Posit Assistant should still be in TabSet1 after reload")
+   expect_false(.rs.isTabChecked(remote, PL_SIDEBAR, "Posit Assistant"),
+                info = "Posit Assistant should not be in sidebar after reload")
+   expect_false(remote$dom.isChecked(remote$dom.querySelector(PL_SIDEBAR_VISIBLE)),
+                info = "Sidebar visibility should still be unchecked after reload")
+
+   # Close dialog
+   remote$keyboard.insertText("<Escape>")
+
+   # 8. Reset layout
+   .rs.resetUILayout(remote)
+})

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PaneLayoutPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PaneLayoutPreferencesPane.java
@@ -919,18 +919,23 @@ public class PaneLayoutPreferencesPane extends PreferencesPane
                consoleLeftOnTop, consoleRightOnTop, additionalColumnCount_,
                sidebar, sidebarVisible, sidebarLocation);
 
-         // Defer setting global value when layout changes require browser rendering.
-         // The panes ValueChangeHandler checks getOffsetWidth() which returns 0 before browser
-         // renders the new layout, causing it to resize all columns to 0.
          if (columnCountChanged || sidebarVisibilityChanged || sidebarLocationChanged)
          {
-            // Only refresh sidebar if it was already visible. When showing a hidden sidebar,
-            // the ValueChangeHandler's showSidebar(true) call handles everything. Calling
-            // refreshSidebar() would cause a redundant destroy/recreate cycle that breaks layout.
+            // Write the new config into the pref layer immediately
+            // (without firing events) so that doSaveChanges()
+            // serializes the correct value. The ValueChangeEvent is
+            // fired in the deferred command below, after the browser
+            // has rendered the new layout — this avoids the
+            // getOffsetWidth()==0 problem that collapses columns.
             boolean sidebarWasVisible = prevConfig.getSidebarVisible();
+            userPrefs_.panes().setGlobalValue(newConfig, false);
             Scheduler.get().scheduleDeferred(() ->
             {
-               userPrefs_.panes().setGlobalValue(newConfig);
+               ValueChangeEvent.fire(
+                  userPrefs_.panes(), userPrefs_.panes().getValue());
+               // Only refresh if the sidebar was already showing;
+               // when first made visible, showSidebar(true) in the
+               // ValueChangeHandler handles initialization.
                if (sidebarWasVisible)
                {
                   paneManager_.clearSidebarCache();


### PR DESCRIPTION
## Intent

Addresses #17177.

## Summary

- Fix a race condition where pane layout changes involving the sidebar (visibility, location, or column count) were not persisted to `rstudio-prefs.json`
- Add BRAT tests verifying that moving Posit Assistant from sidebar to TabSet1 persists across a UI reload

## Details

When sidebar visibility changed (e.g. moving the last tab out of the sidebar), `setGlobalValue` was deferred via `Scheduler.get().scheduleDeferred()` to avoid a `getOffsetWidth()==0` layout bug. But `doSaveChanges()` ran synchronously before the deferred command executed, serializing the stale config.

The fix writes the new config immediately without firing events (so `doSaveChanges()` serializes the correct value), then fires `ValueChangeEvent` in the deferred command after the browser renders.

## Test plan

- [ ] Move Posit Assistant from sidebar to TabSet1 via Pane Layout prefs, click OK, restart — verify it stays in TabSet1
- [ ] Same test but with sidebar initially visible
- [ ] Move tabs between TabSet1/TabSet2 (no sidebar change) — verify still persists (regression)
- [ ] Toggle sidebar location (left → right) — verify persists across restart
- [ ] Add/remove source columns — verify layout persists
- [ ] `cd src/gwt && ant javac` builds cleanly