### PR TITLE
preserve hard file limit when raising soft limit in rsession

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2426,13 +2426,19 @@ int main(int argc, char * const argv[])
       {
          RLimitType soft, hard;
          Error error = core::system::getResourceLimit(core::system::FilesLimit, &soft, &hard);
-         if (!error)
+         if (error)
+         {
+            LOG_WARNING_MESSAGE("Error trying to get system open files limits - using system defaults: " + error.asString());
+         }
+         else
          {
             constexpr RLimitType kDesiredOpenFiles = 4096;
             if (soft < kDesiredOpenFiles && hard > soft)
             {
+               // preserve the existing hard limit -- rsession runs as a non-root
+               // process and could not re-raise the hard limit if we lowered it.
                RLimitType newLimit = std::min(kDesiredOpenFiles, hard);
-               error = core::system::setResourceLimit(core::system::FilesLimit, newLimit);
+               error = core::system::setResourceLimit(core::system::FilesLimit, newLimit, hard);
                if (error)
                {
                   LOG_WARNING_MESSAGE("Unable to raise open file limit: " + error.asString());


### PR DESCRIPTION
## Intent

Addresses review feedback on #17409 ([review](https://github.com/rstudio/rstudio/pull/17409#pullrequestreview-4094290675)) that landed after the original PR was merged.

## Summary

- The single-argument `setResourceLimit(FilesLimit, newLimit)` overload sets **both** the soft and hard limits to `newLimit`. On systems where the hard limit is much higher than 4096 (common on Linux — e.g. 1048576), the merged change irreversibly lowered the hard limit. Since rsession runs as a non-root process, it cannot re-raise its hard limit afterward, and child processes inherit the lowered cap. Switch to the two-argument overload (`newLimit, hard`) so we only raise the soft limit and preserve the existing hard limit.
- Add a warning log when `getResourceLimit()` fails (was silently dropped), matching the pattern already used in `ServerMain.cpp`.

## Test plan

- [ ] rsession builds cleanly on Linux, macOS, and Windows
- [ ] On Linux, confirm the debug log message still appears when the soft limit is raised
- [ ] Confirm the hard limit is preserved (e.g. `prlimit -p \$(pgrep rsession) -n` shows hard limit unchanged)