### PR TITLE
rename CALLBACK for WinAPI compatibility

### DIFF
--- a/src/cpp/core/include/core/Algorithm.hpp
+++ b/src/cpp/core/include/core/Algorithm.hpp
@@ -295,9 +295,9 @@ inline std::string join(Iterator begin,
    return join(begin, end, delim, std::move(callback));
 }
 
-template <typename CALLBACK>
+template <typename VOID_FUNC>
 struct Defer {
-   explicit Defer(CALLBACK func) : func(std::move(func)) {}
+   explicit Defer(VOID_FUNC func) : func(std::move(func)) {}
    ~Defer() { func(); }
 
    Defer() = delete;
@@ -306,7 +306,7 @@ struct Defer {
    Defer& operator=(const Defer&) = delete;
    Defer& operator=(Defer&&) = delete;
 
-   CALLBACK func;
+   VOID_FUNC func;
 };
 
 } // namespace algorithm


### PR DESCRIPTION
### Intent

WinAPI uses `CALLBACK` as a macro, so this code causes build failures on Windows.

### Approach

Rename the template parameter to something safe.

### Automated Tests

We can't put Windows builds in CI because it would take too long, but this will be covered by normal nightlies.

### QA Notes

N/A

### Documentation

N/A.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


