### PR TITLE
Fix Playwright Desktop/Server workflows on Ubuntu 26.04

### DIFF
--- a/e2e/rstudio/README.md
+++ b/e2e/rstudio/README.md
@@ -11,6 +11,22 @@ npm install
 npx playwright install
 ```
 
+### Ubuntu 26.04 LTS
+
+Playwright doesn't yet ship a browser build or system-deps list for Ubuntu 26.04 (the release renamed SONAME-versioned libraries: `libicu74` -> `libicu78`, `libxml2` -> `libxml2-16`, etc.). Until Playwright catches up, point the installer at the Ubuntu 24.04 browser build and install the renamed system libraries by hand:
+
+```bash
+# Intel/AMD64
+PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64 npx playwright install
+
+# ARM64
+PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-arm64 npx playwright install
+
+sudo apt-get install libicu78 libxml2-16 libmanette-0.2-0
+```
+
+Remove the override once Playwright publishes an Ubuntu 26.04 build.
+
 ### Prerequisites
 
 - **Desktop mode**: RStudio Desktop installed at the default path for your OS

--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -199,7 +199,7 @@ export async function launchRStudio(existingConfigRoot?: string): Promise<Deskto
   while (Date.now() < cdpDeadline) {
     if (launchError) throw launchError;
     try {
-      browser = await chromium.connectOverCDP(CDP_URL, { timeout: 1000 });
+      browser = await chromium.connectOverCDP(CDP_URL, { timeout: 5000 });
       break;
     } catch (err) {
       lastConnectErr = err;

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -47,17 +47,31 @@ if (process.env.PW_PROJECT) {
   console.warn('PW_PROJECT is no longer used; switch to --project=desktop|server or PW_RSTUDIO_MODE=desktop|server');
 }
 
-// Always expose both projects so worker processes (which re-load this config without
-// --project in their argv) can resolve whichever project the run selected. Playwright's
-// CLI narrows --project=NAME post-load; PW_RSTUDIO_MODE acts as a default when no flag.
-const modeEnv = process.env.PW_RSTUDIO_MODE?.toLowerCase();
-if (modeEnv && modeEnv !== 'desktop' && modeEnv !== 'server') {
+// Worker processes re-load this config without --project in their argv, so we can't
+// rely on argv to pick the project there. Parse --project once in the main process and
+// forward it via PW_RSTUDIO_MODE; workers inherit process.env at fork time and end up
+// filtering to the same project the main process picked.
+function parseProjectFromArgv(): string | undefined {
+  const argv = process.argv;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--project' && i + 1 < argv.length) return argv[i + 1];
+    const prefix = '--project=';
+    if (argv[i].startsWith(prefix)) return argv[i].slice(prefix.length);
+  }
+  return undefined;
+}
+
+const argvProject = parseProjectFromArgv()?.toLowerCase();
+if (argvProject) {
+  // --project wins over a pre-existing PW_RSTUDIO_MODE (README documents this).
+  process.env.PW_RSTUDIO_MODE = argvProject;
+}
+
+const modeEnv = process.env.PW_RSTUDIO_MODE?.toLowerCase() ?? 'desktop';
+if (modeEnv !== 'desktop' && modeEnv !== 'server') {
   throw new Error(`PW_RSTUDIO_MODE="${modeEnv}" -- expected "desktop" or "server"`);
 }
-const projectFlagPresent = process.argv.some(a => a === '--project' || a.startsWith('--project='));
-const projects = projectFlagPresent
-  ? allProjects
-  : allProjects.filter(p => p.name === (modeEnv ?? 'desktop'));
+const projects = allProjects.filter(p => p.name === modeEnv);
 
 const testIgnore = (process.env.PW_TEST_IGNORE ?? '')
   .split(/\s+/)

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -47,20 +47,17 @@ if (process.env.PW_PROJECT) {
   console.warn('PW_PROJECT is no longer used; switch to --project=desktop|server or PW_RSTUDIO_MODE=desktop|server');
 }
 
-const projectFlagPresent = process.argv.some(a => a === '--project' || a.startsWith('--project='));
+// Always expose both projects so worker processes (which re-load this config without
+// --project in their argv) can resolve whichever project the run selected. Playwright's
+// CLI narrows --project=NAME post-load; PW_RSTUDIO_MODE acts as a default when no flag.
 const modeEnv = process.env.PW_RSTUDIO_MODE?.toLowerCase();
-
-let projects;
-if (projectFlagPresent) {
-  // Expose both projects; Playwright's CLI narrows down to the requested name post-load.
-  projects = allProjects;
-} else if (modeEnv === 'server') {
-  projects = allProjects.filter(p => p.name === 'server');
-} else if (modeEnv === 'desktop' || modeEnv === undefined) {
-  projects = allProjects.filter(p => p.name === 'desktop');
-} else {
+if (modeEnv && modeEnv !== 'desktop' && modeEnv !== 'server') {
   throw new Error(`PW_RSTUDIO_MODE="${modeEnv}" -- expected "desktop" or "server"`);
 }
+const projectFlagPresent = process.argv.some(a => a === '--project' || a.startsWith('--project='));
+const projects = projectFlagPresent
+  ? allProjects
+  : allProjects.filter(p => p.name === (modeEnv ?? 'desktop'));
 
 const testIgnore = (process.env.PW_TEST_IGNORE ?? '')
   .split(/\s+/)

--- a/e2e/rstudio/utils/constants.ts
+++ b/e2e/rstudio/utils/constants.ts
@@ -1,6 +1,6 @@
 export const TIMEOUTS = {
   processCleanup: 1000,
-  rstudioStartup: 10000,
+  rstudioStartup: 30000,
   consoleReady: 15000,
   sessionRestart: 30000,
   settleDelay: 1000,


### PR DESCRIPTION
## Summary

- Forward `--project` to Playwright worker processes via `PW_RSTUDIO_MODE` so workers can resolve the same project the main process selected. Without this, `npx playwright test --project=server` would queue server tests in the main process and then fail in the worker with `Project "server" not found in the worker process`. `--project` continues to win over a pre-existing `PW_RSTUDIO_MODE`.
- Loosen the Desktop CDP connect budget. The fixture polled `chromium.connectOverCDP` with a 1000ms inner timeout inside a 10000ms outer deadline. On slower environments (RStudio Desktop on Ubuntu 26.04 in particular) the websocket opens against a still-initializing Electron, the post-WS protocol handshake takes longer than 1000ms, and every retry trips the inner cap. Bumped to 5000ms inner / 30000ms outer.
- Added a Setup subsection documenting the Playwright workaround for Ubuntu 26.04 LTS (override the platform target to `ubuntu24.04-x64`/`-arm64`, then `apt-get install libicu78 libxml2-16 libmanette-0.2-0`).

## Test plan

- [ ] `npx playwright test tests/panes/editor/code-folding.test.ts --project=server` against an in-tree `rserver-dev` resolves the project in the worker and starts running (no `Project "server" not found` error).
- [ ] `npx playwright test tests/panes/editor/code-folding.test.ts` against installed RStudio Desktop on Ubuntu 26.04 connects CDP and runs to completion.
- [ ] Bare `npx playwright test --list` still defaults to the `desktop` project.
- [ ] `PW_RSTUDIO_MODE=server npx playwright test --list` lists tests under `[server]`.
- [ ] `PW_RSTUDIO_MODE=desktop npx playwright test --list --project=server` lists tests under `[server]` (`--project` wins).