### PR TITLE
Decouple source-mode spell check from yaml-lint

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 - ([#3780](https://github.com/rstudio/rstudio/issues/3780)): When sending a file to the system Trash/Recycle Bin fails, the Files pane now reports the error and leaves the file on disk; previously it would silently fall back to permanently deleting the file.
 - ([#12235](https://github.com/rstudio/rstudio/issues/12235)): RStudio Desktop's Session > New Session now opens noticeably faster.
 - ([#15614](https://github.com/rstudio/rstudio/issues/15614)): The splash screen can again be dismissed with a mouse click or key press.
+- ([#15711](https://github.com/rstudio/rstudio/issues/15711)): Source-mode spell check no longer disappears on Quarto and R Markdown documents when the bundled YAML diagnostics worker fails to respond; spell-check lint is now applied independently of YAML lint.
 - ([#16067](https://github.com/rstudio/rstudio/issues/16067)): Raise the open file descriptor soft limit at session startup to avoid "Too many open files" errors during project file monitoring on Linux.
 - ([#16541](https://github.com/rstudio/rstudio/issues/16541)): Section headers now fold hierarchically based on heading level, matching Positron's default behavior.
 - ([#16966](https://github.com/rstudio/rstudio/issues/16966)): Restored the desktop terminal bell on Linux, now that the underlying Electron crash has been fixed.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
@@ -316,21 +316,26 @@ public class LintManager
                   // lint yaml for rmd files and R chunks within rmd files
                   boolean isRmd = docDisplay_.getFileType().isRmd();
                   boolean isRmdRChunk = docDisplay_.getEditorBehavior().equals(EditorBehavior.AceBehaviorEmbedded) &&
-                        docDisplay_.getFileType().isR();                  
+                        docDisplay_.getFileType().isR();
+                  // Show R lint + spell check immediately so that a hung or failed
+                  // yaml-lint provider can't suppress source-mode spell check
+                  // (see rstudio/rstudio#15711).
+                  showLint(context, lint);
+
                   if ((isRmd || isRmdRChunk) && userPrefs_.showDiagnosticsYaml().getValue())
                   {
                      yamlLinter_.getLint(context.explicit, yamlLint -> {
+                        if (context.token.isInvalid())
+                           return;
+                        if (yamlLint.length() == 0)
+                           return;
                         JsArray<LintItem> allLint = JsArray.createArray().cast();
                         for (int i = 0; i < lint.length(); i++)
                            allLint.push(lint.get(i));
                         for (int i = 0; i < yamlLint.length(); i++)
                            allLint.push(yamlLint.get(i));
                         showLint(context, allLint);
-                     });               
-                  }
-                  else
-                  {
-                     showLint(context, lint);
+                     });
                   }
                }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
@@ -394,6 +394,8 @@ public class LintManager
             @Override
             public void onResponseReceived(JsArray<LintItem> response)
             {
+               if (context.token.isInvalid())
+                  return;
                if (generation != showLintGeneration_)
                   return;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
@@ -364,6 +364,13 @@ public class LintManager
       if (docDisplay_.isPopupVisible())
          return;
 
+      // A single lint cycle can call showLint more than once (e.g. an
+      // immediate R-lint pass followed by a merged R + yaml-lint pass). Each
+      // pass kicks off an async spell-check request, so a stale callback
+      // could otherwise overwrite the latest render. Capture the generation
+      // here and drop the spell-check render if a newer pass has run.
+      final int generation = ++showLintGeneration_;
+
       JsArray<LintItem> finalLint;
 
       // Filter out items at the last cursor position, if the cursor hasn't moved.
@@ -387,6 +394,9 @@ public class LintManager
             @Override
             public void onResponseReceived(JsArray<LintItem> response)
             {
+               if (generation != showLintGeneration_)
+                  return;
+
                for (int i = 0; i < response.length(); i++)
                   finalLint.push(response.get(i));
 
@@ -472,6 +482,7 @@ public class LintManager
    private boolean explicit_;
    private boolean showMarkers_;
    private boolean excludeCurrentStatement_;
+   private int showLintGeneration_ = 0;
    
    private LintServerOperations server_;
    private UserPrefs userPrefs_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
@@ -318,8 +318,7 @@ public class LintManager
                   boolean isRmdRChunk = docDisplay_.getEditorBehavior().equals(EditorBehavior.AceBehaviorEmbedded) &&
                         docDisplay_.getFileType().isR();
                   // Show R lint + spell check immediately so that a hung or failed
-                  // yaml-lint provider can't suppress source-mode spell check
-                  // (see rstudio/rstudio#15711).
+                  // yaml-lint provider can't suppress source-mode spell check.
                   showLint(context, lint);
 
                   if ((isRmd || isRmdRChunk) && userPrefs_.showDiagnosticsYaml().getValue())
@@ -327,6 +326,10 @@ public class LintManager
                      yamlLinter_.getLint(context.explicit, yamlLint -> {
                         if (context.token.isInvalid())
                            return;
+                        // The immediate showLint above already rendered R-lint
+                        // + spell and cleared any prior yaml render. Skipping
+                        // a second showLint here is required so we don't bump
+                        // showLintGeneration_ and drop that pass.
                         if (yamlLint.length() == 0)
                            return;
                         JsArray<LintItem> allLint = JsArray.createArray().cast();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
@@ -371,20 +371,20 @@ public class LintManager
       // here and drop the spell-check render if a newer pass has run.
       final int generation = ++showLintGeneration_;
 
-      JsArray<LintItem> finalLint;
-
-      // Filter out items at the last cursor position, if the cursor hasn't moved.
-      if (context.excludeCurrentStatement && docDisplay_.getCursorPosition().isEqualTo(context.cursorPosition))
+      // Always copy into a fresh array. The spell-check callback below
+      // appends to finalLint, and aliasing the caller's lint array would
+      // leak those spell items back into a subsequent yaml-merge pass and
+      // duplicate them on the next render.
+      JsArray<LintItem> finalLint = JsArray.createArray().cast();
+      boolean filterCursor = context.excludeCurrentStatement &&
+            docDisplay_.getCursorPosition().isEqualTo(context.cursorPosition);
+      Position pos = context.cursorPosition;
+      for (int i = 0; i < lint.length(); i++)
       {
-         finalLint = JsArray.createArray().cast();
-         Position pos = context.cursorPosition;
-         for (int i = 0; i < lint.length(); i++)
-            if (!lint.get(i).asRange().contains(pos))
-               finalLint.push(lint.get(i));
-      }
-      else
-      {
-         finalLint = lint;
+         LintItem item = lint.get(i);
+         if (filterCursor && item.asRange().contains(pos))
+            continue;
+         finalLint.push(item);
       }
 
       if (spellcheck && userPrefs_.realTimeSpellchecking().getValue())


### PR DESCRIPTION
## Intent

Addresses #15711.

## Summary

Source-mode spell check stops working on Quarto and R Markdown documents when the bundled YAML diagnostics worker fails to respond (e.g. an outdated Quarto installation throwing during init). The lint pipeline made spell-check rendering conditional on yaml-lint resolving, so a hung worker silently suppressed spelling diagnostics for the rest of the session.

This branch decouples the two and tightens the spell-check render path against stale callbacks:

- `LintManager.performRLintServerRequest` now calls `showLint(context, lint)` immediately on R-lint completion. Yaml-lint still runs and merges into a second `showLint` pass when (or if) it returns; if it never returns, no harm.
- The yaml-lint callback skips its second `showLint` when the context's invalidation token is no longer current or the yaml result is empty.
- `showLint` allocates a fresh `finalLint` array and treats the caller's `lint` argument as read-only; spell-check items can no longer leak back into a subsequent yaml-merge pass.
- Each `showLint` invocation captures a generation counter; the async spell-check callback bails out if a later pass has run, or if the lint context has been invalidated by a document edit.

## Test plan

- [ ] Install Quarto 1.6.39 (the version that triggers the original report's `Deno is not defined` worker error). Open a `.qmd` document, type a misspelled word in source mode, and confirm the spelling squiggle appears.
- [ ] With a healthy Quarto install, confirm YAML diagnostics in `.qmd` and `.Rmd` front matter still render as before.
- [ ] In a `.Rmd` document, type quickly to trigger overlapping lint cycles; confirm no duplicate spelling markers and no stale lint persists across edits.
- [ ] Toggle Tools → Global Options → Code → Diagnostics → Show diagnostics for YAML on/off; confirm spell check works in both states.