### PR TITLE
fix memory leaks in crypto code

### DIFF
--- a/src/cpp/core/include/core/Algorithm.hpp
+++ b/src/cpp/core/include/core/Algorithm.hpp
@@ -188,7 +188,7 @@ bool get(const AssociativeContainer& container,
 {
    if (!container.count(key))
       return false;
-   
+
    *ppValue = &(const_cast<AssociativeContainer&>(container)[key]);
    return true;
 }
@@ -224,7 +224,7 @@ inline std::vector<std::string> split(const std::string& string,
                                       const std::string& delim)
 {
    std::vector<std::string> result;
-   
+
    if (UNLIKELY(delim.size() == 0))
    {
       std::size_t n = string.size();
@@ -233,22 +233,22 @@ inline std::vector<std::string> split(const std::string& string,
          result.push_back(std::string(string[i], 1));
       return result;
    }
-   
+
    std::string::size_type start = 0;
    std::string::size_type end   = string.find(delim, start);
-   
+
    // Add all of the initial split pieces
    while (end != std::string::npos)
    {
       result.push_back(string_utils::substring(string, start, end));
-      
+
       start = end + delim.size();
       end   = string.find(delim, start);
    }
-   
+
    // Add the final piece
    result.push_back(string_utils::substring(string, start));
-   
+
    // And return!
    return result;
 }
@@ -274,7 +274,7 @@ inline std::string join(Iterator begin,
 {
    if (begin >= end)
       return std::string();
-   
+
    std::string result;
    result += f(*begin);
    for (Iterator it = begin + 1; it != end; ++it)
@@ -283,7 +283,7 @@ inline std::string join(Iterator begin,
       result += f(*it);
    }
    return result;
-   
+
 }
 
 template <typename Iterator>
@@ -294,6 +294,20 @@ inline std::string join(Iterator begin,
    auto callback = [](const std::string& string) { return string; };
    return join(begin, end, delim, std::move(callback));
 }
+
+template <typename CALLBACK>
+struct Defer {
+   explicit Defer(CALLBACK func) : func(std::move(func)) {}
+   ~Defer() { func(); }
+
+   Defer() = delete;
+   Defer(const Defer&) = delete;
+   Defer(Defer&&) = delete;
+   Defer& operator=(const Defer&) = delete;
+   Defer& operator=(Defer&&) = delete;
+
+   CALLBACK func;
+};
 
 } // namespace algorithm
 } // namespace core

--- a/src/cpp/core/system/Crypto.cpp
+++ b/src/cpp/core/system/Crypto.cpp
@@ -41,9 +41,9 @@
 #include <boost/utility.hpp>
 
 #include <shared_core/Error.hpp>
-#include <core/Thread.hpp>
-
+#include <core/Algorithm.hpp>
 #include <core/Log.hpp>
+#include <core/Thread.hpp>
 
 #include <memory>
 
@@ -483,9 +483,23 @@ Error generateRsaCertAndKeyPair(const std::string& in_certCommonName,
 }
 
 namespace {
-EVP_PKEY* s_pRSA;
+EVP_PKEY* s_pRSA = nullptr;
 std::string s_modulo;
 std::string s_exponent;
+}
+
+static std::string bn_to_string(const BIGNUM* bn)
+{
+   if (!bn)
+      return std::string();
+   auto hex = make_unique_ptr(BN_bn2hex(bn), [](char* p){ OPENSSL_free(p); });
+   if (!hex)
+   {
+      Error err = getLastCryptoError(ERROR_LOCATION);
+      LOG_ERROR(err);
+      return std::string();
+   }
+   return hex.get();
 }
 
 core::Error rsaInit()
@@ -498,42 +512,38 @@ core::Error rsaInit()
       return getLastCryptoError(ERROR_LOCATION);
 
    // generate an RSA key pair
-   s_pRSA = EVP_RSA_gen(kRsaKeySizeBits);
+   auto pRSA = make_unique_ptr(EVP_RSA_gen(kRsaKeySizeBits), EVP_PKEY_free);
+   if (!pRSA)
+      return getLastCryptoError(ERROR_LOCATION);
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
    // extract exponent + modulus for future use
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
    const BIGNUM *bn, *be;
-   RSA* pRsaKeyPair = EVP_PKEY_get1_RSA(s_pRSA);
+   auto pRsaKeyPair = make_unique_ptr(EVP_PKEY_get1_RSA(pRSA.get()), RSA_free);
+   if (!pRsaKeyPair)
+      return getLastCryptoError(ERROR_LOCATION);
    bn = pRsaKeyPair->n;
    be = pRsaKeyPair->e;
 #elif OPENSSL_VERSION_NUMBER < 0x30000000L
-   // extract exponent + modulus for future use
    const BIGNUM *bn, *be;
-   RSA* pRsaKeyPair = EVP_PKEY_get0_RSA(s_pRSA);
+   RSA* pRsaKeyPair = EVP_PKEY_get0_RSA(pRSA.get());
    RSA_get0_key(pRsaKeyPair, &bn, &be, nullptr);
 #else
-   // extract exponent + modulus for future use
    BIGNUM* bn = nullptr;
-   if (EVP_PKEY_get_bn_param(s_pRSA, "n", &bn) != 1)
+   algorithm::Defer defer_bn([&bn]{ BN_free(bn); }); // BN_free(nullptr) is a no-op
+   if (EVP_PKEY_get_bn_param(pRSA.get(), "n", &bn) != 1)
       return getLastCryptoError(ERROR_LOCATION);
 
    BIGNUM* be = nullptr;
-   if (EVP_PKEY_get_bn_param(s_pRSA, "e", &be) != 1)
+   algorithm::Defer defer_be([&be]{ BN_free(be); }); // BN_free(nullptr) is a no-op
+   if (EVP_PKEY_get_bn_param(pRSA.get(), "e", &be) != 1)
       return getLastCryptoError(ERROR_LOCATION);
 #endif
 
-   char* n = BN_bn2hex(bn);
-   s_modulo = n;
-   OPENSSL_free(n);
+   s_modulo = bn_to_string(bn);
+   s_exponent = bn_to_string(be);
 
-   char* e = BN_bn2hex(be);
-   s_exponent = e;
-   OPENSSL_free(e);
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-   RSA_free(pRsaKeyPair);
-#endif
-
+   s_pRSA = pRSA.release();
    return Success();
 }
 
