### PR TITLE
Humanize sign-in inactivity timeout message

### DIFF
--- a/src/cpp/server/CMakeLists.txt
+++ b/src/cpp/server/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SERVER_SOURCE_FILES
    ServerErrorCategory.cpp
    ServerEval.cpp
    ServerEnvVars.cpp
+   ServerFormatUtils.cpp
    ServerInit.cpp
    ServerLoginPages.cpp
    ServerLogVars.cpp
@@ -297,7 +298,8 @@ if (RSTUDIO_UNIT_TESTS_ENABLED)
 
   set(SERVER_TEST_FILES
      DBActiveSessionStorageTests.cpp
-     ServerEnvVarsTests.cpp)
+     ServerEnvVarsTests.cpp
+     ServerFormatUtilsTests.cpp)
 
   list(APPEND SERVER_SOURCE_FILES ${SERVER_TEST_FILES})
 

--- a/src/cpp/server/ServerFormatUtils.cpp
+++ b/src/cpp/server/ServerFormatUtils.cpp
@@ -1,0 +1,77 @@
+/*
+ * ServerFormatUtils.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "ServerFormatUtils.hpp"
+
+#include <string>
+#include <vector>
+
+namespace rstudio {
+namespace server {
+
+namespace {
+
+void appendPart(std::vector<std::string>& parts, int n, const char* singular, const char* plural)
+{
+   if (n <= 0)
+      return;
+   parts.push_back(std::to_string(n) + " " + (n == 1 ? singular : plural));
+}
+
+// The empty-vector arm is unreachable from formatLoginTimeoutDuration (which
+// returns early for n < 1 and always pushes at least one part for n >= 1),
+// but is defined for safety so future callers passing an empty vector get a
+// silent empty string rather than UB.
+std::string oxfordJoin(const std::vector<std::string>& parts)
+{
+   if (parts.empty())
+      return std::string();
+   if (parts.size() == 1)
+      return parts[0];
+   if (parts.size() == 2)
+      return parts[0] + " and " + parts[1];
+
+   std::string out;
+   for (std::size_t i = 0; i < parts.size(); ++i)
+   {
+      if (i == parts.size() - 1)
+         out += "and " + parts[i];
+      else
+         out += parts[i] + ", ";
+   }
+   return out;
+}
+
+} // anonymous namespace
+
+std::string formatLoginTimeoutDuration(int minutes)
+{
+   if (minutes < 1)
+      return "0 minutes";
+
+   const int days = minutes / 1440;
+   const int hours = (minutes % 1440) / 60;
+   const int mins = minutes % 60;
+
+   std::vector<std::string> parts;
+   appendPart(parts, days, "day", "days");
+   appendPart(parts, hours, "hour", "hours");
+   appendPart(parts, mins, "minute", "minutes");
+
+   return oxfordJoin(parts);
+}
+
+} // namespace server
+} // namespace rstudio

--- a/src/cpp/server/ServerFormatUtils.hpp
+++ b/src/cpp/server/ServerFormatUtils.hpp
@@ -1,0 +1,42 @@
+/*
+ * ServerFormatUtils.hpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SERVER_FORMAT_UTILS_HPP
+#define SERVER_FORMAT_UTILS_HPP
+
+#include <string>
+
+namespace rstudio {
+namespace server {
+
+// Formats an integer number of minutes into a human-friendly duration string
+// suitable for the sign-in inactivity-timeout message. Decomposes the value
+// into days, hours, and minutes; suppresses zero components; pluralizes each
+// part; and joins parts using Oxford-comma style.
+//
+// Examples:
+//   formatLoginTimeoutDuration(4320) -> "3 days"
+//   formatLoginTimeoutDuration(4319) -> "2 days, 23 hours, and 59 minutes"
+//   formatLoginTimeoutDuration(90)   -> "1 hour and 30 minutes"
+//   formatLoginTimeoutDuration(45)   -> "45 minutes"
+//   formatLoginTimeoutDuration(1)    -> "1 minute"
+//   formatLoginTimeoutDuration(0)    -> "0 minutes"
+//   formatLoginTimeoutDuration(-5)   -> "0 minutes"
+std::string formatLoginTimeoutDuration(int minutes);
+
+} // namespace server
+} // namespace rstudio
+
+#endif // SERVER_FORMAT_UTILS_HPP

--- a/src/cpp/server/ServerFormatUtilsTests.cpp
+++ b/src/cpp/server/ServerFormatUtilsTests.cpp
@@ -1,0 +1,89 @@
+/*
+ * ServerFormatUtilsTests.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "ServerFormatUtils.hpp"
+
+#include <gtest/gtest.h>
+
+namespace rstudio {
+namespace server {
+namespace format_utils {
+namespace tests {
+
+TEST(ServerFormatUtilsTest, ExactDayBoundary)
+{
+   EXPECT_EQ("3 days", formatLoginTimeoutDuration(4320));
+}
+
+TEST(ServerFormatUtilsTest, AllThreeUnits)
+{
+   EXPECT_EQ("2 days, 23 hours, and 59 minutes",
+             formatLoginTimeoutDuration(4319));
+}
+
+TEST(ServerFormatUtilsTest, HoursAndMinutes)
+{
+   EXPECT_EQ("1 hour and 30 minutes", formatLoginTimeoutDuration(90));
+}
+
+TEST(ServerFormatUtilsTest, MinutesOnly)
+{
+   EXPECT_EQ("45 minutes", formatLoginTimeoutDuration(45));
+}
+
+TEST(ServerFormatUtilsTest, SingleMinute)
+{
+   EXPECT_EQ("1 minute", formatLoginTimeoutDuration(1));
+}
+
+TEST(ServerFormatUtilsTest, SingleHour)
+{
+   EXPECT_EQ("1 hour", formatLoginTimeoutDuration(60));
+}
+
+TEST(ServerFormatUtilsTest, SingleDay)
+{
+   EXPECT_EQ("1 day", formatLoginTimeoutDuration(1440));
+}
+
+TEST(ServerFormatUtilsTest, DaysAndHoursNoMinutes)
+{
+   EXPECT_EQ("1 day and 1 hour", formatLoginTimeoutDuration(1500));
+}
+
+TEST(ServerFormatUtilsTest, DaysAndMinutesNoHours)
+{
+   EXPECT_EQ("1 day and 1 minute", formatLoginTimeoutDuration(1441));
+}
+
+TEST(ServerFormatUtilsTest, HoursOnly)
+{
+   EXPECT_EQ("2 hours", formatLoginTimeoutDuration(120));
+}
+
+TEST(ServerFormatUtilsTest, ZeroReturnsZeroMinutes)
+{
+   EXPECT_EQ("0 minutes", formatLoginTimeoutDuration(0));
+}
+
+TEST(ServerFormatUtilsTest, NegativeReturnsZeroMinutes)
+{
+   EXPECT_EQ("0 minutes", formatLoginTimeoutDuration(-5));
+}
+
+} // namespace tests
+} // namespace format_utils
+} // namespace server
+} // namespace rstudio

--- a/src/cpp/server/ServerLoginPages.cpp
+++ b/src/cpp/server/ServerLoginPages.cpp
@@ -29,6 +29,8 @@
 #include <server/auth/ServerAuthHandler.hpp>
 #include <server/auth/ServerAuthHandlerOverlay.hpp>
 
+#include "ServerFormatUtils.hpp"
+
 const char * const kStaySignedInDisplay = "staySignedInDisplay";
 const char * const kAuthTimeoutMinutes = "authTimeoutMinutes";
 const char * const kAuthTimeoutMinutesDisplay = "authTimeoutMinutesDisplay";
@@ -67,7 +69,7 @@ void fillLoginFields(const core::http::Request& request,
    variables[kStaySignedInDisplay] = auth::handler::overlay::canStaySignedIn() ? "block" : "none";
    int timeoutMinutes = server::options().authTimeoutMinutes();
    variables[kAuthTimeoutMinutesDisplay] = timeoutMinutes > 0 ? "block" : "none";
-   variables[kAuthTimeoutMinutes] = core::safe_convert::numberToString(timeoutMinutes);
+   variables[kAuthTimeoutMinutes] = formatLoginTimeoutDuration(timeoutMinutes);
 
    // fill error
    std::string error = request.queryParamValue(kErrorParam);

--- a/src/gwt/www/templates/encrypted-sign-in.htm
+++ b/src/gwt/www/templates/encrypted-sign-in.htm
@@ -100,7 +100,7 @@
               <p style="display: #authTimeoutMinutesDisplay#">
                 <span style="font-size: 10px"
                   >You will automatically be signed out after
-                  #authTimeoutMinutes# minutes of inactivity.</span
+                  #authTimeoutMinutes# of inactivity.</span
                 >
               </p>
             </div>


### PR DESCRIPTION
Open-source companion to rstudio/rstudio-pro#11011.

Renders the sign-in page's inactivity timeout as a friendly duration (e.g. "3 days" or "2 days, 23 hours, and 59 minutes") instead of a raw minute count.