### PR TITLE
fix GWT build and unit tests in git worktrees

### DIFF
--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -87,8 +87,18 @@
    <!-- For automatically re-generating acesupport on change -->
    <property name="acesupport.watcher.dir" value="${tools.dir}/acesupport-watcher"/>
 
+   <!-- Detect git worktree and resolve main repo root for shared dependencies -->
+   <exec executable="git" outputproperty="git.common.dir"
+         failonerror="false" errorproperty="git.common.dir.error">
+      <arg value="rev-parse"/>
+      <arg value="--path-format=absolute"/>
+      <arg value="--git-common-dir"/>
+   </exec>
+   <dirname property="git.main.worktree" file="${git.common.dir}"/>
+
    <!-- Path to GWT libraries -->
    <set-if-exists property="lib.dir" value="../../dependencies/common/gwtproject"/>
+   <set-if-exists property="lib.dir" value="${git.main.worktree}/dependencies/common/gwtproject"/>
    <set-if-exists property="lib.dir" value="/opt/rstudio-tools/dependencies/common/gwtproject"/>
    <set-if-exists property="lib.dir" value="C:/rstudio-tools/dependencies/common/gwtproject"/>
 
@@ -222,7 +232,10 @@
    <!-- panmirror typescript library -->
    <!-- ensure version matches RSTUDIO_NODE_VERSION -->
    <property name="node.version" value="22.13.1"/>
-   <property name="node.dir" value="../../dependencies/common/node/${node.version}"/>
+   <set-if-exists property="node.dir" value="../../dependencies/common/node/${node.version}"/>
+   <set-if-exists property="node.dir" value="${git.main.worktree}/dependencies/common/node/${node.version}"/>
+   <set-if-exists property="node.dir" value="/opt/rstudio-tools/dependencies/common/node/${node.version}"/>
+   <set-if-unset  property="node.dir" value="../../dependencies/common/node/${node.version}"/>
 
 
    <!-- use yarn from system but will prefer yarn from dependencies if available -->
@@ -490,7 +503,7 @@
       <delete dir="${extras.dir}" failonerror="false" />
    </target>
 
-   <target name="build-unittests" description="Builds JUnit unit tests">
+   <target name="build-unittests" depends="acesupport,javac" description="Builds JUnit unit tests">
       <java-compile srcdir="test" includes="org/rstudio/**/client/**">
          <classpath refid="unittest.class.path"/>
          <classpath refid="project.class.path"/>


### PR DESCRIPTION
## Intent

Fixes GWT build targets (`ant javac`, `ant unittest`, etc.) when working in a git worktree.

## Summary

- Use `git rev-parse --git-common-dir` to resolve the main worktree root, then fall back to its `dependencies/` directory for `lib.dir` and `node.dir` when the local relative path doesn't exist
- Add `acesupport` and `javac` as dependencies of `build-unittests` so that `ant unittest` works from a clean state (previously relied on artifacts from prior builds)
- In a normal (non-worktree) checkout, these changes are no-ops — the local relative paths still match first

## Test plan

- [x] Created a detached worktree, ran `ant unittest` from it — all 451 tests pass
- [ ] Verify `ant javac` still works in a normal checkout
- [ ] Verify `ant unittest` still works in a normal checkout
- [ ] Verify `ant draft` still works in a normal checkout