### PR TITLE
Improve clean-rstudio.bat error reporting and robustness

### DIFF
--- a/scripts/clean-rstudio.bat
+++ b/scripts/clean-rstudio.bat
@@ -61,9 +61,9 @@ if exist "%MyDocsDir%\.Renviron" (
 
 echo.
 if %ERRORS% equ 0 (
-    echo Done. Cleaned %CLEANED% item(s), no errors.
+    echo Done. Cleaned %CLEANED% item^(s^), no errors.
 ) else (
-    echo Done. Cleaned %CLEANED% item(s), %ERRORS% FAILED.
+    echo Done. Cleaned %CLEANED% item^(s^), %ERRORS% FAILED.
     echo Re-run after closing RStudio and any R sessions.
     exit /b 1
 )

--- a/scripts/clean-rstudio.bat
+++ b/scripts/clean-rstudio.bat
@@ -17,8 +17,8 @@ if not exist "%~1\" exit /b 0
 echo Removing directory: %~1
 rd /q /s "%~1" 2>nul
 if !ERRORLEVEL! neq 0 (
-    echo ERROR: Failed to remove "%~1" — is something holding it open?
-    echo        Try: handle.exe "%~1" (Sysinternals) to find the locking process.
+    echo ERROR: Failed to remove "%~1" -- is something holding it open?
+    echo        Try: handle.exe "%~1" ^(Sysinternals^) to find the locking process.
     set /a ERRORS+=1
 ) else (
     set /a CLEANED+=1
@@ -30,8 +30,8 @@ if not exist "%~1" exit /b 0
 echo Deleting file: %~1
 del /f "%~1" 2>nul
 if !ERRORLEVEL! neq 0 (
-    echo ERROR: Failed to delete "%~1" — is something holding it open?
-    echo        Try: handle.exe "%~1" (Sysinternals) to find the locking process.
+    echo ERROR: Failed to delete "%~1" -- is something holding it open?
+    echo        Try: handle.exe "%~1" ^(Sysinternals^) to find the locking process.
     set /a ERRORS+=1
 ) else (
     set /a CLEANED+=1

--- a/scripts/clean-rstudio.bat
+++ b/scripts/clean-rstudio.bat
@@ -1,44 +1,71 @@
 @echo off
+setlocal EnableDelayedExpansion
+
 echo About to delete all per-user RStudio state and settings, proceed with caution!
 echo (Does not delete Project-specific state in .Rproj.user, global machine state, or .Renviron)
-set /p=Press [enter] to continue or Ctrl+C
+pause
 
-if EXIST "%localappdata%\RStudio-Desktop\" (
-    rd /q /s "%localappdata%\RStudio-Desktop"
-)
-if EXIST "%localappdata%\RStudio\" (
-    rd /q /s "%localappdata%\RStudio"
-)
-if EXIST "%appdata%\RStudio\" (
-    rd /q /s "%appdata%\RStudio"
-)
-if EXIST "%localappdata%\R\crash-handler-permission" (
-    del "%localappdata%\R\crash-handler-permission"
-)
-if EXIST "%localappdata%\R\crash-handler.conf" (
-    del "%localappdata%\R\crash-handler.conf"
-)
-if EXIST "%appdata%\R\rsconnect" (
-    rd /q /s "%appdata%\R\rsconnect"
-)
-if EXIST "%appdata%\R\config\R\rsconnect" (
-    rd /q /s "%appdata%\R\config\R\rsconnect"
-)
-if EXIST "%USERPROFILE%\.positai\" (
-    rd /q /s "%USERPROFILE%\.positai"
-)
+set ERRORS=0
+set CLEANED=0
 
