### PR TITLE
Add PR-triggered Playwright workflow for macOS 26 with source-to-test mapping

### DIFF
--- a/.github/pw-test-map.yml
+++ b/.github/pw-test-map.yml
@@ -12,16 +12,21 @@
 
 # If every changed file in the PR matches at least one of these patterns,
 # the workflow is skipped entirely. Useful for docs- or release-notes-only
-# PRs.
+# PRs. PR-title overrides (`[full-pw]`, `[skip-pw]`) are evaluated first
+# and take precedence over this list.
 skip_if_only:
   - "**/*.md"
   - "docs/**"
 
-# When no rule matches but the PR is not docs-only, run this minimum
-# signal set.
+# When no map rule matches AND no Playwright test file was edited directly,
+# run this minimum signal set. (A changed `.test.ts` file under
+# `e2e/rstudio/tests/` counts as a match and suppresses this fallback.)
 fallback:
   - "tests/smoke/"
 
+# Coverage below is intentionally partial -- new areas can be added as the
+# Playwright suite grows. Areas not listed (e.g. plots, packages, vcs,
+# connections, jobs) currently land on `fallback`.
 rules:
   - name: posit-assistant
     paths:

--- a/.github/pw-test-map.yml
+++ b/.github/pw-test-map.yml
@@ -15,7 +15,6 @@
 # PRs.
 skip_if_only:
   - "**/*.md"
-  - "NEWS.md"
   - "docs/**"
 
 # When no rule matches but the PR is not docs-only, run this minimum
@@ -27,7 +26,7 @@ rules:
   - name: posit-assistant
     paths:
       - "src/cpp/session/modules/SessionChat*"
-      - "src/cpp/session/modules/**/posit_assistant/**"
+      - "src/cpp/session/modules/posit_assistant/**"
       - "src/gwt/**/views/chat/**"
     tests:
       - "tests/panes/posit-assistant-chat/"

--- a/.github/pw-test-map.yml
+++ b/.github/pw-test-map.yml
@@ -1,0 +1,114 @@
+# Source-to-test mapping for PR-triggered Playwright runs.
+#
+# Read by .github/scripts/pw-pr-select.py during the `select` job of the
+# PR-triggered Playwright workflows (e.g. test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml).
+#
+# Each rule maps a set of source-path glob patterns to a set of Playwright
+# test paths. When any changed file in the PR matches a rule's `paths`,
+# the rule's `tests` are added to the run selector.
+#
+# Glob syntax: `*` matches a single path segment, `**` matches any number
+# of path segments. Patterns are matched against repository-relative paths.
+
+# If every changed file in the PR matches at least one of these patterns,
+# the workflow is skipped entirely. Useful for docs- or release-notes-only
+# PRs.
+skip_if_only:
+  - "**/*.md"
+  - "NEWS.md"
+  - "docs/**"
+
+# When no rule matches but the PR is not docs-only, run this minimum
+# signal set.
+fallback:
+  - "tests/smoke/"
+
+rules:
+  - name: posit-assistant
+    paths:
+      - "src/cpp/session/modules/SessionChat*"
+      - "src/cpp/session/modules/**/posit_assistant/**"
+      - "src/gwt/**/views/chat/**"
+    tests:
+      - "tests/panes/posit-assistant-chat/"
+
+  - name: console
+    paths:
+      - "src/cpp/session/modules/SessionConsole*"
+      - "src/gwt/**/views/console/**"
+    tests:
+      - "tests/panes/console/"
+
+  - name: data-viewer
+    paths:
+      - "src/cpp/session/modules/SessionData*"
+      - "src/cpp/session/modules/SessionViewer*"
+      - "src/gwt/**/views/data/**"
+      - "src/gwt/**/views/viewer/**"
+    tests:
+      - "tests/panes/data-viewer/"
+
+  - name: debugger
+    paths:
+      - "src/cpp/session/modules/SessionBreakpoints*"
+      - "src/cpp/session/modules/SessionEnvironment*"
+      - "src/gwt/**/views/environment/**"
+    tests:
+      - "tests/panes/debugger/"
+
+  - name: editor
+    paths:
+      - "src/cpp/session/modules/SessionSource*"
+      - "src/gwt/**/views/source/**"
+      - "src/gwt/acesupport/**"
+    tests:
+      - "tests/panes/editor/"
+
+  - name: terminal
+    paths:
+      - "src/cpp/session/modules/SessionTerminal*"
+      - "src/gwt/**/views/terminal/**"
+    tests:
+      - "tests/panes/terminal/"
+
+  - name: projects
+    paths:
+      - "src/cpp/session/modules/SessionProjects*"
+      - "src/cpp/session/modules/SessionFiles*"
+    tests:
+      - "tests/projects/"
+
+  - name: help
+    paths:
+      - "src/cpp/session/modules/SessionHelp*"
+      - "src/gwt/**/views/help/**"
+    tests:
+      - "tests/menus/help/"
+
+  - name: layout
+    paths:
+      - "src/gwt/**/workbench/ui/**"
+    tests:
+      - "tests/panes/layout/"
+
+  - name: desktop-host
+    paths:
+      - "src/node/desktop/**"
+    tests:
+      - "tests/smoke/"
+      - "tests/panes/layout/"
+
+  - name: core
+    paths:
+      - "src/cpp/r/R/**"
+      - "src/cpp/session/SessionMain.cpp"
+      - "src/cpp/core/**"
+      - "src/cpp/shared_core/**"
+    tests:
+      - "tests/smoke/"
+
+  - name: user-prefs-schema
+    paths:
+      - "src/cpp/session/resources/schema/user-prefs-schema.json"
+    tests:
+      - "tests/smoke/"

