### PR TITLE
Fix Windows installer File Version mismatch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 - ([#16541](https://github.com/rstudio/rstudio/issues/16541)): Section headers now fold hierarchically based on heading level, matching Positron's default behavior.
 - ([#16966](https://github.com/rstudio/rstudio/issues/16966)): Restored the desktop terminal bell on Linux, now that the underlying Electron crash has been fixed.
 - ([#17084](https://github.com/rstudio/rstudio/issues/17084)): The Shiny test commands (Record Test, Run Tests, Compare Results) now use the `shinytest2` package; `shinytest` has been deprecated.
+- ([#17128](https://github.com/rstudio/rstudio/issues/17128)): The Windows installer's File Version now matches its Product Version; previously the installer concatenated the major and minor version components into a single value that exceeded NSIS's 16-bit-per-component limit and was truncated to an unrelated number.
 - ([#17176](https://github.com/rstudio/rstudio/issues/17176)): Fixed a startup hang when opening a Quarto project containing large directories (e.g. `_targets/`).
 - ([#17417](https://github.com/rstudio/rstudio/issues/17417)): Added missing French translations for newer commands and preferences, removed an orphaned French key, deduplicated stale entries in the French application strings, and normalized line endings in five English string files.
 - ([#17440](https://github.com/rstudio/rstudio/issues/17440)): Fixed an issue where triggering tab completion inside `[` on a large Matrix-package sparse matrix could hang RStudio and exhaust system memory.

--- a/package/win32/cmake/modules/NSIS.template.in
+++ b/package/win32/cmake/modules/NSIS.template.in
@@ -53,8 +53,12 @@
   ; RSTUDIO CHANGE - Add version info
   ;
   ;Version info
-  VIProductVersion "@CPACK_PACKAGE_VERSION_MAJOR_NUMERIC@.@CPACK_PACKAGE_VERSION_MINOR@.@CPACK_PACKAGE_VERSION_PATCH@.0"
+  ; Each component of VIProductVersion must fit in 16 bits (NSIS limit, max
+  ; 65535); concatenating MAJOR+MINOR overflows and gets truncated, leaving
+  ; setup.exe's File Version showing an unrelated value (#17128).
+  VIProductVersion "@CPACK_PACKAGE_VERSION_MAJOR@.@CPACK_PACKAGE_VERSION_MINOR@.@CPACK_PACKAGE_VERSION_PATCH@.0"
   VIAddVersionKey ProductVersion "@CPACK_PACKAGE_VERSION_MAJOR@.@CPACK_PACKAGE_VERSION_MINOR@.@CPACK_PACKAGE_VERSION_PATCH@.0"
+  VIAddVersionKey FileVersion "@CPACK_PACKAGE_VERSION_MAJOR@.@CPACK_PACKAGE_VERSION_MINOR@.@CPACK_PACKAGE_VERSION_PATCH@.0"
   VIAddVersionKey ProductName "RStudio"
   VIAddVersionKey CompanyName "Posit Software, PBC"
   VIAddVersionKey FileDescription "RStudio"


### PR DESCRIPTION
## Intent

Addresses #17128.

## Summary

The Windows installer's **File Version** field on `setup.exe` shows an unrelated number (e.g. `5997.5.0.0` for the 2026.05 release) while **Product Version** correctly shows `2026.05.0.0`.

`VIProductVersion` in `package/win32/cmake/modules/NSIS.template.in` was using `CPACK_PACKAGE_VERSION_MAJOR_NUMERIC`, which concatenates the major and minor components (e.g. `2026` + `05` = `202605`). Each component of `VIProductVersion` must fit in 16 bits (max 65535); `202605` overflows and is truncated to `5997`. Since no `VIAddVersionKey "FileVersion"` was set, NSIS used the truncated binary value as the displayed File Version.

`MAJOR_NUMERIC` was introduced in 2021 (commit `6dc06a46b95`) when `CPACK_PACKAGE_VERSION_MAJOR` contained `%Y-%m` and NSIS rejected the dash. Today `MAJOR` is just the year (e.g. `2026`), so it fits in 16 bits and can be used directly.

## Changes

- `VIProductVersion` now uses `CPACK_PACKAGE_VERSION_MAJOR` directly (year-only) so all four components stay within NSIS's 16-bit-per-component limit.
- Added an explicit `VIAddVersionKey FileVersion` so the displayed File Version is set deterministically rather than depending on NSIS's fallback.
- NEWS.md entry under `### Fixed`.

## Test plan

- [x] Verified locally with a test package build that File Version and Product Version on `setup.exe` now match.