-for /f "tokens=*" %%i in ('powershell /command "[System.Environment]::GetFolderPath([Environment+SpecialFolder]::MyDocuments)"') do set MyDocsDir=%%i
-if EXIST "%MyDocsDir%\.RData" (
-    del "%MyDocsDir%\.RData"
+REM --- Helper: remove a directory if it exists ---
+REM   Uses a subroutine so each call reports what it's doing and whether it succeeded.
+goto :start
+
+:rmdir_if_exists
+if not exist "%~1\" exit /b 0
+echo Removing directory: %~1
+rd /q /s "%~1" 2>nul
+if !ERRORLEVEL! neq 0 (
+    echo ERROR: Failed to remove "%~1" — is something holding it open?
+    echo        Try: handle.exe "%~1" (Sysinternals) to find the locking process.
+    set /a ERRORS+=1
+) else (
+    set /a CLEANED+=1
 )
-if EXIST "%MyDocsDir%\.Rhistory" (
-    del "%MyDocsDir%\.Rhistory"
+exit /b 0
+
+:del_if_exists
+if not exist "%~1" exit /b 0
+echo Deleting file: %~1
+del /f "%~1" 2>nul
+if !ERRORLEVEL! neq 0 (
+    echo ERROR: Failed to delete "%~1" — is something holding it open?
+    echo        Try: handle.exe "%~1" (Sysinternals) to find the locking process.
+    set /a ERRORS+=1
+) else (
+    set /a CLEANED+=1
 )
-if EXIST "%MyDocsDir%\.R\rstudio\" (
-    rd /q /s "%MyDocsDir%\.R\rstudio"
-)
-if EXIST "%MyDocsDir%\.Renviron" (
+exit /b 0
+
+:start
+
+call :rmdir_if_exists "%localappdata%\RStudio-Desktop"
+call :rmdir_if_exists "%localappdata%\RStudio"
+call :rmdir_if_exists "%appdata%\RStudio"
+call :del_if_exists "%localappdata%\R\crash-handler-permission"
+call :del_if_exists "%localappdata%\R\crash-handler.conf"
+call :rmdir_if_exists "%appdata%\R\rsconnect"
+call :rmdir_if_exists "%appdata%\R\config\R\rsconnect"
+call :rmdir_if_exists "%USERPROFILE%\.positai"
+
+for /f "tokens=*" %%i in ('powershell -NoProfile -Command "[System.Environment]::GetFolderPath([Environment+SpecialFolder]::MyDocuments)"') do set MyDocsDir=%%i
+
+call :del_if_exists "%MyDocsDir%\.RData"
+call :del_if_exists "%MyDocsDir%\.Rhistory"
+call :rmdir_if_exists "%MyDocsDir%\.R\rstudio"
+
+if exist "%MyDocsDir%\.Renviron" (
     echo Note: "%MyDocsDir%\.Renviron" found, not deleting
 )
-echo Done cleaning RStudio settings and state
+
+echo.
+if %ERRORS% equ 0 (
+    echo Done. Cleaned %CLEANED% item(s), no errors.
+) else (
+    echo Done. Cleaned %CLEANED% item(s), %ERRORS% FAILED.
+    echo Re-run after closing RStudio and any R sessions.
+    exit /b 1
+)
+
+endlocal


### PR DESCRIPTION
## Intent

Improve the `scripts/clean-rstudio.bat` script so that when a file or directory is locked by another process, the error message identifies which path failed.

## Summary

- Each delete/rmdir operation now echoes the target path before attempting removal, and reports success or failure with a hint to use Sysinternals `handle.exe` for diagnosis
- Extract repeated if-exist/delete logic into `rmdir_if_exists` and `del_if_exists` subroutines
- Escape all literal parentheses inside `if` blocks to prevent cmd.exe parse errors (`(Sysinternals)` → `^(Sysinternals^)`, `item(s)` → `item^(s^)`)
- Replace `set /p` prompt hack with `pause`
- Add `setlocal`/`endlocal` for variable hygiene
- Add `-NoProfile` to powershell invocation
- Add `del /f` to handle read-only files
- Track and report cleaned/failed item counts
- Exit with non-zero status when any operation fails

## Test plan

- [ ] Run `scripts/clean-rstudio.bat` on Windows with RStudio closed — all items cleaned, no errors
- [ ] Run with RStudio open (some paths locked) — locked paths reported by name, others still cleaned
- [ ] Run when already clean (no paths exist) — reports 0 items cleaned, exits 0