### PR TITLE
Fix imperceptible selection in Clouds Midnight theme

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 -
 
 ### Fixed
+- ([#15765](https://github.com/rstudio/rstudio/issues/15765)): Fix imperceptible selection highlighting in Clouds Midnight theme.
 -
 
 ### Dependencies

--- a/src/cpp/session/resources/themes/clouds_midnight.rstheme
+++ b/src/cpp/session/resources/themes/clouds_midnight.rstheme
@@ -16,7 +16,7 @@
   color: #7DA5DC
 }
 .ace_marker-layer .ace_selection {
-  background: #000000
+  background: rgba(100, 133, 200, 0.3)
 }
 .ace_selection.ace_start {
   box-shadow: 0 0 3px 0px #191919;
@@ -30,13 +30,13 @@
   border: 1px solid #BFBFBF
 }
 .ace_marker-layer .ace_active-line {
-  background: rgba(215, 215, 215, 0.031)
+  background: rgba(215, 215, 215, 0.1)
 }
 .ace_gutter-active-line {
-  background-color: rgba(215, 215, 215, 0.031)
+  background-color: rgba(215, 215, 215, 0.1)
 }
 .ace_marker-layer .ace_selected-word {
-  border: 1px solid #000000
+  border: 1px solid rgba(100, 133, 200, 0.6)
 }
 .ace_invisible {
   color: #666


### PR DESCRIPTION
Closes #15765.

The selection and active-line highlight colors in the Clouds Midnight theme were nearly indistinguishable from the background. Updates the selection and active-line colors to provide visible contrast.