### PR TITLE
improve automation runner and add breakpoint regression tests

### DIFF
--- a/src/cpp/core/include/core/system/PosixChildProcessTracker.hpp
+++ b/src/cpp/core/include/core/system/PosixChildProcessTracker.hpp
@@ -36,6 +36,11 @@ class ChildProcessTracker : boost::noncopyable
 {
 public:
 
+  // ExitHandler is called once per reaped child. The int parameter is
+  // the raw waitpid status word -- consumers should use WIFEXITED /
+  // WEXITSTATUS to distinguish a normal exit from WIFSIGNALED /
+  // WTERMSIG (a signal kill), as the encoding differs between the two.
+  // Note that a raw status of 0 unambiguously means exit(0).
   typedef boost::function<void(PidType,int)> ExitHandler;
 
   void addProcess(PidType pid, ExitHandler exitHandler = ExitHandler());

--- a/src/cpp/core/system/PosixChildProcessTracker.cpp
+++ b/src/cpp/core/system/PosixChildProcessTracker.cpp
@@ -77,17 +77,12 @@ void ChildProcessTracker::attemptToReapProcess(
    // reaped the child
    if (result == pid)
    {
-      // confirm this was a real exit
-      bool exited = false;
-      if (WIFEXITED(status))
-      {
-         exited = true;
-         status = WEXITSTATUS(status);
-      }
-      else if (WIFSIGNALED(status))
-      {
-         exited = true;
-      }
+      // confirm this was a real exit (as opposed to SIGSTOP / SIGCONT);
+      // we forward the raw waitpid status word to the handler so callers
+      // can distinguish a normal exit (WIFEXITED) from a signal kill
+      // (WIFSIGNALED) -- decoding here would conflate the two for some
+      // signal numbers.
+      bool exited = WIFEXITED(status) || WIFSIGNALED(status);
 
       // if it was a real exit (as opposed to a SIGSTOP or SIGCONT)
       // then remove the pid from our table and fire the event

--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -537,12 +537,14 @@ Error waitForSignals()
          overlay::shutdown();
 
          // If this SIGTERM was self-sent because the automation host
-         // rsession exited (i.e., test run completed), exit cleanly with
-         // status 0. Re-raising the signal below would terminate us with
-         // exit 143 (128 + SIGTERM), which external test harnesses can't
-         // distinguish from an aborted run. Externally-delivered
-         // termination signals still re-raise and exit with the
-         // conventional 128+signal status.
+         // rsession exited *cleanly* (status 0), exit with status 0.
+         // Re-raising the signal below would terminate us with exit 143
+         // (128 + SIGTERM), which external test harnesses can't
+         // distinguish from an aborted run. A non-clean host exit (crash,
+         // failed startup, test failures) leaves isShuttingDownForAutomation()
+         // false, so we fall through to the conventional re-raise path
+         // and exit with 128+SIGTERM -- signaling failure to the harness.
+         // Externally-delivered termination signals also re-raise.
          if (sig == SIGTERM && server::isShuttingDownForAutomation())
          {
             LOG_INFO_MESSAGE("Automation shutdown complete; exiting with status 0.");

--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -19,6 +19,8 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include <cstdlib>
+
 #include <core/FileLock.hpp>
 #include <core/Log.hpp>
 #include <core/ProgramStatus.hpp>
@@ -533,6 +535,19 @@ Error waitForSignals()
 
          // the overlay shuts down monitored processes that failed to stop
          overlay::shutdown();
+
+         // If this SIGTERM was self-sent because the automation host
+         // rsession exited (i.e., test run completed), exit cleanly with
+         // status 0. Re-raising the signal below would terminate us with
+         // exit 143 (128 + SIGTERM), which external test harnesses can't
+         // distinguish from an aborted run. Externally-delivered
+         // termination signals still re-raise and exit with the
+         // conventional 128+signal status.
+         if (sig == SIGTERM && server::isShuttingDownForAutomation())
+         {
+            LOG_INFO_MESSAGE("Automation shutdown complete; exiting with status 0.");
+            std::exit(0);
+         }
 
          // clear the signal mask
          error = core::system::clearSignalMask();

--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -536,15 +536,12 @@ Error waitForSignals()
          // the overlay shuts down monitored processes that failed to stop
          overlay::shutdown();
 
-         // If this SIGTERM was self-sent because the automation host
-         // rsession exited *cleanly* (status 0), exit with status 0.
-         // Re-raising the signal below would terminate us with exit 143
-         // (128 + SIGTERM), which external test harnesses can't
-         // distinguish from an aborted run. A non-clean host exit (crash,
-         // failed startup, test failures) leaves isShuttingDownForAutomation()
-         // false, so we fall through to the conventional re-raise path
-         // and exit with 128+SIGTERM -- signaling failure to the harness.
-         // Externally-delivered termination signals also re-raise.
+         // Short-circuit the re-raise below for the self-sent SIGTERM
+         // that follows a clean automation host exit; see
+         // s_shuttingDownForAutomation in ServerSessionManager.cpp for
+         // the full rationale (avoids 143-vs-0 ambiguity for external
+         // test harnesses). Externally-delivered SIGTERMs and non-clean
+         // automation exits fall through to the re-raise.
          if (sig == SIGTERM && server::isShuttingDownForAutomation())
          {
             LOG_INFO_MESSAGE("Automation shutdown complete; exiting with status 0.");

--- a/src/cpp/server/include/server/session/ServerSessionManager.hpp
+++ b/src/cpp/server/include/server/session/ServerSessionManager.hpp
@@ -121,9 +121,11 @@ private:
 };
 
 // Returns true if rserver is shutting down because the automation host
-// rsession exited (i.e., the SIGTERM was self-sent from onProcessExit,
-// not delivered externally). Used by the main signal-wait loop to exit
-// with status 0 instead of re-raising SIGTERM (which would yield 143).
+// rsession exited *cleanly* (status 0). Used by the main signal-wait
+// loop to exit with status 0 instead of re-raising SIGTERM (which would
+// yield 143). Returns false for externally-delivered SIGTERMs and for
+// non-zero automation host exits, both of which should fall through to
+// the conventional re-raise path so the harness sees a failure.
 bool isShuttingDownForAutomation();
 
 // set a process config filter

--- a/src/cpp/server/include/server/session/ServerSessionManager.hpp
+++ b/src/cpp/server/include/server/session/ServerSessionManager.hpp
@@ -121,11 +121,8 @@ private:
 };
 
 // Returns true if rserver is shutting down because the automation host
-// rsession exited *cleanly* (status 0). Used by the main signal-wait
-// loop to exit with status 0 instead of re-raising SIGTERM (which would
-// yield 143). Returns false for externally-delivered SIGTERMs and for
-// non-zero automation host exits, both of which should fall through to
-// the conventional re-raise path so the harness sees a failure.
+// rsession exited cleanly. See s_shuttingDownForAutomation in
+// ServerSessionManager.cpp for the full rationale.
 bool isShuttingDownForAutomation();
 
 // set a process config filter

--- a/src/cpp/server/include/server/session/ServerSessionManager.hpp
+++ b/src/cpp/server/include/server/session/ServerSessionManager.hpp
@@ -120,6 +120,12 @@ private:
    core::system::ChildProcessTracker processTracker_;
 };
 
+// Returns true if rserver is shutting down because the automation host
+// rsession exited (i.e., the SIGTERM was self-sent from onProcessExit,
+// not delivered externally). Used by the main signal-wait loop to exit
+// with status 0 instead of re-raising SIGTERM (which would yield 143).
+bool isShuttingDownForAutomation();
+
 // set a process config filter
 void setProcessConfigFilter(const core::system::ProcessConfigFilter& filter);
 

--- a/src/cpp/server/session/ServerSessionManager.cpp
+++ b/src/cpp/server/session/ServerSessionManager.cpp
@@ -68,6 +68,13 @@ static std::string s_launcherToken;
 // than blocking forever in waitForSignals(). Zero means "no host yet".
 static std::atomic<PidType> s_automationHostPid{0};
 
+// Set just before we self-send SIGTERM in onProcessExit. The main signal-
+// wait loop checks isShuttingDownForAutomation() at the end of its SIGTERM
+// branch and std::exit(0)s instead of re-raising the signal -- otherwise
+// the process exits 143 (128 + SIGTERM), and external test harnesses can't
+// distinguish a clean automation completion from an aborted run.
+static std::atomic<bool> s_shuttingDownForAutomation{false};
+
 void readRequestArgs(const core::http::Request& request, core::system::Options *pArgs)
 {
    // we only do this when establishing new sessions via client_init
@@ -294,11 +301,20 @@ void onProcessExit(const std::string& username, PidType pid)
             safe_convert::numberToString(pid) +
             ") exited; signaling rserver shutdown.");
       s_automationHostPid.store(0);
+      // Mark this as the automation shutdown path before sending the
+      // signal so the sigwait loop in ServerMain can distinguish it
+      // from an externally-delivered SIGTERM.
+      s_shuttingDownForAutomation.store(true);
       ::kill(::getpid(), SIGTERM);
    }
 }
 
 } // anonymous namespace
