### PR TITLE
Add main-branch guard to rstudio-update skills; add rstudio-update-quarto

### DIFF
--- a/.claude/skills/rstudio-update-copilot/SKILL.md
+++ b/.claude/skills/rstudio-update-copilot/SKILL.md
@@ -13,11 +13,21 @@ The user provides the **target copilot-language-server version** (e.g. `1.459.0`
 
 ## Steps
 
-### 1. Validate the version
+### 1. Verify starting branch
+
+Before doing anything else, confirm the current branch is `main`. This skill creates a new feature branch off the current branch, so starting off anything other than `main` would base the work on the wrong commit.
+
+```bash
+git branch --show-current
+```
+
+If the output is not `main`, **stop immediately** and warn the user that they must switch to `main` (and pull the latest) before re-running this skill. Do not proceed with any further steps.
+
+### 2. Validate the version
 
 Confirm the version argument matches the format `X.Y.Z` (digits and dots only). If it doesn't, ask the user to correct it before proceeding.
 
-### 2. Check prerequisites
+### 3. Check prerequisites
 
 Before modifying any files, verify that AWS credentials are in place. The upload script needs working AWS access, and discovering a credential problem after editing files wastes effort.
 
@@ -31,13 +41,13 @@ aws sts get-caller-identity
 
 If `aws` or `wget` is missing, tell the user to install it. If `aws sts get-caller-identity` fails, tell the user to configure AWS credentials (e.g. `aws sso login` or `aws configure sso` if SSO isn't set up yet) and try again.
 
-### 3. Create a branch
+### 4. Create a branch
 
 ```bash
 git checkout -b feature/update-copilot-language-server-<VERSION>
 ```
 
-### 4. Update version strings
+### 5. Update version strings
 
 Update `COPILOT_VERSION` in the following four files. Each file uses a slightly different syntax — match the existing pattern exactly.
 
@@ -73,7 +83,7 @@ set COPILOT_VERSION=<VERSION>
 
 After editing, verify all four files contain the new version string.
 
-### 5. Upload to S3
+### 6. Upload to S3
 
 Run the upload script, passing the new version as an argument. This downloads the release from GitHub and uploads it to the rstudio-buildtools S3 bucket.
 
@@ -83,7 +93,7 @@ bash dependencies/tools/upload-copilot-language-server.sh <VERSION>
 
 Confirm exit code 0 and the "Successfully uploaded" message. If it fails, report the error and stop.
 
-### 6. Verify the install
+### 7. Verify the install
 
 The default tools root (`/opt/rstudio-tools/...`) requires elevated privileges, so use a temporary directory to verify the S3 download without needing `sudo`.
 
@@ -97,7 +107,7 @@ Confirm exit code 0. The `trap` ensures the temp directory is cleaned up whether
 
 After verification, tell the user they will need to re-run `dependencies/common/install-copilot-language-server` themselves (with appropriate privileges) to install the new copilot-language-server into their dev environment.
 
-### 7. Commit and open a PR
+### 8. Commit and open a PR
 
 Commit the four modified files and open a pull request:
 

--- a/.claude/skills/rstudio-update-electron/SKILL.md
+++ b/.claude/skills/rstudio-update-electron/SKILL.md
@@ -13,7 +13,17 @@ The user provides the **target Electron version** (e.g. `39.8.4`).
 
 ## Steps
 
-### 1. Update `NEWS.md`
+### 1. Verify starting branch
+
+Before doing anything else, confirm the current branch is `main`. Starting off anything other than `main` would base the work on the wrong commit.
+
+```bash
+git branch --show-current
+```
+
+If the output is not `main`, **stop immediately** and warn the user that they must switch to `main` (and pull the latest) before re-running this skill. Do not proceed with any further steps.
+
+### 2. Update `NEWS.md`
 
 Find the `### Dependencies` section and update the Electron version line:
 
@@ -21,7 +31,7 @@ Find the `### Dependencies` section and update the Electron version line:
 - Electron <NEW_VERSION>
 ```
 
-### 2. Update `src/node/desktop/package.json` and lockfile
+### 3. Update `src/node/desktop/package.json` and lockfile
 
 Run from `src/node/desktop`:
 
@@ -39,7 +49,7 @@ After the install, verify that:
 
 The lockfile must be included in the commit — if it drifts from the manifest, `npm ci` in CI will fail.
 
-### 3. Run tests
+### 4. Run tests
 
 Run from `src/node/desktop`:
 
@@ -49,6 +59,6 @@ cd src/node/desktop && npm test
 
 Confirm the command exits successfully. If tests fail, report the failures and stop.
 
-### 4. Done
+### 5. Done
 
 Report that the Electron version has been updated and both `npm i` and `npm test` passed.

--- a/.claude/skills/rstudio-update-nodejs/SKILL.md
+++ b/.claude/skills/rstudio-update-nodejs/SKILL.md
@@ -26,11 +26,21 @@ Each version is a semver string like `22.14.0` (no `v` prefix).
 
 ## Steps
 
-### 1. Validate the version(s)
+### 1. Verify starting branch
+
+Before doing anything else, confirm the current branch is `main`. This skill creates a new feature branch off the current branch, so starting off anything other than `main` would base the work on the wrong commit.
+
+```bash
+git branch --show-current
+```
+
+If the output is not `main`, **stop immediately** and warn the user that they must switch to `main` (and pull the latest) before re-running this skill. Do not proceed with any further steps.
+
+### 2. Validate the version(s)
 
 Confirm each provided version matches the format `X.Y.Z` (digits and dots only). If any version doesn't match, ask the user to correct it before proceeding.
 
-### 2. Check prerequisites
+### 3. Check prerequisites
 
 Before modifying any files, verify that AWS credentials and required tools are in place. The upload script needs working AWS access, and discovering a credential problem after editing files wastes effort.
 
@@ -44,7 +54,7 @@ aws sts get-caller-identity
 
 If `aws` or `wget` is missing, tell the user to install it. If `aws sts get-caller-identity` fails, tell the user to configure AWS credentials (e.g. `aws sso login` or `aws configure sso` if SSO isn't set up yet) and try again.
 
-### 3. Create a branch
+### 4. Create a branch
 
 Use the following naming convention:
 
@@ -57,13 +67,13 @@ Use the following naming convention:
 git checkout -b <BRANCH_NAME>
 ```
 
-### 4. Update version strings
+### 5. Update version strings
 
 Each file uses a different syntax — match the existing pattern exactly. Only update files for the version(s) being changed.
 
 Before editing, note the current values of `RSTUDIO_NODE_VERSION` and `RSTUDIO_INSTALLED_NODE_VERSION` from `cmake/globals.cmake` so you can find-and-replace accurately.
 
-#### 4a. Build-time Node files (only if updating build)
+#### 5a. Build-time Node files (only if updating build)
 
 **`cmake/globals.cmake`** (~line 243) — CMake cache variable:
 ```cmake
@@ -103,7 +113,7 @@ set(RSTUDIO_NODE_VERSION "<VERSION>")
 "PATH": "${workspaceFolder}\\..\\..\\..\\dependencies\\common\\node\\<VERSION>;${env:PATH}"
 ```
 
-#### 4b. Installed Node files (only if updating installed)
+#### 5b. Installed Node files (only if updating installed)
 
 **`cmake/globals.cmake`** (~line 246) — CMake cache variable:
 ```cmake
@@ -133,7 +143,7 @@ The `v` prefix is required here and only here. All other files use the bare vers
 
 Build-time updates do NOT get a NEWS.md entry — only installed node does.
 
-#### 4c. Verify edits
+#### 5c. Verify edits
 
 Three files contain both versions (`cmake/globals.cmake`, `rstudio-tools.sh`, `rstudio-tools.cmd`). When updating both versions, take care not to cross-contaminate the two variables in these files.
 
@@ -148,13 +158,13 @@ Confirm:
 - Syntax matches each file's format (CMake quotes, bash quotes, batch no-quotes, XML attributes, JSON strings)
 - The `v` prefix appears ONLY in `upload-node.sh`
 
-### 5. Upload to S3
+### 6. Upload to S3
 
 Upload Node.js binaries for each unique new version using `dependencies/tools/upload-node.sh`. This script downloads platform archives from nodejs.org and uploads them to the `rstudio-buildtools` S3 bucket.
 
-The script reads its version from the hardcoded `NODE_VERSION` variable on line 13 (set in Step 4b for installed updates). The upload covers all platforms: darwin-arm64, darwin-x64, linux-arm64, linux-x64, win-x64, win-arm64.
+The script reads its version from the hardcoded `NODE_VERSION` variable on line 13 (set in Step 5b for installed updates). The upload covers all platforms: darwin-arm64, darwin-x64, linux-arm64, linux-x64, win-x64, win-arm64.
 
-**If updating installed** (or both to the same version): `upload-node.sh` already has the correct version from Step 4b. Run it:
+**If updating installed** (or both to the same version): `upload-node.sh` already has the correct version from Step 5b. Run it:
 
 ```bash
 bash dependencies/tools/upload-node.sh
@@ -162,7 +172,7 @@ bash dependencies/tools/upload-node.sh
 
 Confirm exit code 0.
 
-**If updating build only**: `upload-node.sh` wasn't edited in Step 4 (it tracks the installed version by convention). Temporarily edit it to `NODE_VERSION="v<BUILD_VERSION>"`, run it, then revert to the original installed value:
+**If updating build only**: `upload-node.sh` wasn't edited in Step 5 (it tracks the installed version by convention). Temporarily edit it to `NODE_VERSION="v<BUILD_VERSION>"`, run it, then revert to the original installed value:
 
 ```bash
 # Save the original value, set to build version, upload, restore
@@ -170,7 +180,7 @@ bash dependencies/tools/upload-node.sh
 git checkout dependencies/tools/upload-node.sh
 ```
 
-**If updating both to different versions**: `upload-node.sh` was set to the installed version in Step 4b. Upload the build version first (temporarily), then the installed version:
+**If updating both to different versions**: `upload-node.sh` was set to the installed version in Step 5b. Upload the build version first (temporarily), then the installed version:
 
 1. Edit `upload-node.sh` to `NODE_VERSION="v<BUILD_VERSION>"`
 2. Run `bash dependencies/tools/upload-node.sh` — confirm exit code 0
@@ -191,7 +201,7 @@ If both versions were uploaded and they differ, remove both:
 rm -f node-v<BUILD_VERSION>-* node-v<INSTALLED_VERSION>-*
 ```
 
-### 6. Verify the install
+### 7. Verify the install
 
 Run the dependency installer to confirm the S3 binaries download and extract correctly. The script must be run from `dependencies/common/` because it invokes `./install-node` and `./install-yarn` via relative paths. It installs into `dependencies/common/node/` which is gitignored.
 
@@ -218,7 +228,7 @@ bash install-npm-dependencies
 
 Confirm exit code 0. If the install fails, report the error and stop. This also installs the new Node.js locally for development use.
 
-### 7. Commit and open a PR
+### 8. Commit and open a PR
 
 Commit all modified files and open a pull request.
 

--- a/.claude/skills/rstudio-update-quarto/SKILL.md
+++ b/.claude/skills/rstudio-update-quarto/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: rstudio-update-quarto
+description: Use when updating the Quarto version in the RStudio repository, e.g. bumping to a new release. This skill is for macOS and Linux only.
+---
+
+# Update Quarto
+
+Updates the pinned Quarto version across the RStudio codebase, mirrors the new release into the rstudio-buildtools S3 bucket, verifies the install, and opens a PR.
+
+## Arguments
+
+The user provides the **target Quarto version** (e.g. `1.9.36`).
+
+## Steps
+
+### 1. Verify starting branch
+
+Before doing anything else, confirm the current branch is `main`. This skill creates a new feature branch off the current branch, so starting off anything other than `main` would base the work on the wrong commit.
+
+```bash
+git branch --show-current
+```
+
+If the output is not `main`, **stop immediately** and warn the user that they must switch to `main` (and pull the latest) before re-running this skill. Do not proceed with any further steps.
+
+### 2. Validate the version
+
+Confirm the version argument matches the format `X.Y.Z` (digits and dots only). If it doesn't, ask the user to correct it before proceeding.
+
+### 3. Check prerequisites
+
+Before modifying any files, verify that AWS credentials and required tools are in place. The upload script needs working AWS access, and discovering a credential problem after editing files wastes effort.
+
+Run these checks and stop if any fail:
+
+```bash
+command -v aws >/dev/null 2>&1 && echo "aws: ok" || echo "aws: MISSING"
+command -v wget >/dev/null 2>&1 && echo "wget: ok" || echo "wget: MISSING"
+aws sts get-caller-identity
+```
+
+If `aws` or `wget` is missing, tell the user to install it. If `aws sts get-caller-identity` fails, tell the user to configure AWS credentials (e.g. `aws sso login` or `aws configure sso` if SSO isn't set up yet) and try again.
+
+### 4. Create a branch
+
+```bash
+git checkout -b feature/update-quarto-<VERSION>
+```
+
+### 5. Update version strings
+
+Update the Quarto version in the following four files. Each file uses a slightly different syntax — match the existing pattern exactly.
+
+#### `NEWS.md`
+
+In the `### Dependencies` section, update the Quarto line:
+
+```
+- Quarto <VERSION>
+```
+
+#### `dependencies/tools/upload-quarto.sh`
+
+Bash assignment, no quotes:
+
+```bash
+QUARTO_VERSION=<VERSION>
+```
+
+Unlike the copilot upload script, `upload-quarto.sh` does not accept a CLI argument — it reads the version from this hardcoded value, so it must be updated before running the upload step.
+
+#### `dependencies/common/install-quarto`
+
+Bash assignment, no quotes:
+
+```bash
+QUARTO_VERSION=<VERSION>
+```
+
+#### `dependencies/windows/install-dependencies.cmd`
+
+Windows batch syntax, no quotes:
+
+```cmd
+set QUARTO_VERSION=<VERSION>
+```
+
+After editing, verify all four files contain the new version string.
+
+### 6. Upload to S3
+
+Run the upload script. It downloads release archives for all supported platforms (linux-amd64, linux-arm64, linux-rhel7-amd64, macos, win) from the Quarto GitHub releases page and copies each to the `rstudio-buildtools` S3 bucket.
+
+```bash
+bash dependencies/tools/upload-quarto.sh
+```
+
+Confirm exit code 0 and that every platform archive was uploaded. If any download or upload fails, report the error and stop.
+
+The upload script downloads each archive into the current working directory and does **not** clean up afterward, so remove the leftover archives once the upload succeeds:
+
+```bash
+rm -f quarto-<VERSION>-*
+```
+
+### 7. Verify the install
+
+The default tools root (`/opt/rstudio-tools/...`) requires elevated privileges, so use a temporary directory to verify the install without needing `sudo`.
+
+```bash
+VERIFY_DIR="$(mktemp -d)"
+trap 'rm -rf "$VERIFY_DIR"' EXIT
+RSTUDIO_TOOLS_ROOT="$VERIFY_DIR" bash dependencies/common/install-quarto
+```
+
+Confirm exit code 0. The install script checks the resulting `quarto --version` against the expected value, so a successful run end-to-end is meaningful verification that the new release is usable. The `trap` ensures the temp directory is cleaned up whether the install succeeds or fails. If the install fails, report the error and stop.
+
+After verification, tell the user they will need to re-run `dependencies/common/install-quarto` themselves (with appropriate privileges) to install the new Quarto into their dev environment.
+
+### 8. Commit and open a PR
+
+Commit the four modified files and open a pull request:
+
+- **Branch**: `feature/update-quarto-<VERSION>`
+- **Commit message**: `Update Quarto to <VERSION>`
+- **PR title**: `Update Quarto to <VERSION>`
+- **PR body**: mention the version bump and that the S3 upload and local install were verified


### PR DESCRIPTION
## Summary

- Add a Step 1 \"verify starting branch\" check to the `rstudio-update-copilot`, `rstudio-update-electron`, and `rstudio-update-nodejs` skills. Each skill now runs `git branch --show-current` first and stops with a warning if the current branch is not `main`, so the feature branch the skill creates is based on the right commit.
- Add a new `rstudio-update-quarto` skill that mirrors the `rstudio-update-copilot` flow for bumping the pinned Quarto version. It edits `NEWS.md` plus the three Quarto version pins (`dependencies/tools/upload-quarto.sh`, `dependencies/common/install-quarto`, `dependencies/windows/install-dependencies.cmd`), runs the S3 upload, verifies the install in a temp tools root, and opens a PR. The skill calls out Quarto-specific differences from the copilot script (no CLI version arg, no archive cleanup) and handles them.

## Test plan

- [ ] Invoke `rstudio-update-copilot` from a non-main branch and confirm it stops at Step 1 with a warning.
- [ ] Invoke `rstudio-update-electron` from a non-main branch and confirm it stops at Step 1 with a warning.
- [ ] Invoke `rstudio-update-nodejs` from a non-main branch and confirm it stops at Step 1 with a warning.
- [ ] Invoke `rstudio-update-quarto` for a real Quarto bump and verify the four files update, the S3 upload runs to completion, the install verification passes, and the PR is opened correctly.