### PR TITLE
Data viewer: show column count in status bar

### DIFF
--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -1717,6 +1717,9 @@ var updateInfoBar = function() {
 
    var text = "Showing " + first.toLocaleString() + " to " + last.toLocaleString() +
       " of " + activeRows.toLocaleString() + " entries";
+   if (totalCols > 0) {
+      text += ", " + totalCols.toLocaleString() + " columns";
+   }
    if (filteredRows < totalRows) {
       text += " (filtered from " + totalRows.toLocaleString() + " total)";
    }


### PR DESCRIPTION
Closes #17613.

The data viewer status bar shows row counts but not column counts. This adds the total column count to the info text, e.g.:

> Showing 1 to 100 of 100,000 entries, 500 columns

Single-line change in `updateInfoBar()` — appends `, N columns` when `totalCols > 0`.