### PR TITLE
add brat-to-playwright migration plan and skill

### DIFF
--- a/.claude/skills/rstudio-migrate-tests-brat-to-playwright/SKILL.md
+++ b/.claude/skills/rstudio-migrate-tests-brat-to-playwright/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: rstudio-migrate-tests-brat-to-playwright
+description: Migrate R/testthat BRAT automation tests to TypeScript/Playwright. Use when converting tests from rstudio/src/cpp/tests/automation/testthat/ to rstudio/e2e/rstudio/tests/.
+---
+
+# Migrate BRAT Tests to Playwright
+
+Converts R/testthat BRAT tests from `src/cpp/tests/automation/testthat/` to TypeScript/Playwright tests in `e2e/rstudio/tests/`. Sister skill to `rstudio-migrate-tests-selenium-to-playwright`; many process steps are shared.
+
+## Arguments
+
+The user provides one or more targets:
+- A single file: `/rstudio-migrate-tests-brat-to-playwright test-automation-debugger.R`
+- A keyword: `/rstudio-migrate-tests-brat-to-playwright completions`
+- A status keyword: `/rstudio-migrate-tests-brat-to-playwright next` (pick the next Not Started file from the progress doc)
+
+## Hard Rules
+
+1. **Load skills first** -- Always load `rstudio-create-playwright-tests` before any conversion work.
+2. **BRAT is reference, not a blueprint.** BRAT calls internal `.rs.*` APIs and `remote$*` automation methods that have no direct UI equivalent. Use BRAT as the source of truth for *expected values, edge cases, and what behavior to verify* -- then drive the same behavior through the UI in Playwright.
+3. **Check the progress doc** -- Before starting, verify the file hasn't already been converted. Located at `e2e/rstudio/docs/MIGRATION_FROM_BRAT_PROGRESS.md`.
+4. **Tests must work on Desktop and Server** -- Use the unified fixture (`@fixtures/rstudio.fixture`). Tag with `@desktop_only` / `@server_only` only when the behavior genuinely differs.
+5. **A test isn't migrated until it passes.** Run the converted Playwright test against a live RStudio instance. Retry up to 3 times. If still failing, mark it `test.fixme()` with a blocker note and track it as Fixme in the progress doc. Do not list a fixme test as migrated in summaries.
+6. **Don't delete BRAT tests until their Playwright counterparts pass.** Removal happens in the same PR, after the new test is green. Never delete first.
+7. **No Claude dependency** -- Test infrastructure must run from terminal, CI, and GitHub Actions. Claude subagents are convenience, not required.
+
+## Unportable BRAT tests
+
+Some BRAT tests cannot be driven from the UI -- they call `.rs.*` APIs that have no user-observable effect, or they verify internal state directly. For each:
+
+1. Read the BRAT test carefully. What user-facing behavior, if any, is being verified?
+2. Pick a disposition and record it in the progress doc:
+   - **Port via UI** -- find the equivalent user interaction and assert on observable outcomes. Default choice.
+   - **Convert to C++/R unit test** -- if the logic is pure, port it to the appropriate `src/cpp/tests/testthat/` or Google Test file. Note the new location.
+   - **Drop** -- if the behavior isn't user-visible and isn't covered by another layer of testing, delete the BRAT test with a rationale. Requires user approval.
+
+Don't default to Drop. Aim to preserve the behavior coverage.
+
+## Steps
+
+### Step 1: Resolve the target
+
+- Find the file under `src/cpp/tests/automation/testthat/`.
+- Read the full R source. Identify each `.rs.test("name", { ... })` block and its expected outcomes.
+- Check `MIGRATION_FROM_BRAT_PROGRESS.md` for current status and any known overlap with existing Playwright tests.
+
+### Step 2: Read reference materials
+
+- Load the `rstudio-create-playwright-tests` skill.
+- Read the existing Playwright counterpart (if any) -- the progress doc lists likely candidates.
+- Read relevant `e2e/rstudio/pages/` and `e2e/rstudio/actions/` helpers.
+- For complex behavior (e.g. R Markdown chunk execution, debugger stepping), also check the BRAT helper file `src/cpp/tests/automation/testthat/helper-pane-layout.R` if relevant.
+- Check `e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md` -- a Selenium test on the same feature may have been ported and tell you what shape the Playwright version should take.
+
+**For large BRAT files (10+ tests):** consider launching a general-purpose subagent to map each `.rs.test()` block to an existing Playwright test (or no-counterpart). The subagent returns a per-test plan that keeps the main context lean for the writing phase.
+
+### Step 3: Determine the target location
+
+Map the BRAT test to the Playwright directory:
+
+| BRAT file (theme) | Playwright location |
+|-------------------|---------------------|
+| Editor / file types / R Markdown / Quarto / Sweave / refactoring / syntax | `tests/panes/editor/` |
+| Console / completions / restart / history | `tests/panes/console/` or `tests/panes/misc/` |
+| Debugger | `tests/panes/debugger/` |
+| Data viewer | `tests/panes/data-viewer/` |
+| Build / packages / environment / files / terminal | `tests/panes/<area>/` (create if missing) |
+| Chat / guardrails / chat satellite | `tests/panes/posit-assistant-chat/` |
+| Projects | `tests/projects/` |
+| Smoke / startup | `tests/smoke/` |
+
+Use judgment. The Playwright structure is organized by user-facing area, not by BRAT file layout.
+
+### Step 4: Categorize each BRAT test
+
+For each `.rs.test()` block, decide:
+
+- **Already covered** -- a Playwright test exercises the same user-facing behavior. Verify by reading the candidate. If genuinely covered, mark the BRAT test for deletion (no porting work).
+- **Partial** -- behavior is covered but a specific assertion is missing. Add the missing assertion to the existing Playwright test or write a focused new one.
+- **Not covered** -- port from scratch.
+- **Unportable** -- pick a disposition per the section above.
+
+Record each decision in the progress doc.
+
+### Step 5: Write the TypeScript test(s)
+
+Follow the rules in `rstudio-create-playwright-tests`.
+
+BRAT-specific translation guidance:
+
+| BRAT | Playwright |
+|------|------------|
+| `remote$console.execute("expr")` | `consoleActions.typeInConsole(page, "expr")` |
+| `remote$console.executeExpr({ ... })` | Build the R expression as a string, then `typeInConsole`. Use template literals; keep indentation minimal |
+| `remote$console.getOutput()` | Read `#rstudio_console_output` text via locator |
+| `remote$editor.openWithContents(".R", contents, cb)` | Create file in sandbox, `File > Open` or use the `editorActions` helpers |
+| `remote$commands.execute("commandName")` | Prefer the UI path (button, menu, keyboard shortcut). Fall back to `typeInConsole(`.rs.api.executeCommand("commandName")`)` when UI is tangential to the test |
+| `remote$dom.clickElement("#sel")` | `await page.locator('#sel').click()` |
+| `remote$dom.elementExists("#sel")` | `await expect(page.locator('#sel')).toBeVisible()` (or `.toHaveCount(0)` for absence) |
+| `remote$dom.waitForElement("#sel")` | `await expect(page.locator('#sel')).toBeVisible({ timeout: TIMEOUTS.foo })` |
+| `remote$keyboard.insertText("text", "<Enter>")` | `pressSequentially("text")` then `sleep(200)` + `keyboard.press("Enter")` |
+| `remote$keyboard.executeShortcut("Cmd + Shift + P")` | `keyboard.press("ControlOrMeta+Shift+P")` -- see the create-playwright skill for the Cmd vs Ctrl rules |
+| `remote$completions.request("stats::rn")` | Drive completions via UI: type into editor, wait for popup, read items |
+| `remote$session.restart()` | UI: `Session > Restart R` or `keyboard.press("ControlOrMeta+Shift+F10")`; assert with `consoleActions.waitForSessionReady()` |
+| `remote$project.create(...)` | New Project wizard via `projectActions` |
+| `remote$satellites.switchTo("...")` | Open a new Playwright Page handle for the satellite window |
+| `.rs.uiPrefs$foo$set(value)` | `.rs.api.writeRStudioPreference("foo", value)` via console, with `clear()` translated to writing the default in `afterAll` |
+| `.rs.heredoc("...")` | Plain backtick template literal |
+| `.rs.waitUntil("reason", predicate)` | Built-in `expect().toBeVisible()` / `toContainText()` retry. Use polling helpers only when no DOM signal exists |
+| `withr::defer(...)` (per-test cleanup) | `afterEach` hook, or per-test cleanup via `await using` patterns |
+| `withr::defer(.rs.automation.deleteRemote())` (file-level) | No equivalent needed -- the fixture handles teardown |
+| `.rs.markers("wip", "editor")` | `test.fixme()` for wip; tags for categorization (`{ tag: ['@editor'] }`) |
+
+If the BRAT source has several near-identical `.rs.test()` blocks, consider data-driven restructuring (one `forEach` loop) in the Playwright version.
+
+### Step 6: Add missing page objects or actions
+
+If the test needs locators or methods not yet available:
+- Add locators to the appropriate file in `pages/`
+- Add interaction methods to the appropriate file in `actions/`
+- Follow existing patterns
+
+### Step 7: Run the test
+
+**Hard gate (Hard Rule 5):** a test doesn't count as migrated until it passes here.
+
+Defer to `rstudio-run-playwright-tests` for the canonical run commands (Desktop and Server). Present the command and wait for user approval before executing.
+
+Quick reference for Desktop:
+
+```bash
+cd e2e/rstudio && npx playwright test tests/<path>/<file>.test.ts
+```
+
+If the test fails:
+- Review error output
+- Fix and re-run (up to 3 attempts)
+- If still failing, `test.fixme()` the failing test and note the blocker in the progress doc
+
+### Step 8: Delete the BRAT test(s)
+
+Once the Playwright counterpart is green:
+
+- Delete the migrated `.rs.test()` block from the BRAT file.
+- If the BRAT file is now empty (no remaining `.rs.test()` blocks), delete the whole file.
+- If the file becomes empty after this PR but you want to defer the deletion, that's fine -- track it in the progress doc and clean up later.
+
+Never leave a migrated BRAT test in place "for safety" -- the goal is full deprecation.
+
+### Step 9: Reevaluate
+
+After the test passes, review for:
+
+1. **Code clarity** -- Remove unnecessary variables, simplify patterns
+2. **Idiomatic patterns** -- Check against the list in the create-playwright skill
+3. **Selector quality** -- Check against the selector hierarchy
+4. **Playwright + TypeScript conventions** -- async/await, type annotations, built-in assertions, lifecycle hooks
+5. **Duplication** -- Could any new helpers move to actions/?
+
+Present proposed improvements to the user. Apply only if approved. Re-run after changes.
+
+### Step 10: Update progress tracking
+
+Edit `e2e/rstudio/docs/MIGRATION_FROM_BRAT_PROGRESS.md`:
+- Update the file's status (Complete, Partial, Dropped, or Fixme)
+- Add the Playwright target path(s) and test count
+- Add notes for unportable tests (disposition + reasoning)
+- Add fixme tests to the Fixme Tests table with blocker description
+
+### Step 11: Commit and submit
+
+Each substep requires explicit approval before proceeding.
+
+**11.1 Check branch.** Run `git branch --show-current`. Branch prefix: `test/migrate-brat-`. Kebab-case for the descriptive part (e.g., `test/migrate-brat-debugger`). Never commit directly to main.
+
+**11.2 Review changes.** Run `git fetch origin`. Run `git status` (never `-uall`), `git diff`, `git log --oneline -5`. Summarize what changed. Flag anything that shouldn't be committed.
+
+**11.3 Stage and commit.** Stage specific files by name (never `git add -A`). Draft a commit message focused on the "why" -- concise, single line preferred, lowercase first letter (per project convention), no Co-Authored-By. Show the message, wait for approval. Commit, then `git status`.
+
+**11.4 Push.** Show the push command, wait for approval, push with `-u`. Never push to main directly.
+
+**11.5 Create PR.** Draft PR title (under 70 chars, lowercase) and summary. Include an `## Intent` section if the migration addresses a specific issue. Ask about reviewers. Show full PR details, wait for approval. Create with `gh pr create`. Add the `automation` label. Return the PR URL.
+
+**11.6 Merge** (only if the user asks to merge this session).
+
+### Step 12: Roborev review and assessment
+
+Invoke the `roborev-review` skill on the commit. Assess findings before presenting:
+- Read each finding in actual code context
+- Judge real severity; don't blindly trust roborev's label
+- Fix High and Medium findings
+- Fix Low findings only if they're real bugs or silent failures
+- Skip cosmetic Lows and "add tests for simple scripts" suggestions
+
+Apply fixes manually. Do not invoke `roborev-fix`. Re-run the Playwright test after fixes. Re-run `roborev-review` on the new commit. Repeat until no actionable findings remain. Close reviewed findings via `roborev-respond`.
+
+## Compact Instructions
+
+If context compacts mid-migration, preserve:
+- **Source and target paths** for the file being migrated
+- **Per-test status**: which `.rs.test()` blocks ported (passed Step 7), which became `test.fixme()` and why, which were dropped/converted
+- **Page object / action additions** made during the migration
+- **Open roborev findings** in progress: job ID, finding being fixed, severity assessment
+- **Open blockers** flagged for the user (issues to file, upstream bugs found)
+
+If a step has been completed, that fact also survives -- don't redo work the user has already approved.
+
+## Output
+
+After conversion, summarize:
+- BRAT source file and `.rs.test()` blocks handled
+- Playwright target file(s) and location
+- Page objects or actions added/modified
+- Test results (passed / fixme with blockers / dropped with rationale)
+- BRAT lines removed and whether the BRAT file is now empty
+- Improvements made during reevaluation
+- MIGRATION_FROM_BRAT_PROGRESS.md updates

