### PR TITLE
Add Playwright workflow for RStudio Server on Ubuntu 24

### DIFF
--- a/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -92,7 +92,7 @@ jobs:
             echo "  SHA-256:  $SHA"
             echo "  Filename: $FILENAME"
           else
-            FILENAME=$(basename "$URL")
+            FILENAME=$(basename "${URL%%\?*}")
             echo "Using override URL: $URL (SHA-256 verification skipped)"
           fi
           echo "url=$URL" >> "$GITHUB_OUTPUT"
@@ -182,6 +182,7 @@ jobs:
         working-directory: e2e/rstudio
         env:
           PW_RSTUDIO_MODE: server
+          PW_RSTUDIO_EDITION: os
           PW_RSTUDIO_SERVER_URL: http://localhost:8787
           PW_PROJECT_NAME: ${{ inputs.project }}
           PW_GREP: ${{ inputs.grep }}

--- a/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -1,0 +1,233 @@
+name: "Test: E2E Playwright RStudio (Server, Ubuntu 24, Open Source)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      rstudio_installer_url:
+        description: "URL to a Server installer (.deb on Ubuntu, .rpm on RHEL/Fedora). Leave empty to auto-resolve the latest daily for this workflow's platform. To pin a specific build, paste its full URL from dailies.rstudio.com."
+        type: string
+        default: ""
+      r_version:
+        description: "R version to install via rig (e.g. 'release', 'oldrel', 'devel', '4.4.1')."
+        type: string
+        default: "release"
+      project:
+        description: "Playwright project to run: 'desktop' or 'server'. OS and edition are auto-filtered from the host platform and PW_RSTUDIO_EDITION."
+        type: string
+        default: "server"
+      grep:
+        description: "Optional Playwright --grep pattern to filter tests."
+        type: string
+        default: ""
+      test_selector:
+        description: "Optional test paths/files/directories to run (space-separated). Matched as substrings against test file paths. Examples: 'autocomplete.test.ts', 'tests/panes/misc/', 'autocomplete tests/panes/posit-assistant-chat/'. Leave empty to run all tests."
+        type: string
+        default: ""
+  workflow_call:
+    inputs:
+      rstudio_installer_url:
+        type: string
+        default: ""
+      r_version:
+        type: string
+        default: "release"
+      project:
+        type: string
+        default: "server"
+      grep:
+        type: string
+        default: ""
+      test_selector:
+        type: string
+        default: ""
+
+jobs:
+  e2e-server-ubuntu:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    env:
+      R_LIBS_USER: ${{ github.workspace }}/R-libs
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install OS dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Install rig
+        run: |
+          curl -fLs https://github.com/r-lib/rig/releases/download/latest/rig-linux-$(arch)-latest.tar.gz \
+            | sudo tar xz -C /usr/local
+
+      - name: Install R via rig
+        env:
+          R_VERSION: ${{ inputs.r_version }}
+        run: |
+          rig add "$R_VERSION"
+          rig default "$R_VERSION"
+          rig ls
+          mkdir -p "$R_LIBS_USER"
+
+      - name: Resolve RStudio Server .deb URL
+        id: resolve
+        env:
+          INSTALLER_URL: ${{ inputs.rstudio_installer_url }}
+        run: |
+          URL="$INSTALLER_URL"
+          SHA=""
+          FILENAME=""
+          if [ -z "$URL" ]; then
+            MANIFEST=$(curl -fsSL https://dailies.rstudio.com/rstudio/latest/index.json)
+            URL=$(echo "$MANIFEST" | jq -er '.products.server.platforms."noble-amd64".link')
+            SHA=$(echo "$MANIFEST" | jq -er '.products.server.platforms."noble-amd64".sha256')
+            FILENAME=$(echo "$MANIFEST" | jq -er '.products.server.platforms."noble-amd64".filename')
+            echo "Auto-resolved latest noble-amd64 server daily:"
+            echo "  URL:      $URL"
+            echo "  SHA-256:  $SHA"
+            echo "  Filename: $FILENAME"
+          else
+            FILENAME=$(basename "$URL")
+            echo "Using override URL: $URL (SHA-256 verification skipped)"
+          fi
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
+          echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
+
+      - name: Download RStudio Server .deb
+        run: |
+          curl -fsSL --retry 3 --retry-delay 5 \
+            -o "${{ steps.resolve.outputs.filename }}" \
+            "${{ steps.resolve.outputs.url }}"
+
+      - name: Verify SHA-256
+        if: steps.resolve.outputs.sha256 != ''
+        run: |
+          echo "${{ steps.resolve.outputs.sha256 }}  ${{ steps.resolve.outputs.filename }}" \
+            | sha256sum -c -
+
+      - name: Install RStudio Server
+        run: |
+          sudo apt-get install -y "./${{ steps.resolve.outputs.filename }}"
+          sudo rstudio-server verify-installation
+          sudo systemctl status rstudio-server --no-pager
+
+      - name: Generate test credentials
+        run: |
+          USER="pw_$(openssl rand -hex 4)"
+          PASS="$(openssl rand -base64 24)"
+          echo "::add-mask::$USER"
+          echo "::add-mask::$PASS"
+          echo "PW_RSTUDIO_SERVER_USER=$USER" >> "$GITHUB_ENV"
+          echo "PW_RSTUDIO_SERVER_PASSWORD=$PASS" >> "$GITHUB_ENV"
+
+      - name: Create test user
+        run: |
+          sudo useradd -m -s /bin/bash "$PW_RSTUDIO_SERVER_USER"
+          echo "$PW_RSTUDIO_SERVER_USER:$PW_RSTUDIO_SERVER_PASSWORD" | sudo chpasswd
+
+      - name: Wait for rstudio-server
+        run: |
+          for i in {1..30}; do
+            if curl -fsS http://localhost:8787/auth-sign-in >/dev/null 2>&1; then
+              echo "rstudio-server is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "rstudio-server did not become ready"
+          sudo journalctl -u rstudio-server --no-pager -n 200
+          exit 1
+
+      - name: Restore R library cache
+        if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
+        id: r-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-r-${{ inputs.r_version }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
+          restore-keys: |
+            ${{ runner.os }}-r-${{ inputs.r_version }}-
+
+      - name: Install R packages from DESCRIPTION
+        if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
+        run: |
+          Rscript -e '
+            options(repos = c(P3M = "https://packagemanager.posit.co/cran/__linux__/noble/latest"))
+            if (!requireNamespace("pak", quietly = TRUE)) install.packages("pak")
+            pak::local_install_dev_deps(root = "e2e/rstudio", ask = FALSE, upgrade = FALSE)
+          '
+
+      - name: Save R library cache
+        if: hashFiles('e2e/rstudio/DESCRIPTION') != '' && steps.r-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-r-${{ inputs.r_version }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
+
+      - name: Install npm dependencies
+        working-directory: e2e/rstudio
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: e2e/rstudio
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        working-directory: e2e/rstudio
+        env:
+          PW_RSTUDIO_MODE: server
+          PW_RSTUDIO_SERVER_URL: http://localhost:8787
+          PW_PROJECT_NAME: ${{ inputs.project }}
+          PW_GREP: ${{ inputs.grep }}
+          PW_TEST_SELECTOR: ${{ inputs.test_selector }}
+        run: |
+          ARGS=()
+          if [ -n "$PW_TEST_SELECTOR" ]; then
+            set -f
+            ARGS+=($PW_TEST_SELECTOR)
+            set +f
+          fi
+          ARGS+=(--project "$PW_PROJECT_NAME")
+          if [ -n "$PW_GREP" ]; then
+            ARGS+=(--grep "$PW_GREP")
+          fi
+          npx playwright test "${ARGS[@]}"
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: e2e/rstudio/playwright-report/
+          if-no-files-found: ignore
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: e2e/rstudio/test-results/
+          if-no-files-found: ignore
+
+      - name: Capture rstudio-server logs on failure
+        if: failure()
+        run: |
+          sudo journalctl -u rstudio-server --no-pager > rstudio-server.log || true
+          sudo cp -r /var/log/rstudio rstudio-var-log || true
+          sudo chmod -R a+r rstudio-var-log || true
+
+      - name: Upload rstudio-server logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rstudio-server-logs
+          path: |
+            rstudio-server.log
+            rstudio-var-log/
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow, `test-e2e-rstudio-server-os-ubuntu-24.yml`,
that runs the RStudio Playwright suite against an `rstudio-server` instance
installed on `ubuntu-24.04`. Mirrors the existing Desktop Ubuntu 24 workflow
where possible and diverges where Server requires it.

Server-specific differences from the Desktop variant:

- Resolves the installer from `.products.server.platforms."noble-amd64"` in
  the dailies manifest (vs `.products.electron`). Strips query parameters
  before deriving the local filename so presigned/CDN override URLs install
  cleanly.
- Drops `xvfb` -- Server is browser-driven; Playwright launches its own
  Chromium against `http://localhost:8787`.
- Enables and starts `rstudio-server` after install, runs
  `rstudio-server verify-installation`, and waits up to 60 s for the
  `/auth-sign-in` endpoint to respond before running tests.
- Generates a throwaway test user and password per run via `openssl rand`,
  masks both with `::add-mask::`, creates the user with `useradd` + `chpasswd`,
  and exports `PW_RSTUDIO_SERVER_USER` / `PW_RSTUDIO_SERVER_PASSWORD` for
  the Playwright fixture. No credentials are stored in the repo or in
  GitHub Secrets -- the user only exists for the life of the runner VM.
- Sets `PW_RSTUDIO_MODE=server`, `PW_RSTUDIO_EDITION=os`, and
  `PW_RSTUDIO_SERVER_URL=http://localhost:8787`.
- `timeout-minutes: 120` (matching the macOS 26 data point from the rollout).
- On failure, captures `journalctl -u rstudio-server` and `/var/log/rstudio`
  as artifacts for triage.

Inputs match the Desktop workflow with two changes: the `project` input
defaults to `server`, and `rstudio_extra_args` is dropped (Server has no
equivalent launch flags).

Part of the Playwright workflows rollout (item 15).