### PR TITLE
make jenkins checkouts incremental

### DIFF
--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -69,14 +69,20 @@ pipeline {
         }
 
         stage("Checkout") {
-          when { expression { params.COMMIT_HASH != '' } }
-
+          // Always run so CleanBeforeCheckout (in gitCheckoutExtensions) is applied
+          // even when COMMIT_HASH is empty. When unset, fall back to the SCM-configured
+          // branch so the implicit checkout that populated this workspace is repeated
+          // with the standard extensions.
           steps {
-            echo "Commit_hash value: ${params.COMMIT_HASH}"
-            checkout([$class: 'GitSCM',
-                      branches: [[name: "${params.COMMIT_HASH}"]],
-                      extensions: utils.gitCheckoutExtensions(),
-                      userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL ]]])
+            script {
+              echo "Commit_hash value: ${params.COMMIT_HASH}"
+              def branches = params.COMMIT_HASH ? [[name: params.COMMIT_HASH]] : scm.branches
+              def remotes = params.COMMIT_HASH ? [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL]] : scm.userRemoteConfigs
+              checkout([$class: 'GitSCM',
+                        branches: branches,
+                        extensions: utils.gitCheckoutExtensions(),
+                        userRemoteConfigs: remotes])
+            }
           }
         }
 
@@ -185,13 +191,18 @@ pipeline {
 
             stages {
               stage('Checkout') {
-                when { expression { params.COMMIT_HASH != '' } }
                 steps {
-                  // We need to checkout the correct commit again here because the matrix builds run on different agents
-                  checkout([$class: 'GitSCM',
-                            branches: [[name: "${params.COMMIT_HASH}"]],
-                            extensions: utils.gitCheckoutExtensions(),
-                            userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL ]]])
+                  // Re-checkout on the matrix cell agent: when COMMIT_HASH is set, target
+                  // that commit; otherwise repeat the SCM checkout. Always run so
+                  // CleanBeforeCheckout resets untracked files between builds.
+                  script {
+                    def branches = params.COMMIT_HASH ? [[name: params.COMMIT_HASH]] : scm.branches
+                    def remotes = params.COMMIT_HASH ? [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL]] : scm.userRemoteConfigs
+                    checkout([$class: 'GitSCM',
+                              branches: branches,
+                              extensions: utils.gitCheckoutExtensions(),
+                              userRemoteConfigs: remotes])
+                  }
                 }
               }
 

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -75,7 +75,7 @@ pipeline {
             echo "Commit_hash value: ${params.COMMIT_HASH}"
             checkout([$class: 'GitSCM',
                       branches: [[name: "${params.COMMIT_HASH}"]],
-                      extensions: [],
+                      extensions: utils.gitCheckoutExtensions(),
                       userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL ]]])
           }
         }
@@ -190,7 +190,7 @@ pipeline {
                   // We need to checkout the correct commit again here because the matrix builds run on different agents
                   checkout([$class: 'GitSCM',
                             branches: [[name: "${params.COMMIT_HASH}"]],
-                            extensions: [],
+                            extensions: utils.gitCheckoutExtensions(),
                             userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL ]]])
                 }
               }
@@ -396,11 +396,6 @@ pipeline {
                 }
               }
             }
-            post {
-              always {
-                deleteDir()
-              }
-            }
           }
         }
       }
@@ -444,7 +439,6 @@ pipeline {
   post {
     always {
       node('linux') {
-        deleteDir()
         sendNotifications slack_channel: SLACK_CHANNEL
       }
     }

--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -63,7 +63,7 @@ pipeline {
           sleep(time: 5, unit: 'SECONDS')
           checkout([$class: 'GitSCM',
                     branches: [[name: "${params.COMMIT_HASH}"]],
-                    extensions: [],
+                    extensions: utils.gitCheckoutExtensions(),
                     userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: "${GIT_URL}"]]])
         }
       }
