### PR TITLE
add R Notebook render smoke test

### DIFF
--- a/src/cpp/tests/automation/testthat/test-automation-rmarkdown.R
+++ b/src/cpp/tests/automation/testthat/test-automation-rmarkdown.R
@@ -658,17 +658,65 @@ withr::defer(.rs.automation.deleteRemote())
       ---
       title: Paged Table; Explicit Printing
       ---
-      
+
       ```{r}
       print(mtcars)
       ```
    ')
-   
+
    remote$editor.executeWithContents(".Rmd", contents, function(editor) {
       editor$gotoLine(6)
       remote$commands.execute(.rs.appCommands$executeCurrentChunk)
       Sys.sleep(1)
       expect_error(remote$dom.querySelector(".pagedtable"))
    })
+
+})
+
+.rs.test("saving an R Notebook creates an nb.html file", {
+
+   contents <- .rs.heredoc('
+      ---
+      title: "Notebook Test"
+      output: html_notebook
+      ---
+
+      ```{r}
+      print("hello from notebook")
+      ```
+   ')
+
+   # Write the notebook to a known path so we can check for the .nb.html
+   documentPath <- tempfile("notebook-", fileext = ".Rmd")
+   writeLines(contents, con = documentPath)
+   nbHtmlPath <- sub("\\.Rmd$", ".nb.html", documentPath)
+
+   withr::defer({
+      unlink(documentPath)
+      unlink(nbHtmlPath)
+   })
+
+   remote$editor.openDocument(documentPath)
+   editor <- remote$editor.getInstance()
+
+   # Execute the chunk to generate output
+   editor$gotoLine(7)
+   remote$commands.execute(.rs.appCommands$executeCurrentChunk)
+   Sys.sleep(1)
+
+   # Save the document, which should trigger nb.html rendering
+   remote$commands.execute("saveSourceDoc")
+
+   # Wait for the nb.html file to appear
+   .rs.waitUntil("nb.html is created", function() {
+      file.exists(nbHtmlPath)
+   })
+
+   expect_true(file.exists(nbHtmlPath))
+
+   # Verify the rendered file contains expected content
+   nbHtml <- readLines(nbHtmlPath, warn = FALSE)
+   nbHtmlText <- paste(nbHtml, collapse = "\n")
+   expect_true(grepl("hello from notebook", nbHtmlText))
 
 })


### PR DESCRIPTION
## Intent

Add a BRAT automation test that verifies saving an R Notebook (R Markdown with `output: html_notebook`) produces the expected `.nb.html` companion file.

## Summary

- Creates an `.Rmd` with `output: html_notebook`, opens it, executes a chunk, saves, and confirms the `.nb.html` is rendered with expected content
- Added to `test-automation-rmarkdown.R` alongside existing R Markdown tests