### PR TITLE
dismiss chat readline notification when console input is received

### DIFF
--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -220,6 +220,7 @@ const int kAssistantStatusChanged = 202;
 const int kChatBackendExit = 203;
 const int kShowMessage = 204;
 const int kNotebookRenderCompleted = 205;
+const int kConsoleReadCompleted = 206;
 
 }
 
@@ -616,6 +617,8 @@ std::string ClientEvent::typeName() const
          return "chat_backend_exit";
       case client_events::kNotebookRenderCompleted:
          return "notebook_render_completed";
+      case client_events::kConsoleReadCompleted:
+         return "console_read_completed";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " +
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -442,6 +442,15 @@ bool rConsoleRead(const std::string& prompt,
       module_context::events().onConsoleInput(pConsoleInput->text);
    }
 
+   // notify the client that console input has been received
+   if (init::isSessionInitialized())
+   {
+      json::Object data;
+      data["history"] = addToHistory;
+      ClientEvent event(client_events::kConsoleReadCompleted, data);
+      clientEventQueue().add(event);
+   }
+
    // we are about to return input to r so set the flag indicating that state
    setExecuting(true);
 

--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -442,7 +442,9 @@ bool rConsoleRead(const std::string& prompt,
       module_context::events().onConsoleInput(pConsoleInput->text);
    }
 
-   // notify the client that console input has been received
+   // notify the client that console input has been received (including
+   // cancelled input, since consumers may need to dismiss UI affordances
+   // shown while waiting for input)
    if (init::isSessionInitialized())
    {
       json::Object data;

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -221,6 +221,7 @@ extern const int kConsoleWritePendingWarning;
 extern const int kAssistantStatusChanged;
 extern const int kChatBackendExit;
 extern const int kNotebookRenderCompleted;
+extern const int kConsoleReadCompleted;
 
 }
    

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -58,6 +58,7 @@
 #include <r/RSexp.hpp>
 #include <r/RUtil.hpp>
 #include <r/session/RBusy.hpp>
+#include <r/session/RSession.hpp>
 #include <r/session/RConsoleActions.hpp>
 #include <r/session/RConsoleHistory.hpp>
 #include <r/session/REventLoop.hpp>
@@ -1282,6 +1283,13 @@ void processPendingExecution()
          console_input::updateSessionExecuting();
          ClientEvent busyEvent(client_events::kBusy, false);
          module_context::enqueClientEvent(busyEvent);
+
+         // Restore the top-level prompt flag before reissuing. Code executed
+         // by the chat backend may have called readline(), which sets
+         // atTopLevelPrompt to false (hist == 0 in RReadConsole). Without
+         // this reset, the reissued prompt carries busy=true and the chat
+         // pane's "waiting for input" notification is never dismissed.
+         r::session::setAtTopLevelPrompt(true);
          console_input::reissueLastConsolePrompt();
       }
    }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -211,6 +211,7 @@ class ClientEvent extends JavaScriptObject
    public static final String AssistantStatusChanged = "assistant_status_changed";
    public static final String ChatBackendExit = "chat_backend_exit";
    public static final String NotebookRenderCompleted = "notebook_render_completed";
+   public static final String ConsoleReadCompleted = "console_read_completed";
 
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -162,6 +162,7 @@ import org.rstudio.studio.client.workbench.views.connections.model.Connection;
 import org.rstudio.studio.client.workbench.views.connections.model.ConnectionId;
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleActivateEvent;
 import org.rstudio.studio.client.workbench.views.console.events.ConsolePromptEvent;
+import org.rstudio.studio.client.workbench.views.console.events.ConsoleReadCompletedEvent;
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleResetHistoryEvent;
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleWriteErrorEvent;
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleWriteInputEvent;
@@ -1217,6 +1218,11 @@ public class ClientEventDispatcher
                   data.getDocId(),
                   data.getDocPath(),
                   data.getErrorMessage()));
