### PR TITLE
include deferred_init_completed flag in session init event

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -984,6 +984,7 @@ void rSessionInitHook(bool newSession)
    // client connecting after this point (a re-join) can distinguish itself
    // from a client connecting before deferred init has fired
    init::setDeferredInitCompleted(true);
+   dataJson["deferred_init_completed"] = true;
 
    // fire an event to the client
    ClientEvent event(client_events::kDeferredInitCompleted, dataJson);


### PR DESCRIPTION
## Intent

Addresses #17603.

## Summary

The `kDeferredInitCompleted` client event already sets the server-side `init::setDeferredInitCompleted(true)` flag, but the data payload sent to the client did not include `deferred_init_completed`. As a result, clients connecting around the time deferred init fires could miss the signal that init has completed, leaving the Packages pane silently empty on first connect (regression from #17546).

This change adds `deferred_init_completed = true` to the event's `dataJson` so the client can reliably distinguish a connection that occurs after deferred init from one that occurs before.

## Test plan

- [ ] Fresh-start RStudio Server (no prior session state), connect, and verify the Packages pane is populated on first connect across several runs.
- [ ] Verify no regression in normal session startup (packages list still appears, no duplicate refreshes).