### PR TITLE
deliver Posit Assistant auth token via HTTP-only cookie in server mode

### DIFF
--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -112,6 +112,7 @@ void clearChatBackendPort()
    s_chatBackendPort = constants::kChatBackendPortNone;
    staticfiles::setChatBackendPort(constants::kChatBackendPortNone);
    s_chatBackendAuthToken.clear();
+   staticfiles::setChatBackendAuthToken(std::string());
 }
 
 // Track whether session is closing (vs suspending/restarting)
@@ -4645,6 +4646,7 @@ Error startChatBackend(bool resumeConversation)
    // This is defense-in-depth against local non-browser attackers that
    // bypass origin checks (malware, browser extensions, local processes).
    s_chatBackendAuthToken = core::system::generateUuid(false);
+   staticfiles::setChatBackendAuthToken(s_chatBackendAuthToken);
 
    DLOG("Allocated port {} for chat backend", s_chatBackendPort);
 

--- a/src/cpp/session/modules/chat/ChatStaticFiles.cpp
+++ b/src/cpp/session/modules/chat/ChatStaticFiles.cpp
@@ -471,7 +471,8 @@ Error handleAIChatRequest(const http::Request& request,
             {
                http::Cookie cookie(
                   request, "posit-assistant-auth", s_chatBackendAuthToken,
-                  "/", http::Cookie::SameSite::Lax, true /* httpOnly */);
+                  "/", options().sameSite(), true /* httpOnly */,
+                  options().useSecureCookies());
                pResponse->addCookie(cookie);
             }
          }

--- a/src/cpp/session/modules/chat/ChatStaticFiles.cpp
+++ b/src/cpp/session/modules/chat/ChatStaticFiles.cpp
@@ -469,9 +469,27 @@ Error handleAIChatRequest(const http::Request& request,
             std::lock_guard<std::mutex> lock(s_authTokenMutex);
             if (!s_chatBackendAuthToken.empty())
             {
+               // Scope cookie to the session prefix (e.g. "/s/{id}/")
+               // so multi-session deployments don't collide. Extract
+               // the path from proxiedUri() and strip "/ai-chat" onward.
+               std::string cookiePath =
+                  http::URL(request.proxiedUri()).path();
+               std::string aiChatPrefix(kAiChatUriPrefix);
+               if (aiChatPrefix.back() == '/')
+                  aiChatPrefix.pop_back();
+               size_t aiChatPos = cookiePath.find(aiChatPrefix);
+               if (aiChatPos != std::string::npos)
+                  cookiePath = cookiePath.substr(0, aiChatPos);
+               if (cookiePath.empty())
+                  cookiePath = "/";
+               else if (cookiePath.back() != '/')
+                  cookiePath += "/";
+               LOG_DEBUG_MESSAGE("Cookie path for posit-assistant-auth: '" +
+                                 cookiePath + "'");
+
                http::Cookie cookie(
                   request, "posit-assistant-auth", s_chatBackendAuthToken,
-                  "/", options().sameSite(), true /* httpOnly */,
+                  cookiePath, options().sameSite(), true /* httpOnly */,
                   options().useSecureCookies());
                pResponse->addCookie(cookie);
             }

--- a/src/cpp/session/modules/chat/ChatStaticFiles.cpp
+++ b/src/cpp/session/modules/chat/ChatStaticFiles.cpp
@@ -28,6 +28,7 @@
 
 #include <core/FileSerializer.hpp>
 #include <core/StringUtils.hpp>
+#include <core/http/Cookie.hpp>
 #include <core/http/Request.hpp>
 #include <core/http/Response.hpp>
 #include <core/http/URL.hpp>
@@ -60,6 +61,12 @@ constexpr size_t kAiChatUriPrefixLength = 9; // Length of "/ai-chat/"
 // Atomic because it is written from the main thread and read from HTTP
 // handler threads.
 std::atomic<int> s_chatBackendPort{kChatBackendPortNone};
+
+// Chat backend auth token, set by SessionChat.cpp when the backend starts.
+// In server mode, this is delivered to the PA client via an HTTP-only cookie
+// on the index.html response instead of as a URL query parameter.
+std::mutex s_authTokenMutex;
+std::string s_chatBackendAuthToken;
 
 /**
  * Inject theme information into HTML content without inline scripts.
@@ -445,7 +452,30 @@ Error handleAIChatRequest(const http::Request& request,
    if (extension == ".html" || extension == ".htm")
    {
       if (resolvedPath.getFilename() == kIndexFileName)
+      {
          injectThemeInfo(&content);
+
+         // In server mode, deliver the auth token via an HTTP-only cookie
+         // instead of a URL query parameter. This prevents the token from
+         // leaking in browser history, server logs, and the Referer header.
+         // Desktop mode continues to use the URL parameter since it's
+         // localhost-only.
+         bool isServerMode = false;
+#ifdef RSTUDIO_SERVER
+         isServerMode = (options().programMode() == kSessionProgramModeServer);
+#endif
+         if (isServerMode)
+         {
+            std::lock_guard<std::mutex> lock(s_authTokenMutex);
+            if (!s_chatBackendAuthToken.empty())
+            {
+               http::Cookie cookie(
+                  request, "posit-assistant-auth", s_chatBackendAuthToken,
+                  "/", http::Cookie::SameSite::Lax, true /* httpOnly */);
+               pResponse->addCookie(cookie);
+            }
+         }
+      }
       pResponse->setHeader("Content-Security-Policy", buildCspHeader());
    }
    pResponse->setContentType(getContentType(extension));
