### PR TITLE
Refactor FindLibR.cmake and use CMake-configured paths in test runner

### DIFF
--- a/cmake/modules/FindLibR.cmake
+++ b/cmake/modules/FindLibR.cmake
@@ -24,7 +24,8 @@
 # 1. Find the R executable
 # ===========================================================================
 
-# Allow user override via environment variable or CMake variable.
+# If LIBR_HOME is set, use it to locate R. The final LIBR_HOME value
+# is canonicalized via R.home().
 if(DEFINED ENV{LIBR_HOME} AND NOT LIBR_HOME)
    set(LIBR_HOME "$ENV{LIBR_HOME}")
 endif()
@@ -153,8 +154,6 @@ if(NOT _R_RESULT EQUAL 0 OR NOT LIBR_LIB_DIR)
 endif()
 set(LIBR_LIB_DIR "${LIBR_LIB_DIR}" CACHE PATH "R lib directory")
 
-message(STATUS "Found R: ${LIBR_HOME}")
-
 # ===========================================================================
 # 3. Find libraries
 # ===========================================================================
@@ -193,7 +192,7 @@ find_library(LIBR_CORE_LIBRARY NAMES R HINTS ${_LIBR_LIBRARY_HINTS})
 if(LIBR_CORE_LIBRARY)
    set(LIBR_LIBRARIES ${LIBR_CORE_LIBRARY})
 else()
-   message(STATUS "Could not find libR shared library")
+   message(WARNING "Could not find libR shared library")
 endif()
 
 if(WIN32)
@@ -220,7 +219,7 @@ if(LIBR_LIBRARIES)
 endif()
 
 # ===========================================================================
-# 4. Validation and cleanup
+# 4. Validation
 # ===========================================================================
 
 include(FindPackageHandleStandardArgs)

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -189,9 +189,9 @@ export R_LIB_DIR="@LIBR_LIB_DIR@"
 # ensure the configured R is found first in PATH
 export PATH="@LIBR_BIN_DIR@:${PATH}"
 
-# ensure R libraries (libR, libRblas, libRlapack) can be found at runtime
+# ensure R shared libraries can be found at runtime
 if [ "$(uname)" = "Darwin" ]; then
-   export DYLD_LIBRARY_PATH="${R_LIB_DIR}:${DYLD_LIBRARY_PATH}"
+   export DYLD_FALLBACK_LIBRARY_PATH="${R_LIB_DIR}:${DYLD_FALLBACK_LIBRARY_PATH}"
 else
    export LD_LIBRARY_PATH="${R_LIB_DIR}:${LD_LIBRARY_PATH}"
 fi


### PR DESCRIPTION
## Summary

- Restructure `FindLibR.cmake` to follow a clearer linear flow: discover `LIBR_HOME` (supporting `LIBR_HOME` env var), canonicalize via `R.home()`, then query R for all paths uniformly — eliminating duplicated logic across Apple/Unix/Windows code paths.
- Update `rstudio-tests.in` to use CMake-configured R paths (`@LIBR_HOME@`, `@LIBR_DOC_DIR@`, `@LIBR_LIB_DIR@`) instead of invoking R at test runtime, and ensure the configured R is first in `PATH` with its libraries in `LD_LIBRARY_PATH`.

## Test plan

- [ ] Verify CMake configure step succeeds on Linux
- [ ] Verify CMake configure step succeeds on macOS
- [ ] Verify CMake configure step succeeds on Windows
- [ ] Run `rstudio-tests --scope core` and confirm R paths are set correctly
- [ ] Verify build with `LIBR_HOME` environment variable override
