### PR TITLE
Fix typo in odbcBundleFindDriver error message

### DIFF
--- a/src/cpp/session/modules/SessionConnectionsInstaller.R
+++ b/src/cpp/session/modules/SessionConnectionsInstaller.R
@@ -537,7 +537,7 @@
    driverPath <- allFiles[grepl(libraryPattern, allFiles, ignore.case = TRUE)]
 
    if (!identical(length(driverPath), 1L))
-      stop("Failed to find ", library, " inside driver bundle.")
+      stop("Failed to find ", libraryPattern, " inside driver bundle.")
    
    normalizePath(driverPath)
 })


### PR DESCRIPTION
## Intent

Fix incorrect variable reference in `odbcBundleFindDriver` error message.

## Summary

The error message in `.rs.odbcBundleFindDriver` referenced `library` (which resolves to `base::library`, a closure) instead of `libraryPattern`. When the driver search fails, the error message would contain the deparsed body of `base::library` instead of the regex pattern that was actually searched for.