@@ -265,7 +265,6 @@ pipeline {
 
   post {
     always {
-      deleteDir()
       sendNotifications slack_channel: SLACK_CHANNEL
     }
   }

--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -55,16 +55,22 @@ pipeline {
     }
 
     stage ("Checkout") {
-      when { expression { params.COMMIT_HASH != '' } }
-
+      // Always run so CleanBeforeCheckout (in gitCheckoutExtensions) is applied
+      // even when COMMIT_HASH is empty. When unset, fall back to the SCM-configured
+      // branch so the implicit checkout that populated this workspace is repeated
+      // with the standard extensions.
       steps {
-        echo "Commit_hash value: ${params.COMMIT_HASH}"
-        retry(5) {
-          sleep(time: 5, unit: 'SECONDS')
-          checkout([$class: 'GitSCM',
-                    branches: [[name: "${params.COMMIT_HASH}"]],
-                    extensions: utils.gitCheckoutExtensions(),
-                    userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: "${GIT_URL}"]]])
+        script {
+          echo "Commit_hash value: ${params.COMMIT_HASH}"
+          def branches = params.COMMIT_HASH ? [[name: params.COMMIT_HASH]] : scm.branches
+          def remotes = params.COMMIT_HASH ? [[credentialsId: 'posit-jenkins-rstudio', url: "${GIT_URL}"]] : scm.userRemoteConfigs
+          retry(5) {
+            sleep(time: 5, unit: 'SECONDS')
+            checkout([$class: 'GitSCM',
+                      branches: branches,
+                      extensions: utils.gitCheckoutExtensions(),
+                      userRemoteConfigs: remotes])
+          }
         }
       }
     }

--- a/jenkins/Jenkinsfile.pull-request
+++ b/jenkins/Jenkinsfile.pull-request
@@ -49,7 +49,7 @@ pipeline {
           $class: 'GitSCM',
           branches: scm.branches,
           doGenerateSubmoduleConfigurations: true,
-          extensions: scm.extensions + [[$class: 'SubmoduleOption', parentCredentials: true]],
+          extensions: scm.extensions + utils.gitCheckoutExtensions() + [[$class: 'SubmoduleOption', parentCredentials: true]],
           userRemoteConfigs: scm.userRemoteConfigs])
       }
     }

--- a/jenkins/Jenkinsfile.pull-request-build
+++ b/jenkins/Jenkinsfile.pull-request-build
@@ -64,7 +64,7 @@ pipeline {
           $class: 'GitSCM',
           branches: scm.branches,
           doGenerateSubmoduleConfigurations: true,
-          extensions: scm.extensions + [[$class: 'SubmoduleOption', parentCredentials: true]],
+          extensions: scm.extensions + utils.gitCheckoutExtensions() + [[$class: 'SubmoduleOption', parentCredentials: true]],
           userRemoteConfigs: scm.userRemoteConfigs])
       }
     }

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -62,7 +62,7 @@ pipeline {
           steps {
             checkout([$class: 'GitSCM',
               branches: [[name: params.COMMIT_HASH]],
-              extensions: [],
+              extensions: utils.gitCheckoutExtensions(),
               userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL]]])
           }
         }
@@ -88,11 +88,6 @@ pipeline {
               // SHOULD_REBUILD = utils.rebuildCheck()
             }
           }
-        }
-      }
-      post {
-        always {
-          deleteDir()
         }
       }
     }
@@ -126,7 +121,7 @@ pipeline {
           steps {
             checkout([$class: 'GitSCM',
               branches: [[name: params.COMMIT_HASH]],
-              extensions: [],
+              extensions: utils.gitCheckoutExtensions(),
               userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL]]])
           }
         }
@@ -313,12 +308,6 @@ pipeline {
         // Also depends on flavor, so must be in the matrix
         script {
           utils.updateDailyRedirects "${AWS_PATH}/${PACKAGE_NAME}.exe"
-        }
-      }
-
-      post {
-        always {
-          deleteDir()
         }
       }
     } // stage ("Upload Daily Build Redirects")

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -58,12 +58,17 @@ pipeline {
         }
 
         stage ('Checkout') { // checkout stage required here in order for versioning to work properly
-          when { expression { params.COMMIT_HASH != '' } }
+          // Always run so CleanBeforeCheckout (in gitCheckoutExtensions) is applied
+          // even when COMMIT_HASH is empty.
           steps {
-            checkout([$class: 'GitSCM',
-              branches: [[name: params.COMMIT_HASH]],
-              extensions: utils.gitCheckoutExtensions(),
-              userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL]]])
+            script {
+              def branches = params.COMMIT_HASH ? [[name: params.COMMIT_HASH]] : scm.branches
+              def remotes = params.COMMIT_HASH ? [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL]] : scm.userRemoteConfigs
+              checkout([$class: 'GitSCM',
+                branches: branches,
+                extensions: utils.gitCheckoutExtensions(),
+                userRemoteConfigs: remotes])
+            }
           }
         }
 
