### PR TITLE
preserve dismissed summary sidebar across column pagination

### DIFF
--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -139,34 +139,51 @@ has-scope () {
    [ -z "${TEST_SCOPE}" ] || [ "${TEST_SCOPE}" = "$1" ]
 }
 
-case "$1" in
+while [ $# -gt 0 ]; do
+   case "$1" in
 
-"--scope")
+   "--scope")
 
-   if [ -z "$2" ]; then
-      echo "Usage: ./rstudio-tests --scope [core|rserver|rsession|r]"
+      if [ -z "$2" ]; then
+         echo "Usage: ./rstudio-tests --scope [core|rserver|rsession|r]"
+         exit 1
+      fi
+
+      TEST_SCOPE="$2"
+      shift 2
+
+   ;;
+
+   "--filter")
+
+      # used for filtering to a subset of R testthat tests; previously
+      # implied --scope r, but only when --filter came first. Now scope
+      # is taken from --scope if given (so `--scope r --filter foo` works
+      # in either order), and we still default to r when --filter is the
+      # only narrowing option.
+      TEST_FILTER="$2"
+      if [ -z "${TEST_SCOPE}" ]; then
+         TEST_SCOPE="r"
+      fi
+      shift 2
+
+   ;;
+
+   "--help")
+      echo "${USAGE}"
+      exit 0
+
+   ;;
+
+   *)
+      echo "Unknown argument: $1"
+      echo "${USAGE}"
       exit 1
-   fi
 
-   TEST_SCOPE="$2"
-   shift 2
+   ;;
 
-;;
-
-"--filter")
-
-   # used for filtering to a subset of R testthat tests
-   TEST_SCOPE="r"
-   TEST_FILTER="$2"
-   shift 2
-
-;;
-
-"--help")
-   echo "${USAGE}"
-   exit 0
-
-esac
+   esac
+done
 
 # try to find libSegFault if available
 findLibSegFault

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -161,6 +161,11 @@ while [ $# -gt 0 ]; do
       # is taken from --scope if given (so `--scope r --filter foo` works
       # in either order), and we still default to r when --filter is the
       # only narrowing option.
+      if [ -z "$2" ]; then
+         echo "Usage: ./rstudio-tests --filter <pattern>"
+         exit 1
+      fi
+
       TEST_FILTER="$2"
       if [ -z "${TEST_SCOPE}" ]; then
          TEST_SCOPE="r"

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -134,6 +134,22 @@
    as.character(col)
 })
 