--- a/e2e/rstudio/docs/MIGRATION_FROM_BRAT_PROGRESS.md
+++ b/e2e/rstudio/docs/MIGRATION_FROM_BRAT_PROGRESS.md
@@ -1,0 +1,183 @@
+# BRAT-to-Playwright Migration Progress
+
+Source: `src/cpp/tests/automation/testthat/`
+Target: `e2e/rstudio/tests/`
+
+This document tracks the per-file migration of BRAT (R/testthat) automation tests to
+Playwright (TypeScript). See `.claude/skills/rstudio-migrate-tests-brat-to-playwright/SKILL.md`
+for the migration workflow.
+
+## Status legend
+
+File-level status:
+
+- **Not started** -- no work begun
+- **In progress** -- branch open, some tests migrated, file still has BRAT tests
+- **Complete** -- all `.rs.test()` blocks ported (or dropped with rationale); BRAT file deleted or noted as residual
+- **Drop-and-replace** -- whole file recommended for deletion or replacement by non-Playwright coverage (R/JS unit tests)
+- **Dropped** -- intentionally not ported; rationale in Notes
+- **Fixme** -- ported test passes none-of-3 attempts; tracked in the Fixme Tests table below
+
+Test-level dispositions used in the per-file tables below:
+
+- **Covered** -- a Playwright test exercises the same user-facing behavior
+- **Partial** -- behavior overlaps but a specific assertion/input differs; small delta migration
+- **Not covered** -- needs porting
+- **Unportable** -- depends on `.rs.*` internal-API behavior with no observable UI effect
+
+## Summary
+
+| Metric | Count |
+|--------|------:|
+| Total BRAT test files | 32 (+ 1 helper file) |
+| Total `.rs.test()` blocks | ~169 |
+| Tests Covered (eligible for BRAT removal after spot-check) | ~17 |
+| Tests Partial (small delta porting) | ~30 |
+| Tests Not covered (full port) | ~98 |
+| Tests Unportable (drop or convert to unit test) | ~20 |
+| Files Complete | 0 |
+| Files In progress | 0 |
+| Files Not started | 32 |
+
+Phase 1 audit complete (2026-05-19). Phase 2 (per-file migration) begins next.
+
+## Conversion Status
+
+### Editor (8 files, 60 tests)
+
+| BRAT Source | Tests | Counterpart(s) | Status | Per-test (C/P/N/U) | Notes |
+|-------------|------:|---------------|--------|-------------------:|-------|
+| test-automation-editor.R | 4 | -- | Not started | 0/0/4/0 | Whitespace-on-save, whole-word replace, Ace shortcuts in console, findFromSelection |
+| test-automation-code-folding.R | 2 | -- | Drop-and-replace | 0/0/0/2 | Both tests assert `getFoldWidget()` ranges -- Ace internals. Better as JS unit tests in `src/gwt/acesupport/` |
+| test-automation-edit-suggestions.R | 5 | code_suggestions.test.ts, copilot_ghost_text.test.ts | Partial | 0/2/3/0 | Accept/persist cases overlap; 3 token-introspection tests need fresh UI-level ports. BRAT injects via internal `.rs.api.showEditSuggestion`; consider preserving that deterministic mechanism via `executeCommand` in Playwright |
+| test-automation-syntax-highlighting.R | 11 | syntax-highlighting.test.ts (1) | Drop-and-replace | 1/5/0/5 | 10 of 11 assert Ace token types; not user-observable. Hex/named-color tests partially portable via computed `background-color` on rendered spans |
+| test-automation-rmarkdown.R | 18 | rmarkdown.test.ts (7), multiline_chunk_execution.test.ts (1), notebook_save_during_execution.test.ts (1) | Partial | 1/1/16/0 | Biggest single porting opportunity: chunk-options popup UI (~6 tests, all DOM-driven), visual-mode round-trips, chunk-widget visibility, error-halt, history-recall, paged-table, patchwork. 9 of 18 are `skip_on_ci()` |
+| test-automation-quarto.R | 12 | quarto.test.ts (1), multiline_chunk_execution.test.ts (1) | Partial | 0/1/8/3 | Mirrors Rmd chunk-options gap (`.qmd` variants). Raw HTML/LaTeX block preservation via visual mode is portable. 3 token/fold-widget tests are unportable. 7 of 12 are `skip_on_ci()` |
+| test-automation-sweave.R | 2 | -- | Drop-and-replace | 0/0/0/2 | Both assert token/marker internals. Existing Selenium-ported `sweave.test.ts` (not yet in this checkout) covers creation + PDF compile, not highlighting |
+| test-automation-reformat.R | 6 | air_formatting.test.ts (10) | Partial | 2/1/3/0 | Air-formatter cases well covered. Styler tests (3) and Windows-specific newline regression (#17471) need porting. Note BRAT sets prefs via `.rs.uiPrefs$*$set()`; Playwright drives the Options dialog (the real user path) |
+
+### Console, completions, debugger, data viewer (5 files, 41 tests)
+
+| BRAT Source | Tests | Counterpart(s) | Status | Per-test (C/P/N/U) | Notes |
+|-------------|------:|---------------|--------|-------------------:|-------|
+| test-automation-console.R | 8 | console_pane.test.ts (10), console_command_effects.test.ts (8), ansi_erase_in_line.test.ts (8), execute_from_editor.test.ts (2) | Partial | 0/2/6/0 | Biggest gaps in this slice: condition highlighting (errors/warnings/messages spans), `consoleLineLengthLimit` truncation, post-error output (#16337), multi-message annotation, Ctrl+Shift+M/Alt+- shortcuts in console input |
+| test-automation-completions.R | 17 | autocomplete.test.ts (12, runs each test in console + editor) | Partial | 5/1/11/0 | Cores covered (#13196, #13291, #12678). Long tail not covered: roxygen tag completions (.R/.Rmd/.qmd), pipebind placeholder, dollar-names types, column-name quoting, pref toggle, R6 active bindings (#14784), multi-line Tab indent. Playwright adds extras (data.table $, Unicode column names) without BRAT counterpart |
+| test-automation-restart.R | 1 | -- | Not started | 0/0/1/0 | `.rs.api.restartSession('print(x + y)')` -- exercise the equivalent via `restartR` command + post-restart assertion |
+| test-automation-debugger.R | 8 | debugger.test.ts (~15) | Partial | 3/2/3/0 | Core stepping / breakpoints covered (Playwright actually adds Step Into/Out, Continue chains, recover-on-error, env locals, traceback). Gaps: S7 method breakpoints (#16490), package-build paths (#15201 partial), `debugClearBreakpoints` (Desktop messagebox blocker), multi-line `Browse[N]>` regression |
+| test-automation-data-viewer.R | 7 | pagination-sorting.test.ts (5) | Partial | 0/2/5/0 | Complementary, not overlapping. Playwright tests pagination; BRAT tests filter/pin/state-persist/XSS-escaping. Big porting opportunity: filter toolbar, pin icon, refresh state persistence, 3-state sort cycle, HTML-special cell/column escaping |
+
+### Chat / Posit Assistant (3 files, 36 tests)
+
+| BRAT Source | Tests | Counterpart(s) | Status | Per-test (C/P/N/U) | Notes |
+|-------------|------:|---------------|--------|-------------------:|-------|
+| test-automation-chat.R | 2 | open-chat-pane.test.ts, enable-assistant.test.ts, settings-button.test.ts, uninstall-posit-ai.test.ts | Partial | 0/1/1/0 | Port the "no-refresh on Options dismiss" test; add focused restart-survival assertion (uninstall flow covers it partially) |
+| test-automation-chat-satellite.R | 3 | detachable-sidebar.test.ts (1, desktop_only) | Partial | 1/1/0/1 | Desktop pop-out/return covered. Missing: command-based variant (`popOutChat`/`returnChatToMain` invoked via UI command). Server-only Chrome-reload-WindowCloseMonitor test is Unportable in spirit (no user gesture) |
+| test-automation-guardrails.R | 31 | chat-guardrails.test.ts (11) | Partial | 3/7/17/4 | Largest delta. Port missing read paths (`~/.aws/credentials`, `~/.ssh/config`, `~/.netrc`, `id_rsa`, `.env.local`); missing write paths (`~/.ssh`, `file.create`, `file.remove`, `unlink`, `file.copy`); /etc/passwd, /etc/shadow, /etc/passwd write; path-traversal; structural error message; SSH public-key allow case. 4 binding-lifecycle tests (`injectBindings`/`restoreBindings`/`safeEval`/double-inject) are Unportable -- consider R-level testthat |
+
+### Workbench panes / misc (10 files, ~22 tests)
+
+| BRAT Source | Tests | Counterpart(s) | Status | Per-test (C/P/N/U) | Notes |
+|-------------|------:|---------------|--------|-------------------:|-------|
+| test-automation-build-pane.R | 1 | -- | Not started | 0/0/1/0 | `testTestthatFile` command + "Test complete" assertion; skipped on CI |
+| test-automation-environment-pane.R | 0 | -- | Drop-and-replace | -- | File is 1 line / empty. Delete in cleanup PR |
+| test-automation-packages-pane.R | 4 | -- | Not started | 0/0/4/0 | MASS attach/detach via pane checkbox; renv variant (#16842). 4th "we reset state" can fold into setup/teardown |
+| test-automation-files.R | 3 | -- | Not started | 0/0/3/0 | Virtualized Open File dialog (Server-only, 10k temp files); non-virt variant; autosave-unchanged-doc (#16329) |
+| test-automation-files-endpoint.R | 1 | -- | Partial / Unportable-as-UI | 0/1/0/0 | Protocol-level `/files/` cross-site test. Server-only. Better as backend integration test, or use Playwright's `request.fetch()` |
+| test-automation-history.R | 1 | -- | Not started | 0/0/1/0 | `timestamp()` console history recall + Up arrow |
+| test-automation-ignorefiles.R | 1 | -- | Not started | 0/0/1/0 | Regression for `89f6cef5d8`: `.positai` added to `.gitignore` only after directory exists; wizard-driven |
+| test-automation-terminal.R | 2 | -- | Not started | 0/0/2/0 | Create terminal + visibility, run command + `sendTerminalToEditor` |
+| test-automation-tabs.R | 5 | panes/layout/panes.test.ts (18), panes/layout/pane_layout.test.ts (16) | Partial | 0/3/2/0 | Three partial overlaps (core tab list, sidebar-width add/remove tab, layoutZoom variants). Two need fresh ports: tab selection aria-selected, `layoutZoomEnvironment`. Uses helper-pane-layout.R |
+| test-automation-defer-scope.R | 4 | -- | Drop-and-replace | 0/0/0/4 | Tests `.rs.test()` framework + `withr::defer()` semantics. No UI. Moot once BRAT is removed |
+
+### Projects, runtimes, lifecycle (5 files, 8 tests)
+
+| BRAT Source | Tests | Counterpart(s) | Status | Per-test (C/P/N/U) | Notes |
+|-------------|------:|---------------|--------|-------------------:|-------|
+| test-automation-projects.R | 3 | create_projects.test.ts (5), project_trust_dialog.test.ts (8) | Partial | 1/1/1/0 | Default-no-git path conceptually covered. Need: git-checkbox path (assert VCS tab appears), ProjectId-on-demand regression |
+| test-automation-python.R | 1 | -- | Not started | 0/0/1/0 | `reticulate::repl_python()` + Tab completion + dunder-attribute quoting (#14560); skipped on CI in BRAT |
+| test-automation-shinytest2.R | 1 | -- | Partial | 0/1/0/0 | Toolbar-button branch is straightforward; snapshot-review namespace-stub branch is brittle |
+| test-automation-refactoring.R | 1 | -- | Partial | 0/1/0/0 | renameInScope across Rmd chunks (#4961). Needs `editor.selection` shim via `page.evaluate` |
+| test-automation-smoke.R | 1 | smoke/startup.test.ts (2) | Drop | 1/0/0/0 | Smoke-tests the BRAT harness itself; redundant once BRAT is gone |
+| test-automation-suspend.R | 2 | -- | Not started | 0/0/2/0 | Server-mode suspend/resume; loadedNamespaces + attached datasets preserved. Likely `@server_only` |
+
+### Non-test helper files
+
+| File | Role | Disposition |
+|------|------|-------------|
+| helper-pane-layout.R | testthat helper sourced by `test-automation-tabs.R` and `test-automation-chat-satellite.R` | Keep until both files are migrated/removed. Playwright equivalents (`findTabCheckbox`, `isTabChecked`, `toggleTab`, etc.) already exist as private helpers in `panes/layout/panes.test.ts` and `panes/layout/pane_layout.test.ts` -- reuse those, no new shared utility needed |
+
+## Recommended migration order
+
+Phase 2 ordering (one PR per file per Hard Rule):
+
+### Wave 1 -- removals and trivial files (low risk, fast)
+
+1. `environment-pane.R` -- empty file, delete in cleanup PR
+2. `smoke.R` -- covered by `smoke/startup.test.ts`; delete
+3. `defer-scope.R` -- framework-internal, drop as part of BRAT removal
+4. `code-folding.R`, `syntax-highlighting.R`, `sweave.R` -- Drop-and-replace candidates; confirm with user, then write JS-unit replacements or accept reduced coverage
+
+### Wave 2 -- single-test files (one PR per file, ~30 min each)
+
+5. `build-pane.R`, `history.R`, `ignorefiles.R`, `python.R`, `restart.R`, `refactoring.R`, `shinytest2.R`
+
+### Wave 3 -- small partial files
+
+8. `chat.R` (2), `chat-satellite.R` (3), `projects.R` (3), `terminal.R` (2), `suspend.R` (2)
+9. `files.R` (3), `files-endpoint.R` (1), `packages-pane.R` (4), `tabs.R` (5), `editor.R` (4)
+10. `edit-suggestions.R` (5), `reformat.R` (6), `console.R` (8)
+
+### Wave 4 -- large delta migrations
+
+11. `data-viewer.R` (7), `debugger.R` (8)
+12. `completions.R` (17)
+13. `quarto.R` (12), `rmarkdown.R` (18) -- chunk-options popup work likely a shared `actions/` helper
+
+### Wave 5 -- largest
+
+14. `guardrails.R` (31) -- consider splitting into multiple PRs by category (read denials, write denials, system files, path traversal, error messages, binding lifecycle)
+
+### Wave 6 -- BRAT decommissioning (single final PR)
+
+See "Decommissioning checklist" below.
+
+## Open decisions for the user
+
+These need a call before / during migration:
+
+1. **Unportable tests (~20)**: drop entirely vs port to R/JS unit tests. The skill default is case-by-case; current strong candidates for R unit tests are:
+   - 4 binding-lifecycle tests in `guardrails.R` (`injectBindings`/`restoreBindings`/`safeEval`)
+   - 2 code-folding tests
+   - 5+ syntax-highlighting token-type tests
+2. **`skip_on_ci()` BRAT tests (~20+)**: port-and-enable in Playwright, port-and-keep-skipped, or drop? Many are in `rmarkdown.R`, `quarto.R`, `reformat.R`, `tabs.R`
+3. **Mechanism differences**: BRAT often sets prefs via `.rs.uiPrefs$*$set()` while Playwright drives the Options dialog. Default to UI-driving Playwright tests, but for tests where the *only* point is the pref behavior (not the dialog), `.rs.api.writeRStudioPreference()` via console is equivalent and faster
+4. **`edit-suggestions.R` injection mechanism**: BRAT uses `.rs.api.showEditSuggestion` to deterministically inject suggestions. Playwright tests use the real provider (Copilot / Posit Assistant). Decide whether to add a deterministic injection path in Playwright (via `executeCommand`) or accept reduced determinism
+
+## Fixme Tests
+
+Playwright tests that exist but can't pass against current RStudio (e.g. open bug, missing feature). Tracked here so the BRAT counterpart isn't removed prematurely.
+
+| Playwright File | Test Name | Blocker | Notes |
+|-----------------|-----------|---------|-------|
+| -- | -- | -- | None tracked yet |
+
+## Dropped / Unportable Tests
+
+BRAT tests intentionally not ported. Requires user approval per the migration skill.
+
+| BRAT File | Test Name | Disposition | Rationale |
+|-----------|-----------|-------------|-----------|
+| -- | -- | -- | None tracked yet |
+
+## Decommissioning checklist (Phase 3)
+
+Only check off once every BRAT file above is Complete or Dropped.
+
+- [ ] Delete `src/cpp/tests/automation/testthat/`
+- [ ] Delete `src/cpp/tests/automation/CLAUDE.md`
+- [ ] Delete `src/cpp/session/modules/automation/`
+- [ ] Remove `--run-automation`, `--automation-filter`, `--automation-markers` CLI flags (session and rserver)
+- [ ] Remove BRAT-related R helpers (`.rs.automation.*`, `.rs.test`, `.rs.markers`, etc.)
+- [ ] Update root `CLAUDE.md` and `e2e/rstudio/.claude/CLAUDE.md` to remove BRAT references
+- [ ] Update the `rstudio-create-playwright-tests` skill (currently calls BRAT "deepest source of truth")
+- [ ] Remove the `reference_brat_automation.md` user-memory pointer


### PR DESCRIPTION
## Summary

Phase 0 setup for deprecating BRAT (R/testthat) in favor of Playwright. No test code touched yet -- this PR only adds planning and tooling.

Adds:

- `.claude/skills/rstudio-migrate-tests-brat-to-playwright/SKILL.md` -- per-file migration workflow modeled on the existing Selenium-to-Playwright skill, with R/testthat-specific guidance (`.rs.test()` patterns, `.rs.*` API translation table) and an Unportable-tests section for tests that rely on internal APIs with no UI surface.
- `e2e/rstudio/docs/MIGRATION_FROM_BRAT_PROGRESS.md` -- audit and tracking doc. Covers all 32 BRAT files (~169 tests). Cross-referenced against existing Playwright tests by feature area. Populated by four parallel audit passes.

## Audit highlights

- ~17 Covered (eligible for BRAT removal after spot-check)
- ~30 Partial (small delta porting)
- ~95 Not covered (full port)
- ~20 Unportable (drop or convert to JS/R unit test)

Six files recommended Drop-and-replace: `environment-pane.R` (empty), `smoke.R`, `defer-scope.R` (framework internals), `code-folding.R`, `syntax-highlighting.R`, `sweave.R` (Ace token internals, better as JS unit tests).

Biggest porting opportunities: RMarkdown/Quarto chunk-options popup UI, `guardrails.R` variants, data viewer filter/pin/state-persist.

## Next steps

Per the progress doc's "Recommended migration order", Phase 2 starts with Wave 1 (removals and trivial files), one PR per BRAT file. Final PR (Phase 3) decommissions BRAT infrastructure.