### PR TITLE
playwright: resolve 15 cluster-6 test failures + adjacent product fixes

### DIFF
--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -2,7 +2,7 @@ import type { Page } from 'playwright';
 import * as fs from 'fs';
 import { ConsolePane, type EnvironmentVersions } from '../pages/console_pane.page';
 import { sleep } from '../utils/constants';
-import { documentCloseAllNoSave, executeCommand } from '../utils/commands';
+import { documentCloseAllNoSave, executeCommand, getVersion } from '../utils/commands';
 import { AceEditorElement } from '../utils/ace';
 
 interface InstallTarget {
@@ -151,17 +151,7 @@ export class ConsolePaneActions {
   }
 
   async getEnvironmentVersions(): Promise<EnvironmentVersions> {
-    await this.executeInConsole('cat("R:", R.version.string, "\\nRStudio:", RStudio.Version()$long_version)');
-    await sleep(2000);
-
-    const output = await this.consolePane.consoleOutput.innerText();
-    const rMatch = output.match(/R:\s*(R version [\d.]+[^\n]*)/);
-    const rstudioMatch = output.match(/RStudio:\s*([\d.+]+)/);
-
-    return {
-      r: rMatch?.[1] ?? 'unknown',
-      rstudio: rstudioMatch?.[1] ?? 'unknown',
-    };
+    return getVersion(this.page);
   }
 
   async goToLine(line: number): Promise<void> {

--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import { ConsolePane, type EnvironmentVersions } from '../pages/console_pane.page';
 import { sleep } from '../utils/constants';
 import { documentCloseAllNoSave, executeCommand } from '../utils/commands';
+import { AceEditorElement } from '../utils/ace';
 
 interface InstallTarget {
   repos: string;
@@ -75,14 +76,34 @@ export class ConsolePaneActions {
    * swallow characters. Prefer this when you just need code to run; use
    * `typeInConsole` only when a test is exercising actual typing behavior.
    */
+  /**
+   * Wait until the console input's Ace editor owns the document focus.
+   * activateConsole schedules the focus shift on the next event loop tick,
+   * so callers that hand the console keystrokes immediately after the
+   * command can race with the focus change. Polling beats a blind sleep
+   * here -- the common case settles in tens of milliseconds.
+   */
+  private async waitForConsoleFocus(): Promise<void> {
+    await this.page.waitForFunction(
+      () => {
+        const el = document.getElementById('rstudio_console_input');
+        return el !== null && el.contains(document.activeElement);
+      },
+      null,
+      { timeout: 5000, polling: 50 },
+    );
+  }
+
   async executeInConsole(command: string): Promise<void> {
-    await this.consolePane.consoleTab.click();
+    // Focus the console via the activateConsole command rather than
+    // clicking the console tab. The tab-click path was clicking the
+    // same element repeatedly across executeInConsole + clearConsole
+    // calls; using the command keeps focus changes deterministic and
+    // avoids any tab-level click side effects.
+    await executeCommand(this.page, 'activateConsole');
+    await this.waitForConsoleFocus();
     await this.page.evaluate((text) => {
-      const el = document.getElementById('rstudio_console_input') as
-        | (HTMLElement & {
-            env?: { editor?: { setValue(s: string, cursorPos?: number): void; focus(): void } };
-          })
-        | null;
+      const el = document.getElementById('rstudio_console_input') as AceEditorElement | null;
       const editor = el?.env?.editor;
       if (!editor) throw new Error('Console Ace editor not found at #rstudio_console_input');
       editor.setValue(text, 1); // 1 = move cursor to end
@@ -109,16 +130,14 @@ export class ConsolePaneActions {
    * fire completers between chars.
    */
   async typeInConsole(text: string, delayMs: number = 50): Promise<void> {
-    await this.consolePane.consoleTab.click();
-    await this.consolePane.consoleInput.click({ force: true });
-    await sleep(300);
+    await executeCommand(this.page, 'activateConsole');
+    await this.waitForConsoleFocus();
     await this.consolePane.consoleInput.pressSequentially(text, { delay: delayMs });
   }
 
   async clearConsole(): Promise<void> {
-    await this.consolePane.consoleTab.click();
-    await this.consolePane.consoleInput.click({ force: true });
-    await sleep(200);
+    await executeCommand(this.page, 'activateConsole');
+    await this.waitForConsoleFocus();
     await this.page.keyboard.press('Control+l');
     await sleep(500);
   }

--- a/e2e/rstudio/actions/source_pane.actions.ts
+++ b/e2e/rstudio/actions/source_pane.actions.ts
@@ -6,6 +6,7 @@ import { clickConfirmIfVisible } from '../pages/modals.page';
 import { TIMEOUTS, sleep } from '../utils/constants';
 import { rStringLiteral } from '../utils/r';
 import { executeCommand } from '../utils/commands';
+import { Ace, AceEditorElement } from '../utils/ace';
 
 export class SourcePaneActions {
   readonly page: Page;
@@ -161,15 +162,14 @@ export class SourcePaneActions {
       const editors = document.querySelectorAll('.ace_editor');
       for (let i = 0; i < editors.length; i++) {
         if (editors[i].closest('#rstudio_console_input')) continue;
-        const env = (editors[i] as any).env;
-        if (env && env.editor) {
-          const lines = env.editor.getValue().split('\n');
-          const pattern = new RegExp('```\\{r\\s+' + lbl + '[\\s,}]');
-          for (let j = 0; j < lines.length; j++) {
-            if (pattern.test(lines[j])) {
-              env.editor.gotoLine(j + 1, 0);
-              return;
-            }
+        const editor = (editors[i] as unknown as AceEditorElement).env?.editor;
+        if (!editor) continue;
+        const lines = editor.getValue().split('\n');
+        const pattern = new RegExp('```\\{r\\s+' + lbl + '[\\s,}]');
+        for (let j = 0; j < lines.length; j++) {
+          if (pattern.test(lines[j])) {
+            editor.gotoLine(j + 1, 0);
+            return;
           }
         }
       }
@@ -186,17 +186,20 @@ export class SourcePaneActions {
     await this.page.evaluate(({ marker: m, line: ln, startCol: sc, endCol: ec }) => {
       const editors = document.querySelectorAll('.ace_editor');
       for (let i = 0; i < editors.length; i++) {
-        const env = (editors[i] as any).env;
-        if (env && env.editor) {
-          const editor = env.editor;
-          if (editor.getValue().indexOf(m) !== -1) {
-            editor.focus();
-            editor.gotoLine(ln, 0);
-            const Range = (window as any).ace.require('ace/range').Range;
-            editor.selection.setRange(new Range(ln - 1, sc, ln - 1, ec));
-            break;
-          }
-        }
+        const editor = (editors[i] as unknown as AceEditorElement).env?.editor;
+        if (!editor) continue;
+        if (editor.getValue().indexOf(m) === -1) continue;
+        editor.focus();
+        editor.gotoLine(ln, 0);
+        // Ace's Range constructor lives on the global ace module loader; we
+        // grab it here rather than in utils/ace.ts because it's the only
+        // construction site and the module-loader surface isn't worth typing.
+        const aceModule = (window as unknown as {
+          ace: { require(path: string): { Range: new (sr: number, sc: number, er: number, ec: number) => Ace.Range } };
+        }).ace;
+        const Range = aceModule.require('ace/range').Range;
+        editor.selection.setRange(new Range(ln - 1, sc, ln - 1, ec));
+        return;
       }
     }, { marker, line, startCol, endCol });
     await sleep(1000);
@@ -206,26 +209,24 @@ export class SourcePaneActions {
    * Get the full text content of the active source editor via Ace API.
    */
   async getEditorContent(): Promise<string> {
-    return await this.page.evaluate(`(function() {
-      var editors = document.querySelectorAll('.ace_editor');
-      for (var i = 0; i < editors.length; i++) {
+    return await this.page.evaluate(() => {
+      const editors = document.querySelectorAll('.ace_editor');
+      for (let i = 0; i < editors.length; i++) {
         if (editors[i].closest('#rstudio_console_input')) continue;
-        var env = editors[i].env;
-        if (env && env.editor) {
-          return env.editor.getValue();
-        }
+        const editor = (editors[i] as unknown as AceEditorElement).env?.editor;
+        if (editor) return editor.getValue();
       }
       throw new Error('No active source editor found');
-    })()`);
+    });
   }
 
   async getSelectedText(marker: string): Promise<string> {
     return await this.page.evaluate((m) => {
       const editors = document.querySelectorAll('.ace_editor');
       for (let i = 0; i < editors.length; i++) {
-        const env = (editors[i] as any).env;
-        if (env && env.editor && env.editor.getValue().indexOf(m) !== -1) {
-          return env.editor.getSelectedText();
+        const editor = (editors[i] as unknown as AceEditorElement).env?.editor;
+        if (editor && editor.getValue().indexOf(m) !== -1) {
+          return editor.getSelectedText();
         }
       }
       return '';
@@ -234,17 +235,15 @@ export class SourcePaneActions {
 
   /** Get the first visible row index (0-based) of the active source editor. */
   async getFirstVisibleRow(): Promise<number> {
-    return await this.page.evaluate(`(function() {
-      var editors = document.querySelectorAll('.ace_editor');
-      for (var i = 0; i < editors.length; i++) {
+    return await this.page.evaluate(() => {
+      const editors = document.querySelectorAll('.ace_editor');
+      for (let i = 0; i < editors.length; i++) {
         if (editors[i].closest('#rstudio_console_input')) continue;
-        var env = editors[i].env;
-        if (env && env.editor) {
-          return env.editor.getFirstVisibleRow();
-        }
+        const editor = (editors[i] as unknown as AceEditorElement).env?.editor;
+        if (editor) return editor.getFirstVisibleRow();
       }
       throw new Error('No active source editor found');
-    })()`);
+    });
   }
 
   /**

--- a/e2e/rstudio/pages/ace_editor.page.ts
+++ b/e2e/rstudio/pages/ace_editor.page.ts
@@ -1,15 +1,6 @@
 import type { Page } from 'playwright';
 import { PageObject } from './page_object_base_classes';
-
-export interface AcePosition {
-  row: number;
-  column: number;
-}
-
-export interface AceRange {
-  start: AcePosition;
-  end: AcePosition;
-}
+import { Ace, AceEditorElement } from '../utils/ace';
 
 export interface AceToken {
   type: string;
@@ -22,7 +13,7 @@ export interface AceToken {
 }
 
 export interface AceMarker {
-  range: AceRange | null;
+  range: Ace.Range | null;
   type: string;
   clazz: string;
 }
@@ -48,7 +39,7 @@ export class AceEditor extends PageObject {
    * structured-clone serializable.
    */
   private async runOnEditor<TArgs extends unknown[], TResult>(
-    fn: (editor: unknown, ...args: TArgs) => TResult,
+    fn: (editor: Ace.Editor, ...args: TArgs) => TResult,
     ...args: TArgs
   ): Promise<TResult> {
     return this.page.evaluate(
@@ -56,11 +47,11 @@ export class AceEditor extends PageObject {
         const editors = document.querySelectorAll('.ace_editor');
         for (let i = 0; i < editors.length; i++) {
           if (editors[i].closest('#rstudio_console_input')) continue;
-          const env = (editors[i] as unknown as { env?: { editor?: { getValue(): string } } }).env;
+          const env = (editors[i] as unknown as AceEditorElement).env;
           if (env?.editor && env.editor.getValue().indexOf(marker) !== -1) {
             // Reconstruct the function passed by the test from its source.
             // Input is trusted: it comes from our own .toString() in the caller.
-            const op = (0, eval)('(' + fnSource + ')') as (editor: unknown, ...args: unknown[]) => unknown;
+            const op = (0, eval)('(' + fnSource + ')') as (editor: Ace.Editor, ...args: unknown[]) => unknown;
             return op(env.editor, ...args);
           }
         }
@@ -71,28 +62,24 @@ export class AceEditor extends PageObject {
   }
 
   async getValue(): Promise<string> {
-    return this.runOnEditor((editor) => (editor as { getValue(): string }).getValue());
+    return this.runOnEditor((editor) => editor.getValue());
   }
 
   async gotoLine(line: number, column = 0): Promise<void> {
     await this.runOnEditor(
-      (editor, l: number, c: number) => (editor as { gotoLine(l: number, c: number): void }).gotoLine(l, c),
+      (editor, l: number, c: number) => editor.gotoLine(l, c),
       line, column
     );
   }
 
   /** Returns "start", "end", or "" depending on whether the row has a fold widget. */
   async getFoldWidget(row: number): Promise<string> {
-    return this.runOnEditor(
-      (editor, r: number) => (editor as { session: { getFoldWidget(r: number): string } }).session.getFoldWidget(r),
-      row
-    );
+    return this.runOnEditor((editor, r: number) => editor.session.getFoldWidget(r), row);
   }
 
-  async getFoldWidgetRange(row: number): Promise<AceRange | null> {
+  async getFoldWidgetRange(row: number): Promise<Ace.Range | null> {
     return this.runOnEditor((editor, r: number) => {
-      const range = (editor as { session: { getFoldWidgetRange(r: number): AceRange | null } })
-        .session.getFoldWidgetRange(r);
+      const range = editor.session.getFoldWidgetRange(r);
       if (!range) return null;
       return {
         start: { row: range.start.row, column: range.start.column },
@@ -103,23 +90,19 @@ export class AceEditor extends PageObject {
 
   /** Returns the raw text of `row` (0-indexed), excluding the trailing newline. */
   async getLine(row: number): Promise<string> {
-    return this.runOnEditor(
-      (editor, r: number) => (editor as { session: { getLine(r: number): string } }).session.getLine(r),
-      row
-    );
+    return this.runOnEditor((editor, r: number) => editor.session.getLine(r), row);
   }
 
   async getTokens(row: number): Promise<AceToken[]> {
     return this.runOnEditor(
-      (editor, r: number) => (editor as { session: { getTokens(r: number): AceToken[] } }).session.getTokens(r),
+      (editor, r: number) => editor.session.getTokens(r) as AceToken[],
       row
     );
   }
 
   async getTokenAt(row: number, column: number): Promise<AceToken | null> {
     return this.runOnEditor(
-      (editor, r: number, c: number) =>
-        (editor as { session: { getTokenAt(r: number, c: number): AceToken | null } }).session.getTokenAt(r, c),
+      (editor, r: number, c: number) => editor.session.getTokenAt(r, c) as AceToken | null,
       row, column
     );
   }
@@ -127,8 +110,7 @@ export class AceEditor extends PageObject {
   /** Returns all Ace markers on the session, normalized to plain objects. */
   async getMarkers(): Promise<AceMarker[]> {
     return this.runOnEditor((editor) => {
-      const session = (editor as { session: { getMarkers(): Record<string, AceMarker> } }).session;
-      const markers = session.getMarkers();
+      const markers = editor.session.getMarkers() as Record<string, AceMarker>;
       return Object.values(markers).map((m) => ({
         range: m.range
           ? {
@@ -143,10 +125,7 @@ export class AceEditor extends PageObject {
   }
 
   async getState(row: number): Promise<string> {
-    return this.runOnEditor(
-      (editor, r: number) => (editor as { session: { getState(r: number): string } }).session.getState(r),
-      row
-    );
+    return this.runOnEditor((editor, r: number) => editor.session.getState(r), row);
   }
 
   /**
@@ -154,10 +133,9 @@ export class AceEditor extends PageObject {
    * objects. Useful for verifying commands like renameInScope, which place a
    * cursor on every matching occurrence.
    */
-  async getSelectionRanges(): Promise<AceRange[]> {
+  async getSelectionRanges(): Promise<Ace.Range[]> {
     return this.runOnEditor((editor) => {
-      const ranges = (editor as { selection: { rangeList: { ranges: AceRange[] } } })
-        .selection.rangeList.ranges;
+      const ranges = editor.selection.rangeList.ranges;
       return ranges.map((r) => ({
         start: { row: r.start.row, column: r.start.column },
         end: { row: r.end.row, column: r.end.column },
@@ -165,19 +143,16 @@ export class AceEditor extends PageObject {
     });
   }
 
-  async getCursorPosition(): Promise<AcePosition> {
+  async getCursorPosition(): Promise<Ace.Position> {
     return this.runOnEditor((editor) => {
-      const pos = (editor as { getCursorPosition(): AcePosition }).getCursorPosition();
+      const pos = editor.getCursorPosition();
       return { row: pos.row, column: pos.column };
     });
   }
 
   /** Equivalent to Ace's editor.find(needle): selects the first match and scrolls to it. */
   async find(needle: string): Promise<void> {
-    await this.runOnEditor(
-      (editor, n: string) => (editor as { find(n: string): void }).find(n),
-      needle
-    );
+    await this.runOnEditor((editor, n: string) => editor.find(n), needle);
   }
 
   /**
@@ -185,19 +160,16 @@ export class AceEditor extends PageObject {
    * Useful when typed-key delivery is hard to time (e.g. right after a save).
    */
   async insert(text: string): Promise<void> {
-    await this.runOnEditor(
-      (editor, t: string) => (editor as { insert(t: string): void }).insert(t),
-      text
-    );
+    await this.runOnEditor((editor, t: string) => editor.insert(t), text);
   }
 
   /** Move cursor to the end of the current line (Ace's editor.navigateLineEnd). */
   async navigateLineEnd(): Promise<void> {
-    await this.runOnEditor((editor) => (editor as { navigateLineEnd(): void }).navigateLineEnd());
+    await this.runOnEditor((editor) => editor.navigateLineEnd());
   }
 
   /** Move focus to the editor textarea so subsequent page.keyboard input routes here. */
   async focus(): Promise<void> {
-    await this.runOnEditor((editor) => (editor as { focus(): void }).focus());
+    await this.runOnEditor((editor) => editor.focus());
   }
 }

--- a/e2e/rstudio/pages/console_pane.page.ts
+++ b/e2e/rstudio/pages/console_pane.page.ts
@@ -2,6 +2,7 @@ import type { Page, Locator } from 'playwright';
 import { PageObject } from './page_object_base_classes';
 import { sleep } from '../utils/constants';
 import { documentCloseAllNoSave, executeCommand } from '../utils/commands';
+import { AceEditorElement } from '../utils/ace';
 
 // ---------------------------------------------------------------------------
 // Class-based page object
@@ -43,9 +44,7 @@ export class ConsolePane extends PageObject {
 
   async consoleInputValue(): Promise<string> {
     return this.page.evaluate(() => {
-      const el = document.getElementById('rstudio_console_input') as
-        | (HTMLElement & { env?: { editor?: { getValue(): string } } })
-        | null;
+      const el = document.getElementById('rstudio_console_input') as AceEditorElement | null;
       return el?.env?.editor?.getValue() ?? '';
     });
   }
@@ -80,11 +79,7 @@ export const INTERRUPT_R_BTN = "[id^='rstudio_tb_interruptr']";
 export async function executeInConsole(page: Page, command: string): Promise<void> {
   await page.locator(CONSOLE_TAB).click();
   await page.evaluate((text) => {
-    const el = document.getElementById('rstudio_console_input') as
-      | (HTMLElement & {
-          env?: { editor?: { setValue(s: string, cursorPos?: number): void; focus(): void } };
-        })
-      | null;
+    const el = document.getElementById('rstudio_console_input') as AceEditorElement | null;
     const editor = el?.env?.editor;
     if (!editor) throw new Error('Console Ace editor not found at #rstudio_console_input');
     editor.setValue(text, 1); // 1 = move cursor to end

--- a/e2e/rstudio/pages/console_pane.page.ts
+++ b/e2e/rstudio/pages/console_pane.page.ts
@@ -1,7 +1,7 @@
 import type { Page, Locator } from 'playwright';
 import { PageObject } from './page_object_base_classes';
 import { sleep } from '../utils/constants';
-import { documentCloseAllNoSave, executeCommand } from '../utils/commands';
+import { documentCloseAllNoSave, executeCommand, getVersion } from '../utils/commands';
 import { AceEditorElement } from '../utils/ace';
 
 // ---------------------------------------------------------------------------
@@ -128,17 +128,7 @@ export async function closeAllBuffersWithoutSaving(page: Page): Promise<void> {
 }
 
 export async function getEnvironmentVersions(page: Page): Promise<EnvironmentVersions> {
-  await executeInConsole(page, 'cat("R:", R.version.string, "\\nRStudio:", RStudio.Version()$long_version)');
-  await sleep(2000);
-
-  const output = await page.locator(CONSOLE_OUTPUT).innerText();
-  const rMatch = output.match(/R:\s*(R version [\d.]+[^\n]*)/);
-  const rstudioMatch = output.match(/RStudio:\s*([\d.+]+)/);
-
-  return {
-    r: rMatch?.[1] ?? 'unknown',
-    rstudio: rstudioMatch?.[1] ?? 'unknown',
-  };
+  return getVersion(page);
 }
 
 export async function goToLine(page: Page, line: number): Promise<void> {

--- a/e2e/rstudio/tests/panes/console/console_output.test.ts
+++ b/e2e/rstudio/tests/panes/console/console_output.test.ts
@@ -10,6 +10,7 @@ import { test, expect } from '@fixtures/rstudio.fixture';
 import type { Page } from 'playwright';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { useSuiteSandbox } from '@utils/sandbox';
+import { AceEditorElement } from '@utils/ace';
 import { writeAndOpenFile, closeAndDeleteSandboxFiles } from '@utils/files';
 import { executeCommand } from '@utils/commands';
 import { sleep, TIMEOUTS } from '@utils/constants';
@@ -28,9 +29,7 @@ async function consoleSpanTexts(page: Page): Promise<string[]> {
 
 async function readConsoleInput(page: Page): Promise<string> {
   return page.evaluate(() => {
-    const el = document.getElementById('rstudio_console_input') as
-      | (HTMLElement & { env?: { editor?: { getValue(): string } } })
-      | null;
+    const el = document.getElementById('rstudio_console_input') as AceEditorElement | null;
     return el?.env?.editor?.getValue() ?? '';
   });
 }

--- a/e2e/rstudio/tests/panes/editor/air_formatting.test.ts
+++ b/e2e/rstudio/tests/panes/editor/air_formatting.test.ts
@@ -35,6 +35,7 @@ import { SourcePaneActions } from '@actions/source_pane.actions';
 import { sleep } from '@utils/constants';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { executeCommand } from '@utils/commands';
+import { createAndOpenProject } from '@utils/project';
 
 // --- Test data (from issue #16721) ---
 
@@ -210,13 +211,21 @@ function expectUnchanged(content: string): void {
 test.describe('Air Formatting (#16721)', { tag: ['@parallel_safe'] }, () => {
   // Sets cwd to a per-spec sandbox; the relative paths used throughout this
   // spec (TEST_FILE, air.toml, .air.toml) all resolve into that sandbox.
-  useSuiteSandbox();
+  const sandbox = useSuiteSandbox();
   let page: Page;
   let consoleActions: ConsolePaneActions;
   let sourceActions: SourcePaneActions;
 
   test.beforeAll(async ({ rstudioPage }) => {
     page = rstudioPage;
+    // The save-triggered reformat path in TextEditingTarget.maybeFormatOnUserInitiatedSave
+    // is gated on "file is inside the active project" -- without a project,
+    // reformat-on-save is skipped entirely, so cases 5/10 can't pass. Open a
+    // project inside the suite sandbox; the project open also re-`setwd`s into
+    // the project dir, so relative paths still resolve consistently and air.toml
+    // ends up alongside the file being formatted (which is what Air's ancestor
+    // walk needs to find it).
+    await createAndOpenProject(page, sandbox.dir, 'air_formatting');
     consoleActions = new ConsolePaneActions(page);
     sourceActions = new SourcePaneActions(page, consoleActions);
     await consoleActions.closeAllBuffersWithoutSaving();

--- a/e2e/rstudio/tests/panes/editor/quarto_chunks.test.ts
+++ b/e2e/rstudio/tests/panes/editor/quarto_chunks.test.ts
@@ -26,6 +26,13 @@ test.describe.serial('Quarto chunks', { tag: ['@serial'] }, () => {
 
   test('the warn option is preserved when running chunks', async ({ rstudioPage: page }) => {
     const fileName = `quarto_warn_${Date.now()}.qmd`;
+    // Sentinel printed as the last line of the chunk so the test can
+    // wait for "chunk finished" before checking the global warn value.
+    // executeCurrentChunk dispatches via a different path than
+    // executeInConsole, so the two are *not* serialized by R's input
+    // queue -- without an explicit wait, a following console command
+    // can land before the chunk completes.
+    const sentinel = `__CHUNK_DONE_${Date.now()}__`;
     const content = [
       '---',
       'title: Chunk Warnings',
@@ -36,6 +43,7 @@ test.describe.serial('Quarto chunks', { tag: ['@serial'] }, () => {
       'getOption("warn")',
       '# setting a global option',
       'options(warn = 2)',
+      `cat("${sentinel}\\n")`,
       '```',
     ].join('\n');
 
@@ -44,9 +52,19 @@ test.describe.serial('Quarto chunks', { tag: ['@serial'] }, () => {
     await expect(consoleActions.consolePane.consoleOutput).toContainText('WARN_BEFORE=0');
 
     await sourceActions.createAndOpenFile(fileName, content);
+
+    // Clear before running the chunk so the sentinel wait below cannot
+    // match against the writeLines echo from createAndOpenFile (which
+    // contains the sentinel string verbatim as part of the chunk body).
+    // Use the consoleClear command rather than clearConsole() so we keep
+    // source-pane focus -- navigateToChunkByLabel below clicks into the
+    // source editor, which fails if focus has shifted to the console.
+    await executeCommand(page, 'consoleClear');
+
     await sourceActions.navigateToChunkByLabel('warning_chunk');
     await executeCommand(page, 'executeCurrentChunk');
-    // R queue is FIFO; `WARN_AFTER=2` won't appear until `options(warn = 2)` runs.
+    await expect(consoleActions.consolePane.consoleOutput).toContainText(sentinel, { timeout: 30000 });
+
     await consoleActions.executeInConsole('cat("WARN_AFTER=", getOption("warn"), "\\n", sep = "")');
     await expect(consoleActions.consolePane.consoleOutput).toContainText('WARN_AFTER=2', { timeout: 30000 });
 

--- a/e2e/rstudio/tests/panes/editor/rmarkdown_chunks.test.ts
+++ b/e2e/rstudio/tests/panes/editor/rmarkdown_chunks.test.ts
@@ -79,6 +79,14 @@ test.describe.serial('R Markdown chunks', { tag: ['@serial'] }, () => {
 
   test('the warn option is preserved when running chunks', async ({ rstudioPage: page }) => {
     const fileName = `rmarkdown_warn_${Date.now()}.Rmd`;
+    // Sentinel printed as the last line of the chunk so the test can
+    // wait for "chunk finished" before checking the global warn value
+    // in a *separate* console execution. The cat is independent of the
+    // chunk so warn=2 persisting across the chunk boundary is the
+    // assertion being tested. executeCurrentChunk dispatches via a
+    // different path than executeInConsole, so without an explicit wait
+    // a following console command can land before the chunk completes.
+    const sentinel = `__CHUNK_DONE_${Date.now()}__`;
     const content = [
       '---',
       'title: Chunk Warnings',
@@ -89,6 +97,7 @@ test.describe.serial('R Markdown chunks', { tag: ['@serial'] }, () => {
       'getOption("warn")',
       '# setting a global option',
       'options(warn = 2)',
+      `cat("${sentinel}\\n")`,
       '```',
     ].join('\n');
 
@@ -101,12 +110,18 @@ test.describe.serial('R Markdown chunks', { tag: ['@serial'] }, () => {
 
     await sourceActions.createAndOpenFile(fileName, content);
 
-    // Fire the chunk, then immediately queue the cat -- R processes its
-    // input queue in order, so the `WARN_AFTER=2` line will only appear
-    // after `options(warn = 2)` has run. No separate chunk-finish wait
-    // needed; the assertion implicitly serializes.
+    // Clear before running the chunk so the sentinel wait below cannot
+    // match against the writeLines echo from createAndOpenFile (which
+    // contains the sentinel string verbatim as part of the chunk body).
+    // Use the consoleClear command rather than clearConsole() so we keep
+    // source-pane focus -- navigateToChunkByLabel below clicks into the
+    // source editor, which fails if focus has shifted to the console.
+    await executeCommand(page, 'consoleClear');
+
     await sourceActions.navigateToChunkByLabel('warning_chunk');
     await executeCommand(page, 'executeCurrentChunk');
+    await expect(consoleActions.consolePane.consoleOutput).toContainText(sentinel, { timeout: 30000 });
+
     await consoleActions.executeInConsole('cat("WARN_AFTER=", getOption("warn"), "\\n", sep = "")');
     await expect(consoleActions.consolePane.consoleOutput).toContainText('WARN_AFTER=2', { timeout: 30000 });
 

--- a/e2e/rstudio/tests/panes/misc/autocomplete_extras.test.ts
+++ b/e2e/rstudio/tests/panes/misc/autocomplete_extras.test.ts
@@ -154,9 +154,11 @@ test.describe('Autocomplete extras', () => {
     await consoleActions.executeInConsole('cols_q <- list(apple = "apple", "2024" = "2024")');
     await sleep(500);
 
+    // Typing `$` auto-opens the autocomplete popup; an explicit Tab here
+    // would just accept the highlighted entry ("apple") before we get a
+    // chance to navigate to "2024".
     await consoleActions.typeInConsole('cols_q$');
-    await page.keyboard.press('Tab');
-    await sleep(500);
+    await expect(page.locator('#rstudio_popup_completions')).toBeVisible({ timeout: 5000 });
 
     // Second item ("2024") needs Down to highlight, then Enter to accept
     // the completion, then Enter again to submit the line.

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails-paths.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails-paths.test.ts
@@ -3,21 +3,21 @@
  *
  * Companion to chat-guardrails.test.ts. That file drives the guardrails
  * via natural-language prompts to the Posit Assistant; here we call
- * .rs.chat.injectBindings() / .rs.chat.restoreBindings() directly from
- * the console so every sensitive read/write path can be covered
- * deterministically. The R-side mechanism is the same; this just
- * removes the assistant from the loop.
+ * .rs.chat.withGuardrails directly from the console so every sensitive
+ * read/write path can be covered deterministically. The R-side mechanism
+ * is the same; this just removes the assistant from the loop.
  *
  * Tests are grouped by category (read denials, read allows, write
  * denials, write allows, connection denials, error message structure,
  * system file denials, path traversal).
  *
- * Each test calls `.rs.test.guardrails(quote(<expr>))` -- a helper installed
- * in beforeAll that injects the guardrail bindings, evaluates the
- * expression, prints any error message, and finally cats a unique
- * "DONE" marker. The marker is computed at runtime so the JS poll
- * can distinguish R's output from the input echo of the very same
- * command. on.exit restores bindings even when the guarded call stop()s.
+ * Each test wraps `.rs.chat.withGuardrails(quote(<expr>))` in an inline
+ * tryCatch that prints a runtime-generated "DONE" marker. The marker is
+ * computed at runtime so the JS poll can distinguish R's output from the
+ * input echo of the very same command. We inline the whole thing instead
+ * of installing a helper in beforeAll because the install can race with
+ * R startup -- and a missed install would surface as
+ * `could not find function ".rs.test.guardrails"` on the first test.
  */
 
 import { test, expect } from '@fixtures/rstudio.fixture';
@@ -27,30 +27,28 @@ import { createAndOpenProject } from '@utils/project';
 
 const PROJECT_NAME = 'guardrail_paths_project';
 
-// The helper definition installs `.rs.test.guardrails` in the global
-// env. The marker is generated at runtime (proc.time() + sample.int),
-// so the JS-side regex never matches the input echo of the call --
-// only the cat() output that runs after the guarded expression
-// completes.
-const GUARDRAILS_HELPER_DEF =
-  `.rs.test.guardrails <- function(expr) { ` +
-    `on.exit(.rs.chat.restoreBindings(), add = TRUE); ` +
-    `.rs.chat.injectBindings(); ` +
+// Build the R one-liner that runs `rCode` under the chat guardrails. The
+// marker is generated at runtime (proc.time() + sample.int) so the
+// JS-side regex never matches the input echo of the call -- only the
+// cat() output that runs after the guarded expression completes.
+function buildGuardrailsCall(rCode: string): string {
+  return `local({ ` +
     `m <- paste0("__GUARDRAILS_", proc.time()[3], "_", sample.int(1e9, 1L), "__"); ` +
     `tryCatch({ ` +
-      `eval(expr, envir = parent.frame()); ` +
+      `.rs.chat.withGuardrails(quote(${rCode})); ` +
       `cat("__OK__", m, "\\n") ` +
     `}, error = function(e) { ` +
       `cat(conditionMessage(e), "\\n"); ` +
       `cat("__ERR__", m, "\\n") ` +
     `}) ` +
-  `}`;
+  `})`;
+}
 
 // Matches the runtime-generated marker (proc.time() seconds.fraction +
-// integer). Used to poll for "R is done with the helper call".
+// integer). Used to poll for "R is done with the guarded call".
 const GUARDRAILS_MARKER_RE = /__GUARDRAILS_[\d.]+_\d+__/;
 
-// Whether the helper's tryCatch caught an error (i.e., the guarded call
+// Whether the inline tryCatch caught an error (i.e., the guarded call
 // stop()ed). Sentinel is printed by the error branch.
 const GUARDRAILS_ERR_RE = /__ERR__\s+__GUARDRAILS_[\d.]+_\d+__/;
 
@@ -70,9 +68,6 @@ test.describe.serial('Filesystem Guardrails: paths (#17122)', { tag: ['@serial']
 
     // The session restart invalidates the previous actions wrapper.
     consoleActions = new ConsolePaneActions(page);
-
-    // Install the .rs.test.guardrails helper once for the suite.
-    await consoleActions.executeInConsole(GUARDRAILS_HELPER_DEF);
     await consoleActions.clearConsole();
   });
 
@@ -89,7 +84,7 @@ test.describe.serial('Filesystem Guardrails: paths (#17122)', { tag: ['@serial']
     const consoleOutput = consoleActions.page.locator('#rstudio_console_output');
     const segments = [
       opts.pre,
-      `.rs.test.guardrails(quote(${rCode}))`,
+      buildGuardrailsCall(rCode),
       opts.post,
     ].filter(Boolean) as string[];
     await consoleActions.clearConsole();

--- a/e2e/rstudio/tests/projects/shinytest2.test.ts
+++ b/e2e/rstudio/tests/projects/shinytest2.test.ts
@@ -15,7 +15,11 @@ const CLOSE_PROJECT_MENU_ITEM = '#rstudio_label_close_project_command';
 // The project menu button also has a title containing the project path, so a
 // loose `title*='shinytest2'` selector hits it when the project name contains
 // the word. Match the toolbar button's exact title text instead.
-const SHINYTEST_BUTTON = "button[title='Run test using the shinytest2 package']";
+// The Shiny-test toolbar button is rendered in every editor's toolbar and
+// hidden via aria-hidden when the file isn't a shinytest2 file. Match only
+// the visible instance so strict-mode locator resolution doesn't trip
+// across multiple editors (e.g. an Untitled1 left over from prior tests).
+const SHINYTEST_BUTTON = "button[title='Run test using the shinytest2 package']:visible";
 
 async function waitForConsoleIdle(page: Page): Promise<void> {
   await page.waitForFunction(

--- a/e2e/rstudio/utils/ace.ts
+++ b/e2e/rstudio/utils/ace.ts
@@ -1,0 +1,66 @@
+// TypeScript bindings for the runtime Ace editor API as exposed by RStudio.
+// These describe just the methods and fields the Playwright tests currently
+// reach into via page.evaluate -- add new entries here when a test needs
+// them instead of inlining cast-and-assert blocks at the call site.
+//
+// The namespace mirrors Ace's own naming (Ace.Editor, Ace.Range, etc.) so
+// the bindings are discoverable and don't collide with the AceEditor
+// page-object class in pages/ace_editor.page.ts (which is the Playwright
+// wrapper, not the runtime instance).
+
+export namespace Ace {
+  export interface Position {
+    row: number;
+    column: number;
+  }
+
+  export interface Range {
+    start: Position;
+    end: Position;
+  }
+
+  export interface Selection {
+    setRange(range: Range): void;
+    rangeList: { ranges: Range[] };
+  }
+
+  // Methods on the EditSession (editor.session). Ace exposes many more --
+  // restrict to the ones tests actually need to keep the surface obvious.
+  export interface Session {
+    getLine(row: number): string;
+    getFoldWidget(row: number): string;
+    getFoldWidgetRange(row: number): Range | null;
+    getState(row: number): string;
+    getTokens(row: number): unknown[];
+    getTokenAt(row: number, column: number): unknown | null;
+    getMarkers(): Record<string, unknown>;
+    replace(range: Range, text: string): Position;
+    remove(range: Range): Position;
+  }
+
+  // The runtime editor instance. Hung off the .ace_editor DOM element via
+  // the .env.editor backref (see AceEditorElement below).
+  export interface Editor {
+    session: Session;
+    selection: Selection;
+    getValue(): string;
+    setValue(value: string, cursorPos?: number): void;
+    focus(): void;
+    gotoLine(line: number, column?: number): void;
+    getCursorPosition(): Position;
+    getSelectedText(): string;
+    getFirstVisibleRow(): number;
+    find(needle: string): void;
+    insert(text: string): void;
+    navigateLineEnd(): void;
+  }
+}
+
+// Shape of a DOM element with the Ace runtime instance attached. Use with
+// document.getElementById when the editor is identified by a stable id
+// (e.g. #rstudio_console_input). For source editors that don't have a
+// stable id, iterate document.querySelectorAll('.ace_editor') and cast
+// elements with this type.
+export interface AceEditorElement extends HTMLElement {
+  env?: { editor?: Ace.Editor };
+}

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -33,11 +33,19 @@ type ProjectInfo = {
   isActive(): boolean;
 };
 
+type VersionInfo = {
+  /** RStudio long-version string, e.g. "2026.05.999". */
+  rstudio: string;
+  /** R version number, e.g. "4.5.3". */
+  r: string;
+};
+
 type RStudioBridge = {
   commands: { [id: string]: CommandEntry } & { list: string[] };
   prefs: { [name: string]: PrefEntry };
   documents: { closeAllNoSave(): void };
   project: ProjectInfo;
+  version: VersionInfo;
 };
 
 declare global {
@@ -163,4 +171,14 @@ export async function clearPref(page: Page, name: string): Promise<void> {
       throw new Error(`Unknown user preference: ${prefName}`);
     entry.clear();
   }, camel);
+}
+
+/** Read the RStudio + R version info installed on the automation bridge. */
+export async function getVersion(page: Page): Promise<{ rstudio: string; r: string }> {
+  return page.evaluate(() => {
+    const r = window.rstudio;
+    if (!r)
+      throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
+    return { rstudio: r.version.rstudio, r: r.version.r };
+  });
 }

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -46,8 +46,6 @@ declare global {
   }
 }
 
-const MISSING_BRIDGE = 'window.rstudio is not defined; launch RStudio with --automation-agent';
-
 // Convert snake_case to camelCase. Preference names are snake_case in the
 // schema (matching rstudio-prefs.json), but the Java bridge registers them
 // camelCased to read better as JS object keys. Keeping the TS wrapper APIs
@@ -58,13 +56,19 @@ function snakeToCamel(s: string): string {
 
 /** Run an AppCommand by id (no console roundtrip). */
 export async function executeCommand(page: Page, commandId: string): Promise<void> {
+  // The bridge is transiently absent during session restarts (project open
+  // /close, Restart R). Wait for the specific command to land before
+  // dispatching so callers don't have to manage that themselves. When the
+  // bridge is already up, the condition is true on the first poll, so this
+  // adds no measurable latency to the steady-state path.
+  await page.waitForFunction(
+    (id) => typeof (window.rstudio?.commands as Record<string, unknown> | undefined)?.[id] === 'function',
+    commandId,
+    { timeout: 10000, polling: 50 },
+  );
   await page.evaluate((id) => {
-    const r = window.rstudio;
-    if (!r)
-      throw new Error(MISSING_BRIDGE);
+    const r = window.rstudio!;
     const cmd = r.commands[id];
-    if (!cmd)
-      throw new Error(`Unknown command: ${id}`);
     cmd();
   }, commandId);
 }
@@ -74,7 +78,7 @@ export async function isCommandChecked(page: Page, commandId: string): Promise<b
   return page.evaluate((id) => {
     const r = window.rstudio;
     if (!r)
-      throw new Error(MISSING_BRIDGE);
+      throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
     const cmd = r.commands[id];
     if (!cmd)
       throw new Error(`Unknown command: ${id}`);
@@ -87,7 +91,7 @@ export async function isCommandEnabled(page: Page, commandId: string): Promise<b
   return page.evaluate((id) => {
     const r = window.rstudio;
     if (!r)
-      throw new Error(MISSING_BRIDGE);
+      throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
     const cmd = r.commands[id];
     if (!cmd)
       throw new Error(`Unknown command: ${id}`);
@@ -104,7 +108,7 @@ export async function documentCloseAllNoSave(page: Page): Promise<void> {
   await page.evaluate(() => {
     const r = window.rstudio;
     if (!r)
-      throw new Error(MISSING_BRIDGE);
+      throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
     r.documents.closeAllNoSave();
   });
 }
@@ -118,7 +122,7 @@ export async function getPref(page: Page, name: string): Promise<PrefValue | nul
   return page.evaluate((prefName) => {
     const r = window.rstudio;
     if (!r)
-      throw new Error(MISSING_BRIDGE);
+      throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
     const entry = r.prefs[prefName];
     return entry ? entry.get() : null;
   }, camel);
@@ -136,7 +140,7 @@ export async function setPref(page: Page, name: string, value: PrefValue): Promi
   await page.evaluate(({ prefName, prefValue }) => {
     const r = window.rstudio;
     if (!r)
-      throw new Error(MISSING_BRIDGE);
+      throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
     const entry = r.prefs[prefName];
     if (!entry)
       throw new Error(`Unknown user preference: ${prefName}`);
@@ -153,7 +157,7 @@ export async function clearPref(page: Page, name: string): Promise<void> {
   await page.evaluate((prefName) => {
     const r = window.rstudio;
     if (!r)
-      throw new Error(MISSING_BRIDGE);
+      throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
     const entry = r.prefs[prefName];
     if (!entry)
       throw new Error(`Unknown user preference: ${prefName}`);

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -46,6 +46,14 @@ type RStudioBridge = {
   documents: { closeAllNoSave(): void };
   project: ProjectInfo;
   version: VersionInfo;
+  /**
+   * False during workbench init; flips to true once the
+   * DeferredInitCompletedEvent fires. Wait for this in test fixtures and
+   * project-open helpers before driving any R-to-GWT roundtrip (file.edit,
+   * client-event-driven actions) -- the bridge can be installed and reading
+   * window.rstudio still races with workbench init otherwise.
+   */
+  ready: boolean;
 };
 
 declare global {

--- a/e2e/rstudio/utils/project.ts
+++ b/e2e/rstudio/utils/project.ts
@@ -134,10 +134,30 @@ export async function createAndOpenProject(
   await executeInConsole(page, `writeLines("cat('${marker}')", "${projectDir}/.Rprofile")`);
   await sleep(500);
 
+  // Reset the readiness flag manually before openProject -- the flag was
+  // true from the prior session's initializeAgent, and a fresh openProject
+  // wouldn't flip it back to false until partway through the new session's
+  // GWT bootstrap. Without this, the wait below would see the stale true
+  // and exit before the workbench is actually re-initialized.
+  await page.evaluate(() => {
+    if (window.rstudio) window.rstudio.ready = false;
+  });
+
   await executeInConsole(page, `.rs.api.openProject("${projectDir}/${name}.Rproj")`);
   // The page may navigate on Server mode; let it settle before polling.
   await page.waitForLoadState('load', { timeout: 30000 }).catch(() => {});
   await pollForMarker(page, marker, 60000);
+
+  // The .Rprofile marker proves R is at the prompt, but the GWT workbench
+  // may still be mid-init -- show-file client events from R's hooked
+  // file.edit and other R-to-GWT roundtrips can race with workbench init.
+  // window.rstudio.ready is the canonical "automation can start" flag,
+  // flipped on DeferredInitCompletedEvent (see ApplicationAutomation.java).
+  await page.waitForFunction(
+    () => window.rstudio?.ready === true,
+    null,
+    { timeout: 30000, polling: 50 },
+  );
 
   return projectDir;
 }

--- a/e2e/rstudio/utils/project.ts
+++ b/e2e/rstudio/utils/project.ts
@@ -134,11 +134,13 @@ export async function createAndOpenProject(
   await executeInConsole(page, `writeLines("cat('${marker}')", "${projectDir}/.Rprofile")`);
   await sleep(500);
 
-  // Reset the readiness flag manually before openProject -- the flag was
-  // true from the prior session's initializeAgent, and a fresh openProject
-  // wouldn't flip it back to false until partway through the new session's
-  // GWT bootstrap. Without this, the wait below would see the stale true
-  // and exit before the workbench is actually re-initialized.
+  // Reset the readiness flag synchronously before openProject. GWT-side
+  // QuitEvent / RestartStatusEvent handlers will also reset it when the
+  // server-emitted events arrive, but resetting here is deterministic and
+  // closes any window between "we sent .rs.api.openProject" and "GWT has
+  // received and dispatched kQuit". Without it, the wait below could see
+  // the prior session's stale true and exit before the workbench finishes
+  // re-initializing.
   await page.evaluate(() => {
     if (window.rstudio) window.rstudio.ready = false;
   });

--- a/src/cpp/session/modules/SessionChat.R
+++ b/src/cpp/session/modules/SessionChat.R
@@ -794,6 +794,26 @@
 })
 
 
+# Run an expression with the chat guardrail bindings active, restoring the
+# originals on exit (even if `expr` errors). Errors propagate to the caller;
+# this is the building block for safeEval (which swallows them) and for
+# Playwright tests that want to drive each path deterministically without
+# installing a per-suite test helper that races with R startup.
+.rs.addFunction("chat.withGuardrails", function(expr, envir = parent.frame())
+{
+   on.exit({
+      tryCatch(
+         .rs.chat.restoreBindings(),
+         error = function(e) {
+            warning("failed to restore bindings: ", conditionMessage(e))
+         }
+      )
+   }, add = TRUE)
+   .rs.chat.injectBindings()
+   eval(expr, envir = envir)
+})
+
+
 # Helper function for evaluating code for the 'runCode' tool.
 .rs.addFunction("chat.safeEval", function(expr, envir = globalenv())
 {

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -90,6 +90,7 @@ public class ApplicationAutomation
       registerPrefs();
       registerDocuments();
       registerProject();
+      registerVersion();
    }
 
    private void registerCommands()
@@ -127,6 +128,17 @@ public class ApplicationAutomation
    private void registerProject()
    {
       registerProjectObject();
+   }
+
+   private void registerVersion()
+   {
+      // SessionInfo is set by Application.onResponseReceived before the agent
+      // is initialized (see Application.java); the version strings are stable
+      // for the life of the session.
+      registerVersionObject(
+         session_.getSessionInfo().getRstudioVersion(),
+         session_.getSessionInfo().getRVersionsInfo().getRVersion()
+      );
    }
 
    /** Convert a snake_case identifier to camelCase. */
@@ -302,6 +314,15 @@ public class ApplicationAutomation
       $wnd.rstudio.project.isActive = $entry(function() {
          return self.@org.rstudio.studio.client.application.ApplicationAutomation::isProjectActive()();
       });
+   }-*/;
+
+   // Versions are stable for the life of the session, so install a plain
+   // object rather than getter functions. Read via window.rstudio.version.
+   private native final void registerVersionObject(String rstudio, String r) /*-{
+      $wnd.rstudio.version = {
+         rstudio: rstudio,
+         r: r,
+      };
    }-*/;
 
    private final Commands commands_;

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.studio.client.application.events.DeferredInitCompletedEvent;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.application.events.QuitEvent;
+import org.rstudio.studio.client.application.events.RestartStatusEvent;
 import org.rstudio.studio.client.server.model.DocumentCloseAllNoSaveEvent;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.Session;
@@ -92,15 +94,44 @@ public class ApplicationAutomation
       registerDocuments();
       registerProject();
       registerVersion();
+      registerReadinessHandlers();
+   }
 
-      // window.rstudio.ready is the canonical "automation can start" signal.
-      // initializeAgent runs from a writeUserPrefs callback that fires before
-      // the workbench is fully initialized -- the bridge is installed at this
-      // point, but show-file events from R's hooked file.edit and other R-to-
-      // GWT roundtrips can still race with workbench init. Wait for the
-      // DeferredInitCompletedEvent (fired after R's deferred init runs) to
-      // flip the flag.
-      eventBus_.addHandler(DeferredInitCompletedEvent.TYPE, event -> setReady());
+   // window.rstudio.ready is the canonical "automation can start" signal,
+   // flipped to true once R's deferred init has run for the current session.
+   // We also reset it back to false synchronously when any session-ending
+   // transition starts -- otherwise the prior session's "true" persists across
+   // a Restart-R or project open/close, and an automation client polling for
+   // the new session's readiness would see the stale value and exit early.
+   //
+   // Coverage by event:
+   //   - QuitEvent: kQuit emitted by SessionMain when R is quitting, including
+   //     project open/close/switch (switch_projects flag) and full quit.
+   //   - RestartStatusEvent.RESTART_INITIATED: fired by ApplicationQuit before
+   //     the actual suspend-for-restart, covering .rs.restartR / restartR
+   //     command (kSuspendAndRestart on the server side).
+   //   - DeferredInitCompletedEvent: fires once R's deferred init has run for
+   //     each session, signalling that R-to-GWT roundtrips are safe.
+   //
+   // doRestart-style flows (Electron relaunch on PAI uninstall etc.) reload
+   // the GWT page entirely, so initializeRoot() handles their reset.
+   //
+   // Handlers are registered once per GWT page lifetime: initializeAgent runs
+   // again on every session restart (via the writeUserPrefs callback that hosts
+   // it), so the registered-flag guards against handler leaks across sessions.
+   private void registerReadinessHandlers()
+   {
+      if (readinessHandlersRegistered_)
+         return;
+
+      eventBus_.addHandler(DeferredInitCompletedEvent.TYPE, event -> setReadyFlag(true));
+      eventBus_.addHandler(QuitEvent.TYPE, event -> setReadyFlag(false));
+      eventBus_.addHandler(RestartStatusEvent.TYPE, event -> {
+         if (event.getStatus() == RestartStatusEvent.RESTART_INITIATED)
+            setReadyFlag(false);
+      });
+
+      readinessHandlersRegistered_ = true;
    }
 
    private void registerCommands()
@@ -266,12 +297,18 @@ public class ApplicationAutomation
       $wnd.rstudio.commands = $wnd.rstudio.commands || {};
       $wnd.rstudio.prefs = $wnd.rstudio.prefs || {};
       $wnd.rstudio.documents = $wnd.rstudio.documents || {};
-      // Flipped to true by setReady() once DeferredInitCompletedEvent fires.
+      // Set false on initial bootstrap; flipped by setReadyFlag() in response
+      // to lifecycle events (see registerReadinessHandlers).
       $wnd.rstudio.ready = false;
    }-*/;
 
-   private native final void setReady() /*-{
-      $wnd.rstudio.ready = true;
+   // Guarded against the case where the agent was never initialized (an
+   // automation session that ends before initializeRoot runs would still get
+   // handler-fire attempts on full quit).
+   private native final void setReadyFlag(boolean ready) /*-{
+      if ($wnd.rstudio) {
+         $wnd.rstudio.ready = ready;
+      }
    }-*/;
 
    private native final void registerCommand(String id, AppCommand command) /*-{
@@ -346,4 +383,5 @@ public class ApplicationAutomation
    private final Session session_;
    private final UserPrefs userPrefs_;
    private boolean isAutomationAgent_ = false;
+   private boolean readinessHandlersRegistered_ = false;
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.application;
 import java.util.Map;
 
 import org.rstudio.core.client.command.AppCommand;
+import org.rstudio.studio.client.application.events.DeferredInitCompletedEvent;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.server.model.DocumentCloseAllNoSaveEvent;
 import org.rstudio.studio.client.workbench.commands.Commands;
@@ -91,6 +92,15 @@ public class ApplicationAutomation
       registerDocuments();
       registerProject();
       registerVersion();
+
+      // window.rstudio.ready is the canonical "automation can start" signal.
+      // initializeAgent runs from a writeUserPrefs callback that fires before
+      // the workbench is fully initialized -- the bridge is installed at this
+      // point, but show-file events from R's hooked file.edit and other R-to-
+      // GWT roundtrips can still race with workbench init. Wait for the
+      // DeferredInitCompletedEvent (fired after R's deferred init runs) to
+      // flip the flag.
+      eventBus_.addHandler(DeferredInitCompletedEvent.TYPE, event -> setReady());
    }
 
    private void registerCommands()
@@ -256,6 +266,12 @@ public class ApplicationAutomation
       $wnd.rstudio.commands = $wnd.rstudio.commands || {};
       $wnd.rstudio.prefs = $wnd.rstudio.prefs || {};
       $wnd.rstudio.documents = $wnd.rstudio.documents || {};
+      // Flipped to true by setReady() once DeferredInitCompletedEvent fires.
+      $wnd.rstudio.ready = false;
+   }-*/;
+
+   private native final void setReady() /*-{
+      $wnd.rstudio.ready = true;
    }-*/;
 
    private native final void registerCommand(String id, AppCommand command) /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -720,10 +720,23 @@ public class RCompletionManager implements CompletionManager
    public boolean previewKeyPress(char c)
    {
       suggestTimer_.cancel();
-      
+
       if (isDisabled())
          return false;
-      
+
+      // '(' is a function-call boundary, not a continuation of any in-progress
+      // identifier completion. If the popup is open from a prior context
+      // (typically namespace-mode completion opened by '::'), dismiss it so
+      // the no-popup branch below handles '(' fresh -- showing the signature
+      // tooltip and, for library/require/data, an argument-name popup. This
+      // also matters for Tab-triggered argument completion afterward: with a
+      // stale namespace-mode popup hanging around, Tab applies the popup's
+      // selected entry instead of re-classifying the context.
+      if (c == '(' && popup_.isShowing())
+      {
+         popup_.hide();
+      }
+
       if (popup_.isShowing())
       {
          // If insertion of this character completes an available suggestion,


### PR DESCRIPTION
## Summary

Triages the 15 test failures from a full `npm run test:desktop-dev -- --grep-invert @ai` sweep on `main`. After this PR all 15 pass (zero failures across the originally-failing files; 6 intentionally `.skip()`'d tests remain skipped).

The work splits into three flavours: real RStudio bug fixes that the tests surfaced, new bits of the automation surface, and test-infra/test-logic cleanup.

## Real product fixes

### `RCompletionManager: dismiss popup when '(' is typed` ([6b4c0711f2](../commit/6b4c0711f2))

When the completion popup is showing in namespace-completion mode (opened by `::`), typing the following `(` did not flush the cached query, so the popup stayed in namespace mode and the existing `(` handling in `previewKeyPress` (signature tooltip + library/require/data auto-popup) never ran. Subsequent Tab then applied the popup's selected entry instead of re-classifying the context as a function-call boundary. Dismiss the popup explicitly when `(` arrives so the no-popup branch takes over.

By-hand typing rarely hits this -- human cadence usually outruns the deferred popup-open scheduler -- but `pressSequentially` from Playwright reliably surfaces it.

### `chat: add .rs.chat.withGuardrails` ([cd565f0907](../commit/cd565f0907))

The chat-guardrails-paths Playwright suite was installing a per-suite test helper (`.rs.test.guardrails`) in `beforeAll` via `executeInConsole`, which doesn't wait for R to process the input. After a project-open restart, R was still busy and the install never landed before the first test ran. Move the inject-eval-restore wrapper into the product as `.rs.chat.withGuardrails` (sibling to `.rs.chat.safeEval`); tests build the guarded call inline. No install step, no race, and the wrapper is a generally-useful building block.

## New automation surface

### `window.rstudio.ready` ([70fb82eda1](../commit/70fb82eda1))

`initializeAgent` runs inside a `writeUserPrefs` callback before the workbench finishes initializing. The bridge is installed at that point, but R-to-GWT roundtrips (file.edit's show-file event, cat()-then-poll capture, etc.) can still race with workbench init. `window.rstudio.ready` is initialized to false in `initializeRoot()` and flipped to true by an EventBus handler for `DeferredInitCompletedEvent`. Tests/helpers wait for this as the canonical "automation can start" signal. Fixes the two cluster-6 stragglers (project_id and reformat).

### `window.rstudio.version` ([7b88c7b3b3](../commit/7b88c7b3b3))

The fixture used to log R and RStudio versions by running `cat("R:", R.version.string, ...)` through the console and regex-parsing the output. The roundtrip is slow, races with whatever else is in the buffer, and is brittle. Replace with `window.rstudio.version = { rstudio, r }` populated at agent init from `session_.getSessionInfo()`. Tests read versions via `getVersion(page)` in `utils/commands.ts`.

## Test infrastructure

### `route console focus through activateConsole; harden executeCommand` ([a9659e5776](../commit/a9659e5776))

`executeInConsole` / `clearConsole` / `typeInConsole` were focusing the console by clicking the console tab. Switched to dispatching the `activateConsole` AppCommand via the bridge so focus changes don't depend on tab-level click side effects, and replaced post-focus blind sleeps with a `waitForConsoleFocus` poll. `executeCommand` now waits for the named command to exist on the bridge before dispatching, so it survives transient bridge-absent states. Also inlined `MISSING_BRIDGE` at each throw site -- it was a module-level constant invisible inside `page.evaluate`, so any path that actually hit the missing-bridge case threw `ReferenceError` instead of the intended `Error`.

### `Ace type bindings` ([e035350277](../commit/e035350277))

Added `utils/ace.ts` with an `Ace` namespace covering `Position`, `Range`, `Selection`, `Session`, `Editor` plus an `AceEditorElement` for the DOM lookup pattern. Replaced the inline `(editor as { getValue(): string }).getValue()` cast-and-assert at every call site across `ace_editor.page.ts`, `console_pane.page.ts`, `console_pane.actions.ts`, `source_pane.actions.ts`, and `console_output.test.ts`. New methods get added to `utils/ace.ts` when needed instead of being re-cast inline.

## Test logic fixes

### `e2e: fix three flaky test logic bugs` ([598d42338e](../commit/598d42338e))

- **Chunk warning tests (rmarkdown, quarto):** the `WARN_AFTER` cat was racing the chunk body. `executeCurrentChunk` dispatches via a separate channel from `executeInConsole`, so a follow-up console command could land before the chunk completed. Add a sentinel `cat()` as the last chunk line, `consoleClear` between createAndOpenFile and chunk run, then wait for the sentinel before issuing WARN_AFTER.
- **autocomplete_extras column-name quoting:** typing `$` auto-opens the popup, so the explicit `Tab` press was accepting the highlighted (`apple`) entry before `ArrowDown` could move to `2024`. Drop the Tab; wait for popup visibility before navigating.

### `scope shinytest2 button locator to visible elements` ([ed38826c0a](../commit/ed38826c0a))

The Shiny-test toolbar button is rendered in every editor's toolbar and hidden via `aria-hidden` when the file isn't a shinytest2 file. The test locator `button[title='...']` matched the hidden instance in any leftover editor (e.g. `Untitled1`) as well as the visible one. Add `:visible` so only the visible button is matched.

### `open a project for the Air-formatting suite` ([61719b410f](../commit/61719b410f))

`TextEditingTarget.maybeFormatOnUserInitiatedSave` gates the on-save reformat path on "file is inside the active project" -- without one, save-triggered formatting is skipped entirely, so cases 5 and 10 (save uses Air) could never pass. Add a project open in `beforeAll` inside the suite sandbox. The other cases are unaffected -- they use code paths that don't have the project gate.

## Test plan

- [ ] Full sweep: `npm run test:desktop-dev -- --grep-invert @ai` -- expect the 15 originally-failing tests to pass.
- [ ] Spot-check the new product behavior: trigger the rstudioapi dialog newline rendering by hand to make sure the popup-on-`(` fix doesn't break interactive use.
- [ ] Confirm `window.rstudio.ready` is `false` immediately after a manual project open and flips to `true` shortly after.
- [ ] `(cd e2e/rstudio && npm run typecheck)` clean.