### PR TITLE
Standardize Playwright test env vars with PW_ prefix

### DIFF
--- a/.claude/skills/rstudio-create-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-create-playwright-tests/SKILL.md
@@ -44,7 +44,7 @@ description: Complete guide for creating RStudio Playwright tests in TypeScript.
    **Never use raw `Control+End` or `Control+Home`** in tests — always use the helper or a platform guard.
 
    **If unsure**, check what RStudio's own shortcut settings say. If it shows "Ctrl" on macOS (not Cmd), use `Control`.
-8. **Write tests that work on both Desktop and Server** – Tests connect via CDP on Desktop and via browser login on Server, but test logic should be the same. Use stable element IDs instead of wrapper selectors. Use `RSTUDIO_EDITION` env var when branching on mode.
+8. **Write tests that work on both Desktop and Server** – Tests connect via CDP on Desktop and via browser login on Server, but test logic should be the same. Use stable element IDs instead of wrapper selectors. Use `PW_RSTUDIO_MODE` env var when branching on mode.
 9. **Use `.rs.api.executeCommand()` instead of `window.desktopHooks.invokeCommand()`** – `desktopHooks` only exists in Desktop's Electron shell and will crash on Server. `.rs.api.executeCommand()` works in both modes.
 
 ---
@@ -176,8 +176,8 @@ test('writes land in sandbox', async ({ rstudioPage: page }) => {
 **Wizard-driven tests:** the New Project Wizard's parent-directory field is read-only. `setwd()` doesn't redirect it — override the `default_project_location` preference via `.rs.api.writeRStudioPreference()` and restore it in `afterAll`. See `create_projects.test.ts` for the pattern.
 
 **Env vars (optional):**
-- `RSTUDIO_PW_SANDBOX` — override the sandbox root. Unset uses `dirname(tempdir())`.
-- `RSTUDIO_PW_SANDBOX_CREATE` — when `"true"`/`"1"`, auto-create an overridden root if missing. Default `false` (fail loud on typos).
+- `PW_SANDBOX` — override the sandbox root. Unset uses `dirname(tempdir())`.
+- `PW_SANDBOX_CREATE` — when `"true"`/`"1"`, auto-create an overridden root if missing. Default `false` (fail loud on typos).
 
 **Exception:** tests that specifically exercise a fixed path in `~/` as part of the product behavior under test (e.g., `chat-user-skills.test.ts` exercises `~/.positai/skills/`) stay as-is. Sandbox is for redirecting incidental filesystem writes, not for rewriting product semantics.
 

--- a/.claude/skills/rstudio-migrate-tests-selenium-to-playwright/SKILL.md
+++ b/.claude/skills/rstudio-migrate-tests-selenium-to-playwright/SKILL.md
@@ -111,25 +111,25 @@ Tests can run against multiple RStudio Server instances in parallel. This works 
 
 **Targeting a server:**
 ```bash
-RSTUDIO_SERVER_URL=https://server1:80 RSTUDIO_EDITION=server \
+PW_RSTUDIO_SERVER_URL=https://server1:80 PW_RSTUDIO_MODE=server \
   npx playwright test tests/panes/misc/autocomplete.test.ts
 ```
 
 **Parallel execution (5 servers):**
-Each process gets its own `RSTUDIO_SERVER_URL` — no shared config files, no conflicts:
+Each process gets its own `PW_RSTUDIO_SERVER_URL` — no shared config files, no conflicts:
 
 ```bash
 # Terminal / CI / shell script
-RSTUDIO_SERVER_URL=https://server1:80 RSTUDIO_EDITION=server npx playwright test tests/file1.test.ts &
-RSTUDIO_SERVER_URL=https://server2:80 RSTUDIO_EDITION=server npx playwright test tests/file2.test.ts &
-RSTUDIO_SERVER_URL=https://server3:80 RSTUDIO_EDITION=server npx playwright test tests/file3.test.ts &
+PW_RSTUDIO_SERVER_URL=https://server1:80 PW_RSTUDIO_MODE=server npx playwright test tests/file1.test.ts &
+PW_RSTUDIO_SERVER_URL=https://server2:80 PW_RSTUDIO_MODE=server npx playwright test tests/file2.test.ts &
+PW_RSTUDIO_SERVER_URL=https://server3:80 PW_RSTUDIO_MODE=server npx playwright test tests/file3.test.ts &
 wait
 ```
 
 **Claude subagent execution:**
 Same commands, but each Agent tool call targets a different server with `run_in_background: true`. Results are collected and aggregated by the parent agent.
 
-**Desktop mode is unaffected** — it doesn't use `RSTUDIO_SERVER_URL`. The env var is only read by the server fixture path.
+**Desktop mode is unaffected** — it doesn't use `PW_RSTUDIO_SERVER_URL`. The env var is only read by the server fixture path.
 
 ## Output
 

--- a/.claude/skills/rstudio-run-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-run-playwright-tests/SKILL.md
@@ -21,7 +21,7 @@ npx playwright install
 
 ## Desktop Mode (Default)
 
-No special env vars needed — `RSTUDIO_EDITION` defaults to `desktop`.
+No special env vars needed — `PW_RSTUDIO_MODE` defaults to `desktop`.
 
 ```bash
 # All tests
@@ -31,12 +31,12 @@ npx playwright test
 npx playwright test tests/path/to/test.test.ts
 
 # With extra RStudio CLI args
-RSTUDIO_EXTRA_ARGS="--my-flag --other-option" npx playwright test
+PW_RSTUDIO_EXTRA_ARGS="--my-flag --other-option" npx playwright test
 ```
 
 - Connects to RStudio Desktop via CDP on port 9222
 - The fixture handles launching and shutting down RStudio Desktop automatically
-- `RSTUDIO_EXTRA_ARGS` passes space-separated CLI flags to the RStudio process at launch
+- `PW_RSTUDIO_EXTRA_ARGS` passes space-separated CLI flags to the RStudio process at launch
 
 ## Server Mode
 
@@ -44,19 +44,19 @@ Key env vars (3 required, 3 optional):
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `RSTUDIO_EDITION` | Yes | Set to `server` |
-| `RSTUDIO_SERVER_URL` | No | Full URL including port if needed, e.g. `http://10.12.227.184:8787` or `https://dev.example.com/s/abc123/` (default: `http://localhost:8787`) |
-| `RSTUDIO_SERVER_PORT` | No | Override the port in the URL (no default — only set if you need to override what's in the URL) |
-| `RSTUDIO_USER` | Yes | Login username |
-| `RSTUDIO_PASSWORD` | Yes | Login password |
-| `RSTUDIO_LOAD_TIMEOUT` | No | IDE load timeout in ms (default: 60000). Increase for slow servers. |
+| `PW_RSTUDIO_MODE` | Yes | Set to `server` |
+| `PW_RSTUDIO_SERVER_URL` | No | Full URL including port if needed, e.g. `http://10.12.227.184:8787` or `https://dev.example.com/s/abc123/` (default: `http://localhost:8787`) |
+| `PW_RSTUDIO_SERVER_PORT` | No | Override the port in the URL (no default — only set if you need to override what's in the URL) |
+| `PW_RSTUDIO_SERVER_USER` | Yes | Login username |
+| `PW_RSTUDIO_SERVER_PASSWORD` | Yes | Login password |
+| `PW_RSTUDIO_SERVER_LOGIN_TIMEOUT` | No | Post-login wait for the IDE console, in ms (default: 60000). Increase for slow servers. |
 
 ```bash
 # All tests
-RSTUDIO_EDITION=server RSTUDIO_SERVER_URL=http://<ip> RSTUDIO_USER=<user> RSTUDIO_PASSWORD=<pass> npx playwright test
+PW_RSTUDIO_MODE=server PW_RSTUDIO_SERVER_URL=http://<ip> PW_RSTUDIO_SERVER_USER=<user> PW_RSTUDIO_SERVER_PASSWORD=<pass> npx playwright test
 
 # Specific test file
-RSTUDIO_EDITION=server RSTUDIO_SERVER_URL=http://<ip> RSTUDIO_USER=<user> RSTUDIO_PASSWORD=<pass> npx playwright test tests/path/to/test.test.ts
+PW_RSTUDIO_MODE=server PW_RSTUDIO_SERVER_URL=http://<ip> PW_RSTUDIO_SERVER_USER=<user> PW_RSTUDIO_SERVER_PASSWORD=<pass> npx playwright test tests/path/to/test.test.ts
 ```
 
 - The fixture launches a headed Chromium browser, navigates to the server URL, and logs in
@@ -96,7 +96,7 @@ export PW_PROJECT=desktop-os-windows
 npx playwright test
 
 # To switch projects, override PW_PROJECT inline
-PW_PROJECT=server-os-linux RSTUDIO_EDITION=server npx playwright test
+PW_PROJECT=server-os-linux PW_RSTUDIO_MODE=server npx playwright test
 ```
 
 Without `PW_PROJECT`, all 8 projects run (each test executes once per project). `PW_PROJECT` and `--project` conflict--don't use both at the same time. `PW_PROJECT` pre-filters the project list, so `--project` can't select anything outside it.

--- a/e2e/rstudio/README.md
+++ b/e2e/rstudio/README.md
@@ -21,7 +21,7 @@ npx playwright install
 
 ### Desktop Mode (Default)
 
-No special environment variables needed — `RSTUDIO_EDITION` defaults to `desktop`.
+No special environment variables needed — `PW_RSTUDIO_MODE` defaults to `desktop`.
 
 ```bash
 # All tests
@@ -35,20 +35,20 @@ npx playwright test -g "test name here"
 npx playwright test -g "base function: cat("
 
 # With extra RStudio CLI args
-RSTUDIO_EXTRA_ARGS="--my-flag --other-option" npx playwright test
+PW_RSTUDIO_EXTRA_ARGS="--my-flag --other-option" npx playwright test
 ```
 
-The desktop fixture automatically launches RStudio with CDP enabled on a random port (9231-9299), connects Playwright, and shuts down gracefully after tests complete. Override the port with `CDP_PORT=9222`.
+The desktop fixture automatically launches RStudio with CDP enabled on a random port (9231-9299), connects Playwright, and shuts down gracefully after tests complete. Override the port with `PW_CDP_PORT=9222`.
 
 ### Server Mode
 
-Set `RSTUDIO_EDITION=server` and provide credentials:
+Set `PW_RSTUDIO_MODE=server` and provide credentials:
 
 ```bash
-RSTUDIO_EDITION=server \
-  RSTUDIO_SERVER_URL=http://10.0.0.1:8787 \
-  RSTUDIO_USER=myuser \
-  RSTUDIO_PASSWORD=mypass \
+PW_RSTUDIO_MODE=server \
+  PW_RSTUDIO_SERVER_URL=http://10.0.0.1:8787 \
+  PW_RSTUDIO_SERVER_USER=myuser \
+  PW_RSTUDIO_SERVER_PASSWORD=mypass \
   npx playwright test
 ```
 
@@ -93,7 +93,7 @@ The `tsconfig.json` defines path aliases so imports stay clean:
 
 ### Fixtures
 
-The unified fixture (`rstudio.fixture.ts`) checks `RSTUDIO_EDITION` and delegates to the appropriate launcher. It provides a shared `rstudioPage` (a Playwright `Page`) scoped to the worker, so all tests in a file share one RStudio session.
+The unified fixture (`rstudio.fixture.ts`) checks `PW_RSTUDIO_MODE` and delegates to the appropriate launcher. It provides a shared `rstudioPage` (a Playwright `Page`) scoped to the worker, so all tests in a file share one RStudio session.
 
 - **Desktop**: Kills any process on the CDP port, spawns RStudio with `--remote-debugging-port`, connects via `chromium.connectOverCDP()`, waits for the console to be ready.
 - **Server**: Launches a headed Chromium browser, navigates to the server URL, fills in credentials, waits for the IDE to load.
@@ -169,7 +169,13 @@ test('writes land in sandbox', async ({ rstudioPage: page }) => {
 });
 ```
 
-`useSuiteSandbox()` registers `beforeAll`/`afterAll` hooks that create and remove the directory, and `setwd()`s into it. `sandbox.dir` is populated before any test runs; use it when you need an absolute path. If you only need relative paths to land in the sandbox, calling `useSuiteSandbox();` and discarding the return value is enough -- cwd is already redirected. Override the root with `RSTUDIO_PW_SANDBOX`. See the Playwright skill for full details.
+`useSuiteSandbox()` registers `beforeAll`/`afterAll` hooks that create and remove the directory, and `setwd()`s into it. `sandbox.dir` is populated before any test runs; use it when you need an absolute path. If you only need relative paths to land in the sandbox, calling `useSuiteSandbox();` and discarding the return value is enough -- cwd is already redirected. Override the root with `PW_SANDBOX` and `PW_SANDBOX_CREATE`.
+
+**Wizard-driven tests:** the New Project Wizard's parent-directory field is read-only. `setwd()` doesn't redirect it -- override the `default_project_location` preference via `.rs.api.writeRStudioPreference()` and restore it in `afterAll`. See `create_projects.test.ts` for the pattern.
+
+**Exception:** tests that specifically exercise a fixed path in `~/` as part of the product behavior under test (e.g., `chat-user-skills.test.ts` exercises `~/.positai/skills/`) stay as-is. Sandbox is for redirecting incidental filesystem writes, not for rewriting product semantics.
+
+**Low-level helpers:** `createSandbox` / `removeSandbox` are also exported from `@utils/sandbox` if you need to manage the lifecycle manually.
 
 ### Package Dependencies
 
@@ -227,7 +233,7 @@ export PW_PROJECT=desktop-os-windows
 With `PW_PROJECT` set, bare `npx playwright test` runs only that project. To switch projects, override `PW_PROJECT` inline:
 
 ```bash
-PW_PROJECT=server-os-linux RSTUDIO_EDITION=server npx playwright test
+PW_PROJECT=server-os-linux PW_RSTUDIO_MODE=server npx playwright test
 ```
 
 Without `PW_PROJECT` or `--project`, all 8 projects run.
@@ -254,22 +260,22 @@ npx playwright test --grep-invert "@pro_only|@server_only"
 | Variable | Mode | Required | Description |
 |----------|------|----------|-------------|
 | `PW_PROJECT` | Both | No | Select a single project (e.g., `desktop-os-windows`). Trumps `--project`. |
-| `RSTUDIO_EDITION` | Both | No | `desktop` (default) or `server` |
-| `CDP_PORT` | Desktop | No | Override the CDP port (default: random 9231-9299) |
-| `RSTUDIO_SERVER_URL` | Server | No | Full URL, e.g., `http://10.0.0.1:8787` (default: `http://localhost:8787`) |
-| `RSTUDIO_SERVER_PORT` | Server | No | Override the port in the URL |
-| `RSTUDIO_USER` | Server | Yes | Login username |
-| `RSTUDIO_PASSWORD` | Server | Yes | Login password |
-| `RSTUDIO_LOAD_TIMEOUT` | Server | No | IDE load timeout in ms (default: 60000) |
-| `RSTUDIO_EXTRA_ARGS` | Desktop | No | Space-separated extra CLI args passed to RStudio (e.g., `--my-flag --other-option`) |
-| `RSTUDIO_PW_SANDBOX` | Both | No | Override the sandbox root (absolute path). Unset uses `dirname(tempdir())`. |
-| `RSTUDIO_PW_SANDBOX_CREATE` | Both | No | Set to `true`/`1` to auto-create an overridden sandbox root if it's missing. Default `false` — fails loud on typos. |
+| `PW_RSTUDIO_MODE` | Both | No | `desktop` (default) or `server` |
+| `PW_CDP_PORT` | Desktop | No | Override the CDP port (default: random 9231-9299) |
+| `PW_RSTUDIO_SERVER_URL` | Server | No | Full URL, e.g., `http://10.0.0.1:8787` (default: `http://localhost:8787`) |
+| `PW_RSTUDIO_SERVER_PORT` | Server | No | Override the port in the URL |
+| `PW_RSTUDIO_SERVER_USER` | Server | Yes | Login username |
+| `PW_RSTUDIO_SERVER_PASSWORD` | Server | Yes | Login password |
+| `PW_RSTUDIO_SERVER_LOGIN_TIMEOUT` | Server | No | Post-login wait for the IDE console, in ms (default: 60000) |
+| `PW_RSTUDIO_EXTRA_ARGS` | Desktop | No | Space-separated extra CLI args passed to RStudio (e.g., `--my-flag --other-option`) |
+| `PW_SANDBOX` | Both | No | Override the sandbox root (absolute path). Unset uses `dirname(tempdir())`. |
+| `PW_SANDBOX_CREATE` | Both | No | Set to `true`/`1` to auto-create an overridden sandbox root if it's missing. Default `false` — fails loud on typos. |
 
-## Further Reading
+## Claude Skills
 
-For detailed patterns, edge cases, and the reasoning behind these conventions, see the Claude skill files:
+Claude skills are available for use when working with this test suite:
 
-- `.claude/skills/rstudio-create-playwright-tests/SKILL.md` — comprehensive guide to writing tests
+- `.claude/skills/rstudio-create-playwright-tests/SKILL.md` — guide for writing tests
 - `.claude/skills/rstudio-create-playwright-tests/logic-deep-dive.md` — architectural reasoning
 - `.claude/skills/rstudio-run-playwright-tests/SKILL.md` — test execution protocol
 

--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -12,7 +12,7 @@ export const RSTUDIO_PATH = process.platform === 'win32'
   : process.platform === 'darwin'
     ? '/Applications/RStudio.app/Contents/MacOS/RStudio'
     : '/usr/bin/rstudio';
-export const CDP_PORT = Number(process.env.CDP_PORT) || (9231 + Math.floor(Math.random() * 69));
+export const CDP_PORT = Number(process.env.PW_CDP_PORT) || (9231 + Math.floor(Math.random() * 69));
 export const CDP_URL = `http://localhost:${CDP_PORT}`;
 
 export interface DesktopSession {

--- a/e2e/rstudio/fixtures/rstudio.fixture.ts
+++ b/e2e/rstudio/fixtures/rstudio.fixture.ts
@@ -4,7 +4,7 @@ import { launchServer, shutdownServer } from './server.fixture';
 import { sleep } from '../utils/constants';
 import { getEnvironmentVersions, clearConsole } from '../pages/console_pane.page';
 
-const mode = (process.env.RSTUDIO_EDITION || 'desktop').toLowerCase();
+const mode = (process.env.PW_RSTUDIO_MODE || 'desktop').toLowerCase();
 
 const DONT_SAVE_BTN = "button:has-text('Don\\'t Save'), button:has-text('Do not Save'), #rstudio_dlg_no";
 
@@ -18,8 +18,8 @@ async function logVersions(page: Page): Promise<void> {
 /**
  * Unified Playwright Test fixture that provides a shared RStudio page.
  *
- * Set RSTUDIO_EDITION=server to connect to RStudio Server instead of Desktop.
- * Server mode requires RSTUDIO_USER, RSTUDIO_PASSWORD, and optionally RSTUDIO_SERVER_URL.
+ * Set PW_RSTUDIO_MODE=server to connect to RStudio Server instead of Desktop.
+ * Server mode requires PW_RSTUDIO_SERVER_USER, PW_RSTUDIO_SERVER_PASSWORD, and optionally PW_RSTUDIO_SERVER_URL.
  */
 export const test = base.extend<{}, { rstudioPage: Page }>({
   rstudioPage: [async ({}, use) => {

--- a/e2e/rstudio/fixtures/server.fixture.ts
+++ b/e2e/rstudio/fixtures/server.fixture.ts
@@ -12,18 +12,18 @@ export interface ServerSession {
  * Connect to RStudio Server, log in, and return a ready session.
  */
 export async function launchServer(): Promise<ServerSession> {
-  const baseUrl = process.env.RSTUDIO_SERVER_URL || 'http://localhost:8787';
+  const baseUrl = process.env.PW_RSTUDIO_SERVER_URL || 'http://localhost:8787';
   const url = new URL(baseUrl);
-  if (process.env.RSTUDIO_SERVER_PORT) {
-    url.port = process.env.RSTUDIO_SERVER_PORT;
+  if (process.env.PW_RSTUDIO_SERVER_PORT) {
+    url.port = process.env.PW_RSTUDIO_SERVER_PORT;
   }
   const serverUrl = url.toString().replace(/\/$/, '');
-  const username = process.env.RSTUDIO_USER || '';
-  const password = process.env.RSTUDIO_PASSWORD || '';
+  const username = process.env.PW_RSTUDIO_SERVER_USER || '';
+  const password = process.env.PW_RSTUDIO_SERVER_PASSWORD || '';
 
   if (!username || !password) {
     throw new Error(
-      'RSTUDIO_USER and RSTUDIO_PASSWORD environment variables are required for server mode'
+      'PW_RSTUDIO_SERVER_USER and PW_RSTUDIO_SERVER_PASSWORD environment variables are required for server mode'
     );
   }
 
@@ -47,8 +47,8 @@ export async function launchServer(): Promise<ServerSession> {
   console.log(`Logged in as ${username}`);
 
   // Wait for console to be ready
-  const loadTimeout = Number(process.env.RSTUDIO_LOAD_TIMEOUT) || 60_000;
-  await page.waitForSelector(CONSOLE_INPUT, { state: 'visible', timeout: loadTimeout });
+  const loginTimeout = Number(process.env.PW_RSTUDIO_SERVER_LOGIN_TIMEOUT) || 60_000;
+  await page.waitForSelector(CONSOLE_INPUT, { state: 'visible', timeout: loginTimeout });
   console.log('RStudio console is ready');
 
   // Dismiss any leftover save dialog from a previous session

--- a/e2e/rstudio/tests/menus/help/release-notes.test.ts
+++ b/e2e/rstudio/tests/menus/help/release-notes.test.ts
@@ -14,7 +14,7 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { sleep } from '@utils/constants';
 
 const BASE_URL = 'https://www.rstudio.org/links/release_notes';
-const isDesktop = (process.env.RSTUDIO_EDITION || 'desktop').toLowerCase() === 'desktop';
+const isDesktop = (process.env.PW_RSTUDIO_MODE || 'desktop').toLowerCase() === 'desktop';
 
 test.describe('Help > Release Notes - #17330', { tag: ['@parallel_safe'] }, () => {
 

--- a/e2e/rstudio/tests/panes/layout/pane_location_persistence.test.ts
+++ b/e2e/rstudio/tests/panes/layout/pane_location_persistence.test.ts
@@ -91,7 +91,7 @@ async function moveTab(page: Page, tabLabel: string, fromContainer: string, toCo
  * persisted.
  */
 base.describe('Pane location persistence - #17177', () => {
-  base.skip(process.env.RSTUDIO_EDITION === 'server', 'Uses Desktop restart — Server session restart TBD');
+  base.skip(process.env.PW_RSTUDIO_MODE === 'server', 'Uses Desktop restart — Server session restart TBD');
 
   let session: DesktopSession;
 

--- a/e2e/rstudio/tests/panes/misc/s4_unloaded_package.test.ts
+++ b/e2e/rstudio/tests/panes/misc/s4_unloaded_package.test.ts
@@ -151,7 +151,7 @@ async function verifyEnvironmentPane(page: Page): Promise<void> {
 // Test 1: R session restart
 // ==========================================================================
 base.describe.serial('S4 unloaded package -- R session restart (#17353)', { tag: ['@serial'] }, () => {
-  base.skip(process.env.RSTUDIO_EDITION === 'server', 'Uses Desktop launch -- Server not supported');
+  base.skip(process.env.PW_RSTUDIO_MODE === 'server', 'Uses Desktop launch -- Server not supported');
 
   let session: DesktopSession;
   let page: Page;
@@ -185,7 +185,7 @@ base.describe.serial('S4 unloaded package -- R session restart (#17353)', { tag:
 // Test 2: Full RStudio Desktop restart
 // ==========================================================================
 base.describe.serial('S4 unloaded package -- RStudio restart (#17353)', { tag: ['@serial'] }, () => {
-  base.skip(process.env.RSTUDIO_EDITION === 'server', 'Uses Desktop launch -- Server not supported');
+  base.skip(process.env.PW_RSTUDIO_MODE === 'server', 'Uses Desktop launch -- Server not supported');
 
   let session: DesktopSession;
   let page: Page;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/detachable-sidebar.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/detachable-sidebar.test.ts
@@ -11,7 +11,7 @@ import type { Page } from 'playwright';
 const RETURN_TO_MAIN_BTN = '#rstudio_chat_return_to_main_button';
 
 test.describe.serial('Detachable Assistant Sidebar - #16937', () => {
-  test.skip(process.env.RSTUDIO_EDITION === 'server', 'Satellite windows are Desktop-only — Server behavior TBD');
+  test.skip(process.env.PW_RSTUDIO_MODE === 'server', 'Satellite windows are Desktop-only — Server behavior TBD');
 
   let chatPane: ChatPane;
   let chatActions: ChatPaneActions;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/uninstall-posit-ai.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/uninstall-posit-ai.test.ts
@@ -51,7 +51,7 @@ async function invokeUninstallViaPalette(page: Page): Promise<void> {
 }
 
 base.describe.serial('Uninstall Posit Assistant - #17322', { tag: ['@serial'] }, () => {
-  base.skip(process.env.RSTUDIO_EDITION === 'server', 'Uses Desktop restart — Server not supported');
+  base.skip(process.env.PW_RSTUDIO_MODE === 'server', 'Uses Desktop restart — Server not supported');
 
   let session: DesktopSession;
   let page: Page;

--- a/e2e/rstudio/utils/constants.ts
+++ b/e2e/rstudio/utils/constants.ts
@@ -15,8 +15,8 @@ export async function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export const RSTUDIO_EXTRA_ARGS: string[] = process.env.RSTUDIO_EXTRA_ARGS
-  ? process.env.RSTUDIO_EXTRA_ARGS.split(' ').filter(Boolean)
+export const RSTUDIO_EXTRA_ARGS: string[] = process.env.PW_RSTUDIO_EXTRA_ARGS
+  ? process.env.PW_RSTUDIO_EXTRA_ARGS.split(' ').filter(Boolean)
   : [];
 
 export const CODE_SUGGESTION_PROVIDERS: Record<string, string> = {

--- a/e2e/rstudio/utils/sandbox.ts
+++ b/e2e/rstudio/utils/sandbox.ts
@@ -23,13 +23,13 @@ export const SANDBOX_DIR_PREFIX = 'pw_rstudio_';
  * convention. Override with the env vars documented below.
  *
  * Env vars:
- *   RSTUDIO_PW_SANDBOX         Override the sandbox root. Unset uses OS temp parent.
- *   RSTUDIO_PW_SANDBOX_CREATE  When "true"/"1", create an overridden root if missing.
- *                              Default false — fail loud on typos.
+ *   PW_SANDBOX         Override the sandbox root. Unset uses OS temp parent.
+ *   PW_SANDBOX_CREATE  When "true"/"1", create an overridden root if missing.
+ *                      Default false — fail loud on typos.
  */
 
-const SANDBOX_ROOT_ENV = 'RSTUDIO_PW_SANDBOX';
-const SANDBOX_CREATE_ENV = 'RSTUDIO_PW_SANDBOX_CREATE';
+const SANDBOX_ROOT_ENV = 'PW_SANDBOX';
+const SANDBOX_CREATE_ENV = 'PW_SANDBOX_CREATE';
 
 function shouldCreateRoot(): boolean {
   const v = process.env[SANDBOX_CREATE_ENV];


### PR DESCRIPTION
## Summary

- Renames every env var consumed by `e2e/rstudio/` Playwright tests to start with `PW_` for consistency and namespacing.
- Hard cutover -- no legacy fallback. Updates the README, three Claude skill files, and renames the internal `loadTimeout` constant to `loginTimeout`.

| Old | New |
|---|---|
| `CDP_PORT` | `PW_CDP_PORT` |
| `RSTUDIO_EDITION` | `PW_RSTUDIO_MODE` |
| `RSTUDIO_SERVER_URL` | `PW_RSTUDIO_SERVER_URL` |
| `RSTUDIO_SERVER_PORT` | `PW_RSTUDIO_SERVER_PORT` |
| `RSTUDIO_USER` | `PW_RSTUDIO_SERVER_USER` |
| `RSTUDIO_PASSWORD` | `PW_RSTUDIO_SERVER_PASSWORD` |
| `RSTUDIO_LOAD_TIMEOUT` | `PW_RSTUDIO_SERVER_LOGIN_TIMEOUT` |
| `RSTUDIO_EXTRA_ARGS` | `PW_RSTUDIO_EXTRA_ARGS` |
| `RSTUDIO_PW_SANDBOX` | `PW_SANDBOX` |
| `RSTUDIO_PW_SANDBOX_CREATE` | `PW_SANDBOX_CREATE` |

`PW_PROJECT` was already correctly prefixed and is unchanged.