### PR TITLE
escape names when generating object explorer access expressions

### DIFF
--- a/src/cpp/session/modules/SessionObjectExplorer.R
+++ b/src/cpp/session/modules/SessionObjectExplorer.R
@@ -665,7 +665,7 @@
          return()
       
       name <- as.character(key)
-      access <- sprintf("#[\"%s\"]", name)
+      access <- sprintf("#[%s]", encodeString(name, quote = "\""))
       tags <- character()
       childContext <- .rs.explorer.createChildContext(context, name, access, tags)
       
@@ -793,7 +793,7 @@
          else
          {
             name <- names[[i]]
-            access <- sprintf("#[[\"%s\"]]", name)
+            access <- sprintf("#[[%s]]", encodeString(name, quote = "\""))
             tags <- character()
          }
          
@@ -828,7 +828,7 @@
          else
          {
             value <- object[[key]]
-            access <- sprintf("#[[\"%s\"]]", key)
+            access <- sprintf("#[[%s]]", encodeString(key, quote = "\""))
          }
          
          name <- key
@@ -920,7 +920,7 @@
          else
          {
             name <- names[[i]]
-            access <- sprintf("#[[\"%s\"]]", name)
+            access <- sprintf("#[[%s]]", encodeString(name, quote = "\""))
             tags <- character()
          }
          


### PR DESCRIPTION
## Summary

- The Object Explorer builds an `access` string for each inspected child (list element, environment binding, Python dict key, named atomic vector). The frontend stitches these into an `extractingCode` payload that the backend later evaluates via `eval(parse(text = extractingCode))` (or `builtins$eval` for Python).
- Several call sites interpolated the child's name directly via `sprintf("#[[\"%s\"]]", name)` (and similar). A name containing a `"` would produce malformed code, and a maliciously named child (e.g. from an untrusted RDS or a Python dict whose keys came from external input) could inject arbitrary code when the user clicked into it.
- Switched the four affected sites to `encodeString(name, quote = "\"")`, which produces a properly escaped double-quoted literal that round-trips through `parse()` and is also valid as a Python string literal.

Affected sites in `src/cpp/session/modules/SessionObjectExplorer.R`:
- Python dict key (`inspectPythonDict`)
- R list element accessed by name (`inspectList`)
- R environment binding (`inspectEnvironment`)
- R named atomic vector (`inspectDefault`)

The other access-string sites either interpolate integer indices, use `deparse(as.name(...), backtick = TRUE)`, or are static, and don't need changes.

## Test plan

- [ ] In a fresh R session, run `x <- list(); x[['safe']] <- 1; x[['"; cat("pwned\n"); "']] <- 2; View(x)` and click into both children -- the second should resolve to its value (`2`) without printing `pwned`.
- [ ] Repeat with an environment: `e <- new.env(); assign('safe', 1, envir = e); assign('"; cat("pwned\n"); "', 2, envir = e); View(e)`.
- [ ] Repeat with a Python dict (with reticulate active): `View(reticulate::dict('safe' = 1L, '"; print("pwned"); "' = 2L))`.
- [ ] Confirm normal navigation still works for ordinary names (spaces, ASCII punctuation, unicode).