### PR TITLE
Add Partitioned (CHIPS) attribute to SameSite=None cookies

### DIFF
--- a/src/cpp/core/http/Cookie.cpp
+++ b/src/cpp/core/http/Cookie.cpp
@@ -120,6 +120,7 @@ std::string Cookie::cookieHeaderValue() const
    {
       case SameSite::None:
          headerValue << "; SameSite=None";
+         headerValue << "; Partitioned";
          break;
       case SameSite::Lax:
          headerValue << "; SameSite=Lax";


### PR DESCRIPTION
Fixes #17430

When `SameSite=None` is set on a cookie, also emit the `Partitioned` attribute per the [CHIPS spec](https://developer.mozilla.org/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies). This allows cookies to work in cross-origin iframes for users who have opted into third-party cookie blocking.

1-line addition in `Cookie.cpp` — the `Partitioned` attribute is appended whenever `SameSite=None` is emitted.

### Testing
- Embed RStudio Server in a cross-origin iframe with `www-same-site=none`
- Enable third-party cookie blocking in Chrome
- Verify authentication cookies are accepted and sign-in succeeds