### PR TITLE
Fix uninstall Posit AI error when already not installed

### DIFF
--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -5314,8 +5314,15 @@ Error chatUninstallPositAi(const json::JsonRpcRequest& request,
       }
 
       // Already not installed — treat as success so the frontend
-      // proceeds to restart RStudio as expected.
+      // proceeds to restart RStudio as expected. Clear cached state
+      // in case the directory was removed out-of-band while the
+      // session still thinks Posit AI is available.
       DLOG("Posit AI is not installed; nothing to remove");
+      {
+         boost::mutex::scoped_lock lock(s_updateStateMutex);
+         s_updateState = UpdateState();
+      }
+      s_positAssistantVersion.clear();
       pResponse->setResult(json::Value());
       return Success();
    }


### PR DESCRIPTION
## Intent

Addresses #17322.

## Description

When running the "Uninstall Posit AI" command and Posit AI is already not installed (no user-data directory, no env var, no system-level install), the backend returned a `no_such_file_or_directory` error. This caused an error dialog to appear after the confirmation prompt, and RStudio did not restart.

Now the backend treats this as a successful no-op and clears cached update/version state so the frontend proceeds to restart RStudio as expected.