### PR TITLE
avoid crash when environment pane inspects S4 objects with broken packages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,7 @@
 - ([#17115](https://github.com/rstudio/rstudio/issues/17115)): Fixed an issue on macOS Desktop where the "Close" keyboard shortcut in secondary windows (e.g. Shiny app, Help pop-out) were also processed by the main window
 - ([#14882](https://github.com/rstudio/rstudio/issues/14882)): Fixed an issue where YAML comments in R Markdown documents were dropped or displaced when the front matter was modified (e.g. when toggling "Chunk Output in Console")
 - ([#17333](https://github.com/rstudio/rstudio/issues/17333)): Fixed an issue where the publishing wizard would fail when publishing Quarto documents with Quarto v1.9
+- ([#17353](https://github.com/rstudio/rstudio/issues/17353)): Fixed a crash when the Environment pane inspects S4 objects whose defining package has a broken or missing native DLL
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -701,28 +701,24 @@
    # R's error handling cannot intercept. Return a safe minimal description
    # that avoids any S4-dispatching operations.
    # https://github.com/rstudio/rstudio/issues/17353
-   if (isS4(obj))
+   if (.rs.isUnloadedS4(obj))
    {
       cls <- class(obj)
       pkg <- attr(cls, "package")
-      if (is.character(pkg) && length(pkg) == 1L && nzchar(pkg) &&
-          !identical(pkg, ".GlobalEnv") && !isNamespaceLoaded(pkg))
-      {
-         desc <- sprintf("Formal class '%s' [package \"%s\" not loaded]", cls[[1L]], pkg)
-         return(list(
-            name              = .rs.scalar(objName),
-            type              = .rs.scalar(cls[[1L]]),
-            clazz             = c(cls, typeof(obj)),
-            is_data           = .rs.scalar(FALSE),
-            value             = .rs.scalar(desc),
-            description       = .rs.scalar(desc),
-            size              = .rs.scalar(0L),
-            is_size_estimated = .rs.scalar(FALSE),
-            length            = .rs.scalar(0L),
-            contents          = list(),
-            contents_deferred = .rs.scalar(TRUE)
-         ))
-      }
+      desc <- sprintf("Formal class '%s' [package \"%s\" not loaded]", cls[[1L]], pkg)
+      return(list(
+         name              = .rs.scalar(objName),
+         type              = .rs.scalar(cls[[1L]]),
+         clazz             = c(cls, typeof(obj)),
+         is_data           = .rs.scalar(FALSE),
+         value             = .rs.scalar(desc),
+         description       = .rs.scalar(desc),
+         size              = .rs.scalar(0L),
+         is_size_estimated = .rs.scalar(FALSE),
+         length            = .rs.scalar(0L),
+         contents          = list(),
+         contents_deferred = .rs.scalar(FALSE)
+      ))
    }
 
    val <- "(unknown)"
@@ -954,7 +950,34 @@
 .rs.addFunction("getObjectContents", function(objName, env)
 {
    object <- get(objName, envir = env)
+
+   # Guard against S4 objects whose defining package isn't loaded.
+   # See the parallel guard in .rs.describeObject() for details.
+   # https://github.com/rstudio/rstudio/issues/17353
+   if (.rs.isUnloadedS4(object))
+      return(list())
+
    .rs.valueContents(object)
+})
+
+# Check if an object is an S4 instance whose defining package namespace
+# is not currently loaded. Operations on such objects (length(), str(), etc.)
+# can trigger namespace loading and crash the session if the package's native
+# DLL is broken or missing. https://github.com/rstudio/rstudio/issues/17353
+.rs.addFunction("isUnloadedS4", function(obj)
+{
+   if (!isS4(obj))
+      return(FALSE)
+
+   cls <- class(obj)
+   pkg <- attr(cls, "package")
+
+   is.character(pkg) &&
+      length(pkg) == 1L &&
+      !is.na(pkg) &&
+      nzchar(pkg) &&
+      !identical(pkg, ".GlobalEnv") &&
+      !isNamespaceLoaded(pkg)
 })
 
 .rs.addFunction("isAltrep", function(var)


### PR DESCRIPTION
## Intent

Addresses #17353.

## Summary

- When the Environment pane calls `.rs.describeObject()` on S4 objects whose defining package isn't loaded, operations like `length()`, `is()`, and `str()` trigger S4 method dispatch, which calls `.requirePackage()` to load the namespace and its native DLL. If the DLL is broken (e.g. missing entry point), Windows terminates the process with `STATUS_ENTRYPOINT_NOT_FOUND` (`0xC0000139`) before R's `tryCatch` can intervene.
- Added an early check in `.rs.describeObject()` that detects S4 objects with unloaded package namespaces using only safe attribute reads (`isS4()`, `class()`, `attr()`, `isNamespaceLoaded()`), and returns a minimal description that avoids all S4-dispatching operations.
- Affected objects are displayed as `Formal class 'Foo' [package "bar" not loaded]` with deferred contents.

## Test plan

- [ ] Create an S4 object from a package, save to `.RData`, uninstall the package, restart RStudio — session should not crash and the object should appear in the Environment pane with a "not loaded" label
- [ ] Verify S4 objects from loaded packages still display full details as before
- [ ] Verify non-S4 objects are unaffected