### PR TITLE
Widen Environment pane name column default to 40%

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.css
@@ -47,7 +47,7 @@
 
 td.nameCol
 {
-   width: 25%;
+   width: 40%;
    text-overflow: ellipsis;
    overflow-x: hidden;
    border: 1px solid #f0f0f0;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
@@ -47,7 +47,7 @@
 
 .objectGrid td.nameCol
 {
-   width: 25%;
+   width: 40%;
    text-overflow: ellipsis;
    overflow-x: hidden;
    border: 1px solid #f0f0f0;


### PR DESCRIPTION
Addresses #17451

The default name column width of 25% is too narrow to see full variable names, especially when monitoring variables with common prefixes. Widened to 40% in both grid and list views.

This is the simplest fix for the immediate pain point. A more complete solution would persist user-resized column widths across refreshes.