### PR TITLE
Build path-based test exclusion for Playwright and expose grep-invert in workflows

### DIFF
--- a/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
@@ -18,13 +18,21 @@ on:
         type: string
         default: "desktop"
       grep:
-        description: "Optional Playwright --grep pattern to filter tests."
+        description: "Optional Playwright --grep pattern to run only tests whose title matches."
         type: string
         default: ""
       test_selector:
         description: "Optional test paths/files/directories to run (space-separated). Matched as substrings against test file paths. Examples: 'autocomplete.test.ts', 'tests/panes/misc/', 'autocomplete tests/panes/posit-assistant-chat/'. Leave empty to run all tests (default runs autocomplete tests)."
         type: string
         default: "autocomplete.test.ts"
+      test_ignore:
+        description: "Optional test paths/files/directories to exclude (space-separated globs). Examples: '**/code_suggestions.test.ts', '**/posit-assistant-chat/**'. Leave empty to exclude nothing."
+        type: string
+        default: ""
+      grep_invert:
+        description: "Optional Playwright --grep-invert pattern to skip tests by title."
+        type: string
+        default: ""
       rstudio_extra_args:
         description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS."
         type: string
@@ -46,6 +54,12 @@ on:
       test_selector:
         type: string
         default: "autocomplete.test.ts"
+      test_ignore:
+        type: string
+        default: ""
+      grep_invert:
+        type: string
+        default: ""
       rstudio_extra_args:
         type: string
         default: ""
@@ -212,7 +226,9 @@ jobs:
           PW_RSTUDIO_EDITION: os
           PW_PROJECT_NAME: ${{ inputs.project || 'desktop' }}
           PW_GREP: ${{ inputs.grep }}
+          PW_GREP_INVERT: ${{ inputs.grep_invert }}
           PW_TEST_SELECTOR: ${{ inputs.test_selector || 'autocomplete.test.ts' }}
+          PW_TEST_IGNORE: ${{ inputs.test_ignore }}
           PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
         run: |
           $ErrorActionPreference = 'Stop'
