### PR TITLE
Update What's New content and UI for Globemaster Allium

### DIFF
--- a/src/node/desktop/src/assets/whats-new/globemaster-allium/index.html
+++ b/src/node/desktop/src/assets/whats-new/globemaster-allium/index.html
@@ -25,7 +25,7 @@
   <hr class="section-divider">
 
   <div class="feature-section">
-    <p>RStudio now bundles <strong>Quarto 1.9</strong> with Typst book and article support, along with experimental PDF accessibility standards for both LaTeX and Typst. Read more in the <a href="https://www.rstudio.org/links/quarto-1-9">Quarto 1.9 announcement post</a>.</p>
+    <p>RStudio now bundles <strong>Quarto 1.9</strong> with Typst book and article support, along with experimental PDF accessibility standards for both LaTeX and Typst. Read more in the <a href="https://quarto.org/docs/blog/posts/2026-03-24-1.9-release/">Quarto 1.9 announcement post</a>.</p>
   </div>
 
   <div class="feature-section">

--- a/src/node/desktop/src/assets/whats-new/globemaster-allium/index.html
+++ b/src/node/desktop/src/assets/whats-new/globemaster-allium/index.html
@@ -29,7 +29,7 @@
   </div>
 
   <div class="feature-section">
-    <p>You can now also Push Button deploy documents and data applications to <a href="https://www.rstudio.org/links/connect-cloud">Posit Connect Cloud</a> with Push Button deploy support. Posit Connect Cloud is a hosted platform for sharing data assets without managing your own infrastructure with free plans available.</p>
+    <p>You can now also deploy documents and data applications to <a href="https://connect.posit.cloud/">Posit Connect Cloud</a> with Push Button support. Posit Connect Cloud is a hosted platform for sharing data assets without managing your own infrastructure. A free plan is available.</p>
   </div>
 </body>
 </html>

--- a/src/node/desktop/src/assets/whats-new/globemaster-allium/index.html
+++ b/src/node/desktop/src/assets/whats-new/globemaster-allium/index.html
@@ -9,21 +9,27 @@
 </head>
 <body>
   <div class="feature-section">
-    <h2>New Features</h2>
+    <p class="section-label">Introducing</p>
+    <h2>Posit AI</h2>
+    <p class="tagline">A new way to code, explore, and build in RStudio</p>
+    <p><a href="https://posit.co/products/ai/">Posit AI</a> is a new, optional subscription service that powers new AI features in RStudio:</p>
     <ul>
-      <li>Posit Assistant: collaborative chat and completions via Posit-AI</li>
-      <li>Dark mode support for dialogs</li>
-      <li>Support for R 4.6.0</li>
-      <li>Publish to Connect Cloud</li>
+      <li><strong>Posit Assistant:</strong> A conversational agent right inside RStudio that understands your full session context. Ask it to clean data, explore patterns, train models, or even build apps — all within your existing workflow.</li>
+      <li><strong>Next Edit Suggestions (NES):</strong> Get smart, context-aware code completions that adapt as you type, accelerating your coding without breaking the flow.</li>
     </ul>
+    <p><strong>Your privacy matters.</strong> When you create your account, you choose whether to share your trace data (including prompts and AI responses) to help improve Posit AI. If you opt out, we only retain basic operational data for 30 days, and your prompts and responses are never stored. We have a Zero Data Retention agreement with our model provider, Anthropic, meaning your data is processed to generate a response and immediately deleted.</p>
+    <p><strong>RStudio itself remains free and open source.</strong> Posit AI is an optional subscription starting at $20/month with a free trial. <a href="https://posit.co/products/ai/">Learn more</a>.</p>
+    <p>Click the new Posit Assistant icon in the toolbar to get started.</p>
+  </div>
+
+  <hr class="section-divider">
+
+  <div class="feature-section">
+    <p>RStudio now bundles <strong>Quarto 1.9</strong> with Typst book and article support, along with experimental PDF accessibility standards for both LaTeX and Typst. Read more in the <a href="https://www.rstudio.org/links/quarto-1-9">Quarto 1.9 announcement post</a>.</p>
   </div>
 
   <div class="feature-section">
-    <h2>Fixes</h2>
-    <p>
-      For a full list of bug fixes in this release, see the
-      <a href="https://www.rstudio.org/links/release_notes#rstudio-2026.04.0">release notes</a>.
-    </p>
+    <p>You can now also Push Button deploy documents and data applications to <a href="https://www.rstudio.org/links/connect-cloud">Posit Connect Cloud</a> with Push Button deploy support. Posit Connect Cloud is a hosted platform for sharing data assets without managing your own infrastructure with free plans available.</p>
   </div>
 </body>
 </html>

--- a/src/node/desktop/src/assets/whats-new/globemaster-allium/index.html
+++ b/src/node/desktop/src/assets/whats-new/globemaster-allium/index.html
@@ -12,10 +12,11 @@
     <p class="section-label">Introducing</p>
     <h2>Posit AI</h2>
     <p class="tagline">A new way to code, explore, and build in RStudio</p>
-    <p><a href="https://posit.co/products/ai/">Posit AI</a> is a new, optional subscription service that powers new AI features in RStudio:</p>
+    <p><a href="https://posit.co/products/ai/">Posit Assistant</a> is a new, optional AI agent in RStudio, purpose-built for data science.</p>
     <ul>
