### PR TITLE
e2e: deliver Enter to console-input locator; rename internal callers

### DIFF
--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -91,7 +91,11 @@ export class ConsolePaneActions {
     if (await this.page.locator('#rstudio_popup_completions').isVisible()) {
       await this.page.keyboard.press('Escape');
     }
-    await this.page.keyboard.press('Enter');
+    // Press Enter on the console-input textarea explicitly. `page.keyboard.press`
+    // delivers to the focused element; relying on editor.focus() above is racy --
+    // focus can shift between the evaluate() returning and the key press,
+    // leaving the text in the buffer but never submitted.
+    await this.consolePane.consoleInput.press('Enter');
   }
 
   /**
@@ -128,7 +132,7 @@ export class ConsolePaneActions {
   }
 
   async getEnvironmentVersions(): Promise<EnvironmentVersions> {
-    await this.typeInConsole('cat("R:", R.version.string, "\\nRStudio:", RStudio.Version()$long_version)');
+    await this.executeInConsole('cat("R:", R.version.string, "\\nRStudio:", RStudio.Version()$long_version)');
     await sleep(2000);
 
     const output = await this.consolePane.consoleOutput.innerText();
@@ -160,7 +164,7 @@ export class ConsolePaneActions {
     const marker = `__PKG_${Date.now()}__`;
 
     await this.clearConsole();
-    await this.typeInConsole(`cat("${marker}", requireNamespace("${pkg}", quietly = TRUE), "${marker}")`);
+    await this.executeInConsole(`cat("${marker}", requireNamespace("${pkg}", quietly = TRUE), "${marker}")`);
     await sleep(1000);
 
     const output = await this.consolePane.consoleOutput.innerText();
@@ -178,8 +182,8 @@ export class ConsolePaneActions {
     // typeInConsole queues input — if R is busy with install, the cat()
     // will execute after install finishes.
     const { repos, type } = getInstallTarget();
-    await this.typeInConsole(`install.packages("${pkg}", repos = "${repos}", type = "${type}")`);
-    await this.typeInConsole(`cat("${doneMarker}")`);
+    await this.executeInConsole(`install.packages("${pkg}", repos = "${repos}", type = "${type}")`);
+    await this.executeInConsole(`cat("${doneMarker}")`);
 
 
     // Wait for the done marker to appear (indicates install finished)
@@ -198,7 +202,7 @@ export class ConsolePaneActions {
     // queued briefly before R gets to it.
     const verifyMarker = `__PKG_VERIFY_${Date.now()}__`;
     await this.clearConsole();
-    await this.typeInConsole(`cat("${verifyMarker}", requireNamespace("${pkg}", quietly = TRUE), "${verifyMarker}")`);
+    await this.executeInConsole(`cat("${verifyMarker}", requireNamespace("${pkg}", quietly = TRUE), "${verifyMarker}")`);
 
     const verifyPattern = new RegExp(`${verifyMarker}\\s+(TRUE|FALSE)\\s+${verifyMarker}`);
     const verifyDeadline = Date.now() + 15000;
@@ -251,13 +255,13 @@ export class ConsolePaneActions {
     await this.clearConsole();
     const doneMarker = `__UNINSTALL_DONE_${Date.now()}__`;
 
-    await this.typeInConsole(
+    await this.executeInConsole(
       `if ("${pkg}" %in% loadedNamespaces()) { try(detach(paste0("package:", "${pkg}"), character.only = TRUE, unload = TRUE), silent = TRUE); try(unloadNamespace("${pkg}"), silent = TRUE) }`,
     );
-    await this.typeInConsole(
+    await this.executeInConsole(
       `if ("${pkg}" %in% rownames(installed.packages())) remove.packages("${pkg}")`,
     );
-    await this.typeInConsole(`cat("${doneMarker}")`);
+    await this.executeInConsole(`cat("${doneMarker}")`);
 
     const startTime = Date.now();
     let doneMarkerSeen = false;
@@ -273,7 +277,7 @@ export class ConsolePaneActions {
 
     const verifyMarker = `__UNINSTALL_VERIFY_${Date.now()}__`;
     await this.clearConsole();
-    await this.typeInConsole(
+    await this.executeInConsole(
       `cat("${verifyMarker}", "${pkg}" %in% rownames(installed.packages()), "${verifyMarker}")`,
     );
 

--- a/e2e/rstudio/pages/console_pane.page.ts
+++ b/e2e/rstudio/pages/console_pane.page.ts
@@ -94,7 +94,11 @@ export async function executeInConsole(page: Page, command: string): Promise<voi
   if (await page.locator('#rstudio_popup_completions').isVisible()) {
     await page.keyboard.press('Escape');
   }
-  await page.keyboard.press('Enter');
+  // Press Enter on the console-input textarea explicitly. `page.keyboard.press`
+  // delivers to the focused element; relying on editor.focus() above is racy --
+  // focus can shift between the evaluate() returning and the key press, leaving
+  // the text in the buffer but never submitted.
+  await page.locator(CONSOLE_INPUT).press('Enter');
 }
 
 /**
@@ -129,7 +133,7 @@ export async function closeAllBuffersWithoutSaving(page: Page): Promise<void> {
 }
 
 export async function getEnvironmentVersions(page: Page): Promise<EnvironmentVersions> {
-  await typeInConsole(page, 'cat("R:", R.version.string, "\\nRStudio:", RStudio.Version()$long_version)');
+  await executeInConsole(page, 'cat("R:", R.version.string, "\\nRStudio:", RStudio.Version()$long_version)');
   await sleep(2000);
 
   const output = await page.locator(CONSOLE_OUTPUT).innerText();

--- a/e2e/rstudio/tests/panes/packages/packages_pane.test.ts
+++ b/e2e/rstudio/tests/panes/packages/packages_pane.test.ts
@@ -14,7 +14,13 @@ const PACKAGES_PANEL = '#rstudio_workbench_panel_packages';
 const FILES_TAB = '#rstudio_workbench_tab_files';
 
 function checkboxLocator(page: Page, packageName: string) {
-  return page.locator(`${PACKAGES_PANEL} input[type='checkbox'][aria-label='${packageName}']`);
+  // A package can appear in more than one library section (e.g. recommended
+  // packages live in the system lib AND a copy may be present in the user
+  // lib). `.first()` keeps the locator deterministic regardless -- the global
+  // attached-state is what we're verifying, and any one checkbox reflects it.
+  return page
+    .locator(`${PACKAGES_PANEL} input[type='checkbox'][aria-label='${packageName}']`)
+    .first();
 }
 
 async function selectPackagesTab(page: Page): Promise<void> {
@@ -42,32 +48,34 @@ test.describe('Packages pane', () => {
     await page.locator(FILES_TAB).click().catch(() => {});
   });
 
-  test('checkbox reflects loaded state when attaching and detaching MASS', async ({ rstudioPage: page }) => {
-    // MASS ships with recommended packages on every supported R, but skip if not present so
-    // an unusual install doesn't flake.
-    const installed = await consoleActions.ensurePackage('MASS');
-    test.skip(!installed, 'MASS is not installed');
+  test('checkbox reflects loaded state when attaching and detaching DBI', async ({ rstudioPage: page }) => {
+    // Use DBI rather than a recommended package: recommended packages can be
+    // present in both the system lib AND the user lib (when pre-installed by
+    // r-libs-setup.ts), producing duplicate checkboxes that the locator would
+    // need to disambiguate. A non-recommended package guarantees a single row.
+    const installed = await consoleActions.ensurePackage('DBI');
+    test.skip(!installed, 'DBI is not installed');
 
-    // Ensure MASS is not currently attached -- defensive against earlier specs.
+    // Ensure DBI is not currently attached -- defensive against earlier specs.
     await consoleActions.executeInConsole(
-      'if ("package:MASS" %in% search()) detach("package:MASS", character.only = TRUE)',
+      'if ("package:DBI" %in% search()) detach("package:DBI", character.only = TRUE)',
     );
     await sleep(TIMEOUTS.layoutSettle);
 
     await selectPackagesTab(page);
 
-    const checkbox = checkboxLocator(page, 'MASS');
+    const checkbox = checkboxLocator(page, 'DBI');
     await expect(checkbox).toBeVisible({ timeout: TIMEOUTS.consoleReady });
     await expect(checkbox).not.toBeChecked();
 
     // Attach via checkbox.
-    await clickPackageCheckbox(page, 'MASS');
+    await clickPackageCheckbox(page, 'DBI');
     await expect(checkbox).toBeChecked({ timeout: TIMEOUTS.consoleReady });
 
     // Verify package is actually attached via search().
     const attachedMarker = `__ATTACH_${Date.now()}__`;
     await consoleActions.executeInConsole(
-      `cat("${attachedMarker}", "package:MASS" %in% search(), "${attachedMarker}")`,
+      `cat("${attachedMarker}", "package:DBI" %in% search(), "${attachedMarker}")`,
     );
     await expect(consoleActions.consolePane.consoleOutput).toContainText(
       `${attachedMarker} TRUE ${attachedMarker}`,
@@ -75,12 +83,12 @@ test.describe('Packages pane', () => {
     );
 
     // Detach via checkbox.
-    await clickPackageCheckbox(page, 'MASS');
+    await clickPackageCheckbox(page, 'DBI');
     await expect(checkbox).not.toBeChecked({ timeout: TIMEOUTS.consoleReady });
 
     const detachedMarker = `__DETACH_${Date.now()}__`;
     await consoleActions.executeInConsole(
-      `cat("${detachedMarker}", "package:MASS" %in% search(), "${detachedMarker}")`,
+      `cat("${detachedMarker}", "package:DBI" %in% search(), "${detachedMarker}")`,
     );
     await expect(consoleActions.consolePane.consoleOutput).toContainText(
       `${detachedMarker} FALSE ${detachedMarker}`,


### PR DESCRIPTION
## Summary

Three fixes from the Playwright test-triage loop on top of #17723:

1. **Enter delivery in `executeInConsole`**. After `editor.setValue()` + `editor.focus()` inside `page.evaluate(...)`, the original code used `page.keyboard.press('Enter')` to submit -- which targets whichever element is currently focused. Focus can shift between the evaluate returning and the press landing, so the text would sit in the buffer without being submitted. The worker fixture's `getEnvironmentVersions` (logged `R: unknown, RStudio: unknown`) and `ignorefiles.test.ts`'s `captureResult` (timed out finding its markers) both hit this. Switch to `consoleInput.press('Enter')` -- targets the textarea directly, immune to intervening focus changes.

2. **Rename internal callers that the migration script skipped**. The original `typeInConsole -> executeInConsole` migration script in #17723 deliberately skipped `pages/console_pane.page.ts` and `actions/console_pane.actions.ts` (the files defining the helpers themselves). But those files also *contained* call sites -- `getEnvironmentVersions` and the eight `ensurePackage` / `uninstallPackage` callers -- which the rename missed and which now point at the slow no-Enter path. Migrate them properly.

3. **`packages_pane.test.ts`: swap MASS for DBI**. MASS is a recommended package (system lib) AND it's pre-installed into the user lib by `r-libs-setup.ts`'s `REQUIRED_PACKAGES`. The Packages pane renders one row per library, so `[aria-label='MASS']` matches two checkboxes and trips strict mode. DBI is non-recommended -- only one library copy -- so the test is deterministic. Also adds a defensive `.first()` on `checkboxLocator` so the suite stays robust if a future recommended package ends up in two libs.

Other failures from the post-#17723 triage are blocked on #17724/#17725 (bridge `prefSet`/`prefGet`/`prefClear` silently fail for prefs not yet in `Prefs.values_`) -- handled separately.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx playwright test tests/panes/packages/packages_pane.test.ts` -- both tests pass
- [x] `npx playwright test tests/panes/editor/multiline_chunk_execution.test.ts tests/panes/editor/notebook_save_during_execution.test.ts` -- both pass (the `.join('\\n')` fix from #17723 plus the Enter fix here)