### PR TITLE
Call onCompleted when SessionOpener retry limit is exhausted

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 -
 
 ### Fixed
+- ([#17143](https://github.com/rstudio/rstudio/issues/17143)): Call `onCompleted` when SessionOpener retry limit is exhausted.
 -
 
 ### Dependencies

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionOpener.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionOpener.java
@@ -193,7 +193,8 @@ public class SessionOpener
       sendPing(200, 50, onCompleted);
    }
    
-   private void sendPing(int delayMs,
+   // Package-private for testing
+   void sendPing(int delayMs,
                          final int maxRetries,
                          final Command onCompleted)
    {
@@ -216,6 +217,8 @@ public class SessionOpener
             if (retries_++ > maxRetries)
             {
                Debug.logWarning("Error connecting with session.");
+               if (onCompleted != null)
+                  onCompleted.execute();
                return false;
             }
             

--- a/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
+++ b/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
@@ -29,6 +29,7 @@ import org.rstudio.studio.client.common.r.RTokenizerTests;
 import org.rstudio.studio.client.common.sourcemarkers.SourceMarkerItemCodecTests;
 import org.rstudio.studio.client.projects.model.ProjectMRUEntryTests;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobManagerTests;
+import org.rstudio.studio.client.workbench.model.SessionOpenerTests;
 import org.rstudio.studio.client.workbench.views.jobs.view.JobsListTests;
 import org.rstudio.studio.client.workbench.views.output.lint.model.LintItemTests;
 import org.rstudio.studio.client.workbench.views.source.editors.text.assist.RChunkHeaderParserTests;
@@ -56,6 +57,7 @@ public class RStudioUnitTestSuite extends GWTTestSuite
       suite.addTestSuite(TerminalLocalEchoTests.class);
       suite.addTestSuite(TerminalSessionSocketTests.class);
       suite.addTestSuite(JobManagerTests.class);
+      suite.addTestSuite(SessionOpenerTests.class);
       suite.addTestSuite(URIUtilsTests.class);
       suite.addTestSuite(RChunkHeaderParserTests.class);
       suite.addTestSuite(DefaultChunkOptionsPopupPanelTests.class);

--- a/src/gwt/test/org/rstudio/studio/client/workbench/model/SessionOpenerTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/workbench/model/SessionOpenerTests.java
@@ -1,0 +1,95 @@
+/*
+ * SessionOpenerTests.java
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.model;
+
+import com.google.gwt.junit.client.GWTTestCase;
+import com.google.gwt.user.client.Command;
+import com.google.inject.Provider;
+
+import org.rstudio.studio.client.application.model.ApplicationServerOperations;
+import org.rstudio.studio.client.application.model.DummyApplicationServerOperations;
+import org.rstudio.studio.client.common.DummyGlobalDisplay;
+import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.server.VoidResponse;
+
+public class SessionOpenerTests extends GWTTestCase
+{
+   @Override
+   public String getModuleName()
+   {
+      return "org.rstudio.studio.RStudioTests";
+   }
+
+   /**
+    * Verify that onCompleted is called when sendPing exhausts all retries
+    * without a successful ping response (regression test for #17143).
+    */
+   public void testOnCompletedCalledOnRetryExhaustion()
+   {
+      delayTestFinish(5000);
+
+      // Server mock that never responds to ping (simulates unreachable session)
+      ApplicationServerOperations server = new DummyApplicationServerOperations()
+      {
+         @Override
+         public void ping(ServerRequestCallback<VoidResponse> requestCallback)
+         {
+            // Never call back — ping stays in-flight forever
+         }
+      };
+
+      SessionOpener opener = new SessionOpener(
+         nullProvider(),
+         providerOf(new DummyGlobalDisplay()),
+         providerOf(server),
+         nullProvider()
+      );
+
+      // maxRetries=0: first execute() increments retries_ to 1 > 0, hitting exhaustion
+      opener.sendPing(10, 0, new Command()
+      {
+         @Override
+         public void execute()
+         {
+            finishTest();
+         }
+      });
+   }
+
+   @SuppressWarnings("unchecked")
+   private static <T> Provider<T> nullProvider()
+   {
+      return new Provider<T>()
+      {
+         @Override
+         public T get()
+         {
+            return null;
+         }
+      };
+   }
+
+   private static <T> Provider<T> providerOf(final T value)
+   {
+      return new Provider<T>()
+      {
+         @Override
+         public T get()
+         {
+            return value;
+         }
+      };
+   }
+}


### PR DESCRIPTION
Fixes #17143

When `sendPing()` exhausts `maxRetries`, it returned `false` without calling the `onCompleted` callback. This left `suspendingAndRestarting_` permanently true and prevented `RestartStatusEvent.RESTART_COMPLETED` from firing.

2-line fix: call `onCompleted` before returning on retry exhaustion, matching the success paths.