### PR TITLE
Add rstudio-update-copilot skill

### DIFF
--- a/.claude/skills/rstudio-update-copilot/SKILL.md
+++ b/.claude/skills/rstudio-update-copilot/SKILL.md
@@ -89,16 +89,11 @@ The default tools root (`/opt/rstudio-tools/...`) requires elevated privileges, 
 
 ```bash
 VERIFY_DIR="$(mktemp -d)"
+trap 'rm -rf "$VERIFY_DIR"' EXIT
 RSTUDIO_TOOLS_ROOT="$VERIFY_DIR" bash dependencies/common/install-copilot-language-server
 ```
 
-Confirm exit code 0, then clean up:
-
-```bash
-rm -rf "$VERIFY_DIR"
-```
-
-If the install fails, report the error and stop.
+Confirm exit code 0. The `trap` ensures the temp directory is cleaned up whether the install succeeds or fails. If the install fails, report the error and stop.
 
 After verification, tell the user they will need to re-run `dependencies/common/install-copilot-language-server` themselves (with appropriate privileges) to install the new copilot-language-server into their dev environment.
 


### PR DESCRIPTION
## Summary

Adds a Claude Code skill for updating the copilot-language-server version in the RStudio repository. The skill automates:

- Validating the target version and checking AWS prerequisites
- Updating version strings across all four files that reference the copilot version
- Uploading the new release to the rstudio-buildtools S3 bucket
- Verifying the install from S3 (using a temp directory to avoid requiring sudo)
- Committing and opening a PR

## Intent

Developer tooling improvement — no product code changes.

## Test plan

- [ ] Invoke the skill with a copilot-language-server version bump and verify it completes end-to-end