### PR TITLE
Migrate console and create-projects Selenium tests to Playwright

### DIFF
--- a/.claude/skills/rstudio-create-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-create-playwright-tests/SKILL.md
@@ -95,7 +95,7 @@ import { test, expect } from '@fixtures/rstudio.fixture';
 - `await expect(locator).toContainText('...')` — not extract text then assert
 - `expect(items).toEqual(expect.arrayContaining([...]))` — order-independent lists
 - `click({ force: true })` on Ace textareas — overlay intercepts normal clicks
-- `pressSequentially()` for all GWT text inputs (console, editor, dialog/wizard `input.gwt-TextBox`) — `fill()` doesn't fire GWT key events, which can leave change handlers untriggered (e.g., OK button stays disabled)
+- `pressSequentially()` for GWT text inputs whose behavior depends on incremental key events firing (console, editor, most dialog/wizard `input.gwt-TextBox` fields where typing a character enables the OK button, triggers autocomplete, etc.) — `fill()` doesn't fire GWT key events in those cases. This is guidance, not a universal law: inputs driven by a discrete trigger like `press('Enter')` or a button click (e.g., the console Find/Replace bar) typically work fine with `fill()`, and `fill()` has the advantage of replacing existing text instead of appending. If unsure, start with `fill()`; switch to `pressSequentially()` only when the handler doesn't fire
 - `test.fixme()` for failing tests — never comment out
 
 ### Waits and Timing
@@ -125,6 +125,8 @@ await sleep(TIMEOUTS.sessionRestart);
 ```
 
 Add new keys to `utils/constants.ts` `TIMEOUTS` object rather than scattering raw numbers. If a value is used only once and is truly a one-off, add a comment explaining the constraint.
+
+See `utils/constants.ts` for the full list of `TIMEOUTS` keys.
 
 ### Parallel Safety
 

--- a/.claude/skills/rstudio-create-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-create-playwright-tests/SKILL.md
@@ -98,6 +98,34 @@ import { test, expect } from '@fixtures/rstudio.fixture';
 - `pressSequentially()` for all GWT text inputs (console, editor, dialog/wizard `input.gwt-TextBox`) — `fill()` doesn't fire GWT key events, which can leave change handlers untriggered (e.g., OK button stays disabled)
 - `test.fixme()` for failing tests — never comment out
 
+### Waits and Timing
+
+**Default to Playwright's built-in assertions** — they retry automatically until the condition is met or the timeout expires. Reach for `sleep()` only when there is no observable DOM/state change to wait on.
+
+| Situation | Do this | Not this |
+|-----------|---------|----------|
+| Waiting for an element | `await expect(locator).toBeVisible()` | `await sleep(2000)` |
+| Waiting for text | `await expect(locator).toContainText(...)` | `await sleep(1000); check text` |
+| Waiting for element to disappear | `await expect(locator).not.toBeVisible()` | `await sleep(3000)` |
+| Waiting for page/session load | `await page.waitForSelector(sel, { state: 'visible' })` | `await sleep(5000)` |
+
+**When `sleep()` is legitimate:**
+- The 0.2s pause before `keyboard.press("Enter")` after typing (Critical Rule 5 — GWT keystroke processing)
+- Short settling delay after a UI action that has no observable DOM change (e.g., after clicking a menu item before the next element appears — keep it to 200–500ms max)
+- Polling loops where you must wait between retry attempts
+
+**Always use named constants, never magic numbers:**
+
+```typescript
+// Bad
+await sleep(3000);
+
+// Good
+await sleep(TIMEOUTS.sessionRestart);
+```
+
+Add new keys to `utils/constants.ts` `TIMEOUTS` object rather than scattering raw numbers. If a value is used only once and is truly a one-off, add a comment explaining the constraint.
+
 ### Parallel Safety
 
 - Default to `test.describe()` (parallel-safe)

--- a/.claude/skills/rstudio-create-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-create-playwright-tests/SKILL.md
@@ -107,7 +107,7 @@ import { test, expect } from '@fixtures/rstudio.fixture';
 | Waiting for an element | `await expect(locator).toBeVisible()` | `await sleep(2000)` |
 | Waiting for text | `await expect(locator).toContainText(...)` | `await sleep(1000); check text` |
 | Waiting for element to disappear | `await expect(locator).not.toBeVisible()` | `await sleep(3000)` |
-| Waiting for page/session load | `await page.waitForSelector(sel, { state: 'visible' })` | `await sleep(5000)` |
+| Waiting for page/session load | `await expect(page.locator(sel)).toBeVisible({ timeout: TIMEOUTS.sessionRestart })` | `await sleep(5000)` |
 
 **When `sleep()` is legitimate:**
 - The 0.2s pause before `keyboard.press("Enter")` after typing (Critical Rule 5 — GWT keystroke processing)

--- a/.claude/skills/rstudio-migrate-tests-selenium-to-playwright/SKILL.md
+++ b/.claude/skills/rstudio-migrate-tests-selenium-to-playwright/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: migrate-selenium-to-playwright
+name: rstudio-migrate-tests-selenium-to-playwright
 description: Migrate Python Selenium/Selene electron tests to TypeScript/Playwright. Use when converting tests from rstudio-ide-automation/rstudio_server_pro/electron-tests/ to rstudio/e2e/rstudio/tests/.
 ---
 
@@ -10,9 +10,9 @@ Converts Python test files from `rstudio-ide-automation/rstudio_server_pro/elect
 ## Arguments
 
 The user provides one or more targets:
-- A single file: `/migrate-selenium-to-playwright test_desktop_console.py`
-- A directory: `/migrate-selenium-to-playwright GlobalPrefs/`
-- A keyword: `/migrate-selenium-to-playwright citations`
+- A single file: `/rstudio-migrate-tests-selenium-to-playwright test_desktop_console.py`
+- A directory: `/rstudio-migrate-tests-selenium-to-playwright GlobalPrefs/`
+- A keyword: `/rstudio-migrate-tests-selenium-to-playwright citations`
 
 ## Hard Rules
 

--- a/.claude/skills/rstudio-run-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-run-playwright-tests/SKILL.md
@@ -90,13 +90,13 @@ The config defines **projects** that automatically exclude tags not applicable t
 
 ```bash
 # Set once in your shell profile for local development
-export PW_PROJECT=desktop-pro-windows
+export PW_PROJECT=desktop-os-windows
 
 # Then just run
 npx playwright test
 
 # To switch projects, override PW_PROJECT inline
-PW_PROJECT=server-pro-linux RSTUDIO_EDITION=server npx playwright test
+PW_PROJECT=server-os-linux RSTUDIO_EDITION=server npx playwright test
 ```
 
 Without `PW_PROJECT`, all 8 projects run (each test executes once per project). `PW_PROJECT` and `--project` conflict--don't use both at the same time. `PW_PROJECT` pre-filters the project list, so `--project` can't select anything outside it.

