### PR TITLE
Honor newlines in rstudioapi showDialog/showPrompt messages

### DIFF
--- a/.claude/skills/rstudio-run-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-run-playwright-tests/SKILL.md
@@ -57,7 +57,7 @@ Prerequisites for `PW_RSTUDIO_DEV=1` (run from the **repo root**, not `e2e/rstud
 
 1. C++ session built — `cmake --build build` (one-time, plus after C++ edits)
 2. GWT transpiled to JS — `(cd src/gwt && ant draft)` (re-run after Java edits; takes 2-5 min)
-3. Electron deps installed — `(cd src/node/desktop && npm ci)` (one-time; first `npm run start` will do this if needed)
+3. Electron deps installed — `(cd src/node/desktop && npm ci)` (one-time)
 
 The first `npm run start` also runs a webpack compile (~2 min). The fixture extends its CDP-connect deadline to 3 minutes on this path. Subsequent starts are faster.
 

--- a/.claude/skills/rstudio-run-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-run-playwright-tests/SKILL.md
@@ -42,6 +42,27 @@ PW_RSTUDIO_EDITION=pro npx playwright test
 - `PW_RSTUDIO_EXTRA_ARGS` passes space-separated CLI flags to the RStudio process at launch
 - `PW_RSTUDIO_PREFS_OVERRIDE` points at a JSON/JSONC file whose keys override the suite-wide RStudio prefs (`fixtures/base-prefs.jsonc`) per-key
 
+### Testing in-tree changes (dev build)
+
+By default the desktop fixture launches the **installed** RStudio at the OS-default path (e.g. `/Applications/RStudio.app` on macOS). That binary won't reflect uncommitted edits to GWT/Java, C++ session code, or the Electron shell.
+
+To exercise local changes, set `PW_RSTUDIO_DEV=1` -- the fixture then launches the in-tree dev build via `npm run start` (electron-forge) inside `src/node/desktop`:
+
+```bash
+# Run against the in-tree dev build with uncommitted changes
+PW_RSTUDIO_DEV=1 npx playwright test tests/path/to/test.test.ts
+```
+
+Prerequisites for `PW_RSTUDIO_DEV=1`:
+
+1. The C++ session is built — `cmake --build build` (one-time, plus after C++ edits)
+2. GWT is transpiled to JS — `cd src/gwt && ant draft` (re-run after Java edits; takes 2-5 min)
+3. Electron deps are installed — `cd src/node/desktop && npm ci` (one-time; first `npm run start` will do this if needed)
+
+The first `npm run start` also runs a webpack compile (~2 min). The fixture extends its CDP-connect deadline to 3 minutes on this path. Subsequent starts are faster.
+
+Note: tests that exercise the `doRestart()` flow (e.g. uninstall Posit Assistant) aren't fully supported under `PW_RSTUDIO_DEV=1` because Electron's relaunch spawns the same dev executable rather than a fresh CDP-enabled session.
+
 ## Server Mode
 
 Pass `--project=server` and provide credentials.

--- a/.claude/skills/rstudio-run-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-run-playwright-tests/SKILL.md
@@ -65,19 +65,35 @@ Note: tests that exercise the `doRestart()` flow (e.g. uninstall Posit Assistant
 
 ## Server Mode
 
-Pass `--project=server` and provide credentials.
+### Default: in-tree `rserver-dev`
+
+`--project=server` with no env vars spawns a private `rserver-dev` per worker, using the binary at `build/src/cpp/server/rserver` and the config at `build/src/cpp/conf/rserver-dev.conf`. The spawned server runs with `--auth-none`, so no credentials are needed.
+
+```bash
+# All tests against in-tree rserver-dev
+npx playwright test --project=server
+
+# Specific test file
+npx playwright test tests/path/to/test.test.ts --project=server
+```
+
+Prerequisite: build the server first from the **repo root** with `cmake --build build`. Override the binary or config paths with `PW_RSERVER_BIN` / `PW_RSERVER_CONF` if you need to point at a different build.
+
+### Targeting an external server
+
+To skip the spawn and connect to an external server (CI, a remote VM, etc.), set `PW_RSTUDIO_SERVER_URL`. Credentials are needed only when the external server presents a login form.
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `PW_RSTUDIO_SERVER_URL` | No | Full URL including port if needed, e.g. `http://10.12.227.184:8787` or `https://dev.example.com/s/abc123/` (default: `http://localhost:8787`) |
-| `PW_RSTUDIO_SERVER_PORT` | No | Override the port in the URL (no default -- only set if you need to override what's in the URL) |
-| `PW_RSTUDIO_SERVER_USER` | Yes | Login username |
-| `PW_RSTUDIO_SERVER_PASSWORD` | Yes | Login password |
+| `PW_RSTUDIO_SERVER_URL` | When targeting an external server | Full URL including port if needed, e.g. `http://10.12.227.184:8787` or `https://dev.example.com/s/abc123/` |
+| `PW_RSTUDIO_SERVER_PORT` | No | Override the port in the URL (only set if you need to override what's in the URL) |
+| `PW_RSTUDIO_SERVER_USER` | When login is required | Login username |
+| `PW_RSTUDIO_SERVER_PASSWORD` | When login is required | Login password |
 | `PW_RSTUDIO_SERVER_LOGIN_TIMEOUT` | No | Post-login wait for the IDE console, in ms (default: 60000). Increase for slow servers. |
 | `PW_RSTUDIO_EDITION` | No | `os` (default) or `pro`. Filters edition-specific tests. |
 
 ```bash
-# All tests
+# External server with login
 PW_RSTUDIO_SERVER_URL=http://<ip> PW_RSTUDIO_SERVER_USER=<user> PW_RSTUDIO_SERVER_PASSWORD=<pass> npx playwright test --project=server
 
 # Specific test file

--- a/.claude/skills/rstudio-run-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-run-playwright-tests/SKILL.md
@@ -53,11 +53,11 @@ To exercise local changes, set `PW_RSTUDIO_DEV=1` -- the fixture then launches t
 PW_RSTUDIO_DEV=1 npx playwright test tests/path/to/test.test.ts
 ```
 
-Prerequisites for `PW_RSTUDIO_DEV=1`:
+Prerequisites for `PW_RSTUDIO_DEV=1` (run from the **repo root**, not `e2e/rstudio`):
 
-1. The C++ session is built — `cmake --build build` (one-time, plus after C++ edits)
-2. GWT is transpiled to JS — `cd src/gwt && ant draft` (re-run after Java edits; takes 2-5 min)
-3. Electron deps are installed — `cd src/node/desktop && npm ci` (one-time; first `npm run start` will do this if needed)
+1. C++ session built — `cmake --build build` (one-time, plus after C++ edits)
+2. GWT transpiled to JS — `(cd src/gwt && ant draft)` (re-run after Java edits; takes 2-5 min)
+3. Electron deps installed — `(cd src/node/desktop && npm ci)` (one-time; first `npm run start` will do this if needed)
 
 The first `npm run start` also runs a webpack compile (~2 min). The fixture extends its CDP-connect deadline to 3 minutes on this path. Subsequent starts are faster.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 -
 
 ### Fixed
--
+- ([#17701](https://github.com/rstudio/rstudio/issues/17701)): Honor newline characters in `rstudioapi::showDialog()` and `rstudioapi::showPrompt()` messages.
 
 ### Dependencies
 - Ace 1.43.5

--- a/e2e/rstudio/tests/panes/misc/rstudioapi_show_dialog.test.ts
+++ b/e2e/rstudio/tests/panes/misc/rstudioapi_show_dialog.test.ts
@@ -29,6 +29,19 @@ test.describe('rstudioapi dialog newline handling (#17701)', { tag: ['@parallel_
     await consoleActions.clearConsole();
   });
 
+  // If a test fails with the dialog still up, R stays blocked on
+  // showDialogCompleted -- fixture shutdown then triggers the "R session is
+  // busy" quit prompt. Force the dialog closed so cleanup is reliable.
+  test.afterEach(async ({ rstudioPage: page }) => {
+    const cancel = page.locator(`.gwt-DialogBox ${DIALOG_CANCEL}`);
+    const ok = page.locator(`.gwt-DialogBox ${DIALOG_OK}`);
+    if (await cancel.first().isVisible().catch(() => false)) {
+      await cancel.first().click();
+    } else if (await ok.first().isVisible().catch(() => false)) {
+      await ok.first().click();
+    }
+  });
+
   test('showDialog preserves "\\n" as a line break', async ({ rstudioPage: page }) => {
     const title = `showDialog_17701_${Date.now()}`;
 

--- a/e2e/rstudio/tests/panes/misc/rstudioapi_show_dialog.test.ts
+++ b/e2e/rstudio/tests/panes/misc/rstudioapi_show_dialog.test.ts
@@ -1,0 +1,72 @@
+// Regression test for https://github.com/rstudio/rstudio/issues/17701
+//
+// rstudioapi::showDialog() and rstudioapi::showPrompt() silently dropped
+// newline characters from the `message` argument. The fix applies
+// `white-space: pre-line` to the GWT widgets so caller-supplied "\n"
+// characters render as line breaks.
+//
+// Only the GWT-rendered paths are covered here:
+//   - showDialog  -- GWT MessageDialog on both Desktop and Server
+//   - showPrompt  -- GWT TextEntryModalDialog on Electron Desktop and Server
+// showQuestion uses a native Electron dialog on Desktop (not reachable from
+// Playwright); on Server it goes through MultiLineLabel which already handled
+// newlines, so it isn't part of this regression.
+//
+// The R-side calls block until the dialog is dismissed, so each test must
+// click OK/Cancel before issuing the next console command.
+
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+
+const DIALOG_OK = '#rstudio_dlg_ok';
+const DIALOG_CANCEL = '#rstudio_dlg_cancel';
+
+test.describe('rstudioapi dialog newline handling (#17701)', { tag: ['@parallel_safe'] }, () => {
+  let consoleActions: ConsolePaneActions;
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+    await consoleActions.clearConsole();
+  });
+
+  test('showDialog preserves "\\n" as a line break', async ({ rstudioPage: page }) => {
+    const title = `showDialog_17701_${Date.now()}`;
+
+    // Calling .rs.api.showDialog blocks the R thread until the client fires
+    // showDialogCompleted, so this returns immediately after pressing Enter.
+    await consoleActions.executeInConsole(
+      `.rs.api.showDialog("${title}", "line one\\nline two")`,
+    );
+
+    const dialog = page.locator(`.gwt-DialogBox[aria-label="${title}"]`);
+    await expect(dialog).toBeVisible({ timeout: 10000 });
+
+    // GWT HTML widget renders the message in a div.gwt-HTML inside the
+    // dialog. With white-space: pre-line applied, innerText reflects the
+    // literal "\n" as a rendered newline.
+    const messageText = await dialog.locator('.gwt-HTML').innerText();
+    expect(messageText).toMatch(/line one\s*\n\s*line two/);
+
+    await dialog.locator(DIALOG_OK).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('showPrompt preserves "\\n" as a line break', async ({ rstudioPage: page }) => {
+    const title = `showPrompt_17701_${Date.now()}`;
+
+    await consoleActions.executeInConsole(
+      `.rs.api.showPrompt("${title}", "line one\\nline two")`,
+    );
+
+    const dialog = page.locator(`.gwt-DialogBox[aria-label="${title}"]`);
+    await expect(dialog).toBeVisible({ timeout: 10000 });
+
+    // The prompt caption is a FormLabel — the only <label> in the dialog.
+    const messageText = await dialog.locator('label').first().innerText();
+    expect(messageText).toMatch(/line one\s*\n\s*line two/);
+
+    // Cancel so R's showPrompt returns NULL and the session goes idle.
+    await dialog.locator(DIALOG_CANCEL).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+});

--- a/e2e/rstudio/tests/panes/misc/rstudioapi_show_dialog.test.ts
+++ b/e2e/rstudio/tests/panes/misc/rstudioapi_show_dialog.test.ts
@@ -49,20 +49,36 @@ test.describe('rstudioapi dialog newline handling (#17701)', { tag: ['@parallel_
 
   // If a test fails with the dialog still up, R stays blocked on
   // showDialogCompleted -- fixture shutdown then triggers the "R session is
-  // busy" quit prompt. Drain every visible dismiss button (not just the
-  // first) in case multiple modals stacked up, then fall back to Escape so
-  // a dialog with unexpected selectors still gets dismissed.
+  // busy" quit prompt. Drain modals one at a time from the topmost
+  // (last() in DOM order, since GWT appends new modals). Scope dismiss
+  // buttons to each dialog so we never click a covered button on an older
+  // one. If no known selector matches a given dialog, press Escape for
+  // that dialog before moving on. Bounded by MAX_DIALOG_CLEANUP to avoid
+  // hanging if a modal refuses to dismiss.
+  const MAX_DIALOG_CLEANUP = 5;
   test.afterEach(async ({ rstudioPage: page }) => {
-    let dismissed = false;
-    for (const sel of DISMISS_SELECTORS) {
-      const btn = page.locator(`.gwt-DialogBox ${sel}`).first();
-      while (await btn.isVisible().catch(() => false)) {
-        await btn.click();
-        dismissed = true;
+    const dialogs = page.locator('.gwt-DialogBox');
+    for (let i = 0; i < MAX_DIALOG_CLEANUP; i++) {
+      const count = await dialogs.count();
+      if (count === 0) break;
+
+      const top = dialogs.nth(count - 1);
+      let clicked = false;
+      for (const sel of DISMISS_SELECTORS) {
+        const btn = top.locator(sel).first();
+        if (await btn.isVisible().catch(() => false)) {
+          await btn.click();
+          clicked = true;
+          break;
+        }
       }
-    }
-    if (!dismissed && await page.locator('.gwt-DialogBox').first().isVisible().catch(() => false)) {
-      await page.keyboard.press('Escape');
+      if (!clicked) {
+        await page.keyboard.press('Escape');
+      }
+
+      // Wait for the count to drop before processing the next dialog.
+      // Swallow timeouts so the loop bound (not an exception) caps total wait.
+      await expect(dialogs).toHaveCount(count - 1, { timeout: 5000 }).catch(() => {});
     }
   });
 

--- a/e2e/rstudio/tests/panes/misc/rstudioapi_show_dialog.test.ts
+++ b/e2e/rstudio/tests/panes/misc/rstudioapi_show_dialog.test.ts
@@ -29,6 +29,16 @@ const DIALOG_NO = '#rstudio_dlg_no';
 // the action.
 const DISMISS_SELECTORS = [DIALOG_CANCEL, DIALOG_NO, DIALOG_OK];
 
+// Assert that messageText contains the expected lines as distinct rendered
+// rows (split on "\n", trimmed, non-empty). Stronger than a regex with \s*
+// across the newline because it requires the newline character to actually
+// separate the two lines in the rendered output.
+function expectRenderedLines(messageText: string, expected: string[]): void {
+  const lines = messageText.split('\n').map((s) => s.trim()).filter(Boolean);
+  expect(lines).toEqual(expect.arrayContaining(expected));
+  expect(lines.length).toBeGreaterThanOrEqual(expected.length);
+}
+
 test.describe('rstudioapi dialog newline handling (#17701)', { tag: ['@parallel_safe'] }, () => {
   let consoleActions: ConsolePaneActions;
 
@@ -39,52 +49,95 @@ test.describe('rstudioapi dialog newline handling (#17701)', { tag: ['@parallel_
 
   // If a test fails with the dialog still up, R stays blocked on
   // showDialogCompleted -- fixture shutdown then triggers the "R session is
-  // busy" quit prompt. Force the dialog closed so cleanup is reliable.
+  // busy" quit prompt. Drain every visible dismiss button (not just the
+  // first) in case multiple modals stacked up, then fall back to Escape so
+  // a dialog with unexpected selectors still gets dismissed.
   test.afterEach(async ({ rstudioPage: page }) => {
+    let dismissed = false;
     for (const sel of DISMISS_SELECTORS) {
       const btn = page.locator(`.gwt-DialogBox ${sel}`).first();
-      if (await btn.isVisible().catch(() => false)) {
+      while (await btn.isVisible().catch(() => false)) {
         await btn.click();
-        break;
+        dismissed = true;
       }
+    }
+    if (!dismissed && await page.locator('.gwt-DialogBox').first().isVisible().catch(() => false)) {
+      await page.keyboard.press('Escape');
     }
   });
 
   test('showDialog preserves "\\n" as a line break', async ({ rstudioPage: page }) => {
-    const title = `showDialog_17701_${Date.now()}`;
-
     // Calling .rs.api.showDialog blocks the R thread until the client fires
     // showDialogCompleted, so this returns immediately after pressing Enter.
     await consoleActions.executeInConsole(
-      `.rs.api.showDialog("${title}", "line one\\nline two")`,
+      `.rs.api.showDialog("showDialog_17701", "line one\\nline two")`,
     );
 
-    const dialog = page.locator(`.gwt-DialogBox[aria-label="${title}"]`);
+    const dialog = page.locator('.gwt-DialogBox[aria-label="showDialog_17701"]');
     await expect(dialog).toBeVisible({ timeout: 10000 });
 
     // GWT HTML widget renders the message in a div.gwt-HTML inside the
     // dialog. With white-space: pre-line applied, innerText reflects the
     // literal "\n" as a rendered newline.
     const messageText = await dialog.locator('.gwt-HTML').innerText();
-    expect(messageText).toMatch(/line one\s*\n\s*line two/);
+    expectRenderedLines(messageText, ['line one', 'line two']);
+
+    await dialog.locator(DIALOG_OK).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('showDialog renders HTML alongside newlines', async ({ rstudioPage: page }) => {
+    // pre-line preserves "\n" while still honoring HTML tags. Verifies that
+    // existing showDialog callers passing markup (e.g. <b>, links) keep
+    // working after the fix.
+    await consoleActions.executeInConsole(
+      `.rs.api.showDialog("showDialog_17701_html", "<b>line one</b>\\nline two")`,
+    );
+
+    const dialog = page.locator('.gwt-DialogBox[aria-label="showDialog_17701_html"]');
+    await expect(dialog).toBeVisible({ timeout: 10000 });
+
+    const messageBody = dialog.locator('.gwt-HTML');
+    const messageText = await messageBody.innerText();
+    expectRenderedLines(messageText, ['line one', 'line two']);
+    // Literal markup must not bleed into rendered text.
+    expect(messageText).not.toContain('<b>');
+    // Bold element must actually be a node, not just text.
+    await expect(messageBody.locator('b')).toContainText('line one');
+
+    await dialog.locator(DIALOG_OK).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('showDialog preserves consecutive newlines', async ({ rstudioPage: page }) => {
+    // pre-line collapses consecutive spaces but not consecutive newlines,
+    // so a blank line between two text lines should survive.
+    await consoleActions.executeInConsole(
+      `.rs.api.showDialog("showDialog_17701_blank", "line one\\n\\nline two")`,
+    );
+
+    const dialog = page.locator('.gwt-DialogBox[aria-label="showDialog_17701_blank"]');
+    await expect(dialog).toBeVisible({ timeout: 10000 });
+
+    const messageText = await dialog.locator('.gwt-HTML').innerText();
+    // Two newlines must remain in the rendered text.
+    expect(messageText).toMatch(/line one\n\s*\n\s*line two/);
 
     await dialog.locator(DIALOG_OK).click();
     await expect(dialog).not.toBeVisible({ timeout: 5000 });
   });
 
   test('showPrompt preserves "\\n" as a line break', async ({ rstudioPage: page }) => {
-    const title = `showPrompt_17701_${Date.now()}`;
-
     await consoleActions.executeInConsole(
-      `.rs.api.showPrompt("${title}", "line one\\nline two")`,
+      `.rs.api.showPrompt("showPrompt_17701", "line one\\nline two")`,
     );
 
-    const dialog = page.locator(`.gwt-DialogBox[aria-label="${title}"]`);
+    const dialog = page.locator('.gwt-DialogBox[aria-label="showPrompt_17701"]');
     await expect(dialog).toBeVisible({ timeout: 10000 });
 
     // The prompt caption is a FormLabel — the only <label> in the dialog.
     const messageText = await dialog.locator('label').first().innerText();
-    expect(messageText).toMatch(/line one\s*\n\s*line two/);
+    expectRenderedLines(messageText, ['line one', 'line two']);
 
     // Cancel so R's showPrompt returns NULL and the session goes idle.
     await dialog.locator(DIALOG_CANCEL).click();
@@ -92,23 +145,21 @@ test.describe('rstudioapi dialog newline handling (#17701)', { tag: ['@parallel_
   });
 
   test('showQuestion preserves "\\n" as a line break', async ({ rstudioPage: page }) => {
-    const title = `showQuestion_17701_${Date.now()}`;
-
     await consoleActions.executeInConsole(
-      `.rs.api.showQuestion("${title}", "line one\\nline two")`,
+      `.rs.api.showQuestion("showQuestion_17701", "line one\\nline two")`,
     );
 
-    const dialog = page.locator(`.gwt-DialogBox[aria-label="${title}"]`);
+    const dialog = page.locator('.gwt-DialogBox[aria-label="showQuestion_17701"]');
     await expect(dialog).toBeVisible({ timeout: 10000 });
 
     // MessageDialog renders the message through MultiLineLabel, which uses
     // DomUtils.textToHtml to convert "\n" into <br/> tags. The label's CSS
     // class is GWT-obfuscated (setStylePrimaryName replaces gwt-Label with
-    // the themeStyles.dialogMessage() class), so target via the whole-dialog
-    // innerText -- the buttons ("OK", "Cancel") don't contain the marker
-    // string, so the pattern uniquely matches the rendered message.
+    // the themeStyles.dialogMessage() class), so read the whole-dialog
+    // innerText -- the buttons ("OK", "Cancel") don't introduce extra lines
+    // that match the expected text.
     const messageText = await dialog.innerText();
-    expect(messageText).toMatch(/line one\s*\n\s*line two/);
+    expectRenderedLines(messageText, ['line one', 'line two']);
 
     // showYesNoMessage assigns dlg_no to the noLabel button (here labeled
     // "Cancel"); dlg_cancel does not exist on this dialog.

--- a/e2e/rstudio/tests/panes/misc/rstudioapi_show_dialog.test.ts
+++ b/e2e/rstudio/tests/panes/misc/rstudioapi_show_dialog.test.ts
@@ -21,6 +21,14 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 
 const DIALOG_OK = '#rstudio_dlg_ok';
 const DIALOG_CANCEL = '#rstudio_dlg_cancel';
+// showQuestion uses showYesNoMessage, which assigns the yes/no element IDs
+// regardless of the caller-supplied labels ("OK"/"Cancel").
+const DIALOG_NO = '#rstudio_dlg_no';
+
+// Ordered from least-destructive (Cancel/No) to most (OK), used by the
+// afterEach cleanup so a stuck dialog can be dismissed without committing
+// the action.
+const DISMISS_SELECTORS = [DIALOG_CANCEL, DIALOG_NO, DIALOG_OK];
 
 test.describe('rstudioapi dialog newline handling (#17701)', { tag: ['@parallel_safe'] }, () => {
   let consoleActions: ConsolePaneActions;
@@ -34,12 +42,12 @@ test.describe('rstudioapi dialog newline handling (#17701)', { tag: ['@parallel_
   // showDialogCompleted -- fixture shutdown then triggers the "R session is
   // busy" quit prompt. Force the dialog closed so cleanup is reliable.
   test.afterEach(async ({ rstudioPage: page }) => {
-    const cancel = page.locator(`.gwt-DialogBox ${DIALOG_CANCEL}`);
-    const ok = page.locator(`.gwt-DialogBox ${DIALOG_OK}`);
-    if (await cancel.first().isVisible().catch(() => false)) {
-      await cancel.first().click();
-    } else if (await ok.first().isVisible().catch(() => false)) {
-      await ok.first().click();
+    for (const sel of DISMISS_SELECTORS) {
+      const btn = page.locator(`.gwt-DialogBox ${sel}`).first();
+      if (await btn.isVisible().catch(() => false)) {
+        await btn.click();
+        break;
+      }
     }
   });
 
@@ -95,12 +103,17 @@ test.describe('rstudioapi dialog newline handling (#17701)', { tag: ['@parallel_
     await expect(dialog).toBeVisible({ timeout: 10000 });
 
     // MessageDialog renders the message through MultiLineLabel, which uses
-    // DomUtils.textToHtml to convert "\n" into <br/> tags. innerText then
-    // reports the rendered newline.
-    const messageText = await dialog.locator('.gwt-Label').first().innerText();
+    // DomUtils.textToHtml to convert "\n" into <br/> tags. The label's CSS
+    // class is GWT-obfuscated (setStylePrimaryName replaces gwt-Label with
+    // the themeStyles.dialogMessage() class), so target via the whole-dialog
+    // innerText -- the buttons ("OK", "Cancel") don't contain the marker
+    // string, so the pattern uniquely matches the rendered message.
+    const messageText = await dialog.innerText();
     expect(messageText).toMatch(/line one\s*\n\s*line two/);
 
-    await dialog.locator(DIALOG_CANCEL).click();
+    // showYesNoMessage assigns dlg_no to the noLabel button (here labeled
+    // "Cancel"); dlg_cancel does not exist on this dialog.
+    await dialog.locator(DIALOG_NO).click();
     await expect(dialog).not.toBeVisible({ timeout: 5000 });
   });
 });

--- a/e2e/rstudio/tests/panes/misc/rstudioapi_show_dialog.test.ts
+++ b/e2e/rstudio/tests/panes/misc/rstudioapi_show_dialog.test.ts
@@ -5,13 +5,12 @@
 // `white-space: pre-line` to the GWT widgets so caller-supplied "\n"
 // characters render as line breaks.
 //
-// Only the GWT-rendered paths are covered here:
-//   - showDialog    -- GWT MessageDialog on both Desktop and Server
-//   - showPrompt    -- GWT TextEntryModalDialog on Electron Desktop and Server
-//   - showQuestion  -- GWT MessageDialog on Server only (Desktop uses Electron's
-//                      native dialog, which is outside Playwright's reach). This
-//                      path wasn't broken in #17701, but the @server_only test
-//                      guards against future regressions.
+// All three calls render through GWT dialogs in the test suite. Desktop
+// would normally use Electron's native showMessageBox for showQuestion,
+// but fixtures/base-prefs.jsonc sets native_file_dialogs=false so message
+// dialogs are GWT too (Playwright can't reach native dialogs). The
+// showQuestion case wasn't broken in #17701; the test guards against
+// future regressions in the MultiLineLabel rendering path.
 //
 // The R-side calls block until the dialog is dismissed, so each test must
 // click OK/Cancel before issuing the next console command.
@@ -92,7 +91,7 @@ test.describe('rstudioapi dialog newline handling (#17701)', { tag: ['@parallel_
     await expect(dialog).not.toBeVisible({ timeout: 5000 });
   });
 
-  test('showQuestion preserves "\\n" as a line break', { tag: ['@server_only'] }, async ({ rstudioPage: page }) => {
+  test('showQuestion preserves "\\n" as a line break', async ({ rstudioPage: page }) => {
     const title = `showQuestion_17701_${Date.now()}`;
 
     await consoleActions.executeInConsole(

--- a/e2e/rstudio/tests/panes/misc/rstudioapi_show_dialog.test.ts
+++ b/e2e/rstudio/tests/panes/misc/rstudioapi_show_dialog.test.ts
@@ -6,11 +6,12 @@
 // characters render as line breaks.
 //
 // Only the GWT-rendered paths are covered here:
-//   - showDialog  -- GWT MessageDialog on both Desktop and Server
-//   - showPrompt  -- GWT TextEntryModalDialog on Electron Desktop and Server
-// showQuestion uses a native Electron dialog on Desktop (not reachable from
-// Playwright); on Server it goes through MultiLineLabel which already handled
-// newlines, so it isn't part of this regression.
+//   - showDialog    -- GWT MessageDialog on both Desktop and Server
+//   - showPrompt    -- GWT TextEntryModalDialog on Electron Desktop and Server
+//   - showQuestion  -- GWT MessageDialog on Server only (Desktop uses Electron's
+//                      native dialog, which is outside Playwright's reach). This
+//                      path wasn't broken in #17701, but the @server_only test
+//                      guards against future regressions.
 //
 // The R-side calls block until the dialog is dismissed, so each test must
 // click OK/Cancel before issuing the next console command.
@@ -79,6 +80,26 @@ test.describe('rstudioapi dialog newline handling (#17701)', { tag: ['@parallel_
     expect(messageText).toMatch(/line one\s*\n\s*line two/);
 
     // Cancel so R's showPrompt returns NULL and the session goes idle.
+    await dialog.locator(DIALOG_CANCEL).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('showQuestion preserves "\\n" as a line break', { tag: ['@server_only'] }, async ({ rstudioPage: page }) => {
+    const title = `showQuestion_17701_${Date.now()}`;
+
+    await consoleActions.executeInConsole(
+      `.rs.api.showQuestion("${title}", "line one\\nline two")`,
+    );
+
+    const dialog = page.locator(`.gwt-DialogBox[aria-label="${title}"]`);
+    await expect(dialog).toBeVisible({ timeout: 10000 });
+
+    // MessageDialog renders the message through MultiLineLabel, which uses
+    // DomUtils.textToHtml to convert "\n" into <br/> tags. innerText then
+    // reports the rendered newline.
+    const messageText = await dialog.locator('.gwt-Label').first().innerText();
+    expect(messageText).toMatch(/line one\s*\n\s*line two/);
+
     await dialog.locator(DIALOG_CANCEL).click();
     await expect(dialog).not.toBeVisible({ timeout: 5000 });
   });

--- a/src/gwt/src/org/rstudio/core/client/widget/TextEntryModalDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/TextEntryModalDialog.java
@@ -16,6 +16,7 @@ package org.rstudio.core.client.widget;
 
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
 
 import com.google.gwt.user.client.ui.CheckBox;
@@ -103,6 +104,8 @@ public class TextEntryModalDialog extends ModalDialog<String>
       verticalPanel.setWidth(width_ + "px");
       captionLabel_.getElement().getStyle().setMarginBottom(6, Unit.PX);
       captionLabel_.getElement().getStyle().setProperty("display", "inlineBlock");
+      // Preserve "\n" in caller-supplied prompts (e.g. rstudioapi::showPrompt).
+      captionLabel_.getElement().getStyle().setWhiteSpace(Style.WhiteSpace.PRE_LINE);
       verticalPanel.add(captionLabel_);
       textBox_.getElement().getStyle().setMarginBottom(6, Unit.PX);
       verticalPanel.add(textBox_);

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/RStudioAPI.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/RStudioAPI.java
@@ -36,6 +36,7 @@ import org.rstudio.studio.client.common.rstudioapi.model.RStudioAPIServerOperati
 import org.rstudio.studio.client.common.satellite.Satellite;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.safehtml.shared.SafeHtml;
@@ -92,6 +93,9 @@ public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler,
       SafeHtml safeMsg = DialogHtmlSanitizer.sanitizeHtml(message);
       HTML msg = new HTML(safeMsg.asString());
       msg.setWidth("100%");
+      // Preserve "\n" in caller-supplied messages while still honoring
+      // sanitized HTML tags; without this, CSS collapses literal newlines.
+      msg.getElement().getStyle().setWhiteSpace(Style.WhiteSpace.PRE_LINE);
       verticalPanel.add(msg);
       
       if (!StringUtil.isNullOrEmpty(url))


### PR DESCRIPTION
## Intent

Addresses #17701.

`rstudioapi::showDialog()` and `rstudioapi::showPrompt()` were silently dropping `\n` characters from their `message` arguments, while `rstudioapi::showQuestion()` rendered them as line breaks. All three functions hit the same `rs_showDialog` C++ entry point and fire `kRStudioAPIShowDialog`, but the GWT frontend routes them to three different renderers:

| API | Renderer | `\n` handling before |
|---|---|---|
| `showDialog` | `HTML(DialogHtmlSanitizer.sanitizeHtml(message))` | Sanitizer never converts `\n`; CSS collapses the literal newline. |
| `showPrompt` | `TextEntryModalDialog` -> `FormLabel` | Plain text node; CSS collapses the literal newline. |
| `showQuestion` | `MessageDialog.labelForMessage` -> `MultiLineLabel` -> `DomUtils.textToHtml` | `textToHtml` rewrites `\n` -> `<br />`. |

## Changes

Apply `white-space: pre-line` to the two affected widgets so caller-supplied `\n` characters render as line breaks while sanitized HTML tags continue to be honored.

- `src/gwt/src/org/rstudio/studio/client/common/rstudioapi/RStudioAPI.java` -- `showDialog` HTML message
- `src/gwt/src/org/rstudio/core/client/widget/TextEntryModalDialog.java` -- `showPrompt` caption label
- `NEWS.md` -- changelog entry

`showQuestion` is unchanged.

## Test plan

- [ ] In an R console, run:
  ```
  rstudioapi::showDialog(title = "test", message = "test \n test")
  rstudioapi::showPrompt(title = "test", message = "test \n test")
  rstudioapi::showQuestion(title = "test", message = "test \n test")
  ```
  Verify all three dialogs render the message across two lines.
- [ ] Verify on RStudio Desktop (Electron) and RStudio Server.
- [ ] Verify that existing `showDialog` callers passing HTML (e.g. links, `<b>`) still render correctly.