### PR TITLE
fix project template OpenFiles not opening on first run

### DIFF
--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -283,17 +283,22 @@ Error addFirstRunDocsForTemplate(const FilePath& projectFilePath,
       return Success();
 
    json::Object descriptionJson;
-   json::Object inputsJson;
    Error error = json::readObject(projectTemplateOptions.getObject(),
-                                  "description", descriptionJson,
-                                  "inputs", inputsJson);
+                                  "description", descriptionJson);
    if (error)
       return error;
 
-   if (!descriptionJson["open_files"].isArray())
+   json::Value openFilesJson = descriptionJson["open_files"];
+   if (openFilesJson.isNull())
       return Success();
 
-   json::Array openFiles = descriptionJson["open_files"].getArray();
+   if (!openFilesJson.isArray())
+   {
+      LOG_WARNING_MESSAGE("Template 'open_files' field is not an array");
+      return Success();
+   }
+
+   json::Array openFiles = openFilesJson.getArray();
    if (openFiles.isEmpty())
       return Success();
 
@@ -411,7 +416,10 @@ Error createProject(const json::JsonRpcRequest& request,
    // register first-run docs for the template now that the .Rproj file exists
    error = addFirstRunDocsForTemplate(resolvedProjectFilePath, projectTemplateOptions);
    if (error)
+   {
+      error.addProperty("project", resolvedProjectFilePath.getAbsolutePath());
       LOG_ERROR(error);
+   }
 
    return Success();
 }


### PR DESCRIPTION
## Intent

Addresses #17292.

## Summary

- Moved `addFirstRunDocumentsForTemplate` call from R (where the `.Rproj` file didn't yet exist, causing scratch path computation to fail) into C++ `createProject`, after the project file is written to disk.
- Used the resolved project file path so templates that find an existing `.Rproj` also work correctly.
- Extracted a helper function with early returns and an `isArray()` type guard to keep the code flat and defensive.

## Test plan

- [ ] Create a new project from a template that specifies `OpenFiles` — verify the listed files open automatically
- [ ] Create a new project from a template without `OpenFiles` — verify no errors
- [ ] Create a project where an `.Rproj` already exists in the directory — verify the existing path is used and files still open