### PR TITLE
Fix arm64-only macOS package build

### DIFF
--- a/package/osx/cmake/prepare-package.cmake
+++ b/package/osx/cmake/prepare-package.cmake
@@ -101,10 +101,17 @@ else()
 
 endif()
 
-# find out where x64 homebrew lives
-set(HOMEBREW_X64_PREFIX "/usr/local")
+# find out where homebrew lives for the primary architecture
+# UNAME_M reflects the primary build arch: x86_64 when configured under
+# arch -x86_64 (universal or x64-only), arm64 when configured under
+# arch -arm64 (arm64-only)
+if("@UNAME_M@" STREQUAL "arm64")
+   set(HOMEBREW_PRIMARY_PREFIX "/opt/homebrew")
+else()
+   set(HOMEBREW_PRIMARY_PREFIX "/usr/local")
+endif()
 
-# copy required Homebrew libraries
+# copy required Homebrew libraries for the primary architecture
 list(APPEND HOMEBREW_LIBS gettext openssl sqlite3)
 if(@RSTUDIO_PRO_BUILD@)
    list(APPEND HOMEBREW_LIBS krb5 libpq)
@@ -112,7 +119,7 @@ endif()
 
 file(MAKE_DIRECTORY "${X64_FRAMEWORKS_DIRECTORY}")
 foreach(LIB ${HOMEBREW_LIBS})
-   set(LIBPATH "${HOMEBREW_X64_PREFIX}/opt/${LIB}/lib")
+   set(LIBPATH "${HOMEBREW_PRIMARY_PREFIX}/opt/${LIB}/lib")
    file(GLOB LIBFILES "${LIBPATH}/*.dylib")
    foreach(LIBFILE ${LIBFILES})
       file(

--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -260,6 +260,14 @@ set-version ${RSTUDIO_VERSION_FULL}
 case "${arch}" in *arm64*)  build_arm64=1  ;; esac
 case "${arch}" in *x86_64*) build_x86_64=1 ;; esac
 
+# determine the primary build directory: whichever architecture is built
+# first and owns the install/package targets
+if [ -n "${build_x86_64}" ]; then
+   PRIMARY_BUILD_DIR="${BUILD_DIR_X86_64}"
+else
+   PRIMARY_BUILD_DIR="${BUILD_DIR_ARM64}"
+fi
+
 if [ "${clean}" = "1" ]; then
 
    # remove existing build dir
@@ -375,18 +383,43 @@ if [ -n "${build_arm64}" ]; then
    rm -f CMakeCache.txt
    rm -rf build/_CPack_Packages
 
-   info "Configuring for arm64 ..."
-   arch -arm64 "${CMAKE}"                                   \
-      -DCMAKE_BUILD_TYPE=RelWithDebInfo                     \
-      -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"               \
-      -DRSESSION_ALTERNATE_BUILD=1                          \
-      -DRSTUDIO_TARGET=${rstudio_target}                    \
-      -DRSTUDIO_PACKAGE_BUILD=1                             \
-      -DRSTUDIO_TOOLS_ROOT="${RSTUDIO_TOOLS_ROOT}/../arm64" \
-      -DGWT_BUILD=0                                         \
-      -DGWT_COPY=0                                          \
-      -DSCCACHE_ENABLED=$SCCACHE_ENABLED                    \
-      "${PKG_DIR}/../.."
+   if [ -n "${build_x86_64}" ]; then
+
+      # arm64 is the alternate build (universal package)
+      info "Configuring for arm64 (alternate) ..."
+      arch -arm64 "${CMAKE}"                                   \
+         -DCMAKE_BUILD_TYPE=RelWithDebInfo                     \
+         -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"               \
+         -DRSESSION_ALTERNATE_BUILD=1                          \
+         -DRSTUDIO_TARGET=${rstudio_target}                    \
+         -DRSTUDIO_PACKAGE_BUILD=1                             \
+         -DRSTUDIO_TOOLS_ROOT="${RSTUDIO_TOOLS_ROOT}/../arm64" \
+         -DGWT_BUILD=0                                         \
+         -DGWT_COPY=0                                          \
+         -DSCCACHE_ENABLED=$SCCACHE_ENABLED                    \
+         "${PKG_DIR}/../.."
+
+   else
+
+      # arm64 is the primary build (arm64-only package)
+      info "Configuring for arm64 (primary) ..."
+      arch -arm64 "${CMAKE}"                                      \
+         -DCMAKE_BUILD_TYPE=RelWithDebInfo                        \
+         -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"                  \
+         -DRSTUDIO_TARGET=${rstudio_target}                       \
+         -DRSTUDIO_PACKAGE_BUILD=1                                \
+         -DRSTUDIO_TOOLS_ROOT="${RSTUDIO_TOOLS_ROOT}/../arm64"    \
+         -DRSTUDIO_CODESIGN_USE_CREDENTIALS="${use_creds}"        \
+         -DRSTUDIO_CODESIGN_KEYCHAIN_PATH="${KEYCHAIN_PATH}"      \
+         -DGWT_BUILD="${build_gwt}"                               \
+         -DGWT_COPY="${copy_gwt}"                                 \
+         -DGWT_BIN_DIR="${BUILD_DIR_ARM64}/gwt/bin"               \
+         -DGWT_WWW_DIR="${BUILD_DIR_ARM64}/gwt/www"               \
+         -DGWT_EXTRAS_DIR="${BUILD_DIR_ARM64}/gwt/extras"         \
+         -DSCCACHE_ENABLED=$SCCACHE_ENABLED                       \
+         "${PKG_DIR}/../.."
+
+   fi
    info "Done!"
 
    info "Building for arm64 with flags '${MAKEFLAGS}' ..."
