### PR TITLE
Outline pane: recognise roxygen tags

### DIFF
--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -907,9 +907,20 @@ var RCodeModel = function(session, tokenizer,
          type = token.type;
          position = iterator.getCurrentTokenPosition();
 
-         // Skip roxygen comments.
+         // Roxygen comments: detect @tags for the document outline,
+         // then skip the rest of the line.
          var state = Utils.getPrimaryState(this.$session, position.row);
          if (state === "rdoc-start") {
+            if (type === "keyword" && /^@[a-zA-Z]/.test(value)) {
+               var roxyTag = value.replace(/^@/, "");
+               if (roxyTag === "section") {
+                  var lineText = this.$session.getLine(position.row);
+                  var rest = lineText.substring(position.column + value.length).trim();
+                  rest = rest.replace(/:\s*$/, "");
+                  if (rest.length > 0) roxyTag = rest;
+               }
+               this.$scopes.onSectionStart("@" + roxyTag, position);
+            }
             iterator.moveToEndOfRow();
             continue;
          }


### PR DESCRIPTION
Fixes #17545

Roxygen `@tags` (e.g. `@param`, `@returns`, `@export`) now appear in the document outline for .R files. The `@section` tag uses its argument as the label (e.g. `@section Programming notes:` shows as `@Programming notes`).

Previously, the entire roxygen comment block was skipped during outline parsing (`rdoc-start` state → `moveToEndOfRow`). Now we detect keyword tokens matching `@[a-zA-Z]` within that state and register them as sections before skipping the rest of the line.

### Testing
- Open an .R file with roxygen documentation
- Open the document outline (Ctrl+Shift+O)
- Verify `@param`, `@returns`, `@export` etc. appear as entries