### PR TITLE
Spell-check headings in source mode (#17568)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 - ([#17556](https://github.com/rstudio/rstudio/issues/17556)): `difftime` objects (e.g. the result of subtracting two `Sys.time()` values) now show their formatted value in the Environment pane instead of an empty cell.
+- ([#17568](https://github.com/rstudio/rstudio/issues/17568)): Source-mode spell check now flags misspelled words inside Markdown, R Markdown, and Quarto headings; previously only paragraph text was checked.
 - ([#17481](https://github.com/rstudio/rstudio/issues/17481)): Fixed two debugger regressions: top-level breakpoints (e.g. via `debugSource()`) no longer fail to show the debug highlight or call stack, and multi-line input at the `Browse[N]>` prompt no longer clears the captured browser context.
 - ([#3780](https://github.com/rstudio/rstudio/issues/3780)): The Files pane delete confirmation now reflects whether the file will be moved to the system Trash/Recycle Bin or permanently deleted, based on the "Delete files to Trash/Recycle Bin" preference.
 - ([#3780](https://github.com/rstudio/rstudio/issues/3780)): When sending a file to the system Trash/Recycle Bin fails, the Files pane now reports the error and leaves the file on disk; previously it would silently fall back to permanently deleting the file.

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -534,7 +534,8 @@ public class TextFileType extends EditableFileType
          }
 
          return (reCommentType_.match(token.getType(), 0) != null ||
-                 reTextType_.match(token.getType(), 0) != null) &&
+                 reTextType_.match(token.getType(), 0) != null ||
+                 reHeaderType_.match(token.getType(), 0) != null) &&
                  reKeywordType_.match(token.getType(), 0) == null &&
                  reIdentifierType_.match(token.getType(), 0) == null;
       };


### PR DESCRIPTION
## Intent

Addresses #17568.

## Summary

In source mode, real-time spell check did not flag misspelled words inside Markdown, R Markdown, or Quarto headings. The same word in a paragraph was flagged correctly.

`TextFileType.getSpellCheckTokenPredicate()` only accepted tokens whose type matched `\btext\b` or `\bcomment\b`. The body of an ATX heading is tokenized in the `header` state with `defaultToken: "heading"` (see `markdown_highlight_rules.js:340`), and setext underlines produce `markup.heading.N` tokens. Neither matches the predicate, so heading text was filtered out before reaching the spell checker.

The general-purpose `getTokenPredicate()` ten lines above in the same file already handles headings via `reHeaderType_` (`\bheading\b`); the spell-check predicate just wasn't wired up the same way. This adds the heading branch to the spell-check predicate to match.

## Test plan

- [ ] Open a `.md`, `.Rmd`, and `.qmd` file in source mode.
- [ ] Type `## weeird` and confirm a spell-check squiggle appears under `weeird`.
- [ ] Type `weeird` in a paragraph and confirm the existing squiggle still appears.
- [ ] Confirm a setext heading underline (`Heading\n=======`) also gets squiggles on misspellings.
- [ ] Confirm headings inside YAML/code chunks are unaffected (no spurious squiggles).
- [ ] Confirm non-Markdown file types (R, C++) still spell-check only comments.