### PR TITLE
make JSON parsing more permissive

### DIFF
--- a/src/cpp/shared_core/json/Json.cpp
+++ b/src/cpp/shared_core/json/Json.cpp
@@ -37,6 +37,7 @@
 
 
 #include <cstddef>
+#include <cstring>
 
 //
 // Ask rapidjson to use 'std::size_t' internally.
@@ -60,6 +61,8 @@ typedef std::size_t SizeType;
 #endif
 
 #include <rapidjson/document.h>
+#include <rapidjson/encodedstream.h>
+#include <rapidjson/memorystream.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/writer.h>
@@ -689,7 +692,20 @@ bool Value::isUInt64() const
 
 Error Value::parse(const char* in_jsonStr)
 {
-   rapidjson::ParseResult result = m_impl->Document->Parse(in_jsonStr);
+   return Value::parse(std::string(in_jsonStr));
+}
+
+Error Value::parse(const std::string& in_jsonStr)
+{
+   // Wrap the string to use rapidjson's UTF handling, which detects BOMs.
+   rapidjson::MemoryStream byteStream(in_jsonStr.c_str(), in_jsonStr.size());
+   rapidjson::AutoUTFInputStream<unsigned, rapidjson::MemoryStream> stream(byteStream);
+
+   // Parse the JSON permissively.
+   constexpr unsigned FLAGS = rapidjson::kParseTrailingCommasFlag |
+      rapidjson::kParseCommentsFlag |
+      rapidjson::kParseStopWhenDoneFlag;
+   rapidjson::ParseResult result = m_impl->Document->ParseStream<FLAGS, rapidjson::AutoUTF<unsigned>>(stream);
 
    if (result.IsError())
    {
@@ -698,11 +714,6 @@ Error Value::parse(const char* in_jsonStr)
    }
 
    return Success();
-}
-
-Error Value::parse(const std::string& in_jsonStr)
-{
-   return parse(in_jsonStr.c_str());
 }
 
 Error Value::parseAndValidate(const std::string& in_jsonStr, const std::string& in_schema)

--- a/src/cpp/shared_core/json/JsonTests.cpp
+++ b/src/cpp/shared_core/json/JsonTests.cpp
@@ -1085,6 +1085,24 @@ TEST(SharedCoreTest, Json)
    }
 }
 
+TEST(SharedCoreTest, PermissiveParsing)
+{
+   // UTF-8 byte-order mark.
+   static const std::string kBom = "\xEF\xBB\xBF";
+
+   std::string input = kBom + "{\n"
+      "   // line comment in the template\n"
+      "   \"editor.fontSize\": 14,\n"
+      "   /* block comment */\n"
+      "   \"editor.theme\": \"dark\"\n"
+      "}\ntrailing data";
+
+   json::Object obj;
+   ASSERT_FALSE(obj.parse(input));
+   EXPECT_EQ(obj["editor.fontSize"].getInt(), 14);
+   EXPECT_EQ(obj["editor.theme"].getString(), "dark");
+}
+
 } // end namespace tests
 } // end namespace core
 } // end namespace rstudio


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/10974
Open-source counterpart to https://github.com/rstudio/rstudio-pro/pull/11043

The current JSON parser is strictly spec-compliant and doesn't like JSON files with comments, trailing commas, UTF-8 BOMs, or additional non-whitespace bytes after the end of the JSON value.

### Approach

Use the functionality already provided by RapidJSON to permit common deviations from JSON standard.

### Automated Tests

Unit tests are added in the companion PR.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
