### PR TITLE
Fixes for Server Playwright workflow on Ubuntu 24

### DIFF
--- a/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -114,7 +114,9 @@ jobs:
       - name: Install RStudio Server
         run: |
           sudo apt-get install -y "./${{ steps.resolve.outputs.filename }}"
+          sudo systemctl stop rstudio-server
           sudo rstudio-server verify-installation
+          sudo systemctl start rstudio-server
           sudo systemctl status rstudio-server --no-pager
 
       - name: Generate test credentials

--- a/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install OS dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y jq
+          sudo apt-get install -y xvfb jq
 
       - name: Install rig
         run: |
@@ -200,7 +200,8 @@ jobs:
           if [ -n "$PW_GREP" ]; then
             ARGS+=(--grep "$PW_GREP")
           fi
-          npx playwright test "${ARGS[@]}"
+          xvfb-run -a --server-args="-screen 0 1920x1080x24" \
+            npx playwright test "${ARGS[@]}"
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -116,6 +116,17 @@ jobs:
           sudo apt-get install -y "./${{ steps.resolve.outputs.filename }}"
           sudo systemctl stop rstudio-server
           sudo rstudio-server verify-installation
+
+      - name: Configure verbose RStudio Server logging
+        run: |
+          sudo tee /etc/rstudio/logging.conf >/dev/null <<'EOF'
+          [*]
+          log-level=debug
+          logger-type=file
+          EOF
+
+      - name: Start RStudio Server
+        run: |
           sudo systemctl start rstudio-server
           sudo systemctl status rstudio-server --no-pager
 
@@ -219,9 +230,17 @@ jobs:
           path: e2e/rstudio/test-results/
           if-no-files-found: ignore
 
-      - name: Capture rstudio-server logs on failure
+      - name: Capture rstudio-server logs and diagnostics on failure
         if: failure()
         run: |
+          echo "=== /etc/rstudio/logging.conf ==="
+          sudo cat /etc/rstudio/logging.conf 2>&1 || echo "(missing)"
+          echo "=== layout: /var/log/rstudio ==="
+          sudo find /var/log/rstudio -ls 2>&1 || echo "(missing)"
+          echo "=== layout: /var/lib/rstudio-server *.log ==="
+          sudo find /var/lib/rstudio-server -name '*.log' -ls 2>&1 || echo "(missing)"
+          echo "=== full journalctl (last hour, all units) ==="
+          sudo journalctl --since="1 hour ago" --no-pager
           sudo journalctl -u rstudio-server --no-pager > rstudio-server.log || true
           sudo cp -r /var/log/rstudio rstudio-var-log || true
           sudo chmod -R a+r rstudio-var-log || true

--- a/e2e/rstudio/DESCRIPTION
+++ b/e2e/rstudio/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: R Package Dependencies for RStudio Playwright E2E Tests
 Version: 0.0.1
 Description: Lists the R packages that RStudio Playwright tests rely on.
-    Consumed by the workflows at .github/workflows/test-e2e-rstudio-desktop-os-*.yml
+    Consumed by the workflows at .github/workflows/test-e2e-rstudio-*.yml
     via pak::local_install_dev_deps(). Not a real R package -- only the Imports
     field is meaningful here.
 Imports:

--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -154,16 +154,27 @@ export class ConsolePaneActions {
       }
     }
 
-    // Verify installation succeeded
+    // Verify installation succeeded. Poll for the marker -- after a package
+    // installs, R may still be doing post-install work (lazy-load DB, help
+    // index) when the doneMarker emitted, so the verify cat() can sit
+    // queued briefly before R gets to it.
     const verifyMarker = `__PKG_VERIFY_${Date.now()}__`;
     await this.clearConsole();
     await this.typeInConsole(`cat("${verifyMarker}", requireNamespace("${pkg}", quietly = TRUE), "${verifyMarker}")`);
-    await sleep(1000);
 
