### PR TITLE
Restore splash-screen click/key dismiss

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## RStudio 2026.05.0 "Golden Wattle" Release Notes
 
 ### New
+- ([#15614](https://github.com/rstudio/rstudio/issues/15614)): The splash screen can again be dismissed with a mouse click or key press.
 - ([#16541](https://github.com/rstudio/rstudio/issues/16541)): Section headers now fold hierarchically based on heading level, matching Positron's default behavior
 
 ### Fixed

--- a/src/node/desktop/src/main/splash-screen.ts
+++ b/src/node/desktop/src/main/splash-screen.ts
@@ -32,12 +32,6 @@ export function createSplashScreen(): BrowserWindow {
     hasShadow: false,
   });
 
-  // Workaround for Electron crash on Windows when the mouse is over a
-  // transparent frameless window during teardown. Ignoring mouse events
-  // prevents hit tests from triggering during window destruction.
-  // https://github.com/electron/electron/pull/49929
-  splash.setIgnoreMouseEvents(true);
-
   splash.loadURL(SPLASH_WEBPACK_ENTRY).catch((err: unknown) => logger().logError(err));
   return splash;
 }

--- a/src/node/desktop/test/unit/main/whats-new-utils.test.ts
+++ b/src/node/desktop/test/unit/main/whats-new-utils.test.ts
@@ -26,6 +26,18 @@ import {
   createLocalUrlChecker,
 } from '../../../src/main/whats-new-utils';
 
+// Unix-style file URLs (no drive letter) are not valid Windows paths,
+// so fileURLToPath throws on Windows. Skip the corresponding describes
+// there without invoking their bodies; the Windows drive-letter cases
+// are exercised in a dedicated describe.
+function describePosix(title: string, fn: () => void): void {
+  if (process.platform === 'win32') {
+    describe.skip(title, () => { /* skipped on Windows */ });
+  } else {
+    describe(title, fn);
+  }
+}
+
 describe('whats-new-utils', () => {
   describe('toReleaseSlug', () => {
     it('lowercases and replaces spaces with hyphens', () => {
@@ -129,7 +141,7 @@ describe('whats-new-utils', () => {
     });
   });
 
-  describe('createLocalUrlChecker (file mode)', () => {
+  describePosix('createLocalUrlChecker (file mode)', () => {
     const host = 'file:///app/.webpack/renderer/whats_new/index.html';
     const isLocal = createLocalUrlChecker(host, 'globemaster-allium');
 
@@ -172,7 +184,7 @@ describe('whats-new-utils', () => {
     });
   });
 
-  describe('createLocalUrlChecker (invalid slug)', () => {
+  describePosix('createLocalUrlChecker (invalid slug)', () => {
     const host = 'file:///app/.webpack/renderer/whats_new/index.html';
     const isLocal = createLocalUrlChecker(host, '../etc');
 


### PR DESCRIPTION
## Intent

Addresses #15614.

## Summary

- Remove the `setIgnoreMouseEvents(true)` workaround added in #17137. It was needed only to avoid an Electron 39.7.0 hit-test crash during transparent-window teardown on Windows; the upstream fix ([electron/electron#49929](https://github.com/electron/electron/pull/49929)) shipped, and the desktop has since moved to Electron 41.3.0. The click and keypress handlers in `splash.html` were retained in the original PR for easy revert, so removing the ignore-mouse call is enough to make the splash dismissable again.
- Fix an unrelated Windows-only failure in `whats-new-utils.test.ts`. Two `describe` blocks construct `createLocalUrlChecker` with Unix-style file URLs (`file:///app/...`) at the top of the describe body. `createLocalUrlChecker` calls `fileURLToPath`, which on Windows throws `ERR_INVALID_FILE_URL_PATH` for URLs without a drive letter. The throw fires at module-load time and aborts the test file. A `describePosix` helper now skips those describes on Windows without invoking their bodies; the dedicated Windows drive-letter describe still covers Windows-relevant behavior.

## Test plan

- [ ] Build desktop app on Windows and launch RStudio
- [ ] Click on the splash screen and confirm it dismisses
- [ ] Press a key over the splash and confirm it dismisses
- [ ] Confirm no startup crash with the mouse pointer over the splash
- [ ] `npm test` in `src/node/desktop` passes on Windows, macOS, and Linux