### PR TITLE
data viewer: restore column count in status bar

### DIFF
--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -1715,16 +1715,14 @@ var updateInfoBar = function() {
       last = Math.max(first, Math.min(last, activeRows));
    }
 
-   var text = "Showing rows " + first.toLocaleString() + " to " + last.toLocaleString();
+   var text = "Showing " + first.toLocaleString() + " to " + last.toLocaleString() +
+      " of " + activeRows.toLocaleString() + " entries";
    if (filteredRows < totalRows) {
-      text += " of " + activeRows.toLocaleString() + " rows (filtered from " +
-         totalRows.toLocaleString() + " total)";
-   } else {
-      text += " of " + activeRows.toLocaleString() + " total rows";
+      text += " (filtered from " + totalRows.toLocaleString() + " total)";
    }
    if (totalCols > 0) {
       text += ", " + totalCols.toLocaleString() +
-         (totalCols === 1 ? " total column" : " total columns");
+         (totalCols === 1 ? " column" : " columns");
    }
    if (textEl) textEl.textContent = text;
 

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -1715,10 +1715,16 @@ var updateInfoBar = function() {
       last = Math.max(first, Math.min(last, activeRows));
    }
 
-   var text = "Showing " + first.toLocaleString() + " to " + last.toLocaleString() +
-      " of " + activeRows.toLocaleString() + " entries";
+   var text = "Showing rows " + first.toLocaleString() + " to " + last.toLocaleString();
    if (filteredRows < totalRows) {
-      text += " (filtered from " + totalRows.toLocaleString() + " total)";
+      text += " of " + activeRows.toLocaleString() + " rows (filtered from " +
+         totalRows.toLocaleString() + " total)";
+   } else {
+      text += " of " + activeRows.toLocaleString() + " total rows";
+   }
+   if (totalCols > 0) {
+      text += ", " + totalCols.toLocaleString() +
+         (totalCols === 1 ? " total column" : " total columns");
    }
    if (textEl) textEl.textContent = text;
 

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -1718,11 +1718,11 @@ var updateInfoBar = function() {
    var text = "Showing " + first.toLocaleString() + " to " + last.toLocaleString() +
       " of " + activeRows.toLocaleString() + " entries";
    if (filteredRows < totalRows) {
-      text += " (filtered from " + totalRows.toLocaleString() + " total)";
+      text += " (filtered from " + totalRows.toLocaleString() + " total entries)";
    }
    if (totalCols > 0) {
       text += ", " + totalCols.toLocaleString() +
-         (totalCols === 1 ? " column" : " columns");
+         (totalCols === 1 ? " total column" : " total columns");
    }
    if (textEl) textEl.textContent = text;
 

--- a/version/news/os/NEWS-2026.05.0-golden-wattle.md
+++ b/version/news/os/NEWS-2026.05.0-golden-wattle.md
@@ -43,6 +43,7 @@
 - ([rstudio/rstudio-pro#10771](https://github.com/rstudio/rstudio-pro/issues/10771)): Reduced filesystem work performed by the `install.packages()` hook; the before/after scan is now scoped to the requested packages and their dependency closure rather than the entire library.
 - ([rstudio/rstudio-pro#10771](https://github.com/rstudio/rstudio-pro/issues/10771)): Tightened the heuristic used to detect package-management commands at the console prompt, reducing spurious Packages pane refreshes triggered by identifiers like `updates <-` or `installed.packages()`.
 - ([#17446](https://github.com/rstudio/rstudio/issues/17446)): The Packages pane now retrieves vulnerability information from Posit Package Manager via the `POST /filter/packages` endpoint, replacing the legacy `GET /repos/{repo}/vulns` endpoint that was temporarily unavailable in Package Manager `2026.04.0`.
+- ([#17613](https://github.com/rstudio/rstudio/issues/17613)): Restored the column count in the data viewer status bar (e.g. "Showing rows 1 to 18 of 100,000 total rows, 500 total columns"), which had been dropped from the info bar in the vanilla-JS rewrite (#17382).
 
 ### Dependencies
 - Ace 1.43.5


### PR DESCRIPTION
## Intent

Addresses #17613.

The vanilla-JS data viewer rewrite (#17382) dropped the column count from the info bar. The old viewer (DataTables-based) appended `, N total columns` to the `Showing X to Y of N entries` text.

This restores the column count, and at the same time switches "entries" to "rows" so the wording pairs naturally with "columns".

Before:
> Showing 1 to 18 of 100,000 entries

After (unfiltered):
> Showing rows 1 to 18 of 100,000 total rows, 500 total columns

After (filtered):
> Showing rows 1 to 18 of 250 rows (filtered from 100,000 total), 500 total columns

`totalCols` is already tracked by the viewer; the change is purely in `updateInfoBar` in `DataViewer.js`.

No NEWS.md entry: the data viewer rewrite is part of the current (unreleased) Golden Wattle development cycle, so this regression hasn't reached any official-release user.

## Test plan

- [ ] `df <- data.frame(matrix(1:1000000, nrow = 100000, ncol = 500)); View(df)` -- status bar shows row + column counts
- [ ] Apply a global filter that reduces the row count -- status bar shows `(filtered from N total)` and still reports column count
- [ ] 1-column data frame -- status bar reads "1 total column" (singular)
- [ ] Empty data frame (0 rows) -- info bar remains empty (unchanged from prior behavior)