### PR TITLE
Find in Files: refresh button placement + Replace theming

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutput.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutput.css
@@ -101,3 +101,13 @@
    background-color: #A81900;
    color: white;
 }
+
+.rstudio-themes-dark .replaceTextBox {
+   background-color: #1e1e1e;
+   color: #d4d4d4;
+   border: 1px solid #3c3c3c;
+}
+
+.rstudio-themes-dark .replaceTextBox:focus {
+   border-color: #007acc;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPane.java
@@ -85,7 +85,7 @@ public class FindOutputPane extends WorkbenchPane
                turnOnReplaceMode();
          }
       });
-      toolbar.addRightWidget(showFindButton_);
+      toolbar.addLeftWidget(showFindButton_);
 
       showReplaceButton_ = new LeftRightToggleButton(constants_.findLabel(), constants_.replaceLabel(), false);
       showReplaceButton_.setVisible(false);
@@ -97,7 +97,7 @@ public class FindOutputPane extends WorkbenchPane
                turnOffReplaceMode();
          }
       });
-      toolbar.addRightWidget(showReplaceButton_);
+      toolbar.addLeftWidget(showReplaceButton_);
 
       return toolbar;
    }
@@ -109,6 +109,7 @@ public class FindOutputPane extends WorkbenchPane
       replaceMode_ = true;
 
       replaceTextBox_ = new TextBox();
+      replaceTextBox_.addStyleName("replaceTextBox");
       replaceTextBox_.addKeyUpHandler(new KeyUpHandler()
       {
          public void onKeyUp(KeyUpEvent event)


### PR DESCRIPTION
Fixes #17501

Two changes:

1. **Refresh button placement**: Moved the Find/Replace toggle buttons to the left side of the toolbar so the refresh button sits rightmost, matching the convention used by Environment, Files, Plots, and Data Viewer panes.

2. **Replace dialog theming**: Added `.replaceTextBox` CSS class with dark-theme-aware styles so the Replace text input picks up appropriate background, border, and text colors under dark themes.

### Testing
- Open Find in Files (Ctrl+Shift+F), verify refresh button is rightmost
- Switch to a dark theme, open Replace mode, verify the text input has appropriate dark styling