### PR TITLE
Detect .air.toml created mid-session

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 -
 
 ### Fixed
+- ([#17310](https://github.com/rstudio/rstudio/issues/17310)): Detect `.air.toml` created mid-session by adding it to `always_shown_files`.
 -
 
 ### Dependencies

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1094,9 +1094,11 @@
                 "type": "string"
             },
             "default": [
+                ".air.toml",
                 ".build.yml",
                 ".gitlab-ci.yml",
-                ".travis.yml"
+                ".travis.yml",
+                "air.toml"
             ]
         },
         "always_shown_extensions": {
@@ -1107,7 +1109,6 @@
                 "type": "string"
             },
             "default": [
-                ".air.toml",
                 ".circleci",
                 ".env",
                 ".gitattributes",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -2577,7 +2577,7 @@ public class UserPrefsAccessor extends Prefs
          "always_shown_files",
          _constants.alwaysShownFilesTitle(), 
          _constants.alwaysShownFilesDescription(), 
-         JsArrayUtil.createStringArray(".build.yml", ".gitlab-ci.yml", ".travis.yml"));
+         JsArrayUtil.createStringArray(".air.toml", ".build.yml", ".gitlab-ci.yml", ".travis.yml", "air.toml"));
    }
 
    /**
@@ -2589,7 +2589,7 @@ public class UserPrefsAccessor extends Prefs
          "always_shown_extensions",
          _constants.alwaysShownExtensionsTitle(), 
          _constants.alwaysShownExtensionsDescription(), 
-         JsArrayUtil.createStringArray(".air.toml", ".circleci", ".env", ".gitattributes", ".github", ".gitignore", ".httr-oauth", ".lintr", ".positai", ".quartoignore", ".r", ".rbuildignore", ".rdata", ".renvignore", ".renviron", ".rhistory", ".rprofile", ".ruserdata"));
+         JsArrayUtil.createStringArray(".circleci", ".env", ".gitattributes", ".github", ".gitignore", ".httr-oauth", ".lintr", ".positai", ".quartoignore", ".r", ".rbuildignore", ".rdata", ".renvignore", ".renviron", ".rhistory", ".rprofile", ".ruserdata"));
    }
 
    /**


### PR DESCRIPTION
Fixes #17310

The Air formatter config (`air.toml` / `.air.toml`) was only detected at session startup via `onClientInit`. If the file was created mid-session, the formatter would ignore it until restart.

This subscribes to the project file monitor so that creation or modification of `air.toml` / `.air.toml` triggers a file change event to the client, allowing the formatter to pick up the new config immediately.

### Testing
1. Open RStudio with Air formatting enabled but no `air.toml`
2. Create `.air.toml` with custom settings (e.g. `indent-width = 12`)
3. Reformat code — should use the new settings without restart