--- a/.github/pw-test-map.yml
+++ b/.github/pw-test-map.yml
@@ -25,9 +25,19 @@ fallback:
   - "tests/smoke/"
 
 # Coverage below is intentionally partial -- new areas can be added as the
-# Playwright suite grows. Areas not listed (e.g. plots, packages, vcs,
-# connections, jobs) currently land on `fallback`.
+# Playwright suite grows. Areas with no Playwright tests yet (e.g. plots,
+# vcs, connections, jobs) currently land on `fallback`.
 rules:
+  - name: completions
+    paths:
+      - "src/cpp/session/modules/SessionRCompletions*"
+      - "src/cpp/session/modules/SessionReticulate*"
+      - "src/gwt/**/shell/assist/**"
+      - "src/gwt/**/common/codetools/**"
+    tests:
+      - "tests/panes/misc/autocomplete.test.ts"
+      - "tests/panes/misc/python_completions.test.ts"
+
   - name: posit-assistant
     paths:
       - "src/cpp/session/modules/SessionChat*"
@@ -60,6 +70,14 @@ rules:
     tests:
       - "tests/panes/debugger/"
 
+  - name: environment
+    paths:
+      - "src/cpp/session/modules/SessionEnvironment*"
+      - "src/gwt/**/views/environment/**"
+    tests:
+      - "tests/panes/misc/s4_unloaded_package.test.ts"
+      - "tests/panes/misc/rs_value_contents.test.ts"
+
   - name: editor
     paths:
       - "src/cpp/session/modules/SessionSource*"
@@ -75,10 +93,31 @@ rules:
     tests:
       - "tests/panes/terminal/"
 
+  - name: files
+    paths:
+      - "src/cpp/session/modules/SessionFiles*"
+      - "src/gwt/**/views/files/**"
+    tests:
+      - "tests/panes/files/"
+
+  - name: packages
+    paths:
+      - "src/cpp/session/modules/SessionPackages*"
+      - "src/gwt/**/views/packages/**"
+    tests:
+      - "tests/panes/packages/"
+
+  - name: build
+    paths:
+      - "src/cpp/session/modules/build/**"
+      - "src/cpp/session/modules/SessionBuild*"
+      - "src/gwt/**/views/buildtools/**"
+    tests:
+      - "tests/panes/misc/build_pane_testthat.test.ts"
+
   - name: projects
     paths:
       - "src/cpp/session/modules/SessionProjects*"
-      - "src/cpp/session/modules/SessionFiles*"
     tests:
       - "tests/projects/"
 
@@ -110,6 +149,16 @@ rules:
       - "src/cpp/shared_core/**"
     tests:
       - "tests/smoke/"
+
+  - name: session-lifecycle
+    paths:
+      - "src/cpp/session/SessionMain.cpp"
+      - "src/cpp/r/session/RSession*"
+      - "src/cpp/r/session/RSuspend*"
+      - "src/cpp/r/session/RRestartContext*"
+    tests:
+      - "tests/panes/misc/session_restart.test.ts"
+      - "tests/panes/misc/session_suspend.test.ts"
 
   - name: user-prefs-schema
     paths:

