### PR TITLE
Throwaway smoke test for PR-triggered Playwright workflow

### DIFF
--- a/src/cpp/session/modules/SessionConsole.cpp
+++ b/src/cpp/session/modules/SessionConsole.cpp
@@ -2,6 +2,7 @@
  * SessionConsole.cpp
  *
  * Copyright (C) 2022 by Posit Software, PBC
+ * [pw-trigger-smoke: throwaway change to test PR-triggered Playwright workflow]
  *
  * Unless you have received this program directly from Posit Software pursuant
  * to the terms of a commercial license agreement with Posit Software, then


### PR DESCRIPTION
Throwaway PR to verify the PR-triggered Playwright workflow fires correctly.

Changes `src/cpp/session/modules/SessionConsole.cpp` (one comment line), which
should match the `console` rule in `pw-test-map.yml` and emit
`tests/panes/console/` as the selector.

**Do not merge.** Close and delete after verifying the workflow runs.