### PR TITLE
Fix reformat-on-save automation test timing

### DIFF
--- a/src/cpp/tests/automation/testthat/test-automation-reformat.R
+++ b/src/cpp/tests/automation/testthat/test-automation-reformat.R
@@ -39,7 +39,12 @@ remote$console.executeExpr({
    editor <- remote$editor.getInstance()
    editor$insert("1+1; 2+2")
    remote$keyboard.insertText("<Ctrl + S>")
-   contents <- editor$session$doc$getValue()
+   contents <- .rs.waitUntil("document is reformatted", function() {
+      contents <- editor$session$doc$getValue()
+      if (contents != "1+1; 2+2")
+         return(contents)
+      return(FALSE)
+   })
    expect_equal(contents, "1 + 1\n2 + 2\n")
    remote$editor.closeDocument()
    
@@ -90,7 +95,12 @@ remote$console.executeExpr({
    editor <- remote$editor.getInstance()
    editor$insert("example<-function(){1+1;2+2}")
    remote$keyboard.insertText("<Ctrl + S>")
-   contents <- editor$session$doc$getValue()
+   contents <- .rs.waitUntil("document is reformatted", function() {
+      contents <- editor$session$doc$getValue()
+      if (contents != "example<-function(){1+1;2+2}")
+         return(contents)
+      return(FALSE)
+   })
    expect_equal(contents, "example <- function() {\n    1 + 1\n    2 + 2\n}\n")
    remote$editor.closeDocument()
    


### PR DESCRIPTION
## Summary

- Fix race condition in styler and air reformat-on-save BRAT tests where editor content was read immediately after dispatching Ctrl+S, before the async formatting round-trip could complete
- Use `.rs.waitUntil` to poll for the editor content to change from the original unformatted text before asserting on the expected formatted result

## Test plan

- [ ] Run `./rstudio-tests --scope automation --filter reformat` and verify the styler test passes
- [ ] Verify the air test also passes when air is installed