### PR TITLE
Add dotenv for .env.local loading and cross-env for shell parity

### DIFF
--- a/e2e/rstudio/.env.example
+++ b/e2e/rstudio/.env.example
@@ -1,0 +1,26 @@
+# Copy to .env.local and fill in the values you want.
+# .env.local is gitignored. Values here are loaded by playwright.config.ts
+# before any process.env reads. Vars already set in the shell win over
+# values in this file.
+#
+# Point dotenv at a different file with PW_ENV_FILE=<path> on the command line.
+
+# --- Mode and edition ---
+# PW_RSTUDIO_MODE=desktop
+# PW_RSTUDIO_EDITION=os
+
+# --- Desktop mode ---
+# PW_CDP_PORT=9222
+# PW_RSTUDIO_EXTRA_ARGS=--my-flag --other-option
+# PW_RSTUDIO_PREFS_OVERRIDE=/absolute/path/to/prefs.json
+
+# --- Server mode (PW_RSTUDIO_MODE=server) ---
+# PW_RSTUDIO_SERVER_URL=http://localhost:8787
+# PW_RSTUDIO_SERVER_PORT=80
+# PW_RSTUDIO_SERVER_USER=
+# PW_RSTUDIO_SERVER_PASSWORD=
+# PW_RSTUDIO_SERVER_LOGIN_TIMEOUT=60000
+
+# --- Sandbox ---
+# PW_SANDBOX=
+# PW_SANDBOX_CREATE=false

--- a/e2e/rstudio/.gitignore
+++ b/e2e/rstudio/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 dist/
 test-results/
 playwright-report/
+.env
+.env.*
+!.env.example

--- a/e2e/rstudio/README.md
+++ b/e2e/rstudio/README.md
@@ -297,6 +297,44 @@ npx playwright test --grep-invert "@pro_only|@server_only"
 | `PW_SANDBOX` | Both | No | Override the sandbox root (absolute path). Unset uses `dirname(tempdir())`. |
 | `PW_SANDBOX_CREATE` | Both | No | Set to `true`/`1` to auto-create an overridden sandbox root if it's missing. Default `false` — fails loud on typos. |
 
+## Variable Helpers
+
+The examples above use shell-prefix syntax (`KEY=val cmd ...`) which works in bash/zsh but not in `cmd.exe` or PowerShell. Two helpers are wired in for cases where you want a per-run setup without permanently changing your shell or Windows user environment.
+
+### `cross-env` (inline, cross-shell)
+
+`cross-env` parses leading `KEY=VAL` tokens on any shell, so the bash-style examples above work verbatim from PowerShell or `cmd.exe`. Combine it with `--project` to pick the project in the same line:
+
+```powershell
+npx cross-env PW_RSTUDIO_EDITION=pro npx playwright test --project=desktop
+```
+
+On bash/zsh it passes through unchanged; the native `PW_RSTUDIO_EDITION=pro npx playwright test --project=desktop` already works. Its reason for existing is `cmd.exe`/PowerShell, where the prefix syntax otherwise fails.
+
+### `.env.local` (dotenv)
+
+For a saved per-target setup instead of a long command line, `playwright.config.ts` loads `dotenv` before reading any env vars. Create `e2e/rstudio/.env.local` (gitignored) with whatever you want available to the run:
+
+```
+PW_RSTUDIO_MODE=server
+PW_RSTUDIO_EDITION=pro
+PW_RSTUDIO_SERVER_URL=http://10.0.0.5
+PW_RSTUDIO_SERVER_USER=myuser
+PW_RSTUDIO_SERVER_PASSWORD=mypass
+```
+
+Then just run:
+
+```bash
+npx playwright test
+```
+
+Notes:
+- The file is loaded only when Playwright reads its config, so vars never leak into your shell.
+- Vars already set in the shell (including via `cross-env`) win over values in the file; the file provides defaults, not overrides.
+- Point at a different file with `PW_ENV_FILE=.env.staging npx playwright test`. Useful for keeping per-target files (`.env.10-0-0-5`, `.env.pro-staging`).
+- A committed `.env.example` template documents the available keys.
+
 ## Claude Skills
 
 Claude skills are available for use when working with this test suite:

