### PR TITLE
Suspected typo in `r-ldpath.in`

### DIFF
--- a/src/cpp/session/r-ldpath.in
+++ b/src/cpp/session/r-ldpath.in
@@ -15,7 +15,7 @@
 #
 #
 
-RHOME=$1
-. $RHOME/etc/ldpaths
+R_HOME=$1
+. $R_HOME/etc/ldpaths
 echo -n "${@LIBRARY_PATH_ENVVAR@}"
 


### PR DESCRIPTION
At the least this would be unfortunate naming, but I believe this may actually be a typo.

### Intent

Without this change, it seems that `R_HOME` is not set when calling `$RHOME/etc/ldpaths` which means that the system path `/lib` (instead of `$R_HOME/lib`) gets included in `LD_LIBRARY_PATH` when opening a terminal. On most systems this probably has no impact, but we install RStudio under Gentoo Prefix which breaks in this case.

### Approach

I don't pretend to understand the codebase, but the change is tiny, and not exported. It does fix the problem that I have experienced.

### Automated Tests

No additional tests. I did note that the real value of `$R_HOME` is prepended to what is returned by `$RHOME/etc/ldpaths` which I suspect is a workaround for the fact that the correct path to `$R_HOME/lib` was not returned. With this change that path is now duplicated.

### QA Notes

This is related to my experience, mentioned in https://github.com/rstudio/rstudio/issues/15847#issuecomment-3385418370

### Documentation

Bugfix

### Checklist

- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->

I haven't signed the contributor agreement so I expect this PR to be closed/rejected, I don't think you need a contribution from me to fix a trivial typo.


