### PR TITLE
Rename allow-posit-assistant to allow-posit-ai

### DIFF
--- a/docs/user/rstudio/ide/guide/tools/posit-ai.qmd
+++ b/docs/user/rstudio/ide/guide/tools/posit-ai.qmd
@@ -16,7 +16,7 @@ date-meta: 2026-02-25
 With Workbench, a system administrator must first enable Posit AI. To enable it, add the following line:
 
 ```         
-allow-posit-assistant=1
+allow-posit-ai=1
 ```
 
 to `/etc/rstudio/rsession.conf`.

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -524,7 +524,7 @@ void handleClientInit(const boost::function<void()>& initFunction,
    sessionInfo["allow_file_upload"] = options.allowFileUploads();
    sessionInfo["allow_remove_public_folder"] = options.allowRemovePublicFolder();
    sessionInfo["allow_full_ui"] = options.allowFullUI();
-   sessionInfo["posit_assistant_enabled"] = options.positAssistantEnabled() && options.allowPositAssistant();
+   sessionInfo["posit_ai_enabled"] = options.positAssistantEnabled() && options.allowPositAi();
    sessionInfo["websocket_ping_interval"] = options.webSocketPingInterval();
    sessionInfo["websocket_connect_timeout"] = options.webSocketConnectTimeout();
 

--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -317,9 +317,9 @@ protected:
       ("allow-copilot",
       value<bool>(&allowCopilot_)->default_value(true),
       "Indicates whether or not to allow use of Copilot-related features.")
-      ("allow-posit-assistant",
-      value<bool>(&allowPositAssistant_)->default_value(false),
-      "Indicates whether or not to allow use of the Posit AI assistant feature.");
+      ("allow-posit-ai",
+      value<bool>(&allowPositAi_)->default_value(false),
+      "Indicates whether or not to allow use of Posit AI features.");
 
    pR->add_options()
       ("r-core-source",
@@ -587,7 +587,7 @@ public:
    bool allowOverLimitSessions() const { return allowOverLimitSessions_ || allowOverlay(); }
    int abortFreeMemPercent() const { return abortFreeMemPercent_ || allowOverlay(); }
    bool allowCopilot() const { return allowCopilot_ || allowOverlay(); }
-   bool allowPositAssistant() const { return allowPositAssistant_ || allowOverlay(); }
+   bool allowPositAi() const { return allowPositAi_ || allowOverlay(); }
    core::FilePath coreRSourcePath() const { return core::FilePath(coreRSourcePath_); }
    core::FilePath modulesRSourcePath() const { return core::FilePath(modulesRSourcePath_); }
    core::FilePath sessionLibraryPath() const { return core::FilePath(sessionLibraryPath_); }
@@ -720,7 +720,7 @@ protected:
    bool allowOverLimitSessions_;
    int abortFreeMemPercent_;
    bool allowCopilot_;
-   bool allowPositAssistant_;
+   bool allowPositAi_;
    std::string coreRSourcePath_;
    std::string modulesRSourcePath_;
    std::string sessionLibraryPath_;

--- a/src/cpp/session/modules/SessionAssistant.cpp
+++ b/src/cpp/session/modules/SessionAssistant.cpp
@@ -97,7 +97,7 @@ bool isCopilotAllowedByAdmin()
 bool isPositAssistantAllowedByAdmin()
 {
    return
-      session::options().allowPositAssistant() &&
+      session::options().allowPositAi() &&
       session::options().positAssistantEnabled();
 }
 

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -190,11 +190,11 @@ bool peerHasCapability(const std::string& method)
 // Feature availability helper
 // ============================================================================
 // Returns true if the Posit AI feature is enabled. This requires:
-// 1. The allow-posit-assistant admin option (always true in open-source, configurable in Pro)
+// 1. The allow-posit-ai admin option (always true in open-source, configurable in Pro)
 // 2. The posit-assistant-enabled session option
 bool isPaiEnabled()
 {
-   return options().allowPositAssistant() && options().positAssistantEnabled();
+   return options().allowPositAi() && options().positAssistantEnabled();
 }
 
 // Returns true if the user has selected Posit AI as their assistant (for code completions)

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -594,11 +594,11 @@
             "description": "Indicates whether or not to allow use of Copilot-related features."
          },
          {
-            "name": "allow-posit-assistant",
+            "name": "allow-posit-ai",
             "type": "bool",
-            "memberName": "allowPositAssistant_",
+            "memberName": "allowPositAi_",
             "defaultValue": false,
-            "description": "Indicates whether or not to allow use of the Posit AI assistant feature."
+            "description": "Indicates whether or not to allow use of Posit AI features."
          }
       ],
       "r": [

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -432,8 +432,8 @@ public class SessionInfo extends JavaScriptObject
       return this.allow_full_ui;
    }-*/;
 
-   public final native boolean getPositAssistantEnabled() /*-{
-      return this.posit_assistant_enabled;
+   public final native boolean getPositAiEnabled() /*-{
+      return this.posit_ai_enabled;
    }-*/;
 
    public final native int getWebSocketPingInterval() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/PaiUtil.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/PaiUtil.java
@@ -63,7 +63,7 @@ public class PaiUtil
     */
    public boolean isPaiEnabled()
    {
-      return session_.getSessionInfo().getPositAssistantEnabled();
+      return session_.getSessionInfo().getPositAiEnabled();
    }
 
    /**


### PR DESCRIPTION
## Intent

Addresses #17265.

## Summary

- Renames the `allow-posit-assistant` session option to `allow-posit-ai` across the schema, generated header, C++ callers, GWT frontend, and documentation.
- The option gates all Posit AI features (chat and Next Edit Suggestions), not just the assistant. The new name accurately reflects its scope.
- No backward compatibility alias is needed since the feature has not yet shipped.

## Test plan

- [ ] Verify `Rscript scripts/generate-options.R` succeeds
- [ ] Verify `rg "allow.posit.assistant|allowPositAssistant|posit_assistant_enabled"` returns zero matches
- [ ] Verify `cd src/gwt && ant javac` compiles without errors
- [ ] Verify Posit AI features appear (in Workbench) with `allow-posit-ai=1` in `rsession.conf`