--- a/.github/scripts/pw-pr-select.py
+++ b/.github/scripts/pw-pr-select.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Compute the Playwright test selector for a PR-triggered workflow.
+
+Reads .github/pw-test-map.yml and a list of changed paths from stdin
+(one per line). Considers PR title overrides ([full-pw], [skip-pw]).
+Emits GITHUB_OUTPUT lines for `selector`, `skip`, and `full`.
+
+Usage (inside a GitHub Actions step):
+
+    git diff --name-only "origin/$GITHUB_BASE_REF...HEAD" \\
+        | python3 .github/scripts/pw-pr-select.py \\
+            --map .github/pw-test-map.yml \\
+            --title "$PR_TITLE"
+
+Outputs:
+    selector  Space-separated Playwright test paths (empty when full=true).
+    skip      "true" if the workflow should be skipped entirely.
+    full      "true" if the full suite should run (selector is empty).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Translate a gitignore-style glob to a regex.
+
+    - `**` matches any number of path segments (including zero).
+    - `*` matches anything except `/`.
+    - `?` matches a single character except `/`.
+    All other characters are matched literally.
+    """
+    out = []
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "*":
+            if i + 1 < len(pattern) and pattern[i + 1] == "*":
+                out.append(".*")
+                i += 2
+                if i < len(pattern) and pattern[i] == "/":
+                    i += 1
+            else:
+                out.append("[^/]*")
+                i += 1
+        elif c == "?":
+            out.append("[^/]")
+            i += 1
+        else:
+            out.append(re.escape(c))
+            i += 1
+    return re.compile("^" + "".join(out) + "$")
+
+
+def matches_any(path: str, patterns: list[str]) -> bool:
+    return any(glob_to_regex(p).match(path) for p in patterns)
+
+
+def emit(name: str, value: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    line = f"{name}={value}"
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    print(line)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--map", required=True, type=Path)
+    parser.add_argument("--title", default="", help="PR title, for override tokens")
+    args = parser.parse_args()
+
+    title = args.title or ""
+
+    if "[skip-pw]" in title:
+        emit("skip", "true")
+        emit("full", "false")
+        emit("selector", "")
+        return 0
+
+    if "[full-pw]" in title:
+        emit("skip", "false")
+        emit("full", "true")
+        emit("selector", "")
+        return 0
+
+    config = yaml.safe_load(args.map.read_text(encoding="utf-8")) or {}
+    skip_if_only = config.get("skip_if_only", []) or []
+    fallback = config.get("fallback", []) or []
+    rules = config.get("rules", []) or []
+
+    changed = [line.strip() for line in sys.stdin if line.strip()]
+
+    if not changed:
+        # No diff = nothing to test. Skip to avoid burning runner minutes.
+        emit("skip", "true")
+        emit("full", "false")
+        emit("selector", "")
+        return 0
+
+    if all(matches_any(f, skip_if_only) for f in changed):
+        emit("skip", "true")
+        emit("full", "false")
+        emit("selector", "")
+        return 0
+
+    selected: list[str] = []
+    seen: set[str] = set()
+    for rule in rules:
+        patterns = rule.get("paths", []) or []
+        tests = rule.get("tests", []) or []
+        if any(matches_any(f, patterns) for f in changed):
+            for t in tests:
+                if t not in seen:
+                    seen.add(t)
+                    selected.append(t)
+
+    if not selected:
+        selected = list(fallback)
+
+    emit("skip", "false")
+    emit("full", "false")
+    emit("selector", " ".join(selected))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/pw-pr-select.py
+++ b/.github/scripts/pw-pr-select.py
@@ -21,6 +21,7 @@ Outputs:
 from __future__ import annotations
 
 import argparse
+import functools
 import os
 import re
 import sys
@@ -32,26 +33,46 @@ import yaml
 def glob_to_regex(pattern: str) -> re.Pattern[str]:
     """Translate a gitignore-style glob to a regex.
 
