### PR TITLE
Throwaway completions-rule test for PR-triggered Playwright workflow

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.cpp
+++ b/src/cpp/session/modules/SessionRCompletions.cpp
@@ -2,6 +2,7 @@
  * SessionRCompletions.cpp
  *
  * Copyright (C) 2022 by Posit Software, PBC
+ * [pw-trigger-completions: throwaway change to test the completions rule]
  *
  * Unless you have received this program directly from Posit Software pursuant
  * to the terms of a commercial license agreement with Posit Software, then


### PR DESCRIPTION
Throwaway PR to verify the new `completions` rule in `pw-test-map.yml`.

Changes `src/cpp/session/modules/SessionRCompletions.cpp` (one comment line).
Expected selector:

- skip: `false`
- full: `false`
- selector: `tests/panes/misc/autocomplete.test.ts tests/panes/misc/python_completions.test.ts`

**Do not merge.** Close and delete after verifying.