### PR TITLE
Fix rig install on macOS workflow to use .pkg installer

### DIFF
--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -72,7 +72,16 @@ jobs:
           R_VERSION: ${{ inputs.r_version }}
         run: |
           rig add "$R_VERSION"
-          rig default "$R_VERSION"
+          # On macOS rig identifies installed R by major.minor (e.g. "4.4"),
+          # not full patch (e.g. "4.4.3"), since the macOS R installer only
+          # allows one patch version per major.minor on disk. Strip the
+          # patch component for `rig default` while leaving aliases intact.
+          if [[ "$R_VERSION" =~ ^([0-9]+\.[0-9]+)\.[0-9]+$ ]]; then
+            RIG_NAME="${BASH_REMATCH[1]}"
+          else
+            RIG_NAME="$R_VERSION"
+          fi
+          rig default "$RIG_NAME"
           rig ls
           mkdir -p "$R_LIBS_USER"
 

--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -72,16 +72,11 @@ jobs:
           R_VERSION: ${{ inputs.r_version }}
         run: |
           rig add "$R_VERSION"
-          # On macOS rig identifies installed R by major.minor (e.g. "4.4"),
-          # not full patch (e.g. "4.4.3"), since the macOS R installer only
-          # allows one patch version per major.minor on disk. Strip the
-          # patch component for `rig default` while leaving aliases intact.
-          if [[ "$R_VERSION" =~ ^([0-9]+\.[0-9]+)\.[0-9]+$ ]]; then
-            RIG_NAME="${BASH_REMATCH[1]}"
-          else
-            RIG_NAME="$R_VERSION"
-          fi
-          rig default "$RIG_NAME"
+          # rig names installs with arch/major.minor on macOS (e.g. "4.4-arm64"),
+          # not the requested patch or alias. Query rig for the just-installed
+          # name so `rig default` works regardless of input form.
+          INSTALLED_NAME=$(rig list --json | jq -r '.[-1].name')
+          rig default "$INSTALLED_NAME"
           rig ls
           mkdir -p "$R_LIBS_USER"
 

--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -51,7 +51,7 @@ on:
 jobs:
   e2e-desktop-macos:
     runs-on: macos-26
-    timeout-minutes: 60
+    timeout-minutes: 120
     env:
       R_LIBS_USER: ${{ github.workspace }}/R-libs
 

--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -64,8 +64,8 @@ jobs:
 
       - name: Install rig
         run: |
-          curl -fLs https://github.com/r-lib/rig/releases/download/latest/rig-macos-arm64-latest.tar.gz \
-            | sudo tar xz -C /usr/local
+          curl -fLs -o rig.pkg https://github.com/r-lib/rig/releases/download/latest/rig-macos-arm64-latest.pkg
+          sudo installer -pkg rig.pkg -target /
 
       - name: Install R via rig
         env:

--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install rig
         run: |
-          curl -fLs -o rig.pkg https://github.com/r-lib/rig/releases/download/latest/rig-macos-arm64-latest.pkg
+          curl -fLs -o rig.pkg https://github.com/r-lib/rig/releases/download/latest/rig-latest-macOS-arm64.pkg
           sudo installer -pkg rig.pkg -target /
 
       - name: Install R via rig


### PR DESCRIPTION
## Summary

The macOS rig install step in `test-e2e-rstudio-desktop-os-macos-26-arm64.yml` fetched `rig-macos-arm64-latest.tar.gz`, but rig doesn't ship a macOS tarball -- only a `.pkg` installer. Swapped to downloading the `.pkg` and installing via `sudo installer -pkg ... -target /`, matching what rig documents for macOS.