### PR TITLE
Update Posit Assistant manifest download URLs to use cdn.posit.co

### DIFF
--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -3417,8 +3417,8 @@ Error downloadManifest(json::Object* pManifest)
 
    // Get download URI; use test manifest when opted in
    std::string downloadUri = options().positAssistantTestManifest()
-      ? "https://rstudio-buildtools.s3.us-east-1.amazonaws.com/posit-ai-preview/manifest-test.json"
-      : "https://rstudio-buildtools.s3.us-east-1.amazonaws.com/posit-ai-preview/manifest.json";
+      ? "https://cdn.posit.co/posit-ai/manifest-test.json"
+      : "https://cdn.posit.co/posit-ai/manifest.json";
 
    DLOG("Downloading manifest from: {}", downloadUri);
 


### PR DESCRIPTION
## Intent

Addresses https://github.com/rstudio/rstudio/issues/17397.

## Summary

- Updates the Posit Assistant manifest download URLs from `rstudio-buildtools.s3.us-east-1.amazonaws.com/posit-ai-preview/` to `cdn.posit.co/posit-ai/` for both the production and test manifest endpoints.