--- a/e2e/rstudio/README.md
+++ b/e2e/rstudio/README.md
@@ -198,20 +198,20 @@ test('specific test', { tag: ['@macos_only'] }, async ({ rstudioPage: page }) =>
 The config defines **projects** that automatically exclude tags not applicable to a given environment. Use `--project` to select one:
 
 ```bash
-npx playwright test --project=desktop-pro-windows
-npx playwright test --project=server-pro-linux
+npx playwright test --project=desktop-os-windows
+npx playwright test --project=server-os-linux
 ```
 
 To avoid passing `--project` every time, set `PW_PROJECT` in your shell profile:
 
 ```bash
-export PW_PROJECT=desktop-pro-windows
+export PW_PROJECT=desktop-os-windows
 ```
 
 With `PW_PROJECT` set, bare `npx playwright test` runs only that project. To switch projects, override `PW_PROJECT` inline:
 
 ```bash
-PW_PROJECT=server-pro-linux RSTUDIO_EDITION=server npx playwright test
+PW_PROJECT=server-os-linux RSTUDIO_EDITION=server npx playwright test
 ```
 
 Without `PW_PROJECT` or `--project`, all 8 projects run.
@@ -237,7 +237,7 @@ npx playwright test --grep-invert "@pro_only|@server_only"
 
 | Variable | Mode | Required | Description |
 |----------|------|----------|-------------|
-| `PW_PROJECT` | Both | No | Select a single project (e.g., `desktop-pro-windows`). Trumps `--project`. |
+| `PW_PROJECT` | Both | No | Select a single project (e.g., `desktop-os-windows`). Trumps `--project`. |
 | `RSTUDIO_EDITION` | Both | No | `desktop` (default) or `server` |
 | `CDP_PORT` | Desktop | No | Override the CDP port (default: random 9231-9299) |
 | `RSTUDIO_SERVER_URL` | Server | No | Full URL, e.g., `http://10.0.0.1:8787` (default: `http://localhost:8787`) |

--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -132,4 +132,43 @@ export class ConsolePaneActions {
     }
     return failed;
   }
+
+  /**
+   * Uninstall an R package if currently installed. Unloads the namespace first
+   * so downstream `requireNamespace()` checks correctly see it as missing.
+   * Returns true if the package is absent (on disk and unloaded) after the call.
+   *
+   * Avoids `requireNamespace()` for gating — it has a load side-effect that
+   * would leave the namespace cached after remove.packages() wipes the files,
+   * masking the uninstall from later checks.
+   */
+  async uninstallPackage(pkg: string, timeoutMs = 30000): Promise<boolean> {
+    await this.clearConsole();
+    const doneMarker = `__UNINSTALL_DONE_${Date.now()}__`;
+
+    await this.typeInConsole(
+      `if ("${pkg}" %in% loadedNamespaces()) { try(detach(paste0("package:", "${pkg}"), character.only = TRUE, unload = TRUE), silent = TRUE); try(unloadNamespace("${pkg}"), silent = TRUE) }`,
+    );
+    await this.typeInConsole(
+      `if ("${pkg}" %in% rownames(installed.packages())) remove.packages("${pkg}")`,
+    );
+    await this.typeInConsole(`cat("${doneMarker}")`);
+
+    const startTime = Date.now();
+    while (Date.now() - startTime < timeoutMs) {
+      await sleep(1000);
+      const text = await this.consolePane.consoleOutput.innerText();
+      if (text.includes(doneMarker)) break;
+    }
+
+    const verifyMarker = `__UNINSTALL_VERIFY_${Date.now()}__`;
+    await this.clearConsole();
+    await this.typeInConsole(
+      `cat("${verifyMarker}", "${pkg}" %in% rownames(installed.packages()), "${verifyMarker}")`,
+    );
+    await sleep(1000);
+    const output = await this.consolePane.consoleOutput.innerText();
+    const match = output.match(new RegExp(`${verifyMarker}\\s+(TRUE|FALSE)\\s+${verifyMarker}`));
+    return match?.[1] === 'FALSE';
+  }
 }

