### PR TITLE
Add Ubuntu 26.04 LTS (Resolute) dependency script; improve unsupported Debian error

### DIFF
--- a/dependencies/linux/install-dependencies-debian
+++ b/dependencies/linux/install-dependencies-debian
@@ -27,6 +27,6 @@ if command -v lsb_release &> /dev/null; then
   fi
 fi
 
-echo Error: Unsupported Debian release
+echo "Error: Unsupported Debian release (expected script: $platform_script)"
 exit 1
 

--- a/dependencies/linux/install-dependencies-resolute
+++ b/dependencies/linux/install-dependencies-resolute
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+#
+# install-dependencies-resolute
+#
+# Copyright (C) 2026 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+set -e
+
+platform_codename=$(lsb_release -sc)
+if [ $platform_codename != "resolute" ] ; then
+    echo Error: This script is only for use on Ubuntu Resolute
+    exit 1
+fi
+
+echo Installing RStudio dependencies for Ubuntu Resolute
+
+sudo apt-get update
+
+sudo apt-get -y install \
+  ant \
+  build-essential \
+  cmake \
+  clang \
+  curl \
+  debsigs \
+  expect \
+  fakeroot \
+  git \
+  gnupg1 \
+  jq \
+  libacl1-dev \
+  libattr1-dev \
+  libbz2-dev \
+  libcap-dev \
+  libclang-dev \
+  libcurl4-openssl-dev \
+  libfuse2 \
+  libgl1-mesa-dev \
+  libgtk-3-0 \
+  libpam-dev \
+  libpango1.0-dev \
+  libpq-dev \
+  libsqlite3-dev \
+  libssl-dev \
+  libuser1-dev \
+  libxslt1-dev \
+  lsof \
+  openjdk-17-jdk \
+  ninja-build \
+  p7zip-full \
+  patchelf \
+  pkg-config \
+  python3 \
+  python3-venv \
+  r-base-dev \
+  rrdtool \
+  software-properties-common \
+  unzip \
+  uuid-dev \
+  wget \
+  whois \
+  zlib1g-dev
+
+# overlay
+if [ -e install-overlay-common ]
+then
+  ./install-overlay-common
+fi
+
+# If on amd64 system, install gcc-multilib
+arch=$(dpkg --print-architecture)
+if [ $arch = "amd64" ] ; then
+  sudo apt-get -y install gcc-multilib
+fi
+
+# common
+cd ../common
+./install-common noble
+cd ../linux
+
+# Python packages for i18n
+if [ -x "$(command -v python3)" ]; then
+  pushd ../../src/gwt/tools/i18n-helpers
+  python3 -m venv VENV
+  ./VENV/bin/pip install --disable-pip-version-check -r commands.cmd.xml/requirements.txt
+  popd
+fi


### PR DESCRIPTION
## Intent

Adds the dependency install script for Ubuntu 26.04 LTS (Resolute), and improves the error message in `install-dependencies-debian` to include the name of the missing platform script when running on an unsupported Debian/Ubuntu release.