### PR TITLE
disable debugger during environment pane object inspection

### DIFF
--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -563,6 +563,27 @@ assign(".rs.S3Overrides", new.env(parent = emptyenv()), envir = .rs.toolsEnv())
    expr
 })
 
+.rs.addFunction("withDebuggerDisabled", function(expr)
+{
+   # Temporarily disable the R debugger. This prevents breakpoints
+   # (implemented via trace()) and debug()-based stepping from triggering
+   # during the evaluation of 'expr'.
+   #
+   # This is used by environment pane inspection code to avoid recursive
+   # debugger invocations: when stopped at a breakpoint inside an S3 method
+   # (e.g. `[[.some_class`), inspecting objects can dispatch to the same
+   # method, re-triggering the breakpoint and creating infinite recursion.
+   # https://github.com/rstudio/rstudio/issues/16987
+   oldTracing <- tracingState(FALSE)
+   oldDebugging <- debuggingState(FALSE)
+   on.exit({
+      tracingState(oldTracing)
+      debuggingState(oldDebugging)
+   }, add = TRUE)
+
+   expr
+})
+
 .rs.addFunction("sessionModulePath", function()
 {
    .Call("rs_sessionModulePath", PACKAGE = "(embedding)")

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -745,7 +745,7 @@
    {
       val <- .rs.describeCall(obj)
    }
-   else
+   else .rs.withDebuggerDisabled(
    {
       # for large objects (> half MB), don't try to get the value, just show
       # the size. Some functions (e.g. str()) can cause the object to be
@@ -773,7 +773,7 @@
             size_formatted <- format(size, units = "auto", standard = "SI")
             if (is_size_estimated)
                size_formatted <- paste(">", size_formatted)
-            
+
             fmt <- "Large %s (%s%s)"
             val <- sprintf(fmt, class, len_desc, size_formatted)
          }
@@ -801,7 +801,7 @@
             }
          }
       }
-   }
+   })
 
    list(
       name              = .rs.scalar(objName),
@@ -959,7 +959,7 @@
    if (.rs.isUnloadedS4(object))
       return(list())
 
-   .rs.valueContents(object)
+   .rs.withDebuggerDisabled(.rs.valueContents(object))
 })
 
 # Check if an object is an S4 instance whose defining package namespace

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -745,7 +745,7 @@
    {
       val <- .rs.describeCall(obj)
    }
-   else .rs.withDebuggerDisabled(
+   else
    {
       # for large objects (> half MB), don't try to get the value, just show
       # the size. Some functions (e.g. str()) can cause the object to be
@@ -796,12 +796,14 @@
             }
             else
             {
-               # normal object
-               contents <- .rs.valueContents(obj)
+               # normal object -- disable the debugger to prevent recursive
+               # debugger invocations when str() dispatches to user S3 methods
+               # https://github.com/rstudio/rstudio/issues/16987
+               contents <- .rs.withDebuggerDisabled(.rs.valueContents(obj))
             }
          }
       }
-   })
+   }
 
    list(
       name              = .rs.scalar(objName),


### PR DESCRIPTION
## Intent

Addresses #16987.

## Summary

- When stopped at a breakpoint inside an S3 method (e.g. `[[.some_class`), the Environment pane refresh calls `.rs.describeObject()`, which can dispatch to the same method via `str()`, re-triggering the breakpoint and creating infinite recursion.
- Add `.rs.withDebuggerDisabled()`, which temporarily sets `tracingState(FALSE)` and `debuggingState(FALSE)` to suppress both `trace()`-injected breakpoints and `debug()`-based stepping during evaluation.
- Wrap the dispatch-prone paths in `describeObject()` and `getObjectContents()` with this guard.

## Test plan

- [ ] Open a new R script with the reproducer from #16987
- [ ] Set a breakpoint on line 3 (`value`) and source the script
- [ ] Verify the debugger stops at the breakpoint without freezing R
- [ ] Verify the Environment pane displays correctly while in the browser
- [ ] Verify stepping through and exiting the browser works normally
- [ ] Verify that breakpoints still work normally for functions that are *not* called during environment inspection