### PR TITLE
disable @electron/node-gyp default clangcl toolset on windows

### DIFF
--- a/src/node/desktop/.npmrc
+++ b/src/node/desktop/.npmrc
@@ -1,0 +1,6 @@
+; @electron/node-gyp defaults to the ClangCL platform toolset on Windows so
+; native addons match Electron's own toolchain. Most developers don't have
+; the Clang components of Visual Studio installed, which causes node-gyp to
+; fail with a confusing MSB8020 error. RStudio's native modules build cleanly
+; with the standard MSVC toolset, so disable clang here.
+clang=false


### PR DESCRIPTION
## Intent

`@electron/node-gyp` defaults to selecting the ClangCL platform toolset when generating MSBuild projects for Electron native addons (so that the toolchain matches Electron's own clang-cl-built binaries). Most Windows developers don't have the Clang components of Visual Studio installed, so the default produces a confusing `MSB8020` ("ClangCL build tools cannot be found") failure during `npm install` in `src/node/desktop`.

This adds a project-level `.npmrc` that pins `clang=false`, restoring the standard MSVC v143 toolset for our `desktop`/`dock` native modules.

The `clang` flag only affects the Windows MSBuild generator. On macOS and Linux node-gyp uses the Make/Xcode/Ninja generators, which don't honor this flag, and `binding.gyp` doesn't reference the `clang` variable in any conditions, so this is a no-op on non-Windows platforms.

## Test plan

- [ ] On Windows with VS 2022 Community (no Clang components), `npm install` in `src/node/desktop` completes without `MSB8020` errors.
- [ ] On Windows, generated `build/desktop.vcxproj` contains `<PlatformToolset>v143</PlatformToolset>` (not `ClangCL`).
- [ ] On macOS, `npm install` in `src/node/desktop` still succeeds.
- [ ] On Linux, `npm install` in `src/node/desktop` still succeeds.