### PR TITLE
route posit connect cloud account selection through a gwt dialog

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -527,6 +527,19 @@
       PACKAGE = "(embedding)")
 })
 
+.rs.addApiFunction("showMenu", function(title, message, choices) {
+
+   choices <- as.character(choices)
+   if (length(choices) == 0L)
+      return(NULL)
+
+   .Call("rs_showMenu",
+      title = as.character(title)[[1L]],
+      message = as.character(message)[[1L]],
+      choices = choices,
+      PACKAGE = "(embedding)")
+})
+
 .rs.addApiFunction("showQuestion", function(title, message, ok = "OK", cancel = "Cancel") {
    
    # fix up ok, cancel

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -221,6 +221,7 @@ const int kChatBackendExit = 203;
 const int kShowMessage = 204;
 const int kNotebookRenderCompleted = 205;
 const int kConsoleReadCompleted = 206;
+const int kRStudioAPIShowMenu = 207;
 
 }
 
@@ -619,6 +620,8 @@ std::string ClientEvent::typeName() const
          return "notebook_render_completed";
       case client_events::kConsoleReadCompleted:
          return "console_read_completed";
+      case client_events::kRStudioAPIShowMenu:
+         return "rstudioapi_show_menu";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " +
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -222,6 +222,7 @@ extern const int kAssistantStatusChanged;
 extern const int kChatBackendExit;
 extern const int kNotebookRenderCompleted;
 extern const int kConsoleReadCompleted;
+extern const int kRStudioAPIShowMenu;
 
 }
    

--- a/src/cpp/session/modules/RStudioAPI.cpp
+++ b/src/cpp/session/modules/RStudioAPI.cpp
@@ -41,6 +41,7 @@ namespace {
 module_context::WaitForMethodFunction s_waitForShowDialog;
 module_context::WaitForMethodFunction s_waitForOpenFileDialog;
 module_context::WaitForMethodFunction s_waitForRStudioApiResponse;
+module_context::WaitForMethodFunction s_waitForShowMenu;
 
 SEXP rs_executeAppCommand(SEXP commandSEXP, SEXP quietSEXP)
 {
@@ -138,6 +139,57 @@ SEXP rs_showDialog(SEXP titleSEXP,
    }
    CATCH_UNEXPECTED_EXCEPTION
    
+   return R_NilValue;
+}
+
+ClientEvent showMenuEvent(const std::string& title,
+                          const std::string& message,
+                          const std::vector<std::string>& choices)
+{
+   json::Object data;
+   data["title"] = title;
+   data["message"] = message;
+   data["choices"] = json::toJsonArray(choices);
+   return ClientEvent(client_events::kRStudioAPIShowMenu, data);
+}
+
+SEXP rs_showMenu(SEXP titleSEXP,
+                 SEXP messageSEXP,
+                 SEXP choicesSEXP)
+{
+   try
+   {
+      std::string title = r::sexp::asString(titleSEXP);
+      std::string message = r::sexp::asString(messageSEXP);
+
+      std::vector<std::string> choices;
+      if (!r::sexp::fillVectorString(choicesSEXP, &choices))
+         return R_NilValue;
+
+      ClientEvent event = showMenuEvent(title, message, choices);
+
+      // wait for rstudioapi_show_menu_completed
+      json::JsonRpcRequest request;
+      if (!s_waitForShowMenu(&request, event))
+         return R_NilValue;
+
+      // cancel: client sends null
+      if (request.params[0].isNull())
+         return R_NilValue;
+
+      int selection = 0;
+      Error error = json::readParam(request.params, 0, &selection);
+      if (error)
+      {
+         LOG_ERROR(error);
+         return R_NilValue;
+      }
+
+      r::sexp::Protect rProtect;
+      return r::sexp::create(selection, &rProtect);
+   }
+   CATCH_UNEXPECTED_EXCEPTION
+
    return R_NilValue;
 }
 
@@ -325,9 +377,11 @@ Error initialize()
    s_waitForShowDialog         = registerWaitForMethod("rstudioapi_show_dialog_completed");
    s_waitForOpenFileDialog     = registerWaitForMethod("open_file_dialog_completed");
    s_waitForRStudioApiResponse = registerWaitForMethod("rstudioapi_response");
+   s_waitForShowMenu           = registerWaitForMethod("rstudioapi_show_menu_completed");
 
    // register R callables
    RS_REGISTER_CALL_METHOD(rs_showDialog);
+   RS_REGISTER_CALL_METHOD(rs_showMenu);
    RS_REGISTER_CALL_METHOD(rs_openFileDialog);
    RS_REGISTER_CALL_METHOD(rs_executeAppCommand);
    RS_REGISTER_CALL_METHOD(rs_highlightUi);

--- a/src/cpp/session/modules/SessionRSConnect.R
+++ b/src/cpp/session/modules/SessionRSConnect.R
@@ -579,10 +579,32 @@
    eval(cmd, envir = globalenv())
 })
 
