### PR TITLE
Add `test_selector` input to Ubuntu 24 Desktop Playwright GitHub Actions workflow

### DIFF
--- a/.github/workflows/playwright-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/playwright-desktop-os-ubuntu-24.yml
@@ -19,6 +19,10 @@ on:
         description: "Optional Playwright --grep pattern to filter tests."
         type: string
         default: ""
+      test_selector:
+        description: "Optional test paths/files/directories to run (space-separated). Matched as substrings against test file paths. Examples: 'autocomplete.test.ts', 'tests/panes/misc/', 'autocomplete tests/panes/posit-assistant-chat/'. Leave empty to run all tests."
+        type: string
+        default: ""
   workflow_call:
     inputs:
       rstudio_installer_url:
@@ -31,6 +35,9 @@ on:
         type: string
         default: "desktop"
       grep:
+        type: string
+        default: ""
+      test_selector:
         type: string
         default: ""
 
@@ -149,14 +156,17 @@ jobs:
           PW_RSTUDIO_MODE: desktop
           PW_PROJECT_NAME: ${{ inputs.project }}
           PW_GREP: ${{ inputs.grep }}
+          PW_TEST_SELECTOR: ${{ inputs.test_selector }}
         run: |
+          ARGS=(--project "$PW_PROJECT_NAME")
           if [ -n "$PW_GREP" ]; then
-            xvfb-run -a --server-args="-screen 0 1920x1080x24" \
-              npx playwright test --project "$PW_PROJECT_NAME" --grep "$PW_GREP"
-          else
-            xvfb-run -a --server-args="-screen 0 1920x1080x24" \
-              npx playwright test --project "$PW_PROJECT_NAME"
+            ARGS+=(--grep "$PW_GREP")
           fi
+          if [ -n "$PW_TEST_SELECTOR" ]; then
+            ARGS+=($PW_TEST_SELECTOR)
+          fi
+          xvfb-run -a --server-args="-screen 0 1920x1080x24" \
+            npx playwright test "${ARGS[@]}"
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/playwright-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/playwright-desktop-os-ubuntu-24.yml
@@ -84,9 +84,9 @@ jobs:
           FILENAME=""
           if [ -z "$URL" ]; then
             MANIFEST=$(curl -fsSL https://dailies.rstudio.com/rstudio/latest/index.json)
-            URL=$(echo "$MANIFEST" | jq -er '."noble-amd64".link')
-            SHA=$(echo "$MANIFEST" | jq -er '."noble-amd64".sha256')
-            FILENAME=$(echo "$MANIFEST" | jq -er '."noble-amd64".filename')
+            URL=$(echo "$MANIFEST" | jq -er '.products.electron.platforms."noble-amd64".link')
+            SHA=$(echo "$MANIFEST" | jq -er '.products.electron.platforms."noble-amd64".sha256')
+            FILENAME=$(echo "$MANIFEST" | jq -er '.products.electron.platforms."noble-amd64".filename')
             echo "Auto-resolved latest noble-amd64 daily:"
             echo "  URL:      $URL"
             echo "  SHA-256:  $SHA"

--- a/.github/workflows/playwright-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/playwright-desktop-os-ubuntu-24.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Install rig
         run: |
-          curl -fsSL https://github.com/r-lib/rig/releases/latest/download/rig-linux-latest.tar.gz \
+          curl -Ls https://github.com/r-lib/rig/releases/download/latest/rig-linux-$(arch)-latest.tar.gz \
             | sudo tar xz -C /usr/local
 
       - name: Install R via rig

--- a/.github/workflows/playwright-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/playwright-desktop-os-ubuntu-24.yml
@@ -158,14 +158,15 @@ jobs:
           PW_GREP: ${{ inputs.grep }}
           PW_TEST_SELECTOR: ${{ inputs.test_selector }}
         run: |
-          ARGS=(--project "$PW_PROJECT_NAME")
-          if [ -n "$PW_GREP" ]; then
-            ARGS+=(--grep "$PW_GREP")
-          fi
+          ARGS=()
           if [ -n "$PW_TEST_SELECTOR" ]; then
             set -f
             ARGS+=($PW_TEST_SELECTOR)
             set +f
+          fi
+          ARGS+=(--project "$PW_PROJECT_NAME")
+          if [ -n "$PW_GREP" ]; then
+            ARGS+=(--grep "$PW_GREP")
           fi
           xvfb-run -a --server-args="-screen 0 1920x1080x24" \
             npx playwright test "${ARGS[@]}"

--- a/.github/workflows/playwright-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/playwright-desktop-os-ubuntu-24.yml
@@ -163,7 +163,9 @@ jobs:
             ARGS+=(--grep "$PW_GREP")
           fi
           if [ -n "$PW_TEST_SELECTOR" ]; then
+            set -f
             ARGS+=($PW_TEST_SELECTOR)
+            set +f
           fi
           xvfb-run -a --server-args="-screen 0 1920x1080x24" \
             npx playwright test "${ARGS[@]}"

--- a/.github/workflows/playwright-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/playwright-desktop-os-ubuntu-24.yml
@@ -23,6 +23,10 @@ on:
         description: "Optional test paths/files/directories to run (space-separated). Matched as substrings against test file paths. Examples: 'autocomplete.test.ts', 'tests/panes/misc/', 'autocomplete tests/panes/posit-assistant-chat/'. Leave empty to run all tests."
         type: string
         default: ""
+      rstudio_extra_args:
+        description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS."
+        type: string
+        default: ""
   workflow_call:
     inputs:
       rstudio_installer_url:
@@ -38,6 +42,9 @@ on:
         type: string
         default: ""
       test_selector:
+        type: string
+        default: ""
+      rstudio_extra_args:
         type: string
         default: ""
 
@@ -157,6 +164,7 @@ jobs:
           PW_PROJECT_NAME: ${{ inputs.project }}
           PW_GREP: ${{ inputs.grep }}
           PW_TEST_SELECTOR: ${{ inputs.test_selector }}
+          PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
         run: |
           ARGS=()
           if [ -n "$PW_TEST_SELECTOR" ]; then


### PR DESCRIPTION
Adds a `test_selector` input to the GitHub Actions workflow so a manual run can target specific test files or directories without writing a `--grep` regex. Accepts space-separated paths/substrings (e.g. `autocomplete.test.ts`, `tests/panes/misc/`) and is appended as positional args to `npx playwright test`.