### PR TITLE
Audit log direct file downloads from Files pane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@
 - ([rstudio/rstudio-pro#10805](https://github.com/rstudio/rstudio-pro/issues/10805)): Server: Enable TCP keepalive on accepted connections so the operating system reaps half-open sockets from disappeared clients (browser tab hibernation, NAT timeouts) instead of holding them indefinitely.
 - ([rstudio/rstudio-pro#10771](https://github.com/rstudio/rstudio-pro/issues/10771)): Reduced filesystem work performed by the `install.packages()` hook; the before/after scan is now scoped to the requested packages and their dependency closure rather than the entire library.
 - ([rstudio/rstudio-pro#10771](https://github.com/rstudio/rstudio-pro/issues/10771)): Tightened the heuristic used to detect package-management commands at the console prompt, reducing spurious Packages pane refreshes triggered by identifiers like `updates <-` or `installed.packages()`.
+- ([rstudio/rstudio-pro#9965](https://github.com/rstudio/rstudio-pro/issues/9965)): Direct file downloads from the Files pane now generate `session_file_download` audit events, matching the behavior of downloads via More -> Export.
 
 ### Dependencies
 - Ace 1.43.5

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,7 +33,6 @@
 - ([rstudio/rstudio-pro#10805](https://github.com/rstudio/rstudio-pro/issues/10805)): Server: Enable TCP keepalive on accepted connections so the operating system reaps half-open sockets from disappeared clients (browser tab hibernation, NAT timeouts) instead of holding them indefinitely.
 - ([rstudio/rstudio-pro#10771](https://github.com/rstudio/rstudio-pro/issues/10771)): Reduced filesystem work performed by the `install.packages()` hook; the before/after scan is now scoped to the requested packages and their dependency closure rather than the entire library.
 - ([rstudio/rstudio-pro#10771](https://github.com/rstudio/rstudio-pro/issues/10771)): Tightened the heuristic used to detect package-management commands at the console prompt, reducing spurious Packages pane refreshes triggered by identifiers like `updates <-` or `installed.packages()`.
-- ([rstudio/rstudio-pro#9965](https://github.com/rstudio/rstudio-pro/issues/9965)): Direct file downloads from the Files pane now generate `session_file_download` audit events, matching the behavior of downloads via More -> Export.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -86,7 +86,6 @@
 using namespace rstudio::core;
 using namespace http;
 using namespace http::util;
-using namespace rstudio::monitor;
 
 
 namespace rstudio {
@@ -613,9 +612,17 @@ void handleFilesRequest(const http::Request& request,
       }
    }
 
-   // let the monitor client know the user has downloaded this file
-   client().logEvent(Event(kSessionScope, kSessionDownloadEvent,
-                           module_context::createAliasedPath(filePath)));
+   // if this request was initiated as an explicit download from the Files
+   // pane, let the monitor client know the user has downloaded this file
+   // (other consumers of /files/ - file.show(), browseURL(), Sweave/PDF/HTML
+   // previews, and HTML sub-resource fetches - omit the download flag and
+   // are not logged)
+   if (request.queryParamValue("download") == "1")
+   {
+      using namespace monitor;
+      client().logEvent(Event(kSessionScope, kSessionDownloadEvent,
+                              module_context::createAliasedPath(filePath)));
+   }
 
    pResponse->setNoCacheHeaders();
    pResponse->setFile(filePath, request);

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -86,6 +86,7 @@
 using namespace rstudio::core;
 using namespace http;
 using namespace http::util;
+using namespace rstudio::monitor;
 
 
 namespace rstudio {
@@ -611,7 +612,11 @@ void handleFilesRequest(const http::Request& request,
          return;
       }
    }
-   
+
+   // let the monitor client know the user has downloaded this file
+   client().logEvent(Event(kSessionScope, kSessionDownloadEvent,
+                           module_context::createAliasedPath(filePath)));
+
    pResponse->setNoCacheHeaders();
    pResponse->setFile(filePath, request);
 }

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -53,6 +53,8 @@
 
 #include <session/SessionUrlPorts.hpp>
 
+#include <monitor/MonitorClient.hpp>
+
 #include "SessionSpelling.hpp"
 #include "SessionReticulate.hpp"
 
@@ -443,6 +445,17 @@ void handleFileShow(const http::Request& request, http::Response* pResponse)
    {
       pResponse->setNotFoundError(request);
       return;
+   }
+
+   // if this request was initiated as an explicit download from the Files
+   // pane, let the monitor client know the user has downloaded this file.
+   // The Files pane appends ?download=1 only when the user clicked a file
+   // for download; bare /file_show?path=... requests are not logged.
+   if (request.queryParamValue("download") == "1")
+   {
+      using namespace monitor;
+      client().logEvent(Event(kSessionScope, kSessionDownloadEvent,
+                              module_context::createAliasedPath(filePath)));
    }
 
    // send it back

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/BrowserType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/BrowserType.java
@@ -28,7 +28,11 @@ public class BrowserType extends FileType
    @Override
    public void openFile(FileSystemItem file, EventBus eventBus)
    {
-      eventBus.fireEvent(new OpenFileInBrowserEvent(file));
+      // BrowserType is the fallback for non-editable, non-text files - the
+      // file will be fetched and either saved by the browser (binary) or
+      // rendered. Mark this as a download so server-side audit logging
+      // distinguishes it from view-style navigations.
+      eventBus.fireEvent(new OpenFileInBrowserEvent(file, true));
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/OpenFileInBrowserEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/OpenFileInBrowserEvent.java
@@ -29,12 +29,26 @@ public class OpenFileInBrowserEvent extends GwtEvent<OpenFileInBrowserEvent.Hand
 
    public OpenFileInBrowserEvent(FileSystemItem file)
    {
+      this(file, false);
+   }
+
+   public OpenFileInBrowserEvent(FileSystemItem file, boolean isDownload)
+   {
       file_ = file;
+      isDownload_ = isDownload;
    }
 
    public FileSystemItem getFile()
    {
       return file_;
+   }
+
+   // true when the user explicitly initiated a download (e.g. clicked a
+   // binary file in the Files pane); false for view-style navigations
+   // (e.g. clicking a link in source code, or HTML "Show in Browser")
+   public boolean isDownload()
+   {
+      return isDownload_;
    }
 
    @Override
@@ -50,4 +64,5 @@ public class OpenFileInBrowserEvent extends GwtEvent<OpenFileInBrowserEvent.Hand
    }
 
    private final FileSystemItem file_;
+   private final boolean isDownload_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -972,7 +972,7 @@ public class Files
 
    public void onOpenFileInBrowser(OpenFileInBrowserEvent event)
    {
-      showFileInBrowser(event.getFile());
+      showFileInBrowser(event.getFile(), event.isDownload());
    }
 
    public void onDirectoryNavigate(DirectoryNavigateEvent event)
@@ -1097,15 +1097,22 @@ public class Files
 
    private void showFileInBrowser(FileSystemItem file)
    {
+      showFileInBrowser(file, false);
+   }
+
+   private void showFileInBrowser(FileSystemItem file, boolean asDownload)
+   {
       // show the file in a new window if we can get a file url for it
       String fileURL = server_.getFileUrl(file);
       if (fileURL != null)
       {
-         // for server URLs, tag user-initiated Files-pane downloads so the
-         // server can audit them without also auditing internal /files/
-         // traffic (e.g. HTML sub-resources, file.show(), browseURL previews).
+         // for server URLs initiated as a download (e.g. user clicked a
+         // binary file in the Files pane), tag the URL so the server can
+         // audit it without also auditing view-style navigations (HTML
+         // "Show in Browser", source-code link clicks) or internal /files/
+         // traffic (HTML sub-resources, file.show(), browseURL previews).
          // Desktop URLs are file:// and don't go through the session.
-         if (!fileURL.startsWith("file:"))
+         if (asDownload && !fileURL.startsWith("file:"))
             fileURL += (fileURL.contains("?") ? "&" : "?") + "download=1";
          globalDisplay_.openWindow(fileURL);
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -1101,6 +1101,12 @@ public class Files
       String fileURL = server_.getFileUrl(file);
       if (fileURL != null)
       {
+         // for server URLs, tag user-initiated Files-pane downloads so the
+         // server can audit them without also auditing internal /files/
+         // traffic (e.g. HTML sub-resources, file.show(), browseURL previews).
+         // Desktop URLs are file:// and don't go through the session.
+         if (!fileURL.startsWith("file:"))
+            fileURL += (fileURL.contains("?") ? "&" : "?") + "download=1";
          globalDisplay_.openWindow(fileURL);
       }
    }


### PR DESCRIPTION
## Intent

Addresses [rstudio-pro#9965](https://github.com/rstudio/rstudio-pro/issues/9965). Open-source counterpart to [rstudio-pro#10912](https://github.com/rstudio/rstudio-pro/pull/10912), since the change spans open-source code in `src/cpp/session/modules/{SessionFiles,SessionWorkbench}.cpp` plus the GWT Files pane.

## Summary

- Emit a `session_file_download` audit event for user-initiated downloads from the Files pane:
  - `handleFilesRequest` (`/files/<path>`, files in `$HOME`).
  - `handleFileShow` (`/file_show?path=...`, files outside `$HOME`).
- Both handlers log only when the Files pane has signaled an explicit download (binary file click through `BrowserType`). HTML "Show in Browser", Ace-editor link clicks, HTML sub-resources, and other internal `/files/` consumers (`file.show()`, `browseURL`, Sweave, Viewer save-as) are not logged.
- The audit `data` field uses `module_context::createAliasedPath(filePath)` — consistent with the existing download audit calls in the export handlers (which log the raw form-field value); chosen over the raw form value so the resolved `index.html` is captured when a directory is requested, and so paths outside `$HOME` are recorded as absolute.

## Test plan

Run against a Workbench build (audit log is Pro-only). Set `audit-r-sessions=1` in `/etc/rstudio/rserver.conf` and restart `rstudio-server`. OSS builds have no audit-log consumer, so this is the only useful test environment.

**Should log 1 event each:**
- [ ] Click a `.zip` (or other binary) in `$HOME` from the Files pane → 1 event, `data = ~/path/to/file.zip`.
- [ ] Files pane → Go To Folder → `/tmp` → click a binary file → 1 event, `data = /tmp/foo.zip`.
- [ ] Browse to a `/files/<dir>/` containing an `index.html`; the resulting event references the resolved `index.html` path.
- [ ] More → Export... → Download (single file) → 1 event (regression check on existing `/export/` path).
- [ ] More → Export... → Download (multiple files) → 1 event per file.

**Should log 0 events:**
- [ ] HTML "Show in Browser" from Files pane (and the sub-resources of the loaded page).
- [ ] `utils::file.show("~/.Rprofile")`.
- [ ] `browseURL("file://~/some.html")` and the auto-preview after knitting a non-self-contained Rmd in a project.
- [ ] Sweave-compile a `.Rnw` to PDF; preview opens.
- [ ] Viewer → "Save As Web Page" to a path under `~`.
- [ ] Click an Ace-highlighted file URL in a source-code comment.

**Worth eyeballing:**
- [ ] Desktop build (if available): file clicks still open/download; Desktop URLs are `file://` and never go through the session, so 0 audit events regardless.