--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -141,6 +141,10 @@ export class ConsolePaneActions {
    * Avoids `requireNamespace()` for gating — it has a load side-effect that
    * would leave the namespace cached after remove.packages() wipes the files,
    * masking the uninstall from later checks.
+   *
+   * `pkg` must be a valid R package name (letters, digits, dots only, must
+   * start with a letter) — R itself enforces this, so interpolation into the
+   * double-quoted R strings below is safe.
    */
   async uninstallPackage(pkg: string, timeoutMs = 30000): Promise<boolean> {
     await this.clearConsole();
@@ -155,20 +159,31 @@ export class ConsolePaneActions {
     await this.typeInConsole(`cat("${doneMarker}")`);
 
     const startTime = Date.now();
+    let doneMarkerSeen = false;
     while (Date.now() - startTime < timeoutMs) {
       await sleep(1000);
       const text = await this.consolePane.consoleOutput.innerText();
-      if (text.includes(doneMarker)) break;
+      if (text.includes(doneMarker)) {
+        doneMarkerSeen = true;
+        break;
+      }
     }
+    if (!doneMarkerSeen) return false;
 
     const verifyMarker = `__UNINSTALL_VERIFY_${Date.now()}__`;
     await this.clearConsole();
     await this.typeInConsole(
       `cat("${verifyMarker}", "${pkg}" %in% rownames(installed.packages()), "${verifyMarker}")`,
     );
-    await sleep(1000);
-    const output = await this.consolePane.consoleOutput.innerText();
-    const match = output.match(new RegExp(`${verifyMarker}\\s+(TRUE|FALSE)\\s+${verifyMarker}`));
-    return match?.[1] === 'FALSE';
+
+    const verifyStart = Date.now();
+    const verifyPattern = new RegExp(`${verifyMarker}\\s+(TRUE|FALSE)\\s+${verifyMarker}`);
+    while (Date.now() - verifyStart < 15000) {
+      await sleep(500);
+      const output = await this.consolePane.consoleOutput.innerText();
+      const match = output.match(verifyPattern);
+      if (match) return match[1] === 'FALSE';
+    }
+    return false;
   }
 }

--- a/e2e/rstudio/actions/source_pane.actions.ts
+++ b/e2e/rstudio/actions/source_pane.actions.ts
@@ -116,17 +116,22 @@ export class SourcePaneActions {
     await sleep(300);
   }
 
+  /** Move cursor to top of document (cross-platform). */
+  async goToTop(): Promise<void> {
+    await this.sourcePane.aceTextInput.click({ force: true });
+    await sleep(300);
+    const goToTop = process.platform === 'darwin' ? 'Meta+ArrowUp' : 'Control+Home';
+    await this.page.keyboard.press(goToTop);
+    await sleep(300);
+  }
+
   /**
    * Navigate to a chunk by its 1-based index.
    * Clicks into the editor, goes to the top of the document,
    * then calls goToNextChunk N times.
    */
   async navigateToChunkByIndex(chunkNumber: number): Promise<void> {
-    await this.sourcePane.aceTextInput.click({ force: true });
-    await sleep(300);
-    const goToTop = process.platform === 'darwin' ? 'Meta+ArrowUp' : 'Control+Home';
-    await this.page.keyboard.press(goToTop);
-    await sleep(300);
+    await this.goToTop();
     for (let i = 0; i < chunkNumber; i++) {
       await this.consolePaneActions.typeInConsole(".rs.api.executeCommand('goToNextChunk')");
       await sleep(500);

--- a/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
+++ b/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
@@ -9,9 +9,9 @@ Target: `e2e/rstudio/tests/`
 |--------|-------|
 | Total electron test files | 32 |
 | Total electron test methods | 115 |
-| Files fully converted | 13 |
+| Files fully converted | 14 |
 | Files partially converted | 0 |
-| Files not started | 19 |
+| Files not started | 18 |
 
 ## Conversion Status
 
@@ -21,7 +21,7 @@ Target: `e2e/rstudio/tests/`
 |----------------|---------|-------------------|--------|-------|
 | test_desktop_Citations.py | 17 | — | Not started | |
 | test_desktop_Command_Palette.py | 2 | panes/misc/command-palette.test.ts (2) | Complete | |
-| test_desktop_console.py | 11 | — | Not started | |
+| test_desktop_console.py | 11 | panes/console/console_pane.test.ts (8), panes/console/console_command_effects.test.ts (7), panes/console/execute_from_editor.test.ts (1) | Complete | Split by theme; added Find in Console coverage (3 new tests) and upgraded `help.start()` to verify help-pane contents |
 | test_desktop_EnvironmentPane.py | 5 | — | Not started | |
 | test_desktop_FindInFiles.py | 3 | panes/misc/find-in-files.test.ts (3) | Complete | |
 | test_desktop_Package_Installation.py | 1 | — | Not started | |

--- a/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
+++ b/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
@@ -9,9 +9,9 @@ Target: `e2e/rstudio/tests/`
 |--------|-------|
 | Total electron test files | 32 |
 | Total electron test methods | 115 |
-| Files fully converted | 14 |
+| Files fully converted | 15 |
 | Files partially converted | 0 |
-| Files not started | 18 |
+| Files not started | 17 |
 
 ## Conversion Status
 
@@ -74,7 +74,7 @@ Target: `e2e/rstudio/tests/`
 
 | Electron Source | Methods | Playwright Target | Status | Notes |
 |----------------|---------|-------------------|--------|-------|
-| test_desktop_Create_Projects.py | 5 | — | Not started | |
+| test_desktop_Create_Projects.py | 5 | projects/create_projects.test.ts (5) | Complete | |
 
 ## Fixme Tests
 

--- a/e2e/rstudio/pages/console_pane.page.ts
+++ b/e2e/rstudio/pages/console_pane.page.ts
@@ -41,9 +41,12 @@ export class ConsolePane extends PageObject {
   }
 
   async consoleInputValue(): Promise<string> {
-    return this.page.evaluate(
-      "document.getElementById('rstudio_console_input').env.editor.getValue()",
-    );
+    return this.page.evaluate(() => {
+      const el = document.getElementById('rstudio_console_input') as
+        | (HTMLElement & { env?: { editor?: { getValue(): string } } })
+        | null;
+      return el?.env?.editor?.getValue() ?? '';
+    });
   }
 }
 

--- a/e2e/rstudio/pages/console_pane.page.ts
+++ b/e2e/rstudio/pages/console_pane.page.ts
@@ -11,6 +11,14 @@ export class ConsolePane extends PageObject {
   public consoleTab: Locator;
   public consoleOutput: Locator;
   public interruptRBtn: Locator;
+  public tracebackBtn: Locator;
+  public stackTrace: Locator;
+  public findBar: Locator;
+  public findInput: Locator;
+  public findNext: Locator;
+  public findClose: Locator;
+  public findBtn: Locator;
+  public findCaseSensitive: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -18,6 +26,24 @@ export class ConsolePane extends PageObject {
     this.consoleTab = page.locator('#rstudio_workbench_tab_console');
     this.consoleOutput = page.locator('#rstudio_workbench_panel_console');
     this.interruptRBtn = page.locator("[id^='rstudio_tb_interruptr']");
+    this.tracebackBtn = page.locator("[class*='show_traceback_text']");
+    this.stackTrace = page.locator("[class*='stack_trace']");
+
+    // Find in Console: #rstudio_find_replace_bar is the inner panel;
+    // the Close button is a sibling at the shelf level, so scope it at the console panel.
+    const consolePanel = page.locator('#rstudio_workbench_panel_console');
+    this.findBar = consolePanel.locator('#rstudio_find_replace_bar');
+    this.findInput = this.findBar.locator('input[type="text"]');
+    this.findNext = this.findBar.getByRole('button', { name: 'Next' });
+    this.findClose = consolePanel.getByRole('button', { name: 'Close' }).first();
+    this.findBtn = consolePanel.locator('button[aria-label="Find in Console"]').first();
+    this.findCaseSensitive = this.findBar.getByRole('checkbox', { name: 'Case sensitive' });
+  }
+
+  async consoleInputValue(): Promise<string> {
+    return this.page.evaluate(
+      "document.getElementById('rstudio_console_input').env.editor.getValue()",
+    );
   }
 }
 

--- a/e2e/rstudio/tests/panes/console/ansi_erase_in_line.test.ts
+++ b/e2e/rstudio/tests/panes/console/ansi_erase_in_line.test.ts
@@ -10,79 +10,82 @@ test.describe('ANSI Erase in Line (CSI K) - #17070', () => {
     consoleActions = new ConsolePaneActions(page);
   });
 
-  test('EL0 implicit - erase cursor to end of line', async ({ rstudioPage: page }) => {
+  test.beforeEach(async () => {
     await consoleActions.clearConsole();
+  });
+
+  test('EL0 implicit - erase cursor to end of line', async () => {
     await consoleActions.typeInConsole('cat("AAAAAAAAAA\\rBBB\\033[K\\n")');
-    await sleep(1000);
 
-    const fullText = await consoleActions.consolePane.consoleOutput.innerText();
-    const output = getOutputLines(fullText);
-    expect(output).toContain('BBB');
+    await expect(consoleActions.consolePane.consoleOutput).toContainText('BBB');
+    const output = getOutputLines(
+      await consoleActions.consolePane.consoleOutput.innerText(),
+    );
     expect(output).not.toMatch(/BBB.*A/);
   });
 
-  test('EL0 explicit - erase cursor to end of line', async ({ rstudioPage: page }) => {
-    await consoleActions.clearConsole();
+  test('EL0 explicit - erase cursor to end of line', async () => {
     await consoleActions.typeInConsole('cat("AAAAAAAAAA\\rBBB\\033[0K\\n")');
-    await sleep(1000);
 
-    const fullText = await consoleActions.consolePane.consoleOutput.innerText();
-    const output = getOutputLines(fullText);
-    expect(output).toContain('BBB');
+    await expect(consoleActions.consolePane.consoleOutput).toContainText('BBB');
+    const output = getOutputLines(
+      await consoleActions.consolePane.consoleOutput.innerText(),
+    );
     expect(output).not.toMatch(/BBB.*A/);
   });
 
-  test('EL0 progress bar - no trailing artifacts', async ({ rstudioPage: page }) => {
-    await consoleActions.clearConsole();
-    await consoleActions.typeInConsole('for (i in 1:5) { cat(sprintf("\\rStep %d of 5: %s\\033[K", i, strrep(".", i))); Sys.sleep(0.3) }; cat("\\n")');
-    await sleep(3000);
+  test('EL0 progress bar - no trailing artifacts', async () => {
+    await consoleActions.typeInConsole(
+      'for (i in 1:5) { cat(sprintf("\\rStep %d of 5: %s\\033[K", i, strrep(".", i))); Sys.sleep(0.3) }; cat("\\n")',
+    );
 
-    const fullText = await consoleActions.consolePane.consoleOutput.innerText();
-    const output = getOutputLines(fullText);
-    expect(output).toContain('Step 5 of 5: .....');
+    // Loop runs for ~1.5s; allow headroom for the final render.
+    await expect(consoleActions.consolePane.consoleOutput).toContainText(
+      'Step 5 of 5: .....',
+      { timeout: 10000 },
+    );
   });
 
-  test('EL1 - erase beginning of line to cursor', async ({ rstudioPage: page }) => {
-    await consoleActions.clearConsole();
+  test('EL1 - erase beginning of line to cursor', async () => {
     await consoleActions.typeInConsole('cat("ABCDEF\\033[3D\\033[1K\\n")');
-    await sleep(1000);
 
-    const fullText = await consoleActions.consolePane.consoleOutput.innerText();
-    const output = getOutputLines(fullText);
-    expect(output).toContain('EF');
+    await expect(consoleActions.consolePane.consoleOutput).toContainText('EF');
+    const output = getOutputLines(
+      await consoleActions.consolePane.consoleOutput.innerText(),
+    );
     expect(output).not.toMatch(/[ABCD]/);
-
   });
 
-  test('EL2 - erase entire line', async ({ rstudioPage: page }) => {
-    await consoleActions.clearConsole();
+  test('EL2 - erase entire line', async () => {
     await consoleActions.typeInConsole('cat("Hello World\\033[2KGONE\\n")');
-    await sleep(1000);
 
-    const fullText = await consoleActions.consolePane.consoleOutput.innerText();
-    const output = getOutputLines(fullText);
-    expect(output).toContain('GONE');
+    await expect(consoleActions.consolePane.consoleOutput).toContainText('GONE');
+    const output = getOutputLines(
+      await consoleActions.consolePane.consoleOutput.innerText(),
+    );
     expect(output).not.toContain('Hello World');
   });
 
-  test('EL on empty line - no errors', async ({ rstudioPage: page }) => {
-    await consoleActions.clearConsole();
+  test('EL on empty line - no errors', async () => {
+    // Pure side-effect check (no positive marker to wait on).
     await consoleActions.typeInConsole('cat("\\033[K\\n")');
     await sleep(1000);
 
-    const fullText = await consoleActions.consolePane.consoleOutput.innerText();
-    const output = getOutputLines(fullText);
+    const output = getOutputLines(
+      await consoleActions.consolePane.consoleOutput.innerText(),
+    );
     expect(output).not.toMatch(/[Ee]rror/);
   });
 
-  test('EL with colored text - no leftover colored text', async ({ rstudioPage: page }) => {
-    await consoleActions.clearConsole();
-    await consoleActions.typeInConsole('cat("\\033[31mRed Text\\033[0m Uncolored\\rOverwrite\\033[K\\n")');
-    await sleep(1000);
+  test('EL with colored text - no leftover colored text', async () => {
+    await consoleActions.typeInConsole(
+      'cat("\\033[31mRed Text\\033[0m Uncolored\\rOverwrite\\033[K\\n")',
+    );
 
-    const fullText = await consoleActions.consolePane.consoleOutput.innerText();
-    const output = getOutputLines(fullText);
-    expect(output).toContain('Overwrite');
+    await expect(consoleActions.consolePane.consoleOutput).toContainText('Overwrite');
+    const output = getOutputLines(
+      await consoleActions.consolePane.consoleOutput.innerText(),
+    );
     expect(output).not.toContain('Red Text');
     expect(output).not.toContain('Uncolored');
   });

--- a/e2e/rstudio/tests/panes/console/console_command_effects.test.ts
+++ b/e2e/rstudio/tests/panes/console/console_command_effects.test.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { sleep } from '@utils/constants';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+
+test.describe('Console command effects', () => {
+  let consoleActions: ConsolePaneActions;
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+  });
+
+  test.beforeEach(async () => {
+    await consoleActions.clearConsole();
+  });
+
+  test("packageVersion('base') auto-prints the version", async () => {
+    await consoleActions.typeInConsole("packageVersion('base')");
+    await expect(consoleActions.consolePane.consoleOutput).toContainText('[1]');
+  });
+
+  test('help.start() loads the R help index into the Help pane', async ({ rstudioPage: page }) => {
+    await consoleActions.typeInConsole('help.start()');
+    const helpFrame = page.frameLocator('#rstudio_help_frame');
+    await expect(helpFrame.locator('body')).toContainText('Statistical Data Analysis', {
+      timeout: 30000,
+    });
+  });
+
+  test('help(package = "base") loads package help into the Help pane', async ({ rstudioPage: page }) => {
+    await consoleActions.typeInConsole("help(package = 'base')");
+    const helpFrame = page.frameLocator('#rstudio_help_frame');
+    await expect(helpFrame.locator('body')).toContainText('The R Base Package', {
+      timeout: 15000,
+    });
+  });
+
+  test('plot(x, y) renders a plot in the Plots pane', async ({ rstudioPage: page }) => {
+    await consoleActions.typeInConsole('x <- 1');
+    await consoleActions.typeInConsole('y <- 1');
+    await consoleActions.typeInConsole('plot(x, y)');
+    await expect(page.locator('#rstudio_plot_image_frame')).toBeVisible({ timeout: 15000 });
+  });
+
+  test('rstudioDiagnosticsReport() writes a diagnostics report', async () => {
+    test.setTimeout(120000);
+    await consoleActions.typeInConsole('rstudioDiagnosticsReport()');
+    await expect(consoleActions.consolePane.consoleOutput).toContainText(
+      'Diagnostics report written',
+      { timeout: 90000 },
+    );
+  });
+
+  test('install.packages() reports not-available for a non-existent package', async () => {
+    test.setTimeout(60000);
+    await consoleActions.typeInConsole(
+      "install.packages('fake_package', repos = 'https://cran.r-project.org')",
+    );
+    await expect(consoleActions.consolePane.consoleOutput).toContainText(
+      "‘fake_package’ is not available",
+      { timeout: 45000 },
+    );
+  });
+
+  test('install.packages() installs a real CRAN package that library() can load', async () => {
+    test.setTimeout(300000);
+    await consoleActions.uninstallPackage('starwarsdb');
+    const failed = await consoleActions.ensurePackages(['starwarsdb'], 240000);
+    test.skip(failed.length > 0, `Could not install: ${failed.join(', ')}`);
+
+    await consoleActions.clearConsole();
+    await consoleActions.typeInConsole("library('starwarsdb')");
+    await sleep(2000);
+    await expect(consoleActions.consolePane.consoleOutput).not.toContainText(
+      'Error in library',
+    );
+  });
+});

--- a/e2e/rstudio/tests/panes/console/console_command_effects.test.ts
+++ b/e2e/rstudio/tests/panes/console/console_command_effects.test.ts
@@ -63,7 +63,8 @@ test.describe('Console command effects', () => {
 
   test('install.packages() installs a real CRAN package that library() can load', async () => {
     test.setTimeout(300000);
-    await consoleActions.uninstallPackage('starwarsdb');
+    const uninstalled = await consoleActions.uninstallPackage('starwarsdb');
+    test.skip(!uninstalled, 'Could not uninstall starwarsdb to set up a fresh-install scenario');
     const failed = await consoleActions.ensurePackages(['starwarsdb'], 240000);
     test.skip(failed.length > 0, `Could not install: ${failed.join(', ')}`);
 

--- a/e2e/rstudio/tests/panes/console/console_pane.test.ts
+++ b/e2e/rstudio/tests/panes/console/console_pane.test.ts
@@ -107,8 +107,12 @@ test.describe('Console pane', () => {
     });
 
     test.afterEach(async () => {
-      await consoleActions.consolePane.findClose.click();
-      await expect(consoleActions.consolePane.findBar).not.toBeVisible();
+      // Guarded: if beforeEach failed before opening the find bar, clicking
+      // Close here would error and mask the real root cause.
+      if (await consoleActions.consolePane.findBar.isVisible()) {
+        await consoleActions.consolePane.findClose.click();
+        await expect(consoleActions.consolePane.findBar).not.toBeVisible();
+      }
     });
 
     test('finds matches across multiple lines with "the"', async ({ rstudioPage: page }) => {

--- a/e2e/rstudio/tests/panes/console/console_pane.test.ts
+++ b/e2e/rstudio/tests/panes/console/console_pane.test.ts
@@ -1,0 +1,175 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { sleep } from '@utils/constants';
+import { getSelectionInfo } from '@utils/console';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+
+test.describe('Console pane', () => {
+  let consoleActions: ConsolePaneActions;
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+  });
+
+  test.beforeEach(async () => {
+    await consoleActions.clearConsole();
+  });
+
+  test('print() auto-prints its argument', async () => {
+    const phrase = 'If we shadows have offended, think but this, and all is mended.';
+    await consoleActions.typeInConsole(`print("${phrase}")`);
+    await expect(consoleActions.consolePane.consoleOutput).toContainText(`[1] "${phrase}"`);
+  });
+
+  test('unknown identifier prints object-not-found error', async () => {
+    await consoleActions.typeInConsole('fake_command');
+    await expect(consoleActions.consolePane.consoleOutput).toContainText(
+      "Error: object 'fake_command' not found",
+    );
+  });
+
+  test('arrow keys cycle through previous commands', async ({ rstudioPage: page }) => {
+    await consoleActions.typeInConsole("cat('one')");
+    await consoleActions.typeInConsole("cat('two')");
+    await consoleActions.typeInConsole("cat('three')");
+    await expect(consoleActions.consolePane.consoleOutput).toContainText('three');
+
+    const input = consoleActions.consolePane.consoleInput;
+    await input.click({ force: true });
+    await sleep(200);
+
+    const readInput = () => consoleActions.consolePane.consoleInputValue();
+
+    await page.keyboard.press('ArrowUp');
+    await expect.poll(readInput).toBe("cat('three')");
+    await page.keyboard.press('ArrowUp');
+    await expect.poll(readInput).toBe("cat('two')");
+    await page.keyboard.press('ArrowUp');
+    await expect.poll(readInput).toBe("cat('one')");
+    await page.keyboard.press('ArrowDown');
+    await expect.poll(readInput).toBe("cat('two')");
+    await page.keyboard.press('ArrowDown');
+    await expect.poll(readInput).toBe("cat('three')");
+
+    // Escape clears the recalled command; without this, "cat('three')" leaks
+    // into the next test's input and becomes a parse error.
+    await page.keyboard.press('Escape');
+    await expect.poll(readInput).toBe('');
+  });
+
+  test('writeLines outputs all 10000 lines without truncation', async () => {
+    test.setTimeout(90000);
+    await consoleActions.typeInConsole('long <- as.character(1:1E4)');
+    await consoleActions.typeInConsole('writeLines(long)');
+    await expect(consoleActions.consolePane.consoleOutput).toContainText('10000', {
+      timeout: 60000,
+    });
+    await expect(consoleActions.consolePane.consoleOutput).not.toContainText(
+      '<console output truncated>',
+    );
+    await expect(consoleActions.consolePane.consoleOutput).not.toContainText(
+      'writeLines(long)',
+    );
+  });
+
+  test('Show Traceback button reveals the stack for nested calls', async () => {
+    await consoleActions.typeInConsole('f <- function() stop()');
+    await consoleActions.typeInConsole('g <- function() f()');
+    await consoleActions.typeInConsole('h <- function() g()');
+    await consoleActions.typeInConsole('k <- function() h()');
+    await consoleActions.typeInConsole('k()');
+
+    await expect(consoleActions.consolePane.tracebackBtn).toBeVisible({ timeout: 10000 });
+    await consoleActions.consolePane.tracebackBtn.click();
+    await expect(consoleActions.consolePane.stackTrace).toBeVisible();
+
+    const actual = (await consoleActions.consolePane.stackTrace.innerText()).replace(/\s+/g, '');
+    const expected = '5.function()stop()4.function()f()3.function()g()2.function()h()1.k()';
+    expect(actual).toBe(expected);
+  });
+
+  test.describe('Find in Console', () => {
+    test.beforeEach(async () => {
+      await consoleActions.typeInConsole(`a <- "Once more unto the breach, dear friends, once more;"`);
+      await consoleActions.typeInConsole(`b <- "Or close the wall up with our English dead."`);
+      await consoleActions.typeInConsole(`c <- "In peace there's nothing so becomes a man"`);
+      await consoleActions.typeInConsole(`d <- "As modest stillness and humility."`);
+      await consoleActions.clearConsole();
+      await consoleActions.typeInConsole('writeLines(a)');
+      await consoleActions.typeInConsole('writeLines(b)');
+      await consoleActions.typeInConsole('writeLines(c)');
+      await consoleActions.typeInConsole('writeLines(d)');
+      await expect(consoleActions.consolePane.consoleOutput).toContainText(
+        'As modest stillness and humility.',
+      );
+
+      await consoleActions.consolePane.findBtn.click();
+      await expect(consoleActions.consolePane.findBar).toBeVisible();
+    });
+
+    test.afterEach(async () => {
+      await consoleActions.consolePane.findClose.click();
+      await expect(consoleActions.consolePane.findBar).not.toBeVisible();
+    });
+
+    test('finds matches across multiple lines with "the"', async ({ rstudioPage: page }) => {
+      const { findInput, findNext } = consoleActions.consolePane;
+
+      await findInput.fill('the');
+      await findInput.press('Enter');
+
+      const first = await getSelectionInfo(page);
+      expect(first.text.toLowerCase()).toBe('the');
+
+      await findNext.click();
+      const second = await getSelectionInfo(page);
+      expect(second.text.toLowerCase()).toBe('the');
+      expect(second.pos).not.toBe(first.pos);
+
+      await findNext.click();
+      const third = await getSelectionInfo(page);
+      expect(third.text.toLowerCase()).toBe('the');
+      expect(third.pos).not.toBe(second.pos);
+    });
+
+    test('case-insensitive search matches both cases of "once"', async ({ rstudioPage: page }) => {
+      const { findInput, findNext, findCaseSensitive } = consoleActions.consolePane;
+
+      if (await findCaseSensitive.isChecked()) {
+        await findCaseSensitive.uncheck();
+      }
+      await expect(findCaseSensitive).not.toBeChecked();
+
+      await findInput.fill('once');
+      await findInput.press('Enter');
+
+      const first = await getSelectionInfo(page);
+      expect(first.text.toLowerCase()).toBe('once');
+
+      await findNext.click();
+      const second = await getSelectionInfo(page);
+      expect(second.text.toLowerCase()).toBe('once');
+      expect(second.pos).not.toBe(first.pos);
+    });
+
+    test('case-sensitive search matches only exact case of "once"', async ({ rstudioPage: page }) => {
+      const { findInput, findNext, findCaseSensitive } = consoleActions.consolePane;
+
+      await findCaseSensitive.check();
+      await expect(findCaseSensitive).toBeChecked();
+
+      await findInput.fill('once');
+      await findInput.press('Enter');
+
+      const first = await getSelectionInfo(page);
+      expect(first.text).toBe('once');
+
+      await findNext.click();
+      const second = await getSelectionInfo(page);
+      expect(second.text).toBe('once');
+      expect(second.pos).toBe(first.pos);
+
+      await findCaseSensitive.uncheck();
+      await expect(findCaseSensitive).not.toBeChecked();
+    });
+  });
+});

--- a/e2e/rstudio/tests/panes/console/execute_from_editor.test.ts
+++ b/e2e/rstudio/tests/panes/console/execute_from_editor.test.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { sleep } from '@utils/constants';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { SourcePaneActions } from '@actions/source_pane.actions';
+
+test.describe('Run Line button', () => {
+  let consoleActions: ConsolePaneActions;
+  let sourceActions: SourcePaneActions;
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+    sourceActions = new SourcePaneActions(page, consoleActions);
+  });
+
+  test('submits queued lines to the console in document order', async ({ rstudioPage: page }) => {
+    await consoleActions.clearConsole();
+    await consoleActions.typeInConsole('.rs.api.executeCommand("closeAllSourceDocs")');
+
+    const fileName = `submit_order_${Date.now()}.R`;
+    await consoleActions.typeInConsole(
+      `writeLines(c("Sys.sleep(1)", "# 1", "x <- 1", "# 2", "x <- 22", "x"), "${fileName}")`,
+    );
+    await consoleActions.typeInConsole(`file.edit("${fileName}")`);
+    await sleep(1500);
+
+    await sourceActions.goToTop();
+
+    const runLineBtn = page.locator("[class*='run_the_current_line_or_selection']").first();
+    for (let i = 0; i < 4; i++) {
+      await runLineBtn.click();
+    }
+
+    await expect(consoleActions.consolePane.consoleOutput).toContainText('[1] 22', {
+      timeout: 15000,
+    });
+
+    await consoleActions.typeInConsole('.rs.api.executeCommand("closeAllSourceDocs")');
+    await consoleActions.typeInConsole(`unlink("${fileName}")`);
+  });
+});

--- a/e2e/rstudio/tests/projects/create_projects.test.ts
+++ b/e2e/rstudio/tests/projects/create_projects.test.ts
@@ -250,7 +250,11 @@ test.describe.serial('Create Projects in New Directory', () => {
 
       // Capture the actual project directory for later cleanup
       currentProjectDir = await captureResult(page, 'getwd()');
-      expect(currentProjectDir).not.toBe('');
+
+      // Project actually created on disk (.Rproj file exists)
+      const rprojExists = await captureResult(page,
+        `file.exists("${currentProjectDir}/${type.name}.Rproj")`);
+      expect(rprojExists, `.Rproj missing for ${type.name} at ${currentProjectDir}`).toBe('TRUE');
 
       // Project menu reflects the new project
       await expect(page.locator(PROJECT_MENU)).toContainText(type.name, { timeout: 15000 });

--- a/e2e/rstudio/tests/projects/create_projects.test.ts
+++ b/e2e/rstudio/tests/projects/create_projects.test.ts
@@ -64,23 +64,38 @@ const ALL_TYPES = [NEW_PROJECT, R_PACKAGE, SHINY_APP, QUARTO_PROJECT, QUARTO_WEB
 
 // -- Helpers ------------------------------------------------------------------
 
+// Helpers below interpolate rExpression / projectDir / type.name directly into
+// double-quoted R strings. Callers must pass values that do not contain `"` or
+// `\` — all current inputs are controlled (hardcoded R expressions, known-safe
+// project names, Windows paths normalized to forward slashes). If these
+// helpers are ever reused with uncontrolled input, add proper escaping.
 async function captureResult(page: Page, rExpression: string): Promise<string> {
   const marker = `__CP_${Date.now()}__`;
   await typeInConsole(page, `cat("${marker}", ${rExpression}, "${marker}")`);
-  await sleep(1500);
-  const output = await page.locator(CONSOLE_OUTPUT).innerText();
-  const match = output.match(new RegExp(`${marker}\\s+(.*?)\\s+${marker}`));
-  return match ? match[1].trim() : '';
+
+  const pattern = new RegExp(`${marker}\\s+(.*?)\\s+${marker}`);
+  const start = Date.now();
+  while (Date.now() - start < 15000) {
+    await sleep(500);
+    const output = await page.locator(CONSOLE_OUTPUT).innerText();
+    const match = output.match(pattern);
+    if (match) return match[1].trim();
+  }
+  return '';
 }
 
 async function waitForSessionRestart(page: Page): Promise<void> {
-  // Server navigates on project open/close; Desktop reloads in place.
+  // Server navigates on project open/close; Desktop reloads in place, so
+  // waitForLoadState never fires there — intentional catch.
   await page.waitForLoadState('load', { timeout: 30000 }).catch(() => {});
   await sleep(3000);
   await page.waitForSelector(CONSOLE_INPUT, { state: 'visible', timeout: 60000 });
   await sleep(2000);
 
-  // Confirm R is idle by running a trivial command with retries
+  // Confirm R is idle with retries. Individual attempts may fail while the
+  // console is still coming up — intentional catch inside the loop — but if
+  // all three fail we surface the timeout instead of silently returning and
+  // letting downstream code fail mysteriously.
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
       const marker = `__READY_${Date.now()}__`;
@@ -93,6 +108,7 @@ async function waitForSessionRestart(page: Page): Promise<void> {
     }
     await sleep(2000);
   }
+  throw new Error('R session did not become idle within timeout after session restart');
 }
 
 async function openNewProjectWizard(page: Page): Promise<void> {

--- a/e2e/rstudio/tests/projects/create_projects.test.ts
+++ b/e2e/rstudio/tests/projects/create_projects.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
-import { sleep } from '@utils/constants';
+import { sleep, TIMEOUTS } from '@utils/constants';
 import { typeInConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { installDepIfPrompted } from '@pages/modals.page';
 import { SourcePane } from '@pages/source_pane.page';
@@ -75,21 +75,23 @@ async function captureResult(page: Page, rExpression: string): Promise<string> {
 
   const pattern = new RegExp(`${marker}\\s+(.*?)\\s+${marker}`);
   const start = Date.now();
-  while (Date.now() - start < 15000) {
+  while (Date.now() - start < TIMEOUTS.consoleReady) {
     await sleep(500);
     const output = await page.locator(CONSOLE_OUTPUT).innerText();
     const match = output.match(pattern);
     if (match) return match[1].trim();
   }
-  return '';
+  throw new Error(`captureResult: markers not found for "${rExpression}" within ${TIMEOUTS.consoleReady}ms`);
 }
 
 async function waitForSessionRestart(page: Page): Promise<void> {
   // Server navigates on project open/close; Desktop reloads in place, so
   // waitForLoadState never fires there — intentional catch.
-  await page.waitForLoadState('load', { timeout: 30000 }).catch(() => {});
+  await page.waitForLoadState('load', { timeout: TIMEOUTS.sessionRestart }).catch(() => {});
   await sleep(3000);
-  await page.waitForSelector(CONSOLE_INPUT, { state: 'visible', timeout: 60000 });
+  // 2× sessionRestart: after navigation settles, the console element may still
+  // take extra time to mount on slower Server sessions.
+  await page.waitForSelector(CONSOLE_INPUT, { state: 'visible', timeout: TIMEOUTS.sessionRestart * 2 });
   await sleep(2000);
 
   // Confirm R is idle with retries. Individual attempts may fail while the

--- a/e2e/rstudio/tests/projects/create_projects.test.ts
+++ b/e2e/rstudio/tests/projects/create_projects.test.ts
@@ -1,0 +1,250 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { sleep } from '@utils/constants';
+import { typeInConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
+import { installDepIfPrompted } from '@pages/modals.page';
+import { SourcePane } from '@pages/source_pane.page';
+import type { Page } from 'playwright';
+
+// -- Selectors ----------------------------------------------------------------
+
+const PALETTE_LIST = '#rstudio_command_palette_list';
+const WIZARD_DIALOG = '.gwt-DialogBox[aria-label="New Project Wizard"]';
+const NEW_DIRECTORY_OPTION = '#rstudio_label_new_directory_wizard_page';
+const CREATE_PROJECT_BTN = '#rstudio_label_create_project_wizard_confirm';
+const PROJECT_MENU = '#rstudio_project_menubutton_toolbar';
+const CLOSE_PROJECT_MENU_ITEM = '#rstudio_label_close_project_command';
+
+// -- Project type configs -----------------------------------------------------
+
+type ProjectType = {
+  name: string;
+  wizardPageId: string;
+  dirInputId: string;
+  expectedFile: string | null;
+};
+
+const NEW_PROJECT: ProjectType = {
+  name: 'new_project_test_project',
+  wizardPageId: '#rstudio_label_new_project_wizard_page',
+  dirInputId: '#rstudio_new_project_directory_name',
+  expectedFile: null,
+};
+
+// R package names cannot contain underscores (letters/digits/dots only,
+// starting with a letter), so this one can't follow the snake_case convention.
+const R_PACKAGE: ProjectType = {
+  name: 'RPackageTestProject',
+  wizardPageId: '#rstudio_label_r_package_wizard_page',
+  dirInputId: '#rstudio_r_package_directory_name',
+  expectedFile: 'hello.R',
+};
+
+const SHINY_APP: ProjectType = {
+  name: 'shiny_app_test_project',
+  wizardPageId: '#rstudio_label_shiny_application_wizard_page',
+  dirInputId: '#rstudio_shiny_application_directory_name',
+  expectedFile: 'app.R',
+};
+
+const QUARTO_PROJECT: ProjectType = {
+  name: 'quarto_project_test_project',
+  wizardPageId: '#rstudio_label_quarto_project_wizard_page',
+  dirInputId: '#rstudio_quarto_project_directory_name',
+  expectedFile: 'quarto_project_test_project.qmd',
+};
+
+const QUARTO_WEBSITE: ProjectType = {
+  name: 'quarto_website_test_project',
+  wizardPageId: '#rstudio_label_quarto_website_wizard_page',
+  dirInputId: '#rstudio_quarto_website_directory_name',
+  expectedFile: 'index.qmd',
+};
+
+const ALL_TYPES = [NEW_PROJECT, R_PACKAGE, SHINY_APP, QUARTO_PROJECT, QUARTO_WEBSITE];
+
+// -- Helpers ------------------------------------------------------------------
+
+async function captureResult(page: Page, rExpression: string): Promise<string> {
+  const marker = `__CP_${Date.now()}__`;
+  await typeInConsole(page, `cat("${marker}", ${rExpression}, "${marker}")`);
+  await sleep(1500);
+  const output = await page.locator(CONSOLE_OUTPUT).innerText();
+  const match = output.match(new RegExp(`${marker}\\s+(.*?)\\s+${marker}`));
+  return match ? match[1].trim() : '';
+}
+
+async function waitForSessionRestart(page: Page): Promise<void> {
+  // Server navigates on project open/close; Desktop reloads in place.
+  await page.waitForLoadState('load', { timeout: 30000 }).catch(() => {});
+  await sleep(3000);
+  await page.waitForSelector(CONSOLE_INPUT, { state: 'visible', timeout: 60000 });
+  await sleep(2000);
+
+  // Confirm R is idle by running a trivial command with retries
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const marker = `__READY_${Date.now()}__`;
+      await typeInConsole(page, `cat("${marker}")`);
+      await sleep(1500);
+      const output = await page.locator(CONSOLE_OUTPUT).innerText();
+      if (output.includes(marker)) return;
+    } catch {
+      // console may not be ready yet
+    }
+    await sleep(2000);
+  }
+}
+
+async function openNewProjectWizard(page: Page): Promise<void> {
+  // Close any open source docs first to avoid "unsaved changes" dialogs
+  await typeInConsole(page, '.rs.api.closeAllSourceBuffersWithoutSaving()');
+  await sleep(1000);
+
+  // executeCommand("newProject") blocks the R thread with an "R session is busy"
+  // modal on some platforms, so use the command palette instead.
+  await page.keyboard.press('ControlOrMeta+Shift+p');
+  await sleep(1000);
+  await page.keyboard.type('Create a New Project');
+  await sleep(500);
+
+  const item = page.locator(`${PALETTE_LIST} >> text=Create a New Project...`);
+  await expect(item).toBeVisible({ timeout: 5000 });
+  await item.click();
+  await sleep(2000);
+
+  await expect(page.locator(WIZARD_DIALOG)).toBeVisible({ timeout: 15000 });
+}
+
+async function createProjectInNewDir(page: Page, type: ProjectType): Promise<void> {
+  await openNewProjectWizard(page);
+
+  const dialog = page.locator(WIZARD_DIALOG);
+
+  const newDir = dialog.locator(NEW_DIRECTORY_OPTION);
+  await expect(newDir).toBeVisible({ timeout: 5000 });
+  await newDir.click();
+  await sleep(1000);
+
+  const wizardPage = dialog.locator(type.wizardPageId);
+  await expect(wizardPage).toBeVisible({ timeout: 5000 });
+  await wizardPage.click();
+  await sleep(1000);
+
+  const dirInput = dialog.locator(type.dirInputId);
+  await expect(dirInput).toBeVisible({ timeout: 5000 });
+  await dirInput.click();
+  // pressSequentially is required for GWT TextBox to fire keystroke handlers
+  // that enable the Create Project button.
+  await dirInput.pressSequentially(type.name);
+  await sleep(500);
+
+  const createBtn = page.locator(CREATE_PROJECT_BTN);
+  await expect(createBtn).toBeVisible({ timeout: 5000 });
+  await createBtn.click();
+
+  // Wizard should dismiss within a few seconds. If it lingers, the name
+  // likely failed validation (e.g. invalid R package name).
+  await expect(page.locator(WIZARD_DIALOG)).not.toBeVisible({ timeout: 15000 });
+
+  await waitForSessionRestart(page);
+
+  // R Package creation may prompt to install build-tools (devtools/roxygen2).
+  await installDepIfPrompted(page, 3000);
+}
+
+async function closeCurrentProject(page: Page): Promise<void> {
+  const menu = page.locator(PROJECT_MENU);
+  await expect(menu).toBeVisible({ timeout: 10000 });
+  await menu.click();
+
+  const close = page.locator(CLOSE_PROJECT_MENU_ITEM);
+  await expect(close).toBeVisible({ timeout: 5000 });
+  await close.click();
+
+  await waitForSessionRestart(page);
+}
+
+async function cleanupProject(page: Page, projectDir: string): Promise<void> {
+  if (!projectDir) return;
+  const escaped = projectDir.replace(/\\/g, '/');
+  await typeInConsole(page, `unlink("${escaped}", recursive = TRUE)`);
+  await sleep(500);
+}
+
+// -- Tests --------------------------------------------------------------------
+
+test.describe.serial('Create Projects in New Directory', () => {
+  // Tracked per-test so afterEach can clean up on failure
+  let currentProjectDir = '';
+  let source: SourcePane;
+
+  test.beforeEach(async ({ rstudioPage: page }) => {
+    source = new SourcePane(page);
+  });
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    // Dismiss any leftover dialog from a prior failed run
+    for (let i = 0; i < 3; i++) {
+      const overlay = page.locator('.gwt-PopupPanelGlass, [role="alertdialog"]');
+      if (await overlay.first().isVisible({ timeout: 2000 }).catch(() => false)) {
+        await page.keyboard.press('Escape');
+        await sleep(1000);
+      } else {
+        break;
+      }
+    }
+
+    // Close any open project from a prior run
+    const hasProject = await captureResult(page, '!is.null(rstudioapi::getActiveProject())');
+    if (hasProject === 'TRUE') {
+      await closeCurrentProject(page);
+    }
+
+    // Return to home and clean up any stale test directories
+    await typeInConsole(page, 'setwd("~")');
+    await sleep(500);
+    for (const type of ALL_TYPES) {
+      await typeInConsole(page, `unlink("~/${type.name}", recursive = TRUE)`);
+      await sleep(300);
+    }
+  });
+
+  test.afterEach(async ({ rstudioPage: page }) => {
+    // Safety net: if a test failed before its own cleanup ran, close any
+    // open project and delete the captured directory.
+    try {
+      const hasProject = await captureResult(page, '!is.null(rstudioapi::getActiveProject())');
+      if (hasProject === 'TRUE') {
+        await closeCurrentProject(page);
+      }
+    } catch {
+      // best-effort
+    }
+    if (currentProjectDir) {
+      await cleanupProject(page, currentProjectDir).catch(() => {});
+      currentProjectDir = '';
+    }
+  });
+
+  for (const type of ALL_TYPES) {
+    test(`create "${type.name}"`, async ({ rstudioPage: page }) => {
+      await createProjectInNewDir(page, type);
+
+      // Capture the actual project directory for later cleanup
+      currentProjectDir = await captureResult(page, 'getwd()');
+      expect(currentProjectDir).not.toBe('');
+
+      // Project menu reflects the new project
+      await expect(page.locator(PROJECT_MENU)).toContainText(type.name, { timeout: 15000 });
+
+      // Expected starter file is open in the source pane
+      if (type.expectedFile) {
+        await expect(source.selectedTab).toContainText(type.expectedFile, { timeout: 15000 });
+      }
+
+      await closeCurrentProject(page);
+      await cleanupProject(page, currentProjectDir);
+      currentProjectDir = '';
+    });
+  }
+});

--- a/e2e/rstudio/utils/console.ts
+++ b/e2e/rstudio/utils/console.ts
@@ -1,3 +1,21 @@
+import type { Page } from 'playwright';
+
+/**
+ * Read the current browser selection's text plus the screen position of its
+ * bounding rect, which the Find in Console tests use as a match identity
+ * (two matches with the same text can differ only by screen position).
+ */
+export async function getSelectionInfo(
+  page: Page,
+): Promise<{ text: string; pos: string }> {
+  return page.evaluate(() => {
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0) return { text: '', pos: '' };
+    const r = sel.getRangeAt(0).getBoundingClientRect();
+    return { text: sel.toString(), pos: `${r.top},${r.left}` };
+  });
+}
+
 /**
  * Extract only the output lines from the console panel text.
  * Console output includes echoed commands (lines starting with ">")

--- a/e2e/rstudio/utils/constants.ts
+++ b/e2e/rstudio/utils/constants.ts
@@ -2,6 +2,7 @@ export const TIMEOUTS = {
   processCleanup: 1000,
   rstudioStartup: 10000,
   consoleReady: 15000,
+  sessionRestart: 30000,
   settleDelay: 1000,
   fileOpen: 20000,
   ghostText: 30000,


### PR DESCRIPTION
## Summary

- Migrates `test_desktop_console.py` (11 Selenium tests) to Playwright, split across `console_pane.test.ts`, `console_command_effects.test.ts`, and `execute_from_editor.test.ts`; adds 3 new "Find in Console" tests and upgrades `help.start()` to verify help-pane contents.
- Migrates `test_desktop_Create_Projects.py` (5 Selenium tests) to Playwright as `create_projects.test.ts`, covering new directory, R package, Shiny app, Quarto project, and Quarto website project types.
- Renames the migration skill from `migrate-selenium-to-playwright` to `rstudio-migrate-tests-selenium-to-playwright` for consistency with other `rstudio-*` skills.
- Adds a "Waits and Timing" section to the Playwright test-creation skill with guidance on preferring `expect()` assertions over `sleep()`, and introduces `TIMEOUTS.sessionRestart`.
- Addresses roborev review findings across the new tests: polling instead of fixed sleeps, null-guarded DOM access, guarded cleanup, skip-on-failed-uninstall, and an explicit throw when `waitForSessionRestart` exhausts retries.