### PR TITLE
Widen Environment pane name column default to 40%

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.css
@@ -47,7 +47,7 @@
 
 td.nameCol
 {
-   width: 25%;
+   width: 40%;
    text-overflow: ellipsis;
    overflow-x: hidden;
    border: 1px solid #f0f0f0;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
@@ -47,7 +47,7 @@
 
 .objectGrid td.nameCol
 {
-   width: 25%;
+   width: 40%;
    text-overflow: ellipsis;
    overflow-x: hidden;
    border: 1px solid #f0f0f0;


### PR DESCRIPTION
Closes #17451.

The Environment pane's name column defaults to a narrow width that truncates variable names. Widens the default from the current value to 40% so typical names are visible without manual resizing.