### PR TITLE
Fix shallow clone default by getting full git history

### DIFF
--- a/jenkins/Jenkinsfile.build
+++ b/jenkins/Jenkinsfile.build
@@ -56,7 +56,9 @@ pipeline {
       steps {
         script {
           utils = load "${env.WORKSPACE}/jenkins/utils.groovy"
-          
+
+          utils.ensureFullCommitHistory()
+
           // Get the current commit
           COMMIT_HASH = sh returnStdout: true, script: 'git rev-parse HEAD'
 

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -82,6 +82,8 @@ pipeline {
         stage('Versioning') {
           steps {
             script {
+              utils.ensureFullCommitHistory()
+
               (RSTUDIO_VERSION,
                 RSTUDIO_VERSION_MAJOR,
                 RSTUDIO_VERSION_MINOR,

--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -71,6 +71,8 @@ pipeline {
     stage('Versioning') {
       steps {
         script {
+          utils.ensureFullCommitHistory()
+
           (RSTUDIO_VERSION,
             RSTUDIO_VERSION_MAJOR,
             RSTUDIO_VERSION_MINOR,

--- a/jenkins/Jenkinsfile.pull-request
+++ b/jenkins/Jenkinsfile.pull-request
@@ -31,6 +31,7 @@ pipeline {
           sh 'printenv'
           sh "echo 'Loading utils from ${env.WORKSPACE}/jenkins/utils.groovy'"
           utils = load "${env.WORKSPACE}/jenkins/utils.groovy"
+          utils.ensureFullCommitHistory()
           utils.addRemoteRef("${env.CHANGE_TARGET}")
           RSTUDIO_VERSION_FLOWER = readFile(file: 'version/RELEASE').replaceAll(" ", "-").toLowerCase().trim()
           IS_PRO = JOB_URL.contains('Pro')

--- a/jenkins/Jenkinsfile.pull-request-build
+++ b/jenkins/Jenkinsfile.pull-request-build
@@ -32,6 +32,7 @@ pipeline {
 
           sh "echo 'Loading utils from ${env.WORKSPACE}/jenkins/utils.groovy'"
           utils = load "${env.WORKSPACE}/jenkins/utils.groovy"
+          utils.ensureFullCommitHistory()
           utils.addRemoteRef("${env.CHANGE_TARGET}")
 
           RSTUDIO_VERSION_FLOWER = readFile(file: 'version/RELEASE').replaceAll(" ", "-").toLowerCase().trim()

--- a/jenkins/Jenkinsfile.pull-request-build
+++ b/jenkins/Jenkinsfile.pull-request-build
@@ -74,6 +74,8 @@ pipeline {
       steps {
         script {
 
+          utils.ensureFullCommitHistory()
+
           // Tests common to both Workbench and open source
           utils.postReviewCheck(title: "Build Package")
           utils.postReviewCheck(title: "GWT Unit Tests")

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -69,6 +69,8 @@ pipeline {
         stage('Versioning') {
           steps {
             script {
+              utils.ensureFullCommitHistory()
+
               (RSTUDIO_VERSION,
                 RSTUDIO_VERSION_MAJOR,
                 RSTUDIO_VERSION_MINOR,

--- a/jenkins/utils.groovy
+++ b/jenkins/utils.groovy
@@ -732,5 +732,21 @@ def getDocsDraftName(String branchName) {
   return ""
 }
 
+/**
+  * Ensures the full commit history is available for versioning.
+  * If the repo was shallow-cloned, fetches missing commits without
+  * downloading file content to minimize data transfer.
+  */
+void ensureFullCommitHistory() {
+  def isShallow = sh(
+    script: 'git rev-parse --is-shallow-repository',
+    returnStdout: true
+  ).trim()
+  if (isShallow == 'true') {
+    withCredentials([gitUsernamePassword(credentialsId: 'posit-jenkins-rstudio', gitToolName: 'Default')]) {
+      sh 'git fetch --filter=blob:none --unshallow origin'
+    }
+  }
+}
 
 return this


### PR DESCRIPTION
### Intent

We need full git history for generating the rstudio version. 

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Ensure you have updated the QA Notes in the original issue.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


