### PR TITLE
Add csrf check protection to the abort and interrupt operations

### DIFF
--- a/src/cpp/core/include/core/http/HeaderCookieConstants.hpp
+++ b/src/cpp/core/include/core/http/HeaderCookieConstants.hpp
@@ -35,6 +35,8 @@ constexpr const char* kOldCSRFTokenHeader = "X-CSRF-Token";
 // =================================================================================================
 
 // Header Constants ================================================================================
+constexpr const char* kCSRFBypassHeader = "X-RS-CSRF-Bypass";
+constexpr const char* kCSRFBypassSigHeader = "X-RS-CSRF-Bypass-Sig";
 constexpr const char* kCSRFTokenHeader = "X-RS-CSRF-Token";
 constexpr const char* kPostbackExitCodeHeader = "X-Postback-ExitCode";
 constexpr const char* kRStudioRpcCookieHeader = "X-RS-Session-Server-RPC-Cookie";

--- a/src/cpp/server_core/include/server_core/sessions/SessionSignature.hpp
+++ b/src/cpp/server_core/include/server_core/sessions/SessionSignature.hpp
@@ -38,6 +38,17 @@ core::Error verifyRequestSignature(const std::string& rsaPublicKey,
                                    const core::http::Request& request,
                                    bool includeUsername = true);
 
+// Signs the X-RS-CSRF-Bypass header value and sets X-RS-CSRF-Bypass-Sig on the request.
+// No-op if X-RS-CSRF-Bypass is not present.
+core::Error signCSRFBypass(const std::string& rsaPrivateKey,
+                           core::http::Request& request);
+
+// Verifies the X-RS-CSRF-Bypass signature. Returns Success and sets pBypassInfo
+// if valid. Returns an error if the header is missing or the signature is invalid.
+core::Error verifyCSRFBypass(const std::string& rsaPublicKey,
+                             const core::http::Request& request,
+                             std::string* pBypassInfo);
+
 } // namespace sessions
 } // namespace server_core
 } // namespace rstudio

--- a/src/cpp/server_core/sessions/SessionSignature.cpp
+++ b/src/cpp/server_core/sessions/SessionSignature.cpp
@@ -14,6 +14,7 @@
  */
 
 #include <shared_core/Error.hpp>
+#include <core/http/HeaderCookieConstants.hpp>
 #include <core/http/Util.hpp>
 #include <core/system/Crypto.hpp>
 
@@ -213,8 +214,56 @@ Error verifyRequestSignature(const std::string& rsaPublicKey,
    return Success();
 }
 
+Error signCSRFBypass(const std::string& rsaPrivateKey,
+                     http::Request& request)
+{
+   std::string bypassInfo = request.headerValue(kCSRFBypassHeader);
+   if (bypassInfo.empty())
+      return Success();
+
+   std::string signature;
+   Error error = crypto::rsaSign(bypassInfo, rsaPrivateKey, &signature);
+   if (error)
+      return error;
+
+   std::vector<unsigned char> signatureData(signature.begin(), signature.end());
+   std::string signatureHeader;
+   error = crypto::base64Encode(signatureData, signatureHeader);
+   if (error)
+      return error;
+
+   request.setHeader(kCSRFBypassSigHeader, signatureHeader);
+   return Success();
+}
+
+Error verifyCSRFBypass(const std::string& rsaPublicKey,
+                       const http::Request& request,
+                       std::string* pBypassInfo)
+{
+   std::string bypassInfo = request.headerValue(kCSRFBypassHeader);
+   std::string bypassSig = request.headerValue(kCSRFBypassSigHeader);
+   if (bypassInfo.empty() || bypassSig.empty())
+   {
+      return systemError(boost::system::errc::permission_denied,
+                         "Missing CSRF bypass headers",
+                         ERROR_LOCATION);
+   }
+
+   std::vector<unsigned char> decoded;
+   Error error = crypto::base64Decode(bypassSig, decoded);
+   if (error)
+      return error;
+
+   std::string decodedSignature(decoded.begin(), decoded.end());
+   error = crypto::rsaVerify(bypassInfo, decodedSignature, rsaPublicKey);
+   if (error)
+      return error;
+
+   *pBypassInfo = bypassInfo;
+   return Success();
+}
+
 } // namespace sessions
 } // namespace server_core
 } // namespace rstudio
