### PR TITLE
Outline pane: recognise roxygen tags

### DIFF
--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -907,9 +907,20 @@ var RCodeModel = function(session, tokenizer,
          type = token.type;
          position = iterator.getCurrentTokenPosition();
 
-         // Skip roxygen comments.
+         // Roxygen comments: detect @tags for the document outline,
+         // then skip the rest of the line.
          var state = Utils.getPrimaryState(this.$session, position.row);
          if (state === "rdoc-start") {
+            if (type === "keyword" && /^@[a-zA-Z]/.test(value)) {
+               var roxyTag = value.replace(/^@/, "");
+               if (roxyTag === "section") {
+                  var lineText = this.$session.getLine(position.row);
+                  var rest = lineText.substring(position.column + value.length).trim();
+                  rest = rest.replace(/:\s*$/, "");
+                  if (rest.length > 0) roxyTag = rest;
+               }
+               this.$scopes.onSectionStart("@" + roxyTag, position);
+            }
             iterator.moveToEndOfRow();
             continue;
          }


### PR DESCRIPTION
Closes #17545.

Adds recognition of roxygen2 tags (`@param`, `@return`, `@export`, etc.) to the document outline so they appear as navigable entries under their parent function.