### PR TITLE
Update Electron to 41.7.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 ### Dependencies
 - Ace 1.43.5
 - Copilot Language Server 1.480.0
-- Electron 41.5.2
+- Electron 41.7.0
 - Node.js 22.22.2 (copilot, Posit AI)
 - Quarto 1.9.37
 - xterm.js 6.0.0

--- a/src/cpp/tests/automation/testthat/test-automation-terminal.R
+++ b/src/cpp/tests/automation/testthat/test-automation-terminal.R
@@ -87,10 +87,17 @@ withr::defer(.rs.automation.deleteRemote())
    }, swallowErrors = TRUE)
 
    remote$commands.execute("sendTerminalToEditor")
-   
-   editor <- remote$editor.getInstance()
-   contents <- editor$session$doc$getValue()
-   contents <- gsub("\r?\n+", "\n", contents, perl = TRUE)
+
+   # wait for the editor to reflect the sent terminal output; the editor can
+   # populate asynchronously after the command, so reading immediately races
+   # with the buffer flush
+   contents <- NULL
+   .rs.waitUntil("editor contains terminal output", function() {
+      editor <- remote$editor.getInstance()
+      contents <<- gsub("\r?\n+", "\n", editor$session$doc$getValue(), perl = TRUE)
+      grepl("expr 1 + 1\n2\n", contents, fixed = TRUE)
+   }, swallowErrors = TRUE)
+
    expect_true(grepl("expr 1 + 1\n2\n", contents, fixed = TRUE))
    
    # return focus to console

--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -48,7 +48,7 @@
         "chai": "6.2.2",
         "copy-webpack-plugin": "14.0.0",
         "css-loader": "7.1.4",
-        "electron": "41.5.2",
+        "electron": "41.7.0",
         "electron-mocha": "13.1.0",
         "eslint": "10.3.0",
         "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -5549,9 +5549,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "41.5.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.5.2.tgz",
-      "integrity": "sha512-bxlZeH/1WzvKbijmT7dH5MCqlJ/h2SfDJczNhHJe5srDJzZboiOQpwTlUFBecqDbGoBpmEekhDfjbubPnM8G7g==",
+      "version": "41.7.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.7.0.tgz",
+      "integrity": "sha512-U6KAKivjk6YQ0Z5+eloJBjwhbHRE206gvy1UBMw2bSluWtMh5waeXMvX6AT/Ujm5ymYXVJOp7g9N7vOFw16wBQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -47,7 +47,7 @@
     "chai": "6.2.2",
     "copy-webpack-plugin": "14.0.0",
     "css-loader": "7.1.4",
-    "electron": "41.5.2",
+    "electron": "41.7.0",
     "electron-mocha": "13.1.0",
     "eslint": "10.3.0",
     "fork-ts-checker-webpack-plugin": "9.1.0",


### PR DESCRIPTION
## Summary

- Bump Electron from 41.5.2 to 41.7.0 in `src/node/desktop/package.json` (exact pin) and regenerate `package-lock.json`
- Update the `### Dependencies` line in `NEWS.md`

## Test plan

- [x] `npm install --save-dev --save-exact electron@41.7.0` succeeded
- [x] `npm test` in `src/node/desktop` (398 passing)