### PR TITLE
fix .DollarNames types attribute being ignored

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1981,7 +1981,7 @@ assign(x = ".rs.acCompletionTypes",
       }
       
       # Skip type inference if requested.
-      if (identical(suppressTypeInference, TRUE))
+      else if (identical(suppressTypeInference, TRUE))
       {
          type <- .rs.acCompletionTypes$UNKNOWN
       }


### PR DESCRIPTION
## Intent

Addresses https://github.com/rstudio/rstudio/issues/17200.

## Summary

- The `types` attribute on `.DollarNames` return values was being ignored due to a broken `else if` chain in `.rs.getCompletionsDollar`
- In commit 84811c1, when `suppressTypeInference` support was added, a new standalone `if` block was inserted between the types-attribute check and the rest of the inference chain, disconnecting them
- This caused the final `else` block to always run and overwrite user-provided types with inferred ones
- Fix: change `if` to `else if` so the types-attribute check is properly part of the chain

## Test plan

- [ ] Create a custom S3 class with a `.DollarNames` method that returns a `types` attribute
- [ ] Verify that `$<TAB>` completions display the correct icons matching the provided types
- [ ] Verify that `suppressTypeInference` attribute still works correctly
- [ ] Verify that data.frame `$` completions still show the column icon