### PR TITLE
Show TODO/FIXME comments in document outline

### DIFF
--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -914,6 +914,16 @@ var RCodeModel = function(session, tokenizer,
             continue;
          }
 
+         // Detect TODO/FIXME comments for the document outline
+         if (type === "comment.keyword.operator" &&
+             /^(?:TODO|FIXME)$/.test(value))
+         {
+            var todoLine = this.$session.getLine(position.row);
+            var todoText = todoLine.substring(position.column).replace(/^\S+\s*/, "").trim();
+            var todoLabel = value + (todoText ? ": " + todoText : "");
+            this.$scopes.onSectionStart(todoLabel, position);
+         }
+
          // Figure out if we're in R mode. This is a hack since
          // unfortunately the code model is handling both R and
          // non-R modes right now -- for example, '{' should only


### PR DESCRIPTION
Addresses #17277 (part 2: outline integration)

TODO and FIXME comments now appear in the document outline pane, making them easy to navigate to. The entry shows the tag plus trailing text:

```
# TODO: refactor this function ----
# FIXME: handle NULL case
```

Shows as:
- `TODO: refactor this function`
- `FIXME: handle NULL case`

### Testing
- Write `# TODO: something` in an R file
- Open document outline (Ctrl+Shift+O)
- Verify the TODO appears as a navigable entry