@@ -608,19 +618,26 @@ core::Error rsaPrivateDecrypt(const std::string& cipherText, std::string* pPlain
    if (status <= 0)
       return getLastCryptoError(ERROR_LOCATION);
 
-   unsigned char* buffer = (unsigned char*) OPENSSL_malloc(size);
+   auto buffer = make_unique_ptr(
+      (unsigned char*) OPENSSL_malloc(size),
+      [size](unsigned char* p) {
+         // Wipe and deallocate the decryption buffer
+         OPENSSL_cleanse(p, size);
+         OPENSSL_free(p);
+      }
+   );
    if (buffer == nullptr)
       return getLastCryptoError(ERROR_LOCATION);
 
    status = EVP_PKEY_decrypt(
             ctx.get(),
-            buffer, &size,
+            buffer.get(), &size,
             cipherTextBytes.data(), cipherTextBytes.size());
 
    if (status <= 0)
       return getLastCryptoError(ERROR_LOCATION);
 
-   pPlainText->assign(buffer, buffer + size);
+   pPlainText->assign(buffer.get(), buffer.get() + size);
    return Success();
 }
 

--- a/src/tools/valgrind-suppressions
+++ b/src/tools/valgrind-suppressions
@@ -29,12 +29,135 @@
 
 }
 {
-   Boost Remove 
+   Boost Remove
    Memcheck:Cond
    fun:_ZN13rstudio_boost10filesystem6detail28directory_iterator_incrementERNS0_18directory_iteratorEPNS_6system10error_codeE
    fun:_ZN12_GLOBAL__N_114remove_all_auxERKN13rstudio_boost10filesystem4pathENS1_9file_typeEPNS0_6system10error_codeE
    fun:_ZN13rstudio_boost10filesystem6detail10remove_allERKNS0_4pathEPNS_6system10error_codeE
    fun:_ZN13rstudio_boost10filesystem10remove_allERKNS0_4pathE
    fun:_ZNK7rstudio4core8FilePath6removeEv
+   ...
+}
+
+# ---------------------------------------------------------------------------
+# Leak false positives — runtime/library allocations that valgrind reports at
+# process exit but are owned by glibc, OpenSSL, or boost::asio thread-local
+# caches (freed only on thread exit, which doesn't happen before the process
+# does). All known patterns; suppress to keep the leak report actionable.
+# ---------------------------------------------------------------------------
+
+{
+   glibc-NSS-compat-initgroups-module-load
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect
+   fun:malloc
+   ...
+   fun:compat_call.constprop.0
+}
+
+{
+   glibc-cxa-thread-atexit-tls-destructor-record
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:calloc
+   fun:__cxa_thread_atexit_impl
+   fun:__cxa_thread_atexit
+   ...
+}
+
+{
+   glibc-resolv-conf-tls-cache
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect
+   fun:malloc
+   fun:__libc_alloc_buffer_allocate
+   fun:alloc_buffer_allocate
+   fun:__resolv_conf_allocate
+   ...
+}
+
+{
+   boost-asio-tls-recycling-allocator
+   Memcheck:Leak
+   match-leak-kinds: definite,possible
+   fun:memalign
+   fun:_ZN13rstudio_boost4asio11aligned_newEmm
+   ...
+}
+
+{
+   openssl3-tls-DRBG-RAND-context
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect,possible
+   fun:malloc
+   fun:CRYPTO_zalloc
+   fun:EVP_RAND_CTX_new
+   ...
+}
+
+{
+   openssl3-tls-error-queue-mark
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect
+   fun:malloc
+   fun:CRYPTO_zalloc
+   ...
+   fun:ERR_set_mark
+   ...
+}
+
+# ---------------------------------------------------------------------------
+# Program-lifetime objects: real allocations that are never freed because the
+# owning subsystem runs for the whole process. Not bugs, not actionable.
+# ---------------------------------------------------------------------------
+
+{
+   rstudio-load-balancer-monitor-pinned
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   ...
+   fun:_ZN7rstudio6server13load_balancer15monitorLauncherEv
+   ...
+}
+
+{
+   rstudio-load-balancer-monitor-backoff-timer-pinned
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   ...
+   fun:_ZN7rstudio4core18ExponentialBackoff4nextEv
+   ...
+}
+
+# ---------------------------------------------------------------------------
+# Process-monitor worker thread shutdown race: the monitorMain loop sits in
+# `read()` inside a posixCall. At process exit the thread is killed mid-call,
+# so its stack-allocated std::vector buffer and std::function heap object
+# look "definitely lost" because the thread never unwinds. Single-block,
+# one-shot — the per-iteration allocation pattern would show many blocks.
+# ---------------------------------------------------------------------------
+
+{
+   rstudio-process-monitor-thread-shutdown-supervisor-poll
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:_Znwm
+   ...
+   fun:_ZN7rstudio4core6system17ProcessSupervisor4pollEv
+   fun:_ZN7rstudio6server14ProcessMonitor11monitorMainEv
+   ...
+}
+
+{
+   rstudio-process-monitor-thread-shutdown-asyncchildprocess-poll
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:_Znwm
+   ...
+   fun:_ZN7rstudio4core6system17AsyncChildProcess4pollEv
+   ...
+   fun:_ZN7rstudio6server14ProcessMonitor11monitorMainEv
    ...
 }


### PR DESCRIPTION
### Intent

Potentially addresses https://github.com/rstudio/rstudio-pro/issues/10805

There's a memory leak somewhere in rserver. This PR aims to at least partially fix it.

### Approach

Using valgrind I was able to identify a couple of buffers that were never getting freed, so I added some RAII to ensure that it wasn't possible for the function to go out of scope without cleaning up after itself.

These leaks are kind of small, though -- a couple KB per connection, and the customer in question has been complaining about memory usage growing with each update. I suspect that there may be some allocations that aren't technically leaked but never properly cleaned up beyond these. However, there's no point in NOT fixing what's been found so far.

### Automated Tests

This isn't something that can be practically covered by automated testing.

### QA Notes

There's a `valgrind-suppressions` file in `src/tools` that you can use to suppress known false positives, then you can run rserver using:

```
valgrind --tool=memcheck --leak-check=full --suppressions=/path/to/valgrind-suppressions /usr/lib/rstudio-server/bin/rserver --server-daemonize 0
```

Log in and tinker around for a while, then stop the server (ctrl+C should work) and see what valgrind outputs.

### Documentation

N/A, internal bugfix

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