-
 

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -136,11 +136,32 @@ bool parseAndValidateJsonRpcConnection(
    if (options().programMode() == kSessionProgramModeServer && 
        !core::http::validateCSRFHeaders(ptrConnection->request()))
    {
-      LOG_WARNING_MESSAGE("RPC request to '" + ptrConnection->request().uri() + "' has missing or "
-            "mismatched " + std::string(kCSRFTokenCookie) + " cookie or " +
-            std::string(kCSRFTokenHeader) + " header");
-      ptrConnection->sendJsonRpcError(Error(json::errc::Unauthorized, ERROR_LOCATION));
-      return false;
+      // CSRF validation failed - check for a signed server bypass header.
+      // Server-originated requests (session reaper, workbench API) may not have
+      // browser CSRF tokens but carry a signed bypass header instead.
+      std::string bypassInfo;
+      bool bypassed = false;
+#ifdef RSTUDIO_SERVER
+      if (options().verifySignatures() && !options().signingKey().empty())
+      {
+         Error bypassError = server_core::sessions::verifyCSRFBypass(
+             options().signingKey(), ptrConnection->request(), &bypassInfo);
+         if (!bypassError)
+         {
+            bypassed = true;
+            LOG_DEBUG_MESSAGE("CSRF bypassed for '" + ptrConnection->request().uri() +
+                              "' by signed server request (" + bypassInfo + ")");
+         }
+      }
+#endif
+      if (!bypassed)
+      {
+         LOG_WARNING_MESSAGE("RPC request to '" + ptrConnection->request().uri() + "' has missing or "
+               "mismatched " + std::string(kCSRFTokenCookie) + " cookie or " +
+               std::string(kCSRFTokenHeader) + " header");
+         ptrConnection->sendJsonRpcError(Error(json::errc::Unauthorized, ERROR_LOCATION));
+         return false;
+      }
    }
 
    // check for invalid client id - must match, unless it's rserver using quit session from the homepage (no client id in that case)

--- a/src/cpp/session/http/SessionHttpConnectionUtils.cpp
+++ b/src/cpp/session/http/SessionHttpConnectionUtils.cpp
@@ -16,6 +16,8 @@
 
 #include "SessionHttpConnectionUtils.hpp"
 
+#include "session-config.h"
+
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <shared_core/FilePath.hpp>
@@ -24,6 +26,7 @@
 #include <core/FileSerializer.hpp>
 
 
+#include <core/http/CSRFToken.hpp>
 #include <core/http/Response.hpp>
 #include <core/http/Request.hpp>
 
@@ -35,11 +38,16 @@
 
 #include <r/RExec.hpp>
 
+#include <session/SessionConstants.hpp>
 #include <session/SessionMain.hpp>
 #include <session/SessionOptions.hpp>
 #include <session/projects/ProjectsSettings.hpp>
 #include "../SessionRpc.hpp"
 #include "../SessionAsyncRpcConnection.hpp"
+
+#ifdef RSTUDIO_SERVER
+#include <server_core/sessions/SessionSignature.hpp>
+#endif
 
 namespace rstudio {
 namespace session {
@@ -90,6 +98,42 @@ bool isGetEvents(boost::shared_ptr<HttpConnection> ptrConnection)
                                       "events/get_events");
 }
 
+// Validates CSRF for requests handled in the background listener thread.
+// Returns true if CSRF is valid or bypassed by a signed server header.
+bool validateCSRFOrBypass(boost::shared_ptr<HttpConnection> ptrConnection)
+{
+   if (session::options().programMode() != kSessionProgramModeServer)
+      return true;
+
+   if (core::http::validateCSRFHeaders(ptrConnection->request()))
+      return true;
+
+#ifdef RSTUDIO_SERVER
+   if (session::options().verifySignatures() && !session::options().signingKey().empty())
+   {
+      std::string bypassInfo;
+      core::Error error = server_core::sessions::verifyCSRFBypass(
+          session::options().signingKey(), ptrConnection->request(), &bypassInfo);
+      if (!error)
+      {
+         LOG_DEBUG_MESSAGE("CSRF bypassed for '" + ptrConnection->request().uri() +
+                           "' by signed server request (" + bypassInfo + ")");
+         return true;
+      }
+   }
+#endif
+   if (session::options().disableNewCSRFChecks())
+   {
+      LOG_DEBUG_MESSAGE("CSRF validation disabled via disable-new-csrf-checks=1 for '" + ptrConnection->request().uri() + "'");
+      return true;
+   }
+   else
+   {
+      LOG_WARNING_MESSAGE("CSRF validation failed for '" + ptrConnection->request().uri() + "' - use disable-new-csrf-checks=1 in rsession.conf to override this new check.");
+   }
+   return false;
+}
+
 void handleAbortNextProjParam(
                boost::shared_ptr<HttpConnection> ptrConnection)
 {
@@ -122,6 +166,13 @@ bool checkForAbort(boost::shared_ptr<HttpConnection> ptrConnection,
 {
    if (isMethod(ptrConnection, "abort"))
    {
+      if (!validateCSRFOrBypass(ptrConnection))
+      {
+         ptrConnection->sendJsonRpcError(
+             core::Error(core::json::errc::Unauthorized, ERROR_LOCATION));
+         return true;
+      }
+
       // respond and log (try/catch so we are ALWAYS guaranteed to abort)
       try
       {
@@ -183,6 +234,13 @@ bool checkForSuspend(boost::shared_ptr<HttpConnection> ptrConnection)
    using namespace rstudio::core::json;
    if (isMethod(ptrConnection, "suspend_session"))
    {
+      if (!validateCSRFOrBypass(ptrConnection))
+      {
+         ptrConnection->sendJsonRpcError(
+             core::Error(core::json::errc::Unauthorized, ERROR_LOCATION));
+         return true;
+      }
+
       bool force = false;
       JsonRpcRequest jsonRpcRequest;
       core::Error error = parseJsonRpcRequest(ptrConnection->request().body(),
@@ -222,10 +280,17 @@ bool checkForInterrupt(boost::shared_ptr<HttpConnection> ptrConnection)
 {
    using namespace rstudio::core;
    using namespace rstudio::core::json;
-   
+
    if (!isMethod(ptrConnection, "interrupt"))
       return false;
-   
+
+   if (!validateCSRFOrBypass(ptrConnection))
+   {
+      ptrConnection->sendJsonRpcError(
+          core::Error(core::json::errc::Unauthorized, ERROR_LOCATION));
+      return true;
+   }
+
    JsonRpcRequest request;
    Error error = parseJsonRpcRequest(
             ptrConnection->request().body(),

--- a/src/cpp/session/include/session/SessionConstants.hpp
+++ b/src/cpp/session/include/session/SessionConstants.hpp
@@ -87,6 +87,7 @@
 #define kWwwAddressSessionOption          "www-address"
 #define kWwwPortSessionOption             "www-port"
 #define kWwwResusePorts                   "www-reuse-ports"
+#define kDisableNewCSRFChecks             "disable-new-csrf-checks"
 #define kSessionSslCertOption             "cert"
 #define kSessionSslCertKeyOption          "cert-key"
 #define kTerminalPortOption               "terminal-port"

--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -135,7 +135,10 @@ protected:
       "Indicates whether or not to verify signatures on incoming requests. This is generally only used with Launcher sessions.")
       (kWwwResusePorts,
       value<bool>(&wwwReusePorts_)->default_value(false),
-      "Whether or not to reuse last used bound ports when restarting a Launcher session.");
+      "Whether or not to reuse last used bound ports when restarting a Launcher session.")
+      (kDisableNewCSRFChecks,
+      value<bool>(&disableNewCSRFChecks_)->default_value(false),
+      "Certain rpc calls were missing checks for the CSRF token to prevent misuse of these api in a context with lax SameSite cookie policies. Use this option temporarily to override these new checks if you have integrations that rely on the old behavior.");
 
    pSession->add_options()
       ("session-connections-block-suspend",
@@ -525,6 +528,7 @@ public:
    bool standalone() const { return standalone_; }
    bool verifySignatures() const { return verifySignatures_; }
    bool wwwReusePorts() const { return wwwReusePorts_; }
+   bool disableNewCSRFChecks() const { return disableNewCSRFChecks_; }
    bool sessionConnectionsBlockSuspend() const { return sessionConnectionsBlockSuspend_; }
    bool sessionExternalPointersBlockSuspend() const { return sessionExternalPointersBlockSuspend_; }
    int timeoutMinutes() const { return timeoutMinutes_; }
@@ -657,6 +661,7 @@ protected:
    bool standalone_;
    bool verifySignatures_;
    bool wwwReusePorts_;
+   bool disableNewCSRFChecks_;
    bool sessionConnectionsBlockSuspend_;
    bool sessionExternalPointersBlockSuspend_;
    int timeoutMinutes_;

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -169,6 +169,14 @@
             "defaultValue": false,
             "isHidden": true,
             "description": "Whether or not to reuse last used bound ports when restarting a Launcher session."
+         },
+         {
+            "name": {"constant": "kDisableNewCSRFChecks", "value": "disable-new-csrf-checks"},
+            "memberName": "disableNewCSRFChecks_",
+            "type": "bool",
+            "defaultValue": false,
+            "isHidden": true,
+            "description": "Certain rpc calls were missing checks for the CSRF token to prevent misuse of these api in a context with lax SameSite cookie policies. Use this option temporarily to override these new checks if you have integrations that rely on the old behavior."
          }
       ],
       "session": [


### PR DESCRIPTION
### Intent

- added a hidden option to disable the checks to add a workaround in case they cause problems upstream
- this also includes a way rserver can sign requests for rsession to bypass the CSRF check (needed by: https://github.com/rstudio/rstudio-pro/issues/10167 and already reviewed there)

(I'll need to coordinate the merge because the rstudio-pro repo needs a change to use this new mechanism)

