### PR TITLE
Audit-log file downloads by default; tag preview flows with show=1

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2401,22 +2401,25 @@ void showFile(const FilePath& filePath, const std::string& window)
 
 std::string createFileUrl(const core::FilePath& filePath)
 {
-   // determine url based on whether this is in ~ or not
+   // determine url based on whether this is in ~ or not. Tag the result
+   // with show=1 so handleFilesRequest / handleFileShow can distinguish
+   // server-initiated preview/show flows from user-initiated downloads
+   // and skip audit logging for the former.
    std::string url;
    if (isVisibleUserFile(filePath))
    {
       auto home = module_context::userHomePath();
       auto path = filePath.getRelativePath(home);
-      url = "files/" + path;
+      url = "files/" + path + "?show=1";
    }
    else if (isPathViewAllowed(filePath))
    {
-      url = "show" + filePath.getAbsolutePath();
+      url = "show" + filePath.getAbsolutePath() + "?show=1";
    }
    else
    {
       auto path = core::http::util::urlEncode(filePath.getAbsolutePath(), true);
-      url = "file_show?path=" + path;
+      url = "file_show?path=" + path + "&show=1";
    }
    return url;
 }

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2441,12 +2441,19 @@ bool shouldAuditFileDownload(const core::http::Request& request,
    // to disk, so it isn't a download from the user's perspective. Note
    // this means a real "right-click -> Save As" on a rendered PDF will
    // not produce an audit row; that's an accepted trade-off for not
-   // logging the much more common inline-view case. Files with an
-   // unknown / missing extension currently default to "text/plain" via
-   // FilePath::getMimeContentType, so an extensionless binary also
-   // skips audit - this is a known rename-bypass surface, separately
-   // addressed.
-   const std::string mimeType = filePath.getMimeContentType();
+   // logging the much more common inline-view case.
+   //
+   // For the audit decision we pass "application/octet-stream" as the
+   // default Content-Type for unknown extensions, even though the
+   // setFile()/setCacheableFile() response path falls back to
+   // "text/plain". The divergence is intentional: it closes a rename-
+   // bypass (renaming secret.zip to "secret" would otherwise resolve
+   // to text/plain and silently skip the audit) at the cost of also
+   // logging legitimate fetches of extensionless text files
+   // (LICENSE, README, Makefile, etc.). Over-logging is the safer
+   // default for an audit record.
+   const std::string mimeType =
+      filePath.getMimeContentType("application/octet-stream");
    if (mimeType.rfind("text/", 0) == 0     ||
        mimeType.rfind("image/", 0) == 0    ||
        mimeType.rfind("audio/", 0) == 0    ||

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2405,16 +2405,22 @@ bool shouldAuditFileDownload(const core::http::Request& request,
 {
    // Skip when the URL was constructed by an internal preview/show flow
    // (?show=1 marker, set by createFileUrl above and by Files.java's
-   // showFileInBrowser for view-style navigations).
+   // companion showFileInBrowser for view-style navigations).
    if (request.queryParamValue("show") == "1")
+   {
+      LOG_DEBUG_MESSAGE("Audit skipped (?show=1 marker): " +
+                        filePath.getAbsolutePath());
       return false;
+   }
 
    // Skip HTML sub-resource fetches. Browsers signal these via
    // Sec-Fetch-Dest. Top-level navigations send "document" (or omit the
    // header on older browsers); embedded resources send their resource
    // type. Treat anything in the explicit sub-resource set as not-a-
    // download so a single HTML preview doesn't generate an audit row
-   // per asset.
+   // per asset. "iframe" and "frame" are deliberately NOT in this set:
+   // an iframe loading a binary is effectively exfiltration, so let
+   // the Content-Type check below decide.
    const std::string fetchDest = request.headerValue("Sec-Fetch-Dest");
    if (fetchDest == "style"        || fetchDest == "script"        ||
        fetchDest == "image"        || fetchDest == "font"          ||
@@ -2424,14 +2430,22 @@ bool shouldAuditFileDownload(const core::http::Request& request,
        fetchDest == "xslt"         || fetchDest == "report"        ||
        fetchDest == "worker"       || fetchDest == "serviceworker" ||
        fetchDest == "audioworklet" || fetchDest == "paintworklet")
+   {
+      LOG_DEBUG_MESSAGE("Audit skipped (Sec-Fetch-Dest=" + fetchDest +
+                        " sub-resource): " + filePath.getAbsolutePath());
       return false;
+   }
 
    // Skip when the response will be served as a browser-renderable
    // Content-Type. The bytes are being viewed inline rather than saved
    // to disk, so it isn't a download from the user's perspective. Note
    // this means a real "right-click -> Save As" on a rendered PDF will
    // not produce an audit row; that's an accepted trade-off for not
-   // logging the much more common inline-view case.
+   // logging the much more common inline-view case. Files with an
+   // unknown / missing extension currently default to "text/plain" via
+   // FilePath::getMimeContentType, so an extensionless binary also
+   // skips audit - this is a known rename-bypass surface, separately
+   // addressed.
    const std::string mimeType = filePath.getMimeContentType();
    if (mimeType.rfind("text/", 0) == 0     ||
        mimeType.rfind("image/", 0) == 0    ||
@@ -2442,7 +2456,11 @@ bool shouldAuditFileDownload(const core::http::Request& request,
        mimeType == "application/xml"       ||
        mimeType == "application/javascript"||
        mimeType == "application/xhtml+xml")
+   {
+      LOG_DEBUG_MESSAGE("Audit skipped (renderable Content-Type=" +
+                        mimeType + "): " + filePath.getAbsolutePath());
       return false;
+   }
 
    return true;
 }

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2454,15 +2454,12 @@ bool shouldAuditFileDownload(const core::http::Request& request,
    // default for an audit record.
    const std::string mimeType =
       filePath.getMimeContentType("application/octet-stream");
-   if (mimeType.rfind("text/", 0) == 0     ||
-       mimeType.rfind("image/", 0) == 0    ||
-       mimeType.rfind("audio/", 0) == 0    ||
-       mimeType.rfind("video/", 0) == 0    ||
-       mimeType == "application/pdf"       ||
-       mimeType == "application/json"      ||
-       mimeType == "application/xml"       ||
-       mimeType == "application/javascript"||
-       mimeType == "application/xhtml+xml")
+   if (mimeType.rfind("text/", 0) == 0  ||
+       mimeType.rfind("image/", 0) == 0 ||
+       mimeType.rfind("audio/", 0) == 0 ||
+       mimeType.rfind("video/", 0) == 0 ||
+       mimeType == "application/pdf"    ||
+       mimeType == "application/json")
    {
       LOG_DEBUG_MESSAGE("Audit skipped (renderable Content-Type=" +
                         mimeType + "): " + filePath.getAbsolutePath());

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -42,6 +42,7 @@
 #include <core/PeriodicCommand.hpp>
 #include <core/collection/Tree.hpp>
 
+#include <core/http/Request.hpp>
 #include <core/http/Util.hpp>
 
 #include <core/system/Process.hpp>
@@ -2397,6 +2398,53 @@ void showFile(const FilePath& filePath, const std::string& window)
             "on this server.\n");
       }
    }
+}
+
+bool shouldAuditFileDownload(const core::http::Request& request,
+                             const core::FilePath& filePath)
+{
+   // Skip when the URL was constructed by an internal preview/show flow
+   // (?show=1 marker, set by createFileUrl above and by Files.java's
+   // showFileInBrowser for view-style navigations).
+   if (request.queryParamValue("show") == "1")
+      return false;
+
+   // Skip HTML sub-resource fetches. Browsers signal these via
+   // Sec-Fetch-Dest. Top-level navigations send "document" (or omit the
+   // header on older browsers); embedded resources send their resource
+   // type. Treat anything in the explicit sub-resource set as not-a-
+   // download so a single HTML preview doesn't generate an audit row
+   // per asset.
+   const std::string fetchDest = request.headerValue("Sec-Fetch-Dest");
+   if (fetchDest == "style"        || fetchDest == "script"        ||
+       fetchDest == "image"        || fetchDest == "font"          ||
+       fetchDest == "audio"        || fetchDest == "video"         ||
+       fetchDest == "track"        || fetchDest == "object"        ||
+       fetchDest == "embed"        || fetchDest == "manifest"      ||
+       fetchDest == "xslt"         || fetchDest == "report"        ||
+       fetchDest == "worker"       || fetchDest == "serviceworker" ||
+       fetchDest == "audioworklet" || fetchDest == "paintworklet")
+      return false;
+
+   // Skip when the response will be served as a browser-renderable
+   // Content-Type. The bytes are being viewed inline rather than saved
+   // to disk, so it isn't a download from the user's perspective. Note
+   // this means a real "right-click -> Save As" on a rendered PDF will
+   // not produce an audit row; that's an accepted trade-off for not
+   // logging the much more common inline-view case.
+   const std::string mimeType = filePath.getMimeContentType();
+   if (mimeType.rfind("text/", 0) == 0     ||
+       mimeType.rfind("image/", 0) == 0    ||
+       mimeType.rfind("audio/", 0) == 0    ||
+       mimeType.rfind("video/", 0) == 0    ||
+       mimeType == "application/pdf"       ||
+       mimeType == "application/json"      ||
+       mimeType == "application/xml"       ||
+       mimeType == "application/javascript"||
+       mimeType == "application/xhtml+xml")
+      return false;
+
+   return true;
 }
 
 std::string createFileUrl(const core::FilePath& filePath)

--- a/src/cpp/session/SessionModuleContextTests.cpp
+++ b/src/cpp/session/SessionModuleContextTests.cpp
@@ -15,6 +15,9 @@
 
 #include <session/SessionModuleContext.hpp>
 
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include <core/http/Request.hpp>
@@ -100,6 +103,27 @@ TEST(ShouldAuditFileDownloadTest, FetchDestImageSkipsEvenForBinaryExtension)
    EXPECT_FALSE(shouldAuditFileDownload(request, file));
 }
 
+TEST(ShouldAuditFileDownloadTest, AllSubResourceFetchDestsSkip)
+{
+   // Pins the contract that every value the helper recognizes as a
+   // sub-resource actually skips. Uses a non-renderable file type so a
+   // bug that drops the sub-resource branch would surface as a failure
+   // (and not be masked by the renderable-Content-Type branch).
+   const std::vector<std::string> subResourceDests = {
+      "style", "script", "image", "font", "audio", "video",
+      "track", "object", "embed", "manifest", "xslt", "report",
+      "worker", "serviceworker", "audioworklet", "paintworklet"
+   };
+   for (const auto& dest : subResourceDests)
+   {
+      core::http::Request request;
+      initRequest(request, "/files/asset.zip", dest);
+      core::FilePath file("asset.zip");
+      EXPECT_FALSE(shouldAuditFileDownload(request, file))
+         << "Sec-Fetch-Dest=" << dest << " should skip audit";
+   }
+}
+
 // --- Returns false: renderable Content-Type --------------------------------
 
 TEST(ShouldAuditFileDownloadTest, PdfMimeSkips)
@@ -161,6 +185,16 @@ TEST(ShouldAuditFileDownloadTest, OfficeDocxAudits)
    core::http::Request request;
    initRequest(request, "/files/report.docx");
    core::FilePath file("report.docx");
+   EXPECT_TRUE(shouldAuditFileDownload(request, file));
+}
+
+TEST(ShouldAuditFileDownloadTest, OctetStreamAudits)
+{
+   // The canonical "binary, save to disk" Content-Type. Most installer-
+   // style files (.exe, .iso, .dmg, .deb, .dll) resolve to this MIME.
+   core::http::Request request;
+   initRequest(request, "/files/installer.exe");
+   core::FilePath file("installer.exe");
    EXPECT_TRUE(shouldAuditFileDownload(request, file));
 }
 

--- a/src/cpp/session/SessionModuleContextTests.cpp
+++ b/src/cpp/session/SessionModuleContextTests.cpp
@@ -158,16 +158,6 @@ TEST(ShouldAuditFileDownloadTest, JsonMimeSkips)
    EXPECT_FALSE(shouldAuditFileDownload(request, file));
 }
 
