### PR TITLE
fix C++ code completion when CXX_STD >= CXX20

### DIFF
--- a/src/cpp/core/libclang/SourceIndex.cpp
+++ b/src/cpp/core/libclang/SourceIndex.cpp
@@ -259,19 +259,21 @@ TranslationUnit SourceIndex::getTranslationUnit(const std::string& filename,
    
    // fix up '-std=' arguments; in particular, we only pass the C++
    // '-std' flags when compiling C++ sources, and the C '-std' flags
-   // whe compiling C sources
+   // when compiling C sources
    if (FilePath(filename).hasExtensionLowerCase(".c"))
    {
+      // remove C++ std flags (e.g. -std=c++20) from C compilations
       core::algorithm::expel_if(args, [](const std::string& arg)
       {
-         return arg.find("-std") == 0 && arg.find("++") != 0;
+         return arg.find("-std") == 0 && arg.find("++") != std::string::npos;
       });
    }
    else
    {
+      // remove C-only std flags (e.g. -std=c11) from C++ compilations
       core::algorithm::expel_if(args, [](const std::string& arg)
       {
-         return arg.find("-std") == 0 && arg.find("++") == 0;
+         return arg.find("-std") == 0 && arg.find("++") == std::string::npos;
       });
    }
    

--- a/src/cpp/core/libclang/SourceIndex.cpp
+++ b/src/cpp/core/libclang/SourceIndex.cpp
@@ -257,9 +257,8 @@ TranslationUnit SourceIndex::getTranslationUnit(const std::string& filename,
    if (verbose_ >= 3)
      args.push_back("-v");
    
-   // fix up '-std=' arguments; in particular, we only pass the C++
-   // '-std' flags when compiling C++ sources, and the C '-std' flags
-   // when compiling C sources
+   // fix up '-std=' arguments: remove C++ '-std' flags when compiling
+   // C sources, and remove C-only '-std' flags when compiling C++ sources
    if (FilePath(filename).hasExtensionLowerCase(".c"))
    {
       // remove C++ std flags (e.g. -std=c++20) from C compilations

--- a/src/cpp/session/modules/clang/CompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/CompilationDatabase.cpp
@@ -269,13 +269,33 @@ std::vector<std::string> extractCompileArgs(const std::string& line)
 
 std::string extractStdArg(const std::vector<std::string>& args)
 {
+   // return the last '-std=' flag, since when multiple flags are present
+   // the last one takes precedence (matching compiler semantics)
+   std::string result;
    for (const std::string& arg : args)
    {
       if (boost::algorithm::starts_with(arg, "-std="))
-         return arg;
+         result = arg;
    }
+   return result;
+}
 
-   return std::string();
+// When R embeds a default standard in CXX (e.g. '-std=gnu++17') and the
+// package requests a different one via CXX_STD in Makevars, R CMD SHLIB
+// produces both flags. Compilers handle this via "last flag wins", but
+// libclang can get confused (especially with precompiled headers).
+// Deduplicate by keeping only the last '-std=' flag.
+void deduplicateStdArgs(std::vector<std::string>& args)
+{
+   std::string lastStd = extractStdArg(args);
+   if (lastStd.empty())
+      return;
+
+   core::algorithm::expel_if(args, [](const std::string& arg) {
+      return boost::algorithm::starts_with(arg, "-std=");
+   });
+
+   args.push_back(lastStd);
 }
 
 std::string buildFileHash(const FilePath& filePath)
@@ -1130,6 +1150,9 @@ ClangCompilationDatabase::CompilationConfig
    // add them to the compile args
    args.insert(args.begin(), compileArgs.begin(), compileArgs.end());
 
+   // deduplicate '-std=' flags
+   deduplicateStdArgs(args);
+
    CompilationConfig config;
    config.args = args;
    config.PCH = cppPkg;
@@ -1300,6 +1323,14 @@ std::vector<std::string> ClangCompilationDatabase::packageCompilationArgs(
       env.push_back(std::make_pair("USE_CXX1Z", "1"));
       env.push_back(std::make_pair("USE_CXX17", "1"));
    }
+   else if (boost::algorithm::icontains(pkgInfo.systemRequirements(), "C++20"))
+   {
+      env.push_back(std::make_pair("USE_CXX20", "1"));
+   }
+   else if (boost::algorithm::icontains(pkgInfo.systemRequirements(), "C++23"))
+   {
+      env.push_back(std::make_pair("USE_CXX23", "1"));
+   }
 
    // Run R CMD SHLIB
    std::vector<std::string> compileArgs = compileArgsForPackage(env, srcDir, isCpp);
@@ -1327,6 +1358,9 @@ std::vector<std::string> ClangCompilationDatabase::packageCompilationArgs(
 
    // add these to our args
    args.insert(args.begin(), compileArgs.begin(), compileArgs.end());
+
+   // deduplicate '-std=' flags
+   deduplicateStdArgs(args);
 
    if (pPkgInfo)
       *pPkgInfo = pkgInfo;

--- a/src/cpp/session/modules/clang/CompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/CompilationDatabase.cpp
@@ -291,6 +291,16 @@ void deduplicateStdArgs(std::vector<std::string>& args)
    if (lastStd.empty())
       return;
 
+   auto count = std::count_if(args.begin(), args.end(), [](const std::string& arg) {
+      return boost::algorithm::starts_with(arg, "-std=");
+   });
+
+   if (count <= 1)
+      return;
+
+   if (verbose(3))
+      std::cerr << "Deduplicating -std= flags (keeping: " << lastStd << ")" << std::endl;
+
    core::algorithm::expel_if(args, [](const std::string& arg) {
       return boost::algorithm::starts_with(arg, "-std=");
    });


### PR DESCRIPTION
## Intent

Addresses #17159.

## Summary

- In R 4.4+, the default `CXX` variable embeds a standard flag (e.g. `-std=gnu++17`), so `R CMD SHLIB` output contains both the default and the package-requested standard (e.g. `-std=c++20`). This caused `extractStdArg()` to pick the wrong (first) flag, building the precompiled header with C++17 while the translation unit was parsed with C++20 -- producing a fatal PCH mismatch error.
- Fix by deduplicating `-std` flags after assembling compilation args, keeping only the last one (matching compiler "last flag wins" semantics).
- Add `USE_CXX20` / `USE_CXX23` env vars for packages using `SystemRequirements: C++20` or `C++23` in DESCRIPTION.
- Fix a latent bug in `SourceIndex.cpp` where the C vs C++ std flag filtering conditions were always true/false (no-op), so C-only std flags were never removed from C++ compilations.

## Test plan

- [ ] Open an R package with `CXX_STD = CXX20` in `src/Makevars` and verify C++ code completion works
- [ ] Open an R package with `CXX_STD = CXX17` and verify code completion still works (regression check)
- [ ] Verify precompiled headers are built with the correct standard (check `clang_verbose` output)