### PR TITLE
Add getAllLevelValues/getAllCompoundLevelValues to ConfigProfile

### DIFF
--- a/src/cpp/core/ConfigProfile.cpp
+++ b/src/cpp/core/ConfigProfile.cpp
@@ -163,12 +163,16 @@ Error ConfigProfile::parseString(const std::string& profileStr)
       compoundLevels.push_back({{matchingLevel.get().first, levelValue}, compoundValues});
    }
 
-   // stable sort the levels in ascending level number
+   // stable sort both levels vectors in ascending level number
    // this will preserve the order of same-level section overrides
    std::stable_sort(
             levels.begin(),
             levels.end(),
             [](const LevelValues& a, const LevelValues& b) { return a.first.first < b.first.first; });
+   std::stable_sort(
+            compoundLevels.begin(),
+            compoundLevels.end(),
+            [](const LevelCompoundValues& a, const LevelCompoundValues& b) { return a.first.first < b.first.first; });
 
    // assign the temporary variable levels to the class member
    // this assures that we can safely call this method multiple times, preserving the last

--- a/src/cpp/core/ConfigProfileTests.cpp
+++ b/src/cpp/core/ConfigProfileTests.cpp
@@ -440,6 +440,235 @@ TEST(ConfigProfileTest, CanParseTwoLevelCompoundValue)
 }
 
 
