### PR TITLE
fix span markup leak in lint diagnostic gutter tooltip

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - ([#17514](https://github.com/rstudio/rstudio/issues/17514)): Added the `allow-package-source-recording` session option (default `true`); when set to `false`, RStudio will not annotate DESCRIPTION files of packages installed via `install.packages()` with the remote repository they came from.
 
 ### Fixed
+- ([#17581](https://github.com/rstudio/rstudio/issues/17581)): Diagnostic gutter tooltips no longer show literal `<SPAN>` markup around the message; lint annotations now keep the original text alongside any rendered HTML so the tooltip renders cleanly while the diagnostics popup continues to support ANSI-colored content.
 - ([#17556](https://github.com/rstudio/rstudio/issues/17556)): `difftime` objects (e.g. the result of subtracting two `Sys.time()` values) now show their formatted value in the Environment pane instead of an empty cell.
 - ([#17568](https://github.com/rstudio/rstudio/issues/17568)): Source-mode spell check now flags misspelled words inside Markdown, R Markdown, and Quarto headings; previously only paragraph text was checked.
 - ([#17481](https://github.com/rstudio/rstudio/issues/17481)): Fixed two debugger regressions: top-level breakpoints (e.g. via `debugSource()`) no longer fail to show the debug highlight or call stack, and multi-line input at the `Browse[N]>` prompt no longer clears the captured browser context.

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2,7 +2,7 @@
 @eval fixedWidthFont org.rstudio.core.client.theme.ThemeFonts.getFixedWidthFont();
 
 @external fixedWidthFont;
-@external ace_editor, ace_text-layer, ace_gutter, ace_gutter-layer, ace_gutter-cell, ace_gutter_annotation, ace_info, ace_tooltip, ace_content, ace_line;
+@external ace_editor, ace_text-layer, ace_gutter, ace_gutter-layer, ace_gutter-cell, ace_gutter_annotation, ace_info, ace_tooltip, ace_gutter-tooltip, ace_icon, ace_icon_svg, ace_content, ace_line;
 @external ace_info, ace_warning, ace_error;
 @external ace_breakpoint, ace_inactive-breakpoint, ace_pending-breakpoint, ace_executing-line, ace_next-edit-suggestion;
 @external ace_chunk-queued-line, ace_chunk-executed-line, ace_chunk-resting-line, ace_chunk-error-line;
@@ -384,6 +384,13 @@ pre {
    max-height: 300px;
    overflow: hidden;
    white-space: pre-wrap;
+}
+
+.ace_gutter-tooltip .ace_icon,
+.ace_gutter-tooltip .ace_icon_svg {
+   position: relative;
+   left: -4px;
+   top: 1px;
 }
 
 .ace_breakpoint,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/AceAnnotation.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/AceAnnotation.java
@@ -33,21 +33,16 @@ public class AceAnnotation extends JavaScriptObject
          type = "info";
       }
       
-      var annotation = {
+      // 'text' must be set; Ace's gutter tooltip pipes it through createTextNode and would otherwise show 'html' as literal markup.
+      return {
          row: row,
          column: column,
-         type: type
+         type: type,
+         text: text,
+         html: html,
+         className: className,
+         tooltip: tooltip
       };
-      
-      if (html) 
-         annotation.html = html;
-      else
-         annotation.text = text;
-
-      annotation.className = className;
-      annotation.tooltip = tooltip;
-
-      return annotation;
    }-*/;
    
    public final native int row() /*-{ return this.row; }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/LintItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/LintItem.java
@@ -158,20 +158,16 @@ public class LintItem extends JavaScriptObject
             type = "info";
          }
 
+         // 'text' must be set; Ace's gutter tooltip pipes it through createTextNode and would otherwise show 'html' as literal markup.
          var annotation = {
             row: item["start.row"],
             column: item["start.column"],
-            type: type
+            type: type,
+            text: item["text"],
+            html: item["html"],
+            className: item.className,
+            tooltip: item.tooltip
          };
-         
-         var html = item["html"]
-         if (html)
-            annotation.html = html;
-         else 
-            annotation.text = item["text"];
-         
-         annotation.className = item.className;
-         annotation.tooltip = item.tooltip;
 
          aceAnnotations.push(annotation);
       }

--- a/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
+++ b/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
@@ -30,6 +30,7 @@ import org.rstudio.studio.client.common.sourcemarkers.SourceMarkerItemCodecTests
 import org.rstudio.studio.client.projects.model.ProjectMRUEntryTests;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobManagerTests;
 import org.rstudio.studio.client.workbench.views.jobs.view.JobsListTests;
+import org.rstudio.studio.client.workbench.views.output.lint.model.LintItemTests;
 import org.rstudio.studio.client.workbench.views.source.editors.text.assist.RChunkHeaderParserTests;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalLocalEchoTests;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalSessionSocketTests;
@@ -64,6 +65,7 @@ public class RStudioUnitTestSuite extends GWTTestSuite
       suite.addTestSuite(ElementIdsTests.class);
       suite.addTestSuite(ChunkContextUiTests.class);
       suite.addTestSuite(SafeHtmlUtilTests.class);
+      suite.addTestSuite(LintItemTests.class);
       suite.addTestSuite(SourceMarkerItemCodecTests.class);
       suite.addTestSuite(TestMocks.class);
       suite.addTestSuite(ApplicationUtilsTests.class);

--- a/src/gwt/test/org/rstudio/studio/client/workbench/views/output/lint/model/LintItemTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/workbench/views/output/lint/model/LintItemTests.java
@@ -1,0 +1,87 @@
+/*
+ * LintItemTests.java
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.output.lint.model;
+
+import org.rstudio.core.client.StringUtil;
+
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.junit.client.GWTTestCase;
+
+public class LintItemTests extends GWTTestCase
+{
+   @Override
+   public String getModuleName()
+   {
+      return "org.rstudio.studio.RStudioTests";
+   }
+
+   public void testAsAceAnnotationsKeepsTextWhenHtmlIsAlsoSet()
+   {
+      // Regression #17581: Ace's gutter tooltip uses 'text' for displayText
+      // and renders it via createTextNode. If 'text' is dropped when 'html'
+      // is set, the html surfaces as literal markup in the tooltip.
+      LintItem item = LintItem.create(0, 0, 0, 0, "unexpected token", "error");
+      item.setHtml("<span>unexpected token</span>");
+
+      JsArray<LintItem> items = JsArray.createArray().cast();
+      items.push(item);
+
+      JsArray<AceAnnotation> annotations = LintItem.asAceAnnotations(items);
+      assertEquals(1, annotations.length());
+      assertEquals("unexpected token", annotations.get(0).text());
+      assertEquals("<span>unexpected token</span>", annotations.get(0).html());
+   }
+
+   public void testAsAceAnnotationsPopulatesTextWhenHtmlAbsent()
+   {
+      LintItem item = LintItem.create(0, 0, 0, 0, "unexpected token", "error");
+      JsArray<LintItem> items = JsArray.createArray().cast();
+      items.push(item);
+
+      AceAnnotation annotation = LintItem.asAceAnnotations(items).get(0);
+      assertEquals("unexpected token", annotation.text());
+      assertTrue("html should be empty when not set, got: " + annotation.html(),
+                 StringUtil.isNullOrEmpty(annotation.html()));
+   }
+
+   public void testAceAnnotationCreateKeepsTextWhenHtmlIsAlsoSet()
+   {
+      AceAnnotation annotation = AceAnnotation.create(
+            0, 0, "<span>msg</span>", "msg", "error", "ace_error", null);
+      assertEquals("msg", annotation.text());
+      assertEquals("<span>msg</span>", annotation.html());
+   }
+
+   public void testGutterTooltipDisplayTextIsRawMessage()
+   {
+      // Mirrors the regression scenario from #17581: confirm that the value
+      // Ace would feed into createTextNode is the raw lint text, not the html.
+      LintItem item = LintItem.create(0, 0, 0, 0, "unexpected token", "error");
+      item.setHtml("<span>unexpected token</span>");
+      JsArray<LintItem> items = JsArray.createArray().cast();
+      items.push(item);
+
+      AceAnnotation annotation = LintItem.asAceAnnotations(items).get(0);
+      String displayText = simulateAceDisplayText(annotation);
+      assertEquals("unexpected token", displayText);
+      assertFalse("displayText must not contain <span> markup, got: " + displayText,
+                  displayText.contains("<span"));
+   }
+
+   // Mirrors Ace's Gutter.setAnnotations: prefers 'text', falls back to 'html'.
+   private static native String simulateAceDisplayText(AceAnnotation annotation) /*-{
+      return annotation.text ? annotation.text : (annotation.html || "");
+   }-*/;
+}


### PR DESCRIPTION
## Intent

Addresses #17581.

## Summary

- Hovering a diagnostic indicator in the editor gutter showed literal `<SPAN>...</SPAN>` around the message. Regression introduced by the Ace upgrade in #16717: the new `GutterTooltip.showTooltip` renders annotation text via `dom.createTextNode`, which escapes HTML, so the `VirtualConsole`-wrapped HTML added by `TextEditingTargetLintSource.showLint` (originally for ANSI escape support, #12435) surfaces as literal markup.
- Fix is in the data layer: `LintItem.asAceAnnotations` and `AceAnnotation.create` now always populate `text` on the produced annotation. Ace's `Gutter.setAnnotations` prefers `text` for `displayText`, so the tooltip renders cleanly. `html` is still set so `DiagnosticsBackgroundPopup` (which builds a `gwt.user.client.ui.HTML` widget) keeps rendering ANSI-formatted content.
- Small visual alignment tweak for the icon inside `.ace_gutter-tooltip` so the message text is not flush against the severity glyph; required adding `ace_gutter-tooltip`, `ace_icon`, and `ace_icon_svg` to the `@external` declarations in `themeStyles.css`.

## Test plan

- [ ] Open an R source file and enter `y <- function)`; save to trigger diagnostics.
- [ ] Hover the gutter indicator and confirm the tooltip shows the raw error message with no `<SPAN>` markup.
- [ ] Confirm the severity icon has visible separation from the message text.
- [ ] Confirm the inline diagnostics popup (cursor moves into a marker range) still renders correctly.