### PR TITLE
Fix chat-user-skills afterAll wiping ~/.positai/ via relative-path unlink

### DIFF
--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails.test.ts
@@ -24,13 +24,13 @@
  */
 
 import { test, expect } from '@fixtures/rstudio.fixture';
-import type { Page } from 'playwright';
 import { sleep, CHAT_PROVIDERS } from '@utils/constants';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { AssistantOptionsActions } from '@actions/assistant_options.actions';
 import { ChatPaneActions } from '@actions/chat_pane.actions';
 import { ChatPane } from '@pages/chat_pane.page';
 import { useSuiteSandbox } from '@utils/sandbox';
+import { createAndOpenProject } from '@utils/project';
 
 const TS = Date.now();
 const PROJECT_NAME = 'guardrail_test_project';
@@ -39,40 +39,6 @@ const TEMP_FILE = `guardrail_temp_${TS}.txt`;
 const OUTSIDE_FILE = `guardrail_outside_${TS}.txt`;
 const RENAME_SRC = `guardrail_rename_${TS}.txt`;
 const READ_FILE = `guardrail_read_${TS}.R`;
-
-const CONSOLE_INPUT = '#rstudio_console_input .ace_text-input';
-const CONSOLE_OUTPUT = '#rstudio_workbench_panel_console';
-
-/** Wait for session restart after project switch. */
-async function waitForSessionRestart(page: Page): Promise<void> {
-  await page.waitForLoadState('load', { timeout: 30000 }).catch(() => {});
-  await sleep(3000);
-  await page.waitForSelector(CONSOLE_INPUT, { state: 'visible', timeout: 60000 });
-  await sleep(2000);
-
-  await page.waitForFunction(
-    'typeof window.rstudioapi !== "undefined" || typeof window.$RStudio !== "undefined"',
-    null,
-    { timeout: 15000 }
-  ).catch(() => {});
-  await sleep(1000);
-
-  // Confirm R is idle
-  for (let attempt = 0; attempt < 3; attempt++) {
-    try {
-      const marker = `__READY_${Date.now()}__`;
-      await page.locator(CONSOLE_INPUT).click({ force: true });
-      await page.keyboard.pressSequentially(`cat("${marker}")`);
-      await sleep(200);
-      await page.keyboard.press('Enter');
-      await sleep(1500);
-      const output = await page.locator(CONSOLE_OUTPUT).innerText();
-      if (output.includes(marker)) return;
-    } catch { /* console not ready yet */ }
-    await sleep(2000);
-  }
-  console.warn('waitForSessionRestart: R session did not confirm idle after 3 attempts');
-}
 
 test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@serial'] }, () => {
   const sandbox = useSuiteSandbox();
@@ -89,23 +55,9 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@serial'] }, () 
     chatPane = chatActions.chatPane;
 
     sandboxR = sandbox.dir.replace(/\\/g, '/');
-    const projectDir = `${sandboxR}/${PROJECT_NAME}`;
 
     // Create the project inside the sandbox (sandbox afterAll handles teardown).
-    await consoleActions.typeInConsole(
-      `dir.create("${projectDir}")`
-    );
-    await sleep(500);
-    await consoleActions.typeInConsole(
-      `writeLines(c("Version: 1.0", "", "RestoreWorkspace: Default", "SaveWorkspace: Default"), "${projectDir}/${PROJECT_NAME}.Rproj")`
-    );
-    await sleep(500);
-
-    // Switch to the new project (triggers session restart)
-    await consoleActions.typeInConsole(
-      `.rs.api.openProject("${projectDir}/${PROJECT_NAME}.Rproj")`
-    );
-    await waitForSessionRestart(page);
+    await createAndOpenProject(page, sandboxR, PROJECT_NAME);
 
     // Re-create actions after session restart
     consoleActions = new ConsolePaneActions(page);

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
@@ -6,14 +6,17 @@ import { AssistantOptionsActions } from '@actions/assistant_options.actions';
 import { ChatPaneActions } from '@actions/chat_pane.actions';
 import { ChatPane } from '@pages/chat_pane.page';
 import type { EnvironmentVersions } from '@pages/console_pane.page';
+import { useSuiteSandbox } from '@utils/sandbox';
+import { createAndOpenProject } from '@utils/project';
 
 // ---------------------------------------------------------------------------
-// Project-level skill (lives in .positai/skills/ under the workspace root)
+// Project-level skill (lives in <project>/.positai/skills/ under a sandbox
+// project. Absolute paths are computed in beforeAll once the sandbox dir
+// is known.)
 // ---------------------------------------------------------------------------
 
