### PR TITLE
make Select Repository dialog theme aware

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageManagerSelectRepositoryModalDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageManagerSelectRepositoryModalDialog.java
@@ -30,7 +30,6 @@ import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style.Display;
 import com.google.gwt.dom.client.Style.FontStyle;
 import com.google.gwt.dom.client.Style.TextOverflow;
-import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.dom.client.TableCellElement;
 import com.google.gwt.dom.client.TableRowElement;
 import com.google.gwt.event.logical.shared.SelectionEvent;
@@ -151,8 +150,7 @@ public class PackageManagerSelectRepositoryModalDialog extends ModalDialog<Packa
 
       table_.selectRow(0);
 
-      table_.getElement().getStyle().setBorderWidth(1, Unit.PX);
-      table_.getElement().getStyle().setBackgroundColor("white");
+      // border and background color are set via RowTable.css (theme aware)
       tableContainer_.add(table_);
 
       showHiddenReposCb_ = new CheckBox("Show hidden repositories");


### PR DESCRIPTION
## Intent

Addresses #10296 for the Package Manager "Select Repository" dialog.

## Summary

`PackageManagerSelectRepositoryModalDialog` already called `setThemeAware(true)`, but the repositories table was given inline `background-color: white` and a `1px` border, which overrode the theme-aware rules already defined for the `.panel` class in `RowTable.css` (where `.rstudio-themes-dark.rstudio-theme-aware-dialog .panel` sets the dark background, border, text color, and scrollbar).

- Drop the inline `setBackgroundColor("white")` and `setBorderWidth(1, Unit.PX)` on the table element so `RowTable.css` can drive the table's chrome in both light and dark themes (matching how `DirectoryContentsWidget` uses the same widget).
- Remove the now-unused `Style.Unit` import.

## Test plan

- [ ] Open Tools > Install Packages, switch repository to Posit Package Manager, click "Select Repository" with a light theme active; verify the dialog and table look unchanged.
- [ ] Switch to a dark editor theme and reopen the dialog; verify the table background, border, text, and scrollbar match the surrounding dark dialog chrome.