@@ -117,12 +122,18 @@ pipeline {
 
       stages {
         stage ('Checkout') {
-          when { expression { params.COMMIT_HASH != '' } }
+          // Always run so CleanBeforeCheckout (in gitCheckoutExtensions) is applied
+          // even when COMMIT_HASH is empty. The Windows agent's workspace is reused
+          // across builds by customWorkspace; this ensures untracked files are reset.
           steps {
-            checkout([$class: 'GitSCM',
-              branches: [[name: params.COMMIT_HASH]],
-              extensions: utils.gitCheckoutExtensions(),
-              userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL]]])
+            script {
+              def branches = params.COMMIT_HASH ? [[name: params.COMMIT_HASH]] : scm.branches
+              def remotes = params.COMMIT_HASH ? [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL]] : scm.userRemoteConfigs
+              checkout([$class: 'GitSCM',
+                branches: branches,
+                extensions: utils.gitCheckoutExtensions(),
+                userRemoteConfigs: remotes])
+            }
           }
         }
 

--- a/jenkins/utils.groovy
+++ b/jenkins/utils.groovy
@@ -749,4 +749,28 @@ void ensureFullCommitHistory() {
   }
 }
 
+/**
+  * Returns the standard list of GitSCM extensions used for checkout calls.
+  *
+  * - CloneOption with noTags (the build does not depend on git tags) and an
+  *   optional reference repo. When env.GIT_REFERENCE_REPO is set on the agent,
+  *   initial clones reuse objects from that bare clone so only missing objects
+  *   are fetched over the network.
+  * - CleanBeforeCheckout so each checkout resets untracked files before
+  *   fetching, allowing .git to persist across builds (the next fetch is then
+  *   incremental) while still starting each build from a clean tree.
+  *
+  * To enable the cache, set GIT_REFERENCE_REPO on each agent (e.g.
+  * /var/cache/git/rstudio.git) to a periodically-updated bare clone of the
+  * repository. If unset, this returns extensions that still benefit from
+  * noTags and CleanBeforeCheckout.
+  */
+def gitCheckoutExtensions() {
+  def cloneOpts = [$class: 'CloneOption', noTags: true, timeout: 30]
+  if (env.GIT_REFERENCE_REPO) {
+    cloneOpts['reference'] = env.GIT_REFERENCE_REPO
+  }
+  return [cloneOpts, [$class: 'CleanBeforeCheckout']]
+}
+
 return this


### PR DESCRIPTION
## Summary

- Add `gitCheckoutExtensions()` helper in `jenkins/utils.groovy` and use it from every explicit `checkout()` call in the Jenkinsfiles. The helper sets `CloneOption(noTags: true, reference: env.GIT_REFERENCE_REPO)` plus `CleanBeforeCheckout`, so initial clones can reuse objects from a per-agent cache and subsequent builds do incremental `git fetch` over a persistent `.git` dir.
- Drop the post-block `deleteDir()` calls in `Jenkinsfile.linux`, `Jenkinsfile.macos`, and `Jenkinsfile.windows` so the workspace (and `.git`) survives between builds. `CleanBeforeCheckout` still resets the working tree to a clean state on the next checkout, so each build starts from the same baseline as before.

## Notes for deployment

- To get the full benefit, set `GIT_REFERENCE_REPO` on each agent (e.g. `/var/cache/git/rstudio.git`) to a bare clone that is periodically refreshed. Until that's in place, `noTags` and `CleanBeforeCheckout` already help.
- Multibranch pipelines do an implicit checkout before `Load Utils` runs, so these settings should also be mirrored in the Jenkins job config (Branch Sources → Behaviors → Advanced clone behaviors → reference repo + noTags) for the very first checkout of each build.

## Test plan

- [ ] Verify a Jenkins PR build (`Jenkinsfile.pull-request-build`) passes end-to-end.
- [ ] Verify an hourly/daily Linux build (`Jenkinsfile.linux`) passes end-to-end including matrix cells.
- [ ] Verify a macOS build passes end-to-end.
- [ ] Verify a Windows build passes end-to-end (both the linux versioning stage and the windows build stage).
- [ ] On a build machine where `GIT_REFERENCE_REPO` is set, confirm Jenkins logs show `Using reference repository` during the checkout step and that the second build of the same branch is noticeably faster.
- [ ] On a build machine where `GIT_REFERENCE_REPO` is unset, confirm checkouts still succeed (the `reference` field is simply omitted).
- [ ] Confirm the `version/RELEASE`-driven build version is still computed correctly (no tag dependency).