### PR TITLE
add workflow to move addressed issues to test after pr merge

### DIFF
--- a/.github/workflows/move-addressed-issues-to-test.yml
+++ b/.github/workflows/move-addressed-issues-to-test.yml
@@ -18,6 +18,11 @@ name: Move addressed issues to Test
 # convention is used by internal staff, so this trade-off is acceptable:
 # fork PRs that address an issue can be moved to Test manually by a
 # maintainer after merge, as is done today.
+#
+# This file is expected to be carried into the rstudio/rstudio-pro repo by
+# the periodic upstream-merge. The `github.repository` guard on the job
+# below ensures it is a no-op there -- only `rstudio/rstudio` PRs feed
+# project 90, and rstudio-pro has its own automation for its own boards.
 
 on:
   pull_request:
@@ -27,7 +32,9 @@ permissions: {}
 
 jobs:
   move-to-test:
-    if: github.event.pull_request.merged == true
+    if: >-
+      github.event.pull_request.merged == true
+      && github.repository == 'rstudio/rstudio'
     runs-on: ubuntu-latest
     env:
       PROJECT_OWNER: rstudio

--- a/.github/workflows/move-addressed-issues-to-test.yml
+++ b/.github/workflows/move-addressed-issues-to-test.yml
@@ -7,9 +7,15 @@ name: Move addressed issues to Test
 # workflow. Requires the following secrets to be available to this repo:
 #   - WORKBENCH_IDE_RELEASE_APP_ID
 #   - WORKBENCH_IDE_RELEASE_PEM
+#
+# Uses `pull_request_target` (not `pull_request`) so the workflow runs with
+# access to repository secrets even for PRs opened from forks. Safe here
+# because the job does not check out PR code, and the only PR-controlled
+# values used (title/body) are passed through env vars rather than
+# interpolated into shell, so they cannot inject script.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions: {}

--- a/.github/workflows/move-addressed-issues-to-test.yml
+++ b/.github/workflows/move-addressed-issues-to-test.yml
@@ -1,0 +1,144 @@
+name: Move addressed issues to Test
+
+# When a PR is merged, parse its title and body for "Addresses #N" references
+# and move each referenced issue to the "Test" column of project rstudio/90.
+#
+# Requires repo or org secret PROJECTS_TOKEN with:
+#   - Classic PAT: repo + project scopes, or
+#   - Fine-grained PAT / GitHub App with Projects (org) write + Issues read.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  move-to-test:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
+      PROJECT_OWNER: rstudio
+      PROJECT_NUMBER: 90
+      TARGET_STATUS: "Test 👀"
+    steps:
+      - name: Extract addressed issue numbers
+        id: extract
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          {
+            printf '%s\n' "$PR_TITLE"
+            printf '%s\n' "$PR_BODY"
+          } | grep -ohiE '\baddresses[[:space:]]+(rstudio/rstudio)?#[0-9]+' \
+            | grep -oE '[0-9]+' \
+            | sort -u > issues.txt || true
+
+          if [ ! -s issues.txt ]; then
+            echo "No 'Addresses #N' references found."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Found issues:"
+            cat issues.txt
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve project + Status field metadata
+        if: steps.extract.outputs.found == 'true'
+        id: meta
+        run: |
+          gh api graphql \
+            -F owner="$PROJECT_OWNER" \
+            -F number="$PROJECT_NUMBER" \
+            -f query='
+              query($owner: String!, $number: Int!) {
+                organization(login: $owner) {
+                  projectV2(number: $number) {
+                    id
+                    field(name: "Status") {
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        options { id name }
+                      }
+                    }
+                  }
+                }
+              }' > meta.json
+
+          PROJECT_ID=$(jq -r '.data.organization.projectV2.id' meta.json)
+          FIELD_ID=$(jq -r '.data.organization.projectV2.field.id' meta.json)
+          OPTION_ID=$(jq -r --arg name "$TARGET_STATUS" \
+            '.data.organization.projectV2.field.options[] | select(.name == $name) | .id' meta.json)
+
+          if [ -z "$OPTION_ID" ] || [ "$OPTION_ID" = "null" ]; then
+            echo "Could not resolve Status option '$TARGET_STATUS' in project $PROJECT_NUMBER."
+            echo "Available options:"
+            jq '.data.organization.projectV2.field.options' meta.json
+            exit 1
+          fi
+
+          {
+            echo "project_id=$PROJECT_ID"
+            echo "field_id=$FIELD_ID"
+            echo "option_id=$OPTION_ID"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Move each addressed issue to Test
+        if: steps.extract.outputs.found == 'true'
+        env:
+          PROJECT_ID: ${{ steps.meta.outputs.project_id }}
+          FIELD_ID: ${{ steps.meta.outputs.field_id }}
+          OPTION_ID: ${{ steps.meta.outputs.option_id }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          while IFS= read -r ISSUE_NUMBER; do
+            [ -z "$ISSUE_NUMBER" ] && continue
+            echo "::group::Issue #$ISSUE_NUMBER"
+
+            ITEM_ID=$(gh api graphql \
+              -F owner="$REPO_OWNER" \
+              -F repo="$REPO_NAME" \
+              -F number="$ISSUE_NUMBER" \
+              -f query='
+                query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    issue(number: $number) {
+                      projectItems(first: 50) {
+                        nodes {
+                          id
+                          project { number }
+                        }
+                      }
+                    }
+                  }
+                }' \
+              | jq -r --arg pn "$PROJECT_NUMBER" \
+                  '.data.repository.issue.projectItems.nodes[]? | select(.project.number == ($pn | tonumber)) | .id')
+
+            if [ -z "$ITEM_ID" ]; then
+              echo "Issue #$ISSUE_NUMBER is not in project $PROJECT_NUMBER; skipping."
+              echo "::endgroup::"
+              continue
+            fi
+
+            gh api graphql \
+              -f project="$PROJECT_ID" \
+              -f item="$ITEM_ID" \
+              -f field="$FIELD_ID" \
+              -f option="$OPTION_ID" \
+              -f query='
+                mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $project,
+                    itemId: $item,
+                    fieldId: $field,
+                    value: { singleSelectOptionId: $option }
+                  }) { projectV2Item { id } }
+                }' > /dev/null
+
+            echo "Moved issue #$ISSUE_NUMBER to '$TARGET_STATUS'."
+            echo "::endgroup::"
+          done < issues.txt

