### PR TITLE
fix search input padding in Go to File/Function dialog

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -323,6 +323,7 @@ button, input[type="reset"], input[type="button"], input[type="submit"] {
 .gwt-DialogBox .search input[type=text] {
    border: none;
    height: 100%;
+   padding: 0;
 }
 
 iframe {
@@ -1835,6 +1836,7 @@ body.windows table.webGlobalToolbar {
    height: 100%;
    border: 0;
    margin: 0;
+   padding: 0;
    outline: none;
    font-size: 10px;
    background-color: transparent;


### PR DESCRIPTION
## Summary

- The dialog-wide `input[type=text]` styling rule added `padding: 4px 6px` that leaked into the SearchWidget's input in the Go to File/Function dialog, pushing text out of bounds.
- Reset padding in both the `.gwt-DialogBox .search` override and the `.searchBox` base rule.

## Test plan

- [ ] Open Go to File/Function dialog (Ctrl+. / Cmd+.) and verify the input text renders correctly within bounds
- [ ] Verify other dialog text inputs still have proper padding (e.g. Global Options, Find in Files)