+
+bool isShuttingDownForAutomation()
+{
+   return s_shuttingDownForAutomation.load();
+}
 
 SessionManager& sessionManager()
 {

--- a/src/cpp/server/session/ServerSessionManager.cpp
+++ b/src/cpp/server/session/ServerSessionManager.cpp
@@ -41,6 +41,7 @@
 
 #include <atomic>
 #include <csignal>
+#include <sys/wait.h>
 
 using namespace rstudio::core;
 using namespace boost::placeholders;
@@ -68,6 +69,10 @@ static std::string s_launcherToken;
 // than blocking forever in waitForSignals(). Zero means "no host yet".
 static std::atomic<PidType> s_automationHostPid{0};
 
+// Anchor for the SIGTERM/143 invariant -- ServerMain.cpp and the kill()
+// site in onProcessExit() reference this declaration rather than
+// repeating the rationale, so the explanation stays in one place.
+//
 // Set just before we self-send SIGTERM in onProcessExit, but only when
 // the automation host rsession exited cleanly (status 0). The main
 // signal-wait loop checks isShuttingDownForAutomation() at the end of
@@ -78,6 +83,11 @@ static std::atomic<PidType> s_automationHostPid{0};
 // or test framework reported failures), this stays false so we fall
 // through to the conventional re-raise path -- giving the harness a
 // non-zero exit it can detect.
+//
+// Intentionally one-shot: not reset after the SIGTERM fires, because
+// rserver exits right after that. If the lifecycle ever changes so
+// that rserver can re-host an automation session, this flag will need
+// to be cleared at the start of each run.
 static std::atomic<bool> s_shuttingDownForAutomation{false};
 
 void readRequestArgs(const core::http::Request& request, core::system::Options *pArgs)
@@ -296,25 +306,32 @@ core::system::ProcessConfig sessionProcessConfig(
    return config;
 }
 
-void onProcessExit(const std::string& username, PidType pid, int exitStatus)
+void onProcessExit(const std::string& username, PidType pid, int rawStatus)
 {
    PidType automationHost = s_automationHostPid.load();
    if (automationHost != 0 && pid == automationHost)
    {
+      // Decode the raw waitpid status word so the log distinguishes a
+      // normal exit from a signal kill. A raw status of 0 unambiguously
+      // means exit(0); any other value is treated as a non-clean exit.
+      std::string detail;
+      if (WIFEXITED(rawStatus))
+         detail = "exited with code " + safe_convert::numberToString(WEXITSTATUS(rawStatus));
+      else if (WIFSIGNALED(rawStatus))
+         detail = "killed by signal " + safe_convert::numberToString(WTERMSIG(rawStatus));
+      else
+         detail = "exited (raw waitpid status " + safe_convert::numberToString(rawStatus) + ")";
+
       LOG_INFO_MESSAGE(
             "Automation host rsession (pid " +
             safe_convert::numberToString(pid) +
-            ") exited with status " +
-            safe_convert::numberToString(exitStatus) +
+            ") " + detail +
             "; signaling rserver shutdown.");
       s_automationHostPid.store(0);
-      // Only mark this as a clean automation shutdown when the host
-      // actually exited cleanly. ChildProcessTracker passes 0 here for
-      // a normal exit(0); any other value means the host exited non-zero
-      // or was killed by a signal -- in which case we want rserver to
-      // surface a non-zero status to the external harness rather than
-      // masking the failure as a clean run.
-      s_shuttingDownForAutomation.store(exitStatus == 0);
+      // Mark as a clean automation shutdown only when the host exited
+      // cleanly -- see the s_shuttingDownForAutomation declaration above
+      // for why this gates the std::exit(0) vs SIGTERM re-raise path.
+      s_shuttingDownForAutomation.store(rawStatus == 0);
       ::kill(::getpid(), SIGTERM);
    }
 }
@@ -517,9 +534,9 @@ Error SessionManager::launchAndTrackSession(
       }
    }
 
