### PR TITLE
sync clamped editor width when margin column changes

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -307,6 +307,11 @@ public class TextEditingTargetWidget
          }
       }));
 
+      releaseOnDismiss_.add(userPrefs_.marginColumn().bind((arg) ->
+      {
+         Scheduler.get().scheduleDeferred(() -> syncEditorWidth());
+      }));
+
    }
 
    public void initWidgetSize()


### PR DESCRIPTION
## Intent

Addresses https://github.com/rstudio/rstudio/issues/16660.

## Summary

- When the "clamp editor" feature is enabled and the margin column value is changed, the editor width now updates immediately instead of requiring a file switch or reopen.

## Details

`syncEditorWidth()` was only called on ACE render-finished events, so changing the margin column preference updated the print margin position in ACE but never triggered a recalculation of the editor's `maxWidth`. Added a binding for `marginColumn` changes that calls `syncEditorWidth()` via a deferred schedule (to ensure ACE has updated the print margin element before we read its position).

## Test plan

- [ ] Open an R Markdown file
- [ ] Enable "Clamp editor," "Soft-wrap source files," and "Soft-wrap at margin column" in Tools → Global Options → Code → Display
- [ ] Set margin column to 80 and press OK — editor should clamp to 80 columns
- [ ] Re-open options, change margin column to 100, press OK — editor should immediately widen to 100 columns without switching files
- [ ] Toggle "Clamp editor" off — editor should return to full width