### PR TITLE
Remove vestigial Qt-era desktop workarounds

### DIFF
--- a/src/cpp/session/modules/SessionHTMLPreview.cpp
+++ b/src/cpp/session/modules/SessionHTMLPreview.cpp
@@ -775,15 +775,6 @@ void modifyOutputForPreview(std::string* pOutput)
            *pOutput,
             boost::regex("tt, code, pre \\{\\n\\s+font-family:[^\n]+;"),
            "tt, code, pre {\n   font-family: " + preFontFamily() + ";");
-
-#if defined(_WIN32)
-      // add HTML-CSS options required for correct qtwebkit rendering
-      std::string target = "<!-- MathJax scripts -->";
-      boost::algorithm::replace_first(
-               *pOutput,
-               target,
-               target + "\n" kQtMathJaxConfigScript);
-#endif
    }
 
    // serve mathjax locally from this directory

--- a/src/cpp/session/modules/SessionHTMLPreview.hpp
+++ b/src/cpp/session/modules/SessionHTMLPreview.hpp
@@ -16,12 +16,6 @@
 #ifndef SESSION_HTML_PREVIEW_HPP
 #define SESSION_HTML_PREVIEW_HPP
 
-#define kQtMathJaxConfigScript "<script type=\"text/x-mathjax-config\">" \
-   "MathJax.Hub.Config({" \
-   "  \"HTML-CSS\": { minScaleAdjust: 125, availableFonts: [] } " \
-   " });" \
-   "</script>"
-
 #include <shared_core/json/Json.hpp>
 
 namespace rstudio {

--- a/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
+++ b/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
@@ -894,10 +894,8 @@ void handlePresentationRootRequest(const std::string& path,
    revealSizeVars(slideDeck, zoom, true, &vars);
 
    // no transition in desktop mode (qtwebkit can't keep up)
-   bool isDesktop = options().programMode() == kSessionProgramModeDesktop;
-   vars["reveal_transition"] =  isDesktop? "none" : slideDeck.transition();
-   vars["reveal_transition_speed"] = isDesktop ? "default" :
-                                                 slideDeck.transitionSpeed();
+   vars["reveal_transition"] = slideDeck.transition();
+   vars["reveal_transition_speed"] = slideDeck.transitionSpeed();
 
    // rtl
    vars["reveal_rtl"] = slideDeck.rtl();

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -1091,13 +1091,6 @@ private:
          // load the Safe extension before MathJax processes the page
          result.append(kMathjaxSafeConfigScript "\n");
 
-#if defined(_WIN32)
-         // on Windows desktop, also tweak HTML-CSS rendering (font scaling +
-         // disable web fonts) to work around QtWebEngine rendering quirks
-         if (session::options().programMode() == kSessionProgramModeDesktop)
-            result.append(kQtMathJaxConfigScript "\n");
-#endif
-
          result.append(match[0]);
       }
       else if (hasMathjax_)


### PR DESCRIPTION
Fixes #17509

Removes workarounds that were specific to QtWebKit/QtWebEngine, now that RStudio Desktop runs on Electron/Chromium:

- **kQtMathJaxConfigScript** (SessionHTMLPreview.hpp/.cpp, SessionRMarkdown.cpp): Forced `minScaleAdjust: 125` and `availableFonts: []` to compensate for QtWebKit font rendering. Chromium renders MathJax correctly with defaults.

- **Transition disabling** (SlideRequestHandler.cpp): Disabled reveal.js transitions in desktop mode because 'qtwebkit can't keep up'. Chromium handles transitions fine.

Net: -26 lines of dead code, presentations now get transitions on Desktop.

### Testing
- Render an Rmd with MathJax equations on Windows Desktop — verify equations render correctly
- Open a reveal.js presentation on Desktop — verify transitions work