--- a/.github/workflows/move-addressed-issues-to-test.yml
+++ b/.github/workflows/move-addressed-issues-to-test.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Generate GitHub App token
         if: steps.extract.outputs.found == 'true'
         id: generate_token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           client-id: ${{ secrets.WORKBENCH_IDE_RELEASE_APP_ID }}
           private-key: ${{ secrets.WORKBENCH_IDE_RELEASE_PEM }}

--- a/.github/workflows/move-addressed-issues-to-test.yml
+++ b/.github/workflows/move-addressed-issues-to-test.yml
@@ -1,11 +1,12 @@
 name: Move addressed issues to Test
 
 # When a PR is merged, parse its title and body for "Addresses #N" references
-# and move each referenced issue to the "Test" column of project rstudio/90.
+# and move each referenced issue to the "Test 👀" column of project rstudio/90.
 #
-# Requires repo or org secret PROJECTS_TOKEN with:
-#   - Classic PAT: repo + project scopes, or
-#   - Fine-grained PAT / GitHub App with Projects (org) write + Issues read.
+# Authenticates as the same GitHub App used by rstudio-pro's issue-state-sync
+# workflow. Requires the following secrets to be available to this repo:
+#   - WORKBENCH_IDE_RELEASE_APP_ID
+#   - WORKBENCH_IDE_RELEASE_PEM
 
 on:
   pull_request:
@@ -18,7 +19,6 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
       PROJECT_OWNER: rstudio
       PROJECT_NUMBER: 90
       TARGET_STATUS: "Test 👀"
@@ -45,9 +45,20 @@ jobs:
             echo "found=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Generate GitHub App token
+        if: steps.extract.outputs.found == 'true'
+        id: generate_token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          client-id: ${{ secrets.WORKBENCH_IDE_RELEASE_APP_ID }}
+          private-key: ${{ secrets.WORKBENCH_IDE_RELEASE_PEM }}
+          repositories: rstudio
+
       - name: Resolve project + Status field metadata
         if: steps.extract.outputs.found == 'true'
         id: meta
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           gh api graphql \
             -F owner="$PROJECT_OWNER" \
