### PR TITLE
e2e: pre-populate r library, fix nb.html test, console-to-bridge refactor

### DIFF
--- a/e2e/rstudio/README.md
+++ b/e2e/rstudio/README.md
@@ -279,6 +279,10 @@ PW_RSTUDIO_PREFS_OVERRIDE=/path/to/my-prefs.json npx playwright test ...
 
 ### Package Dependencies
 
+`globalSetup` pre-installs a baseline manifest of CRAN packages into the shared `R_LIBS_USER` cache (see *R package pre-population* under Environment Variables). For tests using a package that's already in `REQUIRED_PACKAGES`, no extra setup is required.
+
+For tests using a package outside the manifest, add it via `ensurePackages` in `beforeAll`. The helper installs into the same cache, so subsequent runs are no-ops:
+
 ```typescript
 test.describe('Tests needing packages', () => {
   let missingPackages: string[] = [];
@@ -291,6 +295,8 @@ test.describe('Tests needing packages', () => {
   });
 });
 ```
+
+If you find yourself adding the same package to many tests, promote it into `REQUIRED_PACKAGES` so it gets pre-installed once at setup time.
 
 ## Tags
 
@@ -394,8 +400,14 @@ Include sets the candidate pool; exclude trims it. When both apply, exclude wins
 | `PW_SANDBOX_SKIP_CLEANUP` | Both | No | Set to `true`/`1` to preserve the sandbox at end of run regardless of pass/fail. |
 | `PW_SANDBOX_SEED_POSITAI` | Both | No | Set to `true`/`1` to copy the real `~/.positai/` into the sandbox so Posit Assistant tests start signed in. Default unseeded (signed out). Privacy: tokens land inside the sandbox and persist on failed runs until you delete it -- only set this on machines using a dedicated test account. |
 | `PW_SANDBOX_SEED_COPILOT` | Both | No | Set to `true`/`1` to copy the real GitHub Copilot credentials into the sandbox (`%LOCALAPPDATA%\github-copilot\` on Windows, `~/.config/github-copilot/` on macOS/Linux) so Copilot tests start authenticated. Default unseeded (unauthenticated). Privacy: tokens land inside the sandbox and persist on failed runs until you delete it -- only set this on machines using a dedicated test account. |
+| `PW_RSTUDIO_R_LIBS_USER` | Both | No | Override the R user-library template path (passed to rsession as `R_LIBS_USER`). Defaults to `~/.cache/rstudio-playwright/r-libs/%p/%v` on macOS/Linux and `%LOCALAPPDATA%\rstudio-playwright\r-libs\%p\%v` on Windows. R expands `%p` (platform) and `%v` (R x.y) at startup. The library lives outside the per-run sandbox so packages persist between runs. |
+| `PW_RSTUDIO_R_LIBS_SKIP_PREP` | Both | No | Set to `true`/`1` to skip globalSetup's pre-population of the user library. Useful when running against an R install that already has everything, or to reproduce the empty-library popup behavior on purpose. |
 
 `PW_SANDBOX` itself is internal: it's set by `globalSetup` to the absolute path of the auto-created sandbox subtree and is read by workers, the R workdir helper, and `globalTeardown`. Don't set it manually.
+
+### R package pre-population
+
+Because the Desktop and Server fixtures redirect `HOME` / `USERPROFILE` into the per-run sandbox, R computes an empty default user library and won't see the host user's installed packages. `globalSetup` works around this by pointing `R_LIBS_USER` at a stable per-host cache (see `PW_RSTUDIO_R_LIBS_USER` above) and pre-installing a manifest of packages that tests use -- the list lives in `REQUIRED_PACKAGES` inside `fixtures/r-libs-setup.ts`. The check is idempotent (`installed.packages()` then `setdiff`), so a warm cache adds almost no startup time; the first run installs ~23 packages from CRAN (or PPM on Linux) and may take a few minutes.
 
 ## Variable Helpers
 

--- a/e2e/rstudio/actions/assistant_options.actions.ts
+++ b/e2e/rstudio/actions/assistant_options.actions.ts
@@ -3,6 +3,7 @@ import { expect } from '@playwright/test';
 import { AssistantOptions } from '../pages/assistant_options.page';
 import { ConsolePaneActions } from './console_pane.actions';
 import { sleep } from '../utils/constants';
+import { executeCommand } from '../utils/commands';
 
 export class AssistantOptionsActions {
   readonly page: Page;
@@ -35,7 +36,7 @@ export class AssistantOptionsActions {
   }
 
   async setupAssistantOptions(provider: string): Promise<void> {
-    await this.consolePaneActions.typeInConsole(".rs.api.executeCommand('showOptions')");
+    await executeCommand(this.page, 'showOptions');
     await this.page.waitForSelector('#rstudio_preferences_confirm', { timeout: 15000 });
 
     await expect(this.assistantOptions.assistantTab).toBeVisible({ timeout: 15000 });
@@ -74,7 +75,7 @@ export class AssistantOptionsActions {
   }
 
   async setChatProvider(provider: string): Promise<void> {
-    await this.consolePaneActions.typeInConsole(".rs.api.executeCommand('showOptions')");
+    await executeCommand(this.page, 'showOptions');
     await this.page.waitForSelector('#rstudio_preferences_confirm', { timeout: 15000 });
 
     await expect(this.assistantOptions.assistantTab).toBeVisible({ timeout: 15000 });
@@ -94,15 +95,15 @@ export class AssistantOptionsActions {
     }
 
     // Toggle sidebar twice to refresh a potentially stale chat pane
-    await this.consolePaneActions.typeInConsole(".rs.api.executeCommand('toggleSidebar')");
+    await executeCommand(this.page, 'toggleSidebar');
     await sleep(1000);
-    await this.consolePaneActions.typeInConsole(".rs.api.executeCommand('toggleSidebar')");
+    await executeCommand(this.page, 'toggleSidebar');
     await sleep(1000);
     await this.consolePaneActions.clearConsole();
   }
 
   async getChatProviderValue(): Promise<string> {
-    await this.consolePaneActions.typeInConsole(".rs.api.executeCommand('showOptions')");
+    await executeCommand(this.page, 'showOptions');
     await this.page.waitForSelector('#rstudio_preferences_confirm', { timeout: 15000 });
 
     await expect(this.assistantOptions.assistantTab).toBeVisible({ timeout: 15000 });

--- a/e2e/rstudio/actions/chat_pane.actions.ts
+++ b/e2e/rstudio/actions/chat_pane.actions.ts
@@ -3,6 +3,7 @@ import { expect } from '@playwright/test';
 import { ChatPane } from '../pages/chat_pane.page';
 import { ConsolePaneActions } from './console_pane.actions';
 import { sleep } from '../utils/constants';
+import { executeCommand } from '../utils/commands';
 
 /** Fields returned by the chatCheckForUpdates RPC. */
 export interface UpdateCheckResult {
@@ -87,7 +88,7 @@ export class ChatPaneActions {
   }
 
   async openChatPane(): Promise<void> {
-    await this.consolePaneActions.typeInConsole(".rs.api.executeCommand('activateChat')");
+    await executeCommand(this.page, 'activateChat');
     await sleep(2000);
   }
 

--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -2,7 +2,7 @@ import type { Page } from 'playwright';
 import * as fs from 'fs';
 import { ConsolePane, type EnvironmentVersions } from '../pages/console_pane.page';
 import { sleep } from '../utils/constants';
-import { documentCloseAllNoSave } from '../utils/commands';
+import { documentCloseAllNoSave, executeCommand } from '../utils/commands';
 
 interface InstallTarget {
   repos: string;
@@ -112,7 +112,7 @@ export class ConsolePaneActions {
   }
 
   async goToLine(line: number): Promise<void> {
-    await this.typeInConsole(`.rs.api.executeCommand('goToLine')`);
+    await executeCommand(this.page, 'goToLine');
     await sleep(500);
     await this.page.keyboard.type(String(line));
     await this.page.keyboard.press('Enter');

--- a/e2e/rstudio/actions/source_pane.actions.ts
+++ b/e2e/rstudio/actions/source_pane.actions.ts
@@ -5,6 +5,7 @@ import { ConsolePaneActions } from './console_pane.actions';
 import { clickConfirmIfVisible } from '../pages/modals.page';
 import { TIMEOUTS, sleep } from '../utils/constants';
 import { rStringLiteral } from '../utils/r';
+import { executeCommand } from '../utils/commands';
 
 export class SourcePaneActions {
   readonly page: Page;
@@ -37,9 +38,9 @@ export class SourcePaneActions {
   }
 
   async closeSourceAndDeleteFile(fileName: string): Promise<void> {
-    await this.consolePaneActions.typeInConsole(".rs.api.executeCommand('saveAllSourceDocs')");
+    await executeCommand(this.page, 'saveAllSourceDocs');
     await sleep(1000);
-    await this.consolePaneActions.typeInConsole(".rs.api.executeCommand('closeAllSourceDocs')");
+    await executeCommand(this.page, 'closeAllSourceDocs');
     await sleep(1000);
 
     await expect(this.sourcePane.aceTextInput).toHaveCount(0, { timeout: 5000 }).catch(() => {});
@@ -144,7 +145,7 @@ export class SourcePaneActions {
   async navigateToChunkByIndex(chunkNumber: number): Promise<void> {
     await this.goToTop();
     for (let i = 0; i < chunkNumber; i++) {
-      await this.consolePaneActions.typeInConsole(".rs.api.executeCommand('goToNextChunk')");
+      await executeCommand(this.page, 'goToNextChunk');
       await sleep(500);
     }
   }

--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -8,6 +8,8 @@ import * as path from 'path';
 import stripJsonComments from 'strip-json-comments';
 import { TIMEOUTS, RSTUDIO_EXTRA_ARGS, sleep } from '../utils/constants';
 import { CONSOLE_INPUT, typeInConsole } from '../pages/console_pane.page';
+import { documentCloseAllNoSave } from '../utils/commands';
+import { rLibsUserTemplate } from './r-libs-setup';
 
 const BASE_PREFS_PATH = path.join(__dirname, 'base-prefs.jsonc');
 const OVERRIDE_PREFS_ENV = 'PW_RSTUDIO_PREFS_OVERRIDE';
@@ -240,6 +242,11 @@ export async function launchRStudio(existingConfigRoot?: string): Promise<Deskto
     env: {
       ...process.env,
       HOME: sharedUserHome(),
+      // R expands %p / %v at startup; the resolved path is the same one
+      // globalSetup pre-creates and pre-populates in r-libs-setup.ts. Setting
+      // this explicitly is necessary because HOME is redirected -- without it,
+      // R derives an empty default library inside the per-run sandbox.
+      R_LIBS_USER: rLibsUserTemplate(),
       RSTUDIO_CONFIG_DIR: tempConfig.configDir,
       RSTUDIO_CONFIG_HOME: tempConfig.configHome,
       RSTUDIO_CONFIG_ROOT: tempConfig.root,
@@ -488,7 +495,7 @@ export async function shutdownRStudio(session: DesktopSession): Promise<void> {
   const { page, browser, rstudioProcess } = session;
 
   // Close all source files without prompting to save
-  await typeInConsole(page, '.rs.api.closeAllSourceBuffersWithoutSaving()');
+  await documentCloseAllNoSave(page);
   await sleep(1000);
 
   try {

--- a/e2e/rstudio/fixtures/r-libs-setup.ts
+++ b/e2e/rstudio/fixtures/r-libs-setup.ts
@@ -1,0 +1,206 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+
+/**
+ * Stable per-R-version package library used by every Playwright run, shared
+ * across runs so the same set of CRAN packages doesn't get reinstalled every
+ * time. We can't reuse the host user's library because the Desktop/Server
+ * fixtures redirect HOME / USERPROFILE into the per-run sandbox (see
+ * desktop.fixture.ts) -- under the redirected HOME R computes an empty
+ * default user library, which is what surfaces the "stringr needs to be
+ * updated" popup from rmarkdown's dependency check.
+ *
+ * The path contains R's R_LIBS_USER tokens (`%p` platform, `%v` R x.y) so a
+ * single string works across architectures and R versions without templating
+ * in TypeScript. R expands them at rsession startup; we expand them once here
+ * via Rscript for the pre-create / pre-install step.
+ *
+ * Env var: PW_RSTUDIO_R_LIBS_USER overrides the default template entirely.
+ */
+
+const RSTUDIO_R_LIBS_USER_ENV = 'PW_RSTUDIO_R_LIBS_USER';
+const RSTUDIO_R_LIBS_SKIP_PREP_ENV = 'PW_RSTUDIO_R_LIBS_SKIP_PREP';
+
+/**
+ * Packages every Playwright run should be able to find without paying the
+ * lazy-install tax inside an individual test. The list intentionally mirrors
+ * what the suite already references via `ensurePackages` -- pre-populating it
+ * once in globalSetup means tests start with the dependencies they expect.
+ *
+ * Adding a new package here is cheap; trim only when a package is genuinely
+ * unused by any test in the suite.
+ */
+export const REQUIRED_PACKAGES = [
+  'DBI',
+  'MASS',
+  'S7',
+  'bslib',
+  'data.table',
+  'devtools',
+  'dplyr',
+  'evaluate',
+  'ggplot2',
+  'knitr',
+  'nycflights13',
+  'pillar',
+  'praise',
+  'remotes',
+  'reticulate',
+  'rmarkdown',
+  'rstudioapi',
+  'shiny',
+  'shinytest2',
+  'stringr',
+  'styler',
+  'testthat',
+  'tibble',
+] as const;
+
+/**
+ * Build the default R_LIBS_USER template. Resolved *before* HOME is redirected,
+ * so it points at a stable per-host cache rather than into the per-run sandbox.
+ *
+ *   macOS / Linux:  ~/.cache/rstudio-playwright/r-libs/%p/%v
+ *   Windows:        %LOCALAPPDATA%\rstudio-playwright\r-libs\%p\%v
+ *                   (or ~/AppData/Local/... when LOCALAPPDATA is unset)
+ */
+function defaultRLibsUserTemplate(): string {
+  if (process.platform === 'win32') {
+    const base = process.env.LOCALAPPDATA
+      ?? path.join(os.homedir(), 'AppData', 'Local');
+    return path.join(base, 'rstudio-playwright', 'r-libs', '%p', '%v');
+  }
+  return path.join(os.homedir(), '.cache', 'rstudio-playwright', 'r-libs', '%p', '%v');
+}
+
+/**
+ * Resolve the R_LIBS_USER template -- either the explicit override from
+ * PW_RSTUDIO_R_LIBS_USER or the per-platform default. Returns the *unexpanded*
+ * template (still contains %p / %v / etc.) -- those tokens are interpreted by
+ * R itself at startup.
+ */
+export function rLibsUserTemplate(): string {
+  return process.env[RSTUDIO_R_LIBS_USER_ENV] ?? defaultRLibsUserTemplate();
+}
+
+interface RscriptResult {
+  stdout: string;
+  stderr: string;
+  status: number | null;
+}
+
+/**
+ * Run `Rscript -e <code>` and return the captured streams. We don't use a
+ * shell to avoid quoting hazards when the script contains R syntax. Caller
+ * decides what to do with a non-zero exit.
+ */
+function runRscript(code: string, env: NodeJS.ProcessEnv = process.env): RscriptResult {
+  const result = spawnSync('Rscript', ['--no-save', '--no-restore', '-e', code], {
+    env,
+    encoding: 'utf8',
+  });
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    status: result.status,
+  };
+}
+
+/**
+ * Expand the R_LIBS_USER template into a concrete filesystem path by asking R
+ * what `tools:::.expand_R_libs_env_var` returns for it. We must set the env
+ * var explicitly on the child so R sees our template even if the caller's
+ * environment defines something else.
+ */
+function expandRLibsUserTemplate(template: string): string | null {
+  const env = { ...process.env, R_LIBS_USER: template };
+  const code = [
+    'tryCatch({',
+    '  cat(tools:::.expand_R_libs_env_var(Sys.getenv("R_LIBS_USER")))',
+    '}, error = function(e) {',
+    '  t <- Sys.getenv("R_LIBS_USER")',
+    '  t <- gsub("%V", paste0(R.version$major, ".", R.version$minor), t, fixed = TRUE)',
+    '  t <- gsub("%v", paste0(R.version$major, ".", strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1]), t, fixed = TRUE)',
+    '  t <- gsub("%p", R.version$platform, t, fixed = TRUE)',
+    '  t <- gsub("%o", R.version$os, t, fixed = TRUE)',
+    '  t <- gsub("%a", R.version$arch, t, fixed = TRUE)',
+    '  cat(t)',
+    '})',
+  ].join('\n');
+
+  const res = runRscript(code, env);
+  if (res.status !== 0) return null;
+  const expanded = res.stdout.trim();
+  return expanded.length > 0 ? expanded : null;
+}
+
+/**
+ * Pre-create the R user library and install any packages from
+ * REQUIRED_PACKAGES that are missing. Idempotent: a warm cache results in a
+ * fast `installed.packages()` check and no install call.
+ *
+ * Skipped entirely when PW_RSTUDIO_R_LIBS_SKIP_PREP is "1" / "true" -- useful
+ * for runs against an external R install that already has everything, or to
+ * debug the redirected-empty-lib behavior on purpose.
+ */
+export async function prepareRLibs(): Promise<void> {
+  const skip = ['1', 'true'].includes(
+    (process.env[RSTUDIO_R_LIBS_SKIP_PREP_ENV] ?? '').toLowerCase(),
+  );
+  if (skip) {
+    console.log(`[r-libs] skipping prep (${RSTUDIO_R_LIBS_SKIP_PREP_ENV} set)`);
+    return;
+  }
+
+  const template = rLibsUserTemplate();
+  const expanded = expandRLibsUserTemplate(template);
+  if (!expanded) {
+    console.warn(
+      `[r-libs] could not expand R_LIBS_USER template "${template}" via Rscript; skipping pre-population. Is Rscript on PATH?`,
+    );
+    return;
+  }
+
+  fs.mkdirSync(expanded, { recursive: true });
+  console.log(`[r-libs] user library: ${expanded}`);
+
+  const repos = process.platform === 'linux'
+    ? 'https://packagemanager.posit.co/cran/__linux__/jammy/latest'
+    : 'https://cran.r-project.org';
+  const installType = process.platform === 'linux' ? 'source' : 'binary';
+
+  // Single Rscript invocation: check installed.packages() in the resolved
+  // library, then install any missing entries from the manifest in one batch.
+  // Faster than the per-package check loop ensurePackages uses, and we don't
+  // need its progress markers because there's no console UI here.
+  const pkgsLiteral = REQUIRED_PACKAGES.map((p) => `"${p}"`).join(', ');
+  const installCode = [
+    `lib <- ${JSON.stringify(expanded)}`,
+    '.libPaths(c(lib, .libPaths()))',
+    `required <- c(${pkgsLiteral})`,
+    'have <- rownames(installed.packages(lib.loc = lib))',
+    'missing <- setdiff(required, have)',
+    'if (length(missing) == 0L) {',
+    '  cat("[r-libs] all packages present\\n")',
+    '} else {',
+    '  cat("[r-libs] installing:", paste(missing, collapse = ", "), "\\n")',
+    `  install.packages(missing, lib = lib, repos = ${JSON.stringify(repos)}, type = ${JSON.stringify(installType)})`,
+    '  still <- setdiff(missing, rownames(installed.packages(lib.loc = lib)))',
+    '  if (length(still) > 0L) {',
+    '    cat("[r-libs] WARNING: failed to install:", paste(still, collapse = ", "), "\\n")',
+    '  }',
+    '}',
+  ].join('\n');
+
+  const env = { ...process.env, R_LIBS_USER: template };
+  const res = runRscript(installCode, env);
+  if (res.stdout) process.stdout.write(res.stdout);
+  if (res.stderr) process.stderr.write(res.stderr);
+  if (res.status !== 0) {
+    console.warn(
+      `[r-libs] Rscript exited ${res.status}; some packages may be missing. Tests that need them will fall back to per-test ensurePackages().`,
+    );
+  }
+}

--- a/e2e/rstudio/fixtures/sandbox-setup.ts
+++ b/e2e/rstudio/fixtures/sandbox-setup.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { prepareRLibs } from './r-libs-setup';
 
 /**
  * Create a per-invocation sandbox directory and export its path as PW_SANDBOX.
@@ -143,4 +144,12 @@ export default async function globalSetup() {
 
   process.env.PW_SANDBOX = sandbox;
   console.log(`[sandbox] root: ${sandbox}`);
+
+  // Stable per-host R library, lives outside PW_SANDBOX so it survives across
+  // runs. Without this the redirected HOME (set by Desktop/Server fixtures)
+  // points R at an empty default user library, and the first thing rmarkdown
+  // does on save is open a "stringr needs updating" dialog that hangs the
+  // test. Pre-populating here is idempotent -- a warm cache is a fast
+  // installed.packages() check with no install call.
+  await prepareRLibs();
 }

--- a/e2e/rstudio/fixtures/server.fixture.ts
+++ b/e2e/rstudio/fixtures/server.fixture.ts
@@ -8,6 +8,8 @@ import * as os from 'os';
 import * as path from 'path';
 import { CONSOLE_INPUT, typeInConsole } from '../pages/console_pane.page';
 import { sleep } from '../utils/constants';
+import { setPref, documentCloseAllNoSave } from '../utils/commands';
+import { rLibsUserTemplate } from './r-libs-setup';
 
 // PW_SANDBOX is exported by the globalSetup hook in fixtures/sandbox-setup.ts
 // before any worker spawns. Resolve lazily so importing this module (for
@@ -102,6 +104,10 @@ async function spawnSandboxedRserver(): Promise<SpawnedServer | null> {
     ...process.env,
     HOME: userHome,
     USERPROFILE: userHome,
+    // Mirror the Desktop fixture -- under the redirected HOME, R would
+    // otherwise compute an empty default user library. globalSetup
+    // pre-creates and pre-populates this same path.
+    R_LIBS_USER: rLibsUserTemplate(),
     RS_DB_MIGRATIONS_PATH: process.env.RS_DB_MIGRATIONS_PATH || DEFAULT_DB_MIGRATIONS,
     RSTUDIO_PROJECT_ROOT: process.env.RSTUDIO_PROJECT_ROOT || REPO_ROOT,
     RSTUDIO_CONFIG_HOME: configHome,
@@ -253,7 +259,7 @@ export async function launchServer(): Promise<ServerSession> {
   await page.waitForSelector('#rstudio_mb_files_touch_file', { state: 'visible', timeout: 120_000 });
   console.log('Files pane toolbar is ready');
 
-  await typeInConsole(page, '.rs.api.writeRStudioPreference("save_workspace", "never")');
+  await setPref(page, 'save_workspace', 'never');
   await sleep(1000);
 
   await page.locator(CONSOLE_INPUT).click({ force: true });
@@ -273,7 +279,7 @@ export async function shutdownServer(session: ServerSession): Promise<void> {
   const { page, browser, rserverProcess } = session;
 
   try {
-    await typeInConsole(page, '.rs.api.closeAllSourceBuffersWithoutSaving()');
+    await documentCloseAllNoSave(page);
     await sleep(1000);
     await typeInConsole(page, 'q("no")');
     await sleep(2000);

--- a/e2e/rstudio/package-lock.json
+++ b/e2e/rstudio/package-lock.json
@@ -14,7 +14,9 @@
         "strip-json-comments": "^3.1.1"
       },
       "devDependencies": {
-        "cross-env": "^10.1.0"
+        "@types/node": "^25.9.1",
+        "cross-env": "^10.1.0",
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@epic-web/invariant": {
@@ -37,6 +39,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/cross-env": {
@@ -179,6 +191,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/e2e/rstudio/package.json
+++ b/e2e/rstudio/package.json
@@ -5,7 +5,10 @@
   "scripts": {
     "test": "npx playwright test",
     "test:autocomplete": "npx playwright test autocomplete",
-    "test:report": "npx playwright show-report"
+    "test:dev": "cross-env PW_RSTUDIO_DEV=1 npx playwright test",
+    "test:server": "npx playwright test --project=server",
+    "test:report": "npx playwright show-report",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@playwright/test": "1.59.1",
@@ -14,6 +17,8 @@
     "strip-json-comments": "^3.1.1"
   },
   "devDependencies": {
-    "cross-env": "^10.1.0"
+    "@types/node": "^25.9.1",
+    "cross-env": "^10.1.0",
+    "typescript": "^6.0.3"
   }
 }

--- a/e2e/rstudio/pages/console_pane.page.ts
+++ b/e2e/rstudio/pages/console_pane.page.ts
@@ -1,6 +1,7 @@
 import type { Page, Locator } from 'playwright';
 import { PageObject } from './page_object_base_classes';
 import { sleep } from '../utils/constants';
+import { documentCloseAllNoSave, executeCommand } from '../utils/commands';
 
 // ---------------------------------------------------------------------------
 // Class-based page object
@@ -90,7 +91,7 @@ export async function clearConsole(page: Page): Promise<void> {
 }
 
 export async function closeAllBuffersWithoutSaving(page: Page): Promise<void> {
-  await typeInConsole(page, '.rs.api.closeAllSourceBuffersWithoutSaving()');
+  await documentCloseAllNoSave(page);
   await sleep(1000);
 }
 
@@ -109,7 +110,7 @@ export async function getEnvironmentVersions(page: Page): Promise<EnvironmentVer
 }
 
 export async function goToLine(page: Page, line: number): Promise<void> {
-  await typeInConsole(page, `.rs.api.executeCommand('goToLine')`);
+  await executeCommand(page, 'goToLine');
   await sleep(500);
   await page.keyboard.type(String(line));
   await page.keyboard.press('Enter');

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -3,6 +3,8 @@ import dotenv from 'dotenv';
 import os from 'os';
 import path from 'path';
 
+type ProjectOptions = { mode: 'desktop' | 'server' };
+
 // Load env vars from a dotenv file before any process.env reads below.
 // Path is anchored to this config's directory so it works regardless of cwd.
 // PW_ENV_FILE overrides the default path; existing process.env values win
@@ -77,7 +79,7 @@ const testIgnore = (process.env.PW_TEST_IGNORE ?? '')
   .split(/\s+/)
   .filter(Boolean);
 
-export default defineConfig({
+export default defineConfig<{}, ProjectOptions>({
   testDir: './tests',
   testIgnore: testIgnore.length > 0 ? testIgnore : undefined,
   fullyParallel: false,

--- a/e2e/rstudio/tests/menus/help/release-notes.test.ts
+++ b/e2e/rstudio/tests/menus/help/release-notes.test.ts
@@ -12,6 +12,7 @@ import { expect } from '@playwright/test';
 import { test } from '@fixtures/rstudio.fixture';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { sleep } from '@utils/constants';
+import { executeCommand } from '@utils/commands';
 
 const BASE_URL = 'https://www.rstudio.org/links/release_notes';
 
@@ -27,7 +28,7 @@ test.describe('Help > Release Notes - #17330', { tag: ['@parallel_safe'] }, () =
     // Desktop opens the URL via shell.openExternal() — Playwright cannot
     // intercept it, so we just verify the command doesn't throw.
     await consoleActions.clearConsole();
-    await consoleActions.typeInConsole(".rs.api.executeCommand('showReleaseNotes')");
+    await executeCommand(page, 'showReleaseNotes');
     await sleep(2000);
 
     const output = await page.locator('#rstudio_console_output').innerText();
@@ -38,7 +39,7 @@ test.describe('Help > Release Notes - #17330', { tag: ['@parallel_safe'] }, () =
     const context = page.context();
     const newPagePromise = context.waitForEvent('page', { timeout: 15000 });
 
-    await consoleActions.typeInConsole(".rs.api.executeCommand('showReleaseNotes')");
+    await executeCommand(page, 'showReleaseNotes');
 
     const newPage = await newPagePromise;
     const initialUrl = newPage.url();

--- a/e2e/rstudio/tests/panes/console/execute_from_editor.test.ts
+++ b/e2e/rstudio/tests/panes/console/execute_from_editor.test.ts
@@ -3,6 +3,7 @@ import { sleep } from '@utils/constants';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePaneActions } from '@actions/source_pane.actions';
 import { useSuiteSandbox } from '@utils/sandbox';
+import { documentCloseAllNoSave } from '@utils/commands';
 
 test.describe('Run Line button', () => {
   const sandbox = useSuiteSandbox();
@@ -16,7 +17,7 @@ test.describe('Run Line button', () => {
 
   test('submits queued lines to the console in document order', async ({ rstudioPage: page }) => {
     await consoleActions.clearConsole();
-    await consoleActions.typeInConsole('.rs.api.closeAllSourceBuffersWithoutSaving()');
+    await documentCloseAllNoSave(page);
 
     const sandboxR = sandbox.dir.replace(/\\/g, '/');
     const filePath = `${sandboxR}/submit_order_${Date.now()}.R`;
@@ -37,6 +38,6 @@ test.describe('Run Line button', () => {
       timeout: 15000,
     });
 
-    await consoleActions.typeInConsole('.rs.api.closeAllSourceBuffersWithoutSaving()');
+    await documentCloseAllNoSave(page);
   });
 });

--- a/e2e/rstudio/tests/panes/data-viewer/pagination-sorting.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/pagination-sorting.test.ts
@@ -3,6 +3,7 @@ import { sleep } from '@utils/constants';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePane } from '@pages/source_pane.page';
 import { DataViewerPane } from '@pages/data_viewer.page';
+import { executeCommand } from '@utils/commands';
 
 // Tests from: electron-tests/EditorPane/test_desktop_DataViewer.py
 // Issues: https://github.com/rstudio/rstudio/issues/13220
@@ -22,7 +23,7 @@ test.describe('Data Viewer', () => {
 
   test.afterEach(async ({ rstudioPage: page }) => {
     // Close the data viewer tab after each test
-    await consoleActions.typeInConsole(".rs.api.executeCommand('closeSourceDoc')");
+    await executeCommand(page, 'closeSourceDoc');
     await sleep(1000);
   });
 

--- a/e2e/rstudio/tests/panes/debugger/debugger.test.ts
+++ b/e2e/rstudio/tests/panes/debugger/debugger.test.ts
@@ -4,6 +4,7 @@ import { DebuggerActions } from '@actions/debugger.actions';
 import { EnvironmentPane } from '@pages/environment_pane.page';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { TIMEOUTS, sleep } from '@utils/constants';
+import { executeCommand } from '@utils/commands';
 
 const sandbox = useSuiteSandbox();
 
@@ -87,7 +88,7 @@ test.describe('R debugger', () => {
 
       await debuggerActions.setBreakpoint(2);
 
-      await consoleActions.typeInConsole('.rs.api.executeCommand("sourceActiveDocument")');
+      await executeCommand(consoleActions.page, 'sourceActiveDocument');
 
       await debuggerActions.waitForDebugMode();
       await expect.poll(
@@ -113,7 +114,7 @@ test.describe('R debugger', () => {
       // Source first so the function is in scope — that way the gutter
       // click produces an ACTIVE (.ace_breakpoint) marker rather than a
       // pending / inactive one that wouldn't satisfy our locator.
-      await consoleActions.typeInConsole('.rs.api.executeCommand("sourceActiveDocument")');
+      await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
 
       // Set breakpoint on the brace-expression line (line 3).
@@ -147,7 +148,7 @@ test.describe('R debugger', () => {
 
       await writeAndOpen(fileName, content);
       // Source so the toggled breakpoint becomes ACTIVE rather than INACTIVE.
-      await consoleActions.typeInConsole('.rs.api.executeCommand("sourceActiveDocument")');
+      await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
 
       // Place the cursor on line 2 via the goToLine command.
@@ -196,7 +197,7 @@ test.describe('R debugger', () => {
       ].join('\n');
 
       await writeAndOpen(fileName, content);
-      await consoleActions.typeInConsole('.rs.api.executeCommand("sourceActiveDocument")');
+      await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
       await debuggerActions.setBreakpoint(2);
       await consoleActions.typeInConsole('step_next_fn()');
@@ -224,7 +225,7 @@ test.describe('R debugger', () => {
       ].join('\n');
 
       await writeAndOpen(fileName, content);
-      await consoleActions.typeInConsole('.rs.api.executeCommand("sourceActiveDocument")');
+      await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
       // Breakpoint on the line that calls inner() (line 5).
       await debuggerActions.setBreakpoint(5);
@@ -267,7 +268,7 @@ test.describe('R debugger', () => {
       ].join('\n');
 
       await writeAndOpen(fileName, content);
-      await consoleActions.typeInConsole('.rs.api.executeCommand("sourceActiveDocument")');
+      await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
       await debuggerActions.setBreakpoint(2);
       await consoleActions.typeInConsole('step_finish_fn()');
@@ -294,7 +295,7 @@ test.describe('R debugger', () => {
       ].join('\n');
 
       await writeAndOpen(fileName, content);
-      await consoleActions.typeInConsole('.rs.api.executeCommand("sourceActiveDocument")');
+      await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
       await debuggerActions.setBreakpoint(2);
       await debuggerActions.setBreakpoint(5);
@@ -323,7 +324,7 @@ test.describe('R debugger', () => {
       ].join('\n');
 
       await writeAndOpen(fileName, content);
-      await consoleActions.typeInConsole('.rs.api.executeCommand("sourceActiveDocument")');
+      await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
       await debuggerActions.setBreakpoint(2);
       await consoleActions.typeInConsole('step_stop_fn()');
@@ -349,7 +350,7 @@ test.describe('R debugger', () => {
       ].join('\n');
 
       await writeAndOpen(fileName, content);
-      await consoleActions.typeInConsole('.rs.api.executeCommand("sourceActiveDocument")');
+      await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
       for (const line of [2, 3, 4, 5, 6, 7]) {
         await debuggerActions.setBreakpoint(line);
@@ -408,7 +409,7 @@ test.describe('R debugger', () => {
       ].join('\n');
 
       await writeAndOpen(fileName, content);
-      await consoleActions.typeInConsole('.rs.api.executeCommand("sourceActiveDocument")');
+      await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
       await consoleActions.typeInConsole('browser_entry_fn()');
 
@@ -432,7 +433,7 @@ test.describe('R debugger', () => {
       ].join('\n');
 
       await writeAndOpen(fileName, content);
-      await consoleActions.typeInConsole('.rs.api.executeCommand("sourceActiveDocument")');
+      await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
       await consoleActions.typeInConsole('browser_continue_fn()');
 
@@ -459,7 +460,7 @@ test.describe('R debugger', () => {
       ].join('\n');
 
       await writeAndOpen(fileName, content);
-      await consoleActions.typeInConsole('.rs.api.executeCommand("sourceActiveDocument")');
+      await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
       await consoleActions.typeInConsole('rerun_fn()');
 
@@ -497,7 +498,7 @@ test.describe('R debugger', () => {
       ].join('\n');
 
       await writeAndOpen(fileName, content);
-      await consoleActions.typeInConsole('.rs.api.executeCommand("sourceActiveDocument")');
+      await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
       await consoleActions.typeInConsole('env_locals_fn()');
 
@@ -519,7 +520,7 @@ test.describe('R debugger', () => {
       ].join('\n');
 
       await writeAndOpen(fileName, content);
-      await consoleActions.typeInConsole('.rs.api.executeCommand("sourceActiveDocument")');
+      await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
       await consoleActions.typeInConsole('tb_f()');
 
@@ -556,7 +557,7 @@ test.describe('R debugger', () => {
       ].join('\n');
 
       await writeAndOpen(fileName, content);
-      await consoleActions.typeInConsole('.rs.api.executeCommand("sourceActiveDocument")');
+      await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
       await consoleActions.typeInConsole('fr_f()');
 

--- a/e2e/rstudio/tests/panes/debugger/debugger_extras.test.ts
+++ b/e2e/rstudio/tests/panes/debugger/debugger_extras.test.ts
@@ -18,6 +18,7 @@ import { DebuggerActions } from '@actions/debugger.actions';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { writeAndOpenFile } from '@utils/files';
 import { TIMEOUTS, sleep } from '@utils/constants';
+import { executeCommand } from '@utils/commands';
 
 const sandbox = useSuiteSandbox();
 
@@ -102,7 +103,7 @@ test.describe('R debugger extras', () => {
       ].join('\n');
       await writeAndOpenFile(page, sandbox.dir, fileName, content);
 
-      await consoleActions.typeInConsole('.rs.api.executeCommand("sourceActiveDocument")');
+      await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
 
       await consoleActions.typeInConsole('multiline_fn()');
@@ -199,7 +200,7 @@ test.describe('R debugger extras', () => {
       ).toBe(3);
 
       // Invoke Clear All Breakpoints and confirm the Yes/No dialog.
-      await consoleActions.typeInConsole(".rs.api.executeCommand('debugClearBreakpoints')");
+      await executeCommand(consoleActions.page, 'debugClearBreakpoints');
       const yesBtn = page.locator('#rstudio_dlg_yes');
       await expect(yesBtn).toBeVisible({ timeout: TIMEOUTS.fileOpen });
       await yesBtn.click();
@@ -240,7 +241,7 @@ test.describe('R debugger extras', () => {
 
       // Breakpoint on the body of the S7 method (line 3 = the print() call).
       await debuggerActions.setBreakpoint(3);
-      await consoleActions.typeInConsole('.rs.api.executeCommand("sourceActiveDocument")');
+      await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
 
       // Dispatch through the S3 generic into the S7 method.

--- a/e2e/rstudio/tests/panes/editor/air_formatting.test.ts
+++ b/e2e/rstudio/tests/panes/editor/air_formatting.test.ts
@@ -34,6 +34,7 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePaneActions } from '@actions/source_pane.actions';
 import { sleep } from '@utils/constants';
 import { useSuiteSandbox } from '@utils/sandbox';
+import { executeCommand } from '@utils/commands';
 
 // --- Test data (from issue #16721) ---
 
@@ -58,8 +59,8 @@ const OPTIONS_OK = '#rstudio_preferences_confirm';
 // --- Helpers ---
 
 /** Open Global Options and navigate to Code > Formatting. */
-async function openCodeOptions(page: Page, consoleActions: ConsolePaneActions): Promise<void> {
-  await consoleActions.typeInConsole(".rs.api.executeCommand('showOptions')");
+async function openCodeOptions(page: Page): Promise<void> {
+  await executeCommand(page, 'showOptions');
   await page.waitForSelector(OPTIONS_OK, { timeout: 15000 });
   await sleep(500);
 
@@ -97,11 +98,10 @@ async function closeOptions(page: Page): Promise<void> {
  */
 async function setAirPrefs(
   page: Page,
-  consoleActions: ConsolePaneActions,
   useAir: boolean,
   reformatOnSave: boolean
 ): Promise<void> {
-  await openCodeOptions(page, consoleActions);
+  await openCodeOptions(page);
 
   // "Use Air" must be set first — "Reformat on save" is only visible when Air is checked
   await setCheckbox(page, AIR_CHECKBOX_LABEL, useAir);
@@ -240,7 +240,7 @@ test.describe('Air Formatting (#16721)', { tag: ['@parallel_safe'] }, () => {
   });
 
   test('2: unchecked, air.toml present, manual reformat uses built-in formatter', async () => {
-    await setAirPrefs(page, consoleActions, false, false);
+    await setAirPrefs(page, false, false);
     await createAirConfig(consoleActions);
     await openTestFile(consoleActions, sourceActions);
     await reformatCode(page, sourceActions);
@@ -249,7 +249,7 @@ test.describe('Air Formatting (#16721)', { tag: ['@parallel_safe'] }, () => {
   });
 
   test('3: unchecked, air.toml present, reformat on save leaves code unchanged', async () => {
-    await setAirPrefs(page, consoleActions, false, false);
+    await setAirPrefs(page, false, false);
     await createAirConfig(consoleActions);
     await openTestFile(consoleActions, sourceActions);
     await saveFile(page, sourceActions);
@@ -258,7 +258,7 @@ test.describe('Air Formatting (#16721)', { tag: ['@parallel_safe'] }, () => {
   });
 
   test('4: checked, air.toml present, manual reformat uses Air', async () => {
-    await setAirPrefs(page, consoleActions, true, false);
+    await setAirPrefs(page, true, false);
     await createAirConfig(consoleActions);
     await openTestFile(consoleActions, sourceActions);
     await reformatCode(page, sourceActions);
@@ -267,7 +267,7 @@ test.describe('Air Formatting (#16721)', { tag: ['@parallel_safe'] }, () => {
   });
 
   test('5: checked, air.toml present, save uses Air', async () => {
-    await setAirPrefs(page, consoleActions, true, true);
+    await setAirPrefs(page, true, true);
     await createAirConfig(consoleActions);
     await openTestFile(consoleActions, sourceActions);
     await saveFile(page, sourceActions);
@@ -276,7 +276,7 @@ test.describe('Air Formatting (#16721)', { tag: ['@parallel_safe'] }, () => {
   });
 
   test('6: checked, no config, manual reformat uses built-in formatter', async () => {
-    await setAirPrefs(page, consoleActions, true, false);
+    await setAirPrefs(page, true, false);
     await removeAirConfig(consoleActions);
     await openTestFile(consoleActions, sourceActions);
     await reformatCode(page, sourceActions);
@@ -287,7 +287,7 @@ test.describe('Air Formatting (#16721)', { tag: ['@parallel_safe'] }, () => {
   // --- .air.toml (hidden variant) tests ---
 
   test('7: unchecked, .air.toml present, manual reformat uses built-in formatter', async () => {
-    await setAirPrefs(page, consoleActions, false, false);
+    await setAirPrefs(page, false, false);
     await createAirConfig(consoleActions, DOT_AIR_TOML_FILE);
     await openTestFile(consoleActions, sourceActions);
     await reformatCode(page, sourceActions);
@@ -296,7 +296,7 @@ test.describe('Air Formatting (#16721)', { tag: ['@parallel_safe'] }, () => {
   });
 
   test('8: unchecked, .air.toml present, reformat on save leaves code unchanged', async () => {
-    await setAirPrefs(page, consoleActions, false, false);
+    await setAirPrefs(page, false, false);
     await createAirConfig(consoleActions, DOT_AIR_TOML_FILE);
     await openTestFile(consoleActions, sourceActions);
     await saveFile(page, sourceActions);

--- a/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
@@ -5,6 +5,7 @@ import { AssistantOptionsActions } from '@actions/assistant_options.actions';
 import { SourcePaneActions } from '@actions/source_pane.actions';
 import { SourcePane } from '@pages/source_pane.page';
 import { useSuiteSandbox } from '@utils/sandbox';
+import { documentCloseAllNoSave } from '@utils/commands';
 
 for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
   test.describe(provider, { tag: ['@ai'] }, () => {
@@ -28,7 +29,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
       // a save here would race a now-gone sandbox path from an earlier aborted
       // run and surface an ENOENT "Save File" dialog whose popup-glass blocks
       // every subsequent click.
-      await consoleActions.typeInConsole('.rs.api.closeAllSourceBuffersWithoutSaving()');
+      await documentCloseAllNoSave(page);
       await sleep(1000);
 
       // Delete all possible test files in a single R command
@@ -524,7 +525,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
 
       // Close File A without saving -- the file is in the per-suite sandbox
       // and a save here would race that sandbox's later teardown.
-      await consoleActions.typeInConsole('.rs.api.closeAllSourceBuffersWithoutSaving()');
+      await documentCloseAllNoSave(page);
       await sleep(2000);
 
       // --- File B: same original code, no edits ---
@@ -651,7 +652,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
       // Don't save -- the sandbox is about to be unlinked by useSuiteSandbox's
       // afterAll, so saving races the directory removal and surfaces an
       // "Error Saving File" dialog whose popup-glass blocks the shutdown.
-      await consoleActions.typeInConsole('.rs.api.closeAllSourceBuffersWithoutSaving()');
+      await documentCloseAllNoSave(page);
       await sleep(1000);
 
       const testFiles = [

--- a/e2e/rstudio/tests/panes/editor/multiline_chunk_execution.test.ts
+++ b/e2e/rstudio/tests/panes/editor/multiline_chunk_execution.test.ts
@@ -8,6 +8,7 @@ import { sleep } from '@utils/constants';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePaneActions } from '@actions/source_pane.actions';
 import { useSuiteSandbox } from '@utils/sandbox';
+import { executeCommand } from '@utils/commands';
 
 test.describe('Multiline chunk execution', { tag: ['@parallel_safe'] }, () => {
   // Sets cwd to a per-spec sandbox; relative paths used by createAndOpenFile
@@ -47,13 +48,13 @@ test.describe('Multiline chunk execution', { tag: ['@parallel_safe'] }, () => {
     await expect(sourceActions.sourcePane.selectedTab).toContainText(fileName, { timeout: 20000 });
 
     // Save so it's on disk
-    await consoleActions.typeInConsole(".rs.api.executeCommand('saveSourceDoc')");
+    await executeCommand(page, 'saveSourceDoc');
     await sleep(1000);
 
     // --- Chunk 1: incomplete expression (1 +\n2) ---
     await consoleActions.clearConsole();
     await sourceActions.navigateToChunkByLabel('incomplete_expr');
-    await consoleActions.typeInConsole(".rs.api.executeCommand('executeCurrentChunk')");
+    await executeCommand(page, 'executeCurrentChunk');
 
     // If the bug is present, the chunk hangs and the interrupt button stays visible
     await expect(page.locator("[id^='rstudio_tb_interruptr']")).not.toBeVisible({ timeout: 10000 });
@@ -64,7 +65,7 @@ test.describe('Multiline chunk execution', { tag: ['@parallel_safe'] }, () => {
     // --- Chunk 2: open paren (sum(22,\n23)) ---
     await consoleActions.clearConsole();
     await sourceActions.navigateToChunkByLabel('open_paren');
-    await consoleActions.typeInConsole(".rs.api.executeCommand('executeCurrentChunk')");
+    await executeCommand(page, 'executeCurrentChunk');
 
     await expect(page.locator("[id^='rstudio_tb_interruptr']")).not.toBeVisible({ timeout: 10000 });
     await sleep(1000);

--- a/e2e/rstudio/tests/panes/editor/notebook_save_during_execution.test.ts
+++ b/e2e/rstudio/tests/panes/editor/notebook_save_during_execution.test.ts
@@ -8,6 +8,7 @@ import { sleep } from '@utils/constants';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePaneActions } from '@actions/source_pane.actions';
 import { useSuiteSandbox } from '@utils/sandbox';
+import { executeCommand } from '@utils/commands';
 
 test.describe('Notebook save during execution', { tag: ['@parallel_safe'] }, () => {
   // Sets cwd to a per-spec sandbox; relative paths used by createAndOpenFile
@@ -58,7 +59,7 @@ test.describe('Notebook save during execution', { tag: ['@parallel_safe'] }, () 
     await expect(sourceActions.sourcePane.selectedTab).toContainText(fileName, { timeout: 20000 });
 
     // Save the file first so it's on disk
-    await consoleActions.typeInConsole(".rs.api.executeCommand('saveSourceDoc')");
+    await executeCommand(page, 'saveSourceDoc');
     await sleep(1000);
 
     // Make an edit so the file has unsaved changes — Ctrl+S during execution
@@ -73,7 +74,7 @@ test.describe('Notebook save during execution', { tag: ['@parallel_safe'] }, () 
 
     // Navigate to chunk 1 and execute it
     await sourceActions.navigateToChunkByLabel('slow_plot');
-    await consoleActions.typeInConsole(".rs.api.executeCommand('executeCurrentChunk')");
+    await executeCommand(page, 'executeCurrentChunk');
 
     // While the slow plot is rendering, save the document
     // This is the trigger for the bug — saving during execution corrupts the notebook cache
@@ -93,7 +94,7 @@ test.describe('Notebook save during execution', { tag: ['@parallel_safe'] }, () 
     // Execute chunk 2 to verify chunks are still runnable
     await consoleActions.clearConsole();
     await sourceActions.navigateToChunkByLabel('verify_runnable');
-    await consoleActions.typeInConsole(".rs.api.executeCommand('executeCurrentChunk')");
+    await executeCommand(page, 'executeCurrentChunk');
     await sleep(5000);
 
     // Verify chunk 2 output appeared — proves chunks still work after save-during-execution

--- a/e2e/rstudio/tests/panes/editor/rename_in_scope_rmd.test.ts
+++ b/e2e/rstudio/tests/panes/editor/rename_in_scope_rmd.test.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { sleep, TIMEOUTS } from '@utils/constants';
-import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { AceEditor } from '@pages/ace_editor.page';
 import { writeAndOpenFile, closeAndDeleteSandboxFiles } from '@utils/files';
 import { useSuiteSandbox } from '@utils/sandbox';
+import { executeCommand } from '@utils/commands';
 
 const RMD_CONTENT = `---
 title: Refactoring
@@ -32,11 +32,6 @@ example <- function(variable) {
 test.describe('Rename in scope across Rmd chunks', () => {
   const sandbox = useSuiteSandbox();
   const FILE = 'rename_in_scope.Rmd';
-  let consoleActions: ConsolePaneActions;
-
-  test.beforeAll(async ({ rstudioPage: page }) => {
-    consoleActions = new ConsolePaneActions(page);
-  });
 
   test.afterAll(async ({ rstudioPage: page }) => {
     await closeAndDeleteSandboxFiles(page, sandbox.dir, [FILE]);
@@ -53,7 +48,7 @@ test.describe('Rename in scope across Rmd chunks', () => {
     await editor.gotoLine(7, 0);
     await sleep(200);
 
-    await consoleActions.typeInConsole(`.rs.api.executeCommand("renameInScope")`);
+    await executeCommand(page, 'renameInScope');
 
     await expect.poll(() => editor.getSelectionRanges().then((r) => r.length), {
       timeout: TIMEOUTS.fileEditSettle,

--- a/e2e/rstudio/tests/panes/editor/rmarkdown.test.ts
+++ b/e2e/rstudio/tests/panes/editor/rmarkdown.test.ts
@@ -10,6 +10,7 @@ import {
 import { clearWorkspace } from '@pages/environment_pane.page';
 import { CONSOLE_INPUT } from '@pages/console_pane.page';
 import { useSuiteSandbox } from '@utils/sandbox';
+import { executeCommand, setPref } from '@utils/commands';
 
 test.describe('RMarkdown', () => {
   // Sets cwd to a per-spec sandbox; all relative file paths used by
@@ -69,7 +70,7 @@ test.describe('RMarkdown', () => {
     // Original: test_desktop_RMarkdown.py::test_empty_chunk_does_not_define_variables
 
     // Clear workspace
-    await consoleActions.typeInConsole(".rs.api.executeCommand('activateEnvironment')");
+    await executeCommand(page, 'activateEnvironment');
     await sleep(2000);
     await clearWorkspace(page);
 
@@ -79,11 +80,11 @@ test.describe('RMarkdown', () => {
     await expect(sourceActions.sourcePane.selectedTab).toContainText(fileName, { timeout: 20000 });
 
     // Save the file
-    await consoleActions.typeInConsole(".rs.api.executeCommand('saveSourceDoc')");
+    await executeCommand(page, 'saveSourceDoc');
     await sleep(1000);
 
     // Run all chunks via restart R
-    await consoleActions.typeInConsole(".rs.api.executeCommand('restartRRunAllChunks')");
+    await executeCommand(page, 'restartRRunAllChunks');
     await sleep(5000);
     await expect(page.locator("[id^='rstudio_tb_interruptr']")).not.toBeVisible({ timeout: 30000 });
 
@@ -108,7 +109,7 @@ test.describe('RMarkdown', () => {
     // Original: test_desktop_RMarkdown.py::test_continue_comment_newline_preference
 
     // Enable the preference
-    await consoleActions.typeInConsole('.rs.api.writeRStudioPreference("continue_comments_on_newline", TRUE)');
+    await setPref(page, 'continue_comments_on_newline', true);
     await sleep(1000);
 
     // Create an RMarkdown file, verify no comment is inserted on newline
@@ -158,7 +159,7 @@ test.describe('RMarkdown', () => {
     // Navigate to file and run spellcheck
     await consoleActions.typeInConsole(`rstudioapi::navigateToFile("${fileName}", line=1L)`);
     await sleep(2000);
-    await consoleActions.typeInConsole(".rs.api.executeCommand('checkSpelling')");
+    await executeCommand(page, 'checkSpelling');
     await sleep(5000);
 
     await expect(page.locator('#rstudio_spelling_not_in_dict')).toBeVisible({ timeout: 30000 });
@@ -185,7 +186,7 @@ test.describe('RMarkdown', () => {
     await sourceActions.ensureVisualMode();
 
     // Run spellcheck in visual mode
-    await consoleActions.typeInConsole(".rs.api.executeCommand('checkSpelling')");
+    await executeCommand(page, 'checkSpelling');
     await sleep(5000);
 
     await expect(page.locator('#rstudio_spelling_not_in_dict')).toBeVisible({ timeout: 30000 });
@@ -202,7 +203,7 @@ test.describe('RMarkdown', () => {
     // Original: test_desktop_RMarkdown.py::test_rmd_templates_displays
 
     // Open New R Markdown dialog
-    await consoleActions.typeInConsole(".rs.api.executeCommand('newRMarkdownDoc')");
+    await executeCommand(page, 'newRMarkdownDoc');
     await installDepIfPrompted(page);
 
     // Check templates
@@ -229,7 +230,7 @@ test.describe('RMarkdown', () => {
     // Skipped: https://github.com/rstudio/rstudio/issues/13271
 
     // Create rmarkdown file via command
-    await consoleActions.typeInConsole(".rs.api.executeCommand('newRMarkdownDoc')");
+    await executeCommand(page, 'newRMarkdownDoc');
     await installDepIfPrompted(page);
     await clickConfirmIfVisible(page);
     await expect(sourceActions.sourcePane.selectedTab).toContainText('Untitled', { timeout: 10000 });
@@ -245,20 +246,20 @@ test.describe('RMarkdown', () => {
     await sleep(3000);
 
     // Go to next chunk 3 times to reach plot(pressure) chunk
-    await consoleActions.typeInConsole(".rs.api.executeCommand('goToNextChunk')");
+    await executeCommand(page, 'goToNextChunk');
     await sleep(2000);
-    await consoleActions.typeInConsole(".rs.api.executeCommand('goToNextChunk')");
+    await executeCommand(page, 'goToNextChunk');
     await sleep(2000);
-    await consoleActions.typeInConsole(".rs.api.executeCommand('goToNextChunk')");
+    await executeCommand(page, 'goToNextChunk');
     await sleep(2000);
-    await consoleActions.typeInConsole(".rs.api.executeCommand('executeCurrentChunk')");
+    await executeCommand(page, 'executeCurrentChunk');
     await expect(consoleActions.consolePane.consoleOutput).toContainText('plot(pressure)', { timeout: 10000 });
 
     // Go to previous chunk and verify summary(cars) runs but NOT plot(pressure)
     await consoleActions.clearConsole();
-    await consoleActions.typeInConsole(".rs.api.executeCommand('goToPrevChunk')");
+    await executeCommand(page, 'goToPrevChunk');
     await sleep(2000);
-    await consoleActions.typeInConsole(".rs.api.executeCommand('executeCurrentChunk')");
+    await executeCommand(page, 'executeCurrentChunk');
     const consoleOutput = consoleActions.consolePane.consoleOutput;
     await expect(consoleOutput).toContainText('summary(cars)', { timeout: 10000 });
     await expect(consoleOutput).toContainText('speed');

--- a/e2e/rstudio/tests/panes/editor/rmarkdown_chunks.test.ts
+++ b/e2e/rstudio/tests/panes/editor/rmarkdown_chunks.test.ts
@@ -341,11 +341,7 @@ test.describe.serial('R Markdown chunks', { tag: ['@serial'] }, () => {
     await sourceActions.closeSourceAndDeleteFile(fileNamePrint);
   });
 
-  // FIXME: saveSourceDoc via the executeCommand bridge doesn't appear to
-  // trigger nb.html generation in this flow (the file never appears in the
-  // sandbox dir). Needs investigation of whether the bridge path is missing
-  // a step that the console-driven Save path performs.
-  test.skip('saving an R Notebook creates an nb.html file', async ({ rstudioPage: page }) => {
+  test('saving an R Notebook creates an nb.html file', async ({ rstudioPage: page }) => {
     const fileName = `rmarkdown_nbhtml_${Date.now()}.Rmd`;
     const nbHtmlPath = path.join(sandbox.dir, fileName.replace(/\.Rmd$/, '.nb.html'));
     const content = [
@@ -363,7 +359,14 @@ test.describe.serial('R Markdown chunks', { tag: ['@serial'] }, () => {
     await runChunkByLabelAndWaitForConsoleSignal(
       page, consoleActions, sourceActions, 'nb', 'hello from notebook',
     );
-    await executeCommand(page, 'saveSourceDoc');
+
+    // The saveSourceDoc command is disabled when the doc is clean
+    // (createAndOpenFile leaves the editor matching disk, and running a chunk
+    // doesn't dirty it). Add a trailing newline so Ctrl+S actually saves --
+    // without this the keypress is a silent no-op and nb.html never renders.
+    await sourceActions.goToEnd();
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('ControlOrMeta+s');
 
     // RStudio writes nb.html on save; poll the filesystem for it.
     await expect.poll(() => fs.existsSync(nbHtmlPath), { timeout: 30000, intervals: [500] }).toBe(true);

--- a/e2e/rstudio/tests/panes/files/files.test.ts
+++ b/e2e/rstudio/tests/panes/files/files.test.ts
@@ -11,6 +11,7 @@ import { SourcePane } from '@pages/source_pane.page';
 import { AceEditor } from '@pages/ace_editor.page';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { sleep, TIMEOUTS, typeSlowly } from '@utils/constants';
+import { executeCommand, documentCloseAllNoSave, setPref, clearPref } from '@utils/commands';
 
 const MODAL_DIALOG = '.rstudio_modal_dialog';
 // The Open File dialog renders a virtualized file list as a `<table
@@ -32,7 +33,7 @@ test.describe('Open File dialog (virtualized)', { tag: ['@server_only'] }, () =>
 
   test.afterEach(async ({ rstudioPage: page }) => {
     // Clean up any stub files and close opened source docs.
-    await consoleActions.typeInConsole('.rs.api.closeAllSourceBuffersWithoutSaving()');
+    await documentCloseAllNoSave(page);
     await consoleActions.typeInConsole(`unlink(list.files(${JSON.stringify(sandbox.dir)}, pattern = "\\\\.R$", full.names = TRUE))`);
   });
 
@@ -44,7 +45,7 @@ test.describe('Open File dialog (virtualized)', { tag: ['@server_only'] }, () =>
     );
     await sleep(TIMEOUTS.consoleReady);
 
-    await consoleActions.typeInConsole(".rs.api.executeCommand('openSourceDoc')");
+    await executeCommand(page, 'openSourceDoc');
     await expect(page.locator(MODAL_DIALOG)).toBeVisible({ timeout: TIMEOUTS.consoleReady });
     await sleep(TIMEOUTS.settleDelay);
 
@@ -68,7 +69,7 @@ test.describe('Open File dialog (virtualized)', { tag: ['@server_only'] }, () =>
     );
     await sleep(TIMEOUTS.consoleReady);
 
-    await consoleActions.typeInConsole(".rs.api.executeCommand('openSourceDoc')");
+    await executeCommand(page, 'openSourceDoc');
     await expect(page.locator(MODAL_DIALOG)).toBeVisible({ timeout: TIMEOUTS.consoleReady });
     await sleep(TIMEOUTS.settleDelay);
 
@@ -95,7 +96,7 @@ test.describe('Autosave on blur', () => {
 
   // https://github.com/rstudio/rstudio/issues/16329
   test('unchanged document is not rewritten when focus leaves the source pane', async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole('.rs.uiPrefs$autoSaveOnBlur$set(TRUE)');
+    await setPref(page, 'auto_save_on_blur', true);
     try {
       // Create a file on disk inside the sandbox and open it via file.edit().
       const setupExpr = [
@@ -111,9 +112,9 @@ test.describe('Autosave on blur', () => {
       await consoleActions.typeInConsole(
         '{ .rs_autosave_old <- file.info(.rs_autosave_path)$mtime }',
       );
-      await consoleActions.typeInConsole(".rs.api.executeCommand('activateConsole')");
-      await consoleActions.typeInConsole(".rs.api.executeCommand('activateSource')");
-      await consoleActions.typeInConsole(".rs.api.executeCommand('activateConsole')");
+      await executeCommand(page, 'activateConsole');
+      await executeCommand(page, 'activateSource');
+      await executeCommand(page, 'activateConsole');
 
       const unchangedMarker = `__AUTOSAVE_UNCHANGED_${Date.now()}__`;
       await consoleActions.typeInConsole(
@@ -125,11 +126,11 @@ test.describe('Autosave on blur', () => {
       );
 
       // Edit the source doc via the Ace API, blur, and assert the file was rewritten.
-      await consoleActions.typeInConsole(".rs.api.executeCommand('activateSource')");
+      await executeCommand(page, 'activateSource');
       const editor = new AceEditor(page, '# hello world');
       await editor.gotoLine(2);
       await editor.insert('# this is some text');
-      await consoleActions.typeInConsole(".rs.api.executeCommand('activateConsole')");
+      await executeCommand(page, 'activateConsole');
       // mtime granularity is one second on some filesystems; let the autosave
       // settle before re-stating the file.
       await sleep(1500);
@@ -143,8 +144,8 @@ test.describe('Autosave on blur', () => {
         { timeout: TIMEOUTS.consoleReady },
       );
     } finally {
-      await consoleActions.typeInConsole('.rs.uiPrefs$autoSaveOnBlur$clear()');
-      await consoleActions.typeInConsole('.rs.api.closeAllSourceBuffersWithoutSaving()');
+      await clearPref(page, 'auto_save_on_blur');
+      await documentCloseAllNoSave(page);
       await consoleActions.typeInConsole(
         `{ unlink(file.path(${JSON.stringify(sandbox.dir)}, "autosave.R")); rm(list = ls(pattern = "^\\\\.rs_autosave", envir = globalenv()), envir = globalenv()) }`,
       );

--- a/e2e/rstudio/tests/panes/layout/pane_layout.test.ts
+++ b/e2e/rstudio/tests/panes/layout/pane_layout.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { sleep, TIMEOUTS } from '@utils/constants';
 import { typeInConsole, CONSOLE_INPUT } from '@pages/console_pane.page';
+import { executeCommand } from '@utils/commands';
 import type { Page } from 'playwright';
 
 // Ported from src/cpp/tests/automation/testthat/test-automation-pane-layout.R.
@@ -43,7 +44,7 @@ const ALL_TAB_NAMES = [
 // ---------------------------------------------------------------------------
 
 async function openPaneLayoutOptions(page: Page): Promise<void> {
-  await typeInConsole(page, ".rs.api.executeCommand('paneLayout')");
+  await executeCommand(page, 'paneLayout');
   await page.waitForSelector(DIALOG_BOX, { timeout: TIMEOUTS.consoleReady });
   await page.waitForSelector(PL_PANEL, { timeout: 5000 });
   await sleep(500);
@@ -68,7 +69,7 @@ async function dismissDialogIfOpen(page: Page): Promise<void> {
 async function resetUILayout(page: Page): Promise<void> {
   const sentinel = `__pl_reset_${Date.now()}_${Math.random()}`;
   await page.evaluate((s) => { (window as unknown as Record<string, true>)[s] = true; }, sentinel);
-  await typeInConsole(page, ".rs.api.executeCommand('restoreDefaultPaneAndTabLayoutNoPrompt')");
+  await executeCommand(page, 'restoreDefaultPaneAndTabLayoutNoPrompt');
   await page.waitForFunction(
     (s) => !(s in (window as unknown as Record<string, unknown>)),
     sentinel,
@@ -543,7 +544,7 @@ test.describe.serial('Pane Layout dialog (#test-automation-pane-layout)', { tag:
     await resetUILayout(page);
 
     // Show the sidebar (left is the default)
-    await typeInConsole(page, ".rs.api.executeCommand('toggleSidebar')");
+    await executeCommand(page, 'toggleSidebar');
     await page.waitForSelector(SIDEBAR_PANE, { timeout: 15000 });
 
     await openPaneLayoutOptions(page);
@@ -600,7 +601,7 @@ test.describe.serial('Pane Layout dialog (#test-automation-pane-layout)', { tag:
     await resetUILayout(page);
 
     if ((await page.locator(SIDEBAR_PANE).count()) > 0) {
-      await typeInConsole(page, ".rs.api.executeCommand('toggleSidebar')");
+      await executeCommand(page, 'toggleSidebar');
       await expect(page.locator(SIDEBAR_PANE)).toHaveCount(0, { timeout: 10000 });
     }
 

--- a/e2e/rstudio/tests/panes/layout/pane_location_persistence.test.ts
+++ b/e2e/rstudio/tests/panes/layout/pane_location_persistence.test.ts
@@ -1,7 +1,7 @@
 import { test as base, expect } from '@playwright/test';
 import { launchRStudio, shutdownRStudio, type DesktopSession } from '@fixtures/desktop.fixture';
 import { sleep } from '@utils/constants';
-import { typeInConsole } from '@pages/console_pane.page';
+import { executeCommand } from '@utils/commands';
 import type { Page } from 'playwright';
 
 // Pane Layout preferences dialog selectors
@@ -23,7 +23,7 @@ const TABSET2_PANE = '#rstudio_TabSet2_pane';
  * Open Global Options and navigate to the Pane Layout tab.
  */
 async function openPaneLayoutOptions(page: Page): Promise<void> {
-  await typeInConsole(page, ".rs.api.executeCommand('showOptions')");
+  await executeCommand(page, 'showOptions');
   await page.waitForSelector(OPTIONS_OK, { timeout: 15000 });
   await page.locator(PANE_LAYOUT_TAB).click();
   await expect(page.locator(PANE_LAYOUT_PANEL)).toBeVisible({ timeout: 5000 });

--- a/e2e/rstudio/tests/panes/layout/panes.test.ts
+++ b/e2e/rstudio/tests/panes/layout/panes.test.ts
@@ -5,6 +5,7 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { sleep, TIMEOUTS } from '@utils/constants';
+import { executeCommand, documentCloseAllNoSave } from '@utils/commands';
 import type { Locator, Page } from 'playwright';
 
 // ---------------------------------------------------------------------------
@@ -21,7 +22,6 @@ const SIDEBAR_PANE = '#rstudio_Sidebar_pane';
 const CUSTOMIZE_PANES_BUTTON = '#rstudio_customize_panes';
 const SIDEBAR_CLOSE_BTN = '.rstudio_panel_close_btn_sidebar';
 const MIDDLE_COLUMN_SPLITTER = '#rstudio_middle_column_splitter';
-const CONSOLE_INPUT = '#rstudio_console_input .ace_text-input';
 
 // Pane Layout dialog selectors
 const PL_RIGHT_TOP = '#rstudio_pane_layout_right_top';
@@ -37,38 +37,6 @@ const RESIZE_MIN_DELTA_PX = 20;
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-// Type a command into the Ace console input directly. We force-click the input
-// instead of going through the console tab because zoomed-out panes can leave
-// the tab too narrow to receive a normal click.
-async function executeCommand(page: Page, command: string): Promise<void> {
-  const input = page.locator(CONSOLE_INPUT);
-  await input.click({ force: true });
-  await sleep(200);
-  await input.pressSequentially(`.rs.api.executeCommand('${command}')`);
-  await sleep(200);
-  if (await page.locator('#rstudio_popup_completions').isVisible().catch(() => false)) {
-    await page.keyboard.press('Escape');
-    await sleep(100);
-  }
-  await input.press('Enter');
-}
-
-// Same shape as executeCommand, but types `expr` verbatim so callers can
-// invoke .rs.api functions (which aren't registered commands) or any other
-// R expression in this pane-aware way.
-async function executeRExpr(page: Page, expr: string): Promise<void> {
-  const input = page.locator(CONSOLE_INPUT);
-  await input.click({ force: true });
-  await sleep(200);
-  await input.pressSequentially(expr);
-  await sleep(200);
-  if (await page.locator('#rstudio_popup_completions').isVisible().catch(() => false)) {
-    await page.keyboard.press('Escape');
-    await sleep(100);
-  }
-  await input.press('Enter');
-}
 
 async function getOffsetWidth(page: Page, selector: string): Promise<number> {
   return await page.locator(selector).evaluate(el => (el as HTMLElement).offsetWidth);
@@ -298,7 +266,7 @@ test.describe.serial('Pane and column management', { tag: ['@serial'] }, () => {
     expect(await getOffsetWidth(page, SOURCE3_PANE)).toBeGreaterThan(0);
     expect(await getOffsetHeight(page, SOURCE3_PANE)).toBeGreaterThan(0);
 
-    await executeRExpr(page, '.rs.api.closeAllSourceBuffersWithoutSaving()');
+    await documentCloseAllNoSave(page);
     await expect(page.locator(SOURCE1_PANE)).toHaveCount(0, { timeout: 10000 });
     await expect(page.locator(SOURCE2_PANE)).toHaveCount(0, { timeout: 10000 });
     await expect(page.locator(SOURCE3_PANE)).toHaveCount(0, { timeout: 10000 });

--- a/e2e/rstudio/tests/panes/misc/autocomplete_extras.test.ts
+++ b/e2e/rstudio/tests/panes/misc/autocomplete_extras.test.ts
@@ -25,6 +25,7 @@ import { SourcePaneActions } from '@actions/source_pane.actions';
 import { AutocompleteActions } from '@actions/autocomplete.actions';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { sleep } from '@utils/constants';
+import { setPref, clearPref } from '@utils/commands';
 
 test.describe('Autocomplete extras', () => {
   // setwd into a per-spec sandbox so the relative filenames used by
@@ -131,16 +132,12 @@ test.describe('Autocomplete extras', () => {
     const before = await autocomplete.getCompletionsInEditor([], content, 1, 16);
     expect(before.slice(0, 4)).toEqual(['file =', 'ncolumns =', 'append =', 'sep =']);
 
-    await consoleActions.typeInConsole(
-      '.rs.uiPrefs$codeCompletionIncludeAlreadyUsed$set(TRUE)',
-    );
+    await setPref(consoleActions.page, 'code_completion_include_already_used', true);
     try {
       const after = await autocomplete.getCompletionsInEditor([], content, 1, 16);
       expect(after.slice(0, 5)).toEqual(['x =', 'file =', 'ncolumns =', 'append =', 'sep =']);
     } finally {
-      await consoleActions.typeInConsole(
-        '.rs.uiPrefs$codeCompletionIncludeAlreadyUsed$clear()',
-      );
+      await clearPref(consoleActions.page, 'code_completion_include_already_used');
     }
   });
 

--- a/e2e/rstudio/tests/panes/misc/build_pane_testthat.test.ts
+++ b/e2e/rstudio/tests/panes/misc/build_pane_testthat.test.ts
@@ -4,6 +4,7 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { installDepIfPrompted } from '@pages/modals.page';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { rPathLiteral, rStringLiteral } from '@utils/r';
+import { executeCommand } from '@utils/commands';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { Page } from 'playwright';
@@ -81,7 +82,7 @@ test.describe('Build pane', () => {
     await consoleActions.typeInConsole(`.rs.api.documentOpen(${testFileLit})`);
     await sleep(1000);
 
-    await consoleActions.typeInConsole(`.rs.api.executeCommand("testTestthatFile")`);
+    await executeCommand(page, 'testTestthatFile');
 
     // testTestthatFile checks devtools is current and prompts to install if
     // not; click Yes (no-op if no prompt appears).

--- a/e2e/rstudio/tests/panes/misc/s4_unloaded_package.test.ts
+++ b/e2e/rstudio/tests/panes/misc/s4_unloaded_package.test.ts
@@ -19,6 +19,7 @@ import { launchRStudio, shutdownRStudio, type DesktopSession } from '@fixtures/d
 import { sleep } from '@utils/constants';
 import { typeInConsole, clearConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { YES_BTN } from '@pages/modals.page';
+import { executeCommand, setPref } from '@utils/commands';
 import type { Page } from 'playwright';
 
 const OBJ_NAME = 's4_test_object';
@@ -60,9 +61,9 @@ async function setupWorkspace(page: Page): Promise<void> {
   await sleep(500);
 
   // Enable workspace persistence
-  await typeInConsole(page, '.rs.api.writeRStudioPreference("save_workspace", "always")');
+  await setPref(page, 'save_workspace', 'always');
   await sleep(500);
-  await typeInConsole(page, '.rs.api.writeRStudioPreference("load_workspace", TRUE)');
+  await setPref(page, 'load_workspace', true);
   await sleep(500);
 
   // Save workspace
@@ -93,7 +94,7 @@ async function cleanup(page: Page): Promise<void> {
   await sleep(500);
   await typeInConsole(page, 'unlink(".RData")');
   await sleep(500);
-  await typeInConsole(page, '.rs.api.writeRStudioPreference("save_workspace", "never")');
+  await setPref(page, 'save_workspace', 'never');
   await sleep(500);
   // Reinstall DBI so we leave things as we found them
   await typeInConsole(page, 'install.packages("DBI", repos = "https://cran.r-project.org")');
@@ -133,9 +134,9 @@ async function verifySessionSurvived(page: Page): Promise<void> {
 
 /** Check that the Environment pane renders the "not loaded" label. */
 async function verifyEnvironmentPane(page: Page): Promise<void> {
-  await typeInConsole(page, ".rs.api.executeCommand('activateEnvironment')");
+  await executeCommand(page, 'activateEnvironment');
   await sleep(1000);
-  await typeInConsole(page, ".rs.api.executeCommand('refreshEnvironment')");
+  await executeCommand(page, 'refreshEnvironment');
   await sleep(3000);
 
   const envPanel = page.locator('#rstudio_workbench_panel_environment');
@@ -161,7 +162,7 @@ base.describe.serial('S4 unloaded package -- R session restart (#17353)', { tag:
     await setupWorkspace(page);
 
     // Restart R session
-    await typeInConsole(page, ".rs.api.executeCommand('restartR')");
+    await executeCommand(page, 'restartR');
     await sleep(5000);
     await page.waitForSelector(CONSOLE_INPUT, { state: 'visible', timeout: 30000 });
     await sleep(2000);

--- a/e2e/rstudio/tests/panes/misc/session_suspend.test.ts
+++ b/e2e/rstudio/tests/panes/misc/session_suspend.test.ts
@@ -3,6 +3,7 @@ import { sleep, TIMEOUTS } from '@utils/constants';
 import { typeInConsole, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { waitForSessionRestart } from '@utils/project';
 import { rStringLiteral } from '@utils/r';
+import { executeCommand } from '@utils/commands';
 import type { Page } from 'playwright';
 
 async function captureResult(page: Page, rExpression: string): Promise<string> {
@@ -21,7 +22,7 @@ async function captureResult(page: Page, rExpression: string): Promise<string> {
 }
 
 async function suspendAndResume(page: Page): Promise<void> {
-  await typeInConsole(page, ".rs.api.executeCommand('suspendSession')");
+  await executeCommand(page, 'suspendSession');
   await waitForSessionRestart(page);
 }
 

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-pane-persistence.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-pane-persistence.test.ts
@@ -3,6 +3,7 @@ import { sleep, CHAT_PROVIDERS, TIMEOUTS } from '@utils/constants';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { ChatPaneActions } from '@actions/chat_pane.actions';
 import { restartSessionWithSentinel } from '@utils/project';
+import { executeCommand } from '@utils/commands';
 import type { Page } from 'playwright';
 import { createChatActions } from './_chat-setup';
 
@@ -59,7 +60,7 @@ test.describe.serial('Chat pane persistence', { tag: ['@ai'] }, () => {
     }, CHAT_IFRAME);
 
     // Open Global Options
-    await consoleActions.typeInConsole(".rs.api.executeCommand('showOptions')");
+    await executeCommand(page, 'showOptions');
     const okBtn = page.locator(PREFS_OK_BTN);
     await expect(okBtn).toBeVisible({ timeout: 15000 });
     await sleep(500); // let dialog finish opening

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-satellite-commands.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-satellite-commands.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@fixtures/rstudio.fixture';
 import { sleep, CHAT_PROVIDERS } from '@utils/constants';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { ChatPaneActions } from '@actions/chat_pane.actions';
+import { executeCommand } from '@utils/commands';
 import { createChatActions } from './_chat-setup';
 
 const CHAT_IFRAME = "iframe[title='Posit Assistant']";
@@ -35,7 +36,7 @@ test.describe.serial('Chat satellite -- commands', { tag: ['@ai', '@desktop_only
 
     // Pop out the chat pane via the command.
     const satellitePromise = context.waitForEvent('page', { timeout: 30000 });
-    await consoleActions.typeInConsole(".rs.api.executeCommand('popOutChat')");
+    await executeCommand(page, 'popOutChat');
     const satellitePage = await satellitePromise;
     await satellitePage.waitForLoadState('domcontentloaded');
     await sleep(2000);
@@ -47,7 +48,7 @@ test.describe.serial('Chat satellite -- commands', { tag: ['@ai', '@desktop_only
 
     // Return chat to the main window via the command.
     const closePromise = satellitePage.waitForEvent('close', { timeout: 30000 });
-    await consoleActions.typeInConsole(".rs.api.executeCommand('returnChatToMain')");
+    await executeCommand(page, 'returnChatToMain');
     await closePromise;
 
     // After return, the iframe should be back in the main window.

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
@@ -8,6 +8,7 @@ import { ChatPane } from '@pages/chat_pane.page';
 import type { EnvironmentVersions } from '@pages/console_pane.page';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { createAndOpenProject } from '@utils/project';
+import { setPref } from '@utils/commands';
 import { createChatActions, annotateVersions } from './_chat-setup';
 
 // ---------------------------------------------------------------------------
@@ -120,7 +121,7 @@ test.describe.serial('User-Added Skills', { tag: ['@ai', '@serial'] }, () => {
     // start). Setting the preference to "none" (a valid enum value -- NOT "")
     // triggers onChatProviderChanged() → stopBackend() on the GWT side.
     // -----------------------------------------------------------------------
-    await consoleActions.typeInConsole('.rs.api.writeRStudioPreference("chat_provider", "none")');
+    await setPref(page, 'chat_provider', 'none');
     await sleep(5000);
 
     // -----------------------------------------------------------------------

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/enable-assistant.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/enable-assistant.test.ts
@@ -4,6 +4,7 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { AssistantOptionsActions } from '@actions/assistant_options.actions';
 import { AssistantOptions } from '@pages/assistant_options.page';
 import type { EnvironmentVersions } from '@pages/console_pane.page';
+import { executeCommand } from '@utils/commands';
 import { createChatActions, annotateVersions } from './_chat-setup';
 
 test.describe.serial('Enable Posit Assistant', { tag: ['@ai'] }, () => {
@@ -26,7 +27,7 @@ test.describe.serial('Enable Posit Assistant', { tag: ['@ai'] }, () => {
 
   test('enable Posit Assistant and verify persistence', async ({ rstudioPage: page }) => {
     // First, set to "(None)" to ensure we're starting clean
-    await consoleActions.typeInConsole(".rs.api.executeCommand('showOptions')");
+    await executeCommand(page, 'showOptions');
     await page.waitForSelector('#rstudio_preferences_confirm', { timeout: 15000 });
 
     await expect(assistantOptions.assistantTab).toBeVisible({ timeout: 15000 });

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/open-chat-pane.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/open-chat-pane.test.ts
@@ -4,6 +4,7 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { ChatPaneActions } from '@actions/chat_pane.actions';
 import { ChatPane } from '@pages/chat_pane.page';
 import type { EnvironmentVersions } from '@pages/console_pane.page';
+import { executeCommand } from '@utils/commands';
 import { createChatActions, annotateVersions } from './_chat-setup';
 
 test.describe('Open Chat Pane', { tag: ['@ai'] }, () => {
@@ -33,7 +34,7 @@ test.describe('Open Chat Pane', { tag: ['@ai'] }, () => {
 
     // Close the sidebar if it's open to ensure the chat pane is not visible
     if (await chatIframe.isVisible().catch(() => false)) {
-      await consoleActions.typeInConsole(".rs.api.executeCommand('toggleSidebar')");
+      await executeCommand(page, 'toggleSidebar');
       await sleep(2000);
     }
 
@@ -53,7 +54,7 @@ test.describe('Open Chat Pane', { tag: ['@ai'] }, () => {
 
     // Close the sidebar if it's open to ensure the chat pane is not visible
     if (await chatIframe.isVisible().catch(() => false)) {
-      await consoleActions.typeInConsole(".rs.api.executeCommand('toggleSidebar')");
+      await executeCommand(page, 'toggleSidebar');
       await sleep(2000);
     }
 

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
@@ -5,6 +5,7 @@ import { ChatPaneActions } from '@actions/chat_pane.actions';
 import { ChatPane } from '@pages/chat_pane.page';
 import { VIEWER_FRAME } from '@pages/viewer_pane.page';
 import type { EnvironmentVersions } from '@pages/console_pane.page';
+import { executeCommand, setPref } from '@utils/commands';
 import { createChatActions, annotateVersions } from './_chat-setup';
 
 test.describe.serial('R Shiny Tip Calculator via Posit Assistant', { tag: ['@ai'] }, () => {
@@ -30,7 +31,7 @@ test.describe.serial('R Shiny Tip Calculator via Posit Assistant', { tag: ['@ai'
     missingPackages = await consoleActions.ensurePackages(['shiny', 'bslib', 'rstudioapi'], 180000);
 
     // Force Shiny apps to open in the Viewer pane
-    await consoleActions.typeInConsole('.rs.api.writeRStudioPreference("shiny_viewer_type", "pane")');
+    await setPref(page, 'shiny_viewer_type', 'pane');
     await sleep(1000);
 
     // Clean up any leftover files from previous runs
@@ -38,7 +39,7 @@ test.describe.serial('R Shiny Tip Calculator via Posit Assistant', { tag: ['@ai'
     await sleep(1000);
 
     // Clear the Viewer pane so we don't get false positives from previous content
-    await consoleActions.typeInConsole(".rs.api.executeCommand('viewerClearAll')");
+    await executeCommand(page, 'viewerClearAll');
     await sleep(1000);
 
     // Dismiss the "Clear Viewer" confirmation dialog if it appears

--- a/e2e/rstudio/tests/panes/terminal/terminal.test.ts
+++ b/e2e/rstudio/tests/panes/terminal/terminal.test.ts
@@ -4,6 +4,7 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { typeInConsole, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { AceEditor } from '@pages/ace_editor.page';
 import { rStringLiteral } from '@utils/r';
+import { executeCommand } from '@utils/commands';
 import type { Page } from 'playwright';
 
 const TERMINAL_TAB = '#rstudio_workbench_tab_terminal';
@@ -46,7 +47,7 @@ test.describe.serial('Terminal pane', () => {
 
   test.afterEach(async ({ rstudioPage: page }) => {
     await killAllTerminals(page).catch(() => {});
-    await consoleActions.typeInConsole(".rs.api.executeCommand('activateConsole')").catch(() => {});
+    await executeCommand(page, 'activateConsole').catch(() => {});
   });
 
   test('a terminal can be created and is visible', async ({ rstudioPage: page }) => {
@@ -85,7 +86,7 @@ test.describe.serial('Terminal pane', () => {
     expect(bufferHasResult, 'terminal buffer should contain the result "2"').toBe('TRUE');
 
     // Send the terminal contents to a new editor tab.
-    await consoleActions.typeInConsole(".rs.api.executeCommand('sendTerminalToEditor')");
+    await executeCommand(page, 'sendTerminalToEditor');
 
     // Find the new editor by its marker and assert it contains the expected
     // command + output sequence.

--- a/e2e/rstudio/tests/projects/create_projects.test.ts
+++ b/e2e/rstudio/tests/projects/create_projects.test.ts
@@ -4,6 +4,7 @@ import { typeInConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pan
 import { installDepIfPrompted } from '@pages/modals.page';
 import { SourcePane } from '@pages/source_pane.page';
 import { useSuiteSandbox, SANDBOX_DIR_PREFIX } from '@utils/sandbox';
+import { setPref, documentCloseAllNoSave } from '@utils/commands';
 import type { Page } from 'playwright';
 
 // -- Selectors ----------------------------------------------------------------
@@ -116,7 +117,7 @@ async function waitForSessionRestart(page: Page): Promise<void> {
 
 async function openNewProjectWizard(page: Page): Promise<void> {
   // Close any open source docs first to avoid "unsaved changes" dialogs
-  await typeInConsole(page, '.rs.api.closeAllSourceBuffersWithoutSaving()');
+  await documentCloseAllNoSave(page);
   await sleep(1000);
 
   // executeCommand("newProject") blocks the R thread with an "R session is busy"
@@ -250,19 +251,13 @@ test.describe.serial('Create Projects in New Directory', () => {
     originalDefaultProjectLocation = basename.startsWith(SANDBOX_DIR_PREFIX) ? '' : current;
 
     const escaped = sandbox.dir.replace(/\\/g, '/');
-    await typeInConsole(
-      page,
-      `.rs.api.writeRStudioPreference("default_project_location", "${escaped}")`,
-    );
+    await setPref(page, 'default_project_location', escaped);
     await sleep(TIMEOUTS.pollInterval);
   });
 
   test.afterAll(async ({ rstudioPage: page }) => {
     try {
-      await typeInConsole(
-        page,
-        `.rs.api.writeRStudioPreference("default_project_location", "${originalDefaultProjectLocation}")`,
-      );
+      await setPref(page, 'default_project_location', originalDefaultProjectLocation);
       await sleep(TIMEOUTS.pollInterval);
     } catch (err) {
       console.warn('default_project_location restore failed:', err);

--- a/e2e/rstudio/tests/projects/ignorefiles.test.ts
+++ b/e2e/rstudio/tests/projects/ignorefiles.test.ts
@@ -4,6 +4,7 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { useSuiteSandbox, SANDBOX_DIR_PREFIX } from '@utils/sandbox';
 import { typeInConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { rPathLiteral } from '@utils/r';
+import { setPref } from '@utils/commands';
 import * as fs from 'fs';
 import type { Page } from 'playwright';
 
@@ -76,18 +77,14 @@ test.describe('Project ignore files', () => {
     const basename = current.split(/[/\\]/).pop() ?? '';
     originalDefaultProjectLocation = basename.startsWith(SANDBOX_DIR_PREFIX) ? '' : current;
 
-    await consoleActions.typeInConsole(
-      `.rs.api.writeRStudioPreference("default_project_location", ${rPathLiteral(sandbox.dir)})`,
-    );
+    await setPref(page, 'default_project_location', sandbox.dir);
     await sleep(TIMEOUTS.pollInterval);
   });
 
   test.afterAll(async ({ rstudioPage: page }) => {
     try {
       await closeProjectIfOpen(page);
-      await consoleActions.typeInConsole(
-        `.rs.api.writeRStudioPreference("default_project_location", ${rPathLiteral(originalDefaultProjectLocation)})`,
-      );
+      await setPref(page, 'default_project_location', originalDefaultProjectLocation);
       await sleep(TIMEOUTS.pollInterval);
     } catch (err) {
       console.warn('ignorefiles afterAll cleanup failed:', err);

--- a/e2e/rstudio/tests/projects/project_id.test.ts
+++ b/e2e/rstudio/tests/projects/project_id.test.ts
@@ -4,6 +4,7 @@ import { typeInConsole, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { createAndOpenProject, restartSessionWithSentinel, waitForSessionRestart } from '@utils/project';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { rPathLiteral, rStringLiteral } from '@utils/r';
+import { setPref } from '@utils/commands';
 import type { Page } from 'playwright';
 
 const PROJECT_MENU = '#rstudio_project_menubutton_toolbar';
@@ -50,10 +51,7 @@ test.describe.serial('ProjectId in .Rproj', () => {
 
   test.afterAll(async ({ rstudioPage: page }) => {
     try {
-      await typeInConsole(
-        page,
-        `.rs.api.writeRStudioPreference("project_user_data_directory", "")`,
-      );
+      await setPref(page, 'project_user_data_directory', '');
       await sleep(TIMEOUTS.pollInterval);
       await closeProject(page);
     } catch (err) {
@@ -97,10 +95,7 @@ test.describe.serial('ProjectId in .Rproj', () => {
     expect(projectIdLine.length, 'ProjectId line should be non-empty').toBeGreaterThan(0);
 
     // Clear the pref and restart again. The ProjectId must persist.
-    await typeInConsole(
-      page,
-      `.rs.api.writeRStudioPreference("project_user_data_directory", "")`,
-    );
+    await setPref(page, 'project_user_data_directory', '');
     await sleep(TIMEOUTS.pollInterval);
     await restartSessionWithSentinel(page);
 

--- a/e2e/rstudio/tests/projects/project_trust_dialog.test.ts
+++ b/e2e/rstudio/tests/projects/project_trust_dialog.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@fixtures/rstudio.fixture';
 import { sleep } from '@utils/constants';
 import { typeInConsole, clearConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { useSuiteSandbox, SANDBOX_DIR_PREFIX } from '@utils/sandbox';
+import { executeCommand, setPref, documentCloseAllNoSave } from '@utils/commands';
 import type { Page } from 'playwright';
 
 /**
@@ -94,7 +95,7 @@ async function waitForSessionRestart(page: Page): Promise<void> {
 
 /** Restart R and wait for the console to be ready. */
 async function restartR(page: Page): Promise<void> {
-  await typeInConsole(page, '.rs.api.executeCommand("restartR")');
+  await executeCommand(page, 'restartR');
   await waitForSessionRestart(page);
 }
 
@@ -104,7 +105,7 @@ async function restartR(page: Page): Promise<void> {
  * blocks console access.
  */
 async function restartRExpectingDialog(page: Page): Promise<void> {
-  await typeInConsole(page, '.rs.api.executeCommand("restartR")');
+  await executeCommand(page, 'restartR');
   await sleep(3000);
   await page.waitForSelector(CONSOLE_INPUT, { state: 'visible', timeout: 30000 });
   await sleep(2000);
@@ -161,7 +162,7 @@ async function getWorkingDir(page: Page): Promise<string> {
  */
 async function createProjectViaUI(page: Page, name: string): Promise<void> {
   // Close any open source docs to prevent "unsaved changes" dialogs during project switch
-  await typeInConsole(page, '.rs.api.closeAllSourceBuffersWithoutSaving()');
+  await documentCloseAllNoSave(page);
   await sleep(1000);
 
   // Open command palette and invoke "Create a New Project..."
@@ -253,8 +254,7 @@ test.describe.serial('Project Trust Dialog (#17231)', { tag: ['@server_only', '@
     originalDefaultProjectLocation = basename.startsWith(SANDBOX_DIR_PREFIX) ? '' : current;
 
     const escaped = sandbox.dir.replace(/\\/g, '/');
-    await typeInConsole(page,
-      `.rs.api.writeRStudioPreference("default_project_location", "${escaped}")`);
+    await setPref(page, 'default_project_location', escaped);
     await sleep(500);
   });
 
@@ -268,11 +268,9 @@ test.describe.serial('Project Trust Dialog (#17231)', { tag: ['@server_only', '@
       }
 
       // Restore preferences
-      await typeInConsole(page,
-        `.rs.api.writeRStudioPreference("load_workspace", ${originalLoadWorkspace})`);
+      await setPref(page, 'load_workspace', originalLoadWorkspace === 'TRUE');
       await sleep(500);
-      await typeInConsole(page,
-        `.rs.api.writeRStudioPreference("default_project_location", "${originalDefaultProjectLocation}")`);
+      await setPref(page, 'default_project_location', originalDefaultProjectLocation);
       await sleep(500);
     } catch (err) {
       console.warn('project_trust_dialog afterAll cleanup failed:', err);
@@ -492,7 +490,7 @@ test.describe.serial('Project Trust Dialog (#17231)', { tag: ['@server_only', '@
     await resetTrust(page, projectDir);
 
     // Enable workspace restore
-    await typeInConsole(page, '.rs.api.writeRStudioPreference("load_workspace", TRUE)');
+    await setPref(page, 'load_workspace', true);
     await sleep(500);
 
     // Create an .RData file (empty workspace save)
@@ -527,7 +525,7 @@ test.describe.serial('Project Trust Dialog (#17231)', { tag: ['@server_only', '@
     await resetTrust(page, projectDir);
 
     // Disable workspace restore
-    await typeInConsole(page, '.rs.api.writeRStudioPreference("load_workspace", FALSE)');
+    await setPref(page, 'load_workspace', false);
     await sleep(500);
 
     // .RData still exists from test 7, renv .Rprofile from test 6

--- a/e2e/rstudio/tests/projects/shinytest2.test.ts
+++ b/e2e/rstudio/tests/projects/shinytest2.test.ts
@@ -5,6 +5,7 @@ import { CONFIRM_BTN } from '@pages/modals.page';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { typeInConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { rPathLiteral } from '@utils/r';
+import { executeCommand } from '@utils/commands';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { Page } from 'playwright';
@@ -111,7 +112,7 @@ test.describe('shinytest2 integration', () => {
     // TestsShinyTest -- exercises the AppDriver$new-before-test_that detection.
     await expect(page.locator(SHINYTEST_BUTTON)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
 
-    await consoleActions.typeInConsole('.rs.api.executeCommand("shinyCompareTest")');
+    await executeCommand(page, 'shinyCompareTest');
 
     const okBtn = page.locator(CONFIRM_BTN);
     await expect(okBtn).toBeVisible({ timeout: TIMEOUTS.fileOpen });
@@ -148,7 +149,7 @@ test.describe('shinytest2 integration', () => {
     await consoleActions.typeInConsole(stubInstall);
 
     try {
-      await consoleActions.typeInConsole('.rs.api.executeCommand("shinyCompareTest")');
+      await executeCommand(page, 'shinyCompareTest');
 
       await expect
         .poll(

--- a/e2e/rstudio/tsconfig.json
+++ b/e2e/rstudio/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
@@ -9,6 +9,7 @@
     "rootDir": ".",
     "skipLibCheck": true,
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@fixtures/*": ["fixtures/*"],
       "@utils/*": ["utils/*"],

--- a/e2e/rstudio/utils/files.ts
+++ b/e2e/rstudio/utils/files.ts
@@ -6,6 +6,7 @@ import { typeInConsole } from '../pages/console_pane.page';
 import { SourcePane } from '../pages/source_pane.page';
 import { TIMEOUTS } from './constants';
 import { rPathLiteral, rStringLiteral } from './r';
+import { documentCloseAllNoSave } from './commands';
 
 /**
  * Write `content` to `fileName` in the per-spec sandbox workdir and open it
@@ -55,7 +56,7 @@ export async function closeAndDeleteSandboxFiles(
   sandboxDir: string,
   fileNames: string[],
 ): Promise<void> {
-  await typeInConsole(page, '.rs.api.closeAllSourceBuffersWithoutSaving()');
+  await documentCloseAllNoSave(page);
   const sourcePane = new SourcePane(page);
   await expect(sourcePane.aceTextInput).toHaveCount(0, { timeout: 5000 }).catch(() => {});
   if (fs.existsSync(sandboxDir)) {


### PR DESCRIPTION
## Summary

- Pre-populates a stable per-host R user library at `~/.cache/rstudio-playwright/r-libs/%p/%v` (Windows: `%LOCALAPPDATA%\rstudio-playwright\r-libs\%p\%v`) and plumbs `R_LIBS_USER` through Desktop and Server fixtures, so RStudio sees a populated library under the redirected `HOME`. Without this, rmarkdown's dependency check would prompt to update stringr mid-test (the issue that surfaced when investigating the nb.html test).
- Unskips and fixes the nb.html generation test in `rmarkdown_chunks.test.ts`: `saveSourceDoc` is disabled when the editor matches disk, so the previous bridge call was a silent no-op. Dirties the doc with `Enter` before `Ctrl+S` so `NotebookHtmlRenderer.onSaveFile` actually fires.
- Refactors test code from `typeInConsole(\".rs.api.executeCommand('X')\")` (and `.rs.api.closeAllSourceBuffersWithoutSaving()`) to the bridge helpers (`executeCommand`, `documentCloseAllNoSave`) -- avoids the R-side round trip and console-history pollution.
- New npm scripts `test:dev` (PW_RSTUDIO_DEV=1) and `test:server` (--project=server); other combinations remain env-var driven.
- New env vars `PW_RSTUDIO_R_LIBS_USER` (override the template) and `PW_RSTUDIO_R_LIBS_SKIP_PREP` (skip pre-population); both documented in the README.
- tsconfig: target ES2022, `ignoreDeprecations: \"6.0\"` to silence TS 6 warnings. playwright.config.ts: typed `ProjectOptions` on `defineConfig`.

## Test plan

- [x] Installed-app run: `npx playwright test rmarkdown_chunks.test.ts -g \"nb.html\"` -- nb.html generation test passes (9.4s); globalSetup installs the 23 packages + transitive deps on first run.
- [x] Dev-mode run: `PW_RSTUDIO_DEV=1 npx playwright test rmarkdown_chunks.test.ts -g \"nb.html\"` -- passes (9.3s); warm-cache library prep is a no-op; no teardown error against the dev build's bridge.
- [ ] Suite-wide run to confirm no regressions from the console-to-bridge refactor.