@@ -220,6 +236,10 @@ jobs:
           if (-not [string]::IsNullOrEmpty($env:PW_GREP)) {
             $pwArgs += '--grep'
             $pwArgs += $env:PW_GREP
+          }
+          if (-not [string]::IsNullOrEmpty($env:PW_GREP_INVERT)) {
+            $pwArgs += '--grep-invert'
+            $pwArgs += $env:PW_GREP_INVERT
           }
           if (-not [string]::IsNullOrEmpty($env:PW_TEST_SELECTOR)) {
             $pwArgs += '--'

--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -16,11 +16,19 @@ on:
         type: string
         default: "desktop"
       grep:
-        description: "Optional Playwright --grep pattern to filter tests."
+        description: "Optional Playwright --grep pattern to run only tests whose title matches."
         type: string
         default: ""
       test_selector:
         description: "Optional test paths/files/directories to run (space-separated). Matched as substrings against test file paths. Examples: 'autocomplete.test.ts', 'tests/panes/misc/', 'autocomplete tests/panes/posit-assistant-chat/'. Leave empty to run all tests."
+        type: string
+        default: ""
+      test_ignore:
+        description: "Optional test paths/files/directories to exclude (space-separated globs). Examples: '**/code_suggestions.test.ts', '**/posit-assistant-chat/**'. Leave empty to exclude nothing."
+        type: string
+        default: ""
+      grep_invert:
+        description: "Optional Playwright --grep-invert pattern to skip tests by title."
         type: string
         default: ""
       rstudio_extra_args:
@@ -42,6 +50,12 @@ on:
         type: string
         default: ""
       test_selector:
+        type: string
+        default: ""
+      test_ignore:
+        type: string
+        default: ""
+      grep_invert:
         type: string
         default: ""
       rstudio_extra_args:
@@ -170,7 +184,9 @@ jobs:
           PW_RSTUDIO_MODE: desktop
           PW_PROJECT_NAME: ${{ inputs.project }}
           PW_GREP: ${{ inputs.grep }}
+          PW_GREP_INVERT: ${{ inputs.grep_invert }}
           PW_TEST_SELECTOR: ${{ inputs.test_selector }}
+          PW_TEST_IGNORE: ${{ inputs.test_ignore }}
           PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
         run: |
           ARGS=()
@@ -182,6 +198,9 @@ jobs:
           ARGS+=(--project "$PW_PROJECT_NAME")
           if [ -n "$PW_GREP" ]; then
             ARGS+=(--grep "$PW_GREP")
+          fi
+          if [ -n "$PW_GREP_INVERT" ]; then
+            ARGS+=(--grep-invert "$PW_GREP_INVERT")
           fi
           npx playwright test "${ARGS[@]}"
 

--- a/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -16,11 +16,19 @@ on:
         type: string
         default: "desktop"
       grep:
-        description: "Optional Playwright --grep pattern to filter tests."
+        description: "Optional Playwright --grep pattern to run only tests whose title matches."
         type: string
         default: ""
       test_selector:
         description: "Optional test paths/files/directories to run (space-separated). Matched as substrings against test file paths. Examples: 'autocomplete.test.ts', 'tests/panes/misc/', 'autocomplete tests/panes/posit-assistant-chat/'. Leave empty to run all tests."
+        type: string
+        default: ""
+      test_ignore:
+        description: "Optional test paths/files/directories to exclude (space-separated globs). Examples: '**/code_suggestions.test.ts', '**/posit-assistant-chat/**'. Leave empty to exclude nothing."
+        type: string
+        default: ""
+      grep_invert:
+        description: "Optional Playwright --grep-invert pattern to skip tests by title."
         type: string
         default: ""
       rstudio_extra_args:
@@ -42,6 +50,12 @@ on:
         type: string
         default: ""
       test_selector:
+        type: string
+        default: ""
+      test_ignore:
+        type: string
+        default: ""
+      grep_invert:
         type: string
         default: ""
       rstudio_extra_args:
@@ -163,7 +177,9 @@ jobs:
           PW_RSTUDIO_MODE: desktop
           PW_PROJECT_NAME: ${{ inputs.project }}
           PW_GREP: ${{ inputs.grep }}
+          PW_GREP_INVERT: ${{ inputs.grep_invert }}
           PW_TEST_SELECTOR: ${{ inputs.test_selector }}
+          PW_TEST_IGNORE: ${{ inputs.test_ignore }}
           PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
         run: |
           ARGS=()
@@ -175,6 +191,9 @@ jobs:
           ARGS+=(--project "$PW_PROJECT_NAME")
           if [ -n "$PW_GREP" ]; then
             ARGS+=(--grep "$PW_GREP")
+          fi
+          if [ -n "$PW_GREP_INVERT" ]; then
+            ARGS+=(--grep-invert "$PW_GREP_INVERT")
           fi
           xvfb-run -a --server-args="-screen 0 1920x1080x24" \
             npx playwright test "${ARGS[@]}"

--- a/.github/workflows/test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -16,11 +16,19 @@ on:
         type: string
         default: "desktop"
       grep:
-        description: "Optional Playwright --grep pattern to filter tests."
+        description: "Optional Playwright --grep pattern to run only tests whose title matches."
         type: string
         default: ""
       test_selector:
         description: "Optional test paths/files/directories to run (space-separated). Matched as substrings against test file paths. Examples: 'autocomplete.test.ts', 'tests/panes/misc/', 'autocomplete tests/panes/posit-assistant-chat/'. Leave empty to run all tests."
+        type: string
+        default: ""
+      test_ignore:
+        description: "Optional test paths/files/directories to exclude (space-separated globs). Examples: '**/code_suggestions.test.ts', '**/posit-assistant-chat/**'. Leave empty to exclude nothing."
+        type: string
+        default: ""
+      grep_invert:
+        description: "Optional Playwright --grep-invert pattern to skip tests by title."
         type: string
         default: ""
       rstudio_extra_args:
@@ -42,6 +50,12 @@ on:
         type: string
         default: ""
       test_selector:
+        type: string
+        default: ""
+      test_ignore:
+        type: string
+        default: ""
+      grep_invert:
         type: string
         default: ""
       rstudio_extra_args:
@@ -188,7 +202,9 @@ jobs:
           PW_RSTUDIO_MODE: desktop
           PW_PROJECT_NAME: ${{ inputs.project }}
           PW_GREP: ${{ inputs.grep }}
+          PW_GREP_INVERT: ${{ inputs.grep_invert }}
           PW_TEST_SELECTOR: ${{ inputs.test_selector }}
+          PW_TEST_IGNORE: ${{ inputs.test_ignore }}
           PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
         run: |
           $ErrorActionPreference = 'Stop'
@@ -201,6 +217,10 @@ jobs:
           if (-not [string]::IsNullOrEmpty($env:PW_GREP)) {
             $pwArgs += '--grep'
             $pwArgs += $env:PW_GREP
+          }
+          if (-not [string]::IsNullOrEmpty($env:PW_GREP_INVERT)) {
+            $pwArgs += '--grep-invert'
+            $pwArgs += $env:PW_GREP_INVERT
           }
           npx playwright test @pwArgs
 

--- a/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -16,11 +16,19 @@ on:
         type: string
         default: "server"
       grep:
-        description: "Optional Playwright --grep pattern to filter tests."
+        description: "Optional Playwright --grep pattern to run only tests whose title matches."
         type: string
         default: ""
       test_selector:
         description: "Optional test paths/files/directories to run (space-separated). Matched as substrings against test file paths. Examples: 'autocomplete.test.ts', 'tests/panes/misc/', 'autocomplete tests/panes/posit-assistant-chat/'. Leave empty to run all tests."
+        type: string
+        default: ""
+      test_ignore:
+        description: "Optional test paths/files/directories to exclude (space-separated globs). Examples: '**/code_suggestions.test.ts', '**/posit-assistant-chat/**'. Leave empty to exclude nothing."
+        type: string
+        default: ""
+      grep_invert:
+        description: "Optional Playwright --grep-invert pattern to skip tests by title."
         type: string
         default: ""
   workflow_call:
@@ -38,6 +46,12 @@ on:
         type: string
         default: ""
       test_selector:
+        type: string
+        default: ""
+      test_ignore:
+        type: string
+        default: ""
+      grep_invert:
         type: string
         default: ""
 
@@ -199,7 +213,9 @@ jobs:
           PW_RSTUDIO_SERVER_URL: http://localhost:8787
           PW_PROJECT_NAME: ${{ inputs.project }}
           PW_GREP: ${{ inputs.grep }}
+          PW_GREP_INVERT: ${{ inputs.grep_invert }}
           PW_TEST_SELECTOR: ${{ inputs.test_selector }}
+          PW_TEST_IGNORE: ${{ inputs.test_ignore }}
         run: |
           ARGS=()
           if [ -n "$PW_TEST_SELECTOR" ]; then
@@ -210,6 +226,9 @@ jobs:
           ARGS+=(--project "$PW_PROJECT_NAME")
           if [ -n "$PW_GREP" ]; then
             ARGS+=(--grep "$PW_GREP")
+          fi
+          if [ -n "$PW_GREP_INVERT" ]; then
+            ARGS+=(--grep-invert "$PW_GREP_INVERT")
           fi
           xvfb-run -a --server-args="-screen 0 1920x1080x24" \
             npx playwright test "${ARGS[@]}"

--- a/e2e/rstudio/README.md
+++ b/e2e/rstudio/README.md
@@ -323,6 +323,7 @@ npx playwright test --grep-invert @ai
 | `PW_RSTUDIO_SERVER_LOGIN_TIMEOUT` | Server | No | Post-login wait for the IDE console, in ms (default: 60000) |
 | `PW_RSTUDIO_EXTRA_ARGS` | Desktop | No | Space-separated extra CLI args passed to RStudio (e.g., `--my-flag --other-option`) |
 | `PW_RSTUDIO_PREFS_OVERRIDE` | Desktop | No | Path to a JSON/JSONC file whose keys override `fixtures/base-prefs.jsonc` per-key. |
+| `PW_TEST_IGNORE` | Both | No | Space-separated globs of test paths to exclude (e.g., `**/foo.test.ts **/posit-assistant-chat/**`). Fills the gap that Playwright has no CLI option for path-based exclusion -- file inclusion uses positional CLI arguments, and title filtering uses `--grep`/`--grep-invert`. |
 | `PW_SANDBOX_ROOT` | Both | No | Parent directory under which the per-invocation sandbox is created. Defaults to `os.tmpdir()`. |
 | `PW_SANDBOX_ROOT_CREATE` | Both | No | Set to `true`/`1` to auto-create `PW_SANDBOX_ROOT` if missing. Default `false` -- fails loud on typos. |
 | `PW_SANDBOX_SKIP_CLEANUP` | Both | No | Set to `true`/`1` to preserve the sandbox at end of run regardless of pass/fail. |

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -62,8 +62,13 @@ if (projectFlagPresent) {
   throw new Error(`PW_RSTUDIO_MODE="${modeEnv}" -- expected "desktop" or "server"`);
 }
 
+const testIgnore = (process.env.PW_TEST_IGNORE ?? '')
+  .split(/\s+/)
+  .filter(Boolean);
+
 export default defineConfig({
   testDir: './tests',
+  testIgnore: testIgnore.length > 0 ? testIgnore : undefined,
   fullyParallel: false,
   workers: 1,
   timeout: 300000,


### PR DESCRIPTION
## Summary

- Added `PW_TEST_IGNORE` env-var bridge in `e2e/rstudio/playwright.config.ts`: whitespace-separated globs feed Playwright's `testIgnore` config field to drop matching files at collection time. Closes the gap that Playwright has no CLI option for path-based exclusion.
- Added `test_ignore` and `grep_invert` inputs to all five RStudio Playwright workflows; `grep_invert` maps to `--grep-invert` (title-based exclusion).
- Tightened the `grep` input description across the workflows to specify it filters by test title.
- Documented `PW_TEST_IGNORE` in the README's Environment Variables table.