### PR TITLE
debugger: resolve .rs.captureCurrentEnvironment via tools:rstudio

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - ([#17701](https://github.com/rstudio/rstudio/issues/17701)): Honor newline characters in `rstudioapi::showDialog()` and `rstudioapi::showPrompt()` messages.
 - ([#17729](https://github.com/rstudio/rstudio/issues/17729)): Show distinct copy in the Posit Assistant chat pane and preferences install prompt when the recommended Posit Assistant version is older than the installed one.
 - ([#17738](https://github.com/rstudio/rstudio/issues/17738)): Fix `file.edit()` (and other Source pane open events) silently dropping when invoked during an in-flight `closeAllSourceDocs`.
+- ([#17743](https://github.com/rstudio/rstudio/issues/17743)): Fix the debugger failing to capture the browser environment for functions loaded by the `box` package.
 
 ### Dependencies
 - Ace 1.43.5

--- a/e2e/rstudio/tests/panes/debugger/debugger.test.ts
+++ b/e2e/rstudio/tests/panes/debugger/debugger.test.ts
@@ -447,6 +447,55 @@ test.describe('R debugger', () => {
       await debuggerActions.waitForDebugExit();
       await expect(debuggerActions.debuggerPage.activeDebugLine).toHaveCount(0);
     });
+
+    test('captures environment for functions loaded via box::use', async () => {
+      // Regression coverage for rstudio/rstudio#17743. Box modules live in
+      // hermetic namespace:<mod> -> imports:<mod> -> ... chains that bypass
+      // the user search path, so a bare-name .rs.captureCurrentEnvironment()
+      // lookup from the browser's rho would fail with "could not find
+      // function". RStdCallbacks.cpp now resolves it explicitly through
+      // as.environment("tools:rstudio"). Without that fix, browserEnv stays
+      // NIL, the Environment pane falls back to globalenv, and `localx`
+      // would not appear.
+      const missing = await consoleActions.ensurePackages(['box']);
+      test.skip(missing.length > 0, `Missing: ${missing.join(', ')}`);
+
+      const moduleName = `boxmod${Date.now()}`;
+      const fullPath = `${rPath(sandbox.dir)}/${moduleName}.R`;
+      const moduleContent = heredoc`
+        foo <- function() {
+           localx <- 42
+           browser()
+           localx
+        }
+      `;
+      const lines = moduleContent.split('\n').map(l => JSON.stringify(l)).join(', ');
+      await consoleActions.executeInConsole(
+        `writeLines(c(${lines}), "${fullPath}")`,
+        { wait: true },
+      );
+
+      // box::use(./<name>) resolves relative to cwd in interactive R
+      // sessions, which is what an RStudio session is. setwd persists
+      // beyond the test, but the rest of this file uses absolute sandbox
+      // paths so a stale cwd is harmless.
+      await consoleActions.executeInConsole(
+        `setwd("${rPath(sandbox.dir)}")`,
+        { wait: true },
+      );
+      await consoleActions.executeInConsole(
+        `box::use(./${moduleName})`,
+        { wait: true },
+      );
+      await consoleActions.executeInConsole(`${moduleName}$foo()`);
+
+      await debuggerActions.waitForDebugMode();
+
+      await expect.poll(
+        () => envPane.hasVariable('localx', '42'),
+        { timeout: TIMEOUTS.fileOpen },
+      ).toBe(true);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -325,11 +325,18 @@ int RReadConsole(const char *pmt,
       // s_captureInjected is still true so we skip injection and
       // proceed normally. The next new browse prompt (after stepping)
       // injects again.
+      //
+      // Resolve .rs.captureCurrentEnvironment explicitly through
+      // as.environment("tools:rstudio") rather than relying on the
+      // search path being reachable via lexical scope. Functions
+      // loaded by hermetic module systems (e.g. the 'box' package)
+      // have enclosure chains that bypass the user search path, so
+      // a bare .rs.captureCurrentEnvironment() lookup would fail.
       static bool s_captureInjected = false;
       if (browsing && !s_captureInjected)
       {
          s_captureInjected = true;
-         std::string cmd = ".rs.captureCurrentEnvironment()\n";
+         std::string cmd = "as.environment(\"tools:rstudio\")$.rs.captureCurrentEnvironment()\n";
          cmd.copy((char*)buf, cmd.size());
          buf[cmd.size()] = '\0';
          return 1;


### PR DESCRIPTION
## Intent

Addresses #17743.

## Summary

On every new browse prompt, RStudio injects `.rs.captureCurrentEnvironment()` into the REPL input buffer so that R evaluates it in the browser's rho and `parent.frame()` returns the function being debugged. The bare-name lookup relied on `tools:rstudio` being reachable via the function's enclosure chain.

Functions loaded by the [`box`](https://klmr.me/box/) package live in hermetic module environments whose enclosure chains bypass the user search path entirely, so the lookup fails with:

```
Error in .rs.captureCurrentEnvironment() : 
  could not find function ".rs.captureCurrentEnvironment"
```

This change resolves the function explicitly through `as.environment("tools:rstudio")$.rs.captureCurrentEnvironment()`. `as.environment` is in `base` (always reachable from any env), and the search path is global state independent of any lexical scope, so the lookup succeeds regardless of how the function being debugged was loaded.

## Test plan

- [ ] Set `browser()` in a function inside an R script
- [ ] Load it with `box::use(./script)` and call the function
- [ ] Confirm no `could not find function` error appears at the browse prompt
- [ ] Confirm the Environment pane shows the locals of the box-loaded function
- [ ] Smoke-test the debugger with a plain (non-box) function to confirm no regression