+# Compact, collision-resistant hash of a frame's column names. Used as a
+# fingerprint to detect object reassignment between data viewer loads.
+#
+# Returns NA_character_ for empty / NULL names so the client can treat
+# "no anchor" as always-mismatch; without anchors there's no way to align
+# saved positional state with the current frame, so we want it discarded.
+.rs.addFunction("dataViewer.colsFingerprint", function(x)
+{
+   nms <- names(x)
+   n <- length(nms)
+   if (n == 0L)
+      return(NA_character_)
+
+   paste0(n, ":", .rs.digest(nms))
+})
+
 .rs.addFunction("describeCols", function(x,
                                          maxRows = -1,
                                          maxCols = -1,
@@ -141,18 +157,16 @@
                                          totalCols = -1,
                                          colsFingerprint = NULL)
 {
-   # Capture a fingerprint of the full set of column names before any
-   # subsetting -- the client uses this to detect object reassignment
-   # (e.g. df <- iris after df <- mtcars). Callers that have already
-   # subset x (e.g. describeColSlice) must compute and pass this
-   # themselves so the fingerprint reflects the underlying frame, not
-   # the visible slice. Prefix with the name count and separate names
-   # with the ASCII Unit Separator so names containing a hyphen (common
-   # in real datasets) can't collide -- e.g. c("a-b", "c") vs
-   # c("a", "b-c") would otherwise share a fingerprint.
+   # The client compares this fingerprint against the one stored alongside
+   # saved per-object UI state (pins, widths, sort, filters, sidebar
+   # visibility). A mismatch invalidates the saved state -- without it,
+   # positional indices saved against one frame can land on an unrelated
+   # frame after reassignment (df <- iris; df <- mtcars). Callers that have
+   # already subset x (e.g. describeColSlice) must compute the fingerprint
+   # from the underlying frame and pass it in, otherwise pagination would
+   # silently invalidate state on every column-frame change.
    if (is.null(colsFingerprint))
-      colsFingerprint <- paste0(length(names(x)), ":",
-                                paste(names(x), collapse = "\x1F"))
+      colsFingerprint <- .rs.dataViewer.colsFingerprint(x)
 
    # subset the data if requested
    x <- .rs.subsetData(x, maxRows, maxCols)
@@ -456,14 +470,11 @@
    }
       
    
-   # Compute the fingerprint from the full frame's names (not colSlice's
-   # subset) so it stays stable across pagination -- otherwise saved UI
-   # state, including a dismissed summary sidebar, would be invalidated
-   # on every column-frame change. Format must match describeCols().
-   colsFingerprint <- paste0(length(names(x)), ":",
-                             paste(names(x), collapse = "\x1F"))
-
-   .rs.describeCols(colSlice, -1, -1, 64, totalCols, colsFingerprint)
+   # Pass the fingerprint of the full frame so pagination doesn't fold
+   # each page into a distinct fingerprint -- doing so would invalidate
+   # saved UI state on every page change.
+   .rs.describeCols(colSlice, -1, -1, 64, totalCols,
+                    .rs.dataViewer.colsFingerprint(x))
 })
 
 .rs.addFunction("summarizeColumn", function(x, columnIndex)

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -146,9 +146,13 @@
    # (e.g. df <- iris after df <- mtcars). Callers that have already
    # subset x (e.g. describeColSlice) must compute and pass this
    # themselves so the fingerprint reflects the underlying frame, not
-   # the visible slice.
+   # the visible slice. Prefix with the name count and separate names
+   # with the ASCII Unit Separator so names containing a hyphen (common
+   # in real datasets) can't collide -- e.g. c("a-b", "c") vs
+   # c("a", "b-c") would otherwise share a fingerprint.
    if (is.null(colsFingerprint))
-      colsFingerprint <- paste(names(x), collapse = "-")
+      colsFingerprint <- paste0(length(names(x)), ":",
+                                paste(names(x), collapse = "\x1F"))
 
    # subset the data if requested
    x <- .rs.subsetData(x, maxRows, maxCols)
@@ -455,8 +459,9 @@
    # Compute the fingerprint from the full frame's names (not colSlice's
    # subset) so it stays stable across pagination -- otherwise saved UI
    # state, including a dismissed summary sidebar, would be invalidated
-   # on every column-frame change.
-   colsFingerprint <- paste(names(x), collapse = "-")
+   # on every column-frame change. Format must match describeCols().
+   colsFingerprint <- paste0(length(names(x)), ":",
+                             paste(names(x), collapse = "\x1F"))
 
    .rs.describeCols(colSlice, -1, -1, 64, totalCols, colsFingerprint)
 })

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -138,8 +138,18 @@
                                          maxRows = -1,
                                          maxCols = -1,
                                          maxFactors = 64,
-                                         totalCols = -1)
+                                         totalCols = -1,
+                                         colsFingerprint = NULL)
 {
+   # Capture a fingerprint of the full set of column names before any
+   # subsetting -- the client uses this to detect object reassignment
+   # (e.g. df <- iris after df <- mtcars). Callers that have already
+   # subset x (e.g. describeColSlice) must compute and pass this
+   # themselves so the fingerprint reflects the underlying frame, not
+   # the visible slice.
+   if (is.null(colsFingerprint))
+      colsFingerprint <- paste(names(x), collapse = "-")
+
    # subset the data if requested
    x <- .rs.subsetData(x, maxRows, maxCols)
    
@@ -213,7 +223,8 @@
       col_type_r      = .rs.scalar(""),
       col_na_count    = .rs.scalar(0),
       total_cols      = .rs.scalar(totalCols),
-      total_rows      = .rs.scalar(nrow(x)))
+      total_rows      = .rs.scalar(nrow(x)),
+      cols_fingerprint = .rs.scalar(colsFingerprint))
 
    # Add a max-chars hint for the row names column. Use .row_names_info()
    # so we avoid materializing the full row-name vector for the common
@@ -441,7 +452,13 @@
    }
       
    
