### PR TITLE
bugfix: file.edit during in-flight closeAllSourceDocs silently dropped

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 - ([#17701](https://github.com/rstudio/rstudio/issues/17701)): Honor newline characters in `rstudioapi::showDialog()` and `rstudioapi::showPrompt()` messages.
+- ([#17738](https://github.com/rstudio/rstudio/issues/17738)): Fix `file.edit()` (and other Source pane open events) silently dropping when invoked during an in-flight `closeAllSourceDocs`.
 
 ### Dependencies
 - Ace 1.43.5

--- a/e2e/rstudio/actions/source_pane.actions.ts
+++ b/e2e/rstudio/actions/source_pane.actions.ts
@@ -45,13 +45,8 @@ export class SourcePaneActions {
     await sleep(1000);
     await executeCommand(this.page, 'closeAllSourceDocs');
 
-    // Wait for the source pane to be fully empty -- both no editor mounted
-    // and no tab strip entry. The tab-strip check (selectedTab.count == 0)
-    // is the stronger signal: an immediately-following file.edit can race
-    // GWT's close cleanup and end up not opening the new tab if we only
-    // wait on aceTextInput.
+    // Wait for the editor to detach before unlinking the file.
     await expect(this.sourcePane.aceTextInput).toHaveCount(0, { timeout: 5000 }).catch(() => {});
-    await expect(this.sourcePane.selectedTab).toHaveCount(0, { timeout: 5000 }).catch(() => {});
 
     await this.consolePaneActions.executeInConsole(`unlink("${fileName}")`, { wait: true });
   }

--- a/e2e/rstudio/tests/panes/editor/close_open_race.test.ts
+++ b/e2e/rstudio/tests/panes/editor/close_open_race.test.ts
@@ -1,0 +1,49 @@
+// Regression test for https://github.com/rstudio/rstudio/issues/17738.
+//
+// closeAllSourceDocs starts a SerializedCommandQueue of close operations and,
+// when the last tab closes, fires LastSourceDocClosedEvent ->
+// PaneManager.closeSourceWindow -> WindowStateChangeEvent(HIDE), which kicks
+// off a 250ms animation on the source LogicalWindow. A file.edit arriving in
+// that window would silently drop because WindowFrame.onEnsureVisible only
+// fired the WindowStateChangeEvent(NORMAL) recovery when !isVisible() -- and
+// during the HIDE animation the WindowFrame is still visible in the DOM.
+//
+// The fix tracks the LogicalWindow's state on the WindowFrame and also
+// recovers when that state is HIDE or MINIMIZE. This test asserts that a
+// file.edit issued immediately after closeAllSourceDocs opens its tab.
+
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { SourcePane } from '@pages/source_pane.page';
+import { useSuiteSandbox } from '@utils/sandbox';
+import { writeAndOpenFile } from '@utils/files';
+import { executeCommand } from '@utils/commands';
+
+test.describe('Source pane open during close race', () => {
+  const sandbox = useSuiteSandbox();
+  let consoleActions: ConsolePaneActions;
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+    await consoleActions.closeAllBuffersWithoutSaving();
+  });
+
+  test('file.edit immediately after closeAllSourceDocs still opens the tab', async ({ rstudioPage: page }) => {
+    const initialFile = `race_initial_${Date.now()}.R`;
+    const targetFile = `race_target_${Date.now()}.R`;
+
+    // Open an initial file so closeAllSourceDocs has a tab to close (and the
+    // close pipeline fires LastSourceDocClosedEvent on completion).
+    await writeAndOpenFile(page, sandbox.dir, initialFile, '# initial');
+
+    // Kick off closeAllSourceDocs and -- without waiting for it to drain --
+    // create + open a new file. The interleaving here is exactly what the
+    // issue's reproducer describes.
+    await executeCommand(page, 'closeAllSourceDocs');
+    await consoleActions.executeInConsole(`file.create("${targetFile}")`);
+    await consoleActions.executeInConsole(`file.edit("${targetFile}")`);
+
+    const sourcePane = new SourcePane(page);
+    await expect(sourcePane.selectedTab).toContainText(targetFile, { timeout: 10000 });
+  });
+});

--- a/src/gwt/src/org/rstudio/core/client/layout/LogicalWindow.java
+++ b/src/gwt/src/org/rstudio/core/client/layout/LogicalWindow.java
@@ -122,6 +122,7 @@ public class LogicalWindow implements HasWindowStateChangeHandlers,
    {
       normal_.setMaximizedDependentState(newState);
       normal_.setExclusiveDependentState(newState);
+      normal_.setLogicalState(newState);
       state_ = newState;
 
       if (getActiveWidget() == normal_)

--- a/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
@@ -400,10 +400,25 @@ public class WindowFrame extends Composite
 
    public void onEnsureVisible(EnsureVisibleEvent event)
    {
-      if (!isVisible())
+      // Check logicalState_ in addition to isVisible() because, during the
+      // HIDE animation kicked off by closeAllSourceDocs (LastSourceDocClosedEvent
+      // -> PaneManager.closeSourceWindow), the widget is still in the DOM and
+      // isVisible() returns true even though the logical state is already HIDE.
+      // Without this, a file-open arriving during that window silently lands in
+      // a pane that finishes hiding.
+      if (!isVisible() ||
+          logicalState_ == WindowState.HIDE ||
+          logicalState_ == WindowState.MINIMIZE)
+      {
          fireEvent(new WindowStateChangeEvent(WindowState.NORMAL));
+      }
 
       events_.fireEvent(new WindowEnsureVisibleEvent(this));
+   }
+
+   public void setLogicalState(WindowState state)
+   {
+      logicalState_ = state;
    }
 
    @Override
@@ -459,6 +474,7 @@ public class WindowFrame extends Composite
    private HandlerRegistration ensureHeightRegistration_;
    private Widget previousHeader_;
    private final FlowPanel buttonsArea_;
+   private WindowState logicalState_ = WindowState.NORMAL;
 
    private static final int TOP_SHADOW_WIDTH = 3,
                             LEFT_SHADOW_WIDTH = 3,


### PR DESCRIPTION
## Intent

Addresses #17738.

## Summary

- `WindowFrame.onEnsureVisible` only fired the `WindowStateChangeEvent(NORMAL)` recovery when `!isVisible()`. During the HIDE animation kicked off by `LastSourceDocClosedEvent` -> `PaneManager.closeSourceWindow`, the `WindowFrame` is still mounted in the DOM and `isVisible()` returns true even though the logical state is already `HIDE`. The recovery never fired, the HIDE animation completed, and the file-open landed in an invisible pane.
- Mirror the `LogicalWindow`'s state onto its `WindowFrame` in `transitionToState`, and recover when that mirrored state is `HIDE` or `MINIMIZE` (in addition to `!isVisible()`).
- Add a Playwright regression test that reproduces the issue's exact sequence (open, `closeAllSourceDocs`, immediate `file.edit`).
- Drop the matching workaround from `closeSourceAndDeleteFile` -- the helper now waits only on the editor detach, so the regression test exercises the real behavior rather than the workaround.

## Test plan

- [ ] `ant draft` + repackage desktop, then run `e2e/rstudio/tests/panes/editor/close_open_race.test.ts` on macOS Desktop -- new test passes.
- [ ] Re-run `e2e/rstudio/tests/panes/editor/rmarkdown.test.ts` to confirm the original symptom site is still healthy now that the helper no longer polls `selectedTab`.
- [ ] Manual: maximize Source pane, click into other panes -- confirm `ensureVisible` still doesn't un-maximize unrelated layouts.
- [ ] Manual: minimize Source pane via UI, then trigger a `file.edit` -- the pane should restore.