### PR TITLE
Send NES negative suggestion feedback to Posit AI LSP

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetAssistantHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetAssistantHelper.java
@@ -1247,6 +1247,10 @@ public class TextEditingTargetAssistantHelper
       if (editSuggestion_ == null || editSuggestion_.command == null)
          return false;
 
+      if (editSuggestion_.command.arguments == null
+          || editSuggestion_.command.arguments.length == 0)
+         return false;
+
       // Check if using Posit AI LSP
       return StringUtil.equals(
          assistant_.getAssistantType(),
@@ -1256,20 +1260,27 @@ public class TextEditingTargetAssistantHelper
    /**
     * Sends suggestion feedback to the LSP server via workspace/executeCommand.
     * Sends a completion command with the feedback argument replaced
-    * (e.g. "rejected" or "ignored"). Does not reset suggestion state.
+    * (i.e. "rejected" or "ignored"). Does not reset suggestion state.
     */
    private void sendSuggestionFeedback(String feedback)
    {
-      if (shouldSendDismissFeedback())
+      try
       {
-         AssistantCompletionCommand cmd = new AssistantCompletionCommand();
-         cmd.title = editSuggestion_.command.title;
-         cmd.command = editSuggestion_.command.command;
-         cmd.arguments = new String[] {
-            editSuggestion_.command.arguments[0],
-            feedback
-         };
-         server_.assistantDidAcceptCompletion(cmd, new VoidServerRequestCallback());
+         if (shouldSendDismissFeedback())
+         {
+            AssistantCompletionCommand cmd = new AssistantCompletionCommand();
+            cmd.title = editSuggestion_.command.title;
+            cmd.command = editSuggestion_.command.command;
+            cmd.arguments = new String[] {
+               editSuggestion_.command.arguments[0],
+               feedback
+            };
+            server_.assistantDidAcceptCompletion(cmd, new VoidServerRequestCallback());
+         }
+      }
+      catch (Exception e)
+      {
+         Debug.logException(e);
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetAssistantHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetAssistantHelper.java
@@ -464,6 +464,7 @@ public class TextEditingTargetAssistantHelper
       if (dismissed_)
          return;
 
+      sendSuggestionFeedback("ignored");
       resetSuggestion();
 
       // The completion data gets modified when doing partial (word-by-word)
@@ -640,6 +641,7 @@ public class TextEditingTargetAssistantHelper
          @Override
          protected void discard()
          {
+            sendSuggestionFeedback("rejected");
             resetSuggestion();
          }
 
@@ -1237,6 +1239,41 @@ public class TextEditingTargetAssistantHelper
    }
 
    /**
+    * Checks whether dismiss feedback should be sent to the LSP server.
+    * Only sends dismiss feedback for Posit AI.
+    */
+   private boolean shouldSendDismissFeedback()
+   {
+      if (editSuggestion_ == null || editSuggestion_.command == null)
+         return false;
+
+      // Check if using Posit AI LSP
+      return StringUtil.equals(
+         assistant_.getAssistantType(),
+         UserPrefsAccessor.ASSISTANT_POSIT);
+   }
+
+   /**
+    * Sends suggestion feedback to the LSP server via workspace/executeCommand.
+    * Sends a completion command with the feedback argument replaced
+    * (e.g. "rejected" or "ignored"). Does not reset suggestion state.
+    */
+   private void sendSuggestionFeedback(String feedback)
+   {
+      if (shouldSendDismissFeedback())
+      {
+         AssistantCompletionCommand cmd = new AssistantCompletionCommand();
+         cmd.title = editSuggestion_.command.title;
+         cmd.command = editSuggestion_.command.command;
+         cmd.arguments = new String[] {
+            editSuggestion_.command.arguments[0],
+            feedback
+         };
+         server_.assistantDidAcceptCompletion(cmd, new VoidServerRequestCallback());
+      }
+   }
+
+   /**
     * Creates anchors for the current suggestion range.
     * The start anchor uses the default insertRight=false so it automatically
     * moves forward when text is inserted at its position (e.g., newlines or
@@ -1424,6 +1461,7 @@ public class TextEditingTargetAssistantHelper
                            // (which we need to send back to the server as-is in some language-server methods).
                            AssistantCompletion normalized = normalizeCompletion(completion);
 
+                           sendSuggestionFeedback("ignored");
                            resetSuggestion();
                            editSuggestion_ = new EditSuggestion(normalized);
                            editSuggestion_.type = SuggestionType.GHOST_TEXT;
@@ -1713,6 +1751,7 @@ public class TextEditingTargetAssistantHelper
                   {
                      if (nativeEvent != null && shouldDismissSuggestion(nativeEvent))
                      {
+                        sendSuggestionFeedback("ignored");
                         resetSuggestion();
                      }
                   }
@@ -1771,6 +1810,7 @@ public class TextEditingTargetAssistantHelper
 
                display_.addUndoRedoHandler((event) ->
                {
+                  sendSuggestionFeedback("ignored");
                   resetSuggestion();
                }),
 
@@ -1800,6 +1840,7 @@ public class TextEditingTargetAssistantHelper
                         {
                            event.stopPropagation();
                            event.preventDefault();
+                           sendSuggestionFeedback("rejected");
                            resetSuggestion();
                            return;
                         }
@@ -1831,6 +1872,7 @@ public class TextEditingTargetAssistantHelper
                         {
                            event.stopPropagation();
                            event.preventDefault();
+                           sendSuggestionFeedback("rejected");
                            resetSuggestion();
                            return;
                         }
@@ -1881,6 +1923,7 @@ public class TextEditingTargetAssistantHelper
                         // Let Ace close its popup first
                         if (!display_.hasActiveAceCompleter())
                         {
+                           sendSuggestionFeedback("rejected");
                            hideGhostText();
                            editSuggestion_ = null;
                         }
@@ -2125,6 +2168,7 @@ public class TextEditingTargetAssistantHelper
       // Dismiss any active next edit suggestion
       if (hasActiveSuggestion())
       {
+         sendSuggestionFeedback("rejected");
          resetSuggestion();
       }
    }
@@ -2528,6 +2572,7 @@ public class TextEditingTargetAssistantHelper
       // Cancel all timers and reset suggestion state
       suspendTimer_.cancel();
       nesTimer_.cancel();
+      sendSuggestionFeedback("ignored");
       resetSuggestion();
 
       // Clear diff view state


### PR DESCRIPTION
## Intent

Adds dismiss feedback for NES suggestions via the existing `workspace/executeCommand` telemetry pathway. When a suggestion is dismissed, the completion command's feedback argument is sent as "rejected" (Escape key, Discard button) or "ignored" (typing over, undo, editor close, replacement by new suggestion).

Only applies when using the Posit AI LSP.

## Automated Tests

No automated tests, no observable side effects in RStudio. Verified manually by inspecting LSP request/response logs.                                                               
                                                                          
 ## QA Notes                                                                                                                                                                                                                                  
                                         
  N/A
                                                                                                                                                                                                                                            
## Documentation
                                                                                                                                                                                                                                            
  N/A — no user-facing behavior change.  