### PR TITLE
Add scheduled autocomplete workflow for Windows Server 2025

### DIFF
--- a/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
@@ -50,6 +50,10 @@ on:
         type: string
         default: ""
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   e2e-desktop-windows:
     runs-on: windows-2025
@@ -118,19 +122,25 @@ jobs:
           "filename=$filename" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Download RStudio .exe
+        env:
+          DOWNLOAD_URL: ${{ steps.resolve.outputs.url }}
+          DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}
         run: |
           $ErrorActionPreference = 'Stop'
           Invoke-WebRequest `
-            -Uri '${{ steps.resolve.outputs.url }}' `
-            -OutFile '${{ steps.resolve.outputs.filename }}' `
+            -Uri $env:DOWNLOAD_URL `
+            -OutFile $env:DOWNLOAD_FILENAME `
             -MaximumRetryCount 3 -RetryIntervalSec 5
 
       - name: Verify SHA-256
         if: steps.resolve.outputs.sha256 != ''
+        env:
+          EXPECTED_SHA256: ${{ steps.resolve.outputs.sha256 }}
+          DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $expected = '${{ steps.resolve.outputs.sha256 }}'.ToLower()
-          $actual = (Get-FileHash -Algorithm SHA256 '${{ steps.resolve.outputs.filename }}').Hash.ToLower()
+          $expected = $env:EXPECTED_SHA256.ToLower()
+          $actual = (Get-FileHash -Algorithm SHA256 $env:DOWNLOAD_FILENAME).Hash.ToLower()
           if ($expected -ne $actual) {
             Write-Error "SHA-256 mismatch. Expected: $expected. Actual: $actual."
             exit 1
@@ -138,9 +148,11 @@ jobs:
           Write-Host "SHA-256 OK: $actual"
 
       - name: Install RStudio
+        env:
+          INSTALLER_FILENAME: ${{ steps.resolve.outputs.filename }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $p = Start-Process -FilePath '.\${{ steps.resolve.outputs.filename }}' -ArgumentList '/S' -Wait -PassThru
+          $p = Start-Process -FilePath ".\$env:INSTALLER_FILENAME" -ArgumentList '/S' -Wait -PassThru
           if ($p.ExitCode -ne 0) { Write-Error "RStudio installer exited $($p.ExitCode)"; exit 1 }
           $exe = 'C:\Program Files\RStudio\rstudio.exe'
           if (-not (Test-Path $exe)) {
@@ -155,9 +167,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ inputs.r_version || 'release' }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
+          key: ${{ runner.os }}-r-v1-${{ inputs.r_version || 'release' }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
           restore-keys: |
-            ${{ runner.os }}-r-${{ inputs.r_version || 'release' }}-
+            ${{ runner.os }}-r-v1-${{ inputs.r_version || 'release' }}-
 
       - name: Install R packages from DESCRIPTION
         if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
@@ -174,7 +186,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ inputs.r_version || 'release' }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
+          key: ${{ runner.os }}-r-v1-${{ inputs.r_version || 'release' }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
 
       - name: Install npm dependencies
         working-directory: e2e/rstudio
@@ -188,21 +200,21 @@ jobs:
         working-directory: e2e/rstudio
         env:
           PW_RSTUDIO_MODE: desktop
+          PW_RSTUDIO_EDITION: os
           PW_PROJECT_NAME: ${{ inputs.project || 'desktop' }}
           PW_GREP: ${{ inputs.grep }}
           PW_TEST_SELECTOR: ${{ inputs.test_selector || 'autocomplete.test.ts' }}
           PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $pwArgs = @()
-          if (-not [string]::IsNullOrEmpty($env:PW_TEST_SELECTOR)) {
-            $pwArgs += ($env:PW_TEST_SELECTOR -split '\s+' | Where-Object { $_ -ne '' })
-          }
-          $pwArgs += '--project'
-          $pwArgs += $env:PW_PROJECT_NAME
+          $pwArgs = @('--project', $env:PW_PROJECT_NAME)
           if (-not [string]::IsNullOrEmpty($env:PW_GREP)) {
             $pwArgs += '--grep'
             $pwArgs += $env:PW_GREP
+          }
+          if (-not [string]::IsNullOrEmpty($env:PW_TEST_SELECTOR)) {
+            $pwArgs += '--'
+            $pwArgs += ($env:PW_TEST_SELECTOR -split '\s+' | Where-Object { $_ -ne '' })
           }
           npx playwright test @pwArgs
 

--- a/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
@@ -1,0 +1,223 @@
+name: "Test: E2E Playwright RStudio Autocomplete Scheduled (Desktop, Windows Server 2025 x64, Open Source)"
+
+on:
+  schedule:
+    - cron: '0,30 * * * *'
+  workflow_dispatch:
+    inputs:
+      rstudio_installer_url:
+        description: "URL to a Desktop installer (.deb on Ubuntu, .rpm on RHEL/Fedora, .exe on Windows, .dmg on macOS). Leave empty to auto-resolve the latest daily for this workflow's platform. To pin a specific build, paste its full URL from dailies.rstudio.com."
+        type: string
+        default: ""
+      r_version:
+        description: "R version to install via rig (e.g. 'release', 'oldrel', 'devel', '4.4.1')."
+        type: string
+        default: "release"
+      project:
+        description: "Playwright project to run: 'desktop' or 'server'. OS and edition are auto-filtered from the host platform and PW_RSTUDIO_EDITION."
+        type: string
+        default: "desktop"
+      grep:
+        description: "Optional Playwright --grep pattern to filter tests."
+        type: string
+        default: ""
+      test_selector:
+        description: "Optional test paths/files/directories to run (space-separated). Matched as substrings against test file paths. Examples: 'autocomplete.test.ts', 'tests/panes/misc/', 'autocomplete tests/panes/posit-assistant-chat/'. Leave empty to run all tests."
+        type: string
+        default: "autocomplete.test.ts"
+      rstudio_extra_args:
+        description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS."
+        type: string
+        default: ""
+  workflow_call:
+    inputs:
+      rstudio_installer_url:
+        type: string
+        default: ""
+      r_version:
+        type: string
+        default: "release"
+      project:
+        type: string
+        default: "desktop"
+      grep:
+        type: string
+        default: ""
+      test_selector:
+        type: string
+        default: "autocomplete.test.ts"
+      rstudio_extra_args:
+        type: string
+        default: ""
+
+jobs:
+  e2e-desktop-windows:
+    runs-on: windows-2025
+    timeout-minutes: 120
+    defaults:
+      run:
+        shell: pwsh
+    env:
+      R_LIBS_USER: ${{ github.workspace }}\R-libs
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install rig
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Invoke-WebRequest `
+            -Uri 'https://github.com/r-lib/rig/releases/download/latest/rig-windows-latest.exe' `
+            -OutFile rig-setup.exe `
+            -MaximumRetryCount 3 -RetryIntervalSec 5
+          $p = Start-Process -FilePath .\rig-setup.exe -ArgumentList '/VERYSILENT','/NORESTART' -Wait -PassThru
+          if ($p.ExitCode -ne 0) { Write-Error "rig installer exited $($p.ExitCode)"; exit 1 }
+          Add-Content -Path $env:GITHUB_PATH -Value 'C:\Program Files\rig'
+
+      - name: Install R via rig
+        env:
+          R_VERSION: ${{ inputs.r_version || 'release' }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          rig add $env:R_VERSION
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          rig default $env:R_VERSION
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          rig ls
+          New-Item -ItemType Directory -Force -Path $env:R_LIBS_USER | Out-Null
+
+      - name: Resolve RStudio .exe URL
+        id: resolve
+        env:
+          INSTALLER_URL: ${{ inputs.rstudio_installer_url }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $url = $env:INSTALLER_URL
+          $sha = ''
+          $filename = ''
+          if ([string]::IsNullOrEmpty($url)) {
+            $manifest = Invoke-RestMethod -Uri 'https://dailies.rstudio.com/rstudio/latest/index.json'
+            $win = $manifest.products.electron.platforms.windows
+            $url = $win.link
+            $sha = $win.sha256
+            $filename = $win.filename
+            Write-Host "Auto-resolved latest windows daily:"
+            Write-Host "  URL:      $url"
+            Write-Host "  SHA-256:  $sha"
+            Write-Host "  Filename: $filename"
+          } else {
+            $filename = Split-Path -Leaf $url
+            Write-Host "Using override URL: $url (SHA-256 verification skipped)"
+          }
+          "url=$url"           | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "sha256=$sha"        | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "filename=$filename" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Download RStudio .exe
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Invoke-WebRequest `
+            -Uri '${{ steps.resolve.outputs.url }}' `
+            -OutFile '${{ steps.resolve.outputs.filename }}' `
+            -MaximumRetryCount 3 -RetryIntervalSec 5
+
+      - name: Verify SHA-256
+        if: steps.resolve.outputs.sha256 != ''
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $expected = '${{ steps.resolve.outputs.sha256 }}'.ToLower()
+          $actual = (Get-FileHash -Algorithm SHA256 '${{ steps.resolve.outputs.filename }}').Hash.ToLower()
+          if ($expected -ne $actual) {
+            Write-Error "SHA-256 mismatch. Expected: $expected. Actual: $actual."
+            exit 1
+          }
+          Write-Host "SHA-256 OK: $actual"
+
+      - name: Install RStudio
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $p = Start-Process -FilePath '.\${{ steps.resolve.outputs.filename }}' -ArgumentList '/S' -Wait -PassThru
+          if ($p.ExitCode -ne 0) { Write-Error "RStudio installer exited $($p.ExitCode)"; exit 1 }
+          $exe = 'C:\Program Files\RStudio\rstudio.exe'
+          if (-not (Test-Path $exe)) {
+            Write-Error "RStudio binary not found at $exe after install."
+            exit 1
+          }
+          Get-Item $exe | Format-List FullName, Length, LastWriteTime
+
+      - name: Restore R library cache
+        if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
+        id: r-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-r-${{ inputs.r_version || 'release' }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
+          restore-keys: |
+            ${{ runner.os }}-r-${{ inputs.r_version || 'release' }}-
+
+      - name: Install R packages from DESCRIPTION
+        if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Rscript -e @'
+            options(repos = c(P3M = "https://packagemanager.posit.co/cran/latest"))
+            if (!requireNamespace("pak", quietly = TRUE)) install.packages("pak")
+            pak::local_install_dev_deps(root = "e2e/rstudio", ask = FALSE, upgrade = FALSE)
+          '@
+
+      - name: Save R library cache
+        if: hashFiles('e2e/rstudio/DESCRIPTION') != '' && steps.r-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-r-${{ inputs.r_version || 'release' }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
+
+      - name: Install npm dependencies
+        working-directory: e2e/rstudio
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: e2e/rstudio
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        working-directory: e2e/rstudio
+        env:
+          PW_RSTUDIO_MODE: desktop
+          PW_PROJECT_NAME: ${{ inputs.project || 'desktop' }}
+          PW_GREP: ${{ inputs.grep }}
+          PW_TEST_SELECTOR: ${{ inputs.test_selector || 'autocomplete.test.ts' }}
+          PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $pwArgs = @()
+          if (-not [string]::IsNullOrEmpty($env:PW_TEST_SELECTOR)) {
+            $pwArgs += ($env:PW_TEST_SELECTOR -split '\s+' | Where-Object { $_ -ne '' })
+          }
+          $pwArgs += '--project'
+          $pwArgs += $env:PW_PROJECT_NAME
+          if (-not [string]::IsNullOrEmpty($env:PW_GREP)) {
+            $pwArgs += '--grep'
+            $pwArgs += $env:PW_GREP
+          }
+          npx playwright test @pwArgs
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: e2e/rstudio/playwright-report/
+          if-no-files-found: ignore
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: e2e/rstudio/test-results/
+          if-no-files-found: ignore

--- a/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
@@ -2,7 +2,7 @@ name: "Test: E2E Playwright RStudio Autocomplete Scheduled (Desktop, Windows Ser
 
 on:
   schedule:
-    - cron: '0,30 * * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
     inputs:
       rstudio_installer_url:
@@ -22,7 +22,7 @@ on:
         type: string
         default: ""
       test_selector:
-        description: "Optional test paths/files/directories to run (space-separated). Matched as substrings against test file paths. Examples: 'autocomplete.test.ts', 'tests/panes/misc/', 'autocomplete tests/panes/posit-assistant-chat/'. Leave empty to run all tests."
+        description: "Optional test paths/files/directories to run (space-separated). Matched as substrings against test file paths. Examples: 'autocomplete.test.ts', 'tests/panes/misc/', 'autocomplete tests/panes/posit-assistant-chat/'. Leave empty to run all tests (default runs autocomplete tests)."
         type: string
         default: "autocomplete.test.ts"
       rstudio_extra_args:
@@ -52,7 +52,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   e2e-desktop-windows:
@@ -80,6 +80,11 @@ jobs:
             -MaximumRetryCount 3 -RetryIntervalSec 5
           $p = Start-Process -FilePath .\rig-setup.exe -ArgumentList '/VERYSILENT','/NORESTART' -Wait -PassThru
           if ($p.ExitCode -ne 0) { Write-Error "rig installer exited $($p.ExitCode)"; exit 1 }
+          $rigExe = 'C:\Program Files\rig\rig.exe'
+          if (-not (Test-Path $rigExe)) {
+            Write-Error "rig binary not found at $rigExe after install."
+            exit 1
+          }
           Add-Content -Path $env:GITHUB_PATH -Value 'C:\Program Files\rig'
 
       - name: Install R via rig
@@ -109,6 +114,10 @@ jobs:
             $url = $win.link
             $sha = $win.sha256
             $filename = $win.filename
+            if ([string]::IsNullOrEmpty($url) -or [string]::IsNullOrEmpty($filename) -or [string]::IsNullOrEmpty($sha)) {
+              Write-Error "Daily manifest is missing expected fields (url='$url', filename='$filename', sha256='$sha'). The schema at https://dailies.rstudio.com/rstudio/latest/index.json may have changed."
+              exit 1
+            }
             Write-Host "Auto-resolved latest windows daily:"
             Write-Host "  URL:      $url"
             Write-Host "  SHA-256:  $sha"


### PR DESCRIPTION
## Summary

- Adds a new GitHub Actions workflow that runs the Playwright autocomplete
  tests against the latest RStudio Desktop daily on Windows Server 2025
  every 30 minutes (and on manual dispatch)
- Includes a concurrency block to cancel in-progress runs when a newer
  scheduled run starts
- Hardens PowerShell steps against injection by routing step outputs
  through env vars instead of inline ${{ }} interpolation
- Adds -- sentinel before test selector tokens, PW_RSTUDIO_EDITION: os,
  and a versioned R library cache key