### PR TITLE
Fix theme changes not propagating to satellite windows

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteWindow.java
@@ -68,7 +68,7 @@ public abstract class SatelliteWindow extends Composite
       ElementIds.assignElementId(mainPanel_.getElement(), ElementIds.SATELLITE_PANEL);
 
       // Register an event handler for themes so it will be triggered after a
-      // UIPrefsChangedEvent updates the theme. Do this after SessionInit (if we
+      // UserPrefsChangedEvent updates the theme. Do this after SessionInit (if we
       // do it beforehand we'll trigger the event before the SessionInfo object
       // arrives with the theme settings)
       pEventBus.get().addHandler(SessionInitEvent.TYPE, (evt) ->
@@ -79,7 +79,8 @@ public abstract class SatelliteWindow extends Composite
          // Use UserState.theme() as the authoritative trigger for editor
          // theme changes rather than UserPrefs.editorTheme(). The
          // preferences dialog dispatches UserPrefsChangedEvent before
-         // state_.writeState() completes (PreferencesDialog.doSaveChanges),
+         // the setUserPrefs callback invokes state_.writeState()
+         // (PreferencesDialog.doSaveChanges),
          // so an editorTheme() binding would fire ThemeChangedEvent while
          // UserState.theme() still holds the previous value, causing
          // RStudioThemes.initializeThemes() to read stale state.


### PR DESCRIPTION
## Intent

Addresses #17220.

## Summary

- Replace the `editorTheme()` pref binding in `SatelliteWindow` with a `UserState.theme()` binding so that `ThemeChangedEvent` fires after the authoritative theme value has been updated

The preferences dialog dispatches `UserPrefsChangedEvent` to satellites synchronously before `state_.writeState()` completes. The `editorTheme()` pref binding fired `ThemeChangedEvent` immediately, but `UserState.theme()` still held the previous value at that point, so `RStudioThemes.initializeThemes()` read stale state and satellite CSS classes were never updated to reflect the new theme.

Binding to `UserState.theme()` instead ensures `ThemeChangedEvent` fires once the theme value is current. The `globalTheme()` binding is kept separately for UI chrome changes.

This affects all satellite windows (chat, source, chunks, etc.), not just the Posit Assistant.

## Test plan

- [ ] Open a source satellite window (pop out a source tab); change editor theme in Global Options > Appearance; verify the satellite updates
- [ ] Open the Posit Assistant in a satellite window; change editor theme; verify the satellite updates
- [ ] Verify theme changes still apply correctly in the main window
- [ ] BRAT automation test to follow in a separate PR