### PR TITLE
fix assistant toolbar button visible after restart with chat hidden

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
@@ -291,6 +291,12 @@ public class GlobalToolbar extends Toolbar
             assistantSeparator_.setVisible(visible);
          });
 
+         // Sync initial state: PaneManager may have already set the command
+         // invisible before this handler was registered (see #17368)
+         boolean initialVisible = commands_.assistantPaneToggle().isVisible();
+         assistantButton_.setVisible(initialVisible);
+         assistantSeparator_.setVisible(initialVisible);
+
          eventBus_.addHandler(ChatPaneActiveEvent.TYPE, event ->
                assistantButton_.setLatched(event.isActive()));
 


### PR DESCRIPTION
## Intent

Addresses #17368.

## Summary

- The Posit Assistant toolbar button reappears after restarting RStudio even when the user has removed Chat from all pane layout zones.
- Root cause is a startup timing issue: `PaneManager`'s constructor calls `manageChatCommands()` which sets `assistantPaneToggle` invisible, but this runs **before** `GlobalToolbar.completeInitialization()` registers its `VisibleChangedHandler` (the handler is registered on `SessionInitEvent`, which fires after Workbench creation). The button is then created visible and never updated.
- Fix: sync the button's initial visibility from the command state immediately after registering the handler.

## Test plan

- [ ] Launch RStudio with default settings, confirm the Assistant toolbar button is visible
- [ ] Open **Tools > Global Options > Pane Layout**, uncheck Posit Assistant from all zones (sidebar, tabset1, tabset2), close preferences — button hides
- [ ] Exit and restart RStudio — button should now remain hidden
- [ ] Re-add Posit Assistant to the sidebar, restart — button should reappear