-   // track it for subsequent reaping. _2 forwards the exit status from
-   // ChildProcessTracker so onProcessExit can distinguish a clean
-   // (status 0) automation host exit from a failure.
+   // track it for subsequent reaping. _2 forwards the raw waitpid
+   // status from ChildProcessTracker so onProcessExit can distinguish
+   // a clean automation host exit from a failure.
    processTracker_.addProcess(pid, boost::bind(onProcessExit,
                                                profile.context.username,
                                                pid,

--- a/src/cpp/server/session/ServerSessionManager.cpp
+++ b/src/cpp/server/session/ServerSessionManager.cpp
@@ -68,11 +68,16 @@ static std::string s_launcherToken;
 // than blocking forever in waitForSignals(). Zero means "no host yet".
 static std::atomic<PidType> s_automationHostPid{0};
 
-// Set just before we self-send SIGTERM in onProcessExit. The main signal-
-// wait loop checks isShuttingDownForAutomation() at the end of its SIGTERM
-// branch and std::exit(0)s instead of re-raising the signal -- otherwise
-// the process exits 143 (128 + SIGTERM), and external test harnesses can't
-// distinguish a clean automation completion from an aborted run.
+// Set just before we self-send SIGTERM in onProcessExit, but only when
+// the automation host rsession exited cleanly (status 0). The main
+// signal-wait loop checks isShuttingDownForAutomation() at the end of
+// its SIGTERM branch and std::exit(0)s instead of re-raising the signal
+// -- otherwise the process exits 143 (128 + SIGTERM), and external test
+// harnesses can't distinguish a clean automation completion from an
+// aborted run. If the host exited non-zero (crashed, failed to start,
+// or test framework reported failures), this stays false so we fall
+// through to the conventional re-raise path -- giving the harness a
+// non-zero exit it can detect.
 static std::atomic<bool> s_shuttingDownForAutomation{false};
 
 void readRequestArgs(const core::http::Request& request, core::system::Options *pArgs)
@@ -291,7 +296,7 @@ core::system::ProcessConfig sessionProcessConfig(
    return config;
 }
 
-void onProcessExit(const std::string& username, PidType pid)
+void onProcessExit(const std::string& username, PidType pid, int exitStatus)
 {
    PidType automationHost = s_automationHostPid.load();
    if (automationHost != 0 && pid == automationHost)
@@ -299,12 +304,17 @@ void onProcessExit(const std::string& username, PidType pid)
       LOG_INFO_MESSAGE(
             "Automation host rsession (pid " +
             safe_convert::numberToString(pid) +
-            ") exited; signaling rserver shutdown.");
+            ") exited with status " +
+            safe_convert::numberToString(exitStatus) +
+            "; signaling rserver shutdown.");
       s_automationHostPid.store(0);
-      // Mark this as the automation shutdown path before sending the
-      // signal so the sigwait loop in ServerMain can distinguish it
-      // from an externally-delivered SIGTERM.
-      s_shuttingDownForAutomation.store(true);
+      // Only mark this as a clean automation shutdown when the host
+      // actually exited cleanly. ChildProcessTracker passes 0 here for
+      // a normal exit(0); any other value means the host exited non-zero
+      // or was killed by a signal -- in which case we want rserver to
+      // surface a non-zero status to the external harness rather than
+      // masking the failure as a clean run.
+      s_shuttingDownForAutomation.store(exitStatus == 0);
       ::kill(::getpid(), SIGTERM);
    }
 }
