### PR TITLE
Add 'test/' branch prefix for automated test changes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -441,6 +441,7 @@ For branch naming:
 - Use the 'bugfix/' prefix for code changes which fix an existing issue.
 - Use the 'feature/' prefix for code changes that add or extend existing functionality.
 - Use the 'developer/' prefix for code changes that are primarily for developer ergonomics.
+- Use the 'test/' prefix for code changes that are focused on automated tests.
 
 ## Issues
 


### PR DESCRIPTION
## Summary
- Adds the `test/` prefix to the branch naming conventions in `.claude/CLAUDE.md`, for code changes focused on automated tests