### PR TITLE
show difftime values in the environment pane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - ([#17514](https://github.com/rstudio/rstudio/issues/17514)): Added the `allow-package-source-recording` session option (default `true`); when set to `false`, RStudio will not annotate DESCRIPTION files of packages installed via `install.packages()` with the remote repository they came from.
 
 ### Fixed
+- ([#17556](https://github.com/rstudio/rstudio/issues/17556)): `difftime` objects (e.g. the result of subtracting two `Sys.time()` values) now show their formatted value in the Environment pane instead of an empty cell.
 - ([#17481](https://github.com/rstudio/rstudio/issues/17481)): Fixed two debugger regressions: top-level breakpoints (e.g. via `debugSource()`) no longer fail to show the debug highlight or call stack, and multi-line input at the `Browse[N]>` prompt no longer clears the captured browser context.
 - ([#3780](https://github.com/rstudio/rstudio/issues/3780)): The Files pane delete confirmation now reflects whether the file will be moved to the system Trash/Recycle Bin or permanently deleted, based on the "Delete files to Trash/Recycle Bin" preference.
 - ([#3780](https://github.com/rstudio/rstudio/issues/3780)): When sending a file to the system Trash/Recycle Bin fails, the Files pane now reports the error and leaves the file on disk; previously it would silently fall back to permanently deleting the file.

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -131,7 +131,7 @@
    {
       .rs.getSignature(val)
    }
-   else if (inherits(val, c("Date", "POSIXct", "POSIXlt")))
+   else if (inherits(val, c("Date", "POSIXct", "POSIXlt", "difftime")))
    {
       if (length(val) == 1)
       {

--- a/src/cpp/tests/testthat/test-environment.R
+++ b/src/cpp/tests/testthat/test-environment.R
@@ -126,12 +126,28 @@ test_that("memory usage stats are reasonable", {
 })
 
 test_that("missing arguments can be described", {
-   
+
    # simulate a missing value argument
    delayedAssign("x", quote(expr = ))
    desc <- .rs.describeObject("x", environment())
    expect_identical(desc$name, .rs.scalar("x"))
-   
+
+})
+
+test_that("date/time scalars are formatted in the environment pane", {
+   # https://github.com/rstudio/rstudio/issues/17556
+   # difftime objects previously fell through to NO_VALUE because they
+   # carry attributes (so the atomic-no-attributes branch is skipped) and
+   # weren't included in the date/time class list.
+   env <- new.env(parent = emptyenv())
+   env$dt <- as.difftime(90, units = "secs")
+   env$ts <- .POSIXct(1234567890, tz = "UTC")
+
+   dt_desc <- .rs.describeObject("dt", env)
+   expect_identical(dt_desc$value, .rs.scalar(format(env$dt, usetz = TRUE)))
+
+   ts_desc <- .rs.describeObject("ts", env)
+   expect_identical(ts_desc$value, .rs.scalar(format(env$ts, usetz = TRUE)))
 })
 
 test_that(".rs.isSerializable() works as expected", {


### PR DESCRIPTION
## Intent

Addresses #17556.

`difftime` objects (e.g. the result of `Sys.time() - Sys.time()`) showed an empty cell in the Environment pane. They fell through `valueAsStringImpl` to `NO_VALUE` because they carry attributes (so the atomic-no-attributes branch is skipped) and weren't in the date/time class list at line 134. POSIXct and Date already worked because they were in that list.

## Summary

- Add `"difftime"` to the inherits() class list in `valueAsStringImpl`. Length-1 difftime values now format via `format(val, usetz = TRUE)` (the `usetz` arg is a harmless no-op for `format.difftime`), producing e.g. `"1.5 hours"` or `"-9.5e-07 secs"`. Longer vectors get the `str()` summary, matching POSIXct/Date.
- Add a BRAT test that exercises the formatting path for both scalar `difftime` and `POSIXct` through `.rs.describeObject`.
- NEWS entry under 2026.05.0 "Golden Wattle".

## Test plan

- [ ] Build the session and run `./rstudio-tests --scope rsession --filter test-environment` (or run the new `date/time scalars are formatted in the environment pane` test in BRAT).
- [ ] In RStudio, run `dt <- Sys.time() - Sys.time()` and confirm the Environment pane shows the formatted value (e.g. `-9.5e-07 secs`) rather than an empty cell.
- [ ] Sanity check that `Sys.time()` and `Sys.Date()` values still display correctly (regression check).
- [ ] Try a multi-element difftime (`as.difftime(c(1, 5, 60), units = "secs")`) and confirm it gets a `str()`-style summary.