### PR TITLE
Fixed crash in rare case for user preferences change

### DIFF
--- a/src/cpp/session/prefs/UserPrefsLayer.cpp
+++ b/src/cpp/session/prefs/UserPrefsLayer.cpp
@@ -100,7 +100,7 @@ void UserPrefsLayer::onPrefsFileChanged()
 
       bool existsInNew = itNew != cacheNew.end();
       bool isNew = itOld == cacheOld.end();
-      bool isChanged = !isNew && !((*itOld).getValue() == (*itNew).getValue());
+      bool isChanged = !isNew && existsInNew && !((*itOld).getValue() == (*itNew).getValue());
 
       if (existsInNew && (isNew || isChanged))
       {

--- a/src/cpp/session/prefs/UserPrefsProjectLayer.cpp
+++ b/src/cpp/session/prefs/UserPrefsProjectLayer.cpp
@@ -126,7 +126,7 @@ void UserPrefsProjectLayer::onPrefsFileChanged()
 
       bool existsInNew = itNew != cacheNew.end();
       bool isNew = itOld == cacheOld.end();
-      bool isChanged = !isNew && !((*itOld).getValue() == (*itNew).getValue());
+      bool isChanged = !isNew && existsInNew && !((*itOld).getValue() == (*itNew).getValue());
 
       if (existsInNew && (isNew || isChanged))
       {


### PR DESCRIPTION
If a pref key that existed before gets removed from the prefs file it would crash.

### Intent

Addresses: https://github.com/rstudio/rstudio-pro/issues/10369

### Approach

For some reason, workbench hits this case intermittently so guard to be sure the new entry exists before accessing it.


