### PR TITLE
honor COPILOT_AUTH_PROVIDER again with project-level assistant overrides

### DIFF
--- a/src/cpp/session/modules/SessionAssistant.cpp
+++ b/src/cpp/session/modules/SessionAssistant.cpp
@@ -1384,8 +1384,10 @@ Error startAgent(const std::string& assistantType = "")
       // then used as a signal that they should start the agent process
       sendNotification("initialized", json::Object());
 
-      // Send assistant-specific configuration
-      std::string assistant = prefs::userPrefs().assistant();
+      // Send assistant-specific configuration. Use the type of agent that
+      // actually started rather than the global pref, so configuration is
+      // applied correctly when a project-level override is in effect.
+      const std::string& assistant = s_runningAgentType;
       if (assistant == kAssistantCopilot)
          setCopilotConfiguration();
       else if (assistant == kAssistantPosit)

--- a/src/cpp/session/modules/SessionAssistant.cpp
+++ b/src/cpp/session/modules/SessionAssistant.cpp
@@ -1384,10 +1384,10 @@ Error startAgent(const std::string& assistantType = "")
       // then used as a signal that they should start the agent process
       sendNotification("initialized", json::Object());
 
-      // Send assistant-specific configuration. Use the type of agent that
-      // actually started rather than the global pref, so configuration is
-      // applied correctly when a project-level override is in effect.
-      const std::string& assistant = s_runningAgentType;
+      // Send assistant-specific configuration. Use the 'assistant' captured
+      // from the enclosing scope so configuration is applied for the agent
+      // this initialize was issued against, even if a fast switch changes
+      // the running agent before this continuation fires.
       if (assistant == kAssistantCopilot)
          setCopilotConfiguration();
       else if (assistant == kAssistantPosit)

--- a/src/cpp/session/modules/SessionAssistant.cpp
+++ b/src/cpp/session/modules/SessionAssistant.cpp
@@ -2654,12 +2654,21 @@ Error initialize()
    using boost::bind;
    using namespace module_context;
 
+   // Read project options first so the assistant type resolved below
+   // picks up any project-level override.
+   if (projects::projectContext().hasProject())
+   {
+      Error error = projects::projectContext().readAssistantOptions(&s_assistantProjectOptions);
+      if (error)
+         LOG_ERROR(error);
+   }
+
    // Read default log level from environment variable.
    // RSTUDIO_ASSISTANT_LOG_LEVEL applies to all assistant types;
    // COPILOT_LOG_LEVEL and PAI_LOG_LEVEL only apply to their respective types.
    std::string assistantLogLevel;
    {
-      std::string assistant = prefs::userPrefs().assistant();
+      std::string assistant = getConfiguredAssistantType();
       if (assistant == kAssistantCopilot)
          assistantLogLevel = core::system::getenv("COPILOT_LOG_LEVEL");
       else if (assistant == kAssistantPosit)
@@ -2672,14 +2681,6 @@ Error initialize()
    {
       s_assistantLogLevel = safe_convert::stringTo<int>(assistantLogLevel, 0);
       rstudio::session::logging::setStderrLogLevel("assistant", s_assistantLogLevel);
-   }
-   
-   // Read project options
-   if (projects::projectContext().hasProject())
-   {
-      Error error = projects::projectContext().readAssistantOptions(&s_assistantProjectOptions);
-      if (error)
-         LOG_ERROR(error);
    }
 
    // Synchronize user + project preferences with internal caches

--- a/version/news/os/NEWS-2026.05.0-golden-wattle.md
+++ b/version/news/os/NEWS-2026.05.0-golden-wattle.md
@@ -46,6 +46,7 @@
 - ([#17446](https://github.com/rstudio/rstudio/issues/17446)): The Packages pane now retrieves vulnerability information from Posit Package Manager via the `POST /filter/packages` endpoint, replacing the legacy `GET /repos/{repo}/vulns` endpoint that was temporarily unavailable in Package Manager `2026.04.0`.
 - ([#17613](https://github.com/rstudio/rstudio/issues/17613)): Restored the column count in the data viewer status bar (e.g. "Showing rows 1 to 18 of 100,000 total rows, 500 total columns"), which had been dropped from the info bar in the vanilla-JS rewrite (#17382).
 - ([#17612](https://github.com/rstudio/rstudio/issues/17612)): Limit horizontal overscroll in the data viewer so the last column remains visible at maximum scroll, instead of allowing all unpinned columns to be scrolled off-screen.
+- ([#15211](https://github.com/rstudio/rstudio/issues/15211)): Restored honoring of the `COPILOT_AUTH_PROVIDER` environment variable, used to point Copilot at a GitHub Enterprise sign-in URL.
 
 ### Dependencies
 - Ace 1.43.5


### PR DESCRIPTION
## Intent

Addresses #15211.

## Summary

- The post-initialize callback in `SessionAssistant.cpp` now selects which configuration to send based on the actually-running agent type (`s_runningAgentType`) rather than the global `assistant` user preference. When a project-level override caused Copilot to run while the global preference was set to a different assistant, Copilot's configuration -- including the `COPILOT_AUTH_PROVIDER` env var used for GitHub Enterprise sign-in -- was silently dropped.
- Added a NEWS entry under Fixed.

## Test plan

- [ ] In a session where the global `assistant` pref is set to a non-Copilot value (e.g. `posit`) and a project-level override selects Copilot, set `COPILOT_AUTH_PROVIDER=https://<your-org>.ghe.com` in the environment, open the project, sign in to Copilot, and confirm the sign-in flow uses the GHE URL.
- [ ] In a session where the global `assistant` pref is `copilot`, confirm Copilot sign-in still uses the configured `COPILOT_AUTH_PROVIDER` (no regression in the common case).