### PR TITLE
clear nes gutter icon when ghost-text suggestion is dismissed with escape

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 - ([#5809](https://github.com/rstudio/rstudio/issues/5809)): Roxygen tag autocompletion (e.g. `@param`, `@return`) now works on `#'` lines inside R code chunks of R Markdown and Quarto documents, matching the behavior in plain `.R` files.
 
 ### Fixed
+- ([#17363](https://github.com/rstudio/rstudio/issues/17363)): Posit Assistant: pressing Escape to dismiss a ghost-text Next Edit Suggestion now also clears the NES gutter icon; previously the gutter icon remained visible after dismissal.
 - ([#17589](https://github.com/rstudio/rstudio/issues/17589)): The diagnostics report now includes `positai.log` alongside `rdesktop.log` and the user's `rsession-*.log`.
 - ([#17581](https://github.com/rstudio/rstudio/issues/17581)): Diagnostic gutter tooltips no longer show literal `<SPAN>` markup around the message; lint annotations now keep the original text alongside any rendered HTML so the tooltip renders cleanly while the diagnostics popup continues to support ANSI-colored content.
 - ([#17556](https://github.com/rstudio/rstudio/issues/17556)): `difftime` objects (e.g. the result of subtracting two `Sys.time()` values) now show their formatted value in the Environment pane instead of an empty cell.

--- a/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
@@ -388,8 +388,6 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
     });
 
     test('NES dismissed with Escape', async ({ rstudioPage: page }) => {
-      if (key === 'posit-assistant') test.fixme(true, 'Posit Assistant NES gutter icon persists after Escape (https://github.com/rstudio/rstudio/issues/17363)');
-
       const fileName = `${prefix}_nes_dismiss.R`;
 
       const fileContent =

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetAssistantHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetAssistantHelper.java
@@ -1935,8 +1935,7 @@ public class TextEditingTargetAssistantHelper
                         if (!display_.hasActiveAceCompleter())
                         {
                            sendSuggestionFeedback("rejected");
-                           hideGhostText();
-                           editSuggestion_ = null;
+                           resetSuggestion();
                         }
                      }
                   }


### PR DESCRIPTION
## Intent

Addresses #17363.

## Summary

- The Escape handler for revealed ghost-text Next Edit Suggestions only called `hideGhostText()` and nulled `editSuggestion_`, leaving the entry in `nesGutterRegistrations_` in place. Switch it to `resetSuggestion()`, which also runs `clearSuggestionVisuals()` to remove the gutter registration -- this matches the two sibling Escape handlers above.
- The bug is most visible with Posit AI because its NES can deliver suggestions as zero-width (cursor-insertion) ghost text that fall into this branch; Copilot's NES typically lands in the non-ghost-text edit branch above, which was already correct.
- Unfixme the corresponding e2e test (`NES dismissed with Escape` in `code_suggestions.test.ts`) that was tracking this bug.

## Test plan

- [ ] In RStudio with Posit AI configured and NES enabled, reproduce the steps from #17363: edit `result` -> `final_result` on line 6 of the sample file, wait for the NES suggestion, press <kbd>Escape</kbd>, and confirm the gutter icon is gone.
- [ ] Repeat with GitHub Copilot to confirm no regression.
- [ ] Confirm accepting a suggestion (Tab) still clears the gutter icon for both assistants.
- [ ] Run the `NES dismissed with Escape` e2e test against both providers.