### PR TITLE
playwright: replace blind sleeps with polled waits

### DIFF
--- a/e2e/rstudio/actions/chat_pane.actions.ts
+++ b/e2e/rstudio/actions/chat_pane.actions.ts
@@ -89,7 +89,13 @@ export class ChatPaneActions {
 
   async openChatPane(): Promise<void> {
     await executeCommand(this.page, 'activateChat');
-    await sleep(2000);
+    // Wait for the chat iframe to be present rather than blind-sleeping.
+    // The iframe element appears as soon as the pane is activated, even
+    // before its contents have loaded -- which is what dismissSetupPrompts
+    // and other callers actually need to begin polling for their own
+    // signals (install button, chatRoot, etc.).
+    await expect(this.page.locator("iframe[title='Posit Assistant']"))
+      .toBeVisible({ timeout: 15000 });
   }
 
   async dismissSetupPrompts(): Promise<void> {
@@ -119,7 +125,6 @@ export class ChatPaneActions {
       const trustBtn = this.chatPane.frame.locator("button:has-text('Trust'), button:has-text('trust')");
       await trustBtn.first().click({ timeout: 1500 });
       console.log('Dismissed directory trust prompt');
-      await sleep(1000);
     } catch {
       // No trust prompt
     }
@@ -128,10 +133,10 @@ export class ChatPaneActions {
 
   async clickAllowOnceIfPresent(): Promise<void> {
     try {
-      await sleep(1000);
+      // click() already polls for actionability within its own timeout, so
+      // there's no need to pre-sleep waiting for the dialog to appear.
       await this.chatPane.allowBtn.click({ timeout: 3000 });
       console.log('Clicked "Allow" permission button');
-      await sleep(1000);
     } catch {
       // No permission dialog
     }
@@ -140,17 +145,15 @@ export class ChatPaneActions {
   async allowExecuteCodeForSession(): Promise<void> {
     // Wait for the Allow dialog to appear (dropdown trigger next to Allow button)
     await expect(this.chatPane.allowDropdownTrigger).toBeVisible({ timeout: 60000 });
-    await sleep(500);
 
-    // Click the chevron to open the dropdown menu
+    // Click the chevron to open the dropdown menu; the toBeVisible below
+    // polls for the menu item, replacing a blind post-click sleep.
     await this.chatPane.allowDropdownTrigger.click();
-    await sleep(500);
 
     // Click "Allow for this session"
     await expect(this.chatPane.allowForSessionItem).toBeVisible({ timeout: 5000 });
     await this.chatPane.allowForSessionItem.click();
     console.log('Granted "Allow for this session" permission');
-    await sleep(1000);
   }
 
   /**
@@ -203,11 +206,9 @@ export class ChatPaneActions {
     await expect(this.chatPane.chatTextarea).toBeVisible({ timeout: 15000 });
     await expect(this.chatPane.chatTextarea).toBeEnabled({ timeout: 15000 });
     await this.chatPane.chatTextarea.fill(text);
-    await sleep(200);
 
     await expect(this.chatPane.sendBtn).toBeVisible({ timeout: 15000 });
     await this.chatPane.sendBtn.click();
-    await sleep(1000);
   }
 
   async waitForResponse(initialCount: number, timeout: number = 60000): Promise<number> {
@@ -260,16 +261,14 @@ export class ChatPaneActions {
   async getPositAssistantVersion(): Promise<string> {
     try {
       await this.chatPane.moreBtn.click({ timeout: 5000 });
-      await sleep(500);
-
+      // .first().click() polls for the menu item, replacing the
+      // previous post-click sleep.
       await this.chatPane.aboutItem.first().click();
-      await sleep(1000);
 
       await this.chatPane.dialogOverlay.waitFor({ state: 'visible', timeout: 5000 });
       const dialogText = await this.chatPane.dialogOverlay.innerText();
 
       await this.page.keyboard.press('Escape');
-      await sleep(500);
 
       const versionMatch = dialogText.match(/(\d+\.\d+\.\d+)/);
       return versionMatch?.[1] ?? 'unknown';
@@ -284,7 +283,9 @@ export class ChatPaneActions {
       return; // Already in a fresh conversation
     }
     await this.chatPane.newConversationBtn.click({ timeout: 10000 });
-    await sleep(2000);
+    // Poll for the conversation to reset (message list emptied) instead
+    // of blind-sleeping after the click.
+    await expect.poll(() => this.chatPane.getMessageCount(), { timeout: 10000 }).toBe(0);
   }
 
   /**
@@ -292,17 +293,18 @@ export class ChatPaneActions {
    * @param name The new name for the conversation
    */
   async renameConversation(name: string): Promise<void> {
-    // Open history panel to access conversation list
+    // Open history panel to access conversation list. toggleConversationHistory
+    // polls for the list to appear, so no post-call sleep is needed here.
     await this.toggleConversationHistory();
-    await sleep(1000);
 
-    // Get the first (current/active) conversation item
+    // Get the first (current/active) conversation item. Each toBeVisible
+    // below polls, replacing what used to be a chain of blind sleeps
+    // between hover, click, menu-item click, and input fill.
     const activeConvItem = this.chatPane.conversationList.first();
     await expect(activeConvItem).toBeVisible({ timeout: 5000 });
 
     // Hover over the conversation item to reveal the menu button
     await activeConvItem.hover();
-    await sleep(500);
 
     // Look for the menu button (three dots) within the conversation item
     const menuBtn = activeConvItem.locator('button, [role="button"]').first();
@@ -310,13 +312,11 @@ export class ChatPaneActions {
     // force: true because GWT console DOM elements report overlapping coordinates
     // even though the panes are visually separate
     await menuBtn.click({ force: true });
-    await sleep(300);
 
     // Click the Rename option from the context menu
     const renameItem = this.chatPane.getRenameMenuItem();
     await expect(renameItem).toBeVisible({ timeout: 5000 });
     await renameItem.click();
-    await sleep(300);
 
     // The input field should now be visible and editable
     const nameInput = this.chatPane.getConversationNameInput();
@@ -326,17 +326,16 @@ export class ChatPaneActions {
     // Clear the current name and type the new name
     await nameInput.clear();
     await nameInput.fill(name);
-    await sleep(200);
 
     // Press Enter to confirm the rename
     await nameInput.press('Enter');
-    await sleep(500);
 
     console.log(`Renamed conversation to "${name}"`);
   }
 
   async toggleConversationHistory(): Promise<void> {
     await this.chatPane.historyBtn.click({ timeout: 10000 });
-    await sleep(1000);
+    // Poll for the conversation list panel to appear (replaces post-click sleep).
+    await expect(this.chatPane.conversationList.first()).toBeVisible({ timeout: 10000 });
   }
 }

--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -1,6 +1,11 @@
 import type { Page } from 'playwright';
 import * as fs from 'fs';
-import { ConsolePane, type EnvironmentVersions } from '../pages/console_pane.page';
+import {
+  ConsolePane,
+  waitForConsoleIdle,
+  type EnvironmentVersions,
+  type ExecuteInConsoleOptions,
+} from '../pages/console_pane.page';
 import { sleep } from '../utils/constants';
 import { documentCloseAllNoSave, executeCommand, getVersion } from '../utils/commands';
 import { AceEditorElement } from '../utils/ace';
@@ -94,7 +99,7 @@ export class ConsolePaneActions {
     );
   }
 
-  async executeInConsole(command: string): Promise<void> {
+  async executeInConsole(command: string, opts: ExecuteInConsoleOptions = {}): Promise<void> {
     // Focus the console via the activateConsole command rather than
     // clicking the console tab. The tab-click path was clicking the
     // same element repeatedly across executeInConsole + clearConsole
@@ -117,6 +122,9 @@ export class ConsolePaneActions {
     // focus can shift between the evaluate() returning and the key press,
     // leaving the text in the buffer but never submitted.
     await this.consolePane.consoleInput.press('Enter');
+    if (opts.wait) {
+      await waitForConsoleIdle(this.page, opts.timeout);
+    }
   }
 
   /**

--- a/e2e/rstudio/actions/source_pane.actions.ts
+++ b/e2e/rstudio/actions/source_pane.actions.ts
@@ -28,10 +28,12 @@ export class SourcePaneActions {
    * plain `writeLines("...", ...)` template; that gotcha is gone.
    */
   async createAndOpenFile(fileName: string, fileContent: string): Promise<void> {
+    // wait: true ensures the writeLines completes before file.edit() reads
+    // the file we just wrote (polls the busy class, no blind sleep).
     await this.consolePaneActions.executeInConsole(
       `writeLines(${rStringLiteral(fileContent)}, ${rStringLiteral(fileName)})`,
+      { wait: true },
     );
-    await sleep(1000);
 
     await this.consolePaneActions.executeInConsole(`file.edit(${rStringLiteral(fileName)})`);
 
@@ -42,27 +44,27 @@ export class SourcePaneActions {
     await executeCommand(this.page, 'saveAllSourceDocs');
     await sleep(1000);
     await executeCommand(this.page, 'closeAllSourceDocs');
-    await sleep(1000);
 
+    // Wait for the source pane to be fully empty -- both no editor mounted
+    // and no tab strip entry. The tab-strip check (selectedTab.count == 0)
+    // is the stronger signal: an immediately-following file.edit can race
+    // GWT's close cleanup and end up not opening the new tab if we only
+    // wait on aceTextInput.
     await expect(this.sourcePane.aceTextInput).toHaveCount(0, { timeout: 5000 }).catch(() => {});
-    await sleep(500);
+    await expect(this.sourcePane.selectedTab).toHaveCount(0, { timeout: 5000 }).catch(() => {});
 
-    await this.consolePaneActions.executeInConsole(`unlink("${fileName}")`);
-    await sleep(500);
+    await this.consolePaneActions.executeInConsole(`unlink("${fileName}")`, { wait: true });
   }
 
   async sendText(text: string): Promise<void> {
     await this.sourcePane.contentPane.click();
-    await sleep(300);
     await this.page.keyboard.type(text);
-    await sleep(300);
   }
 
   async acceptNesRename(): Promise<string> {
     const { nesApply, ghostText, nesInsertionPreview, nesGutter, nesSuggestionContent } = this.sourcePane;
 
     await expect(nesApply.or(ghostText).or(nesInsertionPreview).or(nesGutter).first()).toBeVisible({ timeout: TIMEOUTS.nesApply });
-    await sleep(2000);
 
     if (await nesApply.first().isVisible()) {
       const nesSuggestion = nesSuggestionContent.first();
@@ -72,45 +74,37 @@ export class SourcePaneActions {
       console.log('  NES Apply suggestion (text): ' + nesSuggestionText);
       console.log('  NES Apply suggestion (html): ' + nesSuggestionHtml);
       await nesApply.first().click();
-      await sleep(2000);
       return 'apply';
     } else if (await nesInsertionPreview.first().isVisible()) {
       const insertionText = await nesInsertionPreview.first().textContent();
       const count = await nesInsertionPreview.count();
       console.log(`  NES inline diff: "${insertionText}" (${count} suggestion(s) visible)`);
       await this.page.keyboard.press('ControlOrMeta+;');
-      await sleep(2000);
       return 'inline-diff';
     } else if (await ghostText.first().isVisible()) {
       const ghostTextParts = await ghostText.allTextContents();
       console.log('  NES ghost text: "' + ghostTextParts.join('') + '"');
       await this.page.keyboard.press('ControlOrMeta+;');
-      await sleep(2000);
       return 'ghost-text';
     } else {
       console.log('  NES gutter icon detected — clicking to reveal suggestion...');
       await nesGutter.first().click();
-      await sleep(2000);
 
       try {
         await expect(nesApply.or(ghostText).or(nesInsertionPreview).first()).toBeVisible({ timeout: 15000 });
-        await sleep(2000);
 
         if (await nesApply.first().isVisible()) {
           const nesSuggestionText = await nesSuggestionContent.first().textContent();
           console.log('  NES Apply suggestion (after gutter click): ' + nesSuggestionText);
           await nesApply.first().click();
-          await sleep(2000);
         } else if (await nesInsertionPreview.first().isVisible()) {
           const insertionText = await nesInsertionPreview.first().textContent();
           console.log('  NES inline diff (after gutter click): "' + insertionText + '"');
           await this.page.keyboard.press('ControlOrMeta+;');
-          await sleep(2000);
         } else {
           const ghostParts = await ghostText.allTextContents();
           console.log('  NES ghost text (after gutter click): "' + ghostParts.join('') + '"');
           await this.page.keyboard.press('ControlOrMeta+;');
-          await sleep(2000);
         }
         return 'gutter-clicked';
       } catch {
@@ -123,19 +117,15 @@ export class SourcePaneActions {
   /** Move cursor to end of document (cross-platform). */
   async goToEnd(): Promise<void> {
     await this.sourcePane.aceTextInput.click({ force: true });
-    await sleep(300);
     const goToEnd = process.platform === 'darwin' ? 'Meta+ArrowDown' : 'Control+End';
     await this.page.keyboard.press(goToEnd);
-    await sleep(300);
   }
 
   /** Move cursor to top of document (cross-platform). */
   async goToTop(): Promise<void> {
     await this.sourcePane.aceTextInput.click({ force: true });
-    await sleep(300);
     const goToTop = process.platform === 'darwin' ? 'Meta+ArrowUp' : 'Control+Home';
     await this.page.keyboard.press(goToTop);
-    await sleep(300);
   }
 
   /**
@@ -157,7 +147,6 @@ export class SourcePaneActions {
    */
   async navigateToChunkByLabel(label: string): Promise<void> {
     await this.sourcePane.aceTextInput.click({ force: true });
-    await sleep(300);
     await this.page.evaluate((lbl) => {
       const editors = document.querySelectorAll('.ace_editor');
       for (let i = 0; i < editors.length; i++) {
@@ -174,7 +163,6 @@ export class SourcePaneActions {
         }
       }
     }, label);
-    await sleep(300);
   }
 
   /**

--- a/e2e/rstudio/pages/console_pane.page.ts
+++ b/e2e/rstudio/pages/console_pane.page.ts
@@ -1,6 +1,7 @@
-import type { Page, Locator } from 'playwright';
+import type { Page } from 'playwright';
+import type { Locator } from 'playwright';
 import { PageObject } from './page_object_base_classes';
-import { sleep } from '../utils/constants';
+import { sleep, TIMEOUTS } from '../utils/constants';
 import { documentCloseAllNoSave, executeCommand, getVersion } from '../utils/commands';
 import { AceEditorElement } from '../utils/ace';
 
@@ -69,14 +70,60 @@ export const CONSOLE_OUTPUT = '#rstudio_workbench_panel_console';
 export const INTERRUPT_R_BTN = "[id^='rstudio_tb_interruptr']";
 
 /**
+ * Wait for the console input to clear its "busy" class -- i.e. for R to
+ * finish processing whatever it's running. Polls the DOM at 100ms intervals.
+ * Default timeout is generous (TIMEOUTS.sessionRestart) so it covers project
+ * opens and session restarts; pass a smaller value for snappier per-command
+ * waits, or a larger one for long-running calls like `install.packages`.
+ */
+export async function waitForConsoleIdle(
+  page: Page,
+  timeout: number = TIMEOUTS.sessionRestart,
+): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const el = document.getElementById('rstudio_console_input');
+      return !!el && !el.classList.contains('rstudio-console-busy');
+    },
+    null,
+    { timeout, polling: 100 },
+  );
+}
+
+/** Options accepted by `executeInConsole`. */
+export interface ExecuteInConsoleOptions {
+  /**
+   * If true, wait for R to finish processing the command before returning
+   * (via `waitForConsoleIdle`). Defaults to false to preserve the
+   * fire-and-forget semantics callers may rely on (e.g. queuing an install
+   * then a marker command). Use `wait: true` when the next step depends on
+   * R having completed -- it's faster and more reliable than a blind sleep.
+   */
+  wait?: boolean;
+  /**
+   * Timeout for the `wait: true` poll, in ms. Defaults to
+   * `TIMEOUTS.sessionRestart`. Raise this for slow commands like
+   * `install.packages`.
+   */
+  timeout?: number;
+}
+
+/**
  * Submit an R expression to the console. Writes the text directly into the
  * console's Ace editor and presses Enter -- no per-key typing -- so it doesn't
  * race with autocomplete popups, tooltip handlers, or other live-edit UI that
  * can swallow characters or steal focus. Prefer this when you just need code
  * to run; use `typeInConsole` only when a test is exercising actual typing
  * behavior (e.g. autocomplete triggering).
+ *
+ * Pass `{ wait: true }` when the next step depends on R having finished the
+ * command -- it polls the console-busy class instead of sleeping.
  */
-export async function executeInConsole(page: Page, command: string): Promise<void> {
+export async function executeInConsole(
+  page: Page,
+  command: string,
+  opts: ExecuteInConsoleOptions = {},
+): Promise<void> {
   await page.locator(CONSOLE_TAB).click();
   await page.evaluate((text) => {
     const el = document.getElementById('rstudio_console_input') as AceEditorElement | null;
@@ -94,6 +141,9 @@ export async function executeInConsole(page: Page, command: string): Promise<voi
   // focus can shift between the evaluate() returning and the key press, leaving
   // the text in the buffer but never submitted.
   await page.locator(CONSOLE_INPUT).press('Enter');
+  if (opts.wait) {
+    await waitForConsoleIdle(page, opts.timeout);
+  }
 }
 
 /**
@@ -107,6 +157,50 @@ export async function executeInConsole(page: Page, command: string): Promise<voi
  * human typing speed and gives the editor time to dispatch input events and
  * fire completers between chars.
  */
+/** Default CRAN mirror for `ensurePackageInstalled`. */
+export const DEFAULT_CRAN_REPOS = 'https://cran.r-project.org';
+
+/** Options accepted by `ensurePackageInstalled`. */
+export interface EnsurePackageInstalledOptions {
+  /** Repos URL; defaults to `DEFAULT_CRAN_REPOS`. */
+  repos?: string;
+  /** Install type ("binary" / "source"); defaults to `getOption("pkgType")`. */
+  type?: string;
+  /** Total timeout for the install, ms. Defaults to 120000 (2 min). */
+  timeout?: number;
+}
+
+/**
+ * Install an R package only if it isn't already on disk. Wraps the R-side
+ * `.rs.ensurePackageInstalled` helper, which checks the library before
+ * downloading -- much faster than a blind `install.packages` when the package
+ * is already present, which is the common case on repeated test runs.
+ *
+ * `repos` defaults to CRAN. Override it (e.g. with Posit Public Package
+ * Manager's per-distro endpoint) for faster Linux installs.
+ *
+ * Don't use this in tests that are exercising `install.packages` behavior
+ * itself -- call `executeInConsole(page, 'install.packages(...)', { wait: true })`
+ * directly there.
+ */
+export async function ensurePackageInstalled(
+  page: Page,
+  packageName: string,
+  opts: EnsurePackageInstalledOptions = {},
+): Promise<void> {
+  const repos = opts.repos ?? DEFAULT_CRAN_REPOS;
+  const args: string[] = [
+    JSON.stringify(packageName),
+    `repos = ${JSON.stringify(repos)}`,
+  ];
+  if (opts.type !== undefined) args.push(`type = ${JSON.stringify(opts.type)}`);
+  await executeInConsole(
+    page,
+    `.rs.ensurePackageInstalled(${args.join(', ')})`,
+    { wait: true, timeout: opts.timeout ?? 120000 },
+  );
+}
+
 export async function typeInConsole(page: Page, text: string, delayMs: number = 50): Promise<void> {
   await page.locator(CONSOLE_TAB).click();
   await page.locator(CONSOLE_INPUT).click({ force: true });

--- a/e2e/rstudio/tests/panes/editor/rmarkdown.test.ts
+++ b/e2e/rstudio/tests/panes/editor/rmarkdown.test.ts
@@ -40,13 +40,10 @@ test.describe('RMarkdown', () => {
 
     // Set preview to Viewer pane
     await sourceActions.sourcePane.formatOptions.click();
-    await sleep(500);
     await sourceActions.sourcePane.viewerPaneOption.click();
-    await sleep(500);
 
     // Knit to HTML
     await sourceActions.sourcePane.knitOptions.click();
-    await sleep(500);
     await sourceActions.sourcePane.knitHtml.click();
     await installDepIfPrompted(page);
 
@@ -63,7 +60,6 @@ test.describe('RMarkdown', () => {
     // Cleanup
     await sourceActions.closeSourceAndDeleteFile(fileName);
     await consoleActions.executeInConsole(`unlink("${fileName.replace('.rmd', '.html')}")`);
-    await sleep(500);
   });
 
   test('empty chunk does not define variables', async ({ rstudioPage: page }) => {
@@ -71,7 +67,6 @@ test.describe('RMarkdown', () => {
 
     // Clear workspace
     await executeCommand(page, 'activateEnvironment');
-    await sleep(2000);
     await clearWorkspace(page);
 
     // Create an rmd file with a chunk
@@ -81,9 +76,10 @@ test.describe('RMarkdown', () => {
 
     // Save the file
     await executeCommand(page, 'saveSourceDoc');
-    await sleep(1000);
 
-    // Run all chunks via restart R
+    // Run all chunks via restart R. The 5s lead-in guards against the
+    // not.toBeVisible check below succeeding before the interrupt button has
+    // had a chance to appear (i.e. before the restart actually fires).
     await executeCommand(page, 'restartRRunAllChunks');
     await sleep(5000);
     await expect(page.locator("[id^='rstudio_tb_interruptr']")).not.toBeVisible({ timeout: 30000 });
@@ -97,8 +93,7 @@ test.describe('RMarkdown', () => {
 
     // Verify no variables in global env
     await consoleActions.clearConsole();
-    await consoleActions.executeInConsole('ls(envir = globalenv())');
-    await sleep(2000);
+    await consoleActions.executeInConsole('ls(envir = globalenv())', { wait: true });
     await expect(consoleOutput).toContainText('character(0)', { timeout: 10000 });
 
     // Cleanup
@@ -108,41 +103,34 @@ test.describe('RMarkdown', () => {
   test('continue comment newline preference', async ({ rstudioPage: page }) => {
     // Original: test_desktop_RMarkdown.py::test_continue_comment_newline_preference
 
-    // Enable the preference
+    // Enable the preference (setPref is a JS-side bridge call, no R round-trip)
     await setPref(page, 'continue_comments_on_newline', true);
-    await sleep(1000);
 
     // Create an RMarkdown file, verify no comment is inserted on newline
     const rmdFileName = `rmarkdown_commentnewline_${Date.now()}.rmd`;
-    await consoleActions.executeInConsole(`file.create("${rmdFileName}")`);
-    await sleep(1000);
+    await consoleActions.executeInConsole(`file.create("${rmdFileName}")`, { wait: true });
     await consoleActions.executeInConsole(`file.edit("${rmdFileName}")`);
     await expect(sourceActions.sourcePane.selectedTab).toContainText(rmdFileName, { timeout: 20000 });
 
     await sourceActions.sendText('# Section');
-    await sleep(1000);
     await page.keyboard.press('Enter');
-    await sleep(1000);
     await expect(sourceActions.sourcePane.contentPane).toHaveText('# Section');
 
     await consoleActions.closeAllBuffersWithoutSaving();
-    await consoleActions.executeInConsole(`unlink("${rmdFileName}")`);
-    await sleep(500);
+    await consoleActions.executeInConsole(`unlink("${rmdFileName}")`, { wait: true });
 
     // Check that an R file DOES insert a comment on newline
     const rFileName = `rmarkdown_commentnewline_${Date.now()}.r`;
-    await consoleActions.executeInConsole(`file.create("${rFileName}")`);
-    await sleep(1000);
+    await consoleActions.executeInConsole(`file.create("${rFileName}")`, { wait: true });
     await consoleActions.executeInConsole(`file.edit("${rFileName}")`);
     await expect(sourceActions.sourcePane.selectedTab).toContainText(rFileName, { timeout: 20000 });
 
     await sourceActions.sendText('# This is a Comment');
-    await sleep(1000);
     await page.keyboard.press('Enter');
-    await sleep(1000);
-    const editorText = await sourceActions.sourcePane.contentPane.innerText();
-    expect(editorText).toContain('# This is a Comment');
-    expect(editorText).toMatch(/# This is a Comment[\s\S]*# /);
+    // Ace inserts a "# " continuation after the newline when the
+    // continue_comments_on_newline pref is set. innerText collapses the
+    // newline, so the polled text reads as "# This is a Comment# ".
+    await expect(sourceActions.sourcePane.contentPane).toContainText(/# This is a Comment.*# /);
 
     // Cleanup
     await sourceActions.closeSourceAndDeleteFile(rFileName);
@@ -156,17 +144,16 @@ test.describe('RMarkdown', () => {
     await sourceActions.createAndOpenFile(fileName, rmarkdownSource);
     await expect(sourceActions.sourcePane.publishBtn).toBeVisible({ timeout: 10000 });
 
-    // Navigate to file and run spellcheck
-    await consoleActions.executeInConsole(`rstudioapi::navigateToFile("${fileName}", line=1L)`);
-    await sleep(2000);
+    // Navigate to file and run spellcheck. The toBeVisible/toHaveValue below
+    // already poll, so the prior sleeps after navigate/checkSpelling were
+    // redundant slack.
+    await consoleActions.executeInConsole(`rstudioapi::navigateToFile("${fileName}", line=1L)`, { wait: true });
     await executeCommand(page, 'checkSpelling');
-    await sleep(5000);
 
     await expect(page.locator('#rstudio_spelling_not_in_dict')).toBeVisible({ timeout: 30000 });
     await expect(page.locator('#rstudio_spelling_not_in_dict')).toHaveValue('missssssspelled');
     await expect(page.locator('select[aria-label="Suggestions"] option[value="misspelling"]')).toBeVisible({ timeout: 30000 });
     await page.locator(CANCEL_BTN).click();
-    await sleep(1000);
 
     // Cleanup
     await sourceActions.closeSourceAndDeleteFile(fileName);
@@ -181,19 +168,16 @@ test.describe('RMarkdown', () => {
     await expect(sourceActions.sourcePane.publishBtn).toBeVisible({ timeout: 10000 });
 
     // Switch to visual mode
-    await consoleActions.executeInConsole(`rstudioapi::navigateToFile("${fileName}", line=1L)`);
-    await sleep(1000);
+    await consoleActions.executeInConsole(`rstudioapi::navigateToFile("${fileName}", line=1L)`, { wait: true });
     await sourceActions.ensureVisualMode();
 
     // Run spellcheck in visual mode
     await executeCommand(page, 'checkSpelling');
-    await sleep(5000);
 
     await expect(page.locator('#rstudio_spelling_not_in_dict')).toBeVisible({ timeout: 30000 });
     await expect(page.locator('#rstudio_spelling_not_in_dict')).toHaveValue('missssssspelled');
     await expect(page.locator('select[aria-label="Suggestions"] option[value="misspelling"]')).toBeVisible({ timeout: 30000 });
     await page.locator(CANCEL_BTN).click();
-    await sleep(1000);
 
     // Cleanup
     await sourceActions.closeSourceAndDeleteFile(fileName);
@@ -210,7 +194,6 @@ test.describe('RMarkdown', () => {
     const rmdModal = page.locator(RMARKDOWN_MODAL);
     await expect(rmdModal).toBeVisible({ timeout: 10000 });
     await page.locator(`xpath=${TEMPLATE_OPTION}`).click();
-    await sleep(1000);
 
     const templateList = page.locator(TEMPLATE_LIST);
     await expect(templateList).toBeVisible({ timeout: 5000 });
@@ -218,7 +201,6 @@ test.describe('RMarkdown', () => {
 
     // Confirm to create the file
     await page.locator(CONFIRM_BTN).click();
-    await sleep(2000);
     await sourceActions.ensureVisualMode();
     await expect(page.locator('.ProseMirror')).toContainText('Theming with bslib and thematic', { timeout: 10000 });
 

--- a/e2e/rstudio/tests/panes/misc/s4_unloaded_package.test.ts
+++ b/e2e/rstudio/tests/panes/misc/s4_unloaded_package.test.ts
@@ -17,7 +17,14 @@
 import { test as base, expect } from '@playwright/test';
 import { launchRStudio, shutdownRStudio, type DesktopSession } from '@fixtures/desktop.fixture';
 import { sleep } from '@utils/constants';
-import { executeInConsole, clearConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
+import {
+  executeInConsole,
+  clearConsole,
+  ensurePackageInstalled,
+  waitForConsoleIdle,
+  CONSOLE_INPUT,
+  CONSOLE_OUTPUT,
+} from '@pages/console_pane.page';
 import { YES_BTN } from '@pages/modals.page';
 import { executeCommand, setPref } from '@utils/commands';
 import type { Page } from 'playwright';
@@ -28,8 +35,7 @@ const OBJ_NAME = 's4_test_object';
 async function captureResult(page: Page, rExpr: string): Promise<string> {
   const marker = `__S4_${Date.now()}__`;
   await clearConsole(page);
-  await executeInConsole(page, `cat("${marker}", ${rExpr}, "${marker}")`);
-  await sleep(2000);
+  await executeInConsole(page, `cat("${marker}", ${rExpr}, "${marker}")`, { wait: true });
 
   const output = await page.locator(CONSOLE_OUTPUT).innerText();
   const match = output.match(new RegExp(`${marker}\\s+([\\s\\S]*?)\\s+${marker}`));
@@ -42,45 +48,39 @@ async function captureResult(page: Page, rExpr: string): Promise<string> {
  * Also creates plain objects as controls for the Environment pane.
  */
 async function setupWorkspace(page: Page): Promise<void> {
-  // Install DBI (binary, fast -- only dependency is methods which is always loaded)
-  await executeInConsole(page, 'install.packages("DBI", repos = "https://cran.r-project.org")');
-  await sleep(15000);
+  // Install DBI if not already present (binary, fast -- only dep is methods,
+  // which is always loaded). ensurePackageInstalled skips the download when
+  // DBI was left behind by a prior run.
+  await ensurePackageInstalled(page, 'DBI');
 
   // Create an S4 object from DBI
-  await executeInConsole(page, 'library(DBI)');
-  await sleep(1000);
-  await executeInConsole(page, `${OBJ_NAME} <- DBI::SQL("SELECT 1")`);
-  await sleep(500);
+  await executeInConsole(page, 'library(DBI)', { wait: true });
+  await executeInConsole(page, `${OBJ_NAME} <- DBI::SQL("SELECT 1")`, { wait: true });
 
   // Plain objects as controls
-  await executeInConsole(page, 'x <- 1');
-  await sleep(500);
-  await executeInConsole(page, 'y <- 22');
-  await sleep(500);
-  await executeInConsole(page, `z <- "I'll so offend, to make offense a skill"`);
-  await sleep(500);
+  await executeInConsole(page, 'x <- 1', { wait: true });
+  await executeInConsole(page, 'y <- 22', { wait: true });
+  await executeInConsole(page, `z <- "I'll so offend, to make offense a skill"`, { wait: true });
 
-  // Enable workspace persistence
+  // Enable workspace persistence (setPref is a JS-side bridge call -- no R round-trip)
   await setPref(page, 'save_workspace', 'always');
-  await sleep(500);
   await setPref(page, 'load_workspace', true);
-  await sleep(500);
 
   // Save workspace
-  await executeInConsole(page, 'save.image()');
-  await sleep(1000);
+  await executeInConsole(page, 'save.image()', { wait: true });
 
-  // Remove DBI so it won't be loadable after restart.
-  // This may trigger a "loaded packages" dialog -- click Yes if it appears.
+  // Remove DBI so it won't be loadable after restart. This may trigger a
+  // "loaded packages" dialog -- click Yes if it appears. Can't pass
+  // { wait: true } here: if the dialog blocks R, the busy class would never
+  // clear. Fire-and-forget, click the dialog if present, then wait for idle.
   await executeInConsole(page, 'remove.packages("DBI")');
-  await sleep(1000);
   try {
     await page.locator(YES_BTN).click({ timeout: 3000 });
     console.log('Clicked Yes on loaded-packages dialog');
   } catch {
     // No dialog appeared
   }
-  await sleep(3000);
+  await waitForConsoleIdle(page);
 
   // Verify removal succeeded by checking the disk (not requireNamespace, which
   // returns TRUE for already-loaded namespaces even after the files are deleted)
@@ -90,15 +90,16 @@ async function setupWorkspace(page: Page): Promise<void> {
 
 /** Remove test objects, delete .RData, restore preferences, reinstall DBI. */
 async function cleanup(page: Page): Promise<void> {
-  await executeInConsole(page, `suppressWarnings(rm("${OBJ_NAME}", "x", "y", "z", envir = .GlobalEnv))`);
-  await sleep(500);
-  await executeInConsole(page, 'unlink(".RData")');
-  await sleep(500);
+  await executeInConsole(
+    page,
+    `suppressWarnings(rm("${OBJ_NAME}", "x", "y", "z", envir = .GlobalEnv))`,
+    { wait: true },
+  );
+  await executeInConsole(page, 'unlink(".RData")', { wait: true });
   await setPref(page, 'save_workspace', 'never');
-  await sleep(500);
-  // Reinstall DBI so we leave things as we found them
-  await executeInConsole(page, 'install.packages("DBI", repos = "https://cran.r-project.org")');
-  await sleep(15000);
+  // Reinstall DBI so we leave things as we found them. The test just removed
+  // it, so ensurePackageInstalled will see the gap and do a real install.
+  await ensurePackageInstalled(page, 'DBI');
 }
 
 /** Verify the session survived and the S4 object is handled safely. */
@@ -106,8 +107,7 @@ async function verifySessionSurvived(page: Page): Promise<void> {
   // Session is alive
   const aliveMarker = `__ALIVE_${Date.now()}__`;
   await clearConsole(page);
-  await executeInConsole(page, `cat("${aliveMarker}")`);
-  await sleep(2000);
+  await executeInConsole(page, `cat("${aliveMarker}")`, { wait: true });
   const output = await page.locator(CONSOLE_OUTPUT).innerText();
   expect(output).toContain(aliveMarker);
 
@@ -135,13 +135,12 @@ async function verifySessionSurvived(page: Page): Promise<void> {
 /** Check that the Environment pane renders the "not loaded" label. */
 async function verifyEnvironmentPane(page: Page): Promise<void> {
   await executeCommand(page, 'activateEnvironment');
-  await sleep(1000);
   await executeCommand(page, 'refreshEnvironment');
-  await sleep(3000);
 
   const envPanel = page.locator('#rstudio_workbench_panel_environment');
 
-  // Control objects should be visible (confirms the pane is populated)
+  // Control objects should be visible (confirms the pane is populated).
+  // The toContainText polls so we don't need to sleep after refreshEnvironment.
   await expect(envPanel).toContainText('22', { timeout: 10000 });
 
   // S4 object should show the "not loaded" description
@@ -161,11 +160,14 @@ base.describe.serial('S4 unloaded package -- R session restart (#17353)', { tag:
 
     await setupWorkspace(page);
 
-    // Restart R session
+    // Restart R session. The 5s lead-in is a guard against restartR being
+    // dispatched before the prior commands have fully drained -- waitForConsoleIdle
+    // can otherwise see a momentarily-idle busy class. Replace later once the
+    // restartR command has a confirmable post-condition.
     await executeCommand(page, 'restartR');
     await sleep(5000);
     await page.waitForSelector(CONSOLE_INPUT, { state: 'visible', timeout: 30000 });
-    await sleep(2000);
+    await waitForConsoleIdle(page);
 
     await verifySessionSurvived(page);
   });
@@ -197,7 +199,7 @@ base.describe.serial('S4 unloaded package -- RStudio restart (#17353)', { tag: [
     console.log('Relaunching RStudio...');
     session = await launchRStudio();
     page = session.page;
-    await sleep(2000);
+    await waitForConsoleIdle(page);
 
     await verifySessionSurvived(page);
   });

--- a/e2e/rstudio/utils/project.ts
+++ b/e2e/rstudio/utils/project.ts
@@ -1,6 +1,16 @@
 import type { Page } from 'playwright';
-import { executeInConsole, CONSOLE_TAB, CONSOLE_INPUT, CONSOLE_OUTPUT } from '../pages/console_pane.page';
+import {
+  executeInConsole,
+  waitForConsoleIdle,
+  CONSOLE_TAB,
+  CONSOLE_INPUT,
+  CONSOLE_OUTPUT,
+} from '../pages/console_pane.page';
 import { sleep, TIMEOUTS } from './constants';
+
+// Re-exported from pages/console_pane.page.ts; preserved here so existing
+// `import { waitForConsoleIdle } from '@utils/project'` call sites keep working.
+export { waitForConsoleIdle };
 
 const PROJECT_MENU = '#rstudio_project_menubutton_toolbar';
 const CLOSE_PROJECT_MENU_ITEM = '#rstudio_label_close_project_command';
@@ -162,22 +172,6 @@ export async function createAndOpenProject(
   );
 
   return projectDir;
-}
-
-/**
- * Wait for the console input to clear its "busy" class. Use after explicit
- * session restarts and project opens to make sure the next R-side action
- * isn't enqueued behind a long-running startup command.
- */
-export async function waitForConsoleIdle(page: Page): Promise<void> {
-  await page.waitForFunction(
-    () => {
-      const el = document.getElementById('rstudio_console_input');
-      return !!el && !el.classList.contains('rstudio-console-busy');
-    },
-    null,
-    { timeout: TIMEOUTS.sessionRestart, polling: 100 },
-  );
 }
 
 /**

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -368,6 +368,19 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    detach(pos = match(pkg, search()))
 })
 
+# Install a package only if it isn't already installed. Checks the on-disk
+# library for the package directory rather than calling requireNamespace(),
+# so the package's namespace is not loaded as a side effect. Useful for test
+# setup and other contexts that need a package present but don't want the
+# cost of a redundant download + reinstall when it's already there.
+.rs.addFunction("ensurePackageInstalled", function(packageName,
+                                                   repos = getOption("repos"),
+                                                   type = getOption("pkgType"))
+{
+   if (!nzchar(system.file(package = packageName)))
+      install.packages(packageName, repos = repos, type = type)
+})
+
 .rs.addFunction("getPackageVersion", function(packageName)
 {
    v <- suppressWarnings(utils:::packageDescription(packageName,


### PR DESCRIPTION
## Summary
- Add `{ wait, timeout }` option to `executeInConsole` (free function and class method). With `wait: true` it polls the `rstudio-console-busy` class instead of having callers blind-sleep after every R command.
- Add `.rs.ensurePackageInstalled` (R) and `ensurePackageInstalled` (TS) so test setup can no-op when a package is already on disk -- replaces ~30 s of blind `install.packages` waits in `s4_unloaded_package`.
- Sweep blind sleeps in `source_pane.actions.ts`, `chat_pane.actions.ts`, `rmarkdown.test.ts`, `s4_unloaded_package.test.ts`. `s4_unloaded_package` drops from ~5 min to 1.3 min; `rmarkdown.test.ts` from 2.1 min to 58.6 s; suite-wide blind-sleep budget falls by ~125 s.
- Harden `closeSourceAndDeleteFile` to wait on both `aceTextInput.toHaveCount(0)` and `selectedTab.toHaveCount(0)` -- workaround for #17738 (`file.edit` racing `closeAllSourceDocs`).

## Test plan
- [x] `npm run test:desktop-dev -- tests/panes/editor/rmarkdown.test.ts` -- 6 passed in 58.6 s
- [x] `npm run test:desktop-dev -- tests/panes/misc/s4_unloaded_package.test.ts` -- 4 passed in 1.3 min (covers R restart + RStudio restart paths)
- [x] `npx tsc --noEmit` clean
- [ ] Posit Assistant chat suite (uses `chat_pane.actions.ts`) -- run when AI credentials are set up
- [ ] `code_suggestions.test.ts` -- not touched here; future follow-up once we settle a story for the stale NES gutter (#17108)

Filed #17738 for the underlying `file.edit` / `closeAllSourceDocs` race; this PR works around it test-side rather than fixing the IDE.
