### PR TITLE
Find in Files: move refresh button rightmost + theme Replace dialog

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutput.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutput.css
@@ -101,3 +101,13 @@
    background-color: #A81900;
    color: white;
 }
+
+.rstudio-themes-dark .replaceTextBox {
+   background-color: #1e1e1e;
+   color: #d4d4d4;
+   border: 1px solid #3c3c3c;
+}
+
+.rstudio-themes-dark .replaceTextBox:focus {
+   border-color: #007acc;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPane.java
@@ -85,7 +85,7 @@ public class FindOutputPane extends WorkbenchPane
                turnOnReplaceMode();
          }
       });
-      toolbar.addRightWidget(showFindButton_);
+      toolbar.addLeftWidget(showFindButton_);
 
       showReplaceButton_ = new LeftRightToggleButton(constants_.findLabel(), constants_.replaceLabel(), false);
       showReplaceButton_.setVisible(false);
@@ -97,7 +97,7 @@ public class FindOutputPane extends WorkbenchPane
                turnOffReplaceMode();
          }
       });
-      toolbar.addRightWidget(showReplaceButton_);
+      toolbar.addLeftWidget(showReplaceButton_);
 
       return toolbar;
    }
@@ -109,6 +109,7 @@ public class FindOutputPane extends WorkbenchPane
       replaceMode_ = true;
 
       replaceTextBox_ = new TextBox();
+      replaceTextBox_.addStyleName("replaceTextBox");
       replaceTextBox_.addKeyUpHandler(new KeyUpHandler()
       {
          public void onKeyUp(KeyUpEvent event)


### PR DESCRIPTION
Closes #17501.

Two small UX fixes for the Find in Files pane:
1. Moves the refresh button to the rightmost position in the toolbar for consistency with other panes
2. Applies proper theme colors to the Replace dialog so it doesn't appear unstyled in dark themes