### PR TITLE
Add chat-user-skills Playwright test and Selenium migration skill

### DIFF
--- a/.claude/skills/migrate-selenium-to-playwright/SKILL.md
+++ b/.claude/skills/migrate-selenium-to-playwright/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: migrate-selenium-to-playwright
-description: Migrate Python Selenium/Selene electron tests to TypeScript/Playwright. Use when converting tests from rstudio-ide-automation/electron-tests/ to rstudio/e2e/rstudio/tests/.
+description: Migrate Python Selenium/Selene electron tests to TypeScript/Playwright. Use when converting tests from rstudio-ide-automation/rstudio_server_pro/electron-tests/ to rstudio/e2e/rstudio/tests/.
 ---
 
 # Migrate Electron Tests to Playwright
@@ -36,8 +36,7 @@ The user provides one or more targets:
 - Check BRAT (`rstudio/src/cpp/tests/automation/testthat/`) for related R-based test automation
 - Check `rstudio-ide-automation/rstudio_server_pro/electron-tests/` for other Selenium/Selene electron tests covering the same functionality — useful for test logic, assertions, and expected values
 - Check `rstudio-ide-automation/rstudio_server_pro/tests/` for Selenium/Selene server tests covering the same functionality — useful for test logic, assertions, and expected values
-- Check `rstudio-ide-automation/e2e/tests/` for existing TypeScript/Playwright conversions of the same or similar tests — may already have working locators and patterns
-- Check `rstudio-pro/e2e/` for Workbench e2e patterns — `.or()` locator chaining, `clickIfVisible()` helpers, input fill with retry, reload-on-hang recovery
+- Check `rstudio-pro/e2e/` for Workbench e2e patterns (examples include `.or()` locator chaining, `clickIfVisible()` helpers, input fill with retry, reload-on-hang recovery) -- look for anything else reusable
 - Read relevant existing Playwright page objects in `e2e/rstudio/pages/`
 - Read relevant existing Playwright actions in `e2e/rstudio/actions/`
 
@@ -58,37 +57,11 @@ Use judgment — the Playwright structure is organized by function, not by the e
 
 ### Step 4: Write the TypeScript test
 
-Follow these rules:
+Follow the rules in the `rstudio-create-playwright-tests` skill (already loaded per Hard Rule 1). That skill covers imports, selector hierarchy, idiomatic patterns, parallel safety, package dependencies, cross-platform considerations, Ace/NES patterns, and CDP setup.
 
-**Imports:**
-```typescript
-import { test, expect } from '@fixtures/rstudio.fixture';
-```
-
-**Selector quality hierarchy (prefer in order):**
-1. `#id` — stable RStudio IDs (e.g., `#rstudio_console_input`)
-2. `aria-label` / `getByRole()` — accessible attributes
-3. CSS attribute selectors (`[class*=...]`, `[id^=...]`) — dynamic/partial IDs
-4. XPath — only when CSS can't express the query
-5. Never use `gwt-uid-XXXX` IDs — they change on every restart
-
-**Idiomatic Playwright patterns:**
-- `await expect(locator).toBeVisible()` — not manual waits + null checks
-- `await expect(locator).toContainText('...')` — not extract text then assert
-- `expect(items).toEqual(expect.arrayContaining([...]))` — for order-independent lists
-- `click({ force: true })` on Ace textareas — overlay intercepts normal clicks
-- `pressSequentially()` for console/editor input — character-by-character
-- `test.fixme()` for tests that can't pass yet — never comment out or omit
-
-**Parallel safety:**
-- Default to `test.describe()` (parallel-safe)
-- Use `test.describe.serial()` only when tests depend on shared state
-- Tag accordingly: `{ tag: ['@parallel_safe'] }` or `{ tag: ['@serial'] }`
-
-**Package dependencies:**
-- Use `consoleActions.ensurePackages()` in `beforeAll`
-- Skip tests if packages can't be installed: `test.skip(missingPackages.length > 0, ...)`
-- Never chain `install.packages()` with semicolons
+Migration-specific guidance:
+- Use `test.fixme()` for tests that can't pass yet -- never comment out or omit.
+- If the Selenium source has multiple near-identical methods, consider data-driven restructuring (one `forEach` loop) in the Playwright version.
 
 ### Step 5: Add missing page objects or actions
 
