### PR TITLE
Document how to disable Posit Assistant and the What's New dialog

### DIFF
--- a/docs/user/rstudio/_quarto.yml
+++ b/docs/user/rstudio/_quarto.yml
@@ -117,6 +117,7 @@ website:
         collapse-level: 1
         contents:
           - ide/reference/shortcuts.qmd
+          - ide/reference/environment-variables.qmd
           
           
   page-footer:

--- a/docs/user/rstudio/ide/guide/tools/posit-ai.qmd
+++ b/docs/user/rstudio/ide/guide/tools/posit-ai.qmd
@@ -44,9 +44,9 @@ To uninstall the downloaded Posit Assistant components, select **Help** \> **Dia
 
 RStudio preserves your chat history and account settings, which remain available if you reinstall Posit Assistant.
 
-## Hiding Posit Assistant Features
+## Hiding Posit Assistant features
 
-To disable and hide the Posit Assistant features entirely, set the `RSTUDIO_DISABLE_POSIT_ASSISTANT` environment variable to any value (e.g. `RSTUDIO_DISABLE_POSIT_ASSISTANT=1`) before starting RStudio. When set, the Posit Assistant toolbar button and pane are not displayed, and Posit Assistant cannot be installed or used in that session.
+To disable and hide the Posit Assistant features entirely, set the `RSTUDIO_DISABLE_POSIT_ASSISTANT` environment variable to any value (e.g., `RSTUDIO_DISABLE_POSIT_ASSISTANT=1`) before starting RStudio. When the variable is set, RStudio does not display the Posit Assistant toolbar button or pane, and you cannot install or use Posit Assistant in that session.
 
 On RStudio Server, administrators can also disable Posit Assistant for all users by adding the following line to `/etc/rstudio/rsession.conf`:
 

