### PR TITLE
Fix Posit Assistant icon selectors, shiny deps, and palette helper

### DIFF
--- a/e2e/rstudio/actions/chat_pane.actions.ts
+++ b/e2e/rstudio/actions/chat_pane.actions.ts
@@ -258,7 +258,7 @@ export class ChatPaneActions {
 
   async getPositAssistantVersion(): Promise<string> {
     try {
-      await this.chatPane.settingsBtn.click({ timeout: 5000 });
+      await this.chatPane.moreBtn.click({ timeout: 5000 });
       await sleep(500);
 
       await this.chatPane.aboutItem.first().click();

--- a/e2e/rstudio/pages/chat_pane.page.ts
+++ b/e2e/rstudio/pages/chat_pane.page.ts
@@ -21,7 +21,7 @@ export class ChatPane extends FramePageObject {
   public installBtn: Locator;
   public updateBtn: Locator;
   public ignoreBtn: Locator;
-  public settingsBtn: Locator;
+  public moreBtn: Locator;
   public settingsMenu: Locator;
   public configurePositAiItem: Locator;
   public aboutItem: Locator;
@@ -53,12 +53,12 @@ export class ChatPane extends FramePageObject {
     this.installBtn = this.frame.locator("button:has-text('Install')");
     this.updateBtn = this.frame.locator("button:has-text('Update')");
     this.ignoreBtn = this.frame.locator("button:has-text('Ignore')");
-    this.settingsBtn = this.frame.locator("xpath=//span[contains(text(), 'Settings')]/ancestor::button");
+    this.moreBtn = this.frame.getByRole('button', { name: 'More' });
     this.settingsMenu = this.frame.locator("[data-slot='dropdown-menu-content']");
     this.configurePositAiItem = this.frame.locator("xpath=//span[contains(text(), 'Configure Posit AI')] | //div[contains(text(), 'Configure Posit AI')] | //*[@role='menuitem'][contains(., 'Configure Posit AI')]");
     this.aboutItem = this.frame.locator("xpath=//span[contains(text(), 'About')] | //div[contains(text(), 'About')] | //*[@role='menuitem'][contains(., 'About')]");
-    this.newConversationBtn = this.frame.locator("button:has(svg.lucide-plus)");
-    this.historyBtn = this.frame.locator("button:has(svg.lucide-history)");
+    this.newConversationBtn = this.frame.getByRole('button', { name: 'New conversation' });
+    this.historyBtn = this.frame.getByRole('button', { name: 'Conversation history' });
     this.conversationList = this.frame.locator("[class*='conversation']");
 
     // Blocking state elements

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/settings-button.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/settings-button.test.ts
@@ -36,10 +36,10 @@ test.describe.serial('Settings Button', () => {
 
   test('settings menu opens with expected items and About dialog', async ({ rstudioPage: page }) => {
     // Verify settings button is visible
-    await expect(chatPane.settingsBtn).toBeVisible({ timeout: 10000 });
+    await expect(chatPane.moreBtn).toBeVisible({ timeout: 10000 });
 
     // Open the dropdown menu
-    await chatPane.settingsBtn.click();
+    await chatPane.moreBtn.click();
     await sleep(500);
 
     await expect(chatPane.settingsMenu).toBeVisible({ timeout: 5000 });

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
@@ -12,6 +12,7 @@ test.describe.serial('R Shiny Tip Calculator via Posit Assistant', () => {
   let chatActions: ChatPaneActions;
   let consoleActions: ConsolePaneActions;
   let versions: EnvironmentVersions;
+  let missingPackages: string[] = [];
 
   const PROMPT = `Create a Shiny for R web app for a tip calculator. The app can only depend on packages that are already installed--nothing that isn't already installed. The app should be a single file. It should have a slider from $0 to $100 for the bill amount. It should have four buttons: 10%, 15%, 20%, and 25%. The output, the tip, should be based on the value in the slider and the chosen button. The buttons and slider should both be oriented horizontally, the slider above the buttons. The bill and tip amount should be displayed above the slider. The title of the page should be "Wacky Tip Calculator for R". Then run the app in the viewer pane and make sure that it can be seen. The app MUST be viewable in the RStudio viewer pane. Then say "Wacky Tip Calculator for R has started" when the app starts running.`;
 
@@ -23,6 +24,10 @@ test.describe.serial('R Shiny Tip Calculator via Posit Assistant', () => {
 
     versions = await consoleActions.getEnvironmentVersions();
     await consoleActions.clearConsole();
+
+    // The prompt forbids the assistant from installing packages, so shiny + bslib
+    // must be present in the sandbox-redirected user library before the test runs.
+    missingPackages = await consoleActions.ensurePackages(['shiny', 'bslib', 'rstudioapi'], 180000);
 
     // Force Shiny apps to open in the Viewer pane
     await consoleActions.typeInConsole('.rs.api.writeRStudioPreference("shiny_viewer_type", "pane")');
@@ -70,6 +75,8 @@ test.describe.serial('R Shiny Tip Calculator via Posit Assistant', () => {
   });
 
   test('Create and run R Shiny tip calculator', async ({ rstudioPage: page }) => {
+    test.skip(missingPackages.length > 0, `Missing packages: ${missingPackages.join(', ')}`);
+
     // Start a fresh conversation
     await chatActions.startNewConversation();
 

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/uninstall-posit-ai.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/uninstall-posit-ai.test.ts
@@ -39,10 +39,10 @@ const PALETTE_LIST = '#rstudio_command_palette_list';
  */
 async function invokeUninstallViaPalette(page: Page): Promise<void> {
   await page.evaluate("window.desktopHooks.invokeCommand('showCommandPalette')");
-  await sleep(1000);
 
-  await page.keyboard.type('Uninstall Posit Assistant');
-  await sleep(500);
+  const search = page.locator('#rstudio_command_palette_search');
+  await expect(search).toBeVisible({ timeout: 5000 });
+  await search.pressSequentially('Uninstall Posit Assistant');
 
   const paletteItem = page.locator(`${PALETTE_LIST} >> text=Uninstall Posit Assistant`);
   await expect(paletteItem).toBeVisible({ timeout: 5000 });
@@ -82,17 +82,19 @@ base.describe.serial('Uninstall Posit Assistant - #17322', { tag: ['@serial', '@
   // -----------------------------------------------------------------------
   base('Uninstall Posit Assistant visible in command palette', async () => {
     await page.evaluate("window.desktopHooks.invokeCommand('showCommandPalette')");
-    await sleep(1000);
 
-    await page.keyboard.type('Uninstall Posit Assistant');
-    await sleep(500);
+    const search = page.locator('#rstudio_command_palette_search');
+    await expect(search).toBeVisible({ timeout: 5000 });
+    await search.pressSequentially('Uninstall Posit Assistant');
 
     const paletteItem = page.locator(`${PALETTE_LIST} >> text=Uninstall Posit Assistant`);
     await expect(paletteItem).toBeVisible({ timeout: 5000 });
 
-    // Close palette without invoking
-    await page.keyboard.press('Escape');
-    await sleep(500);
+    // Close palette via the canonical toggle so the launcher's state machine
+    // returns to Hidden. Escape dismisses the DOM but does not always update
+    // the state, leaving the next showCommandPalette toggling the wrong way.
+    await page.evaluate("window.desktopHooks.invokeCommand('showCommandPalette')");
+    await expect(search).not.toBeVisible({ timeout: 5000 });
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Chat pane icon selectors: lucide-icon CSS selectors broke when the icons were swapped. Switched `historyBtn`, `newConversationBtn`, and `settingsBtn` (renamed to `moreBtn`) to `getByRole({ name })` so they target the accessible name instead of fragile icon classes.
- shiny-app-r test deps: with the per-invocation sandbox redirecting HOME, the host's R user library isn't visible to the test. The prompt forbids the assistant from installing packages, so the test now calls `ensurePackages(['shiny', 'bslib', 'rstudioapi'])` in beforeAll and `test.skip`s if any fail to install.
- Uninstall test command-palette helper: `keyboard.type` raced with the palette's focus transfer (sometimes typing into the console). Switched to locating `#rstudio_command_palette_search` and using `pressSequentially()`. Also replaced the Escape-to-close after test 1 with a canonical `showCommandPalette` toggle, because Escape leaves the launcher's state machine stuck at Showing and the next show call dismisses instead of opening.