### PR TITLE
Disable GWT Super Dev Mode redirect hook in production desktop builds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 - ([#16541](https://github.com/rstudio/rstudio/issues/16541)): Section headers now fold hierarchically based on heading level, matching Positron's default behavior
 
 ### Fixed
-- ([#12235](https://github.com/rstudio/rstudio/issues/12235)): Fixed a ~4 second delay on RStudio Desktop's "Session > New Session" caused by Chromium DOM Storage lock contention against the parent process during GWT bootstrap.
+- ([#12235](https://github.com/rstudio/rstudio/issues/12235)): RStudio Desktop's Session > New Session now opens noticeably faster.
 - ([#17440](https://github.com/rstudio/rstudio/issues/17440)): Fixed an issue where triggering tab completion inside `[` on a large Matrix-package sparse matrix could hang RStudio and exhaust system memory
 - ([#17176](https://github.com/rstudio/rstudio/issues/17176)): Fixed a startup hang when opening a Quarto project containing large directories (e.g. `_targets/`).
 - ([#16067](https://github.com/rstudio/rstudio/issues/16067)): Raise the open file descriptor soft limit at session startup to avoid "Too many open files" errors during project file monitoring on Linux.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - ([#16541](https://github.com/rstudio/rstudio/issues/16541)): Section headers now fold hierarchically based on heading level, matching Positron's default behavior
 
 ### Fixed
+- ([#12235](https://github.com/rstudio/rstudio/issues/12235)): Fixed a ~4 second delay on RStudio Desktop's "Session > New Session" caused by Chromium DOM Storage lock contention against the parent process during GWT bootstrap.
 - ([#17440](https://github.com/rstudio/rstudio/issues/17440)): Fixed an issue where triggering tab completion inside `[` on a large Matrix-package sparse matrix could hang RStudio and exhaust system memory
 - ([#17176](https://github.com/rstudio/rstudio/issues/17176)): Fixed a startup hang when opening a Quarto project containing large directories (e.g. `_targets/`).
 - ([#16067](https://github.com/rstudio/rstudio/issues/16067)): Raise the open file descriptor soft limit at session startup to avoid "Too many open files" errors during project file monitoring on Linux.

--- a/src/gwt/src/org/rstudio/studio/RStudioDesktop.gwt.xml
+++ b/src/gwt/src/org/rstudio/studio/RStudioDesktop.gwt.xml
@@ -3,4 +3,10 @@
 <module rename-to="rstudio">
    <inherits name="org.rstudio.studio.RStudio" />
    <set-property name="compiler.stackMode" value="native"/>
+
+   <!-- Suppress the Super Dev Mode redirect hook in production desktop builds.
+        The hook is the only sessionStorage access in the GWT bootstrap; in the
+        Electron child process spawned by Session > New Session it contends with
+        the parent's Session Storage LevelDB lock and adds ~4s to startup. -->
+   <set-configuration-property name="devModeRedirectEnabled" value="false"/>
 </module>


### PR DESCRIPTION
## Intent

Addresses #12235.

## Summary

The new window opened by Session > New Session takes ~4s longer to reach `dom-ready` than the first launch. The delay comes from the GWT bootstrap (`rstudio.nocache.js`): its Super Dev Mode redirect hook calls `sessionStorage.setItem` during startup, and in the spawned Electron child that call contends with the parent's Session Storage LevelDB lock for ~4s before timing out.

The redirect hook is only useful for the Super Dev Mode workflow, which has its own GWT module (`RStudioDesktopSuperDevMode`). Setting `devModeRedirectEnabled=false` on the production `RStudioDesktop` module makes the linker emit an empty fragment in place of `DevModeRedirectHook.js`, so the production bootstrap no longer touches `sessionStorage`.

## Verification

- Rebuilt `rstudio.nocache.js` against the `RStudioDesktop` module (`ant gwtc -Dgwt.main.module=org.rstudio.studio.RStudioDesktop`).
- `grep -c sessionStorage` on the resulting `rstudio.nocache.js` returns `0` (was `2` previously).
- Related dev-mode constants (`_gwt_dummy_`, `__gwtDevModeHook`, `Ignoring non-whitelisted`) are also absent from the output.

## Test plan

Note that this may be a non-determistic change depending on platform, phase of the moon, colour of your socks, etc. On my Mac dev machine, it was a consistent ~4 second improvement in startup time.

- [ ] Build a packaged desktop install (`make-package --install --arch=arm64 --build-dmg=0`) and confirm Session > New Session no longer pauses ~4s before the new window paints.
- [ ] Confirm `ant desktop` (Super Dev Mode against `RStudioDesktopSuperDevMode`) still works, since that module is unchanged.