### PR TITLE
encode character/locale/url values in data import code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,8 +21,7 @@
 
 ### Fixed
 - 
-- Data Import: column names from imported files are now properly escaped when generating preview and import code.
-- ([#17510](https://github.com/rstudio/rstudio/issues/17510)): Data Import: character options, locale values, and import URLs are now encoded as R string literals when generating preview and import code, matching the column-name treatment.
+- ([#17510](https://github.com/rstudio/rstudio/issues/17510)): Data Import: column names, character options, locale values, and import URLs are now encoded as R string literals when generating preview and import code.
 - ([rstudio/rstudio-pro#10805](https://github.com/rstudio/rstudio-pro/issues/10805)): Server: Enable TCP keepalive on accepted connections so the operating system reaps half-open sockets from disappeared clients (browser tab hibernation, NAT timeouts) instead of holding them indefinitely.
 - ([#12235](https://github.com/rstudio/rstudio/issues/12235)): RStudio Desktop's Session > New Session now opens noticeably faster.
 - ([#17440](https://github.com/rstudio/rstudio/issues/17440)): Fixed an issue where triggering tab completion inside `[` on a large Matrix-package sparse matrix could hang RStudio and exhaust system memory

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 ### Fixed
 - 
 - Data Import: column names from imported files are now properly escaped when generating preview and import code.
+- ([#17510](https://github.com/rstudio/rstudio/issues/17510)): Data Import: character options, locale values, and import URLs are now encoded as R string literals when generating preview and import code, matching the column-name treatment.
 - ([rstudio/rstudio-pro#10805](https://github.com/rstudio/rstudio-pro/issues/10805)): Server: Enable TCP keepalive on accepted connections so the operating system reaps half-open sockets from disappeared clients (browser tab hibernation, NAT timeouts) instead of holding them indefinitely.
 - ([#12235](https://github.com/rstudio/rstudio/issues/12235)): RStudio Desktop's Session > New Session now opens noticeably faster.
 - ([#17440](https://github.com/rstudio/rstudio/issues/17440)): Fixed an issue where triggering tab completion inside `[` on a large Matrix-package sparse matrix could hang RStudio and exhaust system memory

--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -80,9 +80,7 @@
 
       switch(optionType,
          "character" = {
-            optionValue <- gsub("\\", "\\\\", optionValue, fixed = TRUE)
-            optionValue <- gsub("\"", "\\\"", optionValue, fixed = TRUE)
-            return (paste("\"", optionValue, "\"", sep = ""))
+            return (encodeString(optionValue, quote = "\""))
          },
          "locale" = {
             localeDefaults <- formals(readr::locale)
@@ -90,7 +88,11 @@
             localeOrNull <- function(paramName, jsonName) {
                if (!identical(localeDefaults[[paramName]], optionValue[[jsonName]])) {
                   if (typeof(localeDefaults[[paramName]]) == "character") {
-                     paste(paramName, " = \"", optionValue[[jsonName]], "\"", sep = "")
+                     sprintf(
+                        "%s = %s",
+                        paramName,
+                        encodeString(optionValue[[jsonName]], quote = "\"")
+                     )
                   }
                   else {
                      paste(paramName, " = ", optionValue[[jsonName]])
@@ -342,25 +344,25 @@
 
          cacheDataCode <- append(
             cacheDataCode,
-            paste(
+            sprintf(
+               "%s <- %s",
                cacheUrlName,
-               " <- \"",
-               downloadResource,
-               "\"",
-               sep = "")
+               encodeString(downloadResource, quote = "\"")
+            )
          )
 
          if (cacheDataWorkingDir)
          {
             cacheDataCode <- append(
                cacheDataCode,
-               paste(
+               sprintf(
+                  "%s <- %s",
                   cacheVariableName,
-                  " <- \"",
-                  options$dataName,
-                  resourceExtension,
-                  "\"",
-                  sep = "")
+                  encodeString(
+                     paste(options$dataName, resourceExtension, sep = ""),
+                     quote = "\""
+                  )
+               )
             )
          }
          else
@@ -375,7 +377,11 @@
 
             cacheDataCode <- append(
                cacheDataCode,
-               paste(cacheVariableName, " <- \"", localFile, "\"", sep = "")
+               sprintf(
+                  "%s <- %s",
+                  cacheVariableName,
+                  encodeString(localFile, quote = "\"")
+               )
             )
          }
 

--- a/src/cpp/tests/testthat/test-data-import.R
+++ b/src/cpp/tests/testthat/test-data-import.R
@@ -66,3 +66,110 @@ test_that("assembleDataImport escapes column names against R code injection", {
       expect_equal(names(eval(col_types)$cols), evil)
    }
 })
+
+test_that("assembleDataImport escapes character option values", {
+   skip_if_not_installed("readr")
+
+   # Same shape of test as the column-name case, but exercising the
+   # "character" option-type path used for read_csv arguments such as `na`.
+   evilValues <- list(
+      injection = 'NA"); .rs.injection.sentinel <- TRUE; c("',
+      backslash = 'na\\sentinel',
+      newline   = 'na\nsentinel'
+   )
+
+   for (evil in evilValues)
+   {
+      opts <- list(
+         mode = "text",
+         importLocation = "data.csv",
+         delimiter = ",",
+         na = evil,
+         openDataViewer = FALSE
+      )
+
+      info <- .rs.assembleDataImport(opts)
+
+      parsed <- parse(text = info$previewCode)
+      expect_length(parsed, 1L)
+      expect_equal(as.character(parsed[[1L]][[1L]]), c("::", "readr", "read_csv"))
+
+      # The na argument should round-trip to the original (unescaped) string.
+      expect_equal(parsed[[1L]]$na, evil)
+   }
+})
+
+test_that("assembleDataImport escapes locale option values", {
+   skip_if_not_installed("readr")
+
+   # Locale values reach the generated code via the "locale" option-type
+   # branch, which formerly pasted the value into "..." with no escaping.
+   evil <- 'UTC"); .rs.injection.sentinel <- TRUE; readr::locale("'
+
+   opts <- list(
+      mode = "text",
+      importLocation = "data.csv",
+      delimiter = ",",
+      locale = list(
+         dateName     = "en",
+         dateFormat   = "%AD",
+         timeFormat   = "%AT",
+         decimalMark  = ".",
+         groupingMark = ",",
+         tz           = evil,
+         encoding     = "UTF-8",
+         asciify      = FALSE
+      ),
+      openDataViewer = FALSE
+   )
+
+   info <- .rs.assembleDataImport(opts)
+
+   parsed <- parse(text = info$previewCode)
+   expect_length(parsed, 1L)
+
+   # The malicious tz value should round-trip in the parsed locale() call.
+   # We inspect the AST rather than eval() since readr::locale validates
+   # tz strings against the system tz database.
+   localeCall <- parsed[[1L]]$locale
+   expect_false(is.null(localeCall))
+   expect_equal(localeCall$tz, evil)
+})
+
+test_that("assembleDataImport escapes import URLs in cache code", {
+   skip_if_not_installed("readr")
+
+   # When canCacheData is TRUE and importLocation is a URL, the assembled
+   # importCode includes assignments such as `url <- "<importLocation>"`.
+   # The URL must be encoded as an R string literal.
+   evilUrl <- 'https://example.com/"); .rs.injection.sentinel <- TRUE; x <- c("data.csv'
+
+   opts <- list(
+      mode = "text",
+      importLocation = evilUrl,
+      delimiter = ",",
+      canCacheData = TRUE,
+      openDataViewer = FALSE
+   )
+
+   info <- .rs.assembleDataImport(opts)
+
+   # importCode must parse as a sequence of top-level expressions; if the URL
+   # escapes its string literal, parse() will reject the input.
+   parsed <- parse(text = info$importCode)
+   expect_gt(length(parsed), 0L)
+
+   # Locate the `url <- "..."` assignment and confirm it round-trips.
+   urlValue <- NULL
+   for (expr in as.list(parsed))
+   {
+      if (is.call(expr) && identical(as.character(expr[[1L]]), "<-") &&
+          identical(as.character(expr[[2L]]), "url"))
+      {
+         urlValue <- expr[[3L]]
+         break
+      }
+   }
+   expect_false(is.null(urlValue))
+   expect_equal(urlValue, evilUrl)
+})


### PR DESCRIPTION
## Intent

Addresses #17510.

## Summary

Generalizes the column-name fix from #17505 to the remaining string interpolations in `SessionDataImportV2.R`. Each value spliced into code that is later passed to `eval(parse())` is now run through `encodeString(..., quote = "\"")` instead of being wrapped in quotes by hand.

Sites updated in `assembleDataImportParameters` / `cacheCodeFromOptions`:
- `"character"` option-type branch (e.g. `na`, `delim`, `quote`, `comment`).
- `"locale"` option-type branch (character-typed `locale()` arguments such as `tz`, `encoding`).
- `cacheUrlName <- "<url>"` (download URL).
- `cacheVariableName <- "<dataName + extension>"` and `cacheVariableName <- "<localFile>"` (download target paths).

The factor `levels = ...` interpolation in the column-definition branch is intentionally left as-is -- it splices in raw R code (e.g. `c("a", "b")`), not a string literal.

The NEWS entry from #17505 is collapsed into a single line referencing #17510, since the two PRs together describe one logical change.

## PR base / stacking

This PR is stacked on top of #17505 (base = `bugfix/data-import-column-name-injection`). Once #17505 merges, this branch can be retargeted to `main`. The diff against the stacked base is just the changes for #17510.

## Test plan

- [x] `./rstudio-tests --scope r --filter test-data-import` passes (3257 PASS, 0 FAIL).
- [ ] Open the Import Dataset dialog (text mode) on a CSV with `na` strings or import URLs containing characters such as `"`, `\`, or newlines, and confirm the generated preview/import code is syntactically valid and the values round-trip.