### PR TITLE
automation: reshape bridge as window.rstudio.* namespaced API

### DIFF
--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -124,7 +124,7 @@ export class ConsolePaneActions {
   }
 
   async closeAllBuffersWithoutSaving(): Promise<void> {
-    // Use the rstudioCallbacks bridge instead of typing `.rs.api.close...`
+    // Use the window.rstudio bridge instead of typing `.rs.api.close...`
     // into the console: the R session isn't busy while the close fires, so
     // RStudio's "session is busy" confirmation dialog can't intervene.
     await documentCloseAllNoSave(this.page);

--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -210,9 +210,9 @@ export async function launchRStudio(existingConfigRoot?: string): Promise<Deskto
 
   // Start RStudio with remote debugging enabled. --automation-agent is
   // forwarded to rsession (see session-launcher.ts), which causes
-  // ApplicationAutomation to expose `window.rstudioCallbacks` -- the
-  // command-execution and command-state helpers our tests drive instead of
-  // typing commands through the console.
+  // ApplicationAutomation to expose `window.rstudio` -- the command,
+  // preference, and document helpers our tests drive instead of typing
+  // commands through the console.
   const rstudioArgs = [
     `--remote-debugging-port=${CDP_PORT}`,
     `--user-data-dir=${tempConfig.electronUserData}`,
@@ -502,9 +502,16 @@ function getRStudioPids(): Set<number> {
 export async function shutdownRStudio(session: DesktopSession): Promise<void> {
   const { page, browser, rstudioProcess } = session;
 
-  // Close all source files without prompting to save
-  await documentCloseAllNoSave(page);
-  await sleep(1000);
+  // Close all source files without prompting to save. If a test left the page
+  // in the middle of a navigation (e.g. opening a project triggers a session
+  // restart), `page.evaluate` will reject with "context was destroyed" --
+  // we don't care, we're shutting down anyway.
+  try {
+    await documentCloseAllNoSave(page);
+    await sleep(1000);
+  } catch {
+    // Page context may already be gone; we still force-kill below.
+  }
 
   try {
     await executeInConsole(page, 'q(save = "no")');

--- a/e2e/rstudio/fixtures/server.fixture.ts
+++ b/e2e/rstudio/fixtures/server.fixture.ts
@@ -123,7 +123,7 @@ async function spawnSandboxedRserver(): Promise<SpawnedServer | null> {
     `--secure-cookie-key-file=${secureCookieKey}`,
     `--config-file=${rserverConf}`,
     // Forward --automation-agent to every rsession this server spawns so
-    // window.rstudioCallbacks is exposed to the Playwright command bridge in
+    // window.rstudio is exposed to the Playwright command bridge in
     // @utils/commands. Matches what desktop.fixture.ts does directly to its
     // single rsession.
     `--automation-agent=1`,

--- a/e2e/rstudio/tests/projects/ignorefiles.test.ts
+++ b/e2e/rstudio/tests/projects/ignorefiles.test.ts
@@ -2,9 +2,10 @@ import { test, expect } from '@fixtures/rstudio.fixture';
 import { sleep, TIMEOUTS } from '@utils/constants';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { useSuiteSandbox, SANDBOX_DIR_PREFIX } from '@utils/sandbox';
-import { executeInConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
+import { executeInConsole, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { rPathLiteral } from '@utils/r';
 import { setPref } from '@utils/commands';
+import { closeProjectIfOpen, waitForConsoleIdle } from '@utils/project';
 import * as fs from 'fs';
 import type { Page } from 'playwright';
 
@@ -16,18 +17,6 @@ const PROJECT_NAME_INPUT = '#rstudio_new_project_directory_name';
 const GIT_CHECKBOX = '#rstudio_new_project_git_repo input';
 const CREATE_PROJECT_BTN = '#rstudio_label_create_project_wizard_confirm';
 const PROJECT_MENU = '#rstudio_project_menubutton_toolbar';
-const CLOSE_PROJECT_MENU_ITEM = '#rstudio_label_close_project_command';
-
-async function waitForConsoleIdle(page: Page): Promise<void> {
-  await page.waitForFunction(
-    () => {
-      const el = document.getElementById('rstudio_console_input');
-      return !!el && !el.classList.contains('rstudio-console-busy');
-    },
-    null,
-    { timeout: TIMEOUTS.sessionRestart, polling: 100 },
-  );
-}
 
 async function captureResult(page: Page, rExpression: string): Promise<string> {
   const marker = `__IG_${Date.now()}__`;
@@ -41,20 +30,6 @@ async function captureResult(page: Page, rExpression: string): Promise<string> {
     if (match) return match[1].trim();
   }
   throw new Error(`captureResult: markers not found for "${rExpression}"`);
-}
-
-async function closeProjectIfOpen(page: Page): Promise<void> {
-  const hasProject = await captureResult(page, '!is.null(rstudioapi::getActiveProject())');
-  if (hasProject !== 'TRUE') return;
-
-  await page.locator(PROJECT_MENU).click();
-  await page.locator(CLOSE_PROJECT_MENU_ITEM).click();
-  await page.waitForLoadState('load', { timeout: TIMEOUTS.sessionRestart }).catch(() => {});
-  await page.waitForSelector(CONSOLE_INPUT, {
-    state: 'visible',
-    timeout: TIMEOUTS.sessionRestart,
-  });
-  await waitForConsoleIdle(page);
 }
 
 test.describe('Project ignore files', () => {

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -1,54 +1,97 @@
 import type { Page } from '@playwright/test';
 
-// `window.rstudioCallbacks` is registered when rsession runs with
-// `--automation-agent` (the Desktop fixture forwards that flag). The bridge
-// lets tests trigger and inspect AppCommands without typing through the
-// console -- avoiding the focus-shift and pane-collapse pitfalls that the
-// console path runs into.
+// `window.rstudio` is registered when rsession runs with --automation-agent
+// (the Desktop fixture forwards that flag). The bridge lets tests trigger and
+// inspect AppCommands, read/write preferences, and dispatch a few document
+// actions without going through the R console -- avoiding focus-shift and
+// pane-collapse pitfalls that the console path runs into.
+//
+// See ApplicationAutomation.java for the Java side. The shape is enumerated
+// up front: every command and every preference is registered at agent init,
+// so a missing-by-name lookup is a real "doesn't exist" (not just "not yet
+// touched by GWT code").
 
 type PrefValue = boolean | number | string;
 
-type RStudioCallbacks = {
-  commandExecute(id: string): void;
-  commandIsChecked(id: string): boolean;
-  commandIsEnabled(id: string): boolean;
-  commandList(): string[];
-  documentCloseAllNoSave(): void;
-  prefGet(name: string): PrefValue | null;
-  prefSet(name: string, value: PrefValue): void;
-  prefClear(name: string): void;
+type CommandEntry = {
+  (): void;
+  isChecked(): boolean;
+  isEnabled(): boolean;
+};
+
+type PrefEntry = {
+  get(): PrefValue | null;
+  set(value: PrefValue): void;
+  clear(): void;
+};
+
+type ProjectInfo = {
+  /** Active project file path (absolute), or null if no project is open. */
+  path(): string | null;
+  /** Active project display name, or null if no project is open. */
+  name(): string | null;
+  isActive(): boolean;
+};
+
+type RStudioBridge = {
+  commands: { [id: string]: CommandEntry } & { list: string[] };
+  prefs: { [name: string]: PrefEntry };
+  documents: { closeAllNoSave(): void };
+  project: ProjectInfo;
 };
 
 declare global {
   interface Window {
-    rstudioCallbacks?: RStudioCallbacks;
+    rstudio?: RStudioBridge;
   }
+}
+
+const MISSING_BRIDGE = 'window.rstudio is not defined; launch RStudio with --automation-agent';
+
+// Convert snake_case to camelCase. Preference names are snake_case in the
+// schema (matching rstudio-prefs.json), but the Java bridge registers them
+// camelCased to read better as JS object keys. Keeping the TS wrapper APIs
+// snake_case lets callers continue to use the canonical pref name.
+function snakeToCamel(s: string): string {
+  return s.replace(/_([a-z])/g, (_match, c: string) => c.toUpperCase());
 }
 
 /** Run an AppCommand by id (no console roundtrip). */
 export async function executeCommand(page: Page, commandId: string): Promise<void> {
   await page.evaluate((id) => {
-    const cb = window.rstudioCallbacks;
-    if (!cb) throw new Error('window.rstudioCallbacks is not defined; launch RStudio with --automation-agent');
-    cb.commandExecute(id);
+    const r = window.rstudio;
+    if (!r)
+      throw new Error(MISSING_BRIDGE);
+    const cmd = r.commands[id];
+    if (!cmd)
+      throw new Error(`Unknown command: ${id}`);
+    cmd();
   }, commandId);
 }
 
 /** True when the named AppCommand reports `isChecked` (e.g. an active layout zoom). */
 export async function isCommandChecked(page: Page, commandId: string): Promise<boolean> {
   return page.evaluate((id) => {
-    const cb = window.rstudioCallbacks;
-    if (!cb) throw new Error('window.rstudioCallbacks is not defined; launch RStudio with --automation-agent');
-    return cb.commandIsChecked(id);
+    const r = window.rstudio;
+    if (!r)
+      throw new Error(MISSING_BRIDGE);
+    const cmd = r.commands[id];
+    if (!cmd)
+      throw new Error(`Unknown command: ${id}`);
+    return cmd.isChecked();
   }, commandId);
 }
 
 /** True when the named AppCommand is currently enabled. */
 export async function isCommandEnabled(page: Page, commandId: string): Promise<boolean> {
   return page.evaluate((id) => {
-    const cb = window.rstudioCallbacks;
-    if (!cb) throw new Error('window.rstudioCallbacks is not defined; launch RStudio with --automation-agent');
-    return cb.commandIsEnabled(id);
+    const r = window.rstudio;
+    if (!r)
+      throw new Error(MISSING_BRIDGE);
+    const cmd = r.commands[id];
+    if (!cmd)
+      throw new Error(`Unknown command: ${id}`);
+    return cmd.isEnabled();
   }, commandId);
 }
 
@@ -59,9 +102,10 @@ export async function isCommandEnabled(page: Page, commandId: string): Promise<b
  */
 export async function documentCloseAllNoSave(page: Page): Promise<void> {
   await page.evaluate(() => {
-    const cb = window.rstudioCallbacks;
-    if (!cb) throw new Error('window.rstudioCallbacks is not defined; launch RStudio with --automation-agent');
-    cb.documentCloseAllNoSave();
+    const r = window.rstudio;
+    if (!r)
+      throw new Error(MISSING_BRIDGE);
+    r.documents.closeAllNoSave();
   });
 }
 
@@ -70,11 +114,14 @@ export async function documentCloseAllNoSave(page: Page): Promise<void> {
  * unknown.
  */
 export async function getPref(page: Page, name: string): Promise<PrefValue | null> {
+  const camel = snakeToCamel(name);
   return page.evaluate((prefName) => {
-    const cb = window.rstudioCallbacks;
-    if (!cb) throw new Error('window.rstudioCallbacks is not defined; launch RStudio with --automation-agent');
-    return cb.prefGet(prefName);
-  }, name);
+    const r = window.rstudio;
+    if (!r)
+      throw new Error(MISSING_BRIDGE);
+    const entry = r.prefs[prefName];
+    return entry ? entry.get() : null;
+  }, camel);
 }
 
 /**
@@ -85,11 +132,16 @@ export async function getPref(page: Page, name: string): Promise<PrefValue | nul
  * prefs, a string for string/enum prefs.
  */
 export async function setPref(page: Page, name: string, value: PrefValue): Promise<void> {
+  const camel = snakeToCamel(name);
   await page.evaluate(({ prefName, prefValue }) => {
-    const cb = window.rstudioCallbacks;
-    if (!cb) throw new Error('window.rstudioCallbacks is not defined; launch RStudio with --automation-agent');
-    cb.prefSet(prefName, prefValue);
-  }, { prefName: name, prefValue: value });
+    const r = window.rstudio;
+    if (!r)
+      throw new Error(MISSING_BRIDGE);
+    const entry = r.prefs[prefName];
+    if (!entry)
+      throw new Error(`Unknown user preference: ${prefName}`);
+    entry.set(prefValue);
+  }, { prefName: camel, prefValue: value });
 }
 
 /**
@@ -97,9 +149,14 @@ export async function setPref(page: Page, name: string, value: PrefValue): Promi
  * to `.rs.uiPrefs$<name>$clear()`.
  */
 export async function clearPref(page: Page, name: string): Promise<void> {
+  const camel = snakeToCamel(name);
   await page.evaluate((prefName) => {
-    const cb = window.rstudioCallbacks;
-    if (!cb) throw new Error('window.rstudioCallbacks is not defined; launch RStudio with --automation-agent');
-    cb.prefClear(prefName);
-  }, name);
+    const r = window.rstudio;
+    if (!r)
+      throw new Error(MISSING_BRIDGE);
+    const entry = r.prefs[prefName];
+    if (!entry)
+      throw new Error(`Unknown user preference: ${prefName}`);
+    entry.clear();
+  }, camel);
 }

--- a/e2e/rstudio/utils/project.ts
+++ b/e2e/rstudio/utils/project.ts
@@ -167,13 +167,22 @@ export async function waitForConsoleIdle(page: Page): Promise<void> {
  * triggers RStudio's "R session is currently busy. Are you sure you want to
  * quit?" confirmation dialog and hangs the test.
  *
+ * "Close project" is effectively a workbench rebuild -- the same Electron
+ * window swaps out the project-bound page for a fresh no-project page. So we
+ * wait not just for the console to come back, but for the new
+ * `window.rstudio` automation bridge to finish installing and any modal
+ * error from a too-early Files pane query ("Error navigating to ~") to have
+ * surfaced and been dismissed. Without this, the caller's next action can
+ * land while the new workbench is still mid-init.
+ *
  * No-op when no project is open (the toolbar label is "Project: (None)" or
  * the button isn't rendered).
  */
 export async function closeProjectIfOpen(page: Page): Promise<void> {
   const menu = page.locator(PROJECT_MENU);
   const label = (await menu.innerText().catch(() => '')).trim();
-  if (label.includes('(None)') || label === '') return;
+  if (label.includes('(None)') || label === '')
+    return;
 
   await menu.click();
   await page.locator(CLOSE_PROJECT_MENU_ITEM).click();
@@ -183,4 +192,23 @@ export async function closeProjectIfOpen(page: Page): Promise<void> {
     timeout: TIMEOUTS.sessionRestart,
   });
   await waitForConsoleIdle(page);
+
+  // Wait for the new no-project session to finish installing its automation
+  // bridge AND report no active project. The bridge re-installs when the
+  // workbench rebuilds; `project.isActive()` returns false only once the new
+  // SessionInfo has propagated. Polling on both signals catches the case
+  // where the bridge is from the previous (project-bound) session.
+  await page.waitForFunction(
+    () => window.rstudio?.project?.isActive() === false,
+    null,
+    { timeout: TIMEOUTS.sessionRestart, polling: 100 },
+  );
+
+  // Dismiss any modal error dialog that surfaced while the new workbench
+  // was initializing -- e.g. a Files-pane refresh racing the rsession's
+  // home-dir hand-off can show "Error navigating to ~". Click whatever
+  // OK button is on top; absence is fine.
+  const okButton = page.locator('button:has-text("OK")').first();
+  if (await okButton.isVisible({ timeout: 500 }).catch(() => false))
+    await okButton.click();
 }

--- a/src/cpp/server/include/server/ServerOptions.gen.hpp
+++ b/src/cpp/server/include/server/ServerOptions.gen.hpp
@@ -65,7 +65,7 @@ protected:
    pAutomation->add_options()
       ("automation-agent",
       value<bool>(&automationAgent_)->default_value(false)->implicit_value(true),
-      "Forward --automation-agent to every spawned rsession so window.rstudioCallbacks is exposed to external test drivers (e.g. Playwright).");
+      "Forward --automation-agent to every spawned rsession so window.rstudio is exposed to external test drivers (e.g. Playwright).");
 
    pVerify->add_options()
       ("verify-installation",

--- a/src/cpp/server/server-options.json
+++ b/src/cpp/server/server-options.json
@@ -27,7 +27,7 @@
             "defaultValue": false,
             "implicitValue": true,
             "isHidden": true,
-            "description": "Forward --automation-agent to every spawned rsession so window.rstudioCallbacks is exposed to external test drivers (e.g. Playwright)."
+            "description": "Forward --automation-agent to every spawned rsession so window.rstudio is exposed to external test drivers (e.g. Playwright)."
          }
       ],
       "verify": [

--- a/src/cpp/server/session/ServerSessionManager.cpp
+++ b/src/cpp/server/session/ServerSessionManager.cpp
@@ -223,9 +223,9 @@ core::system::ProcessConfig sessionProcessConfig(
    environment.push_back({kServerRpcSocketPathEnvVar, serverRpcSocketPath().getAbsolutePath()});
    environment.push_back({kServerRpcSecretEnvVar, core::socket_rpc::secret()});
    
-   // Forward --automation-agent so the rsession exposes window.rstudioCallbacks
+   // Forward --automation-agent so the rsession exposes window.rstudio
    // (the bridge that external drivers like the Playwright test suite use to
-   // invoke AppCommands).
+   // invoke AppCommands and read/write preferences).
    if (server::options().automationAgent())
       args.push_back(std::make_pair("--" kAutomationAgentSessionOption, std::string("1")));
 

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -15,45 +15,65 @@
 package org.rstudio.studio.client.application;
 
 import java.util.Map;
-import java.util.Set;
 
 import org.rstudio.core.client.command.AppCommand;
-import org.rstudio.core.client.js.JsUtil;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.server.model.DocumentCloseAllNoSaveEvent;
 import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.prefs.model.Prefs;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 
-import com.google.gwt.core.client.JsArrayString;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
+/**
+ * Exposes a JS-facing automation surface at <code>window.rstudio</code> when
+ * rsession is launched with <code>--automation-agent</code>. The surface is
+ * read by external test drivers (Playwright tests under <code>e2e/rstudio</code>)
+ * to drive commands, read/write preferences, and dispatch a few document
+ * actions without going through the R console.
+ *
+ * <h2>Shape</h2>
+ *
+ * <pre>
+ *   window.rstudio.commands.&lt;commandId&gt;()           // execute
+ *   window.rstudio.commands.&lt;commandId&gt;.isChecked()
+ *   window.rstudio.commands.&lt;commandId&gt;.isEnabled()
+ *   window.rstudio.commands.list                       // string[] of all command ids
+ *
+ *   window.rstudio.prefs.&lt;camelCaseName&gt;.get()
+ *   window.rstudio.prefs.&lt;camelCaseName&gt;.set(value)
+ *   window.rstudio.prefs.&lt;camelCaseName&gt;.clear()
+ *
+ *   window.rstudio.documents.closeAllNoSave()
+ *
+ *   window.rstudio.project.path()       // active project file path, or null
+ *   window.rstudio.project.name()       // active project display name, or null
+ *   window.rstudio.project.isActive()   // boolean
+ * </pre>
+ *
+ * <h2>Why enumerate everything up front</h2>
+ *
+ * Commands and preferences are both populated lazily in their respective
+ * caches (Commands and Prefs.values_). If a caller looks up a pref that no
+ * GWT code has accessed yet, the lookup returns null and the old flat-callback
+ * bridge would silently no-op. Enumerating <code>commands_.getCommands()</code>
+ * and <code>userPrefs_.allPrefs()</code> at startup populates both caches so
+ * the bridge surface is complete from the first call.
+ */
 @Singleton
 public class ApplicationAutomation
 {
-   static interface NullaryCallback<R>
-   {
-      public R execute();
-   }
-
-   static interface UnaryCallback<R, T>
-   {
-      public R execute(T value);
-   }
-
-   static interface BinaryCallback<R, T1, T2>
-   {
-      public R execute(T1 value1, T2 value2);
-   }
-
    @Inject
    public ApplicationAutomation(Commands commands,
                                 EventBus eventBus,
+                                Session session,
                                 UserPrefs userPrefs)
    {
       commands_ = commands;
       eventBus_ = eventBus;
+      session_ = session;
       userPrefs_ = userPrefs;
    }
 
@@ -65,126 +85,111 @@ public class ApplicationAutomation
    public final void initializeAgent()
    {
       isAutomationAgent_ = true;
+      initializeRoot();
+      registerCommands();
+      registerPrefs();
+      registerDocuments();
+      registerProject();
+   }
 
-      initializeCallbacks();
-
-      exportCallback("commandExecute", new UnaryCallback<Void, String>()
+   private void registerCommands()
+   {
+      Map<String, AppCommand> commands = commands_.getCommands();
+      String[] commandIds = new String[commands.size()];
+      int i = 0;
+      for (Map.Entry<String, AppCommand> entry : commands.entrySet())
       {
-         @Override
-         public Void execute(String commandId)
-         {
-            AppCommand command = commands_.getCommandById(commandId);
-            command.execute();
-            return null;
-         }
-      });
+         String id = entry.getKey();
+         registerCommand(id, entry.getValue());
+         commandIds[i++] = id;
+      }
+      registerCommandList(commandIds);
+   }
 
-      exportCallback("commandList", new NullaryCallback<JsArrayString>()
+   private void registerPrefs()
+   {
+      // allPrefs() invokes each pref's factory method (defaultProjectLocation(),
+      // saveWorkspace(), ...), which constructs the PrefValue and registers it
+      // in Prefs.values_ as a side effect. Without this warm-up, prefs that
+      // haven't been accessed yet would be undiscoverable by name -- the bug
+      // tracked in #17724.
+      for (Prefs.PrefValue<?> pref : userPrefs_.allPrefs())
       {
-         @Override
-         public JsArrayString execute()
-         {
-            Map<String, AppCommand> allCommands = commands_.getCommands();
-            Set<String> commandIds = allCommands.keySet();
-            return JsUtil.toJsArrayString(commandIds);
-         }
-      });
+         registerPref(snakeToCamel(pref.getId()), pref);
+      }
+   }
 
-      exportCallback("commandIsChecked", new UnaryCallback<Boolean, String>()
-      {
-         @Override
-         public Boolean execute(String commandId)
-         {
-            AppCommand command = commands_.getCommandById(commandId);
-            return command.isChecked();
-         }
-      });
+   private void registerDocuments()
+   {
+      registerDocumentsObject();
+   }
 
-      exportCallback("commandIsEnabled", new UnaryCallback<Boolean, String>()
-      {
-         @Override
-         public Boolean execute(String commandId)
-         {
-            AppCommand command = commands_.getCommandById(commandId);
-            return command.isEnabled();
-         }
-      });
+   private void registerProject()
+   {
+      registerProjectObject();
+   }
 
-      // Close every open source document, discarding unsaved changes. The
-      // .rs.api.closeAllSourceBuffersWithoutSaving R API fires the same
-      // DocumentCloseAllNoSave client event via a server roundtrip; this
-      // callback lets tests skip that round trip so the R session isn't busy
-      // executing R code while the close runs (which would surface the
-      // "session is busy, are you sure?" confirmation dialog and hang).
-      exportCallback("documentCloseAllNoSave", new NullaryCallback<Void>()
+   /** Convert a snake_case identifier to camelCase. */
+   private static String snakeToCamel(String s)
+   {
+      StringBuilder sb = new StringBuilder(s.length());
+      boolean upperNext = false;
+      for (int i = 0; i < s.length(); i++)
       {
-         @Override
-         public Void execute()
+         char c = s.charAt(i);
+         if (c == '_')
          {
-            eventBus_.dispatchEvent(new DocumentCloseAllNoSaveEvent());
-            return null;
+            upperNext = true;
          }
-      });
+         else if (upperNext)
+         {
+            sb.append(Character.toUpperCase(c));
+            upperNext = false;
+         }
+         else
+         {
+            sb.append(c);
+         }
+      }
+      return sb.toString();
+   }
 
-      // Read a user preference by name. Returns the live (project-then-user-
-      // then-default) value as a JS-marshalable Object: Boolean, String,
-      // Integer/Double, or null when the pref is unknown.
-      exportCallback("prefGet", new UnaryCallback<Object, String>()
-      {
-         @Override
-         public Object execute(String name)
-         {
-            Prefs.PrefValue<?> pref = userPrefs_.getPrefValue(name);
-            return pref == null ? null : pref.getValue();
-         }
-      });
+   // --- Helpers called from JSNI -------------------------------------------
+   //
+   // JSNI marshals JS primitives into Java boxed types: JS boolean ->
+   // java.lang.Boolean, JS number -> java.lang.Double, JS string ->
+   // java.lang.String. setPrefValue() dispatches by the pref's declared type,
+   // narrowing the Number for int prefs.
 
-      // Set a user preference and persist via the same RPC the Options dialog
-      // uses. Dispatches by the pref's declared type rather than the JS value's
-      // type so a JS number passed for a Boolean pref is a hard error, not a
-      // silent coercion.
-      exportCallback("prefSet", new BinaryCallback<Void, String, Object>()
-      {
-         @Override
-         public Void execute(String name, Object value)
-         {
-            setPref(name, value);
-            userPrefs_.writeUserPrefs();
-            return null;
-         }
-      });
+   private void executeCommand(AppCommand command)
+   {
+      command.execute();
+   }
 
-      // Remove a user-layer preference value, falling back to the default.
-      // Mirrors .rs.uiPrefs$<name>$clear().
-      exportCallback("prefClear", new UnaryCallback<Void, String>()
-      {
-         @Override
-         public Void execute(String name)
-         {
-            Prefs.PrefValue<?> pref = userPrefs_.getPrefValue(name);
-            if (pref == null)
-               throw new RuntimeException("Unknown user preference: " + name);
-            pref.removeGlobalValue(true);
-            userPrefs_.writeUserPrefs();
-            return null;
-         }
-      });
+   private boolean isCommandChecked(AppCommand command)
+   {
+      return command.isChecked();
+   }
+
+   private boolean isCommandEnabled(AppCommand command)
+   {
+      return command.isEnabled();
+   }
+
+   private Object getPrefValue(Prefs.PrefValue<?> pref)
+   {
+      return pref.getValue();
    }
 
    @SuppressWarnings("unchecked")
-   private void setPref(String name, Object value)
+   private void setPrefValue(Prefs.PrefValue<?> pref, Object value)
    {
-      Prefs.PrefValue<?> pref = userPrefs_.getPrefValue(name);
-      if (pref == null)
-         throw new RuntimeException("Unknown user preference: " + name);
-
       if (pref instanceof Prefs.BooleanValue)
       {
          ((Prefs.PrefValue<Boolean>) pref).setGlobalValue((Boolean) value);
       }
       else if (pref instanceof Prefs.IntValue)
       {
-         // JS numbers arrive as java.lang.Double; narrow before assigning.
          ((Prefs.PrefValue<Integer>) pref).setGlobalValue(((Number) value).intValue());
       }
       else if (pref instanceof Prefs.DoubleValue)
@@ -198,38 +203,110 @@ public class ApplicationAutomation
       else
       {
          throw new RuntimeException(
-            "Unsupported preference type for " + name + ": " + pref.getClass().getSimpleName());
+            "Unsupported preference type for " + pref.getId() + ": " + pref.getClass().getSimpleName());
       }
+      userPrefs_.writeUserPrefs();
    }
 
-   private native final void initializeCallbacks()
-   /*-{
-      $wnd.rstudioCallbacks = $wnd.rstudioCallbacks || {};
+   private void clearPrefValue(Prefs.PrefValue<?> pref)
+   {
+      pref.removeGlobalValue(true);
+      userPrefs_.writeUserPrefs();
+   }
+
+   private void dispatchCloseAllNoSave()
+   {
+      eventBus_.dispatchEvent(new DocumentCloseAllNoSaveEvent());
+   }
+
+   // Always read through session_.getSessionInfo() rather than capturing a
+   // reference at install time -- a session restart (e.g. close-project)
+   // replaces the SessionInfo JSO, and we want callers to see the live state.
+   private String getActiveProjectPath()
+   {
+      return session_.getSessionInfo().getActiveProjectFile();
+   }
+
+   private String getActiveProjectName()
+   {
+      return session_.getSessionInfo().getActiveProjectName();
+   }
+
+   private boolean isProjectActive()
+   {
+      return getActiveProjectPath() != null;
+   }
+
+   // --- JSNI surface installation ------------------------------------------
+
+   private native final void initializeRoot() /*-{
+      $wnd.rstudio = $wnd.rstudio || {};
+      $wnd.rstudio.commands = $wnd.rstudio.commands || {};
+      $wnd.rstudio.prefs = $wnd.rstudio.prefs || {};
+      $wnd.rstudio.documents = $wnd.rstudio.documents || {};
    }-*/;
 
-   private native final <R> void exportCallback(String name, NullaryCallback<R> callback)
-   /*-{
-      $wnd.rstudioCallbacks[name] = $entry(function() {
-         return callback.@org.rstudio.studio.client.application.ApplicationAutomation.NullaryCallback::execute(*)();
+   private native final void registerCommand(String id, AppCommand command) /*-{
+      var self = this;
+      var fn = $entry(function() {
+         self.@org.rstudio.studio.client.application.ApplicationAutomation::executeCommand(*)(command);
+      });
+      fn.isChecked = $entry(function() {
+         return self.@org.rstudio.studio.client.application.ApplicationAutomation::isCommandChecked(*)(command);
+      });
+      fn.isEnabled = $entry(function() {
+         return self.@org.rstudio.studio.client.application.ApplicationAutomation::isCommandEnabled(*)(command);
+      });
+      $wnd.rstudio.commands[id] = fn;
+   }-*/;
+
+   private native final void registerCommandList(String[] ids) /*-{
+      var list = [];
+      for (var i = 0; i < ids.length; i++) {
+         list.push(ids[i]);
+      }
+      $wnd.rstudio.commands.list = list;
+   }-*/;
+
+   private native final void registerPref(String name, Prefs.PrefValue<?> pref) /*-{
+      var self = this;
+      $wnd.rstudio.prefs[name] = {
+         get: $entry(function() {
+            return self.@org.rstudio.studio.client.application.ApplicationAutomation::getPrefValue(*)(pref);
+         }),
+         set: $entry(function(value) {
+            self.@org.rstudio.studio.client.application.ApplicationAutomation::setPrefValue(*)(pref, value);
+         }),
+         clear: $entry(function() {
+            self.@org.rstudio.studio.client.application.ApplicationAutomation::clearPrefValue(*)(pref);
+         })
+      };
+   }-*/;
+
+   private native final void registerDocumentsObject() /*-{
+      var self = this;
+      $wnd.rstudio.documents.closeAllNoSave = $entry(function() {
+         self.@org.rstudio.studio.client.application.ApplicationAutomation::dispatchCloseAllNoSave()();
       });
    }-*/;
 
-   private native final <R, T> void exportCallback(String name, UnaryCallback<R, T> callback)
-   /*-{
-      $wnd.rstudioCallbacks[name] = $entry(function(value) {
-         return callback.@org.rstudio.studio.client.application.ApplicationAutomation.UnaryCallback::execute(*)(value);
+   private native final void registerProjectObject() /*-{
+      var self = this;
+      $wnd.rstudio.project = $wnd.rstudio.project || {};
+      $wnd.rstudio.project.path = $entry(function() {
+         return self.@org.rstudio.studio.client.application.ApplicationAutomation::getActiveProjectPath()();
       });
-   }-*/;
-
-   private native final <R, T1, T2> void exportCallback(String name, BinaryCallback<R, T1, T2> callback)
-   /*-{
-      $wnd.rstudioCallbacks[name] = $entry(function(value1, value2) {
-         return callback.@org.rstudio.studio.client.application.ApplicationAutomation.BinaryCallback::execute(*)(value1, value2);
+      $wnd.rstudio.project.name = $entry(function() {
+         return self.@org.rstudio.studio.client.application.ApplicationAutomation::getActiveProjectName()();
+      });
+      $wnd.rstudio.project.isActive = $entry(function() {
+         return self.@org.rstudio.studio.client.application.ApplicationAutomation::isProjectActive()();
       });
    }-*/;
 
    private final Commands commands_;
    private final EventBus eventBus_;
+   private final Session session_;
    private final UserPrefs userPrefs_;
    private boolean isAutomationAgent_ = false;
 }

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -117,8 +117,26 @@ export class DesktopOptionsImpl implements DesktopOptions {
     }
   }
 
+  // electron-store persists via write-temp + renameSync. That rename can race
+  // against external cleanup of the user-data-dir (e.g. Playwright sandbox
+  // teardown), surfacing as an ENOENT thrown synchronously out of config.set().
+  // Because every call here happens on the main process, an unhandled throw
+  // pops Electron's "JavaScript error in main process" modal. Settings are
+  // best-effort persistence -- the read path falls back to defaults if the
+  // value is missing -- so swallow the error and log instead.
+  private safeSet(key: string, value: any): void {
+    try {
+      this.config.set(key, value);
+    } catch (e: unknown) {
+      logger().logErrorAtLevel(
+        'debug',
+        `Failed to persist desktop option '${key}': ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+  }
+
   public setProportionalFont(font?: string): void {
-    this.config.set(kProportionalFont, font ?? '');
+    this.safeSet(kProportionalFont, font ?? '');
   }
 
   public proportionalFont(): string {
@@ -126,7 +144,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public setFixedWidthFont(fixedWidthFont: string): void {
-    this.config.set(kFixedWidthFont, fixedWidthFont);
+    this.safeSet(kFixedWidthFont, fixedWidthFont);
   }
 
   public fixedWidthFont(): string | undefined {
@@ -134,7 +152,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
 
     if (!fontName) {
       fontName = this.legacyOptions.fixedWidthFont() ?? '';
-      this.config.set(kFixedWidthFont, fontName);
+      this.safeSet(kFixedWidthFont, fontName);
     }
 
     return fontName;
@@ -146,7 +164,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
     if (zoom < min || zoom > max) {
       throw new Error(`Invalid zoom level: Must be between ${min} and ${max}`);
     }
-    this.config.set(kZoomLevel, zoom);
+    this.safeSet(kZoomLevel, zoom);
   }
 
   public zoomLevel(): number {
@@ -159,14 +177,14 @@ export class DesktopOptionsImpl implements DesktopOptions {
       if (zoomLevel < min || zoomLevel > max) {
         zoomLevel = properties.view.default.zoomLevel;
       }
-      this.config.set(kZoomLevel, zoomLevel);
+      this.safeSet(kZoomLevel, zoomLevel);
     }
 
     return zoomLevel;
   }
 
   public saveWindowBounds(bounds: WindowBounds): void {
-    this.config.set(kWindowBounds, bounds);
+    this.safeSet(kWindowBounds, bounds);
   }
 
   public windowBounds(): WindowBounds {
@@ -198,7 +216,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public setAccessibility(accessibility: boolean): void {
-    this.config.set(kAccessibility, accessibility);
+    this.safeSet(kAccessibility, accessibility);
   }
 
   public accessibility(): boolean {
@@ -206,7 +224,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public setEnableSplashScreen(enabled: boolean): void {
-    this.config.set(kEnableSplashScreen, enabled);
+    this.safeSet(kEnableSplashScreen, enabled);
   }
 
   public enableSplashScreen(): boolean {
@@ -214,7 +232,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public setDisableRendererAccessibility(accessibility: boolean): void {
-    this.config.set(kDisableRendererAccessibility, accessibility);
+    this.safeSet(kDisableRendererAccessibility, accessibility);
   }
 
   public disableRendererAccessibility(): boolean {
@@ -222,7 +240,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public setIgnoredUpdateVersions(ignoredUpdateVersions: string[]): void {
-    this.config.set(kIgnoredUpdateVersions, ignoredUpdateVersions);
+    this.safeSet(kIgnoredUpdateVersions, ignoredUpdateVersions);
   }
 
   public ignoredUpdateVersions(): string[] {
@@ -230,7 +248,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public setRenderingEngine(renderingEngine: string): void {
-    this.config.set(kRendererEngine, renderingEngine);
+    this.safeSet(kRendererEngine, renderingEngine);
   }
 
   public renderingEngine(): string {
@@ -238,7 +256,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public setUseGpuExclusionList(value: boolean) {
-    this.config.set(kRendererUseGpuExclusionList, value);
+    this.safeSet(kRendererUseGpuExclusionList, value);
   }
 
   public useGpuExclusionList(): boolean {
@@ -246,7 +264,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public setUseGpuDriverBugWorkarounds(value: boolean) {
-    this.config.set(kRendererUseGpuDriverBugWorkarounds, value);
+    this.safeSet(kRendererUseGpuDriverBugWorkarounds, value);
   }
 
   public useGpuDriverBugWorkarounds(): boolean {
@@ -259,7 +277,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
     if (!isAppleSilicon) {
       return;
     }
-    this.config.set(kCheckForRosetta, value);
+    this.safeSet(kCheckForRosetta, value);
   }
 
   // MacOS Apple Silicon-only option
@@ -294,7 +312,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public setUseDefault32BitR(useDefault: boolean) {
-    this.config.set(kUseDefault32BitR, useDefault);
+    this.safeSet(kUseDefault32BitR, useDefault);
   }
 
   // Windows-only option
@@ -303,7 +321,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public setUseDefault64BitR(useDefault: boolean) {
-    this.config.set(kUseDefault64BitR, useDefault);
+    this.safeSet(kUseDefault64BitR, useDefault);
   }
 
   // Windows-only option
@@ -312,7 +330,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
       return;
     }
 
-    this.config.set(kRExecutablePath, normalizeSeparatorsNative(rExecutablePath));
+    this.safeSet(kRExecutablePath, normalizeSeparatorsNative(rExecutablePath));
   }
 
   // Windows-only option
@@ -345,7 +363,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
     if (process.platform !== 'win32') {
       return;
     }
-    this.config.set(kPreferR64, peferR64);
+    this.safeSet(kPreferR64, peferR64);
   }
 
   // Windows-only option


### PR DESCRIPTION
## Intent

Addresses #17724 and #17725.

## Summary

Replaces the flat `window.rstudioCallbacks` automation surface with a namespaced one at `window.rstudio`. Every `AppCommand` and every `PrefValue` is enumerated at agent init and registered as a typed JS object:

```js
window.rstudio.commands.<id>()             // execute
window.rstudio.commands.<id>.isChecked()
window.rstudio.commands.<id>.isEnabled()
window.rstudio.commands.list               // string[] of all command ids

window.rstudio.prefs.<camelName>.get()
window.rstudio.prefs.<camelName>.set(value)
window.rstudio.prefs.<camelName>.clear()

window.rstudio.documents.closeAllNoSave()

window.rstudio.project.path()              // active project file or null
window.rstudio.project.name()
window.rstudio.project.isActive()
```

The enumeration is the cure for #17724: calling `userPrefs_.allPrefs()` at agent init forces every `UserPrefsAccessor` factory to run, which registers the corresponding `PrefValue` in `Prefs.values_`. Before this, looking up a pref the GWT code hadn't already accessed returned null, and the bridge's `pref == null` throw was silently swallowed by GWT's `$entry` wrapper -- so test calls like `setPref('default_project_location', sandbox.dir)` no-op'd and the wizard saw the wrong (default) value. With the warm-up, every pref is addressable by name from the first call.

The `project` namespace gives tests a precise readiness signal after `closeProject`, which on Desktop tears down the project-bound page and rebuilds the workbench. `utils/project.ts`'s `closeProjectIfOpen` now polls `rstudio.project.isActive() === false` rather than just waiting for the console to come back -- the console can settle a few hundred ms before the Files pane refreshes, and a Files-pane refresh racing the rsession's home-dir hand-off was popping an "Error navigating to ~" modal. `closeProjectIfOpen` also dismisses any such modal as a defensive last step. `tests/projects/ignorefiles.test.ts` drops its duplicate local copy of `closeProjectIfOpen` and imports the canonical one.

### Drive-bys bundled in

- **`electron-desktop-options.ts`** wraps every `config.set` in a `safeSet()` helper. `electron-store` persists via temp-file + `renameSync`, and that rename can race against external cleanup of the user-data-dir (Playwright sandbox teardown). The error was popping Electron's "JavaScript error in main process" modal mid-shutdown. Settings are best-effort persistence -- the read paths already fall back to defaults -- so we now log and continue.
- **`shutdownRStudio`** wraps the first `documentCloseAllNoSave` in try/catch. If a test left the page mid-navigation (e.g. opening a project triggers a session restart that swaps the page), `page.evaluate` rejects with "context destroyed" and the rest of shutdown (q(), poll + force-kill) would skip. The bridge call is no longer load-bearing -- the force-kill fallback covers it.

### Caller migration

`utils/commands.ts` is rewritten against the new shape; the public API (`executeCommand`, `setPref`, `getPref`, `clearPref`, `isCommandChecked`, `isCommandEnabled`, `documentCloseAllNoSave`) keeps its existing function signatures, so test call sites don't change. Pref names stay snake_case at the TS API boundary and are converted to camelCase internally before the bridge lookup.

## Test plan

- [x] `npm run typecheck` (e2e/rstudio) clean
- [x] `ant draft` (src/gwt) clean
- [x] `npm run typecheck` and `npm run lint` (src/node/desktop) clean
- [x] `Rscript scripts/generate-options.R` regenerated `ServerOptions.gen.hpp`
- [x] `npm run test:dev -- tests/projects/ignorefiles.test.ts` passes -- the canonical victim of #17724 now succeeds end-to-end
- [ ] Full `npm run test:dev -- --grep-invert @ai` -- attempted locally but the host went to sleep mid-run, so the 16-failure / 35-did-not-run result isn't trustworthy. Will rely on CI.