### PR TITLE
fix styler reformat adding newlines on windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 - ([#5809](https://github.com/rstudio/rstudio/issues/5809)): Roxygen tag autocompletion (e.g. `@param`, `@return`) now works on `#'` lines inside R code chunks of R Markdown and Quarto documents, matching the behavior in plain `.R` files.
 
 ### Fixed
+- ([#17471](https://github.com/rstudio/rstudio/issues/17471)): Reformat Document with the styler formatter no longer inserts extra blank lines on Windows. The temporary file written by styler uses platform-native line endings (CRLF on Windows), and RStudio now normalizes those to LF when computing the edits to apply, so the diff against the LF-normalized in-memory document doesn't produce spurious `\r` insertions that Ace would convert into blank lines.
 - ([#17363](https://github.com/rstudio/rstudio/issues/17363)): Posit Assistant: pressing Escape to dismiss a ghost-text Next Edit Suggestion now also clears the NES gutter icon; previously the gutter icon remained visible after dismissal.
 - ([#17589](https://github.com/rstudio/rstudio/issues/17589)): The diagnostics report now includes `positai.log` alongside `rdesktop.log` and the user's `rsession-*.log`.
 - ([#17581](https://github.com/rstudio/rstudio/issues/17581)): Diagnostic gutter tooltips no longer show literal `<SPAN>` markup around the message; lint annotations now keep the original text alongside any rendered HTML so the tooltip renders cleanly while the diagnostics popup continues to support ANSI-colored content.

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -959,7 +959,9 @@ Error formatDocument(
       // Read the newly-formatted document, normalizing line endings so that
       // line-ending differences between the in-memory document (LF) and the
       // formatter output (potentially CRLF on Windows) don't produce spurious
-      // edits.
+      // \r insertions in the diff. Such \r insertions would be turned into
+      // extra newlines on the client by Ace's Document.$split regex when
+      // applied via replaceRange. See issue 17471.
       std::string formatted;
       error = core::readStringFromFile(codePath, &formatted, string_utils::LineEndingPosix);
       if (error)
@@ -1025,8 +1027,10 @@ Error formatCode(
    return formatDocumentImpl(codePath, continuation, [=]()
    {
       // read from the tempfile we wrote, normalizing line endings so that
-      // CRLF written by some formatters on Windows doesn't produce spurious
-      // edits when diffed against the LF-normalized document contents
+      // CRLF written by some formatters on Windows doesn't leave stray \r
+      // characters in the result; Ace's Document.$split regex would turn
+      // those into extra newlines when the result is inserted via
+      // replaceRange. See issue 17471.
       std::string code;
       Error error = readStringFromFile(codePath, &code, string_utils::LineEndingPosix);
       if (error)

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -956,9 +956,12 @@ Error formatDocument(
       Error error;
       json::JsonRpcResponse response;
 
-      // Read the newly-formatted document
+      // Read the newly-formatted document, normalizing line endings so that
+      // line-ending differences between the in-memory document (LF) and the
+      // formatter output (potentially CRLF on Windows) don't produce spurious
+      // edits.
       std::string formatted;
-      error = core::readStringFromFile(codePath, &formatted);
+      error = core::readStringFromFile(codePath, &formatted, string_utils::LineEndingPosix);
       if (error)
          LOG_ERROR(error);
 
@@ -1021,16 +1024,16 @@ Error formatCode(
    FilePath codeDir = data.codeDir;
    return formatDocumentImpl(codePath, continuation, [=]()
    {
-      // read from the tempfile we wrote
+      // read from the tempfile we wrote, normalizing line endings so that
+      // CRLF written by some formatters on Windows doesn't produce spurious
+      // edits when diffed against the LF-normalized document contents
       std::string code;
-      Error error = readStringFromFile(codePath, &code);
+      Error error = readStringFromFile(codePath, &code, string_utils::LineEndingPosix);
       if (error)
          LOG_ERROR(error);
 
       // trim a final newline in the formatted selection
-      if (boost::algorithm::ends_with(code, "\r\n"))
-         code = code.substr(0, code.length() - 2);
-      else if (boost::algorithm::ends_with(code, "\n"))
+      if (boost::algorithm::ends_with(code, "\n"))
          code = code.substr(0, code.length() - 1);
 
       // add back in the indent we computed (only if air formatter was used)

--- a/src/cpp/tests/automation/testthat/test-automation-reformat.R
+++ b/src/cpp/tests/automation/testthat/test-automation-reformat.R
@@ -23,11 +23,11 @@ remote$console.executeExpr({
 })
 
 .rs.test("styler: documents can be reformatted on save", {
-   
+
    skip_on_ci()
    if (!remote$package.isInstalled("styler"))
       skip("styler is not installed")
-   
+
    remote$console.executeExpr({
       .rs.uiPrefs$reformatOnSave$set(TRUE)
       .rs.uiPrefs$codeFormatter$set("styler")
@@ -35,7 +35,7 @@ remote$console.executeExpr({
 
    name <- basename(tempfile("script-", fileext = ".R"))
    remote$editor.openDocument(name)
-   
+
    editor <- remote$editor.getInstance()
    editor$insert("1+1; 2+2")
    remote$keyboard.insertText("<Ctrl + S>")
@@ -47,11 +47,48 @@ remote$console.executeExpr({
    })
    expect_equal(contents, "1 + 1\n2 + 2\n")
    remote$editor.closeDocument()
-   
+
    remote$console.executeExpr({
       .rs.uiPrefs$reformatOnSave$set(FALSE)
       .rs.uiPrefs$codeFormatter$set("none")
    })
+})
+
+# https://github.com/rstudio/rstudio/issues/17471
+.rs.test("styler: Reformat Document does not add extra newlines", {
+
+   skip_on_ci()
+   if (!remote$package.isInstalled("styler"))
+      skip("styler is not installed")
+
+   remote$console.executeExpr({
+      .rs.uiPrefs$codeFormatter$set("styler")
+   })
+   withr::defer(remote$console.executeExpr({
+      .rs.uiPrefs$codeFormatter$set("none")
+   }))
+
+   # Two lines of code followed by a blank line. styler's writeLines on
+   # Windows would write CRLF; without the line-ending normalization fix,
+   # the diff against the LF-normalized document inserts \r characters
+   # that Ace turns into extra blank lines between the two statements.
+   initial <- "print(\"test\")\nprint(\"test\")\n\n"
+   remote$editor.executeWithContents(".R", initial, function(editor) {
+      remote$commands.execute(.rs.appCommands$reformatDocument)
+      contents <- .rs.waitUntil("document is reformatted", function() {
+         contents <- editor$getValue()
+         if (contents != initial)
+            return(contents)
+         return(FALSE)
+      })
+      expect_equal(contents, "print(\"test\")\nprint(\"test\")\n")
+
+      # Reformatting again should leave the document unchanged.
+      remote$commands.execute(.rs.appCommands$reformatDocument)
+      Sys.sleep(1)
+      expect_equal(editor$getValue(), "print(\"test\")\nprint(\"test\")\n")
+   })
+
 })
 
 .rs.test("air: documents can be reformatted on save", {

--- a/src/cpp/tests/automation/testthat/test-automation-reformat.R
+++ b/src/cpp/tests/automation/testthat/test-automation-reformat.R
@@ -23,11 +23,11 @@ remote$console.executeExpr({
 })
 
 .rs.test("styler: documents can be reformatted on save", {
-
+   
    skip_on_ci()
    if (!remote$package.isInstalled("styler"))
       skip("styler is not installed")
-
+   
    remote$console.executeExpr({
       .rs.uiPrefs$reformatOnSave$set(TRUE)
       .rs.uiPrefs$codeFormatter$set("styler")
@@ -35,7 +35,7 @@ remote$console.executeExpr({
 
    name <- basename(tempfile("script-", fileext = ".R"))
    remote$editor.openDocument(name)
-
+   
    editor <- remote$editor.getInstance()
    editor$insert("1+1; 2+2")
    remote$keyboard.insertText("<Ctrl + S>")
@@ -47,7 +47,7 @@ remote$console.executeExpr({
    })
    expect_equal(contents, "1 + 1\n2 + 2\n")
    remote$editor.closeDocument()
-
+   
    remote$console.executeExpr({
       .rs.uiPrefs$reformatOnSave$set(FALSE)
       .rs.uiPrefs$codeFormatter$set("none")
@@ -55,9 +55,16 @@ remote$console.executeExpr({
 })
 
 # https://github.com/rstudio/rstudio/issues/17471
-.rs.test("styler: Reformat Document does not add extra newlines", {
+# Bug is Windows-only: styler's writeLines writes CRLF on Windows, which
+# the formatter callers then read back. Without LineEndingPosix normalization
+# the character-level diff against the LF-normalized in-memory document
+# produces \r insertions before each \n; on the client, Ace's Document.$split
+# regex turns each inserted bare \r into another \n, doubling line breaks.
+# On macOS/Linux styler writes LF and the bug doesn't manifest.
+.rs.test("styler: Reformat Document does not add extra newlines on Windows", {
 
    skip_on_ci()
+   skip_if(!.rs.platform.isWindows, "styler only writes CRLF on Windows")
    if (!remote$package.isInstalled("styler"))
       skip("styler is not installed")
 
@@ -68,11 +75,8 @@ remote$console.executeExpr({
       .rs.uiPrefs$codeFormatter$set("none")
    }))
 
-   # Two lines of code followed by a blank line. styler's writeLines on
-   # Windows would write CRLF; without the line-ending normalization fix,
-   # the diff against the LF-normalized document inserts \r characters
-   # that Ace turns into extra blank lines between the two statements.
    initial <- "print(\"test\")\nprint(\"test\")\n\n"
+   expected <- "print(\"test\")\nprint(\"test\")\n"
    remote$editor.executeWithContents(".R", initial, function(editor) {
       remote$commands.execute(.rs.appCommands$reformatDocument)
       contents <- .rs.waitUntil("document is reformatted", function() {
@@ -81,12 +85,41 @@ remote$console.executeExpr({
             return(contents)
          return(FALSE)
       })
-      expect_equal(contents, "print(\"test\")\nprint(\"test\")\n")
+      expect_equal(contents, expected)
+   })
 
-      # Reformatting again should leave the document unchanged.
-      remote$commands.execute(.rs.appCommands$reformatDocument)
-      Sys.sleep(1)
-      expect_equal(editor$getValue(), "print(\"test\")\nprint(\"test\")\n")
+})
+
+# Regression test for the selection-reformat (formatCode) code path of #17471.
+# The full-document path is covered above; this also guards against stray \r
+# being left in selection-reformat output if line-ending normalization is
+# later dropped from the C++ formatCode handler.
+.rs.test("styler: Reformat Code (selection) does not add extra newlines on Windows", {
+
+   skip_on_ci()
+   skip_if(!.rs.platform.isWindows, "styler only writes CRLF on Windows")
+   if (!remote$package.isInstalled("styler"))
+      skip("styler is not installed")
+
+   remote$console.executeExpr({
+      .rs.uiPrefs$codeFormatter$set("styler")
+   })
+   withr::defer(remote$console.executeExpr({
+      .rs.uiPrefs$codeFormatter$set("none")
+   }))
+
+   initial <- "1+1; 2+2\n3+3; 4+4\n"
+   expected <- "1 + 1\n2 + 2\n3 + 3\n4 + 4\n"
+   remote$editor.executeWithContents(".R", initial, function(editor) {
+      editor$selectAll()
+      remote$commands.execute(.rs.appCommands$reformatCode)
+      contents <- .rs.waitUntil("selection is reformatted", function() {
+         contents <- editor$getValue()
+         if (contents != initial)
+            return(contents)
+         return(FALSE)
+      })
+      expect_equal(contents, expected)
    })
 
 })


### PR DESCRIPTION
## Intent

Addresses #17471.

## Summary

On Windows, `Reformat Document` with the styler formatter would insert extra blank lines into the document, with more lines added each time the command was invoked.

Root cause: styler's `write_utf8()` (in `R/io.R`) writes back to the file via `writeLines(..., useBytes = TRUE)`. `useBytes = TRUE` skips encoding conversion but does not bypass the file connection's text mode, so on Windows the file is written with CRLF. RStudio read this back with the default `LineEndingPassthrough`, and the character-level diff against the LF-normalized in-memory document produced `\r` insertions before each `\n`. On the client, Ace's `Document.$split` regex normalizes `\r\n|\r` to `\n` when text is inserted via `replaceRange`, so every inserted bare `\r` became another `\n` - doubling the line breaks.

Fix: normalize line endings to LF when reading the formatter's output. Two one-line changes in `formatDocument` and `formatCode`, plus simplification of a now-redundant trailing-CRLF check.

## Test plan

- [ ] Confirm the original reproducer no longer adds blank lines on Windows (Code > Reformat Document with styler):
  ```r
  print("test")
  print("test")
  ```
  Expected: unchanged after reformat, stable across repeated reformats.
- [ ] Repeat with each of the other scenarios listed in #17471 (trailing whitespace variants, leading blank lines).
- [ ] Existing styler/air automation tests in `test-automation-reformat.R` still pass on macOS / Linux.
- [ ] New regression test (`styler: Reformat Document does not add extra newlines`) passes.