### PR TITLE
Add admin-RPC SO_PEERCRED gate and widen RPC peer UID to int64_t

### DIFF
--- a/src/cpp/core/include/core/http/Request.hpp
+++ b/src/cpp/core/include/core/http/Request.hpp
@@ -113,7 +113,7 @@ public:
    std::string forwarded() const { return headerValue("Forwarded"); }
    
    // only applies to local stream connections (returns -1 if unknown)
-   int remoteUid() const { return remoteUid_; }
+   int64_t remoteUid() const { return remoteUid_; }
    
    boost::posix_time::ptime ifModifiedSince() const;
    
@@ -242,7 +242,7 @@ private:
 
    std::string method_;
    std::string uri_;
-   int remoteUid_;
+   int64_t remoteUid_;
    std::string username_;
    std::string handlerPrefix_;
    long requestSequence_ = 0;

--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -864,9 +864,23 @@ int main(int argc, char * const argv[])
                        ", min: " + std::to_string(system::crypto::getMinimumEncryptionVersion()));
 
       // initialize secure cookie module
-      error = core::http::secure_cookie::initialize(options.secureCookieKeyFile());
-      if (error)
-         return core::system::exitFailure(error, ERROR_LOCATION);
+      // In verify-installation mode, skip if the key file exists but is not
+      // readable by the caller - the cookie key is not needed for the session
+      // launch + exit path that verify-installation follows.
+      {
+         FilePath cookieKeyPath = options.secureCookieKeyFile().isEmpty()
+            ? key_file::systemKeyFilePath("secure-cookie-key")
+            : options.secureCookieKeyFile();
+         bool skip = options.verifyInstallation() &&
+                     cookieKeyPath.exists() &&
+                     ::access(cookieKeyPath.getAbsolutePath().c_str(), R_OK) != 0;
+         if (!skip)
+         {
+            error = core::http::secure_cookie::initialize(cookieKeyPath);
+            if (error)
+               return core::system::exitFailure(error, ERROR_LOCATION);
+         }
+      }
 
       // execute any database commands if passed
       if (!options.dbCommand().empty())
@@ -937,18 +951,29 @@ int main(int argc, char * const argv[])
          uri_handlers::setRequestFilter(rootPathRequestFilter);
       }
       // initialize socket rpc so we can send distributed events
-      error = key_file::readSecureKeyFile("session-rpc-key", &s_rpcSecret);
-      if (error)
-         return core::system::exitFailure(error, ERROR_LOCATION);
+      // In verify-installation mode, skip if the key file exists but is not
+      // readable - the session RPC is unused for the verify-installation path.
+      {
+         FilePath rpcKeyPath = key_file::systemKeyFilePath("session-rpc-key");
+         bool skip = options.verifyInstallation() &&
+                     rpcKeyPath.exists() &&
+                     ::access(rpcKeyPath.getAbsolutePath().c_str(), R_OK) != 0;
+         if (!skip)
+         {
+            error = key_file::readSecureKeyFile("session-rpc-key", &s_rpcSecret);
+            if (error)
+               return core::system::exitFailure(error, ERROR_LOCATION);
 
-      error = core::socket_rpc::initializeSecret(s_rpcSecret);
-      if (error)
-         return core::system::exitFailure(error, ERROR_LOCATION);
+            error = core::socket_rpc::initializeSecret(s_rpcSecret);
+            if (error)
+               return core::system::exitFailure(error, ERROR_LOCATION);
 
-      // initialize the session rpc handler
-      error = session_rpc::initialize();
-      if (error)
-         return core::system::exitFailure(error, ERROR_LOCATION);
+            // session_rpc::initialize reads session-rpc-key; must be skipped together with initializeSecret
+            error = session_rpc::initialize();
+            if (error)
+               return core::system::exitFailure(error, ERROR_LOCATION);
+         }
+      }
 
       // call overlay initialize
       error = overlay::initialize(serverUser);

