### PR TITLE
Posit Assistant: open at line and reveal in Files pane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 ## RStudio 2026.05.0 "Golden Wattle" Release Notes
 
 ### New
+- ([#17477](https://github.com/rstudio/rstudio/issues/17477)): Posit Assistant: the `ui/openDocument` JSON-RPC method now accepts an optional 1-based `line` parameter, and RStudio advertises the `ui/openDocument/line` capability so the assistant can open documents at a specific line.
+- ([#17478](https://github.com/rstudio/rstudio/issues/17478)): Posit Assistant: added the `ui/revealInFilesPane` JSON-RPC method, which navigates the Files pane to a directory (or to a file's parent directory) and brings the pane to the front.
 - ([#17514](https://github.com/rstudio/rstudio/issues/17514)): Added the `allow-package-source-recording` session option (default `true`); when set to `false`, RStudio will not annotate DESCRIPTION files of packages installed via `install.packages()` with the remote repository they came from.
 
 ### Fixed

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -2936,14 +2936,72 @@ void handleOpenDocument(core::system::ProcessOperations& ops,
    // Resolve aliased paths (e.g., ~/file.R)
    FilePath resolvedPath = module_context::resolveAliasedPath(filePath);
 
-   // Open the file in the editor
-   module_context::editFile(resolvedPath);
+   // Optional 1-based line number; default of -1 disables line positioning
+   int line = -1;
+   json::readObject(params, "line", line);
+
+   // Open the file in the editor (editFile expects a 1-based line number, or
+   // -1 to skip line positioning)
+   module_context::editFile(resolvedPath, line >= 1 ? line : -1);
 
    // Return success
    json::Object result;
    result["success"] = true;
 
-   DLOG("Opened document: {}", resolvedPath.getAbsolutePath());
+   DLOG("Opened document: {} (line={})", resolvedPath.getAbsolutePath(), line);
+   sendJsonRpcResponse(ops, requestId, result);
+}
+
+void handleRevealInFilesPane(core::system::ProcessOperations& ops,
+                             const json::Value& requestId,
+                             const json::Object& params)
+{
+   DLOG("Handling ui/revealInFilesPane request");
+
+   // Extract path parameter
+   std::string path;
+   Error error = json::readObject(params, "path", path);
+   if (error)
+   {
+      sendJsonRpcError(ops, requestId, kJsonRpcInvalidParams, "Invalid params: path required");
+      return;
+   }
+
+   // Convert URI to path if needed (handles file:// URIs)
+   std::string filePath = uriToPath(path);
+
+   if (filePath.empty())
+   {
+      sendJsonRpcError(ops, requestId, kJsonRpcInvalidParams, "Invalid path: " + path);
+      return;
+   }
+
+   // Resolve aliased paths (e.g., ~/folder)
+   FilePath resolvedPath = module_context::resolveAliasedPath(filePath);
+
+   if (!resolvedPath.exists())
+   {
+      sendJsonRpcError(ops, requestId, kJsonRpcInvalidParams,
+                       "Path does not exist: " + path);
+      return;
+   }
+
+   // If the path points to a file, reveal its parent directory in the Files pane
+   FilePath dirPath = resolvedPath.isDirectory() ? resolvedPath : resolvedPath.getParent();
+
+   // Fire a directory_navigate client event with activate=true to bring the
+   // Files pane to the front
+   json::Object eventData;
+   eventData["directory"] = module_context::createAliasedPath(dirPath);
+   eventData["activate"] = true;
+   ClientEvent event(client_events::kDirectoryNavigate, eventData);
+   module_context::enqueClientEvent(event);
+
+   // Return success
+   json::Object result;
+   result["success"] = true;
+
+   DLOG("Revealed in Files pane: {}", dirPath.getAbsolutePath());
    sendJsonRpcResponse(ops, requestId, result);
 }
 
@@ -3087,6 +3145,10 @@ void handleRequest(core::system::ProcessOperations& ops,
    else if (method == "ui/openDocument")
    {
       handleOpenDocument(ops, requestId, params);
+   }
+   else if (method == "ui/revealInFilesPane")
+   {
+      handleRevealInFilesPane(ops, requestId, params);
    }
    else
    {

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -2938,11 +2938,22 @@ void handleOpenDocument(core::system::ProcessOperations& ops,
 
    // Optional 1-based line number; default of -1 disables line positioning
    int line = -1;
-   json::readObject(params, "line", line);
+   auto lineIt = params.find("line");
+   if (lineIt != params.end())
+   {
+      const json::Value& lineValue = (*lineIt).getValue();
+      if (!lineValue.isInt() || lineValue.getInt() < 1)
+      {
+         sendJsonRpcError(ops, requestId, kJsonRpcInvalidParams,
+                          "Invalid params: line must be a positive integer");
+         return;
+      }
+      line = lineValue.getInt();
+   }
 
    // Open the file in the editor (editFile expects a 1-based line number, or
    // -1 to skip line positioning)
-   module_context::editFile(resolvedPath, line >= 1 ? line : -1);
+   module_context::editFile(resolvedPath, line);
 
    // Return success
    json::Object result;

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -2933,7 +2933,9 @@ void handleOpenDocument(core::system::ProcessOperations& ops,
       return;
    }
 
-   // Resolve aliased paths (e.g., ~/file.R)
+   // Resolve aliased paths (e.g., ~/file.R). We intentionally do not check for
+   // existence here -- callers may legitimately ask to open a path that does
+   // not yet exist (the editor will create a new buffer).
    FilePath resolvedPath = module_context::resolveAliasedPath(filePath);
 
    // Optional 1-based line number; default of -1 disables line positioning
@@ -2951,15 +2953,18 @@ void handleOpenDocument(core::system::ProcessOperations& ops,
       line = lineValue.getInt();
    }
 
-   // Open the file in the editor (editFile expects a 1-based line number, or
-   // -1 to skip line positioning)
+   // Open the file in the editor (editFile expects a 1-based line number; any
+   // negative value skips line positioning)
    module_context::editFile(resolvedPath, line);
 
    // Return success
    json::Object result;
    result["success"] = true;
 
-   DLOG("Opened document: {} (line={})", resolvedPath.getAbsolutePath(), line);
+   if (line > 0)
+      DLOG("Opened document: {} (line={})", resolvedPath.getAbsolutePath(), line);
+   else
+      DLOG("Opened document: {}", resolvedPath.getAbsolutePath());
    sendJsonRpcResponse(ops, requestId, result);
 }
 
@@ -2987,7 +2992,9 @@ void handleRevealInFilesPane(core::system::ProcessOperations& ops,
       return;
    }
 
-   // Resolve aliased paths (e.g., ~/folder)
+   // Resolve aliased paths (e.g., ~/folder). Unlike ui/openDocument, reveal
+   // requires an existing target -- we cannot navigate the Files pane to a
+   // path that is not on disk.
    FilePath resolvedPath = module_context::resolveAliasedPath(filePath);
 
    if (!resolvedPath.exists())

--- a/src/cpp/session/modules/chat/ChatConstants.cpp
+++ b/src/cpp/session/modules/chat/ChatConstants.cpp
@@ -47,6 +47,8 @@ const std::vector<std::string>& rstudioCapabilities()
       "workspace/insertIntoNewFile",
       "workspace/insertAtCursor",
       "ui/openDocument",
+      "ui/openDocument/line",
+      "ui/revealInFilesPane",
    };
    return s_capabilities;
 }


### PR DESCRIPTION
## Intent

Addresses #17477 and #17478.

## Summary

- `ui/openDocument` now accepts an optional 1-based `line` parameter and the rstudio peer advertises the `ui/openDocument/line` capability so Posit Assistant can open documents at a specific line. Invalid `line` values (non-integer or `< 1`) are rejected with `kJsonRpcInvalidParams`.
- Adds the `ui/revealInFilesPane` JSON-RPC method (and capability), which navigates the Files pane to a directory, or to a file's parent directory, and brings the pane to the front.
- This PR is the RStudio side only; wiring the new ``revealInFileExplorer`` UI method through to the new JSON-RPC call in Posit Assistant is tracked separately.

## Test plan

The `revealInFilesPane` call won't work until this change is made in `assistant` and a new build installed: https://github.com/posit-dev/assistant/issues/1235

- [ ] With a build of Posit Assistant that recognises the new capabilities, ask the assistant for a markdown link of the form `[file](path:NNN)` and confirm clicking it opens the file at line `NNN`.
- [ ] Send a request with a malformed `line` param (e.g. a string or `0`) and verify rsession returns a JSON-RPC `Invalid params` error.
- [ ] Confirm `ui/openDocument/line` and `ui/revealInFilesPane` appear in the `protocol/getVersion` capabilities list.