### PR TITLE
Support folding of ::: fenced divs in Quarto/Rmd

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 -
 
 ### Fixed
+- ([#14066](https://github.com/rstudio/rstudio/issues/14066)): Support folding of `:::` fenced divs in Quarto and R Markdown documents.
 -
 
 ### Dependencies

--- a/src/gwt/acesupport/acemode/markdown_folding.js
+++ b/src/gwt/acesupport/acemode/markdown_folding.js
@@ -61,7 +61,7 @@ oop.inherits(FoldMode, BaseFoldMode);
 
 (function() {
 
-    this.foldingStartMarker = /^(?:[=-]+\s*$|#{1,6} |`{3})/;
+    this.foldingStartMarker = /^(?:[=-]+\s*$|#{1,6} |`{3}|:{3,}\s*\{)/;
 
     this.getFoldWidget = function(session, foldStyle, row) {
 
@@ -78,6 +78,12 @@ oop.inherits(FoldMode, BaseFoldMode);
             return Utils.getPrimaryState(session, row) === "start" ?
                 FOLD_END :
                 FOLD_START;
+        }
+
+        if (line[0] == ":")
+        {
+            // ::: {.callout-note} is a fold start, bare ::: is fold end
+            return /^:{3,}\s*\{/.test(line) ? FOLD_START : FOLD_END;
         }
 
         return FOLD_NONE;
@@ -108,6 +114,21 @@ oop.inherits(FoldMode, BaseFoldMode);
                 }
                 return new Range(row, line.length, startRow, 0);
             }
+        }
+
+        if (line[0] == ":" && /^:{3,}\s*\{/.test(line)) {
+            // Find matching closing :::
+            var depth = 1;
+            while (++row < maxRow) {
+                line = session.getLine(row);
+                if (/^:{3,}\s*\{/.test(line)) depth++;
+                else if (/^:{3,}\s*$/.test(line)) {
+                    depth--;
+                    if (depth === 0) break;
+                }
+            }
+            if (depth === 0)
+                return new Range(startRow, startColumn, row, 0);
         }
 
         var token;

--- a/src/gwt/acesupport/acemode/rmarkdown_folding.js
+++ b/src/gwt/acesupport/acemode/rmarkdown_folding.js
@@ -131,6 +131,14 @@ var FOLD_WIDGET_END   = "end";
          }
       }
 
+      // Fenced divs: ::: {.class} is fold start, bare ::: is fold end
+      var line = session.getLine(row);
+      if (/^:{3,}\s*\{/.test(line)) {
+         return FOLD_WIDGET_START;
+      } else if (/^:{3,}\s*$/.test(line)) {
+         return foldStyle === FOLD_STYLE_MARKBEGINEND ? FOLD_WIDGET_END : FOLD_WIDGET_NONE;
+      }
+
       return FOLD_WIDGET_NONE;
    };
 
@@ -144,6 +152,12 @@ var FOLD_WIDGET_END   = "end";
       var match = /^\s*(`{3,})/.exec(line);
       if (match !== null) {
          var pattern = new RegExp("^\\s*(`{" + match[1].length + "})(?!`)");
+         return this.$getBracedWidgetRange(session, foldStyle, row, pattern);
+      }
+
+      // Handle fenced div folds (::: {.class} ... :::)
+      if (/^:{3,}\s*\{/.test(trimmed)) {
+         var pattern = /^:{3,}\s*$/;
          return this.$getBracedWidgetRange(session, foldStyle, row, pattern);
       }
 


### PR DESCRIPTION
Fixes #14066

Quarto callout blocks (`::: {.callout-note}`) and other fenced divs were not foldable, and their presence disrupted heading-based folding.

**Changes to `markdown_folding.js`:**
- Added `:{3,}\s*\{` to `foldingStartMarker`
- `::: {.class}` → fold start, bare `:::` → fold end
- Fold range finder handles nested fenced divs via depth counting

### Testing
```markdown
## Section

::: {.callout-note}
This should be foldable
:::

## Next Section
```

The callout block should show a fold widget and collapse independently of the heading.

Verified: `node --check` passes.