### PR TITLE
enable roxygen tag autocompletion in Rmd code chunks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 - ([#17478](https://github.com/rstudio/rstudio/issues/17478)): Posit Assistant: added the `ui/revealInFilesPane` JSON-RPC method, which navigates the Files pane to a directory (or to a file's parent directory) and brings the pane to the front.
 - ([#17479](https://github.com/rstudio/rstudio/issues/17479)): Posit Assistant: added the `ui/previewUrl` JSON-RPC method, which navigates the Viewer pane to an `http(s)` URL (e.g., a local Shiny app); supports an optional `height` parameter that mirrors `rstudioapi::viewer()` (`-1` for maximize, `0` for no change, positive for pixels).
 - ([#17514](https://github.com/rstudio/rstudio/issues/17514)): Added the `allow-package-source-recording` session option (default `true`); when set to `false`, RStudio will not annotate DESCRIPTION files of packages installed via `install.packages()` with the remote repository they came from.
+- ([#5809](https://github.com/rstudio/rstudio/issues/5809)): Roxygen tag autocompletion (e.g. `@param`, `@return`) now works on `#'` lines inside R code chunks of R Markdown and Quarto documents, matching the behavior in plain `.R` files.
 
 ### Fixed
 - ([#17481](https://github.com/rstudio/rstudio/issues/17481)): Fixed two debugger regressions: top-level breakpoints (e.g. via `debugSource()`) no longer fail to show the debug highlight or call stack, and multi-line input at the `Browse[N]>` prompt no longer clears the captured browser context.

--- a/src/cpp/tests/automation/testthat/test-automation-completions.R
+++ b/src/cpp/tests/automation/testthat/test-automation-completions.R
@@ -270,7 +270,29 @@ withr::defer(.rs.automation.deleteRemote())
    ")
 
    remote$editor.executeWithContents(".Rmd", contents, function(editor) {
-      editor$gotoLine(6, 7)
+      editor$gotoLine(6, 5)
+      completions <- remote$completions.request()
+      expect_true("@param" %in% trimws(completions))
+   })
+
+})
+
+# https://github.com/rstudio/rstudio/issues/5809
+.rs.test("roxygen tag completions are provided inside R chunks of qmd files", {
+
+   contents <- .rs.heredoc("
+      ---
+      title: Test
+      ---
+
+      ```{r}
+      #' @
+      identity2 <- function(x) x
+      ```
+   ")
+
+   remote$editor.executeWithContents(".qmd", contents, function(editor) {
+      editor$gotoLine(6, 5)
       completions <- remote$completions.request()
       expect_true("@param" %in% trimws(completions))
    })

--- a/src/cpp/tests/automation/testthat/test-automation-completions.R
+++ b/src/cpp/tests/automation/testthat/test-automation-completions.R
@@ -239,6 +239,44 @@ withr::defer(.rs.automation.deleteRemote())
    
 })
 
+# https://github.com/rstudio/rstudio/issues/5809
+.rs.test("roxygen tag completions are provided in .R files", {
+
+   contents <- .rs.heredoc("
+      #' @
+      identity2 <- function(x) x
+   ")
+
+   remote$editor.executeWithContents(".R", contents, function(editor) {
+      editor$gotoLine(1, 5)
+      completions <- remote$completions.request()
+      expect_true("@param" %in% trimws(completions))
+   })
+
+})
+
+# https://github.com/rstudio/rstudio/issues/5809
+.rs.test("roxygen tag completions are provided inside R chunks of Rmd files", {
+
+   contents <- .rs.heredoc("
+      ---
+      title: Test
+      ---
+
+      ```{r}
+      #' @
+      identity2 <- function(x) x
+      ```
+   ")
+
+   remote$editor.executeWithContents(".Rmd", contents, function(editor) {
+      editor$gotoLine(6, 7)
+      completions <- remote$completions.request()
+      expect_true("@param" %in% trimws(completions))
+   })
+
+})
+
 .rs.test("completions from the pipe placeholder are provided", {
    
    # completions without identifier following pipebind operator

--- a/src/gwt/acesupport/acemode/rmarkdown.js
+++ b/src/gwt/acesupport/acemode/rmarkdown.js
@@ -117,7 +117,15 @@ oop.inherits(Mode, MarkdownMode);
 
    function activeMode(state)
    {
-      return Utils.activeMode(state, "markdown");
+      var mode = Utils.activeMode(state, "markdown");
+      // roxygen (rdoc) blocks within R / C++ chunks belong to those chunks'
+      // languages -- otherwise lines like #' @param in an R chunk would be
+      // reported as r-rdoc and routed to Markdown handling.
+      if (mode === "r-rdoc")
+         return "r";
+      else if (mode === "r-cpp-rdoc")
+         return "r-cpp";
+      return mode;
    }
 
    this.insertChunkInfo = {

--- a/src/gwt/acesupport/acemode/rmarkdown.js
+++ b/src/gwt/acesupport/acemode/rmarkdown.js
@@ -118,13 +118,11 @@ oop.inherits(Mode, MarkdownMode);
    function activeMode(state)
    {
       var mode = Utils.activeMode(state, "markdown");
-      // roxygen (rdoc) blocks within R / C++ chunks belong to those chunks'
-      // languages -- otherwise lines like #' @param in an R chunk would be
+      // roxygen (rdoc) blocks within a chunk belong to that chunk's
+      // language -- otherwise lines like #' @param in an R chunk would be
       // reported as r-rdoc and routed to Markdown handling.
-      if (mode === "r-rdoc")
-         return "r";
-      else if (mode === "r-cpp-rdoc")
-         return "r-cpp";
+      if (Utils.endsWith(mode, "-rdoc"))
+         return mode.slice(0, -"-rdoc".length);
       return mode;
    }
 


### PR DESCRIPTION
## Intent

Addresses #5809.

## Summary

- A `#' @param` line inside an R code chunk in an Rmd/qmd document ends in tokenizer state `r-rdoc-start` (R rules with `rdoc-` prefix, then re-prefixed with `r-` by the Rmd embed).
- `Utils.activeMode` strips the trailing state segment and returns `"r-rdoc"`.
- `rmarkdown.js`'s `getLanguageMode` only matched `mode === "r"` and so reported these lines as `"Markdown"`. The `DelegatingCompletionManager` then picked the Markdown completion manager, and `RCompletionManager.previewKeyPress` bailed at the `!isCursorInRMode` check -- typing `@` never triggered the popup.
- Fix: in the local `activeMode` helper, normalize `r-rdoc` to `r` (and `r-cpp-rdoc` to `r-cpp`). Sibling helpers `rhtml.js` and `sweave.js` already use `state.match(/^r-/)` and don't have this bug.

Roxygen comment-line continuation already worked in Rmd because it goes through `TextEditingTargetQuartoHelper.continueSpecialCommentOnNewline`, which is mode-agnostic.

## Test plan

- [ ] Open an Rmd document, type `#' @par` at the start of a line in an R chunk; the roxygen tag completion popup appears, suggesting `@param`.
- [ ] Same in a qmd document.
- [ ] Same in a `.R` file (regression check).
- [ ] Pressing Enter on a `#'` line in an Rmd R chunk still continues the roxygen comment with `#' ` on the new line.
- [ ] Autocompletion of regular R identifiers in an Rmd R chunk (outside of `#'` lines) continues to work.