### PR TITLE
skip inheritDotParams tests when system.Rd macros file is missing

### DIFF
--- a/src/cpp/tests/testthat/test-completions-inherit-dot-params.R
+++ b/src/cpp/tests/testthat/test-completions-inherit-dot-params.R
@@ -33,11 +33,25 @@ make_matched_call <- function(named_args = character()) {
    ))
 }
 
-fixture_rd <- tools::parse_Rd(
+has_system_rd_macros <- file.exists(
+   file.path(R.home("share"), "Rd", "macros", "system.Rd")
+)
+
+test_that <- function(desc, code) {
+   if (!has_system_rd_macros) {
+      testthat::test_that(desc, testthat::skip("system.Rd macros file not available"))
+      return(invisible(NULL))
+   }
+   call <- sys.call()
+   call[[1L]] <- quote(testthat::test_that)
+   eval(call, envir = parent.frame())
+}
+
+fixture_rd <- if (has_system_rd_macros) tools::parse_Rd(
    testthat::test_path("fixtures/wrapper-inheritDotParams.Rd")
 )
 
-fixture_rd_partial <- tools::parse_Rd(
+fixture_rd_partial <- if (has_system_rd_macros) tools::parse_Rd(
    testthat::test_path("fixtures/wrapper-inheritDotParams-partial.Rd")
 )
 


### PR DESCRIPTION
## Intent

`tools::parse_Rd()` requires the system macros file (`system.Rd`) to exist.
On minimal R installations where this file is absent, `parse_Rd()` segfaults
(signal 11), crashing the entire test suite.

This shadows `test_that()` within the file so that all tests are gracefully
skipped when the macros file is not available. The fixture Rd parsing at the
top level is also guarded.

## Test plan

- Verify tests pass normally on systems with a complete R installation
- Verify tests are skipped (not crashed) on systems missing `system.Rd`