### PR TITLE
Fix code highlighting for multi-line backtick identifiers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 -
 
 ### Fixed
+- ([#17458](https://github.com/rstudio/rstudio/issues/17458)): Fix incorrect code highlighting when a backtick-quoted identifier contains a newline.
 -
 
 ### Dependencies

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -387,7 +387,9 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
         next  : "start"
       },
       {
-        defaultToken : "identifier"
+        token : "identifier",
+        regex : ".+",
+        merge : true
       }
     ];
 

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -370,6 +370,24 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
         regex : "[`](?:(?:\\\\.)|(?:[^`\\\\]))*?[`]",
         merge : false,
         next  : "start"
+      },
+      {
+        // Multi-line backtick identifier: opening backtick without closing on same line
+        token : "identifier",
+        regex : "[`]",
+        merge : false,
+        next  : "qidentifier"
+      }
+    ];
+
+    rules["qidentifier"] = [
+      {
+        token : "identifier",
+        regex : "(?:(?:\\\\.)|(?:[^`\\\\]))*?[`]",
+        next  : "start"
+      },
+      {
+        defaultToken : "identifier"
       }
     ];
 


### PR DESCRIPTION
Addresses #17458

When a backtick-quoted identifier spans multiple lines (e.g. a tibble column name containing a literal newline), the single-line regex couldn't match the closing backtick. The tokenizer fell through, and an apostrophe within the identifier was treated as a string delimiter — breaking highlighting for the rest of the file.

Added a `qidentifier` state that handles continuation of backtick identifiers across line boundaries.

### Repro
```r
library(tibble)
d = tibble("[EN] What's\nyour name" = "Bob")
d$\`[EN] What's
your name\`
print("This should be highlighted as code, not string")
```

### Testing
- Paste the repro above into an R script
- Verify `print(...)` is highlighted as code, not as a string