### PR TITLE
e2e: add executeInConsole helper; force-kill orphaned electron

### DIFF
--- a/e2e/rstudio/actions/autocomplete.actions.ts
+++ b/e2e/rstudio/actions/autocomplete.actions.ts
@@ -53,14 +53,12 @@ export class AutocompleteActions {
    */
   async getCompletionsInConsole(setupCode: string[], triggerText: string): Promise<string[]> {
     for (const code of setupCode) {
-      await this.consoleActions.typeInConsole(code);
+      await this.consoleActions.executeInConsole(code);
       await sleep(1000);
     }
 
-    // Type trigger text without executing
-    await this.consoleActions.consolePane.consoleInput.click({ force: true });
-    await sleep(300);
-    await this.consoleActions.consolePane.consoleInput.pressSequentially(triggerText);
+    // Type trigger text without executing -- needs per-key events to fire the completer.
+    await this.consoleActions.typeInConsole(triggerText);
     await sleep(500);
 
     // If autocomplete already appeared (e.g. after typing $ or (), use it;
@@ -93,7 +91,7 @@ export class AutocompleteActions {
     extension: string = 'R',
   ): Promise<string[]> {
     for (const code of setupCode) {
-      await this.consoleActions.typeInConsole(code);
+      await this.consoleActions.executeInConsole(code);
       await sleep(1000);
     }
 

--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -68,17 +68,47 @@ export class ConsolePaneActions {
     this.consolePane = new ConsolePane(page);
   }
 
-  async typeInConsole(command: string): Promise<void> {
+  /**
+   * Submit an R expression to the console. Writes the text directly into the
+   * console's Ace editor and presses Enter -- no per-key typing -- so it
+   * doesn't race with autocomplete popups or other live-edit UI that can
+   * swallow characters. Prefer this when you just need code to run; use
+   * `typeInConsole` only when a test is exercising actual typing behavior.
+   */
+  async executeInConsole(command: string): Promise<void> {
     await this.consolePane.consoleTab.click();
-    await this.consolePane.consoleInput.click({ force: true });
-    await sleep(500);
-    await this.consolePane.consoleInput.pressSequentially(command);
-    await sleep(200);
+    await this.page.evaluate((text) => {
+      const el = document.getElementById('rstudio_console_input') as
+        | (HTMLElement & {
+            env?: { editor?: { setValue(s: string, cursorPos?: number): void; focus(): void } };
+          })
+        | null;
+      const editor = el?.env?.editor;
+      if (!editor) throw new Error('Console Ace editor not found at #rstudio_console_input');
+      editor.setValue(text, 1); // 1 = move cursor to end
+      editor.focus();
+    }, command);
     if (await this.page.locator('#rstudio_popup_completions').isVisible()) {
       await this.page.keyboard.press('Escape');
-      await sleep(100);
     }
-    await this.consolePane.consoleInput.press('Enter');
+    await this.page.keyboard.press('Enter');
+  }
+
+  /**
+   * Simulate user typing one keystroke at a time into the console input. Does
+   * NOT press Enter -- the caller controls submission. Use only when a test
+   * needs to exercise live-edit behavior that `executeInConsole`'s programmatic
+   * write doesn't trigger (e.g. autocomplete popups).
+   *
+   * `delayMs` is the per-keystroke delay; default 50ms is close to typical
+   * human typing speed and gives the editor time to dispatch input events and
+   * fire completers between chars.
+   */
+  async typeInConsole(text: string, delayMs: number = 50): Promise<void> {
+    await this.consolePane.consoleTab.click();
+    await this.consolePane.consoleInput.click({ force: true });
+    await sleep(300);
+    await this.consolePane.consoleInput.pressSequentially(text, { delay: delayMs });
   }
 
   async clearConsole(): Promise<void> {

--- a/e2e/rstudio/actions/source_pane.actions.ts
+++ b/e2e/rstudio/actions/source_pane.actions.ts
@@ -27,12 +27,12 @@ export class SourcePaneActions {
    * plain `writeLines("...", ...)` template; that gotcha is gone.
    */
   async createAndOpenFile(fileName: string, fileContent: string): Promise<void> {
-    await this.consolePaneActions.typeInConsole(
+    await this.consolePaneActions.executeInConsole(
       `writeLines(${rStringLiteral(fileContent)}, ${rStringLiteral(fileName)})`,
     );
     await sleep(1000);
 
-    await this.consolePaneActions.typeInConsole(`file.edit(${rStringLiteral(fileName)})`);
+    await this.consolePaneActions.executeInConsole(`file.edit(${rStringLiteral(fileName)})`);
 
     await expect(this.sourcePane.selectedTab).toContainText(fileName, { timeout: TIMEOUTS.fileOpen });
   }
@@ -46,7 +46,7 @@ export class SourcePaneActions {
     await expect(this.sourcePane.aceTextInput).toHaveCount(0, { timeout: 5000 }).catch(() => {});
     await sleep(500);
 
-    await this.consolePaneActions.typeInConsole(`unlink("${fileName}")`);
+    await this.consolePaneActions.executeInConsole(`unlink("${fileName}")`);
     await sleep(500);
   }
 

--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import stripJsonComments from 'strip-json-comments';
 import { TIMEOUTS, RSTUDIO_EXTRA_ARGS, sleep } from '../utils/constants';
-import { CONSOLE_INPUT, typeInConsole } from '../pages/console_pane.page';
+import { CONSOLE_INPUT, executeInConsole } from '../pages/console_pane.page';
 import { documentCloseAllNoSave } from '../utils/commands';
 import { rLibsUserTemplate } from './r-libs-setup';
 
@@ -486,7 +486,15 @@ function getRStudioPids(): Set<number> {
 }
 
 /**
- * Graceful shutdown: q() in console, close browser, kill process.
+ * Graceful shutdown: q() in console, close browser, kill process if it
+ * hasn't exited on its own.
+ *
+ * `browser.close()` over a CDP connection only disconnects the CDP session
+ * -- it does not terminate the underlying Electron process. And `q()`
+ * cascading to a full Electron quit is best-effort (a pending modal, a
+ * hung renderer, etc. can leave Electron alive after rsession exits). So
+ * after attempting graceful shutdown we always verify the process tree
+ * actually exited, and force-kill if not.
  *
  * No per-spec config-tree cleanup -- the sandbox-wide globalTeardown
  * removes everything under PW_SANDBOX at end of run.
@@ -499,12 +507,19 @@ export async function shutdownRStudio(session: DesktopSession): Promise<void> {
   await sleep(1000);
 
   try {
-    await typeInConsole(page, 'q(save = "no")');
-    await sleep(5000); // Give RStudio time to shut down and release port
-    await browser.close();
+    await executeInConsole(page, 'q(save = "no")');
   } catch {
-    await browser.close().catch(() => {});
-    // Only force kill if graceful shutdown failed
+    // Console may already be unresponsive; we still force-kill below.
+  }
+  await browser.close().catch(() => {});
+
+  // Wait briefly for Electron to exit on its own, then force-kill if it
+  // hasn't. Polling avoids a fixed sleep when the graceful path works.
+  const exitDeadline = Date.now() + 5000;
+  while (Date.now() < exitDeadline && rstudioProcess.exitCode === null && rstudioProcess.signalCode === null) {
+    await sleep(100);
+  }
+  if (rstudioProcess.exitCode === null && rstudioProcess.signalCode === null) {
     killProcessTree(rstudioProcess);
   }
 }

--- a/e2e/rstudio/fixtures/server.fixture.ts
+++ b/e2e/rstudio/fixtures/server.fixture.ts
@@ -6,7 +6,7 @@ import { createServer } from 'net';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { CONSOLE_INPUT, typeInConsole } from '../pages/console_pane.page';
+import { CONSOLE_INPUT, executeInConsole } from '../pages/console_pane.page';
 import { sleep } from '../utils/constants';
 import { setPref, documentCloseAllNoSave } from '../utils/commands';
 import { rLibsUserTemplate } from './r-libs-setup';
@@ -281,7 +281,7 @@ export async function shutdownServer(session: ServerSession): Promise<void> {
   try {
     await documentCloseAllNoSave(page);
     await sleep(1000);
-    await typeInConsole(page, 'q("no")');
+    await executeInConsole(page, 'q("no")');
     await sleep(2000);
   } catch {
     // Page may already be closed

--- a/e2e/rstudio/pages/console_pane.page.ts
+++ b/e2e/rstudio/pages/console_pane.page.ts
@@ -69,17 +69,50 @@ export const CONSOLE_TAB = '#rstudio_workbench_tab_console';
 export const CONSOLE_OUTPUT = '#rstudio_workbench_panel_console';
 export const INTERRUPT_R_BTN = "[id^='rstudio_tb_interruptr']";
 
-export async function typeInConsole(page: Page, command: string): Promise<void> {
+/**
+ * Submit an R expression to the console. Writes the text directly into the
+ * console's Ace editor and presses Enter -- no per-key typing -- so it doesn't
+ * race with autocomplete popups, tooltip handlers, or other live-edit UI that
+ * can swallow characters or steal focus. Prefer this when you just need code
+ * to run; use `typeInConsole` only when a test is exercising actual typing
+ * behavior (e.g. autocomplete triggering).
+ */
+export async function executeInConsole(page: Page, command: string): Promise<void> {
   await page.locator(CONSOLE_TAB).click();
-  await page.locator(CONSOLE_INPUT).click({ force: true });
-  await sleep(500);
-  await page.locator(CONSOLE_INPUT).pressSequentially(command);
-  await sleep(200);
+  await page.evaluate((text) => {
+    const el = document.getElementById('rstudio_console_input') as
+      | (HTMLElement & {
+          env?: { editor?: { setValue(s: string, cursorPos?: number): void; focus(): void } };
+        })
+      | null;
+    const editor = el?.env?.editor;
+    if (!editor) throw new Error('Console Ace editor not found at #rstudio_console_input');
+    editor.setValue(text, 1); // 1 = move cursor to end
+    editor.focus();
+  }, command);
+  // Defensive: a popup may have been left open by previous interaction.
   if (await page.locator('#rstudio_popup_completions').isVisible()) {
     await page.keyboard.press('Escape');
-    await sleep(100);
   }
-  await page.locator(CONSOLE_INPUT).press('Enter');
+  await page.keyboard.press('Enter');
+}
+
+/**
+ * Simulate user typing one keystroke at a time into the console input. Does
+ * NOT press Enter -- the caller controls submission. Use this only when a
+ * test needs to exercise live-edit behavior that `executeInConsole`'s
+ * programmatic write doesn't trigger (e.g. autocomplete popups, parameter
+ * tooltips).
+ *
+ * `delayMs` is the per-keystroke delay; default 50ms is close to typical
+ * human typing speed and gives the editor time to dispatch input events and
+ * fire completers between chars.
+ */
+export async function typeInConsole(page: Page, text: string, delayMs: number = 50): Promise<void> {
+  await page.locator(CONSOLE_TAB).click();
+  await page.locator(CONSOLE_INPUT).click({ force: true });
+  await sleep(300);
+  await page.locator(CONSOLE_INPUT).pressSequentially(text, { delay: delayMs });
 }
 
 export async function clearConsole(page: Page): Promise<void> {

--- a/e2e/rstudio/tests/panes/console/ansi_erase_in_line.test.ts
+++ b/e2e/rstudio/tests/panes/console/ansi_erase_in_line.test.ts
@@ -15,7 +15,7 @@ test.describe('ANSI Erase in Line (CSI K) - #17070', () => {
   });
 
   test('EL0 implicit - erase cursor to end of line', async () => {
-    await consoleActions.typeInConsole('cat("AAAAAAAAAA\\rBBB\\033[K\\n")');
+    await consoleActions.executeInConsole('cat("AAAAAAAAAA\\rBBB\\033[K\\n")');
 
     await expect(consoleActions.consolePane.consoleOutput).toContainText('BBB');
     const output = getOutputLines(
@@ -25,7 +25,7 @@ test.describe('ANSI Erase in Line (CSI K) - #17070', () => {
   });
 
   test('EL0 explicit - erase cursor to end of line', async () => {
-    await consoleActions.typeInConsole('cat("AAAAAAAAAA\\rBBB\\033[0K\\n")');
+    await consoleActions.executeInConsole('cat("AAAAAAAAAA\\rBBB\\033[0K\\n")');
 
     await expect(consoleActions.consolePane.consoleOutput).toContainText('BBB');
     const output = getOutputLines(
@@ -35,7 +35,7 @@ test.describe('ANSI Erase in Line (CSI K) - #17070', () => {
   });
 
   test('EL0 progress bar - no trailing artifacts', async () => {
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       'for (i in 1:5) { cat(sprintf("\\rStep %d of 5: %s\\033[K", i, strrep(".", i))); Sys.sleep(0.3) }; cat("\\n")',
     );
 
@@ -47,7 +47,7 @@ test.describe('ANSI Erase in Line (CSI K) - #17070', () => {
   });
 
   test('EL1 - erase beginning of line to cursor', async () => {
-    await consoleActions.typeInConsole('cat("ABCDEF\\033[3D\\033[1K\\n")');
+    await consoleActions.executeInConsole('cat("ABCDEF\\033[3D\\033[1K\\n")');
 
     await expect(consoleActions.consolePane.consoleOutput).toContainText('EF');
     const output = getOutputLines(
@@ -57,7 +57,7 @@ test.describe('ANSI Erase in Line (CSI K) - #17070', () => {
   });
 
   test('EL2 - erase entire line', async () => {
-    await consoleActions.typeInConsole('cat("Hello World\\033[2KGONE\\n")');
+    await consoleActions.executeInConsole('cat("Hello World\\033[2KGONE\\n")');
 
     await expect(consoleActions.consolePane.consoleOutput).toContainText('GONE');
     const output = getOutputLines(
@@ -68,7 +68,7 @@ test.describe('ANSI Erase in Line (CSI K) - #17070', () => {
 
   test('EL on empty line - no errors', async () => {
     // Pure side-effect check (no positive marker to wait on).
-    await consoleActions.typeInConsole('cat("\\033[K\\n")');
+    await consoleActions.executeInConsole('cat("\\033[K\\n")');
     await sleep(1000);
 
     const output = getOutputLines(
@@ -78,7 +78,7 @@ test.describe('ANSI Erase in Line (CSI K) - #17070', () => {
   });
 
   test('EL with colored text - no leftover colored text', async () => {
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       'cat("\\033[31mRed Text\\033[0m Uncolored\\rOverwrite\\033[K\\n")',
     );
 

--- a/e2e/rstudio/tests/panes/console/console_command_effects.test.ts
+++ b/e2e/rstudio/tests/panes/console/console_command_effects.test.ts
@@ -14,12 +14,12 @@ test.describe('Console command effects', () => {
   });
 
   test("packageVersion('base') auto-prints the version", async () => {
-    await consoleActions.typeInConsole("packageVersion('base')");
+    await consoleActions.executeInConsole("packageVersion('base')");
     await expect(consoleActions.consolePane.consoleOutput).toContainText('[1]');
   });
 
   test('help.start() loads the R help index into the Help pane', async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole('help.start()');
+    await consoleActions.executeInConsole('help.start()');
     const helpFrame = page.frameLocator('#rstudio_help_frame');
     await expect(helpFrame.locator('body')).toContainText('Statistical Data Analysis', {
       timeout: 30000,
@@ -27,7 +27,7 @@ test.describe('Console command effects', () => {
   });
 
   test('help(package = "base") loads package help into the Help pane', async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole("help(package = 'base')");
+    await consoleActions.executeInConsole("help(package = 'base')");
     const helpFrame = page.frameLocator('#rstudio_help_frame');
     await expect(helpFrame.locator('body')).toContainText('The R Base Package', {
       timeout: 15000,
@@ -35,15 +35,15 @@ test.describe('Console command effects', () => {
   });
 
   test('plot(x, y) renders a plot in the Plots pane', async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole('x <- 1');
-    await consoleActions.typeInConsole('y <- 1');
-    await consoleActions.typeInConsole('plot(x, y)');
+    await consoleActions.executeInConsole('x <- 1');
+    await consoleActions.executeInConsole('y <- 1');
+    await consoleActions.executeInConsole('plot(x, y)');
     await expect(page.locator('#rstudio_plot_image_frame')).toBeVisible({ timeout: 15000 });
   });
 
   test('rstudioDiagnosticsReport() writes a diagnostics report', async () => {
     test.setTimeout(120000);
-    await consoleActions.typeInConsole('rstudioDiagnosticsReport()');
+    await consoleActions.executeInConsole('rstudioDiagnosticsReport()');
     await expect(consoleActions.consolePane.consoleOutput).toContainText(
       'Diagnostics report written',
       { timeout: 90000 },
@@ -52,7 +52,7 @@ test.describe('Console command effects', () => {
 
   test('install.packages() reports not-available for a non-existent package', async () => {
     test.setTimeout(60000);
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       "install.packages('fake_package', repos = 'https://cran.r-project.org')",
     );
     await expect(consoleActions.consolePane.consoleOutput).toContainText(
@@ -69,7 +69,7 @@ test.describe('Console command effects', () => {
     test.skip(failed.length > 0, `Could not install: ${failed.join(', ')}`);
 
     await consoleActions.clearConsole();
-    await consoleActions.typeInConsole("library('praise')");
+    await consoleActions.executeInConsole("library('praise')");
     await sleep(2000);
     await expect(consoleActions.consolePane.consoleOutput).not.toContainText(
       'Error in library',

--- a/e2e/rstudio/tests/panes/console/console_output.test.ts
+++ b/e2e/rstudio/tests/panes/console/console_output.test.ts
@@ -59,7 +59,7 @@ test.describe('Console output and annotation', () => {
       '"\\u2714 xxx \\u001b[31myyy\\u001b[39m zzz"',
       '"\\n"',
     ].join(', ');
-    await consoleActions.typeInConsole(`cat(${literal})`);
+    await consoleActions.executeInConsole(`cat(${literal})`);
 
     await expect.poll(async () => {
       const text = await consoleActions.consolePane.consoleOutput.innerText();
@@ -73,11 +73,11 @@ test.describe('Console output and annotation', () => {
   });
 
   test('errors are highlighted when consoleHighlightConditions is set', async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       '.rs.uiPrefs$consoleHighlightConditions$set("errors_warnings_messages")',
     );
     try {
-      await consoleActions.typeInConsole('stop("This is an error.")');
+      await consoleActions.executeInConsole('stop("This is an error.")');
       await expect(consoleActions.consolePane.consoleOutput)
         .toContainText('Error: This is an error.');
 
@@ -87,31 +87,31 @@ test.describe('Console output and annotation', () => {
       await expect.poll(() => consoleSpanTexts(page))
         .toEqual(expect.arrayContaining(['Error']));
     } finally {
-      await consoleActions.typeInConsole('.rs.uiPrefs$consoleHighlightConditions$clear()');
+      await consoleActions.executeInConsole('.rs.uiPrefs$consoleHighlightConditions$clear()');
     }
   });
 
   test('warnings are highlighted with options(warn = 0) and options(warn = 1)', async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       '.rs.uiPrefs$consoleHighlightConditions$set("errors_warnings_messages")',
     );
     try {
       // warn = 0 defers warnings -- the prefix is "Warning message" once R
       // surfaces them at the prompt.
-      await consoleActions.typeInConsole('{ options(warn = 0); warning("This is a warning.") }');
+      await consoleActions.executeInConsole('{ options(warn = 0); warning("This is a warning.") }');
       await expect.poll(() => consoleSpanTexts(page))
         .toEqual(expect.arrayContaining(['Warning message']));
 
       // warn = 1 surfaces warnings immediately; the prefix is "Warning".
       await consoleActions.clearConsole();
-      await consoleActions.typeInConsole('{ options(warn = 1); warning("This is a warning.") }');
+      await consoleActions.executeInConsole('{ options(warn = 1); warning("This is a warning.") }');
       await expect(consoleActions.consolePane.consoleOutput)
         .toContainText('Warning: This is a warning.');
       await expect.poll(() => consoleSpanTexts(page))
         .toEqual(expect.arrayContaining(['Warning']));
     } finally {
-      await consoleActions.typeInConsole('options(warn = 0)');
-      await consoleActions.typeInConsole('.rs.uiPrefs$consoleHighlightConditions$clear()');
+      await consoleActions.executeInConsole('options(warn = 0)');
+      await consoleActions.executeInConsole('.rs.uiPrefs$consoleHighlightConditions$clear()');
     }
   });
 
@@ -123,7 +123,7 @@ test.describe('Console output and annotation', () => {
       'options(warn = 0)',
       'inherits(x, "error")',
     ].join('; ');
-    await consoleActions.typeInConsole(`{ ${expr} }`);
+    await consoleActions.executeInConsole(`{ ${expr} }`);
 
     await expect(consoleActions.consolePane.consoleOutput)
       .toContainText('[1] TRUE');
@@ -131,7 +131,7 @@ test.describe('Console output and annotation', () => {
 
   // https://github.com/rstudio/rstudio/issues/16038
   test('carriage returns do not break output annotation', async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole('{ message("M1"); cat("O1\\r"); message("M2") }');
+    await consoleActions.executeInConsole('{ message("M1"); cat("O1\\r"); message("M2") }');
 
     // The output should annotate M1 and M2; O1 was overwritten by the
     // carriage return so its span must not exist. The DOM nests spans
@@ -142,14 +142,14 @@ test.describe('Console output and annotation', () => {
       return unique.filter((t) => t === 'M1' || t === 'M2' || t === 'O1');
     }).toEqual(['M1', 'M2']);
 
-    await consoleActions.typeInConsole('writeLines("This is some more output.")');
+    await consoleActions.executeInConsole('writeLines("This is some more output.")');
     await expect(consoleActions.consolePane.consoleOutput)
       .toContainText('This is some more output.');
 
     // Backspace via message() should likewise not survive into the final
     // rendered output -- the result is "M2" not "M1\b2".
     await consoleActions.clearConsole();
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       '{ message("M1", appendLF = FALSE); message("\\b", appendLF = FALSE); message("2") }',
     );
     await expect.poll(async () => {
@@ -162,16 +162,16 @@ test.describe('Console output and annotation', () => {
   });
 
   test('long lines are truncated when consoleLineLengthLimit is reduced', async () => {
-    await consoleActions.typeInConsole('.rs.uiPrefs$consoleLineLengthLimit$set(10L)');
+    await consoleActions.executeInConsole('.rs.uiPrefs$consoleLineLengthLimit$set(10L)');
     try {
-      await consoleActions.typeInConsole(
+      await consoleActions.executeInConsole(
         'cat(paste(rep.int("a", 1E4), collapse = ""), sep = "\\n")',
       );
       await expect(consoleActions.consolePane.consoleOutput)
         .toContainText('aaaaaaaaaa ... <truncated>');
     } finally {
       // Restore the default so the pref doesn't bleed into later tests.
-      await consoleActions.typeInConsole('.rs.uiPrefs$consoleLineLengthLimit$set(2000L)');
+      await consoleActions.executeInConsole('.rs.uiPrefs$consoleLineLengthLimit$set(2000L)');
     }
   });
 });
@@ -210,7 +210,7 @@ test.describe('Error output after caught try()', () => {
     await sleep(TIMEOUTS.settleDelay);
 
     await consoleActions.clearConsole();
-    await consoleActions.typeInConsole('foo()');
+    await consoleActions.executeInConsole('foo()');
 
     await expect(consoleActions.consolePane.consoleOutput)
       .toContainText('Some output.');

--- a/e2e/rstudio/tests/panes/console/console_pane.test.ts
+++ b/e2e/rstudio/tests/panes/console/console_pane.test.ts
@@ -16,21 +16,21 @@ test.describe('Console pane', () => {
 
   test('print() auto-prints its argument', async () => {
     const phrase = 'If we shadows have offended, think but this, and all is mended.';
-    await consoleActions.typeInConsole(`print("${phrase}")`);
+    await consoleActions.executeInConsole(`print("${phrase}")`);
     await expect(consoleActions.consolePane.consoleOutput).toContainText(`[1] "${phrase}"`);
   });
 
   test('unknown identifier prints object-not-found error', async () => {
-    await consoleActions.typeInConsole('fake_command');
+    await consoleActions.executeInConsole('fake_command');
     await expect(consoleActions.consolePane.consoleOutput).toContainText(
       "Error: object 'fake_command' not found",
     );
   });
 
   test('arrow keys cycle through previous commands', async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole("cat('one')");
-    await consoleActions.typeInConsole("cat('two')");
-    await consoleActions.typeInConsole("cat('three')");
+    await consoleActions.executeInConsole("cat('one')");
+    await consoleActions.executeInConsole("cat('two')");
+    await consoleActions.executeInConsole("cat('three')");
     await expect(consoleActions.consolePane.consoleOutput).toContainText('three');
 
     const input = consoleActions.consolePane.consoleInput;
@@ -57,7 +57,7 @@ test.describe('Console pane', () => {
   });
 
   test('timestamp() adds an entry to console history', async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole('timestamp(quiet = TRUE)');
+    await consoleActions.executeInConsole('timestamp(quiet = TRUE)');
 
     // timestamp(quiet = TRUE) produces no console output, so there is no
     // text-based gate signalling that R is idle. Wait for the busy class to
@@ -86,8 +86,8 @@ test.describe('Console pane', () => {
 
   test('writeLines outputs all 10000 lines without truncation', async () => {
     test.setTimeout(90000);
-    await consoleActions.typeInConsole('long <- as.character(1:1E4)');
-    await consoleActions.typeInConsole('writeLines(long)');
+    await consoleActions.executeInConsole('long <- as.character(1:1E4)');
+    await consoleActions.executeInConsole('writeLines(long)');
     await expect(consoleActions.consolePane.consoleOutput).toContainText('10000', {
       timeout: 60000,
     });
@@ -100,11 +100,11 @@ test.describe('Console pane', () => {
   });
 
   test('Show Traceback button reveals the stack for nested calls', async () => {
-    await consoleActions.typeInConsole('f <- function() stop()');
-    await consoleActions.typeInConsole('g <- function() f()');
-    await consoleActions.typeInConsole('h <- function() g()');
-    await consoleActions.typeInConsole('k <- function() h()');
-    await consoleActions.typeInConsole('k()');
+    await consoleActions.executeInConsole('f <- function() stop()');
+    await consoleActions.executeInConsole('g <- function() f()');
+    await consoleActions.executeInConsole('h <- function() g()');
+    await consoleActions.executeInConsole('k <- function() h()');
+    await consoleActions.executeInConsole('k()');
 
     await expect(consoleActions.consolePane.tracebackBtn).toBeVisible({ timeout: 10000 });
     await consoleActions.consolePane.tracebackBtn.click();
@@ -117,15 +117,15 @@ test.describe('Console pane', () => {
 
   test.describe('Find in Console', () => {
     test.beforeEach(async () => {
-      await consoleActions.typeInConsole(`a <- "Once more unto the breach, dear friends, once more;"`);
-      await consoleActions.typeInConsole(`b <- "Or close the wall up with our English dead."`);
-      await consoleActions.typeInConsole(`c <- "In peace there's nothing so becomes a man"`);
-      await consoleActions.typeInConsole(`d <- "As modest stillness and humility."`);
+      await consoleActions.executeInConsole(`a <- "Once more unto the breach, dear friends, once more;"`);
+      await consoleActions.executeInConsole(`b <- "Or close the wall up with our English dead."`);
+      await consoleActions.executeInConsole(`c <- "In peace there's nothing so becomes a man"`);
+      await consoleActions.executeInConsole(`d <- "As modest stillness and humility."`);
       await consoleActions.clearConsole();
-      await consoleActions.typeInConsole('writeLines(a)');
-      await consoleActions.typeInConsole('writeLines(b)');
-      await consoleActions.typeInConsole('writeLines(c)');
-      await consoleActions.typeInConsole('writeLines(d)');
+      await consoleActions.executeInConsole('writeLines(a)');
+      await consoleActions.executeInConsole('writeLines(b)');
+      await consoleActions.executeInConsole('writeLines(c)');
+      await consoleActions.executeInConsole('writeLines(d)');
       await expect(consoleActions.consolePane.consoleOutput).toContainText(
         'As modest stillness and humility.',
       );

--- a/e2e/rstudio/tests/panes/console/execute_from_editor.test.ts
+++ b/e2e/rstudio/tests/panes/console/execute_from_editor.test.ts
@@ -21,10 +21,10 @@ test.describe('Run Line button', () => {
 
     const sandboxR = sandbox.dir.replace(/\\/g, '/');
     const filePath = `${sandboxR}/submit_order_${Date.now()}.R`;
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       `writeLines(c("Sys.sleep(1)", "# 1", "x <- 1", "# 2", "x <- 22", "x"), "${filePath}")`,
     );
-    await consoleActions.typeInConsole(`file.edit("${filePath}")`);
+    await consoleActions.executeInConsole(`file.edit("${filePath}")`);
     await sleep(1500);
 
     await sourceActions.goToTop();

--- a/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
@@ -65,7 +65,7 @@ test.describe('Data Viewer', () => {
 
   // https://github.com/rstudio/rstudio/pull/14657
   test('viewer opens for a temporary R expression', async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole('View(subset(mtcars, mpg >= 30))');
+    await consoleActions.executeInConsole('View(subset(mtcars, mpg >= 30))');
     await expect(page.locator(VIEWER_FRAME))
       .toHaveAttribute('src', /gridviewer\.html/, { timeout: TIMEOUTS.fileOpen });
   });
@@ -73,7 +73,7 @@ test.describe('Data Viewer', () => {
   test('search filter + viewerLink opens an explorer tab for the cell', async ({ rstudioPage: page }) => {
     // data.frame with a list column: the data viewer renders each list
     // entry as a clickable viewerLink that opens the cell explorer.
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       '{ d <- data.frame(x = letters); d$y <- lapply(letters, as.list); row.names(d) <- LETTERS; View(d) }',
     );
     await waitForViewer(dataViewer);
@@ -103,7 +103,7 @@ test.describe('Data Viewer', () => {
   });
 
   test('sort headers cycle through asc, desc, and unsorted', async () => {
-    await consoleActions.typeInConsole('View(mtcars)');
+    await consoleActions.executeInConsole('View(mtcars)');
     await waitForViewer(dataViewer);
 
     const header = dataViewer.frame.locator('th[data-col-idx="1"]');
@@ -130,7 +130,7 @@ test.describe('Data Viewer', () => {
   });
 
   test('pin icon moves a column to the pinned prefix', async () => {
-    await consoleActions.typeInConsole('View(mtcars)');
+    await consoleActions.executeInConsole('View(mtcars)');
     await waitForViewer(dataViewer);
 
     // Initial layout: rownames column (0), then mtcars columns 1..n in order.
@@ -157,7 +157,7 @@ test.describe('Data Viewer', () => {
   test('per-object state survives a refresh', async ({ rstudioPage: page }) => {
     // Use a uniquely-named object so localStorage for this viewer can't be
     // contaminated by a previous test that happened to View(mtcars).
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       '{ .rs.persist_test_df <- mtcars; View(.rs.persist_test_df) }',
     );
     try {
@@ -190,7 +190,7 @@ test.describe('Data Viewer', () => {
         return /sorting_desc/.test(c1) && /\bpinned\b/.test(c3);
       }).toBe(true);
     } finally {
-      await consoleActions.typeInConsole(
+      await consoleActions.executeInConsole(
         'rm(".rs.persist_test_df", envir = .GlobalEnv)',
       );
     }
@@ -201,7 +201,7 @@ test.describe('Data Viewer', () => {
     // The security property is that nothing user-supplied becomes a real
     // DOM element.
     const setup = `{ .rs.escape_test_df <- data.frame(a = c("<script>x</script>", "tom & jerry", "\\"quoted\\"", "it's"), stringsAsFactors = FALSE); View(.rs.escape_test_df) }`;
-    await consoleActions.typeInConsole(setup);
+    await consoleActions.executeInConsole(setup);
     try {
       await waitForViewer(dataViewer);
 
@@ -224,14 +224,14 @@ test.describe('Data Viewer', () => {
       expect(cellHtml).toContain('&lt;script&gt;');
       expect(cellHtml).toContain('tom &amp; jerry');
     } finally {
-      await consoleActions.typeInConsole(
+      await consoleActions.executeInConsole(
         'rm(".rs.escape_test_df", envir = .GlobalEnv)',
       );
     }
   });
 
   test('HTML-special column names render as text, not markup', async () => {
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       '{ .rs.escape_hdr_df <- data.frame(x = 1, check.names = FALSE); names(.rs.escape_hdr_df) <- "<b>&\\"\'"; View(.rs.escape_hdr_df) }',
     );
     try {
@@ -253,7 +253,7 @@ test.describe('Data Viewer', () => {
       expect(html).toContain('&amp;');
       expect(html).not.toContain('<b>');
     } finally {
-      await consoleActions.typeInConsole(
+      await consoleActions.executeInConsole(
         'rm(".rs.escape_hdr_df", envir = .GlobalEnv)',
       );
     }

--- a/e2e/rstudio/tests/panes/data-viewer/pagination-sorting.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/pagination-sorting.test.ts
@@ -31,9 +31,9 @@ test.describe('Data Viewer', () => {
   // Issue 13220 — Large data frame navigation
   // -----------------------------------------------------------------------
   test('large data frame - navigation arrows and column pagination', async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole('df <- data.frame(matrix(1:1000000, nrow=100000, ncol=500))');
+    await consoleActions.executeInConsole('df <- data.frame(matrix(1:1000000, nrow=100000, ncol=500))');
     await sleep(2000);
-    await consoleActions.typeInConsole('View(df)');
+    await consoleActions.executeInConsole('View(df)');
     await sleep(3000);
 
     await expect(sourcePane.selectedTab).toContainText('df');
@@ -70,9 +70,9 @@ test.describe('Data Viewer', () => {
   // Odd-numbered columns (edge case for pagination)
   // -----------------------------------------------------------------------
   test('odd-numbered column count - pagination edge case', async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole('df <- data.frame(matrix(1:1000000, nrow=1000, ncol=227))');
+    await consoleActions.executeInConsole('df <- data.frame(matrix(1:1000000, nrow=1000, ncol=227))');
     await sleep(2000);
-    await consoleActions.typeInConsole('View(df)');
+    await consoleActions.executeInConsole('View(df)');
     await sleep(3000);
 
     await expect(sourcePane.selectedTab).toContainText('df');
@@ -96,9 +96,9 @@ test.describe('Data Viewer', () => {
   // Sorting
   // -----------------------------------------------------------------------
   test('column sorting - descending order', async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole('df <- data.frame(matrix(1:1000000, nrow=100000, ncol=500))');
+    await consoleActions.executeInConsole('df <- data.frame(matrix(1:1000000, nrow=100000, ncol=500))');
     await sleep(2000);
-    await consoleActions.typeInConsole('View(df)');
+    await consoleActions.executeInConsole('View(df)');
     await sleep(3000);
 
     await expect(sourcePane.selectedTab).toContainText('df');
@@ -123,15 +123,15 @@ test.describe('Data Viewer', () => {
   // -----------------------------------------------------------------------
   test('sorting after navigating to later columns (#13328)', async ({ rstudioPage: page }) => {
     // Create a 10-row x 400-column data frame with shifted values
-    await consoleActions.typeInConsole('data <- replicate(400, 0:9, simplify = FALSE)');
+    await consoleActions.executeInConsole('data <- replicate(400, 0:9, simplify = FALSE)');
     await sleep(1000);
-    await consoleActions.typeInConsole('for (i in seq_along(data)) { data[[i]] <- (data[[i]] + i) %% 10 }');
+    await consoleActions.executeInConsole('for (i in seq_along(data)) { data[[i]] <- (data[[i]] + i) %% 10 }');
     await sleep(1000);
-    await consoleActions.typeInConsole('names(data) <- paste0("V", 1:400)');
+    await consoleActions.executeInConsole('names(data) <- paste0("V", 1:400)');
     await sleep(500);
-    await consoleActions.typeInConsole('df <- as.data.frame(data)');
+    await consoleActions.executeInConsole('df <- as.data.frame(data)');
     await sleep(500);
-    await consoleActions.typeInConsole('View(df)');
+    await consoleActions.executeInConsole('View(df)');
     await sleep(3000);
 
     await expect(dataViewer.columnNumberInput).toHaveValue('1 - 200');

--- a/e2e/rstudio/tests/panes/debugger/debugger.test.ts
+++ b/e2e/rstudio/tests/panes/debugger/debugger.test.ts
@@ -26,9 +26,9 @@ async function writeAndOpen(fileName: string, content: string): Promise<void> {
   // string-escape rules (\\, \", \n, \t, \uXXXX) match R's, so JSON.stringify
   // each line and join with commas to produce a valid R argument list.
   const lines = content.split('\n').map(l => JSON.stringify(l)).join(', ');
-  await consoleActions.typeInConsole(`writeLines(c(${lines}), "${fullPath}")`);
+  await consoleActions.executeInConsole(`writeLines(c(${lines}), "${fullPath}")`);
   await sleep(TIMEOUTS.settleDelay);
-  await consoleActions.typeInConsole(`file.edit("${fullPath}")`);
+  await consoleActions.executeInConsole(`file.edit("${fullPath}")`);
   await sleep(TIMEOUTS.fileEditSettle);
 }
 
@@ -120,7 +120,7 @@ test.describe('R debugger', () => {
       // Set breakpoint on the brace-expression line (line 3).
       await debuggerActions.setBreakpoint(3);
 
-      await consoleActions.typeInConsole('brace_fn()');
+      await consoleActions.executeInConsole('brace_fn()');
 
       await debuggerActions.waitForDebugMode();
 
@@ -200,7 +200,7 @@ test.describe('R debugger', () => {
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
       await debuggerActions.setBreakpoint(2);
-      await consoleActions.typeInConsole('step_next_fn()');
+      await consoleActions.executeInConsole('step_next_fn()');
 
       await debuggerActions.waitForDebugMode();
       const startRow = await debuggerActions.getActiveDebugLineRow();
@@ -229,7 +229,7 @@ test.describe('R debugger', () => {
       await sleep(TIMEOUTS.settleDelay);
       // Breakpoint on the line that calls inner() (line 5).
       await debuggerActions.setBreakpoint(5);
-      await consoleActions.typeInConsole('outer()');
+      await consoleActions.executeInConsole('outer()');
 
       await debuggerActions.waitForDebugMode();
 
@@ -271,7 +271,7 @@ test.describe('R debugger', () => {
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
       await debuggerActions.setBreakpoint(2);
-      await consoleActions.typeInConsole('step_finish_fn()');
+      await consoleActions.executeInConsole('step_finish_fn()');
 
       await debuggerActions.waitForDebugMode();
       await debuggerActions.stepOut();
@@ -299,7 +299,7 @@ test.describe('R debugger', () => {
       await sleep(TIMEOUTS.settleDelay);
       await debuggerActions.setBreakpoint(2);
       await debuggerActions.setBreakpoint(5);
-      await consoleActions.typeInConsole('step_continue_fn()');
+      await consoleActions.executeInConsole('step_continue_fn()');
 
       await debuggerActions.waitForDebugMode();
       await expect.poll(
@@ -327,7 +327,7 @@ test.describe('R debugger', () => {
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
       await debuggerActions.setBreakpoint(2);
-      await consoleActions.typeInConsole('step_stop_fn()');
+      await consoleActions.executeInConsole('step_stop_fn()');
 
       await debuggerActions.waitForDebugMode();
       await debuggerActions.stopDebug();
@@ -355,7 +355,7 @@ test.describe('R debugger', () => {
       for (const line of [2, 3, 4, 5, 6, 7]) {
         await debuggerActions.setBreakpoint(line);
       }
-      await consoleActions.typeInConsole('five_continues_fn()');
+      await consoleActions.executeInConsole('five_continues_fn()');
 
       await debuggerActions.waitForDebugMode();
       await expect.poll(
@@ -411,7 +411,7 @@ test.describe('R debugger', () => {
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
-      await consoleActions.typeInConsole('browser_entry_fn()');
+      await consoleActions.executeInConsole('browser_entry_fn()');
 
       await debuggerActions.waitForDebugMode();
       // After browser() on line 2, R pauses on the browser() call itself
@@ -435,7 +435,7 @@ test.describe('R debugger', () => {
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
-      await consoleActions.typeInConsole('browser_continue_fn()');
+      await consoleActions.executeInConsole('browser_continue_fn()');
 
       await debuggerActions.waitForDebugMode();
       await debuggerActions.continueDebug();
@@ -462,7 +462,7 @@ test.describe('R debugger', () => {
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
-      await consoleActions.typeInConsole('rerun_fn()');
+      await consoleActions.executeInConsole('rerun_fn()');
 
       // The error widget — and the "Rerun with Debug" link inside it —
       // should appear in the console after the error fires.
@@ -500,7 +500,7 @@ test.describe('R debugger', () => {
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
-      await consoleActions.typeInConsole('env_locals_fn()');
+      await consoleActions.executeInConsole('env_locals_fn()');
 
       await debuggerActions.waitForDebugMode();
 
@@ -522,7 +522,7 @@ test.describe('R debugger', () => {
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
-      await consoleActions.typeInConsole('tb_f()');
+      await consoleActions.executeInConsole('tb_f()');
 
       await debuggerActions.waitForDebugMode();
 
@@ -559,7 +559,7 @@ test.describe('R debugger', () => {
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
-      await consoleActions.typeInConsole('fr_f()');
+      await consoleActions.executeInConsole('fr_f()');
 
       await debuggerActions.waitForDebugMode();
 

--- a/e2e/rstudio/tests/panes/debugger/debugger_extras.test.ts
+++ b/e2e/rstudio/tests/panes/debugger/debugger_extras.test.ts
@@ -40,7 +40,7 @@ async function resetAfterTest(): Promise<void> {
 }
 
 // Insert multi-line text into the console input as one raw insert and
-// press Enter to submit. typeInConsole turns each \n into an Enter
+// press Enter to submit. executeInConsole turns each \n into an Enter
 // keystroke (Ace's keyboard handler treats it as commit-this-line), which
 // would commit prematurely. keyboard.insertText sends the entire text via
 // CDP's Input.insertText so R's parser sees it as one input and emits the
@@ -106,7 +106,7 @@ test.describe('R debugger extras', () => {
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
       await sleep(TIMEOUTS.settleDelay);
 
-      await consoleActions.typeInConsole('multiline_fn()');
+      await consoleActions.executeInConsole('multiline_fn()');
       await debuggerActions.waitForDebugMode();
       await expect(debuggerActions.debuggerPage.activeDebugLine.first())
         .toBeVisible({ timeout: TIMEOUTS.fileOpen });
@@ -245,7 +245,7 @@ test.describe('R debugger extras', () => {
       await sleep(TIMEOUTS.settleDelay);
 
       // Dispatch through the S3 generic into the S7 method.
-      await consoleActions.typeInConsole(
+      await consoleActions.executeInConsole(
         '{ object <- structure(1:10, class = "s7mean"); mean(object) }',
       );
 

--- a/e2e/rstudio/tests/panes/editor/air_formatting.test.ts
+++ b/e2e/rstudio/tests/panes/editor/air_formatting.test.ts
@@ -117,13 +117,13 @@ async function setAirPrefs(
 
 /** Reset Air-related preferences programmatically (for setup/cleanup, not the test itself). */
 async function resetAirPrefs(consoleActions: ConsolePaneActions): Promise<void> {
-  await consoleActions.typeInConsole('{ .rs.uiPrefs$codeFormatter$set("none"); .rs.uiPrefs$useAirFormatter$set(FALSE); .rs.uiPrefs$reformatOnSave$set(FALSE) }');
+  await consoleActions.executeInConsole('{ .rs.uiPrefs$codeFormatter$set("none"); .rs.uiPrefs$useAirFormatter$set(FALSE); .rs.uiPrefs$reformatOnSave$set(FALSE) }');
   await sleep(1000);
 }
 
 /** Create an Air config file in the working directory. */
 async function createAirConfig(consoleActions: ConsolePaneActions, fileName: string = AIR_TOML_FILE): Promise<void> {
-  await consoleActions.typeInConsole(
+  await consoleActions.executeInConsole(
     `writeLines(c("[format]", "line-width = 20", "indent-width = 12", 'indent-style = "space"', "persistent-line-breaks = true", 'exclude = ["tmp/", ".git/", "renv/"]', "default-exclude = true"), "${fileName}")`
   );
   await sleep(500);
@@ -131,7 +131,7 @@ async function createAirConfig(consoleActions: ConsolePaneActions, fileName: str
 
 /** Remove both air.toml and .air.toml if they exist. */
 async function removeAirConfig(consoleActions: ConsolePaneActions): Promise<void> {
-  await consoleActions.typeInConsole(`{ unlink("${AIR_TOML_FILE}"); unlink("${DOT_AIR_TOML_FILE}") }`);
+  await consoleActions.executeInConsole(`{ unlink("${AIR_TOML_FILE}"); unlink("${DOT_AIR_TOML_FILE}") }`);
   await sleep(500);
 }
 
@@ -140,11 +140,11 @@ async function openTestFile(
   consoleActions: ConsolePaneActions,
   sourceActions: SourcePaneActions
 ): Promise<void> {
-  await consoleActions.typeInConsole(
+  await consoleActions.executeInConsole(
     `writeLines(c("x<-1+2+3", "y<-list(a=1,b=2,c=3)"), "${TEST_FILE}")`
   );
   await sleep(500);
-  await consoleActions.typeInConsole(`file.edit("${TEST_FILE}")`);
+  await consoleActions.executeInConsole(`file.edit("${TEST_FILE}")`);
   await expect(sourceActions.sourcePane.selectedTab).toContainText(TEST_FILE, { timeout: 10000 });
   await sleep(1000);
 }

--- a/e2e/rstudio/tests/panes/editor/code-folding.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code-folding.test.ts
@@ -17,13 +17,13 @@ test.describe('Code folding', () => {
   });
 
   test.afterEach(async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole('.rs.uiPrefs$hierarchicalSectionFolding$clear()');
+    await consoleActions.executeInConsole('.rs.uiPrefs$hierarchicalSectionFolding$clear()');
     await closeAndDeleteSandboxFiles(page, sandbox.dir, ['code_folding.R']);
   });
 
   // https://github.com/rstudio/rstudio/issues/16541
   test('hierarchical section folding respects heading depth', async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole('.rs.uiPrefs$hierarchicalSectionFolding$set(TRUE)');
+    await consoleActions.executeInConsole('.rs.uiPrefs$hierarchicalSectionFolding$set(TRUE)');
 
     const content = `# Section 1 ----
 code_1 <- 1
@@ -65,7 +65,7 @@ code_2 <- 4
 
   // https://github.com/rstudio/rstudio/issues/16541
   test('flat section folding stops at any section header', async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole('.rs.uiPrefs$hierarchicalSectionFolding$set(FALSE)');
+    await consoleActions.executeInConsole('.rs.uiPrefs$hierarchicalSectionFolding$set(FALSE)');
 
     const content = `# Section 1 ----
 code_1 <- 1

--- a/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
@@ -49,7 +49,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
         `${prefix}_statusbar_nav.R`,
       ];
       const unlinkExpr = testFiles.map(f => `"${f}"`).join(', ');
-      await consoleActions.typeInConsole(`for (f in c(${unlinkExpr})) unlink(f)`);
+      await consoleActions.executeInConsole(`for (f in c(${unlinkExpr})) unlink(f)`);
       await sleep(2000);
 
       await assistantActions.setupAssistantOptions(provider);
@@ -547,7 +547,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
       expect(leaked).toBe(false);
 
       await sourceActions.closeSourceAndDeleteFile(fileNameB);
-      await consoleActions.typeInConsole(`unlink("${fileNameA}")`);
+      await consoleActions.executeInConsole(`unlink("${fileNameA}")`);
       await sleep(500);
     });
 
@@ -671,7 +671,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
         `${prefix}_statusbar_nav.R`,
       ];
       const unlinkExpr = testFiles.map(f => `"${f}"`).join(', ');
-      await consoleActions.typeInConsole(`for (f in c(${unlinkExpr})) unlink(f)`);
+      await consoleActions.executeInConsole(`for (f in c(${unlinkExpr})) unlink(f)`);
       await sleep(2000);
     });
   });

--- a/e2e/rstudio/tests/panes/editor/edit_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/edit_suggestions.test.ts
@@ -40,7 +40,7 @@ test.describe('Edit suggestions (showEditSuggestion injection)', () => {
 
   test('ghost text suggestions can be prefix-matched', async ({ rstudioPage: page }) => {
     await writeAndOpenFile(page, sandbox.dir, FILES.prefix, '');
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       '.rs.api.showEditSuggestion(c(1, 1, 1, 1), "hello")',
     );
 
@@ -76,7 +76,7 @@ test.describe('Edit suggestions (showEditSuggestion injection)', () => {
   // accept, and inline insertion-preview.
   test.fixme('ghost text suggestions survive document mutations', async ({ rstudioPage: page }) => {
     await writeAndOpenFile(page, sandbox.dir, FILES.mutate, '# abc def');
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       '.rs.api.showEditSuggestion(c(1, 3, 1, 6), "ABC")',
     );
     const editor = new AceEditor(page, 'abc def');
@@ -92,7 +92,7 @@ test.describe('Edit suggestions (showEditSuggestion injection)', () => {
   test('ghost text moves on document edit', async ({ rstudioPage: page }) => {
     // Six newlines map to seven rows once Ace counts the trailing empty line.
     await writeAndOpenFile(page, sandbox.dir, FILES.move, '\n\n\n\n\n\n');
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       '.rs.api.showEditSuggestion(c(3, 1, 3, 1), "Hello world!")',
     );
 
@@ -119,7 +119,7 @@ test.describe('Edit suggestions (showEditSuggestion injection)', () => {
 
   test('ghost text is cleared from old row when newline inserted above', async ({ rstudioPage: page }) => {
     await writeAndOpenFile(page, sandbox.dir, FILES.clearOldRow, '\n\n\n\n\n\n');
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       '.rs.api.showEditSuggestion(c(3, 1, 3, 1), "Hello world!")',
     );
 
@@ -149,7 +149,7 @@ test.describe('Edit suggestions (showEditSuggestion injection)', () => {
   test('edit suggestions render inline when appropriate', async ({ rstudioPage: page }) => {
     const contents = '# Create a 3D point.\npoint <- function(x, y, z) {}\n';
     await writeAndOpenFile(page, sandbox.dir, FILES.inline, contents);
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       '.rs.api.showEditSuggestion(c(1, 12, 1, 14), "4D")',
     );
 

--- a/e2e/rstudio/tests/panes/editor/editor.test.ts
+++ b/e2e/rstudio/tests/panes/editor/editor.test.ts
@@ -42,7 +42,7 @@ test.describe('Editor', () => {
   });
 
   test('trailing whitespace is trimmed on save when pref is enabled', async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole('.rs.uiPrefs$stripTrailingWhitespace$set(TRUE)');
+    await consoleActions.executeInConsole('.rs.uiPrefs$stripTrailingWhitespace$set(TRUE)');
     try {
       const content = '# comment 1  \n# comment 2 \n# comment 3   \n';
       await writeAndOpenFile(page, sandbox.dir, 'editor_whitespace.R', content);
@@ -59,7 +59,7 @@ test.describe('Editor', () => {
         return (await editor.getValue()).trim();
       }).toBe('# comment 1\n# comment 2\n# comment 3\n# comment 4');
     } finally {
-      await consoleActions.typeInConsole('.rs.uiPrefs$stripTrailingWhitespace$clear()');
+      await consoleActions.executeInConsole('.rs.uiPrefs$stripTrailingWhitespace$clear()');
     }
   });
 

--- a/e2e/rstudio/tests/panes/editor/multiline_chunk_execution.test.ts
+++ b/e2e/rstudio/tests/panes/editor/multiline_chunk_execution.test.ts
@@ -42,7 +42,7 @@ test.describe('Multiline chunk execution', { tag: ['@parallel_safe'] }, () => {
       'sum(22,',
       '23)',
       '```',
-    ].join('\\n');
+    ].join('\n');
 
     await sourceActions.createAndOpenFile(fileName, rmdContent);
     await expect(sourceActions.sourcePane.selectedTab).toContainText(fileName, { timeout: 20000 });

--- a/e2e/rstudio/tests/panes/editor/notebook_save_during_execution.test.ts
+++ b/e2e/rstudio/tests/panes/editor/notebook_save_during_execution.test.ts
@@ -53,7 +53,7 @@ test.describe('Notebook save during execution', { tag: ['@parallel_safe'] }, () 
       "print('The quality of mercy is not strained')",
       "print('Chunks still work.')",
       '```',
-    ].join('\\n');
+    ].join('\n');
 
     await sourceActions.createAndOpenFile(fileName, rmdContent);
     await expect(sourceActions.sourcePane.selectedTab).toContainText(fileName, { timeout: 20000 });

--- a/e2e/rstudio/tests/panes/editor/quarto.test.ts
+++ b/e2e/rstudio/tests/panes/editor/quarto.test.ts
@@ -89,7 +89,7 @@ test.describe('Quarto', () => {
 
     // Cleanup
     await sourceActions.closeSourceAndDeleteFile(fileName);
-    await consoleActions.typeInConsole(`unlink("${fileName.replace('.qmd', '.html')}")`);
+    await consoleActions.executeInConsole(`unlink("${fileName.replace('.qmd', '.html')}")`);
     await sleep(500);
   });
 });

--- a/e2e/rstudio/tests/panes/editor/quarto_chunks.test.ts
+++ b/e2e/rstudio/tests/panes/editor/quarto_chunks.test.ts
@@ -40,17 +40,17 @@ test.describe.serial('Quarto chunks', { tag: ['@serial'] }, () => {
     ].join('\n');
 
     await consoleActions.clearConsole();
-    await consoleActions.typeInConsole('options(warn = 0); cat("WARN_BEFORE=", getOption("warn"), "\\n", sep = "")');
+    await consoleActions.executeInConsole('options(warn = 0); cat("WARN_BEFORE=", getOption("warn"), "\\n", sep = "")');
     await expect(consoleActions.consolePane.consoleOutput).toContainText('WARN_BEFORE=0');
 
     await sourceActions.createAndOpenFile(fileName, content);
     await sourceActions.navigateToChunkByLabel('warning_chunk');
     await executeCommand(page, 'executeCurrentChunk');
     // R queue is FIFO; `WARN_AFTER=2` won't appear until `options(warn = 2)` runs.
-    await consoleActions.typeInConsole('cat("WARN_AFTER=", getOption("warn"), "\\n", sep = "")');
+    await consoleActions.executeInConsole('cat("WARN_AFTER=", getOption("warn"), "\\n", sep = "")');
     await expect(consoleActions.consolePane.consoleOutput).toContainText('WARN_AFTER=2', { timeout: 30000 });
 
-    await consoleActions.typeInConsole('options(warn = 0)');
+    await consoleActions.executeInConsole('options(warn = 0)');
     await sourceActions.closeSourceAndDeleteFile(fileName);
   });
 

--- a/e2e/rstudio/tests/panes/editor/reformat.test.ts
+++ b/e2e/rstudio/tests/panes/editor/reformat.test.ts
@@ -78,13 +78,13 @@ test.describe.serial('styler reformat on save', () => {
     projectDir = await createAndOpenProject(page, sandbox.dir, 'reformat-styler-project');
     await waitForConsoleIdle(page);
 
-    await consoleActions.typeInConsole('.rs.uiPrefs$reformatOnSave$set(TRUE)');
-    await consoleActions.typeInConsole('.rs.uiPrefs$codeFormatter$set("styler")');
+    await consoleActions.executeInConsole('.rs.uiPrefs$reformatOnSave$set(TRUE)');
+    await consoleActions.executeInConsole('.rs.uiPrefs$codeFormatter$set("styler")');
   });
 
   test.afterAll(async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole('.rs.uiPrefs$reformatOnSave$clear()');
-    await consoleActions.typeInConsole('.rs.uiPrefs$codeFormatter$clear()');
+    await consoleActions.executeInConsole('.rs.uiPrefs$reformatOnSave$clear()');
+    await consoleActions.executeInConsole('.rs.uiPrefs$codeFormatter$clear()');
     await consoleActions.closeAllBuffersWithoutSaving();
     await waitForConsoleIdle(page);
     await closeProjectIfOpen(page);
@@ -140,14 +140,14 @@ test.describe('styler reformat #17471 (Windows)', { tag: ['@windows_only'] }, ()
   });
 
   test.afterEach(async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole('.rs.uiPrefs$codeFormatter$clear()');
+    await consoleActions.executeInConsole('.rs.uiPrefs$codeFormatter$clear()');
     await closeAndDeleteSandboxFiles(page, sandbox.dir, [FILE_STYLER_DOC, FILE_STYLER_SEL]);
   });
 
   test('Reformat Document does not add extra newlines', async ({ rstudioPage: page }) => {
     test.skip(missingPackages.length > 0, `styler not available: ${missingPackages.join(', ')}`);
 
-    await consoleActions.typeInConsole('.rs.uiPrefs$codeFormatter$set("styler")');
+    await consoleActions.executeInConsole('.rs.uiPrefs$codeFormatter$set("styler")');
 
     const initial = 'print("test")\nprint("test")\n\n';
     const expected = 'print("test")\nprint("test")\n';
@@ -163,7 +163,7 @@ test.describe('styler reformat #17471 (Windows)', { tag: ['@windows_only'] }, ()
   test('Reformat Code (selection) does not add extra newlines', async ({ rstudioPage: page }) => {
     test.skip(missingPackages.length > 0, `styler not available: ${missingPackages.join(', ')}`);
 
-    await consoleActions.typeInConsole('.rs.uiPrefs$codeFormatter$set("styler")');
+    await consoleActions.executeInConsole('.rs.uiPrefs$codeFormatter$set("styler")');
 
     const initial = '1+1; 2+2\n3+3; 4+4\n';
     const expected = '1 + 1\n2 + 2\n3 + 3\n4 + 4\n';

--- a/e2e/rstudio/tests/panes/editor/rmarkdown.test.ts
+++ b/e2e/rstudio/tests/panes/editor/rmarkdown.test.ts
@@ -62,7 +62,7 @@ test.describe('RMarkdown', () => {
 
     // Cleanup
     await sourceActions.closeSourceAndDeleteFile(fileName);
-    await consoleActions.typeInConsole(`unlink("${fileName.replace('.rmd', '.html')}")`);
+    await consoleActions.executeInConsole(`unlink("${fileName.replace('.rmd', '.html')}")`);
     await sleep(500);
   });
 
@@ -97,7 +97,7 @@ test.describe('RMarkdown', () => {
 
     // Verify no variables in global env
     await consoleActions.clearConsole();
-    await consoleActions.typeInConsole('ls(envir = globalenv())');
+    await consoleActions.executeInConsole('ls(envir = globalenv())');
     await sleep(2000);
     await expect(consoleOutput).toContainText('character(0)', { timeout: 10000 });
 
@@ -114,9 +114,9 @@ test.describe('RMarkdown', () => {
 
     // Create an RMarkdown file, verify no comment is inserted on newline
     const rmdFileName = `rmarkdown_commentnewline_${Date.now()}.rmd`;
-    await consoleActions.typeInConsole(`file.create("${rmdFileName}")`);
+    await consoleActions.executeInConsole(`file.create("${rmdFileName}")`);
     await sleep(1000);
-    await consoleActions.typeInConsole(`file.edit("${rmdFileName}")`);
+    await consoleActions.executeInConsole(`file.edit("${rmdFileName}")`);
     await expect(sourceActions.sourcePane.selectedTab).toContainText(rmdFileName, { timeout: 20000 });
 
     await sourceActions.sendText('# Section');
@@ -126,14 +126,14 @@ test.describe('RMarkdown', () => {
     await expect(sourceActions.sourcePane.contentPane).toHaveText('# Section');
 
     await consoleActions.closeAllBuffersWithoutSaving();
-    await consoleActions.typeInConsole(`unlink("${rmdFileName}")`);
+    await consoleActions.executeInConsole(`unlink("${rmdFileName}")`);
     await sleep(500);
 
     // Check that an R file DOES insert a comment on newline
     const rFileName = `rmarkdown_commentnewline_${Date.now()}.r`;
-    await consoleActions.typeInConsole(`file.create("${rFileName}")`);
+    await consoleActions.executeInConsole(`file.create("${rFileName}")`);
     await sleep(1000);
-    await consoleActions.typeInConsole(`file.edit("${rFileName}")`);
+    await consoleActions.executeInConsole(`file.edit("${rFileName}")`);
     await expect(sourceActions.sourcePane.selectedTab).toContainText(rFileName, { timeout: 20000 });
 
     await sourceActions.sendText('# This is a Comment');
@@ -157,7 +157,7 @@ test.describe('RMarkdown', () => {
     await expect(sourceActions.sourcePane.publishBtn).toBeVisible({ timeout: 10000 });
 
     // Navigate to file and run spellcheck
-    await consoleActions.typeInConsole(`rstudioapi::navigateToFile("${fileName}", line=1L)`);
+    await consoleActions.executeInConsole(`rstudioapi::navigateToFile("${fileName}", line=1L)`);
     await sleep(2000);
     await executeCommand(page, 'checkSpelling');
     await sleep(5000);
@@ -181,7 +181,7 @@ test.describe('RMarkdown', () => {
     await expect(sourceActions.sourcePane.publishBtn).toBeVisible({ timeout: 10000 });
 
     // Switch to visual mode
-    await consoleActions.typeInConsole(`rstudioapi::navigateToFile("${fileName}", line=1L)`);
+    await consoleActions.executeInConsole(`rstudioapi::navigateToFile("${fileName}", line=1L)`);
     await sleep(1000);
     await sourceActions.ensureVisualMode();
 

--- a/e2e/rstudio/tests/panes/editor/rmarkdown_chunks.test.ts
+++ b/e2e/rstudio/tests/panes/editor/rmarkdown_chunks.test.ts
@@ -55,7 +55,7 @@ async function runChunkByLabelAndWaitForMarker(
 ): Promise<void> {
   await sourceActions.navigateToChunkByLabel(label);
   await executeCommand(page, 'executeCurrentChunk');
-  await consoleActions.typeInConsole(
+  await consoleActions.executeInConsole(
     `cat(paste0("__CHUNKDONE_", proc.time()[3], "_", sample.int(1e9, 1L), "__"), "\\n")`
   );
   await expect(consoleActions.consolePane.consoleOutput).toContainText(
@@ -96,7 +96,7 @@ test.describe.serial('R Markdown chunks', { tag: ['@serial'] }, () => {
     // appears in the cat *output*, not the (unescaped) input echo --
     // the input has `WARN_BEFORE="` followed by a comma.
     await consoleActions.clearConsole();
-    await consoleActions.typeInConsole('options(warn = 0); cat("WARN_BEFORE=", getOption("warn"), "\\n", sep = "")');
+    await consoleActions.executeInConsole('options(warn = 0); cat("WARN_BEFORE=", getOption("warn"), "\\n", sep = "")');
     await expect(consoleActions.consolePane.consoleOutput).toContainText('WARN_BEFORE=0');
 
     await sourceActions.createAndOpenFile(fileName, content);
@@ -107,11 +107,11 @@ test.describe.serial('R Markdown chunks', { tag: ['@serial'] }, () => {
     // needed; the assertion implicitly serializes.
     await sourceActions.navigateToChunkByLabel('warning_chunk');
     await executeCommand(page, 'executeCurrentChunk');
-    await consoleActions.typeInConsole('cat("WARN_AFTER=", getOption("warn"), "\\n", sep = "")');
+    await consoleActions.executeInConsole('cat("WARN_AFTER=", getOption("warn"), "\\n", sep = "")');
     await expect(consoleActions.consolePane.consoleOutput).toContainText('WARN_AFTER=2', { timeout: 30000 });
 
     // Reset warn before closing
-    await consoleActions.typeInConsole('options(warn = 0)');
+    await consoleActions.executeInConsole('options(warn = 0)');
     await sourceActions.closeSourceAndDeleteFile(fileName);
   });
 

--- a/e2e/rstudio/tests/panes/editor/syntax-highlighting.test.ts
+++ b/e2e/rstudio/tests/panes/editor/syntax-highlighting.test.ts
@@ -59,7 +59,7 @@ Goodbye, world!
 :::
 `;
 
-    await consoleActions.typeInConsole('.rs.writeUserPref("rainbow_fenced_divs", TRUE)');
+    await consoleActions.executeInConsole('.rs.writeUserPref("rainbow_fenced_divs", TRUE)');
     try {
       await writeAndOpenFile(page, sandbox.dir, 'syntax_highlight.Rmd', content);
 
@@ -86,7 +86,7 @@ Goodbye, world!
 
       expect(await editor.getState(5)).toBe('start');
     } finally {
-      await consoleActions.typeInConsole('.rs.writeUserPref("rainbow_fenced_divs", FALSE)');
+      await consoleActions.executeInConsole('.rs.writeUserPref("rainbow_fenced_divs", FALSE)');
     }
   });
 

--- a/e2e/rstudio/tests/panes/files/files.test.ts
+++ b/e2e/rstudio/tests/panes/files/files.test.ts
@@ -34,13 +34,13 @@ test.describe('Open File dialog (virtualized)', { tag: ['@server_only'] }, () =>
   test.afterEach(async ({ rstudioPage: page }) => {
     // Clean up any stub files and close opened source docs.
     await documentCloseAllNoSave(page);
-    await consoleActions.typeInConsole(`unlink(list.files(${JSON.stringify(sandbox.dir)}, pattern = "\\\\.R$", full.names = TRUE))`);
+    await consoleActions.executeInConsole(`unlink(list.files(${JSON.stringify(sandbox.dir)}, pattern = "\\\\.R$", full.names = TRUE))`);
   });
 
   test('handles a large flat directory (>500 files)', async ({ rstudioPage: page }) => {
     // Create 10000 stub .R files in the suite sandbox -- enough to force the
     // virtualized list path.
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       `{ setwd(${JSON.stringify(sandbox.dir)}); files <- sprintf("%04i.R", 0:9999); invisible(file.create(files)) }`,
     );
     await sleep(TIMEOUTS.consoleReady);
@@ -64,7 +64,7 @@ test.describe('Open File dialog (virtualized)', { tag: ['@server_only'] }, () =>
   test('handles a moderate flat directory (<500 files)', async ({ rstudioPage: page }) => {
     // 451 stub files keeps us below the virtualization threshold; the dialog
     // should still resolve a typed prefix to the only matching file.
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       `{ setwd(${JSON.stringify(sandbox.dir)}); files <- sprintf("%03i.R", 0:450); invisible(file.create(files)) }`,
     );
     await sleep(TIMEOUTS.consoleReady);
@@ -105,11 +105,11 @@ test.describe('Autosave on blur', () => {
         'assign(".rs_autosave_path", con, envir = globalenv())',
         'file.edit(con) }',
       ].join('; ');
-      await consoleActions.typeInConsole(setupExpr);
+      await consoleActions.executeInConsole(setupExpr);
       await sleep(TIMEOUTS.fileEditSettle);
 
       // Record mtime, blur the source pane, and assert it didn't change.
-      await consoleActions.typeInConsole(
+      await consoleActions.executeInConsole(
         '{ .rs_autosave_old <- file.info(.rs_autosave_path)$mtime }',
       );
       await executeCommand(page, 'activateConsole');
@@ -117,7 +117,7 @@ test.describe('Autosave on blur', () => {
       await executeCommand(page, 'activateConsole');
 
       const unchangedMarker = `__AUTOSAVE_UNCHANGED_${Date.now()}__`;
-      await consoleActions.typeInConsole(
+      await consoleActions.executeInConsole(
         `{ .rs_autosave_new <- file.info(.rs_autosave_path)$mtime; cat("${unchangedMarker}", isTRUE(.rs_autosave_old == .rs_autosave_new), "${unchangedMarker}") }`,
       );
       await expect(consoleActions.consolePane.consoleOutput).toContainText(
@@ -136,7 +136,7 @@ test.describe('Autosave on blur', () => {
       await sleep(1500);
 
       const changedMarker = `__AUTOSAVE_CHANGED_${Date.now()}__`;
-      await consoleActions.typeInConsole(
+      await consoleActions.executeInConsole(
         `{ .rs_autosave_after <- file.info(.rs_autosave_path)$mtime; cat("${changedMarker}", isTRUE(.rs_autosave_old == .rs_autosave_after), "${changedMarker}") }`,
       );
       await expect(consoleActions.consolePane.consoleOutput).toContainText(
@@ -146,7 +146,7 @@ test.describe('Autosave on blur', () => {
     } finally {
       await clearPref(page, 'auto_save_on_blur');
       await documentCloseAllNoSave(page);
-      await consoleActions.typeInConsole(
+      await consoleActions.executeInConsole(
         `{ unlink(file.path(${JSON.stringify(sandbox.dir)}, "autosave.R")); rm(list = ls(pattern = "^\\\\.rs_autosave", envir = globalenv()), envir = globalenv()) }`,
       );
     }

--- a/e2e/rstudio/tests/panes/files/files_endpoint.test.ts
+++ b/e2e/rstudio/tests/panes/files/files_endpoint.test.ts
@@ -31,14 +31,14 @@ test.describe('/files/ HTTP endpoint cross-site protections', { tag: ['@server_o
     // Drop a small file in the user home directory so the handler reaches
     // the Sec-Fetch-Site check before any not-found logic. The leading '.'
     // keeps it out of the visible Files pane.
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       `writeLines('test content', file.path('~', '${TEST_FILE}'))`,
     );
     await sleep(TIMEOUTS.settleDelay);
   });
 
   test.afterAll(async () => {
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       `unlink(file.path('~', '${TEST_FILE}'))`,
     );
   });

--- a/e2e/rstudio/tests/panes/layout/pane_layout.test.ts
+++ b/e2e/rstudio/tests/panes/layout/pane_layout.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { sleep, TIMEOUTS } from '@utils/constants';
-import { typeInConsole, CONSOLE_INPUT } from '@pages/console_pane.page';
+import { executeInConsole, CONSOLE_INPUT } from '@pages/console_pane.page';
 import { executeCommand } from '@utils/commands';
 import type { Page } from 'playwright';
 

--- a/e2e/rstudio/tests/panes/misc/autocomplete.test.ts
+++ b/e2e/rstudio/tests/panes/misc/autocomplete.test.ts
@@ -18,7 +18,7 @@ for (const context of contexts) {
       sourceActions = new SourcePaneActions(page, consoleActions);
       autocomplete = new AutocompleteActions(page, consoleActions, sourceActions);
       await consoleActions.closeAllBuffersWithoutSaving();
-      await consoleActions.typeInConsole('rm(list = ls())');
+      await consoleActions.executeInConsole('rm(list = ls())');
       await sleep(500);
     });
 

--- a/e2e/rstudio/tests/panes/misc/autocomplete_extras.test.ts
+++ b/e2e/rstudio/tests/panes/misc/autocomplete_extras.test.ts
@@ -39,7 +39,7 @@ test.describe('Autocomplete extras', () => {
     const sourceActions = new SourcePaneActions(page, consoleActions);
     autocomplete = new AutocompleteActions(page, consoleActions, sourceActions);
     await consoleActions.closeAllBuffersWithoutSaving();
-    await consoleActions.typeInConsole('rm(list = ls())');
+    await consoleActions.executeInConsole('rm(list = ls())');
     await sleep(500);
   });
 
@@ -69,7 +69,7 @@ test.describe('Autocomplete extras', () => {
       'nms <- .rs.getNames(n)',
     ];
     for (const code of setup) {
-      await consoleActions.typeInConsole(code);
+      await consoleActions.executeInConsole(code);
       await sleep(500);
     }
 
@@ -78,9 +78,7 @@ test.describe('Autocomplete extras', () => {
     expect(before).not.toMatch(/\[1\]\s*"active"/);
 
     // Triggering completions on `n` (Tab) must also not evaluate it.
-    await consoleActions.consolePane.consoleInput.click({ force: true });
-    await sleep(200);
-    await consoleActions.consolePane.consoleInput.pressSequentially('n');
+    await consoleActions.typeInConsole('n');
     await page.keyboard.press('Tab');
     await sleep(500);
     await page.keyboard.press('Escape');
@@ -153,12 +151,10 @@ test.describe('Autocomplete extras', () => {
 
   // https://github.com/rstudio/rstudio/issues/13290
   test('column names with special chars are properly quoted on accept', async ({ rstudioPage: page }) => {
-    await consoleActions.typeInConsole('cols_q <- list(apple = "apple", "2024" = "2024")');
+    await consoleActions.executeInConsole('cols_q <- list(apple = "apple", "2024" = "2024")');
     await sleep(500);
 
-    await consoleActions.consolePane.consoleInput.click({ force: true });
-    await sleep(200);
-    await consoleActions.consolePane.consoleInput.pressSequentially('cols_q$');
+    await consoleActions.typeInConsole('cols_q$');
     await page.keyboard.press('Tab');
     await sleep(500);
 

--- a/e2e/rstudio/tests/panes/misc/build_pane_testthat.test.ts
+++ b/e2e/rstudio/tests/panes/misc/build_pane_testthat.test.ts
@@ -63,10 +63,10 @@ test.describe('Build pane', () => {
     // Create the package skeleton and open the project. openProject restarts R,
     // so wait for both the project label to update and the console to be idle
     // before continuing.
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       `.rs.rpc.package_skeleton(packageName = ${projectNameLit}, packageDirectory = ${projectDirLit}, sourceFiles = character(), usingRcpp = FALSE)`,
     );
-    await consoleActions.typeInConsole(`.rs.api.openProject(${projectDirLit})`);
+    await consoleActions.executeInConsole(`.rs.api.openProject(${projectDirLit})`);
     await expect(page.locator(PROJECT_MENU)).toContainText(projectName, {
       timeout: TIMEOUTS.sessionRestart,
     });
@@ -79,7 +79,7 @@ test.describe('Build pane', () => {
       testFile,
       'test_that("we can run a test", {\n  expect_equal(2 + 2, 4)\n})\n',
     );
-    await consoleActions.typeInConsole(`.rs.api.documentOpen(${testFileLit})`);
+    await consoleActions.executeInConsole(`.rs.api.documentOpen(${testFileLit})`);
     await sleep(1000);
 
     await executeCommand(page, 'testTestthatFile');

--- a/e2e/rstudio/tests/panes/misc/python_completions.test.ts
+++ b/e2e/rstudio/tests/panes/misc/python_completions.test.ts
@@ -21,7 +21,7 @@ async function exitPythonReplIfActive(
   const text = await consoleActions.consolePane.consoleOutput.innerText();
   // Trailing >>> indicates the Python REPL is still the active prompt.
   if (!text.trimEnd().endsWith('>>>')) return;
-  await consoleActions.typeInConsole('exit');
+  await consoleActions.executeInConsole('exit');
   await waitForConsoleIdle(page);
 }
 
@@ -45,16 +45,14 @@ test.describe('Python REPL completions', () => {
   test('Tab-completion of __dunder__ attributes does not add quotes', async ({ rstudioPage: page }) => {
     test.skip(missingPackages.length > 0, `Missing: ${missingPackages.join(', ')}`);
 
-    await consoleActions.typeInConsole('reticulate::repl_python()');
+    await consoleActions.executeInConsole('reticulate::repl_python()');
     await waitForConsoleIdle(page);
-    await consoleActions.typeInConsole('import sys');
+    await consoleActions.executeInConsole('import sys');
     await waitForConsoleIdle(page);
 
     // Type the partial attribute, give the completion engine time to respond,
     // then accept with Tab and execute with Enter.
-    await consoleActions.consolePane.consoleInput.click({ force: true });
-    await sleep(300);
-    await consoleActions.consolePane.consoleInput.pressSequentially('sys.__name');
+    await consoleActions.typeInConsole('sys.__name');
     await sleep(3000);
 
     await page.keyboard.press('Tab');

--- a/e2e/rstudio/tests/panes/misc/rs_value_contents.test.ts
+++ b/e2e/rstudio/tests/panes/misc/rs_value_contents.test.ts
@@ -19,7 +19,7 @@ async function getValueContents(
 ): Promise<string> {
   const marker = `__VC_${Date.now()}__`;
   await consoleActions.clearConsole();
-  await consoleActions.typeInConsole(
+  await consoleActions.executeInConsole(
     `cat("${marker}", paste(.rs.valueContents(${rExpr}), collapse = "|||"), "${marker}")`
   );
   await sleep(2000);
@@ -42,9 +42,9 @@ test.describe('Environment pane valueContents', { tag: ['@parallel_safe'] }, () 
   // Regression: user-defined str method drops first list element (#16985)
   // -----------------------------------------------------------------------
   test('first list element is not dropped with user-defined str method (#16985)', async () => {
-    await consoleActions.typeInConsole('obj <- structure(list(x = 10, y = 20), class = "myclass")');
+    await consoleActions.executeInConsole('obj <- structure(list(x = 10, y = 20), class = "myclass")');
     await sleep(1000);
-    await consoleActions.typeInConsole('str.myclass <- function(object, ...) { cat("myclass:\\n"); NextMethod() }');
+    await consoleActions.executeInConsole('str.myclass <- function(object, ...) { cat("myclass:\\n"); NextMethod() }');
     await sleep(1000);
 
     // Before the fix, "$ x" was dropped; only "$ y" appeared.
@@ -52,7 +52,7 @@ test.describe('Environment pane valueContents', { tag: ['@parallel_safe'] }, () 
     expect(contents).toContain('$ x');
     expect(contents).toContain('$ y');
 
-    await consoleActions.typeInConsole('rm(obj, str.myclass)');
+    await consoleActions.executeInConsole('rm(obj, str.myclass)');
     await sleep(500);
   });
 
@@ -60,7 +60,7 @@ test.describe('Environment pane valueContents', { tag: ['@parallel_safe'] }, () 
   // Standard list (no user str method) — header should be stripped normally
   // -----------------------------------------------------------------------
   test('standard list displays all elements correctly', async () => {
-    await consoleActions.typeInConsole('plain_list <- list(a = 1, b = 2, c = 3)');
+    await consoleActions.executeInConsole('plain_list <- list(a = 1, b = 2, c = 3)');
     await sleep(1000);
 
     const contents = await getValueContents(consoleActions, 'plain_list');
@@ -70,7 +70,7 @@ test.describe('Environment pane valueContents', { tag: ['@parallel_safe'] }, () 
     // The "List of 3" header should have been stripped
     expect(contents).not.toContain('List of');
 
-    await consoleActions.typeInConsole('rm(plain_list)');
+    await consoleActions.executeInConsole('rm(plain_list)');
     await sleep(500);
   });
 
@@ -78,7 +78,7 @@ test.describe('Environment pane valueContents', { tag: ['@parallel_safe'] }, () 
   // Data frame — header should be stripped normally
   // -----------------------------------------------------------------------
   test('data frame displays all columns correctly', async () => {
-    await consoleActions.typeInConsole('df <- data.frame(name = c("a", "b"), val = c(1, 2))');
+    await consoleActions.executeInConsole('df <- data.frame(name = c("a", "b"), val = c(1, 2))');
     await sleep(1000);
 
     const contents = await getValueContents(consoleActions, 'df');
@@ -87,7 +87,7 @@ test.describe('Environment pane valueContents', { tag: ['@parallel_safe'] }, () 
     // The header (e.g. "'data.frame': 2 obs. of 2 variables:") should be stripped
     expect(contents).not.toContain('data.frame');
 
-    await consoleActions.typeInConsole('rm(df)');
+    await consoleActions.executeInConsole('rm(df)');
     await sleep(500);
   });
 
@@ -99,14 +99,14 @@ test.describe('Environment pane valueContents', { tag: ['@parallel_safe'] }, () 
     // A nested list where each element expands to multiple str lines
     // (sub-header + 4 values = 5 lines × 40 groups + 1 header = 201 lines)
     // triggers the n > 150 truncation path in .rs.valueContentsImpl().
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       'nested <- setNames(lapply(1:40, function(i) list(a = i, b = i, c = i, d = i)), paste0("g_", 1:40))'
     );
     await sleep(1000);
 
     const marker = `__NEST_${Date.now()}__`;
     await consoleActions.clearConsole();
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       `vc <- .rs.valueContents(nested); cat("${marker}", length(vc), vc[1], vc[length(vc)], "${marker}")`
     );
     await sleep(2000);
@@ -123,7 +123,7 @@ test.describe('Environment pane valueContents', { tag: ['@parallel_safe'] }, () 
     // Truncation message at the end
     expect(contents).toContain('lines omitted');
 
-    await consoleActions.typeInConsole('rm(nested, vc)');
+    await consoleActions.executeInConsole('rm(nested, vc)');
     await sleep(500);
   });
 });

--- a/e2e/rstudio/tests/panes/misc/s4_unloaded_package.test.ts
+++ b/e2e/rstudio/tests/panes/misc/s4_unloaded_package.test.ts
@@ -17,7 +17,7 @@
 import { test as base, expect } from '@playwright/test';
 import { launchRStudio, shutdownRStudio, type DesktopSession } from '@fixtures/desktop.fixture';
 import { sleep } from '@utils/constants';
-import { typeInConsole, clearConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
+import { executeInConsole, clearConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { YES_BTN } from '@pages/modals.page';
 import { executeCommand, setPref } from '@utils/commands';
 import type { Page } from 'playwright';
@@ -28,7 +28,7 @@ const OBJ_NAME = 's4_test_object';
 async function captureResult(page: Page, rExpr: string): Promise<string> {
   const marker = `__S4_${Date.now()}__`;
   await clearConsole(page);
-  await typeInConsole(page, `cat("${marker}", ${rExpr}, "${marker}")`);
+  await executeInConsole(page, `cat("${marker}", ${rExpr}, "${marker}")`);
   await sleep(2000);
 
   const output = await page.locator(CONSOLE_OUTPUT).innerText();
@@ -43,21 +43,21 @@ async function captureResult(page: Page, rExpr: string): Promise<string> {
  */
 async function setupWorkspace(page: Page): Promise<void> {
   // Install DBI (binary, fast -- only dependency is methods which is always loaded)
-  await typeInConsole(page, 'install.packages("DBI", repos = "https://cran.r-project.org")');
+  await executeInConsole(page, 'install.packages("DBI", repos = "https://cran.r-project.org")');
   await sleep(15000);
 
   // Create an S4 object from DBI
-  await typeInConsole(page, 'library(DBI)');
+  await executeInConsole(page, 'library(DBI)');
   await sleep(1000);
-  await typeInConsole(page, `${OBJ_NAME} <- DBI::SQL("SELECT 1")`);
+  await executeInConsole(page, `${OBJ_NAME} <- DBI::SQL("SELECT 1")`);
   await sleep(500);
 
   // Plain objects as controls
-  await typeInConsole(page, 'x <- 1');
+  await executeInConsole(page, 'x <- 1');
   await sleep(500);
-  await typeInConsole(page, 'y <- 22');
+  await executeInConsole(page, 'y <- 22');
   await sleep(500);
-  await typeInConsole(page, `z <- "I'll so offend, to make offense a skill"`);
+  await executeInConsole(page, `z <- "I'll so offend, to make offense a skill"`);
   await sleep(500);
 
   // Enable workspace persistence
@@ -67,12 +67,12 @@ async function setupWorkspace(page: Page): Promise<void> {
   await sleep(500);
 
   // Save workspace
-  await typeInConsole(page, 'save.image()');
+  await executeInConsole(page, 'save.image()');
   await sleep(1000);
 
   // Remove DBI so it won't be loadable after restart.
   // This may trigger a "loaded packages" dialog -- click Yes if it appears.
-  await typeInConsole(page, 'remove.packages("DBI")');
+  await executeInConsole(page, 'remove.packages("DBI")');
   await sleep(1000);
   try {
     await page.locator(YES_BTN).click({ timeout: 3000 });
@@ -90,14 +90,14 @@ async function setupWorkspace(page: Page): Promise<void> {
 
 /** Remove test objects, delete .RData, restore preferences, reinstall DBI. */
 async function cleanup(page: Page): Promise<void> {
-  await typeInConsole(page, `suppressWarnings(rm("${OBJ_NAME}", "x", "y", "z", envir = .GlobalEnv))`);
+  await executeInConsole(page, `suppressWarnings(rm("${OBJ_NAME}", "x", "y", "z", envir = .GlobalEnv))`);
   await sleep(500);
-  await typeInConsole(page, 'unlink(".RData")');
+  await executeInConsole(page, 'unlink(".RData")');
   await sleep(500);
   await setPref(page, 'save_workspace', 'never');
   await sleep(500);
   // Reinstall DBI so we leave things as we found them
-  await typeInConsole(page, 'install.packages("DBI", repos = "https://cran.r-project.org")');
+  await executeInConsole(page, 'install.packages("DBI", repos = "https://cran.r-project.org")');
   await sleep(15000);
 }
 
@@ -106,7 +106,7 @@ async function verifySessionSurvived(page: Page): Promise<void> {
   // Session is alive
   const aliveMarker = `__ALIVE_${Date.now()}__`;
   await clearConsole(page);
-  await typeInConsole(page, `cat("${aliveMarker}")`);
+  await executeInConsole(page, `cat("${aliveMarker}")`);
   await sleep(2000);
   const output = await page.locator(CONSOLE_OUTPUT).innerText();
   expect(output).toContain(aliveMarker);

--- a/e2e/rstudio/tests/panes/misc/session_restart.test.ts
+++ b/e2e/rstudio/tests/panes/misc/session_restart.test.ts
@@ -11,8 +11,8 @@ test.describe('Session restart', () => {
   });
 
   test('variables defined before restart are visible to the after-restart command', async () => {
-    await consoleActions.typeInConsole('x <- 1; y <- 2');
-    await consoleActions.typeInConsole(".rs.api.restartSession('print(x + y)')");
+    await consoleActions.executeInConsole('x <- 1; y <- 2');
+    await consoleActions.executeInConsole(".rs.api.restartSession('print(x + y)')");
 
     await expect(consoleActions.consolePane.consoleOutput).toContainText('[1] 3', {
       timeout: TIMEOUTS.sessionRestart,

--- a/e2e/rstudio/tests/panes/misc/session_suspend.test.ts
+++ b/e2e/rstudio/tests/panes/misc/session_suspend.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { sleep, TIMEOUTS } from '@utils/constants';
-import { typeInConsole, CONSOLE_OUTPUT } from '@pages/console_pane.page';
+import { executeInConsole, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { waitForSessionRestart } from '@utils/project';
 import { rStringLiteral } from '@utils/r';
 import { executeCommand } from '@utils/commands';
@@ -8,7 +8,7 @@ import type { Page } from 'playwright';
 
 async function captureResult(page: Page, rExpression: string): Promise<string> {
   const marker = `__SUSP_${Date.now()}__`;
-  await typeInConsole(page, `cat(${rStringLiteral(marker)}, ${rExpression}, ${rStringLiteral(marker)})`);
+  await executeInConsole(page, `cat(${rStringLiteral(marker)}, ${rExpression}, ${rStringLiteral(marker)})`);
 
   const pattern = new RegExp(`${marker}\\s+(.*?)\\s+${marker}`, 's');
   const start = Date.now();
@@ -30,7 +30,7 @@ async function suspendAndResume(page: Page): Promise<void> {
 // equivalent flow, so these tests are tagged @server_only.
 test.describe.serial('Session suspend/resume', { tag: ['@server_only'] }, () => {
   test('loaded packages are preserved on suspend + resume', async ({ rstudioPage: page }) => {
-    await typeInConsole(page, 'library(tools)');
+    await executeInConsole(page, 'library(tools)');
     await sleep(TIMEOUTS.pollInterval);
 
     await suspendAndResume(page);
@@ -40,7 +40,7 @@ test.describe.serial('Session suspend/resume', { tag: ['@server_only'] }, () => 
   });
 
   test('attached datasets are preserved on suspend + resume', async ({ rstudioPage: page }) => {
-    await typeInConsole(
+    await executeInConsole(
       page,
       'attach(list(apple = 1, banana = 2, cherry = 3), name = "my-attached-dataset")',
     );
@@ -58,7 +58,7 @@ test.describe.serial('Session suspend/resume', { tag: ['@server_only'] }, () => 
       const sum = await captureResult(page, 'apple + banana + cherry');
       expect(sum, 'attached values should still resolve').toBe('6');
     } finally {
-      await typeInConsole(page, 'try(detach("my-attached-dataset"), silent = TRUE)');
+      await executeInConsole(page, 'try(detach("my-attached-dataset"), silent = TRUE)');
       await sleep(TIMEOUTS.pollInterval);
     }
   });

--- a/e2e/rstudio/tests/panes/packages/packages_pane.test.ts
+++ b/e2e/rstudio/tests/panes/packages/packages_pane.test.ts
@@ -49,7 +49,7 @@ test.describe('Packages pane', () => {
     test.skip(!installed, 'MASS is not installed');
 
     // Ensure MASS is not currently attached -- defensive against earlier specs.
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       'if ("package:MASS" %in% search()) detach("package:MASS", character.only = TRUE)',
     );
     await sleep(TIMEOUTS.layoutSettle);
@@ -66,7 +66,7 @@ test.describe('Packages pane', () => {
 
     // Verify package is actually attached via search().
     const attachedMarker = `__ATTACH_${Date.now()}__`;
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       `cat("${attachedMarker}", "package:MASS" %in% search(), "${attachedMarker}")`,
     );
     await expect(consoleActions.consolePane.consoleOutput).toContainText(
@@ -79,7 +79,7 @@ test.describe('Packages pane', () => {
     await expect(checkbox).not.toBeChecked({ timeout: TIMEOUTS.consoleReady });
 
     const detachedMarker = `__DETACH_${Date.now()}__`;
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       `cat("${detachedMarker}", "package:MASS" %in% search(), "${detachedMarker}")`,
     );
     await expect(consoleActions.consolePane.consoleOutput).toContainText(

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails-paths.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails-paths.test.ts
@@ -72,7 +72,7 @@ test.describe.serial('Filesystem Guardrails: paths (#17122)', { tag: ['@serial']
     consoleActions = new ConsolePaneActions(page);
 
     // Install the .rs.test.guardrails helper once for the suite.
-    await consoleActions.typeInConsole(GUARDRAILS_HELPER_DEF);
+    await consoleActions.executeInConsole(GUARDRAILS_HELPER_DEF);
     await consoleActions.clearConsole();
   });
 
@@ -93,7 +93,7 @@ test.describe.serial('Filesystem Guardrails: paths (#17122)', { tag: ['@serial']
       opts.post,
     ].filter(Boolean) as string[];
     await consoleActions.clearConsole();
-    await consoleActions.typeInConsole(segments.join('; '));
+    await consoleActions.executeInConsole(segments.join('; '));
     // The DONE marker is printed AFTER the guarded call finishes. Polling
     // for it via Playwright's auto-retry replaces the previous blind sleep.
     // (Any `post` cleanup runs after the marker is printed but before R
@@ -335,8 +335,8 @@ test.describe.serial('Filesystem Guardrails: paths (#17122)', { tag: ['@serial']
   test.fixme('bindings are restored after safeEval', async () => {
     // Sketch: .rs.chat.safeEval(quote(1 + 1)), then a write+unlink inside
     // tempdir should NOT produce a "blocked" message. Try:
-    //   await consoleActions.typeInConsole('.rs.chat.safeEval(quote(1 + 1))');
-    //   await consoleActions.typeInConsole(
+    //   await consoleActions.executeInConsole('.rs.chat.safeEval(quote(1 + 1))');
+    //   await consoleActions.executeInConsole(
     //     'p <- file.path(tempdir(), "lifecycle.txt"); writeLines("x", p); unlink(p)'
     //   );
     //   // wait for a runtime marker, then assert no "blocked" in console

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails.test.ts
@@ -73,7 +73,7 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@serial']
     // Files inside the project and outside-project files now live in the
     // sandbox and are removed by the sandbox afterAll (registered by
     // useSuiteSandbox). Only the tempdir file is outside the sandbox.
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       `unlink(file.path(tempdir(), "${TEMP_FILE}"))`
     );
     await sleep(500);
@@ -108,7 +108,7 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@serial']
   async function fileExists(rPathExpr: string): Promise<boolean> {
     const marker = `__EXISTS_${Date.now()}__`;
     await consoleActions.clearConsole();
-    await consoleActions.typeInConsole(`cat("${marker}", file.exists(${rPathExpr}), "${marker}")`);
+    await consoleActions.executeInConsole(`cat("${marker}", file.exists(${rPathExpr}), "${marker}")`);
     await sleep(1500);
     const output = await consoleActions.consolePane.consoleOutput.innerText();
     const match = output.match(new RegExp(`${marker}\\s+(TRUE|FALSE)\\s+${marker}`));
@@ -153,7 +153,7 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@serial']
 
   test('4: rename from project to outside is denied', async () => {
     // Create source file inside the project via console
-    await consoleActions.typeInConsole(`writeLines("rename me", "${RENAME_SRC}")`);
+    await consoleActions.executeInConsole(`writeLines("rename me", "${RENAME_SRC}")`);
     await sleep(500);
 
     const outsideDest = `${sandboxR}/${RENAME_SRC}`;
@@ -166,7 +166,7 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@serial']
     // Destination should not exist
     expect(await fileExists(`"${outsideDest}"`)).toBe(false);
 
-    await consoleActions.typeInConsole(`unlink("${RENAME_SRC}")`);
+    await consoleActions.executeInConsole(`unlink("${RENAME_SRC}")`);
     await sleep(500);
   });
 
@@ -174,7 +174,7 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@serial']
 
   test('5: read sensitive .env file is denied', async () => {
     // Plant a .env file with a known secret via the console
-    await consoleActions.typeInConsole('writeLines("SECRET_KEY=abc123", ".env")');
+    await consoleActions.executeInConsole('writeLines("SECRET_KEY=abc123", ".env")');
     await sleep(500);
 
     const response = await askAssistant(
@@ -184,12 +184,12 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@serial']
     // The secret value must not appear in the response
     expect(response).not.toContain('abc123');
 
-    await consoleActions.typeInConsole('unlink(".env")');
+    await consoleActions.executeInConsole('unlink(".env")');
     await sleep(500);
   });
 
   test('6: read .Renviron file is denied', async () => {
-    await consoleActions.typeInConsole('writeLines("DB_PASSWORD=secret", ".Renviron")');
+    await consoleActions.executeInConsole('writeLines("DB_PASSWORD=secret", ".Renviron")');
     await sleep(500);
 
     const response = await askAssistant(
@@ -198,7 +198,7 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@serial']
 
     expect(response).not.toContain('DB_PASSWORD=secret');
 
-    await consoleActions.typeInConsole('unlink(".Renviron")');
+    await consoleActions.executeInConsole('unlink(".Renviron")');
     await sleep(500);
   });
 
@@ -208,7 +208,7 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@serial']
     // prefers its own read tool over R code, bypassing the R guardrails.
     test.skip(true, '.Rprofile not in databot read tool deny list');
 
-    await consoleActions.typeInConsole('writeLines("options(secret.key = 123)", ".Rprofile")');
+    await consoleActions.executeInConsole('writeLines("options(secret.key = 123)", ".Rprofile")');
     await sleep(500);
 
     const response = await askAssistant(
@@ -217,12 +217,12 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@serial']
 
     expect(response).not.toContain('options(secret.key = 123)');
 
-    await consoleActions.typeInConsole('unlink(".Rprofile")');
+    await consoleActions.executeInConsole('unlink(".Rprofile")');
     await sleep(500);
   });
 
   test('8: file() connection to sensitive path is denied', async () => {
-    await consoleActions.typeInConsole('writeLines("API_TOKEN=xyz789", ".env")');
+    await consoleActions.executeInConsole('writeLines("API_TOKEN=xyz789", ".env")');
     await sleep(500);
 
     const response = await askAssistant(
@@ -231,7 +231,7 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@serial']
 
     expect(response).not.toContain('API_TOKEN=xyz789');
 
-    await consoleActions.typeInConsole('unlink(".env")');
+    await consoleActions.executeInConsole('unlink(".env")');
     await sleep(500);
   });
 
@@ -239,7 +239,7 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@serial']
 
   test('9: read normal file is allowed', async () => {
     // Create the file via console
-    await consoleActions.typeInConsole(`writeLines("x <- 42", "${READ_FILE}")`);
+    await consoleActions.executeInConsole(`writeLines("x <- 42", "${READ_FILE}")`);
     await sleep(500);
 
     const response = await askAssistant(
@@ -249,7 +249,7 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@serial']
     // The assistant should be able to show the file content
     expect(response).toContain('x <- 42');
 
-    await consoleActions.typeInConsole(`unlink("${READ_FILE}")`);
+    await consoleActions.executeInConsole(`unlink("${READ_FILE}")`);
     await sleep(500);
   });
 
@@ -261,7 +261,7 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@serial']
     const file = `guardrail_restore_${TS}.txt`;
 
     await consoleActions.clearConsole();
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       `writeLines("manual_test", file.path(tempdir(), "${file}"))`
     );
     await sleep(1500);
@@ -270,7 +270,7 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@serial']
     expect(output.toLowerCase()).not.toContain('blocked');
     expect(await fileExists(`file.path(tempdir(), "${file}")`)).toBe(true);
 
-    await consoleActions.typeInConsole(`unlink(file.path(tempdir(), "${file}"))`);
+    await consoleActions.executeInConsole(`unlink(file.path(tempdir(), "${file}"))`);
     await sleep(500);
   });
 
@@ -281,14 +281,14 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@serial']
     const rPath = `"${sandboxR}/${file}"`;
 
     await consoleActions.clearConsole();
-    await consoleActions.typeInConsole(`writeLines("user_test", ${rPath})`);
+    await consoleActions.executeInConsole(`writeLines("user_test", ${rPath})`);
     await sleep(1500);
 
     const output = await consoleActions.consolePane.consoleOutput.innerText();
     expect(output.toLowerCase()).not.toContain('blocked');
     expect(await fileExists(rPath)).toBe(true);
 
-    await consoleActions.typeInConsole(`unlink(${rPath})`);
+    await consoleActions.executeInConsole(`unlink(${rPath})`);
     await sleep(500);
   });
 });

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
@@ -68,13 +68,13 @@ async function createSkillFile(
   description: string,
   marker: string,
 ): Promise<void> {
-  await consoleActions.typeInConsole(`dir.create("${dir}", recursive = TRUE)`);
+  await consoleActions.executeInConsole(`dir.create("${dir}", recursive = TRUE)`);
   await sleep(1000);
 
   // Keep content minimal to stay under ~300 chars for pressSequentially reliability
   const cmd =
     `writeLines(c("---", "name: ${name}", "description: ${description}", "---", "", "Start with: ${marker}", "Markers are MANDATORY."), "${filePath}")`;
-  await consoleActions.typeInConsole(cmd);
+  await consoleActions.executeInConsole(cmd);
   await sleep(1000);
 }
 
@@ -152,12 +152,12 @@ test.describe.serial('User-Added Skills', { tag: ['@ai', '@serial'] }, () => {
     // Step 4: Verify both files exist and have correct content
     // -----------------------------------------------------------------------
     await consoleActions.clearConsole();
-    await consoleActions.typeInConsole(`cat(readLines("${projectSkillPath}"), sep = "\\n")`);
+    await consoleActions.executeInConsole(`cat(readLines("${projectSkillPath}"), sep = "\\n")`);
     await sleep(2000);
     const projectOutput = await consoleActions.consolePane.consoleOutput.innerText();
 
     await consoleActions.clearConsole();
-    await consoleActions.typeInConsole(`cat(readLines("${userSkillPath()}"), sep = "\\n")`);
+    await consoleActions.executeInConsole(`cat(readLines("${userSkillPath()}"), sep = "\\n")`);
     await sleep(2000);
     const userOutput = await consoleActions.consolePane.consoleOutput.innerText();
 
@@ -187,7 +187,7 @@ test.describe.serial('User-Added Skills', { tag: ['@ai', '@serial'] }, () => {
     // tree, so no explicit cleanup is needed for it here.
 
     // Clean up only the specific user-level skill we created (leave ~/.positai/ intact)
-    await consoleActions.typeInConsole(`unlink("${userSkillDir()}", recursive = TRUE)`);
+    await consoleActions.executeInConsole(`unlink("${userSkillDir()}", recursive = TRUE)`);
     await sleep(1000);
   });
 

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/readline-notification.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/readline-notification.test.ts
@@ -61,11 +61,7 @@ test.describe.serial('Readline Notification in Chat Pane', { tag: ['@ai', '@seri
     await expect(chatPane.readlineNotification).toBeVisible();
 
     // --- Step 6: Provide input in the Console to unblock readline ---
-    await consoleActions.consolePane.consoleTab.click();
-    await sleep(500);
-    await consoleActions.consolePane.consoleInput.click({ force: true });
-    await sleep(500);
-    await consoleActions.consolePane.consoleInput.pressSequentially('Prospero');
+    await consoleActions.typeInConsole('Prospero');
     await sleep(300);
     await page.keyboard.press('Enter');
 

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
@@ -35,7 +35,7 @@ test.describe.serial('R Shiny Tip Calculator via Posit Assistant', { tag: ['@ai'
     await sleep(1000);
 
     // Clean up any leftover files from previous runs
-    await consoleActions.typeInConsole('unlink("app.R")');
+    await consoleActions.executeInConsole('unlink("app.R")');
     await sleep(1000);
 
     // Clear the Viewer pane so we don't get false positives from previous content
@@ -93,7 +93,7 @@ test.describe.serial('R Shiny Tip Calculator via Posit Assistant', { tag: ['@ai'
     }
 
     // Clean up created file(s)
-    await consoleActions.typeInConsole('unlink("app.R")');
+    await consoleActions.executeInConsole('unlink("app.R")');
     await sleep(1000);
   });
 

--- a/e2e/rstudio/tests/panes/terminal/terminal.test.ts
+++ b/e2e/rstudio/tests/panes/terminal/terminal.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { sleep, TIMEOUTS } from '@utils/constants';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
-import { typeInConsole, CONSOLE_OUTPUT } from '@pages/console_pane.page';
+import { executeInConsole, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { AceEditor } from '@pages/ace_editor.page';
 import { rStringLiteral } from '@utils/r';
 import { executeCommand } from '@utils/commands';
@@ -12,7 +12,7 @@ const XTERM_SELECTOR = '.xterm';
 
 async function captureResult(page: Page, rExpression: string): Promise<string> {
   const marker = `__TERM_${Date.now()}__`;
-  await typeInConsole(page, `cat(${rStringLiteral(marker)}, ${rExpression}, ${rStringLiteral(marker)})`);
+  await executeInConsole(page, `cat(${rStringLiteral(marker)}, ${rExpression}, ${rStringLiteral(marker)})`);
 
   const pattern = new RegExp(`${marker}\\s+(.*?)\\s+${marker}`, 's');
   const start = Date.now();
@@ -26,12 +26,12 @@ async function captureResult(page: Page, rExpression: string): Promise<string> {
 }
 
 async function killAllTerminals(page: Page): Promise<void> {
-  await typeInConsole(page, 'rstudioapi::terminalKill(rstudioapi::terminalList())');
+  await executeInConsole(page, 'rstudioapi::terminalKill(rstudioapi::terminalList())');
   await sleep(TIMEOUTS.pollInterval);
 }
 
 async function openTerminal(page: Page): Promise<void> {
-  await typeInConsole(page, 'rstudioapi::terminalCreate(show = TRUE)');
+  await executeInConsole(page, 'rstudioapi::terminalCreate(show = TRUE)');
   await expect(page.locator(XTERM_SELECTOR)).toBeVisible({ timeout: TIMEOUTS.consoleReady });
   await expect(page.locator(TERMINAL_TAB)).toHaveAttribute('aria-selected', 'true', {
     timeout: TIMEOUTS.consoleReady,

--- a/e2e/rstudio/tests/projects/create_projects.test.ts
+++ b/e2e/rstudio/tests/projects/create_projects.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { sleep, TIMEOUTS } from '@utils/constants';
-import { typeInConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
+import { executeInConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { installDepIfPrompted } from '@pages/modals.page';
 import { SourcePane } from '@pages/source_pane.page';
 import { useSuiteSandbox, SANDBOX_DIR_PREFIX } from '@utils/sandbox';
@@ -73,7 +73,7 @@ const ALL_TYPES = [NEW_PROJECT, R_PACKAGE, SHINY_APP, QUARTO_PROJECT, QUARTO_WEB
 // helpers are ever reused with uncontrolled input, add proper escaping.
 async function captureResult(page: Page, rExpression: string): Promise<string> {
   const marker = `__CP_${Date.now()}__`;
-  await typeInConsole(page, `cat("${marker}", ${rExpression}, "${marker}")`);
+  await executeInConsole(page, `cat("${marker}", ${rExpression}, "${marker}")`);
 
   const pattern = new RegExp(`${marker}\\s+(.*?)\\s+${marker}`);
   const start = Date.now();
@@ -103,7 +103,7 @@ async function waitForSessionRestart(page: Page): Promise<void> {
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
       const marker = `__READY_${Date.now()}__`;
-      await typeInConsole(page, `cat("${marker}")`);
+      await executeInConsole(page, `cat("${marker}")`);
       await sleep(1500);
       const output = await page.locator(CONSOLE_OUTPUT).innerText();
       if (output.includes(marker)) return;
@@ -202,7 +202,7 @@ async function closeCurrentProject(page: Page): Promise<void> {
 async function cleanupProject(page: Page, projectDir: string): Promise<void> {
   if (!projectDir) return;
   const escaped = projectDir.replace(/\\/g, '/');
-  await typeInConsole(page, `unlink("${escaped}", recursive = TRUE)`);
+  await executeInConsole(page, `unlink("${escaped}", recursive = TRUE)`);
   await sleep(500);
 }
 

--- a/e2e/rstudio/tests/projects/ignorefiles.test.ts
+++ b/e2e/rstudio/tests/projects/ignorefiles.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@fixtures/rstudio.fixture';
 import { sleep, TIMEOUTS } from '@utils/constants';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { useSuiteSandbox, SANDBOX_DIR_PREFIX } from '@utils/sandbox';
-import { typeInConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
+import { executeInConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { rPathLiteral } from '@utils/r';
 import { setPref } from '@utils/commands';
 import * as fs from 'fs';
@@ -31,7 +31,7 @@ async function waitForConsoleIdle(page: Page): Promise<void> {
 
 async function captureResult(page: Page, rExpression: string): Promise<string> {
   const marker = `__IG_${Date.now()}__`;
-  await typeInConsole(page, `cat("${marker}", ${rExpression}, "${marker}")`);
+  await executeInConsole(page, `cat("${marker}", ${rExpression}, "${marker}")`);
   const pattern = new RegExp(`${marker}\\s+(.*?)\\s+${marker}`);
   const deadline = Date.now() + TIMEOUTS.consoleReady;
   while (Date.now() < deadline) {
@@ -137,7 +137,7 @@ test.describe('Project ignore files', () => {
     expect(fs.readFileSync(gitignorePath, 'utf8').split('\n')).not.toContain('.positai');
 
     // Create .positai via rsession so the file monitor picks it up.
-    await consoleActions.typeInConsole(`dir.create("${projectDir}/.positai")`);
+    await consoleActions.executeInConsole(`dir.create("${projectDir}/.positai")`);
 
     await expect
       .poll(() => fs.readFileSync(gitignorePath, 'utf8').split('\n').includes('.positai'), {

--- a/e2e/rstudio/tests/projects/project_id.test.ts
+++ b/e2e/rstudio/tests/projects/project_id.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { sleep, TIMEOUTS } from '@utils/constants';
-import { typeInConsole, CONSOLE_OUTPUT } from '@pages/console_pane.page';
+import { executeInConsole, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { createAndOpenProject, restartSessionWithSentinel, waitForSessionRestart } from '@utils/project';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { rPathLiteral, rStringLiteral } from '@utils/r';
@@ -12,7 +12,7 @@ const CLOSE_PROJECT_MENU_ITEM = '#rstudio_label_close_project_command';
 
 async function captureResult(page: Page, rExpression: string): Promise<string> {
   const marker = `__PI_${Date.now()}__`;
-  await typeInConsole(page, `cat(${rStringLiteral(marker)}, ${rExpression}, ${rStringLiteral(marker)})`);
+  await executeInConsole(page, `cat(${rStringLiteral(marker)}, ${rExpression}, ${rStringLiteral(marker)})`);
 
   const pattern = new RegExp(`${marker}\\s+(.*?)\\s+${marker}`, 's');
   const start = Date.now();
@@ -72,9 +72,9 @@ test.describe.serial('ProjectId in .Rproj', () => {
     expect(hasProjectId, 'fresh .Rproj should not contain ProjectId').toBe('FALSE');
 
     // Set the project user-data directory pref, then restart.
-    await typeInConsole(page, `dir.create(${dataDirLit})`);
+    await executeInConsole(page, `dir.create(${dataDirLit})`);
     await sleep(TIMEOUTS.pollInterval);
-    await typeInConsole(
+    await executeInConsole(
       page,
       `.rs.api.writeRStudioPreference("project_user_data_directory", normalizePath(${dataDirLit}))`,
     );

--- a/e2e/rstudio/tests/projects/project_trust_dialog.test.ts
+++ b/e2e/rstudio/tests/projects/project_trust_dialog.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { sleep } from '@utils/constants';
-import { typeInConsole, clearConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
+import { executeInConsole, clearConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { useSuiteSandbox, SANDBOX_DIR_PREFIX } from '@utils/sandbox';
 import { executeCommand, setPref, documentCloseAllNoSave } from '@utils/commands';
 import type { Page } from 'playwright';
@@ -47,7 +47,7 @@ async function captureResult(page: Page, rExpression: string): Promise<string> {
   // not be fully connected yet and the first attempt can silently fail.
   for (let attempt = 0; attempt < 3; attempt++) {
     await clearConsole(page);
-    await typeInConsole(page, `cat("${marker}", ${rExpression}, "${marker}")`);
+    await executeInConsole(page, `cat("${marker}", ${rExpression}, "${marker}")`);
     await sleep(1500);
     const output = await page.locator(CONSOLE_OUTPUT).innerText();
     const re = new RegExp(`${marker}\\s+(.*?)\\s+${marker}`);
@@ -82,12 +82,12 @@ async function waitForSessionRestart(page: Page): Promise<void> {
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
       const marker = `__READY_${Date.now()}__`;
-      await typeInConsole(page, `cat("${marker}")`);
+      await executeInConsole(page, `cat("${marker}")`);
       await sleep(1500);
       const output = await page.locator(CONSOLE_OUTPUT).innerText();
       if (output.includes(marker)) return;
     } catch {
-      // typeInConsole may fail if console isn't ready
+      // executeInConsole may fail if console isn't ready
     }
     await sleep(2000);
   }
@@ -125,9 +125,9 @@ async function isTrustDialogVisible(page: Page, timeout = 10000): Promise<boolea
 async function resetTrust(page: Page, dir?: string): Promise<void> {
   if (dir) {
     const escaped = dir.replace(/\\/g, '/');
-    await typeInConsole(page, `.rs.trust.reset("${escaped}")`);
+    await executeInConsole(page, `.rs.trust.reset("${escaped}")`);
   } else {
-    await typeInConsole(page, '.rs.trust.reset()');
+    await executeInConsole(page, '.rs.trust.reset()');
   }
   await sleep(500);
 }
@@ -136,9 +136,9 @@ async function resetTrust(page: Page, dir?: string): Promise<void> {
 async function revokeTrust(page: Page, dir?: string): Promise<void> {
   if (dir) {
     const escaped = dir.replace(/\\/g, '/');
-    await typeInConsole(page, `.rs.trust.revoke("${escaped}")`);
+    await executeInConsole(page, `.rs.trust.revoke("${escaped}")`);
   } else {
-    await typeInConsole(page, '.rs.trust.revoke()');
+    await executeInConsole(page, '.rs.trust.revoke()');
   }
   await sleep(500);
 }
@@ -146,7 +146,7 @@ async function revokeTrust(page: Page, dir?: string): Promise<void> {
 /** Write a .Rprofile in the given directory. */
 async function writeRprofile(page: Page, dir: string, content: string): Promise<void> {
   const escaped = dir.replace(/\\/g, '/');
-  await typeInConsole(page, `writeLines('${content}', file.path("${escaped}", ".Rprofile"))`);
+  await executeInConsole(page, `writeLines('${content}', file.path("${escaped}", ".Rprofile"))`);
   await sleep(500);
 }
 
@@ -464,9 +464,9 @@ test.describe.serial('Project Trust Dialog (#17231)', { tag: ['@server_only', '@
     // so it doesn't error when sourced (no risky files → trust not required → .Rprofile runs)
     await writeRprofile(page, projectDir, 'source("renv/activate.R")');
     const escaped = projectDir.replace(/\\/g, '/');
-    await typeInConsole(page, `dir.create(file.path("${escaped}", "renv"), showWarnings = FALSE)`);
+    await executeInConsole(page, `dir.create(file.path("${escaped}", "renv"), showWarnings = FALSE)`);
     await sleep(300);
-    await typeInConsole(page, `writeLines("# dummy", file.path("${escaped}", "renv", "activate.R"))`);
+    await executeInConsole(page, `writeLines("# dummy", file.path("${escaped}", "renv", "activate.R"))`);
     await sleep(300);
 
     // Restart R
@@ -495,7 +495,7 @@ test.describe.serial('Project Trust Dialog (#17231)', { tag: ['@server_only', '@
 
     // Create an .RData file (empty workspace save)
     const escaped = projectDir.replace(/\\/g, '/');
-    await typeInConsole(page, `save(list = character(0), file = file.path("${escaped}", ".RData"))`);
+    await executeInConsole(page, `save(list = character(0), file = file.path("${escaped}", ".RData"))`);
     await sleep(500);
 
     // Restart — dialog expected for .RData

--- a/e2e/rstudio/tests/projects/shinytest2.test.ts
+++ b/e2e/rstudio/tests/projects/shinytest2.test.ts
@@ -3,7 +3,7 @@ import { sleep, TIMEOUTS } from '@utils/constants';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { CONFIRM_BTN } from '@pages/modals.page';
 import { useSuiteSandbox } from '@utils/sandbox';
-import { typeInConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
+import { executeInConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { rPathLiteral } from '@utils/r';
 import { executeCommand } from '@utils/commands';
 import * as fs from 'fs';
@@ -70,17 +70,17 @@ async function scaffoldShinytest2Project(
   const appPathLit = rPathLiteral(`${projectDir}/app.R`);
   const testPathLit = rPathLiteral(testFilePath);
 
-  await consoleActions.typeInConsole(`.rs.api.initializeProject(${projectDirLit})`);
-  await consoleActions.typeInConsole(`.rs.api.openProject(${projectDirLit})`);
+  await consoleActions.executeInConsole(`.rs.api.initializeProject(${projectDirLit})`);
+  await consoleActions.executeInConsole(`.rs.api.openProject(${projectDirLit})`);
   await expect(page.locator(PROJECT_MENU)).toContainText(projectName, {
     timeout: TIMEOUTS.sessionRestart,
   });
   await waitForConsoleIdle(page);
 
-  await consoleActions.typeInConsole(
+  await consoleActions.executeInConsole(
     `file.copy(file.path(system.file("examples", package = "shiny"), "01_hello", "app.R"), ${appPathLit}, overwrite = TRUE)`,
   );
-  await consoleActions.typeInConsole(`.rs.api.documentOpen(${testPathLit})`);
+  await consoleActions.executeInConsole(`.rs.api.documentOpen(${testPathLit})`);
   await sleep(1000);
 }
 
@@ -134,10 +134,10 @@ test.describe('shinytest2 integration', () => {
     // instead of actually launching diffviewer.
     const snapDirLit = rPathLiteral(`${projectDir}/tests/testthat/_snaps/hello`);
     const snapFileLit = rPathLiteral(`${projectDir}/tests/testthat/_snaps/hello/snapshot.new.png`);
-    await consoleActions.typeInConsole(
+    await consoleActions.executeInConsole(
       `dir.create(${snapDirLit}, recursive = TRUE, showWarnings = FALSE)`,
     );
-    await consoleActions.typeInConsole(`file.create(${snapFileLit})`);
+    await consoleActions.executeInConsole(`file.create(${snapFileLit})`);
 
     const stubInstall = [
       'ns <- asNamespace("testthat")',
@@ -146,7 +146,7 @@ test.describe('shinytest2 integration', () => {
       'ns$snapshot_review <- function(files = NULL, path = "tests/testthat", ...) { cat("CAPTURED snapshot_review path=", path, "\\n", sep = "") }',
       'lockBinding("snapshot_review", ns)',
     ].join('; ');
-    await consoleActions.typeInConsole(stubInstall);
+    await consoleActions.executeInConsole(stubInstall);
 
     try {
       await executeCommand(page, 'shinyCompareTest');
@@ -164,7 +164,7 @@ test.describe('shinytest2 integration', () => {
         'ns$snapshot_review <- .rs.original.snapshot_review',
         'lockBinding("snapshot_review", ns)',
       ].join('; ');
-      await typeInConsole(page, restore).catch(() => {});
+      await executeInConsole(page, restore).catch(() => {});
     }
   });
 });

--- a/e2e/rstudio/utils/files.ts
+++ b/e2e/rstudio/utils/files.ts
@@ -2,7 +2,7 @@ import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
-import { typeInConsole } from '../pages/console_pane.page';
+import { executeInConsole } from '../pages/console_pane.page';
 import { SourcePane } from '../pages/source_pane.page';
 import { TIMEOUTS } from './constants';
 import { rPathLiteral, rStringLiteral } from './r';
@@ -33,9 +33,9 @@ export async function writeAndOpenFile(
   if (fs.existsSync(sandboxDir)) {
     fs.writeFileSync(fullPath, content);
   } else {
-    await typeInConsole(page, `writeLines(${rStringLiteral(content)}, ${rFullPath})`);
+    await executeInConsole(page, `writeLines(${rStringLiteral(content)}, ${rFullPath})`);
   }
-  await typeInConsole(page, `file.edit(${rFullPath})`);
+  await executeInConsole(page, `file.edit(${rFullPath})`);
   // The source tab shows the basename, not the full path.
   const tab = page.locator("[class*='rstudio_source_panel'] [class*='PanelTab-selected']");
   await expect(tab).toContainText(fileName, { timeout: TIMEOUTS.fileOpen });
@@ -70,6 +70,6 @@ export async function closeAndDeleteSandboxFiles(
   } else {
     // Remote workdir -- fall back to R-side unlink with absolute paths.
     const vec = fileNames.map((f) => rPathLiteral(path.join(sandboxDir, f))).join(', ');
-    await typeInConsole(page, `unlink(c(${vec}))`);
+    await executeInConsole(page, `unlink(c(${vec}))`);
   }
 }

--- a/e2e/rstudio/utils/project.ts
+++ b/e2e/rstudio/utils/project.ts
@@ -1,5 +1,5 @@
 import type { Page } from 'playwright';
-import { typeInConsole, CONSOLE_TAB, CONSOLE_INPUT, CONSOLE_OUTPUT } from '../pages/console_pane.page';
+import { executeInConsole, CONSOLE_TAB, CONSOLE_INPUT, CONSOLE_OUTPUT } from '../pages/console_pane.page';
 import { sleep, TIMEOUTS } from './constants';
 
 const PROJECT_MENU = '#rstudio_project_menubutton_toolbar';
@@ -63,7 +63,7 @@ export async function restartSessionWithSentinel(page: Page): Promise<void> {
   // "pause" between restart and marker reflects real package-restore work --
   // we accept it as the price of a reliable readiness signal. See
   // src/cpp/r/session/RSessionState.cpp:920-956 for the dispatch logic.
-  await typeInConsole(page, `.rs.api.restartSession(command = "cat('${marker}')")`);
+  await executeInConsole(page, `.rs.api.restartSession(command = "cat('${marker}')")`);
   await pollForMarker(page, marker, 30000);
 }
 
@@ -124,17 +124,17 @@ export async function createAndOpenProject(
   const projectDir = `${parentDirR}/${name}`;
   const marker = `__READY_${Date.now()}__`;
 
-  await typeInConsole(page, `dir.create("${projectDir}")`);
+  await executeInConsole(page, `dir.create("${projectDir}")`);
   await sleep(500);
-  await typeInConsole(
+  await executeInConsole(
     page,
     `writeLines(c("Version: 1.0", "", "RestoreWorkspace: Default", "SaveWorkspace: Default"), "${projectDir}/${name}.Rproj")`
   );
   await sleep(500);
-  await typeInConsole(page, `writeLines("cat('${marker}')", "${projectDir}/.Rprofile")`);
+  await executeInConsole(page, `writeLines("cat('${marker}')", "${projectDir}/.Rprofile")`);
   await sleep(500);
 
-  await typeInConsole(page, `.rs.api.openProject("${projectDir}/${name}.Rproj")`);
+  await executeInConsole(page, `.rs.api.openProject("${projectDir}/${name}.Rproj")`);
   // The page may navigate on Server mode; let it settle before polling.
   await page.waitForLoadState('load', { timeout: 30000 }).catch(() => {});
   await pollForMarker(page, marker, 60000);

--- a/e2e/rstudio/utils/r.ts
+++ b/e2e/rstudio/utils/r.ts
@@ -3,7 +3,7 @@
  * interpolated into R commands fed through the console.
  *
  * RStudio Playwright tests routinely build R expressions via template
- * literals -- typeInConsole(`.rs.api.openProject("${path}")`) and similar.
+ * literals -- executeInConsole(`.rs.api.openProject("${path}")`) and similar.
  * Naive interpolation is fragile: any embedded `"`, `\`, or control char in
  * the value can break R parsing or, worse, silently change semantics.
  * Centralizing the encoding here keeps each test honest and lets us harden

--- a/e2e/rstudio/utils/sandbox.ts
+++ b/e2e/rstudio/utils/sandbox.ts
@@ -1,7 +1,7 @@
 import type { Page } from '@playwright/test';
 import * as path from 'path';
 import { test } from '../fixtures/rstudio.fixture';
-import { typeInConsole, CONSOLE_OUTPUT } from '../pages/console_pane.page';
+import { executeInConsole, CONSOLE_OUTPUT } from '../pages/console_pane.page';
 import { sleep, TIMEOUTS } from './constants';
 
 /**
@@ -45,7 +45,7 @@ function rootExpr(): string {
 export async function createSandbox(page: Page): Promise<string> {
   const marker = `__SANDBOX_${Date.now()}__`;
 
-  // Build the R expression on a single line so typeInConsole's single
+  // Build the R expression on a single line so executeInConsole's single
   // press('Enter') executes it atomically.
   const rCode = [
     `{ root <- ${rootExpr()}`,
@@ -55,7 +55,7 @@ export async function createSandbox(page: Page): Promise<string> {
     `cat("${marker}", d, "${marker}") }`,
   ].join('; ');
 
-  await typeInConsole(page, rCode);
+  await executeInConsole(page, rCode);
 
   const pattern = new RegExp(`${marker}\\s+(.*?)\\s+${marker}`);
   const start = Date.now();
@@ -105,7 +105,7 @@ export async function createSandbox(page: Page): Promise<string> {
  * Usage:
  *   const sandbox = useSuiteSandbox();
  *   test('...', async ({ rstudioPage }) => {
- *     await typeInConsole(rstudioPage, `writeLines("x", "${sandbox.dir}/foo.txt")`);
+ *     await executeInConsole(rstudioPage, `writeLines("x", "${sandbox.dir}/foo.txt")`);
  *   });
  */
 export function useSuiteSandbox(): { dir: string } {


### PR DESCRIPTION
## Summary

- **`executeInConsole(page, code)`** — new fast/reliable helper. Writes the text directly into the console's Ace editor via `setValue()` and presses Enter. No per-key typing, so it doesn't race with autocomplete popups or tooltip handlers that can swallow characters mid-typing. Use whenever a test just needs code to run.
- **`typeInConsole(page, text, delayMs = 50)`** — repurposed for the slow/explicit path. Keeps `pressSequentially` but with a 50ms-per-keystroke default (close to typical human typing speed) so completers and tooltips get time to fire between chars. Does **not** press Enter; caller controls submission. Use only when a test is exercising live-edit behavior (autocomplete, parameter tips, etc.).
- Migrated all 50 callers via a one-off Node script. Autocomplete-style sites that were calling `consoleInput.pressSequentially(...)` directly now go through the new `typeInConsole`.
- **`shutdownRStudio` no longer orphans Electron.** `browser.close()` over a CDP connection only disconnects the CDP session, and `q()` cascading to a full Electron quit is best-effort. The previous code only force-killed in the `catch` branch, so a "successful" graceful path that didn't actually exit Electron left a stray RStudio.app per test file. Now polls `rstudioProcess.exitCode` briefly and force-kills if still alive.
- Drive-by: two tests used `.join('\\n')` to assemble Rmd content, writing the literal two-char string `\n` into the file on disk instead of newlines (`notebook_save_during_execution.test.ts`, `multiline_chunk_execution.test.ts`).

## Motivation

A `library(DBI)` / `DBI::SQL("SELECT 1")` sequence in `s4_unloaded_package.test.ts` was landing in the console as `DBI::SQL("Library/x <- 1` (with the next test's setup commands then becoming continuations of an unclosed string). The cause was the path autocompleter intercepting keystrokes mid-`pressSequentially`. The same class of race could affect any console-input test, so the right fix is to stop synthesizing keystrokes when we don't actually need to test typing — go through Ace's API instead. That mirrors the recent "console-to-bridge" direction in #17716.

The leftover-Electron fix is independent but closely related: it was masking the keystroke-race symptom (instances piled up across the run, each with a different broken console state), so it's bundled here.

## Test plan

- [x] `npm run typecheck` is clean
- [ ] Playwright suite (`npx playwright test --grep-invert @ai`) — currently running locally; the previous run failed entirely on the (now-shipped) `prefSet` / `documentCloseAllNoSave` bridge regression. Will update once it completes.