### PR TITLE
Fix Show Posit Assistant command missing from menu and palette

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -2675,7 +2675,7 @@ public class PaneManager
 
    private void manageChatCommands()
    {
-      boolean showPaiUi = paiUtil_.isPaiSelected();
+      boolean showPaiUi = paiUtil_.isPaiEnabled();
       commands_.activateChat().setVisible(showPaiUi);
       commands_.layoutZoomChat().setVisible(showPaiUi);
    }
@@ -2699,7 +2699,7 @@ public class PaneManager
       commands.add(commands_.layoutZoomViewer());
       commands.add(commands_.layoutZoomConnections());
       commands.add(commands_.layoutZoomPresentation2());
-      if (paiUtil_.isPaiSelected())
+      if (paiUtil_.isPaiEnabled())
          commands.add(commands_.layoutZoomChat());
 
       return commands;


### PR DESCRIPTION
## Intent

Addresses https://github.com/rstudio/rstudio/issues/17335.

## Summary

- Chat command visibility (`manageChatCommands` and `getLayoutCommands`) was gated on `isPaiSelected()`, which checks the `assistant` user preference (code suggestions/NES). The chat tab existence is gated on `isPaiEnabled()` (the server-side feature flag). When the assistant preference was set to anything other than "posit" — at the global or project level — the command disappeared even though the chat pane was still available.
- Switch both call sites to use `isPaiEnabled()`, matching the chat tab gate.

## Test plan

- [ ] Set `assistant` to "copilot" in Global Options > Assistant (leave `chat_provider` as "posit"), restart RStudio, confirm "Show Posit Assistant" appears in View menu, command palette, and Ctrl+Shift+I works
- [ ] In a project, set Assistant to "GitHub Copilot" in Project Options > Assistant (leave chat provider as "Posit Assistant"), reopen the project, confirm the command is still present
- [ ] Set `RSTUDIO_DISABLE_POSIT_AI=1` env var before launch, confirm the command is hidden and the chat tab is absent