### PR TITLE
Help pane: preserve top alignment of argument names

### DIFF
--- a/src/cpp/session/resources/R.css
+++ b/src/cpp/session/resources/R.css
@@ -131,7 +131,8 @@ table p {
    margin-bottom: 6px;
 }
 
-h3.r-arguments-title + table tr td:first-child {
+h3.r-arguments-title + table tr td:first-child,
+h3.r-arguments-title ~ table tr td:first-child {
    vertical-align: top;
    min-width: 24px;
    padding-right: 12px;


### PR DESCRIPTION
Closes #17621.

The CSS selector `h3.r-arguments-title + table` only matches the first table immediately after the heading. When help pages have multiple argument tables (separated by other elements), subsequent tables lose the `vertical-align: top` rule and argument names center-align against their descriptions.

Fix: add the general sibling combinator (`~`) so the rule applies to all tables following the arguments heading, not just the first.