### PR TITLE
Throwaway fallback test for PR-triggered Playwright workflow

### DIFF
--- a/src/cpp/session/modules/SessionPlots.cpp
+++ b/src/cpp/session/modules/SessionPlots.cpp
@@ -2,6 +2,7 @@
  * SessionPlots.cpp
  *
  * Copyright (C) 2022 by Posit Software, PBC
+ * [pw-trigger-fallback: throwaway change to test fallback selector behavior]
  *
  * Unless you have received this program directly from Posit Software pursuant
  * to the terms of a commercial license agreement with Posit Software, then


### PR DESCRIPTION
Throwaway PR to verify the fallback selector behavior.

Changes `src/cpp/session/modules/SessionPlots.cpp` (one comment line). Plots
is intentionally not covered by any rule in `pw-test-map.yml`, so the
selector should fall back to `tests/smoke/`.

Expected select job output:
- skip: `false`
- full: `false`
- selector: `tests/smoke/`

**Do not merge.** Close and delete after verifying.