@@ -99,10 +72,12 @@ If the test needs locators or methods not yet available:
 
 ### Step 6: Run the test
 
-Present the command and wait for user approval before executing.
+Defer to the `rstudio-run-playwright-tests` skill for the canonical run commands (Desktop and Server). Present the command and wait for user approval before executing.
+
+Quick reference for Desktop:
 
 ```bash
-cd rstudio/e2e/rstudio && npx playwright test tests/<path>/<file>.test.ts
+cd e2e/rstudio && npx playwright test tests/<path>/<file>.test.ts --project desktop-os-windows
 ```
 
 If the test fails:
@@ -164,4 +139,4 @@ After conversion, summarize:
 - Page objects or actions added/modified
 - Test results (passed/fixme with blockers)
 - Improvements made during reevaluation
-- MIGRATION_PROGRESS.md updates
+- MIGRATION_FROM_SELENIUM_PROGRESS.md updates

--- a/.claude/skills/migrate-selenium-to-playwright/SKILL.md
+++ b/.claude/skills/migrate-selenium-to-playwright/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: migrate-selenium-to-playwright
+description: Migrate Python Selenium/Selene electron tests to TypeScript/Playwright. Use when converting tests from rstudio-ide-automation/electron-tests/ to rstudio/e2e/rstudio/tests/.
+---
+
+# Migrate Electron Tests to Playwright
+
+Converts Python test files from `rstudio-ide-automation/rstudio_server_pro/electron-tests/` to TypeScript/Playwright tests in `rstudio/e2e/rstudio/tests/`.
+
+## Arguments
+
+The user provides one or more targets:
+- A single file: `/migrate-selenium-to-playwright test_desktop_console.py`
+- A directory: `/migrate-selenium-to-playwright GlobalPrefs/`
+- A keyword: `/migrate-selenium-to-playwright citations`
+
+## Hard Rules
+
+1. **Load skills first** — Always load `rstudio-create-playwright-tests` before doing any conversion work.
+2. **Check BRAT for ground truth** — Before writing assertions, check `rstudio/src/cpp/tests/automation/testthat/` for existing R-based tests that cover the same functionality. They contain expected values and test patterns.
+3. **Check MIGRATION_FROM_SELENIUM_PROGRESS.md** — Before starting, verify the file hasn't already been converted or partially converted. Located at `e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md`.
+4. **Tests must work on Desktop and Server** — Use the unified fixture (`@fixtures/rstudio.fixture`). Don't hardcode Desktop-only patterns.
+5. **No Claude dependency** — All test infrastructure must be runnable from terminal, CI, and GitHub Actions. Claude subagents are a convenience layer, not a requirement.
+
+## Steps
+
+### Step 1: Resolve the target
+
+- Search for the file under `electron-tests/`
+- Read the full Python source — understand test methods, fixtures, imports, page objects
+- Check `e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md` for current status
+
+### Step 2: Read reference materials
+
+- Load `rstudio-create-playwright-tests` skill
+- Check BRAT (`rstudio/src/cpp/tests/automation/testthat/`) for related R-based test automation
+- Check `rstudio-ide-automation/rstudio_server_pro/electron-tests/` for other Selenium/Selene electron tests covering the same functionality — useful for test logic, assertions, and expected values
+- Check `rstudio-ide-automation/rstudio_server_pro/tests/` for Selenium/Selene server tests covering the same functionality — useful for test logic, assertions, and expected values
+- Check `rstudio-ide-automation/e2e/tests/` for existing TypeScript/Playwright conversions of the same or similar tests — may already have working locators and patterns
+- Check `rstudio-pro/e2e/` for Workbench e2e patterns — `.or()` locator chaining, `clickIfVisible()` helpers, input fill with retry, reload-on-hang recovery
+- Read relevant existing Playwright page objects in `e2e/rstudio/pages/`
+- Read relevant existing Playwright actions in `e2e/rstudio/actions/`
+
+### Step 3: Determine the target location
+
+Map the electron-test to the Playwright directory structure:
+
+| Electron Location | Playwright Location |
+|-------------------|---------------------|
+| Root-level console/terminal tests | `tests/panes/console/` |
+| EditorPane/ tests | `tests/panes/editor/` |
+| GlobalPrefs/ tests | `tests/panes/preferences/` |
+| Licensing/ tests | `tests/licensing/` |
+| Projects/ tests | `tests/projects/` |
+| Cross-pane tests (autocomplete, etc.) | `tests/panes/misc/` |
+
+Use judgment — the Playwright structure is organized by function, not by the electron-tests layout.
+
+### Step 4: Write the TypeScript test
+
+Follow these rules:
+
+**Imports:**
+```typescript
+import { test, expect } from '@fixtures/rstudio.fixture';
+```
+
+**Selector quality hierarchy (prefer in order):**
+1. `#id` — stable RStudio IDs (e.g., `#rstudio_console_input`)
+2. `aria-label` / `getByRole()` — accessible attributes
+3. CSS attribute selectors (`[class*=...]`, `[id^=...]`) — dynamic/partial IDs
+4. XPath — only when CSS can't express the query
+5. Never use `gwt-uid-XXXX` IDs — they change on every restart
+
+**Idiomatic Playwright patterns:**
+- `await expect(locator).toBeVisible()` — not manual waits + null checks
+- `await expect(locator).toContainText('...')` — not extract text then assert
+- `expect(items).toEqual(expect.arrayContaining([...]))` — for order-independent lists
+- `click({ force: true })` on Ace textareas — overlay intercepts normal clicks
+- `pressSequentially()` for console/editor input — character-by-character
+- `test.fixme()` for tests that can't pass yet — never comment out or omit
+
+**Parallel safety:**
+- Default to `test.describe()` (parallel-safe)
+- Use `test.describe.serial()` only when tests depend on shared state
+- Tag accordingly: `{ tag: ['@parallel_safe'] }` or `{ tag: ['@serial'] }`
+
+**Package dependencies:**
+- Use `consoleActions.ensurePackages()` in `beforeAll`
+- Skip tests if packages can't be installed: `test.skip(missingPackages.length > 0, ...)`
+- Never chain `install.packages()` with semicolons
+
+### Step 5: Add missing page objects or actions
+
+If the test needs locators or methods not yet available:
+- Add locators to the appropriate file in `pages/`
+- Add interaction methods to the appropriate file in `actions/`
+- Follow existing patterns in those files
+
+### Step 6: Run the test
+
+Present the command and wait for user approval before executing.
+
+```bash
+cd rstudio/e2e/rstudio && npx playwright test tests/<path>/<file>.test.ts
+```
+
+If the test fails:
+- Review error output
+- Fix and re-run (up to 3 attempts)
+- If still failing, use `test.fixme()` for the failing test and note the blocker
+
+### Step 7: Reevaluate
+
+After the test passes, review for:
+
+1. **Code clarity** — Remove unnecessary variables, simplify patterns, ensure descriptive test names
+2. **Idiomatic patterns** — Check against the list in Step 4
+3. **Selector quality** — Check against the hierarchy in Step 4
+4. **Playwright + TypeScript conventions** — Verify the code follows standard Playwright and TypeScript conventions (e.g., proper async/await usage, correct type annotations, Playwright's built-in assertions over manual checks, proper use of lifecycle hooks, no floating promises). Consult official Playwright docs and TypeScript best practices if uncertain.
+5. **Duplication** — Could any new helpers be shared via actions classes?
+
+Present proposed improvements to the user. Only apply if approved. Re-run after changes.
+
+### Step 8: Update progress tracking
+
+Edit `e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md`:
+- Update the file's status (Complete, Partial, or Fixme)
+- Add the Playwright target path and test count
+- Add notes if relevant
+- Add any fixme tests to the Fixme Tests table with blocker description
+
+## Server Mode Parallelism
+
+Tests can run against multiple RStudio Server instances in parallel. This works from terminal, CI, or Claude subagents.
+
+**Targeting a server:**
+```bash
+RSTUDIO_SERVER_URL=https://server1:80 RSTUDIO_EDITION=server \
+  npx playwright test tests/panes/misc/autocomplete.test.ts
+```
+
+**Parallel execution (5 servers):**
+Each process gets its own `RSTUDIO_SERVER_URL` — no shared config files, no conflicts:
+
+```bash
+# Terminal / CI / shell script
+RSTUDIO_SERVER_URL=https://server1:80 RSTUDIO_EDITION=server npx playwright test tests/file1.test.ts &
+RSTUDIO_SERVER_URL=https://server2:80 RSTUDIO_EDITION=server npx playwright test tests/file2.test.ts &
+RSTUDIO_SERVER_URL=https://server3:80 RSTUDIO_EDITION=server npx playwright test tests/file3.test.ts &
+wait
+```
+
+**Claude subagent execution:**
+Same commands, but each Agent tool call targets a different server with `run_in_background: true`. Results are collected and aggregated by the parent agent.
+
+**Desktop mode is unaffected** — it doesn't use `RSTUDIO_SERVER_URL`. The env var is only read by the server fixture path.
+
+## Output
+
+After conversion, summarize:
+- Source file and methods converted
+- Playwright target file and location
+- Page objects or actions added/modified
+- Test results (passed/fixme with blockers)
+- Improvements made during reevaluation
+- MIGRATION_PROGRESS.md updates

--- a/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
+++ b/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
@@ -1,0 +1,100 @@
+# Electron-to-Playwright Migration Progress
+
+Source: `rstudio-ide-automation/rstudio_server_pro/electron-tests/`
+Target: `e2e/rstudio/tests/`
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Total electron test files | 33 |
+| Total electron test methods | 124 |
+| Files fully converted | 13 |
+| Files partially converted | 0 |
+| Files not started | 20 |
+| Playwright-only tests (no electron source) | 10 |
+
+## Conversion Status
+
+### Root-level tests (12 files, 66 methods)
+
+| Electron Source | Methods | Playwright Target | Status | Notes |
+|----------------|---------|-------------------|--------|-------|
+| test_desktop_Autocomplete.py | 9 | — | Not started | |
+| test_desktop_Citations.py | 17 | — | Not started | |
+| test_desktop_Command_Palette.py | 2 | panes/misc/command-palette.test.ts (2) | Complete | |
+| test_desktop_console.py | 11 | — | Not started | |
+| test_desktop_EnvironmentPane.py | 5 | — | Not started | |
+| test_desktop_FindInFiles.py | 3 | panes/misc/find-in-files.test.ts (3) | Complete | |
+| test_desktop_Package_Installation.py | 1 | — | Not started | |
+| test_desktop_PlotsPane.py | 11 | — | Not started | |
+| test_desktop_R.py | 1 | — | Not started | |
+| test_desktop_R_Session_Restart.py | 1 | — | Not started | |
+| test_desktop_terminal.py | 4 | — | Not started | |
+| test_desktop_ViewerPane.py | 1 | panes/viewer/htmlwidgets.test.ts (1) | Complete | |
+
+### EditorPane (10 files, 37 methods)
+
+| Electron Source | Methods | Playwright Target | Status | Notes |
+|----------------|---------|-------------------|--------|-------|
+| test_desktop_CodeSuggestions.ts | — | panes/editor/code_suggestions.test.ts (5) | Complete | Already TypeScript in electron-tests |
+| test_desktop_Copilot.py | 12 | panes/editor/copilot_ghost_text.test.ts (22) | Complete | Restructured with loops; test_enabling_copilot not included |
+| test_desktop_Create_File_Types.py | 6 | panes/editor/create_file_types.test.ts (19) | Complete | Data-driven; 15 no-modal + 4 modal tests; includes Sweave creation. TODO: 3 WIP types from Selenium still need conversion (newRDocumentationDoc, newRPlumberDoc, newRPresentationDoc) — each requires extra dialog fields |
+| test_desktop_DataViewer.py | 4 | panes/data-viewer/pagination-sorting.test.ts (4) | Complete | |
+| test_desktop_Markdown.py | 2 | panes/editor/markdown.test.ts (2) | Complete | |
+| test_desktop_Quarto.py | 1 | panes/editor/quarto.test.ts (1) | Complete | |
+| test_desktop_RMarkdown.py | 7 | panes/editor/rmarkdown.test.ts (6) | Complete | |
+| test_desktop_RNotebook.py | 1 | panes/editor/rnotebook.test.ts (1) | Complete | |
+| test_desktop_Sweave.py | 2 | panes/editor/sweave.test.ts (2) | Complete | Creation test covered by create_file_types; added PDF compile test |
+| test_desktop_SyntaxHighlighting.py | 1 | panes/editor/syntax-highlighting.test.ts (1) | Complete | |
+
+### GlobalPrefs (10 files, 19 methods)
+
+| Electron Source | Methods | Playwright Target | Status | Notes |
+|----------------|---------|-------------------|--------|-------|
+| test_desktop_GlobalPrefAccessibility.py | 6 | — | Not started | |
+| test_desktop_GlobalPrefAppearance.py | 1 | — | Not started | |
+| test_desktop_GlobalPrefCode.py | 2 | — | Not started | |
+| test_desktop_GlobalPrefGeneral.py | 3 | — | Not started | |
+| test_desktop_GlobalPrefPackages.py | 2 | — | Not started | |
+| test_desktop_GlobalPrefPaneLayout.py | 1 | — | Not started | |
+| test_desktop_GlobalPrefRMarkdown.py | 1 | — | Not started | |
+| test_desktop_GlobalPrefSpelling.py | 1 | — | Not started | |
+| test_desktop_GlobalPrefSweave.py | 1 | — | Not started | |
+| test_desktop_GlobalPrefTerminal.py | 1 | — | Not started | |
+
+### Licensing (4 files, 9 methods)
+
+| Electron Source | Methods | Playwright Target | Status | Notes |
+|----------------|---------|-------------------|--------|-------|
+| test_desktop_activate_license.py | 3 | — | Not started | |
+| test_desktop_license.py | 2 | — | Not started | |
+| test_desktop_License_Diagnostics.py | 2 | — | Not started | |
+| test_desktop_remove_license.py | 2 | — | Not started | |
+
+### Projects (1 file, 5 methods)
+
+| Electron Source | Methods | Playwright Target | Status | Notes |
+|----------------|---------|-------------------|--------|-------|
+| test_desktop_Create_Projects.py | 5 | — | Not started | |
+
+## Playwright-Only Tests (no electron source)
+
+| Playwright Test | Tests | Origin |
+|----------------|-------|--------|
+| panes/console/ansi_erase_in_line.test.ts | 7 | New |
+| panes/layout/pane_location_persistence.test.ts | 1 | New — issue #17177 |
+| panes/posit-assistant-chat/chat-messaging.test.ts | 3 | New |
+| panes/posit-assistant-chat/conversation-history.test.ts | 1 | New |
+| panes/posit-assistant-chat/detachable-sidebar.test.ts | 1 | New |
+| panes/posit-assistant-chat/enable-assistant.test.ts | 1 | New |
+| panes/posit-assistant-chat/open-chat-pane.test.ts | 2 | New |
+| panes/posit-assistant-chat/settings-button.test.ts | 1 | New |
+| panes/posit-assistant-chat/shiny-app-python.test.ts | 1 | New |
+| panes/posit-assistant-chat/shiny-app-r.test.ts | 1 | New |
+
+## Fixme Tests
+
+| Playwright File | Test Name | Blocker | Notes |
+|----------------|-----------|---------|-------|
+| — | — | — | None tracked yet |

--- a/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
+++ b/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
@@ -7,20 +7,18 @@ Target: `e2e/rstudio/tests/`
 
 | Metric | Count |
 |--------|-------|
-| Total electron test files | 33 |
-| Total electron test methods | 124 |
+| Total electron test files | 32 |
+| Total electron test methods | 115 |
 | Files fully converted | 13 |
 | Files partially converted | 0 |
-| Files not started | 20 |
-| Playwright-only tests (no electron source) | 10 |
+| Files not started | 19 |
 
 ## Conversion Status
 
-### Root-level tests (12 files, 66 methods)
+### Root-level tests (11 files, 57 methods)
 
 | Electron Source | Methods | Playwright Target | Status | Notes |
 |----------------|---------|-------------------|--------|-------|
-| test_desktop_Autocomplete.py | 9 | — | Not started | |
 | test_desktop_Citations.py | 17 | — | Not started | |
 | test_desktop_Command_Palette.py | 2 | panes/misc/command-palette.test.ts (2) | Complete | |
 | test_desktop_console.py | 11 | — | Not started | |
@@ -77,21 +75,6 @@ Target: `e2e/rstudio/tests/`
 | Electron Source | Methods | Playwright Target | Status | Notes |
 |----------------|---------|-------------------|--------|-------|
 | test_desktop_Create_Projects.py | 5 | — | Not started | |
-
-## Playwright-Only Tests (no electron source)
-
-| Playwright Test | Tests | Origin |
-|----------------|-------|--------|
-| panes/console/ansi_erase_in_line.test.ts | 7 | New |
-| panes/layout/pane_location_persistence.test.ts | 1 | New — issue #17177 |
-| panes/posit-assistant-chat/chat-messaging.test.ts | 3 | New |
-| panes/posit-assistant-chat/conversation-history.test.ts | 1 | New |
-| panes/posit-assistant-chat/detachable-sidebar.test.ts | 1 | New |
-| panes/posit-assistant-chat/enable-assistant.test.ts | 1 | New |
-| panes/posit-assistant-chat/open-chat-pane.test.ts | 2 | New |
-| panes/posit-assistant-chat/settings-button.test.ts | 1 | New |
-| panes/posit-assistant-chat/shiny-app-python.test.ts | 1 | New |
-| panes/posit-assistant-chat/shiny-app-r.test.ts | 1 | New |
 
 ## Fixme Tests
 

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
@@ -1,0 +1,238 @@
+import { homedir } from 'os';
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { sleep, CHAT_PROVIDERS } from '@utils/constants';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { AssistantOptionsActions } from '@actions/assistant_options.actions';
+import { ChatPaneActions } from '@actions/chat_pane.actions';
+import { ChatPane } from '@pages/chat_pane.page';
+import type { EnvironmentVersions } from '@pages/console_pane.page';
+
+// ---------------------------------------------------------------------------
+// Project-level skill (lives in .positai/skills/ under the workspace root)
+// ---------------------------------------------------------------------------
+
+const PROJECT_SKILL_NAME = 'custom-data-summary';
+const PROJECT_SKILL_DIR = `.positai/skills/${PROJECT_SKILL_NAME}`;
+const PROJECT_SKILL_PATH = `${PROJECT_SKILL_DIR}/SKILL.md`;
+const PROJECT_MARKER = 'PROJECT_SKILL_ACTIVE_QA7742';
+
+// ---------------------------------------------------------------------------
+// User-level skill (lives in ~/.positai/skills/ under the user home dir)
+//
+// On Windows, R's ~ expands to Documents, not the actual home directory.
+// Databot uses Node's os.homedir() for tilde expansion, so we must use
+// the same value to place the file where databot will look.
+// ---------------------------------------------------------------------------
+
+const USER_HOME = homedir().replace(/\\/g, '/');
+const USER_SKILL_NAME = 'custom-code-review';
+const USER_SKILL_DIR = `${USER_HOME}/.positai/skills/${USER_SKILL_NAME}`;
+const USER_SKILL_PATH = `${USER_SKILL_DIR}/SKILL.md`;
+const USER_MARKER = 'USER_SKILL_REVIEW_QA8853';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a SKILL.md file via two short R console commands.
+ *
+ * Long single commands through pressSequentially are fragile (autocomplete
+ * interference, timing issues). Instead we use two short commands:
+ * 1. dir.create() for the directory
+ * 2. writeLines(c(...)) for the file content (kept minimal)
+ */
+async function createSkillFile(
+  consoleActions: ConsolePaneActions,
+  dir: string,
+  filePath: string,
+  name: string,
+  description: string,
+  marker: string,
+): Promise<void> {
+  await consoleActions.typeInConsole(`dir.create("${dir}", recursive = TRUE)`);
+  await sleep(1000);
+
+  // Keep content minimal to stay under ~300 chars for pressSequentially reliability
+  const cmd =
+    `writeLines(c("---", "name: ${name}", "description: ${description}", "---", "", "Start with: ${marker}", "Markers are MANDATORY."), "${filePath}")`;
+  await consoleActions.typeInConsole(cmd);
+  await sleep(1000);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe.serial('User-Added Skills', { tag: ['@serial'] }, () => {
+  let chatPane: ChatPane;
+  let chatActions: ChatPaneActions;
+  let consoleActions: ConsolePaneActions;
+  let assistantActions: AssistantOptionsActions;
+  let versions: EnvironmentVersions;
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+    assistantActions = new AssistantOptionsActions(page, consoleActions);
+    chatActions = new ChatPaneActions(page, consoleActions);
+    chatPane = chatActions.chatPane;
+
+    versions = await consoleActions.getEnvironmentVersions();
+    console.log(`R: ${versions.r}, RStudio: ${versions.rstudio}`);
+    await consoleActions.clearConsole();
+
+    // -----------------------------------------------------------------------
+    // Step 1: Stop any running backend FIRST.
+    //
+    // The default chat_provider is "posit", so the backend auto-starts when
+    // RStudio launches. We must stop it before creating skill files, because
+    // skills are only discovered during DatabotCore.initialize() (at process
+    // start). Setting the preference to "none" (a valid enum value -- NOT "")
+    // triggers onChatProviderChanged() → stopBackend() on the GWT side.
+    // -----------------------------------------------------------------------
+    console.log('Stopping chat backend (setting chat_provider to "none")');
+    await consoleActions.typeInConsole('.rs.api.writeRStudioPreference("chat_provider", "none")');
+    await sleep(5000);
+
+    // -----------------------------------------------------------------------
+    // Step 2: Create a project-level skill (.positai/skills/ in workspace)
+    // -----------------------------------------------------------------------
+    console.log(`Creating project skill at: ${PROJECT_SKILL_PATH}`);
+    await createSkillFile(
+      consoleActions,
+      PROJECT_SKILL_DIR,
+      PROJECT_SKILL_PATH,
+      PROJECT_SKILL_NAME,
+      'Summarize or describe a dataset.',
+      PROJECT_MARKER,
+    );
+
+    // -----------------------------------------------------------------------
+    // Step 3: Create a user-level skill (~/.positai/skills/ in home dir)
+    // -----------------------------------------------------------------------
+    console.log(`Creating user skill at: ${USER_SKILL_PATH}`);
+    await createSkillFile(
+      consoleActions,
+      USER_SKILL_DIR,
+      USER_SKILL_PATH,
+      USER_SKILL_NAME,
+      'Review or critique a code snippet.',
+      USER_MARKER,
+    );
+
+    // -----------------------------------------------------------------------
+    // Step 4: Verify both files exist and have correct content
+    // -----------------------------------------------------------------------
+    await consoleActions.clearConsole();
+    await consoleActions.typeInConsole(`cat(readLines("${PROJECT_SKILL_PATH}"), sep = "\\n")`);
+    await sleep(2000);
+    const projectOutput = await consoleActions.consolePane.consoleOutput.innerText();
+    console.log(`Project skill content:\n${projectOutput}`);
+
+    await consoleActions.clearConsole();
+    await consoleActions.typeInConsole(`cat(readLines("${USER_SKILL_PATH}"), sep = "\\n")`);
+    await sleep(2000);
+    const userOutput = await consoleActions.consolePane.consoleOutput.innerText();
+    console.log(`User skill content:\n${userOutput}`);
+
+    // -----------------------------------------------------------------------
+    // Step 5: Start a fresh backend by setting chat_provider back to "posit".
+    //
+    // This triggers onChatProviderChanged() → checkForUpdates() → startBackend()
+    // The new backend process runs DatabotCore.initialize() → discoverSkills()
+    // which picks up our newly created skill files.
+    // -----------------------------------------------------------------------
+    console.log('Starting fresh backend via Options dialog');
+    await assistantActions.setChatProvider(CHAT_PROVIDERS['posit-assistant']);
+
+    // -----------------------------------------------------------------------
+    // Step 6: Open the chat pane and wait for the UI to be ready
+    // -----------------------------------------------------------------------
+    await chatActions.openChatPane();
+    await chatActions.dismissSetupPrompts();
+  });
+
+  test.beforeEach(async () => {
+    test.info().annotations.push(
+      { type: 'R version', description: versions.r },
+      { type: 'RStudio version', description: versions.rstudio },
+    );
+  });
+
+  test.afterAll(async () => {
+    // Clean up the project-level skill directory
+    await consoleActions.typeInConsole('unlink(".positai", recursive = TRUE)');
+    await sleep(1000);
+
+    // Clean up only the specific user-level skill we created (leave ~/.positai/ intact)
+    await consoleActions.typeInConsole(`unlink("${USER_SKILL_DIR}", recursive = TRUE)`);
+    await sleep(1000);
+  });
+
+  test('both custom skills are discovered by assistant', async () => {
+    await chatActions.startNewConversation();
+
+    const initialCount = await chatPane.getMessageCount();
+    await chatActions.sendChatMessage(
+      'List all Agent Skills that are currently available to you. ' +
+      'Include the exact name of each skill.'
+    );
+    const newCount = await chatActions.waitForResponse(initialCount);
+    expect(newCount).toBeGreaterThan(initialCount);
+
+    // The response should mention both custom skills by name
+    const lastMessage = chatPane.messageItem.last();
+    await expect(lastMessage).toContainText(PROJECT_SKILL_NAME, { timeout: 10000 });
+    await expect(lastMessage).toContainText(USER_SKILL_NAME, { timeout: 10000 });
+  });
+
+  test('project-level skill markers appear in response', async () => {
+    await chatActions.startNewConversation();
+
+    const initialCount = await chatPane.getMessageCount();
+    await chatActions.sendChatMessage(
+      'Summarize the iris dataset. ' +
+      'Use your available Agent Skills. ' +
+      'Do not run any code.'
+    );
+
+    // Wait for the full response, handling any Allow dialogs that appear
+    await chatActions.pollWithAllowDialogs(async () => {
+      const isStillProcessing = await chatPane.isStopButtonVisible();
+      const messageCount = await chatPane.getMessageCount();
+      return !isStillProcessing && messageCount > initialCount;
+    }, 120000);
+
+    // Verify the response contains the markers from our project skill
+    const lastMessage = chatPane.messageItem.last();
+    const responseText = await lastMessage.innerText();
+
+    console.log(`Project skill response preview: ${responseText.substring(0, 500)}`);
+    expect(responseText).toContain(PROJECT_MARKER);
+  });
+
+  test('user-level skill markers appear in response', async () => {
+    await chatActions.startNewConversation();
+
+    const initialCount = await chatPane.getMessageCount();
+    await chatActions.sendChatMessage(
+      'Review this R code snippet and provide feedback: x <- 1:10; mean(x). ' +
+      'Use your available Agent Skills. ' +
+      'Do not run any code.'
+    );
+
+    // Wait for the full response, handling any Allow dialogs that appear
+    await chatActions.pollWithAllowDialogs(async () => {
+      const isStillProcessing = await chatPane.isStopButtonVisible();
+      const messageCount = await chatPane.getMessageCount();
+      return !isStillProcessing && messageCount > initialCount;
+    }, 120000);
+
+    // Verify the response contains the marker from our user-level skill
+    const lastMessage = chatPane.messageItem.last();
+    const responseText = await lastMessage.innerText();
+
+    console.log(`User skill response preview: ${responseText.substring(0, 500)}`);
+    expect(responseText).toContain(USER_MARKER);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `chat-user-skills.test.ts` Playwright test covering Posit Assistant user skills
- Add `migrate-selenium-to-playwright` skill documenting the Selenium--Playwright migration process
- Add `MIGRATION_FROM_SELENIUM_PROGRESS.md` tracking doc