### PR TITLE
fix data viewer zebra striping flipping during virtual scroll

### DIFF
--- a/src/cpp/session/resources/grid/DataViewer.css
+++ b/src/cpp/session/resources/grid/DataViewer.css
@@ -145,12 +145,9 @@ th:focus-visible {
    opacity: 1;
 }
 
-/* Virtual scroll spacer row -- specificity must beat tbody tr:nth-child/hover rules.
-   Diagonal stripes suggest pending/loading data. */
+/* Virtual scroll spacer row. Diagonal stripes suggest pending/loading data. */
 tbody tr.spacer-row td,
-tbody tr.spacer-row:nth-child(odd) td,
-tbody tr.spacer-row:hover td,
-tbody tr.spacer-row:nth-child(odd):hover td {
+tbody tr.spacer-row:hover td {
    padding: 0;
    border: none;
    background:
@@ -179,12 +176,14 @@ tbody tr:hover td:not(.first-child) {
    background-color: var(--grid-row-hover-bg);
 }
 
-/* Alternating row stripe */
-tbody tr:nth-child(odd) td:not(.first-child) {
+/* Alternating row stripe -- keyed off a class set by the renderer from the
+   data-row index, since the virtualized tbody only holds the visible window
+   plus spacer rows and DOM position would flip the pattern as we scroll. */
+tbody tr.odd-row td:not(.first-child) {
    background-color: var(--grid-row-stripe-bg);
 }
 
-tbody tr:nth-child(odd):hover td:not(.first-child) {
+tbody tr.odd-row:hover td:not(.first-child) {
    background-color: var(--grid-row-hover-bg);
 }
 

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -1687,6 +1687,10 @@ var buildRow = function(r) {
    tr.setAttribute("role", "row");
    // aria-rowindex is 1-based and includes the header row.
    tr.setAttribute("aria-rowindex", String(r + 2));
+   // Zebra striping is driven by data-row parity, not DOM position. The tbody
+   // contains a leading spacer row plus only the virtual window of data rows,
+   // so :nth-child would flip the stripe pattern as the window slides.
+   if (r % 2 === 1) tr.classList.add("odd-row");
 
    for (var c = 0; c < columnOrder.length; c++) {
       var colIdx = columnOrder[c];


### PR DESCRIPTION
## Intent

Fix a regression in the new data viewer where the zebra-striping pattern flips for any given data row as the user scrolls through a virtualized table.

The stripe rule was keyed off `tbody tr:nth-child(odd)`, but the virtualized `tbody` contains a leading spacer row plus only the visible window of data rows. A data row's DOM position is `(r - newStart) + 2`, so the parity for any given data-row index flips with `newStart` as the window slides during scroll.

## Changes

- `DataViewer.js` -- `buildRow` adds an `odd-row` class to data rows when the data-row index `r` is odd, so the stripe key follows the actual row index rather than DOM position.
- `DataViewer.css` -- stripe and hover-stripe rules switched from `:nth-child(odd)` to `tr.odd-row`. The spacer-row override no longer needs `:nth-child(odd)` variants, since spacer rows don't carry the new class.

No `NEWS.md` entry: the data viewer rewrite (#17382 / #17539) ships in the upcoming 2026.05.0 "Golden Wattle" release, so the bug was introduced in unreleased code.

## Test plan

- [ ] Open a data frame larger than the viewport (e.g. `View(ggplot2::diamonds)`).
- [ ] Confirm rows alternate stripe/no-stripe consistently from row 0 onward.
- [ ] Scroll down a few full pages and confirm a given row's stripe state never changes as it scrolls in/out of view.
- [ ] Scroll back up and confirm the pattern remains stable.
- [ ] Confirm the row-number column (first column) remains unstriped.
- [ ] Confirm the spacer area at the top/bottom of the virtual scroll still shows the diagonal "loading" gradient and is not striped.
- [ ] Hover a row in both odd and even positions and confirm the hover background paints over the stripe correctly.