### PR TITLE
Data viewer: show column count in status bar

### DIFF
--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -1717,6 +1717,9 @@ var updateInfoBar = function() {
 
    var text = "Showing " + first.toLocaleString() + " to " + last.toLocaleString() +
       " of " + activeRows.toLocaleString() + " entries";
+   if (totalCols > 0) {
+      text += ", " + totalCols.toLocaleString() + " columns";
+   }
    if (filteredRows < totalRows) {
       text += " (filtered from " + totalRows.toLocaleString() + " total)";
    }


### PR DESCRIPTION
Fixes #17613

The status line now displays the total column count alongside the row range:

`Showing 1 to 50 of 100,000 entries, 500 columns`

Uses the existing `totalCols` variable which is already tracked by the data viewer.

### Testing
- Open a wide data frame: `View(data.frame(matrix(1:1000, nrow=10, ncol=100)))`
- Verify the status bar shows column count