### PR TITLE
add preference to control Posit Assistant toolbar button visibility

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -460,6 +460,7 @@ namespace prefs {
 #define kAssistantNesEnabled "assistant_nes_enabled"
 #define kAssistantNesAutoshow "assistant_nes_autoshow"
 #define kAssistantShowMessages "assistant_show_messages"
+#define kAssistantToolbarButtonVisible "assistant_toolbar_button_visible"
 #define kCopilotEnabled "copilot_enabled"
 #define kCopilotCompletionsTrigger "copilot_completions_trigger"
 #define kCopilotCompletionsTriggerAuto "auto"
@@ -2104,6 +2105,12 @@ public:
     */
    bool assistantShowMessages();
    core::Error setAssistantShowMessages(bool val);
+
+   /**
+    * When enabled, the Posit Assistant button is displayed in the main toolbar.
+    */
+   bool assistantToolbarButtonVisible();
+   core::Error setAssistantToolbarButtonVisible(bool val);
 
    /**
     * When enabled, RStudio will use GitHub Copilot to provide code suggestions.

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -2502,6 +2502,15 @@
    clear = function() { .rs.clearUserPref("assistant_show_messages") }
 )
 
+# Show Posit Assistant button in toolbar
+#
+# When enabled, the Posit Assistant button is displayed in the main toolbar.
+.rs.uiPrefs$assistantToolbarButtonVisible <- list(
+   get = function() { .rs.getUserPref("assistant_toolbar_button_visible") },
+   set = function(value) { .rs.setUserPref("assistant_toolbar_button_visible", value) },
+   clear = function() { .rs.clearUserPref("assistant_toolbar_button_visible") }
+)
+
 # Enable GitHub Copilot
 #
 # When enabled, RStudio will use GitHub Copilot to provide code suggestions.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -3508,6 +3508,19 @@ core::Error UserPrefValues::setAssistantShowMessages(bool val)
 }
 
 /**
+ * When enabled, the Posit Assistant button is displayed in the main toolbar.
+ */
+bool UserPrefValues::assistantToolbarButtonVisible()
+{
+   return readPref<bool>("assistant_toolbar_button_visible");
+}
+
+core::Error UserPrefValues::setAssistantToolbarButtonVisible(bool val)
+{
+   return writePref("assistant_toolbar_button_visible", val);
+}
+
+/**
  * When enabled, RStudio will use GitHub Copilot to provide code suggestions.
  */
 bool UserPrefValues::copilotEnabled()
@@ -4012,6 +4025,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kAssistantNesEnabled,
       kAssistantNesAutoshow,
       kAssistantShowMessages,
+      kAssistantToolbarButtonVisible,
       kCopilotEnabled,
       kCopilotCompletionsTrigger,
       kCopilotCompletionsDelay,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1851,6 +1851,12 @@
             "title": "Display account and billing messages from Posit Assistant",
             "description": "When enabled, RStudio will show messages from the Posit Assistant in a message box."
         },
