### PR TITLE
hide posit assistant toolbar button when chat pane removed from layout

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -476,6 +476,7 @@ public class PaneManager
          commands_.openSourceDocNewColumn().setVisible(visible);
 
          manageLayoutCommands();
+         manageChatCommands();
       });
 
       eventBus_.addHandler(ZoomPaneEvent.TYPE, event ->
@@ -2743,11 +2744,20 @@ public class PaneManager
 
    private void manageChatCommands()
    {
-      boolean showPaiUi = paiUtil_.isPositAssistantEnabled();
+      boolean showPaiUi = paiUtil_.isPositAssistantEnabled() && !isTabHidden(Tab.Chat);
       commands_.activateChat().setVisible(showPaiUi);
       commands_.layoutZoomChat().setVisible(showPaiUi);
       commands_.assistantPaneToggle().setVisible(
             showPaiUi && paiUtil_.isChatProviderPosit());
+   }
+
+   private boolean isTabHidden(Tab tab)
+   {
+      WorkbenchTabPanel panel = getOwnerTabPanel(tab);
+      if (panel == null)
+         return true;
+      LogicalWindow parent = panel.getParentWindow();
+      return parent == panesByName_.get(UserPrefsAccessor.Panes.QUADRANTS_HIDDENTABSET);
    }
 
    private List<AppCommand> getLayoutCommands()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -1913,6 +1913,10 @@ public class PaneManager
             panel = tabSet2TabPanel_;
             moveHiddenTabToTabSet2(tab, tabs2_);
          }
+
+         // Refresh chat command visibility now that the tab is no longer hidden
+         if (tab == Tab.Chat)
+            manageChatCommands();
       }
 
       // Ensure that the pane is visible (otherwise tab selection will fail)
@@ -2757,6 +2761,8 @@ public class PaneManager
       if (panel == null)
          return true;
       LogicalWindow parent = panel.getParentWindow();
+      if (parent == null)
+         return true;
       return parent == panesByName_.get(UserPrefsAccessor.Panes.QUADRANTS_HIDDENTABSET);
    }
 


### PR DESCRIPTION
## Intent

Addresses #17368.

## Summary

- Hide the Posit Assistant toolbar button (and related chat commands) when the user has removed the chat pane from their pane layout
- Add `isTabHidden()` helper that checks whether a tab's owner panel belongs to the hidden tabset
- Call `manageChatCommands()` on pane layout changes so the button visibility updates immediately

## Test plan

- [ ] Open Pane Layout preferences, uncheck "Posit Assistant" from sidebar/tabset1/tabset2, close preferences — verify the toolbar button is hidden
- [ ] Re-add the chat pane to a tabset — verify the toolbar button reappears
- [ ] With Posit Assistant disabled globally, verify the button remains hidden regardless of pane layout