### PR TITLE
add CMakePresets.json with cross-platform configuration

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,6 +7,11 @@
          "displayName": "Default",
          "generator": "Ninja",
          "binaryDir": "${sourceDir}/build",
+         "condition": {
+            "type": "notEquals",
+            "lhs": "${hostSystemName}",
+            "rhs": "Windows"
+         },
          "cacheVariables": {
             "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
          }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,26 @@
+{
+   "version": 3,
+   "cmakeMinimumRequired": { "major": 3, "minor": 22, "patch": 0 },
+   "configurePresets": [
+      {
+         "name": "default",
+         "displayName": "Default",
+         "generator": "Ninja",
+         "binaryDir": "${sourceDir}/build",
+         "cacheVariables": {
+            "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+         }
+      },
+      {
+         "name": "windows-x64",
+         "displayName": "Windows x64",
+         "inherits": "default",
+         "condition": {
+            "type": "equals",
+            "lhs": "${hostSystemName}",
+            "rhs": "Windows"
+         },
+         "architecture": { "value": "x64", "strategy": "external" }
+      }
+   ]
+}


### PR DESCRIPTION
## Summary

- Adds `CMakePresets.json` at the repo root with a cross-platform `default` preset and a Windows-specific `windows-x64` preset.
- On Windows, the `windows-x64` preset uses `architecture: { value: "x64", strategy: "external" }`, which causes CMake Tools (VSCode) and Visual Studio to source `vcvarsall.bat x64` automatically. This avoids a class of failures where the Ninja CMake cache pins the x86 `cl.exe` (`Hostx64\x86\cl.exe`) while the project compiles with `_WIN64` defined, causing `<atomic>` to reach for `_InterlockedCompareExchange128_nf` (which does not exist on 32-bit targets).
- The `default` preset matches the existing `cmake.generator: "Ninja"` and `build/` conventions already used in `.vscode/open-source/settings.json`.
- The `windows-x64` preset is `condition`-gated on `${hostSystemName}`, so on macOS/Linux only `Default` shows up and behavior is unchanged from the current kits + settings.json flow.
- Picked up automatically by CMake Tools (`cmake.useCMakePresets` defaults to `auto`) and by `cmake --preset` from the CLI. No `.vscode/settings.json` changes required.

## Test plan

- [ ] On Windows: `CMake: Delete Cache and Reconfigure`, then `CMake: Select Configure Preset` -> `Windows x64`. Verify `build/CMakeCache.txt` shows `Hostx64\x64\cl.exe`.
- [ ] On Windows: configure + build from VSCode succeeds without the `_InterlockedCompareExchange128_nf` error.
- [ ] On macOS/Linux: only `Default` shows in the CMake Tools picker. Configure + build behaves identically to the prior kits-based flow.
- [ ] `cmake --list-presets` shows both presets on Windows, only `default` on non-Windows.