### PR TITLE
Dark theme support for New Connection Wizard dialog

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -216,6 +216,8 @@ public interface DesktopFrame extends JavaScriptPassthrough
 
    void setShinyDialogUrl(String url);
 
+   void injectShinyDialogCss(String css);
+
    void allowNavigation(String url, CommandWithArg<Boolean> callback);
 
    void setBusy(boolean busy);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionInstallOdbcHost.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionInstallOdbcHost.ui.xml
@@ -14,6 +14,16 @@
         border: solid 1px #9d9d9d;
         margin-top: 8px;
       }
+
+      @external rstudio-themes-dark;
+      @external rstudio-theme-aware-dialog;
+      @eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.darkGreyBorder;
+      @eval THEME_DARKGREY_INACTIVE org.rstudio.core.client.theme.ThemeColors.darkGreyInactiveBackground;
+
+      .rstudio-themes-dark.rstudio-theme-aware-dialog .console {
+         background: THEME_DARKGREY_INACTIVE;
+         border-color: THEME_DARKGREY_BORDER;
+      }
    </ui:style>
 
    <g:HTMLPanel stylePrimaryName="{style.panel}">

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.css
@@ -25,3 +25,11 @@
 .wizardPageWarningImage {
 
 }
+
+@external rstudio-themes-dark;
+@external rstudio-theme-aware-dialog;
+@eval THEME_DARKGREY_INACTIVE org.rstudio.core.client.theme.ThemeColors.darkGreyInactiveBackground;
+
+.rstudio-themes-dark.rstudio-theme-aware-dialog .wizardPageWarningPanel {
+   background: THEME_DARKGREY_INACTIVE;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionPreInstallOdbcHost.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionPreInstallOdbcHost.ui.xml
@@ -49,6 +49,16 @@
          overflow: hidden;
          width: 494px;
       }
+
+      @external rstudio-themes-dark;
+      @external rstudio-theme-aware-dialog;
+      @eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.darkGreyBorder;
+      @eval THEME_DARKGREY_INACTIVE org.rstudio.core.client.theme.ThemeColors.darkGreyInactiveBackground;
+
+      .rstudio-themes-dark.rstudio-theme-aware-dialog .warning {
+         border-color: THEME_DARKGREY_BORDER;
+         background: THEME_DARKGREY_INACTIVE;
+      }
    </ui:style>
 
    <g:HTMLPanel stylePrimaryName="{style.panel}">

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.css
@@ -2,9 +2,11 @@
 @external macintosh;
 
 @external rstudio-themes-dark;
+@external rstudio-theme-aware-dialog;
 @external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
 
 @eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.darkGreyBorder;
+@eval THEME_DARKGREY_MOST_INACTIVE org.rstudio.core.client.theme.ThemeColors.darkGreyMostInactiveBackground;
 
 .infoPanel {
    width: 500px;
@@ -38,16 +40,10 @@
    font-size: 9pt;
 }
 
-.codeViewer {
-   border: 1px solid #BBB !important;
-   background-color: #FFF;
-   width: 100% !important;
-   height: 75px !important;
-   font-size: 9pt;
-}
-
-.rstudio-themes-dark-grey .codeViewer {
+.rstudio-themes-dark-grey .codeViewer,
+.rstudio-themes-dark.rstudio-theme-aware-dialog .codeViewer {
    border: 1px solid THEME_DARKGREY_BORDER !important;
+   background-color: THEME_DARKGREY_MOST_INACTIVE;
 }
 
 .dialogCodePanel {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.java
@@ -35,6 +35,8 @@ import org.rstudio.studio.client.server.VoidResponse;
 import org.rstudio.studio.client.server.remote.RResult;
 import org.rstudio.studio.client.shiny.events.ShinyFrameNavigatedEvent;
 import org.rstudio.studio.client.shiny.model.ShinyApplicationParams;
+import org.rstudio.core.client.theme.ThemeColors;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.views.connections.ConnectionsConstants;
 import org.rstudio.studio.client.workbench.views.connections.events.NewConnectionDialogUpdatedEvent;
 import org.rstudio.studio.client.workbench.views.connections.model.ConnectionOptions;
@@ -43,7 +45,7 @@ import org.rstudio.studio.client.workbench.views.connections.model.NewConnection
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.StyleElement;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.dom.client.LoadEvent;
 import com.google.gwt.event.dom.client.LoadHandler;
 import com.google.gwt.resources.client.ClientBundle;
@@ -64,13 +66,15 @@ public class NewConnectionShinyHost extends Composite
                            GlobalDisplay globalDisplay,
                            ConnectionsServerOperations server,
                            ShinyServerOperations shinyServer,
-                           DependencyManager dependencyManager)
+                           DependencyManager dependencyManager,
+                           UserPrefs userPrefs)
    {
       events_ = events;
       globalDisplay_ = globalDisplay;
       server_ = server;
       shinyServer_ = shinyServer;
       dependencyManager_ = dependencyManager;
+      userPrefs_ = userPrefs;
    }
 
    public void onBeforeActivate(Operation operation, NewConnectionInfo info)
