### PR TITLE
fix Connect Cloud republish failing with parse error

### DIFF
--- a/src/cpp/session/modules/SessionRSConnect.cpp
+++ b/src/cpp/session/modules/SessionRSConnect.cpp
@@ -271,9 +271,9 @@ public:
 
       // form the deploy command to hand off to the async deploy process
       cmd += "rsconnect::deployApp("
-             "appDir = '" + string_utils::singleQuotedStrEscape(appDir) + "'," +
+             "appDir = '" + string_utils::singleQuotedStrEscape(appDir) + "', " +
              (recordDir.empty() ? "" : "recordDir = '" + 
-                string_utils::singleQuotedStrEscape(recordDir) + "',") +
+                string_utils::singleQuotedStrEscape(recordDir) + "', ") +
              (pDeploy->manifestPath_.isEmpty() ? "" : "appFileManifest = '" +
                                                     string_utils::singleQuotedStrEscape(
                                                        pDeploy->manifestPath_.getAbsolutePath()) + "', ") +
@@ -281,12 +281,13 @@ public:
                 string_utils::singleQuotedStrEscape(primaryDoc) + "', ") +
              (sourceDoc.empty() ? "" : "appSourceDoc = '" + 
                 string_utils::singleQuotedStrEscape(sourceDoc) + "', ") +
-             "account = '" + string_utils::singleQuotedStrEscape(account) + "',"
+             "account = '" + string_utils::singleQuotedStrEscape(account) + "', "
              "server = '" + string_utils::singleQuotedStrEscape(server) + "', "
              "appName = '" + string_utils::singleQuotedStrEscape(appName) + "', " + 
              (appTitle.empty() ? "" : "appTitle = '" + 
                 string_utils::singleQuotedStrEscape(appTitle) + "', ") + 
-             (appId.empty() ? "" : "appId = " + appId + ", ") + 
+             (appId.empty() ? "" : "appId = '" +
+                string_utils::singleQuotedStrEscape(appId) + "', ") +
              (contentCategory.empty() ? "" : "contentCategory = '" + 
                 contentCategory + "', ") +
              "launch.browser = function (url) { "


### PR DESCRIPTION
## Intent

Addresses #17306.

## Summary

- Quote and escape the `appId` parameter in the R expression constructed for `rsconnect::deployApp()`, fixing Connect Cloud republish which uses UUID content IDs that cause R parse errors when inserted unquoted
- Add consistent spacing after commas in the generated R expression

## Details

The R command constructed in `SessionRSConnect.cpp` for deploying content inserted `appId` as a bare value (`appId = <value>`). This works for numeric IDs (Connect, ShinyApps.io) but fails for Connect Cloud, which uses UUID-style content IDs (e.g. `550e8400-e29b-41d4-a716-...`). Unquoted, R's parser chokes on UUID segments like `41d4` — `41` is parsed as a number and `d4` as an adjacent symbol with no operator between them, producing `Error: unexpected symbol`.

The `appId` was the only parameter in the `deployApp()` call not wrapped in single quotes. Now it is quoted and escaped like all other string parameters. Verified in the `rsconnect` package source that `appId` is never type-checked as numeric — it's used only in string comparisons against deployment records and in URL path construction, so passing it as a character string is safe for all publish targets.