### PR TITLE
Add PR-triggered Playwright workflow for Ubuntu 22 with source build

### DIFF
--- a/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
@@ -152,7 +152,7 @@ jobs:
           # conflicts with the pkg-config package install-dependencies-jammy
           # requests.
           sudo apt-get remove -y pkgconf 2>/dev/null || true
-          sudo ./install-dependencies-jammy
+          sudo USE_BUNDLED_LIBUV=1 ./install-dependencies-jammy
           sudo apt-get install -y libuv1-dev xvfb
 
       - name: Install rig

--- a/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
@@ -32,6 +32,9 @@ env:
 
 jobs:
   select:
+    # Restrict to PRs filed from branches in this repo (i.e. Posit folks).
+    # Fork PRs from external contributors don't trigger this workflow.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -130,7 +133,9 @@ jobs:
 
   build_and_test:
     needs: select
-    if: needs.select.outputs.skip != 'true'
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && needs.select.outputs.skip != 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 180
     env:

--- a/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
@@ -145,6 +145,11 @@ jobs:
 
       - name: Install build dependencies (jammy)
         run: |
+          sudo apt-get update
+          # ubuntu-22.04 runners ship with pkgconf preinstalled, which
+          # conflicts with the pkg-config package install-dependencies-jammy
+          # requests.
+          sudo apt-get remove -y pkgconf 2>/dev/null || true
           sudo ./dependencies/linux/install-dependencies-jammy
           sudo apt-get install -y xvfb
 

--- a/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
@@ -160,6 +160,9 @@ jobs:
           sudo USE_BUNDLED_LIBUV=1 ./install-dependencies-jammy
           sudo apt-get install -y libuv1-dev xvfb
 
+      - name: Restore workspace ownership after sudo install
+        run: sudo chown -R "$USER:$USER" .
+
       - name: Install rig
         run: |
           curl -fLs https://github.com/r-lib/rig/releases/download/latest/rig-linux-latest.tar.gz \

--- a/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
@@ -144,13 +144,14 @@ jobs:
           node-version: 24
 
       - name: Install build dependencies (jammy)
+        working-directory: dependencies/linux
         run: |
           sudo apt-get update
           # ubuntu-22.04 runners ship with pkgconf preinstalled, which
           # conflicts with the pkg-config package install-dependencies-jammy
           # requests.
           sudo apt-get remove -y pkgconf 2>/dev/null || true
-          sudo ./dependencies/linux/install-dependencies-jammy
+          sudo ./install-dependencies-jammy
           sudo apt-get install -y xvfb
 
       - name: Install rig

