### PR TITLE
Remove HUNSPELL download from Windows install-dependencies.cmd

### DIFF
--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -129,11 +129,6 @@ set LIBCLANG_FOLDER=libclang\%LIBCLANG_VERSION%
 set LIBCLANG_OUTPUT=
 
 
-set HUNSPELL_URL=hunspell/hunspell-v1.7.2.7z
-set HUNSPELL_FOLDER=hunspell-v1.7.2
-set HUNSPELL_OUTPUT=
-
-
 set NODEBUILD_VERSION=%RSTUDIO_NODE_VERSION%
 set NODEBUILD_LABEL=node (%NODEBUILD_VERSION%; build)
 set NODEBUILD_FILE=node-v%NODEBUILD_VERSION%-win-x64
@@ -227,7 +222,6 @@ call install-packages.cmd
 :: Install the rest of our dependencies in the 'windows' folder.
 cd ..\windows
 
-%RUN% install HUNSPELL
 %RUN% install GNUDIFF
 %RUN% install GNUGREP
 %RUN% install SUMATRA


### PR DESCRIPTION
Hunspell is now fetched via CMake (`src/cpp/ext/CMakeLists.txt`), so the Windows dependency script no longer needs to download and extract it.

Verified that nothing in `package/win32/make-package.bat` or the wider build expects `dependencies/windows/hunspell-v1.7.2/` to exist; `rstudio-hunspell` is built entirely from the CMake-managed `HUNSPELL_SOURCE_DIR`. The `hunspell-*/` and `hunspell/` entries in `dependencies/windows/.gitignore` are left in place so developers with pre-existing extracted copies don't accidentally commit them.

## Test plan
- [x] Run `dependencies\windows\install-dependencies.cmd` on a clean tree and confirm no hunspell download is attempted
- [x] Run a full Windows package build (`package\win32\make-package.bat`) and confirm hunspell is fetched/built via CMake as expected