### PR TITLE
drop stale brat provenance comments from ported tests

### DIFF
--- a/e2e/rstudio/tests/panes/files/files_endpoint.test.ts
+++ b/e2e/rstudio/tests/panes/files/files_endpoint.test.ts
@@ -1,7 +1,5 @@
 // /files/ HTTP endpoint cross-site protections (rstudio-pro#10980).
 //
-// Ported from src/cpp/tests/automation/testthat/test-automation-files-endpoint.R.
-//
 // The /files/ endpoint serves user-controlled files with native MIME types
 // and must reject cross-site requests so attacker pages can't redirect
 // victims into loading attacker HTML in the RStudio session origin.

--- a/e2e/rstudio/tests/panes/layout/pane_layout.test.ts
+++ b/e2e/rstudio/tests/panes/layout/pane_layout.test.ts
@@ -4,8 +4,6 @@ import { typeInConsole, CONSOLE_INPUT } from '@pages/console_pane.page';
 import { executeCommand } from '@utils/commands';
 import type { Page } from 'playwright';
 
-// Ported from src/cpp/tests/automation/testthat/test-automation-pane-layout.R.
-
 // Pane layout dialog: quadrant containers
 const PL_LEFT_TOP = '#rstudio_pane_layout_left_top';
 const PL_LEFT_BOTTOM = '#rstudio_pane_layout_left_bottom';

--- a/e2e/rstudio/tests/panes/layout/panes.test.ts
+++ b/e2e/rstudio/tests/panes/layout/panes.test.ts
@@ -1,6 +1,4 @@
 // Tests related to pane and column management.
-//
-// Ported from src/cpp/tests/automation/testthat/test-automation-panes.R.
 
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { ConsolePaneActions } from '@actions/console_pane.actions';


### PR DESCRIPTION
## Summary

- Three Playwright tests (`files_endpoint`, `pane_layout`, `panes`) carried `// Ported from src/cpp/tests/automation/testthat/test-automation-*.R` header lines.
- Those source files were removed alongside the BRAT infrastructure in #17714 / #17715, so the pointers no longer resolve.
- This PR drops the stale comments. No functional change.

## Test plan

- [ ] `npx tsc --noEmit` (comment-only edits; expect no diagnostics)