-    - `**` matches any number of path segments (including zero).
-    - `*` matches anything except `/`.
-    - `?` matches a single character except `/`.
+    Semantics (whole-segment `**`):
+    - `**/`  at the start matches zero or more leading path segments.
+    - `/**/` between segments matches zero or more whole segments.
+    - `/**`  at the end matches the rest of the path (any depth, or nothing).
+    - `*`    matches anything except `/`.
+    - `?`    matches a single character except `/`.
     All other characters are matched literally.
     """
-    out = []
+    out: list[str] = []
     i = 0
-    while i < len(pattern):
+    n = len(pattern)
+
+    # Leading `**/`: zero or more segments at the start.
+    if pattern.startswith("**/"):
+        out.append("(?:.*/)?")
+        i = 3
+
+    while i < n:
         c = pattern[i]
-        if c == "*":
-            if i + 1 < len(pattern) and pattern[i + 1] == "*":
+        if c == "*" and i + 1 < n and pattern[i + 1] == "*":
+            # `**` only valid as `/**/` between segments or `/**` at end.
+            # The leading-`/` should already be in `out`; we replace it.
+            if out and out[-1] == "/" and i + 2 < n and pattern[i + 2] == "/":
+                out[-1] = "(?:/.*)?/"
+                i += 3
+            elif out and out[-1] == "/" and i + 2 == n:
+                out[-1] = "(?:/.*)?"
+                i += 2
+            else:
+                # Treat a bare or malformed `**` as `.*` (rare).
                 out.append(".*")
                 i += 2
-                if i < len(pattern) and pattern[i] == "/":
-                    i += 1
-            else:
-                out.append("[^/]*")
-                i += 1
+        elif c == "*":
+            out.append("[^/]*")
+            i += 1
         elif c == "?":
             out.append("[^/]")
+            i += 1
+        elif c == "/":
+            out.append("/")
             i += 1
         else:
             out.append(re.escape(c))
@@ -59,8 +80,13 @@ def glob_to_regex(pattern: str) -> re.Pattern[str]:
     return re.compile("^" + "".join(out) + "$")
 
 
+@functools.lru_cache(maxsize=None)
+def _compile(pattern: str) -> re.Pattern[str]:
+    return glob_to_regex(pattern)
+
+
 def matches_any(path: str, patterns: list[str]) -> bool:
-    return any(glob_to_regex(p).match(path) for p in patterns)
+    return any(_compile(p).match(path) for p in patterns)
 
 
 def emit(name: str, value: str) -> None:
@@ -72,11 +98,81 @@ def emit(name: str, value: str) -> None:
     print(line)
 
 
+E2E_TESTS_PREFIX = "e2e/rstudio/tests/"
+
+
+def e2e_test_selector(path: str) -> str | None:
+    """If `path` is a Playwright test file under e2e/rstudio/tests/, return
+    the selector to run it. Otherwise return None.
+
+    Selectors are returned relative to e2e/rstudio/ (Playwright's working
+    directory). Only `.test.ts` files are mapped; other files under
+    tests/ (fixtures, helpers) are ignored here and may match map rules
+    or fall through to the fallback.
+    """
+    if not path.startswith(E2E_TESTS_PREFIX):
+        return None
+    if not path.endswith(".test.ts"):
+        return None
+    return path[len("e2e/rstudio/"):]
+
+
+def run_self_test() -> int:
+    cases = [
+        # (pattern, path, expected_match)
+        ("src/**", "src/foo.cpp", True),
+        ("src/**", "src/a/b/c.cpp", True),
+        ("src/**", "srcfoo", False),
+        ("src/gwt/**/views/chat/**", "src/gwt/foo/views/chat/x", True),
+        ("src/gwt/**/views/chat/**", "src/gwt/views/chat/x", True),  # zero segments
+        ("src/gwt/**/views/chat/**", "src/gwt/foo/aviews/chat/x", False),  # whole-segment
+        ("src/cpp/session/modules/posit_assistant/**", "src/cpp/session/modules/posit_assistant/foo.cpp", True),
+        ("**/*.md", "NEWS.md", True),
+        ("**/*.md", "docs/api.md", True),
+        ("**/*.md", "src/foo.cpp", False),
+        ("docs/**", "docs/api.md", True),
+        ("docs/**", "src/docs/api.md", False),
+        ("src/cpp/session/modules/SessionChat*", "src/cpp/session/modules/SessionChat.cpp", True),
+        ("src/cpp/session/modules/SessionChat*", "src/cpp/session/modules/SessionConsole.cpp", False),
+    ]
+    failed = 0
+    for pat, path, expected in cases:
+        got = bool(glob_to_regex(pat).match(path))
+        if got != expected:
+            failed += 1
+            print(f"FAIL: pattern={pat!r} path={path!r} expected={expected} got={got}", file=sys.stderr)
+    e2e_cases = [
+        ("e2e/rstudio/tests/panes/console/foo.test.ts", "tests/panes/console/foo.test.ts"),
+        ("e2e/rstudio/tests/sandbox.test.ts", "tests/sandbox.test.ts"),
+        ("e2e/rstudio/tests/projects/create_projects.test.ts", "tests/projects/create_projects.test.ts"),
+        ("e2e/rstudio/tests/panes/console/helpers.ts", None),  # not a .test.ts
+        ("e2e/rstudio/playwright.config.ts", None),
+        ("src/cpp/foo.cpp", None),
+    ]
+    for path, expected in e2e_cases:
+        got = e2e_test_selector(path)
+        if got != expected:
+            failed += 1
+            print(f"FAIL: e2e_test_selector({path!r}) expected={expected!r} got={got!r}", file=sys.stderr)
+    if failed:
+        print(f"{failed} self-test case(s) failed", file=sys.stderr)
+        return 1
+    print(f"All {len(cases) + len(e2e_cases)} self-test cases passed")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--map", required=True, type=Path)
+    parser.add_argument("--map", type=Path, help="Path to pw-test-map.yml")
     parser.add_argument("--title", default="", help="PR title, for override tokens")
+    parser.add_argument("--self-test", action="store_true", help="Run internal assertions and exit")
     args = parser.parse_args()
+
+    if args.self_test:
+        return run_self_test()
+
+    if args.map is None:
+        parser.error("--map is required unless --self-test is given")
 
     title = args.title or ""
 
@@ -114,14 +210,25 @@ def main() -> int:
 
     selected: list[str] = []
     seen: set[str] = set()
+
+    def add(t: str) -> None:
+        if t not in seen:
+            seen.add(t)
+            selected.append(t)
+
     for rule in rules:
         patterns = rule.get("paths", []) or []
         tests = rule.get("tests", []) or []
         if any(matches_any(f, patterns) for f in changed):
             for t in tests:
-                if t not in seen:
-                    seen.add(t)
-                    selected.append(t)
+                add(t)
+
+    # Implicit rule: a changed Playwright test file maps to its own area.
+    # Keeps the scope tight when only test code is edited.
+    for f in changed:
+        sel = e2e_test_selector(f)
+        if sel is not None:
+            add(sel)
 
     if not selected:
         selected = list(fallback)

--- a/.github/scripts/pw-pr-select.py
+++ b/.github/scripts/pw-pr-select.py
@@ -16,18 +16,34 @@ Outputs:
     selector  Space-separated Playwright test paths (empty when full=true).
     skip      "true" if the workflow should be skipped entirely.
     full      "true" if the full suite should run (selector is empty).
+
+Selection logic (first match wins):
+    1. PR title contains `[skip-pw]`  -> skip.
+    2. PR title contains `[full-pw]`  -> full suite.
+    3. Empty diff                     -> skip with a stderr warning.
+    4. All changed files match `skip_if_only` patterns -> skip.
+    5. Union of: each YAML rule whose `paths` match any changed file
+       contributes its `tests`, AND each changed `.test.ts` file under
+       `e2e/rstudio/tests/` contributes itself.
+    6. If the union from step 5 is empty, use `fallback`.
 """
 
 from __future__ import annotations
 
 import argparse
