### PR TITLE
Fix flaky FindSubprocessNameViaPgrep test with race condition

### DIFF
--- a/src/cpp/core/system/PosixSystemTests.cpp
+++ b/src/cpp/core/system/PosixSystemTests.cpp
@@ -118,7 +118,9 @@ TEST(PosixTests, FindSubprocessNameViaPgrep)
    }
    else
    {
-      // we now have a subprocess
+      // we now have a subprocess, need a slight pause to allow the child
+      // process to complete exec before pgrep can find it
+      ::sleep(1);
       std::vector<SubprocInfo> children = getSubprocessesViaPgrep(getpid());
       EXPECT_TRUE(children.size() >= 1u);
       if (children.size() >= 1u)


### PR DESCRIPTION
## Summary
- Adds a `::sleep(1)` before the `pgrep` call in `FindSubprocessNameViaPgrep` to allow the child process time to complete `exec`, fixing a race condition that started consistently failing on CI around March 17.
- Mirrors the same pattern already used in the Mac equivalent test (`FindSubprocessNameMac`).

## Test plan
- [x] Verified test passes locally in dev container
- [x] Confirmed this is the test causing CI failures (not the R test noise in the logs)