@@ -507,10 +517,13 @@ Error SessionManager::launchAndTrackSession(
       }
    }
 
-   // track it for subsequent reaping
+   // track it for subsequent reaping. _2 forwards the exit status from
+   // ChildProcessTracker so onProcessExit can distinguish a clean
+   // (status 0) automation host exit from a failure.
    processTracker_.addProcess(pid, boost::bind(onProcessExit,
                                                profile.context.username,
-                                               pid));
+                                               pid,
+                                               _2));
 
    // return success
    return Success();

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1123,25 +1123,38 @@ void rConsoleWrite(const std::string& output, int otype)
    console_output::simulateLatency();
 #endif
 
-   // When running automation tests, tee R's console output to both a
-   // log file (for post-run inspection) and the rsession's inherited
-   // stderr (so a controlling terminal like rserver-dev sees it live).
+#ifndef _WIN32
+   // When running automation tests, tee R's console output to a log
+   // file (for post-run inspection), and also to the rsession's
+   // inherited stderr when stderr is an interactive terminal (so a
+   // controlling terminal like rserver-dev sees it live). Without the
+   // isatty() gate the duplicate would also land in whatever pipe
+   // captured stderr -- e.g. the host RStudio's Console when the
+   // automation run was triggered from inside another RStudio.
    // Normally these writes go only to the IDE event queue below, so
    // there's no other way for a headless test runner to observe them.