-   .rs.describeCols(colSlice, -1, -1, 64, totalCols)
+   # Compute the fingerprint from the full frame's names (not colSlice's
+   # subset) so it stays stable across pagination -- otherwise saved UI
+   # state, including a dismissed summary sidebar, would be invalidated
+   # on every column-frame change.
+   colsFingerprint <- paste(names(x), collapse = "-")
+
+   .rs.describeCols(colSlice, -1, -1, 64, totalCols, colsFingerprint)
 })
 
 .rs.addFunction("summarizeColumn", function(x, columnIndex)

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -137,9 +137,10 @@
 # Compact, collision-resistant hash of a frame's column names. Used as a
 # fingerprint to detect object reassignment between data viewer loads.
 #
-# Returns NA_character_ for empty / NULL names so the client can treat
-# "no anchor" as always-mismatch; without anchors there's no way to align
-# saved positional state with the current frame, so we want it discarded.
+# Returns NA_character_ for empty / NULL names, and also when the digest
+# helper itself fails -- in both cases the client treats "no anchor" as
+# always-mismatch and discards any saved positional state, since there
+# is no safe way to align indices against a frame we can't fingerprint.
 .rs.addFunction("dataViewer.colsFingerprint", function(x)
 {
    nms <- names(x)
@@ -147,7 +148,11 @@
    if (n == 0L)
       return(NA_character_)
 
-   paste0(n, ":", .rs.digest(nms))
+   hash <- .rs.digest(nms)
+   if (is.na(hash))
+      return(NA_character_)
+
+   paste0(n, ":", hash)
 })
 
 .rs.addFunction("describeCols", function(x,

--- a/src/cpp/session/modules/SessionRUtil.R
+++ b/src/cpp/session/modules/SessionRUtil.R
@@ -226,3 +226,41 @@
 {
    .Call("rs_getSessionOverlayOption", as.character(key), PACKAGE = "(embedding)")
 })
+
+# SHA-256 hex digest of an R value. Avoids pulling in the digest package
+# for the small set of internal places where we need a stable, bounded
+# identity token for an in-memory value.
+#
+# Supports a deliberately limited set of inputs:
+#
+#   - character / raw          -> hashed directly (raw bytes, or each string
+#                                joined with the ASCII Unit Separator so
+#                                names containing reserved characters can't
+#                                collide).
+#   - everything else          -> serialize() then hash.
+#
+# Returns NA_character_ if the C++ hash call fails (e.g. crypto init issue).
+.rs.addFunction("digest", function(x)
+{
+   bytes <- if (is.raw(x))
+   {
+      x
+   }
+   else if (is.character(x))
+   {
+      # Length-prefix to disambiguate c("a", "b") from c("ab"), and use
+      # the Unit Separator (illegal inside any sensible string identifier)
+      # so concatenation can't smear element boundaries.
+      charToRaw(paste(c(length(x), x), collapse = "\x1F"))
+   }
+   else
+   {
+      serialize(x, connection = NULL, ascii = FALSE)
+   }
+
+   hash <- .Call("rs_sha256", bytes, PACKAGE = "(embedding)")
+   if (is.null(hash))
+      NA_character_
+   else
+      hash
+})

--- a/src/cpp/session/modules/SessionRUtil.R
+++ b/src/cpp/session/modules/SessionRUtil.R
@@ -231,32 +231,18 @@
 # for the small set of internal places where we need a stable, bounded
 # identity token for an in-memory value.
 #
-# Supports a deliberately limited set of inputs:
-#
-#   - character / raw          -> hashed directly (raw bytes, or each string
-#                                joined with the ASCII Unit Separator so
-#                                names containing reserved characters can't
-#                                collide).
-#   - everything else          -> serialize() then hash.
+# Raw vectors are hashed directly. Everything else (including character
+# vectors) goes through serialize() so element boundaries are encoded
+# unambiguously -- any hand-rolled framing of a character vector via a
+# delimiter can collide on strings that happen to contain that delimiter.
 #
 # Returns NA_character_ if the C++ hash call fails (e.g. crypto init issue).
 .rs.addFunction("digest", function(x)
 {
    bytes <- if (is.raw(x))
-   {
       x
-   }
-   else if (is.character(x))
-   {
-      # Length-prefix to disambiguate c("a", "b") from c("ab"), and use
-      # the Unit Separator (illegal inside any sensible string identifier)
-      # so concatenation can't smear element boundaries.
-      charToRaw(paste(c(length(x), x), collapse = "\x1F"))
-   }
    else
-   {
       serialize(x, connection = NULL, ascii = FALSE)
-   }
 
    hash <- .Call("rs_sha256", bytes, PACKAGE = "(embedding)")
    if (is.null(hash))

--- a/src/cpp/session/modules/SessionRUtil.cpp
+++ b/src/cpp/session/modules/SessionRUtil.cpp
@@ -27,6 +27,7 @@
 
 #include <core/Log.hpp>
 #include <core/Exec.hpp>
+#include <core/system/Crypto.hpp>
 #include <core/system/Xdg.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/Macros.hpp>
@@ -389,6 +390,35 @@ SEXP rs_userDataDir()
    return r::sexp::createUtf8(userDataDir, &protect);
 }
 
+// SHA-256 hex digest of a raw or character SEXP. Used by .rs.digest as a
+// dependency-free alternative to digest::digest for the (small) set of
+// places we need a stable hash of in-memory R values.
+SEXP rs_sha256(SEXP inputSEXP)
+{
+   std::string input;
+   if (TYPEOF(inputSEXP) == RAWSXP)
+   {
+      input.assign(
+            reinterpret_cast<const char*>(RAW(inputSEXP)),
+            static_cast<std::size_t>(Rf_xlength(inputSEXP)));
+   }
+   else
+   {
+      input = r::sexp::asString(inputSEXP);
+   }
+
+   std::string hashHex;
+   Error error = core::system::crypto::sha256Hex(input, &hashHex);
+   if (error)
+   {
+      LOG_ERROR(error);
+      return R_NilValue;
+   }
+
+   r::sexp::Protect protect;
+   return r::sexp::create(hashHex, &protect);
+}
+
 } // anonymous namespace
 
 Error initialize()
@@ -405,6 +435,7 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_utf8ToSystem);
    RS_REGISTER_CALL_METHOD(rs_getSessionOverlayOption);
    RS_REGISTER_CALL_METHOD(rs_userDataDir);
+   RS_REGISTER_CALL_METHOD(rs_sha256);
 
    using boost::bind;
    using namespace module_context;

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -63,6 +63,13 @@ var AVG_CHAR_REF_STRING =
 var STATE_VERSION = 2;
 var STATE_KEY_PREFIX = "rstudio.dataViewer:";
 
+// Per-load sentinel used in place of a real column fingerprint when the
+// server response omits one. Comparing two sentinels from different page
+// loads always produces a mismatch, so missing fingerprint data triggers
+// state invalidation rather than silently passing the equality check.
+var MISSING_FINGERPRINT_SENTINEL =
+   "__missing__:" + Math.random().toString(36).slice(2) + ":" + Date.now();
+
 // User-facing timings, all in milliseconds. Tweak together when tuning feel.
 var TIMING = {
    filterDebounce: 200,         // numeric/text filter input -> applyFilters
@@ -3377,15 +3384,21 @@ var stateKey = function() {
 // Fingerprint of the underlying frame's column structure. The server
 // computes this from the full column names (not the paginated slice) and
 // returns it on the rownames metadata, so the value stays stable as the
-// user pages through columns. applySavedState uses it to ignore state
-// saved against an incompatible object that was reassigned to the same
-// env+obj name (e.g. df <- mtcars; df <- iris) -- otherwise width/sort/
-// filter indices and per-column filter values would be applied silently
-// to mismatched columns.
+// user pages through columns. Anything that mutates names(x) on the
+// server (reassignment, `names(df) <- ...`, `df$new <- ...`) flips the
+// fingerprint; applySavedState uses it to ignore state saved against an
+// incompatible frame -- otherwise width/sort/filter indices and per-
+// column filter values would be applied silently to mismatched columns.
+//
+// Falls back to a per-load random sentinel when the server omits the
+// fingerprint, so missing data always mismatches saved state instead of
+// silently passing the equality check.
 var columnFingerprint = function() {
-   if (!cols || !cols[0]) return "";
+   if (!cols || !cols[0]) return MISSING_FINGERPRINT_SENTINEL;
    var fp = cols[0].cols_fingerprint;
-   return typeof fp === "string" ? fp : "";
+   return typeof fp === "string" && fp.length > 0
+      ? fp
+      : MISSING_FINGERPRINT_SENTINEL;
 };
 
 var saveState = function() {
@@ -3428,7 +3441,12 @@ var loadSavedState = function() {
       var state = JSON.parse(raw);
       if (state.version !== STATE_VERSION) {
          // Stale schema; remove so it doesn't accumulate forever.
+         // Log once so support can correlate user reports of "my pins
+         // disappeared after upgrade" with the schema bump.
          try { localStorage.removeItem(key); } catch (_) {}
+         console.info(
+            "Data viewer: discarding saved state from older schema (v" +
+            state.version + " -> v" + STATE_VERSION + ")");
          return null;
       }
       return state;
@@ -3454,8 +3472,10 @@ var applySavedState = function(state) {
    // pinned-column indices, manual widths, and filter values are all
    // positional, so applying them to an unrelated frame would corrupt
    // the user's view (e.g. typed filter strings landing on numeric
-   // columns) with no obvious recovery.
-   if (typeof state.columns === "string" &&
+   // columns) with no obvious recovery. Fail-closed: if state.columns
+   // is missing or non-string (older format, corrupt payload), discard
+   // rather than apply blind.
+   if (typeof state.columns !== "string" ||
        state.columns !== columnFingerprint()) {
       clearSavedState();
       return;

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -3169,14 +3169,19 @@ var initGrid = function(resCols, data) {
    window.dataTableMaxColumns = totalCols;
    window.dataTableColumnOffset = 0;
 
-   // Apply the data_viewer_show_summary preference as the default for
-   // objects the user hasn't already customized. When saved state has a
-   // sidebar choice, applySavedState below restores it -- skipping this
-   // overwrite keeps a dismissed summary dismissed across re-bootstraps
-   // from column pagination, where the in-memory sidebarVisible already
-   // reflects the user's choice.
+   // Apply the data_viewer_show_summary preference as the default. When
+   // applySavedState will actually restore a saved sidebar choice (its
+   // fingerprint matches the current frame), skip this overwrite -- that's
+   // what keeps a dismissed sidebar dismissed across re-bootstraps from
+   // column pagination. On a fingerprint mismatch (e.g. object reassigned
+   // to a different column set) applySavedState drops the saved state
+   // without applying its sidebar choice, so the URL default is still
+   // needed.
    var savedState = loadSavedState();
-   if (!savedState || typeof savedState.sidebarVisible !== "boolean") {
+   var willRestoreSidebar = savedState &&
+      typeof savedState.sidebarVisible === "boolean" &&
+      savedState.columns === columnFingerprint();
+   if (!willRestoreSidebar) {
       sidebarVisible = loc.showSummary;
    }
 

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -60,7 +60,7 @@ var AVG_CHAR_REF_STRING =
 // STATE_VERSION when the stored state shape changes incompatibly so old
 // payloads are dropped on next read instead of being applied with
 // mismatched indices.
-var STATE_VERSION = 1;
+var STATE_VERSION = 2;
 var STATE_KEY_PREFIX = "rstudio.dataViewer:";
 
 // User-facing timings, all in milliseconds. Tweak together when tuning feel.
@@ -3169,13 +3169,20 @@ var initGrid = function(resCols, data) {
    window.dataTableMaxColumns = totalCols;
    window.dataTableColumnOffset = 0;
 
-   // Apply the data_viewer_show_summary preference as the default; saved
-   // per-object state (below) overrides it when present.
-   sidebarVisible = loc.showSummary;
+   // Apply the data_viewer_show_summary preference as the default for
+   // objects the user hasn't already customized. When saved state has a
+   // sidebar choice, applySavedState below restores it -- skipping this
+   // overwrite keeps a dismissed summary dismissed across re-bootstraps
+   // from column pagination, where the in-memory sidebarVisible already
+   // reflects the user's choice.
+   var savedState = loadSavedState();
+   if (!savedState || typeof savedState.sidebarVisible !== "boolean") {
+      sidebarVisible = loc.showSummary;
+   }
 
    // Restore saved per-object UI state before headers are built (so pinning
    // order is correct) and before fetchRows (so sort/filters are sent).
-   applySavedState(loadSavedState());
+   applySavedState(savedState);
 
    // Build headers (pinned columns first, then unpinned)
    columnOrder = getColumnOrder();
@@ -3362,18 +3369,18 @@ var stateKey = function() {
       encodeURIComponent(loc.obj);
 };
 
-// Fingerprint of the current column structure -- a join of names lets
-// applySavedState ignore state saved against an incompatible object that
-// was reassigned to the same env+obj name (e.g. df <- mtcars; df <- iris).
-// Width/sort/filter indices and per-column filter values would otherwise
-// be applied silently to mismatched columns.
+// Fingerprint of the underlying frame's column structure. The server
+// computes this from the full column names (not the paginated slice) and
+// returns it on the rownames metadata, so the value stays stable as the
+// user pages through columns. applySavedState uses it to ignore state
+// saved against an incompatible object that was reassigned to the same
+// env+obj name (e.g. df <- mtcars; df <- iris) -- otherwise width/sort/
+// filter indices and per-column filter values would be applied silently
+// to mismatched columns.
 var columnFingerprint = function() {
-   if (!cols) return "";
-   var names = [];
-   for (var i = 0; i < cols.length; i++) {
-      names.push(cols[i].col_name || "");
-   }
-   return names.join(" ");
+   if (!cols || !cols[0]) return "";
+   var fp = cols[0].cols_fingerprint;
+   return typeof fp === "string" ? fp : "";
 };
 
 var saveState = function() {

--- a/src/cpp/tests/testthat/test-dataviewer.R
+++ b/src/cpp/tests/testthat/test-dataviewer.R
@@ -119,6 +119,17 @@ test_that(".rs.describeColSlice() emits a fingerprint stable across pagination",
                     slice_a[[1]]$cols_fingerprint)
 })
 
+test_that(".rs.describeCols() fingerprint distinguishes hyphen-collisions", {
+   # Reassignments like c("a-b", "c") vs c("a", "b-c") must not produce
+   # identical fingerprints, otherwise the per-object state check intended
+   # to detect object reassignment would silently apply mismatched indices.
+   x1 <- setNames(data.frame(1:3, 4:6), c("a-b", "c"))
+   x2 <- setNames(data.frame(1:3, 4:6), c("a", "b-c"))
+   fp1 <- .rs.describeCols(x1)[[1]]$cols_fingerprint
+   fp2 <- .rs.describeCols(x2)[[1]]$cols_fingerprint
+   expect_false(identical(fp1, fp2))
+})
+
 # Helper: strip the rs.scalar class wrapper so tests can compare against
 # bare R values without forcing every expect_equal to know the wrapping.
 .rs.summarize.bare <- function(x) {

--- a/src/cpp/tests/testthat/test-dataviewer.R
+++ b/src/cpp/tests/testthat/test-dataviewer.R
@@ -93,6 +93,32 @@ test_that(".rs.describeColSlice() returns NULL for empty data frames", {
    expect_equal(.rs.describeColSlice(tbl, 1, 1), NULL)
 })
 
+test_that(".rs.describeColSlice() emits a fingerprint stable across pagination", {
+   tbl <- as.data.frame(setNames(
+      replicate(20, 1:5, simplify = FALSE),
+      paste0("X", 1:20)
+   ))
+   slice_a <- .rs.describeColSlice(tbl, 1, 5)
+   slice_b <- .rs.describeColSlice(tbl, 6, 10)
+   slice_c <- .rs.describeColSlice(tbl, 16, 20)
+
+   # Same underlying frame -> identical fingerprint regardless of slice.
+   expect_identical(slice_a[[1]]$cols_fingerprint, slice_b[[1]]$cols_fingerprint)
+   expect_identical(slice_a[[1]]$cols_fingerprint, slice_c[[1]]$cols_fingerprint)
+
+   # A different frame produces a different fingerprint.
+   other <- data.frame(a = 1:5, b = 1:5, c = 1:5)
+   slice_other <- .rs.describeColSlice(other, 1, 3)
+   expect_false(identical(slice_a[[1]]$cols_fingerprint,
+                          slice_other[[1]]$cols_fingerprint))
+
+   # describeCols (the non-paginated path) also emits a fingerprint, and it
+   # matches the slice-path fingerprint for the same underlying frame.
+   direct <- .rs.describeCols(tbl)
+   expect_identical(direct[[1]]$cols_fingerprint,
+                    slice_a[[1]]$cols_fingerprint)
+})
+
 # Helper: strip the rs.scalar class wrapper so tests can compare against
 # bare R values without forcing every expect_equal to know the wrapping.
 .rs.summarize.bare <- function(x) {

--- a/src/cpp/tests/testthat/test-dataviewer.R
+++ b/src/cpp/tests/testthat/test-dataviewer.R
@@ -102,6 +102,11 @@ test_that(".rs.describeColSlice() emits a fingerprint stable across pagination",
    slice_b <- .rs.describeColSlice(tbl, 6, 10)
    slice_c <- .rs.describeColSlice(tbl, 16, 20)
 
+   # The rownames slot is always the first column and is where the
+   # fingerprint is attached. Anchor that here so a refactor that moves
+   # the slot doesn't make the rest of the test silently pass on NULLs.
+   expect_equal(slice_a[[1]]$col_type, .rs.scalar("rownames"))
+
    # Same underlying frame -> identical fingerprint regardless of slice.
    expect_identical(slice_a[[1]]$cols_fingerprint, slice_b[[1]]$cols_fingerprint)
    expect_identical(slice_a[[1]]$cols_fingerprint, slice_c[[1]]$cols_fingerprint)
@@ -128,6 +133,32 @@ test_that(".rs.describeCols() fingerprint distinguishes hyphen-collisions", {
    fp1 <- .rs.describeCols(x1)[[1]]$cols_fingerprint
    fp2 <- .rs.describeCols(x2)[[1]]$cols_fingerprint
    expect_false(identical(fp1, fp2))
+})
+
+test_that(".rs.dataViewer.colsFingerprint() returns NA for empty/NULL names", {
+   # The client treats a null/missing fingerprint as always-mismatch and
+   # discards any saved per-object state -- there's no anchor to align
+   # positional indices against, so applying them would be unsafe.
+   expect_true(is.na(.rs.dataViewer.colsFingerprint(data.frame())))
+
+   noNames <- data.frame(1:3, 4:6)
+   names(noNames) <- NULL
+   expect_true(is.na(.rs.dataViewer.colsFingerprint(noNames)))
+
+   # Empty character vector (the zero-length-names case the client guards
+   # against) must hash to NA, not to digest("")
+   expect_true(is.na(.rs.dataViewer.colsFingerprint(structure(list(), names = character()))))
+})
+
+test_that(".rs.digest() distinguishes character vectors that concat-collide", {
+   # Without length-prefix / unit-separator framing, c("a","b") and
+   # c("ab") would hash identically -- a regression here would silently
+   # weaken the data viewer fingerprint.
+   expect_false(identical(.rs.digest(c("a", "b")), .rs.digest("ab")))
+   expect_false(identical(.rs.digest(c("a-b", "c")), .rs.digest(c("a", "b-c"))))
+
+   # Stable across calls.
+   expect_identical(.rs.digest(c("x", "y")), .rs.digest(c("x", "y")))
 })
 
 # Helper: strip the rs.scalar class wrapper so tests can compare against


### PR DESCRIPTION
## Intent

Addresses #17564.

## Summary

- The data viewer's per-object UI state (sidebar visibility, pinned columns, sort, filters, manual widths) was being silently wiped from `localStorage` on every column-frame pagination. The user-visible symptom is the one reported: dismissing the Summary sidebar and then paginating brings the sidebar back.
- Root cause: the "is this the same underlying frame?" fingerprint was built from the *visible* column slice (`DataViewer.js` `columnFingerprint`), so the fingerprint inevitably mismatched whenever the client paged through columns -- `applySavedState` then called `clearSavedState()` and dropped everything.
- Fix: compute the fingerprint server-side from the *full* set of column names (in `.rs.describeCols` / `.rs.describeColSlice`) and surface it on the rownames metadata as `cols_fingerprint`. The client reads it instead of joining visible names, so it stays stable across pagination and only changes on a legitimate object reassignment.
- Defense in depth: in `initGrid`, the `data_viewer_show_summary` URL default no longer overwrites `sidebarVisible` when saved state already has a sidebar choice.
- Bumped `STATE_VERSION` to 2 so any saved state from the previous schema is cleanly discarded on first read.

## Test plan

- [ ] `df <- data.frame(matrix(1:1000000, nrow = 100000, ncol = 500))`, `View(df)`, dismiss the Summary sidebar, then click the right-paginate arrow. Sidebar stays dismissed.
- [ ] Verify the same with `data_viewer_show_summary` user pref set to off.
- [ ] Pin a column, sort, set a filter; reload the viewer (close + reopen via `View(df)`). State persists.
- [ ] `df <- mtcars; View(df); df <- iris; View(df)`. The iris view comes up fresh (no stale pins/filters from mtcars).
- [ ] `./rstudio-tests --scope r` -- new regression test in `test-dataviewer.R` verifying fingerprint stability across slices.