### PR TITLE
avoid duplicate package state refresh on session startup

### DIFF
--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -320,6 +320,11 @@ void handleClientInit(const boost::function<void()>& initFunction,
 
    // resumed
    sessionInfo["resumed"] = resumed;
+
+   // whether R's deferred init hook has already completed for the current R
+   // session -- false during fresh start or suspend/resume (event still to
+   // fire), true on re-join (event already fired)
+   sessionInfo["deferred_init_completed"] = init::isDeferredInitCompleted();
    if (resumed)
    {
       // console actions

--- a/src/cpp/session/SessionInit.cpp
+++ b/src/cpp/session/SessionInit.cpp
@@ -35,6 +35,11 @@ namespace {
 // tweak their behavior when the process is first starting
 std::atomic<bool> s_sessionInitialized(false);
 
+// has R's deferred init hook completed for the current R session? used by
+// clientInit so the frontend can distinguish a re-join (deferred init already
+// completed) from a fresh start or suspend/resume (event still to fire)
+std::atomic<bool> s_deferredInitCompleted(false);
+
 } // anonymous namespace
 
 bool ensureSessionInitializedImpl()
@@ -83,6 +88,16 @@ bool isSessionInitialized()
 bool isSessionInitializedAndRestored()
 {
    return isSessionInitialized() && rstudio::r::session::isSessionRestored();
+}
+
+void setDeferredInitCompleted(bool completed)
+{
+   s_deferredInitCompleted = completed;
+}
+
+bool isDeferredInitCompleted()
+{
+   return s_deferredInitCompleted;
 }
 
 } // namespace init

--- a/src/cpp/session/SessionInit.hpp
+++ b/src/cpp/session/SessionInit.hpp
@@ -29,6 +29,9 @@ void ensureSessionInitialized();
 bool isSessionInitialized();
 bool isSessionInitializedAndRestored();
 
+void setDeferredInitCompleted(bool completed);
+bool isDeferredInitCompleted();
+
 } // namespace init
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -571,6 +571,10 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
    // save state we need to reference later
    suspend::setSessionResumed(rInitInfo.resumed);
 
+   // a fresh R session is starting (or restarting) -- the deferred init hook
+   // has not yet run for this R session
+   init::setDeferredInitCompleted(false);
+
    // record built-in waitForMethod handlers
    module_context::registerWaitForMethod(kLocatorCompleted);
    module_context::registerWaitForMethod(kEditCompleted);
@@ -974,6 +978,11 @@ void rSessionInitHook(bool newSession)
    dataJson["startup_files_suppressed"] =
       modules::trust::shouldSuppressStartupFiles();
    dataJson["trust_request"] = modules::trust::trustRequestData();
+
+   // record that deferred init has completed for this R session, so that a
+   // client connecting after this point (a re-join) can distinguish itself
+   // from a client connecting before deferred init has fired
+   init::setDeferredInitCompleted(true);
 
    // fire an event to the client
    ClientEvent event(client_events::kDeferredInitCompleted, dataJson);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -155,6 +155,10 @@ public class SessionInfo extends JavaScriptObject
       return this.resumed;
    }-*/;
 
+   public final native boolean getDeferredInitCompleted() /*-{
+      return !!this.deferred_init_completed;
+   }-*/;
+
    public final native String getDefaultPrompt() /*-{
       return this.prompt;
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -156,7 +156,12 @@ public class SessionInfo extends JavaScriptObject
    }-*/;
 
    public final native boolean getDeferredInitCompleted() /*-{
-      return !!this.deferred_init_completed;
+      // default to true if the field is missing or non-boolean -- worst case
+      // is one redundant fetch (the pre-flag behavior); the alternative is a
+      // silent failure where the Packages pane never populates
+      return typeof this.deferred_init_completed === "boolean"
+         ? this.deferred_init_completed
+         : true;
    }-*/;
 
    public final native String getDefaultPrompt() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -195,6 +195,8 @@ public class Packages
       // For re-join scenarios (where R has been running and already completed
       // its deferred init), we need to fetch the package state ourselves --
       // the deferred init event won't fire again until the next R restart.
+      // We pass showProgress=true here -- the handler uses false because it
+      // runs in the background, but re-join is a user-visible reconnect.
       // For new sessions and suspend/resume, the event is still to come, so
       // we let the handler do the work to avoid a redundant call.
       if (session.getSessionInfo().getDeferredInitCompleted())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -90,7 +90,6 @@ import org.rstudio.studio.client.workbench.views.packages.ui.CleanUnusedDialog;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.Timer;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
@@ -188,19 +187,18 @@ public class Packages
          private PackageInstallOptions lastKnownState_;
       };
 
-      updatePackageState(true, false);
+      // Register the deferred init handler immediately so we get notified
+      // when R finishes its deferred init (for fresh starts, suspend/resume,
+      // and session restarts).
+      events.addHandler(DeferredInitCompletedEvent.TYPE, this);
 
-      // after 2 seconds also add the DeferredInitCompleted handler
-      // (we wait because if we don't then on first load in a new
-      // session where the packages tab is showing updatePackageState
-      // will be called twice)
-      new Timer() {
-         @Override
-         public void run()
-         {
-            events.addHandler(DeferredInitCompletedEvent.TYPE, Packages.this);
-         }
-      }.schedule(2000);
+      // For re-join scenarios (where R has been running and already completed
+      // its deferred init), we need to fetch the package state ourselves --
+      // the deferred init event won't fire again until the next R restart.
+      // For new sessions and suspend/resume, the event is still to come, so
+      // we let the handler do the work to avoid a redundant call.
+      if (session.getSessionInfo().getDeferredInitCompleted())
+         updatePackageState(true, false);
    }
 
    void onInstallPackage()


### PR DESCRIPTION
## Summary

- The `Packages` presenter previously called `updatePackageState` once from its constructor and registered a `DeferredInitCompletedEvent` handler 2 seconds later. The 2-second delay was meant to ensure the handler was registered after R's deferred init had fired (so a fresh new session got a single refresh), but on slow filesystems the deferred init can take longer than 2 seconds, causing the refresh to run twice.
- Replaces the timer-based heuristic with an explicit signal: a new `deferred_init_completed` flag on `sessionInfo`. The flag is reset in `rInit` and set in `rSessionInitHook`, so it accurately reports whether R's deferred init hook has run for the current R session.
- The `Packages` constructor now registers its handler immediately and only fetches the initial package state itself when re-joining a session whose deferred init has already completed. For fresh starts, suspend/resume, and session restarts the event handler performs the single refresh when the event fires.

## Test plan

- [ ] Start a new R session on a slow filesystem and confirm the Packages pane refreshes only once.
- [ ] Open a second browser tab against an already-running session (re-join) and confirm the Packages pane populates without waiting on a deferred init event.
- [ ] Suspend and resume an R session (server mode) and confirm a single refresh happens after the resume completes.
- [ ] Restart the R session (Session > Restart R) and confirm the Packages pane refreshes once after restart.