-import functools
 import os
 import re
 import sys
 from pathlib import Path
 
 import yaml
+
+
+E2E_TESTS_PREFIX = "e2e/rstudio/tests/"
+
+
+class GlobError(ValueError):
+    """Raised when a glob pattern is malformed."""
 
 
 def glob_to_regex(pattern: str) -> re.Pattern[str]:
@@ -40,31 +56,37 @@ def glob_to_regex(pattern: str) -> re.Pattern[str]:
     - `*`    matches anything except `/`.
     - `?`    matches a single character except `/`.
     All other characters are matched literally.
+
+    A `**` outside the three positions above (e.g. `src/**foo`) is
+    malformed and raises GlobError -- catching typos early is more
+    valuable than guessing the author's intent.
     """
     out: list[str] = []
     i = 0
     n = len(pattern)
 
-    # Leading `**/`: zero or more segments at the start.
     if pattern.startswith("**/"):
         out.append("(?:.*/)?")
         i = 3
 
     while i < n:
         c = pattern[i]
-        if c == "*" and i + 1 < n and pattern[i + 1] == "*":
-            # `**` only valid as `/**/` between segments or `/**` at end.
-            # The leading-`/` should already be in `out`; we replace it.
-            if out and out[-1] == "/" and i + 2 < n and pattern[i + 2] == "/":
-                out[-1] = "(?:/.*)?/"
-                i += 3
-            elif out and out[-1] == "/" and i + 2 == n:
-                out[-1] = "(?:/.*)?"
-                i += 2
+        if c == "/" and pattern[i + 1:i + 3] == "**":
+            # `/**` at end of pattern, or `/**/` between segments.
+            if i + 3 == n:
+                out.append("(?:/.*)?")
+                i = n
+            elif pattern[i + 3] == "/":
+                out.append("(?:/.*)?/")
+                i += 4
             else:
-                # Treat a bare or malformed `**` as `.*` (rare).
-                out.append(".*")
-                i += 2
+                raise GlobError(
+                    f"`**` must stand alone as a path segment in {pattern!r}"
+                )
+        elif c == "*" and i + 1 < n and pattern[i + 1] == "*":
+            raise GlobError(
+                f"`**` must stand alone as a path segment in {pattern!r}"
+            )
         elif c == "*":
             out.append("[^/]*")
             i += 1
@@ -80,13 +102,8 @@ def glob_to_regex(pattern: str) -> re.Pattern[str]:
     return re.compile("^" + "".join(out) + "$")
 
 
-@functools.lru_cache(maxsize=None)
-def _compile(pattern: str) -> re.Pattern[str]:
-    return glob_to_regex(pattern)
-
-
-def matches_any(path: str, patterns: list[str]) -> bool:
-    return any(_compile(p).match(path) for p in patterns)
+def matches_any(path: str, compiled: list[re.Pattern[str]]) -> bool:
+    return any(p.match(path) for p in compiled)
 
 
 def emit(name: str, value: str) -> None:
@@ -98,17 +115,23 @@ def emit(name: str, value: str) -> None:
     print(line)
 
 
-E2E_TESTS_PREFIX = "e2e/rstudio/tests/"
+def list_field(d: dict, key: str) -> list:
+    """Return d[key] as a list, treating missing or None as []."""
+    return d.get(key) or []
 
 
 def e2e_test_selector(path: str) -> str | None:
-    """If `path` is a Playwright test file under e2e/rstudio/tests/, return
-    the selector to run it. Otherwise return None.
+    """If `path` is a Playwright `.test.ts` file under e2e/rstudio/tests/,
+    return the selector to run it (relative to e2e/rstudio/). Otherwise
+    return None.
 
-    Selectors are returned relative to e2e/rstudio/ (Playwright's working
-    directory). Only `.test.ts` files are mapped; other files under
-    tests/ (fixtures, helpers) are ignored here and may match map rules
-    or fall through to the fallback.
+    This sits outside the YAML rules because the mapping is identity
+    (a changed test file maps to itself); encoding it as data would
+    require a self-referential rule per directory.
+
+    Non-`.test.ts` files under tests/ (fixtures, helpers) are not
+    selected by this function and currently fall through to the
+    fallback set.
     """
     if not path.startswith(E2E_TESTS_PREFIX):
         return None
@@ -117,8 +140,13 @@ def e2e_test_selector(path: str) -> str | None:
     return path[len("e2e/rstudio/"):]
 
 
+def annotate_error(file: str, message: str) -> None:
+    """Emit a GitHub Actions error annotation tied to a file."""
+    print(f"::error file={file}::{message}", file=sys.stderr)
+
+
 def run_self_test() -> int:
