### PR TITLE
Help pane: preserve top alignment of argument names

### DIFF
--- a/src/cpp/session/resources/R.css
+++ b/src/cpp/session/resources/R.css
@@ -131,7 +131,8 @@ table p {
    margin-bottom: 6px;
 }
 
-h3.r-arguments-title + table tr td:first-child {
+h3.r-arguments-title + table tr td:first-child,
+h3.r-arguments-title ~ table tr td:first-child {
    vertical-align: top;
    min-width: 24px;
    padding-right: 12px;


### PR DESCRIPTION
Fixes #17621

The CSS selector `h3.r-arguments-title + table` only matches when the `<table>` is an immediate sibling of the `<h3>`. In R >= 4.6.0 the help HTML structure can include intermediate elements between the heading and the arguments table, breaking the adjacent sibling selector.

Adding the general sibling selector (`~`) ensures the `vertical-align: top` rule applies regardless of intervening elements.

### Testing
- Run `?dplyr::mutate` or any function with long argument descriptions
- Verify argument names are top-aligned, not vertically centered