### PR TITLE
Add RSTUDIO_DISABLE_POSIT_AI environment variable

### DIFF
--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -524,7 +524,9 @@ void handleClientInit(const boost::function<void()>& initFunction,
    sessionInfo["allow_file_upload"] = options.allowFileUploads();
    sessionInfo["allow_remove_public_folder"] = options.allowRemovePublicFolder();
    sessionInfo["allow_full_ui"] = options.allowFullUI();
-   sessionInfo["posit_ai_enabled"] = options.positAssistantEnabled() && options.allowPositAi();
+   sessionInfo["posit_ai_enabled"] = options.positAssistantEnabled() &&
+      options.allowPositAi() &&
+      core::system::getenv("RSTUDIO_DISABLE_POSIT_AI").empty();
    sessionInfo["websocket_ping_interval"] = options.webSocketPingInterval();
    sessionInfo["websocket_connect_timeout"] = options.webSocketConnectTimeout();
 

--- a/src/cpp/session/modules/SessionAssistant.cpp
+++ b/src/cpp/session/modules/SessionAssistant.cpp
@@ -98,7 +98,8 @@ bool isPositAssistantAllowedByAdmin()
 {
    return
       session::options().allowPositAi() &&
-      session::options().positAssistantEnabled();
+      session::options().positAssistantEnabled() &&
+      core::system::getenv("RSTUDIO_DISABLE_POSIT_AI").empty();
 }
 
 struct AssistantRequest

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -194,7 +194,9 @@ bool peerHasCapability(const std::string& method)
 // 2. The posit-assistant-enabled session option
 bool isPaiEnabled()
 {
-   return options().allowPositAi() && options().positAssistantEnabled();
+   return options().allowPositAi() &&
+          options().positAssistantEnabled() &&
+          core::system::getenv("RSTUDIO_DISABLE_POSIT_AI").empty();
 }
 
 // Returns true if the user has selected Posit AI as their assistant (for code completions)


### PR DESCRIPTION
## Intent

Addresses #17234.

## Summary

- Add `RSTUDIO_DISABLE_POSIT_AI` environment variable so open-source RStudio users and administrators can disable all Posit AI features on both Desktop and Server editions
- When set (any value), produces the same behavior as `allow-posit-ai=false` in RStudio Pro: hides the chat pane, removes Posit AI from assistant preferences, and resets related user preferences
- Follows the existing `RSTUDIO_DISABLE_*` convention (`RSTUDIO_DISABLE_PUBLISH`, `RSTUDIO_DISABLE_PACKAGES`, etc.)

## Test plan

- [ ] Set `RSTUDIO_DISABLE_POSIT_AI=1`, launch RStudio, verify chat pane is hidden and Posit AI is absent from assistant preferences
- [ ] Unset the env var, launch RStudio, verify all Posit AI features are visible
- [ ] Verify the env var works on both Desktop and Server editions