### PR TITLE
fix data viewer active-cell outline lingering after focus leaves grid

### DIFF
--- a/src/cpp/session/resources/grid/DataViewer.css
+++ b/src/cpp/session/resources/grid/DataViewer.css
@@ -190,8 +190,11 @@ tbody tr:nth-child(odd):hover td:not(.first-child) {
 
 /* Active cell highlight (keyboard nav + click). Outline draws outside
    the cell box so it doesn't shift layout, and beats the row-hover
-   background by virtue of being a separate paint phase. */
-td.activeCell {
+   background by virtue of being a separate paint phase. Scoped to
+   :focus-within so the outline disappears when focus leaves the grid
+   (e.g. Shift+Tab to the toolbar) -- otherwise it would look like
+   keyboard focus is in two places. */
+#gridViewport:focus-within td.activeCell {
    outline: 2px solid var(--grid-focus-border);
    outline-offset: -2px;
 }


### PR DESCRIPTION
## Summary

- The data viewer's active-cell outline doubled as the keyboard focus indicator, but the CSS rule applied unconditionally whenever a cell carried the `.activeCell` class.
- After clicking a cell and Shift+Tab'ing out of the grid, the outline lingered, making it look like keyboard focus was in two places at once.
- Scoped the outline to `#gridViewport:focus-within td.activeCell` so it only paints while the grid (or one of its descendants, e.g. an inline filter popup) actually holds focus. The active-cell state is preserved, so the outline reappears at the same cell when focus returns.

## Test plan

- [ ] Open a data frame in the data viewer.
- [ ] Click a cell -- verify the blue outline appears.
- [ ] Press Shift+Tab to move focus to the refresh button's dropdown -- verify the outline disappears.
- [ ] Tab back into the grid -- verify the outline reappears at the same cell.
- [ ] Use arrow keys to navigate -- verify the outline tracks the active cell as before.