### PR TITLE
Install ARM64 cross-compiler in Windows build prereqs

### DIFF
--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -90,6 +90,7 @@ $installArgs = @(
     '--installPath', '"C:/Program Files/Microsoft Visual Studio/2022/BuildTools"',
     '--add', 'Microsoft.VisualStudio.Workload.VCTools',
     '--add', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+    '--add', 'Microsoft.VisualStudio.Component.VC.Tools.ARM64',
     '--add', 'Microsoft.VisualStudio.Component.Windows11SDK.26100'
 )
 $vsProcess = Start-Process -FilePath ".\vs_buildtools.exe" -ArgumentList $installArgs -Wait -NoNewWindow -PassThru

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -49,6 +49,7 @@ RUN `
     --installPath "C:/Program Files/Microsoft Visual Studio/2022/BuildTools" `
     --add Microsoft.VisualStudio.Workload.VCTools `
     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+    --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 `
     --add Microsoft.VisualStudio.Component.Windows11SDK.26100
 
 # Try testing the build tools. You might see some telemetry errors here;


### PR DESCRIPTION
## Intent

Addresses #11977 (first step).

Adds the `Microsoft.VisualStudio.Component.VC.Tools.ARM64` component to both Windows Visual Studio Build Tools install lists:

- `docker/jenkins/Dockerfile.windows` (the Jenkins Windows build image)
- `dependencies/windows/Install-RStudio-Prereqs.ps1` (developer bootstrap)

This installs the `Hostx64\arm64` and `Hostx86\arm64` MSVC cross toolchains alongside the existing x86/x64 ones. Nothing in the build is wired up to use them yet -- subsequent PRs will add an ARM64 rsession variant analogous to the existing 32-bit `SessionWin32` flow, so an x64 RStudio Desktop running on Windows-on-ARM can launch a native ARM64 R session.

## Adding the ARM64 tools to an existing dev box

Developers who already have VS 2022 Build Tools installed don't need to rerun the full `Install-RStudio-Prereqs.ps1`. From an **administrator PowerShell** prompt:

```powershell
& "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" modify `
    --installPath "C:\Program Files\Microsoft Visual Studio\2022\BuildTools" `
    --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 `
    --passive --norestart
```

(`--norestart` requires either `--passive` or `--quiet`; `--passive` keeps a progress UI visible.) After it finishes, `C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\<ver>\bin\Hostx64\arm64\cl.exe` should exist.

## Verification

The point of merging this now is to confirm the change rebuilds the Jenkins Windows Docker image cleanly before further ARM64 work lands on top of it.

## Test plan

- [ ] Jenkins Windows image builds successfully with the new component included
- [ ] Existing x64 / x86 Windows builds continue to succeed against the rebuilt image