### PR TITLE
Highlight hex floating point literals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 -
 
 ### Fixed
+- ([#14363](https://github.com/rstudio/rstudio/issues/14363)): Recognize hex floating point literals (e.g. `0x1.1p1`) in the tokenizer and syntax highlighter.
 -
 
 ### Dependencies

--- a/src/cpp/core/r_util/RTokenizer.cpp
+++ b/src/cpp/core/r_util/RTokenizer.cpp
@@ -55,7 +55,7 @@ private:
    friend TokenPatterns& tokenPatterns();
    TokenPatterns()
       : NUMBER(L"[0-9]*(\\.[0-9]*)?([eE][+-]?[0-9]*)?[Li]?"),
-        HEX_NUMBER(L"0x[0-9a-fA-F]*L?"),
+        HEX_NUMBER(L"0x[0-9a-fA-F]*(\\.[0-9a-fA-F]*)?([pP][+-]?[0-9]+)?[Li]?"),
         USER_OPERATOR(L"%[^\\n%]*%"),
         WHITESPACE(L"[\\s\x00A0\x3000]+"),
         COMMENT(L"#[^\\n]*$")

--- a/src/cpp/core/r_util/RTokenizerTests.cpp
+++ b/src/cpp/core/r_util/RTokenizerTests.cpp
@@ -139,6 +139,12 @@ void testNumbers()
    v.verify(L"0xcafebad");
    v.verify(L"1L");
    v.verify(L"0x10L");
+   v.verify(L"0x1.1p1");
+   v.verify(L"0x1p-2");
+   v.verify(L"0x1.8p0L");
+   v.verify(L"0x1.0p-1022");
+   v.verify(L"0xAp3");
+   v.verify(L"0x1.FFFp10i");
    v.verify(L"1000000L");
    v.verify(L"1e6L");
    v.verify(L"1.1L");

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -351,8 +351,8 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
 
     rules["#number"] = [
       {
-        token : "constant.numeric", // hex
-        regex : "0[xX][0-9a-fA-F]+[Li]?",
+        token : "constant.numeric", // hex (integer and floating point)
+        regex : "0[xX][0-9a-fA-F]+(?:\\.[0-9a-fA-F]*)?(?:[pP][+-]?\\d+)?[Li]?",
         merge : false,
         next  : "start"
       },


### PR DESCRIPTION
Fixes #14363

R supports hex floating point constants since R 4.0 (e.g. `0x1.1p1`, `0x1p-2`, `0x1.8p0L`). The tokenizer only matched integer hex (`0xFF`).

Extended the regex to optionally match:
- Hex fractional part: `\.[0-9a-fA-F]*`
- Binary exponent: `[pP][+-]?\d+`

### Testing
```r
x <- 0x1.8p0   # 1.5
y <- 0x1p-2    # 0.25
z <- 0x1.1p1L  # integer
```

All should be highlighted as `constant.numeric`.

Verified: `node --check` passes, regex tested against all R hex float forms.