### PR TITLE
fix double-load and gray-screen on automation-agent startup

### DIFF
--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import stripJsonComments from 'strip-json-comments';
 import { TIMEOUTS, RSTUDIO_EXTRA_ARGS, sleep } from '../utils/constants';
 import { CONSOLE_INPUT, executeInConsole } from '../pages/console_pane.page';
-import { documentCloseAllNoSave } from '../utils/commands';
+import { documentCloseAllNoSave, executeCommand } from '../utils/commands';
 import { rLibsUserTemplate } from './r-libs-setup';
 
 const BASE_PREFS_PATH = path.join(__dirname, 'base-prefs.jsonc');
@@ -107,6 +107,57 @@ export interface DesktopSession {
   configRoot: string;
 }
 
+// Gated diagnostic: when PW_DEBUG_LAUNCH=1 is set, attach listeners to every
+// existing and future page in every context, so we can see the navigation /
+// load / console / error sequence that produces the renderer's "double load"
+// behavior during startup. Output is prefixed `[debug-launch]` with relative
+// timestamps. Leave the flag unset for normal runs.
+function attachLaunchDebug(browser: Browser): void {
+  if (process.env.PW_DEBUG_LAUNCH !== '1' && process.env.PW_DEBUG_LAUNCH !== 'true') {
+    return;
+  }
+
+  const t0 = Date.now();
+  const stamp = () => `+${(Date.now() - t0).toString().padStart(5, ' ')}ms`;
+  let pageSeq = 0;
+
+  const attach = (p: Page): void => {
+    const label = `p${pageSeq++}`;
+    console.log(`[debug-launch] ${stamp()} ${label}: page created, url=${p.url()}`);
+
+    p.on('framenavigated', (frame) => {
+      if (frame === p.mainFrame()) {
+        console.log(`[debug-launch] ${stamp()} ${label}: navigated -> ${frame.url()}`);
+      }
+    });
+    p.on('load', () => {
+      console.log(`[debug-launch] ${stamp()} ${label}: load (url=${p.url()})`);
+    });
+    p.on('domcontentloaded', () => {
+      console.log(`[debug-launch] ${stamp()} ${label}: domcontentloaded (url=${p.url()})`);
+    });
+    p.on('console', (msg) => {
+      const t = msg.type();
+      if (t === 'error' || t === 'warning' || t === 'info') {
+        console.log(`[debug-launch] ${stamp()} ${label}: console.${t}: ${msg.text()}`);
+      }
+    });
+    p.on('pageerror', (err) => {
+      console.log(`[debug-launch] ${stamp()} ${label}: pageerror: ${err.message}`);
+    });
+    p.on('close', () => {
+      console.log(`[debug-launch] ${stamp()} ${label}: closed`);
+    });
+  };
+
+  for (const ctx of browser.contexts()) {
+    ctx.on('page', attach);
+    for (const existing of ctx.pages()) {
+      attach(existing);
+    }
+  }
+}
+
 interface TempConfig {
   root: string;
   configHome: string;
@@ -154,7 +205,9 @@ function createTempConfig(): TempConfig {
  * directory across a quit-and-restart so prefs/state persist.
  */
 export async function launchRStudio(existingConfigRoot?: string): Promise<DesktopSession> {
-  // Clean up any existing RStudio on our specific CDP port
+  // Clean up any existing RStudio on our specific CDP port. The port is
+  // random per worker (9231-9299), so a collision is rare -- only happens
+  // when an orphaned process from a prior interrupted run is still bound.
   console.log(`CDP port: ${CDP_PORT}`);
   console.log(`Cleaning up any RStudio on port ${CDP_PORT}...`);
   try {
@@ -166,13 +219,14 @@ export async function launchRStudio(existingConfigRoot?: string): Promise<Deskto
     } else {
       execSync(`lsof -ti :${CDP_PORT} | xargs kill -9 2>/dev/null`, { stdio: 'ignore' });
     }
-    await sleep(5000); // Give RStudio time to shut down gracefully
   } catch {
     // No process on that port, that's fine
   }
-  await sleep(TIMEOUTS.processCleanup);
 
-  // Wait for port to be released (up to 15 seconds)
+  // Wait for the port to be free. When nothing was ever bound, the first
+  // probe throws immediately and we break out in microseconds. When we
+  // just killed something, the OS usually releases the port within a few
+  // hundred ms; the 15s ceiling is purely a safety net.
   const portDeadline = Date.now() + 15000;
   while (Date.now() < portDeadline) {
     try {
@@ -181,12 +235,12 @@ export async function launchRStudio(existingConfigRoot?: string): Promise<Deskto
         if (!result.trim()) break;
       } else {
         execSync(`lsof -i :${CDP_PORT} -t`, { encoding: 'utf-8' });
-        // If lsof succeeds, port is still in use — keep waiting
+        // If lsof succeeds, port is still in use -- keep waiting
       }
     } catch {
       break; // No connections on the port
     }
-    await sleep(1000);
+    await sleep(100);
   }
 
   // Set up the isolated config directory (or reuse one across a restart)
@@ -254,7 +308,7 @@ export async function launchRStudio(existingConfigRoot?: string): Promise<Deskto
       RSTUDIO_DISABLE_WHATS_NEW: '1',
       // Suppress the Electron splash screen during automation; otherwise CDP
       // can grab the splash window before the main app loads (see the
-      // desktopHooks-poll loop below).
+      // automation-bridge poll loop below).
       RS_NO_SPLASH: '1',
       USERPROFILE: sharedUserHome(),
     },
