### PR TITLE
fix test-api.R to call internal API instead of rstudioapi

### DIFF
--- a/src/cpp/tests/testthat/test-api.R
+++ b/src/cpp/tests/testthat/test-api.R
@@ -24,14 +24,14 @@ test_that("invalid marker type generates informative error", {
    zerolength_type[["type"]] <- character(0)
    
    expect_error(
-      rstudioapi::sourceMarkers(name = "with_NULL_type",
-                                markers = list(NULL_type)),
+      .rs.api.sourceMarkers(name = "with_NULL_type",
+                            markers = list(NULL_type)),
       regexp = "Invalid marker type", fixed = TRUE
    )
-   
+
    expect_error(
-      rstudioapi::sourceMarkers(name = "with_zerolength_type",
-                                markers = list(zerolength_type)),
+      .rs.api.sourceMarkers(name = "with_zerolength_type",
+                            markers = list(zerolength_type)),
       regexp = "Invalid marker type", fixed = TRUE
    )
 })


### PR DESCRIPTION
## Summary

- The C++ test runner (`./rstudio-tests --scope r`) does not have `rstudioapi` installed in its R library, so the new tests in `test-api.R` were failing in CI with `there is no package called 'rstudioapi'` before reaching the `Invalid marker type` assertion they were meant to verify.
- The validation being tested lives in `.rs.api.sourceMarkers` in `src/cpp/r/R/Api.R`; `rstudioapi::sourceMarkers` is a thin wrapper that delegates to it. Switching the test to call `.rs.api.sourceMarkers` directly removes the unnecessary external dependency and matches the pattern used by other tests in this folder (e.g. `test-document-apis.R` calls `.rs.api.insertText`).

## Test plan

- [ ] `./rstudio-tests --scope r --filter test-api` passes locally
- [ ] CI run on this branch is green for the `r` scope tests