### PR TITLE
Fix theme propagation in popped-out chat satellite window

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatSatelliteWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatSatelliteWindow.java
@@ -19,6 +19,7 @@ import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.SessionSerializationEvent;
+import org.rstudio.studio.client.application.events.ThemeChangedEvent;
 import org.rstudio.studio.client.application.model.SessionSerializationAction;
 import org.rstudio.studio.client.common.satellite.SatelliteWindow;
 import org.rstudio.studio.client.workbench.commands.Commands;
@@ -184,6 +185,30 @@ public class ChatSatelliteWindow extends SatelliteWindow
    public boolean supportsThemes()
    {
       return true;
+   }
+
+   @Override
+   public void onThemeChanged(ThemeChangedEvent event)
+   {
+      // Apply theme to satellite document (toolbar, etc.)
+      super.onThemeChanged(event);
+
+      // Clear color cache and re-inject variables into the chat iframe.
+      // This mirrors ChatPane's ThemeChangedEvent handler: calling
+      // injectThemeVariables() directly ensures CSS variables are updated
+      // regardless of the isEligibleForCustomStyles() check inside
+      // RStudioThemedFrame.addThemesStyle().
+      ThemeColorExtractor.clearCache();
+      if (frame_ != null)
+      {
+         frame_.injectThemeVariables();
+      }
+
+      // Update suspended overlay color for new theme
+      if (suspendedOverlay_ != null)
+      {
+         updateSuspendedOverlayStyle();
+      }
    }
 
    @Override


### PR DESCRIPTION
## Intent

Addresses https://github.com/rstudio/rstudio/issues/17220.

## Summary

- Override `onThemeChanged()` in `ChatSatelliteWindow` to clear the `ThemeColorExtractor` cache and re-inject CSS theme variables into the chat iframe when the editor theme changes
- This mirrors the existing handler in `ChatPane`, which calls `injectThemeVariables()` directly to ensure CSS variables are updated

## Background

When the chat pane is popped out into a satellite window, changing the editor theme did not update the chat iframe's theming. The satellite window relied on `RStudioThemedFrame`'s built-in theme handler, which goes through `addThemesStyle()` but does not clear the `ThemeColorExtractor` color cache first. `ChatPane` (main window) has its own explicit handler that clears the cache and calls `injectThemeVariables()` directly, which is why theming worked correctly in the main pane.

## Test plan

- Start RStudio Desktop with default layout and theme (Textmate)
- Show the sidebar and pop out the Posit Assistant into a separate window
- Tools > Global Options > Appearance: Choose a different editor theme (e.g. "Cobalt") and click OK
- Verify the separate window's chat UI updates its colors to match the new theme
- Return chat to main window and verify theming still works correctly