### PR TITLE
Use direct S3 URLs for manifest download

### DIFF
--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -3438,10 +3438,10 @@ Error downloadManifest(json::Object* pManifest)
    }
 #endif
 
-   // Get download URI via redirector; use test manifest when opted in
+   // Get download URI; use test manifest when opted in
    std::string downloadUri = options().positAssistantTestManifest()
-      ? "https://www.rstudio.org/links/posit-assistant-manifest-test"
-      : "https://www.rstudio.org/links/posit-assistant-manifest";
+      ? "https://rstudio-buildtools.s3.us-east-1.amazonaws.com/posit-ai-preview/manifest-test.json"
+      : "https://rstudio-buildtools.s3.us-east-1.amazonaws.com/posit-ai-preview/manifest.json";
 
    DLOG("Downloading manifest from: {}", downloadUri);
 


### PR DESCRIPTION
Should address #17045

## Description

This is a short-term change to deal with problems some are encountering with the rstudio redirector in front of the manifest.json download, e.g. https://github.com/rstudio/rstudio/issues/17045

The ultimate fix will be to change to a stable CDN URL ( #17298) for both the manifest and the Posit AI packages; that is being configured, and in the meantime making this change to eliminate use of the rstudio redirector.

## Summary

- Replace `rstudio.org/links` redirector URLs for the Posit Assistant manifest with direct S3 URLs
- The redirector was not intended for high-volume use (every RStudio start with Posit AI enabled) and has caused download failures for some users
- Uses `rstudio-buildtools.s3.us-east-1.amazonaws.com/posit-ai-preview/manifest.json` directly, bypassing the redirect

## Test plan

- [ ] Start RStudio with Posit AI enabled and verify the manifest downloads successfully