+TEST(ConfigProfileTest, GetAllLevelValues)
+{
+   // Profile with all three levels; max-cpus set at global and group but not at user level.
+   // @everyone and bob have a different param set (max-mem-mb) so the section is present in
+   // levels_ but max-cpus is absent → getAllLevelValues should return nullopt for those levels.
+   // Note: Boost's read_ini silently drops completely empty sections, so we must have at least
+   // one param in each section to ensure it is retained.
+   std::string profileStr = R"([*]
+          max-cpus=4.0
+
+          [@scientists]
+          max-cpus=8.0
+
+          [@everyone]
+          max-mem-mb=100.0
+
+          [alice]
+          max-cpus=2.0
+
+          [bob]
+          max-mem-mb=200.0)";
+
+   ConfigProfile profile;
+   profile.addSections({{0, "*"}, {1, "@"}, {2, std::string()}});
+   profile.addParams("max-cpus", 0.0, "max-mem-mb", 0.0);
+
+   Error error = profile.parseString(profileStr);
+   ASSERT_FALSE(error);
+
+   // alice in scientists: global=4, scientists=8, everyone=nullopt, user=2
+   // Order: global, groups (scientists, everyone), user
+   {
+      std::vector<std::optional<double>> values;
+      error = profile.getAllLevelValues("max-cpus", &values,
+                                        {{0, std::string()}, {1, "scientists"}, {1, "everyone"}, {2, "alice"}});
+      ASSERT_FALSE(error);
+      ASSERT_EQ(4u, values.size());
+      ASSERT_TRUE(values[0].has_value());  ASSERT_EQ(4.0, *values[0]);   // global
+      ASSERT_TRUE(values[1].has_value());  ASSERT_EQ(8.0, *values[1]);   // @scientists
+      ASSERT_FALSE(values[2].has_value());                                // @everyone: section present, param not set
+      ASSERT_TRUE(values[3].has_value());  ASSERT_EQ(2.0, *values[3]);   // alice
+   }
+
+   // bob in scientists: global=4, scientists=8, bob section present but max-cpus not set
+   {
+      std::vector<std::optional<double>> values;
+      error = profile.getAllLevelValues("max-cpus", &values,
+                                        {{0, std::string()}, {1, "scientists"}, {2, "bob"}});
+      ASSERT_FALSE(error);
+      ASSERT_EQ(3u, values.size());
+      ASSERT_TRUE(values[0].has_value());  ASSERT_EQ(4.0, *values[0]);
+      ASSERT_TRUE(values[1].has_value());  ASSERT_EQ(8.0, *values[1]);
+      ASSERT_FALSE(values[2].has_value());  // bob section present, param not set
+   }
+
+   // absent section (no config block) is omitted entirely
+   {
+      std::vector<std::optional<double>> values;
+      error = profile.getAllLevelValues("max-cpus", &values,
+                                        {{0, std::string()}, {2, "charlie"}});  // charlie has no section
+      ASSERT_FALSE(error);
+      ASSERT_EQ(1u, values.size());  // only global; charlie's absent section is omitted
+      ASSERT_TRUE(values[0].has_value());  ASSERT_EQ(4.0, *values[0]);
+   }
+
+   // unregistered param returns error
+   {
+      std::vector<std::optional<double>> values;
+      error = profile.getAllLevelValues("nonexistent", &values, {{0, std::string()}});
+      ASSERT_TRUE(error);
+   }
+
+   // bad value (non-numeric string where double expected) returns error
+   {
+      ConfigProfile badProfile;
+      badProfile.addSections({{0, "*"}, {2, std::string()}});
+      badProfile.addParams("max-cpus", 0.0);
+
+      Error parseError = badProfile.parseString("[*]\nmax-cpus=not-a-number\n");
+      ASSERT_FALSE(parseError);
+
+      std::vector<std::optional<double>> values;
+      error = badProfile.getAllLevelValues("max-cpus", &values, {{0, std::string()}});
+      ASSERT_TRUE(error);
+      // getMessage() returns the system error string ("Invalid argument"), not our description.
+      // The custom message with context is stored as the "description" property.
+      EXPECT_NE(std::string::npos, error.getProperty("description").find("not-a-number"));
+      EXPECT_NE(std::string::npos, error.getProperty("description").find("max-cpus"));
+   }
+}
+
+TEST(ConfigProfileTest, GetAllLevelValuesOutOfOrder)
+{
+   // Sections listed in reverse level order (user first, then group, then global).
+   // getAllLevelValues must still return values in ascending level order
+   // regardless of the order sections appear in the INI string.
+   std::string profileStr = R"([alice]
+          max-cpus=2.0
+
+          [@scientists]
+          max-cpus=8.0
+
+          [*]
+          max-cpus=4.0)";
+
+   ConfigProfile profile;
+   profile.addSections({{0, "*"}, {1, "@"}, {2, std::string()}});
+   profile.addParams("max-cpus", 0.0);
+
+   Error error = profile.parseString(profileStr);
+   ASSERT_FALSE(error);
+
+   std::vector<std::optional<double>> values;
+   error = profile.getAllLevelValues("max-cpus", &values,
+                                    {{0, std::string()}, {1, "scientists"}, {2, "alice"}});
+   ASSERT_FALSE(error);
+   ASSERT_EQ(3u, values.size());
+   // Output must be in ascending level order: global (0), group (1), user (2)
+   ASSERT_TRUE(values[0].has_value());  ASSERT_EQ(4.0, *values[0]);  // global — level 0
+   ASSERT_TRUE(values[1].has_value());  ASSERT_EQ(8.0, *values[1]);  // @scientists — level 1
+   ASSERT_TRUE(values[2].has_value());  ASSERT_EQ(2.0, *values[2]);  // alice — level 2
+}
+
+TEST(ConfigProfileTest, GetAllCompoundLevelValues)
+{
+   // @everyone and bob have a simple param (max-cpus) rather than the compound param so the
+   // section is retained by the INI parser but constraints is absent → nullopt.
+   std::string profileStr = R"([*]
+          constraints/cpu=x86
+
+          [@scientists]
+          constraints/gpu=nvidia
+
+          [@everyone]
+          max-cpus=5.0
+
+          [alice]
+          constraints/node=gpu-node
+
+          [bob]
+          max-cpus=10.0)";
+
+   ConfigProfile profile;
+   profile.addSections({{0, "*"}, {1, "@"}, {2, std::string()}});
+   profile.addParams("constraints", ConfigProfile::ValuesMap{}, "max-cpus", 0.0);
+
+   Error error = profile.parseString(profileStr);
+   ASSERT_FALSE(error);
+
+   // alice in scientists: global, scientists, everyone (no compound), alice
+   {
+      std::vector<std::optional<ConfigProfile::ValuesMap>> values;
+      error = profile.getAllCompoundLevelValues("constraints", &values,
+                                               {{0, std::string()}, {1, "scientists"}, {1, "everyone"}, {2, "alice"}});
+      ASSERT_FALSE(error);
+      ASSERT_EQ(4u, values.size());
+      ASSERT_TRUE(values[0].has_value());
+      ASSERT_EQ("x86", (*values[0]).at("cpu"));   // global
+      ASSERT_TRUE(values[1].has_value());
+      ASSERT_EQ("nvidia", (*values[1]).at("gpu")); // @scientists
+      ASSERT_FALSE(values[2].has_value());          // @everyone: section present, compound param not set
+      ASSERT_TRUE(values[3].has_value());
+      ASSERT_EQ("gpu-node", (*values[3]).at("node")); // alice
+   }
+
+   // bob: global, bob section present but compound param not set
+   {
+      std::vector<std::optional<ConfigProfile::ValuesMap>> values;
+      error = profile.getAllCompoundLevelValues("constraints", &values,
+                                               {{0, std::string()}, {2, "bob"}});
+      ASSERT_FALSE(error);
+      ASSERT_EQ(2u, values.size());
+      ASSERT_TRUE(values[0].has_value());
+      ASSERT_FALSE(values[1].has_value());  // bob section present, param not set
+   }
+
+   // charlie has no section — absent section omitted
+   {
+      std::vector<std::optional<ConfigProfile::ValuesMap>> values;
+      error = profile.getAllCompoundLevelValues("constraints", &values,
+                                               {{0, std::string()}, {2, "charlie"}});
+      ASSERT_FALSE(error);
+      ASSERT_EQ(1u, values.size());
+      ASSERT_TRUE(values[0].has_value());
+   }
+
+   // unregistered param returns error
+   {
+      std::vector<std::optional<ConfigProfile::ValuesMap>> values;
+      error = profile.getAllCompoundLevelValues("nonexistent", &values, {{0, std::string()}});
+      ASSERT_TRUE(error);
+   }
+}
+
+TEST(ConfigProfileTest, GetAllCompoundLevelValuesOutOfOrder)
+{
+   // Sections listed in reverse level order (user first, then group, then global).
+   // getAllCompoundLevelValues must still return values in ascending level order
+   // regardless of the order sections appear in the INI string.
+   std::string profileStr = R"([alice]
+          constraints/node=gpu-node
+
+          [@scientists]
+          constraints/gpu=nvidia
+
+          [*]
+          constraints/cpu=x86)";
+
+   ConfigProfile profile;
+   profile.addSections({{0, "*"}, {1, "@"}, {2, std::string()}});
+   profile.addParams("constraints", ConfigProfile::ValuesMap{});
+
+   Error error = profile.parseString(profileStr);
+   ASSERT_FALSE(error);
+
+   std::vector<std::optional<ConfigProfile::ValuesMap>> values;
+   error = profile.getAllCompoundLevelValues("constraints", &values,
+                                            {{0, std::string()}, {1, "scientists"}, {2, "alice"}});
+   ASSERT_FALSE(error);
+   ASSERT_EQ(3u, values.size());
+   // Output must be in ascending level order: global (0), group (1), user (2)
+   ASSERT_TRUE(values[0].has_value());
+   ASSERT_EQ("x86",      (*values[0]).at("cpu"));   // global — level 0
+   ASSERT_TRUE(values[1].has_value());
+   ASSERT_EQ("nvidia",   (*values[1]).at("gpu"));   // @scientists — level 1
+   ASSERT_TRUE(values[2].has_value());
+   ASSERT_EQ("gpu-node", (*values[2]).at("node"));  // alice — level 2
+}
+
 } // namespace tests
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/include/core/ConfigProfile.hpp
+++ b/src/cpp/core/include/core/ConfigProfile.hpp
@@ -17,6 +17,7 @@
 #define CORE_CONFIG_PROFILE_HPP
 
 #include <map>