@@ -333,35 +387,58 @@ export async function launchRStudio(existingConfigRoot?: string): Promise<Deskto
     );
   }
 
+  attachLaunchDebug(browser);
+
   // If anything fails after CDP connect, kill the process to avoid orphaning RStudio.
   try {
     // The splash screen briefly holds its own page that gets replaced by the
-    // main GWT window. Poll until we find a live page whose window has
-    // desktopHooks installed -- that is the main app.
+    // main GWT window. In GWT super dev mode there is also a transient
+    // "Compiling RStudio" page that briefly exposes window.rstudio just
+    // before the codeserver redirects to the compiled app. To avoid
+    // latching onto either of those, poll for a page whose automation
+    // bridge stays installed on the *same* page across consecutive polls.
     const pageDeadline = Date.now() + 30000;
+    const requiredStableMs = 1000;
     let page: Page | undefined;
+    let stablePage: Page | undefined;
+    let stableSince = 0;
+
     while (Date.now() < pageDeadline && !page) {
+      let foundPage: Page | undefined;
       for (const ctx of browser.contexts()) {
         for (const candidate of ctx.pages()) {
           if (candidate.isClosed()) continue;
           try {
-            const hasHooks = await candidate.evaluate(
-              'typeof window.desktopHooks?.invokeCommand === "function"',
+            const hasBridge = await candidate.evaluate(
+              'typeof window.rstudio?.commands?.activateConsole === "function"',
             );
-            if (hasHooks === true) {
-              page = candidate;
+            if (hasBridge === true) {
+              foundPage = candidate;
               break;
             }
           } catch {
             // Page may be navigating or closing during splash -> main transition.
           }
         }
-        if (page) break;
+        if (foundPage) break;
       }
-      if (!page) await sleep(250);
+
+      if (foundPage && foundPage === stablePage) {
+        if (Date.now() - stableSince >= requiredStableMs) {
+          page = stablePage;
+          break;
+        }
+      } else {
+        // Either no page has the bridge right now, or a different page does
+        // than the one we were tracking. Restart the stability window.
+        stablePage = foundPage;
+        stableSince = foundPage ? Date.now() : 0;
+      }
+
+      await sleep(250);
     }
     if (!page) {
-      throw new Error('GWT app did not finish loading within 30s (no page with window.desktopHooks)');
+      throw new Error('GWT app did not finish loading within 30s (no stable page with window.rstudio bridge)');
     }
 
     // Dismiss any "save changes" modal from a previous interrupted run
@@ -387,7 +464,7 @@ export async function launchRStudio(existingConfigRoot?: string): Promise<Deskto
     }
 
     // Activate console (makes it visible without zooming)
-    await page.evaluate("window.desktopHooks.invokeCommand('activateConsole')");
+    await executeCommand(page, 'activateConsole');
 
     // Wait for the console input to be visible AND R to be idle (no
     // rstudio-console-busy class on #rstudio_console_input). The latter is

--- a/e2e/rstudio/scripts/desktop-dev.ts
+++ b/e2e/rstudio/scripts/desktop-dev.ts
@@ -4,10 +4,10 @@
 // then invokes Playwright against the desktop project with PW_RSTUDIO_DEV=1
 // so the desktop.fixture launches the in-tree Electron dev build.
 
-import { checkGwtDevmode, runCmakeBuild, runPlaywright } from './dev-common';
+import { checkGwtBuildReady, runCmakeBuild, runPlaywright } from './dev-common';
 
 const TAG = 'desktop-dev';
 
 runCmakeBuild(TAG);
-checkGwtDevmode(TAG);
+checkGwtBuildReady(TAG);
 runPlaywright(TAG, ['--project=desktop', ...process.argv.slice(2)], { PW_RSTUDIO_DEV: '1' });

--- a/e2e/rstudio/scripts/dev-common.ts
+++ b/e2e/rstudio/scripts/dev-common.ts
@@ -91,17 +91,32 @@ export function isGwtDevmodeRunning(): boolean {
   return result.status === 0;
 }
 
-export function checkGwtDevmode(tag: string): void {
-  step(tag, 'Checking GWT devmode...');
+// True if a precompiled GWT bootstrap exists on disk. `ant draft` writes
+// this; presence is enough to know the dev build can serve a working IDE
+// without devmode. We don't bother comparing source mtimes -- if the user
+// edits Java without re-running `ant draft`, that's on them.
+function hasPrecompiledGwt(): boolean {
+  return fs.existsSync(path.join(REPO_ROOT, 'src/gwt/www/rstudio/rstudio.nocache.js'));
+}
 
-  if (!isGwtDevmodeRunning()) {
-    console.log(
-      'GWT devmode is not running. Start it in another terminal with:\n' +
-        '    (cd src/gwt && ant devmode)',
-    );
+export function checkGwtBuildReady(tag: string): void {
+  step(tag, 'Checking GWT build state...');
+
+  if (isGwtDevmodeRunning()) {
+    console.log(`[${tag}] GWT devmode is running.`);
+    return;
   }
 
-  console.log(`[${tag}] GWT devmode is running.`);
+  if (hasPrecompiledGwt()) {
+    console.log(`[${tag}] Precompiled GWT bootstrap present (devmode not running).`);
+    return;
+  }
+
+  console.log(
+    `[${tag}] WARNING: no GWT build available. Tests will likely fail until you run one of:\n` +
+      '    (cd src/gwt && ant devmode)   # active development\n' +
+      '    (cd src/gwt && ant draft)     # one-shot precompile',
+  );
 }
 
 // Spawn `npx playwright test ...` with the supplied args appended and the

--- a/e2e/rstudio/scripts/dev-common.ts
+++ b/e2e/rstudio/scripts/dev-common.ts
@@ -95,8 +95,7 @@ export function checkGwtDevmode(tag: string): void {
   step(tag, 'Checking GWT devmode...');
 
   if (!isGwtDevmodeRunning()) {
-    fail(
-      tag,
+    console.log(
       'GWT devmode is not running. Start it in another terminal with:\n' +
         '    (cd src/gwt && ant devmode)',
     );

--- a/e2e/rstudio/scripts/server-dev.ts
+++ b/e2e/rstudio/scripts/server-dev.ts
@@ -5,10 +5,10 @@
 // against the server project. The server.fixture handles spawning the
 // in-tree rserver-dev binary and config.
 
-import { checkGwtDevmode, runCmakeBuild, runPlaywright } from './dev-common';
+import { checkGwtBuildReady, runCmakeBuild, runPlaywright } from './dev-common';
 
 const TAG = 'server-dev';
 
 runCmakeBuild(TAG);
-checkGwtDevmode(TAG);
+checkGwtBuildReady(TAG);
 runPlaywright(TAG, ['--project=server', ...process.argv.slice(2)]);

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -252,15 +252,9 @@ public class Application implements ApplicationEventHandlers
                   Desktop.getFrame().setProjectDirectory(projectDir.getPath());
             }
             
-            if (sessionInfo.isAutomationAgent())
-            {
-               ApplicationAutomation automation = pAutomation_.get();
-               automation.initializeAgent();
-            }
-            
             // load MathJax
             MathJaxLoader.ensureMathJaxLoaded();
-            
+
             // set up drag-drop handlers
             if (Desktop.isDesktop())
             {
@@ -276,11 +270,18 @@ public class Application implements ApplicationEventHandlers
 
             // initialize workbench
             // refresh prefs incase they were loaded without sessionInfo (this happens exclusively
-            // in desktop mode, though unsure why)
+            // in desktop mode, though unsure why). The automation agent must be initialized
+            // after this refresh -- registerPrefs() iterates userPrefs_.allPrefs(), and in desktop
+            // mode that returns an incomplete set until the pref refresh has run.
             userState_.get().writeState(boolArg ->
             {
                userPrefs_.get().writeUserPrefs(boolArg1 ->
                {
+                  if (sessionInfo.isAutomationAgent())
+                  {
+                     ApplicationAutomation automation = pAutomation_.get();
+                     automation.initializeAgent();
+                  }
                   initializeWorkbench();
                });
             });

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -14,7 +14,7 @@
  */
 
 import { ChildProcess } from 'child_process';
-import { BrowserWindow, dialog, session, shell } from 'electron';
+import { app, BrowserWindow, dialog, session, shell } from 'electron';
 
 import { Err } from '../core/err';
 import { logger } from '../core/logger';
@@ -53,6 +53,30 @@ let reloadCount = 0;
 
 // amount of time to wait before each reload, in milliseconds
 const reloadWaitDuration = 200;
+
+// When launched with --automation-agent we pre-seed the WEBDIALOG cookie so
+// that the GWT bootstrap loads the web-dialogs permutation on the very first
+// load. base-prefs.jsonc (used by Playwright tests) sets
+// native_file_dialogs: false; without the cookie pre-seed, GWT initially
+// boots the native-dialogs permutation, Application.initializeWorkbench()
+// detects the pref/cookie mismatch, and fires a ReloadEvent that costs ~4s
+// per test launch. The expiry mirrors WebDialogCookie.java in GWT.
+async function preSeedAutomationCookies(targetUrl: string): Promise<void> {
+  if (!app.commandLine.hasSwitch('automation-agent')) {
+    return;
+  }
+
+  try {
+    await session.defaultSession.cookies.set({
+      url: targetUrl,
+      name: 'WEBDIALOG',
+      value: '1',
+      expirationDate: new Date(Date.UTC(5000, 11, 31)).getTime() / 1000,
+    });
+  } catch (err) {
+    logger().logError(err as Error);
+  }
+}
 
 export class MainWindow extends GwtWindow {
   static FIRST_WORKBENCH_INITIALIZED = 'main-window-first_workbench_initialized';
@@ -234,6 +258,8 @@ export class MainWindow extends GwtWindow {
       logger().logDebug(`Setting base URL: ${url}`);
       this.options.baseUrl = url;
     }
+
+    await preSeedAutomationCookies(url);
 
     this.window.loadURL(url).catch((reason) => {
       logger().logErrorMessage(`Failed to load ${url}: ${reason}`);


### PR DESCRIPTION
## Summary

Three tightly related fixes that came out of triaging the Playwright desktop-dev tests after a fresh `ant devmode` recompile. The first is a real bug (any automation user hits it after #17728 lands); the other two eliminate startup races / costs that the test fixture exposed.

### 1. `automation: defer initializeAgent until after pref refresh` ([Application.java](src/gwt/src/org/rstudio/studio/client/application/Application.java))

`ApplicationAutomation.initializeAgent()` now iterates `userPrefs_.allPrefs()` to populate the `window.rstudio` bridge (#17728). In desktop mode, prefs are loaded without `sessionInfo` on the initial pass and only fully populated inside a `writeUserPrefs(...)` callback (the existing comment in `Application.java` already flagged this). Previously `initializeAgent()` ran *before* that callback, so it hit a half-populated pref set and crashed GWT bootstrap with a gray-screen renderer. Move the call inside the callback.

### 2. `electron: pre-seed WEBDIALOG cookie when launched with --automation-agent` ([main-window.ts](src/node/desktop/src/main/main-window.ts))

GWT's bootstrap reads the `WEBDIALOG` cookie as a deferred-binding property (`rstudio.useNativeDialogs` in `RStudio.gwt.xml`) to pick the dialog permutation at compile-time. `e2e/rstudio/fixtures/base-prefs.jsonc` sets `native_file_dialogs: false` so Playwright can drive dialogs; in a fresh `electron-userdata` the cookie is unset, so `initializeWorkbench()` detected a pref/cookie mismatch on first load and fired a `ReloadEvent` that cost ~4s per test launch. Pre-seeding the cookie before `loadURL` when `--automation-agent` is on makes GWT pick the right permutation on the very first load.

### 3. `e2e: switch desktop fixture to window.rstudio bridge; tighten port cleanup` ([desktop.fixture.ts](e2e/rstudio/fixtures/desktop.fixture.ts), [dev-common.ts](e2e/rstudio/scripts/dev-common.ts))

- Wait on and invoke `window.rstudio.commands.activateConsole` instead of `window.desktopHooks.invokeCommand`. The new automation bridge (#17728) is what tests use elsewhere via `utils/commands.ts`; the `desktopHooks` path was racy during startup.
- Require the bridge to remain present on the same page for >= 1s before proceeding -- guards against transient detections during super-dev-mode's compile-and-redirect dance.
- Add a `PW_DEBUG_LAUNCH=1` gated diagnostic that attaches Playwright page-event listeners (`framenavigated` / `load` / `console` / `pageerror`) to every context+page with relative timestamps. Useful for debugging future startup races.
- Replace blind sleeps in the CDP-port cleanup (5s + 1s) with the existing `lsof` poll loop tightened to 100ms. Saves ~6s per launch in the common no-collision case.
- Relax the GWT-devmode prerequisite check in the wrapper to a warning, so the script still works when GWT is precompiled via `ant draft`.

## Test plan

- [ ] Run `npm run test:desktop-dev -- tests/smoke/startup.test.ts` with `ant devmode` running -- should reach "RStudio console is ready" without a mid-startup reload.
- [ ] Run with `ant draft` precompiled, no `ant devmode` -- should still pass.
- [ ] Verify no regression in regular Desktop (`npm run test:desktop`) and Server (`npm run test:server`).
- [ ] `PW_DEBUG_LAUNCH=1 npm run test:desktop-dev -- tests/smoke/startup.test.ts` -- confirm timeline log appears.