### PR TITLE
data viewer: add Reset View action to options menu

### DIFF
--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -3656,6 +3656,11 @@ window.refreshData = function() {
    bootstrap();
 };
 
+window.refreshAndReset = function() {
+   clearSavedState();
+   bootstrap();
+};
+
 window.toggleSidebar = function() {
    toggleSidebar();
 };

--- a/src/gwt/src/org/rstudio/studio/client/dataviewer/DataTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/dataviewer/DataTable.java
@@ -56,6 +56,7 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.user.client.ui.SuggestOracle;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -211,6 +212,11 @@ public class DataTable
             onStateChanged();
          }
       };
+      optionsMenu_.addItem(new MenuItem(
+            constants_.optionsResetView(),
+            false,
+            () -> refreshAndReset()));
+      optionsMenu_.addSeparator();
       optionsMenu_.addItem(showSummaryItem_);
       optionsMenuButton_ = new ToolbarMenuButton(
             ToolbarButton.NoText,
@@ -429,6 +435,17 @@ public class DataTable
 
       refreshData(getWindow());
    }
+
+   public void refreshAndReset()
+   {
+      filtered_ = false;
+      if (searchWidget_ != null)
+         searchWidget_.setText("", false);
+      if (filterButton_ != null)
+         filterButton_.setLatched(false);
+
+      refreshAndReset(getWindow());
+   }
    
    public void onActivate()
    {
@@ -494,6 +511,14 @@ public class DataTable
          frame.refreshData();
       else
          @org.rstudio.studio.client.dataviewer.DataTable::logMissingFrameMethod(Ljava/lang/String;)("refreshData");
+   }-*/;
+
+   private static final native void refreshAndReset(WindowEx frame) /*-{
+      if (!frame) return;
+      if (frame.refreshAndReset)
+         frame.refreshAndReset();
+      else
+         @org.rstudio.studio.client.dataviewer.DataTable::logMissingFrameMethod(Ljava/lang/String;)("refreshAndReset");
    }-*/;
 
    private static final native void applySearch(WindowEx frame, String text) /*-{

--- a/src/gwt/src/org/rstudio/studio/client/dataviewer/DataViewerConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/dataviewer/DataViewerConstants.java
@@ -23,5 +23,6 @@ public interface DataViewerConstants extends Constants {
     String toolbarLabel();
     String refreshButtonTitle();
     String optionsButtonTitle();
+    String optionsResetView();
     String optionsShowSummaryDefault();
 }

--- a/src/gwt/src/org/rstudio/studio/client/dataviewer/DataViewerConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/dataviewer/DataViewerConstants_en.properties
@@ -5,4 +5,5 @@ searchWidgetLabel=Search data table
 toolbarLabel=(Displaying up to 1,000 records)
 refreshButtonTitle=Refresh data viewer
 optionsButtonTitle=Data viewer options
+optionsResetView=Reset View
 optionsShowSummaryDefault=Show Summary panel by default

--- a/src/gwt/src/org/rstudio/studio/client/dataviewer/DataViewerConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/dataviewer/DataViewerConstants_fr.properties
@@ -5,4 +5,5 @@ searchWidgetLabel=Recherche dans le tableau de données
 toolbarLabel=(Affichage jusqu'à 1 000 enregistrements)
 refreshButtonTitle=Actualiser l'aperçu de données
 optionsButtonTitle=Options de l'aperçu de données
+optionsResetView=Réinitialiser la vue
 optionsShowSummaryDefault=Afficher le panneau Résumé par défaut


### PR DESCRIPTION
## Summary

- Adds a "Reset View" item to the options dropdown next to the Refresh button in the data viewer toolbar.
- Selecting it wipes the persisted per-table view state (sort, filters, pinned columns, manual column widths, sidebar visibility) and re-bootstraps the grid so the table renders with defaults.
- The existing Refresh button is unchanged: it still re-fetches data and the round-trip through localStorage preserves view state. Reset View is the explicit opt-in way to start fresh.

## Implementation notes

- `DataViewer.js`: new `window.refreshAndReset` calls the existing `clearSavedState()` (drops the localStorage entry) before `bootstrap()`. `bootstrap()` -> `destroyGrid()` -> `resetGridState()` already clears in-memory state; with localStorage now empty, the subsequent `applySavedState` is a no-op and the grid renders with defaults.
- `DataTable.java`: `refreshAndReset()` mirrors `refreshData()`'s toolbar reset (clears the search widget text, unlatches the filter button) before invoking the JS-side method via a JSNI bridge that matches the pattern already used for `refreshData`/`applySearch`/etc.
- New `MenuItem` is added to `optionsMenu_` above the existing `showSummaryItem_`, with an `addSeparator()` between them. `Reset View` is a per-table action; `Show Summary panel by default` is a global user preference, so the separator marks the conceptual boundary.
- `Reset View` does not touch the `data_viewer_show_summary` user preference (deliberately) since that lives outside the per-table localStorage entry.
- New i18n key `optionsResetView` added in `DataViewerConstants.java` plus English and French properties files.

## Test plan

- [ ] Open the data viewer dropdown next to Refresh; menu reads `Reset View` then a separator then `Show Summary panel by default`.
- [ ] Apply a sort, a column filter, pin a column, drag a column wider; click `Reset View`; sort/filter/pin/width all revert to defaults and the data is re-fetched.
- [ ] Toggle the sidebar off via the sidebar button, click `Reset View`; sidebar reverts to its default visibility.
- [ ] Confirm the "Show Summary panel by default" preference is unchanged after `Reset View`.
- [ ] Confirm clicking the regular Refresh button still preserves view state across the refresh.
- [ ] Verify French locale shows `Réinitialiser la vue` for the menu item.