### PR TITLE
add automation callbacks for prefs and close-all-no-save

### DIFF
--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -2,6 +2,7 @@ import type { Page } from 'playwright';
 import * as fs from 'fs';
 import { ConsolePane, type EnvironmentVersions } from '../pages/console_pane.page';
 import { sleep } from '../utils/constants';
+import { documentCloseAllNoSave } from '../utils/commands';
 
 interface InstallTarget {
   repos: string;
@@ -89,8 +90,11 @@ export class ConsolePaneActions {
   }
 
   async closeAllBuffersWithoutSaving(): Promise<void> {
-    await this.typeInConsole('.rs.api.closeAllSourceBuffersWithoutSaving()');
-    await sleep(1000);
+    // Use the rstudioCallbacks bridge instead of typing `.rs.api.close...`
+    // into the console: the R session isn't busy while the close fires, so
+    // RStudio's "session is busy" confirmation dialog can't intervene.
+    await documentCloseAllNoSave(this.page);
+    await sleep(500);
   }
 
   async getEnvironmentVersions(): Promise<EnvironmentVersions> {

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -6,11 +6,17 @@ import type { Page } from '@playwright/test';
 // console -- avoiding the focus-shift and pane-collapse pitfalls that the
 // console path runs into.
 
+type PrefValue = boolean | number | string;
+
 type RStudioCallbacks = {
   commandExecute(id: string): void;
   commandIsChecked(id: string): boolean;
   commandIsEnabled(id: string): boolean;
   commandList(): string[];
+  documentCloseAllNoSave(): void;
+  prefGet(name: string): PrefValue | null;
+  prefSet(name: string, value: PrefValue): void;
+  prefClear(name: string): void;
 };
 
 declare global {
@@ -44,4 +50,56 @@ export async function isCommandEnabled(page: Page, commandId: string): Promise<b
     if (!cb) throw new Error('window.rstudioCallbacks is not defined; launch RStudio with --automation-agent');
     return cb.commandIsEnabled(id);
   }, commandId);
+}
+
+/**
+ * Close every open source document, discarding unsaved changes. Equivalent
+ * to `.rs.api.closeAllSourceBuffersWithoutSaving()` but skips the R-side
+ * round trip (and therefore the "session is busy" dialog risk).
+ */
+export async function documentCloseAllNoSave(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const cb = window.rstudioCallbacks;
+    if (!cb) throw new Error('window.rstudioCallbacks is not defined; launch RStudio with --automation-agent');
+    cb.documentCloseAllNoSave();
+  });
+}
+
+/**
+ * Read a user preference by name. Returns null when the preference name is
+ * unknown.
+ */
+export async function getPref(page: Page, name: string): Promise<PrefValue | null> {
+  return page.evaluate((prefName) => {
+    const cb = window.rstudioCallbacks;
+    if (!cb) throw new Error('window.rstudioCallbacks is not defined; launch RStudio with --automation-agent');
+    return cb.prefGet(prefName);
+  }, name);
+}
+
+/**
+ * Set a user preference and persist it. Equivalent to
+ * `.rs.api.writeRStudioPreference(name, value)` / `.rs.uiPrefs$<name>$set(value)`.
+ * The bridge dispatches by the preference's declared type, so the JS value
+ * must match: pass a boolean for boolean prefs, a number for integer/double
+ * prefs, a string for string/enum prefs.
+ */
+export async function setPref(page: Page, name: string, value: PrefValue): Promise<void> {
+  await page.evaluate(({ prefName, prefValue }) => {
+    const cb = window.rstudioCallbacks;
+    if (!cb) throw new Error('window.rstudioCallbacks is not defined; launch RStudio with --automation-agent');
+    cb.prefSet(prefName, prefValue);
+  }, { prefName: name, prefValue: value });
+}
+
+/**
+ * Remove a user-layer preference value (the default takes over). Equivalent
+ * to `.rs.uiPrefs$<name>$clear()`.
+ */
+export async function clearPref(page: Page, name: string): Promise<void> {
+  await page.evaluate((prefName) => {
+    const cb = window.rstudioCallbacks;
+    if (!cb) throw new Error('window.rstudioCallbacks is not defined; launch RStudio with --automation-agent');
+    cb.prefClear(prefName);
+  }, name);
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -19,7 +19,11 @@ import java.util.Set;
 
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.js.JsUtil;
+import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.server.model.DocumentCloseAllNoSaveEvent;
 import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.prefs.model.Prefs;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 
 import com.google.gwt.core.client.JsArrayString;
 import com.google.inject.Inject;
@@ -32,18 +36,27 @@ public class ApplicationAutomation
    {
       public R execute();
    }
-   
+
    static interface UnaryCallback<R, T>
    {
       public R execute(T value);
    }
-   
+
+   static interface BinaryCallback<R, T1, T2>
+   {
+      public R execute(T1 value1, T2 value2);
+   }
+
    @Inject
-   public ApplicationAutomation(Commands commands)
+   public ApplicationAutomation(Commands commands,
+                                EventBus eventBus,
+                                UserPrefs userPrefs)
    {
       commands_ = commands;
+      eventBus_ = eventBus;
+      userPrefs_ = userPrefs;
    }
-   
+
    public final boolean isAutomationHost()
    {
       return isAutomationHost_;
@@ -52,18 +65,18 @@ public class ApplicationAutomation
    {
       return isAutomationAgent_;
    }
-   
+
    public final void initializeHost()
    {
       isAutomationHost_ = true;
    }
-   
+
    public final void initializeAgent()
    {
       isAutomationAgent_ = true;
-      
+
       initializeCallbacks();
-      
+
       exportCallback("commandExecute", new UnaryCallback<Void, String>()
       {
          @Override
@@ -74,7 +87,7 @@ public class ApplicationAutomation
             return null;
          }
       });
-      
+
       exportCallback("commandList", new NullaryCallback<JsArrayString>()
       {
          @Override
@@ -105,28 +118,128 @@ public class ApplicationAutomation
             return command.isEnabled();
          }
       });
+
+      // Close every open source document, discarding unsaved changes. The
+      // .rs.api.closeAllSourceBuffersWithoutSaving R API fires the same
+      // DocumentCloseAllNoSave client event via a server roundtrip; this
+      // callback lets tests skip that round trip so the R session isn't busy
+      // executing R code while the close runs (which would surface the
+      // "session is busy, are you sure?" confirmation dialog and hang).
+      exportCallback("documentCloseAllNoSave", new NullaryCallback<Void>()
+      {
+         @Override
+         public Void execute()
+         {
+            eventBus_.dispatchEvent(new DocumentCloseAllNoSaveEvent());
+            return null;
+         }
+      });
+
+      // Read a user preference by name. Returns the live (project-then-user-
+      // then-default) value as a JS-marshalable Object: Boolean, String,
+      // Integer/Double, or null when the pref is unknown.
+      exportCallback("prefGet", new UnaryCallback<Object, String>()
+      {
+         @Override
+         public Object execute(String name)
+         {
+            Prefs.PrefValue<?> pref = userPrefs_.getPrefValue(name);
+            return pref == null ? null : pref.getValue();
+         }
+      });
+
+      // Set a user preference and persist via the same RPC the Options dialog
+      // uses. Dispatches by the pref's declared type rather than the JS value's
+      // type so a JS number passed for a Boolean pref is a hard error, not a
+      // silent coercion.
+      exportCallback("prefSet", new BinaryCallback<Void, String, Object>()
+      {
+         @Override
+         public Void execute(String name, Object value)
+         {
+            setPref(name, value);
+            userPrefs_.writeUserPrefs();
+            return null;
+         }
+      });
+
+      // Remove a user-layer preference value, falling back to the default.
+      // Mirrors .rs.uiPrefs$<name>$clear().
+      exportCallback("prefClear", new UnaryCallback<Void, String>()
+      {
+         @Override
+         public Void execute(String name)
+         {
+            Prefs.PrefValue<?> pref = userPrefs_.getPrefValue(name);
+            if (pref == null)
+               throw new RuntimeException("Unknown user preference: " + name);
+            pref.removeGlobalValue(true);
+            userPrefs_.writeUserPrefs();
+            return null;
+         }
+      });
    }
