### PR TITLE
Pin panmirror to release/rstudio-golden-wattle

### DIFF
--- a/dependencies/common/install-panmirror
+++ b/dependencies/common/install-panmirror
@@ -35,8 +35,8 @@ info "QUARTO_DIR: ${QUARTO_DIR}"
 # clone quarto monorepo if not already cloned
 if ! test -e "$QUARTO_DIR"; then
   echo "Cloning quarto repo"
-  git clone https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
-  # git clone --branch release/rstudio-golden-wattle https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
+  # git clone https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
+  git clone --branch release/rstudio-golden-wattle https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
   pushd $QUARTO_DIR
   git rev-parse HEAD
   popd
@@ -46,8 +46,8 @@ else
   pushd $QUARTO_DIR
   git fetch
   git reset --hard && git clean -dfx
-  git checkout main
-  # git checkout release/rstudio-golden-wattle
+  # git checkout main
+  git checkout release/rstudio-golden-wattle
   git pull
   git rev-parse HEAD
 

--- a/dependencies/windows/install-panmirror/clone-panmirror-repo.cmd
+++ b/dependencies/windows/install-panmirror/clone-panmirror-repo.cmd
@@ -12,8 +12,8 @@ pushd ..\..\..\src\gwt\lib
 ::            "panmirror check for changes" command to use the equivalent.
 
 if not exist quarto (
-  git clone https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
-  REM git clone --branch release/rstudio-golden-wattle https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
+  REM git clone https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
+  git clone --branch release/rstudio-golden-wattle https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
   pushd ..\..\..\src\gwt\lib\quarto
   git rev-parse HEAD
   popd
@@ -22,8 +22,8 @@ if not exist quarto (
   git fetch
   git reset --hard
   git clean -dfx
-  git checkout main
-  REM git checkout release/rstudio-golden-wattle
+  REM git checkout main
+  git checkout release/rstudio-golden-wattle
   git pull
   git rev-parse HEAD
   popd

--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -104,8 +104,8 @@ COPY package/linux/install-dependencies /tmp/
 RUN /bin/bash /tmp/install-dependencies
 
 # panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-golden-wattle panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-golden-wattle panmirror.version.json
 
 # copy common dependency installation scripts
 RUN mkdir -p /opt/rstudio-tools/dependencies/common

--- a/docker/jenkins/Dockerfile.focal
+++ b/docker/jenkins/Dockerfile.focal
@@ -110,8 +110,8 @@ RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-golden-wattle panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-golden-wattle panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common focal

--- a/docker/jenkins/Dockerfile.jammy
+++ b/docker/jenkins/Dockerfile.jammy
@@ -128,8 +128,8 @@ RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-golden-wattle panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-golden-wattle panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common jammy

--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -93,8 +93,8 @@ RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-golden-wattle panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-golden-wattle panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common opensuse15

--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -97,8 +97,8 @@ RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-golden-wattle panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-golden-wattle panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common rhel8

--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -100,8 +100,8 @@ RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-golden-wattle panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-golden-wattle panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common rhel9

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -129,8 +129,8 @@ COPY dependencies/common 'C:\rstudio-tools\dependencies\common'
 COPY dependencies/windows 'C:\rstudio-tools\dependencies\windows'
 
 # panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-golden-wattle panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-golden-wattle panmirror.version.json
 
 ENV DOCKER_IMAGE_BUILD=1
 WORKDIR C:/rstudio-tools/dependencies/windows


### PR DESCRIPTION
## Intent

Addresses #17355.

## Summary

Pins the panmirror (Quarto) dependency to the `release/rstudio-golden-wattle` branch so future builds of this RStudio release pull consistent panmirror bits instead of tracking `main`. Updated in both install scripts (`dependencies/common/install-panmirror`, `dependencies/windows/install-panmirror/clone-panmirror-repo.cmd`) and the seven Jenkins Dockerfiles that probe the panmirror branch HEAD for cache invalidation.

## Test plan

- [ ] Verify a clean Linux build clones the `release/rstudio-golden-wattle` branch
- [ ] Verify a clean Windows build clones the `release/rstudio-golden-wattle` branch
- [ ] Confirm Jenkins Docker images rebuild when the release branch HEAD advances