### PR TITLE
Add PR milestone and issue labeling guidelines to CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -401,6 +401,7 @@ When generating a pull request that fixes a known issue, please ensure the pull 
 
     Addresses <issue>.
 
+When generating a pull request, set the Milestone of the pull request to match contents of @version/RELEASE, if there is a matching milestone already defined. Never create a new milestone.
 
 ## Git Conventions
 
@@ -414,3 +415,10 @@ For branch naming:
 - Use the 'bugfix/' prefix for code changes which fix an existing issue.
 - Use the 'feature/' prefix for code changes that add or extend existing functionality.
 - Use the 'developer/' prefix for code changes that are primarily for developer ergonomics.
+
+## Issues
+
+- When opening an issue, always add the label `new`
+- If the issue describes a bug, add the label `bug`
+- If the issue is for a new feature or enhancements to an existing feature, add the label `enhancement`
+ 


### PR DESCRIPTION
## Summary

- Add instruction to set PR milestones based on `@version/RELEASE`
- Add issue labeling guidelines (`new`, `bug`, `enhancement`)

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub