### PR TITLE
Fix two one-line issues

### DIFF
--- a/src/cpp/core/r_util/RActiveSessionsStorage.cpp
+++ b/src/cpp/core/r_util/RActiveSessionsStorage.cpp
@@ -334,7 +334,7 @@ Error RpcActiveSessionsStorage::listSessionProperties(
       if (!(*itr).isObject())
          continue;
 
-      const json::Object& sessionObj = (*itr).getObject();
+      const json::Object sessionObj = (*itr).getObject();
       std::string id;
       error = json::readObject(sessionObj, kSessionStorageIdField, id);
       if (error)
@@ -346,7 +346,7 @@ Error RpcActiveSessionsStorage::listSessionProperties(
       std::map<std::string, std::string> props;
       for (auto memberIt = sessionObj.begin(); memberIt != sessionObj.end(); ++memberIt)
       {
-         const std::string& key = (*memberIt).getName();
+         const std::string key = (*memberIt).getName();
          if (key == kSessionStorageIdField)
             continue; // skip the id field itself
          if ((*memberIt).getValue().isString())

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2496,7 +2496,7 @@ int main(int argc, char * const argv[])
       // it is created with the default value of ~, so if our session options
       // have specified that a different directory should be used, we should
       // persist the value to the session state as soon as possible
-      module_context::activeSession().setWorkingDir(workingDir.getAbsolutePath());
+      module_context::activeSession().setWorkingDir(module_context::createAliasedPath(workingDir));
 
       // initialize directory trust state before R initialization
       modules::trust::initializeTrustState();


### PR DESCRIPTION
### Intent

- Avoid 'use after free' in rpc session storage list sessions (caught by cmake -DRSTUDIO_ASAN=ON)
- Consistent use of aliased paths for working-dir (addresses: https://github.com/rstudio/rstudio-pro/issues/8790)


