### PR TITLE
suppress errors in get_help RPC handler

### DIFF
--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -343,7 +343,10 @@ options(help_type = "html")
       return()
    
    envir <- .rs.getActiveFrame()
-   out <- .rs.getHelpRpcImpl(what, from, type, envir)
+   out <- tryCatch(
+      .rs.getHelpRpcImpl(what, from, type, envir),
+      error = function(e) NULL
+   )
    if (is.null(out))
       return()
    


### PR DESCRIPTION
## Intent

Addresses #17156.

## Summary

- Wrap the `get_help` RPC handler in a `tryCatch` so that errors during help retrieval (e.g. `tools:::httpd()` failing with "cannot open the connection") silently return no result rather than surfacing an error dialog

A previous fix (c826ce0d4d) added error suppression for the `getHelpColumn` code path specifically, but the same class of error can occur through any path that reaches `tools:::httpd()` — including `getHelpFunction`, `getHelpArgument`, `getHelpDataFrame`, etc.

**Note:** This fix is speculative. We haven't been able to reproduce the issue locally, but the error in the report (`Error in file(out, "wt") : cannot open the connection`) points to a failure inside R's help rendering system that we should be resilient to.

## Test plan

- [ ] Verify autocomplete help tooltips still work normally
- [ ] Verify that if `tools:::httpd()` errors, the tooltip is simply not shown (no error dialog)