### PR TITLE
fix TypeError on ace editor attach by lifting pref bind() out of varargs

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -307,6 +307,34 @@ public class AceEditorWidget extends Composite
 
    private void attachImpl()
    {
+      // Pref bindings are extracted into their own statements (rather than
+      // inlined into the variadic add() below) to work around a GWT compiler
+      // issue that produced "execute is not a function" errors at runtime when
+      // the bind() calls were mixed into a long varargs literal alongside
+      // CommandWithArg-bearing addEventListener() calls.
+      HandlerRegistration tabKeyReg = uiPrefs_.tabKeyMoveFocus().bind(new CommandWithArg<Boolean>()
+      {
+         @Override
+         public void execute(Boolean movesFocus)
+         {
+            if (tabKeyMode_ == TabKeyMode.TrackUserPref && tabMovesFocus_ != movesFocus)
+            {
+               editor_.setTabMovesFocus(movesFocus);
+               tabMovesFocus_ = movesFocus;
+            }
+         }
+      });
+
+      HandlerRegistration scrollReg = uiPrefs_.editorScrollMultiplier().bind(new CommandWithArg<Integer>()
+      {
+         @Override
+         public void execute(Integer scrollPercentage)
+         {
+            double scrollRatio = ((double) scrollPercentage) / 100.0;
+            syncScrollSpeed(scrollRatio);
+         }
+      });
+
       aceEventHandlers_.add(
 
          AceEditorNative.addEventListener(
@@ -392,31 +420,8 @@ public class AceEditorWidget extends Composite
                   }
                }),
 
-         // This command binding has to be an anonymous inner class (not a lambda)
-         // due to an issue with using lambda bindings with Ace, which sometimes
-         // results in a blocking exception on startup in devmode.
-         uiPrefs_.tabKeyMoveFocus().bind(new CommandWithArg<Boolean>()
-         {
-            @Override
-            public void execute(Boolean movesFocus)
-            {
-               if (tabKeyMode_ == TabKeyMode.TrackUserPref && tabMovesFocus_ != movesFocus)
-               {
-                  editor_.setTabMovesFocus(movesFocus);
-                  tabMovesFocus_ = movesFocus;
-               }
-            }
-         }),
-
-         uiPrefs_.editorScrollMultiplier().bind(new CommandWithArg<Integer>()
-         {
-            @Override
-            public void execute(Integer scrollPercentage)
-            {
-               double scrollRatio = ((double) scrollPercentage) / 100.0;
-               syncScrollSpeed(scrollRatio);
-            }
-         })
+         tabKeyReg,
+         scrollReg
       );
 
       globalEventHandlers_.add(


### PR DESCRIPTION
## Summary

Fixes a `(TypeError) : handler.execute is not a function` thrown from `Prefs.JsonValue.bind()` on the synchronous initial `handler.execute(getValue())` call when an `AceEditorWidget` attaches to the DOM.

## Cause

In `AceEditorWidget.attachImpl()`, two `pref.bind(new CommandWithArg<...> { ... })` calls were inlined as arguments to a long variadic `aceEventHandlers_.add(addEventListener(...), addEventListener(...), ..., bind(...), bind(...))` literal alongside many other `CommandWithArg`-bearing expressions. That shape — multiple `CommandWithArg`-bearing arguments mixed into a single varargs literal that also contains a `bind()` call — triggers a GWT compiler optimization quirk that produces a JS callsite where the handler object's `execute` method has been pruned/renamed away, causing a runtime `TypeError`.

The bug was introduced by #17012 (`Fix AceEditor subsystem lifecycle across detach/re-attach cycles`), which moved the pref bindings from `onLoad()` into the new `attachImpl()` method and changed `aceEventHandlers_` to use the variadic `HandlerRegistrations.add(HandlerRegistration...)` form.

## Fix

Lift the two `bind()` calls out of the varargs literal into their own `HandlerRegistration` local variables, and pass those locals into `aceEventHandlers_.add(...)` like any other registration. Each `bind()` call is now type-checked in isolation before its result becomes part of the variadic array, sidestepping the optimizer issue without changing semantics.

A code comment documents the rule (don't put `bind()` calls inline alongside other `CommandWithArg`-bearing arguments in a single varargs `add()` literal) for future contributors.

I scanned the rest of the repo for the same pattern; no other call sites are at risk. Other `bind()` usages either stand alone, sit in their own one-argument `add()`, or are the sole argument to a `new HandlerRegistrations(...)` constructor.

## Test plan

- [ ] `cd src/gwt && ant javac` — compiles cleanly
- [ ] `cd src/gwt && ant draft` — produces runnable JS
- [ ] Open RStudio Server in a browser, open a source file, confirm no `TypeError` is logged and tab-key behavior + scroll-speed pref both still drive the editor
- [ ] Toggle "Use Tab key to move focus" in Global Options and confirm the editor reflects the new value live