### PR TITLE
constrain /help/presentation/ to the active presentation

### DIFF
--- a/src/cpp/session/modules/presentation/SessionPresentation.cpp
+++ b/src/cpp/session/modules/presentation/SessionPresentation.cpp
@@ -92,8 +92,19 @@ SEXP rs_showPresentationHelpDoc(SEXP helpDocSEXP)
                                  "No presentation is currently active");
       }
 
-      // resolve against presentation directory
       std::string helpDoc = r::sexp::asString(helpDocSEXP);
+
+      // doc must be relative to the presentation directory - the URL
+      // contract for /help/presentation/?doc= does not accept absolute
+      // paths
+      if (FilePath(helpDoc).isAbsolute())
+      {
+         throw r::exec::RErrorException(
+                                 "Help doc path must be relative to the "
+                                 "presentation directory");
+      }
+
+      // resolve against presentation directory to verify existence
       FilePath helpDocPath = presentation::state::directory().completeChildPath(
          helpDoc);
       if (!helpDocPath.exists())
@@ -102,10 +113,10 @@ SEXP rs_showPresentationHelpDoc(SEXP helpDocSEXP)
                                         + " not found.");
       }
 
-      // build url and fire event
-      std::string url = "help/presentation/?file=";
-      std::string file = module_context::createAliasedPath(helpDocPath);
-      url += http::util::urlEncode(file, true);
+      // build url with the relative path; the server resolves it
+      // against the active presentation's directory
+      std::string url = "help/presentation/?doc=";
+      url += http::util::urlEncode(helpDoc, true);
 
       ClientEvent event(client_events::kShowHelp, url);
       module_context::enqueClientEvent(event);

--- a/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
+++ b/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
@@ -1104,6 +1104,8 @@ void handlePresentationFileRequest(const http::Request& request,
    setWebCacheableFileResponse(filePath, request, pResponse);
 }
 