+   // POSIX-only: the automation harness uses /tmp/rstudio-automation as
+   // a discoverable fixed path, matching the R-side report directory in
+   // SessionAutomation.R; the Windows automation entrypoint doesn't
+   // currently flow through here.
    if (rsession::options().runAutomation())
    {
-      // Function-local static: opened once on first call (C++11 guarantees
-      // thread-safe initialization), reused thereafter, closed at process
-      // exit. Truncates on open so each test run starts with a clean log.
-      static std::ofstream& automationLog = []() -> std::ofstream& {
-         static std::ofstream stream;
+      // Opened once on first call (C++11 guarantees thread-safe init),
+      // reused thereafter, closed at process exit. Truncates on open so
+      // each test run starts with a clean log.
+      static std::ofstream automationLog = []() -> std::ofstream {
+         std::ofstream stream;
          FilePath logDir("/tmp/rstudio-automation");
          Error error = logDir.ensureDirectory();
          if (error)
+         {
             LOG_ERROR(error);
-         else
-            stream.open(logDir.completePath("console.log").getAbsolutePath(),
-                        std::ios::out | std::ios::trunc);
+            return stream;
+         }
+         std::string logPath = logDir.completePath("console.log").getAbsolutePath();
+         stream.open(logPath, std::ios::out | std::ios::trunc);
+         if (!stream.is_open())
+            LOG_WARNING_MESSAGE("Failed to open automation console log: " + logPath);
          return stream;
       }();
       if (automationLog.is_open())
@@ -1149,9 +1162,14 @@ void rConsoleWrite(const std::string& output, int otype)
          automationLog << output;
          automationLog.flush();
       }
-      std::cerr << output;
-      std::cerr.flush();
+      static const bool stderrIsTty = ::isatty(STDERR_FILENO) != 0;
+      if (stderrIsTty)
+      {
+         std::cerr << output;
+         std::cerr.flush();
+      }
    }
+#endif
 
    // notify listeners
    auto type = (otype == 1)

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -31,6 +31,7 @@
 #include <vector>
 #include <cstdlib>
 #include <csignal>
+#include <fstream>
 
 #include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
@@ -1121,6 +1122,36 @@ void rConsoleWrite(const std::string& output, int otype)
 #ifndef RSTUDIO_PACKAGE_BUILD
    console_output::simulateLatency();
 #endif
+
+   // When running automation tests, tee R's console output to both a
+   // log file (for post-run inspection) and the rsession's inherited
+   // stderr (so a controlling terminal like rserver-dev sees it live).
+   // Normally these writes go only to the IDE event queue below, so
+   // there's no other way for a headless test runner to observe them.
+   if (rsession::options().runAutomation())
+   {
+      // Function-local static: opened once on first call (C++11 guarantees
+      // thread-safe initialization), reused thereafter, closed at process
+      // exit. Truncates on open so each test run starts with a clean log.
+      static std::ofstream& automationLog = []() -> std::ofstream& {
+         static std::ofstream stream;
+         FilePath logDir("/tmp/rstudio-automation");
+         Error error = logDir.ensureDirectory();
+         if (error)
+            LOG_ERROR(error);
+         else
+            stream.open(logDir.completePath("console.log").getAbsolutePath(),
+                        std::ios::out | std::ios::trunc);
+         return stream;
+      }();
+      if (automationLog.is_open())
+      {
+         automationLog << output;
+         automationLog.flush();
+      }
+      std::cerr << output;
+      std::cerr.flush();
+   }
 
    // notify listeners
    auto type = (otype == 1)

--- a/src/cpp/tests/automation/testthat/test-automation-debugger.R
+++ b/src/cpp/tests/automation/testthat/test-automation-debugger.R
@@ -320,3 +320,172 @@ withr::defer(.rs.automation.deleteRemote())
    })
    remote$keyboard.insertText("<Ctrl + L>")
 })
+
+# https://github.com/rstudio/rstudio/issues/9450
+# Clicking a gutter cell that already has a breakpoint should remove both
+# the in-memory entry and the visual marker. Reports of "sticky" breakpoints
+# in the original issue describe markers that survive the second click.
+.rs.test("clicking a top-level breakpoint marker toggles it off", {
+
+   contents <- .rs.heredoc('
+      x <- 1
+      y <- 2
+      z <- x + y
+   ')
+
+   remote$editor.executeWithContents(".R", contents, function(editor) {
+
+      # children[[1L]] is the second gutter cell -- 0-based indexing through
+      # the BRAT R wrapper, so this targets line 2 ("y <- 2"). Top-level
+      # breakpoints land in STATE_ACTIVE immediately, surfacing as the
+      # "ace_breakpoint" class with no STATE_PROCESSING / pending flicker.
+      gutterLayer <- remote$js.querySelector(".ace_gutter-layer")
+      gutterCell <- gutterLayer$children[[1L]]
+      remote$dom.clickElement(objectId = gutterCell, horizontalOffset = -6L)
+
+      .rs.waitUntil("breakpoint marker appears", function() {
+         remote$dom.elementExists(".ace_breakpoint")
+      })
+      breakpointEls <- remote$js.querySelectorAll(".ace_breakpoint")
+      expect_equal(length(breakpointEls), 1L)
+
+      # Click the same gutter cell to toggle the breakpoint off.
+      gutterLayer <- remote$js.querySelector(".ace_gutter-layer")
+      gutterCell <- gutterLayer$children[[1L]]
+      remote$dom.clickElement(objectId = gutterCell, horizontalOffset = -6L)
+
+      # Marker (in any of its visual states) should be gone.
+      .rs.waitUntil("breakpoint marker is removed", function() {
+         !remote$dom.elementExists(".ace_breakpoint") &&
+            !remote$dom.elementExists(".ace_pending-breakpoint") &&
+            !remote$dom.elementExists(".ace_inactive-breakpoint")
+      })
+      expect_false(remote$dom.elementExists(".ace_breakpoint"))
+      expect_false(remote$dom.elementExists(".ace_pending-breakpoint"))
+      expect_false(remote$dom.elementExists(".ace_inactive-breakpoint"))
+   })
+})
+
+# https://github.com/rstudio/rstudio/issues/9450
+# "Clear All Breakpoints" should remove every marker on every line. The
+# original issue reports cases where some markers survived the command.
+.rs.test("Clear All Breakpoints removes every breakpoint marker", {
+
+   contents <- .rs.heredoc('
+      x <- 1
+      y <- 2
+      z <- x + y
+   ')
+
+   remote$editor.executeWithContents(".R", contents, function(editor) {
+
+      # Place a top-level breakpoint on each of the three lines.
+      for (idx in 0:2)
+      {
+         gutterLayer <- remote$js.querySelector(".ace_gutter-layer")
+         gutterCell <- gutterLayer$children[[idx]]
+         remote$dom.clickElement(objectId = gutterCell, horizontalOffset = -6L)
+      }
+
+      .rs.waitUntil("three breakpoint markers present", function() {
+         breakpointEls <- remote$js.querySelectorAll(".ace_breakpoint")
+         length(breakpointEls) == 3L
+      })
+      breakpointEls <- remote$js.querySelectorAll(".ace_breakpoint")
+      expect_equal(length(breakpointEls), 3L)
+
+      # Invoke Clear All Breakpoints; this fires a Yes/No confirmation
+      # before BreakpointManager.clearAllBreakpoints() runs.
+      remote$commands.execute("debugClearBreakpoints")
+      remote$dom.waitForElement("#rstudio_dlg_yes")
+      remote$dom.clickElement("#rstudio_dlg_yes")
+
+      .rs.waitUntil("all breakpoint markers removed", function() {
+         !remote$dom.elementExists(".ace_breakpoint") &&
+            !remote$dom.elementExists(".ace_pending-breakpoint") &&
+            !remote$dom.elementExists(".ace_inactive-breakpoint")
+      })
+      expect_false(remote$dom.elementExists(".ace_breakpoint"))
+      expect_false(remote$dom.elementExists(".ace_pending-breakpoint"))
+      expect_false(remote$dom.elementExists(".ace_inactive-breakpoint"))
+   })
+})
+
+# https://github.com/rstudio/rstudio/issues/9450
+# Pisca46's report: a package breakpoint that has been clicked off should
+# stay off across a package rebuild. PackageLoadedEvent triggers
+# BreakpointManager.updatePackageBreakpoints(); with the breakpoint already
+# removed from breakpoints_, no marker should reappear.
+.rs.test("cleared package breakpoints stay cleared across rebuild", {
+
+   remote$project.create(projectName = "rstudio.automation", type = "package")
+   withr::defer({
+      remote$editor.closeDocument()
+      Sys.sleep(1)
+      remote$project.close()
+   })
+
+   # Close any open documents from the project template.
+   remote$console.executeExpr(
+      .rs.api.closeAllSourceBuffersWithoutSaving()
+   )
+
+   # Add a source document with a function we can set a breakpoint inside.
+   remote$console.executeExpr(file.edit("R/example.R"))
+   remote$commands.execute("activateSource")
+
+   code <- .rs.heredoc('
+      example <- function() {
+         1 + 1
+         2 + 2
+         3 + 3
+      }
+   ')
+
+   editor <- remote$editor.getInstance()
+   editor$insert(code)
+   Sys.sleep(0.1)
+
+   remote$commands.execute("saveSourceDoc")
+   remote$commands.execute("buildAll")
+   .rs.waitUntil("build has completed", function() {
+      output <- remote$console.getOutput()
+      any(output == "> library(rstudio.automation)")
+   }, swallowErrors = TRUE)
+   remote$console.clear()
+
+   # Place a function breakpoint on line 3 ("2 + 2") -- this exercises the
+   # TYPE_FUNCTION / package path that goes through trace() in R, as opposed
+   # to the simpler TYPE_TOPLEVEL flow in the earlier tests. We use the same
+   # gutterEls index ([[3]]) and offset as test-automation-debugger.R's
+   # "package functions can be debugged after build and reload" test.
+   gutterEls <- remote$js.querySelectorAll(".ace_gutter-cell")
+   remote$dom.clickElement(objectId = gutterEls[[3]], horizontalOffset = -4L)
+   .rs.waitUntil("breakpoint marker appears", function() {
+      remote$dom.elementExists(".ace_breakpoint")
+   })
+
+   # Click the same gutter cell again to remove the breakpoint.
+   gutterEls <- remote$js.querySelectorAll(".ace_gutter-cell")
+   remote$dom.clickElement(objectId = gutterEls[[3]], horizontalOffset = -4L)
+   .rs.waitUntil("breakpoint marker is removed", function() {
+      !remote$dom.elementExists(".ace_breakpoint") &&
+         !remote$dom.elementExists(".ace_pending-breakpoint") &&
+         !remote$dom.elementExists(".ace_inactive-breakpoint")
+   })
+
+   # Rebuild the package. PackageLoadedEvent fires on completion and runs
+   # BreakpointManager.updatePackageBreakpoints("rstudio.automation", true);
+   # with breakpoints_ empty, this should be a no-op.
+   remote$console.clear()
+   remote$commands.execute("buildAll")
+   .rs.waitUntil("rebuild has completed", function() {
+      output <- remote$console.getOutput()
+      any(output == "> library(rstudio.automation)")
+   }, swallowErrors = TRUE)
+
+   # No marker of any kind should have reappeared.
+   expect_false(remote$dom.elementExists(".ace_breakpoint"))
+   expect_false(remote$dom.elementExists(".ace_pending-breakpoint"))
+   expect_false(remote$dom.elementExists(".ace_inactive-breakpoint"))
+})

--- a/src/cpp/tests/automation/testthat/test-automation-debugger.R
+++ b/src/cpp/tests/automation/testthat/test-automation-debugger.R
@@ -339,6 +339,9 @@ withr::defer(.rs.automation.deleteRemote())
       # the BRAT R wrapper, so this targets line 2 ("y <- 2"). Top-level
       # breakpoints land in STATE_ACTIVE immediately, surfacing as the
       # "ace_breakpoint" class with no STATE_PROCESSING / pending flicker.
+      # horizontalOffset of -6L targets the breakpoint area in the
+      # top-level (non-package) gutter; package projects render a
+      # slightly different gutter and use -4L (see the package test below).
       gutterLayer <- remote$js.querySelector(".ace_gutter-layer")
       gutterCell <- gutterLayer$children[[1L]]
       remote$dom.clickElement(objectId = gutterCell, horizontalOffset = -6L)
@@ -421,6 +424,10 @@ withr::defer(.rs.automation.deleteRemote())
    remote$project.create(projectName = "rstudio.automation", type = "package")
    withr::defer({
       remote$editor.closeDocument()
+      # Defensive pause: closeDocument() returns before the IDE has
+      # fully unwound the document; closing the project too eagerly
+      # races with the unsaved-changes path and the dirty-state probe
+      # of the editor instance.
       Sys.sleep(1)
       remote$project.close()
    })
@@ -444,21 +451,31 @@ withr::defer(.rs.automation.deleteRemote())
 
    editor <- remote$editor.getInstance()
    editor$insert(code)
-   Sys.sleep(0.1)
+   .rs.waitUntil("code is present in editor", function() {
+      grepl("example <- function", editor$getValue(), fixed = TRUE)
+   })
 
    remote$commands.execute("saveSourceDoc")
    remote$commands.execute("buildAll")
+   # Short-circuit with the last lines of console output if the build
+   # crashes or errors -- otherwise a generic .rs.waitUntil() timeout
+   # shows up downstream as a confusing subscript error on gutterEls[[3]].
    .rs.waitUntil("build has completed", function() {
       output <- remote$console.getOutput()
+      if (any(grepl("Execution halted|^ERROR\\b", output)))
+         stop("build failed:\n",
+              paste(utils::tail(output, 20), collapse = "\n"))
       any(output == "> library(rstudio.automation)")
-   }, swallowErrors = TRUE)
+   })
    remote$console.clear()
 
    # Place a function breakpoint on line 3 ("2 + 2") -- this exercises the
    # TYPE_FUNCTION / package path that goes through trace() in R, as opposed
-   # to the simpler TYPE_TOPLEVEL flow in the earlier tests. We use the same
-   # gutterEls index ([[3]]) and offset as test-automation-debugger.R's
-   # "package functions can be debugged after build and reload" test.
+   # to the simpler TYPE_TOPLEVEL flow in the earlier tests. The horizontal
+   # offset of -4L (vs -6L for top-level files above) targets the package
+   # gutter's breakpoint area; the value mirrors the #15201 test ("package
+   # functions can be debugged after build and reload") and is empirically
+   # calibrated -- package projects render a slightly different gutter.
    gutterEls <- remote$js.querySelectorAll(".ace_gutter-cell")
    remote$dom.clickElement(objectId = gutterEls[[3]], horizontalOffset = -4L)
    .rs.waitUntil("breakpoint marker appears", function() {
@@ -481,8 +498,11 @@ withr::defer(.rs.automation.deleteRemote())
    remote$commands.execute("buildAll")
    .rs.waitUntil("rebuild has completed", function() {
       output <- remote$console.getOutput()
+      if (any(grepl("Execution halted|^ERROR\\b", output)))
+         stop("rebuild failed:\n",
+              paste(utils::tail(output, 20), collapse = "\n"))
       any(output == "> library(rstudio.automation)")
-   }, swallowErrors = TRUE)
+   })
 
    # No marker of any kind should have reappeared.
    expect_false(remote$dom.elementExists(".ace_breakpoint"))

--- a/src/cpp/tests/automation/testthat/test-automation-smoke.R
+++ b/src/cpp/tests/automation/testthat/test-automation-smoke.R
@@ -1,0 +1,13 @@
+
+library(testthat)
+
+self <- remote <- .rs.automation.newRemote()
+withr::defer(.rs.automation.deleteRemote())
+
+# Trivial smoke test for iterating on the automation harness itself
+# (e.g., output capture, exit-code wiring). Keep the body minimal so
+# Chrome launch dominates the wall time; this file exists so we don't
+# have to run the full debugger suite to validate harness changes.
+.rs.test("automation harness smoke test", {
+   expect_true(TRUE)
+})


### PR DESCRIPTION
## Summary

Two related improvements to the BRAT automation harness, plus regression tests for issue #9450 (sticky breakpoints):

- **Clean exit status for automation runs.** When the automation host `rsession` exits, `ServerSessionManager` self-sends SIGTERM to shut down `rserver`. The signal-wait loop in `ServerMain` previously re-raised SIGTERM, terminating with status 143 (128 + SIGTERM) -- indistinguishable to external test harnesses from an aborted run. Now we mark the automation shutdown path via `isShuttingDownForAutomation()` and `std::exit(0)` instead; externally-delivered SIGTERMs still re-raise as before.
- **Visible console output during automation.** `rConsoleWrite()` now tees R's console output to both the inherited stderr (so a controlling terminal like `rserver-dev` sees it live) and `/tmp/rstudio-automation/console.log` (for post-run inspection) when `runAutomation()` is set. Without this, the only sink for console output was the IDE event queue, which a headless test runner can't observe.
- **Regression tests for #9450.** Three new tests in `test-automation-debugger.R` cover top-level breakpoint toggle, Clear All Breakpoints, and package-breakpoint persistence across a rebuild. Adds `test-automation-smoke.R` for iterating on the harness itself without running the full debugger suite.

## Test plan

- [ ] `./rserver-dev --run-automation --automation-filter=automation-smoke` exits with status 0 and prints console output to the terminal
- [ ] `./rserver-dev --run-automation --automation-filter=automation-debugger` -- all three new breakpoint tests pass
- [ ] An externally-delivered `kill <rserver-pid>` still exits with status 143 (verify the automation-path check doesn't swallow real SIGTERMs)