### PR TITLE
Prevent fatal error if git credentials don't exist

### DIFF
--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -48,7 +48,7 @@ pipeline {
       // https://issues.jenkins.io/browse/JENKINS-62249?focusedId=408066&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-408066
       steps {
         sh '''
-          printf "\\n" | git credential-osxkeychain erase host=github.com protocol=https
+          printf "\\n" | git credential-osxkeychain erase host=github.com protocol=https || true
         '''
       }
     }


### PR DESCRIPTION
### Intent

The "Clean Credentials" stage in the macOS Jenkins build fails when there is no GitHub HTTPS credential stored in the macOS Keychain. `git credential-osxkeychain erase` returns exit code 1 with "failed to erase: -1" (meaning "item not found"), which causes the entire build to abort.

Related Jenkins issue: https://issues.jenkins.io/browse/JENKINS-62249

### Approach

Append `|| true` to the `git credential-osxkeychain erase` command so that a missing credential is not treated as a fatal error. This preserves the intended behavior (clearing stale credentials when they exist) while allowing the build to continue when the keychain has no matching entry.

### Automated Tests

N/A — this is a one-line Jenkins pipeline change.

### QA Notes

N/A — CI-only change.

### Documentation

No documentation changes needed.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests