### PR TITLE
Remove debug console.log statements from Posit Assistant chat tests

### DIFF
--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-messaging.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-messaging.test.ts
@@ -65,7 +65,6 @@ test.describe.serial('Chat Messaging', () => {
       await chatActions.sendChatMessage(message);
       const countAfter = await chatActions.waitForResponse(countBefore);
       expect(countAfter).toBeGreaterThan(countBefore);
-      console.log(`Turn "${message}" — messages: ${countBefore} → ${countAfter}`);
     }
 
     // Verify the assistant tracked context: x = 1, x + 22 = 23
@@ -84,7 +83,6 @@ test.describe.serial('Chat Messaging', () => {
     await chatActions.startNewConversation();
     const resetCount = await chatPane.getMessageCount();
     expect(resetCount).toBe(0);
-    console.log(`New conversation reset — messages: ${resetCount}`);
 
     // Verify the new conversation works
     const newConvCount = await chatPane.getMessageCount();

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
@@ -112,14 +112,12 @@ test.describe.serial('User-Added Skills', { tag: ['@serial'] }, () => {
     // start). Setting the preference to "none" (a valid enum value -- NOT "")
     // triggers onChatProviderChanged() → stopBackend() on the GWT side.
     // -----------------------------------------------------------------------
-    console.log('Stopping chat backend (setting chat_provider to "none")');
     await consoleActions.typeInConsole('.rs.api.writeRStudioPreference("chat_provider", "none")');
     await sleep(5000);
 
     // -----------------------------------------------------------------------
     // Step 2: Create a project-level skill (.positai/skills/ in workspace)
     // -----------------------------------------------------------------------
-    console.log(`Creating project skill at: ${projectSkillPath}`);
     await createSkillFile(
       consoleActions,
       projectSkillDir,
@@ -132,7 +130,6 @@ test.describe.serial('User-Added Skills', { tag: ['@serial'] }, () => {
     // -----------------------------------------------------------------------
     // Step 3: Create a user-level skill (~/.positai/skills/ in home dir)
     // -----------------------------------------------------------------------
-    console.log(`Creating user skill at: ${USER_SKILL_PATH}`);
     await createSkillFile(
       consoleActions,
       USER_SKILL_DIR,
@@ -149,13 +146,11 @@ test.describe.serial('User-Added Skills', { tag: ['@serial'] }, () => {
     await consoleActions.typeInConsole(`cat(readLines("${projectSkillPath}"), sep = "\\n")`);
     await sleep(2000);
     const projectOutput = await consoleActions.consolePane.consoleOutput.innerText();
-    console.log(`Project skill content:\n${projectOutput}`);
 
     await consoleActions.clearConsole();
     await consoleActions.typeInConsole(`cat(readLines("${USER_SKILL_PATH}"), sep = "\\n")`);
     await sleep(2000);
     const userOutput = await consoleActions.consolePane.consoleOutput.innerText();
-    console.log(`User skill content:\n${userOutput}`);
 
     // -----------------------------------------------------------------------
     // Step 5: Start a fresh backend by setting chat_provider back to "posit".
@@ -164,7 +159,6 @@ test.describe.serial('User-Added Skills', { tag: ['@serial'] }, () => {
     // The new backend process runs DatabotCore.initialize() → discoverSkills()
     // which picks up our newly created skill files.
     // -----------------------------------------------------------------------
-    console.log('Starting fresh backend via Options dialog');
     await assistantActions.setChatProvider(CHAT_PROVIDERS['posit-assistant']);
 
     // -----------------------------------------------------------------------
@@ -229,7 +223,6 @@ test.describe.serial('User-Added Skills', { tag: ['@serial'] }, () => {
     const lastMessage = chatPane.messageItem.last();
     const responseText = await lastMessage.innerText();
 
-    console.log(`Project skill response preview: ${responseText.substring(0, 500)}`);
     expect(responseText).toContain(PROJECT_MARKER);
   });
 
@@ -254,7 +247,6 @@ test.describe.serial('User-Added Skills', { tag: ['@serial'] }, () => {
     const lastMessage = chatPane.messageItem.last();
     const responseText = await lastMessage.innerText();
 
-    console.log(`User skill response preview: ${responseText.substring(0, 500)}`);
     expect(responseText).toContain(USER_MARKER);
   });
 });

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-websocket-url.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-websocket-url.test.ts
@@ -39,7 +39,6 @@ test.describe('Chat WebSocket URL', () => {
         const url: string | undefined = body?.result?.url;
         if (url && url.includes('ai-chat') && !wsPath) {
           wsPath = url;
-          console.log(`Captured WebSocket path from RPC: ${wsPath}`);
         }
       } catch {
         // Not JSON or body already consumed
@@ -64,9 +63,6 @@ test.describe('Chat WebSocket URL', () => {
     // iframe's WebSocket connected successfully.
     await expect(chatPane.chatRoot).toBeVisible({ timeout: 30000 });
 
-    console.log(`WebSocket path: "${wsPath}"`);
-    console.log(`Page URL: ${page.url()}`);
-
     // Verify we captured the URL from the RPC response
     expect(wsPath, 'RPC response should contain the ai-chat WebSocket path').toContain('/ai-chat');
 
@@ -84,7 +80,6 @@ test.describe('Chat WebSocket URL', () => {
     if (pathSegments.length > 0 && !['s', 'p'].includes(pathSegments[0])) {
       const rootPrefix = '/' + pathSegments[0];
       expect(wsPath).toContain(rootPrefix);
-      console.log(`Verified WebSocket path includes root prefix: ${rootPrefix}`);
     }
 
     // Prove the WebSocket actually works -- send a message and get a response.
@@ -93,6 +88,5 @@ test.describe('Chat WebSocket URL', () => {
     await chatActions.sendChatMessage('Say hello in one word');
     const newCount = await chatActions.waitForResponse(initialCount);
     expect(newCount).toBeGreaterThan(initialCount);
-    console.log(`Chat round-trip succeeded: ${initialCount} → ${newCount} messages`);
   });
 });

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/deprecate-pai-blocking.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/deprecate-pai-blocking.test.ts
@@ -110,7 +110,6 @@ test.describe.serial('Deprecate old Posit AI builds -- #17145', { tag: ['@serial
     await chatActions.openChatPane();
     await chatActions.dismissSetupPrompts();
     await expect(chatPane.chatTextarea).toBeVisible({ timeout: 60000 });
-    console.log('Chat pane loaded normally, ready for blocking tests');
 
     // Install RPC interceptor to verify mocks are fulfilled
     await chatActions.interceptUpdateCheck();

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/detachable-sidebar.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/detachable-sidebar.test.ts
@@ -50,7 +50,6 @@ test.describe.serial('Detachable Assistant Sidebar - #16937', { tag: ['@desktop_
     // Verify the response contains "Loki"
     const firstResponse = chatPane.messageItem.last();
     await expect(firstResponse).toContainText('Loki', { timeout: 10000 });
-    console.log(`Phase 1 complete — ${countAfterFirst} messages in main window`);
 
     // Record message count before detach
     const messagesBeforeDetach = await chatPane.getMessageCount();
@@ -65,15 +64,12 @@ test.describe.serial('Detachable Assistant Sidebar - #16937', { tag: ['@desktop_
     await satellitePage.waitForLoadState('domcontentloaded');
     await sleep(3000);
 
-    console.log(`Satellite window opened — title: "${await satellitePage.title()}"`);
-
     // Create a ChatPane scoped to the satellite page
     const satelliteChatPane = new ChatPane(satellitePage);
 
     // Verify conversation continuity: same message count
     const satelliteMessageCount = await satelliteChatPane.getMessageCount();
     expect(satelliteMessageCount).toBe(messagesBeforeDetach);
-    console.log(`Phase 2 — satellite has ${satelliteMessageCount} messages (expected ${messagesBeforeDetach})`);
 
     // Verify the original response is still there
     const satelliteLastMessage = satelliteChatPane.messageItem.last();
@@ -89,7 +85,6 @@ test.describe.serial('Detachable Assistant Sidebar - #16937', { tag: ['@desktop_
 
     const secondResponse = satelliteChatPane.messageItem.last();
     await expect(secondResponse).toContainText('Thor', { timeout: 10000 });
-    console.log(`Phase 3 complete — ${countAfterSecond} messages in satellite`);
 
     const messagesBeforeReturn = await satelliteChatPane.getMessageCount();
 
@@ -100,7 +95,6 @@ test.describe.serial('Detachable Assistant Sidebar - #16937', { tag: ['@desktop_
     // Verify all messages persist in the main window
     const mainMessageCount = await chatPane.getMessageCount();
     expect(mainMessageCount).toBe(messagesBeforeReturn);
-    console.log(`Phase 4 — main window has ${mainMessageCount} messages (expected ${messagesBeforeReturn})`);
 
     // Verify both responses are present
     const allMessages = chatPane.messageItem;
@@ -112,6 +106,5 @@ test.describe.serial('Detachable Assistant Sidebar - #16937', { tag: ['@desktop_
 
     expect(combinedText).toContain('Loki');
     expect(combinedText).toContain('Thor');
-    console.log('Conversation continuity verified across detach/reattach cycle');
   });
 });

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/enable-assistant.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/enable-assistant.test.ts
@@ -48,6 +48,5 @@ test.describe.serial('Enable Posit Assistant', () => {
     // Reopen options and verify the selection persisted
     const value = await assistantActions.getChatProviderValue();
     expect(value).toBe('posit');
-    console.log(`Chat provider value after re-open: "${value}"`);
   });
 });

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/readline-notification.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/readline-notification.test.ts
@@ -53,13 +53,11 @@ test.describe.serial('Readline Notification in Chat Pane', { tag: ['@serial'] },
     // which blocks R waiting for console input.
     await chatActions.pollWithAllowDialogs(async () => {
       const visible = await chatPane.readlineNotification.isVisible().catch(() => false);
-      if (visible) console.log('Readline notification appeared');
       return visible;
     });
 
     // --- Step 4: Assert notification is visible ---
     await expect(chatPane.readlineNotification).toBeVisible({ timeout: 5000 });
-    console.log('Verified: "R is waiting for input in the Console." notification is visible');
 
     // --- Step 5: Type a message in chat and press Enter — nothing should happen ---
     const messageCountBefore = await chatPane.getMessageCount();
@@ -67,17 +65,14 @@ test.describe.serial('Readline Notification in Chat Pane', { tag: ['@serial'] },
     await sleep(200);
     await chatPane.sendBtn.click({ timeout: 2000 }).catch(() => {
       // Send button may be disabled or unresponsive — that's expected
-      console.log('Send button click did not go through (expected)');
     });
     await sleep(1000);
 
     const messageCountAfter = await chatPane.getMessageCount();
     expect(messageCountAfter).toBe(messageCountBefore);
-    console.log(`Chat message count unchanged: ${messageCountBefore} → ${messageCountAfter}`);
 
     // Notification should still be visible
     await expect(chatPane.readlineNotification).toBeVisible();
-    console.log('Verified: notification still visible after attempting to send chat message');
 
     // --- Step 6: Provide input in the Console to unblock readline ---
     await consoleActions.consolePane.consoleTab.click();
@@ -87,11 +82,9 @@ test.describe.serial('Readline Notification in Chat Pane', { tag: ['@serial'] },
     await consoleActions.consolePane.consoleInput.pressSequentially('Prospero');
     await sleep(300);
     await page.keyboard.press('Enter');
-    console.log('Typed "Prospero" in console to respond to readline');
 
     // --- Step 7: Assert notification disappears ---
     await expect(chatPane.readlineNotification).toBeHidden({ timeout: 15000 });
-    console.log('Verified: readline notification dismissed after providing console input');
 
     // --- Step 8: Verify chat resumes working after readline completes ---
     // Wait for the assistant to finish processing the readline response
@@ -106,12 +99,10 @@ test.describe.serial('Readline Notification in Chat Pane', { tag: ['@serial'] },
     const countBeforeQuote = await chatPane.getMessageCount();
     await chatActions.sendChatMessage('Print "We are such stuff as dreams are made on" to the R console using cat().');
     await chatActions.waitForResponse(countBeforeQuote);
-    console.log('Sent follow-up message to verify chat is functional');
 
     // Verify the quote appears in console output
     await expect(consoleActions.consolePane.consoleOutput).toContainText(
       'We are such stuff as dreams are made on', { timeout: 15000 }
     );
-    console.log('Verified: Tempest quote printed to console — chat is fully functional after readline');
   });
 });

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
@@ -83,7 +83,6 @@ test.describe.serial('R Shiny Tip Calculator via Posit Assistant', () => {
       if (!isStillProcessing && messageCount >= 2) {
         const lastText = await chatPane.messageItem.last().innerText().catch(() => '');
         if (lastText.includes('Wacky Tip Calculator for R has started') && !lastText.includes('Create a Shiny for R')) {
-          console.log('Completion signal found: "Wacky Tip Calculator for R has started" in last message');
           return true;
         }
       }

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/uninstall-posit-ai.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/uninstall-posit-ai.test.ts
@@ -159,9 +159,7 @@ base.describe.serial('Uninstall Posit Assistant - #17322', { tag: ['@serial', '@
     // Install button should already be visible from test 4
     await expect(chatActions.chatPane.installBtn).toBeVisible({ timeout: 15000 });
     await chatActions.chatPane.installBtn.click();
-    console.log('Clicked Install — waiting for PAI installation...');
 
     await expect(chatActions.chatPane.chatRoot).toBeVisible({ timeout: 120000 });
-    console.log('PAI reinstalled successfully');
   });
 });


### PR DESCRIPTION
## Summary

Removes 35 `console.log` calls left over from test development across nine
Posit Assistant chat test files in `e2e/rstudio/tests/panes/posit-assistant-chat/`.

No logic, assertions, or control flow are affected. Playwright's HTML
report and trace already capture the same diagnostic information that
these logs provided.

Kept the four `console.log` calls in `shiny-app-python.test.ts`, which is WIP.