### PR TITLE
Add Playwright E2E workflow for Desktop on Windows Server 2025

### DIFF
--- a/.github/workflows/test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -1,0 +1,215 @@
+name: "Test: E2E Playwright RStudio (Desktop, Windows Server 2025 x64, Open Source)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      rstudio_installer_url:
+        description: "URL to a Desktop installer (.deb on Ubuntu, .rpm on RHEL/Fedora, .exe on Windows, .dmg on macOS). Leave empty to auto-resolve the latest daily for this workflow's platform. To pin a specific build, paste its full URL from dailies.rstudio.com."
+        type: string
+        default: ""
+      r_version:
+        description: "R version to install via rig (e.g. 'release', 'oldrel', 'devel', '4.4.1')."
+        type: string
+        default: "release"
+      project:
+        description: "Playwright project to run: 'desktop' or 'server'. OS and edition are auto-filtered from the host platform and PW_RSTUDIO_EDITION."
+        type: string
+        default: "desktop"
+      grep:
+        description: "Optional Playwright --grep pattern to filter tests."
+        type: string
+        default: ""
+      test_selector:
+        description: "Optional test paths/files/directories to run (space-separated). Matched as substrings against test file paths. Examples: 'autocomplete.test.ts', 'tests/panes/misc/', 'autocomplete tests/panes/posit-assistant-chat/'. Leave empty to run all tests."
+        type: string
+        default: ""
+      rstudio_extra_args:
+        description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS."
+        type: string
+        default: ""
+  workflow_call:
+    inputs:
+      rstudio_installer_url:
+        type: string
+        default: ""
+      r_version:
+        type: string
+        default: "release"
+      project:
+        type: string
+        default: "desktop"
+      grep:
+        type: string
+        default: ""
+      test_selector:
+        type: string
+        default: ""
+      rstudio_extra_args:
+        type: string
+        default: ""
+
+jobs:
+  e2e-desktop-windows:
+    runs-on: windows-2025
+    timeout-minutes: 120
+    defaults:
+      run:
+        shell: pwsh
+    env:
+      R_LIBS_USER: ${{ github.workspace }}\R-libs
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install rig
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Invoke-WebRequest `
+            -Uri 'https://github.com/r-lib/rig/releases/download/latest/rig-windows-latest.exe' `
+            -OutFile rig-setup.exe
+          Start-Process -FilePath .\rig-setup.exe -ArgumentList '/VERYSILENT','/NORESTART' -Wait
+          Add-Content -Path $env:GITHUB_PATH -Value 'C:\Program Files\rig'
+
+      - name: Install R via rig
+        env:
+          R_VERSION: ${{ inputs.r_version }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          rig add $env:R_VERSION
+          rig default $env:R_VERSION
+          rig ls
+          New-Item -ItemType Directory -Force -Path $env:R_LIBS_USER | Out-Null
+
+      - name: Resolve RStudio .exe URL
+        id: resolve
+        env:
+          INSTALLER_URL: ${{ inputs.rstudio_installer_url }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $url = $env:INSTALLER_URL
+          $sha = ''
+          $filename = ''
+          if ([string]::IsNullOrEmpty($url)) {
+            $manifest = Invoke-RestMethod -Uri 'https://dailies.rstudio.com/rstudio/latest/index.json'
+            $win = $manifest.products.electron.platforms.windows
+            $url = $win.link
+            $sha = $win.sha256
+            $filename = $win.filename
+            Write-Host "Auto-resolved latest windows daily:"
+            Write-Host "  URL:      $url"
+            Write-Host "  SHA-256:  $sha"
+            Write-Host "  Filename: $filename"
+          } else {
+            $filename = Split-Path -Leaf $url
+            Write-Host "Using override URL: $url (SHA-256 verification skipped)"
+          }
+          "url=$url"           | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "sha256=$sha"        | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "filename=$filename" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Download RStudio .exe
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Invoke-WebRequest `
+            -Uri '${{ steps.resolve.outputs.url }}' `
+            -OutFile '${{ steps.resolve.outputs.filename }}'
+
+      - name: Verify SHA-256
+        if: steps.resolve.outputs.sha256 != ''
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $expected = '${{ steps.resolve.outputs.sha256 }}'.ToLower()
+          $actual = (Get-FileHash -Algorithm SHA256 '${{ steps.resolve.outputs.filename }}').Hash.ToLower()
+          if ($expected -ne $actual) {
+            Write-Error "SHA-256 mismatch. Expected: $expected. Actual: $actual."
+            exit 1
+          }
+          Write-Host "SHA-256 OK: $actual"
+
+      - name: Install RStudio
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Start-Process -FilePath '.\${{ steps.resolve.outputs.filename }}' -ArgumentList '/S' -Wait
+          $exe = 'C:\Program Files\RStudio\rstudio.exe'
+          if (-not (Test-Path $exe)) {
+            Write-Error "RStudio binary not found at $exe after install."
+            exit 1
+          }
+          Get-Item $exe | Format-List FullName, Length, LastWriteTime
+
+      - name: Restore R library cache
+        if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
+        id: r-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-r-${{ inputs.r_version }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
+          restore-keys: |
+            ${{ runner.os }}-r-${{ inputs.r_version }}-
+
+      - name: Install R packages from DESCRIPTION
+        if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Rscript -e @'
+            options(repos = c(P3M = "https://packagemanager.posit.co/cran/latest"))
+            if (!requireNamespace("pak", quietly = TRUE)) install.packages("pak")
+            pak::local_install_dev_deps(root = "e2e/rstudio", ask = FALSE, upgrade = FALSE)
+          '@
+
+      - name: Save R library cache
+        if: hashFiles('e2e/rstudio/DESCRIPTION') != '' && steps.r-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-r-${{ inputs.r_version }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
+
+      - name: Install npm dependencies
+        working-directory: e2e/rstudio
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: e2e/rstudio
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        working-directory: e2e/rstudio
+        env:
+          PW_RSTUDIO_MODE: desktop
+          PW_PROJECT_NAME: ${{ inputs.project }}
+          PW_GREP: ${{ inputs.grep }}
+          PW_TEST_SELECTOR: ${{ inputs.test_selector }}
+          PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $pwArgs = @()
+          if (-not [string]::IsNullOrEmpty($env:PW_TEST_SELECTOR)) {
+            $pwArgs += ($env:PW_TEST_SELECTOR -split '\s+' | Where-Object { $_ -ne '' })
+          }
+          $pwArgs += '--project'
+          $pwArgs += $env:PW_PROJECT_NAME
+          if (-not [string]::IsNullOrEmpty($env:PW_GREP)) {
+            $pwArgs += '--grep'
+            $pwArgs += $env:PW_GREP
+          }
+          npx playwright test @pwArgs
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: e2e/rstudio/playwright-report/
+          if-no-files-found: ignore
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: e2e/rstudio/test-results/
+          if-no-files-found: ignore

--- a/.github/workflows/test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -70,8 +70,10 @@ jobs:
           $ErrorActionPreference = 'Stop'
           Invoke-WebRequest `
             -Uri 'https://github.com/r-lib/rig/releases/download/latest/rig-windows-latest.exe' `
-            -OutFile rig-setup.exe
-          Start-Process -FilePath .\rig-setup.exe -ArgumentList '/VERYSILENT','/NORESTART' -Wait
+            -OutFile rig-setup.exe `
+            -MaximumRetryCount 3 -RetryIntervalSec 5
+          $p = Start-Process -FilePath .\rig-setup.exe -ArgumentList '/VERYSILENT','/NORESTART' -Wait -PassThru
+          if ($p.ExitCode -ne 0) { Write-Error "rig installer exited $($p.ExitCode)"; exit 1 }
           Add-Content -Path $env:GITHUB_PATH -Value 'C:\Program Files\rig'
 
       - name: Install R via rig
@@ -80,7 +82,9 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           rig add $env:R_VERSION
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           rig default $env:R_VERSION
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           rig ls
           New-Item -ItemType Directory -Force -Path $env:R_LIBS_USER | Out-Null
 
@@ -116,7 +120,8 @@ jobs:
           $ErrorActionPreference = 'Stop'
           Invoke-WebRequest `
             -Uri '${{ steps.resolve.outputs.url }}' `
-            -OutFile '${{ steps.resolve.outputs.filename }}'
+            -OutFile '${{ steps.resolve.outputs.filename }}' `
+            -MaximumRetryCount 3 -RetryIntervalSec 5
 
       - name: Verify SHA-256
         if: steps.resolve.outputs.sha256 != ''
@@ -133,7 +138,8 @@ jobs:
       - name: Install RStudio
         run: |
           $ErrorActionPreference = 'Stop'
-          Start-Process -FilePath '.\${{ steps.resolve.outputs.filename }}' -ArgumentList '/S' -Wait
+          $p = Start-Process -FilePath '.\${{ steps.resolve.outputs.filename }}' -ArgumentList '/S' -Wait -PassThru
+          if ($p.ExitCode -ne 0) { Write-Error "RStudio installer exited $($p.ExitCode)"; exit 1 }
           $exe = 'C:\Program Files\RStudio\rstudio.exe'
           if (-not (Test-Path $exe)) {
             Write-Error "RStudio binary not found at $exe after install."


### PR DESCRIPTION
New GitHub Actions workflow that runs the Playwright E2E suite against RStudio Desktop
on the `windows-2025` runner. Mirrors the existing macOS 26 ARM64 and Ubuntu 24 siblings
so the matrix gains x64 Windows coverage.

Note on the runner choice: we'd prefer Windows 11 x64 to match what most users run, but
GitHub Actions doesn't host a Windows 11 x64 runner -- only `windows-11-arm` exists, and
RStudio Desktop has no ARM Windows build yet. `windows-2025` (Windows Server 2025) is the
closest available stand-in, sharing the same Windows NT 10.0 kernel family and Win32 API
surface as Windows 11. We'll switch to a Windows 11 x64 runner if and when GitHub adds one.

Uses native PowerShell throughout. Auto-resolves the latest daily Windows `.exe` from
`dailies.rstudio.com/rstudio/latest/index.json` (override URL also accepted), verifies
SHA-256, silent-installs to `C:\Program Files\RStudio\rstudio.exe`, installs R via `rig`,
sets up R packages from `e2e/rstudio/DESCRIPTION` with caching, and runs `npx playwright test`
with the selected project / grep / test_selector inputs.

Default `timeout-minutes: 120`, matching the macOS 26 sibling.