-   
+
+   @SuppressWarnings("unchecked")
+   private void setPref(String name, Object value)
+   {
+      Prefs.PrefValue<?> pref = userPrefs_.getPrefValue(name);
+      if (pref == null)
+         throw new RuntimeException("Unknown user preference: " + name);
+
+      if (pref instanceof Prefs.BooleanValue)
+      {
+         ((Prefs.PrefValue<Boolean>) pref).setGlobalValue((Boolean) value);
+      }
+      else if (pref instanceof Prefs.IntValue)
+      {
+         // JS numbers arrive as java.lang.Double; narrow before assigning.
+         ((Prefs.PrefValue<Integer>) pref).setGlobalValue(((Number) value).intValue());
+      }
+      else if (pref instanceof Prefs.DoubleValue)
+      {
+         ((Prefs.PrefValue<Double>) pref).setGlobalValue(((Number) value).doubleValue());
+      }
+      else if (pref instanceof Prefs.StringValue || pref instanceof Prefs.EnumValue)
+      {
+         ((Prefs.PrefValue<String>) pref).setGlobalValue((String) value);
+      }
+      else
+      {
+         throw new RuntimeException(
+            "Unsupported preference type for " + name + ": " + pref.getClass().getSimpleName());
+      }
+   }
+
    private native final void initializeCallbacks()
    /*-{
       $wnd.rstudioCallbacks = $wnd.rstudioCallbacks || {};
    }-*/;
