### PR TITLE
Update Electron to 41.5.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,7 +27,7 @@
 ### Dependencies
 - Ace 1.43.5
 - Copilot Language Server 1.480.0
-- Electron 41.3.0
+- Electron 41.5.0
 - Node.js 22.22.2 (copilot, Posit AI)
 - Quarto 1.9.37
 - xterm.js 6.0.0

--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -48,7 +48,7 @@
         "chai": "6.2.2",
         "copy-webpack-plugin": "14.0.0",
         "css-loader": "7.1.4",
-        "electron": "41.3.0",
+        "electron": "41.5.0",
         "electron-mocha": "13.1.0",
         "eslint": "10.3.0",
         "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -5549,9 +5549,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "41.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.3.0.tgz",
-      "integrity": "sha512-2Q5aeocmFdeheZGDUTrAvSR3t+n0c3d104AJWWEnt7syJU0tE4VdibMYaPtQ47QuXSoUf0/xSsfUUvu/uSXIfg==",
+      "version": "41.5.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.5.0.tgz",
+      "integrity": "sha512-x9j9//PubUA4EjDtQbZhtk3prolandqCKgit0uCIqc1jb8FTskPbnJtxcDFB1aejczJcuERgjPixBUaMwoWyJg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -47,7 +47,7 @@
     "chai": "6.2.2",
     "copy-webpack-plugin": "14.0.0",
     "css-loader": "7.1.4",
-    "electron": "41.3.0",
+    "electron": "41.5.0",
     "electron-mocha": "13.1.0",
     "eslint": "10.3.0",
     "fork-ts-checker-webpack-plugin": "9.1.0",


### PR DESCRIPTION
Continuation of https://github.com/rstudio/rstudio/issues/17469.

## Summary

- Bump pinned Electron version from 41.3.0 to 41.5.0 in `src/node/desktop/package.json` and `package-lock.json`
- Update the Dependencies entry in `NEWS.md`

## Test plan

- [x] `npm install --save-dev --save-exact electron@41.5.0` exits cleanly
- [x] `npm test` passes (396 tests)