### PR TITLE
anchor run-tests filter to current file

### DIFF
--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -246,8 +246,11 @@ bool collectForcePackageRebuild()
 std::string regexLiteralEscape(const std::string& str)
 {
    static const std::string meta = ".\\+*?[](){}^$|";
+   if (str.find_first_of(meta) == std::string::npos)
+      return str;
+
    std::string result;
-   result.reserve(str.size());
+   result.reserve(str.size() + 4);
    for (char c : str)
    {
       if (meta.find(c) != std::string::npos)

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -243,7 +243,7 @@ bool collectForcePackageRebuild()
    }
 }
 
-std::string regexLiteralEscape(const std::string& str)
+std::string regexLiteralEscape(std::string str)
 {
    static const std::string meta = ".\\+*?[](){}^$|";
    if (str.find_first_of(meta) == std::string::npos)

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -243,6 +243,20 @@ bool collectForcePackageRebuild()
    }
 }
 
+std::string regexLiteralEscape(const std::string& str)
+{
+   static const std::string meta = ".\\+*?[](){}^$|";
+   std::string result;
+   result.reserve(str.size());
+   for (char c : str)
+   {
+      if (meta.find(c) != std::string::npos)
+         result.push_back('\\');
+      result.push_back(c);
+   }
+   return result;
+}
+
 
 const char * const kRoxygenizePackage = "roxygenize-package";
 const char * const kBuildSourcePackage = "build-source-package";
@@ -1205,9 +1219,9 @@ private:
 
       // check if this is a tests/testthat/test-<name>.R file in a package project;
       // if so, use devtools::test(filter = "^<name>$") instead of testthat::test_file().
-      // The filter is matched as a regex by testthat::test_dir, so anchor it with
-      // ^ and $ to avoid running other test files whose names happen to contain
-      // <name> as a substring (e.g. test-prereg.R also running test-mod-prereg.R).
+      // The filter is matched as a regex by testthat::test_dir, so escape any
+      // regex metacharacters in <name> and anchor with ^/$ so we run only the
+      // current test file (e.g. test-prereg.R must not also run test-mod-prereg.R).
       boost::smatch match;
       boost::regex reTestThat("tests/testthat/test-(.+)\\.[rR]$");
       std::string path = testPath.getAbsolutePath();
@@ -1215,7 +1229,7 @@ private:
           useDevtools() &&
           boost::regex_search(path, match, reTestThat))
       {
-         std::string filterName = singleQuotedStrEscape(match[1]);
+         std::string filterName = singleQuotedStrEscape(regexLiteralEscape(match[1]));
          command = fmt::format("devtools::test(filter = '^{}$')", filterName);
          pkgOptions.workingDir = projects::projectContext().buildTargetPath();
          enqueCommandString(command);

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -250,7 +250,7 @@ std::string regexLiteralEscape(const std::string& str)
       return str;
 
    std::string result;
-   result.reserve(str.size() + 4);
+   result.reserve(str.size() * 2);
    for (char c : str)
    {
       if (meta.find(c) != std::string::npos)

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -1204,7 +1204,10 @@ private:
       std::string command;
 
       // check if this is a tests/testthat/test-<name>.R file in a package project;
-      // if so, use devtools::test(filter = "<name>") instead of testthat::test_file()
+      // if so, use devtools::test(filter = "^<name>$") instead of testthat::test_file().
+      // The filter is matched as a regex by testthat::test_dir, so anchor it with
+      // ^ and $ to avoid running other test files whose names happen to contain
+      // <name> as a substring (e.g. test-prereg.R also running test-mod-prereg.R).
       boost::smatch match;
       boost::regex reTestThat("tests/testthat/test-(.+)\\.[rR]$");
       std::string path = testPath.getAbsolutePath();
@@ -1213,7 +1216,7 @@ private:
           boost::regex_search(path, match, reTestThat))
       {
          std::string filterName = singleQuotedStrEscape(match[1]);
-         command = fmt::format("devtools::test(filter = '{}')", filterName);
+         command = fmt::format("devtools::test(filter = '^{}$')", filterName);
          pkgOptions.workingDir = projects::projectContext().buildTargetPath();
          enqueCommandString(command);
       }


### PR DESCRIPTION
## Intent

Addresses #17610.

## Summary

- The "Run Tests" button on a `tests/testthat/test-<name>.R` file invokes `devtools::test(filter = '<name>')`, but `testthat::test_dir()` matches `filter` as a regex (via `grepl()`), so `test-prereg.R` also runs `test-mod-prereg.R`.
- Anchor the filter with `^` and `$` so only the current test file is executed.
- Also escape POSIX ERE metacharacters in `<name>` (`. \ + * ? [ ] ( ) { } ^ $ |`) before substituting, so files like `test-foo.bar.R` don't produce the regex `^foo.bar$` (which would also match `fooxbar`, `foo-bar`, ...). With the fix, that filename produces `^foo\\.bar$` and matches only `foo.bar`.

This is a regression from #17229, which has not shipped in an official release, so no `NEWS.md` entry is added.

## Test plan

- [ ] Open a package project containing both `tests/testthat/test-prereg.R` and `tests/testthat/test-mod-prereg.R`.
- [ ] With `test-prereg.R` open, click "Run Tests"; confirm the Build pane shows `devtools::test(filter = '^prereg$')` and only `prereg` tests run.
- [ ] Confirm the unrelated `test-mod-prereg.R` file is not run.
- [ ] If feasible, add a test file whose name contains a regex metacharacter (e.g. `test-foo.bar.R`) and confirm the Build pane shows `devtools::test(filter = '^foo\\.bar$')` and the test runs.