@@ -415,8 +448,8 @@ if [ "${build_package}" = "1" ]; then
    rm -rf "${INSTALL_DIR}"
    mkdir -p "${INSTALL_DIR}"
 
-   # perform install
-   cd "${BUILD_DIR_X86_64}"
+   # perform install from the primary build directory
+   cd "${PRIMARY_BUILD_DIR}"
    "${CMAKE}" --build . --target install -- ${MAKEFLAGS}
 
    if [ "${build_dmg}" = "1" ]; then
@@ -443,9 +476,9 @@ if [ "${build_package}" = "1" ]; then
          "${RSTUDIO_BUNDLE_NAME}.dmg"
 
       # move to expected location in build folder
-      mv "${RSTUDIO_BUNDLE_NAME}.dmg" "${BUILD_DIR_X86_64}/"
+      mv "${RSTUDIO_BUNDLE_NAME}.dmg" "${PRIMARY_BUILD_DIR}/"
 
-      info "'${BUILD_DIR_X86_64}/${RSTUDIO_BUNDLE_NAME}.dmg' has been created."
+      info "'${PRIMARY_BUILD_DIR}/${RSTUDIO_BUNDLE_NAME}.dmg' has been created."
 
    fi
 

--- a/package/osx/scripts/merge-electron.mjs
+++ b/package/osx/scripts/merge-electron.mjs
@@ -6,15 +6,17 @@ import { makeUniversalApp } from '@electron/universal';
 
 const [node, script, x64AppPath, arm64AppPath, outPath] = process.argv;
 
-// for x64, we don't build a universal application; instead,
-// we just copy the x64 Electron bits directly into the package
 let tmpPath = "";
+let hasX64Build = existsSync(x64AppPath);
 let hasArm64Build = existsSync(arm64AppPath);
-if (hasArm64Build) {
+let builtUniversal = false;
+
+if (hasX64Build && hasArm64Build) {
 
   // build universal application in temporary directory,
   // then merge it all together when we're done
   tmpPath = `${outPath}.tmp`;
+  builtUniversal = true;
 
   // merge the two builds together
   console.log("# Building universal Desktop application.")
@@ -27,11 +29,24 @@ if (hasArm64Build) {
     force: true,
   });
 
-} else {
+} else if (hasX64Build) {
 
   console.log("# Building x86_64 Electron application");
   console.log(`- [i] x64AppPath: ${x64AppPath}`)
   tmpPath = x64AppPath;
+
+} else if (hasArm64Build) {
+
+  console.log("# Building arm64 Electron application");
+  console.log(`- [i] arm64AppPath: ${arm64AppPath}`)
+  tmpPath = arm64AppPath;
+
+} else {
+
+  console.error("Error: no Electron application builds found");
+  console.error(`- [i] x64AppPath: ${x64AppPath}`)
+  console.error(`- [i] arm64AppPath: ${arm64AppPath}`)
+  process.exit(1);
 
 }
 
@@ -40,8 +55,8 @@ console.log("- [i] Merging desktop and session packages ...")
 execSync(`rsync -a "${tmpPath}/" "${outPath}/"`, { stdio: 'inherit' });
 console.log("- [i] Done!")
 
-// clean up
-if (hasArm64Build) {
+// clean up the temporary universal build directory
+if (builtUniversal) {
   rmSync(tmpPath, { recursive: true });
 }
 


### PR DESCRIPTION
Fix `make-package` on macOS to be capable of producing an Apple-Silicon-only .dmg package. It already supported building an x64-only package (though that probably hasn't been tested in years).

This produces an RStudio without an x64 rsession, so cannot use Intel R on an ARM Mac with a build produced this way; this is looking ahead to the day when Apple drops Rosetta2 support altogether.

Marked as draft; this can wait until we branch for release.

## Summary

- Fix `make-package --arch=arm64` failing with `cd: No such file or directory` at the package step
- Introduce `PRIMARY_BUILD_DIR` so the install/DMG steps use the correct build directory for whichever architecture is primary
- When arm64 is the only target, configure it as the primary build (with GWT, codesign, install scripts) instead of as an alternate
- Update `merge-electron.mjs` to handle arm64-only Electron apps
- Make `prepare-package.cmake` select the correct Homebrew prefix based on `UNAME_M` so primary binaries get the right dylib paths

The universal build (`--arch=x86_64,arm64`) is unchanged.

## Test plan

- [ ] Build with `./make-package --arch=arm64 --build-dmg=0` on Apple Silicon and confirm it completes and produces `install/RStudio.app`
- [ ] Launch the produced `RStudio.app` against an arm64 R installation and confirm the session starts
- [ ] Build with `./make-package --arch=x86_64,arm64 --build-dmg=0` on Apple Silicon to verify no regression in the universal build