@@ -477,6 +507,12 @@ void setChatBackendPort(int port)
 {
    s_chatBackendPort = port;
    rebuildCspHeaderCache();
+}
+
+void setChatBackendAuthToken(const std::string& token)
+{
+   std::lock_guard<std::mutex> lock(s_authTokenMutex);
+   s_chatBackendAuthToken = token;
 }
 
 } // namespace staticfiles

--- a/src/cpp/session/modules/chat/ChatStaticFiles.hpp
+++ b/src/cpp/session/modules/chat/ChatStaticFiles.hpp
@@ -113,6 +113,17 @@ core::Error handleAIChatRequest(const core::http::Request& request,
  */
 void setChatBackendPort(int port);
 
+/**
+ * Set the chat backend auth token.
+ *
+ * Called by SessionChat when the backend process starts or stops. In server
+ * mode, this token is delivered to the PA client via an HTTP-only cookie on
+ * the index.html response (rather than as a URL query parameter) to avoid
+ * leaking credentials in browser history, server logs, and the Referer header.
+ * Pass an empty string to clear.
+ */
+void setChatBackendAuthToken(const std::string& token);
+
 } // namespace staticfiles
 } // namespace chat
 } // namespace modules

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPresenter.java
@@ -1189,10 +1189,15 @@ public class ChatPresenter extends BasePresenter
       // Try relative URL first, which should work in both dev and production
       String baseUrl = "ai-chat/index.html";
 
-      // Append WebSocket URL, auth token, and timestamp as query parameters to bust cache
+      // Append WebSocket URL and timestamp as query parameters to bust cache
       long timestamp = System.currentTimeMillis();
       String params = "?wsUrl=" + URL.encodeQueryString(wsUrl) + "&_t=" + timestamp;
-      if (authToken != null && !authToken.isEmpty())
+
+      // In Desktop mode, pass the auth token as a URL parameter since the
+      // WebSocket connects to localhost directly. In Server mode, the token
+      // is delivered via an HTTP-only cookie set by the static file handler,
+      // avoiding exposure in browser history, logs, and the Referer header.
+      if (Desktop.hasDesktopFrame() && authToken != null && !authToken.isEmpty())
       {
          params += "&authToken=" + URL.encodeQueryString(authToken);
       }


### PR DESCRIPTION
### Intent

Deliver the Posit Assistant auth token via an HTTP-only cookie instead of a URL query parameter in server mode, preventing credential leakage in browser history, server access logs, and the `Referer` header.

Addresses Issue 3 of rstudio/rstudio#17423.

### Approach

- Added `setChatBackendAuthToken()` to `ChatStaticFiles` so the static file handler has access to the current auth token.
- When serving `index.html` in server mode, the handler now sets an HTTP-only, `SameSite=Lax` cookie (`posit-assistant-auth`) containing the token.
- On the frontend (`ChatPresenter.java`), the auth token URL parameter is now only appended in Desktop mode (`Desktop.hasDesktopFrame()`). In server mode, the browser automatically sends the cookie with subsequent requests.
- The token is cleared from `ChatStaticFiles` when the backend stops, matching the existing cleanup in `clearChatBackendPort()`.

### Automated Tests

No automated tests added. This is a transport-layer change for an unreleased feature; manual QA covers verifying the cookie is set in server mode and the URL parameter is absent.

### QA Notes

1. **Server mode**: Open Posit Assistant, verify the chat iframe loads. Inspect the network tab — `index.html` response should include a `Set-Cookie: posit-assistant-auth=...` header with `HttpOnly` and `SameSite=Lax`. The iframe URL should **not** contain an `authToken` query parameter.
2. **Desktop mode**: Open Posit Assistant, verify the chat iframe loads. The iframe URL **should** contain the `authToken` query parameter (no cookie).
3. Verify chat functionality works end-to-end in both modes.

### Documentation

No documentation changes needed — this is an internal implementation detail.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests