### PR TITLE
Show web socket connection errors in Posit Assistant pane

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPane.java
@@ -1006,10 +1006,11 @@ public class ChatPane
    private native void setupMessageListener() /*-{
       var self = this;
 
-      // Listen for button clicks via postMessage from our iframe only
+      // Listen for postMessage from our iframe only (source + origin check)
       $wnd.addEventListener('message', function(event) {
          var frame = self.@org.rstudio.studio.client.workbench.views.chat.ChatPane::getFrameElement()();
          if (!frame || event.source !== frame.contentWindow) return;
+         if (event.origin !== $wnd.location.origin) return;
 
          if (event.data === 'restart-backend') {
             self.@org.rstudio.studio.client.workbench.views.chat.ChatPane::handleRestartRequest()();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPane.java
@@ -58,7 +58,8 @@ public class ChatPane
       UPDATE_COMPLETE,
       UPDATE_ERROR,
       UPDATE_CHECK_FAILURE,
-      READLINE
+      READLINE,
+      CONNECTION_LOST
    }
 
    @Inject
@@ -560,6 +561,45 @@ public class ChatPane
    }
 
    @Override
+   public void showConnectionLostNotification(String message)
+   {
+      // Don't overwrite higher-priority update notifications
+      if (currentNotificationType_ == NotificationType.UPDATING ||
+          currentNotificationType_ == NotificationType.UPDATE_ERROR ||
+          currentNotificationType_ == NotificationType.UPDATE_COMPLETE ||
+          currentNotificationType_ == NotificationType.UPDATE_CHECK_FAILURE)
+      {
+         return;
+      }
+
+      setNotificationIcon(MessageDialogImages.INSTANCE.dialog_error2x());
+      updateMessageLabel_.setHTML(SafeHtmlUtils.htmlEscape(message));
+
+      new NotificationBuilder(updateButtonPanel_, RES.styles().chatNotificationButton())
+         .clear()
+         .addButton(constants_.chatRestartButton(), () -> {
+            if (observer_ != null)
+            {
+               observer_.onRestartBackend();
+            }
+         })
+         .addButton(constants_.chatDismiss(), () -> hideUpdateNotification());
+
+      currentNotificationType_ = NotificationType.CONNECTION_LOST;
+      updateNotificationPanel_.setVisible(true);
+      updateFrameLayout();
+   }
+
+   @Override
+   public void hideConnectionLostNotification()
+   {
+      if (currentNotificationType_ == NotificationType.CONNECTION_LOST)
+      {
+         hideUpdateNotification();
+      }
+   }
+
+   @Override
    public void showReadlineNotification()
    {
       // Don't overwrite higher-priority update notifications
@@ -992,6 +1032,15 @@ public class ChatPane
          else if (event.data === 'retry-manifest') {
             self.@org.rstudio.studio.client.workbench.views.chat.ChatPane::handleRetryManifestRequest()();
          }
+         else if (event.data && event.data.type === 'assistant-error') {
+            self.@org.rstudio.studio.client.workbench.views.chat.ChatPane::handleIframeError(Ljava/lang/String;)(event.data.message || '');
+         }
+         else if (event.data && event.data.type === 'assistant-warning') {
+            self.@org.rstudio.studio.client.workbench.views.chat.ChatPane::handleIframeWarning(Ljava/lang/String;)(event.data.message || '');
+         }
+         else if (event.data && event.data.type === 'assistant-connected') {
+            self.@org.rstudio.studio.client.workbench.views.chat.ChatPane::handleIframeConnected()();
+         }
       });
    }-*/;
 
