### PR TITLE
Fix What's New dialog blending into background on Linux

### DIFF
--- a/src/node/desktop/src/main/whats-new-window.ts
+++ b/src/node/desktop/src/main/whats-new-window.ts
@@ -189,6 +189,7 @@ export function showWhatsNewWindow(options: WhatsNewWindowOptions): BrowserWindo
     release: options.releaseSlug,
     releaseName: options.releaseName,
     version: options.version,
+    platform: process.platform,
   });
   const url = `${WHATS_NEW_WEBPACK_ENTRY}${separator}${params.toString()}`;
 

--- a/src/node/desktop/src/ui/whats-new/whats-new-host.html
+++ b/src/node/desktop/src/ui/whats-new/whats-new-host.html
@@ -15,6 +15,9 @@
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: #ffffff;
       color: #1a1a1a;
+    }
+
+    html.linux body {
       border: 1px solid #d1d5db;
     }
 

--- a/src/node/desktop/src/ui/whats-new/whats-new-host.html
+++ b/src/node/desktop/src/ui/whats-new/whats-new-host.html
@@ -15,6 +15,7 @@
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: #ffffff;
       color: #1a1a1a;
+      border: 1px solid #d1d5db;
     }
 
     .container {

--- a/src/node/desktop/src/ui/whats-new/whats-new-host.ts
+++ b/src/node/desktop/src/ui/whats-new/whats-new-host.ts
@@ -35,6 +35,12 @@ function init(): void {
   const release = params.get('release') ?? '';
   const releaseName = params.get('releaseName') ?? '';
   const version = params.get('version') ?? '';
+  const platform = params.get('platform') ?? '';
+
+  // Add platform class to <html> so CSS can target platform-specific styles
+  if (platform) {
+    document.documentElement.classList.add(platform);
+  }
 
   // Validate slug before constructing any path
   if (!release || !SLUG_PATTERN.test(release)) {


### PR DESCRIPTION
Addresses #17413

## Intent

On Linux Desktop (Ubuntu 24, GNOME, Wayland), the frameless What's New dialog has no compositor-drawn shadow, causing it to blend into the white window behind it.

## Before

<img width="3148" height="1948" alt="whats-new-linux" src="https://github.com/user-attachments/assets/fc72fc76-929a-4fed-85e9-036dc1192b35" />

## After

<img width="2078" height="1526" alt="improve" src="https://github.com/user-attachments/assets/5e88a205-a2a5-46b5-866e-90e92d1d9dc8" />

## Summary

- Pass `process.platform` as a query parameter to the What's New host page
- Add the platform string as a CSS class on `<html>` so styles can target it
- Apply a subtle `1px solid #d1d5db` border on `html.linux body` only, keeping macOS and Windows unchanged

## Test plan

- [ ] Verify the border appears on Linux Desktop (Ubuntu/GNOME/Wayland)
- [ ] Verify no border appears on macOS Desktop
- [ ] Verify no border appears on Windows Desktop