### PR TITLE
Update default database.conf with improved documentation

### DIFF
--- a/src/cpp/server/extras/conf/database.conf
+++ b/src/cpp/server/extras/conf/database.conf
@@ -1,54 +1,40 @@
-# This file contains database configuration.
+# Database Configuration File
 #
-# RStudio Server needs an external database for storage of specific configuration and runtime information.
+# Full Configuration Reference: https://docs.posit.co/ide/server-pro/admin/database/configuration.html
+
+#-----------------------------------------------------------------------------------------#
+# Database Provider
 #
-# Simply uncomment the lines below and modify it to suit your needs.
-# For more documentation, see the Posit Workbench Administration Guide.
+# SQLite is used by default (no configuration required). An empty file or the
+# absence of this file will use an internal SQLite database. PostgreSQL is required for
+# load-balanced (multi-node) deployments.
+# Supported PostgreSQL versions: 13 through 17.
+#-----------------------------------------------------------------------------------------#
+
+#-----------------------------------------------------------------------------------------#
+# PostgreSQL Configuration
 #
-#
-# =================================================================================================================
-# sqlite configuration
-# =================================================================================================================
-#
-# Specifies the database provider to use
-#provider=sqlite
-#
-# Directory in which the sqlite database will be written
-#directory=/var/lib/rstudio-server
-#
-# =================================================================================================================
-# postgresql configuration
-# =================================================================================================================
-# Note: when connecting to a PostgreSQL database for the first time, you must ensure that the database 
-# already exists and is empty! The RStudio Server database must not be shared with any other applications.
-#
-# Specifies the database provider to use
+# https://docs.posit.co/ide/server-pro/admin/database/configuration.html#postgresql
+# Uncomment and configure the settings below to switch from SQLite to PostgreSQL.
+# The database must be created manually before the server connects to it.
+# It is strongly recommended to encrypt the password using: rstudio-server encrypt-password
+# Set this file to 600 permissions: chmod 600 /etc/rstudio/database.conf
+#-----------------------------------------------------------------------------------------#
 #provider=postgresql
-#
-# Specifies the host (hostname or IP address) of the database host
 #host=localhost
-#
-# Specifies the database to connect to
-#database=rstudio
-#
-# Specifies the TCP port where the database is listening for connections
+#database=posit
 #port=5432
+#username=posit
+#password=
+
+#-----------------------------------------------------------------------------------------#
+# PostgreSQL Connection URI (Alternative)
 #
-# Specifies the database connection username
-#username=postgres
-#
-# Specifies the database connection password. 
-# !!! This should not be used for production environments. Use an alternate form of authentication instead. !!!
-#password=postgres
-#
-# Specifies the maximum amount of seconds allowed before a database connection attempt is considered failed
-#connection-timeout-seconds=10
-#
-# Specifies the connection URL in the form of a postgresql:// connection URL. This should be used
-# in production environments to allow you to use a secure form of authentication, such as SSL (TLS) 
-# certificate based authentication. The URL below is an example of a connection URL that uses SSL (TLS)
-# certificate based authentication.
-# If set, this parameter will override all other settings except provider. If password is supplied, it 
-# will be appended to the URI. !!! Password should not be supplied in a production environment. !!!
-#connection-uri=postgresql://postgres@localhost:5432/rstudio?sslmode=verify-full&sslcert=/etc/ssl/certs/postgresql/postgresql.crt&sslkey=/etc/ssl/certs/cacert/postgresql/postgresql.key&sslrootcert=/etc/ssl/certs/cacert/postgresql/root.crt&options=-csearch_path=public
-# =================================================================================================================
+# https://docs.posit.co/ide/server-pro/admin/database/configuration.html#ssl-certificate-authentication
+# Use connection-uri instead of individual host/port/database settings for advanced
+# options like SSL certificate authentication. When set, connection-uri overrides
+# host, port, database, and username (but not password).
+#-----------------------------------------------------------------------------------------#
+#provider=postgresql
+#connection-uri=postgresql://posit@localhost:5432/posit?sslmode=verify-full
+#password=


### PR DESCRIPTION
## Summary
- Modernize the default `database.conf` file with clearer section-based structure
- Add documentation links to the Posit admin guide
- Remove outdated patterns (password placeholders with "!!!" warnings, verbose per-line comments)
- Add alternative connection URI section for SSL certificate authentication

## Context
This is a companion PR for rstudio/rstudio-pro#11085, which is updating all default configuration files with comprehensive documentation. Per reviewer feedback, `database.conf` changes should go through the open-source repo first.

## Test plan
- [ ] Verify fresh install with no `database.conf` still uses SQLite by default
- [ ] Verify PostgreSQL configuration works when uncommenting the relevant section

🤖 Generated with [Claude Code](https://claude.com/claude-code)