-    const verifyOutput = await this.consolePane.consoleOutput.innerText();
-    const verifyMatch = verifyOutput.match(new RegExp(`${verifyMarker}\\s+(TRUE|FALSE)\\s+${verifyMarker}`));
+    const verifyPattern = new RegExp(`${verifyMarker}\\s+(TRUE|FALSE)\\s+${verifyMarker}`);
+    const verifyDeadline = Date.now() + 15000;
+    let installed = false;
+    while (Date.now() < verifyDeadline) {
+      await sleep(500);
+      const verifyOutput = await this.consolePane.consoleOutput.innerText();
+      const verifyMatch = verifyOutput.match(verifyPattern);
+      if (verifyMatch) {
+        installed = verifyMatch[1] === 'TRUE';
+        break;
+      }
+    }
 
-    const installed = verifyMatch?.[1] === 'TRUE';
     if (installed) {
       console.log(`Package ${pkg} is now available.`);
     } else {

--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -1,6 +1,58 @@
 import type { Page } from 'playwright';
+import * as fs from 'fs';
 import { ConsolePane, type EnvironmentVersions } from '../pages/console_pane.page';
 import { sleep } from '../utils/constants';
+
+interface InstallTarget {
+  repos: string;
+  type: 'binary' | 'source';
+}
+
+let cachedInstallTarget: InstallTarget | null = null;
+
+// Returns the repo URL and install type to use for install.packages().
+// On Linux, prefer Posit Public Package Manager's per-distro binary repo so
+// installs don't compile from source (which can take minutes for packages
+// with heavy C/C++ deps like duckdb).
+function getInstallTarget(): InstallTarget {
+  if (cachedInstallTarget) return cachedInstallTarget;
+
+  if (process.platform === 'win32' || process.platform === 'darwin') {
+    cachedInstallTarget = { repos: 'https://cran.r-project.org', type: 'binary' };
+    return cachedInstallTarget;
+  }
+
+  const distro = detectLinuxDistro();
+  cachedInstallTarget = distro
+    ? {
+        repos: `https://packagemanager.posit.co/cran/__linux__/${distro}/latest`,
+        type: 'binary',
+      }
+    : { repos: 'https://cran.r-project.org', type: 'source' };
+  return cachedInstallTarget;
+}
+
+// Returns the PPM distro slug for the current Linux host, or '' if unknown.
+// Ubuntu/Debian use VERSION_CODENAME (e.g. "noble", "jammy", "bookworm").
+// RHEL family (rhel/rocky/almalinux/centos) has no codename; PPM serves
+// them as "rhel<major>" derived from VERSION_ID.
+function detectLinuxDistro(): string {
+  const osRelease = fs.readFileSync('/etc/os-release', 'utf8');
+  const get = (key: string): string =>
+    osRelease.match(new RegExp(`^${key}=("?)([^"\\n]+)\\1`, 'm'))?.[2] ?? '';
+
+  const codename = get('VERSION_CODENAME');
+  if (codename) return codename;
+
+  const id = get('ID');
+  const idLike = get('ID_LIKE').split(/\s+/);
+  const rhelFamily = new Set(['rhel', 'rocky', 'almalinux', 'centos']);
+  if (rhelFamily.has(id) || idLike.includes('rhel')) {
+    const major = get('VERSION_ID').split('.')[0];
+    if (major) return `rhel${major}`;
+  }
+  return '';
+}
 
 export class ConsolePaneActions {
   readonly page: Page;
@@ -87,8 +139,8 @@ export class ConsolePaneActions {
     // Run install, then print marker as a separate command.
     // typeInConsole queues input — if R is busy with install, the cat()
     // will execute after install finishes.
-    const installType = 'ifelse(.Platform$OS.type == "windows" || Sys.info()["sysname"] == "Darwin", "binary", "source")';
-    await this.typeInConsole(`install.packages("${pkg}", repos = "https://cran.r-project.org", type = ${installType})`);
+    const { repos, type } = getInstallTarget();
+    await this.typeInConsole(`install.packages("${pkg}", repos = "${repos}", type = "${type}")`);
     await this.typeInConsole(`cat("${doneMarker}")`);
 
 

--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -23,10 +23,14 @@ function getInstallTarget(): InstallTarget {
   }
 
   const distro = detectLinuxDistro();
+  // On Linux, R has no formal "binary" type -- PPM's __linux__/<distro>/latest
+  // endpoint serves precompiled tarballs that R fetches via type="source".
+  // Passing type="binary" here causes R to look for a nonexistent format and
+  // silently skip the install.
   cachedInstallTarget = distro
     ? {
         repos: `https://packagemanager.posit.co/cran/__linux__/${distro}/latest`,
-        type: 'binary',
+        type: 'source',
       }
     : { repos: 'https://cran.r-project.org', type: 'source' };
   return cachedInstallTarget;

--- a/e2e/rstudio/tests/panes/console/console_command_effects.test.ts
+++ b/e2e/rstudio/tests/panes/console/console_command_effects.test.ts
@@ -65,7 +65,7 @@ test.describe('Console command effects', () => {
     test.setTimeout(60000);
     const uninstalled = await consoleActions.uninstallPackage('praise');
     test.skip(!uninstalled, 'Could not uninstall praise to set up a fresh-install scenario');
-    const failed = await consoleActions.ensurePackages(['praise'], 30000);
+    const failed = await consoleActions.ensurePackages(['praise'], 60000);
     test.skip(failed.length > 0, `Could not install: ${failed.join(', ')}`);
 
     await consoleActions.clearConsole();

--- a/e2e/rstudio/tests/panes/console/console_command_effects.test.ts
+++ b/e2e/rstudio/tests/panes/console/console_command_effects.test.ts
@@ -62,14 +62,14 @@ test.describe('Console command effects', () => {
   });
 
   test('install.packages() installs a real CRAN package that library() can load', async () => {
-    test.setTimeout(300000);
-    const uninstalled = await consoleActions.uninstallPackage('starwarsdb');
-    test.skip(!uninstalled, 'Could not uninstall starwarsdb to set up a fresh-install scenario');
-    const failed = await consoleActions.ensurePackages(['starwarsdb'], 240000);
+    test.setTimeout(60000);
+    const uninstalled = await consoleActions.uninstallPackage('praise');
+    test.skip(!uninstalled, 'Could not uninstall praise to set up a fresh-install scenario');
+    const failed = await consoleActions.ensurePackages(['praise'], 30000);
     test.skip(failed.length > 0, `Could not install: ${failed.join(', ')}`);
 
     await consoleActions.clearConsole();
-    await consoleActions.typeInConsole("library('starwarsdb')");
+    await consoleActions.typeInConsole("library('praise')");
     await sleep(2000);
     await expect(consoleActions.consolePane.consoleOutput).not.toContainText(
       'Error in library',


### PR DESCRIPTION
## Summary

Fixes for the new RStudio Server Playwright workflow added in #17580,
discovered during first-run testing.

Currently includes:

- **Stop the server before running `verify-installation`.** The `.deb`
  postinst auto-starts `rstudio-server`, but `rstudio-server verify-installation`
  refuses to run while the service is up ("Server is running and must be
  stopped before running verify-installation"). The workflow now stops the
  service, runs the verify, and restarts it.
- **Update `DESCRIPTION` glob.** The `e2e/rstudio/DESCRIPTION` file's
  `Description:` field referenced `test-e2e-rstudio-desktop-os-*.yml`,
  which no longer matches the new Server workflow (or future Pro variants).
  Broadened to `test-e2e-rstudio-*.yml`.
- **Run Playwright under `xvfb-run`.** The Server Playwright fixture
  (`server.fixture.ts`) hardcodes `headless: false`, so Chromium needs an
  X server even though the RStudio Server itself is browser-based. Re-added
  `xvfb` to the OS deps and wrapped the test step with `xvfb-run`, matching
  the Desktop workflow pattern. A separate follow-up will make headless
  configurable in the fixture so future runs can skip xvfb.
- **Enable debug logging and capture richer diagnostics on failure.** The
  default `/etc/rstudio/logging.conf` ships at warn-level, so the logs we
  captured on the first failed run had almost nothing in them. The workflow
  now writes a debug-level config before starting `rstudio-server`, and the
  failure-capture step also dumps the logging config, the on-disk log
  layout, and the full journalctl into the GH Actions log so the next
  failure is actually diagnosable.