@@ -209,26 +213,87 @@ public class NewConnectionShinyHost extends Composite
       });
    }
 
+   private boolean isDialogDarkTheme()
+   {
+      boolean useDark = userPrefs_ != null &&
+         userPrefs_.useDarkThemeModalDialogs().getValue();
+      Element container = Document.get().getElementById("rstudio_container");
+      return useDark && container != null &&
+         container.hasClassName("rstudio-themes-dark");
+   }
+
+   private String buildCustomCss()
+   {
+      String css =
+         "body {\n" +
+         "  background: none;\n" +
+         "  font-family : \"Lucida Sans\", \"DejaVu Sans\", \"Lucida Grande\", \"Segoe UI\", Verdana, Helvetica, sans-serif;\n" +
+         "  font-size : 12px;\n" +
+         "  -ms-user-select : none;\n" +
+         "  -moz-user-select : none;\n" +
+         "  -webkit-user-select : none;\n" +
+         "  user-select : none;\n" +
+         "  margin: 0;\n" +
+         "  margin-top: 7px;\n" +
+         "}\n";
+
+      if (isDialogDarkTheme())
+      {
+         String bg = ThemeColors.darkDialogControlBackground;
+         String border = ThemeColors.darkGreyBorder;
+         String bgDeep = ThemeColors.darkGreyMostInactiveBackground;
+
+         css +=
+            "body, label, .control-label { color: #eee !important; }\n" +
+            "select, input[type=\"text\"], input[type=\"password\"], " +
+            "input[type=\"number\"], textarea, .form-control {\n" +
+            "  background-color: " + bg + " !important;\n" +
+            "  border-color: " + border + " !important;\n" +
+            "  color: #eee !important;\n" +
+            "}\n" +
+            "select option {\n" +
+            "  background-color: " + bg + ";\n" +
+            "  color: #eee;\n" +
+            "}\n" +
+            "select option:checked {\n" +
+            "  background-color: " + bgDeep + ";\n" +
+            "  color: #eee;\n" +
+            "}\n";
+      }
+
+      return css;
+   }
+
+   private native void injectCssIntoIFrame(Element iframe, String css) /*-{
+      try {
+         var doc = iframe.contentDocument || iframe.contentWindow.document;
+         var style = doc.createElement('style');
+         style.textContent = css;
+         (doc.head || doc.documentElement).appendChild(style);
+      } catch (e) {
+         // cross-origin iframe; styling is best-effort
+         $wnd.console.log('injectCssIntoIFrame: ' + e);
+      }
+   }-*/;
+
    private void appendStyle(RStudioFrame frame)
    {
-      Document document = frame.getWindow().getDocument();
-      
-      String customStyle = "\n" +
-      "body {\n" +
-      "  background: none;\n" +
-      "  font-family : \"Lucida Sans\", \"DejaVu Sans\", \"Lucida Grande\", \"Segoe UI\", Verdana, Helvetica, sans-serif;\n" +
-      "  font-size : 12px;\n" +
-      "  -ms-user-select : none;\n" +
-      "  -moz-user-select : none;\n" +
-      "  -webkit-user-select : none;\n" +
-      "  user-select : none;\n" +
-      "  margin: 0;\n" +
-      "  margin-top: 7px;\n" +
-      "}\n";
-      
-      StyleElement style = document.createStyleElement();
-      style.setInnerHTML(customStyle);
-      document.getHead().appendChild(style);
+      String css = buildCustomCss();
+
+      if (Desktop.hasDesktopFrame())
+      {
+         // In Desktop, the Shiny iframe is cross-origin (different port)
+         // so we cannot access its document directly. Use the Electron
+         // bridge to inject CSS via WebFrameMain.executeJavaScript().
+         Desktop.getFrame().injectShinyDialogCss(css);
+      }
+      else
+      {
+         // In Server, the iframe is same-origin (proxied). Use native
+         // JS to inject into the iframe's document context directly,
+         // ensuring the style element is created in the correct document.
+         injectCssIntoIFrame(frame.getIFrame(), css);
+      }
    }
 
    public ConnectionOptions collectInput()
