### PR TITLE
ppm: query filter/packages by installed (name, version)

### DIFF
--- a/src/cpp/session/modules/SessionPPM.R
+++ b/src/cpp/session/modules/SessionPPM.R
@@ -40,12 +40,12 @@
       installed.packages(priority = "NA"),
       stringsAsFactors = FALSE
    )
-   pkgNames <- paste(db[["Package"]], db[["Version"]], sep = "==")
+   pkgKeys <- paste(db[["Package"]], db[["Version"]], sep = "==")
 
    lapply(repos, function(repoUrl)
    {
       tryCatch(
-         .rs.ppm.getVulnerabilityInformationImpl(repoUrl, pkgNames),
+         .rs.ppm.getVulnerabilityInformationImpl(repoUrl, pkgKeys),
          error = function(cnd)
          {
             .rs.logErrorMessage(sprintf(
@@ -58,12 +58,12 @@
    })
 })
 
-.rs.addFunction("ppm.getVulnerabilityInformationImpl", function(repoUrl, pkgNames)
+.rs.addFunction("ppm.getVulnerabilityInformationImpl", function(repoUrl, pkgKeys)
 {
    empty <- structure(list(), names = character())
 
    # nothing to ask about
-   if (length(pkgNames) == 0L)
+   if (length(pkgKeys) == 0L)
       return(empty)
 
    # Per-repo cache lives in an environment keyed by "name==version" so we
@@ -78,7 +78,7 @@
 
    # only ask PPM about (name, version) pairs we haven't seen this session
    cachedKeys <- ls(envir = cache, all.names = TRUE)
-   newKeys <- setdiff(pkgNames, cachedKeys)
+   newKeys <- setdiff(pkgKeys, cachedKeys)
    if (length(newKeys) > 0L)
    {
       fetched <- .rs.ppm.fetchVulnerabilityInformation(repoUrl, newKeys)
@@ -86,7 +86,7 @@
       # NULL means the request failed; skip the cache update so the next
       # refresh can retry rather than masking vulns with empty entries
       if (is.null(fetched))
-         return(.rs.ppm.aggregateVulnsByName(cache, pkgNames))
+         return(.rs.ppm.aggregateVulnsByName(cache, pkgKeys))
 
       # record every requested key (empty list for the ones PPM didn't
       # report on) so we don't keep re-querying packages with no vulns
@@ -97,10 +97,10 @@
       }
    }
 
-   .rs.ppm.aggregateVulnsByName(cache, pkgNames)
+   .rs.ppm.aggregateVulnsByName(cache, pkgKeys)
 })
 
-.rs.addFunction("ppm.fetchVulnerabilityInformation", function(repoUrl, pkgNames)
+.rs.addFunction("ppm.fetchVulnerabilityInformation", function(repoUrl, pkgKeys)
 {
    ppmUrl <- .rs.ppm.fromRepositoryUrl(repoUrl)
    if (length(ppmUrl) == 0L)
@@ -119,7 +119,7 @@
    # ask PPM for vulnerability info on each requested (name, version)
    data <- list(
       repo                 = ppmUrl[["repos"]],
-      names                = as.list(pkgNames),
+      names                = as.list(pkgKeys),
       has_vulns            = TRUE,
       omit_dependencies    = TRUE,
       omit_downloads       = TRUE,
@@ -221,56 +221,21 @@
    .rs.markScalars(byKey)
 })
 
-.rs.addFunction("ppm.aggregateVulnsByName", function(cache, pkgNames)
+.rs.addFunction("ppm.aggregateVulnsByName", function(cache, pkgKeys)
 {
-   empty <- structure(list(), names = character())
+   # project the cache down to the currently-installed (name, version) keys
+   # and re-label them with just the package name
+   entries <- as.list(cache)[pkgKeys]
+   names(entries) <- sub("==.*$", "", names(entries))
 
-   # collect per-(name, version) entries from the cache into the by-name
-   # shape the Packages pane expects, skipping keys that aren't currently
-   # installed (e.g. an old version left behind after an upgrade)
-   vulns <- empty
-   for (key in pkgNames)
-   {
-      pkgVulns <- cache[[key]]
-      if (length(pkgVulns) == 0L)
-         next
+   # group by package name and concatenate; a single installed version is
+   # the common case, but the same package can show up across multiple
+   # libraries, in which case the vuln lists join
+   groups <- split(entries, names(entries))
+   vulns <- lapply(groups, function(group) do.call(c, unname(group)))
 
-      name <- sub("==.*$", "", key)
-      vulns[[name]] <- c(vulns[[name]], pkgVulns)
-   }
-
-   # dedupe vulns by id within each package, merging the per-record
-   # 'versions' maps so the UI's per-version check still finds every
-   # affected installed version. PPM may report a different versions
-   # subset alongside each (package, version) record.
-   for (name in names(vulns))
-   {
-      pkgVulns <- vulns[[name]]
-      merged <- list()
-      indices <- list()
-      for (i in seq_along(pkgVulns))
-      {
-         vuln <- pkgVulns[[i]]
-         id <- .rs.nullCoalesce(vuln[["id"]], "")
-         slot <- indices[[id]]
-         if (is.null(slot))
-         {
-            slot <- length(merged) + 1L
-            indices[[id]] <- slot
-            merged[[slot]] <- vuln
-         }
-         else
-         {
-            existing <- merged[[slot]]
-            combined <- c(existing[["versions"]], vuln[["versions"]])
-            existing[["versions"]] <- combined[!duplicated(names(combined))]
-            merged[[slot]] <- existing
-         }
-      }
-      vulns[[name]] <- merged
-   }
-
-   .rs.markScalars(vulns)
+   # drop packages with no vulns
+   .rs.markScalars(vulns[lengths(vulns) > 0L])
 })
 
 .rs.addFunction("ppm.fromRepositoryUrl", function(url)

--- a/src/cpp/session/modules/SessionPPM.R
+++ b/src/cpp/session/modules/SessionPPM.R
@@ -223,9 +223,10 @@
 
 .rs.addFunction("ppm.aggregateVulnsByName", function(cache, pkgKeys)
 {
-   # project the cache down to the currently-installed (name, version) keys
-   # and re-label them with just the package name
-   entries <- as.list(cache)[pkgKeys]
+   # pull only the cache entries for currently-installed (name, version)
+   # keys, then re-label by just the package name
+   keys <- intersect(pkgKeys, ls(envir = cache, all.names = TRUE))
+   entries <- mget(keys, envir = cache)
    names(entries) <- sub("==.*$", "", names(entries))
 
    # group by package name and concatenate; a single installed version is

--- a/src/cpp/session/modules/SessionPPM.R
+++ b/src/cpp/session/modules/SessionPPM.R
@@ -31,10 +31,21 @@
    # For each available repository, ask it for vulnerability information,
    # then merge that all together.
    repos <- .rs.nullCoalesce(repos, getOption("repos"))
+
+   # PPM's filter/packages endpoint defaults to the current snapshot's latest
+   # version of each package, so a vuln that only affects an older installed
+   # version is silently dropped. Ask explicitly for the installed (name,
+   # version) pairs instead.
+   db <- as.data.frame(
+      installed.packages(priority = "NA"),
+      stringsAsFactors = FALSE
+   )
+   pkgNames <- paste(db[["Package"]], db[["Version"]], sep = "==")
+
    lapply(repos, function(repoUrl)
    {
       tryCatch(
-         .rs.ppm.getVulnerabilityInformationImpl(repoUrl),
+         .rs.ppm.getVulnerabilityInformationImpl(repoUrl, pkgNames),
          error = function(cnd)
          {
             .rs.logErrorMessage(sprintf(
@@ -47,20 +58,56 @@
    })
 })
 
-.rs.addFunction("ppm.getVulnerabilityInformationImpl", function(repoUrl)
+.rs.addFunction("ppm.getVulnerabilityInformationImpl", function(repoUrl, pkgNames)
 {
-   # If we have cached information available, use it.
-   if (exists(repoUrl, envir = .rs.ppm.vulns))
-      return(get(repoUrl, envir = .rs.ppm.vulns))
-
    empty <- structure(list(), names = character())
 
-   ppmUrl <- .rs.ppm.fromRepositoryUrl(repoUrl)
-   if (length(ppmUrl) == 0L)
+   # nothing to ask about
+   if (length(pkgNames) == 0L)
       return(empty)
 
+   # Per-repo cache lives in an environment keyed by "name==version" so we
+   # can request only newly-installed (or upgraded) packages on subsequent
+   # refreshes, and stale entries from old versions don't survive an upgrade.
+   cache <- .rs.ppm.vulns[[repoUrl]]
+   if (is.null(cache))
+   {
+      cache <- new.env(parent = emptyenv())
+      assign(repoUrl, cache, envir = .rs.ppm.vulns)
+   }
+
+   # only ask PPM about (name, version) pairs we haven't seen this session
+   cachedKeys <- ls(envir = cache, all.names = TRUE)
+   newKeys <- setdiff(pkgNames, cachedKeys)
+   if (length(newKeys) > 0L)
+   {
+      fetched <- .rs.ppm.fetchVulnerabilityInformation(repoUrl, newKeys)
+
+      # NULL means the request failed; skip the cache update so the next
+      # refresh can retry rather than masking vulns with empty entries
+      if (is.null(fetched))
+         return(.rs.ppm.aggregateVulnsByName(cache, pkgNames))
+
+      # record every requested key (empty list for the ones PPM didn't
+      # report on) so we don't keep re-querying packages with no vulns
+      for (key in newKeys)
+      {
+         entry <- fetched[[key]]
+         assign(key, if (is.null(entry)) list() else entry, envir = cache)
+      }
+   }
+
+   .rs.ppm.aggregateVulnsByName(cache, pkgNames)
+})
+
+.rs.addFunction("ppm.fetchVulnerabilityInformation", function(repoUrl, pkgNames)
+{
+   ppmUrl <- .rs.ppm.fromRepositoryUrl(repoUrl)
+   if (length(ppmUrl) == 0L)
+      return(NULL)
+
    if (!requireNamespace("curl", quietly = TRUE))
-      return(empty)
+      return(NULL)
 
    # build a curl handle for the request
    verbose <- isTRUE(as.logical(Sys.getenv("PWB_PPM_CURL_VERBOSE", unset = "FALSE")))
@@ -69,11 +116,11 @@
    headers <- list("Content-Type" = "application/json")
    curl::handle_setheaders(handle, .list = headers)
 
-   # ask PPM for every package in this repo with a known vulnerability
+   # ask PPM for vulnerability info on each requested (name, version)
    data <- list(
       repo                 = ppmUrl[["repos"]],
+      names                = as.list(pkgNames),
       has_vulns            = TRUE,
-      vulns                = TRUE,
       omit_dependencies    = TRUE,
       omit_downloads       = TRUE,
       omit_package_details = TRUE
@@ -113,7 +160,7 @@
          "PPM vulnerability request to %s failed: %s",
          endpoint, conditionMessage(response)
       ))
-      return(empty)
+      return(NULL)
    }
 
    if (response$status_code < 200L || response$status_code >= 300L)
@@ -122,19 +169,11 @@
          "PPM vulnerability request to %s returned HTTP %d",
          endpoint, response$status_code
       ))
-      return(empty)
+      return(NULL)
    }
 
    contents <- enc2utf8(rawToChar(response$content))
-   vulns <- .rs.ppm.parseVulnerabilityResponse(contents)
-
-   # parser returns NULL when the NDJSON stream contained an error
-   # record; in that case skip the cache so the next refresh can retry
-   if (is.null(vulns))
-      return(empty)
-
-   assign(repoUrl, vulns, envir = .rs.ppm.vulns)
-   vulns
+   .rs.ppm.parseVulnerabilityResponse(contents)
 })
 
 .rs.addFunction("ppm.parseVulnerabilityResponse", function(contents)
@@ -164,16 +203,39 @@
       }
    }
 
-   # the endpoint returns one record per (package, version) pair; group the
-   # vulns by package name to match the shape consumers expect
-   vulns <- empty
+   # group vulns by "name==version" so cached entries can be invalidated
+   # individually when a specific installed version is upgraded
+   byKey <- empty
    for (record in records)
    {
       name <- record[["name"]]
+      version <- record[["version"]]
       pkgVulns <- record[["vulns"]]
-      if (is.null(name) || length(pkgVulns) == 0L)
+      if (is.null(name) || is.null(version) || length(pkgVulns) == 0L)
          next
 
+      key <- paste(name, version, sep = "==")
+      byKey[[key]] <- c(byKey[[key]], pkgVulns)
+   }
+
+   .rs.markScalars(byKey)
+})
+
+.rs.addFunction("ppm.aggregateVulnsByName", function(cache, pkgNames)
+{
+   empty <- structure(list(), names = character())
+
+   # collect per-(name, version) entries from the cache into the by-name
+   # shape the Packages pane expects, skipping keys that aren't currently
+   # installed (e.g. an old version left behind after an upgrade)
+   vulns <- empty
+   for (key in pkgNames)
+   {
+      pkgVulns <- cache[[key]]
+      if (length(pkgVulns) == 0L)
+         next
+
+      name <- sub("==.*$", "", key)
       vulns[[name]] <- c(vulns[[name]], pkgVulns)
    }
 

--- a/src/cpp/tests/testthat/test-ppm.R
+++ b/src/cpp/tests/testthat/test-ppm.R
@@ -20,20 +20,31 @@ context("ppm")
 # .rs.markScalars before returning).
 expected <- function(...) .rs.markScalars(list(...))
 
+# Helper: build a cache environment populated with the given keyed entries,
+# matching the layout used by .rs.ppm.getVulnerabilityInformationImpl.
+cacheEnv <- function(...)
+{
+   entries <- list(...)
+   env <- new.env(parent = emptyenv())
+   for (key in names(entries))
+      assign(key, entries[[key]], envir = env)
+   env
+}
+
 test_that("parseVulnerabilityResponse handles an empty body", {
    result <- .rs.ppm.parseVulnerabilityResponse("")
    expect_equal(result, structure(list(), names = character()))
 })
 
-test_that("parseVulnerabilityResponse parses a single record with one vuln", {
+test_that("parseVulnerabilityResponse parses a single record into a name==version key", {
    contents <- '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1","summary":"hi"}]}'
    result <- .rs.ppm.parseVulnerabilityResponse(contents)
    expect_equal(result, expected(
-      pkgA = list(list(id = "V1", summary = "hi"))
+      `pkgA==1.0.0` = list(list(id = "V1", summary = "hi"))
    ))
 })
 
-test_that("parseVulnerabilityResponse dedupes the same vuln across versions", {
+test_that("parseVulnerabilityResponse keeps each (name, version) pair in its own key", {
    contents <- paste(
       '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1","summary":"hi"}]}',
       '{"name":"pkgA","version":"1.1.0","vulns":[{"id":"V1","summary":"hi"}]}',
@@ -41,26 +52,12 @@ test_that("parseVulnerabilityResponse dedupes the same vuln across versions", {
    )
    result <- .rs.ppm.parseVulnerabilityResponse(contents)
    expect_equal(result, expected(
-      pkgA = list(list(id = "V1", summary = "hi"))
+      `pkgA==1.0.0` = list(list(id = "V1", summary = "hi")),
+      `pkgA==1.1.0` = list(list(id = "V1", summary = "hi"))
    ))
 })
 
-test_that("parseVulnerabilityResponse keeps disjoint vulns from different versions", {
-   contents <- paste(
-      '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1","summary":"first"}]}',
-      '{"name":"pkgA","version":"2.0.0","vulns":[{"id":"V2","summary":"second"}]}',
-      sep = "\n"
-   )
-   result <- .rs.ppm.parseVulnerabilityResponse(contents)
-   expect_equal(result, expected(
-      pkgA = list(
-         list(id = "V1", summary = "first"),
-         list(id = "V2", summary = "second")
-      )
-   ))
-})
-
-test_that("parseVulnerabilityResponse groups vulns across distinct packages", {
+test_that("parseVulnerabilityResponse groups records across distinct packages", {
    contents <- paste(
       '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1"}]}',
       '{"name":"pkgB","version":"0.2.0","vulns":[{"id":"V2"}]}',
@@ -68,8 +65,8 @@ test_that("parseVulnerabilityResponse groups vulns across distinct packages", {
    )
    result <- .rs.ppm.parseVulnerabilityResponse(contents)
    expect_equal(result, expected(
-      pkgA = list(list(id = "V1")),
-      pkgB = list(list(id = "V2"))
+      `pkgA==1.0.0` = list(list(id = "V1")),
+      `pkgB==0.2.0` = list(list(id = "V2"))
    ))
 })
 
@@ -94,7 +91,7 @@ test_that("parseVulnerabilityResponse skips records with no vulns field", {
    )
    result <- .rs.ppm.parseVulnerabilityResponse(contents)
    expect_equal(result, expected(
-      pkgB = list(list(id = "V2"))
+      `pkgB==0.1.0` = list(list(id = "V2"))
    ))
 })
 
@@ -106,7 +103,7 @@ test_that("parseVulnerabilityResponse skips records with empty vulns arrays", {
    )
    result <- .rs.ppm.parseVulnerabilityResponse(contents)
    expect_equal(result, expected(
-      pkgB = list(list(id = "V2"))
+      `pkgB==0.1.0` = list(list(id = "V2"))
    ))
 })
 
@@ -118,7 +115,19 @@ test_that("parseVulnerabilityResponse skips records missing the name field", {
    )
    result <- .rs.ppm.parseVulnerabilityResponse(contents)
    expect_equal(result, expected(
-      pkgB = list(list(id = "V2"))
+      `pkgB==0.1.0` = list(list(id = "V2"))
+   ))
+})
+
+test_that("parseVulnerabilityResponse skips records missing the version field", {
+   contents <- paste(
+      '{"name":"pkgA","vulns":[{"id":"V1"}]}',
+      '{"name":"pkgB","version":"0.1.0","vulns":[{"id":"V2"}]}',
+      sep = "\n"
+   )
+   result <- .rs.ppm.parseVulnerabilityResponse(contents)
+   expect_equal(result, expected(
+      `pkgB==0.1.0` = list(list(id = "V2"))
    ))
 })
 
@@ -132,24 +141,8 @@ test_that("parseVulnerabilityResponse tolerates blank lines between records", {
    )
    result <- .rs.ppm.parseVulnerabilityResponse(contents)
    expect_equal(result, expected(
-      pkgA = list(list(id = "V1")),
-      pkgB = list(list(id = "V2"))
-   ))
-})
-
-test_that("parseVulnerabilityResponse merges versions maps when deduping by id", {
-   contents <- paste(
-      '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1","versions":{"1.0.0":true}}]}',
-      '{"name":"pkgA","version":"1.1.0","vulns":[{"id":"V1","versions":{"1.1.0":true}}]}',
-      '{"name":"pkgA","version":"1.2.0","vulns":[{"id":"V1","versions":{"1.0.0":true,"1.2.0":true}}]}',
-      sep = "\n"
-   )
-   result <- .rs.ppm.parseVulnerabilityResponse(contents)
-   expect_equal(result, expected(
-      pkgA = list(list(
-         id = "V1",
-         versions = list(`1.0.0` = TRUE, `1.1.0` = TRUE, `1.2.0` = TRUE)
-      ))
+      `pkgA==1.0.0` = list(list(id = "V1")),
+      `pkgB==0.2.0` = list(list(id = "V2"))
    ))
 })
 
@@ -163,7 +156,7 @@ test_that("parseVulnerabilityResponse preserves nested vuln fields", {
    )
    result <- .rs.ppm.parseVulnerabilityResponse(contents)
    expect_equal(result, expected(
-      pkgA = list(list(
+      `pkgA==1.0.0` = list(list(
          id = "V1",
          summary = "s",
          details = "d",
@@ -190,45 +183,8 @@ test_that("parseVulnerabilityResponse skips malformed JSON lines", {
    )
    result <- .rs.ppm.parseVulnerabilityResponse(contents)
    expect_equal(result, expected(
-      pkgA = list(list(id = "V1")),
-      pkgB = list(list(id = "V2"))
-   ))
-})
-
-test_that("parseVulnerabilityResponse keeps id-less vulns separate", {
-   # Each id-less vuln coalesces to id = "", but R's list[[""]] always
-   # reads NULL while each write appends a fresh positional slot, so the
-   # dedup loop treats them as distinct. In practice PPM always emits an
-   # OSV id; this just pins the fallback behavior.
-   contents <- paste(
-      '{"name":"pkgA","version":"1.0.0","vulns":[{"summary":"one"}]}',
-      '{"name":"pkgA","version":"1.1.0","vulns":[{"summary":"two"}]}',
-      sep = "\n"
-   )
-   result <- .rs.ppm.parseVulnerabilityResponse(contents)
-   expect_equal(result, expected(
-      pkgA = list(
-         list(summary = "one"),
-         list(summary = "two")
-      )
-   ))
-})
-
-test_that("parseVulnerabilityResponse keeps the first record on same-id dedup", {
-   # When the same vuln id appears with different summaries across versions,
-   # the first occurrence wins; only the versions map gets merged.
-   contents <- paste(
-      '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1","summary":"first","versions":{"1.0.0":true}}]}',
-      '{"name":"pkgA","version":"2.0.0","vulns":[{"id":"V1","summary":"second","versions":{"2.0.0":true}}]}',
-      sep = "\n"
-   )
-   result <- .rs.ppm.parseVulnerabilityResponse(contents)
-   expect_equal(result, expected(
-      pkgA = list(list(
-         id = "V1",
-         summary = "first",
-         versions = list(`1.0.0` = TRUE, `2.0.0` = TRUE)
-      ))
+      `pkgA==1.0.0` = list(list(id = "V1")),
+      `pkgB==0.1.0` = list(list(id = "V2"))
    ))
 })
 
@@ -240,7 +196,127 @@ test_that("parseVulnerabilityResponse tolerates CRLF line endings", {
    )
    result <- .rs.ppm.parseVulnerabilityResponse(contents)
    expect_equal(result, expected(
-      pkgA = list(list(id = "V1")),
+      `pkgA==1.0.0` = list(list(id = "V1")),
+      `pkgB==0.2.0` = list(list(id = "V2"))
+   ))
+})
+
+test_that("aggregateVulnsByName collects a single (name, version) into the by-name shape", {
+   cache <- cacheEnv(
+      `pkgA==1.0.0` = list(list(id = "V1", summary = "hi"))
+   )
+   result <- .rs.ppm.aggregateVulnsByName(cache, "pkgA==1.0.0")
+   expect_equal(result, expected(
+      pkgA = list(list(id = "V1", summary = "hi"))
+   ))
+})
+
+test_that("aggregateVulnsByName dedupes the same vuln across multiple installed versions", {
+   cache <- cacheEnv(
+      `pkgA==1.0.0` = list(list(id = "V1", summary = "hi")),
+      `pkgA==1.1.0` = list(list(id = "V1", summary = "hi"))
+   )
+   result <- .rs.ppm.aggregateVulnsByName(cache, c("pkgA==1.0.0", "pkgA==1.1.0"))
+   expect_equal(result, expected(
+      pkgA = list(list(id = "V1", summary = "hi"))
+   ))
+})
+
+test_that("aggregateVulnsByName keeps disjoint vulns from different versions", {
+   cache <- cacheEnv(
+      `pkgA==1.0.0` = list(list(id = "V1", summary = "first")),
+      `pkgA==2.0.0` = list(list(id = "V2", summary = "second"))
+   )
+   result <- .rs.ppm.aggregateVulnsByName(cache, c("pkgA==1.0.0", "pkgA==2.0.0"))
+   expect_equal(result, expected(
+      pkgA = list(
+         list(id = "V1", summary = "first"),
+         list(id = "V2", summary = "second")
+      )
+   ))
+})
+
+test_that("aggregateVulnsByName merges versions maps when deduping by id", {
+   cache <- cacheEnv(
+      `pkgA==1.0.0` = list(list(id = "V1", versions = list(`1.0.0` = TRUE))),
+      `pkgA==1.1.0` = list(list(id = "V1", versions = list(`1.1.0` = TRUE))),
+      `pkgA==1.2.0` = list(list(
+         id = "V1",
+         versions = list(`1.0.0` = TRUE, `1.2.0` = TRUE)
+      ))
+   )
+   result <- .rs.ppm.aggregateVulnsByName(
+      cache,
+      c("pkgA==1.0.0", "pkgA==1.1.0", "pkgA==1.2.0")
+   )
+   expect_equal(result, expected(
+      pkgA = list(list(
+         id = "V1",
+         versions = list(`1.0.0` = TRUE, `1.1.0` = TRUE, `1.2.0` = TRUE)
+      ))
+   ))
+})
+
+test_that("aggregateVulnsByName keeps id-less vulns separate", {
+   # Each id-less vuln coalesces to id = "", but R's list[[""]] always
+   # reads NULL while each write appends a fresh positional slot, so the
+   # dedup loop treats them as distinct. In practice PPM always emits an
+   # OSV id; this just pins the fallback behavior.
+   cache <- cacheEnv(
+      `pkgA==1.0.0` = list(list(summary = "one")),
+      `pkgA==1.1.0` = list(list(summary = "two"))
+   )
+   result <- .rs.ppm.aggregateVulnsByName(cache, c("pkgA==1.0.0", "pkgA==1.1.0"))
+   expect_equal(result, expected(
+      pkgA = list(
+         list(summary = "one"),
+         list(summary = "two")
+      )
+   ))
+})
+
+test_that("aggregateVulnsByName keeps the first record on same-id dedup", {
+   # When the same vuln id appears with different summaries across versions,
+   # the first occurrence wins; only the versions map gets merged.
+   cache <- cacheEnv(
+      `pkgA==1.0.0` = list(list(
+         id = "V1", summary = "first", versions = list(`1.0.0` = TRUE)
+      )),
+      `pkgA==2.0.0` = list(list(
+         id = "V1", summary = "second", versions = list(`2.0.0` = TRUE)
+      ))
+   )
+   result <- .rs.ppm.aggregateVulnsByName(cache, c("pkgA==1.0.0", "pkgA==2.0.0"))
+   expect_equal(result, expected(
+      pkgA = list(list(
+         id = "V1",
+         summary = "first",
+         versions = list(`1.0.0` = TRUE, `2.0.0` = TRUE)
+      ))
+   ))
+})
+
+test_that("aggregateVulnsByName skips cache entries that aren't currently installed", {
+   # A package upgrade leaves the old (name, version) key behind in the
+   # cache. aggregateVulnsByName must filter by the currently-installed
+   # set so the orphan doesn't leak back into the UI.
+   cache <- cacheEnv(
+      `pkgA==1.0.0` = list(list(id = "V1", summary = "stale")),
+      `pkgA==2.0.0` = list()
+   )
+   result <- .rs.ppm.aggregateVulnsByName(cache, "pkgA==2.0.0")
+   expect_equal(result, structure(list(), names = character()))
+})
+
+test_that("aggregateVulnsByName skips cached entries with empty vuln lists", {
+   # PPM may have nothing to say about a package, in which case the cache
+   # holds an empty list as a "queried, no vulns" marker.
+   cache <- cacheEnv(
+      `pkgA==1.0.0` = list(),
+      `pkgB==0.1.0` = list(list(id = "V2"))
+   )
+   result <- .rs.ppm.aggregateVulnsByName(cache, c("pkgA==1.0.0", "pkgB==0.1.0"))
+   expect_equal(result, expected(
       pkgB = list(list(id = "V2"))
    ))
 })

--- a/src/cpp/tests/testthat/test-ppm.R
+++ b/src/cpp/tests/testthat/test-ppm.R
@@ -211,95 +211,40 @@ test_that("aggregateVulnsByName collects a single (name, version) into the by-na
    ))
 })
 
-test_that("aggregateVulnsByName dedupes the same vuln across multiple installed versions", {
+test_that("aggregateVulnsByName groups vulns across multiple installed versions", {
+   # PPM returns the same vuln list for every queried version of a given
+   # package, but a user with the same package in two libraries will see
+   # both versions cached. We concatenate without deduping; the rare
+   # duplicate is cosmetic only -- the frontend's per-row check uses each
+   # vuln's versions map, not list position.
    cache <- cacheEnv(
       `pkgA==1.0.0` = list(list(id = "V1", summary = "hi")),
       `pkgA==1.1.0` = list(list(id = "V1", summary = "hi"))
    )
    result <- .rs.ppm.aggregateVulnsByName(cache, c("pkgA==1.0.0", "pkgA==1.1.0"))
    expect_equal(result, expected(
-      pkgA = list(list(id = "V1", summary = "hi"))
+      pkgA = list(
+         list(id = "V1", summary = "hi"),
+         list(id = "V1", summary = "hi")
+      )
    ))
 })
 
-test_that("aggregateVulnsByName keeps disjoint vulns from different versions", {
+test_that("aggregateVulnsByName groups vulns across distinct packages", {
    cache <- cacheEnv(
       `pkgA==1.0.0` = list(list(id = "V1", summary = "first")),
-      `pkgA==2.0.0` = list(list(id = "V2", summary = "second"))
+      `pkgB==2.0.0` = list(list(id = "V2", summary = "second"))
    )
-   result <- .rs.ppm.aggregateVulnsByName(cache, c("pkgA==1.0.0", "pkgA==2.0.0"))
+   result <- .rs.ppm.aggregateVulnsByName(cache, c("pkgA==1.0.0", "pkgB==2.0.0"))
    expect_equal(result, expected(
-      pkgA = list(
-         list(id = "V1", summary = "first"),
-         list(id = "V2", summary = "second")
-      )
-   ))
-})
-
-test_that("aggregateVulnsByName merges versions maps when deduping by id", {
-   cache <- cacheEnv(
-      `pkgA==1.0.0` = list(list(id = "V1", versions = list(`1.0.0` = TRUE))),
-      `pkgA==1.1.0` = list(list(id = "V1", versions = list(`1.1.0` = TRUE))),
-      `pkgA==1.2.0` = list(list(
-         id = "V1",
-         versions = list(`1.0.0` = TRUE, `1.2.0` = TRUE)
-      ))
-   )
-   result <- .rs.ppm.aggregateVulnsByName(
-      cache,
-      c("pkgA==1.0.0", "pkgA==1.1.0", "pkgA==1.2.0")
-   )
-   expect_equal(result, expected(
-      pkgA = list(list(
-         id = "V1",
-         versions = list(`1.0.0` = TRUE, `1.1.0` = TRUE, `1.2.0` = TRUE)
-      ))
-   ))
-})
-
-test_that("aggregateVulnsByName keeps id-less vulns separate", {
-   # Each id-less vuln coalesces to id = "", but R's list[[""]] always
-   # reads NULL while each write appends a fresh positional slot, so the
-   # dedup loop treats them as distinct. In practice PPM always emits an
-   # OSV id; this just pins the fallback behavior.
-   cache <- cacheEnv(
-      `pkgA==1.0.0` = list(list(summary = "one")),
-      `pkgA==1.1.0` = list(list(summary = "two"))
-   )
-   result <- .rs.ppm.aggregateVulnsByName(cache, c("pkgA==1.0.0", "pkgA==1.1.0"))
-   expect_equal(result, expected(
-      pkgA = list(
-         list(summary = "one"),
-         list(summary = "two")
-      )
-   ))
-})
-
-test_that("aggregateVulnsByName keeps the first record on same-id dedup", {
-   # When the same vuln id appears with different summaries across versions,
-   # the first occurrence wins; only the versions map gets merged.
-   cache <- cacheEnv(
-      `pkgA==1.0.0` = list(list(
-         id = "V1", summary = "first", versions = list(`1.0.0` = TRUE)
-      )),
-      `pkgA==2.0.0` = list(list(
-         id = "V1", summary = "second", versions = list(`2.0.0` = TRUE)
-      ))
-   )
-   result <- .rs.ppm.aggregateVulnsByName(cache, c("pkgA==1.0.0", "pkgA==2.0.0"))
-   expect_equal(result, expected(
-      pkgA = list(list(
-         id = "V1",
-         summary = "first",
-         versions = list(`1.0.0` = TRUE, `2.0.0` = TRUE)
-      ))
+      pkgA = list(list(id = "V1", summary = "first")),
+      pkgB = list(list(id = "V2", summary = "second"))
    ))
 })
 
 test_that("aggregateVulnsByName skips cache entries that aren't currently installed", {
    # A package upgrade leaves the old (name, version) key behind in the
-   # cache. aggregateVulnsByName must filter by the currently-installed
-   # set so the orphan doesn't leak back into the UI.
+   # cache. Filtering by pkgKeys means the orphan doesn't leak back to the UI.
    cache <- cacheEnv(
       `pkgA==1.0.0` = list(list(id = "V1", summary = "stale")),
       `pkgA==2.0.0` = list()


### PR DESCRIPTION
## Intent

Addresses #17630.

The Packages pane stopped rendering the RSEC advisory badge after #17602 migrated vulnerability lookup from \`/repos/{repo}/vulns\` to \`POST /filter/packages\`. The new endpoint defaults to the current snapshot's latest version of each package, so vulns that only affect older installed versions (e.g. \`commonmark@1.7\`) were silently dropped.

## Summary

- Send the installed \`name==version\` pairs explicitly as the \`names\` filter so PPM evaluates them against the installed versions.
- Restructure the per-session cache into a per-repo environment keyed by \`name==version\`. A package install or upgrade only triggers a request for the new keys (via \`setdiff\`), and stale entries from old versions don't outlive an upgrade.
- Drop the dedupe-by-id / merge-versions-maps logic. Confirmed empirically against \`packagemanager.posit.co\` that PPM returns the same vuln list (and the same versions map per vuln) for every queried version of a package, so the merge was a no-op in every realistic case.
- Drop the bogus \`vulns: true\` request field -- it isn't in \`FilterPackagesRequest\` and was silently ignored.

## Test plan

- [x] \`rstudio-tests --scope r --filter ppm\` passes (19 / 19).
- [ ] On a Workbench daily after this lands, verify the badge renders next to \`commonmark\` after \`renv::install("commonmark@1.7")\`.
- [ ] QA: \`test_PackagesPane::test_vulnerability_information_from_package_manager\` passes again on the rhel8 / ubuntu24 / debian13 / rhel10 pipelines.