### PR TITLE
Add support for partitioned cookies (CHIPS) on port-token cookie

### DIFF
--- a/src/cpp/core/http/Cookie.cpp
+++ b/src/cpp/core/http/Cookie.cpp
@@ -136,7 +136,11 @@ std::string Cookie::cookieHeaderValue() const
    if (secure_)
       headerValue << "; secure";
 
-   // return the header value 
+   // partitioned if specified (CHIPS: requires Secure and SameSite=None)
+   if (partitioned_)
+      headerValue << "; Partitioned";
+
+   // return the header value
    return headerValue.str();
 }
 

--- a/src/cpp/core/http/Response.cpp
+++ b/src/cpp/core/http/Response.cpp
@@ -395,6 +395,7 @@ void Response::addCookie(const Cookie& cookie)
       Cookie legacyCookie = cookie;
       legacyCookie.setName(legacyCookie.name() + kLegacyCookieSuffix);
       legacyCookie.setSameSite(Cookie::SameSite::Undefined);
+      legacyCookie.setPartitioned(false);
       addHeader("Set-Cookie", legacyCookie.cookieHeaderValue());
    }
 }

--- a/src/cpp/core/include/core/http/Cookie.hpp
+++ b/src/cpp/core/include/core/http/Cookie.hpp
@@ -73,6 +73,9 @@ public:
    void setSameSite(SameSite sameSite);
    SameSite sameSite() const { return sameSite_; }
 
+   void setPartitioned(bool partitioned) { partitioned_ = partitioned; }
+   bool partitioned() const { return partitioned_; }
+
    std::string cookieHeaderValue() const;
 
 private:
@@ -84,6 +87,7 @@ private:
    SameSite sameSite_;
    bool httpOnly_;
    bool secure_;
+   bool partitioned_ = false;
 };
 
 

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -162,14 +162,21 @@ Error makePortTokenCookie(boost::shared_ptr<HttpConnection> ptrConnection,
 
    // create the cookie; don't set an expiry date as this will be a session cookie
    http::Cookie cookie(
-            ptrConnection->request(), 
-            kPortTokenCookie, 
-            persistentState().portToken(), 
+            ptrConnection->request(),
+            kPortTokenCookie,
+            persistentState().portToken(),
             path,
             options().sameSite(),
             true, // HTTP only -- client doesn't get to read this token
             options().useSecureCookies()
          );
+
+   // When SameSite=None and Secure, add the Partitioned attribute (CHIPS)
+   // so the cookie works in cross-origin iframes despite third-party cookie
+   // restrictions (e.g., Chrome Privacy Sandbox).
+   if (cookie.sameSite() == http::Cookie::SameSite::None && cookie.secure())
+      cookie.setPartitioned(true);
+
    response.addCookie(cookie);
 
    return Success();


### PR DESCRIPTION
## Intent

Addresses issue 5 of https://github.com/rstudio/rstudio/issues/17423.
Addresses https://github.com/rstudio/rstudio/issues/17430.

Adds support for the `Partitioned` cookie attribute ([CHIPS](https://developer.mozilla.org/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies)) to all `SameSite=None; Secure` cookies. When RStudio Server is embedded in a cross-origin iframe (e.g., a portal or LMS) with `www-same-site=none`, browsers that enforce third-party cookie restrictions (or users who opt into blocking them) will reject these cookies unless they carry the `Partitioned` attribute — breaking sign-in, CSRF validation, and port-mapped content.

## Approach

- Added a `partitioned_` member to `core::http::Cookie` with getter/setter, emitting `; Partitioned` in the `Set-Cookie` header value.
- In `Response::addCookie()`, automatically set `Partitioned` on any cookie with `SameSite=None` and `Secure`. This covers all cookie-setting call sites (auth, CSRF, port-token, etc.) without requiring per-site opt-in.
- The legacy cookie copy (with `SameSite=Undefined`) explicitly clears `Partitioned`, since CHIPS requires `SameSite=None; Secure`.

## Automated Tests

No automated tests — this requires a cross-origin iframe environment with third-party cookie restrictions enabled to verify.

## QA Notes

See https://github.com/rstudio/rstudio/issues/17423.

## Documentation

No documentation changes needed. This is an internal cookie attribute change that requires no user-facing configuration.

## Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests