### PR TITLE
Collapse Playwright projects to desktop|server with auto-filtering

### DIFF
--- a/.claude/skills/rstudio-create-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-create-playwright-tests/SKILL.md
@@ -44,7 +44,7 @@ description: Complete guide for creating RStudio Playwright tests in TypeScript.
    **Never use raw `Control+End` or `Control+Home`** in tests — always use the helper or a platform guard.
 
    **If unsure**, check what RStudio's own shortcut settings say. If it shows "Ctrl" on macOS (not Cmd), use `Control`.
-8. **Write tests that work on both Desktop and Server** – Tests connect via CDP on Desktop and via browser login on Server, but test logic should be the same. Use stable element IDs instead of wrapper selectors. Use `PW_RSTUDIO_MODE` env var when branching on mode.
+8. **Write tests that work on both Desktop and Server** – Tests connect via CDP on Desktop and via browser login on Server, but test logic should be the same. Use stable element IDs instead of wrapper selectors. When a test only applies to one mode, prefer the `@desktop_only` or `@server_only` tag (handled by project-level `grepInvert`); use `testInfo.project.name` only when runtime branching is genuinely required.
 9. **Use `.rs.api.executeCommand()` instead of `window.desktopHooks.invokeCommand()`** – `desktopHooks` only exists in Desktop's Electron shell and will crash on Server. `.rs.api.executeCommand()` works in both modes.
 
 ---

--- a/.claude/skills/rstudio-migrate-tests-selenium-to-playwright/SKILL.md
+++ b/.claude/skills/rstudio-migrate-tests-selenium-to-playwright/SKILL.md
@@ -93,7 +93,7 @@ Defer to the `rstudio-run-playwright-tests` skill for the canonical run commands
 Quick reference for Desktop:
 
 ```bash
-cd e2e/rstudio && npx playwright test tests/<path>/<file>.test.ts --project desktop-os-windows
+cd e2e/rstudio && npx playwright test tests/<path>/<file>.test.ts
 ```
 
 If the test fails:
@@ -177,8 +177,8 @@ Tests can run against multiple RStudio Server instances in parallel. This works 
 
 **Targeting a server:**
 ```bash
-PW_RSTUDIO_SERVER_URL=https://server1:80 PW_RSTUDIO_MODE=server \
-  npx playwright test tests/panes/misc/autocomplete.test.ts
+PW_RSTUDIO_SERVER_URL=https://server1:80 \
+  npx playwright test tests/panes/misc/autocomplete.test.ts --project=server
 ```
 
 **Parallel execution (5 servers):**
@@ -186,9 +186,9 @@ Each process gets its own `PW_RSTUDIO_SERVER_URL` — no shared config files, no
 
 ```bash
 # Terminal / CI / shell script
-PW_RSTUDIO_SERVER_URL=https://server1:80 PW_RSTUDIO_MODE=server npx playwright test tests/file1.test.ts &
-PW_RSTUDIO_SERVER_URL=https://server2:80 PW_RSTUDIO_MODE=server npx playwright test tests/file2.test.ts &
-PW_RSTUDIO_SERVER_URL=https://server3:80 PW_RSTUDIO_MODE=server npx playwright test tests/file3.test.ts &
+PW_RSTUDIO_SERVER_URL=https://server1:80 npx playwright test tests/file1.test.ts --project=server &
+PW_RSTUDIO_SERVER_URL=https://server2:80 npx playwright test tests/file2.test.ts --project=server &
+PW_RSTUDIO_SERVER_URL=https://server3:80 npx playwright test tests/file3.test.ts --project=server &
 wait
 ```
 

--- a/.claude/skills/rstudio-run-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-run-playwright-tests/SKILL.md
@@ -21,7 +21,7 @@ npx playwright install
 
 ## Desktop Mode (Default)
 
-No special env vars needed — `PW_RSTUDIO_MODE` defaults to `desktop`.
+No flag needed -- `desktop` is the default project.
 
 ```bash
 # All tests
@@ -32,6 +32,9 @@ npx playwright test tests/path/to/test.test.ts
 
 # With extra RStudio CLI args
 PW_RSTUDIO_EXTRA_ARGS="--my-flag --other-option" npx playwright test
+
+# Pro edition
+PW_RSTUDIO_EDITION=pro npx playwright test
 ```
 
 - Connects to RStudio Desktop via CDP on port 9222
@@ -41,27 +44,31 @@ PW_RSTUDIO_EXTRA_ARGS="--my-flag --other-option" npx playwright test
 
 ## Server Mode
 
-Key env vars (3 required, 3 optional):
+Pass `--project=server` and provide credentials.
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `PW_RSTUDIO_MODE` | Yes | Set to `server` |
 | `PW_RSTUDIO_SERVER_URL` | No | Full URL including port if needed, e.g. `http://10.12.227.184:8787` or `https://dev.example.com/s/abc123/` (default: `http://localhost:8787`) |
-| `PW_RSTUDIO_SERVER_PORT` | No | Override the port in the URL (no default — only set if you need to override what's in the URL) |
+| `PW_RSTUDIO_SERVER_PORT` | No | Override the port in the URL (no default -- only set if you need to override what's in the URL) |
 | `PW_RSTUDIO_SERVER_USER` | Yes | Login username |
 | `PW_RSTUDIO_SERVER_PASSWORD` | Yes | Login password |
 | `PW_RSTUDIO_SERVER_LOGIN_TIMEOUT` | No | Post-login wait for the IDE console, in ms (default: 60000). Increase for slow servers. |
+| `PW_RSTUDIO_EDITION` | No | `os` (default) or `pro`. Filters edition-specific tests. |
 
 ```bash
 # All tests
-PW_RSTUDIO_MODE=server PW_RSTUDIO_SERVER_URL=http://<ip> PW_RSTUDIO_SERVER_USER=<user> PW_RSTUDIO_SERVER_PASSWORD=<pass> npx playwright test
+PW_RSTUDIO_SERVER_URL=http://<ip> PW_RSTUDIO_SERVER_USER=<user> PW_RSTUDIO_SERVER_PASSWORD=<pass> npx playwright test --project=server
 
 # Specific test file
-PW_RSTUDIO_MODE=server PW_RSTUDIO_SERVER_URL=http://<ip> PW_RSTUDIO_SERVER_USER=<user> PW_RSTUDIO_SERVER_PASSWORD=<pass> npx playwright test tests/path/to/test.test.ts
+PW_RSTUDIO_SERVER_URL=http://<ip> PW_RSTUDIO_SERVER_USER=<user> PW_RSTUDIO_SERVER_PASSWORD=<pass> npx playwright test tests/path/to/test.test.ts --project=server
+
+# Pro edition
+PW_RSTUDIO_EDITION=pro PW_RSTUDIO_SERVER_URL=http://<ip> PW_RSTUDIO_SERVER_USER=<user> PW_RSTUDIO_SERVER_PASSWORD=<pass> npx playwright test --project=server
 ```
 
 - The fixture launches a headed Chromium browser, navigates to the server URL, and logs in
-- Always ask the user for the username and password — never assume credentials
+- Always ask the user for the username and password -- never assume credentials
+- `PW_RSTUDIO_MODE=desktop|server` is a fallback when `--project` isn't passed; if both are set, `--project` wins
 
 ## Common Options
 
@@ -87,22 +94,13 @@ Tests use Playwright tags to indicate platform, edition, and product tier constr
 
 ### Filtering by Tag
 
-The config defines **projects** that automatically exclude tags not applicable to a given environment. Use `PW_PROJECT` to select one:
+The config defines two **projects** -- `desktop` (default) and `server` -- each with a `grepInvert` computed at config load:
 
-```bash
-# Set once in your shell profile for local development
-export PW_PROJECT=desktop-os-windows
+- **OS**: `desktop` excludes OS-only tags that don't match the host (`os.platform()`); `server` always excludes `@windows_only|@macos_only` (server targets Linux).
+- **Edition**: `PW_RSTUDIO_EDITION=os` (default) excludes `@pro_only`; `PW_RSTUDIO_EDITION=pro` excludes `@os_only`.
+- **Mode**: each project also excludes the opposite mode's tag.
 
-# Then just run
-npx playwright test
-
-# To switch projects, override PW_PROJECT inline
-PW_PROJECT=server-os-linux PW_RSTUDIO_MODE=server npx playwright test
-```
-
-Without `PW_PROJECT`, all 8 projects run (each test executes once per project). `PW_PROJECT` and `--project` conflict--don't use both at the same time. `PW_PROJECT` pre-filters the project list, so `--project` can't select anything outside it.
-
-Available projects: `desktop-os-windows`, `desktop-os-macos`, `desktop-os-linux`, `desktop-pro-windows`, `desktop-pro-macos`, `desktop-pro-linux`, `server-os-linux`, `server-pro-linux`.
+Select a project with `--project=desktop` or `--project=server`. `PW_RSTUDIO_MODE=desktop|server` is a fallback when `--project` isn't passed; if both are set, `--project` wins.
 
 You can also filter manually with `--grep` and `--grep-invert`:
 

--- a/e2e/rstudio/README.md
+++ b/e2e/rstudio/README.md
@@ -21,7 +21,7 @@ npx playwright install
 
 ### Pick a mode
 
-The suite has two Playwright projects: `desktop` (default) and `server`. Each filters tests automatically by host OS (via `os.platform()`) and by edition (via `PW_RSTUDIO_EDITION`, default `os`).
+The suite has two Playwright projects: `desktop` (default) and `server`. Each filters tests automatically by edition (via `PW_RSTUDIO_EDITION`, default `os`) and by OS -- `desktop` from the host's `os.platform()`, `server` always against Linux.
 
 ### Desktop Mode (Default)
 

--- a/e2e/rstudio/README.md
+++ b/e2e/rstudio/README.md
@@ -19,56 +19,55 @@ npx playwright install
 
 ## Running Tests
 
-### Pick a project first
+### Pick a mode
 
-Bare `npx playwright test` runs the suite against all 8 projects sequentially--hours of test time. Always pass `--project=<name>` (or set `PW_PROJECT`) to scope to one configuration.
-
-Available projects: `desktop-os-windows`, `desktop-os-macos`, `desktop-os-linux`, `desktop-pro-windows`, `desktop-pro-macos`, `desktop-pro-linux`, `server-os-linux`, `server-pro-linux`.
+The suite has two Playwright projects: `desktop` (default) and `server`. Each filters tests automatically by host OS (via `os.platform()`) and by edition (via `PW_RSTUDIO_EDITION`, default `os`).
 
 ### Desktop Mode (Default)
 
-No special environment variables needed--`PW_RSTUDIO_MODE` defaults to `desktop`.
+No flag needed--`desktop` is the default project.
 
 ```bash
 # All tests
-npx playwright test --project=desktop-os-macos
+npx playwright test
 
 # Specific test file
-npx playwright test tests/panes/misc/autocomplete.test.ts --project=desktop-os-windows
+npx playwright test tests/panes/misc/autocomplete.test.ts
 
 # Specific test by name
-npx playwright test -g "test name here" --project=desktop-os-linux
-npx playwright test -g "base function: cat(" --project=desktop-pro-macos
+npx playwright test -g "test name here"
+npx playwright test -g "base function: cat("
 
 # With extra RStudio CLI args
-PW_RSTUDIO_EXTRA_ARGS="--my-flag --other-option" npx playwright test --project=desktop-pro-windows
+PW_RSTUDIO_EXTRA_ARGS="--my-flag --other-option" npx playwright test
 
-# Pro on Linux
-npx playwright test --project=desktop-pro-linux
+# Pro edition
+PW_RSTUDIO_EDITION=pro npx playwright test
 ```
 
 The desktop fixture automatically launches RStudio with CDP enabled on a random port (9231-9299), connects Playwright, and shuts down gracefully after tests complete. Override the port with `PW_CDP_PORT=9222`.
 
 ### Server Mode
 
-Set `PW_RSTUDIO_MODE=server` and provide credentials. `PW_RSTUDIO_SERVER_URL` defaults to `http://localhost:8787`; `PW_RSTUDIO_SERVER_PORT` overrides the port in the URL when set (no default--if unset, the port comes from the URL).
+Pass `--project=server` and provide credentials. `PW_RSTUDIO_SERVER_URL` defaults to `http://localhost:8787`; `PW_RSTUDIO_SERVER_PORT` overrides the port in the URL when set (no default--if unset, the port comes from the URL).
 
 ```bash
-PW_RSTUDIO_MODE=server \
-  PW_RSTUDIO_SERVER_URL=http://10.0.0.1 \
+PW_RSTUDIO_SERVER_URL=http://10.0.0.1 \
   PW_RSTUDIO_SERVER_PORT=80 \
   PW_RSTUDIO_SERVER_USER=myuser \
   PW_RSTUDIO_SERVER_PASSWORD=mypass \
-  npx playwright test --project=server-os-linux
+  npx playwright test --project=server
 
-# Pro on Linux
-PW_RSTUDIO_MODE=server \
+# Pro edition
+PW_RSTUDIO_EDITION=pro \
   PW_RSTUDIO_SERVER_URL=http://10.0.0.2 \
   PW_RSTUDIO_SERVER_PORT=80 \
   PW_RSTUDIO_SERVER_USER=myuser \
   PW_RSTUDIO_SERVER_PASSWORD=mypass \
-  npx playwright test --project=server-pro-linux
+  npx playwright test --project=server
 ```
+
+`PW_RSTUDIO_MODE=desktop|server` is a fallback when `--project` isn't passed; if both are set, `--project` wins.
 
 ### Viewing the Report
 
@@ -111,7 +110,7 @@ The `tsconfig.json` defines path aliases so imports stay clean:
 
 ### Fixtures
 
-The unified fixture (`rstudio.fixture.ts`) checks `PW_RSTUDIO_MODE` and delegates to the appropriate launcher. It provides a shared `rstudioPage` (a Playwright `Page`) scoped to the worker, so all tests in a file share one RStudio session.
+The unified fixture (`rstudio.fixture.ts`) reads the per-project `mode` option (set in `playwright.config.ts`) and delegates to the appropriate launcher. It provides a shared `rstudioPage` (a Playwright `Page`) scoped to the worker, so all tests in a file share one RStudio session.
 
 - **Desktop**: Kills any process on the CDP port, spawns RStudio with `--remote-debugging-port`, connects via `chromium.connectOverCDP()`, waits for the console to be ready.
 - **Server**: Launches a headed Chromium browser, navigates to the server URL, fills in credentials, waits for the IDE to load.
@@ -253,30 +252,20 @@ test('specific test', { tag: ['@macos_only'] }, async ({ rstudioPage: page }) =>
 
 ### Filtering by Tag
 
-The config defines **projects** that automatically exclude tags not applicable to a given environment. Use `--project` to select one:
+The config defines two **projects** -- `desktop` and `server` -- each with a `grepInvert` computed at config load:
+
+- **OS**: `desktop` excludes OS-only tags that don't match the host (`os.platform()`); `server` always excludes `@windows_only|@macos_only` (server targets Linux).
+- **Edition**: `PW_RSTUDIO_EDITION=os` (default) excludes `@pro_only`; `PW_RSTUDIO_EDITION=pro` excludes `@os_only`.
+- **Mode**: each project also excludes the opposite mode's tag (`@server_only` from `desktop`, `@desktop_only` from `server`).
+
+Select a project with `--project`:
 
 ```bash
-npx playwright test --project=desktop-os-windows
-npx playwright test --project=server-os-linux
+npx playwright test --project=desktop
+npx playwright test --project=server
 ```
 
-To avoid passing `--project` every time, set `PW_PROJECT` in your shell profile:
-
-```bash
-export PW_PROJECT=desktop-os-windows
-```
-
-With `PW_PROJECT` set, bare `npx playwright test` runs only that project. To switch projects, override `PW_PROJECT` inline:
-
-```bash
-PW_PROJECT=server-os-linux PW_RSTUDIO_MODE=server npx playwright test
-```
-
-Without `PW_PROJECT` or `--project`, all 8 projects run.
-
-**Note:** `PW_PROJECT` and `--project` conflict--don't use both at the same time. `PW_PROJECT` pre-filters the project list, so `--project` can't select anything outside it. To use `--project`, unset `PW_PROJECT` first.
-
-Available projects: `desktop-os-windows`, `desktop-os-macos`, `desktop-os-linux`, `desktop-pro-windows`, `desktop-pro-macos`, `desktop-pro-linux`, `server-os-linux`, `server-pro-linux`.
+`PW_RSTUDIO_MODE=desktop|server` is a fallback for shell aliases when `--project` isn't passed. **`--project` wins** when both are set.
 
 You can also filter manually with `--grep` and `--grep-invert`:
 
@@ -295,8 +284,8 @@ npx playwright test --grep-invert "@pro_only|@server_only"
 
 | Variable | Mode | Required | Description |
 |----------|------|----------|-------------|
-| `PW_PROJECT` | Both | No | Select a single project (e.g., `desktop-os-windows`). Trumps `--project`. |
-| `PW_RSTUDIO_MODE` | Both | No | `desktop` (default) or `server` |
+| `PW_RSTUDIO_MODE` | Both | No | Fallback for `--project` (`desktop` or `server`); `--project` wins if both set. Default: `desktop`. |
+| `PW_RSTUDIO_EDITION` | Both | No | `os` (default) or `pro`. Filters out `@pro_only` or `@os_only` tagged tests. |
 | `PW_CDP_PORT` | Desktop | No | Override the CDP port (default: random 9231-9299) |
 | `PW_RSTUDIO_SERVER_URL` | Server | No | Full URL, e.g., `http://10.0.0.1:8787` (default: `http://localhost:8787`) |
 | `PW_RSTUDIO_SERVER_PORT` | Server | No | Override the port in the URL |

--- a/e2e/rstudio/fixtures/rstudio.fixture.ts
+++ b/e2e/rstudio/fixtures/rstudio.fixture.ts
@@ -4,9 +4,9 @@ import { launchServer, shutdownServer } from './server.fixture';
 import { sleep } from '../utils/constants';
 import { getEnvironmentVersions, clearConsole } from '../pages/console_pane.page';
 
-const mode = (process.env.PW_RSTUDIO_MODE || 'desktop').toLowerCase();
-
 const DONT_SAVE_BTN = "button:has-text('Don\\'t Save'), button:has-text('Do not Save'), #rstudio_dlg_no";
+
+type Mode = 'desktop' | 'server';
 
 /** Capture R/RStudio versions once per worker and log them. */
 async function logVersions(page: Page): Promise<void> {
@@ -18,11 +18,12 @@ async function logVersions(page: Page): Promise<void> {
 /**
  * Unified Playwright Test fixture that provides a shared RStudio page.
  *
- * Set PW_RSTUDIO_MODE=server to connect to RStudio Server instead of Desktop.
- * Server mode requires PW_RSTUDIO_SERVER_USER, PW_RSTUDIO_SERVER_PASSWORD, and optionally PW_RSTUDIO_SERVER_URL.
+ * The `mode` option is set per-project in playwright.config.ts; select with
+ * `--project=desktop` (default) or `--project=server`.
  */
-export const test = base.extend<{}, { rstudioPage: Page }>({
-  rstudioPage: [async ({}, use) => {
+export const test = base.extend<{}, { mode: Mode; rstudioPage: Page }>({
+  mode: ['desktop', { option: true, scope: 'worker' }],
+  rstudioPage: [async ({ mode }, use) => {
     if (mode === 'server') {
       const session = await launchServer();
       await logVersions(session.page);

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -38,6 +38,7 @@ const modeEnv = process.env.PW_RSTUDIO_MODE?.toLowerCase();
 
 let projects;
 if (projectFlagPresent) {
+  // Expose both projects; Playwright's CLI narrows down to the requested name post-load.
   projects = allProjects;
 } else if (modeEnv === 'server') {
   projects = allProjects.filter(p => p.name === 'server');

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -1,60 +1,50 @@
 import { defineConfig } from '@playwright/test';
+import os from 'os';
+
+const platform = os.platform();
+const desktopOsExclusions: string[] = [];
+if (platform !== 'win32')  desktopOsExclusions.push('@windows_only');
+if (platform !== 'darwin') desktopOsExclusions.push('@macos_only');
+if (platform !== 'linux')  desktopOsExclusions.push('@linux_only');
+
+// Server always targets Linux regardless of host OS, so its OS filter is hardcoded.
+const serverOsExclusions = ['@windows_only', '@macos_only'];
+
+const edition = (process.env.PW_RSTUDIO_EDITION ?? 'os').toLowerCase();
+if (edition !== 'os' && edition !== 'pro') {
+  throw new Error(`PW_RSTUDIO_EDITION="${edition}" -- expected "os" or "pro"`);
+}
+const editionExclusions = edition === 'os' ? ['@pro_only'] : ['@os_only'];
 
 const allProjects = [
-  // Desktop open-source
   {
-    name: 'desktop-os-windows',
-    grepInvert: /@server_only|@pro_only|@macos_only|@linux_only/,
+    name: 'desktop',
+    use: { mode: 'desktop' as const },
+    grepInvert: new RegExp(['@server_only', ...desktopOsExclusions, ...editionExclusions].join('|')),
   },
   {
-    name: 'desktop-os-macos',
-    grepInvert: /@server_only|@pro_only|@windows_only|@linux_only/,
-  },
-  {
-    name: 'desktop-os-linux',
-    grepInvert: /@server_only|@pro_only|@windows_only|@macos_only/,
-  },
-  // Desktop Pro
-  {
-    name: 'desktop-pro-windows',
-    grepInvert: /@server_only|@os_only|@macos_only|@linux_only/,
-  },
-  {
-    name: 'desktop-pro-macos',
-    grepInvert: /@server_only|@os_only|@windows_only|@linux_only/,
-  },
-  {
-    name: 'desktop-pro-linux',
-    grepInvert: /@server_only|@os_only|@windows_only|@macos_only/,
-  },
-  // Server (Linux only)
-  {
-    name: 'server-os-linux',
-    grepInvert: /@desktop_only|@pro_only|@windows_only|@macos_only/,
-  },
-  {
-    name: 'server-pro-linux',
-    grepInvert: /@desktop_only|@os_only|@windows_only|@macos_only/,
+    name: 'server',
+    use: { mode: 'server' as const },
+    grepInvert: new RegExp(['@desktop_only', ...serverOsExclusions, ...editionExclusions].join('|')),
   },
 ];
 
-// PW_PROJECT selects a single project for local runs (e.g. "desktop-pro-windows").
-// When unset, all projects are available — CI runs all, or use --project to pick one.
-// PW_PROJECT and --project conflict -- don't use both at the same time.
-// PW_PROJECT pre-filters the project list, so --project can't select anything outside it.
-const selectedProject = process.env.PW_PROJECT;
-const projects = selectedProject
-  ? allProjects.filter(p => p.name === selectedProject)
-  : allProjects;
+if (process.env.PW_PROJECT) {
+  console.warn('PW_PROJECT is no longer used; switch to --project=desktop|server or PW_RSTUDIO_MODE=desktop|server');
+}
 
-if (selectedProject) {
-  if (projects.length === 0) {
-    throw new Error(
-      `PW_PROJECT="${selectedProject}" does not match any project. ` +
-      `Available: ${allProjects.map(p => p.name).join(', ')}`
-    );
-  }
-  console.log(`Project: ${selectedProject} (via PW_PROJECT)`);
+const projectFlagPresent = process.argv.some(a => a === '--project' || a.startsWith('--project='));
+const modeEnv = process.env.PW_RSTUDIO_MODE?.toLowerCase();
+
+let projects;
+if (projectFlagPresent) {
+  projects = allProjects;
+} else if (modeEnv === 'server') {
+  projects = allProjects.filter(p => p.name === 'server');
+} else if (modeEnv === 'desktop' || modeEnv === undefined) {
+  projects = allProjects.filter(p => p.name === 'desktop');
+} else {
+  throw new Error(`PW_RSTUDIO_MODE="${modeEnv}" -- expected "desktop" or "server"`);
 }
 
 export default defineConfig({

--- a/e2e/rstudio/tests/menus/help/release-notes.test.ts
+++ b/e2e/rstudio/tests/menus/help/release-notes.test.ts
@@ -14,7 +14,6 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { sleep } from '@utils/constants';
 
 const BASE_URL = 'https://www.rstudio.org/links/release_notes';
-const isDesktop = (process.env.PW_RSTUDIO_MODE || 'desktop').toLowerCase() === 'desktop';
 
 test.describe('Help > Release Notes - #17330', { tag: ['@parallel_safe'] }, () => {
 
@@ -24,41 +23,38 @@ test.describe('Help > Release Notes - #17330', { tag: ['@parallel_safe'] }, () =
     consoleActions = new ConsolePaneActions(page);
   });
 
-  if (isDesktop) {
-    test('command executes without error', async ({ rstudioPage: page }) => {
-      // Desktop opens the URL via shell.openExternal() — Playwright cannot
-      // intercept it, so we just verify the command doesn't throw.
-      await consoleActions.clearConsole();
-      await consoleActions.typeInConsole(".rs.api.executeCommand('showReleaseNotes')");
-      await sleep(2000);
+  test('command executes without error', { tag: ['@desktop_only'] }, async ({ rstudioPage: page }) => {
+    // Desktop opens the URL via shell.openExternal() — Playwright cannot
+    // intercept it, so we just verify the command doesn't throw.
+    await consoleActions.clearConsole();
+    await consoleActions.typeInConsole(".rs.api.executeCommand('showReleaseNotes')");
+    await sleep(2000);
 
-      // Verify no error appeared in the console
-      const output = await page.locator('#rstudio_console_output').innerText();
-      expect(output).not.toContain('Error');
-    });
-  } else {
-    test('opens correct URL', async ({ rstudioPage: page }) => {
-      const context = page.context();
-      const newPagePromise = context.waitForEvent('page', { timeout: 15000 });
+    const output = await page.locator('#rstudio_console_output').innerText();
+    expect(output).not.toContain('Error');
+  });
 
-      await consoleActions.typeInConsole(".rs.api.executeCommand('showReleaseNotes')");
+  test('opens correct URL', { tag: ['@server_only'] }, async ({ rstudioPage: page }) => {
+    const context = page.context();
+    const newPagePromise = context.waitForEvent('page', { timeout: 15000 });
 
-      const newPage = await newPagePromise;
-      const initialUrl = newPage.url();
-      expect(initialUrl).toContain(BASE_URL);
+    await consoleActions.typeInConsole(".rs.api.executeCommand('showReleaseNotes')");
 
-      // Verify the redirect lands on the Posit docs release notes page
-      await newPage.waitForLoadState('load', { timeout: 15000 });
-      const finalUrl = newPage.url();
-      expect(finalUrl).toContain('docs.posit.co/ide/news/');
+    const newPage = await newPagePromise;
+    const initialUrl = newPage.url();
+    expect(initialUrl).toContain(BASE_URL);
 
-      // If the initial URL had a version fragment, verify it survived the redirect
-      const fragment = new URL(initialUrl).hash;
-      if (fragment) {
-        expect(finalUrl).toContain(fragment);
-      }
+    // Verify the redirect lands on the Posit docs release notes page
+    await newPage.waitForLoadState('load', { timeout: 15000 });
+    const finalUrl = newPage.url();
+    expect(finalUrl).toContain('docs.posit.co/ide/news/');
 
-      await newPage.close();
-    });
-  }
+    // If the initial URL had a version fragment, verify it survived the redirect
+    const fragment = new URL(initialUrl).hash;
+    if (fragment) {
+      expect(finalUrl).toContain(fragment);
+    }
+
+    await newPage.close();
+  });
 });

--- a/e2e/rstudio/tests/panes/layout/pane_location_persistence.test.ts
+++ b/e2e/rstudio/tests/panes/layout/pane_location_persistence.test.ts
@@ -90,9 +90,7 @@ async function moveTab(page: Page, tabLabel: string, fromContainer: string, toCo
  * to the sidebar in a single session, then restarts and checks both
  * persisted.
  */
-base.describe('Pane location persistence - #17177', () => {
-  base.skip(process.env.PW_RSTUDIO_MODE === 'server', 'Uses Desktop restart — Server session restart TBD');
-
+base.describe('Pane location persistence - #17177', { tag: ['@desktop_only'] }, () => {
   let session: DesktopSession;
 
   base('Pane assignments persist after restart', async () => {

--- a/e2e/rstudio/tests/panes/misc/s4_unloaded_package.test.ts
+++ b/e2e/rstudio/tests/panes/misc/s4_unloaded_package.test.ts
@@ -150,9 +150,7 @@ async function verifyEnvironmentPane(page: Page): Promise<void> {
 // ==========================================================================
 // Test 1: R session restart
 // ==========================================================================
-base.describe.serial('S4 unloaded package -- R session restart (#17353)', { tag: ['@serial'] }, () => {
-  base.skip(process.env.PW_RSTUDIO_MODE === 'server', 'Uses Desktop launch -- Server not supported');
-
+base.describe.serial('S4 unloaded package -- R session restart (#17353)', { tag: ['@serial', '@desktop_only'] }, () => {
   let session: DesktopSession;
   let page: Page;
 
@@ -184,9 +182,7 @@ base.describe.serial('S4 unloaded package -- R session restart (#17353)', { tag:
 // ==========================================================================
 // Test 2: Full RStudio Desktop restart
 // ==========================================================================
-base.describe.serial('S4 unloaded package -- RStudio restart (#17353)', { tag: ['@serial'] }, () => {
-  base.skip(process.env.PW_RSTUDIO_MODE === 'server', 'Uses Desktop launch -- Server not supported');
-
+base.describe.serial('S4 unloaded package -- RStudio restart (#17353)', { tag: ['@serial', '@desktop_only'] }, () => {
   let session: DesktopSession;
   let page: Page;
 

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/detachable-sidebar.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/detachable-sidebar.test.ts
@@ -10,9 +10,7 @@ import type { Page } from 'playwright';
 // Return button in satellite window (has explicit ElementIds assignment)
 const RETURN_TO_MAIN_BTN = '#rstudio_chat_return_to_main_button';
 
-test.describe.serial('Detachable Assistant Sidebar - #16937', () => {
-  test.skip(process.env.PW_RSTUDIO_MODE === 'server', 'Satellite windows are Desktop-only — Server behavior TBD');
-
+test.describe.serial('Detachable Assistant Sidebar - #16937', { tag: ['@desktop_only'] }, () => {
   let chatPane: ChatPane;
   let chatActions: ChatPaneActions;
   let consoleActions: ConsolePaneActions;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/uninstall-posit-ai.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/uninstall-posit-ai.test.ts
@@ -50,9 +50,7 @@ async function invokeUninstallViaPalette(page: Page): Promise<void> {
   await sleep(500);
 }
 
-base.describe.serial('Uninstall Posit Assistant - #17322', { tag: ['@serial'] }, () => {
-  base.skip(process.env.PW_RSTUDIO_MODE === 'server', 'Uses Desktop restart — Server not supported');
-
+base.describe.serial('Uninstall Posit Assistant - #17322', { tag: ['@serial', '@desktop_only'] }, () => {
   let session: DesktopSession;
   let page: Page;
   let consoleActions: ConsolePaneActions;


### PR DESCRIPTION
## Summary

Replaces the eight named Playwright projects (`desktop-os-*`, `desktop-pro-*`, `server-*-linux`) with two: `desktop` and `server`. Each computes its `grepInvert` at config load:

- **OS**: `desktop` filters OS-only tags by `os.platform()`; `server` hardcodes `@windows_only|@macos_only` (server always targets Linux).
- **Edition**: `PW_RSTUDIO_EDITION=os` (default) excludes `@pro_only`; `PW_RSTUDIO_EDITION=pro` excludes `@os_only`.
- **Mode**: each project excludes the opposite mode's tag.

`PW_RSTUDIO_MODE=desktop|server` is retained as a fallback when `--project` isn't passed; `--project` wins. `PW_PROJECT` is removed (warns if set).

Tests that previously branched on `process.env.PW_RSTUDIO_MODE` now use `@desktop_only`/`@server_only` tags. Fixture exposes a worker-scoped `mode` option set per-project.

README and Playwright skills (`run`, `create`, `migrate`) updated.