### PR TITLE
Add missing libuv-devel to openSUSE 15 Docker build

### DIFF
--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -39,6 +39,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     libtool \
     libwebp-devel \
     libuuid-devel \
+    libuv-devel \
     libxml2-devel \
     lsof \
     make \


### PR DESCRIPTION
## Intent

Fixes the openSUSE 15 Docker build failure caused by a missing libuv dependency.

## Summary

- Add `libuv-devel` to the zypper install list in `docker/jenkins/Dockerfile.opensuse15`

## Test plan

- [ ] Verify the openSUSE 15 Docker image builds successfully