@@ -293,5 +358,6 @@ public class NewConnectionShinyHost extends Composite
    private ConnectionsServerOperations server_;
    private ShinyServerOperations shinyServer_;
    private DependencyManager dependencyManager_;
+   private UserPrefs userPrefs_;
    private static final ConnectionsConstants constants_ = GWT.create(ConnectionsConstants.class);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetHost.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetHost.css
@@ -117,3 +117,13 @@
 .warningImage {
 
 }
+
+@external rstudio-themes-dark;
+@external rstudio-theme-aware-dialog;
+@eval THEME_DARKGREY_INACTIVE org.rstudio.core.client.theme.ThemeColors.darkGreyInactiveBackground;
+@eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.darkGreyBorder;
+
+.rstudio-themes-dark.rstudio-theme-aware-dialog .warningPanel {
+   background: THEME_DARKGREY_INACTIVE;
+   border-color: THEME_DARKGREY_BORDER;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionWizard.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionWizard.css
@@ -14,3 +14,15 @@
 @sprite .newConnectionWizardBackground {
    gwt-image: 'newConnectionWizardBackground';
 }
+
+@external rstudio-themes-dark;
+@external rstudio-theme-aware-dialog;
+@eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.darkGreyBorder;
+
+.rstudio-themes-dark.rstudio-theme-aware-dialog .wizardBodyPanel {
+   border-top-color: THEME_DARKGREY_BORDER;
+}
+
+.rstudio-themes-dark.rstudio-theme-aware-dialog .newConnectionWizardBackground {
+   background-image: none;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionWizard.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionWizard.java
@@ -70,6 +70,7 @@ public class NewConnectionWizard extends Wizard<NewConnectionContext, Connection
          false,
          true);
       setHelpLink(mainHelpLink_);
+      setThemeAware(true);
 
       RStudioGinjector.INSTANCE.injectMembers(this);
    }

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -102,6 +102,7 @@ export class DesktopBrowserWindow extends EventEmitter {
   tutorialUrl: string | undefined;
   presentationUrl: string | undefined;
   shinyDialogUrl: string | undefined;
+  shinyDialogFullUrl: string | undefined;
   mainWindow?: MainWindow;
 
   // debouncing due to https://github.com/rstudio/rstudio/issues/13027
@@ -523,6 +524,43 @@ export class DesktopBrowserWindow extends EventEmitter {
     }
 
     this.shinyDialogUrl = getAuthority(shinyDialogUrl);
+    this.shinyDialogFullUrl = makeAbsoluteUrl(shinyDialogUrl).toString();
+  }
+
+  injectShinyDialogCss(css: string): void {
+    if (!this.shinyDialogFullUrl) return;
+
+    let shinyOriginPath: string;
+    try {
+      const parsed = new URL(this.shinyDialogFullUrl);
+      shinyOriginPath = (parsed.origin + parsed.pathname).replace(/\/+$/, '');
+    } catch {
+      return;
+    }
+
+    for (const frame of this.window.webContents.mainFrame.framesInSubtree) {
+      let frameOriginPath: string;
+      try {
+        const parsed = new URL(frame.url);
+        frameOriginPath = (parsed.origin + parsed.pathname).replace(/\/+$/, '');
+      } catch {
+        continue;
+      }
+      if (frameOriginPath === shinyOriginPath) {
+        frame
+          .executeJavaScript(
+            `(function() {
+              var s = document.createElement('style');
+              s.textContent = ${JSON.stringify(css)};
+              document.head.appendChild(s);
+            })();`,
+          )
+          .catch(() => {
+            // frame may have navigated away
+          });
+        break;
+      }
+    }
   }
 
   getBaseUrl(): string {

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -953,6 +953,10 @@ export class GwtCallback extends EventEmitter {
       this.getSender('desktop_set_shiny_dialog_url', event.processId, event.frameId).setShinyDialogUrl(url);
     });
 