-   
+
    private native final <R> void exportCallback(String name, NullaryCallback<R> callback)
    /*-{
       $wnd.rstudioCallbacks[name] = $entry(function() {
          return callback.@org.rstudio.studio.client.application.ApplicationAutomation.NullaryCallback::execute(*)();
       });
    }-*/;
-   
+
    private native final <R, T> void exportCallback(String name, UnaryCallback<R, T> callback)
    /*-{
       $wnd.rstudioCallbacks[name] = $entry(function(value) {
          return callback.@org.rstudio.studio.client.application.ApplicationAutomation.UnaryCallback::execute(*)(value);
       });
    }-*/;
-   
+
+   private native final <R, T1, T2> void exportCallback(String name, BinaryCallback<R, T1, T2> callback)
+   /*-{
+      $wnd.rstudioCallbacks[name] = $entry(function(value1, value2) {
+         return callback.@org.rstudio.studio.client.application.ApplicationAutomation.BinaryCallback::execute(*)(value1, value2);
+      });
+   }-*/;
+
    private final Commands commands_;
+   private final EventBus eventBus_;
+   private final UserPrefs userPrefs_;
    private boolean isAutomationHost_ = false;
    private boolean isAutomationAgent_ = false;
 }


### PR DESCRIPTION
## Summary

Extends \`window.rstudioCallbacks\` (registered when rsession runs with \`--automation-agent\`) with three additional surfaces, so Playwright tests can drive these from JS instead of typing R into the console.

\`\`\`
documentCloseAllNoSave()      // == .rs.api.closeAllSourceBuffersWithoutSaving, no R round trip
prefGet(name)                 // Boolean / Integer / Double / String / null
prefSet(name, value)          // typed by the pref's declared type; persisted via the same RPC the Options dialog uses
prefClear(name)               // == .rs.uiPrefs\$<name>\$clear()
\`\`\`

Motivation:

- The R-side close-all path runs through R, which means the R session is busy executing R code at the very moment GWT issues its \"safe-to-close?\" check. RStudio surfaces \"R session is currently busy. Are you sure you want to quit?\" and the close hangs. The new \`documentCloseAllNoSave\` bridge fires the same \`DocumentCloseAllNoSaveEvent\` directly via the event bus -- no R, no dialog.
- \`typeInConsole('.rs.uiPrefs\$X\$set(...)')\` is the only pref-setting path tests currently have. It is fragile to console-focus state and serializes behind whatever else R is doing. A direct bridge is faster and immune to console state.

\`ConsolePaneActions.closeAllBuffersWithoutSaving\` now uses the new bridge; the matching \`@utils/commands\` exports the helpers (\`documentCloseAllNoSave\`, \`getPref\`, \`setPref\`, \`clearPref\`) for tests to call directly.

Wider adoption (replacing existing \`typeInConsole('.rs.api.close...\`)\` call sites in individual tests, switching reformat-pref setup to \`setPref\`) is left for follow-up PRs to keep this change focused.

## Test plan

- [x] \`npx playwright test tests/panes/files/files.test.ts --project=server\` -- 3/3 pass against in-tree rserver-dev with the rebuilt GWT output (\`beforeAll\` calls \`closeAllBuffersWithoutSaving\` and now goes through the new bridge).
- [x] \`ant javac\` clean.
- [ ] Adoption of \`setPref\` / \`clearPref\` in tests will land in subsequent PRs.