@@ -1050,6 +1099,30 @@ public class ChatPane
       if (observer_ != null)
       {
          observer_.onReturnChatToMain();
+      }
+   }
+
+   private void handleIframeError(String message)
+   {
+      if (observer_ != null)
+      {
+         observer_.onIframeError(message);
+      }
+   }
+
+   private void handleIframeWarning(String message)
+   {
+      if (observer_ != null)
+      {
+         observer_.onIframeWarning(message);
+      }
+   }
+
+   private void handleIframeConnected()
+   {
+      if (observer_ != null)
+      {
+         observer_.onIframeConnected();
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPresenter.java
@@ -88,6 +88,9 @@ public class ChatPresenter extends BasePresenter
          void onRetryManifest();
          void onActivateChat();
          void onReturnChatToMain();
+         void onIframeError(String message);
+         void onIframeWarning(String message);
+         void onIframeConnected();
       }
 
       interface UpdateObserver
@@ -117,6 +120,8 @@ public class ChatPresenter extends BasePresenter
       void showUnsupportedVersionNoUpdate(String currentVersion);
       void showUnsupportedProtocol();
       void showManifestUnavailable(String errorMessage);
+      void showConnectionLostNotification(String message);
+      void hideConnectionLostNotification();
       void showReadlineNotification();
       void hideReadlineNotification();
 
@@ -221,6 +226,25 @@ public class ChatPresenter extends BasePresenter
          public void onReturnChatToMain()
          {
             returnChatToMain();
+         }
+
+         @Override
+         public void onIframeError(String message)
+         {
+            Debug.log("Chat iframe error: " + message);
+            display_.showConnectionLostNotification(message);
+         }
+
+         @Override
+         public void onIframeWarning(String message)
+         {
+            Debug.log("Chat iframe warning: " + message);
+         }
+
+         @Override
+         public void onIframeConnected()
+         {
+            display_.hideConnectionLostNotification();
          }
       });
 
@@ -1128,6 +1152,7 @@ public class ChatPresenter extends BasePresenter
       }
 
       initializing_ = true;
+      display_.hideConnectionLostNotification();
       display_.setStatus(Display.Status.RESTARTING);
 
       server_.chatStartBackend(new ServerRequestCallback<JsObject>()


### PR DESCRIPTION
## Intent

Addresses issue 6 of #17423: no user-visible error on WebSocket connection failure.

When the Posit Assistant WebSocket connection fails or enters a silent reconnect loop, users see a dead chat pane with no explanation. This PR adds a notification bar that surfaces connection errors to the user.

## Approach

The assistant iframe tracks consecutive WebSocket reconnect failures and notifies the RStudio parent frame via `postMessage` (a browser-internal channel unaffected by network issues). RStudio shows a non-destructive notification bar with "Restart" and "Dismiss" buttons — the iframe stays alive so reconnection can still succeed. When the connection recovers, the assistant sends an `assistant-connected` message and the notification auto-dismisses.

**Assistant side** (posit-dev/assistant#1069):
- `websocket-backend.ts`: Tracks `reconnectFailures` counter. After 3 consecutive failures, sends `{ type: 'assistant-error', message }` to the parent frame. On reconnect, sends `{ type: 'assistant-connected' }` to dismiss the notification. Uses `window.location.origin` (not `*`) for `postMessage` target.
- `rstudioBackend.ts`: Overrides `handleAuthExpired()` to notify the parent on auth token expiry.

**RStudio side** (this PR):
- `ChatPane.java`: Listens for `assistant-error`, `assistant-warning`, and `assistant-connected` postMessages (with source + origin validation). Shows connection errors as a notification bar using the existing notification infrastructure. Hides on `assistant-connected` or restart.
- `ChatPresenter.java`: Observer callbacks `onIframeError()`, `onIframeWarning()`, `onIframeConnected()`. Error shows the notification bar; connected hides it; restart dismisses it before starting the restart flow.

**Interaction with existing crash handling:** When the backend process crashes, both `ChatBackendExitEvent` and the iframe's reconnect failure notification may fire. The crash handler calls `showCrashedMessage()` which replaces the iframe entirely, taking precedence over the notification bar. No conflict.

## QA Notes

**Repro (connection failure):**
1. Open chat, find the backend port: `ps aux | grep "dist/server/main.js"`
2. Block the port: `sudo iptables -A OUTPUT -p tcp --dport <port> -d 127.0.0.1 -j REJECT`
3. Refresh the page and open the chat pane
4. After ~3 seconds, a notification bar should appear: "Unable to connect to Posit Assistant. Retrying..."
5. Unblock: `sudo iptables -D OUTPUT -p tcp --dport <port> -d 127.0.0.1 -j REJECT`
6. Notification should auto-dismiss when connection recovers

**Verify no regression:**
- Normal startup: no notification should appear
- Backend crash (`kill <pid>`): existing crash handler should still show "Process Exited" with restart button

## Automated Tests

No automated tests — the notification requires simulating WebSocket connection failures which is not covered by existing test infrastructure.

## Documentation

No documentation changes needed — this is an internal UX improvement for error feedback.

## Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests