### PR TITLE
Refactor bind address into helper and add unit tests

### DIFF
--- a/src/cpp/core/include/core/system/PosixSystem.hpp
+++ b/src/cpp/core/include/core/system/PosixSystem.hpp
@@ -122,10 +122,11 @@ std::ostream& operator<<(std::ostream& os, const ProcessInfo& info);
 
 core::Error ipAddresses(std::vector<posix::IpAddress>* pAddresses, bool includeIPv6 = false);
 
-// Resolves a bind address for IPv4/IPv6 compatibility.
-// If "0.0.0.0" but the system only has IPv6, returns "::".
-// If "::" but the system has no IPv6, returns "0.0.0.0".
-// Otherwise returns the address unchanged.
+// Resolves a wildcard bind address for IPv4/IPv6 compatibility.
+// If "0.0.0.0" but the system has no routable IPv4 (only loopback) and has
+// routable IPv6, returns "::".
+// If "::" but the system has no IPv6 interfaces, returns "0.0.0.0".
+// Non-wildcard addresses are returned unchanged.
 std::string resolveBindAddress(const std::string& address);
 
 // core dump restriction

--- a/src/cpp/core/include/core/system/PosixSystem.hpp
+++ b/src/cpp/core/include/core/system/PosixSystem.hpp
@@ -122,6 +122,12 @@ std::ostream& operator<<(std::ostream& os, const ProcessInfo& info);
 
 core::Error ipAddresses(std::vector<posix::IpAddress>* pAddresses, bool includeIPv6 = false);
 
+// Resolves a bind address for IPv4/IPv6 compatibility.
+// If "0.0.0.0" but the system only has IPv6, returns "::".
+// If "::" but the system has no IPv6, returns "0.0.0.0".
+// Otherwise returns the address unchanged.
+std::string resolveBindAddress(const std::string& address);
+
 // core dump restriction
 core::Error restrictCoreDumps();
 core::Error enableCoreDumps();

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -2084,13 +2084,21 @@ Error ipAddresses(std::vector<posix::IpAddress>* pAddresses,
     return posix::getIpAddresses(*pAddresses, includeIPv6);
 }
 
