### PR TITLE
data viewer: cache total table width for overscroll calc

### DIFF
--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -195,9 +195,11 @@ var columnOrder = [];
 // (in the Column resize state group above).
 var measuredWidths = [];
 
-// Sum of column widths, kept in sync by autoSizeColumns/applyResizeDelta.
-// Read by applyPinnedColumns -- using table.offsetWidth there is
-// unreliable under box-sizing: border-box + dynamic paddingRight.
+// Authoritative table content width; mirrors the sum of measuredWidths after
+// autoSizeColumns. Prefer this over deriving content width from
+// table.offsetWidth - paddingRight, which the browser may reconcile
+// inconsistently when box-sizing: border-box, table-layout: fixed, and a
+// dynamic paddingRight all interact.
 var totalTableWidth = 0;
 
 // Canvas-based text measurer. Lazily initialized so a non-DOM context
@@ -900,6 +902,12 @@ var applyPinnedColumns = function() {
    var thead = document.getElementById("data_cols");
    if (!thead) return;
 
+   // No-op if column widths haven't been measured yet (e.g. autoSizeColumns
+   // bailed because the viewport was hidden). Without a real totalTableWidth
+   // the overscroll calculation below would silently produce paddingRight=0;
+   // wait for the next autoSizeColumns + applyPinnedColumns pair instead.
+   if (totalTableWidth === 0) return;
+
    var pinned = getPinnedOffsets();
 
    for (var i = 0; i < thead.children.length; i++) {
@@ -1181,8 +1189,8 @@ var applyResizeDelta = function(delta) {
    var table = document.getElementById("rsGridData");
    if (table) {
       table.style.width = (origTableWidth + delta) + "px";
+      totalTableWidth = origTableWidth + delta;
    }
-   totalTableWidth = origTableWidth + delta;
 
    invalidatePinnedOffsets();
    // Note: saveState fires once at end of drag (in endResize), not on every
@@ -2343,6 +2351,11 @@ var toggleSidebar = function() {
    if (toggle) toggle.setAttribute("aria-expanded", sidebarVisible ? "true" : "false");
    // Trigger grid resize after transition
    setTimeout(function() {
+      // viewport.clientWidth changes when the sidebar opens/closes, which
+      // can flip the totalTableWidth > viewport.clientWidth comparison in
+      // applyPinnedColumns -- recompute paddingRight so the horizontal
+      // overscroll matches the new viewport width.
+      applyPinnedColumns();
       renderVisibleRows(true);
       updateInfoBar();
       updateCustomScrollbars();

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -195,6 +195,11 @@ var columnOrder = [];
 // (in the Column resize state group above).
 var measuredWidths = [];
 
+// Sum of column widths, kept in sync by autoSizeColumns/applyResizeDelta.
+// Read by applyPinnedColumns -- using table.offsetWidth there is
+// unreliable under box-sizing: border-box + dynamic paddingRight.
+var totalTableWidth = 0;
+
 // Canvas-based text measurer. Lazily initialized so a non-DOM context
 // (tests) doesn't pay the canvas allocation up front.
 var measureCanvas = null;
@@ -929,9 +934,7 @@ var applyPinnedColumns = function() {
    var viewport = document.getElementById("gridViewport");
    var table = document.getElementById("rsGridData");
    if (viewport && table) {
-      var currentPad = parseFloat(table.style.paddingRight) || 0;
-      var contentWidth = table.offsetWidth - currentPad;
-      var overscroll = contentWidth > viewport.clientWidth
+      var overscroll = totalTableWidth > viewport.clientWidth
          ? Math.max(0, viewport.clientWidth - pinned.totalWidth)
          : 0;
       table.style.paddingRight = overscroll + "px";
@@ -1074,6 +1077,7 @@ var autoSizeColumns = function() {
       table.style.tableLayout = "fixed";
    }
 
+   totalTableWidth = totalWidth;
    invalidatePinnedOffsets();
 };
 
@@ -1093,7 +1097,7 @@ var initResizeHandlers = function() {
       var th = getHeaderCell(resizingColIdx);
       if (th) {
          initResizingWidth = th.offsetWidth;
-         origTableWidth = document.getElementById("rsGridData").offsetWidth;
+         origTableWidth = totalTableWidth;
          if (typeof origColWidths[resizingColIdx] === "undefined") {
             origColWidths[resizingColIdx] = initResizingWidth;
          }
@@ -1178,6 +1182,7 @@ var applyResizeDelta = function(delta) {
    if (table) {
       table.style.width = (origTableWidth + delta) + "px";
    }
+   totalTableWidth = origTableWidth + delta;
 
    invalidatePinnedOffsets();
    // Note: saveState fires once at end of drag (in endResize), not on every
@@ -3042,6 +3047,7 @@ var resetGridState = function() {
    measuredWidths = [];
    manualWidths = [];
    origColWidths = [];
+   totalTableWidth = 0;
 
    // Render window
    renderStart = 0;


### PR DESCRIPTION
## Summary

Cache the total column width (`totalTableWidth`) in `autoSizeColumns` and
`applyResizeDelta`, and read it directly in `applyPinnedColumns` instead
of deriving content width from `table.offsetWidth - paddingRight`.

The derivation was unreliable: with the global `* { box-sizing: border-box }`
rule and the dynamic `paddingRight` we set for horizontal overscroll,
`table.offsetWidth` and the implicit content area diverge in ways that
depend on browser-specific table-layout decisions. Caching the column
sum makes the overscroll calculation a function of saved state rather
than live layout, so it stays consistent across pane resizes regardless
of how the browser reconciles the conflicting layout constraints.

No NEWS entry: this code shipped in #17382 (data viewer rewrite) and has
not been released.

## Test plan

- [ ] View a data frame whose columns extend past the pane width; resize the pane horizontally and verify column widths do not shift
- [ ] View a small data frame that fits the pane; verify no phantom right-padding/horizontal scrollbar appears
- [ ] Pin and unpin columns; verify pinned columns position correctly
- [ ] Manually resize a column via the resizer; verify the table grows/shrinks and pinned-column overscroll updates correctly
- [ ] Toggle the sidebar/filter UI; verify column layout stays stable