-# Connect a Posit Connect Cloud account via OAuth device flow.
-# NOTE: This blocks the R session while waiting for the user to authenticate
-# in the browser. RStudio will be unresponsive until auth completes or times out.
+# Drop-in replacement for rsconnect:::cli_menu that routes the selection
+# through a GWT dialog instead of prompting on the R console. Signature
+# matches rsconnect:::cli_menu(header, prompt, choices, quit = NULL, ...).
+.rs.addFunction("cliMenu", function(header, prompt, choices, quit = NULL, ...) {
+   selected <- .rs.api.showMenu(
+      title = header,
+      message = prompt,
+      choices = choices
+   )
+   if (is.null(selected))
+      stop("Account selection cancelled.", call. = FALSE)
+   selected
+})
+
+# Connect a Posit Connect Cloud account via OAuth device flow. The R session
+# is blocked while waiting for the browser authentication to complete. The
+# override of rsconnect:::cli_menu below keeps the multi-account prompt out
+# of the R console (where a modal glass panel would block it) and into a
+# GWT dialog instead (see issue #17441).
 .rs.addJsonRpcHandler("connect_cloud_user", function() {
+   original <- .rs.tryCatch(
+      .rs.replaceBinding("cli_menu", "rsconnect", .rs.cliMenu)
+   )
+   if (!inherits(original, "error"))
+      on.exit(.rs.replaceBinding("cli_menu", "rsconnect", original), add = TRUE)
+
    rsconnect::connectCloudUser()
 })
 

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/RStudioAPI.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/RStudioAPI.java
@@ -30,6 +30,8 @@ import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.StudioClientCommonConstants;
 import org.rstudio.studio.client.common.rstudioapi.events.RStudioAPIShowDialogEvent;
+import org.rstudio.studio.client.common.rstudioapi.events.RStudioAPIShowMenuEvent;
+import org.rstudio.studio.client.common.rstudioapi.model.ChoiceListDialog;
 import org.rstudio.studio.client.common.rstudioapi.model.RStudioAPIServerOperations;
 import org.rstudio.studio.client.common.satellite.Satellite;
 
@@ -43,7 +45,8 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 @Singleton
-public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler
+public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler,
+                                   RStudioAPIShowMenuEvent.Handler
 {
    public RStudioAPI()
    {
@@ -59,6 +62,7 @@ public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler
       server_ = server;
 
       events_.addHandler(RStudioAPIShowDialogEvent.TYPE, this);
+      events_.addHandler(RStudioAPIShowMenuEvent.TYPE, this);
    }
    
    public interface Styles extends CssResource
@@ -178,6 +182,29 @@ public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler
          ok,
          cancel,
          true);
