### PR TITLE
preserve top alignment of help argument names with r-devel

### DIFF
--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -367,9 +367,11 @@ public:
       boost::algorithm::replace_all(dest, "src=\"/", "src=\"" + baseUrl + "/");
       boost::algorithm::replace_all(dest, "src='/", "src='" + baseUrl + "/");
       
-      // add classes to headers
-      boost::regex reHeader("<h3>Arguments</h3>");
-      std::string reFormat("<h3 class=\"r-arguments-title\">Arguments</h3>");
+      // add classes to headers; the h3 may carry an id attribute when R's
+      // dynamic help server emits a table of contents (R >= 4.6.0), so
+      // preserve any existing attributes via the capture group
+      boost::regex reHeader("<h3([^>]*)>Arguments</h3>");
+      std::string reFormat("<h3$1 class=\"r-arguments-title\">Arguments</h3>");
       boost::algorithm::replace_all_regex(dest, reHeader, reFormat);
       
       // append javascript callbacks

--- a/version/news/os/NEWS-2026.05.0-golden-wattle.md
+++ b/version/news/os/NEWS-2026.05.0-golden-wattle.md
@@ -11,6 +11,7 @@
 - ([#5809](https://github.com/rstudio/rstudio/issues/5809)): Roxygen tag autocompletion (e.g. `@param`, `@return`) now works on `#'` lines inside R code chunks of R Markdown and Quarto documents, matching the behavior in plain `.R` files.
 
 ### Fixed
+- ([#17621](https://github.com/rstudio/rstudio/issues/17621)): Restored top alignment of argument names in the Help pane when running against R 4.6.0 or newer. R's dynamic help server now emits an `id` attribute on section headers (e.g. `<h3 id='_sec_arguments'>Arguments</h3>`), which broke the literal-string match RStudio used to tag the Arguments header for styling.
 - ([#17471](https://github.com/rstudio/rstudio/issues/17471)): Reformat Document with the styler formatter no longer inserts extra blank lines on Windows. The temporary file written by styler uses platform-native line endings (CRLF on Windows), and RStudio now normalizes those to LF when computing the edits to apply, so the diff against the LF-normalized in-memory document doesn't produce spurious `\r` insertions that Ace would convert into blank lines.
 - ([#17363](https://github.com/rstudio/rstudio/issues/17363)): Posit Assistant: pressing Escape to dismiss a ghost-text Next Edit Suggestion now also clears the NES gutter icon; previously the gutter icon remained visible after dismissal.
 - ([#17589](https://github.com/rstudio/rstudio/issues/17589)): The diagnostics report now includes `positai.log` alongside `rdesktop.log` and the user's `rsession-*.log`.


### PR DESCRIPTION
## Intent

Addresses #17621.

## Summary

- The fix in #13477 added a `r-arguments-title` class to the Arguments section header in R help, then used a sibling-combinator CSS rule (`h3.r-arguments-title + table tr td:first-child { vertical-align: top; ... }`) to top-align argument names.
- R 4.6.0 (r-devel) changes the default of `getOption("help.htmltoc")` to `TRUE` in `tools::httpd()`. With `toc = TRUE`, `Rd2HTML` writes section headers with an `id` attribute (e.g. `<h3 id='_sec_arguments'>Arguments</h3>`). The literal-string regex in `SessionHelp.cpp` no longer matched, so the class was never added and argument names reverted to vertically-centered.
- Broaden the regex to capture any attributes on the `<h3>` and preserve them in the replacement: `<h3([^>]*)>Arguments</h3>` -> `<h3$1 class="r-arguments-title">Arguments</h3>`. This handles both pre-4.6 (`<h3>Arguments</h3>`) and 4.6+ (`<h3 id='_sec_arguments'>Arguments</h3>`) output.

## Test plan

- [ ] Verified locally with a small Boost regex harness that both formats (with/without `id`, single- and double-quoted) rewrite correctly and non-matching strings pass through.
- [ ] Build `rsession`: `cmake --build build --target rsession`.
- [ ] Open `?t.test` in the Help pane against R-devel; confirm argument names are top-aligned with their descriptions (Issue [#17621](https://github.com/rstudio/rstudio/issues/17621)).
- [ ] Open `?t.test` against R 4.5.x; confirm no regression in the pre-existing behavior.