@@ -88,6 +99,7 @@ jobs:
       - name: Move each addressed issue to Test
         if: steps.extract.outputs.found == 'true'
         env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           PROJECT_ID: ${{ steps.meta.outputs.project_id }}
           FIELD_ID: ${{ steps.meta.outputs.field_id }}
           OPTION_ID: ${{ steps.meta.outputs.option_id }}

--- a/.github/workflows/move-addressed-issues-to-test.yml
+++ b/.github/workflows/move-addressed-issues-to-test.yml
@@ -8,14 +8,19 @@ name: Move addressed issues to Test
 #   - WORKBENCH_IDE_RELEASE_APP_ID
 #   - WORKBENCH_IDE_RELEASE_PEM
 #
-# Uses `pull_request_target` (not `pull_request`) so the workflow runs with
-# access to repository secrets even for PRs opened from forks. Safe here
-# because the job does not check out PR code, and the only PR-controlled
-# values used (title/body) are passed through env vars rather than
-# interpolated into shell, so they cannot inject script.
+# Scope: this intentionally uses `pull_request` (not `pull_request_target`),
+# which means it will NOT run for PRs opened from forks -- GitHub does not
+# expose repository secrets to `pull_request` workflows on fork PRs, so the
+# App-token step would fail. Switching to `pull_request_target` would cover
+# fork PRs but introduces a well-known security footgun (any future edit
+# that checks out PR code or expands ${{ github.event.pull_request.* }}
+# into shell becomes a remote-code-execution path). The `Addresses #N`
+# convention is used by internal staff, so this trade-off is acceptable:
+# fork PRs that address an issue can be moved to Test manually by a
+# maintainer after merge, as is done today.
 
 on:
-  pull_request_target:
+  pull_request:
     types: [closed]
 
 permissions: {}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/move-addressed-issues-to-test.yml`, which runs on `pull_request: closed` (filtered to merged PRs) and automates the manual "move issue to Test" step we currently do after every merge.

The workflow:
- Parses the PR title and body for `Addresses #N` references (also accepts `Addresses rstudio/rstudio#N`).
- Resolves the project ID, Status field ID, and `Test 👀` option ID for `rstudio/projects/90` via one GraphQL call (so renaming/reordering Status options on the board won't break it -- only renaming `Test 👀` itself would).
- For each referenced issue, finds its item in project 90 and sets Status to `Test 👀`. Issues not on the board are skipped.

## Auth

Reuses the same GitHub App as rstudio-pro's `ide-issue-state-sync.yml`. No new credentials introduced -- we just need the existing App's secrets exposed to this repo.

## Required setup before merging

This PR is intentionally **draft** -- the workflow will fail at the "Generate GitHub App token" step until both secrets below are accessible:

- [ ] `WORKBENCH_IDE_RELEASE_APP_ID`
- [ ] `WORKBENCH_IDE_RELEASE_PEM`

These already exist in `rstudio-pro` and the App already has Projects + Issues access to `rstudio/projects/90` (it's the same App that powers the every-2-hours status -> open/closed sync). Easiest path: scope the existing org-level secrets so they're also available to `rstudio/rstudio`, or copy them as repo secrets here.

- [ ] Confirm the Status option on project 90 is still exactly `Test 👀` -- the workflow fails loudly with the available options listed if not.

## Relationship to existing automation

Complementary, not overlapping, with `rstudio-pro/.github/workflows/ide-issue-state-sync.yml`:
- Existing flow: every 2h, reads project status and updates issue open/closed state (status -> issue).
- This flow: on PR merge, reads `Addresses #N` and writes status -> `Test 👀` (PR -> status).

## Known limitations

- Only scans PR title + body, not commit messages. PRs that put `Addresses #N` only in commits won't be picked up.
- Same-repo references only -- `Addresses rstudio/rstudio-pro#N` is intentionally ignored (different board).
- `Addresses #1 ... Addresses #2` works; shorthand like `Addresses #1, #2` only catches `#1`.

## Test plan

- [ ] Provision the two secrets above.
- [ ] Verify GraphQL resolution: temporarily add a `workflow_dispatch` trigger with an issue-number input on a side branch, run against a known on-board issue, confirm it moves to `Test 👀`.
- [ ] Confirm an issue not in project 90 is skipped (logs say "skipping"), not errored.
- [ ] Confirm a PR with no `Addresses` line short-circuits cleanly.
- [ ] Merge a real PR that addresses an issue and verify the move happens end-to-end.
- [ ] Remove the temporary `workflow_dispatch` trigger before considering this complete.