### PR TITLE
data viewer: show active sort in status bar

### DIFF
--- a/src/cpp/session/resources/grid/DataViewer.css
+++ b/src/cpp/session/resources/grid/DataViewer.css
@@ -636,6 +636,15 @@ th.columnClickable div {
    height: var(--info-bar-height);
    text-align: left;
    flex-shrink: 0;
+   box-sizing: border-box;
+}
+
+#rsGridData_info_sort {
+   float: right;
+}
+
+#rsGridData_info_text {
+   overflow: hidden;
 }
 
 

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -1652,15 +1652,19 @@ var updateInfoBar = function() {
 
    var info = document.getElementById("rsGridData_info");
    if (!info) return;
+   var textEl = document.getElementById("rsGridData_info_text");
+   var sortEl = document.getElementById("rsGridData_info_sort");
 
    if (statusTextOverride) {
-      info.textContent = statusTextOverride;
+      if (textEl) textEl.textContent = statusTextOverride;
+      if (sortEl) sortEl.textContent = "";
       return;
    }
 
    var activeRows = filteredRows;
    if (totalRows === 0) {
-      info.textContent = "";
+      if (textEl) textEl.textContent = "";
+      if (sortEl) sortEl.textContent = "";
       return;
    }
 
@@ -1709,7 +1713,14 @@ var updateInfoBar = function() {
    if (filteredRows < totalRows) {
       text += " (filtered from " + totalRows.toLocaleString() + " total)";
    }
-   info.textContent = text;
+   if (textEl) textEl.textContent = text;
+
+   var sortText = "";
+   if (sortColumn >= 0 && sortDirection && cols && cols[sortColumn]) {
+      var dirText = sortDirection === "asc" ? "ascending" : "descending";
+      sortText = "Sorted by: " + cols[sortColumn].col_name + " (" + dirText + ")";
+   }
+   if (sortEl) sortEl.textContent = sortText;
 };
 
 var buildRow = function(r) {
@@ -3501,8 +3512,10 @@ var destroyGrid = function() {
    var tbody = document.getElementById("gridBody");
    if (tbody) { tbody.innerHTML = ""; }
 
-   var info = document.getElementById("rsGridData_info");
-   if (info) info.textContent = "";
+   var infoText = document.getElementById("rsGridData_info_text");
+   if (infoText) infoText.textContent = "";
+   var infoSort = document.getElementById("rsGridData_info_sort");
+   if (infoSort) infoSort.textContent = "";
 
    var viewport = document.getElementById("gridViewport");
    if (viewport) {

--- a/src/cpp/session/resources/grid/gridviewer.html
+++ b/src/cpp/session/resources/grid/gridviewer.html
@@ -23,7 +23,10 @@
                     <tbody id="gridBody"></tbody>
                 </table>
             </div>
-            <div id="rsGridData_info" aria-live="polite" aria-atomic="true"></div>
+            <div id="rsGridData_info" aria-live="polite" aria-atomic="true">
+                <div id="rsGridData_info_sort"></div>
+                <div id="rsGridData_info_text"></div>
+            </div>
         </div>
 
         <div id="sidebarPanel">


### PR DESCRIPTION
## Summary

- Surface the active sort in the data viewer's status bar so users have a persistent reminder of how rows are ordered.
- New text reads `Sorted by: <colname> (ascending|descending)` and is shown only when a sort is active; nothing is shown when unsorted (current behavior).
- Placed on the right side of the status bar, with the existing `Showing X to Y of Z entries` text remaining on the left.

## Implementation notes

- `gridviewer.html`: `#rsGridData_info` now contains two child divs -- `#rsGridData_info_sort` (first in source) and `#rsGridData_info_text`.
- `DataViewer.css`: sort div is `float: right`; text div uses `overflow: hidden` so it forms a new BFC and sits to the left of the float instead of running underneath it. Added `box-sizing: border-box` on the parent so its `padding: 5px` doesn't push the contents past the 100% width.
- `DataViewer.js`: `updateInfoBar` writes to the two child divs separately. `destroyGrid` clears the children rather than setting the parent's `textContent`, which would otherwise delete the children and break the next render.

Single-column sort only -- the underlying sort model is single-column today (`order[0]` in the fetch params), so no multi-column rendering is needed.

## Test plan

- [ ] Open a data frame in the data viewer; status bar shows only `Showing X to Y of Z entries`.
- [ ] Click a column header to sort ascending; status bar shows `Sorted by: <name> (ascending)` on the right.
- [ ] Click again to sort descending; right text updates to `(descending)`.
- [ ] Click a third time to clear the sort; right text disappears.
- [ ] Apply a filter that reduces rows; left text shows `(filtered from N total)` and the sort indicator continues to render alongside it.
- [ ] Apply a filter that returns zero rows; both texts behave sensibly (sort still shown when set).
- [ ] Resize the viewer narrow enough that the two texts would overlap; long column names get clipped on the right rather than wrapping under.