-      <li><strong>Posit Assistant:</strong> A conversational agent right inside RStudio that understands your full session context. Ask it to clean data, explore patterns, train models, or even build apps — all within your existing workflow.</li>
+      <li><strong>Posit Assistant:</strong> A conversational agent right inside RStudio that understands your full session context. Ask it to clean data, explore patterns, train models, or even build apps - all within your existing workflow.</li>
       <li><strong>Next Edit Suggestions (NES):</strong> Get smart, context-aware code completions that adapt as you type, accelerating your coding without breaking the flow.</li>
+      <li><a href="https://posit.co/products/ai/">Posit AI</a> is the subscription service that powers Posit Assistant.</li>
     </ul>
     <p><strong>Your privacy matters.</strong> When you create your account, you choose whether to share your trace data (including prompts and AI responses) to help improve Posit AI. If you opt out, we only retain basic operational data for 30 days, and your prompts and responses are never stored. We have a Zero Data Retention agreement with our model provider, Anthropic, meaning your data is processed to generate a response and immediately deleted.</p>
     <p><strong>RStudio itself remains free and open source.</strong> Posit AI is an optional subscription starting at $20/month with a free trial. <a href="https://posit.co/products/ai/">Learn more</a>.</p>

--- a/src/node/desktop/src/assets/whats-new/whats-new-base.css
+++ b/src/node/desktop/src/assets/whats-new/whats-new-base.css
@@ -82,26 +82,6 @@ code {
   margin-bottom: 0;
 }
 
-/* Page header (title + version) */
-.page-header {
-  margin-bottom: 28px;
-  padding-bottom: 16px;
-  border-bottom: 1px solid #e5e7eb;
-}
-
-h1.page-title {
-  font-size: 20px;
-  font-weight: 700;
-  color: #1a1a1a;
-  margin: 0 0 4px 0;
-}
-
-.page-version {
-  font-size: 12px;
-  color: #6b7280;
-  margin: 0;
-}
-
 /* Section overline label (e.g. "INTRODUCING") */
 .section-label {
   font-size: 11px;

--- a/src/node/desktop/src/assets/whats-new/whats-new-base.css
+++ b/src/node/desktop/src/assets/whats-new/whats-new-base.css
@@ -81,3 +81,47 @@ code {
 .feature-section:last-child {
   margin-bottom: 0;
 }
+
+/* Page header (title + version) */
+.page-header {
+  margin-bottom: 28px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+h1.page-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #1a1a1a;
+  margin: 0 0 4px 0;
+}
+
+.page-version {
+  font-size: 12px;
+  color: #6b7280;
+  margin: 0;
+}
+
+/* Section overline label (e.g. "INTRODUCING") */
+.section-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #6b7280;
+  margin: 0 0 4px 0;
+}
+
+/* Tagline beneath a section heading */
+.tagline {
+  font-size: 13px;
+  color: #6b7280;
+  margin: 0 0 14px 0;
+}
+
+/* Divider between major sections */
+.section-divider {
+  border: none;
+  border-top: 1px solid #e5e7eb;
+  margin: 0 0 28px 0;
+}

--- a/src/node/desktop/src/main/whats-new-window.ts
+++ b/src/node/desktop/src/main/whats-new-window.ts
@@ -49,7 +49,10 @@ export function showWhatsNewWindow(options: WhatsNewWindowOptions): BrowserWindo
     return activeWindow;
   }
 
-  const workAreaHeight = screen.getPrimaryDisplay().workAreaSize.height;
+  const display = options.parent
+    ? screen.getDisplayMatching(options.parent.getBounds())
+    : screen.getPrimaryDisplay();
+  const workAreaHeight = display.workAreaSize.height;
   const height = Math.min(825, workAreaHeight);
 
   const win = new BrowserWindow({

--- a/src/node/desktop/src/main/whats-new-window.ts
+++ b/src/node/desktop/src/main/whats-new-window.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { BrowserWindow, ipcMain, session, shell } from 'electron';
+import { BrowserWindow, ipcMain, screen, session, shell } from 'electron';
 
 import { logger } from '../core/logger';
 import { createLocalUrlChecker } from './whats-new-utils';
@@ -49,9 +49,12 @@ export function showWhatsNewWindow(options: WhatsNewWindowOptions): BrowserWindo
     return activeWindow;
   }
 
+  const workAreaHeight = screen.getPrimaryDisplay().workAreaSize.height;
+  const height = Math.min(825, workAreaHeight);
+
   const win = new BrowserWindow({
     width: 900,
-    height: 650,
+    height,
     minWidth: 500,
     minHeight: 400,
     center: true,


### PR DESCRIPTION
## Intent

Addresses #17369.

## Summary

- Rewrite the What's New page content to lead with the Posit AI introduction (Assistant + Next Edit Suggestions), followed by Quarto 1.9 and Connect Cloud highlights
- Add CSS styles for section labels, taglines, and section dividers
- Increase the default window height to 825px, clamped at runtime to the hosting display's work area so it fits on smaller screens
- Pass the platform to the renderer so CSS can target platform-specific styles (e.g. Linux border)

<img width="1198" height="901" alt="whats-new-v3" src="https://github.com/user-attachments/assets/c6dedc5b-02c0-4579-95cd-32fd674409fb" />

## Test plan

- [ ] Open the What's New dialog on a primary monitor and verify it displays at 825px height (or smaller if the screen is smaller)
- [ ] If multi-monitor, move the parent window to a smaller secondary display and reopen — verify the dialog fits within that display's work area
- [ ] Verify all links open in the system browser
- [ ] Verify the content renders correctly: section label, heading, tagline, bullet points, divider, and subsequent sections
- [ ] Check on Linux that the window border is visible