+    ipcMain.on('desktop_inject_shiny_dialog_css', (event, css) => {
+      this.getSender('desktop_inject_shiny_dialog_css', event.processId, event.frameId).injectShinyDialogCss(css);
+    });
+
     ipcMain.handle('desktop_allow_navigation', (event, url) => {
       return this.getSender('desktop_allow_navigation', event.processId, event.frameId).allowNavigation(url);
     });

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -610,6 +610,10 @@ export function getDesktopBridge() {
       ipcRenderer.send('desktop_set_shiny_dialog_url', url);
     },
 
+    injectShinyDialogCss: (css: string) => {
+      ipcRenderer.send('desktop_inject_shiny_dialog_css', css);
+    },
+
     allowNavigation: (url: string, callback: VoidCallback<boolean>) => {
       ipcRenderer
         .invoke('desktop_allow_navigation', url)


### PR DESCRIPTION
## Intent

Additional work on https://github.com/rstudio/rstudio/issues/10296

Adds dark theme support for the New Connection Wizard dialog and all its sub-pages.

## Summary

**GWT changes:**
- Call `setThemeAware(true)` in `NewConnectionWizard` constructor
- Add dark CSS overrides for the wizard body panel border, warning panels, code viewer, ODBC console/pre-install areas
- Remove `newConnectionWizardBackground` sprite image in dark mode — all connection pages override `getWizardPageBackgroundStyle()` with this custom sprite, which was not covered by the base `Wizard.css` dark override
- Remove duplicate `.codeViewer` CSS block in `NewConnectionShinyHost.css`

**Shiny iframe dark mode (Spark Connection, etc.):**
- Inject dark-mode CSS into the Shiny mini-UI iframe for labels, form controls, and select option elements
- In Server, use native JSNI to inject styles into the same-origin iframe document
- In Desktop, add an Electron bridge method (`injectShinyDialogCss`) that uses `WebFrameMain.executeJavaScript()` to inject CSS into cross-origin iframes, matching the Shiny dialog frame by its full URL

## Example Screenshots

<img width="545" height="429" alt="01-livy-connection-light" src="https://github.com/user-attachments/assets/fa1d38da-a88c-4d27-87ba-af1b9cae3fff" />
<img width="549" height="432" alt="02-livy-connection-dark" src="https://github.com/user-attachments/assets/6bea5a2f-767a-4ba9-bc66-0e00eca90981" />
<img width="545" height="429" alt="03-new-connection-light" src="https://github.com/user-attachments/assets/6d66cf5e-23bb-4736-9a97-2215a2702334" />
<img width="551" height="429" alt="04-new-connection-dark" src="https://github.com/user-attachments/assets/4aefc7a1-774b-45fa-814c-3fedd9ce259c" />
<img width="547" height="430" alt="05-spark-connection-light" src="https://github.com/user-attachments/assets/3de7da3b-8c83-4a91-a403-757e3b07bf31" />
<img width="547" height="434" alt="06-spark-connection-dark" src="https://github.com/user-attachments/assets/6b595a4f-3289-4e96-bd66-5ee1d53c625a" />


## Test plan

- [ ] Open New Connection wizard with a dark editor theme enabled
- [ ] Verify connection selector page: items have dark backgrounds, arrows visible
- [ ] Navigate to a Snippet connection (e.g., Livy): text inputs dark, code viewer dark
- [ ] Navigate to a Shiny connection (e.g., Spark): labels readable, form controls dark (Desktop)
- [ ] Navigate to ODBC install/pre-install pages if available: console and warning areas dark
- [ ] Verify all above also look correct with a light editor theme (no regressions)