### PR TITLE
add sprintf-style formatting and once = TRUE to .rs.log*Message

### DIFF
--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -30,25 +30,46 @@
    .Call("rs_showErrorMessage", title, message, PACKAGE = "(embedding)")
 })
 
-.rs.addFunction("logErrorMessage", function(message)
+# cache of (method + message) digests already logged with once = TRUE
+assign(".rs.loggedMessageCache", new.env(parent = emptyenv()), envir = .rs.toolsEnv())
+
+.rs.addFunction("logMessageImpl", function(method, fmt, args, once)
 {
-   if (inherits(message, "condition"))
-      message <- paste(conditionMessage(message), collapse = "\n")
-   .Call("rs_logErrorMessage", message, PACKAGE = "(embedding)")
+   if (inherits(fmt, "condition"))
+      message <- paste(conditionMessage(fmt), collapse = "\n")
+   else if (length(args))
+      message <- do.call(base::sprintf, c(list(fmt), args))
+   else
+      message <- fmt
+
+   if (isTRUE(once))
+   {
+      key <- .rs.digest(c(method, message))
+      if (!is.na(key))
+      {
+         cache <- .rs.loggedMessageCache
+         if (exists(key, envir = cache, inherits = FALSE))
+            return(invisible())
+         assign(key, TRUE, envir = cache)
+      }
+   }
+
+   .Call(method, message, PACKAGE = "(embedding)")
 })
 
-.rs.addFunction("logWarningMessage", function(message)
+.rs.addFunction("logErrorMessage", function(fmt, ..., once = FALSE)
 {
-   if (inherits(message, "condition"))
-      message <- paste(conditionMessage(message), collapse = "\n")
-   .Call("rs_logWarningMessage", message, PACKAGE = "(embedding)")
+   .rs.logMessageImpl("rs_logErrorMessage", fmt, list(...), once)
 })
 
-.rs.addFunction("logInfoMessage", function(message)
+.rs.addFunction("logWarningMessage", function(fmt, ..., once = FALSE)
 {
-   if (inherits(message, "condition"))
-      message <- paste(conditionMessage(message), collapse = "\n")
-   .Call("rs_logInfoMessage", message, PACKAGE = "(embedding)")
+   .rs.logMessageImpl("rs_logWarningMessage", fmt, list(...), once)
+})
+
+.rs.addFunction("logInfoMessage", function(fmt, ..., once = FALSE)
+{
+   .rs.logMessageImpl("rs_logInfoMessage", fmt, list(...), once)
 })
 
 .rs.addFunction("format", function(object, ...)

--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -33,6 +33,12 @@
 # cache of (method + message) digests already logged with once = TRUE
 assign(".rs.loggedMessageCache", new.env(parent = emptyenv()), envir = .rs.toolsEnv())
 
+# indirection point so tests can stub the emit step without intercepting .Call
+.rs.addFunction("logMessageEmit", function(method, message)
+{
+   .Call(method, message, PACKAGE = "(embedding)")
+})
+
 .rs.addFunction("logMessageImpl", function(method, fmt, args, once)
 {
    if (inherits(fmt, "condition"))
@@ -54,7 +60,7 @@ assign(".rs.loggedMessageCache", new.env(parent = emptyenv()), envir = .rs.tools
       }
    }
 
-   .Call(method, message, PACKAGE = "(embedding)")
+   .rs.logMessageEmit(method, message)
 })
 
 .rs.addFunction("logErrorMessage", function(fmt, ..., once = FALSE)

--- a/src/cpp/tests/testthat/test-log-message.R
+++ b/src/cpp/tests/testthat/test-log-message.R
@@ -1,0 +1,70 @@
+#
+# test-log-message.R
+#
+# Copyright (C) 2026 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+context("log message helpers")
+
+# Captures arguments passed to .rs.logMessageEmit during 'expr'. The full
+# .rs.log*Message -> .rs.logMessageImpl -> .rs.logMessageEmit chain runs
+# normally, but the final .Call is intercepted so we can assert on what
+# would have been logged.
+withCapturedLogs <- function(expr) {
+   captured <- list()
+   rsEnv <- as.environment("tools:rstudio")
+   original <- get(".rs.logMessageEmit", envir = rsEnv)
+   on.exit(assign(".rs.logMessageEmit", original, envir = rsEnv), add = TRUE)
+   assign(".rs.logMessageEmit", function(method, message) {
+      captured[[length(captured) + 1L]] <<- list(method = method, message = message)
+   }, envir = rsEnv)
+   force(expr)
+   captured
+}
+
+clearLogCache <- function() {
+   rm(list = ls(envir = .rs.loggedMessageCache, all.names = TRUE),
+      envir = .rs.loggedMessageCache)
+}
+
+test_that(".rs.log*Message passes literal text verbatim when ... is empty", {
+   logs <- withCapturedLogs({
+      .rs.logInfoMessage("progress: 100% complete")
+   })
+   expect_length(logs, 1L)
+   expect_equal(logs[[1]]$method, "rs_logInfoMessage")
+   expect_equal(logs[[1]]$message, "progress: 100% complete")
+})
+
+test_that(".rs.log*Message applies sprintf when ... is non-empty", {
+   logs <- withCapturedLogs({
+      .rs.logWarningMessage("hello %s, count = %d", "world", 42L)
+   })
+   expect_length(logs, 1L)
+   expect_equal(logs[[1]]$method, "rs_logWarningMessage")
+   expect_equal(logs[[1]]$message, "hello world, count = 42")
+})
+
+test_that(".rs.log*Message with once = TRUE suppresses repeats but lets others through", {
+   clearLogCache()
+   on.exit(clearLogCache(), add = TRUE)
+
+   logs <- withCapturedLogs({
+      .rs.logErrorMessage("duplicate message", once = TRUE)
+      .rs.logErrorMessage("duplicate message", once = TRUE)   # suppressed
+      .rs.logErrorMessage("duplicate message")                # once = FALSE, still logs
+      .rs.logErrorMessage("different message", once = TRUE)   # distinct, logs
+   })
+
+   messages <- vapply(logs, `[[`, character(1L), "message")
+   expect_equal(messages, c("duplicate message", "duplicate message", "different message"))
+})


### PR DESCRIPTION
## Summary

- Adds a shared `.rs.logMessageImpl(method, fmt, args, once)` helper in `ModuleTools.R`.
- `.rs.logErrorMessage`, `.rs.logWarningMessage`, and `.rs.logInfoMessage` now accept `fmt, ..., once = FALSE` so callers can write `.rs.logInfoMessage("processed %d items", n)` instead of wrapping every call in `sprintf()`.
- When `once = TRUE`, repeat calls with the same `(method, formatted message)` are suppressed for the remainder of the session. Dedup keys are SHA-256 digests via `.rs.digest` (so the cache holds 64-char hex strings, not raw messages).

## Backward compatibility

`sprintf` only runs when `...` is non-empty, so existing single-argument callers (including ones whose message text contains `%`, and the `tryCatch(error = .rs.logWarningMessage)` callback pattern that receives a condition) behave identically. The four existing `.rs.log*Message(sprintf(...))` call sites in `SessionPPM.R` / `SessionPackages.R` will be tidied up in a follow-up.

## Test plan

- [ ] Build session and verify `.rs.logInfoMessage("hello")` still logs as before.
- [ ] `.rs.logInfoMessage("hello %s", "world")` logs `hello world`.
- [ ] `.rs.logWarningMessage("100% done")` logs verbatim (no sprintf interpretation, `...` is empty).
- [ ] Calling `.rs.logInfoMessage("repeat", once = TRUE)` twice produces a single log entry; a third call with `once = FALSE` logs again.
- [ ] `tryCatch(stop("boom"), error = .rs.logWarningMessage)` still logs the condition message.