### PR TITLE
playwright: heredoc helper + source-only R install fix

### DIFF
--- a/e2e/rstudio/fixtures/r-libs-setup.ts
+++ b/e2e/rstudio/fixtures/r-libs-setup.ts
@@ -3,6 +3,8 @@ import * as os from 'os';
 import * as path from 'path';
 import { spawnSync } from 'child_process';
 
+import { heredoc } from '../utils/heredoc';
+
 /**
  * Stable per-R-version package library used by every Playwright run, shared
  * across runs so the same set of CRAN packages doesn't get reinstalled every
@@ -116,19 +118,19 @@ function runRscript(code: string, env: NodeJS.ProcessEnv = process.env): Rscript
  */
 function expandRLibsUserTemplate(template: string): string | null {
   const env = { ...process.env, R_LIBS_USER: template };
-  const code = [
-    'tryCatch({',
-    '  cat(tools:::.expand_R_libs_env_var(Sys.getenv("R_LIBS_USER")))',
-    '}, error = function(e) {',
-    '  t <- Sys.getenv("R_LIBS_USER")',
-    '  t <- gsub("%V", paste0(R.version$major, ".", R.version$minor), t, fixed = TRUE)',
-    '  t <- gsub("%v", paste0(R.version$major, ".", strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1]), t, fixed = TRUE)',
-    '  t <- gsub("%p", R.version$platform, t, fixed = TRUE)',
-    '  t <- gsub("%o", R.version$os, t, fixed = TRUE)',
-    '  t <- gsub("%a", R.version$arch, t, fixed = TRUE)',
-    '  cat(t)',
-    '})',
-  ].join('\n');
+  const code = heredoc`
+    tryCatch({
+      cat(tools:::.expand_R_libs_env_var(Sys.getenv("R_LIBS_USER")))
+    }, error = function(e) {
+      t <- Sys.getenv("R_LIBS_USER")
+      t <- gsub("%V", paste0(R.version$major, ".", R.version$minor), t, fixed = TRUE)
+      t <- gsub("%v", paste0(R.version$major, ".", strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1]), t, fixed = TRUE)
+      t <- gsub("%p", R.version$platform, t, fixed = TRUE)
+      t <- gsub("%o", R.version$os, t, fixed = TRUE)
+      t <- gsub("%a", R.version$arch, t, fixed = TRUE)
+      cat(t)
+    })
+  `;
 
   const res = runRscript(code, env);
   if (res.status !== 0) return null;
@@ -169,30 +171,34 @@ export async function prepareRLibs(): Promise<void> {
   const repos = process.platform === 'linux'
     ? 'https://packagemanager.posit.co/cran/__linux__/jammy/latest'
     : 'https://cran.r-project.org';
-  const installType = process.platform === 'linux' ? 'source' : 'binary';
 
   // Single Rscript invocation: check installed.packages() in the resolved
   // library, then install any missing entries from the manifest in one batch.
   // Faster than the per-package check loop ensurePackages uses, and we don't
   // need its progress markers because there's no console UI here.
+  //
+  // installType is chosen at runtime via .Platform$pkgType so source-only R
+  // builds (e.g. some macOS configurations where CRAN has no matching binary)
+  // don't fall over on a forced type = "binary".
   const pkgsLiteral = REQUIRED_PACKAGES.map((p) => `"${p}"`).join(', ');
-  const installCode = [
-    `lib <- ${JSON.stringify(expanded)}`,
-    '.libPaths(c(lib, .libPaths()))',
-    `required <- c(${pkgsLiteral})`,
-    'have <- rownames(installed.packages(lib.loc = lib))',
-    'missing <- setdiff(required, have)',
-    'if (length(missing) == 0L) {',
-    '  cat("[r-libs] all packages present\\n")',
-    '} else {',
-    '  cat("[r-libs] installing:", paste(missing, collapse = ", "), "\\n")',
-    `  install.packages(missing, lib = lib, repos = ${JSON.stringify(repos)}, type = ${JSON.stringify(installType)})`,
-    '  still <- setdiff(missing, rownames(installed.packages(lib.loc = lib)))',
-    '  if (length(still) > 0L) {',
-    '    cat("[r-libs] WARNING: failed to install:", paste(still, collapse = ", "), "\\n")',
-    '  }',
-    '}',
-  ].join('\n');
+  const installCode = heredoc`
+    lib <- ${JSON.stringify(expanded)}
+    .libPaths(c(lib, .libPaths()))
+    required <- c(${pkgsLiteral})
+    have <- rownames(installed.packages(lib.loc = lib))
+    missing <- setdiff(required, have)
+    if (length(missing) == 0L) {
+      cat("[r-libs] all packages present\n")
+    } else {
+      cat("[r-libs] installing:", paste(missing, collapse = ", "), "\n")
+      installType <- if (identical(.Platform$pkgType, "source")) "source" else "binary"
+      install.packages(missing, lib = lib, repos = ${JSON.stringify(repos)}, type = installType)
+      still <- setdiff(missing, rownames(installed.packages(lib.loc = lib)))
+      if (length(still) > 0L) {
+        cat("[r-libs] WARNING: failed to install:", paste(still, collapse = ", "), "\n")
+      }
+    }
+  `;
 
   const env = { ...process.env, R_LIBS_USER: template };
   const res = runRscript(installCode, env);

--- a/e2e/rstudio/tests/panes/console/console_output.test.ts
+++ b/e2e/rstudio/tests/panes/console/console_output.test.ts
@@ -14,6 +14,7 @@ import { AceEditorElement } from '@utils/ace';
 import { writeAndOpenFile, closeAndDeleteSandboxFiles } from '@utils/files';
 import { executeCommand } from '@utils/commands';
 import { sleep, TIMEOUTS } from '@utils/constants';
+import { heredoc } from '@utils/heredoc';
 
 const CONSOLE_OUTPUT = '#rstudio_console_output';
 
@@ -194,15 +195,14 @@ test.describe('Error output after caught try()', () => {
   });
 
   test('output after a caught error is not dropped', async ({ rstudioPage: page }) => {
-    const contents = [
-      'foo <- function() {',
-      '  writeLines("Some output.")',
-      '  try(stop("try(silent = FALSE)"), silent = FALSE)',
-      '  writeLines("Some more output.")',
-      '  stop("Error.")',
-      '}',
-      '',
-    ].join('\n');
+    const contents = heredoc`
+      foo <- function() {
+        writeLines("Some output.")
+        try(stop("try(silent = FALSE)"), silent = FALSE)
+        writeLines("Some more output.")
+        stop("Error.")
+      }
+    ` + '\n';
     await writeAndOpenFile(page, sandbox.dir, FILE, contents);
 
     await executeCommand(page, 'sourceActiveDocument');

--- a/e2e/rstudio/tests/panes/debugger/debugger.test.ts
+++ b/e2e/rstudio/tests/panes/debugger/debugger.test.ts
@@ -5,6 +5,7 @@ import { EnvironmentPane } from '@pages/environment_pane.page';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { TIMEOUTS, sleep } from '@utils/constants';
 import { executeCommand } from '@utils/commands';
+import { heredoc } from '@utils/heredoc';
 
 const sandbox = useSuiteSandbox();
 
@@ -82,11 +83,11 @@ test.describe('R debugger', () => {
       // function. setTopLevelBreakpoint sets STATE_ACTIVE immediately, no
       // function lookup. Sourcing the file fires it on the breakpoint line.
       const fileName = `bp_toplevel_${Date.now()}.R`;
-      const content = [
-        'x <- 1',
-        'y <- 22',
-        'z <- x + y',
-      ].join('\n');
+      const content = heredoc`
+        x <- 1
+        y <- 22
+        z <- x + y
+      `;
 
       await writeAndOpen(fileName, content);
 
@@ -104,14 +105,14 @@ test.describe('R debugger', () => {
     test('single gutter breakpoint highlights correct row', async () => {
       // Regression coverage for rstudio/rstudio#15072.
       const fileName = `bp_brace_${Date.now()}.R`;
-      const content = [
-        'brace_fn <- function() {',
-        '   1 + 1',
-        '   {',
-        '      2 + 2',
-        '   }',
-        '}',
-      ].join('\n');
+      const content = heredoc`
+        brace_fn <- function() {
+           1 + 1
+           {
+              2 + 2
+           }
+        }
+      `;
 
       await writeAndOpen(fileName, content);
 
@@ -142,13 +143,13 @@ test.describe('R debugger', () => {
 
     test('Shift+F9 toggles a breakpoint at the cursor', async () => {
       const fileName = `bp_toggle_${Date.now()}.R`;
-      const content = [
-        'toggle_fn <- function() {',
-        '   a <- 1',
-        '   b <- 2',
-        '   a + b',
-        '}',
-      ].join('\n');
+      const content = heredoc`
+        toggle_fn <- function() {
+           a <- 1
+           b <- 2
+           a + b
+        }
+      `;
 
       await writeAndOpen(fileName, content);
       // Source so the toggled breakpoint becomes ACTIVE rather than INACTIVE.
@@ -191,14 +192,14 @@ test.describe('R debugger', () => {
 
     test('Step Next advances to the following line', async () => {
       const fileName = `step_next_${Date.now()}.R`;
-      const content = [
-        'step_next_fn <- function() {',
-        '   a <- 1',
-        '   b <- 2',
-        '   c <- 3',
-        '   a + b + c',
-        '}',
-      ].join('\n');
+      const content = heredoc`
+        step_next_fn <- function() {
+           a <- 1
+           b <- 2
+           c <- 3
+           a + b + c
+        }
+      `;
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
@@ -219,14 +220,14 @@ test.describe('R debugger', () => {
 
     test('Step Into descends into a nested function call', async () => {
       const fileName = `step_into_${Date.now()}.R`;
-      const content = [
-        'inner <- function() {',
-        '   1 + 1',
-        '}',
-        'outer <- function() {',
-        '   inner()',
-        '}',
-      ].join('\n');
+      const content = heredoc`
+        inner <- function() {
+           1 + 1
+        }
+        outer <- function() {
+           inner()
+        }
+      `;
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
@@ -262,14 +263,14 @@ test.describe('R debugger', () => {
 
     test('Finish executes the remainder of the current function', async () => {
       const fileName = `step_finish_${Date.now()}.R`;
-      const content = [
-        'step_finish_fn <- function() {',
-        '   a <- 1',
-        '   a + 1',
-        '   a + 2',
-        '   a + 3',
-        '}',
-      ].join('\n');
+      const content = heredoc`
+        step_finish_fn <- function() {
+           a <- 1
+           a + 1
+           a + 2
+           a + 3
+        }
+      `;
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
@@ -288,15 +289,15 @@ test.describe('R debugger', () => {
       // Continue-stepping coverage for rstudio/rstudio#15201 without the
       // package-build setup.
       const fileName = `step_continue_${Date.now()}.R`;
-      const content = [
-        'step_continue_fn <- function() {',
-        '   a <- 1',
-        '   b <- 2',
-        '   c <- 3',
-        '   d <- 4',
-        '   a + b + c + d',
-        '}',
-      ].join('\n');
+      const content = heredoc`
+        step_continue_fn <- function() {
+           a <- 1
+           b <- 2
+           c <- 3
+           d <- 4
+           a + b + c + d
+        }
+      `;
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
@@ -320,12 +321,12 @@ test.describe('R debugger', () => {
 
     test('Stop button cleanly exits debug', async () => {
       const fileName = `step_stop_${Date.now()}.R`;
-      const content = [
-        'step_stop_fn <- function() {',
-        '   a <- 1',
-        '   a + 1',
-        '}',
-      ].join('\n');
+      const content = heredoc`
+        step_stop_fn <- function() {
+           a <- 1
+           a + 1
+        }
+      `;
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
@@ -342,16 +343,16 @@ test.describe('R debugger', () => {
 
     test('Continue chains through six breakpoints', async () => {
       const fileName = `continue_chain_${Date.now()}.R`;
-      const content = [
-        'five_continues_fn <- function() {',
-        '   a <- 1',
-        '   b <- 2',
-        '   c <- 3',
-        '   d <- 4',
-        '   e <- 5',
-        '   f <- 6',
-        '}',
-      ].join('\n');
+      const content = heredoc`
+        five_continues_fn <- function() {
+           a <- 1
+           b <- 2
+           c <- 3
+           d <- 4
+           e <- 5
+           f <- 6
+        }
+      `;
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
@@ -404,13 +405,13 @@ test.describe('R debugger', () => {
 
     test('browser() in a function enters debug mode', async () => {
       const fileName = `browser_entry_${Date.now()}.R`;
-      const content = [
-        'browser_entry_fn <- function() {',
-        '   browser()',
-        '   x <- 1',
-        '   x + 1',
-        '}',
-      ].join('\n');
+      const content = heredoc`
+        browser_entry_fn <- function() {
+           browser()
+           x <- 1
+           x + 1
+        }
+      `;
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
@@ -429,12 +430,12 @@ test.describe('R debugger', () => {
 
     test('Continue past browser() exits debug', async () => {
       const fileName = `browser_continue_${Date.now()}.R`;
-      const content = [
-        'browser_continue_fn <- function() {',
-        '   browser()',
-        '   "done"',
-        '}',
-      ].join('\n');
+      const content = heredoc`
+        browser_continue_fn <- function() {
+           browser()
+           "done"
+        }
+      `;
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
@@ -457,11 +458,11 @@ test.describe('R debugger', () => {
 
     test('Rerun with Debug link reopens the failing call in the debugger', async () => {
       const fileName = `rerun_${Date.now()}.R`;
-      const content = [
-        'rerun_fn <- function() {',
-        '   stop("intentional")',
-        '}',
-      ].join('\n');
+      const content = heredoc`
+        rerun_fn <- function() {
+           stop("intentional")
+        }
+      `;
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
@@ -493,13 +494,13 @@ test.describe('R debugger', () => {
 
     test('Environment pane shows local frame variables', async () => {
       const fileName = `env_locals_${Date.now()}.R`;
-      const content = [
-        'env_locals_fn <- function() {',
-        '   localx <- 42',
-        '   browser()',
-        '   localx',
-        '}',
-      ].join('\n');
+      const content = heredoc`
+        env_locals_fn <- function() {
+           localx <- 42
+           browser()
+           localx
+        }
+      `;
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
@@ -517,11 +518,11 @@ test.describe('R debugger', () => {
 
     test('Traceback pane lists the call stack', async () => {
       const fileName = `tb_stack_${Date.now()}.R`;
-      const content = [
-        'tb_h <- function() browser()',
-        'tb_g <- function() tb_h()',
-        'tb_f <- function() tb_g()',
-      ].join('\n');
+      const content = heredoc`
+        tb_h <- function() browser()
+        tb_g <- function() tb_h()
+        tb_f <- function() tb_g()
+      `;
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
@@ -544,21 +545,21 @@ test.describe('R debugger', () => {
 
     test('Clicking a call frame switches Environment context', async () => {
       const fileName = `tb_click_${Date.now()}.R`;
-      const content = [
-        'fr_h <- function() {',
-        '   marker_h <- "in_h"',
-        '   browser()',
-        '   marker_h',
-        '}',
-        'fr_g <- function() {',
-        '   marker_g <- "in_g"',
-        '   fr_h()',
-        '}',
-        'fr_f <- function() {',
-        '   marker_f <- "in_f"',
-        '   fr_g()',
-        '}',
-      ].join('\n');
+      const content = heredoc`
+        fr_h <- function() {
+           marker_h <- "in_h"
+           browser()
+           marker_h
+        }
+        fr_g <- function() {
+           marker_g <- "in_g"
+           fr_h()
+        }
+        fr_f <- function() {
+           marker_f <- "in_f"
+           fr_g()
+        }
+      `;
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');

--- a/e2e/rstudio/tests/panes/debugger/debugger_extras.test.ts
+++ b/e2e/rstudio/tests/panes/debugger/debugger_extras.test.ts
@@ -19,6 +19,7 @@ import { useSuiteSandbox } from '@utils/sandbox';
 import { writeAndOpenFile } from '@utils/files';
 import { TIMEOUTS, sleep } from '@utils/constants';
 import { executeCommand } from '@utils/commands';
+import { heredoc } from '@utils/heredoc';
 
 const sandbox = useSuiteSandbox();
 
@@ -93,14 +94,13 @@ test.describe('R debugger extras', () => {
 
     test('multi-line input at Browse[N]> preserves browser state', async ({ rstudioPage: page }) => {
       const fileName = `browser_multiline_${Date.now()}.R`;
-      const content = [
-        'multiline_fn <- function() {',
-        '   x <- 1',
-        '   browser()',
-        '   x + 1',
-        '}',
-        '',
-      ].join('\n');
+      const content = heredoc`
+        multiline_fn <- function() {
+           x <- 1
+           browser()
+           x + 1
+        }
+      ` + '\n';
       await writeAndOpenFile(page, sandbox.dir, fileName, content);
 
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
@@ -115,16 +115,16 @@ test.describe('R debugger extras', () => {
       // to parse line-by-line, issuing continuation prompts ("+ ") between
       // lines; pre-fix those continuations cleared the captured browser
       // environment mid-eval.
-      const multiline = [
-        '{',
-        '   status <- .rs.isBrowserActive()',
-        '   envIsGlobal <- identical(',
-        '      .Call("rs_getBrowserEnv", PACKAGE = "(embedding)"),',
-        '      globalenv()',
-        '   )',
-        '   cat("DBG isBrowserActive:", status, "envIsGlobal:", envIsGlobal, "\\n")',
-        '}',
-      ].join('\n');
+      const multiline = heredoc`
+        {
+           status <- .rs.isBrowserActive()
+           envIsGlobal <- identical(
+              .Call("rs_getBrowserEnv", PACKAGE = "(embedding)"),
+              globalenv()
+           )
+           cat("DBG isBrowserActive:", status, "envIsGlobal:", envIsGlobal, "\n")
+        }
+      `;
       await consoleSubmitMultiline(page, multiline);
 
       // R may step into a nested debug invocation while parsing the block
@@ -152,12 +152,11 @@ test.describe('R debugger extras', () => {
 
     test('clicking a top-level breakpoint marker toggles it off', async ({ rstudioPage: page }) => {
       const fileName = `bp_gutter_toggle_${Date.now()}.R`;
-      const content = [
-        'x <- 1',
-        'y <- 2',
-        'z <- x + y',
-        '',
-      ].join('\n');
+      const content = heredoc`
+        x <- 1
+        y <- 2
+        z <- x + y
+      ` + '\n';
       await writeAndOpenFile(page, sandbox.dir, fileName, content);
 
       // Set a breakpoint on line 2.
@@ -187,7 +186,11 @@ test.describe('R debugger extras', () => {
 
     test('removes every breakpoint marker', async ({ rstudioPage: page }) => {
       const fileName = `bp_clear_all_${Date.now()}.R`;
-      const content = ['x <- 1', 'y <- 2', 'z <- x + y', ''].join('\n');
+      const content = heredoc`
+        x <- 1
+        y <- 2
+        z <- x + y
+      ` + '\n';
       await writeAndOpenFile(page, sandbox.dir, fileName, content);
 
       // Place a top-level breakpoint on each of the three lines.
@@ -230,13 +233,12 @@ test.describe('R debugger extras', () => {
       test.skip(s7Missing.length > 0, `S7 not available: ${s7Missing.join(', ')}`);
 
       const fileName = `s7_breakpoint_${Date.now()}.R`;
-      const content = [
-        's7mean <- S7::new_class("s7mean")',
-        'S7::method(mean, s7mean) <- function(x, ...) {',
-        '   print("This is my S7 method.")',
-        '}',
-        '',
-      ].join('\n');
+      const content = heredoc`
+        s7mean <- S7::new_class("s7mean")
+        S7::method(mean, s7mean) <- function(x, ...) {
+           print("This is my S7 method.")
+        }
+      ` + '\n';
       await writeAndOpenFile(page, sandbox.dir, fileName, content);
 
       // Breakpoint on the body of the S7 method (line 3 = the print() call).

--- a/e2e/rstudio/utils/heredoc.ts
+++ b/e2e/rstudio/utils/heredoc.ts
@@ -1,0 +1,45 @@
+/**
+ * Tagged template that strips one leading newline, trailing whitespace after
+ * the last newline, and the common leading indent across non-blank lines.
+ * Lets us write embedded code (R, shell, ...) at the indent of the host
+ * source file instead of building it from arrays of strings joined by '\n'.
+ *
+ *   const code = heredoc`
+ *     lib <- ${JSON.stringify(lib)}
+ *     install.packages("pkg", lib = lib)
+ *   `;
+ *
+ * yields: `lib <- "/foo"\ninstall.packages("pkg", lib = lib)`.
+ *
+ * Template parts are read in raw form (`strings.raw`) so JS escape sequences
+ * pass through to the target language untouched -- write `"\n"` to mean an R
+ * newline escape, not a JS newline character. Real line breaks in the source
+ * are still real line breaks.
+ *
+ * Interpolated values are coerced via String(). Multi-line interpolations are
+ * inserted verbatim and can pull the computed minimum indent down to zero --
+ * pre-indent them if that matters.
+ */
+export function heredoc(
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+): string {
+  let raw = strings.raw[0];
+  for (let i = 0; i < values.length; i++) {
+    raw += String(values[i]) + strings.raw[i + 1];
+  }
+
+  raw = raw.replace(/\r\n?/g, '\n');
+  raw = raw.replace(/^\n/, '').replace(/\n[ \t]*$/, '');
+
+  const lines = raw.split('\n');
+  const indents: number[] = [];
+  for (const line of lines) {
+    if (line.trim().length === 0) continue;
+    indents.push(/^[ \t]*/.exec(line)![0].length);
+  }
+  if (indents.length === 0) return raw;
+  const minIndent = Math.min(...indents);
+  if (minIndent === 0) return raw;
+  return lines.map((l) => l.slice(minIndent)).join('\n');
+}


### PR DESCRIPTION
## Summary

- `r-libs-setup.ts` no longer hardcodes the install type from `process.platform`. It now picks `binary` vs `source` at runtime via `.Platform$pkgType`, so source-only R builds (e.g. some macOS configurations where CRAN has no matching binary) don't fall over on a forced `type = "binary"`.
- Adds a `heredoc` tagged-template utility (`utils/heredoc.ts`) that strips one leading newline, trailing whitespace after the last newline, and the common leading indent across non-blank lines. Reads template parts in raw form (`strings.raw`) so JS escape sequences pass through to the target language untouched -- write `"\n"` to mean R's newline escape, not a JS newline.
- Converts the clean-pattern `[...].join('\n')` sites in `r-libs-setup.ts`, `debugger.test.ts`, `debugger_extras.test.ts`, and `console_output.test.ts` to use the helper. Rmd/Quarto fixture files (which use literal backtick fences) are intentionally left as-is -- template literals would require backtick escaping there, which is worse than the array form.

## Test plan

- [x] `npx tsc --noEmit` clean in `e2e/rstudio`
- [x] `top-level breakpoint pauses when the file is sourced` (debugger.test.ts) passes locally
- [x] `multi-line input at Browse[N]> preserves browser state` (debugger_extras.test.ts, exercises the `\n` escape case) passes locally
- [x] `output after a caught error is not dropped` (console_output.test.ts, exercises the trailing-newline case) passes locally
- [x] `r-libs-setup` globalSetup runs and picks `binary` correctly on macOS arm64 (verified via `praise_1.0.0.tgz` download from CRAN)