### PR TITLE
pass completion data with copilot status bar event

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetAssistantHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetAssistantHelper.java
@@ -1399,14 +1399,11 @@ public class TextEditingTargetAssistantHelper
                               }
                            }
 
-                           events_.fireEvent(new AssistantEvent(
-                                 completions.isEmpty()
-                                    ? AssistantEventType.COMPLETION_RECEIVED_NONE
-                                    : AssistantEventType.COMPLETION_RECEIVED_SOME));
-
                            // If we don't have any completions available, fall back to NES for Copilot
                            if (completions.isEmpty())
                            {
+                              events_.fireEvent(new AssistantEvent(AssistantEventType.COMPLETION_RECEIVED_NONE));
+
                               if (shouldFallbackToNes())
                               {
                                  nesTimer_.schedule(20);
@@ -1418,6 +1415,9 @@ public class TextEditingTargetAssistantHelper
                            // the user to view/select them. For now, use the last one.
                            // https://github.com/rstudio/rstudio/issues/16055
                            AssistantCompletion completion = completions.get(completions.size() - 1);
+
+                           events_.fireEvent(new AssistantEvent(
+                              AssistantEventType.COMPLETION_RECEIVED_SOME, completion));
 
                            // The completion data gets modified when doing partial (word-by-word)
                            // completions, so we need to use a copy and preserve the original


### PR DESCRIPTION
## Intent

Addresses #17372.

## Summary

- The Copilot inline completion path fired the `COMPLETION_RECEIVED_SOME` event without attaching the `AssistantCompletion` object as event data
- The status bar click handler in `TextEditingTarget` needs this data to create the scroll-to-position behavior, so the "Completion response received" link was never functional for Copilot completions
- Now passes the selected completion when firing the event, matching what the NES / Posit Assistant path already does

## Test plan

- [ ] Enable GitHub Copilot as the code assistant
- [ ] Open an R script with enough content to scroll
- [ ] Trigger a Copilot ghost text suggestion
- [ ] Scroll away from the suggestion location
- [ ] Click "Completion response received" in the status bar — editor should scroll back to the suggestion