### PR TITLE
add stringr to automation test package dependencies

### DIFF
--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -57,7 +57,7 @@
 {
    packages <- c(
       "devtools", "dplyr", "here", "httr", "later", "processx",
-      "ps", "reticulate", "styler", "testthat", "usethis",
+      "ps", "reticulate", "stringr", "styler", "testthat", "usethis",
       "websocket", "withr", "xml2"
    )
    


### PR DESCRIPTION
## Summary

- Add `stringr` to the list of packages installed by the automation test bootstrap in `SessionAutomation.R`, so the automation suite can run on a fresh environment without manual package installation.

## Test plan

- [ ] Run RStudio automation tests on a clean R library and confirm no missing-package errors for `stringr`.