### PR TITLE
Allow skipping Homebrew formulae via RSTUDIO_SKIP_FORMULAS

### DIFF
--- a/dependencies/osx/README.md
+++ b/dependencies/osx/README.md
@@ -56,6 +56,14 @@ Additional dependencies can be satisfied by running the following script:
 Note that this script includes download, extraction, and compilation of
 boost so can take some time to complete.
 
+To skip specific Homebrew formulae -- for example, when R is already
+installed from the CRAN `.pkg` -- set `RSTUDIO_SKIP_FORMULAS` to a
+space-separated list of formula names before running the script:
+
+```bash
+RSTUDIO_SKIP_FORMULAS="r" ./install-dependencies-osx
+```
+
 Building the RStudio Distribution
 =============================================================================
 

--- a/dependencies/osx/install-dependencies-osx-arch
+++ b/dependencies/osx/install-dependencies-osx-arch
@@ -61,9 +61,16 @@ if ! is-jenkins; then
   fi
 fi
 
+# Formulae listed in RSTUDIO_SKIP_FORMULAS (space-separated) are skipped --
+# useful when a dependency is already provided outside Homebrew, e.g. R
+# installed from the CRAN .pkg under /Library/Frameworks/R.framework.
+read -r -a SKIP_FORMULAS <<< "${RSTUDIO_SKIP_FORMULAS:-}"
+
 HOMEBREW_PREFIX=$(brew --prefix)
 for FORMULA in "${FORMULAS[@]}"; do
-   if [ -d "${HOMEBREW_PREFIX}/opt/${FORMULA}" ]; then
+   if [[ " ${SKIP_FORMULAS[*]} " == *" ${FORMULA} "* ]]; then
+      info "${FORMULA} skipped (listed in RSTUDIO_SKIP_FORMULAS)."
+   elif [ -d "${HOMEBREW_PREFIX}/opt/${FORMULA}" ]; then
       info "${FORMULA} already installed."
    else
       brew install "${FORMULA}" || true


### PR DESCRIPTION
## Summary

- `dependencies/osx/install-dependencies-osx-arch` now honors a `RSTUDIO_SKIP_FORMULAS` env var (space-separated formula names) and skips those formulae when iterating the install list.
- Documented the variable in `dependencies/osx/README.md` with the motivating example: R already installed from the CRAN `.pkg`.

## Test plan

- [ ] `RSTUDIO_SKIP_FORMULAS="r" ./install-dependencies-osx` skips the `r` formula and proceeds with the rest of the install.
- [ ] Running without the variable leaves existing behavior unchanged (still installs `r` if missing, reports "already installed" if present).
- [ ] Skip list matches versioned formulae correctly (e.g. `postgresql@14`).