### PR TITLE
ppm: switch vulnerability lookup to filter/packages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@
 - ([rstudio/rstudio-pro#10805](https://github.com/rstudio/rstudio-pro/issues/10805)): Server: Enable TCP keepalive on accepted connections so the operating system reaps half-open sockets from disappeared clients (browser tab hibernation, NAT timeouts) instead of holding them indefinitely.
 - ([rstudio/rstudio-pro#10771](https://github.com/rstudio/rstudio-pro/issues/10771)): Reduced filesystem work performed by the `install.packages()` hook; the before/after scan is now scoped to the requested packages and their dependency closure rather than the entire library.
 - ([rstudio/rstudio-pro#10771](https://github.com/rstudio/rstudio-pro/issues/10771)): Tightened the heuristic used to detect package-management commands at the console prompt, reducing spurious Packages pane refreshes triggered by identifiers like `updates <-` or `installed.packages()`.
+- ([#17446](https://github.com/rstudio/rstudio/issues/17446)): The Packages pane now retrieves vulnerability information from Posit Package Manager via the `POST /filter/packages` endpoint, replacing the legacy `GET /repos/{repo}/vulns` endpoint that was temporarily unavailable in Package Manager `2026.04.0`.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/cpp/session/modules/SessionPPM.R
+++ b/src/cpp/session/modules/SessionPPM.R
@@ -45,31 +45,110 @@
    # If we have cached information available, use it.
    if (exists(repoUrl, envir = .rs.ppm.vulns))
       return(get(repoUrl, envir = .rs.ppm.vulns))
-   
-   # Request vulnerabilities
+
+   empty <- structure(list(), names = character())
+
    ppmUrl <- .rs.ppm.fromRepositoryUrl(repoUrl)
    if (length(ppmUrl) == 0L)
-      return(structure(list(), names = character()))
-   
-   fmt <- "%s/__api__/repos/%s/vulns"
-   endpoint <- sprintf(fmt, ppmUrl$root, ppmUrl$repos)
-   destfile <- tempfile("ppm-vuln-")
-   
-   status <- tryCatch(
-      download.file(endpoint, destfile = destfile, quiet = TRUE),
+      return(empty)
+
+   if (!requireNamespace("curl", quietly = TRUE))
+      return(empty)
+
+   # build a curl handle for the request
+   verbose <- Sys.getenv("PWB_PPM_CURL_VERBOSE", unset = "FALSE")
+   handle <- curl::new_handle(verbose = if (verbose) TRUE else FALSE)
+
+   headers <- list("Content-Type" = "application/json")
+   curl::handle_setheaders(handle, .list = headers)
+
+   # ask PPM for every package in this repo with a known vulnerability
+   data <- list(
+      repo                 = ppmUrl[["repos"]],
+      has_vulns            = TRUE,
+      vulns                = TRUE,
+      omit_dependencies    = TRUE,
+      omit_downloads       = TRUE,
+      omit_package_details = TRUE
+   )
+
+   json <- .rs.toJSON(data, unbox = TRUE)
+
+   curl::handle_setopt(
+      handle     = handle,
+      post       = TRUE,
+      postfields = json
+   )
+
+   # use netrc if available
+   netrcFile <- .rs.netrcPath()
+   if (file.exists(netrcFile))
+   {
+      curl::handle_setopt(
+         handle     = handle,
+         httpauth   = 1L,
+         netrc      = 1L,
+         netrc_file = path.expand(netrcFile)
+      )
+   }
+
+   endpoint <- file.path(ppmUrl[["root"]], "__api__/filter/packages")
+   response <- tryCatch(
+      curl::curl_fetch_memory(endpoint, handle = handle),
       condition = identity
    )
-   
-   if (inherits(status, "condition"))
-      return(structure(list(), names = character()))
-   
-   contents <- readLines(destfile, warn = FALSE)
-   json <- .rs.fromJSON(contents)
-   vulns <- .rs.markScalars(json)
-   
+
+   if (inherits(response, "condition"))
+      return(empty)
+
+   contents <- enc2utf8(rawToChar(response$content))
+   vulns <- .rs.ppm.parseVulnerabilityResponse(contents)
+
    # Cache the result and return.
    assign(repoUrl, vulns, envir = .rs.ppm.vulns)
    vulns
+})
+
+.rs.addFunction("ppm.parseVulnerabilityResponse", function(contents)
+{
+   empty <- structure(list(), names = character())
+
+   splat <- strsplit(contents, "\n", fixed = TRUE)[[1L]]
+   splat <- splat[nzchar(splat)]
+   records <- lapply(splat, .rs.fromJSON)
+
+   # bail out if the server reported an error on any line
+   for (record in records)
+   {
+      if (is.character(record[["error"]]))
+         return(empty)
+   }
+
+   # the endpoint returns one record per (package, version) pair; group the
+   # vulns by package name to match the shape consumers expect
+   vulns <- empty
+   for (record in records)
+   {
+      name <- record[["name"]]
+      pkgVulns <- record[["vulns"]]
+      if (is.null(name) || length(pkgVulns) == 0L)
+         next
+
+      vulns[[name]] <- c(vulns[[name]], pkgVulns)
+   }
+
+   # dedupe vulns by id within each package, since the same vuln may apply
+   # to multiple versions of a package
+   for (name in names(vulns))
+   {
+      pkgVulns <- vulns[[name]]
+      ids <- character(length(pkgVulns))
+      for (i in seq_along(pkgVulns))
+         ids[[i]] <- .rs.nullCoalesce(pkgVulns[[i]][["id"]], "")
+      vulns[[name]] <- pkgVulns[!duplicated(ids)]
+   }
+
+   .rs.markScalars(vulns)
 })
 
 .rs.addFunction("ppm.fromRepositoryUrl", function(url)

--- a/src/cpp/session/modules/SessionPPM.R
+++ b/src/cpp/session/modules/SessionPPM.R
@@ -56,8 +56,8 @@
       return(empty)
 
    # build a curl handle for the request
-   verbose <- Sys.getenv("PWB_PPM_CURL_VERBOSE", unset = "FALSE")
-   handle <- curl::new_handle(verbose = if (verbose) TRUE else FALSE)
+   verbose <- isTRUE(as.logical(Sys.getenv("PWB_PPM_CURL_VERBOSE", unset = "FALSE")))
+   handle <- curl::new_handle(verbose = verbose)
 
    headers <- list("Content-Type" = "application/json")
    curl::handle_setheaders(handle, .list = headers)
@@ -137,15 +137,35 @@
       vulns[[name]] <- c(vulns[[name]], pkgVulns)
    }
 
-   # dedupe vulns by id within each package, since the same vuln may apply
-   # to multiple versions of a package
+   # dedupe vulns by id within each package, merging the per-record
+   # 'versions' maps so the UI's per-version check still finds every
+   # affected installed version. PPM may report a different versions
+   # subset alongside each (package, version) record.
    for (name in names(vulns))
    {
       pkgVulns <- vulns[[name]]
-      ids <- character(length(pkgVulns))
+      merged <- list()
+      indices <- list()
       for (i in seq_along(pkgVulns))
-         ids[[i]] <- .rs.nullCoalesce(pkgVulns[[i]][["id"]], "")
-      vulns[[name]] <- pkgVulns[!duplicated(ids)]
+      {
+         vuln <- pkgVulns[[i]]
+         id <- .rs.nullCoalesce(vuln[["id"]], "")
+         slot <- indices[[id]]
+         if (is.null(slot))
+         {
+            slot <- length(merged) + 1L
+            indices[[id]] <- slot
+            merged[[slot]] <- vuln
+         }
+         else
+         {
+            existing <- merged[[slot]]
+            combined <- c(existing[["versions"]], vuln[["versions"]])
+            existing[["versions"]] <- combined[!duplicated(names(combined))]
+            merged[[slot]] <- existing
+         }
+      }
+      vulns[[name]] <- merged
    }
 
    .rs.markScalars(vulns)
@@ -233,8 +253,8 @@
       return(cache)
    
    # begin building a curl handle
-   verbose <- Sys.getenv("PWB_PPM_CURL_VERBOSE", unset = "FALSE")
-   handle <- curl::new_handle(verbose = if (verbose) TRUE else FALSE)
+   verbose <- isTRUE(as.logical(Sys.getenv("PWB_PPM_CURL_VERBOSE", unset = "FALSE")))
+   handle <- curl::new_handle(verbose = verbose)
    
    # set headers for request
    headers <- list("Content-Type" = "application/json")

--- a/src/cpp/session/modules/SessionPPM.R
+++ b/src/cpp/session/modules/SessionPPM.R
@@ -35,7 +35,14 @@
    {
       tryCatch(
          .rs.ppm.getVulnerabilityInformationImpl(repoUrl),
-         error = function(cnd) structure(list(), names = character())
+         error = function(cnd)
+         {
+            .rs.logErrorMessage(sprintf(
+               "error fetching PPM vulnerability info for %s: %s",
+               repoUrl, conditionMessage(cnd)
+            ))
+            structure(list(), names = character())
+         }
       )
    })
 })
@@ -80,13 +87,15 @@
       postfields = json
    )
 
-   # use netrc if available
+   # the legacy /repos/{repo}/vulns endpoint was effectively anonymous;
+   # filter/packages requires auth on locked-down PPM instances, so wire
+   # up netrc when the user has one configured
    netrcFile <- .rs.netrcPath()
    if (file.exists(netrcFile))
    {
       curl::handle_setopt(
          handle     = handle,
-         httpauth   = 1L,
+         httpauth   = 1L,         # CURLAUTH_BASIC
          netrc      = 1L,
          netrc_file = path.expand(netrcFile)
       )
@@ -95,16 +104,35 @@
    endpoint <- file.path(ppmUrl[["root"]], "__api__/filter/packages")
    response <- tryCatch(
       curl::curl_fetch_memory(endpoint, handle = handle),
-      condition = identity
+      error = identity
    )
 
    if (inherits(response, "condition"))
+   {
+      .rs.logErrorMessage(sprintf(
+         "PPM vulnerability request to %s failed: %s",
+         endpoint, conditionMessage(response)
+      ))
       return(empty)
+   }
+
+   if (response$status_code < 200L || response$status_code >= 300L)
+   {
+      .rs.logErrorMessage(sprintf(
+         "PPM vulnerability request to %s returned HTTP %d",
+         endpoint, response$status_code
+      ))
+      return(empty)
+   }
 
    contents <- enc2utf8(rawToChar(response$content))
    vulns <- .rs.ppm.parseVulnerabilityResponse(contents)
 
-   # Cache the result and return.
+   # parser returns NULL when the NDJSON stream contained an error
+   # record; in that case skip the cache so the next refresh can retry
+   if (is.null(vulns))
+      return(empty)
+
    assign(repoUrl, vulns, envir = .rs.ppm.vulns)
    vulns
 })
@@ -113,15 +141,27 @@
 {
    empty <- structure(list(), names = character())
 
+   # tolerate CRLF in case a proxy or PPM build rewrites line endings
+   contents <- gsub("\r", "", contents, fixed = TRUE)
    splat <- strsplit(contents, "\n", fixed = TRUE)[[1L]]
    splat <- splat[nzchar(splat)]
    records <- lapply(splat, .rs.fromJSON)
 
-   # bail out if the server reported an error on any line
+   # bail out if the server reported an error on any line. Returning NULL
+   # (rather than empty) lets the caller distinguish "no vulns" from
+   # "request failed" and skip the cache, so a transient failure doesn't
+   # mask vulns for the rest of the session.
    for (record in records)
    {
       if (is.character(record[["error"]]))
-         return(empty)
+      {
+         code <- .rs.nullCoalesce(record[["code"]], "unknown")
+         warning(sprintf(
+            "error requesting package vulnerabilities; %s [error code %s]",
+            record[["error"]], as.character(code)
+         ), call. = FALSE)
+         return(NULL)
+      }
    }
 
    # the endpoint returns one record per (package, version) pair; group the

--- a/src/cpp/tests/testthat/test-ppm.R
+++ b/src/cpp/tests/testthat/test-ppm.R
@@ -134,6 +134,22 @@ test_that("parseVulnerabilityResponse tolerates blank lines between records", {
    ))
 })
 
+test_that("parseVulnerabilityResponse merges versions maps when deduping by id", {
+   contents <- paste(
+      '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1","versions":{"1.0.0":true}}]}',
+      '{"name":"pkgA","version":"1.1.0","vulns":[{"id":"V1","versions":{"1.1.0":true}}]}',
+      '{"name":"pkgA","version":"1.2.0","vulns":[{"id":"V1","versions":{"1.0.0":true,"1.2.0":true}}]}',
+      sep = "\n"
+   )
+   result <- .rs.ppm.parseVulnerabilityResponse(contents)
+   expect_equal(result, expected(
+      pkgA = list(list(
+         id = "V1",
+         versions = list(`1.0.0` = TRUE, `1.1.0` = TRUE, `1.2.0` = TRUE)
+      ))
+   ))
+})
+
 test_that("parseVulnerabilityResponse preserves nested vuln fields", {
    contents <- paste0(
       '{"name":"pkgA","version":"1.0.0","vulns":[',

--- a/src/cpp/tests/testthat/test-ppm.R
+++ b/src/cpp/tests/testthat/test-ppm.R
@@ -73,14 +73,17 @@ test_that("parseVulnerabilityResponse groups vulns across distinct packages", {
    ))
 })
 
-test_that("parseVulnerabilityResponse returns empty when any record is an error", {
+test_that("parseVulnerabilityResponse returns NULL and warns when any record is an error", {
    contents <- paste(
       '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1"}]}',
       '{"error":"not allowed","code":"403"}',
       sep = "\n"
    )
-   result <- .rs.ppm.parseVulnerabilityResponse(contents)
-   expect_equal(result, structure(list(), names = character()))
+   expect_warning(
+      result <- .rs.ppm.parseVulnerabilityResponse(contents),
+      "error requesting package vulnerabilities.*not allowed.*403"
+   )
+   expect_null(result)
 })
 
 test_that("parseVulnerabilityResponse skips records with no vulns field", {

--- a/src/cpp/tests/testthat/test-ppm.R
+++ b/src/cpp/tests/testthat/test-ppm.R
@@ -177,3 +177,70 @@ test_that("parseVulnerabilityResponse preserves nested vuln fields", {
       ))
    ))
 })
+
+test_that("parseVulnerabilityResponse skips malformed JSON lines", {
+   # .rs.fromJSON returns NULL on parse failure; the parser silently
+   # skips those records. Pin the contract so a future change makes a
+   # deliberate decision rather than an accidental one.
+   contents <- paste(
+      '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1"}]}',
+      '{this is not json',
+      '{"name":"pkgB","version":"0.1.0","vulns":[{"id":"V2"}]}',
+      sep = "\n"
+   )
+   result <- .rs.ppm.parseVulnerabilityResponse(contents)
+   expect_equal(result, expected(
+      pkgA = list(list(id = "V1")),
+      pkgB = list(list(id = "V2"))
+   ))
+})
+
+test_that("parseVulnerabilityResponse keeps id-less vulns separate", {
+   # Each id-less vuln coalesces to id = "", but R's list[[""]] always
+   # reads NULL while each write appends a fresh positional slot, so the
+   # dedup loop treats them as distinct. In practice PPM always emits an
+   # OSV id; this just pins the fallback behavior.
+   contents <- paste(
+      '{"name":"pkgA","version":"1.0.0","vulns":[{"summary":"one"}]}',
+      '{"name":"pkgA","version":"1.1.0","vulns":[{"summary":"two"}]}',
+      sep = "\n"
+   )
+   result <- .rs.ppm.parseVulnerabilityResponse(contents)
+   expect_equal(result, expected(
+      pkgA = list(
+         list(summary = "one"),
+         list(summary = "two")
+      )
+   ))
+})
+
+test_that("parseVulnerabilityResponse keeps the first record on same-id dedup", {
+   # When the same vuln id appears with different summaries across versions,
+   # the first occurrence wins; only the versions map gets merged.
+   contents <- paste(
+      '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1","summary":"first","versions":{"1.0.0":true}}]}',
+      '{"name":"pkgA","version":"2.0.0","vulns":[{"id":"V1","summary":"second","versions":{"2.0.0":true}}]}',
+      sep = "\n"
+   )
+   result <- .rs.ppm.parseVulnerabilityResponse(contents)
+   expect_equal(result, expected(
+      pkgA = list(list(
+         id = "V1",
+         summary = "first",
+         versions = list(`1.0.0` = TRUE, `2.0.0` = TRUE)
+      ))
+   ))
+})
+
+test_that("parseVulnerabilityResponse tolerates CRLF line endings", {
+   contents <- paste(
+      '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1"}]}',
+      '{"name":"pkgB","version":"0.2.0","vulns":[{"id":"V2"}]}',
+      sep = "\r\n"
+   )
+   result <- .rs.ppm.parseVulnerabilityResponse(contents)
+   expect_equal(result, expected(
+      pkgA = list(list(id = "V1")),
+      pkgB = list(list(id = "V2"))
+   ))
+})

--- a/src/cpp/tests/testthat/test-ppm.R
+++ b/src/cpp/tests/testthat/test-ppm.R
@@ -1,0 +1,160 @@
+#
+# test-ppm.R
+#
+# Copyright (C) 2026 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+context("ppm")
+
+# Helper: produce expected structures pre-marked with .rs.scalar so they
+# compare equal to the parser's output (which runs everything through
+# .rs.markScalars before returning).
+expected <- function(...) .rs.markScalars(list(...))
+
+test_that("parseVulnerabilityResponse handles an empty body", {
+   result <- .rs.ppm.parseVulnerabilityResponse("")
+   expect_equal(result, structure(list(), names = character()))
+})
+
+test_that("parseVulnerabilityResponse parses a single record with one vuln", {
+   contents <- '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1","summary":"hi"}]}'
+   result <- .rs.ppm.parseVulnerabilityResponse(contents)
+   expect_equal(result, expected(
+      pkgA = list(list(id = "V1", summary = "hi"))
+   ))
+})
+
+test_that("parseVulnerabilityResponse dedupes the same vuln across versions", {
+   contents <- paste(
+      '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1","summary":"hi"}]}',
+      '{"name":"pkgA","version":"1.1.0","vulns":[{"id":"V1","summary":"hi"}]}',
+      sep = "\n"
+   )
+   result <- .rs.ppm.parseVulnerabilityResponse(contents)
+   expect_equal(result, expected(
+      pkgA = list(list(id = "V1", summary = "hi"))
+   ))
+})
+
+test_that("parseVulnerabilityResponse keeps disjoint vulns from different versions", {
+   contents <- paste(
+      '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1","summary":"first"}]}',
+      '{"name":"pkgA","version":"2.0.0","vulns":[{"id":"V2","summary":"second"}]}',
+      sep = "\n"
+   )
+   result <- .rs.ppm.parseVulnerabilityResponse(contents)
+   expect_equal(result, expected(
+      pkgA = list(
+         list(id = "V1", summary = "first"),
+         list(id = "V2", summary = "second")
+      )
+   ))
+})
+
+test_that("parseVulnerabilityResponse groups vulns across distinct packages", {
+   contents <- paste(
+      '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1"}]}',
+      '{"name":"pkgB","version":"0.2.0","vulns":[{"id":"V2"}]}',
+      sep = "\n"
+   )
+   result <- .rs.ppm.parseVulnerabilityResponse(contents)
+   expect_equal(result, expected(
+      pkgA = list(list(id = "V1")),
+      pkgB = list(list(id = "V2"))
+   ))
+})
+
+test_that("parseVulnerabilityResponse returns empty when any record is an error", {
+   contents <- paste(
+      '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1"}]}',
+      '{"error":"not allowed","code":"403"}',
+      sep = "\n"
+   )
+   result <- .rs.ppm.parseVulnerabilityResponse(contents)
+   expect_equal(result, structure(list(), names = character()))
+})
+
+test_that("parseVulnerabilityResponse skips records with no vulns field", {
+   contents <- paste(
+      '{"name":"pkgA","version":"1.0.0"}',
+      '{"name":"pkgB","version":"0.1.0","vulns":[{"id":"V2"}]}',
+      sep = "\n"
+   )
+   result <- .rs.ppm.parseVulnerabilityResponse(contents)
+   expect_equal(result, expected(
+      pkgB = list(list(id = "V2"))
+   ))
+})
+
+test_that("parseVulnerabilityResponse skips records with empty vulns arrays", {
+   contents <- paste(
+      '{"name":"pkgA","version":"1.0.0","vulns":[]}',
+      '{"name":"pkgB","version":"0.1.0","vulns":[{"id":"V2"}]}',
+      sep = "\n"
+   )
+   result <- .rs.ppm.parseVulnerabilityResponse(contents)
+   expect_equal(result, expected(
+      pkgB = list(list(id = "V2"))
+   ))
+})
+
+test_that("parseVulnerabilityResponse skips records missing the name field", {
+   contents <- paste(
+      '{"version":"1.0.0","vulns":[{"id":"V1"}]}',
+      '{"name":"pkgB","version":"0.1.0","vulns":[{"id":"V2"}]}',
+      sep = "\n"
+   )
+   result <- .rs.ppm.parseVulnerabilityResponse(contents)
+   expect_equal(result, expected(
+      pkgB = list(list(id = "V2"))
+   ))
+})
+
+test_that("parseVulnerabilityResponse tolerates blank lines between records", {
+   contents <- paste(
+      '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1"}]}',
+      "",
+      '{"name":"pkgB","version":"0.2.0","vulns":[{"id":"V2"}]}',
+      "",
+      sep = "\n"
+   )
+   result <- .rs.ppm.parseVulnerabilityResponse(contents)
+   expect_equal(result, expected(
+      pkgA = list(list(id = "V1")),
+      pkgB = list(list(id = "V2"))
+   ))
+})
+
+test_that("parseVulnerabilityResponse preserves nested vuln fields", {
+   contents <- paste0(
+      '{"name":"pkgA","version":"1.0.0","vulns":[',
+      '{"id":"V1","summary":"s","details":"d","modified":"m","published":"p",',
+      '"ranges":[{"type":"SEMVER","events":[{"introduced":"0","fixed":"2"}]}],',
+      '"versions":{"1.0.0":true}}',
+      ']}'
+   )
+   result <- .rs.ppm.parseVulnerabilityResponse(contents)
+   expect_equal(result, expected(
+      pkgA = list(list(
+         id = "V1",
+         summary = "s",
+         details = "d",
+         modified = "m",
+         published = "p",
+         ranges = list(list(
+            type = "SEMVER",
+            events = list(list(introduced = "0", fixed = "2"))
+         )),
+         versions = list(`1.0.0` = TRUE)
+      ))
+   ))
+})


### PR DESCRIPTION
## Intent

Addresses #17446.

The Packages pane retrieves vulnerability info from Posit Package Manager via `.rs.ppm.getVulnerabilityInformation`. That function was calling the legacy `GET /repos/{repo}/vulns` endpoint, which was removed in Package Manager `2026.04.0` (and only restored in `2026.04.1`). This PR migrates the call to the more general `POST /filter/packages` with `has_vulns: true`, which is the recommended long-term home for this query.

## Implementation

`src/cpp/session/modules/SessionPPM.R`:
- `.rs.ppm.getVulnerabilityInformationImpl` now POSTs to `<root>/__api__/filter/packages` via `curl::curl_fetch_memory`, mirroring the pattern already used by `.rs.ppm.updateMetadataCache` in the same file. Netrc auth, the `PWB_PPM_CURL_VERBOSE` toggle, and the per-`repoUrl` cache are preserved.
- The NDJSON parse/group/dedup logic is factored into a new pure helper `.rs.ppm.parseVulnerabilityResponse(contents)` so it can be unit-tested without mocking the HTTP layer.
- The endpoint returns one record per (package, version), so the helper groups vulns by package name (matching the existing `{package -> [vulns]}` shape consumed by `SessionPackages.cpp` and `PackageVulnerabilityTypes.java`) and dedupes by vuln `id` within each package.

## Tests

New `src/cpp/tests/testthat/test-ppm.R` covers the parser:
- empty body
- single record / single vuln
- multi-version dedup (same vuln id across versions)
- multi-version with disjoint vuln ids retained
- grouping across distinct packages
- error record short-circuits to empty
- records missing the `vulns` field skipped
- records with empty `vulns` arrays skipped
- records missing the `name` field skipped
- blank lines between records tolerated
- nested vuln fields (`ranges`, `events`, `versions`) preserved

## Test plan

- [x] `./rstudio-tests --scope r --filter ppm` -> `[FAIL 0 | PASS 3314]`
- [ ] Manual verification against a live PPM instance (Packages pane vulnerability indicators still appear)