-std::string resolveBindAddress(const std::string& address)
+namespace detail {
+
+std::string stripIpv6ScopeId(const std::string& address)
 {
-   std::vector<posix::IpAddress> addrs;
-   Error error = ipAddresses(&addrs, true);
-   if (error)
+   if (address.find(':') == std::string::npos)
       return address;
 
+   const size_t scopePos = address.find('%');
+   return scopePos == std::string::npos ? address : address.substr(0, scopePos);
+}
+
+std::string resolveBindAddressForAddresses(
+      const std::string& address,
+      const std::vector<posix::IpAddress>& addrs)
+{
    if (address == "0.0.0.0")
    {
       bool hasNonLocalIpv4 = false;
@@ -2100,7 +2108,13 @@ std::string resolveBindAddress(const std::string& address)
 
       for (const posix::IpAddress& ip : addrs)
       {
-         auto addr = boost::asio::ip::make_address(ip.Address);
+         const bool hasScopeId = ip.Address.find('%') != std::string::npos;
+         boost::system::error_code ec;
+         boost::asio::ip::address addr =
+            boost::asio::ip::make_address(stripIpv6ScopeId(ip.Address), ec);
+         if (ec)
+            continue;
+
          if (addr.is_v4())
          {
             hasIpv4 = true;
@@ -2110,7 +2124,8 @@ std::string resolveBindAddress(const std::string& address)
          else if (addr.is_v6())
          {
             hasIpv6 = true;
-            if (!addr.is_loopback() && ip.Address.find("%") == std::string::npos)
+            if (!addr.is_loopback() && !hasScopeId &&
+                !addr.to_v6().is_link_local())
                hasNonLocalIpv6 = true;
          }
       }
@@ -2126,7 +2141,12 @@ std::string resolveBindAddress(const std::string& address)
       bool hasIpv6 = false;
       for (const posix::IpAddress& ip : addrs)
       {
-         auto addr = boost::asio::ip::make_address(ip.Address);
+         boost::system::error_code ec;
+         boost::asio::ip::address addr =
+            boost::asio::ip::make_address(stripIpv6ScopeId(ip.Address), ec);
+         if (ec)
+            continue;
+
          if (addr.is_v6())
          {
             hasIpv6 = true;
@@ -2141,6 +2161,26 @@ std::string resolveBindAddress(const std::string& address)
    }
 
    return address;
+}
+
+} // namespace detail
+
+std::string resolveBindAddress(const std::string& address)
+{
+   if (address != "0.0.0.0" && address != "::")
+      return address;
+
+   std::vector<posix::IpAddress> addrs;
+   Error error = ipAddresses(&addrs, true);
+   if (error)
+   {
+      LOG_DEBUG_MESSAGE(
+            "Falling back to configured bind address '" + address +
+            "' because interface discovery failed: " + error.asString());
+      return address;
+   }
+
+   return detail::resolveBindAddressForAddresses(address, addrs);
 }
 
 Error restrictCoreDumps()

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -66,6 +66,7 @@
 #endif
 
 #include <boost/algorithm/string.hpp>
+#include <boost/asio/ip/address.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/bind/bind.hpp>
@@ -2083,6 +2084,64 @@ Error ipAddresses(std::vector<posix::IpAddress>* pAddresses,
     return posix::getIpAddresses(*pAddresses, includeIPv6);
 }
 
+std::string resolveBindAddress(const std::string& address)
+{
+   std::vector<posix::IpAddress> addrs;
+   Error error = ipAddresses(&addrs, true);
+   if (error)
+      return address;
+
+   if (address == "0.0.0.0")
+   {
+      bool hasNonLocalIpv4 = false;
+      bool hasNonLocalIpv6 = false;
+      bool hasIpv4 = false;
+      bool hasIpv6 = false;
+
+      for (const posix::IpAddress& ip : addrs)
+      {
+         auto addr = boost::asio::ip::make_address(ip.Address);
+         if (addr.is_v4())
+         {
+            hasIpv4 = true;
+            if (!addr.is_loopback())
+               hasNonLocalIpv4 = true;
+         }
+         else if (addr.is_v6())
+         {
+            hasIpv6 = true;
+            if (!addr.is_loopback() && ip.Address.find("%") == std::string::npos)
+               hasNonLocalIpv6 = true;
+         }
+      }
+
+      if ((!hasNonLocalIpv4 && hasNonLocalIpv6) ||
+          (!hasIpv4 && hasIpv6))
+      {
+         return "::";
+      }
+   }
+   else if (address == "::")
+   {
+      bool hasIpv6 = false;
+      for (const posix::IpAddress& ip : addrs)
+      {
+         auto addr = boost::asio::ip::make_address(ip.Address);
+         if (addr.is_v6())
+         {
+            hasIpv6 = true;
+            break;
+         }
+      }
+
+      if (!hasIpv6)
+      {
+         return "0.0.0.0";
+      }
+   }
+
+   return address;
+}
 
 Error restrictCoreDumps()
 {

--- a/src/cpp/core/system/PosixSystemTests.cpp
+++ b/src/cpp/core/system/PosixSystemTests.cpp
@@ -31,6 +31,14 @@ namespace system {
 
 OSInfo parseOsReleaseContent(const std::string&);
 
+namespace detail {
+
+std::string resolveBindAddressForAddresses(
+      const std::string& address,
+      const std::vector<posix::IpAddress>& addrs);
+
+} // namespace detail
+
 namespace tests {
 
 #ifdef __linux__
@@ -55,6 +63,15 @@ static std::string getNoGroupName()
 }
 
 #endif
+
+static posix::IpAddress ipAddress(const std::string& name,
+                                  const std::string& address)
+{
+   posix::IpAddress ip;
+   ip.Name = name;
+   ip.Address = address;
+   return ip;
+}
 
 TEST(PosixTests, FindProgramFindsWhich)
 {
@@ -624,6 +641,67 @@ TEST(PosixTests, ResolveBindAddressIPv6Wildcard)
 {
    std::string result = resolveBindAddress("::");
    EXPECT_TRUE(result == "::" || result == "0.0.0.0");
+}
+
+TEST(PosixTests, ResolveBindAddressForAddressesPrefersIpv6WhenOnlyIpv6Available)
+{
+   std::vector<posix::IpAddress> addrs = {
+      ipAddress("lo", "::1"),
+      ipAddress("eth0", "2001:db8::10")
+   };
+
+   EXPECT_EQ(detail::resolveBindAddressForAddresses("0.0.0.0", addrs), "::");
+}
+
+TEST(PosixTests, ResolveBindAddressForAddressesKeepsIpv4OnDualStackHosts)
+{
+   std::vector<posix::IpAddress> addrs = {
+      ipAddress("lo", "127.0.0.1"),
+      ipAddress("eth0", "192.168.1.10"),
+      ipAddress("eth0", "2001:db8::10")
+   };
+
+   EXPECT_EQ(detail::resolveBindAddressForAddresses("0.0.0.0", addrs), "0.0.0.0");
+}
+
+TEST(PosixTests, ResolveBindAddressForAddressesIgnoresScopedIpv6ForIpv4Wildcard)
+{
+   std::vector<posix::IpAddress> addrs = {
+      ipAddress("lo", "127.0.0.1"),
+      ipAddress("eth0", "fe80::1%eth0")
+   };
+
+   EXPECT_EQ(detail::resolveBindAddressForAddresses("0.0.0.0", addrs), "0.0.0.0");
+}
+
+TEST(PosixTests, ResolveBindAddressForAddressesIgnoresLinkLocalIpv6ForIpv4Wildcard)
+{
+   std::vector<posix::IpAddress> addrs = {
+      ipAddress("lo", "127.0.0.1"),
+      ipAddress("eth0", "fe80::1")
+   };
+
+   EXPECT_EQ(detail::resolveBindAddressForAddresses("0.0.0.0", addrs), "0.0.0.0");
+}
+
+TEST(PosixTests, ResolveBindAddressForAddressesSkipsUnparseableAddresses)
+{
+   std::vector<posix::IpAddress> addrs = {
+      ipAddress("bad0", "not-an-address"),
+      ipAddress("eth0", "2001:db8::10")
+   };
+
+   EXPECT_EQ(detail::resolveBindAddressForAddresses("0.0.0.0", addrs), "::");
+}
+
+TEST(PosixTests, ResolveBindAddressForAddressesFallsBackToIpv4WithoutIpv6)
+{
+   std::vector<posix::IpAddress> addrs = {
+      ipAddress("lo", "127.0.0.1"),
+      ipAddress("eth0", "192.168.1.10")
+   };
+
+   EXPECT_EQ(detail::resolveBindAddressForAddresses("::", addrs), "0.0.0.0");
 }
 
 TEST(PosixTests, ParseOsReleaseQuoted)

--- a/src/cpp/core/system/PosixSystemTests.cpp
+++ b/src/cpp/core/system/PosixSystemTests.cpp
@@ -606,6 +606,26 @@ TEST_F(PosixTestsRequiresPrivilege, DISABLED_PermanentlyDropPrivChecksGroupMembe
    EXPECT_EQ(egid, testGroup.groupId);
 }
 
+TEST(PosixTests, ResolveBindAddressPassthroughForSpecificAddress)
+{
+   EXPECT_EQ(resolveBindAddress("127.0.0.1"), "127.0.0.1");
+   EXPECT_EQ(resolveBindAddress("192.168.1.1"), "192.168.1.1");
+   EXPECT_EQ(resolveBindAddress("::1"), "::1");
+   EXPECT_EQ(resolveBindAddress(""), "");
+}
+
+TEST(PosixTests, ResolveBindAddressIPv4Wildcard)
+{
+   std::string result = resolveBindAddress("0.0.0.0");
+   EXPECT_TRUE(result == "0.0.0.0" || result == "::");
+}
+
+TEST(PosixTests, ResolveBindAddressIPv6Wildcard)
+{
+   std::string result = resolveBindAddress("::");
+   EXPECT_TRUE(result == "::" || result == "0.0.0.0");
+}
+
 TEST(PosixTests, ParseOsReleaseQuoted)
 {
    std::string content = R"(

--- a/src/cpp/session/http/SessionPosixHttpConnectionListener.cpp
+++ b/src/cpp/session/http/SessionPosixHttpConnectionListener.cpp
@@ -117,68 +117,7 @@ void initializeHttpConnectionListener()
    {
       if (session::options().standalone())
       {
-         std::string wwwAddress = options.wwwAddress();
-
-         // if we are supposed to bind to the all address but there are no IPv4 addresses,
-         // simply bind to all ipv6 interfaces. we prefer non-loopback ipv4 or non-link local ipv6
-         if (wwwAddress == "0.0.0.0")
-         {
-            std::vector<core::system::posix::IpAddress> addrs;
-            Error error = core::system::ipAddresses(&addrs, true);
-            if (!error)
-            {
-               bool hasNonLocalIpv4 = false;
-               bool hasNonLocalIpv6 = false;
-               bool hasIpv4 = false;
-               bool hasIpv6 = false;
-
-               for (const core::system::posix::IpAddress& ip : addrs)
-               {
-                  auto addr = boost::asio::ip::make_address(ip.Address);
-                  if (addr.is_v4())
-                  {
-                     hasIpv4 = true;
-                     if (!addr.is_loopback())
-                        hasNonLocalIpv4 =  true;
-                  }
-                  else if (addr.is_v6())
-                  {
-                     hasIpv6 = true;
-                     if (!addr.is_loopback() && ip.Address.find("%") == std::string::npos)
-                        hasNonLocalIpv6 = true;
-                  }
-               }
-
-               if ((!hasNonLocalIpv4 && hasNonLocalIpv6) ||
-                   (!hasIpv4 && hasIpv6))
-               {
-                  wwwAddress = "::";
-               }
-            }
-         }
-         else if (wwwAddress == "::")
-         {
-            std::vector<core::system::posix::IpAddress> addrs;
-            Error error = core::system::ipAddresses(&addrs, true);
-            if (!error)
-            {
-               bool hasIpv6 = false;
-               for (const core::system::posix::IpAddress& ip : addrs)
-               {
-                  auto addr = boost::asio::ip::make_address(ip.Address);
-                  if (addr.is_v6())
-                  {
-                     hasIpv6 = true;
-                     break;
-                  }
-               }
-
-               if (!hasIpv6)
-               {
-                  wwwAddress = "0.0.0.0";
-               }
-            }
-         }
+         std::string wwwAddress = core::system::resolveBindAddress(options.wwwAddress());
 
          // reuse the port we were bound to before restart if specified - this is done
          // to enable smooth session restarts for launcher sessions


### PR DESCRIPTION
### Intent

OS component of https://github.com/rstudio/rstudio-pro/pull/10416.

### Approach

This is mainly just refactoring the functionality to bind to IPv6 addresses into a helper function and doesn't change functionality.

### Automated Tests

Added unit tests.

### QA Notes

See Pro PR for QA notes.

### Documentation

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


