### PR TITLE
enable mathjax safe extension to block javascript: hrefs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,7 @@
 
 ### Fixed
 - 
-- Enabled the MathJax `Safe` extension in the IDE, the HTML preview, the presentation preview, and the rendered R Markdown viewer. This neutralizes unsafe TeX commands (e.g. `\href` to a `javascript:` URI) that an `.Rmd` file could otherwise use to run script in the IDE's same-origin context.
+- ([#17508](https://github.com/rstudio/rstudio/issues/17508)): Enabled the MathJax `Safe` extension in the IDE, the HTML preview, the presentation preview, and the rendered R Markdown viewer.
 - ([rstudio/rstudio-pro#10805](https://github.com/rstudio/rstudio-pro/issues/10805)): Server: Enable TCP keepalive on accepted connections so the operating system reaps half-open sockets from disappeared clients (browser tab hibernation, NAT timeouts) instead of holding them indefinitely.
 - ([#12235](https://github.com/rstudio/rstudio/issues/12235)): RStudio Desktop's Session > New Session now opens noticeably faster.
 - ([#17440](https://github.com/rstudio/rstudio/issues/17440)): Fixed an issue where triggering tab completion inside `[` on a large Matrix-package sparse matrix could hang RStudio and exhaust system memory

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 - 
+- Enabled the MathJax `Safe` extension in the IDE, the HTML preview, the presentation preview, and the rendered R Markdown viewer. This neutralizes unsafe TeX commands (e.g. `\href` to a `javascript:` URI) that an `.Rmd` file could otherwise use to run script in the IDE's same-origin context.
 - ([rstudio/rstudio-pro#10805](https://github.com/rstudio/rstudio-pro/issues/10805)): Server: Enable TCP keepalive on accepted connections so the operating system reaps half-open sockets from disappeared clients (browser tab hibernation, NAT timeouts) instead of holding them indefinitely.
 - ([#12235](https://github.com/rstudio/rstudio/issues/12235)): RStudio Desktop's Session > New Session now opens noticeably faster.
 - ([#17440](https://github.com/rstudio/rstudio/issues/17440)): Fixed an issue where triggering tab completion inside `[` on a large Matrix-package sparse matrix could hang RStudio and exhaust system memory

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -68,6 +68,15 @@
 #define kMathjaxSegment "mathjax"
 #define kMathjaxBeginComment "<!-- dynamically load mathjax"
 
+// Enables the MathJax Safe extension, which neutralizes unsafe TeX commands
+// (e.g. \href to a javascript: URI, dangerous CSS in \style) when rendering
+// user-authored math. Required because rendered Rmd output is loaded into the
+// IDE's same-origin Viewer pane.
+#define kMathjaxSafeConfigScript \
+   "<script type=\"text/x-mathjax-config\">" \
+   "MathJax.Hub.Config({ extensions: [\"Safe.js\"] });" \
+   "</script>"
+
 #define kStandardRenderFunc "rmarkdown::render"
 #define kShinyRenderFunc "rmarkdown::run"
 
@@ -1077,17 +1086,17 @@ private:
       }
       else if (match[0] == kMathjaxBeginComment)
       {
-         // we found the start of the MathJax section; add the MathJax config
-         // block if we're in a configuration that requires it
-#if defined(_WIN32)
-         if (session::options().programMode() != kSessionProgramModeDesktop)
-            return match[0];
+         // we found the start of the MathJax section; emit a config block to
+         // load the Safe extension before MathJax processes the page
+         result.append(kMathjaxSafeConfigScript "\n");
 
-         result.append(kQtMathJaxConfigScript "\n");
-         result.append(match[0]);
-#else
-         return match[0];
+#if defined(_WIN32)
+         // on Windows desktop also add the QtWebEngine-specific config block
+         if (session::options().programMode() == kSessionProgramModeDesktop)
+            result.append(kQtMathJaxConfigScript "\n");
 #endif
+
+         result.append(match[0]);
       }
       else if (hasMathjax_)
       {

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -70,8 +70,9 @@
 
 // Enables the MathJax Safe extension, which neutralizes unsafe TeX commands
 // (e.g. \href to a javascript: URI, dangerous CSS in \style) when rendering
-// user-authored math. Required because rendered Rmd output is loaded into the
-// IDE's same-origin Viewer pane.
+// user-authored math. Required for rendered Rmd output because it is loaded
+// into IDE-controlled web views (the Viewer pane, the HTML preview, and the
+// presentation preview) that share the IDE's same-origin context.
 #define kMathjaxSafeConfigScript \
    "<script type=\"text/x-mathjax-config\">" \
    "MathJax.Hub.Config({ extensions: [\"Safe.js\"] });" \
@@ -1091,7 +1092,8 @@ private:
          result.append(kMathjaxSafeConfigScript "\n");
 
 #if defined(_WIN32)
-         // on Windows desktop also add the QtWebEngine-specific config block
+         // on Windows desktop, also tweak HTML-CSS rendering (font scaling +
+         // disable web fonts) to work around QtWebEngine rendering quirks
          if (session::options().programMode() == kSessionProgramModeDesktop)
             result.append(kQtMathJaxConfigScript "\n");
 #endif

--- a/src/cpp/session/resources/mathjax.html
+++ b/src/cpp/session/resources/mathjax.html
@@ -1,4 +1,9 @@
 <!-- MathJax scripts -->
+<script type="text/x-mathjax-config">
+  MathJax.Hub.Config({
+    extensions: ["Safe.js"]
+  });
+</script>
 <script type="text/javascript" src="https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 

--- a/src/cpp/session/resources/presentation/mathjax.html
+++ b/src/cpp/session/resources/presentation/mathjax.html
@@ -1,5 +1,6 @@
 <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
+    extensions: ["Safe.js"],
     showProcessingMessages: false,
     messageStyle: "none"
   });

--- a/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxLoader.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxLoader.java
@@ -99,7 +99,7 @@ public class MathJaxLoader
          return;
 
       $wnd.MathJax = {
-         extensions: ['tex2jax.js'],
+         extensions: ['tex2jax.js', 'Safe.js'],
          jax: ['input/TeX', 'output/HTML-CSS'],
          tex2jax: {
             inlineMath:  [['$', '$'], ['\\(', '\\)']],


### PR DESCRIPTION
## Intent

Addresses an internal security report: MathJax 2.7.9 ships in RStudio without the `Safe` extension, so `\href{javascript:...}{...}` inside a `.Rmd` file produces a clickable anchor in the IDE's same-origin DOM. A user clicking that link runs attacker JavaScript in the session origin, which can then call any RPC the user is authorized to call (including code execution).

## Summary

- Add `Safe.js` to the IDE's MathJax extensions list (`MathJaxLoader.java`). Covers the visual editor and the source-mode inline math preview.
- Inject a `text/x-mathjax-config` block enabling Safe in `mathjax.html` (HTML preview) and `presentation/mathjax.html` (slide preview).
- Inject the same block in `MathjaxFilter::substitute` whenever the rmarkdown loader marker is rewritten, so rendered Rmd output served by the session also runs Safe. Refactored the existing Windows-desktop-only `kQtMathJaxConfigScript` injection so the two config blocks coexist cleanly.

The Viewer pane's iframe is unsandboxed for local URLs (`ViewerPane.java:454-456`), so HTML preview / presentation / rendered Rmd all share the IDE origin and need the same treatment as the IDE itself.

## Test plan

- [ ] Open an `.Rmd` containing `$\href{javascript:alert(1)}{x}$` in the visual editor: rendered link's `href` should be empty (Safe strips it); clicking does nothing.
- [ ] Same payload with the source-mode inline math preview enabled.
- [ ] Knit the `.Rmd` to HTML and verify the rendered Viewer iframe is also neutralized.
- [ ] Render an `.Rpres` with the same payload and view in the Presentation pane.
- [ ] Sanity check: ordinary math (`$\frac{1}{2}$`, AMS environments, `\boxed`, etc.) still renders normally in all four contexts.