### PR TITLE
fix Connect Cloud republish losing previously-used title

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/AppNameTextbox.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/AppNameTextbox.java
@@ -157,7 +157,7 @@ public class AppNameTextbox extends Composite
    {
       if (StringUtil.isNullOrEmpty(title))
          title = name;
-      appTitle_.setTitle(title);
+      appTitle_.setText(title);
       name_ = name;
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -900,13 +900,15 @@ public class RSConnectDeploy extends Composite
                      public void onResponseReceived(
                            RSConnectApplicationResult info)
                      {
-                        // create a single-entry array with the app ID 
-                        JsArray<RSConnectApplicationInfo> infos = 
-                              JsArray.createArray().cast();
+                        appProgressPanel_.setVisible(false);
                         if (info.getApp() != null)
                         {
-                           infos.push(info.getApp());
-                           onAppsReceived_.onResponseReceived(infos);
+                           // we found the app by ID; show its info directly
+                           // without requiring a name match (the app's name on
+                           // the server may differ from the local record, e.g.
+                           // on Connect Cloud where the API doesn't return a
+                           // name field)
+                           showAppInfo(info.getApp());
                         }
                         else if (!StringUtil.isNullOrEmpty(info.getError()))
                         {


### PR DESCRIPTION
Addresses #17306

## Intent

Fixes republishing to Connect Cloud when the title was changed from the default filename-based title.

## Summary

When republishing a document to Connect Cloud after changing its title on the first publish, the deploy dialog would:
- Briefly show the correct (previously-used) title
- Revert to the filename-based title
- Treat the republish as a new deployment rather than an update

**Root cause:** `setPreviousInfo()` fetches the app by its known ID, then routes the result through `onAppsReceived_` which compares `info.getName()` against the local deployment record name. The Connect Cloud content API doesn't return a `name` field in its response, so this comparison always fails, triggering `forgetPreviousDeployment()`.

**Fix:** When the app is successfully found by ID, call `showAppInfo()` directly instead of routing through the name-matching callback. The name comparison is only needed when searching a list of apps by name (the `getRSConnectAppList` path).

Also fixes `AppNameTextbox.setDetails()` which called `setTitle()` (sets the HTML tooltip attribute) instead of `setText()` (sets the visible text content).

## QA Notes

1. Publish a `.qmd` document (e.g. `yoyo.qmd`) to Connect Cloud, **changing** the title from the default to something else (e.g. "momo")
2. Republish — the dialog should show the previously-used title "momo" and republish as an update to the same content
3. Verify that the default case (publishing without changing the title, then republishing) still works