### PR TITLE
Add Partitioned attribute to SameSite=None cookies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 -
 
 ### Fixed
+- ([#17430](https://github.com/rstudio/rstudio/issues/17430)): Add `Partitioned` (CHIPS) attribute to `SameSite=None` cookies.
 -
 
 ### Dependencies

--- a/src/cpp/core/http/Cookie.cpp
+++ b/src/cpp/core/http/Cookie.cpp
@@ -120,6 +120,7 @@ std::string Cookie::cookieHeaderValue() const
    {
       case SameSite::None:
          headerValue << "; SameSite=None";
+         headerValue << "; Partitioned";
          break;
       case SameSite::Lax:
          headerValue << "; SameSite=Lax";


### PR DESCRIPTION
Closes #17430.

Chrome 114+ requires the `Partitioned` attribute on `SameSite=None` cookies for cross-origin iframe contexts (CHIPS). Without it, RStudio Server embedded in iframes loses session cookies.

Adds `; Partitioned` to the cookie header when `SameSite=None` is set.