+} // anonymous namespace
+
 bool isPathWithin(const FilePath& filePath, const FilePath& dirPath)
 {
    if (!filePath.exists() || !dirPath.exists())
@@ -1119,15 +1121,12 @@ bool isPathWithin(const FilePath& filePath, const FilePath& dirPath)
 // automatically on every fetch and JavaScript cannot forge it. Reject
 // anything that is identified as cross-site. Older browsers omit the
 // header; in that case fall through and rely on the path constraint.
-bool isPresentationHelpFetchSiteAllowed(const core::http::Request& request)
+bool isPresentationHelpFetchSiteAllowed(const std::string& fetchSite)
 {
-   std::string fetchSite = request.headerValue("Sec-Fetch-Site");
    if (fetchSite.empty())
       return true;
    return fetchSite == "same-origin" || fetchSite == "none";
 }
-
-} // anonymous namespace
 
 bool clearKnitrCache(ErrorResponse* pErrorResponse)
 {
@@ -1220,7 +1219,7 @@ void handlePresentationHelpRequest(const core::http::Request& request,
    // Reject obvious cross-site requests before doing anything else.
    // The presentation help endpoint can knit R Markdown via knitr,
    // which executes embedded R code; CSRF here means RCE.
-   if (!isPresentationHelpFetchSiteAllowed(request))
+   if (!isPresentationHelpFetchSiteAllowed(request.headerValue("Sec-Fetch-Site")))
    {
       pResponse->setNotFoundError(request);
       return;

--- a/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
+++ b/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
@@ -1111,9 +1111,14 @@ bool isPathWithin(const FilePath& filePath, const FilePath& dirPath)
    if (!filePath.exists() || !dirPath.exists())
       return false;
 
-   // canonicalize both sides so symlinks and ".." cannot escape
+   // Canonicalize both sides so symlinks and ".." get resolved.
+   // getCanonicalPath() falls back to a lexical normalization if the
+   // filesystem call fails, in which case symlink resolution is not
+   // guaranteed; defend against that by failing closed on empty.
    FilePath canonicalFile(filePath.getCanonicalPath());
    FilePath canonicalDir(dirPath.getCanonicalPath());
+   if (canonicalFile.isEmpty() || canonicalDir.isEmpty())
+      return false;
    return canonicalFile.isWithin(canonicalDir);
 }
 
@@ -1240,7 +1245,7 @@ void handlePresentationHelpRequest(const core::http::Request& request,
 
       FilePath presDir = presentation::state::directory();
       FilePath filePath = presDir.completePath(doc);
-      if (!isPathWithin(filePath, presDir))
+      if (filePath.isDirectory() || !isPathWithin(filePath, presDir))
       {
          pResponse->setNotFoundError(request);
          return;
@@ -1274,7 +1279,7 @@ void handlePresentationHelpRequest(const core::http::Request& request,
       std::string path = http::util::pathAfterPrefix(request,
                                                      "/help/presentation/");
       FilePath target = s_presentationHelpDir.completePath(path);
-      if (!isPathWithin(target, s_presentationHelpDir))
+      if (target.isDirectory() || !isPathWithin(target, s_presentationHelpDir))
       {
          pResponse->setNotFoundError(request);
          return;

--- a/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
+++ b/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
@@ -1209,7 +1209,7 @@ void handlePresentationHelpRequest(const core::http::Request& request,
                                    const std::string& jsCallbacks,
                                    core::http::Response* pResponse)
 {
-   // We save the directory used by the most recent (validated) file=
+   // We save the directory used by the most recent (validated) doc=
    // request so relative resource fetches (images, css, ...) referenced
    // from a rendered help doc can still resolve after the presentation
    // tab closes. The directory is only ever set from a path that was
@@ -1226,21 +1226,22 @@ void handlePresentationHelpRequest(const core::http::Request& request,
       return;
    }
 
-   std::string file = request.queryParamValue("file");
-   if (!file.empty())
+   // doc= names a help doc relative to the active presentation. The
+   // URL contract is "always relative" - absolute paths are rejected so
+   // the URL cannot express anything outside the presentation directory
+   // (rstudio-pro#10907).
+   std::string doc = request.queryParamValue("doc");
+   if (!doc.empty())
    {
-      // file= requires an active presentation, and the requested file
-      // must live within that presentation's directory. Without this
-      // constraint, any reachable .Rmd would be auto-knit by an attacker
-      // (rstudio-pro#10907).
-      if (!presentation::state::isActive())
+      if (!presentation::state::isActive() || FilePath(doc).isAbsolute())
       {
          pResponse->setNotFoundError(request);
          return;
       }
 
-      FilePath filePath = module_context::resolveAliasedPath(file);
-      if (!isPathWithin(filePath, presentation::state::directory()))
+      FilePath presDir = presentation::state::directory();
+      FilePath filePath = presDir.completePath(doc);
+      if (!isPathWithin(filePath, presDir))
       {
          pResponse->setNotFoundError(request);
          return;
@@ -1262,9 +1263,9 @@ void handlePresentationHelpRequest(const core::http::Request& request,
    }
    else
    {
-      // relative file reference - serve only if a help dir was set by
-      // an earlier authorized file= request, and only for paths that
-      // canonically resolve to within that dir
+      // relative resource fetch from a rendered help doc - serve only
+      // if a help dir was set by an earlier authorized doc= request,
+      // and only for paths that canonically resolve to within that dir
       if (!s_presentationHelpDir.exists())
       {
          pResponse->setNotFoundError(request);

--- a/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
+++ b/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
@@ -1104,6 +1104,29 @@ void handlePresentationFileRequest(const http::Request& request,
    setWebCacheableFileResponse(filePath, request, pResponse);
 }
 
+bool isPathWithin(const FilePath& filePath, const FilePath& dirPath)
+{
+   if (!filePath.exists() || !dirPath.exists())
+      return false;
+
+   // canonicalize both sides so symlinks and ".." cannot escape
+   FilePath canonicalFile(filePath.getCanonicalPath());
+   FilePath canonicalDir(dirPath.getCanonicalPath());
+   return canonicalFile.isWithin(canonicalDir);
+}
+
+// Defense in depth against CSRF: modern browsers set Sec-Fetch-Site
+// automatically on every fetch and JavaScript cannot forge it. Reject
+// anything that is identified as cross-site. Older browsers omit the
+// header; in that case fall through and rely on the path constraint.
+bool isPresentationHelpFetchSiteAllowed(const core::http::Request& request)
+{
+   std::string fetchSite = request.headerValue("Sec-Fetch-Site");
+   if (fetchSite.empty())
+      return true;
+   return fetchSite == "same-origin" || fetchSite == "none";
+}
+
 } // anonymous namespace
 
 bool clearKnitrCache(ErrorResponse* pErrorResponse)
@@ -1186,29 +1209,45 @@ void handlePresentationHelpRequest(const core::http::Request& request,
                                    const std::string& jsCallbacks,
                                    core::http::Response* pResponse)
 {
-   // we save the most recent /help/presentation/&file=parameter so we
-   // can resolve relative file references against it. we do this
-   // separately from presentation::state::directory so that the help
-   // urls can be available within the help pane (and history)
-   // independent of the duration of the presentation tab
+   // We save the directory used by the most recent (validated) file=
+   // request so relative resource fetches (images, css, ...) referenced
+   // from a rendered help doc can still resolve after the presentation
+   // tab closes. The directory is only ever set from a path that was
+   // already validated as being within the active presentation, so it
+   // is safe to keep using once a presentation has been displayed.
    static FilePath s_presentationHelpDir;
 
-   // check if this is a root request
+   // Reject obvious cross-site requests before doing anything else.
+   // The presentation help endpoint can knit R Markdown via knitr,
+   // which executes embedded R code; CSRF here means RCE.
+   if (!isPresentationHelpFetchSiteAllowed(request))
+   {
+      pResponse->setNotFoundError(request);
+      return;
+   }
+
    std::string file = request.queryParamValue("file");
    if (!file.empty())
    {
-      // ensure file exists
-      FilePath filePath = module_context::resolveAliasedPath(file);
-      if (!filePath.exists())
+      // file= requires an active presentation, and the requested file
+      // must live within that presentation's directory. Without this
+      // constraint, any reachable .Rmd would be auto-knit by an attacker
+      // (rstudio-pro#10907).
+      if (!presentation::state::isActive())
       {
          pResponse->setNotFoundError(request);
          return;
       }
 
-      // save the help dir
+      FilePath filePath = module_context::resolveAliasedPath(file);
+      if (!isPathWithin(filePath, presentation::state::directory()))
+      {
+         pResponse->setNotFoundError(request);
+         return;
+      }
+
       s_presentationHelpDir = filePath.getParent();
 
-      // check for markdown
       if (filePath.getMimeContentType() == "text/x-markdown" ||
           filePath.getMimeContentType() == "text/x-r-markdown")
       {
@@ -1216,32 +1255,32 @@ void handlePresentationHelpRequest(const core::http::Request& request,
                                                jsCallbacks,
                                                pResponse);
       }
-
-      // just a stock file
       else
       {
          setWebCacheableFileResponse(filePath, request, pResponse);
       }
    }
-
-   // it's a relative file reference
    else
    {
-      // make sure the directory exists
+      // relative file reference - serve only if a help dir was set by
+      // an earlier authorized file= request, and only for paths that
+      // canonically resolve to within that dir
       if (!s_presentationHelpDir.exists())
       {
-         pResponse->setNotFoundError(s_presentationHelpDir.getAbsolutePath(), request);
+         pResponse->setNotFoundError(request);
          return;
       }
 
-      // resolve the file reference
       std::string path = http::util::pathAfterPrefix(request,
                                                      "/help/presentation/");
+      FilePath target = s_presentationHelpDir.completePath(path);
+      if (!isPathWithin(target, s_presentationHelpDir))
+      {
+         pResponse->setNotFoundError(request);
+         return;
+      }
 
-      // serve the file back
-      setWebCacheableFileResponse(
-         s_presentationHelpDir.completePath(path),
-                                  request, pResponse);
+      setWebCacheableFileResponse(target, request, pResponse);
    }
 }
 

--- a/src/cpp/session/modules/presentation/SlideRequestHandler.hpp
+++ b/src/cpp/session/modules/presentation/SlideRequestHandler.hpp
@@ -59,7 +59,8 @@ void handlePresentationHelpRequest(const core::http::Request& request,
 
 // Returns true if `filePath` canonically resolves to a location within
 // `dirPath`. Both paths must exist on disk; returns false if either is
-// missing. Canonicalization defeats symlink and ".." escapes.
+// missing. Resolves symlinks and ".." components, with a lexical
+// fallback if the filesystem call fails.
 bool isPathWithin(const core::FilePath& filePath,
                   const core::FilePath& dirPath);
 

--- a/src/cpp/session/modules/presentation/SlideRequestHandler.hpp
+++ b/src/cpp/session/modules/presentation/SlideRequestHandler.hpp
@@ -57,6 +57,18 @@ void handlePresentationHelpRequest(const core::http::Request& request,
                                    const std::string& jsCallbacks,
                                    core::http::Response* pResponse);
 
+// Returns true if `filePath` canonically resolves to a location within
+// `dirPath`. Both paths must exist on disk; returns false if either is
+// missing. Canonicalization defeats symlink and ".." escapes.
+bool isPathWithin(const core::FilePath& filePath,
+                  const core::FilePath& dirPath);
+
+// Returns true if `fetchSite` (a Sec-Fetch-Site header value) does not
+// indicate a cross-site request. Empty values (older browsers without
+// Fetch Metadata) are treated as allowed; in that case the path
+// constraint is the security boundary.
+bool isPresentationHelpFetchSiteAllowed(const std::string& fetchSite);
+
 bool savePresentationAsStandalone(const core::FilePath& filePath,
                                   ErrorResponse* pErrorResponse);
 

--- a/src/cpp/session/modules/presentation/SlideRequestHandlerTests.cpp
+++ b/src/cpp/session/modules/presentation/SlideRequestHandlerTests.cpp
@@ -1,0 +1,190 @@
+/*
+ * SlideRequestHandlerTests.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "SlideRequestHandler.hpp"
+
+#include <gtest/gtest.h>
+
+#include <core/FileSerializer.hpp>
+
+#include <shared_core/FilePath.hpp>
+
+using namespace rstudio::core;
+using namespace rstudio::session::modules::presentation;
+
+namespace {
+
+class TempDir
+{
+public:
+   TempDir()
+   {
+      FilePath::tempFilePath(path_);
+      path_.ensureDirectory();
+   }
+
+   ~TempDir()
+   {
+      path_.removeIfExists();
+   }
+
+   const FilePath& path() const { return path_; }
+
+   FilePath child(const std::string& name) const
+   {
+      return path_.completeChildPath(name);
+   }
+
+   FilePath childDir(const std::string& name) const
+   {
+      FilePath dir = path_.completeChildPath(name);
+      dir.ensureDirectory();
+      return dir;
+   }
+
+   FilePath childFile(const std::string& name, const std::string& contents = "x") const
+   {
+      FilePath file = path_.completeChildPath(name);
+      writeStringToFile(file, contents);
+      return file;
+   }
+
+private:
+   FilePath path_;
+};
+
+} // anonymous namespace
+
+
+TEST(SlideRequestHandlerFetchSite, AllowsSameOrigin)
+{
+   EXPECT_TRUE(isPresentationHelpFetchSiteAllowed("same-origin"));
+}
+
+TEST(SlideRequestHandlerFetchSite, AllowsUserInitiatedNavigation)
+{
+   // Sec-Fetch-Site: none -- typed URL, bookmark, etc.
+   EXPECT_TRUE(isPresentationHelpFetchSiteAllowed("none"));
+}
+
+TEST(SlideRequestHandlerFetchSite, AllowsMissingHeader)
+{
+   // Older browsers without Fetch Metadata. Path constraint is the
+   // security boundary in this case.
+   EXPECT_TRUE(isPresentationHelpFetchSiteAllowed(""));
+}
+
+TEST(SlideRequestHandlerFetchSite, RejectsCrossSite)
+{
+   EXPECT_FALSE(isPresentationHelpFetchSiteAllowed("cross-site"));
+}
+
+TEST(SlideRequestHandlerFetchSite, RejectsSameSite)
+{
+   // same-site is not same-origin (different subdomain on same
+   // registrable domain) -- reject for this endpoint.
+   EXPECT_FALSE(isPresentationHelpFetchSiteAllowed("same-site"));
+}
+
+TEST(SlideRequestHandlerFetchSite, RejectsUnknownValue)
+{
+   EXPECT_FALSE(isPresentationHelpFetchSiteAllowed("malicious"));
+}
+
+
+TEST(SlideRequestHandlerIsPathWithin, AcceptsFileInDirectory)
+{
+   TempDir tmp;
+   FilePath file = tmp.childFile("doc.md");
+
+   EXPECT_TRUE(isPathWithin(file, tmp.path()));
+}
+
+TEST(SlideRequestHandlerIsPathWithin, AcceptsFileInSubdirectory)
+{
+   TempDir tmp;
+   FilePath sub = tmp.childDir("sub");
+   FilePath file = sub.completeChildPath("doc.md");
+   writeStringToFile(file, "x");
+
+   EXPECT_TRUE(isPathWithin(file, tmp.path()));
+}
+
+TEST(SlideRequestHandlerIsPathWithin, RejectsFileOutsideDirectory)
+{
+   TempDir parent;
+   FilePath presDir = parent.childDir("presentation");
+   FilePath outside = parent.childFile("outside.md");
+
+   EXPECT_FALSE(isPathWithin(outside, presDir));
+}
+
+TEST(SlideRequestHandlerIsPathWithin, RejectsDotDotEscape)
+{
+   TempDir parent;
+   FilePath presDir = parent.childDir("presentation");
+   FilePath outside = parent.childFile("outside.md");
+
+   // simulate `presDir.completePath("../outside.md")`
+   FilePath resolved = presDir.completePath("../outside.md");
+   EXPECT_FALSE(isPathWithin(resolved, presDir));
+}
+
+TEST(SlideRequestHandlerIsPathWithin, AcceptsDotDotThatStaysWithin)
+{
+   TempDir tmp;
+   FilePath sub = tmp.childDir("sub");
+   FilePath file = tmp.childFile("doc.md");
+
+   // sub/../doc.md canonicalizes to doc.md, which is within tmp
+   FilePath resolved = sub.completePath("../doc.md");
+   EXPECT_TRUE(isPathWithin(resolved, tmp.path()));
+}
+
+TEST(SlideRequestHandlerIsPathWithin, RejectsNonexistentFile)
+{
+   TempDir tmp;
+   FilePath missing = tmp.path().completeChildPath("missing.md");
+
+   EXPECT_FALSE(isPathWithin(missing, tmp.path()));
+}
+
+TEST(SlideRequestHandlerIsPathWithin, RejectsNonexistentDirectory)
+{
+   TempDir tmp;
+   FilePath file = tmp.childFile("doc.md");
+   FilePath missingDir = tmp.path().completeChildPath("missing-dir");
+
+   EXPECT_FALSE(isPathWithin(file, missingDir));
+}
+
+#ifndef _WIN32
+TEST(SlideRequestHandlerIsPathWithin, RejectsSymlinkEscape)
+{
+   TempDir parent;
+   FilePath presDir = parent.childDir("presentation");
+   FilePath outside = parent.childFile("outside.md");
+
+   // create a symlink inside presDir that points to a file outside it
+   FilePath link = presDir.completeChildPath("escape.md");
+   int rc = ::symlink(outside.getAbsolutePath().c_str(),
+                      link.getAbsolutePath().c_str());
+   ASSERT_EQ(rc, 0);
+
+   // canonicalization should resolve the symlink to its real target,
+   // which lives outside presDir, so isPathWithin must reject
+   EXPECT_FALSE(isPathWithin(link, presDir));
+}
+#endif

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/presentation/PresentationDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/presentation/PresentationDispatcher.java
@@ -142,7 +142,7 @@ public class PresentationDispatcher
          String param2)
    {
       if (cmdName == "help-doc")
-         performHelpDocCommand(param1, param2);
+         performHelpDocCommand(param1);
       else if (cmdName == "help-topic")
          performHelpTopicCommand(param1, param2);
       else if (cmdName == "console")
@@ -167,7 +167,7 @@ public class PresentationDispatcher
    }
 
 
-   private void performHelpDocCommand(String docPath, String param2)
+   private void performHelpDocCommand(String docPath)
    {
       if (docPath != null)
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/presentation/PresentationDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/presentation/PresentationDispatcher.java
@@ -167,13 +167,13 @@ public class PresentationDispatcher
    }
 
 
-   private void performHelpDocCommand(String param1, String param2)
+   private void performHelpDocCommand(String docPath, String param2)
    {
-      if (param1 != null)
+      if (docPath != null)
       {
          // Send the path as a presentation-relative reference; the
          // server resolves it against the active presentation directory.
-         String url = "help/presentation/?doc=" + URL.encodeQueryString(param1);
+         String url = "help/presentation/?doc=" + URL.encodeQueryString(docPath);
          eventBus_.fireEvent(new ShowHelpEvent(url));
       }
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/presentation/PresentationDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/presentation/PresentationDispatcher.java
@@ -171,9 +171,10 @@ public class PresentationDispatcher
    {
       if (param1 != null)
       {
-         String docFile = getPresentationPath(param1);
-         String url = "help/presentation/?file=" + URL.encodeQueryString(docFile);
-         eventBus_.fireEvent(new ShowHelpEvent(url));  
+         // Send the path as a presentation-relative reference; the
+         // server resolves it against the active presentation directory.
+         String url = "help/presentation/?doc=" + URL.encodeQueryString(param1);
+         eventBus_.fireEvent(new ShowHelpEvent(url));
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/presentation/PresentationDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/presentation/PresentationDispatcher.java
@@ -144,7 +144,7 @@ public class PresentationDispatcher
       if (cmdName == "help-doc")
          performHelpDocCommand(param1);
       else if (cmdName == "help-topic")
-         performHelpTopicCommand(param1, param2);
+         performHelpTopicCommand(param1);
       else if (cmdName == "console")
          performConsoleCommand(params);
       else if (cmdName == "console-input")
@@ -178,22 +178,22 @@ public class PresentationDispatcher
       }
    }
 
-   private void performHelpTopicCommand(String param1, String param2)
+   private void performHelpTopicCommand(String topicSpec)
    {
-      // split on :: if it's there
-      if (param1 != null)
-      {
-         String topic = param1;
-         String packageName = null;
-         int delimLoc = param1.indexOf("::");
-         if (delimLoc != -1)
-         {
-            packageName = StringUtil.substring(param1, 0, delimLoc);
-            topic = StringUtil.substring(param1, delimLoc+2);
-         }
+      if (topicSpec == null)
+         return;
 
-         server_.showHelpTopic(topic, packageName, RCompletionType.FUNCTION);
+      // split on :: if present (e.g. "package::topic")
+      String topic = topicSpec;
+      String packageName = null;
+      int delimLoc = topicSpec.indexOf("::");
+      if (delimLoc != -1)
+      {
+         packageName = StringUtil.substring(topicSpec, 0, delimLoc);
+         topic = StringUtil.substring(topicSpec, delimLoc + 2);
       }
+
+      server_.showHelpTopic(topic, packageName, RCompletionType.FUNCTION);
    }
 
    private void performConsoleCommand(String params)


### PR DESCRIPTION
## Intent

Addresses rstudio-pro#10907 (open-source companion).

## Summary

- The `/help/presentation/?file=<path>` endpoint accepted any aliased path the session could read and, for `.Rmd` files, knit them via knitr -- which executes embedded R code chunks. A cross-site GET (e.g. an attacker page redirecting the browser to a malicious `.Rmd` cloned into the workspace) was therefore an RCE primitive.
- This PR constrains the endpoint to the active presentation directory, switches the URL contract from `?file=<aliased-absolute>` to `?doc=<relative>` so out-of-presentation paths are inexpressible by construction, and adds a `Sec-Fetch-Site` cross-site rejection as defense in depth.
- Both call sites that emit these URLs (`rs_showPresentationHelpDoc` and `PresentationDispatcher.performHelpDocCommand`) already started from a presentation-relative path and unnecessarily promoted to absolute before encoding, so the contract change is a simplification on the producer side.

## Affected scope

The `/help/presentation/` endpoint and `presentation::state` are exclusive to the legacy R Presentations (`.Rpres`) subsystem. Quarto presentations live in `presentation2/` and the `quarto/` session module and have their own pipeline -- they do not touch this endpoint and are not affected.

Note: the `.Rpres` preview pane has a separate, pre-existing rendering bug tracked in #17573 (only the title slide paints). That bug does not change the security obligation here, but it does mean the in-the-wild exposure is small.

## What's covered

- File path constraint (canonical `isWithin`) blocks `..` traversal and symlink escape.
- Active-presentation requirement on `?doc=` requests.
- Relative-only URL contract: `FilePath::isAbsolute()` rejected up front in both R-side and server-side.
- `Sec-Fetch-Site` rejects cross-site requests on modern browsers; older browsers fall through and rely on the path constraint.
- Path traversal also blocked on the relative-resource fetch path (no-`?doc=` branch), via the same canonical `isWithin` check against `s_presentationHelpDir`.
- Unit tests for the policy primitives (`isPathWithin`, `isPresentationHelpFetchSiteAllowed`) -- 14 tests, all passing under `./rstudio-tests --scope rsession`.

## Remaining surface (worth flagging for review)

1. **Auto-knit on GET, within the presentation directory.** An attacker who can drop an `.Rmd` into a directory the user has *already opened as a presentation* still gets RCE on first view. The threat model has narrowed sharply, but a structurally cleaner fix would be "knit only on RPC, serve cached `.md` on GET" -- bigger change, deferred.
2. **Adjacent handlers in the same module not audited.** `handlePresentationPaneRequest` and `handlePresentationViewInBrowserRequest` also serve files keyed off `presentation::state::directory()`. They may have analogous issues. Worth a skim before merging.
3. **No handler-level integration test.** Unit tests cover the policy primitives but not the wiring (header name, param name, order of checks). A BRAT test exercising the endpoint with adversarial inputs would be a good follow-up.

## Behavior change worth noting

Help docs referenced via `showPresentationHelpDoc("../somewhere/help.md")` will stop loading. Prior to this PR the URL accepted any reachable path; now it only accepts paths that resolve inside the presentation directory. I don't see uses of this pattern in the codebase, but `.Rpres` files in the wild may need help docs moved into the presentation directory.

## Test plan

- [ ] `./rstudio-tests --scope rsession` passes (14 new tests in `SlideRequestHandlerFetchSite` and `SlideRequestHandlerIsPathWithin`).
- [ ] Manual: open an `.Rpres`, navigate to a `help-doc:` slide, confirm the help pane loads the doc. (Note: blocked by #17573 if you can't get past the title slide; the help endpoint itself can be tested independently with curl.)
- [ ] Manual: confirm the original PoC (`/help/presentation/?file=~/cloned-repo/exfil.Rmd`) returns 404 instead of executing the embedded R code.
- [ ] Manual: confirm `/help/presentation/?doc=../etc/passwd` returns 404.
- [ ] Manual: confirm a request with `Sec-Fetch-Site: cross-site` returns 404.