-TEST(ShouldAuditFileDownloadTest, NoExtensionDefaultsToTextAndSkips)
-{
-   // FilePath::getMimeContentType defaults to "text/plain" for files with
-   // an unknown / missing extension. The browser will render those inline.
-   core::http::Request request;
-   initRequest(request, "/files/README");
-   core::FilePath file("README");
-   EXPECT_FALSE(shouldAuditFileDownload(request, file));
-}
-
 // --- Returns true: audited downloads ---------------------------------------
 
 TEST(ShouldAuditFileDownloadTest, ZipAudits)
@@ -195,6 +185,19 @@ TEST(ShouldAuditFileDownloadTest, OctetStreamAudits)
    core::http::Request request;
    initRequest(request, "/files/installer.exe");
    core::FilePath file("installer.exe");
+   EXPECT_TRUE(shouldAuditFileDownload(request, file));
+}
+
+TEST(ShouldAuditFileDownloadTest, NoExtensionAuditsAsOctetStream)
+{
+   // The helper passes "application/octet-stream" as the explicit
+   // default to getMimeContentType, so files with unknown / missing
+   // extensions audit. Closes the rename-bypass surface (e.g. renaming
+   // secret.zip to "secret") at the cost of also auditing legitimate
+   // extensionless text-file fetches (README, LICENSE, etc.).
+   core::http::Request request;
+   initRequest(request, "/files/README");
+   core::FilePath file("README");
    EXPECT_TRUE(shouldAuditFileDownload(request, file));
 }
 

