### PR TITLE
Restore desktop terminal bell on Linux

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - ([#17176](https://github.com/rstudio/rstudio/issues/17176)): Fixed a startup hang when opening a Quarto project containing large directories (e.g. `_targets/`).
 - ([#16067](https://github.com/rstudio/rstudio/issues/16067)): Raise the open file descriptor soft limit at session startup to avoid "Too many open files" errors during project file monitoring on Linux.
 - ([#17417](https://github.com/rstudio/rstudio/issues/17417)): Added missing French translations for newer commands and preferences, removed an orphaned French key, deduplicated stale entries in the French application strings, and normalized line endings in five English string files.
+- ([#16966](https://github.com/rstudio/rstudio/issues/16966)): Restored the desktop terminal bell on Linux, now that the underlying Electron crash has been fixed.
 
 ### Dependencies
 - Ace 1.43.5

--- a/dependencies/linux/install-dependencies-resolute
+++ b/dependencies/linux/install-dependencies-resolute
@@ -86,7 +86,7 @@ fi
 
 # common
 cd ../common
-./install-common noble
+./install-common resolute
 cd ../linux
 
 # Python packages for i18n

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -971,13 +971,7 @@ public class TerminalSession extends XTermWidget
     */
    private void playBell()
    {
-      if (BrowseCap.isLinuxDesktop())
-      {
-         // Avoid using desktop bell on Linux until https://github.com/rstudio/rstudio/issues/16966
-         // is resolved, which will require an Electron update.
-         playBellWeb();
-      }
-      else if (Desktop.isDesktop())
+      if (Desktop.isDesktop())
       {
          Desktop.getFrame().beep();
       }


### PR DESCRIPTION
## Intent

Addresses #16966.

## Summary

- Reverts the workaround in 693b1b9ff5 that routed the Linux desktop terminal bell through the web fallback. The underlying Electron crash is fixed in Electron 41, so `Desktop.getFrame().beep()` can be used on Linux desktop again.
- Also includes an unrelated tweak to `dependencies/linux/install-dependencies-resolute` so it passes `resolute` (not `noble`) to `install-common`.

## Test plan

- [ ] On Linux desktop, trigger the terminal bell (e.g. `printf '\a'` in the RStudio terminal) and confirm the system bell plays without crashing the IDE.
- [ ] On RStudio Server in a browser, confirm the synthesized web bell still plays.