### PR TITLE
Enable display of What's New at startup

### DIFF
--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -541,11 +541,6 @@ export class SessionLauncher {
       return true;
     }
 
-    // TODO(#17369): Re-enable auto-show at startup once test environments
-    // have been updated to handle the What's New window. Until then, only
-    // the RSTUDIO_SHOW_WHATS_NEW env var and Help > What's New trigger it.
-    return false;
-
     // RSTUDIO_DISABLE_WHATS_NEW: force skip
     if (getenv('RSTUDIO_DISABLE_WHATS_NEW')) {
       return false;


### PR DESCRIPTION
## Intent

Addresses #17371.

Removes the temporary early-return guard from `shouldShowWhatsNew()` that was blocking auto-display of the What's New dialog at startup. The full logic is now active:

- Build-type gating (release builds only)
- Seen-state checking (won't show if already seen this release)
- `RSTUDIO_SHOW_WHATS_NEW` env var to force-show (bypasses all checks)
- `RSTUDIO_DISABLE_WHATS_NEW` env var to force-skip (for test/automation environments)