### PR TITLE
encode user-provided strings in data import preview/import code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,8 +21,7 @@
 
 ### Fixed
 - 
-- Data Import: column names from imported files are now properly escaped when generating preview and import code.
-- ([#17510](https://github.com/rstudio/rstudio/issues/17510)): Data Import: character options, locale values, and import URLs are now encoded as R string literals when generating preview and import code, matching the column-name treatment.
+- ([#17510](https://github.com/rstudio/rstudio/issues/17510)): Data Import: column names, character options, locale values, and import URLs are now encoded as R string literals when generating preview and import code.
 - ([rstudio/rstudio-pro#10805](https://github.com/rstudio/rstudio-pro/issues/10805)): Server: Enable TCP keepalive on accepted connections so the operating system reaps half-open sockets from disappeared clients (browser tab hibernation, NAT timeouts) instead of holding them indefinitely.
 - ([#12235](https://github.com/rstudio/rstudio/issues/12235)): RStudio Desktop's Session > New Session now opens noticeably faster.
 - ([#17440](https://github.com/rstudio/rstudio/issues/17440)): Fixed an issue where triggering tab completion inside `[` on a large Matrix-package sparse matrix could hang RStudio and exhaust system memory

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 ### Fixed
 - 
 - Data Import: column names from imported files are now properly escaped when generating preview and import code.
+- ([#17510](https://github.com/rstudio/rstudio/issues/17510)): Data Import: character options, locale values, and import URLs are now encoded as R string literals when generating preview and import code, matching the column-name treatment.
 - ([rstudio/rstudio-pro#10805](https://github.com/rstudio/rstudio-pro/issues/10805)): Server: Enable TCP keepalive on accepted connections so the operating system reaps half-open sockets from disappeared clients (browser tab hibernation, NAT timeouts) instead of holding them indefinitely.
 - ([#12235](https://github.com/rstudio/rstudio/issues/12235)): RStudio Desktop's Session > New Session now opens noticeably faster.
 - ([#17440](https://github.com/rstudio/rstudio/issues/17440)): Fixed an issue where triggering tab completion inside `[` on a large Matrix-package sparse matrix could hang RStudio and exhaust system memory

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 - 
+- Data Import: column names from imported files are now properly escaped when generating preview and import code.
 - ([rstudio/rstudio-pro#10805](https://github.com/rstudio/rstudio-pro/issues/10805)): Server: Enable TCP keepalive on accepted connections so the operating system reaps half-open sockets from disappeared clients (browser tab hibernation, NAT timeouts) instead of holding them indefinitely.
 - ([#12235](https://github.com/rstudio/rstudio/issues/12235)): RStudio Desktop's Session > New Session now opens noticeably faster.
 - ([#17440](https://github.com/rstudio/rstudio/issues/17440)): Fixed an issue where triggering tab completion inside `[` on a large Matrix-package sparse matrix could hang RStudio and exhaust system memory

--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -80,9 +80,7 @@
 
       switch(optionType,
          "character" = {
-            optionValue <- gsub("\\", "\\\\", optionValue, fixed = TRUE)
-            optionValue <- gsub("\"", "\\\"", optionValue, fixed = TRUE)
-            return (paste("\"", optionValue, "\"", sep = ""))
+            return (encodeString(optionValue, quote = "\""))
          },
          "locale" = {
             localeDefaults <- formals(readr::locale)
@@ -90,7 +88,11 @@
             localeOrNull <- function(paramName, jsonName) {
                if (!identical(localeDefaults[[paramName]], optionValue[[jsonName]])) {
                   if (typeof(localeDefaults[[paramName]]) == "character") {
-                     paste(paramName, " = \"", optionValue[[jsonName]], "\"", sep = "")
+                     sprintf(
+                        "%s = %s",
+                        paramName,
+                        encodeString(optionValue[[jsonName]], quote = "\"")
+                     )
                   }
                   else {
                      paste(paramName, " = ", optionValue[[jsonName]])
@@ -342,25 +344,25 @@
 
          cacheDataCode <- append(
             cacheDataCode,
-            paste(
+            sprintf(
+               "%s <- %s",
                cacheUrlName,
-               " <- \"",
-               downloadResource,
-               "\"",
-               sep = "")
+               encodeString(downloadResource, quote = "\"")
+            )
          )
 
          if (cacheDataWorkingDir)
          {
             cacheDataCode <- append(
                cacheDataCode,
-               paste(
+               sprintf(
+                  "%s <- %s",
                   cacheVariableName,
-                  " <- \"",
-                  options$dataName,
-                  resourceExtension,
-                  "\"",
-                  sep = "")
+                  encodeString(
+                     paste(options$dataName, resourceExtension, sep = ""),
+                     quote = "\""
+                  )
+               )
             )
          }
          else
@@ -375,7 +377,11 @@
 
             cacheDataCode <- append(
                cacheDataCode,
-               paste(cacheVariableName, " <- \"", localFile, "\"", sep = "")
+               sprintf(
+                  "%s <- %s",
+                  cacheVariableName,
+                  encodeString(localFile, quote = "\"")
+               )
             )
          }
 

--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -143,7 +143,13 @@
                      }
                      else
                      {
-                        parseString <- paste("format = \"", col_parseString, "\"", sep = "")
+                        # Same trust-boundary concern as col_name above: encode
+                        # as an R string literal before splicing into code that
+                        # will be eval(parse())'d.
+                        parseString <- sprintf(
+                           "format = %s",
+                           encodeString(col_parseString, quote = "\"")
+                        )
                      }
                   }
 

--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -124,6 +124,11 @@
                col_assignedType <- col$assignedType[[1]]
                col_name <- col$name[[1]]
 
+               # Column names originate from the file being imported and so
+               # cannot be trusted; encode as an R string literal before
+               # interpolating into code that will be eval(parse())'d.
+               col_name_literal <- encodeString(col_name, quote = "\"")
+
                if ((!identical(dataImportOptions$columnsOnly, TRUE) && !identical(col_assignedType, NULL)) || 
                   identical(col_only, TRUE))
                {
@@ -159,7 +164,7 @@
                      )
                   }
 
-                  colParams[[col_name]] <- paste("\"", col_name, "\" = ", colType, sep="")
+                  colParams[[col_name]] <- paste(col_name_literal, " = ", colType, sep="")
                }
             }
 

--- a/src/cpp/tests/testthat/test-data-import.R
+++ b/src/cpp/tests/testthat/test-data-import.R
@@ -1,0 +1,59 @@
+#
+# test-data-import.R
+#
+# Copyright (C) 2026 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+context("data import")
+
+test_that("assembleDataImport escapes column names against R code injection", {
+   skip_if_not_installed("readr")
+
+   # A column name containing R syntax that would, without escaping, close the
+   # cols() argument and inject a top-level call.
+   evil <- 'foo"); .rs.injection.sentinel <- TRUE; readr::cols("'
+
+   opts <- list(
+      mode = "text",
+      importLocation = "data.csv",
+      delimiter = ",",
+      columnDefinitions = list(
+         list(
+            name = evil,
+            assignedType = "character",
+            only = NULL,
+            parseString = NULL,
+            index = 0,
+            rType = "character"
+         )
+      ),
+      openDataViewer = FALSE
+   )
+
+   info <- .rs.assembleDataImport(opts)
+
+   # The assembled previewCode must parse as a single top-level expression.
+   # If the column name escapes the cols() argument, parse() yields multiple
+   # expressions instead.
+   parsed <- parse(text = info$previewCode)
+   expect_length(parsed, 1L)
+
+   # The single expression must be a call to readr::read_csv.
+   expect_equal(as.character(parsed[[1L]][[1L]]), c("::", "readr", "read_csv"))
+
+   # The column name should round-trip: the col_types argument should contain
+   # one named slot whose name equals the original (unescaped) malicious string.
+   call <- parsed[[1L]]
+   col_types <- call$col_types
+   expect_false(is.null(col_types))
+   expect_equal(names(eval(col_types)$cols), evil)
+})

--- a/src/cpp/tests/testthat/test-data-import.R
+++ b/src/cpp/tests/testthat/test-data-import.R
@@ -18,42 +18,51 @@ context("data import")
 test_that("assembleDataImport escapes column names against R code injection", {
    skip_if_not_installed("readr")
 
-   # A column name containing R syntax that would, without escaping, close the
-   # cols() argument and inject a top-level call.
-   evil <- 'foo"); .rs.injection.sentinel <- TRUE; readr::cols("'
-
-   opts <- list(
-      mode = "text",
-      importLocation = "data.csv",
-      delimiter = ",",
-      columnDefinitions = list(
-         list(
-            name = evil,
-            assignedType = "character",
-            only = NULL,
-            parseString = NULL,
-            index = 0,
-            rType = "character"
-         )
-      ),
-      openDataViewer = FALSE
+   # Each entry is a column name that, without escaping, would either escape
+   # the cols() argument and inject a top-level call (the quote/paren case),
+   # or break parse() outright (the backslash/newline cases).
+   evilNames <- list(
+      injection = 'foo"); .rs.injection.sentinel <- TRUE; readr::cols("',
+      backslash = 'foo\\bar',
+      newline   = 'foo\nbar'
    )
 
-   info <- .rs.assembleDataImport(opts)
+   for (evil in evilNames)
+   {
+      opts <- list(
+         mode = "text",
+         importLocation = "data.csv",
+         delimiter = ",",
+         columnDefinitions = list(
+            list(
+               name = evil,
+               assignedType = "character",
+               only = NULL,
+               parseString = NULL,
+               index = 0,
+               rType = "character"
+            )
+         ),
+         openDataViewer = FALSE
+      )
 
-   # The assembled previewCode must parse as a single top-level expression.
-   # If the column name escapes the cols() argument, parse() yields multiple
-   # expressions instead.
-   parsed <- parse(text = info$previewCode)
-   expect_length(parsed, 1L)
+      info <- .rs.assembleDataImport(opts)
 
-   # The single expression must be a call to readr::read_csv.
-   expect_equal(as.character(parsed[[1L]][[1L]]), c("::", "readr", "read_csv"))
+      # The assembled previewCode must parse as a single top-level expression.
+      # If the column name escapes the cols() argument, parse() yields multiple
+      # expressions instead.
+      parsed <- parse(text = info$previewCode)
+      expect_length(parsed, 1L)
 
-   # The column name should round-trip: the col_types argument should contain
-   # one named slot whose name equals the original (unescaped) malicious string.
-   call <- parsed[[1L]]
-   col_types <- call$col_types
-   expect_false(is.null(col_types))
-   expect_equal(names(eval(col_types)$cols), evil)
+      # The single expression must be a call to readr::read_csv. R deparses
+      # readr::read_csv as a 3-element call object: `::`, `readr`, `read_csv`.
+      expect_equal(as.character(parsed[[1L]][[1L]]), c("::", "readr", "read_csv"))
+
+      # The column name should round-trip: the col_types argument should contain
+      # one named slot whose name equals the original (unescaped) malicious string.
+      call <- parsed[[1L]]
+      col_types <- call$col_types
+      expect_false(is.null(col_types))
+      expect_equal(names(eval(col_types)$cols), evil)
+   }
 })

--- a/src/cpp/tests/testthat/test-data-import.R
+++ b/src/cpp/tests/testthat/test-data-import.R
@@ -66,3 +66,110 @@ test_that("assembleDataImport escapes column names against R code injection", {
       expect_equal(names(eval(col_types)$cols), evil)
    }
 })
+
+test_that("assembleDataImport escapes character option values", {
+   skip_if_not_installed("readr")
+
+   # Same shape of test as the column-name case, but exercising the
+   # "character" option-type path used for read_csv arguments such as `na`.
+   evilValues <- list(
+      injection = 'NA"); .rs.injection.sentinel <- TRUE; c("',
+      backslash = 'na\\sentinel',
+      newline   = 'na\nsentinel'
+   )
+
+   for (evil in evilValues)
+   {
+      opts <- list(
+         mode = "text",
+         importLocation = "data.csv",
+         delimiter = ",",
+         na = evil,
+         openDataViewer = FALSE
+      )
+
+      info <- .rs.assembleDataImport(opts)
+
+      parsed <- parse(text = info$previewCode)
+      expect_length(parsed, 1L)
+      expect_equal(as.character(parsed[[1L]][[1L]]), c("::", "readr", "read_csv"))
+
+      # The na argument should round-trip to the original (unescaped) string.
+      expect_equal(parsed[[1L]]$na, evil)
+   }
+})
+
+test_that("assembleDataImport escapes locale option values", {
+   skip_if_not_installed("readr")
+
+   # Locale values reach the generated code via the "locale" option-type
+   # branch, which formerly pasted the value into "..." with no escaping.
+   evil <- 'UTC"); .rs.injection.sentinel <- TRUE; readr::locale("'
+
+   opts <- list(
+      mode = "text",
+      importLocation = "data.csv",
+      delimiter = ",",
+      locale = list(
+         dateName     = "en",
+         dateFormat   = "%AD",
+         timeFormat   = "%AT",
+         decimalMark  = ".",
+         groupingMark = ",",
+         tz           = evil,
+         encoding     = "UTF-8",
+         asciify      = FALSE
+      ),
+      openDataViewer = FALSE
+   )
+
+   info <- .rs.assembleDataImport(opts)
+
+   parsed <- parse(text = info$previewCode)
+   expect_length(parsed, 1L)
+
+   # The malicious tz value should round-trip in the parsed locale() call.
+   # We inspect the AST rather than eval() since readr::locale validates
+   # tz strings against the system tz database.
+   localeCall <- parsed[[1L]]$locale
+   expect_false(is.null(localeCall))
+   expect_equal(localeCall$tz, evil)
+})
+
+test_that("assembleDataImport escapes import URLs in cache code", {
+   skip_if_not_installed("readr")
+
+   # When canCacheData is TRUE and importLocation is a URL, the assembled
+   # importCode includes assignments such as `url <- "<importLocation>"`.
+   # The URL must be encoded as an R string literal.
+   evilUrl <- 'https://example.com/"); .rs.injection.sentinel <- TRUE; x <- c("data.csv'
+
+   opts <- list(
+      mode = "text",
+      importLocation = evilUrl,
+      delimiter = ",",
+      canCacheData = TRUE,
+      openDataViewer = FALSE
+   )
+
+   info <- .rs.assembleDataImport(opts)
+
+   # importCode must parse as a sequence of top-level expressions; if the URL
+   # escapes its string literal, parse() will reject the input.
+   parsed <- parse(text = info$importCode)
+   expect_gt(length(parsed), 0L)
+
+   # Locate the `url <- "..."` assignment and confirm it round-trips.
+   urlValue <- NULL
+   for (expr in as.list(parsed))
+   {
+      if (is.call(expr) && identical(as.character(expr[[1L]]), "<-") &&
+          identical(as.character(expr[[2L]]), "url"))
+      {
+         urlValue <- expr[[3L]]
+         break
+      }
+   }
+   expect_false(is.null(urlValue))
+   expect_equal(urlValue, evilUrl)
+})


### PR DESCRIPTION
## Intent

Addresses #17510.

## Summary

`assembleDataImport()` and its helpers build R source code by string concatenation, then later pass that source through `eval(parse())`. Several inputs to that pipeline -- column names, column parse formats, character options, locale option values, and import URLs -- originate outside the session and were spliced in via hand-rolled `paste("\"", x, "\"", ...)` (or no escaping at all). Values that contained R-syntactically-significant characters (`"`, `\`, newlines, control chars) could either break parsing or, in the column-name and import-URL cases, inject a top-level call.

This PR routes every such value through `encodeString(x, quote = "\"")` before splicing, in `src/cpp/session/modules/SessionDataImportV2.R`:

- Column names (`columnDefinitionsReadR` branch).
- `format = "..."` strings for `col_date()` / `col_time()` / `col_datetime()` (the `levels = ...` factor branch is intentionally left alone -- it splices raw R code, not a string literal).
- `"character"` option-type branch (e.g. `na`, `delim`, `quote`, `comment`).
- `"locale"` option-type branch (character-typed `locale()` arguments such as `tz`, `encoding`).
- `cacheUrlName <- "<url>"`, `cacheVariableName <- "<dataName + ext>"`, and `cacheVariableName <- "<localFile>"` in `cacheCodeFromOptions`.

Adds regression tests in `src/cpp/tests/testthat/test-data-import.R` that exercise quote/paren injection, embedded backslash, and embedded newline values across column names, character options, locale values, and import URLs.

## Test plan

- [x] `./rstudio-tests --scope r --filter test-data-import` passes.
- [ ] Open the Import Dataset dialog (text mode) on a CSV whose header / `na` strings / import URL contains characters such as `"`, `\`, or newlines, and confirm the generated preview/import code is syntactically valid and the values round-trip into the imported data.