--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -868,15 +868,24 @@ int main(int argc, char * const argv[])
       // readable by the caller - the cookie key is not needed for the session
       // launch + exit path that verify-installation follows.
       {
-         FilePath cookieKeyPath = options.secureCookieKeyFile().isEmpty()
-            ? key_file::systemKeyFilePath("secure-cookie-key")
-            : options.secureCookieKeyFile();
-         bool skip = options.verifyInstallation() &&
-                     cookieKeyPath.exists() &&
-                     ::access(cookieKeyPath.getAbsolutePath().c_str(), R_OK) != 0;
+         const FilePath& cookieKeyFile = options.secureCookieKeyFile();
+         bool skip = false;
+         if (options.verifyInstallation())
+         {
+            FilePath probePath = cookieKeyFile.isEmpty()
+               ? key_file::systemKeyFilePath("secure-cookie-key")
+               : cookieKeyFile;
+            skip = probePath.exists() &&
+                   ::access(probePath.getAbsolutePath().c_str(), R_OK) != 0;
+         }
          if (!skip)
          {
-            error = core::http::secure_cookie::initialize(cookieKeyPath);
+            // When no explicit key file is configured, route through the
+            // parameterless overload so unprivileged callers get the
+            // user-cache fallback in key_file::readSecureKeyFile.
+            error = cookieKeyFile.isEmpty()
+               ? core::http::secure_cookie::initialize()
+               : core::http::secure_cookie::initialize(cookieKeyFile);
             if (error)
                return core::system::exitFailure(error, ERROR_LOCATION);
          }

--- a/src/cpp/server/session/ServerSessionRpc.cpp
+++ b/src/cpp/server/session/ServerSessionRpc.cpp
@@ -24,6 +24,7 @@
 #include <server_core/http/SecureCookie.hpp>
 #include <server_core/SecureKeyFile.hpp>
 
+#include <server/ServerOptions.hpp>
 #include <server/ServerPaths.hpp>
 #include <server/session/ServerSessionManager.hpp>
 
@@ -41,7 +42,8 @@ namespace overlay {
 typedef boost::function<void(
    const auth::SecureAsyncUriHandlerFunction&,
    http::AsyncUriHandlerFunction,
-   bool,
+   bool /*fallbackAllowed*/,
+   bool /*requireAdminAuth*/,
    boost::shared_ptr<core::http::AsyncConnection>)> ValidationHandler;
 
 Error initialize(
@@ -66,6 +68,15 @@ namespace {
 std::string s_sessionSharedSecret;
 boost::shared_ptr<http::AsyncServer> s_pSessionRpcServer;
 
+// Cached uid of the configured server-user (e.g. "rstudio-server"), resolved
+// once at session_rpc::initialize(). Used by the admin-endpoint authorization
+// gate in validationHandler so the decision is driven by SO_PEERCRED, not by
+// any cookie-derived username. -1 means lookup failed/uninitialized; in that
+// case only uid=0 (root) callers can satisfy the gate.
+// int64_t avoids the uid_t->int narrowing that would misidentify UID >= 2^31 or
+// the nobody sentinel (4294967295) as the uninitialized sentinel.
+int64_t s_serverUserUid = -1;
+
 void sessionProfileFilter(core::r_util::SessionLaunchProfile* pProfile)
 {
    pProfile->config.environment.push_back(
@@ -77,6 +88,18 @@ void writeInvalidRequest(boost::shared_ptr<core::http::AsyncConnection> pConnect
    http::Response& response = pConnection->response();
    response.setStatusCode(core::http::status::BadRequest);
    response.setStatusMessage("Invalid request.");
+   pConnection->writeResponse();
+}
+
+// Used by the admin-auth gate in validationHandler. The caller is authenticated
+// (or anonymous on the cookie-less path) but not authorized for an admin RPC.
+// 403 is the right status here - the request itself is well-formed.
+void writeForbiddenResponse(boost::shared_ptr<core::http::AsyncConnection> pConnection,
+                            const std::string& reason)
+{
+   http::Response& response = pConnection->response();
+   response.setStatusCode(core::http::status::Forbidden);
+   response.setStatusMessage(reason);
    pConnection->writeResponse();
 }
 
@@ -113,6 +136,7 @@ void validationHandler(
       const auth::SecureAsyncUriHandlerFunction& handler,
       http::AsyncUriHandlerFunction unauthorizedResponseFunction,
       bool fallbackAllowed, // failure should not be logged
+      bool requireAdminAuth, // endpoint registered with allowUserAccess=false
       boost::shared_ptr<core::http::AsyncConnection> pConnection)
 {
    std::string username;
@@ -145,7 +169,7 @@ void validationHandler(
       }
 
       // get user on the other end of the socket (if available)
-      int uid = pConnection->request().remoteUid();
+      int64_t uid = pConnection->request().remoteUid();
       if (uid != -1)
       {
          core::system::User user;
@@ -162,6 +186,34 @@ void validationHandler(
       }
    }
    pConnection->setUsername(username);
+
+   // API-level authorization for endpoints registered with allowUserAccess=false:
+   // require the caller to be root or the configured server-user. Decision is
+   // driven by SO_PEERCRED (not by `username`, which can come from a cookie).
+   if (requireAdminAuth)
+   {
+      const int64_t uid = pConnection->request().remoteUid();
+      if (uid == -1)
+      {
+         LOG_WARNING_MESSAGE("Admin RPC " + pConnection->request().uri() +
+                             " rejected: no peer credentials");
+         writeForbiddenResponse(pConnection,
+            "Forbidden: admin operations require local socket transport");
+         return;
+      }
+      if (uid != 0 && uid != s_serverUserUid)
+      {
+         LOG_WARNING_MESSAGE("Admin RPC " + pConnection->request().uri() +
+                             " rejected: caller uid=" + std::to_string(uid) +
+                             " is not root or " + server::options().serverUser());
+         writeForbiddenResponse(pConnection,
+            "Forbidden: admin operations require root or " +
+            server::options().serverUser());
+         return;
+      }
+      LOG_DEBUG_MESSAGE("Admin RPC " + pConnection->request().uri() +
+                        " invoked by uid=" + std::to_string(uid));
+   }
 
    LOG_DEBUG_MESSAGE("Handling session rpc: " + pConnection->request().debugInfo());
 
@@ -182,6 +234,7 @@ void addHandler(const std::string& prefix,
                                    handler,
                                    writeInvalidRequest,
                                    false /*fallbackAllowed*/,
+                                   !allowUserAccess /*requireAdminAuth*/,
                                    _1));
 
       overlay::addHandler(prefix, handler, allowUserAccess);
@@ -198,6 +251,7 @@ void addHttpProxyHandler(const std::string &prefix,
                                    handler,
                                    writeInvalidRequest,
                                    false /*fallbackAllowed*/,
+                                   false /*requireAdminAuth - proxy handlers are not admin-only*/,
                                    _1));
 
       overlay::addHttpProxyHandler(prefix, handler);
@@ -243,6 +297,19 @@ Error initialize()
                                        &s_sessionSharedSecret);
    if (error)
       return error;
+
+   // resolve the configured server-user's uid so the admin-RPC gate in
+   // validationHandler can compare peer-creds numerically rather than via
+   // a (cookie-derived) username
+   {
+      core::system::User saUser;
+      core::Error saErr = core::system::User::getUserFromIdentifier(
+            server::options().serverUser(), saUser);
+      if (saErr)
+         LOG_ERROR(saErr);
+      else
+         s_serverUserUid = static_cast<int64_t>(saUser.getUserId());
+   }
 
    // inject the shared secret into the session
    sessionManager().addSessionLaunchProfileFilter(sessionProfileFilter);

--- a/src/cpp/server/session/ServerSessionRpcOverlay.cpp
+++ b/src/cpp/server/session/ServerSessionRpcOverlay.cpp
@@ -29,7 +29,8 @@ namespace overlay {
 typedef boost::function<void(
    const auth::SecureAsyncUriHandlerFunction&,
    http::AsyncUriHandlerFunction,
-   bool,
+   bool /*fallbackAllowed*/,
+   bool /*requireAdminAuth*/,
    boost::shared_ptr<core::http::AsyncConnection>)> ValidationHandler;
 
 ValidationHandler s_validationHandler;

--- a/src/cpp/server_core/SecureKeyFile.cpp
+++ b/src/cpp/server_core/SecureKeyFile.cpp
@@ -113,39 +113,30 @@ core::Error readSecureKeyFile(const std::string& filename,
                               std::string* pContentsHash,
                               std::string* pKeyPathUsed)
 {
-   // For non-root callers, prefer an existing user-cache key. This
-   // preserves the prior behavior for unprivileged installs that already
-   // generated their key under ~/.cache/rstudio, avoiding a one-time
-   // session invalidation when the service-account search path was added
-   // for service-user deployments below.
-   if (!core::system::effectiveUserIsRoot())
-   {
-      core::FilePath cachePath =
-         core::system::xdg::userCacheDir().completePath(filename);
-      if (cachePath.exists())
-      {
-         LOG_INFO_MESSAGE("Running without privilege; using secure key at " +
-                          cachePath.getAbsolutePath());
-         return readSecureKeyFile(cachePath, pContents, pContentsHash, pKeyPathUsed);
-      }
-   }
-
-   // Otherwise try system paths - a service account owns these and can
-   // read them, which is required when rserver and rsession share a key
-   // under /var/lib/rstudio-server.
+   // Try system paths first - the service account owns these and can read
+   // them, so non-root rserver deployments share /var/lib/rstudio-server
+   // with privileged setup steps.
    core::FilePath secureKeyPath = core::system::xdg::findSystemConfigFile(
          "secure key", filename);
    if (!secureKeyPath.exists())
       secureKeyPath = core::FilePath("/var/lib/rstudio-server")
          .completePath(filename);
 
-   // If no system key exists and we're not privileged, generate one in
-   // the user cache.
+   // If no system key exists and we're not privileged, fall back to the
+   // user cache (read if present, generate otherwise).
    if (!secureKeyPath.exists() && !core::system::effectiveUserIsRoot())
    {
       secureKeyPath = core::system::xdg::userCacheDir().completePath(filename);
-      LOG_INFO_MESSAGE("Running without privilege; generating secure key at " +
-                       secureKeyPath.getAbsolutePath());
+      if (secureKeyPath.exists())
+      {
+         LOG_INFO_MESSAGE("Running without privilege; using secure key at " +
+                          secureKeyPath.getAbsolutePath());
+      }
+      else
+      {
+         LOG_INFO_MESSAGE("Running without privilege; generating secure key at " +
+                          secureKeyPath.getAbsolutePath());
+      }
    }
 
    return readSecureKeyFile(secureKeyPath, pContents, pContentsHash, pKeyPathUsed);

--- a/src/cpp/server_core/SecureKeyFile.cpp
+++ b/src/cpp/server_core/SecureKeyFile.cpp
@@ -114,17 +114,15 @@ core::Error readSecureKeyFile(const std::string& filename,
                               std::string* pKeyPathUsed)
 {
    // determine path to use for secure cookie key file
-   core::FilePath secureKeyPath;
-   if (core::system::effectiveUserIsRoot())
-   {
-      // check in our default configuration folder
-      secureKeyPath = core::system::xdg::findSystemConfigFile(
-            "secure key", filename);
-      if (!secureKeyPath.exists())
-         secureKeyPath = core::FilePath("/var/lib/rstudio-server")
-            .completePath(filename);
-   }
-   else
+   // always try system paths first - the service account owns these and can read them
+   core::FilePath secureKeyPath = core::system::xdg::findSystemConfigFile(
+         "secure key", filename);
+   if (!secureKeyPath.exists())
+      secureKeyPath = core::FilePath("/var/lib/rstudio-server")
+         .completePath(filename);
+
+   // if no system key exists and we're not privileged, fall back to user cache
+   if (!secureKeyPath.exists() && !core::system::effectiveUserIsRoot())
    {
       secureKeyPath = core::system::xdg::userCacheDir().completePath(filename);
       if (secureKeyPath.exists())
@@ -138,6 +136,14 @@ core::Error readSecureKeyFile(const std::string& filename,
    }
 
    return readSecureKeyFile(secureKeyPath, pContents, pContentsHash, pKeyPathUsed);
+}
+
+core::FilePath systemKeyFilePath(const std::string& filename)
+{
+   core::FilePath path = core::system::xdg::findSystemConfigFile("secure key", filename);
+   if (!path.exists())
+      path = core::FilePath("/var/lib/rstudio-server").completePath(filename);
+   return path;
 }
 
 core::Error readSecureKeyFile(const FilePath& secureKeyPath,

--- a/src/cpp/server_core/SecureKeyFile.cpp
+++ b/src/cpp/server_core/SecureKeyFile.cpp
@@ -113,26 +113,39 @@ core::Error readSecureKeyFile(const std::string& filename,
                               std::string* pContentsHash,
                               std::string* pKeyPathUsed)
 {
-   // determine path to use for secure cookie key file
-   // always try system paths first - the service account owns these and can read them
+   // For non-root callers, prefer an existing user-cache key. This
+   // preserves the prior behavior for unprivileged installs that already
+   // generated their key under ~/.cache/rstudio, avoiding a one-time
+   // session invalidation when the service-account search path was added
+   // for service-user deployments below.
+   if (!core::system::effectiveUserIsRoot())
+   {
+      core::FilePath cachePath =
+         core::system::xdg::userCacheDir().completePath(filename);
+      if (cachePath.exists())
+      {
+         LOG_INFO_MESSAGE("Running without privilege; using secure key at " +
+                          cachePath.getAbsolutePath());
+         return readSecureKeyFile(cachePath, pContents, pContentsHash, pKeyPathUsed);
+      }
+   }
+
+   // Otherwise try system paths - a service account owns these and can
+   // read them, which is required when rserver and rsession share a key
+   // under /var/lib/rstudio-server.
    core::FilePath secureKeyPath = core::system::xdg::findSystemConfigFile(
          "secure key", filename);
    if (!secureKeyPath.exists())
       secureKeyPath = core::FilePath("/var/lib/rstudio-server")
          .completePath(filename);
 
-   // if no system key exists and we're not privileged, fall back to user cache
+   // If no system key exists and we're not privileged, generate one in
+   // the user cache.
    if (!secureKeyPath.exists() && !core::system::effectiveUserIsRoot())
    {
       secureKeyPath = core::system::xdg::userCacheDir().completePath(filename);
-      if (secureKeyPath.exists())
-      {
-         LOG_INFO_MESSAGE("Running without privilege; using secure key at " + secureKeyPath.getAbsolutePath());
-      }
-      else
-      {
-         LOG_INFO_MESSAGE("Running without privilege; generating secure key at " + secureKeyPath.getAbsolutePath());
-      }
+      LOG_INFO_MESSAGE("Running without privilege; generating secure key at " +
+                       secureKeyPath.getAbsolutePath());
    }
 
    return readSecureKeyFile(secureKeyPath, pContents, pContentsHash, pKeyPathUsed);
@@ -140,7 +153,9 @@ core::Error readSecureKeyFile(const std::string& filename,
 
 core::FilePath systemKeyFilePath(const std::string& filename)
 {
-   core::FilePath path = core::system::xdg::findSystemConfigFile("secure key", filename);
+   // use the silent variant; callers use this as a probe and the
+   // INFO-logging findSystemConfigFile would emit a line on every miss
+   core::FilePath path = core::system::xdg::systemConfigFile(filename);
    if (!path.exists())
       path = core::FilePath("/var/lib/rstudio-server").completePath(filename);
    return path;

--- a/src/cpp/server_core/include/server_core/SecureKeyFile.hpp
+++ b/src/cpp/server_core/include/server_core/SecureKeyFile.hpp
@@ -50,6 +50,10 @@ core::Error readSecureKeyFile(const std::string& filename,
                               std::string* pContentsHash,
                               std::string* pKeyFileUsed);
 
+// Returns the system path where the named key file lives (or would live).
+// Does not attempt to read or create the file.
+core::FilePath systemKeyFilePath(const std::string& filename);
+
 } // namespace key_file
 } // namespace server
 } // namespace rstudio

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -425,7 +425,7 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
    std::string limitUid = core::system::getenv(kRStudioLimitRpcClientUid);
    if (!limitUid.empty())
    {
-      limitRpcClientUid_ = core::safe_convert::stringTo<int>(limitUid, -1);
+      limitRpcClientUid_ = core::safe_convert::stringTo<int64_t>(limitUid, -1);
       core::system::unsetenv(kRStudioLimitRpcClientUid);
    }
 

--- a/src/cpp/session/http/SessionLocalStreamHttpConnectionListener.hpp
+++ b/src/cpp/session/http/SessionLocalStreamHttpConnectionListener.hpp
@@ -41,7 +41,7 @@ public:
    LocalStreamHttpConnectionListener(const FilePath& streamPath,
                                      core::FileMode streamFileMode,
                                      const std::string& secret,
-                                     int limitRpcClientUid)
+                                     int64_t limitRpcClientUid)
       : localStreamPath_(streamPath),
         streamFileMode_(streamFileMode),
         secret_(secret)
@@ -53,7 +53,7 @@ public:
          permittedClients_.push_back(currentUserIdentity().userId);
 
          // also add rpc client
-         permittedClients_.push_back(limitRpcClientUid);
+         permittedClients_.push_back(static_cast<UidType>(limitRpcClientUid));
       }
    }
 

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -222,7 +222,7 @@ public:
       initialProjectPath_.clear();
    }
 
-   int limitRpcClientUid() const
+   int64_t limitRpcClientUid() const
    {
       return limitRpcClientUid_;
    }
@@ -279,7 +279,7 @@ private:
    core::FilePath resourcePath_;
 
    unsigned int authMinimumUserId_;
-   int limitRpcClientUid_;
+   int64_t limitRpcClientUid_;
 
    // in-session generated RSA keys
    std::string sessionRsaPublicKey_;


### PR DESCRIPTION
## Intent

Open-source portion of [rstudio/rstudio-pro#10941](https://github.com/rstudio/rstudio-pro/pull/10941). The bot flagged 8 OSS files modified there; this PR ports those changes so the rstudio-pro PR can pull them in via `upstream/pull-upstream`.

## Summary

- **`ServerSessionRpc.cpp`** — Adds a `requireAdminAuth` parameter through `validationHandler` / `addHandler` / `addHttpProxyHandler`. When set (i.e. endpoint registered with `allowUserAccess=false`), the handler now rejects callers whose `SO_PEERCRED` uid is neither root nor the configured server-user with a 403. Server-user uid is resolved once at `session_rpc::initialize()` via `User::getUserFromIdentifier` and cached as `int64_t`. Decision is driven by peer creds, not by the (cookie-derived) username.

- **`ServerSessionRpcOverlay.cpp`** — Widens the OSS overlay typedef so the link-time signature matches the new `validationHandler`.

- **`SecureKeyFile.{cpp,hpp}`** — `readSecureKeyFile` now always tries the system paths first (the service account owns those and can read them), falling back to the user cache only when no system key exists and the caller is unprivileged. Adds `systemKeyFilePath()` to expose the system path without reading or creating the file.

- **`ServerMain.cpp`** — In `--verify-installation` mode, skips `secure_cookie::initialize` and `session_rpc::initialize` when the relevant key file exists but is unreadable by the caller. Verify-installation only needs to launch + exit a session, so the cookie/RPC keys are not on its critical path. Uses `systemKeyFilePath()` so we can probe the path without reading.

- **UID widening** — `Request::remoteUid_`, `SessionOptions::limitRpcClientUid_`, `SessionLocalStreamHttpConnectionListener` ctor arg, and the `safe_convert::stringTo` call all widened from `int` to `int64_t`. `uid_t` -> `int` is narrowing on platforms where `uid_t` is 32-bit unsigned; the `nobody` sentinel `4294967294` was being misread as `-1`.

## Test plan

- [x] `cmake --build build --target rserver` (Server target, boost 1.87, macOS arm64) builds clean
- [x] `cmake --build build --target rsession` builds clean
- [x] No new compiler warnings
- [ ] End-to-end exercise lives in rstudio-pro (the new `e2e/tests/cli_rpc_permissions.test.ts` from #10941); the OSS code path here is exercised indirectly by anything that goes through `session_rpc::validationHandler`. No OSS endpoint currently registers with `allowUserAccess=false`, so the new gate is dead code in pure OSS until rstudio-pro lights it up.

## NEWS

No entry needed — this is internal infrastructure. The new admin gate has no OSS-visible behavior (no OSS endpoint registers as admin-only). The UID widening fixes a latent narrowing bug that was not user-reachable in pure OSS.