--- a/e2e/rstudio/package-lock.json
+++ b/e2e/rstudio/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "dependencies": {
         "@playwright/test": "1.59.1",
+        "dotenv": "^17.4.2",
         "playwright": "1.59.1",
         "strip-json-comments": "^3.1.1"
       },
       "devDependencies": {
-        "cross-env": "^10.1.0",
-        "dotenv": "^17.4.2"
+        "cross-env": "^10.1.0"
       }
     },
     "node_modules/@epic-web/invariant": {
@@ -76,7 +76,6 @@
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
       "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/e2e/rstudio/package-lock.json
+++ b/e2e/rstudio/package-lock.json
@@ -11,7 +11,18 @@
         "@playwright/test": "1.59.1",
         "playwright": "1.59.1",
         "strip-json-comments": "^3.1.1"
+      },
+      "devDependencies": {
+        "cross-env": "^10.1.0",
+        "dotenv": "^17.4.2"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@playwright/test": {
       "version": "1.59.1",
@@ -28,6 +39,52 @@
         "node": ">=18"
       }
     },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -40,6 +97,23 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/playwright": {
@@ -72,6 +146,29 @@
         "node": ">=18"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -82,6 +179,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     }
   }

--- a/e2e/rstudio/package.json
+++ b/e2e/rstudio/package.json
@@ -11,5 +11,9 @@
     "@playwright/test": "1.59.1",
     "playwright": "1.59.1",
     "strip-json-comments": "^3.1.1"
+  },
+  "devDependencies": {
+    "cross-env": "^10.1.0",
+    "dotenv": "^17.4.2"
   }
 }

--- a/e2e/rstudio/package.json
+++ b/e2e/rstudio/package.json
@@ -9,11 +9,11 @@
   },
   "dependencies": {
     "@playwright/test": "1.59.1",
+    "dotenv": "^17.4.2",
     "playwright": "1.59.1",
     "strip-json-comments": "^3.1.1"
   },
   "devDependencies": {
-    "cross-env": "^10.1.0",
-    "dotenv": "^17.4.2"
+    "cross-env": "^10.1.0"
   }
 }

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -1,11 +1,19 @@
 import { defineConfig } from '@playwright/test';
 import dotenv from 'dotenv';
 import os from 'os';
+import path from 'path';
 
 // Load env vars from a dotenv file before any process.env reads below.
+// Path is anchored to this config's directory so it works regardless of cwd.
 // PW_ENV_FILE overrides the default path; existing process.env values win
-// (dotenv does not overwrite vars already set in the shell).
-dotenv.config({ path: process.env.PW_ENV_FILE ?? '.env.local' });
+// (dotenv does not overwrite vars already set in the shell). When PW_ENV_FILE
+// is set explicitly, a missing/unreadable file is a hard error to catch typos.
+const envFile = process.env.PW_ENV_FILE;
+const envFilePath = path.resolve(__dirname, envFile ?? '.env.local');
+const dotenvResult = dotenv.config({ path: envFilePath });
+if (envFile && dotenvResult.error) {
+  throw new Error(`PW_ENV_FILE="${envFile}" set but could not load ${envFilePath}: ${dotenvResult.error.message}`);
+}
 
 const platform = os.platform();
 const desktopOsExclusions: string[] = [];

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -1,5 +1,11 @@
 import { defineConfig } from '@playwright/test';
+import dotenv from 'dotenv';
 import os from 'os';
+
+// Load env vars from a dotenv file before any process.env reads below.
+// PW_ENV_FILE overrides the default path; existing process.env values win
+// (dotenv does not overwrite vars already set in the shell).
+dotenv.config({ path: process.env.PW_ENV_FILE ?? '.env.local' });
 
 const platform = os.platform();
 const desktopOsExclusions: string[] = [];


### PR DESCRIPTION
## Summary

Adds two helpers for managing Playwright env vars without permanently changing the shell or user environment, addressing different needs:

- **dotenv** loads `e2e/rstudio/.env.local` (gitignored) in `playwright.config.ts` before any `process.env` reads. The path is anchored to the config's directory via `__dirname`, so it works regardless of cwd. `PW_ENV_FILE` overrides the default and, when set explicitly, a missing or unreadable file is a hard error to catch typos (matching the existing `PW_SANDBOX_CREATE` fail-loud convention). Shell-set vars still win over file values.
- **cross-env** lets the bash-style `KEY=VAL cmd ...` examples in the README work verbatim from PowerShell and `cmd.exe`. On bash/zsh it passes through unchanged.

A committed `.env.example` documents the available `PW_*` keys. README has a new "Variable Helpers" section walking through both patterns.