### PR TITLE
Update protocol version to 10.0 for Posit AI

### DIFF
--- a/src/cpp/session/modules/chat/ChatConstants.cpp
+++ b/src/cpp/session/modules/chat/ChatConstants.cpp
@@ -29,7 +29,7 @@ const char* const kIndexFileName = "index.html";
 const char* const kCspConfigPath = "dist/csp.json";
 
 // Protocol Version (SUPPORTED_PROTOCOL_VERSION)
-const char* const kProtocolVersion = "9.0";
+const char* const kProtocolVersion = "10.0";
 
 // Capabilities: JSON-RPC methods that RStudio handles
 const std::vector<std::string>& rstudioCapabilities()


### PR DESCRIPTION
### Intent

In preparation for releasing a new recommended Early Access RStudio build, bumping the protocol version. This allows us to publish new builds of Posit AI for RStudio without impacting the current early access RStudio build (2024.04.0+347).

