### PR TITLE
Update what's new dialog to mention NES in Posit AI bullet

### DIFF
--- a/src/node/desktop/src/assets/whats-new/globemaster-allium/index.html
+++ b/src/node/desktop/src/assets/whats-new/globemaster-allium/index.html
@@ -16,7 +16,7 @@
     <ul>
       <li><strong>Posit Assistant:</strong> A conversational agent right inside RStudio that understands your full session context. Ask it to clean data, explore patterns, train models, or even build apps - all within your existing workflow.</li>
       <li><strong>Next Edit Suggestions (NES):</strong> Get smart, context-aware code completions that adapt as you type, accelerating your coding without breaking the flow.</li>
-      <li><a href="https://posit.co/products/ai/">Posit AI</a> is the subscription service that powers Posit Assistant.</li>
+      <li><a href="https://posit.co/products/ai/">Posit AI</a> is the subscription service that powers Posit Assistant and NES.</li>
     </ul>
     <p><strong>Your privacy matters.</strong> When you create your account, you choose whether to share your trace data (including prompts and AI responses) to help improve Posit AI. If you opt out, we only retain basic operational data for 30 days, and your prompts and responses are never stored. We have a Zero Data Retention agreement with our model provider, Anthropic, meaning your data is processed to generate a response and immediately deleted.</p>
     <p><strong>RStudio itself remains free and open source.</strong> Posit AI is an optional subscription starting at $20/month with a free trial. <a href="https://posit.co/products/ai/">Learn more</a>.</p>


### PR DESCRIPTION
### Intent

Updates the What's New dialog copy to mention NES alongside Posit Assistant in the third bullet point, so it reads "powers Posit Assistant and NES" instead of just "powers Posit Assistant."

### Approach

One-line text change in the What's New HTML content.

### Automated Tests

N/A — copy-only change.

### QA Notes

Open the What's New dialog and verify the third bullet under Posit AI reads: "Posit AI is the subscription service that powers Posit Assistant and NES."

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` — N/A, unreleased feature copy tweak
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests