### PR TITLE
Add posit_assistant_test_manifest user preference

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -463,6 +463,7 @@ namespace prefs {
 #define kAssistantNesAutoshow "assistant_nes_autoshow"
 #define kAssistantShowMessages "assistant_show_messages"
 #define kAssistantToolbarButtonVisible "assistant_toolbar_button_visible"
+#define kPositAssistantTestManifest "posit_assistant_test_manifest"
 #define kCopilotEnabled "copilot_enabled"
 #define kCopilotCompletionsTrigger "copilot_completions_trigger"
 #define kCopilotCompletionsTriggerAuto "auto"
@@ -2125,6 +2126,12 @@ public:
     */
    bool assistantToolbarButtonVisible();
    core::Error setAssistantToolbarButtonVisible(bool val);
+
+   /**
+    * Use a pre-release version of the Posit Assistant for testing purposes. Do not use for production work.
+    */
+   bool positAssistantTestManifest();
+   core::Error setPositAssistantTestManifest(bool val);
 
    /**
     * When enabled, RStudio will use GitHub Copilot to provide code suggestions.

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -3564,8 +3564,11 @@ Error downloadManifest(json::Object* pManifest)
    }
 #endif
 
-   // Get download URI; use test manifest when opted in
-   std::string downloadUri = options().positAssistantTestManifest()
+   // Get download URI; use test manifest when opted in via either the
+   // command-line/session option or the user preference.
+   bool useTestManifest = options().positAssistantTestManifest() ||
+                          prefs::userPrefs().positAssistantTestManifest();
+   std::string downloadUri = useTestManifest
       ? "https://cdn.posit.co/posit-ai/manifest-test.json"
       : "https://cdn.posit.co/posit-ai/manifest.json";
 

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -3691,6 +3691,27 @@ void showRStudioVersionWarning(
    module_context::enqueClientEvent(event);
 }
 
+// Show warning bar when Posit Assistant is using the test manifest.
+void showTestManifestWarning()
+{
+   json::Object msgJson;
+   msgJson["severe"] = false;
+   msgJson["message"] =
+      "Posit Assistant is using the pre-release (test) manifest. "
+      "Do not use for production work.";
+   ClientEvent event(client_events::kShowWarningBar, msgJson);
+   module_context::enqueClientEvent(event);
+}
+
+void onDeferredInit(bool)
+{
+   if (options().positAssistantTestManifest() ||
+       prefs::userPrefs().positAssistantTestManifest())
+   {
+      showTestManifestWarning();
+   }
+}
+
 // Constraints from the manifest's "unsupported" object. Versions below
 // minimumPackageVersion or listed in packageVersions are blocked, as are
 // listed protocol versions.
@@ -5788,6 +5809,7 @@ Error initialize()
    events().onBackgroundProcessing.connect(onBackgroundProcessing);
    events().onShutdown.connect(onShutdown);
    events().onProjectOptionsUpdated.connect(onProjectOptionsUpdated);
+   events().onDeferredInit.connect(onDeferredInit);
 
    // Register handler to detect session close (vs suspend/restart)
    events().onQuit.connect([]() {

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -2531,6 +2531,16 @@
    clear = function() { .rs.clearUserPref("assistant_toolbar_button_visible") }
 )
 
+# Use pre-release version of Posit Assistant (restart required)
+#
+# Use a pre-release version of the Posit Assistant for testing purposes. Do not
+# use for production work.
+.rs.uiPrefs$positAssistantTestManifest <- list(
+   get = function() { .rs.getUserPref("posit_assistant_test_manifest") },
+   set = function(value) { .rs.setUserPref("posit_assistant_test_manifest", value) },
+   clear = function() { .rs.clearUserPref("posit_assistant_test_manifest") }
+)
+
 # Enable GitHub Copilot
 #
 # When enabled, RStudio will use GitHub Copilot to provide code suggestions.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -3547,6 +3547,19 @@ core::Error UserPrefValues::setAssistantToolbarButtonVisible(bool val)
 }
 
 /**
+ * Use a pre-release version of the Posit Assistant for testing purposes. Do not use for production work.
+ */
+bool UserPrefValues::positAssistantTestManifest()
+{
+   return readPref<bool>("posit_assistant_test_manifest");
+}
+
+core::Error UserPrefValues::setPositAssistantTestManifest(bool val)
+{
+   return writePref("posit_assistant_test_manifest", val);
+}
+
+/**
  * When enabled, RStudio will use GitHub Copilot to provide code suggestions.
  */
 bool UserPrefValues::copilotEnabled()
@@ -4054,6 +4067,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kAssistantNesAutoshow,
       kAssistantShowMessages,
       kAssistantToolbarButtonVisible,
+      kPositAssistantTestManifest,
       kCopilotEnabled,
       kCopilotCompletionsTrigger,
       kCopilotCompletionsDelay,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1869,6 +1869,12 @@
             "title": "Show Posit Assistant button in toolbar",
             "description": "When enabled, the Posit Assistant button is displayed in the main toolbar."
         },
+        "posit_assistant_test_manifest": {
+            "type": "boolean",
+            "default": false,
+            "title": "Use pre-release version of Posit Assistant (restart required)",
+            "description": "Use a pre-release version of the Posit Assistant for testing purposes. Do not use for production work."
+        },
         "copilot_enabled": {
             "type": "boolean",
             "default": false,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -315,6 +315,7 @@ public class UserPrefsAccessor extends Prefs
    public static final String ASSISTANT_NES_AUTOSHOW = "assistant_nes_autoshow";
    public static final String ASSISTANT_SHOW_MESSAGES = "assistant_show_messages";
    public static final String ASSISTANT_TOOLBAR_BUTTON_VISIBLE = "assistant_toolbar_button_visible";
+   public static final String POSIT_ASSISTANT_TEST_MANIFEST = "posit_assistant_test_manifest";
    public static final String COPILOT_ENABLED = "copilot_enabled";
    public static final String COPILOT_COMPLETIONS_TRIGGER = "copilot_completions_trigger";
    public static final String COPILOT_COMPLETIONS_DELAY = "copilot_completions_delay";
@@ -4184,6 +4185,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Use a pre-release version of the Posit Assistant for testing purposes. Do not use for production work.
+    */
+   public PrefValue<Boolean> positAssistantTestManifest()
+   {
+      return bool(
+         "posit_assistant_test_manifest",
+         _constants.positAssistantTestManifestTitle(), 
+         _constants.positAssistantTestManifestDescription(), 
+         false);
+   }
+
+   /**
     * When enabled, RStudio will use GitHub Copilot to provide code suggestions.
     */
    public PrefValue<Boolean> copilotEnabled()
@@ -5007,6 +5020,8 @@ public class UserPrefsAccessor extends Prefs
          assistantShowMessages().setValue(layer, source.getBool("assistant_show_messages"));
       if (source.hasKey("assistant_toolbar_button_visible"))
          assistantToolbarButtonVisible().setValue(layer, source.getBool("assistant_toolbar_button_visible"));
+      if (source.hasKey("posit_assistant_test_manifest"))
+         positAssistantTestManifest().setValue(layer, source.getBool("posit_assistant_test_manifest"));
       if (source.hasKey("copilot_enabled"))
          copilotEnabled().setValue(layer, source.getBool("copilot_enabled"));
       if (source.hasKey("copilot_completions_trigger"))
@@ -5318,6 +5333,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(assistantNesAutoshow());
       prefs.add(assistantShowMessages());
       prefs.add(assistantToolbarButtonVisible());
+      prefs.add(positAssistantTestManifest());
       prefs.add(copilotEnabled());
       prefs.add(copilotCompletionsTrigger());
       prefs.add(copilotCompletionsDelay());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -2276,6 +2276,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String assistantToolbarButtonVisibleDescription();
 
    /**
+    * Use a pre-release version of the Posit Assistant for testing purposes. Do not use for production work.
+    */
+   @DefaultStringValue("Use pre-release version of Posit Assistant (restart required)")
+   String positAssistantTestManifestTitle();
+   @DefaultStringValue("Use a pre-release version of the Posit Assistant for testing purposes. Do not use for production work.")
+   String positAssistantTestManifestDescription();
+
+   /**
     * When enabled, RStudio will use GitHub Copilot to provide code suggestions.
     */
    @DefaultStringValue("Enable GitHub Copilot")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -1143,6 +1143,10 @@ assistantShowMessagesDescription = When enabled, RStudio will show messages from
 assistantToolbarButtonVisibleTitle = Show Posit Assistant button in toolbar
 assistantToolbarButtonVisibleDescription = When enabled, the Posit Assistant button is displayed in the main toolbar.
 
+# Use a pre-release version of the Posit Assistant for testing purposes. Do not use for production work.
+positAssistantTestManifestTitle = Use pre-release version of Posit Assistant (restart required)
+positAssistantTestManifestDescription = Use a pre-release version of the Posit Assistant for testing purposes. Do not use for production work.
+
 # When enabled, RStudio will use GitHub Copilot to provide code suggestions.
 copilotEnabledTitle = Enable GitHub Copilot
 copilotEnabledDescription = When enabled, RStudio will use GitHub Copilot to provide code suggestions.


### PR DESCRIPTION
## Summary
- Adds the `posit_assistant_test_manifest` user preference; when true, RStudio downloads the pre-release Posit Assistant manifest (`manifest-test.json`) instead of `manifest.json`. The existing `posit-assistant-test-manifest` session option / command-line switch continues to work, and either source enabling the test manifest is sufficient.
- The preference is intentionally not surfaced in the Assistant preferences pane; it is only reachable via the command palette.
- Changing the preference requires a restart; this must be done manually (command-palette pref changes don't trigger restarts)
- On every session start, a non-severe warning bar is shown when test-manifest mode is active so the state is visible to the user.

### Command Palette

<img width="626" height="125" alt="command-palette" src="https://github.com/user-attachments/assets/548037a4-9a35-432f-af65-de5c13895ac1" />

### Warning bar

<img width="603" height="125" alt="warning-bar" src="https://github.com/user-attachments/assets/7279e97c-d5d4-453d-8962-351ab6ee3edd" />

## Test plan
- [x] Build RStudio Desktop with these changes.
- [x] Confirm `posit_assistant_test_manifest` appears in the command palette (via the standard pref-to-palette wiring) and toggling it persists.
- [x] With the pref disabled and the session option unset, restart and confirm RStudio downloads `https://cdn.posit.co/posit-ai/manifest.json` (verify in chat logs).
- [x] Enable the pref, restart, and confirm RStudio downloads `https://cdn.posit.co/posit-ai/manifest-test.json` and shows the "pre-release (test) manifest" warning bar.
- [x] Disable the pref but launch with `--posit-assistant-test-manifest`; confirm the test manifest is still used and the warning bar appears.