### PR TITLE
block cross-site requests to /files/ endpoint

### DIFF
--- a/src/cpp/server/session/ServerSessionManager.cpp
+++ b/src/cpp/server/session/ServerSessionManager.cpp
@@ -256,12 +256,22 @@ core::system::ProcessConfig sessionProcessConfig(
       if (!projectRoot.empty())
          environment.push_back({ "RSTUDIO_AUTOMATION_ROOT", projectRoot });
       
-      // forward filter and markers if available
+      // Forward filter and markers if available. The CLI options take
+      // precedence; otherwise fall back to RSTUDIO_AUTOMATION_FILTER /
+      // RSTUDIO_AUTOMATION_MARKERS in rserver's own environment so a
+      // caller can scope a run via `RSTUDIO_AUTOMATION_FILTER=... \
+      // ./rserver-dev --run-automation` without having to plumb
+      // --automation-filter explicitly. The rsession environment is
+      // built from this list; nothing else propagates by inheritance.
       std::string filter = server::options().automationFilter();
+      if (filter.empty())
+         filter = core::system::getenv("RSTUDIO_AUTOMATION_FILTER");
       if (!filter.empty())
          environment.push_back({ "RSTUDIO_AUTOMATION_FILTER", filter });
-      
+
       std::string markers = server::options().automationMarkers();
+      if (markers.empty())
+         markers = core::system::getenv("RSTUDIO_AUTOMATION_MARKERS");
       if (!markers.empty())
          environment.push_back({ "RSTUDIO_AUTOMATION_MARKERS", markers });
    }

--- a/src/cpp/server/session/ServerSessionManager.cpp
+++ b/src/cpp/server/session/ServerSessionManager.cpp
@@ -39,6 +39,8 @@
 #include "../ServerMetrics.hpp"
 #include "server-config.h"
 
+#include <atomic>
+#include <csignal>
 
 using namespace rstudio::core;
 using namespace boost::placeholders;