-    cases = [
+    glob_cases = [
         # (pattern, path, expected_match)
         ("src/**", "src/foo.cpp", True),
         ("src/**", "src/a/b/c.cpp", True),
@@ -135,29 +163,44 @@ def run_self_test() -> int:
         ("src/cpp/session/modules/SessionChat*", "src/cpp/session/modules/SessionChat.cpp", True),
         ("src/cpp/session/modules/SessionChat*", "src/cpp/session/modules/SessionConsole.cpp", False),
     ]
-    failed = 0
-    for pat, path, expected in cases:
-        got = bool(glob_to_regex(pat).match(path))
-        if got != expected:
-            failed += 1
-            print(f"FAIL: pattern={pat!r} path={path!r} expected={expected} got={got}", file=sys.stderr)
     e2e_cases = [
         ("e2e/rstudio/tests/panes/console/foo.test.ts", "tests/panes/console/foo.test.ts"),
         ("e2e/rstudio/tests/sandbox.test.ts", "tests/sandbox.test.ts"),
         ("e2e/rstudio/tests/projects/create_projects.test.ts", "tests/projects/create_projects.test.ts"),
-        ("e2e/rstudio/tests/panes/console/helpers.ts", None),  # not a .test.ts
+        ("e2e/rstudio/tests/panes/console/helpers.ts", None),
         ("e2e/rstudio/playwright.config.ts", None),
         ("src/cpp/foo.cpp", None),
     ]
+    malformed_patterns = [
+        "src/**foo",       # `**` not segment-aligned
+        "foo**bar",        # `**` mid-segment
+        "src/**foo/bar",   # `**` glued to following text
+    ]
+
+    failed = 0
+    for pat, path, expected in glob_cases:
+        got = bool(glob_to_regex(pat).match(path))
+        if got != expected:
+            failed += 1
+            print(f"FAIL: pattern={pat!r} path={path!r} expected={expected} got={got}", file=sys.stderr)
     for path, expected in e2e_cases:
         got = e2e_test_selector(path)
         if got != expected:
             failed += 1
             print(f"FAIL: e2e_test_selector({path!r}) expected={expected!r} got={got!r}", file=sys.stderr)
+    for pat in malformed_patterns:
+        try:
+            glob_to_regex(pat)
+        except GlobError:
+            continue
+        failed += 1
+        print(f"FAIL: expected GlobError for malformed pattern {pat!r}", file=sys.stderr)
+
+    total = len(glob_cases) + len(e2e_cases) + len(malformed_patterns)
     if failed:
-        print(f"{failed} self-test case(s) failed", file=sys.stderr)
+        print(f"{failed} of {total} self-test case(s) failed", file=sys.stderr)
         return 1
-    print(f"All {len(cases) + len(e2e_cases)} self-test cases passed")
+    print(f"All {total} self-test cases passed")
     return 0
 
 
@@ -188,15 +231,36 @@ def main() -> int:
         emit("selector", "")
         return 0
 
-    config = yaml.safe_load(args.map.read_text(encoding="utf-8")) or {}
-    skip_if_only = config.get("skip_if_only", []) or []
-    fallback = config.get("fallback", []) or []
-    rules = config.get("rules", []) or []
+    map_path = str(args.map)
+    try:
+        config = yaml.safe_load(args.map.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as e:
+        annotate_error(map_path, f"Failed to parse YAML: {e}")
+        return 1
+    if not isinstance(config, dict):
+        annotate_error(map_path, "Top-level YAML must be a mapping")
+        return 1
+
+    try:
+        skip_if_only = [glob_to_regex(p) for p in list_field(config, "skip_if_only")]
+        compiled_rules = [
+            (
+                [glob_to_regex(p) for p in list_field(rule, "paths")],
+                list_field(rule, "tests"),
+            )
+            for rule in list_field(config, "rules")
+        ]
+    except GlobError as e:
+        annotate_error(map_path, str(e))
+        return 1
+    fallback = list_field(config, "fallback")
 
     changed = [line.strip() for line in sys.stdin if line.strip()]
 
     if not changed:
-        # No diff = nothing to test. Skip to avoid burning runner minutes.
+        # PR with zero changed files is unusual (GitHub generally won't open
+        # one); log loudly so the cause is visible if it ever happens.
+        print("WARNING: no changed files in diff; skipping Playwright run", file=sys.stderr)
         emit("skip", "true")
         emit("full", "false")
         emit("selector", "")
@@ -209,26 +273,15 @@ def main() -> int:
         return 0
 
     selected: list[str] = []
-    seen: set[str] = set()
-
-    def add(t: str) -> None:
-        if t not in seen:
-            seen.add(t)
-            selected.append(t)
-
-    for rule in rules:
-        patterns = rule.get("paths", []) or []
-        tests = rule.get("tests", []) or []
+    for patterns, tests in compiled_rules:
         if any(matches_any(f, patterns) for f in changed):
-            for t in tests:
-                add(t)
-
-    # Implicit rule: a changed Playwright test file maps to its own area.
-    # Keeps the scope tight when only test code is edited.
+            selected.extend(tests)
     for f in changed:
         sel = e2e_test_selector(f)
         if sel is not None:
-            add(sel)
+            selected.append(sel)
+
+    selected = list(dict.fromkeys(selected))  # order-preserving dedupe
 
     if not selected:
         selected = list(fallback)

--- a/.github/scripts/pw-pr-select.py
+++ b/.github/scripts/pw-pr-select.py
@@ -3,16 +3,18 @@
 
 Reads .github/pw-test-map.yml and a list of changed paths from stdin
 (one per line). Considers PR title overrides ([full-pw], [skip-pw]).
-Emits GITHUB_OUTPUT lines for `selector`, `skip`, and `full`.
+Prints `key=value` lines to stdout; the calling workflow tees stdout
+into `$GITHUB_OUTPUT` to set step outputs.
 
 Usage (inside a GitHub Actions step):
 
     git diff --name-only "origin/$GITHUB_BASE_REF...HEAD" \\
         | python3 .github/scripts/pw-pr-select.py \\
             --map .github/pw-test-map.yml \\
-            --title "$PR_TITLE"
+            --title "$PR_TITLE" \\
+        | tee -a "$GITHUB_OUTPUT"
 
-Outputs:
+Outputs (printed as `key=value` on stdout):
     selector  Space-separated Playwright test paths (empty when full=true).
     skip      "true" if the workflow should be skipped entirely.
     full      "true" if the full suite should run (selector is empty).
@@ -31,7 +33,6 @@ Selection logic (first match wins):
 from __future__ import annotations
 
 import argparse
-import os
 import re
 import sys
 from pathlib import Path
@@ -107,12 +108,12 @@ def matches_any(path: str, compiled: list[re.Pattern[str]]) -> bool:
 
 
 def emit(name: str, value: str) -> None:
-    output_path = os.environ.get("GITHUB_OUTPUT")
-    line = f"{name}={value}"
-    if output_path:
-        with open(output_path, "a", encoding="utf-8") as fh:
-            fh.write(line + "\n")
-    print(line)
+    # Print key=value to stdout. The caller (GitHub Actions workflow)
+    # is responsible for routing stdout into $GITHUB_OUTPUT. Keeping
+    # the env-var read out of Python avoids a tainted-path warning
+    # from static analyzers and makes the script easier to test
+    # standalone.
+    print(f"{name}={value}")
 
 
 def list_field(d: dict, key: str) -> list:

--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
@@ -1,0 +1,60 @@
+name: "Test: E2E Playwright RStudio (Desktop, macOS 26 ARM64, Open Source, PR-triggered)"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "src/**"
+      - "e2e/rstudio/**"
+      - ".github/pw-test-map.yml"
+      - ".github/scripts/pw-pr-select.py"
+      - ".github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml"
+      - ".github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml"
+
+concurrency:
+  group: pw-pr-macos-26-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  select:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      selector: ${{ steps.compute.outputs.selector }}
+      skip:     ${{ steps.compute.outputs.skip }}
+      full:     ${{ steps.compute.outputs.full }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install PyYAML
+        run: pip install --user pyyaml
+
+      - name: List changed files
+        id: changed
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          git diff --name-only "origin/$BASE_REF...HEAD" > changed.txt
+          echo "Changed files:"
+          cat changed.txt
+
+      - name: Compute selector
+        id: compute
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          python3 .github/scripts/pw-pr-select.py \
+            --map .github/pw-test-map.yml \
+            --title "$PR_TITLE" < changed.txt
+
+  run-macos-26:
+    needs: select
+    if: needs.select.outputs.skip != 'true'
+    uses: ./.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+    with:
+      test_selector: ${{ needs.select.outputs.selector }}
+      project: desktop
+      r_version: "4.5.3"

--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
@@ -47,7 +47,8 @@ jobs:
           git diff --name-only "origin/$BASE_REF...HEAD" | tee /dev/stderr \
             | python3 .github/scripts/pw-pr-select.py \
                 --map .github/pw-test-map.yml \
-                --title "$PR_TITLE"
+                --title "$PR_TITLE" \
+            | tee -a "$GITHUB_OUTPUT"
 
       - name: Write selection decision to step summary
         if: always()

--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
@@ -2,7 +2,7 @@ name: "Test: E2E Playwright RStudio (Desktop, macOS 26 ARM64, Open Source, PR-tr
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited]
     paths:
       - "src/**"
       - "e2e/rstudio/**"
@@ -36,7 +36,6 @@ jobs:
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          git fetch --no-tags --depth=1 origin "$BASE_REF"
           git diff --name-only "origin/$BASE_REF...HEAD" > changed.txt
           echo "Changed files:"
           cat changed.txt

--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
@@ -2,6 +2,9 @@ name: "Test: E2E Playwright RStudio (Desktop, macOS 26 ARM64, Open Source, PR-tr
 
 on:
   pull_request:
+    # `edited` is included so that toggling `[full-pw]` or `[skip-pw]` in
+    # the PR title (after the PR is open) re-fires the workflow. The
+    # concurrency block below cancels any older in-flight run.
     types: [opened, synchronize, reopened, edited]
     paths:
       - "src/**"
@@ -29,25 +32,37 @@ jobs:
           fetch-depth: 0
 
       - name: Install PyYAML
-        run: pip install --user pyyaml
+        run: python3 -m pip install --user 'pyyaml==6.0.2'
 
-      - name: List changed files
-        id: changed
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: |
-          git diff --name-only "origin/$BASE_REF...HEAD" > changed.txt
-          echo "Changed files:"
-          cat changed.txt
+      - name: Verify selector self-test
+        run: python3 .github/scripts/pw-pr-select.py --self-test
 
       - name: Compute selector
         id: compute
         env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          python3 .github/scripts/pw-pr-select.py \
-            --map .github/pw-test-map.yml \
-            --title "$PR_TITLE" < changed.txt
+          echo "Changed files:"
+          git diff --name-only "origin/$BASE_REF...HEAD" | tee /dev/stderr \
+            | python3 .github/scripts/pw-pr-select.py \
+                --map .github/pw-test-map.yml \
+                --title "$PR_TITLE"
+
+      - name: Write selection decision to step summary
+        if: always()
+        env:
+          SKIP:     ${{ steps.compute.outputs.skip }}
+          FULL:     ${{ steps.compute.outputs.full }}
+          SELECTOR: ${{ steps.compute.outputs.selector }}
+        run: |
+          {
+            echo "### Playwright selection"
+            echo ""
+            echo "- skip: \`${SKIP:-<unset>}\`"
+            echo "- full: \`${FULL:-<unset>}\`"
+            echo "- selector: \`${SELECTOR:-<empty>}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   run-macos-26:
     needs: select


### PR DESCRIPTION
## Summary

Phase 1 of PR-triggered Playwright: routing, selection, and orchestration.

- Adds `.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml`,
  triggered on `pull_request` against any base branch. A `select` job
  inspects the diff via `git diff --name-only` and computes the Playwright
  test selector; a `run-macos-26` job then `workflow_call`s the existing
  macOS 26 ARM64 workflow with that selector (R pinned to 4.5.3).
- Adds `.github/pw-test-map.yml`, a source-to-test mapping config. Each
  rule maps source-path globs (`*`, `**`) to Playwright test paths.
  Editable without touching the workflow.
- Adds `.github/scripts/pw-pr-select.py`, which reads the mapping and the
  list of changed files and emits `selector`, `skip`, and `full` outputs
  for the workflow. Writes only to stdout; the workflow tees stdout into
  `$GITHUB_OUTPUT` (avoids Snyk path-traversal false positives on env-var
  file paths).
- PR title tokens: `[full-pw]` forces the full suite; `[skip-pw]` skips
  the workflow entirely.
- When no rule matches and the PR is not docs-only, falls back to
  `tests/smoke/` as a minimum signal.
- Concurrency group cancels in-flight runs when a new commit is pushed
  to the same PR.

## What this validates

- Workflow plumbing (trigger, selector, workflow_call fan-out).
- Test-code changes (edits under `e2e/rstudio/`).

## What this does NOT yet validate

- The PR's own product-code changes (C++/GWT/Electron). The binary under
  test is the latest daily from `dailies.rstudio.com` -- built before the
  PR's changes exist. A PR that modifies `SessionRCompletions.cpp` will
  trigger the completions tests, but they run against yesterday's binary.
- Phase 2 (tracked separately) adds a `build_from_source` toggle on the
  callee so PR runs build the tree on the runner and test against that
  binary.

## Rule coverage (18 rules)

| Rule | Source paths | Tests |
|------|-------------|-------|
| completions | `SessionRCompletions*`, `SessionReticulate*`, GWT shell/assist, codetools | autocomplete, python_completions |
| posit-assistant | `SessionChat*`, posit_assistant/, GWT views/chat | posit-assistant-chat/ |
| console | `SessionConsole*`, GWT views/console | console/ |
| data-viewer | `SessionData*`, `SessionViewer*`, GWT views/data+viewer | data-viewer/ |
| debugger | `SessionBreakpoints*`, `SessionEnvironment*`, GWT views/environment | debugger/ |
| environment | `SessionEnvironment*`, GWT views/environment | s4_unloaded_package, rs_value_contents |
| editor | `SessionSource*`, GWT views/source, acesupport | editor/ |
| terminal | `SessionTerminal*`, GWT views/terminal | terminal/ |
| files | `SessionFiles*`, GWT views/files | files/ |
| packages | `SessionPackages*`, GWT views/packages | packages/ |
| build | modules/build/**, `SessionBuild*`, GWT views/buildtools | build_pane_testthat |
| projects | `SessionProjects*` | projects/ |
| help | `SessionHelp*`, GWT views/help | menus/help/ |
| layout | GWT workbench/ui | panes/layout/ |
| desktop-host | src/node/desktop/** | smoke/, panes/layout/ |
| core | src/cpp/r/R/**, SessionMain.cpp, core/, shared_core/ | smoke/ |
| session-lifecycle | SessionMain.cpp, RSession*, RSuspend*, RRestartContext* | session_restart, session_suspend |
| user-prefs-schema | user-prefs-schema.json | smoke/ |

Fallback (no rule matches, not docs-only): `tests/smoke/`