+        "assistant_toolbar_button_visible": {
+            "type": "boolean",
+            "default": true,
+            "title": "Show Posit Assistant button in toolbar",
+            "description": "When enabled, the Posit Assistant button is displayed in the main toolbar."
+        },
         "copilot_enabled": {
             "type": "boolean",
             "default": false,

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1680,7 +1680,7 @@ body.windows .toolbar {
 }
 
 .assistantToggleButton .toolbarButtonLabel {
-   margin-top: 3px;
+   margin-top: 2px;
 }
 
 .assistantToggleButton.toolbarButtonLatched {

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarButton.java
@@ -173,6 +173,10 @@ public class ToolbarButton extends FocusWidget
 
       final HandlerRegistration mouseDown = addMouseDownHandler(event ->
       {
+         // Only handle primary (left) mouse button
+         if (event.getNativeButton() != NativeEvent.BUTTON_LEFT)
+            return;
+
          event.preventDefault();
          event.stopPropagation();
 

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarButton.java
@@ -173,10 +173,6 @@ public class ToolbarButton extends FocusWidget
 
       final HandlerRegistration mouseDown = addMouseDownHandler(event ->
       {
-         // Only handle primary (left) mouse button
-         if (event.getNativeButton() != NativeEvent.BUTTON_LEFT)
-            return;
-
          event.preventDefault();
          event.stopPropagation();
 

--- a/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants.java
@@ -123,6 +123,7 @@ public interface StudioClientApplicationConstants extends com.google.gwt.i18n.cl
     String showSidebarTitle();
     String hideSidebarTitle();
     String positAssistantTitle();
+    String hidePositAssistantButton();
     String restrictedModeTitle();
     String toolBarButtonText();
     String popupMenuProgressMessage();

--- a/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_en.properties
@@ -107,6 +107,7 @@ workspacePanesTitle=Workspace Panes
 showSidebarTitle=Show Sidebar
 hideSidebarTitle=Hide Sidebar
 positAssistantTitle=Posit Assistant
+hidePositAssistantButton=Hide Posit Assistant Button
 restrictedModeTitle=Restricted Mode: startup files were not executed for this project
 toolBarButtonText=Project: (None)
 popupMenuProgressMessage=Looking for projects...

--- a/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_fr.properties
@@ -107,6 +107,7 @@ workspacePanesTitle=Panneaux de l''espace de travail
 showSidebarTitle=Afficher la barre latérale
 hideSidebarTitle=Masquer la barre latérale
 positAssistantTitle=Posit Assistant
+hidePositAssistantButton=Masquer le bouton Posit Assistant
 restrictedModeTitle=Mode restreint : les fichiers de démarrage n''ont pas été exécutés pour ce projet
 toolBarButtonText=Projet : (Aucun)
 popupMenuProgressMessage=Recherche de projets...

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
@@ -29,6 +29,9 @@ import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.application.StudioClientApplicationConstants;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.ThemeChangedEvent;
+
+import com.google.gwt.event.dom.client.ContextMenuEvent;
+import com.google.gwt.user.client.ui.MenuItem;
 import org.rstudio.studio.client.application.ui.addins.AddinsToolbarButton;
 import org.rstudio.studio.client.common.icons.StandardIcons;
 import org.rstudio.studio.client.common.vcs.VCSConstants;
@@ -282,26 +285,44 @@ public class GlobalToolbar extends Toolbar
                ThemeResources.INSTANCE.themeStyles().assistantToggleButton());
          ElementIds.assignElementId(assistantButton_, ElementIds.ASSISTANT_TOGGLE_BUTTON);
          addRightWidget(assistantButton_);
-         assistantSeparator_ = addRightSeparator();
+         Widget sep = Toolbar.getSeparator();
+         sep.addStyleName(ThemeResources.INSTANCE.themeStyles().toolbarSeparator());
+         assistantSeparator_ = addRightWidget(sep);
 
          // Track command visibility to show/hide the button dynamically
-         commands_.assistantPaneToggle().addVisibleChangedHandler(event -> {
-            boolean visible = commands_.assistantPaneToggle().isVisible();
-            assistantButton_.setVisible(visible);
-            assistantSeparator_.setVisible(visible);
-         });
+         commands_.assistantPaneToggle().addVisibleChangedHandler(event ->
+               updateAssistantButtonVisibility());
+
+         // Hide/show when the preference changes
+         userPrefs_.assistantToolbarButtonVisible().addValueChangeHandler(event ->
+               updateAssistantButtonVisibility());
 
          // Sync initial state: PaneManager may have already set the command
          // invisible before this handler was registered (see #17368)
-         boolean initialVisible = commands_.assistantPaneToggle().isVisible();
-         assistantButton_.setVisible(initialVisible);
-         assistantSeparator_.setVisible(initialVisible);
+         updateAssistantButtonVisibility();
 
          eventBus_.addHandler(ChatPaneActiveEvent.TYPE, event ->
                assistantButton_.setLatched(event.isActive()));
 
          eventBus_.addHandler(ThemeChangedEvent.TYPE, event ->
                updateAssistantButtonIcon());
+
+         // Right-click context menu to hide the button
+         assistantButton_.addDomHandler(contextMenuEvent -> {
+            contextMenuEvent.preventDefault();
+            contextMenuEvent.stopPropagation();
+            ToolbarPopupMenu menu = new ToolbarPopupMenu();
+            menu.addItem(new MenuItem(
+                  constants_.hidePositAssistantButton(),
+                  () -> {
+                     userPrefs_.assistantToolbarButtonVisible().setGlobalValue(false);
+                     userPrefs_.writeUserPrefs(completed -> {});
+                  }));
+            menu.showRelativeTo(
+                  contextMenuEvent.getNativeEvent().getClientX(),
+                  contextMenuEvent.getNativeEvent().getClientY(),
+                  ElementIds.ASSISTANT_TOGGLE_BUTTON + "_context");
+         }, ContextMenuEvent.getType());
       }
 
       // restricted mode indicator (managed by TrustPresenter)
@@ -341,6 +362,17 @@ public class GlobalToolbar extends Toolbar
          return isVisible
             ? new ImageResource2x(StandardIcons.INSTANCE.toggleSidebarLeftVisible2x())
             : new ImageResource2x(StandardIcons.INSTANCE.toggleSidebarLeftHidden2x());
+      }
+   }
+
+   private void updateAssistantButtonVisibility()
+   {
+      if (assistantButton_ != null)
+      {
+         boolean visible = commands_.assistantPaneToggle().isVisible() &&
+                           userPrefs_.assistantToolbarButtonVisible().getValue();
+         assistantButton_.setVisible(visible);
+         assistantSeparator_.setVisible(visible);
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
@@ -30,7 +30,9 @@ import org.rstudio.studio.client.application.StudioClientApplicationConstants;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.ThemeChangedEvent;
 
+import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.ContextMenuEvent;
+import com.google.gwt.event.dom.client.MouseDownEvent;
 import com.google.gwt.user.client.ui.MenuItem;
 import org.rstudio.studio.client.application.ui.addins.AddinsToolbarButton;
 import org.rstudio.studio.client.common.icons.StandardIcons;
@@ -307,14 +309,26 @@ public class GlobalToolbar extends Toolbar
          eventBus_.addHandler(ThemeChangedEvent.TYPE, event ->
                updateAssistantButtonIcon());
 
+         // Prevent non-primary clicks from activating the button
+         assistantButton_.addDomHandler(mouseDownEvent ->
+         {
+            if (mouseDownEvent.getNativeButton() != NativeEvent.BUTTON_LEFT)
+            {
+               mouseDownEvent.preventDefault();
+               mouseDownEvent.stopPropagation();
+            }
+         }, MouseDownEvent.getType());
+
          // Right-click context menu to hide the button
-         assistantButton_.addDomHandler(contextMenuEvent -> {
+         assistantButton_.addDomHandler(contextMenuEvent ->
+         {
             contextMenuEvent.preventDefault();
             contextMenuEvent.stopPropagation();
             ToolbarPopupMenu menu = new ToolbarPopupMenu();
             menu.addItem(new MenuItem(
                   constants_.hidePositAssistantButton(),
-                  () -> {
+                  () ->
+                  {
                      userPrefs_.assistantToolbarButtonVisible().setGlobalValue(false);
                      userPrefs_.writeUserPrefs(completed -> {});
                   }));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -312,6 +312,7 @@ public class UserPrefsAccessor extends Prefs
    public static final String ASSISTANT_NES_ENABLED = "assistant_nes_enabled";
    public static final String ASSISTANT_NES_AUTOSHOW = "assistant_nes_autoshow";
    public static final String ASSISTANT_SHOW_MESSAGES = "assistant_show_messages";
+   public static final String ASSISTANT_TOOLBAR_BUTTON_VISIBLE = "assistant_toolbar_button_visible";
    public static final String COPILOT_ENABLED = "copilot_enabled";
    public static final String COPILOT_COMPLETIONS_TRIGGER = "copilot_completions_trigger";
    public static final String COPILOT_COMPLETIONS_DELAY = "copilot_completions_delay";
@@ -4145,6 +4146,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * When enabled, the Posit Assistant button is displayed in the main toolbar.
+    */
+   public PrefValue<Boolean> assistantToolbarButtonVisible()
+   {
+      return bool(
+         "assistant_toolbar_button_visible",
+         _constants.assistantToolbarButtonVisibleTitle(), 
+         _constants.assistantToolbarButtonVisibleDescription(), 
+         true);
+   }
+
+   /**
     * When enabled, RStudio will use GitHub Copilot to provide code suggestions.
     */
    public PrefValue<Boolean> copilotEnabled()
@@ -4962,6 +4975,8 @@ public class UserPrefsAccessor extends Prefs
          assistantNesAutoshow().setValue(layer, source.getBool("assistant_nes_autoshow"));
       if (source.hasKey("assistant_show_messages"))
          assistantShowMessages().setValue(layer, source.getBool("assistant_show_messages"));
+      if (source.hasKey("assistant_toolbar_button_visible"))
+         assistantToolbarButtonVisible().setValue(layer, source.getBool("assistant_toolbar_button_visible"));
       if (source.hasKey("copilot_enabled"))
          copilotEnabled().setValue(layer, source.getBool("copilot_enabled"));
       if (source.hasKey("copilot_completions_trigger"))
@@ -5270,6 +5285,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(assistantNesEnabled());
       prefs.add(assistantNesAutoshow());
       prefs.add(assistantShowMessages());
+      prefs.add(assistantToolbarButtonVisible());
       prefs.add(copilotEnabled());
       prefs.add(copilotCompletionsTrigger());
       prefs.add(copilotCompletionsDelay());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -2252,6 +2252,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String assistantShowMessagesDescription();
 
    /**
+    * When enabled, the Posit Assistant button is displayed in the main toolbar.
+    */
+   @DefaultStringValue("Show Posit Assistant button in toolbar")
+   String assistantToolbarButtonVisibleTitle();
+   @DefaultStringValue("When enabled, the Posit Assistant button is displayed in the main toolbar.")
+   String assistantToolbarButtonVisibleDescription();
+
+   /**
     * When enabled, RStudio will use GitHub Copilot to provide code suggestions.
     */
    @DefaultStringValue("Enable GitHub Copilot")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -1131,6 +1131,10 @@ assistantNesAutoshowDescription = When enabled, next edit suggestions will be au
 assistantShowMessagesTitle = Display account and billing messages from Posit Assistant
 assistantShowMessagesDescription = When enabled, RStudio will show messages from the Posit Assistant in a message box.
 
+# When enabled, the Posit Assistant button is displayed in the main toolbar.
+assistantToolbarButtonVisibleTitle = Show Posit Assistant button in toolbar
+assistantToolbarButtonVisibleDescription = When enabled, the Posit Assistant button is displayed in the main toolbar.
+
 # When enabled, RStudio will use GitHub Copilot to provide code suggestions.
 copilotEnabledTitle = Enable GitHub Copilot
 copilotEnabledDescription = When enabled, RStudio will use GitHub Copilot to provide code suggestions.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AssistantPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AssistantPreferencesPane.java
@@ -221,6 +221,7 @@ public class AssistantPreferencesPane extends PreferencesPane
       lblProjectOverride_.getElement().getStyle().setFontStyle(FontStyle.ITALIC);
 
       cbAssistantShowMessages_ = checkboxPref(prefs_.assistantShowMessages(), true);
+      cbAssistantToolbarButtonVisible_ = checkboxPref(prefs_.assistantToolbarButtonVisible(), true);
       selAssistantTabKeyBehavior_ = new SelectWidget(
             prefsConstants_.assistantTabKeyBehaviorTitle(),
             new String[] {
@@ -348,6 +349,8 @@ public class AssistantPreferencesPane extends PreferencesPane
             checkPositAssistantInstallation(/* forAssistant= */ false);
          }
       });
+
+      add(cbAssistantToolbarButtonVisible_);
 
       // Code suggestions section
       add(spacedBefore(headerLabel(constants_.assistantSuggestionsHeader())));
@@ -1349,6 +1352,7 @@ public class AssistantPreferencesPane extends PreferencesPane
    private final Label lblAssistantStatus_;
    private final Spinner imgRefreshSpinner_;
    private final CheckBox cbAssistantShowMessages_;
+   private final CheckBox cbAssistantToolbarButtonVisible_;
    private final CheckBox cbAssistantNesEnabled_;
    private final CheckBox cbAssistantNesCollapse_;
    private final List<SmallButton> statusButtons_;


### PR DESCRIPTION
## Summary

- Adds a new `assistant_toolbar_button_visible` user preference (default `true`) that controls whether the Posit Assistant button is shown in the main toolbar
- Right-clicking the button shows a context menu with "Hide Posit Assistant Button", which disables the preference and hides the button
- A checkbox in the Assistant preferences pane allows re-enabling the button
- Fixes `ToolbarButton` mouseDown handler to only respond to the primary mouse button, preventing right-click from also activating the button
- Tweaks assistant button label margin-top from 3px to 2px

## Test plan

- [ ] Verify the Posit Assistant button appears by default in the toolbar
- [ ] Right-click the button and confirm the context menu appears with "Hide Posit Assistant Button"
- [ ] Click the menu item and confirm the button (and its separator) disappear
- [ ] Open Global Options > Assistant and confirm the "Show Posit Assistant button in toolbar" checkbox is unchecked
- [ ] Re-enable the checkbox, apply, and confirm the button reappears
- [ ] Verify that right-clicking the button no longer toggles the assistant pane
- [ ] Verify the separator is not drawn when the button is hidden