+         }
+         else if (type == ClientEvent.ConsoleReadCompleted)
+         {
+            ConsoleReadCompletedEvent.Data data = event.getData();
+            eventBus_.dispatchEvent(new ConsoleReadCompletedEvent(data.getHistory()));
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPresenter.java
@@ -51,6 +51,7 @@ import org.rstudio.studio.client.workbench.views.chat.events.ChatSatelliteAction
 import org.rstudio.studio.client.workbench.views.chat.model.ChatSatelliteParams;
 import org.rstudio.studio.client.workbench.views.chat.server.ChatServerOperations;
 import org.rstudio.studio.client.workbench.views.console.events.ConsolePromptEvent;
+import org.rstudio.studio.client.workbench.views.console.events.ConsoleReadCompletedEvent;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.RepeatingCommand;
@@ -59,6 +60,7 @@ import com.google.inject.Inject;
 
 public class ChatPresenter extends BasePresenter
    implements ConsolePromptEvent.Handler,
+              ConsoleReadCompletedEvent.Handler,
               SatelliteClosedEvent.Handler,
               ChatReturnToMainEvent.Handler,
               ChatSatelliteActionEvent.Handler
@@ -249,6 +251,9 @@ public class ChatPresenter extends BasePresenter
       // Listen for console prompt events (to detect when R is waiting for input)
       events_.addHandler(ConsolePromptEvent.TYPE, this);
 
+      // Listen for console read completion (to dismiss notification after readline)
+      events_.addHandler(ConsoleReadCompletedEvent.TYPE, this);
+
       // Listen for backend exit events (crashes)
       events_.addHandler(ChatBackendExitEvent.TYPE, new ChatBackendExitEvent.Handler()
       {
@@ -434,6 +439,16 @@ public class ChatPresenter extends BasePresenter
       if (event.getPrompt().getBusy())
          display_.showReadlineNotification();
       else
+         display_.hideReadlineNotification();
+   }
+
+   // When console input is received for a sub-prompt (readline, browser, scan,
+   // etc.), dismiss the notification immediately rather than waiting for R to
+   // return to the top-level REPL.
+   @Override
+   public void onConsoleReadCompleted(ConsoleReadCompletedEvent event)
+   {
+      if (!event.getHistory())
          display_.hideReadlineNotification();
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPresenter.java
@@ -442,9 +442,10 @@ public class ChatPresenter extends BasePresenter
          display_.hideReadlineNotification();
    }
 
-   // When console input is received for a sub-prompt (readline, browser, scan,
-   // etc.), dismiss the notification immediately rather than waiting for R to
-   // return to the top-level REPL.
+   // When console input is received for a sub-prompt (readline, scan, etc.),
+   // dismiss the notification immediately rather than waiting for R to return
+   // to the top-level REPL. Browser prompts are not handled here because they
+   // add to history; they are dismissed by onConsolePrompt() instead.
    @Override
    public void onConsoleReadCompleted(ConsoleReadCompletedEvent event)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/events/ConsoleReadCompletedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/events/ConsoleReadCompletedEvent.java
@@ -1,0 +1,62 @@
+/*
+ * ConsoleReadCompletedEvent.java
+ *
+ * Copyright (C) 2025 by Posit Software, PBC
+ *
+ * This program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.console.events;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class ConsoleReadCompletedEvent extends GwtEvent<ConsoleReadCompletedEvent.Handler>
+{
+   public interface Handler extends EventHandler
+   {
+      void onConsoleReadCompleted(ConsoleReadCompletedEvent event);
+   }
+
+   public static class Data extends JavaScriptObject
+   {
+      protected Data()
+      {
+      }
+
+      public native final boolean getHistory() /*-{
+         return this.history;
+      }-*/;
+   }
+
+   public ConsoleReadCompletedEvent(boolean history)
+   {
+      history_ = history;
+   }
+
+   public boolean getHistory()
+   {
+      return history_;
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onConsoleReadCompleted(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<>();
+
+   private final boolean history_;
+}


### PR DESCRIPTION
## Intent

Addresses #17347.

## Summary

- Added a new `kConsoleReadCompleted` client event, fired from `rConsoleRead()` whenever console input is received. It carries the `addToHistory` flag (`true` for top-level REPL, `false` for sub-prompts like `readline`/`browser`/`scan`). `ChatPresenter` uses this to dismiss the "R is waiting for input" notification as soon as the user provides input, rather than waiting for R to return to the top-level REPL.
- Fixed stale `atTopLevelPrompt` state in `processPendingExecution()`: code executed by the chat backend that called `readline()` left this flag as `false`, causing `reissueLastConsolePrompt()` to fire with `busy=true` and the notification to persist indefinitely.

## Test plan

- [ ] Open the chat pane and ask the assistant to write and run code using `readline()` (e.g. "Write R code that asks the user for their name and counts the letters. Use readline. Run the code.")
- [ ] When prompted, provide input in the Console — notification should dismiss immediately
- [ ] Run `(function() { readline("prompt: "); Sys.sleep(5) })()` in the Console with the chat pane open — notification should dismiss after providing input, not after the sleep completes
- [ ] Verify normal `browser()` notification still appears and dismisses correctly