+const PROJECT_NAME = 'user_skills_test_project';
 const PROJECT_SKILL_NAME = 'custom-data-summary';
-const PROJECT_SKILL_DIR = `.positai/skills/${PROJECT_SKILL_NAME}`;
-const PROJECT_SKILL_PATH = `${PROJECT_SKILL_DIR}/SKILL.md`;
 const PROJECT_MARKER = 'PROJECT_SKILL_ACTIVE_QA7742';
 
 // ---------------------------------------------------------------------------
@@ -65,11 +68,14 @@ async function createSkillFile(
 // ---------------------------------------------------------------------------
 
 test.describe.serial('User-Added Skills', { tag: ['@serial'] }, () => {
+  const sandbox = useSuiteSandbox();
   let chatPane: ChatPane;
   let chatActions: ChatPaneActions;
   let consoleActions: ConsolePaneActions;
   let assistantActions: AssistantOptionsActions;
   let versions: EnvironmentVersions;
+  let projectSkillDir = '';
+  let projectSkillPath = '';
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
@@ -78,6 +84,23 @@ test.describe.serial('User-Added Skills', { tag: ['@serial'] }, () => {
     chatPane = chatActions.chatPane;
 
     versions = await consoleActions.getEnvironmentVersions();
+    await consoleActions.clearConsole();
+
+    // -----------------------------------------------------------------------
+    // Step 0: Create a real project inside the sandbox so the
+    // "project-level" skill actually lands in a project directory rather
+    // than in the user's home dir.
+    // -----------------------------------------------------------------------
+    const sandboxR = sandbox.dir.replace(/\\/g, '/');
+    const projectDir = await createAndOpenProject(page, sandboxR, PROJECT_NAME);
+    projectSkillDir = `${projectDir}/.positai/skills/${PROJECT_SKILL_NAME}`;
+    projectSkillPath = `${projectSkillDir}/SKILL.md`;
+
+    // Re-create actions after session restart
+    consoleActions = new ConsolePaneActions(page);
+    assistantActions = new AssistantOptionsActions(page, consoleActions);
+    chatActions = new ChatPaneActions(page, consoleActions);
+    chatPane = chatActions.chatPane;
     await consoleActions.clearConsole();
 
     // -----------------------------------------------------------------------
@@ -96,11 +119,11 @@ test.describe.serial('User-Added Skills', { tag: ['@serial'] }, () => {
     // -----------------------------------------------------------------------
     // Step 2: Create a project-level skill (.positai/skills/ in workspace)
     // -----------------------------------------------------------------------
-    console.log(`Creating project skill at: ${PROJECT_SKILL_PATH}`);
+    console.log(`Creating project skill at: ${projectSkillPath}`);
     await createSkillFile(
       consoleActions,
-      PROJECT_SKILL_DIR,
-      PROJECT_SKILL_PATH,
+      projectSkillDir,
+      projectSkillPath,
       PROJECT_SKILL_NAME,
       'Summarize or describe a dataset.',
       PROJECT_MARKER,
@@ -123,7 +146,7 @@ test.describe.serial('User-Added Skills', { tag: ['@serial'] }, () => {
     // Step 4: Verify both files exist and have correct content
     // -----------------------------------------------------------------------
     await consoleActions.clearConsole();
-    await consoleActions.typeInConsole(`cat(readLines("${PROJECT_SKILL_PATH}"), sep = "\\n")`);
+    await consoleActions.typeInConsole(`cat(readLines("${projectSkillPath}"), sep = "\\n")`);
     await sleep(2000);
     const projectOutput = await consoleActions.consolePane.consoleOutput.innerText();
     console.log(`Project skill content:\n${projectOutput}`);
@@ -159,9 +182,9 @@ test.describe.serial('User-Added Skills', { tag: ['@serial'] }, () => {
   });
 
   test.afterAll(async () => {
-    // Clean up the project-level skill directory
-    await consoleActions.typeInConsole('unlink(".positai", recursive = TRUE)');
-    await sleep(1000);
+    // The project-level skill lives inside the sandbox project; the sandbox
+    // afterAll (registered by useSuiteSandbox) removes the entire sandbox
+    // tree, so no explicit cleanup is needed for it here.
 
     // Clean up only the specific user-level skill we created (leave ~/.positai/ intact)
     await consoleActions.typeInConsole(`unlink("${USER_SKILL_DIR}", recursive = TRUE)`);

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
@@ -83,7 +83,6 @@ test.describe.serial('User-Added Skills', { tag: ['@serial'] }, () => {
     chatActions = new ChatPaneActions(page, consoleActions);
     chatPane = chatActions.chatPane;
 
-    versions = await consoleActions.getEnvironmentVersions();
     await consoleActions.clearConsole();
 
     // -----------------------------------------------------------------------
@@ -102,6 +101,7 @@ test.describe.serial('User-Added Skills', { tag: ['@serial'] }, () => {
     chatActions = new ChatPaneActions(page, consoleActions);
     chatPane = chatActions.chatPane;
     await consoleActions.clearConsole();
+    versions = await consoleActions.getEnvironmentVersions();
 
     // -----------------------------------------------------------------------
     // Step 1: Stop any running backend FIRST.

--- a/e2e/rstudio/utils/project.ts
+++ b/e2e/rstudio/utils/project.ts
@@ -1,0 +1,69 @@
+import type { Page } from 'playwright';
+import { typeInConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '../pages/console_pane.page';
+import { sleep } from './constants';
+
+/**
+ * Wait for the R session to settle after a project switch. The IDE reloads
+ * and the console becomes briefly unavailable; this best-effort sequence
+ * waits for the page to load, the console input to reappear, and R to
+ * confirm idle by echoing a unique marker.
+ *
+ * Logs a warning and returns if R does not confirm idle within three attempts;
+ * the caller decides how to proceed.
+ */
+export async function waitForSessionRestart(page: Page): Promise<void> {
+  await page.waitForLoadState('load', { timeout: 30000 }).catch(() => {});
+  await sleep(3000);
+  await page.waitForSelector(CONSOLE_INPUT, { state: 'visible', timeout: 60000 });
+  await sleep(2000);
+
+  await page.waitForFunction(
+    'typeof window.rstudioapi !== "undefined" || typeof window.$RStudio !== "undefined"',
+    null,
+    { timeout: 15000 }
+  ).catch(() => {});
+  await sleep(1000);
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const marker = `__READY_${Date.now()}__`;
+      await page.locator(CONSOLE_INPUT).click({ force: true });
+      await page.keyboard.pressSequentially(`cat("${marker}")`);
+      await sleep(200);
+      await page.keyboard.press('Enter');
+      await sleep(1500);
+      const output = await page.locator(CONSOLE_OUTPUT).innerText();
+      if (output.includes(marker)) return;
+    } catch { /* console not ready yet */ }
+    await sleep(2000);
+  }
+  console.warn('waitForSessionRestart: R session did not confirm idle after 3 attempts');
+}
+
+/**
+ * Create a fresh project directory inside `parentDir`, write a minimal
+ * `.Rproj` file, and open the project in RStudio. Triggers a session
+ * restart and waits for it to complete. Returns the absolute project
+ * directory path.
+ */
+export async function createAndOpenProject(
+  page: Page,
+  parentDir: string,
+  name: string,
+): Promise<string> {
+  const parentDirR = parentDir.replace(/\\/g, '/');
+  const projectDir = `${parentDirR}/${name}`;
+
+  await typeInConsole(page, `dir.create("${projectDir}")`);
+  await sleep(500);
+  await typeInConsole(
+    page,
+    `writeLines(c("Version: 1.0", "", "RestoreWorkspace: Default", "SaveWorkspace: Default"), "${projectDir}/${name}.Rproj")`
+  );
+  await sleep(500);
+
+  await typeInConsole(page, `.rs.api.openProject("${projectDir}/${name}.Rproj")`);
+  await waitForSessionRestart(page);
+
+  return projectDir;
+}

--- a/e2e/rstudio/utils/project.ts
+++ b/e2e/rstudio/utils/project.ts
@@ -45,6 +45,9 @@ export async function waitForSessionRestart(page: Page): Promise<void> {
  * `.Rproj` file, and open the project in RStudio. Triggers a session
  * restart and waits for it to complete. Returns the absolute project
  * directory path.
+ *
+ * Callers must reconstruct any page-action wrappers held over this call;
+ * the session restart invalidates them.
  */
 export async function createAndOpenProject(
   page: Page,


### PR DESCRIPTION
## Summary

The `chat-user-skills` test's `afterAll` ran `unlink(".positai", recursive = TRUE)` in R
with a relative path. Since R's cwd defaults to the user home directory when no project is
open, this wiped `~/.positai/` entirely -- including the auth store at
`~/.positai/store/data.json` -- on every test run, signing Posit AI out.

The fix creates a real RStudio project inside the suite sandbox so that:
- The project-level skill lands in `<project>/.positai/skills/` (correct)
- The user-level skill cleanup uses an absolute path (safe)
- The destructive relative-path unlink is removed entirely

Also extracts a shared `utils/project.ts` utility (`createAndOpenProject`,
`waitForSessionRestart`) from `chat-guardrails`, which already had this logic inline.