### PR TITLE
require rsconnect >= 1.8.0 when deploying to Connect Cloud

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -253,11 +253,14 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       // build dependency array -- same as rsconnect, but require
       // rsconnect >= 1.8.0 for Connect Cloud support
       List<Dependency> deps = getFeatureDependencies("rsconnect");
-      for (Dependency dep : deps)
+      for (int i = 0; i < deps.size(); i++)
       {
+         Dependency dep = deps.get(i);
          if (StringUtil.equals(dep.getName(), "rsconnect"))
          {
-            dep.setVersion("1.8.0");
+            // Replace with a fresh Dependency to avoid mutating the
+            // shared object in the session's DependencyList cache.
+            deps.set(i, Dependency.cranPackage("rsconnect", "1.8.0"));
             break;
          }
       }

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -23,7 +23,6 @@ import org.rstudio.core.client.CommandWith2Args;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
-import org.rstudio.core.client.Version;
 import org.rstudio.core.client.widget.MessageDialog;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.ProgressIndicator;
@@ -237,7 +236,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       List<Dependency> deps = getFeatureDependencies("rsconnect");
       if (requiresRmarkdown)
          deps.addAll(getFeatureDependencies("rmarkdown"));
-      
+
       withDependencies(
         constants_.publishingPaneHeader(),
         userAction,
@@ -245,6 +244,30 @@ public class DependencyManager implements InstallShinyEvent.Handler,
         userPrompt,
         deps,
         true, // silently update any embedded packages needed (none at present)
+        onCompleted
+      );
+   }
+
+   public void withConnectCloudDependencies(String userAction, final CommandWithArg<Boolean> onCompleted)
+   {
+      // build dependency array -- same as rsconnect, but require
+      // rsconnect >= 1.8.0 for Connect Cloud support
+      List<Dependency> deps = getFeatureDependencies("rsconnect");
+      for (Dependency dep : deps)
+      {
+         if (StringUtil.equals(dep.getName(), "rsconnect"))
+         {
+            dep.setVersion("1.8.0");
+            break;
+         }
+      }
+
+      withDependencies(
+        constants_.publishingPaneHeader(),
+        userAction,
+        getFeatureDescription("rsconnect"),
+        deps,
+        true,
         onCompleted
       );
    }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
@@ -578,6 +578,26 @@ public class RSConnect implements SessionInitEvent.Handler,
    public void onRSConnectDeployInitiated(
          final RSConnectDeployInitiatedEvent event)
    {
+      // if deploying to Connect Cloud, ensure rsconnect >= 1.8.0 is installed
+      if (CONNECT_CLOUD_SERVICE_NAME.equalsIgnoreCase(
+            event.getRecord().getServer()))
+      {
+         dependencyManager_.withConnectCloudDependencies(
+            constants_.publishingContentLabel(),
+            (succeeded) ->
+            {
+               if (succeeded)
+                  lintAndDeploy(event);
+            });
+      }
+      else
+      {
+         lintAndDeploy(event);
+      }
+   }
+
+   private void lintAndDeploy(final RSConnectDeployInitiatedEvent event)
+   {
       // shortcut: when deploying static content we don't need to do any linting
       if (event.getSettings().getAsStatic())
       {


### PR DESCRIPTION
## Intent

Addresses #17391.

## Summary

- Added `withConnectCloudDependencies()` to `DependencyManager` which requires rsconnect >= 1.8.0 (instead of the default 1.3.1) for Connect Cloud support
- Before deploying to a Connect Cloud account, the dependency check now runs so users are prompted to install/upgrade rsconnect if needed

## Test plan

- [ ] Deploy to Connect Cloud with rsconnect < 1.8.0 installed; verify upgrade prompt appears
- [ ] Deploy to Connect Cloud with rsconnect >= 1.8.0 installed; verify no prompt, deploy proceeds normally
- [ ] Deploy to ShinyApps.io or Posit Connect; verify no change in behavior (no 1.8.0 requirement)