--- a/src/cpp/session/SessionModuleContextTests.cpp
+++ b/src/cpp/session/SessionModuleContextTests.cpp
@@ -1,0 +1,193 @@
+/*
+ * SessionModuleContextTests.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <session/SessionModuleContext.hpp>
+
+#include <gtest/gtest.h>
+
+#include <core/http/Request.hpp>
+#include <shared_core/FilePath.hpp>
+
+namespace rstudio {
+namespace session {
+namespace module_context {
+namespace tests {
+
+namespace {
+
+core::http::Request makeRequest(const std::string& uri,
+                                const std::string& fetchDest = "")
+{
+   core::http::Request request;
+   request.setUri(uri);
+   if (!fetchDest.empty())
+      request.setHeader("Sec-Fetch-Dest", fetchDest);
+   return request;
+}
+
+} // anonymous namespace
+
+// --- Returns false: ?show=1 marker -----------------------------------------
+
+TEST(ShouldAuditFileDownloadTest, ShowOneSkipsForNonRenderable)
+{
+   // ?show=1 forces a skip even for binary types that the browser would
+   // otherwise download (file.show() of a zip, etc.).
+   core::http::Request request = makeRequest("/files/archive.zip?show=1");
+   core::FilePath file("archive.zip");
+   EXPECT_FALSE(shouldAuditFileDownload(request, file));
+}
+
+TEST(ShouldAuditFileDownloadTest, ShowOneSkipsRegardlessOfFetchDest)
+{
+   // The preview marker wins over Sec-Fetch-Dest analysis.
+   core::http::Request request = makeRequest("/files/archive.zip?show=1",
+                                             "document");
+   core::FilePath file("archive.zip");
+   EXPECT_FALSE(shouldAuditFileDownload(request, file));
+}
+
+TEST(ShouldAuditFileDownloadTest, ShowZeroStillAudits)
+{
+   // Only the exact value "1" trips the gate; other values fall through.
+   core::http::Request request = makeRequest("/files/archive.zip?show=0");
+   core::FilePath file("archive.zip");
+   EXPECT_TRUE(shouldAuditFileDownload(request, file));
+}
+
+// --- Returns false: Sec-Fetch-Dest sub-resource ----------------------------
+
+TEST(ShouldAuditFileDownloadTest, FetchDestStyleSkips)
+{
+   core::http::Request request = makeRequest("/files/main.css", "style");
+   core::FilePath file("main.css");
+   EXPECT_FALSE(shouldAuditFileDownload(request, file));
+}
+
+TEST(ShouldAuditFileDownloadTest, FetchDestScriptSkips)
+{
+   core::http::Request request = makeRequest("/files/bundle.js", "script");
+   core::FilePath file("bundle.js");
+   EXPECT_FALSE(shouldAuditFileDownload(request, file));
+}
+
+TEST(ShouldAuditFileDownloadTest, FetchDestImageSkipsEvenForBinaryExtension)
+{
+   // Sub-resource Sec-Fetch-Dest skips even when the file is a non-
+   // renderable type, since the browser is fetching it as an embedded
+   // asset of another page rather than as a download.
+   core::http::Request request = makeRequest("/files/embedded.zip", "image");
+   core::FilePath file("embedded.zip");
+   EXPECT_FALSE(shouldAuditFileDownload(request, file));
+}
+
+// --- Returns false: renderable Content-Type --------------------------------
+
+TEST(ShouldAuditFileDownloadTest, PdfMimeSkips)
+{
+   core::http::Request request = makeRequest("/files/report.pdf");
+   core::FilePath file("report.pdf");
+   EXPECT_FALSE(shouldAuditFileDownload(request, file));
+}
+
+TEST(ShouldAuditFileDownloadTest, HtmlMimeSkips)
+{
+   core::http::Request request = makeRequest("/files/index.html");
+   core::FilePath file("index.html");
+   EXPECT_FALSE(shouldAuditFileDownload(request, file));
+}
+
+TEST(ShouldAuditFileDownloadTest, ImageMimeSkips)
+{
+   core::http::Request request = makeRequest("/files/photo.png");
+   core::FilePath file("photo.png");
+   EXPECT_FALSE(shouldAuditFileDownload(request, file));
+}
+
+TEST(ShouldAuditFileDownloadTest, JsonMimeSkips)
+{
+   core::http::Request request = makeRequest("/files/data.json");
+   core::FilePath file("data.json");
+   EXPECT_FALSE(shouldAuditFileDownload(request, file));
+}
+
+TEST(ShouldAuditFileDownloadTest, NoExtensionDefaultsToTextAndSkips)
+{
+   // FilePath::getMimeContentType defaults to "text/plain" for files with
+   // an unknown / missing extension. The browser will render those inline.
+   core::http::Request request = makeRequest("/files/README");
+   core::FilePath file("README");
+   EXPECT_FALSE(shouldAuditFileDownload(request, file));
+}
+
+// --- Returns true: audited downloads ---------------------------------------
+
+TEST(ShouldAuditFileDownloadTest, ZipAudits)
+{
+   core::http::Request request = makeRequest("/files/archive.zip");
+   core::FilePath file("archive.zip");
+   EXPECT_TRUE(shouldAuditFileDownload(request, file));
+}
+
+TEST(ShouldAuditFileDownloadTest, OfficeDocxAudits)
+{
+   // Office formats serve as application/vnd.openxmlformats-officedocument.*
+   // - not in the renderable set, so they audit.
+   core::http::Request request = makeRequest("/files/report.docx");
+   core::FilePath file("report.docx");
+   EXPECT_TRUE(shouldAuditFileDownload(request, file));
+}
+
+TEST(ShouldAuditFileDownloadTest, DocumentFetchDestForBinaryAudits)
+{
+   // Top-level navigation to a non-renderable type is the prototypical
+   // "user typed a download URL" case and must produce an audit row.
+   core::http::Request request = makeRequest("/files/archive.zip", "document");
+   core::FilePath file("archive.zip");
+   EXPECT_TRUE(shouldAuditFileDownload(request, file));
+}
+
+TEST(ShouldAuditFileDownloadTest, MissingFetchDestForBinaryAudits)
+{
+   // Older browsers don't send Sec-Fetch-Dest; treat absence as
+   // "top-level navigation" and audit when the type is non-renderable.
+   core::http::Request request = makeRequest("/files/archive.zip");
+   core::FilePath file("archive.zip");
+   EXPECT_TRUE(shouldAuditFileDownload(request, file));
+}
+
+TEST(ShouldAuditFileDownloadTest, IframeFetchDestForBinaryAudits)
+{
+   // iframe is intentionally not in the sub-resource skip set - if an
+   // iframe loads a binary, it's effectively exfiltration and should be
+   // audited.
+   core::http::Request request = makeRequest("/files/archive.zip", "iframe");
+   core::FilePath file("archive.zip");
+   EXPECT_TRUE(shouldAuditFileDownload(request, file));
+}
+
+TEST(ShouldAuditFileDownloadTest, IframeFetchDestForRenderableSkips)
+{
+   // iframe loading a renderable type (HTML, etc.) is just sub-view
+   // behavior; skip via the Content-Type branch.
+   core::http::Request request = makeRequest("/files/page.html", "iframe");
+   core::FilePath file("page.html");
+   EXPECT_FALSE(shouldAuditFileDownload(request, file));
+}
+
+} // namespace tests
+} // namespace module_context
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/session/SessionModuleContextTests.cpp
+++ b/src/cpp/session/SessionModuleContextTests.cpp
@@ -27,14 +27,16 @@ namespace tests {
 
 namespace {
 
-core::http::Request makeRequest(const std::string& uri,
-                                const std::string& fetchDest = "")
+// http::Request is non-copyable (inherits from boost::noncopyable via
+// Message), so the helper writes through a caller-owned instance rather
+// than returning by value.
+void initRequest(core::http::Request& request,
+                 const std::string& uri,
+                 const std::string& fetchDest = "")
 {
-   core::http::Request request;
    request.setUri(uri);
    if (!fetchDest.empty())
       request.setHeader("Sec-Fetch-Dest", fetchDest);
-   return request;
 }
 
 } // anonymous namespace
@@ -45,7 +47,8 @@ TEST(ShouldAuditFileDownloadTest, ShowOneSkipsForNonRenderable)
 {
    // ?show=1 forces a skip even for binary types that the browser would
    // otherwise download (file.show() of a zip, etc.).
-   core::http::Request request = makeRequest("/files/archive.zip?show=1");
+   core::http::Request request;
+   initRequest(request, "/files/archive.zip?show=1");
    core::FilePath file("archive.zip");
    EXPECT_FALSE(shouldAuditFileDownload(request, file));
 }
@@ -53,8 +56,8 @@ TEST(ShouldAuditFileDownloadTest, ShowOneSkipsForNonRenderable)
 TEST(ShouldAuditFileDownloadTest, ShowOneSkipsRegardlessOfFetchDest)
 {
    // The preview marker wins over Sec-Fetch-Dest analysis.
-   core::http::Request request = makeRequest("/files/archive.zip?show=1",
-                                             "document");
+   core::http::Request request;
+   initRequest(request, "/files/archive.zip?show=1", "document");
    core::FilePath file("archive.zip");
    EXPECT_FALSE(shouldAuditFileDownload(request, file));
 }
@@ -62,7 +65,8 @@ TEST(ShouldAuditFileDownloadTest, ShowOneSkipsRegardlessOfFetchDest)
 TEST(ShouldAuditFileDownloadTest, ShowZeroStillAudits)
 {
    // Only the exact value "1" trips the gate; other values fall through.
-   core::http::Request request = makeRequest("/files/archive.zip?show=0");
+   core::http::Request request;
+   initRequest(request, "/files/archive.zip?show=0");
    core::FilePath file("archive.zip");
    EXPECT_TRUE(shouldAuditFileDownload(request, file));
 }
@@ -71,14 +75,16 @@ TEST(ShouldAuditFileDownloadTest, ShowZeroStillAudits)
 
 TEST(ShouldAuditFileDownloadTest, FetchDestStyleSkips)
 {
-   core::http::Request request = makeRequest("/files/main.css", "style");
+   core::http::Request request;
+   initRequest(request, "/files/main.css", "style");
    core::FilePath file("main.css");
    EXPECT_FALSE(shouldAuditFileDownload(request, file));
 }
 
 TEST(ShouldAuditFileDownloadTest, FetchDestScriptSkips)
 {
-   core::http::Request request = makeRequest("/files/bundle.js", "script");
+   core::http::Request request;
+   initRequest(request, "/files/bundle.js", "script");
    core::FilePath file("bundle.js");
    EXPECT_FALSE(shouldAuditFileDownload(request, file));
 }
@@ -88,7 +94,8 @@ TEST(ShouldAuditFileDownloadTest, FetchDestImageSkipsEvenForBinaryExtension)
    // Sub-resource Sec-Fetch-Dest skips even when the file is a non-
    // renderable type, since the browser is fetching it as an embedded
    // asset of another page rather than as a download.
-   core::http::Request request = makeRequest("/files/embedded.zip", "image");
+   core::http::Request request;
+   initRequest(request, "/files/embedded.zip", "image");
    core::FilePath file("embedded.zip");
    EXPECT_FALSE(shouldAuditFileDownload(request, file));
 }
@@ -97,28 +104,32 @@ TEST(ShouldAuditFileDownloadTest, FetchDestImageSkipsEvenForBinaryExtension)
 
 TEST(ShouldAuditFileDownloadTest, PdfMimeSkips)
 {
-   core::http::Request request = makeRequest("/files/report.pdf");
+   core::http::Request request;
+   initRequest(request, "/files/report.pdf");
    core::FilePath file("report.pdf");
    EXPECT_FALSE(shouldAuditFileDownload(request, file));
 }
 
 TEST(ShouldAuditFileDownloadTest, HtmlMimeSkips)
 {
-   core::http::Request request = makeRequest("/files/index.html");
+   core::http::Request request;
+   initRequest(request, "/files/index.html");
    core::FilePath file("index.html");
    EXPECT_FALSE(shouldAuditFileDownload(request, file));
 }
 
 TEST(ShouldAuditFileDownloadTest, ImageMimeSkips)
 {
-   core::http::Request request = makeRequest("/files/photo.png");
+   core::http::Request request;
+   initRequest(request, "/files/photo.png");
    core::FilePath file("photo.png");
    EXPECT_FALSE(shouldAuditFileDownload(request, file));
 }
 
 TEST(ShouldAuditFileDownloadTest, JsonMimeSkips)
 {
-   core::http::Request request = makeRequest("/files/data.json");
+   core::http::Request request;
+   initRequest(request, "/files/data.json");
    core::FilePath file("data.json");
    EXPECT_FALSE(shouldAuditFileDownload(request, file));
 }
@@ -127,7 +138,8 @@ TEST(ShouldAuditFileDownloadTest, NoExtensionDefaultsToTextAndSkips)
 {
    // FilePath::getMimeContentType defaults to "text/plain" for files with
    // an unknown / missing extension. The browser will render those inline.
-   core::http::Request request = makeRequest("/files/README");
+   core::http::Request request;
+   initRequest(request, "/files/README");
    core::FilePath file("README");
    EXPECT_FALSE(shouldAuditFileDownload(request, file));
 }
@@ -136,7 +148,8 @@ TEST(ShouldAuditFileDownloadTest, NoExtensionDefaultsToTextAndSkips)
 
 TEST(ShouldAuditFileDownloadTest, ZipAudits)
 {
-   core::http::Request request = makeRequest("/files/archive.zip");
+   core::http::Request request;
+   initRequest(request, "/files/archive.zip");
    core::FilePath file("archive.zip");
    EXPECT_TRUE(shouldAuditFileDownload(request, file));
 }
@@ -145,7 +158,8 @@ TEST(ShouldAuditFileDownloadTest, OfficeDocxAudits)
 {
    // Office formats serve as application/vnd.openxmlformats-officedocument.*
    // - not in the renderable set, so they audit.
-   core::http::Request request = makeRequest("/files/report.docx");
+   core::http::Request request;
+   initRequest(request, "/files/report.docx");
    core::FilePath file("report.docx");
    EXPECT_TRUE(shouldAuditFileDownload(request, file));
 }
@@ -154,7 +168,8 @@ TEST(ShouldAuditFileDownloadTest, DocumentFetchDestForBinaryAudits)
 {
    // Top-level navigation to a non-renderable type is the prototypical
    // "user typed a download URL" case and must produce an audit row.
-   core::http::Request request = makeRequest("/files/archive.zip", "document");
+   core::http::Request request;
+   initRequest(request, "/files/archive.zip", "document");
    core::FilePath file("archive.zip");
    EXPECT_TRUE(shouldAuditFileDownload(request, file));
 }
@@ -163,7 +178,8 @@ TEST(ShouldAuditFileDownloadTest, MissingFetchDestForBinaryAudits)
 {
    // Older browsers don't send Sec-Fetch-Dest; treat absence as
    // "top-level navigation" and audit when the type is non-renderable.
-   core::http::Request request = makeRequest("/files/archive.zip");
+   core::http::Request request;
+   initRequest(request, "/files/archive.zip");
    core::FilePath file("archive.zip");
    EXPECT_TRUE(shouldAuditFileDownload(request, file));
 }
@@ -173,7 +189,8 @@ TEST(ShouldAuditFileDownloadTest, IframeFetchDestForBinaryAudits)
    // iframe is intentionally not in the sub-resource skip set - if an
    // iframe loads a binary, it's effectively exfiltration and should be
    // audited.
-   core::http::Request request = makeRequest("/files/archive.zip", "iframe");
+   core::http::Request request;
+   initRequest(request, "/files/archive.zip", "iframe");
    core::FilePath file("archive.zip");
    EXPECT_TRUE(shouldAuditFileDownload(request, file));
 }
@@ -182,7 +199,8 @@ TEST(ShouldAuditFileDownloadTest, IframeFetchDestForRenderableSkips)
 {
    // iframe loading a renderable type (HTML, etc.) is just sub-view
    // behavior; skip via the Content-Type branch.
-   core::http::Request request = makeRequest("/files/page.html", "iframe");
+   core::http::Request request;
+   initRequest(request, "/files/page.html", "iframe");
    core::FilePath file("page.html");
    EXPECT_FALSE(shouldAuditFileDownload(request, file));
 }

--- a/src/cpp/session/SessionModuleContextTests.cpp
+++ b/src/cpp/session/SessionModuleContextTests.cpp
@@ -242,6 +242,28 @@ TEST(ShouldAuditFileDownloadTest, IframeFetchDestForRenderableSkips)
    EXPECT_FALSE(shouldAuditFileDownload(request, file));
 }
 
+// --- Producer-side: createFileUrl round-trip --------------------------------
+
+TEST(CreateFileUrlTest, HomeFileRoundTripSkipsAudit)
+{
+   // Regression test for the producer-consumer contract between
+   // createFileUrl and shouldAuditFileDownload. If a future edit drops
+   // the ?show=1 marker in the in-home branch of createFileUrl, this
+   // round trip will fail (the URL won't trigger the preview skip and
+   // - because .zip resolves to application/zip - the helper will
+   // return true instead of false).
+   core::FilePath file = userHomePath().completeChildPath("preview.zip");
+   const std::string url = createFileUrl(file);
+   ASSERT_NE(url.find("show=1"), std::string::npos)
+      << "createFileUrl output missing show=1: " << url;
+
+   core::http::Request request;
+   request.setUri("/" + url);
+   EXPECT_FALSE(shouldAuditFileDownload(request, file))
+      << "round-trip URL " << url
+      << " should skip audit via the ?show=1 marker";
+}
+
 } // namespace tests
 } // namespace module_context
 } // namespace session

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -88,7 +88,7 @@ enum PackageCompatStatus
    COMPAT_UNKNOWN = 4
 };
     
-// paths
+// paths 
 core::FilePath userHomePath();
 std::string createAliasedPath(const core::FileInfo& fileInfo);
 std::string createAliasedPath(const core::FilePath& path);
@@ -96,12 +96,14 @@ std::string createFileUrl(const core::FilePath& path);
 core::FilePath resolveAliasedPath(const std::string& aliasedPath);
 
 // Returns true if a /files/ or /file_show request for filePath should
-// produce a session_file_download audit event. Returns false when the
-// request is a server-initiated preview/show (URL has ?show=1), an HTML
-// sub-resource fetch (Sec-Fetch-Dest is style/script/image/etc.), or
-// when the response will be served as a browser-renderable Content-Type
-// (text/*, image/*, audio/*, video/*, application/pdf, etc.) and the
-// bytes will be viewed inline rather than saved.
+// produce a session_file_download audit event. Returns false when:
+//   (1) the URL carries ?show=1 (server-initiated preview/show flow),
+//   (2) Sec-Fetch-Dest indicates a sub-resource (style/script/image/
+//       font/audio/video/track/object/embed/manifest/xslt/report/
+//       worker/serviceworker/audioworklet/paintworklet), or
+//   (3) the file's Content-Type is browser-renderable: text/*, image/*,
+//       audio/*, video/*, application/pdf, application/json,
+//       application/xml, application/javascript, application/xhtml+xml.
 bool shouldAuditFileDownload(const core::http::Request& request,
                              const core::FilePath& filePath);
 core::FilePath userScratchPath();

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -102,8 +102,7 @@ core::FilePath resolveAliasedPath(const std::string& aliasedPath);
 //       font/audio/video/track/object/embed/manifest/xslt/report/
 //       worker/serviceworker/audioworklet/paintworklet), or
 //   (3) the file's Content-Type is browser-renderable: text/*, image/*,
-//       audio/*, video/*, application/pdf, application/json,
-//       application/xml, application/javascript, application/xhtml+xml.
+//       audio/*, video/*, application/pdf, application/json.
 bool shouldAuditFileDownload(const core::http::Request& request,
                              const core::FilePath& filePath);
 core::FilePath userScratchPath();

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -88,12 +88,22 @@ enum PackageCompatStatus
    COMPAT_UNKNOWN = 4
 };
     
-// paths 
+// paths
 core::FilePath userHomePath();
 std::string createAliasedPath(const core::FileInfo& fileInfo);
 std::string createAliasedPath(const core::FilePath& path);
 std::string createFileUrl(const core::FilePath& path);
 core::FilePath resolveAliasedPath(const std::string& aliasedPath);
+
+// Returns true if a /files/ or /file_show request for filePath should
+// produce a session_file_download audit event. Returns false when the
+// request is a server-initiated preview/show (URL has ?show=1), an HTML
+// sub-resource fetch (Sec-Fetch-Dest is style/script/image/etc.), or
+// when the response will be served as a browser-renderable Content-Type
+// (text/*, image/*, audio/*, video/*, application/pdf, etc.) and the
+// bytes will be viewed inline rather than saved.
+bool shouldAuditFileDownload(const core::http::Request& request,
+                             const core::FilePath& filePath);
 core::FilePath userScratchPath();
 core::FilePath userUploadedFilesScratchPath();
 core::FilePath scopedScratchPath();

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -612,16 +612,30 @@ void handleFilesRequest(const http::Request& request,
       }
    }
 
-   // if this request was initiated as an explicit download from the Files
-   // pane, let the monitor client know the user has downloaded this file
-   // (other consumers of /files/ - file.show(), browseURL(), Sweave/PDF/HTML
-   // previews, and HTML sub-resource fetches - omit the download flag and
-   // are not logged)
-   if (request.queryParamValue("download") == "1")
+   // Audit user-initiated downloads. Skip when:
+   //  - the URL was constructed by an internal preview/show flow
+   //    (?show=1 marker, set by module_context::createFileUrl); or
+   //  - the request is an HTML sub-resource fetch, identified via
+   //    Sec-Fetch-Dest. We log when the header is missing (older
+   //    browsers default to "log") or signals a top-level navigation.
    {
-      using namespace monitor;
-      client().logEvent(Event(kSessionScope, kSessionDownloadEvent,
-                              module_context::createAliasedPath(filePath)));
+      const std::string fetchDest = request.headerValue("Sec-Fetch-Dest");
+      const bool isSubResource =
+         fetchDest == "style"        || fetchDest == "script"        ||
+         fetchDest == "image"        || fetchDest == "font"          ||
+         fetchDest == "audio"        || fetchDest == "video"         ||
+         fetchDest == "track"        || fetchDest == "object"        ||
+         fetchDest == "embed"        || fetchDest == "manifest"      ||
+         fetchDest == "xslt"         || fetchDest == "report"        ||
+         fetchDest == "worker"       || fetchDest == "serviceworker" ||
+         fetchDest == "audioworklet" || fetchDest == "paintworklet";
+      const bool isPreview = request.queryParamValue("show") == "1";
+      if (!isSubResource && !isPreview)
+      {
+         using namespace monitor;
+         client().logEvent(Event(kSessionScope, kSessionDownloadEvent,
+                                 module_context::createAliasedPath(filePath)));
+      }
    }
 
    pResponse->setNoCacheHeaders();

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -612,30 +612,11 @@ void handleFilesRequest(const http::Request& request,
       }
    }
 
-   // Audit user-initiated downloads. Skip when:
-   //  - the URL was constructed by an internal preview/show flow
-   //    (?show=1 marker, set by module_context::createFileUrl); or
-   //  - the request is an HTML sub-resource fetch, identified via
-   //    Sec-Fetch-Dest. We log when the header is missing (older
-   //    browsers default to "log") or signals a top-level navigation.
+   if (module_context::shouldAuditFileDownload(request, filePath))
    {
-      const std::string fetchDest = request.headerValue("Sec-Fetch-Dest");
-      const bool isSubResource =
-         fetchDest == "style"        || fetchDest == "script"        ||
-         fetchDest == "image"        || fetchDest == "font"          ||
-         fetchDest == "audio"        || fetchDest == "video"         ||
-         fetchDest == "track"        || fetchDest == "object"        ||
-         fetchDest == "embed"        || fetchDest == "manifest"      ||
-         fetchDest == "xslt"         || fetchDest == "report"        ||
-         fetchDest == "worker"       || fetchDest == "serviceworker" ||
-         fetchDest == "audioworklet" || fetchDest == "paintworklet";
-      const bool isPreview = request.queryParamValue("show") == "1";
-      if (!isSubResource && !isPreview)
-      {
-         using namespace monitor;
-         client().logEvent(Event(kSessionScope, kSessionDownloadEvent,
-                                 module_context::createAliasedPath(filePath)));
-      }
+      using namespace monitor;
+      client().logEvent(Event(kSessionScope, kSessionDownloadEvent,
+                              module_context::createAliasedPath(filePath)));
    }
 
    pResponse->setNoCacheHeaders();

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -447,30 +447,11 @@ void handleFileShow(const http::Request& request, http::Response* pResponse)
       return;
    }
 
-   // Audit user-initiated downloads. Skip when:
-   //  - the URL was constructed by an internal preview/show flow
-   //    (?show=1 marker, set by module_context::createFileUrl); or
-   //  - the request is an HTML sub-resource fetch, identified via
-   //    Sec-Fetch-Dest. We log when the header is missing (older
-   //    browsers default to "log") or signals a top-level navigation.
+   if (module_context::shouldAuditFileDownload(request, filePath))
    {
-      const std::string fetchDest = request.headerValue("Sec-Fetch-Dest");
-      const bool isSubResource =
-         fetchDest == "style"        || fetchDest == "script"        ||
-         fetchDest == "image"        || fetchDest == "font"          ||
-         fetchDest == "audio"        || fetchDest == "video"         ||
-         fetchDest == "track"        || fetchDest == "object"        ||
-         fetchDest == "embed"        || fetchDest == "manifest"      ||
-         fetchDest == "xslt"         || fetchDest == "report"        ||
-         fetchDest == "worker"       || fetchDest == "serviceworker" ||
-         fetchDest == "audioworklet" || fetchDest == "paintworklet";
-      const bool isPreview = request.queryParamValue("show") == "1";
-      if (!isSubResource && !isPreview)
-      {
-         using namespace monitor;
-         client().logEvent(Event(kSessionScope, kSessionDownloadEvent,
-                                 module_context::createAliasedPath(filePath)));
-      }
+      using namespace monitor;
+      client().logEvent(Event(kSessionScope, kSessionDownloadEvent,
+                              module_context::createAliasedPath(filePath)));
    }
 
    // send it back

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -447,15 +447,30 @@ void handleFileShow(const http::Request& request, http::Response* pResponse)
       return;
    }
 
-   // if this request was initiated as an explicit download from the Files
-   // pane, let the monitor client know the user has downloaded this file.
-   // The Files pane appends ?download=1 only when the user clicked a file
-   // for download; bare /file_show?path=... requests are not logged.
-   if (request.queryParamValue("download") == "1")
+   // Audit user-initiated downloads. Skip when:
+   //  - the URL was constructed by an internal preview/show flow
+   //    (?show=1 marker, set by module_context::createFileUrl); or
+   //  - the request is an HTML sub-resource fetch, identified via
+   //    Sec-Fetch-Dest. We log when the header is missing (older
+   //    browsers default to "log") or signals a top-level navigation.
    {
-      using namespace monitor;
-      client().logEvent(Event(kSessionScope, kSessionDownloadEvent,
-                              module_context::createAliasedPath(filePath)));
+      const std::string fetchDest = request.headerValue("Sec-Fetch-Dest");
+      const bool isSubResource =
+         fetchDest == "style"        || fetchDest == "script"        ||
+         fetchDest == "image"        || fetchDest == "font"          ||
+         fetchDest == "audio"        || fetchDest == "video"         ||
+         fetchDest == "track"        || fetchDest == "object"        ||
+         fetchDest == "embed"        || fetchDest == "manifest"      ||
+         fetchDest == "xslt"         || fetchDest == "report"        ||
+         fetchDest == "worker"       || fetchDest == "serviceworker" ||
+         fetchDest == "audioworklet" || fetchDest == "paintworklet";
+      const bool isPreview = request.queryParamValue("show") == "1";
+      if (!isSubResource && !isPreview)
+      {
+         using namespace monitor;
+         client().logEvent(Event(kSessionScope, kSessionDownloadEvent,
+                                 module_context::createAliasedPath(filePath)));
+      }
    }
 
    // send it back

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -1106,14 +1106,15 @@ public class Files
       String fileURL = server_.getFileUrl(file);
       if (fileURL != null)
       {
-         // for server URLs initiated as a download (e.g. user clicked a
-         // binary file in the Files pane), tag the URL so the server can
-         // audit it without also auditing view-style navigations (HTML
-         // "Show in Browser", source-code link clicks) or internal /files/
-         // traffic (HTML sub-resources, file.show(), browseURL previews).
+         // for server URLs that aren't user-initiated downloads (HTML
+         // "Show in Browser", source-code link clicks), tag the URL so
+         // the server skips audit logging - matching the marker that
+         // module_context::createFileUrl applies to server-side preview
+         // flows. Files-pane downloads stay unmarked and are logged like
+         // any other top-level navigation.
          // Desktop URLs are file:// and don't go through the session.
-         if (asDownload && !fileURL.startsWith("file:"))
-            fileURL += (fileURL.contains("?") ? "&" : "?") + "download=1";
+         if (!asDownload && !fileURL.startsWith("file:"))
+            fileURL += (fileURL.contains("?") ? "&" : "?") + "show=1";
          globalDisplay_.openWindow(fileURL);
       }
    }


### PR DESCRIPTION
## Intent

Addresses [rstudio-pro#11010](https://github.com/rstudio/rstudio-pro/issues/11010). Follow-up to #17561, which introduced an audit-log gap described in the linked issue.

Additionally, I noticed that clicking a PDF file in the files pane doesn't actually download it, it just opens the pdf in a new tab like how it does with a txt file. From the previous issue, Claude thought that all binary files were downloaded automatically when they were clicked in the files pane so in PR rstudio/rstudio#17561, it logged PDF clicks as `session_file_download` events in the audit log. But nothing is actually downloaded when the PDF is clicked so it shouldn't be logged that way. So as part of this PR, the `session_file_download` logging for PDF clicks was removed.

## Summary

- Refactors the audit-log decision into a single `module_context::shouldAuditFileDownload(request, filePath)` helper used by both `handleFilesRequest` (`/files/<path>`) and `handleFileShow` (`/file_show?path=...`).
- The helper returns false (skip the audit) when any of the following is true:
  1. The request URL carries a `?show=1` marker - added by `module_context::createFileUrl` for all server-initiated preview/show flows (`utils::file.show()`, `browseURL()`, Sweave/PDF preview, Workbench Show PDF, Viewer save-as, Viewer non-temp HTML fallback) and by `Files.java`'s `showFileInBrowser` for view-style navigations (HTML "Show in Browser", Ace-editor link clicks).
  2. `Sec-Fetch-Dest` indicates a sub-resource fetch (`style`, `script`, `image`, `font`, etc.) - i.e. the request was a CSS/JS/image embedded in an HTML page rather than a top-level navigation.
  3. The file will be served with a Content-Type the browser renders inline (`text/*`, `image/*`, `audio/*`, `video/*`, `application/pdf`, `application/json`). The bytes are being viewed, not saved.
- Otherwise the helper returns true and the request is audited. This means Files-pane downloads of binary types (`.zip`, `.docx`, etc.) audit; HTML "Show in Browser", PDF inline render, and the various server-initiated preview flows do not.
- The audit `data` field uses `module_context::createAliasedPath(filePath)` - consistent with the existing download audit calls in the export handlers (`~/...` for in-home, absolute path for out-of-home, resolved `index.html` for directory rewrites).
- For files with an unknown / missing extension, the audit decision uses `application/octet-stream` as the explicit default; the response path keeps its `text/plain` default unchanged. Trade-off: this also logs legitimate fetches of extensionless text files (README, LICENSE, etc.).
- Adds 20 unit tests in `src/cpp/session/SessionModuleContextTests.cpp` covering each skip branch, a table-driven check of all 16 Sec-Fetch-Dest sub-resource values, the `OctetStreamAudits` and `NoExtensionAuditsAsOctetStream` cases, and an end-to-end round-trip that feeds `createFileUrl` output back through `shouldAuditFileDownload` to pin the producer-consumer contract. Run with:
  ```
  ./rstudio-tests --scope rsession
  ```

## Test plan
Added to the issue

I ran thru the test cases in my dev container and the PR build from https://github.com/rstudio/rstudio-pro/pull/11016