+   }
+
+   private void showMenu(String title, String message, String[] choices)
+   {
+      ChoiceListDialog dlg = new ChoiceListDialog(
+         title,
+         message,
+         choices,
+         (Integer selection) ->
+            server_.showMenuCompleted(selection, new SimpleRequestCallback<>()),
+         () ->
+            server_.showMenuCompleted(null, new SimpleRequestCallback<>()));
+      dlg.showModal();
+   }
+
+   @Override
+   public void onRStudioAPIShowMenuEvent(RStudioAPIShowMenuEvent event)
+   {
+      // Only the main window responds (same convention as the show-dialog event).
+      if (Satellite.isCurrentWindowSatellite())
+         return;
+
+      showMenu(event.getTitle(), event.getMessage(), event.getChoices());
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/events/RStudioAPIShowMenuEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/events/RStudioAPIShowMenuEvent.java
@@ -1,0 +1,89 @@
+/*
+ * RStudioAPIShowMenuEvent.java
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.common.rstudioapi.events;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class RStudioAPIShowMenuEvent extends GwtEvent<RStudioAPIShowMenuEvent.Handler>
+{
+   public static class Data extends JavaScriptObject
+   {
+      protected Data()
+      {
+      }
+
+      public final native String getTitle() /*-{
+         return this.title;
+      }-*/;
+
+      public final native String getMessage() /*-{
+         return this.message;
+      }-*/;
+
+      public final native JsArrayString getChoices() /*-{
+         return this.choices;
+      }-*/;
+   }
+
+   public interface Handler extends EventHandler
+   {
+      void onRStudioAPIShowMenuEvent(RStudioAPIShowMenuEvent event);
+   }
+
+   public RStudioAPIShowMenuEvent(Data data)
+   {
+      data_ = data;
+   }
+
+   public String getTitle()
+   {
+      return data_.getTitle();
+   }
+
+   public String getMessage()
+   {
+      return data_.getMessage();
+   }
+
+   public String[] getChoices()
+   {
+      JsArrayString jsChoices = data_.getChoices();
+      int n = jsChoices == null ? 0 : jsChoices.length();
+      String[] result = new String[n];
+      for (int i = 0; i < n; i++)
+         result[i] = jsChoices.get(i);
+      return result;
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onRStudioAPIShowMenuEvent(this);
+   }
+
+   private final Data data_;
+
+   public static final Type<Handler> TYPE = new Type<>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/model/ChoiceListDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/model/ChoiceListDialog.java
@@ -1,0 +1,95 @@
+/*
+ * ChoiceListDialog.java
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.common.rstudioapi.model;
+
+import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.widget.FormListBox;
+import org.rstudio.core.client.widget.ModalDialog;
+import org.rstudio.core.client.widget.Operation;
+import org.rstudio.core.client.widget.OperationWithInput;
+
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.dom.client.DoubleClickEvent;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.user.client.ui.Widget;
+
+public class ChoiceListDialog extends ModalDialog<Integer>
+{
+   public ChoiceListDialog(String title,
+                           String message,
+                           String[] choices,
+                           OperationWithInput<Integer> operation,
+                           Operation cancelOperation)
+   {
+      super(StringUtil.isNullOrEmpty(title) ? "Select" : title,
+            Roles.getDialogRole(),
+            operation,
+            cancelOperation);
+      message_ = message;
+      choices_ = choices == null ? new String[0] : choices;
+      setThemeAware(true);
+   }
+
+   @Override
+   protected Widget createMainWidget()
+   {
+      VerticalPanel panel = new VerticalPanel();
+      panel.setWidth("400px");
+
+      if (!StringUtil.isNullOrEmpty(message_))
+      {
+         Label msg = new Label(message_);
+         msg.getElement().getStyle().setPaddingBottom(8, Unit.PX);
+         panel.add(msg);
+      }
+
+      listBox_ = new FormListBox();
+      listBox_.setWidth("100%");
+      int visible = Math.min(Math.max(choices_.length, 3), 10);
+      listBox_.setVisibleItemCount(visible);
+      for (String choice : choices_)
+         listBox_.addItem(choice);
+      if (choices_.length > 0)
+         listBox_.setSelectedIndex(0);
+
+      // double-click to accept the selection
+      listBox_.addDoubleClickHandler((DoubleClickEvent event) -> clickOkButton());
+
+      panel.add(listBox_);
+      return panel;
+   }
+
+   @Override
+   protected Integer collectInput()
+   {
+      int idx = listBox_ == null ? -1 : listBox_.getSelectedIndex();
+      if (idx < 0)
+         return null;
+      return idx + 1;
+   }
+
+   @Override
+   protected boolean validate(Integer input)
+   {
+      return input != null && input > 0;
+   }
+
+   private final String message_;
+   private final String[] choices_;
+   private FormListBox listBox_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/model/RStudioAPIServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/model/RStudioAPIServerOperations.java
@@ -24,6 +24,9 @@ public interface RStudioAPIServerOperations extends CryptoServerOperations
                             boolean ok,
                             ServerRequestCallback<VoidResponse> callback);
 
+   void showMenuCompleted(Integer selection,
+                          ServerRequestCallback<VoidResponse> callback);
+
    void askSecretCompleted(String value,
                            boolean remember,
                            boolean changed,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -212,6 +212,7 @@ class ClientEvent extends JavaScriptObject
    public static final String ChatBackendExit = "chat_backend_exit";
    public static final String NotebookRenderCompleted = "notebook_render_completed";
    public static final String ConsoleReadCompleted = "console_read_completed";
+   public static final String RStudioAPIShowMenu = "rstudioapi_show_menu";
 
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -63,6 +63,7 @@ import org.rstudio.studio.client.common.dependencies.events.InstallShinyEvent;
 import org.rstudio.studio.client.common.rpubs.events.RPubsUploadStatusEvent;
 import org.rstudio.studio.client.common.rstudioapi.events.AskSecretEvent;
 import org.rstudio.studio.client.common.rstudioapi.events.RStudioAPIShowDialogEvent;
+import org.rstudio.studio.client.common.rstudioapi.events.RStudioAPIShowMenuEvent;
 import org.rstudio.studio.client.common.sourcemarkers.SourceMarker;
 import org.rstudio.studio.client.common.synctex.events.SynctexEditFileEvent;
 import org.rstudio.studio.client.common.synctex.model.SourceLocation;
@@ -992,6 +993,11 @@ public class ClientEventDispatcher
          {
             RStudioAPIShowDialogEvent.Data data = event.getData();
             eventBus_.dispatchEvent(new RStudioAPIShowDialogEvent(data));
+         }
+         else if (type == ClientEvent.RStudioAPIShowMenu)
+         {
+            RStudioAPIShowMenuEvent.Data data = event.getData();
+            eventBus_.dispatchEvent(new RStudioAPIShowMenuEvent(data));
          }
          else if (type == ClientEvent.ObjectExplorerEvent)
          {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -6588,6 +6588,15 @@ public class RemoteServer implements Server
    }
 
    @Override
+   public void showMenuCompleted(Integer selection,
+                                 ServerRequestCallback<VoidResponse> callback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, selection == null ? JSONNull.getInstance() : new JSONNumber(selection));
+      sendRequest(RPC_SCOPE, RSTUDIOAPI_SHOW_MENU_COMPLETED, params, true, callback);
+   }
+
+   @Override
    public void stopShinyApp(String id, ServerRequestCallback<VoidResponse> callback)
    {
       JSONArray params = new JSONArray();
@@ -7631,6 +7640,7 @@ public class RemoteServer implements Server
 
    private static final String LAUNCH_EMBEDDED_SHINY_CONNECTION_UI = "launch_embedded_shiny_connection_ui";
    private static final String RSTUDIOAPI_SHOW_DIALOG_COMPLETED = "rstudioapi_show_dialog_completed";
+   private static final String RSTUDIOAPI_SHOW_MENU_COMPLETED = "rstudioapi_show_menu_completed";
 
    private static final String STOP_SHINY_APP = "stop_shiny_app";
 


### PR DESCRIPTION
## Intent

Addresses #17441.

## Summary

- Adds a general-purpose show-menu API modeled on `rs_showDialog`: `rs_showMenu` C++ entry point, `.rs.api.showMenu` R wrapper, `ChoiceListDialog` GWT dialog, and a `showMenuCompleted` RPC. Returns a 1-based selection, or `NULL` on cancel.
- Scopes a `.rs.replaceBinding` override inside the `connect_cloud_user` RPC handler so that `rsconnect:::cli_menu` is swapped for a named `.rs.cliMenu` helper that routes the multi-account prompt through the new GWT dialog instead of `readline()` on the R console.

This breaks the deadlock in the reported issue: previously, a Posit Cloud user with multiple Connect Cloud accounts would hit `cli_menu()` in the R session while the publishing wizard's glass panel blocked the console, leaving force-quit as the only escape.

## Test plan

OAuth device flows are hard to automate here; this needs manual verification:

- [ ] Single-account Posit Connect Cloud login: connects as before.
- [ ] Multi-account Posit Connect Cloud login: the new GWT dialog appears; selecting an account registers it; the Publishing accounts list refreshes.
- [ ] Cancel the multi-account dialog: the RPC errors cleanly, the wizard surfaces the error, and a retry still works (the namespace binding is restored via `on.exit`).
- [ ] `cd src/gwt && ant draft` + desktop build, then verify end-to-end in the running IDE.