+#include <optional>
 
 #include <boost/any.hpp>
 #include <boost/function.hpp>
@@ -133,11 +134,106 @@ public:
                   catch (const boost::bad_lexical_cast&)
                   {
                      return systemError(boost::system::errc::invalid_argument,
-                                        "Invalid type requested for param " + paramName,
+                                        "Invalid value '" + iter->second + "' for param " + paramName,
                                         ERROR_LOCATION);
                   }
                }
             }
+         }
+      }
+
+      return Success();
+   }
+
+   // Returns the explicitly-set value (or nullopt) for each matched config section, in
+   // level-ascending order (global -> groups in config order -> user). Absent sections
+   // (no config block for this level) are omitted entirely. Present sections where the
+   // param is not set emit nullopt.
+   //
+   // Output order follows the order levels appear in levels_ (established by parseString),
+   // not the order of the `levels` filter parameter passed by the caller.
+   template <typename T>
+   core::Error getAllLevelValues(const std::string& paramName,
+                                 std::vector<std::optional<T>>* pValues,
+                                 const std::vector<Level>& levelFilter) const
+   {
+      DefaultParamValuesMap::const_iterator defaultValuesIter = defaultValues_.find(paramName);
+      if (defaultValuesIter == defaultValues_.end())
+      {
+         return systemError(boost::system::errc::invalid_argument,
+                            "Parameter '" + paramName + "' not found in registered params",
+                            ERROR_LOCATION);
+      }
+
+      pValues->clear();
+
+      // levels_ is already sorted ascending by parseString
+      for (const LevelValues& configLevel : levels_)
+      {
+         bool matches = std::any_of(levelFilter.begin(), levelFilter.end(),
+                                    [&configLevel](const Level& l) { return l == configLevel.first; });
+         if (!matches)
+            continue;
+
+         ValuesMap::const_iterator iter = configLevel.second.find(paramName);
+         if (iter == configLevel.second.end())
+         {
+            pValues->push_back(std::nullopt);
+         }
+         else
+         {
+            try
+            {
+               pValues->push_back(boost::lexical_cast<T>(iter->second));
+            }
+            catch (const boost::bad_lexical_cast&)
+            {
+               return systemError(boost::system::errc::invalid_argument,
+                                  "Invalid value '" + iter->second + "' for param " + paramName,
+                                  ERROR_LOCATION);
+            }
+         }
+      }
+
+      return Success();
+   }
+
+   // Returns the explicitly-set ValuesMap (or nullopt) for each matched config section,
+   // in level-ascending order (global -> groups in config order -> user). Absent sections
+   // (no config block for this level) are omitted entirely. Present sections where the
+   // compound param is not set emit nullopt. Mirrors getAllLevelValues but for compound
+   // params stored in compoundLevels_. Compound param values are always raw strings;
+   // callers perform any type conversion on the individual map entries.
+   core::Error getAllCompoundLevelValues(const std::string& paramName,
+                                        std::vector<std::optional<ValuesMap>>* pValues,
+                                        const std::vector<Level>& levelFilter) const
+   {
+      DefaultParamValuesMap::const_iterator defaultValuesIter = defaultValues_.find(paramName);
+      if (defaultValuesIter == defaultValues_.end())
+      {
+         return systemError(boost::system::errc::invalid_argument,
+                            "Parameter '" + paramName + "' not found in registered params",
+                            ERROR_LOCATION);
+      }
+
+      pValues->clear();
+
+      // compoundLevels_ is already sorted ascending by parseString
+      for (const LevelCompoundValues& configLevel : compoundLevels_)
+      {
+         bool matches = std::any_of(levelFilter.begin(), levelFilter.end(),
+                                    [&configLevel](const Level& l) { return l == configLevel.first; });
+         if (!matches)
+            continue;
+
+         CompoundMap::const_iterator iter = configLevel.second.find(paramName);
+         if (iter == configLevel.second.end())
+         {
+            pValues->push_back(std::nullopt);
+         }
+         else
+         {
+            pValues->push_back(iter->second);
          }
       }
 


### PR DESCRIPTION
Adds two new query methods that return the explicitly-set value (or nullopt) for each matched config section in level-ascending order, rather than the final resolved value that getParam() returns. This allows callers to inspect what each profile level contributes before applying their own resolution strategy.

Also improves error messages: "Parameter not found" now includes the parameter name, and the lexical-cast failure message now includes the bad value string alongside the param name.

