### PR TITLE
limit data viewer horizontal overscroll

### DIFF
--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -964,23 +964,20 @@ var applyPinnedColumns = function() {
    }
 
    // Horizontal overscroll: lets the user scroll the rightmost column to sit
-   // just past the pinned columns for side-by-side context. Only meaningful
-   // when content is wider than the viewport -- otherwise it would introduce
-   // a phantom scrollbar over empty space. We reserve room for the rightmost
-   // column so it stays visible at maximum scroll; without this reservation
-   // the user can scroll every unpinned column off-screen (issue #17612).
+   // just past the pinned columns for side-by-side context. Applied even when
+   // all columns fit in the viewport so horizontal scrolling is consistently
+   // available. We reserve room for the rightmost column so it stays visible
+   // at maximum scroll; without this reservation the user can scroll every
+   // unpinned column off-screen (issue #17612).
    var viewport = document.getElementById("gridViewport");
    var table = document.getElementById("rsGridData");
    if (viewport && table) {
-      var overscroll = 0;
-      if (totalTableWidth > viewport.clientWidth) {
-         var lastIdx = columnOrder.length - 1;
-         var lastTh = lastIdx >= 0 ? thead.children[lastIdx] : null;
-         var lastUnpinnedWidth = (lastTh && !isColumnPinned(columnOrder[lastIdx]))
-            ? lastTh.offsetWidth : 0;
-         overscroll = Math.max(0,
-            viewport.clientWidth - pinned.totalWidth - lastUnpinnedWidth);
-      }
+      var lastIdx = columnOrder.length - 1;
+      var lastTh = lastIdx >= 0 ? thead.children[lastIdx] : null;
+      var lastUnpinnedWidth = (lastTh && !isColumnPinned(columnOrder[lastIdx]))
+         ? lastTh.offsetWidth : 0;
+      var overscroll = Math.max(0,
+         viewport.clientWidth - pinned.totalWidth - lastUnpinnedWidth);
       table.style.paddingRight = overscroll + "px";
    }
 };
