### PR TITLE
show Connect Cloud as publishing target for website content types

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishWizard.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishWizard.java
@@ -45,8 +45,8 @@ public class RSConnectPublishWizard
          // can be published to Connect if user has accounts configured
          return new PublishMultiplePage(constants_.publish(), constants_.publish(), null, input, null);
       }
-      else if ((input.isWebsiteRmd() ||
-               (!input.isMultiRmd() && !input.isExternalUIEnabled())))
+      else if (!input.isExternalUIEnabled() &&
+               (input.isWebsiteRmd() || !input.isMultiRmd()))
       {
          // only self-managed Connect is available (website or external
          // publishing disabled), so skip the service selection page


### PR DESCRIPTION
## Intent

Addresses #17412.

## Summary

- The publish wizard unconditionally skipped the service selection page for website content types (Quarto Website, Quarto Book, R Markdown Website), going straight to a Connect-only page — so Connect Cloud was never offered as a destination for these types.
- Restructure the condition in `RSConnectPublishWizard.createFirstPage()` so the service selection page is only skipped when external publishing (Connect Cloud) is disabled.

## Test plan

- [ ] Register a Connect Cloud publishing destination
- [ ] Publish a Quarto Website — verify Connect Cloud appears as an option
- [ ] Publish a Quarto Book — verify Connect Cloud appears as an option
- [ ] Publish a simple R Markdown Website — verify Connect Cloud appears as an option
- [ ] Publish an R Markdown file — verify both Connect and Connect Cloud still appear
- [ ] Publish a Quarto file — verify both Connect and Connect Cloud still appear
- [ ] With no Connect Cloud account configured, verify website publishing still goes directly to the Connect-only page (no service selection)