### PR TITLE
Fix R packages install on the Windows autocomplete scheduled workflow

### DIFF
--- a/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
@@ -2,7 +2,7 @@ name: "Test: E2E Playwright RStudio Autocomplete Scheduled (Desktop, Windows Ser
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 8,20 * * *'
   workflow_dispatch:
     inputs:
       rstudio_installer_url:

--- a/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
@@ -182,13 +182,13 @@ jobs:
 
       - name: Install R packages from DESCRIPTION
         if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
+        shell: bash
         run: |
-          $ErrorActionPreference = 'Stop'
-          Rscript -e @'
+          Rscript -e '
             options(repos = c(P3M = "https://packagemanager.posit.co/cran/latest"))
             if (!requireNamespace("pak", quietly = TRUE)) install.packages("pak")
             pak::local_install_dev_deps(root = "e2e/rstudio", ask = FALSE, upgrade = FALSE)
-          '@
+          '
 
       - name: Save R library cache
         if: hashFiles('e2e/rstudio/DESCRIPTION') != '' && steps.r-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

- The "Install R packages from DESCRIPTION" step on `test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml` was failing every scheduled run with `Error: unexpected '/' in "  options(repos = c(P3M = https:/"`. PowerShell on Windows strips inner `"` when handing a multi-line string to native `Rscript.exe`, so the URL literal in `options(repos = ...)` arrived at R without its quotes. Switching that one step to `shell: bash` with `Rscript -e '...'` matches the working Ubuntu and macOS jobs and passes the script through intact. Bash inherits Actions' default `set -e -o pipefail`, so the dropped `$ErrorActionPreference = 'Stop'` line doesn't change fail-fast behavior.
- Reduces the schedule from hourly (`0 * * * *`) to twice daily (`0 8,20 * * *`, i.e. 4 AM and 4 PM Eastern in summer). The workflow installs a full RStudio Desktop daily and runs Playwright autocomplete tests; hourly was overkill.