### PR TITLE
Include positai.log in diagnostics report

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - ([#17514](https://github.com/rstudio/rstudio/issues/17514)): Added the `allow-package-source-recording` session option (default `true`); when set to `false`, RStudio will not annotate DESCRIPTION files of packages installed via `install.packages()` with the remote repository they came from.
 
 ### Fixed
+- ([#17589](https://github.com/rstudio/rstudio/issues/17589)): The diagnostics report now includes `positai.log` alongside `rdesktop.log` and the user's `rsession-*.log`.
 - ([#17581](https://github.com/rstudio/rstudio/issues/17581)): Diagnostic gutter tooltips no longer show literal `<SPAN>` markup around the message; lint annotations now keep the original text alongside any rendered HTML so the tooltip renders cleanly while the diagnostics popup continues to support ANSI-colored content.
 - ([#17556](https://github.com/rstudio/rstudio/issues/17556)): `difftime` objects (e.g. the result of subtracting two `Sys.time()` values) now show their formatted value in the Environment pane instead of an empty cell.
 - ([#17568](https://github.com/rstudio/rstudio/issues/17568)): Source-mode spell check now flags misspelled words inside Markdown, R Markdown, and Quarto headings; previously only paragraph text was checked.

--- a/src/cpp/diagnostics/DiagnosticsMain.cpp
+++ b/src/cpp/diagnostics/DiagnosticsMain.cpp
@@ -95,6 +95,7 @@ int main(int argc, char** argv)
 
    writeLogFile("rdesktop.log", std::cout);
    writeLogFile("rsession-" + core::system::username() + ".log", std::cout);
+   writeLogFile("positai.log", std::cout);
    writeUserPrefs(std::cout);
 
    return EXIT_SUCCESS;


### PR DESCRIPTION
## Intent

Addresses #17589.

## Summary

- Add `positai.log` to the diagnostics report emitted by `src/cpp/diagnostics/DiagnosticsMain.cpp`, alongside the existing `rdesktop.log` and `rsession-<user>.log` entries.
- Users without Posit AI installed will see a `(Not Found)` entry for `positai.log`, consistent with how the report already handles missing files.

## Test plan

- [ ] Build the `diagnostics` target (`cmake --build build --target diagnostics`).
- [ ] Run the diagnostics binary on a system with Posit AI installed and confirm `positai.log` appears in the output with its contents.
- [ ] Run the diagnostics binary on a system without Posit AI installed and confirm `positai.log` appears with `(Not Found)` rather than producing an error.
- [ ] In RStudio Desktop, run **Help > Diagnostics > Diagnostics Report** and confirm `positai.log` is included in the saved report.

## QA Notes

Low risk: the change is a single additional `writeLogFile()` call in the diagnostics binary. The report's existing missing-file path handles the case where `positai.log` does not exist. No other binaries or code paths consume this file list.