### PR TITLE
avoid updating ignore files when assistant is disabled

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1533,6 +1533,20 @@ bool disablePackages()
    return !core::system::getenv("RSTUDIO_DISABLE_PACKAGES").empty();
 }
 
+bool isPositAssistantEnabledByAdmin()
+{
+   return session::options().allowPositAssistant() &&
+          session::options().positAssistantEnabled() &&
+          core::system::getenv("RSTUDIO_DISABLE_POSIT_ASSISTANT").empty();
+}
+
+bool isPositAssistantEnabled()
+{
+   return isPositAssistantEnabledByAdmin() &&
+          (prefs::userPrefs().assistant() != kAssistantNone ||
+           prefs::userPrefs().chatProvider() != kChatProviderNone);
+}
+
 // check if a package is installed
 bool isPackageInstalled(const std::string& packageName)
 {

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -161,6 +161,13 @@ bool restoreWorkspaceEnabled();
 // is the packages pane disabled
 bool disablePackages();
 
+// is the Posit Assistant feature enabled by the administrator?
+// checks: allow-posit-assistant, posit-assistant-enabled, RSTUDIO_DISABLE_POSIT_ASSISTANT
+bool isPositAssistantEnabledByAdmin();
+
+// is the Posit Assistant feature active? (admin enabled + user has an assistant or chat provider selected)
+bool isPositAssistantEnabled();
+
 // check if a package is installed
 bool isPackageInstalled(const std::string& packageName);
 

--- a/src/cpp/session/include/session/projects/SessionProjects.hpp
+++ b/src/cpp/session/include/session/projects/SessionProjects.hpp
@@ -266,6 +266,7 @@ private:
    void updatePackageInfo();
 
    void augmentRbuildignore();
+   void onUserPrefsChanged(const std::string& layer, const std::string& pref);
 
    // adds default open docs if specified in the project and it has
    // never been opened before

--- a/src/cpp/session/modules/SessionAssistant.cpp
+++ b/src/cpp/session/modules/SessionAssistant.cpp
@@ -96,10 +96,7 @@ bool isCopilotAllowedByAdmin()
 
 bool isPositAssistantAllowedByAdmin()
 {
-   return
-      session::options().allowPositAssistant() &&
-      session::options().positAssistantEnabled() &&
-      core::system::getenv("RSTUDIO_DISABLE_POSIT_ASSISTANT").empty();
+   return module_context::isPositAssistantEnabledByAdmin();
 }
 
 struct AssistantRequest

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -188,14 +188,9 @@ bool peerHasCapability(const std::string& method)
 // ============================================================================
 // Feature availability helper
 // ============================================================================
-// Returns true if the Posit Assistant feature is enabled. This requires:
-// 1. The allow-posit-assistant admin option (always true in open-source, configurable in Pro)
-// 2. The posit-assistant-enabled session option
 bool isPositAssistantEnabled()
 {
-   return options().allowPositAssistant() &&
-          options().positAssistantEnabled() &&
-          core::system::getenv("RSTUDIO_DISABLE_POSIT_ASSISTANT").empty();
+   return module_context::isPositAssistantEnabledByAdmin();
 }
 
 // Returns true if the user has selected Posit AI as their assistant (for code completions)

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -5281,7 +5281,7 @@ Error chatGetUpdateStatus(const json::JsonRpcRequest& request,
    return Success();
 }
 
-// NOTE: No isPositAssistantWanted()/isPositAssistantEnabled() gate — the user may have
+// NOTE: No isPositAssistantWanted()/isPositAssistantEnabledByAdmin() gate — the user may have
 // disabled Posit Assistant but still wants to clean up installed files.
 Error chatUninstallPositAssistant(const json::JsonRpcRequest& request,
                            json::JsonRpcResponse* pResponse)

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -188,7 +188,7 @@ bool peerHasCapability(const std::string& method)
 // ============================================================================
 // Feature availability helper
 // ============================================================================
-bool isPositAssistantEnabled()
+bool isPositAssistantEnabledByAdmin()
 {
    return module_context::isPositAssistantEnabledByAdmin();
 }
@@ -5680,14 +5680,14 @@ Error initialize()
 
    // Validate assistant preference consistency
    // If user has Posit AI selected but Posit Assistant is no longer available, reset to "none"
-   if (isPaiSelected() && !isPositAssistantEnabled())
+   if (isPaiSelected() && !isPositAssistantEnabledByAdmin())
    {
       prefs::userPrefs().setAssistant(kAssistantNone);
    }
 
    // Validate chat provider preference consistency
    // If user has Posit selected as chat provider but PAI is no longer available, reset to "none"
-   if (isChatProviderPosit() && !isPositAssistantEnabled())
+   if (isChatProviderPosit() && !isPositAssistantEnabledByAdmin())
    {
       prefs::userPrefs().setChatProvider(kChatProviderNone);
    }

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -3224,24 +3224,34 @@ std::string nonPathGitBinDir()
 
 void onUserSettingsChanged(const std::string& layer, const std::string& pref)
 {
-   if (pref != kGitExePath)
-      return;
-
-   FilePath gitExePath(prefs::userPrefs().gitExePath());
-   if (session::options().allowVcsExecutableEdit() && !gitExePath.isEmpty())
+   if (pref == kGitExePath)
    {
-      // if there is an explicit value then set it
-      s_gitExePath = gitExePath.getAbsolutePath();
-   }
-   else
-   {
-      // if we are relying on an auto-detected value then scan on windows
-      // and reset to empty on posix
+      FilePath gitExePath(prefs::userPrefs().gitExePath());
+      if (session::options().allowVcsExecutableEdit() && !gitExePath.isEmpty())
+      {
+         // if there is an explicit value then set it
+         s_gitExePath = gitExePath.getAbsolutePath();
+      }
+      else
+      {
+         // if we are relying on an auto-detected value then scan on windows
+         // and reset to empty on posix
 #ifdef _WIN32
-      detectAndSaveGitExePath();
+         detectAndSaveGitExePath();
 #else
-      s_gitExePath = "";
+         s_gitExePath = "";
 #endif
+      }
+   }
+   else if (pref == kAssistant || pref == kChatProvider)
+   {
+      if (!s_git_.root().isEmpty())
+      {
+         FilePath gitIgnore = s_git_.root().completeChildPath(".gitignore");
+         Error error = augmentGitIgnore(gitIgnore);
+         if (error)
+            LOG_ERROR(error);
+      }
    }
 }
 

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -3046,12 +3046,7 @@ Error addFilesToGitIgnore(const FilePath& gitIgnoreFile,
 Error augmentGitIgnore(const FilePath& gitIgnoreFile)
 {
    // only add AI-related ignores when the assistant is enabled
-   bool assistantActive =
-      session::options().allowPositAssistant() &&
-      session::options().positAssistantEnabled() &&
-      core::system::getenv("RSTUDIO_DISABLE_POSIT_ASSISTANT").empty() &&
-      (prefs::userPrefs().assistant() != kAssistantNone ||
-       prefs::userPrefs().chatProvider() != kChatProviderNone);
+   bool assistantActive = module_context::isPositAssistantEnabled();
 
    // Add stuff to .gitignore
    std::vector<std::string> filesToIgnore;
@@ -3101,6 +3096,7 @@ Error augmentGitIgnore(const FilePath& gitIgnoreFile)
       // Use libgit2 to check if paths are already covered by existing
       // gitignore rules (including global gitignore, parent directories,
       // wildcard rules, etc.)
+      // NOTE: assumes gitIgnoreFile is at the repo root (matches the sole call site)
       FilePath repoRoot = gitIgnoreFile.getParent();
       libgit2::Git git(repoRoot);
 
@@ -3117,6 +3113,8 @@ Error augmentGitIgnore(const FilePath& gitIgnoreFile)
          std::string packageName = r_util::packageNameFromDirectory(repoRoot);
          if (!packageName.empty())
          {
+            // test representative paths — gitignore glob * matches zero-or-more
+            // characters, so e.g. "mypackage.tar.gz" matches "mypackage*.tar.gz"
             if (!git.isIgnored(packageName + ".Rcheck"))
                filesToIgnore.push_back(packageName + ".Rcheck/");
             if (!git.isIgnored(packageName + ".tar.gz"))

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -3096,7 +3096,9 @@ Error augmentGitIgnore(const FilePath& gitIgnoreFile)
       // Use libgit2 to check if paths are already covered by existing
       // gitignore rules (including global gitignore, parent directories,
       // wildcard rules, etc.)
-      // NOTE: assumes gitIgnoreFile is at the repo root (matches the sole call site)
+      // NOTE: assumes gitIgnoreFile is at the repo root (matches the sole call site).
+      // If the repo fails to open, isIgnored() returns false for all paths,
+      // so all entries get appended as a safe fallback.
       FilePath repoRoot = gitIgnoreFile.getParent();
       libgit2::Git git(repoRoot);
 
@@ -3124,7 +3126,7 @@ Error augmentGitIgnore(const FilePath& gitIgnoreFile)
          }
       }
 
-      if (filesToIgnore.size() == 0)
+      if (filesToIgnore.empty())
          return Success();
 
       // check if we need an extra newline before appending

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -63,6 +63,7 @@
 #include <session/prefs/UserPrefs.hpp>
 
 #include "SessionAskPass.hpp"
+#include "SessionLibGit2.hpp"
 
 #include "SessionVCS.hpp"
 
@@ -3044,6 +3045,14 @@ Error addFilesToGitIgnore(const FilePath& gitIgnoreFile,
 
 Error augmentGitIgnore(const FilePath& gitIgnoreFile)
 {
+   // only add AI-related ignores when the assistant is enabled
+   bool assistantActive =
+      session::options().allowPositAssistant() &&
+      session::options().positAssistantEnabled() &&
+      core::system::getenv("RSTUDIO_DISABLE_POSIT_ASSISTANT").empty() &&
+      (prefs::userPrefs().assistant() != kAssistantNone ||
+       prefs::userPrefs().chatProvider() != kChatProviderNone);
+
    // Add stuff to .gitignore
    std::vector<std::string> filesToIgnore;
    if (!gitIgnoreFile.exists())
@@ -3055,7 +3064,9 @@ Error augmentGitIgnore(const FilePath& gitIgnoreFile)
       filesToIgnore.push_back(".Rhistory");
       filesToIgnore.push_back(".RData");
       filesToIgnore.push_back(".Ruserdata");
-      filesToIgnore.push_back(".positai");
+
+      if (assistantActive)
+         filesToIgnore.push_back(".positai");
 
       // if this is a package dir with a src directory then
       // also ignore native code build artifacts
@@ -3087,41 +3098,43 @@ Error augmentGitIgnore(const FilePath& gitIgnoreFile)
    }
    else
    {
-      // If .gitignore exists, add .Rproj.user unless it's already there
+      // Use libgit2 to check if paths are already covered by existing
+      // gitignore rules (including global gitignore, parent directories,
+      // wildcard rules, etc.)
+      FilePath repoRoot = gitIgnoreFile.getParent();
+      libgit2::Git git(repoRoot);
 
+      std::vector<std::string> filesToIgnore;
+
+      if (!git.isIgnored(".Rproj.user"))
+         filesToIgnore.push_back(".Rproj.user");
+
+      if (assistantActive && !git.isIgnored(".positai"))
+         filesToIgnore.push_back(".positai");
+
+      if (session::options().packageOutputInPackageFolder())
+      {
+         std::string packageName = r_util::packageNameFromDirectory(repoRoot);
+         if (!packageName.empty())
+         {
+            if (!git.isIgnored(packageName + ".Rcheck"))
+               filesToIgnore.push_back(packageName + ".Rcheck/");
+            if (!git.isIgnored(packageName + ".tar.gz"))
+               filesToIgnore.push_back(packageName + "*.tar.gz");
+            if (!git.isIgnored(packageName + ".tgz"))
+               filesToIgnore.push_back(packageName + "*.tgz");
+         }
+      }
+
+      if (filesToIgnore.size() == 0)
+         return Success();
+
+      // check if we need an extra newline before appending
       std::string strIgnore;
       Error error = core::readStringFromFile(gitIgnoreFile, &strIgnore);
       if (error)
          return error;
 
-      std::vector<std::string> filesToIgnore;
-
-      if (!regex_utils::search(strIgnore, boost::regex(R"(^/?\.Rproj\.user/?$)")))
-         filesToIgnore.push_back(".Rproj.user");
-
-      if (!regex_utils::search(strIgnore, boost::regex(R"(^/?\.positai/?$)")))
-         filesToIgnore.push_back(".positai");
-
-      if (session::options().packageOutputInPackageFolder())
-      {
-         // add any missing exclusions for package build/check output
-         std::string packageName = r_util::packageNameFromDirectory(gitIgnoreFile.getParent());
-         if (!packageName.empty())
-         {
-            std::string packageNameRegex = "^";
-            packageNameRegex += packageName;
-            if (!regex_utils::search(strIgnore, boost::regex(packageNameRegex + R"(\.Rcheck/$)")))
-               filesToIgnore.push_back(packageName + ".Rcheck/");
-            if (!regex_utils::search(strIgnore, boost::regex(packageNameRegex + R"(.*\.tar\.gz$)")))
-               filesToIgnore.push_back(packageName + "*.tar.gz");
-            if (!regex_utils::search(strIgnore, boost::regex(packageNameRegex + R"(.*\.tgz$)")))
-               filesToIgnore.push_back(packageName + "*.tgz");
-         }
-      }
-      
-      if (filesToIgnore.size() == 0)
-         return Success();
-      
       bool addExtraNewline = strIgnore.size() > 0
                              && strIgnore[strIgnore.size() - 1] != '\n';
 

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -3045,7 +3045,7 @@ Error addFilesToGitIgnore(const FilePath& gitIgnoreFile,
 
 Error augmentGitIgnore(const FilePath& gitIgnoreFile)
 {
-   // only add AI-related ignores when the assistant is enabled
+   // only add AI-related ignores when the assistant is active
    bool assistantActive = module_context::isPositAssistantEnabled();
 
    // Add stuff to .gitignore
@@ -3096,7 +3096,7 @@ Error augmentGitIgnore(const FilePath& gitIgnoreFile)
       // Use libgit2 to check if paths are already covered by existing
       // gitignore rules (including global gitignore, parent directories,
       // wildcard rules, etc.)
-      // NOTE: assumes gitIgnoreFile is at the repo root (matches the sole call site).
+      // NOTE: assumes gitIgnoreFile is at the repo root.
       // If the repo fails to open, isIgnored() returns false for all paths,
       // so all entries get appended as a safe fallback.
       FilePath repoRoot = gitIgnoreFile.getParent();

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -524,12 +524,20 @@ std::string nonPathSvnBinDir()
       return std::string();
 }
 
+Error augmentSvnIgnore();
+
 void onUserSettingsChanged(const std::string& layer, const std::string& pref)
 {
-   if (pref != kSvnExePath)
-      return;
-
-   initSvnBin();
+   if (pref == kSvnExePath)
+   {
+      initSvnBin();
+   }
+   else if (pref == kAssistant || pref == kChatProvider)
+   {
+      Error error = augmentSvnIgnore();
+      if (error)
+         LOG_ERROR(error);
+   }
 }
 
 std::string translateItemStatus(const std::string& status)

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -534,9 +534,12 @@ void onUserSettingsChanged(const std::string& layer, const std::string& pref)
    }
    else if (pref == kAssistant || pref == kChatProvider)
    {
-      Error error = augmentSvnIgnore();
-      if (error)
-         LOG_ERROR(error);
+      if (!s_workingDir.isEmpty())
+      {
+         Error error = augmentSvnIgnore();
+         if (error)
+            LOG_ERROR(error);
+      }
    }
 }
 
@@ -1775,7 +1778,7 @@ void SvnFileDecorationContext::decorateFile(const core::FilePath& filePath,
 
 Error augmentSvnIgnore()
 {
-   // only add AI-related ignores when the assistant is enabled
+   // only add AI-related ignores when the assistant is active
    bool assistantActive = module_context::isPositAssistantEnabled();
 
    // check for existing svn:ignore

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -1767,6 +1767,14 @@ void SvnFileDecorationContext::decorateFile(const core::FilePath& filePath,
 
 Error augmentSvnIgnore()
 {
+   // only add AI-related ignores when the assistant is enabled
+   bool assistantActive =
+      session::options().allowPositAssistant() &&
+      session::options().positAssistantEnabled() &&
+      core::system::getenv("RSTUDIO_DISABLE_POSIT_ASSISTANT").empty() &&
+      (prefs::userPrefs().assistant() != kAssistantNone ||
+       prefs::userPrefs().chatProvider() != kChatProviderNone);
+
    // check for existing svn:ignore
    core::system::ProcessResult result;
    Error error = getIgnores(s_workingDir, &result);
@@ -1787,7 +1795,8 @@ Error augmentSvnIgnore()
       svnIgnore += ".Rhistory\n";
       svnIgnore += ".RData\n";
       svnIgnore += ".Ruserdata\n";
-      svnIgnore += ".positai\n";
+      if (assistantActive)
+         svnIgnore += ".positai\n";
    }
    else
    {
@@ -1800,7 +1809,8 @@ Error augmentSvnIgnore()
       std::string additions;
       if (!regex_utils::search(svnIgnore, boost::regex("^\\.Rproj\\.user$")))
          additions += ".Rproj.user\n";
-      if (!regex_utils::search(svnIgnore, boost::regex("^\\.positai$")))
+      if (assistantActive &&
+          !regex_utils::search(svnIgnore, boost::regex("^\\.positai$")))
          additions += ".positai\n";
 
       if (additions.empty())

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -1768,12 +1768,7 @@ void SvnFileDecorationContext::decorateFile(const core::FilePath& filePath,
 Error augmentSvnIgnore()
 {
    // only add AI-related ignores when the assistant is enabled
-   bool assistantActive =
-      session::options().allowPositAssistant() &&
-      session::options().positAssistantEnabled() &&
-      core::system::getenv("RSTUDIO_DISABLE_POSIT_ASSISTANT").empty() &&
-      (prefs::userPrefs().assistant() != kAssistantNone ||
-       prefs::userPrefs().chatProvider() != kChatProviderNone);
+   bool assistantActive = module_context::isPositAssistantEnabled();
 
    // check for existing svn:ignore
    core::system::ProcessResult result;
@@ -1805,7 +1800,7 @@ Error augmentSvnIgnore()
       if (addExtraNewline)
          svnIgnore += "\n";
 
-      // Add .Rproj.user and .positai unless they're already there
+      // Add missing entries
       std::string additions;
       if (!regex_utils::search(svnIgnore, boost::regex("^\\.Rproj\\.user$")))
          additions += ".Rproj.user\n";

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -1828,8 +1828,8 @@ Error augmentSvnIgnore()
    if (error)
       return error;
 
-   if (result.exitStatus != EXIT_SUCCESS)
-      LOG_ERROR_MESSAGE(result.stdErr);
+   if (setResult.exitStatus != EXIT_SUCCESS)
+      LOG_ERROR_MESSAGE(setResult.stdErr);
 
    return Success();
 }

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -423,10 +423,22 @@ void ProjectContext::augmentRbuildignore()
       const char * const kIgnorePositai = R"(^\.positai$)";
       const char * const kIgnoreClaude = R"(^\.claude$)";
 
+      // check if the AI assistant is active (admin + user level)
+      bool assistantActive =
+         session::options().allowPositAssistant() &&
+         session::options().positAssistantEnabled() &&
+         core::system::getenv("RSTUDIO_DISABLE_POSIT_ASSISTANT").empty() &&
+         (prefs::userPrefs().assistant() != kAssistantNone ||
+          prefs::userPrefs().chatProvider() != kChatProviderNone);
+
       std::string ignoreLines = kIgnoreRproj + newLine +
-                                kIgnoreRprojUser + newLine +
-                                kIgnorePositai + newLine +
-                                kIgnoreClaude + newLine;
+                                kIgnoreRprojUser + newLine;
+
+      if (assistantActive)
+      {
+         ignoreLines += kIgnorePositai + newLine;
+         ignoreLines += kIgnoreClaude + newLine;
+      }
 
       if (session::options().packageOutputInPackageFolder())
       {
@@ -472,8 +484,8 @@ void ProjectContext::augmentRbuildignore()
          // for previous less precisely specified .Rproj entries
          bool hasRProj = strIgnore.find(R"(\.Rproj$)") != std::string::npos;
          bool hasRProjUser = strIgnore.find(kIgnoreRprojUser) != std::string::npos;
-         bool hasPositai = strIgnore.find(kIgnorePositai) != std::string::npos;
-         bool hasClaude = strIgnore.find(kIgnoreClaude) != std::string::npos;
+         bool hasPositai = !assistantActive || strIgnore.find(kIgnorePositai) != std::string::npos;
+         bool hasClaude = !assistantActive || strIgnore.find(kIgnoreClaude) != std::string::npos;
          bool hasAllPackageExclusions = true;
 
          bool addExtraNewline = strIgnore.size() > 0

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -536,6 +536,13 @@ void ProjectContext::augmentRbuildignore()
    }
 }
 
+void ProjectContext::onUserPrefsChanged(const std::string& layer,
+                                        const std::string& pref)
+{
+   if (pref == kAssistant || pref == kChatProvider)
+      augmentRbuildignore();
+}
+
 SEXP rs_getProjectDirectory()
 {
    SEXP absolutePathSEXP = R_NilValue;
@@ -613,6 +620,10 @@ Error ProjectContext::initialize()
 
       // augment .Rbuildignore if this is a package
       augmentRbuildignore();
+
+      // re-augment .Rbuildignore when assistant prefs change
+      prefs::userPrefs().onChanged.connect(
+                   boost::bind(&ProjectContext::onUserPrefsChanged, this, _1, _2));
 
       // subscribe to deferred init (for initializing our file monitor)
       if (config().enableCodeIndexing)

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -424,12 +424,7 @@ void ProjectContext::augmentRbuildignore()
       const char * const kIgnoreClaude = R"(^\.claude$)";
 
       // check if the AI assistant is active (admin + user level)
-      bool assistantActive =
-         session::options().allowPositAssistant() &&
-         session::options().positAssistantEnabled() &&
-         core::system::getenv("RSTUDIO_DISABLE_POSIT_ASSISTANT").empty() &&
-         (prefs::userPrefs().assistant() != kAssistantNone ||
-          prefs::userPrefs().chatProvider() != kChatProviderNone);
+      bool assistantActive = module_context::isPositAssistantEnabled();
 
       std::string ignoreLines = kIgnoreRproj + newLine +
                                 kIgnoreRprojUser + newLine;


### PR DESCRIPTION
## Intent

Addresses #17407.

## Summary

- Skip adding `.positai` and `.claude` to `.gitignore`, `.Rbuildignore`, and `svn:ignore` when the AI assistant is disabled — respects both admin-level settings (`allowPositAssistant`, `positAssistantEnabled`, `RSTUDIO_DISABLE_POSIT_ASSISTANT`) and user-level preferences (`assistant`, `chatProvider`)
- Switch `.gitignore` augmentation to use libgit2's `git_ignore_path_is_ignored()` instead of regex matching, so paths already covered by broader rules (wildcards, global gitignore, parent directories) are not redundantly added

## Test plan

- [ ] With assistant disabled at admin level (`--posit-assistant-enabled=0`), open a new R package project and verify `.positai`/`.claude` are not added to `.gitignore` or `.Rbuildignore`
- [ ] With user prefs `assistant: "none"` and `chatProvider: "none"`, open a new R package project and verify `.positai`/`.claude` are not added
- [ ] With assistant enabled, verify `.positai` and `.claude` are still added as before
- [ ] With a global gitignore rule covering `.Rproj.user` (e.g. `.*`), open a project with an existing `.gitignore` and verify `.Rproj.user` is not redundantly appended