### PR TITLE
ensure libSegFault produces symbolic backtraces on crash

### DIFF
--- a/cmake/globals.cmake
+++ b/cmake/globals.cmake
@@ -455,7 +455,7 @@ macro(add_stripped_executable _target)
          # strip debug info
          add_custom_command(TARGET ${_target} POST_BUILD
                             COMMAND objcopy --only-keep-debug ${_target} ${_target}.debug
-                            COMMAND objcopy --strip-debug --strip-unneeded ${_target}
+                            COMMAND objcopy --strip-debug ${_target}
                             COMMAND objcopy --add-gnu-debuglink=${_target}.debug ${_target}
                             COMMENT "Stripping ${_target}")
       elseif(APPLE)

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -117,6 +117,10 @@ if(UNIX)
          add_definitions(-fstack-protector-strong)
       endif()
       set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -Wl,-z,relro,-z,now")
+
+      # export all symbols to the dynamic symbol table so that libSegFault
+      # (and glibc's backtrace()) can produce symbolic stack traces on crash
+      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -rdynamic")
    endif()
 
    # other useful gcc diagnostics


### PR DESCRIPTION
## Intent

Ensure that libSegFault produces usable stack traces when unit tests crash, rather than just a register dump with an empty backtrace.

## Summary

- Add `-rdynamic` to the Linux linker flags so all symbols are exported to the dynamic symbol table, enabling `backtrace()` to resolve function names
- Remove `--strip-unneeded` from the `objcopy` strip step in package builds, keeping only `--strip-debug`, so the dynamic symbol table survives stripping

Without these changes, libSegFault prints only a register dump followed by an empty "Backtrace:" section.

## Test plan

- [ ] Verify Linux package build still succeeds
- [ ] Confirm binary size increase is minimal (only the `.dynsym` table is retained, not DWARF debug info)
- [ ] Trigger a test crash and verify the backtrace now shows function names