@@ -2418,9 +2415,8 @@ var toggleSidebar = function() {
    // Trigger grid resize after transition
    setTimeout(function() {
       // viewport.clientWidth changes when the sidebar opens/closes, which
-      // can flip the totalTableWidth > viewport.clientWidth comparison in
-      // applyPinnedColumns -- recompute paddingRight so the horizontal
-      // overscroll matches the new viewport width.
+      // feeds into the overscroll calculation in applyPinnedColumns --
+      // recompute paddingRight so it matches the new viewport width.
       applyPinnedColumns();
       renderVisibleRows(true);
       updateInfoBar();

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -968,16 +968,22 @@ var applyPinnedColumns = function() {
    // all columns fit in the viewport so horizontal scrolling is consistently
    // available. We reserve room for the rightmost column so it stays visible
    // at maximum scroll; without this reservation the user can scroll every
-   // unpinned column off-screen (issue #17612).
+   // unpinned column off-screen (issue #17612). If every column is pinned
+   // (or none exist) there is nothing to scroll past, so we skip the padding
+   // to avoid a phantom scrollbar over empty space.
    var viewport = document.getElementById("gridViewport");
    var table = document.getElementById("rsGridData");
    if (viewport && table) {
+      var overscroll = 0;
       var lastIdx = columnOrder.length - 1;
-      var lastTh = lastIdx >= 0 ? thead.children[lastIdx] : null;
-      var lastUnpinnedWidth = (lastTh && !isColumnPinned(columnOrder[lastIdx]))
-         ? lastTh.offsetWidth : 0;
-      var overscroll = Math.max(0,
-         viewport.clientWidth - pinned.totalWidth - lastUnpinnedWidth);
+      // columnOrder places pinned columns before unpinned, so the last entry
+      // being unpinned is sufficient to confirm an unpinned column exists.
+      if (lastIdx >= 0 && !isColumnPinned(columnOrder[lastIdx])) {
+         var lastTh = thead.children[lastIdx];
+         var lastUnpinnedWidth = lastTh ? lastTh.offsetWidth : 0;
+         overscroll = Math.max(0,
+            viewport.clientWidth - pinned.totalWidth - lastUnpinnedWidth);
+      }
       table.style.paddingRight = overscroll + "px";
    }
 };

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -966,13 +966,21 @@ var applyPinnedColumns = function() {
    // Horizontal overscroll: lets the user scroll the rightmost column to sit
    // just past the pinned columns for side-by-side context. Only meaningful
    // when content is wider than the viewport -- otherwise it would introduce
-   // a phantom scrollbar over empty space.
+   // a phantom scrollbar over empty space. We reserve room for the rightmost
+   // column so it stays visible at maximum scroll; without this reservation
+   // the user can scroll every unpinned column off-screen (issue #17612).
    var viewport = document.getElementById("gridViewport");
    var table = document.getElementById("rsGridData");
    if (viewport && table) {
-      var overscroll = totalTableWidth > viewport.clientWidth
-         ? Math.max(0, viewport.clientWidth - pinned.totalWidth)
-         : 0;
+      var overscroll = 0;
+      if (totalTableWidth > viewport.clientWidth) {
+         var lastIdx = columnOrder.length - 1;
+         var lastTh = lastIdx >= 0 ? thead.children[lastIdx] : null;
+         var lastUnpinnedWidth = (lastTh && !isColumnPinned(columnOrder[lastIdx]))
+            ? lastTh.offsetWidth : 0;
+         overscroll = Math.max(0,
+            viewport.clientWidth - pinned.totalWidth - lastUnpinnedWidth);
+      }
       table.style.paddingRight = overscroll + "px";
    }
 };
@@ -1167,6 +1175,15 @@ var initResizeHandlers = function() {
       if (resizingColIdx === null) return;
       resizingColIdx = null;
       saveState();
+      // applyResizeDelta updates totalTableWidth on every mousemove but
+      // skips applyPinnedColumns/updateCustomScrollbars to avoid jank
+      // (200+ DOM writes plus layout reads per frame). Sync them once at
+      // end of drag so the overscroll padding and scrollbar thumb size
+      // match the new column widths.
+      if (didResize) {
+         applyPinnedColumns();
+         updateCustomScrollbars();
+      }
       // Reset didResize after the click event that follows mouseup has been
       // dispatched, so exactly one click is suppressed (the one synthesized
       // from this drag) and subsequent clicks sort normally.

--- a/version/news/os/NEWS-2026.05.0-golden-wattle.md
+++ b/version/news/os/NEWS-2026.05.0-golden-wattle.md
@@ -43,6 +43,7 @@
 - ([rstudio/rstudio-pro#10771](https://github.com/rstudio/rstudio-pro/issues/10771)): Reduced filesystem work performed by the `install.packages()` hook; the before/after scan is now scoped to the requested packages and their dependency closure rather than the entire library.
 - ([rstudio/rstudio-pro#10771](https://github.com/rstudio/rstudio-pro/issues/10771)): Tightened the heuristic used to detect package-management commands at the console prompt, reducing spurious Packages pane refreshes triggered by identifiers like `updates <-` or `installed.packages()`.
 - ([#17446](https://github.com/rstudio/rstudio/issues/17446)): The Packages pane now retrieves vulnerability information from Posit Package Manager via the `POST /filter/packages` endpoint, replacing the legacy `GET /repos/{repo}/vulns` endpoint that was temporarily unavailable in Package Manager `2026.04.0`.
+- ([#17612](https://github.com/rstudio/rstudio/issues/17612)): Limit horizontal overscroll in the data viewer so the last column remains visible at maximum scroll, instead of allowing all unpinned columns to be scrolled off-screen.
 
 ### Dependencies
 - Ace 1.43.5


### PR DESCRIPTION
## Intent

Addresses #17612.

## Summary

- Cap the data viewer's horizontal overscroll padding so the rightmost column stays on-screen at maximum scroll; previously the user could scroll every unpinned column off-screen, leaving only the pinned columns (and empty padding) visible.
- The side-by-side-with-pinned intent is preserved: at maximum scroll, the last column now sits right next to the pinned columns.
- Sync `paddingRight` and the custom scrollbar thumb at the end of a column-resize drag. `applyResizeDelta` intentionally skips this on every mousemove to avoid jank (200+ DOM writes plus several layout reads per frame); doing it once at end of drag is enough to keep the overscroll padding and scrollbar matched to the new column widths.

## Test plan

- [ ] Reproduce the original issue: `View(data.frame(matrix(1:1000000, nrow = 100000, ncol = 500)))`, scroll horizontally to the right edge, confirm the last column (X500) remains visible adjacent to the rownames column instead of scrolling out of sight.
- [ ] With multiple pinned columns, scroll to the right edge and confirm the last column lands next to the pinned block (not in the middle of the viewport, not off-screen).
- [ ] Narrow viewport so only the rownames column fits comfortably; confirm overscroll degrades to 0 rather than going negative.
- [ ] All columns pinned: confirm no overscroll padding is applied (no phantom scrollbar).
- [ ] Resize a column wider than the viewport; release; confirm the scrollbar thumb and overscroll padding immediately reflect the new width without needing to scroll first.
- [ ] Click (without dragging) on a column resizer and release; confirm no spurious re-layout (didResize gate).