### PR TITLE
Add placeholder What's New content for Blue Plumbago

### DIFF
--- a/src/node/desktop/src/assets/whats-new/blue-plumbago/index.html
+++ b/src/node/desktop/src/assets/whats-new/blue-plumbago/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' file:;">
+  <link rel="stylesheet" href="../whats-new-base.css">
+  <title>What's New in RStudio</title>
+</head>
+<body>
+  <div class="feature-section">
+    <h2>New Features</h2>
+    <ul>
+      <li>Feature description here</li>
+    </ul>
+  </div>
+
+  <div class="feature-section">
+    <h2>Fixes</h2>
+    <p>
+      For a full list of bug fixes in this release, see the
+      <a href="https://www.rstudio.org/links/release_notes#rstudio-2026.06.0">release notes</a>.
+    </p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds a placeholder `index.html` under `src/node/desktop/src/assets/whats-new/blue-plumbago/` for the 2026.06 (Blue Plumbago) release, following the same pattern as `golden-wattle` and `globemaster-allium`.
- Uses the template from the directory's `README.md`, with the release notes link pointing at `rstudio-2026.06.0`. Content will be filled in as the release takes shape.

## Test plan

- [x] `cd src/node/desktop && npm test` (398 passing)