--- a/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
@@ -1,0 +1,223 @@
+name: "Test: E2E Playwright RStudio (Desktop, Ubuntu 22, Open Source, PR-triggered, build-from-source)"
+
+on:
+  pull_request:
+    # `edited` is included so toggling `[full-pw]` or `[skip-pw]` in the PR
+    # title (after the PR is open) re-fires the workflow. The concurrency
+    # block below cancels any older in-flight run.
+    types: [opened, synchronize, reopened, edited]
+    paths:
+      - "src/**"
+      - "e2e/rstudio/**"
+      - ".github/pw-test-map.yml"
+      - ".github/scripts/pw-pr-select.py"
+      - ".github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml"
+      - "dependencies/linux/install-dependencies-jammy"
+
+concurrency:
+  group: pw-pr-ubuntu-22-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  # Paths excluded until test/ron/playwright-auth-setup merges.
+  # When that lands, remove this and the "Filter excluded paths" step.
+  EXCLUDED_PATHS: |
+    tests/panes/posit-assistant-chat/
+    tests/panes/editor/code_suggestions.test.ts
+    tests/panes/editor/edit_suggestions.test.ts
+
+jobs:
+  select:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      selector: ${{ steps.filter.outputs.selector }}
+      skip:     ${{ steps.filter.outputs.skip }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install PyYAML
+        run: python3 -m pip install --user 'pyyaml==6.0.2'
+
+      - name: Verify selector self-test
+        run: python3 .github/scripts/pw-pr-select.py --self-test
+
+      - name: Compute selector
+        id: compute
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "Changed files:"
+          git diff --name-only "origin/$BASE_REF...HEAD" | tee /dev/stderr \
+            | python3 .github/scripts/pw-pr-select.py \
+                --map .github/pw-test-map.yml \
+                --title "$PR_TITLE" \
+            | tee -a "$GITHUB_OUTPUT"
+
+      - name: Filter excluded paths from selector
+        id: filter
+        working-directory: e2e/rstudio
+        env:
+          RAW_SELECTOR: ${{ steps.compute.outputs.selector }}
+          FULL:         ${{ steps.compute.outputs.full }}
+          SKIP_IN:      ${{ steps.compute.outputs.skip }}
+        run: |
+          mapfile -t EXCLUDED < <(printf '%s\n' "${EXCLUDED_PATHS:-}" \
+            | sed 's|^[[:space:]]*||;s|[[:space:]]*$||' | sed '/^$/d')
+
+          excluded_match() {
+            local p="$1" pref
+            for pref in "${EXCLUDED[@]}"; do
+              case "$p" in "$pref"*) return 0 ;; esac
+            done
+            return 1
+          }
+
+          if [ "$SKIP_IN" = "true" ]; then
+            echo "selector=" >> "$GITHUB_OUTPUT"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$FULL" = "true" ] || [ -z "$RAW_SELECTOR" ]; then
+            CANDIDATES=$(find tests -name '*.test.ts' -type f | sort)
+          else
+            CANDIDATES=$(printf '%s\n' $RAW_SELECTOR)
+          fi
+
+          KEPT=(); DROPPED=()
+          while IFS= read -r p; do
+            [ -z "$p" ] && continue
+            if excluded_match "$p"; then DROPPED+=("$p"); else KEPT+=("$p"); fi
+          done <<< "$CANDIDATES"
+
+          if [ ${#DROPPED[@]} -gt 0 ]; then
+            {
+              echo "### Excluded tests (require auth)"
+              printf -- '- %s\n' "${DROPPED[@]}"
+              echo ""
+              echo "_Will run once test/ron/playwright-auth-setup merges._"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [ ${#KEPT[@]} -eq 0 ]; then
+            echo "selector=" >> "$GITHUB_OUTPUT"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "selector=${KEPT[*]}" >> "$GITHUB_OUTPUT"
+            echo "skip=false"          >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Write selection decision to step summary
+        if: always()
+        env:
+          SKIP:     ${{ steps.filter.outputs.skip }}
+          SELECTOR: ${{ steps.filter.outputs.selector }}
+        run: |
+          {
+            echo "### Playwright selection"
+            echo ""
+            echo "- skip: \`${SKIP:-<unset>}\`"
+            echo "- selector: \`${SELECTOR:-<empty>}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  build_and_test:
+    needs: select
+    if: needs.select.outputs.skip != 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
+    env:
+      R_LIBS_USER:        ${{ github.workspace }}/R-libs
+      PW_RSTUDIO_EDITION: os
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install build dependencies (jammy)
+        run: |
+          sudo ./dependencies/linux/install-dependencies-jammy
+          sudo apt-get install -y xvfb
+
+      - name: Install rig
+        run: |
+          curl -fLs https://github.com/r-lib/rig/releases/download/latest/rig-linux-latest.tar.gz \
+            | sudo tar xz -C /usr/local
+
+      - name: Install R via rig
+        run: |
+          rig add 4.5.3
+          rig default 4.5.3
+          mkdir -p "$R_LIBS_USER"
+
+      - name: Configure CMake
+        run: |
+          mkdir -p build
+          cd build
+          cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ..
+
+      - name: Build C++ (rsession, rserver, core)
+        working-directory: build
+        run: cmake --build . --target all -j"$(nproc)"
+
+      - name: Build GWT (draft)
+        working-directory: src/gwt
+        run: ant draft
+
+      - name: Install Electron desktop npm dependencies
+        working-directory: src/node/desktop
+        run: npm ci
+
+      - name: Install R packages from DESCRIPTION
+        if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
+        run: |
+          Rscript -e '
+            options(repos = c(P3M = "https://packagemanager.posit.co/cran/__linux__/jammy/latest"))
+            if (!requireNamespace("pak", quietly = TRUE)) install.packages("pak")
+            pak::local_install_dev_deps(root = "e2e/rstudio", ask = FALSE, upgrade = FALSE)
+          '
+
+      - name: Install Playwright npm dependencies
+        working-directory: e2e/rstudio
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: e2e/rstudio
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests against dev build
+        working-directory: e2e/rstudio
+        env:
+          PW_RSTUDIO_MODE:  desktop
+          PW_RSTUDIO_DEV:   "1"
+          PW_TEST_SELECTOR: ${{ needs.select.outputs.selector }}
+        run: |
+          echo "Selector: $PW_TEST_SELECTOR"
+          read -ra FILES <<< "$PW_TEST_SELECTOR"
+          xvfb-run -a --server-args="-screen 0 1920x1080x24" \
+            npx playwright test "${FILES[@]}" --project desktop
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: e2e/rstudio/playwright-report/
+          if-no-files-found: ignore
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: e2e/rstudio/test-results/
+          if-no-files-found: ignore

--- a/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
@@ -144,6 +144,11 @@ jobs:
         with:
           node-version: 24
 
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
       - name: Install build dependencies (jammy)
         working-directory: dependencies/linux
         run: |

--- a/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
@@ -152,7 +152,7 @@ jobs:
           # requests.
           sudo apt-get remove -y pkgconf 2>/dev/null || true
           sudo ./install-dependencies-jammy
-          sudo apt-get install -y xvfb
+          sudo apt-get install -y libuv1-dev xvfb
 
       - name: Install rig
         run: |
@@ -187,7 +187,10 @@ jobs:
         if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
         run: |
           Rscript -e '
-            options(repos = c(P3M = "https://packagemanager.posit.co/cran/__linux__/jammy/latest"))
+            options(
+              repos = c(P3M = "https://packagemanager.posit.co/cran/__linux__/jammy/latest"),
+              HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version$platform, R.version$arch, R.version$os))
+            )
             if (!requireNamespace("pak", quietly = TRUE)) install.packages("pak")
             pak::local_install_dev_deps(root = "e2e/rstudio", ask = FALSE, upgrade = FALSE)
           '

--- a/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
@@ -136,6 +136,7 @@ jobs:
     env:
       R_LIBS_USER:        ${{ github.workspace }}/R-libs
       PW_RSTUDIO_EDITION: os
+      USE_BUNDLED_LIBUV:  "1"
     steps:
       - uses: actions/checkout@v4
 
@@ -185,8 +186,6 @@ jobs:
 
       - name: Install R packages from DESCRIPTION
         if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
-        env:
-          USE_BUNDLED_LIBUV: "1"
         run: |
           Rscript -e '
             options(

--- a/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-22-pr.yml
@@ -185,6 +185,8 @@ jobs:
 
       - name: Install R packages from DESCRIPTION
         if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
+        env:
+          USE_BUNDLED_LIBUV: "1"
         run: |
           Rscript -e '
             options(

--- a/src/cpp/session/modules/SessionRCompletions.cpp
+++ b/src/cpp/session/modules/SessionRCompletions.cpp
@@ -13,8 +13,6 @@
  *
  */
 
-// Throwaway: trigger completions-rule tests in PR CI (will revert)
-
 #include "SessionRCompletions.hpp"
 
 #include <gsl/gsl-lite.hpp>

--- a/src/cpp/session/modules/SessionRCompletions.cpp
+++ b/src/cpp/session/modules/SessionRCompletions.cpp
@@ -13,6 +13,8 @@
  *
  */
 
+// Throwaway: trigger completions-rule tests in PR CI (will revert)
+
 #include "SessionRCompletions.hpp"
 
 #include <gsl/gsl-lite.hpp>


### PR DESCRIPTION
## Summary

Adds a PR-triggered Playwright workflow for Ubuntu 22 (jammy, amd64) that builds RStudio Desktop from source on the runner, then runs the suite against that build via `PW_RSTUDIO_DEV=1` (#17700).

Sibling to #17706 (macOS 26 ARM PR-triggered workflow), but uses a source build instead of the latest daily. This is the first per-OS PR workflow that actually validates the PR's product-code changes; the existing PR workflows test against the daily binary.

Selector logic is the same as #17706 (`pw-pr-select.py` against the diff, plus `[full-pw]`/`[skip-pw]` PR-title overrides). Adds a path filter that excludes Posit Assistant and code/edit-suggestion tests until `test/ron/playwright-auth-setup` merges.

First run is expected to be 90-150 min uncached. Build caching (sccache, `actions/cache` for `node_modules` / GWT output) is deferred to a follow-up.