@@ -59,6 +61,12 @@ namespace server {
 namespace {
 
 static std::string s_launcherToken;
+
+// PID of the rsession launched as the automation host (the one we passed
+// --run-automation=1 to). When that process exits we raise SIGTERM on
+// ourselves so rserver completes its normal shutdown sequence rather
+// than blocking forever in waitForSignals(). Zero means "no host yet".
+static std::atomic<PidType> s_automationHostPid{0};
 
 void readRequestArgs(const core::http::Request& request, core::system::Options *pArgs)
 {
@@ -268,6 +276,16 @@ core::system::ProcessConfig sessionProcessConfig(
 
 void onProcessExit(const std::string& username, PidType pid)
 {
+   PidType automationHost = s_automationHostPid.load();
+   if (automationHost != 0 && pid == automationHost)
+   {
+      LOG_INFO_MESSAGE(
+            "Automation host rsession (pid " +
+            safe_convert::numberToString(pid) +
+            ") exited; signaling rserver shutdown.");
+      s_automationHostPid.store(0);
+      ::kill(::getpid(), SIGTERM);
+   }
 }
 
 } // anonymous namespace
@@ -446,6 +464,22 @@ Error SessionManager::launchAndTrackSession(
    LOG_DEBUG_MESSAGE("Launched session process for user: " + runAsUser + ": " + profile.executablePath +
                      " pid: " + safe_convert::numberToString(pid));
    metrics::sessionLaunch(metrics::kEditorRStudio);
+
+   // If this rsession was launched as the automation host (i.e., the
+   // first session under --run-automation, the one that was passed
+   // --run-automation=1 in createSessionLaunchProfile), remember its
+   // pid so onProcessExit can shut rserver down when it exits.
+   if (server::options().runAutomation())
+   {
+      for (const auto& arg : config.args)
+      {
+         if (arg.first == "--run-automation" && arg.second == "1")
+         {
+            s_automationHostPid.store(pid);
+            break;
+         }
+      }
+   }
 
    // track it for subsequent reaping
    processTracker_.addProcess(pid, boost::bind(onProcessExit,

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -616,14 +616,21 @@ void handleFilesRequest(const http::Request& request,
       std::string referer = request.headerValue("Referer");
       if (!referer.empty())
       {
-         std::string refererHost = http::URL(referer).host();
-         std::string requestHost = http::URL(request.proxiedUri()).host();
-         if (refererHost != requestHost)
+         // Compare scheme + host + effective port so that http vs https on
+         // the same host don't get treated as same-origin, and so that
+         // implicit default ports (e.g. "example.com" vs "example.com:80")
+         // canonicalize to the same value.
+         http::URL refererUrl(referer);
+         http::URL requestUrl(request.proxiedUri());
+         if (refererUrl.protocol() != requestUrl.protocol() ||
+             refererUrl.hostWithPort() != requestUrl.hostWithPort())
          {
             WLOGF("Rejecting /files/ request with mismatched Referer "
-                  "(no Sec-Fetch-Site; Referer host '{}' vs request host '{}') "
-                  "for URI {}",
-                  refererHost, requestHost, request.uri());
+                  "(no Sec-Fetch-Site; Referer origin '{}://{}' vs "
+                  "request origin '{}://{}') for URI {}",
+                  refererUrl.protocol(), refererUrl.hostWithPort(),
+                  requestUrl.protocol(), requestUrl.hostWithPort(),
+                  request.uri());
             pResponse->setError(http::status::BadRequest,
                                 "Cross-origin request not allowed");
             return;

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -44,7 +44,6 @@
 #include <core/http/Util.hpp>
 #include <core/http/Request.hpp>
 #include <core/http/Response.hpp>
-#include <core/http/URL.hpp>
 #include <core/http/CSRFToken.hpp>
 
 #include <core/system/ShellUtils.hpp>
@@ -573,24 +572,30 @@ void handleFilesRequest(const http::Request& request,
       return;
    }
 
-   // Require a same-origin Referer header. Files served from the user's
-   // home directory are returned with native MIME types (HTML as text/html),
+   // Block cross-site requests to /files/. The handler serves files from
+   // the user's home directory with native MIME types (HTML as text/html),
    // so loading one cross-origin would execute attacker-controlled content
-   // in the RStudio session origin. The default cross-origin check in
-   // AsyncServerImpl only rejects when Origin/Referer is present and
-   // mismatched, so an empty Referer (e.g. via Referrer-Policy: no-referrer)
-   // would otherwise slip through.
+   // in the RStudio session origin. The default Origin/Referer check in
+   // AsyncServerImpl only rejects when those headers are present and
+   // mismatched, so a redirect from an attacker page that strips the
+   // Referer (e.g. via Referrer-Policy: no-referrer) slips through.
+   //
+   // Sec-Fetch-Site is a browser-controlled Fetch Metadata header that
+   // can't be set or stripped from page-level JavaScript or referrer
+   // policy, so it remains a reliable signal even when Referer is gone.
+   // We reject only "cross-site" so that user-initiated navigations
+   // (typed URL / bookmark, value "none") and same-origin / same-site
+   // navigations from inside RStudio continue to work.
    //
    // Addresses rstudio-pro#10980.
-   std::string referer = request.headerValue("Referer");
-   std::string refererHost = http::URL(referer).host();
-   std::string requestHost = http::URL(request.proxiedUri()).host();
-   if (refererHost.empty() || refererHost != requestHost)
+   std::string secFetchSite = request.headerValue("Sec-Fetch-Site");
+   if (secFetchSite == "cross-site")
    {
-      WLOGF("Rejecting /files/ request with missing or mismatched Referer "
-            "(got '{}', expected '{}') for URI {}",
-            refererHost, requestHost, request.uri());
-      pResponse->setError(http::status::BadRequest, "Invalid Referer");
+      WLOGF("Rejecting cross-site /files/ request (Sec-Fetch-Site: '{}') "
+            "for URI {}",
+            secFetchSite, request.uri());
+      pResponse->setError(http::status::BadRequest,
+                          "Cross-site request not allowed");
       return;
    }
 

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -576,42 +576,49 @@ void handleFilesRequest(const http::Request& request,
    // Block cross-site requests to /files/. The handler serves files from
    // the user's home directory with native MIME types (HTML as text/html),
    // so loading one cross-origin would execute attacker-controlled content
-   // in the RStudio session origin. The default Origin/Referer check in
-   // AsyncServerImpl only rejects when those headers are present and
-   // mismatched, so a redirect from an attacker page that strips the
-   // Referer (e.g. via Referrer-Policy: no-referrer) slips through.
+   // in the RStudio session origin.
+   //
+   // AsyncServerImpl's pre-handler Origin/Referer check is gated on the
+   // www-enable-origin-check option, which defaults to false. In a
+   // default open-source deployment the upstream check is inactive, so
+   // this handler is the primary cross-origin defense for /files/. Posit
+   // Workbench typically enables www-enable-origin-check, in which case
+   // the upstream layer provides a redundant outer check.
    //
    // Sec-Fetch-Site is a browser-controlled Fetch Metadata header that
    // can't be set or stripped from page-level JavaScript or referrer
    // policy, so it remains a reliable signal even when Referer is gone.
-   // We reject "cross-site" so user-initiated navigations (typed URL /
-   // bookmark, value "none") and same-origin / same-site navigations
-   // from inside RStudio continue to work. "same-site" is allowed so
-   // that Posit Workbench front-ends iframe-embedding RStudio across
-   // sibling subdomains keep functioning.
+   // We allow only the spec-defined "trusted" values (same-origin,
+   // same-site, none); any other non-empty value -- including future
+   // spec additions or non-canonical casings -- is treated as cross-site
+   // and rejected. "same-site" is allowed deliberately so that Posit
+   // Workbench front-ends iframe-embedding RStudio across sibling
+   // subdomains keep functioning; "none" covers user-typed URLs and
+   // bookmarks.
    //
    // For older browsers that don't send Sec-Fetch-Site, fall back to a
-   // same-origin Referer check. AsyncServerImpl already rejects non-empty
-   // mismatched Origin/Referer for all requests, so this is mostly
-   // defense-in-depth, but keeping the policy explicit at the handler
-   // makes the security contract for /files/ self-documenting. The
-   // "everything missing" case (no Sec-Fetch-Site, no Referer) is
-   // intentionally allowed to preserve direct URL navigation in older
-   // browsers; the AsyncServerImpl layer is what closes that gap when
-   // Referer is present but stripped of credentials.
+   // same-origin Referer check. The "everything missing" case (no
+   // Sec-Fetch-Site, no Referer) is intentionally allowed to preserve
+   // direct URL navigation in older browsers; that residual window is
+   // the documented trade-off.
    //
    // Addresses rstudio-pro#10980.
    std::string secFetchSite = request.headerValue("Sec-Fetch-Site");
-   if (secFetchSite == "cross-site")
+   if (!secFetchSite.empty())
    {
-      WLOGF("Rejecting cross-site /files/ request (Sec-Fetch-Site: '{}') "
-            "for URI {}",
-            secFetchSite, request.uri());
-      pResponse->setError(http::status::BadRequest,
-                          "Cross-site request not allowed");
-      return;
+      if (secFetchSite != "same-origin" &&
+          secFetchSite != "same-site" &&
+          secFetchSite != "none")
+      {
+         WLOGF("Rejecting cross-site /files/ request (Sec-Fetch-Site: '{}') "
+               "for URI {}",
+               secFetchSite, request.uri());
+         pResponse->setError(http::status::BadRequest,
+                             "Cross-site request not allowed");
+         return;
+      }
    }
-   else if (secFetchSite.empty())
+   else
    {
       std::string referer = request.headerValue("Referer");
       if (!referer.empty())
@@ -619,10 +626,15 @@ void handleFilesRequest(const http::Request& request,
          // Compare scheme + host + effective port so that http vs https on
          // the same host don't get treated as same-origin, and so that
          // implicit default ports (e.g. "example.com" vs "example.com:80")
-         // canonicalize to the same value.
+         // canonicalize to the same value. Fail closed if either URL
+         // fails to parse so a malformed Referer (e.g. "javascript:..."
+         // or garbage) can't slip through by collapsing both sides to
+         // empty strings.
          http::URL refererUrl(referer);
          http::URL requestUrl(request.proxiedUri());
-         if (refererUrl.protocol() != requestUrl.protocol() ||
+         if (!refererUrl.isValid() ||
+             !requestUrl.isValid() ||
+             refererUrl.protocol() != requestUrl.protocol() ||
              refererUrl.hostWithPort() != requestUrl.hostWithPort())
          {
             WLOGF("Rejecting /files/ request with mismatched Referer "

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -44,6 +44,7 @@
 #include <core/http/Util.hpp>
 #include <core/http/Request.hpp>
 #include <core/http/Response.hpp>
+#include <core/http/URL.hpp>
 #include <core/http/CSRFToken.hpp>
 
 #include <core/system/ShellUtils.hpp>
@@ -583,9 +584,21 @@ void handleFilesRequest(const http::Request& request,
    // Sec-Fetch-Site is a browser-controlled Fetch Metadata header that
    // can't be set or stripped from page-level JavaScript or referrer
    // policy, so it remains a reliable signal even when Referer is gone.
-   // We reject only "cross-site" so that user-initiated navigations
-   // (typed URL / bookmark, value "none") and same-origin / same-site
-   // navigations from inside RStudio continue to work.
+   // We reject "cross-site" so user-initiated navigations (typed URL /
+   // bookmark, value "none") and same-origin / same-site navigations
+   // from inside RStudio continue to work. "same-site" is allowed so
+   // that Posit Workbench front-ends iframe-embedding RStudio across
+   // sibling subdomains keep functioning.
+   //
+   // For older browsers that don't send Sec-Fetch-Site, fall back to a
+   // same-origin Referer check. AsyncServerImpl already rejects non-empty
+   // mismatched Origin/Referer for all requests, so this is mostly
+   // defense-in-depth, but keeping the policy explicit at the handler
+   // makes the security contract for /files/ self-documenting. The
+   // "everything missing" case (no Sec-Fetch-Site, no Referer) is
+   // intentionally allowed to preserve direct URL navigation in older
+   // browsers; the AsyncServerImpl layer is what closes that gap when
+   // Referer is present but stripped of credentials.
    //
    // Addresses rstudio-pro#10980.
    std::string secFetchSite = request.headerValue("Sec-Fetch-Site");
@@ -597,6 +610,25 @@ void handleFilesRequest(const http::Request& request,
       pResponse->setError(http::status::BadRequest,
                           "Cross-site request not allowed");
       return;
+   }
+   else if (secFetchSite.empty())
+   {
+      std::string referer = request.headerValue("Referer");
+      if (!referer.empty())
+      {
+         std::string refererHost = http::URL(referer).host();
+         std::string requestHost = http::URL(request.proxiedUri()).host();
+         if (refererHost != requestHost)
+         {
+            WLOGF("Rejecting /files/ request with mismatched Referer "
+                  "(no Sec-Fetch-Site; Referer host '{}' vs request host '{}') "
+                  "for URI {}",
+                  refererHost, requestHost, request.uri());
+            pResponse->setError(http::status::BadRequest,
+                                "Cross-origin request not allowed");
+            return;
+         }
+      }
    }
 
    // get prefix and uri (strip query string)

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -44,6 +44,7 @@
 #include <core/http/Util.hpp>
 #include <core/http/Request.hpp>
 #include <core/http/Response.hpp>
+#include <core/http/URL.hpp>
 #include <core/http/CSRFToken.hpp>
 
 #include <core/system/ShellUtils.hpp>
@@ -562,16 +563,37 @@ core::Error touchFile(const core::json::JsonRpcRequest& request,
    return Success();
 }
 
-void handleFilesRequest(const http::Request& request, 
+void handleFilesRequest(const http::Request& request,
                         http::Response* pResponse)
-{   
+{
    Options& options = session::options();
    if (options.programMode() != kSessionProgramModeServer)
    {
       pResponse->setNotFoundError(request);
       return;
    }
-   
+
+   // Require a same-origin Referer header. Files served from the user's
+   // home directory are returned with native MIME types (HTML as text/html),
+   // so loading one cross-origin would execute attacker-controlled content
+   // in the RStudio session origin. The default cross-origin check in
+   // AsyncServerImpl only rejects when Origin/Referer is present and
+   // mismatched, so an empty Referer (e.g. via Referrer-Policy: no-referrer)
+   // would otherwise slip through.
+   //
+   // Addresses rstudio-pro#10980.
+   std::string referer = request.headerValue("Referer");
+   std::string refererHost = http::URL(referer).host();
+   std::string requestHost = http::URL(request.proxiedUri()).host();
+   if (refererHost.empty() || refererHost != requestHost)
+   {
+      WLOGF("Rejecting /files/ request with missing or mismatched Referer "
+            "(got '{}', expected '{}') for URI {}",
+            refererHost, requestHost, request.uri());
+      pResponse->setError(http::status::BadRequest, "Invalid Referer");
+      return;
+   }
+
    // get prefix and uri (strip query string)
    std::string prefix = "/files/";
    std::string uri = request.uri();

--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -327,14 +327,31 @@
       proc <- procs[i, ]
       if (identical(proc$status, "zombie"))
          next
-      
-      conns <- ps::ps_connections(proc$ps_handle[[1L]])
-      if (8788L %in% conns$lport)
+
+      conns <- .rs.tryCatch(ps::ps_connections(proc$ps_handle[[1L]]))
+      if (!isTRUE(8788L %in% conns$lport))
+         next
+
+      handle <- ps::ps_handle(pid = proc$pid)
+
+      # ps_kill() on Unix sends SIGTERM, waits up to `grace` ms, then
+      # escalates to SIGKILL. Use a generous grace period so rserver
+      # has a chance to do its own cleanup. After ps_kill returns we
+      # still need to wait for the kernel to reap the process so the
+      # listening socket on port 8788 is released before the caller
+      # binds a new rserver to the same port.
+      .rs.tryCatch(ps::ps_kill(handle, grace = 2000))
+
+      deadline <- Sys.time() + 5
+      while (isTRUE(.rs.tryCatch(ps::ps_is_running(handle))) &&
+             Sys.time() < deadline)
       {
-         handle <- ps::ps_handle(pid = proc$pid)
-         return(ps::ps_kill(handle))
+         Sys.sleep(0.1)
       }
+
+      return(invisible(TRUE))
    }
+   invisible(FALSE)
 })
 
 .rs.addFunction("automation.ensureRunningServerInstance", function(serverDataDir)
@@ -851,9 +868,12 @@
    }
    reportDir <- Sys.getenv("RSTUDIO_AUTOMATION_REPORT_DIR",
                            unset = defaultReportDir)
-   .rs.ensureDirectory(reportDir)
    reportFile <- .rs.nullCoalesce(reportFile, file.path(reportDir, "results.xml"))
-   failuresFile <- file.path(reportDir, "failures.log")
+   # Place the failure log next to the resolved report file so the two
+   # are always discovered together, even when --automation-report-file
+   # points outside the default report directory.
+   failuresFile <- file.path(dirname(reportFile), "failures.log")
+   .rs.ensureDirectory(dirname(reportFile))
 
    # Create a junit-style reporter, for Jenkins.
    junitReporter <- testthat::JunitReporter$new(file = reportFile)

--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -340,13 +340,28 @@
       # still need to wait for the kernel to reap the process so the
       # listening socket on port 8788 is released before the caller
       # binds a new rserver to the same port.
-      .rs.tryCatch(ps::ps_kill(handle, grace = 2000))
+      #
+      # Let ps_kill errors propagate (e.g., EPERM): silently swallowing
+      # them would let the caller try to bind 8788 against a still-live
+      # rserver and produce a confusing 'address already in use'.
+      ps::ps_kill(handle, grace = 2000)
 
       deadline <- Sys.time() + 5
       while (isTRUE(.rs.tryCatch(ps::ps_is_running(handle))) &&
              Sys.time() < deadline)
       {
          Sys.sleep(0.1)
+      }
+
+      # Fail closed if the process didn't actually exit. Reporting
+      # success here would let the caller race a still-listening
+      # rserver and mask whatever kept it alive.
+      if (isTRUE(.rs.tryCatch(ps::ps_is_running(handle))))
+      {
+         stop(sprintf(
+            "Failed to terminate existing rserver (pid %d) on port 8788 within 5s.",
+            proc$pid
+         ))
       }
 
       return(invisible(TRUE))

--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -339,19 +339,14 @@
 
 .rs.addFunction("automation.ensureRunningServerInstance", function(serverDataDir)
 {
-   # Check and see if we already have an rserver instance listening.
-   procs <- subset(ps::ps(), name == "rserver")
-   for (i in seq_len(nrow(procs)))
-   {
-      proc <- procs[i, ]
-      if (identical(proc$status, "zombie"))
-         next
-      
-      conns <- .rs.tryCatch(ps::ps_connections(proc$ps_handle[[1L]]))
-      if (8788L %in% conns$lport)
-         return(TRUE)
-   }
-   
+   # Always kill any existing automation rserver listening on 8788 and
+   # start a fresh one. Reusing an existing instance silently masks code
+   # changes (so tests run against a stale binary) and stale instances
+   # accumulate across runs when the cleanup finalizer doesn't fire
+   # (Ctrl+C, crashes, terminal closes). The kill is a no-op if nothing
+   # is listening.
+   .rs.automation.killAutomationServer()
+
    # Get the path to the rserver executable.
    parentHandle <- ps::ps_parent()
    parentEnv <- ps::ps_environ(parentHandle)
@@ -841,17 +836,31 @@
       RSTUDIO_AUTOMATION_REUSE_REMOTE = "TRUE"
    )
    
-   # Figure out where we're writing our test results.
-   reportFile <- .rs.nullCoalesce(reportFile, {
-      tempfile("junit-", fileext = ".xml")
-   })
-   
+   # Figure out where we're writing our test results. Default to a fixed
+   # path under the OS temp directory so the report is discoverable
+   # without having to grep per-session tempdirs. Override via
+   # RSTUDIO_AUTOMATION_REPORT_DIR or the --automation-report-file option.
+   defaultReportDir <- if (.rs.platform.isWindows)
+   {
+      file.path(Sys.getenv("TEMP", unset = Sys.getenv("TMP", unset = "C:/Temp")),
+                "rstudio-automation")
+   }
+   else
+   {
+      "/tmp/rstudio-automation"
+   }
+   reportDir <- Sys.getenv("RSTUDIO_AUTOMATION_REPORT_DIR",
+                           unset = defaultReportDir)
+   .rs.ensureDirectory(reportDir)
+   reportFile <- .rs.nullCoalesce(reportFile, file.path(reportDir, "results.xml"))
+   failuresFile <- file.path(reportDir, "failures.log")
+
    # Create a junit-style reporter, for Jenkins.
    junitReporter <- testthat::JunitReporter$new(file = reportFile)
-   
+
    # Create a regular progress reporter.
    progressReporter <- testthat::ProgressReporter$new()
-   
+
    # Use a custom reporter for screenshot handling.
    ScreenshotReporter <- R6::R6Class(
       classname = "RStudioScreenshotReporter",
@@ -863,15 +872,62 @@
          }
       )
    )
-   
+
    screenshotReporter <- ScreenshotReporter$new()
-   
+
+   # Reporter that writes test failures to a plain-text log file via
+   # file(). The standard reporters use cat() which goes to R's console
+   # and is captured by rsession (so the lines never reach the terminal
+   # or a redirectable file descriptor); writing through file() bypasses
+   # that capture so the failures end up on disk for inspection after
+   # the run.
+   FailureLogReporter <- R6::R6Class(
+      classname = "RStudioFailureLogReporter",
+      inherit = testthat::Reporter,
+      public = list(
+         con = NULL,
+         currentContext = NULL,
+         currentTest = NULL,
+         initialize = function(file) {
+            self$con <- base::file(file, open = "w")
+         },
+         start_context = function(context) {
+            self$currentContext <- context
+         },
+         start_test = function(context, test) {
+            self$currentTest <- test
+         },
+         add_result = function(context, test, result) {
+            if (inherits(result, c("expectation_failure", "expectation_error")))
+            {
+               ref <- if (!is.null(result$srcref))
+                  paste(format(result$srcref), collapse = " ")
+               else
+                  "<unknown>"
+               writeLines(c(
+                  sprintf("[FAIL] %s :: %s", self$currentContext, self$currentTest),
+                  sprintf("  at %s", ref),
+                  paste0("  ", strsplit(format(result), "\n", fixed = TRUE)[[1]]),
+                  ""
+               ), con = self$con)
+               flush(self$con)
+            }
+         },
+         end_reporter = function() {
+            close(self$con)
+         }
+      )
+   )
+
+   failureLogReporter <- FailureLogReporter$new(file = failuresFile)
+
    # Combine with the default reporter.
    multiReporter <- testthat::MultiReporter$new(
       reporters = list(
          progressReporter,
          junitReporter,
-         screenshotReporter
+         screenshotReporter,
+         failureLogReporter
       )
    )
    
@@ -905,7 +961,13 @@
       writeLines(stripped, con = reportFile)
    }
 
-   writeLines(c("", "==> Finishing running RStudio automation", ""))
+   writeLines(c(
+      "",
+      "==> Finishing running RStudio automation",
+      sprintf("    JUnit report:  %s", reportFile),
+      sprintf("    Failure log:   %s", failuresFile),
+      ""
+   ))
 
    # Quit when we're done.
    quit(save = "no", status = 0L)

--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -960,7 +960,11 @@
    invisible(.rs.api.executeCommand("consoleClear"))
    writeLines(c("", "==> Running RStudio automation tests", ""))
    
-   # Run tests.
+   # Run tests. RSTUDIO_AUTOMATION_FILTER is set on this rsession by
+   # rserver in sessionProcessConfig() (ServerSessionManager.cpp), sourced
+   # from --automation-filter or rserver's inherited env. The rsession
+   # environment is built explicitly, so exporting this var in the shell
+   # without going through rserver has no effect here.
    filter <- Sys.getenv("RSTUDIO_AUTOMATION_FILTER", unset = NA)
    testthat::test_dir(
       path = "testthat",

--- a/src/cpp/session/modules/automation/SessionAutomation.R
+++ b/src/cpp/session/modules/automation/SessionAutomation.R
@@ -341,10 +341,14 @@
       # listening socket on port 8788 is released before the caller
       # binds a new rserver to the same port.
       #
-      # Let ps_kill errors propagate (e.g., EPERM): silently swallowing
-      # them would let the caller try to bind 8788 against a still-live
-      # rserver and produce a confusing 'address already in use'.
-      ps::ps_kill(handle, grace = 2000)
+      # Tolerate the benign race where the process exits between
+      # discovery and kill: older `ps` versions raise no_such_process
+      # in that case. Real failures (e.g., EPERM) still propagate so
+      # we don't silently let the caller race a still-live rserver.
+      tryCatch(
+         ps::ps_kill(handle, grace = 2000),
+         no_such_process = function(cnd) invisible(NULL)
+      )
 
       deadline <- Sys.time() + 5
       while (isTRUE(.rs.tryCatch(ps::ps_is_running(handle))) &&

--- a/src/cpp/tests/automation/testthat/test-automation-files-endpoint.R
+++ b/src/cpp/tests/automation/testthat/test-automation-files-endpoint.R
@@ -44,6 +44,18 @@ withr::defer(.rs.automation.deleteRemote())
       httr::status_code(request(headers))
    }
 
+   # The BRAT server runs without --www-enable-origin-check=1, so
+   # AsyncServerImpl's pre-handler Origin/Referer check is inactive. Every
+   # 400 below is therefore produced by the /files/ handler itself, which
+   # is also the situation in a default open-source deployment.
+
+   # Warm up: the very first httr request against a fresh rserver goes
+   # through session-establishment scaffolding before the /files/ handler
+   # gets a chance to run, so its response status doesn't reflect the
+   # cross-site policy. Make a throwaway request first so subsequent
+   # assertions actually exercise the handler.
+   invisible(request(list(list(`Sec-Fetch-Site` = "same-origin"))))
+
    # Primary check: Sec-Fetch-Site == "cross-site" is the explicit attacker
    # signal and must be rejected.
    expect_equal(
@@ -55,9 +67,27 @@ withr::defer(.rs.automation.deleteRemote())
    # URLs and bookmarks. "same-origin" covers in-RStudio navigation.
    # "same-site" is allowed deliberately so Posit Workbench front-ends
    # iframe-embedding RStudio across sibling subdomains keep functioning.
-   expect_equal(getStatus(list(list(`Sec-Fetch-Site` = "same-origin"))), 200)
-   expect_equal(getStatus(list(list(`Sec-Fetch-Site` = "same-site"))),   200)
-   expect_equal(getStatus(list(list(`Sec-Fetch-Site` = "none"))),        200)
+   sameOriginResponse <- request(list(list(`Sec-Fetch-Site` = "same-origin")))
+   expect_equal(httr::status_code(sameOriginResponse), 200)
+   # Tie "200" to "served the file" so a regression that returns 200 with
+   # the wrong contents (e.g. an empty body) doesn't go unnoticed.
+   expect_equal(
+      .rs.trimWhitespace(httr::content(sameOriginResponse, "text", encoding = "UTF-8")),
+      "test content"
+   )
+   expect_equal(getStatus(list(list(`Sec-Fetch-Site` = "same-site"))), 200)
+   expect_equal(getStatus(list(list(`Sec-Fetch-Site` = "none"))),      200)
+
+   # The Sec-Fetch-Site comparison is case-sensitive (per spec, browsers
+   # send the lowercase tokens). A capitalized value isn't on the
+   # allow-list, so it must be treated as cross-site and rejected. Pin
+   # this so a future change to case-insensitive matching is a deliberate
+   # decision rather than an accident.
+   expect_equal(getStatus(list(list(`Sec-Fetch-Site` = "Cross-Site"))), 400)
+
+   # Unknown / future Sec-Fetch-Site values must default to deny rather
+   # than fall through both branches and silently allow the request.
+   expect_equal(getStatus(list(list(`Sec-Fetch-Site` = "garbage"))), 400)
 
    # Older browsers don't send Sec-Fetch-Site. The handler's fallback
    # check then enforces a same-origin Referer when one is present.
@@ -70,9 +100,8 @@ withr::defer(.rs.automation.deleteRemote())
       200
    )
 
-   # Sec-Fetch-Site absent + cross-origin Referer -> rejected. This is
-   # caught by AsyncServerImpl's pre-handler check, but the assertion
-   # documents the end-to-end policy.
+   # Sec-Fetch-Site absent + cross-origin Referer -> rejected by the
+   # handler's Referer fallback.
    expect_equal(
       getStatus(list(list(Referer = crossOriginReferer))),
       400
@@ -85,20 +114,29 @@ withr::defer(.rs.automation.deleteRemote())
 
    # Edge case: same host:port but different scheme is NOT same-origin.
    # The handler compares scheme + host:port to canonicalize away from
-   # bare-host-equality bugs. AsyncServerImpl's pre-handler check is
-   # host-only, so it lets this through; the /files/ handler rejects it.
+   # bare-host-equality bugs. (AsyncServerImpl's pre-handler check is
+   # scheme-agnostic -- it compares host:port but ignores http vs https
+   # -- so even when that layer is enabled in Workbench, this handler is
+   # what catches the cross-scheme case.)
    crossSchemeReferer <- sprintf("https://localhost:8788/")
    expect_equal(
       getStatus(list(list(Referer = crossSchemeReferer))),
       400
    )
 
-   # Edge case: same scheme + same host but different port -> rejected.
-   # Caught upstream by AsyncServerImpl, but asserted here so a
-   # regression that loosens host:port comparison is visible.
+   # Edge case: same scheme + same host but different port -> rejected
+   # by the handler's host:port comparison.
    crossPortReferer <- "http://localhost:9999/"
    expect_equal(
       getStatus(list(list(Referer = crossPortReferer))),
       400
    )
+
+   # Malformed Referer values must fail closed: the URL parser rejects
+   # anything outside http/https/file/ftp(s), so these all produce empty
+   # protocol/host. The handler treats that as a parse failure and
+   # rejects rather than collapsing both sides to empty and matching.
+   expect_equal(getStatus(list(list(Referer = "javascript:alert(1)"))), 400)
+   expect_equal(getStatus(list(list(Referer = "about:blank"))),         400)
+   expect_equal(getStatus(list(list(Referer = "not a url"))),           400)
 })

--- a/src/cpp/tests/automation/testthat/test-automation-files-endpoint.R
+++ b/src/cpp/tests/automation/testthat/test-automation-files-endpoint.R
@@ -14,7 +14,7 @@ withr::defer(.rs.automation.deleteRemote())
 # automation.ensureRunningServerInstance), so we can drive raw HTTP requests
 # from the test driver via httr without dealing with auth cookies.
 
-.rs.test("/files/ rejects cross-site requests", {
+.rs.test("/files/ enforces cross-site protections", {
    skip_if(.rs.isDesktop())
 
    # Drop a small test file in the home directory so the handler reaches the
@@ -32,28 +32,54 @@ withr::defer(.rs.automation.deleteRemote())
       ))
    })
 
-   url <- sprintf("http://localhost:8788/files/%s", testFile)
-   getStatus <- function(secFetchSite = NULL) {
-      response <- if (is.null(secFetchSite)) {
-         httr::GET(url)
-      } else {
-         httr::GET(url, httr::add_headers(`Sec-Fetch-Site` = secFetchSite))
-      }
-      httr::status_code(response)
+   serverHost <- "http://localhost:8788"
+   url <- sprintf("%s/files/%s", serverHost, testFile)
+   request <- function(headers = list()) {
+      args <- c(list(url), lapply(headers, function(v) {
+         do.call(httr::add_headers, v)
+      }))
+      do.call(httr::GET, args)
+   }
+   getStatus <- function(headers = list()) {
+      httr::status_code(request(headers))
    }
 
-   # Cross-site requests must be rejected.
-   expect_equal(getStatus("cross-site"), 400)
+   # Primary check: Sec-Fetch-Site == "cross-site" is the explicit attacker
+   # signal and must be rejected.
+   expect_equal(
+      getStatus(list(list(`Sec-Fetch-Site` = "cross-site"))),
+      400
+   )
 
-   # All other Sec-Fetch-Site values are legitimate and must pass through.
-   # "none" covers user-typed URLs and bookmarks; "same-origin" / "same-site"
-   # cover navigations from inside RStudio (or a sibling subdomain).
-   expect_equal(getStatus("same-origin"), 200)
-   expect_equal(getStatus("same-site"),   200)
-   expect_equal(getStatus("none"),        200)
+   # Other Sec-Fetch-Site values are legitimate. "none" covers user-typed
+   # URLs and bookmarks. "same-origin" covers in-RStudio navigation.
+   # "same-site" is allowed deliberately so Posit Workbench front-ends
+   # iframe-embedding RStudio across sibling subdomains keep functioning.
+   expect_equal(getStatus(list(list(`Sec-Fetch-Site` = "same-origin"))), 200)
+   expect_equal(getStatus(list(list(`Sec-Fetch-Site` = "same-site"))),   200)
+   expect_equal(getStatus(list(list(`Sec-Fetch-Site` = "none"))),        200)
 
-   # Older browsers don't send Sec-Fetch-* headers at all; the existing
-   # AsyncServerImpl Origin/Referer check still catches non-empty mismatched
-   # Referers, so we accept the absent-header case here.
-   expect_equal(getStatus(NULL), 200)
+   # Older browsers don't send Sec-Fetch-Site. The handler's fallback
+   # check then enforces a same-origin Referer when one is present.
+   sameOriginReferer <- sprintf("%s/", serverHost)
+   crossOriginReferer <- "https://attacker.example/"
+
+   # Sec-Fetch-Site absent + same-origin Referer -> allowed.
+   expect_equal(
+      getStatus(list(list(Referer = sameOriginReferer))),
+      200
+   )
+
+   # Sec-Fetch-Site absent + cross-origin Referer -> rejected. This is
+   # caught by AsyncServerImpl's pre-handler check, but the assertion
+   # documents the end-to-end policy.
+   expect_equal(
+      getStatus(list(list(Referer = crossOriginReferer))),
+      400
+   )
+
+   # Sec-Fetch-Site absent + Referer absent -> allowed. This preserves
+   # direct URL navigation in older browsers; the residual attack window
+   # (older browser + attacker-strips-referer) is the documented trade-off.
+   expect_equal(getStatus(), 200)
 })

--- a/src/cpp/tests/automation/testthat/test-automation-files-endpoint.R
+++ b/src/cpp/tests/automation/testthat/test-automation-files-endpoint.R
@@ -1,0 +1,59 @@
+
+library(testthat)
+
+self <- remote <- .rs.automation.newRemote()
+withr::defer(.rs.automation.deleteRemote())
+
+
+# Tests for the /files/ HTTP endpoint security check (rstudio-pro#10980).
+# The endpoint serves user-controlled files with native MIME types and must
+# reject cross-site requests so attacker pages can't redirect victims into
+# loading attacker HTML in the RStudio session origin.
+#
+# The BRAT server runs at http://localhost:8788 with --auth-none=1 (see
+# automation.ensureRunningServerInstance), so we can drive raw HTTP requests
+# from the test driver via httr without dealing with auth cookies.
+
+.rs.test("/files/ rejects cross-site requests", {
+   skip_if(.rs.isDesktop())
+
+   # Drop a small test file in the home directory so the handler reaches the
+   # Sec-Fetch-Site check before any not-found logic. Use a leading '.' so we
+   # don't pollute the visible Files pane during test runs.
+   testFile <- ".rstudio-test-files-endpoint"
+   remote$console.execute(sprintf(
+      "writeLines('test content', file.path('~', '%s'))",
+      testFile
+   ))
+   withr::defer({
+      remote$console.execute(sprintf(
+         "unlink(file.path('~', '%s'))",
+         testFile
+      ))
+   })
+
+   url <- sprintf("http://localhost:8788/files/%s", testFile)
+   getStatus <- function(secFetchSite = NULL) {
+      response <- if (is.null(secFetchSite)) {
+         httr::GET(url)
+      } else {
+         httr::GET(url, httr::add_headers(`Sec-Fetch-Site` = secFetchSite))
+      }
+      httr::status_code(response)
+   }
+
+   # Cross-site requests must be rejected.
+   expect_equal(getStatus("cross-site"), 400)
+
+   # All other Sec-Fetch-Site values are legitimate and must pass through.
+   # "none" covers user-typed URLs and bookmarks; "same-origin" / "same-site"
+   # cover navigations from inside RStudio (or a sibling subdomain).
+   expect_equal(getStatus("same-origin"), 200)
+   expect_equal(getStatus("same-site"),   200)
+   expect_equal(getStatus("none"),        200)
+
+   # Older browsers don't send Sec-Fetch-* headers at all; the existing
+   # AsyncServerImpl Origin/Referer check still catches non-empty mismatched
+   # Referers, so we accept the absent-header case here.
+   expect_equal(getStatus(NULL), 200)
+})

--- a/src/cpp/tests/automation/testthat/test-automation-files-endpoint.R
+++ b/src/cpp/tests/automation/testthat/test-automation-files-endpoint.R
@@ -82,4 +82,23 @@ withr::defer(.rs.automation.deleteRemote())
    # direct URL navigation in older browsers; the residual attack window
    # (older browser + attacker-strips-referer) is the documented trade-off.
    expect_equal(getStatus(), 200)
+
+   # Edge case: same host:port but different scheme is NOT same-origin.
+   # The handler compares scheme + host:port to canonicalize away from
+   # bare-host-equality bugs. AsyncServerImpl's pre-handler check is
+   # host-only, so it lets this through; the /files/ handler rejects it.
+   crossSchemeReferer <- sprintf("https://localhost:8788/")
+   expect_equal(
+      getStatus(list(list(Referer = crossSchemeReferer))),
+      400
+   )
+
+   # Edge case: same scheme + same host but different port -> rejected.
+   # Caught upstream by AsyncServerImpl, but asserted here so a
+   # regression that loosens host:port comparison is visible.
+   crossPortReferer <- "http://localhost:9999/"
+   expect_equal(
+      getStatus(list(list(Referer = crossPortReferer))),
+      400
+   )
 })


### PR DESCRIPTION
## Intent

Addresses rstudio/rstudio-pro#10980.

## Summary

The `/files/` request handler in `SessionFiles.cpp` serves user-controlled
files from the home directory with native MIME types (HTML as `text/html`),
so loading one cross-origin can execute attacker-controlled content in the
RStudio session origin.

The default cross-origin check in `AsyncServerImpl` only rejects requests
where Origin/Referer is present and mismatched, so an attacker page that
redirects to `/files/` with `Referrer-Policy: no-referrer` slips through.

Use the [Fetch Metadata](https://w3c.github.io/webappsec-fetch-metadata/)
`Sec-Fetch-Site` header to identify the bad case directly. The header is
browser-controlled and not settable from page-level JavaScript or
referrer policy, so it remains a reliable signal even when Referer is
stripped. We reject only `Sec-Fetch-Site: cross-site`:

| Origin of request | `Sec-Fetch-Site` | Outcome |
|---|---|---|
| User typed URL / bookmark | `none` | allowed |
| Click within RStudio | `same-origin` | allowed |
| RStudio in iframe of same site (e.g. Workbench UI) | `same-site` | allowed |
| Attacker redirect (incl. `no-referrer`) | `cross-site` | **rejected (400)** |
| Older browser w/ no Fetch Metadata | header absent | allowed; `AsyncServerImpl` still catches non-empty mismatched Referer |

## Test plan

- [ ] Verify normal in-RStudio file viewing (Files pane "View File", Rmd
  output, HTML preview, plot export) still works.
- [ ] Verify direct browser access to `/files/<path>` (typed URL or
  bookmark) still works.
- [ ] Verify a cross-site simulated request to `/files/` is rejected with
  400 (e.g. `curl -H 'Sec-Fetch-Site: cross-site' http://localhost:8787/files/foo.html`).
- [ ] Confirm desktop mode still 404s early (program-mode check runs
  before the Sec-Fetch-Site check).