--- a/docs/user/rstudio/ide/guide/tools/posit-ai.qmd
+++ b/docs/user/rstudio/ide/guide/tools/posit-ai.qmd
@@ -43,3 +43,15 @@ For information on using Posit Assistant, visit the [Posit Assistant documentati
 To uninstall the downloaded Posit Assistant components, select **Help** \> **Diagnostics** \> **Uninstall Posit Assistant**. RStudio restarts after the uninstall completes.
 
 RStudio preserves your chat history and account settings, which remain available if you reinstall Posit Assistant.
+
+## Hiding Posit Assistant Features
+
+To disable and hide the Posit Assistant features entirely, set the `RSTUDIO_DISABLE_POSIT_ASSISTANT` environment variable to any value (e.g. `RSTUDIO_DISABLE_POSIT_ASSISTANT=1`) before starting RStudio. When set, the Posit Assistant toolbar button and pane are not displayed, and Posit Assistant cannot be installed or used in that session.
+
+On RStudio Server, administrators can also disable Posit Assistant for all users by adding the following line to `/etc/rstudio/rsession.conf`:
+
+```ini
+posit-assistant-enabled=0
+```
+
+See the [Environment Variables](../../reference/environment-variables.qmd) reference for other environment variables that affect RStudio.

--- a/docs/user/rstudio/ide/reference/environment-variables.qmd
+++ b/docs/user/rstudio/ide/reference/environment-variables.qmd
@@ -1,19 +1,19 @@
 ---
-title: "Environment Variables"
+title: "Environment variables"
 date-meta: 2026-05-04
 ---
 
-Certain aspects of RStudio can be controlled by setting environment variables before starting RStudio. These variables are read at startup, so they must be set in the environment that launches RStudio (for example, in your shell profile, a launcher script, or your operating system's environment settings).
+You can control certain aspects of RStudio by setting environment variables before starting it. RStudio reads these variables at startup, so set them in the environment that launches RStudio (for example, in your shell profile, a launcher script, or your operating system's environment settings).
 
-In the table below, a **Value** of "Non-empty" means the variable is treated as enabled whenever it is set to any string other than the empty string. Setting the variable to `1` is the conventional choice, but values such as `true`, `yes`, or even `0` and `false` will also enable the behavior because the variable is non-empty. To turn the behavior off, unset the variable rather than setting it to an empty string.
+In the table below, a Value of "Non-empty" means RStudio treats the variable as enabled whenever you set it to any string other than the empty string. Setting the variable to `1` is the conventional choice, but values such as `true`, `yes`, or even `0` and `false` also enable the behavior because the variable is non-empty. To turn the behavior off, unset the variable rather than setting it to an empty string.
 
 | Environment Variable | Value | Platform | Impact |
 |---|---|---|---|
 | `RS_NO_SPLASH` | Non-empty | Desktop | Disables the splash screen shown while RStudio is starting up. |
 | `RSTUDIO_DISABLE_CHECK_FOR_UPDATES` | Non-empty | Desktop, Server | Disables automatic checks for new RStudio releases. |
-| `RSTUDIO_DISABLE_EXTERNAL_PUBLISH` | Non-empty | Desktop, Server | Disables publishing to external services such as RPubs. Publishing to internal services (e.g. Posit Connect) remains available. |
+| `RSTUDIO_DISABLE_EXTERNAL_PUBLISH` | Non-empty | Desktop, Server | Disables publishing to external services such as RPubs. Publishing to internal services (e.g., Posit Connect) remains available. |
 | `RSTUDIO_DISABLE_PACKAGES` | Non-empty | Desktop, Server | Disables the package management UI. |
 | `RSTUDIO_DISABLE_PACKAGE_INSTALL_PROMPT` | Non-empty | Desktop, Server | Suppresses prompts to install missing packages required by your code. |
-| `RSTUDIO_DISABLE_POSIT_ASSISTANT` | Non-empty | Desktop, Server | Disables and hides the [Posit Assistant](../guide/tools/posit-ai.qmd) features. The Posit Assistant toolbar button and pane are not displayed, and Posit Assistant cannot be installed or used. |
+| `RSTUDIO_DISABLE_POSIT_ASSISTANT` | Non-empty | Desktop, Server | Disables and hides the [Posit Assistant](../guide/tools/posit-ai.qmd) features. RStudio does not display the Posit Assistant toolbar button or pane, and you cannot install or use Posit Assistant. |
 | `RSTUDIO_DISABLE_PUBLISH` | Non-empty | Desktop, Server | Disables content publishing entirely, including both internal and external services. |
 | `RSTUDIO_DISABLE_WHATS_NEW` | Non-empty | Desktop | Suppresses the "What's New" dialog that is otherwise shown after RStudio is updated to a new version. |

--- a/docs/user/rstudio/ide/reference/environment-variables.qmd
+++ b/docs/user/rstudio/ide/reference/environment-variables.qmd
@@ -10,7 +10,7 @@ In the table below, a Value of "Non-empty" means RStudio treats the variable as 
 | Environment Variable | Value | Platform | Impact |
 |---|---|---|---|
 | `RS_NO_SPLASH` | Non-empty | Desktop | Disables the splash screen shown while RStudio is starting up. |
-| `RSTUDIO_DISABLE_CHECK_FOR_UPDATES` | Non-empty | Desktop, Server | Disables automatic checks for new RStudio releases. |
+| `RSTUDIO_DISABLE_CHECK_FOR_UPDATES` | Non-empty | Desktop | Disables automatic checks for new RStudio releases. |
 | `RSTUDIO_DISABLE_EXTERNAL_PUBLISH` | Non-empty | Desktop, Server | Disables publishing to external services such as RPubs. Publishing to internal services (e.g., Posit Connect) remains available. |
 | `RSTUDIO_DISABLE_PACKAGES` | Non-empty | Desktop, Server | Disables the package management UI. |
 | `RSTUDIO_DISABLE_PACKAGE_INSTALL_PROMPT` | Non-empty | Desktop, Server | Suppresses prompts to install missing packages required by your code. |

--- a/docs/user/rstudio/ide/reference/environment-variables.qmd
+++ b/docs/user/rstudio/ide/reference/environment-variables.qmd
@@ -5,7 +5,7 @@ date-meta: 2026-05-04
 
 Certain aspects of RStudio can be controlled by setting environment variables before starting RStudio. These variables are read at startup, so they must be set in the environment that launches RStudio (for example, in your shell profile, a launcher script, or your operating system's environment settings).
 
-| Environment Variable | Value | Supported In | Impact |
+| Environment Variable | Value | Platform | Impact |
 |---|---|---|---|
 | `RSTUDIO_DISABLE_POSIT_ASSISTANT` | Any non-empty value (e.g. `1`) | Desktop, Server | Disables and hides the [Posit Assistant](../guide/tools/posit-ai.qmd) features. The Posit Assistant toolbar button and pane are not displayed, and Posit Assistant cannot be installed or used. |
 | `RSTUDIO_DISABLE_WHATS_NEW` | `1` | Desktop | Suppresses the "What's New" dialog that is otherwise shown after RStudio is updated to a new version. |

--- a/docs/user/rstudio/ide/reference/environment-variables.qmd
+++ b/docs/user/rstudio/ide/reference/environment-variables.qmd
@@ -1,0 +1,13 @@
+---
+title: "Environment Variables"
+date-meta: 2026-05-04
+---
+
+Certain aspects of RStudio can be controlled by setting environment variables before starting RStudio. These variables are read at startup, so they must be set in the environment that launches RStudio (for example, in your shell profile, a launcher script, or your operating system's environment settings).
+
+The following table lists environment variables recognized by RStudio Desktop and, where noted, RStudio Server.
+
+| Environment Variable | Value | Impact |
+|---|---|---|
+| `RSTUDIO_DISABLE_POSIT_ASSISTANT` | Any non-empty value (e.g. `1`) | Disables and hides the [Posit Assistant](../guide/tools/posit-ai.qmd) features. The Posit Assistant toolbar button and pane are not displayed, and Posit Assistant cannot be installed or used. Applies to RStudio Desktop and RStudio Server. |
+| `RSTUDIO_DISABLE_WHATS_NEW` | `1` | Suppresses the "What's New" dialog that is otherwise shown after RStudio is updated to a new version. RStudio Desktop only. |

--- a/docs/user/rstudio/ide/reference/environment-variables.qmd
+++ b/docs/user/rstudio/ide/reference/environment-variables.qmd
@@ -5,9 +5,7 @@ date-meta: 2026-05-04
 
 Certain aspects of RStudio can be controlled by setting environment variables before starting RStudio. These variables are read at startup, so they must be set in the environment that launches RStudio (for example, in your shell profile, a launcher script, or your operating system's environment settings).
 
-The following table lists environment variables recognized by RStudio Desktop and, where noted, RStudio Server.
-
-| Environment Variable | Value | Impact |
-|---|---|---|
-| `RSTUDIO_DISABLE_POSIT_ASSISTANT` | Any non-empty value (e.g. `1`) | Disables and hides the [Posit Assistant](../guide/tools/posit-ai.qmd) features. The Posit Assistant toolbar button and pane are not displayed, and Posit Assistant cannot be installed or used. Applies to RStudio Desktop and RStudio Server. |
-| `RSTUDIO_DISABLE_WHATS_NEW` | `1` | Suppresses the "What's New" dialog that is otherwise shown after RStudio is updated to a new version. RStudio Desktop only. |
+| Environment Variable | Value | Supported In | Impact |
+|---|---|---|---|
+| `RSTUDIO_DISABLE_POSIT_ASSISTANT` | Any non-empty value (e.g. `1`) | Desktop, Server | Disables and hides the [Posit Assistant](../guide/tools/posit-ai.qmd) features. The Posit Assistant toolbar button and pane are not displayed, and Posit Assistant cannot be installed or used. |
+| `RSTUDIO_DISABLE_WHATS_NEW` | `1` | Desktop | Suppresses the "What's New" dialog that is otherwise shown after RStudio is updated to a new version. |

--- a/docs/user/rstudio/ide/reference/environment-variables.qmd
+++ b/docs/user/rstudio/ide/reference/environment-variables.qmd
@@ -7,5 +7,11 @@ Certain aspects of RStudio can be controlled by setting environment variables be
 
 | Environment Variable | Value | Platform | Impact |
 |---|---|---|---|
+| `RS_NO_SPLASH` | Any non-empty value (e.g. `1`) | Desktop | Disables the splash screen shown while RStudio is starting up. |
+| `RSTUDIO_DISABLE_CHECK_FOR_UPDATES` | Any non-empty value (e.g. `1`) | Desktop, Server | Disables automatic checks for new RStudio releases. |
+| `RSTUDIO_DISABLE_EXTERNAL_PUBLISH` | Any non-empty value (e.g. `1`) | Desktop, Server | Disables publishing to external services such as RPubs. Publishing to internal services (e.g. Posit Connect) remains available. |
+| `RSTUDIO_DISABLE_PACKAGES` | Any non-empty value (e.g. `1`) | Desktop, Server | Disables the package management UI. |
+| `RSTUDIO_DISABLE_PACKAGE_INSTALL_PROMPT` | Any non-empty value (e.g. `1`) | Desktop, Server | Suppresses prompts to install missing packages required by your code. |
 | `RSTUDIO_DISABLE_POSIT_ASSISTANT` | Any non-empty value (e.g. `1`) | Desktop, Server | Disables and hides the [Posit Assistant](../guide/tools/posit-ai.qmd) features. The Posit Assistant toolbar button and pane are not displayed, and Posit Assistant cannot be installed or used. |
+| `RSTUDIO_DISABLE_PUBLISH` | Any non-empty value (e.g. `1`) | Desktop, Server | Disables content publishing entirely, including both internal and external services. |
 | `RSTUDIO_DISABLE_WHATS_NEW` | Any non-empty value (e.g. `1`) | Desktop | Suppresses the "What's New" dialog that is otherwise shown after RStudio is updated to a new version. |

--- a/docs/user/rstudio/ide/reference/environment-variables.qmd
+++ b/docs/user/rstudio/ide/reference/environment-variables.qmd
@@ -8,4 +8,4 @@ Certain aspects of RStudio can be controlled by setting environment variables be
 | Environment Variable | Value | Platform | Impact |
 |---|---|---|---|
 | `RSTUDIO_DISABLE_POSIT_ASSISTANT` | Any non-empty value (e.g. `1`) | Desktop, Server | Disables and hides the [Posit Assistant](../guide/tools/posit-ai.qmd) features. The Posit Assistant toolbar button and pane are not displayed, and Posit Assistant cannot be installed or used. |
-| `RSTUDIO_DISABLE_WHATS_NEW` | `1` | Desktop | Suppresses the "What's New" dialog that is otherwise shown after RStudio is updated to a new version. |
+| `RSTUDIO_DISABLE_WHATS_NEW` | Any non-empty value (e.g. `1`) | Desktop | Suppresses the "What's New" dialog that is otherwise shown after RStudio is updated to a new version. |

--- a/docs/user/rstudio/ide/reference/environment-variables.qmd
+++ b/docs/user/rstudio/ide/reference/environment-variables.qmd
@@ -5,13 +5,15 @@ date-meta: 2026-05-04
 
 Certain aspects of RStudio can be controlled by setting environment variables before starting RStudio. These variables are read at startup, so they must be set in the environment that launches RStudio (for example, in your shell profile, a launcher script, or your operating system's environment settings).
 
+In the table below, a **Value** of "Non-empty value" means the variable is treated as enabled whenever it is set to any string other than the empty string. Setting the variable to `1` is the conventional choice, but values such as `true`, `yes`, or even `0` and `false` will also enable the behavior because the variable is non-empty. To turn the behavior off, unset the variable rather than setting it to an empty string.
+
 | Environment Variable | Value | Platform | Impact |
 |---|---|---|---|
-| `RS_NO_SPLASH` | Any non-empty value (e.g. `1`) | Desktop | Disables the splash screen shown while RStudio is starting up. |
-| `RSTUDIO_DISABLE_CHECK_FOR_UPDATES` | Any non-empty value (e.g. `1`) | Desktop, Server | Disables automatic checks for new RStudio releases. |
-| `RSTUDIO_DISABLE_EXTERNAL_PUBLISH` | Any non-empty value (e.g. `1`) | Desktop, Server | Disables publishing to external services such as RPubs. Publishing to internal services (e.g. Posit Connect) remains available. |
-| `RSTUDIO_DISABLE_PACKAGES` | Any non-empty value (e.g. `1`) | Desktop, Server | Disables the package management UI. |
-| `RSTUDIO_DISABLE_PACKAGE_INSTALL_PROMPT` | Any non-empty value (e.g. `1`) | Desktop, Server | Suppresses prompts to install missing packages required by your code. |
-| `RSTUDIO_DISABLE_POSIT_ASSISTANT` | Any non-empty value (e.g. `1`) | Desktop, Server | Disables and hides the [Posit Assistant](../guide/tools/posit-ai.qmd) features. The Posit Assistant toolbar button and pane are not displayed, and Posit Assistant cannot be installed or used. |
-| `RSTUDIO_DISABLE_PUBLISH` | Any non-empty value (e.g. `1`) | Desktop, Server | Disables content publishing entirely, including both internal and external services. |
-| `RSTUDIO_DISABLE_WHATS_NEW` | Any non-empty value (e.g. `1`) | Desktop | Suppresses the "What's New" dialog that is otherwise shown after RStudio is updated to a new version. |
+| `RS_NO_SPLASH` | Non-empty value | Desktop | Disables the splash screen shown while RStudio is starting up. |
+| `RSTUDIO_DISABLE_CHECK_FOR_UPDATES` | Non-empty value | Desktop, Server | Disables automatic checks for new RStudio releases. |
+| `RSTUDIO_DISABLE_EXTERNAL_PUBLISH` | Non-empty value | Desktop, Server | Disables publishing to external services such as RPubs. Publishing to internal services (e.g. Posit Connect) remains available. |
+| `RSTUDIO_DISABLE_PACKAGES` | Non-empty value | Desktop, Server | Disables the package management UI. |
+| `RSTUDIO_DISABLE_PACKAGE_INSTALL_PROMPT` | Non-empty value | Desktop, Server | Suppresses prompts to install missing packages required by your code. |
+| `RSTUDIO_DISABLE_POSIT_ASSISTANT` | Non-empty value | Desktop, Server | Disables and hides the [Posit Assistant](../guide/tools/posit-ai.qmd) features. The Posit Assistant toolbar button and pane are not displayed, and Posit Assistant cannot be installed or used. |
+| `RSTUDIO_DISABLE_PUBLISH` | Non-empty value | Desktop, Server | Disables content publishing entirely, including both internal and external services. |
+| `RSTUDIO_DISABLE_WHATS_NEW` | Non-empty value | Desktop | Suppresses the "What's New" dialog that is otherwise shown after RStudio is updated to a new version. |

--- a/docs/user/rstudio/ide/reference/environment-variables.qmd
+++ b/docs/user/rstudio/ide/reference/environment-variables.qmd
@@ -5,15 +5,15 @@ date-meta: 2026-05-04
 
 Certain aspects of RStudio can be controlled by setting environment variables before starting RStudio. These variables are read at startup, so they must be set in the environment that launches RStudio (for example, in your shell profile, a launcher script, or your operating system's environment settings).
 
-In the table below, a **Value** of "Non-empty value" means the variable is treated as enabled whenever it is set to any string other than the empty string. Setting the variable to `1` is the conventional choice, but values such as `true`, `yes`, or even `0` and `false` will also enable the behavior because the variable is non-empty. To turn the behavior off, unset the variable rather than setting it to an empty string.
+In the table below, a **Value** of "Non-empty" means the variable is treated as enabled whenever it is set to any string other than the empty string. Setting the variable to `1` is the conventional choice, but values such as `true`, `yes`, or even `0` and `false` will also enable the behavior because the variable is non-empty. To turn the behavior off, unset the variable rather than setting it to an empty string.
 
 | Environment Variable | Value | Platform | Impact |
 |---|---|---|---|
-| `RS_NO_SPLASH` | Non-empty value | Desktop | Disables the splash screen shown while RStudio is starting up. |
-| `RSTUDIO_DISABLE_CHECK_FOR_UPDATES` | Non-empty value | Desktop, Server | Disables automatic checks for new RStudio releases. |
-| `RSTUDIO_DISABLE_EXTERNAL_PUBLISH` | Non-empty value | Desktop, Server | Disables publishing to external services such as RPubs. Publishing to internal services (e.g. Posit Connect) remains available. |
-| `RSTUDIO_DISABLE_PACKAGES` | Non-empty value | Desktop, Server | Disables the package management UI. |
-| `RSTUDIO_DISABLE_PACKAGE_INSTALL_PROMPT` | Non-empty value | Desktop, Server | Suppresses prompts to install missing packages required by your code. |
-| `RSTUDIO_DISABLE_POSIT_ASSISTANT` | Non-empty value | Desktop, Server | Disables and hides the [Posit Assistant](../guide/tools/posit-ai.qmd) features. The Posit Assistant toolbar button and pane are not displayed, and Posit Assistant cannot be installed or used. |
-| `RSTUDIO_DISABLE_PUBLISH` | Non-empty value | Desktop, Server | Disables content publishing entirely, including both internal and external services. |
-| `RSTUDIO_DISABLE_WHATS_NEW` | Non-empty value | Desktop | Suppresses the "What's New" dialog that is otherwise shown after RStudio is updated to a new version. |
+| `RS_NO_SPLASH` | Non-empty | Desktop | Disables the splash screen shown while RStudio is starting up. |
+| `RSTUDIO_DISABLE_CHECK_FOR_UPDATES` | Non-empty | Desktop, Server | Disables automatic checks for new RStudio releases. |
+| `RSTUDIO_DISABLE_EXTERNAL_PUBLISH` | Non-empty | Desktop, Server | Disables publishing to external services such as RPubs. Publishing to internal services (e.g. Posit Connect) remains available. |
+| `RSTUDIO_DISABLE_PACKAGES` | Non-empty | Desktop, Server | Disables the package management UI. |
+| `RSTUDIO_DISABLE_PACKAGE_INSTALL_PROMPT` | Non-empty | Desktop, Server | Suppresses prompts to install missing packages required by your code. |
+| `RSTUDIO_DISABLE_POSIT_ASSISTANT` | Non-empty | Desktop, Server | Disables and hides the [Posit Assistant](../guide/tools/posit-ai.qmd) features. The Posit Assistant toolbar button and pane are not displayed, and Posit Assistant cannot be installed or used. |
+| `RSTUDIO_DISABLE_PUBLISH` | Non-empty | Desktop, Server | Disables content publishing entirely, including both internal and external services. |
+| `RSTUDIO_DISABLE_WHATS_NEW` | Non-empty | Desktop | Suppresses the "What's New" dialog that is otherwise shown after RStudio is updated to a new version. |


### PR DESCRIPTION
## Intent

Addresses #17518.

## Summary

- Adds a "Hiding Posit Assistant features" section to the Posit Assistant guide page covering the `RSTUDIO_DISABLE_POSIT_ASSISTANT` environment variable and the `posit-assistant-enabled=0` rsession.conf setting for Server.
- Adds a new "Environment variables" reference page listing RStudio environment variables, the value to set, the platform each applies to, and the impact. Includes `RS_NO_SPLASH`, `RSTUDIO_DISABLE_CHECK_FOR_UPDATES`, `RSTUDIO_DISABLE_EXTERNAL_PUBLISH`, `RSTUDIO_DISABLE_PACKAGES`, `RSTUDIO_DISABLE_PACKAGE_INSTALL_PROMPT`, `RSTUDIO_DISABLE_POSIT_ASSISTANT`, `RSTUDIO_DISABLE_PUBLISH`, and `RSTUDIO_DISABLE_WHATS_NEW`.
- Wires the new reference page into the user guide sidebar.

## Test plan

- [ ] Render the user guide locally and confirm the new "Environment variables" page appears under Reference.
- [ ] Confirm the "Hiding Posit Assistant features" section renders at the end of the Posit Assistant page and the cross-link to the Environment variables page resolves.