### PR TITLE
playwright: saveDocument helper + e2e test reliability fixes

### DIFF
--- a/e2e/rstudio/.gitignore
+++ b/e2e/rstudio/.gitignore
@@ -5,3 +5,6 @@ playwright-report/
 .env
 .env.*
 !.env.example
+
+# Local-only notes, scratchpads, audit lists, etc.
+*.local.md

--- a/e2e/rstudio/actions/assistant_options.actions.ts
+++ b/e2e/rstudio/actions/assistant_options.actions.ts
@@ -18,21 +18,23 @@ export class AssistantOptionsActions {
 
   /** Accept the "Update Posit Assistant" dialog if it appears, then dismiss "Installation Complete" */
   private async acceptUpdateDialog(): Promise<void> {
-    try {
-      const updateBtn = this.page.locator('#rstudio_dlg_yes');
-      if (await updateBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
-        await updateBtn.click();
-        console.log('Accepted Posit Assistant update dialog');
-
-        // Wait for "Installation Complete" dialog and dismiss it
-        const installOkBtn = this.page.locator('#rstudio_dlg_ok');
-        await installOkBtn.click({ timeout: 30000 });
-        console.log('Dismissed Installation Complete dialog');
-        await sleep(500);
-      }
-    } catch {
-      // No update dialog
+    // Caller already settled (selectOption + sleep), so an Update dialog --
+    // if it's going to appear -- is rendered by now. isVisible() snapshot
+    // returns instantly when absent.
+    const updateBtn = this.page.locator('#rstudio_dlg_yes');
+    if (!(await updateBtn.isVisible())) {
+      return;
     }
+    await updateBtn.click();
+    console.log('Accepted Posit Assistant update dialog');
+
+    // Wait for "Installation Complete" dialog and dismiss it. This wait IS
+    // legitimate -- the install runs asynchronously and the OK button only
+    // appears once it completes.
+    const installOkBtn = this.page.locator('#rstudio_dlg_ok');
+    await installOkBtn.click({ timeout: 30000 });
+    console.log('Dismissed Installation Complete dialog');
+    await sleep(500);
   }
 
   async setupAssistantOptions(provider: string): Promise<void> {
@@ -88,8 +90,10 @@ export class AssistantOptionsActions {
     await sleep(1000);
     await this.acceptUpdateDialog();
 
-    // Update dialog may have closed Options; only click OK if still visible
-    if (await this.assistantOptions.optionsOkButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+    // Update dialog may have closed Options; only click OK if still visible.
+    // Snapshot isVisible() -- absence (Options already closed) is the common
+    // case and we shouldn't burn extra time waiting for an element that's gone.
+    if (await this.assistantOptions.optionsOkButton.isVisible()) {
       await this.assistantOptions.optionsOkButton.click();
       await expect(this.assistantOptions.optionsOkButton).toBeHidden({ timeout: 15000 });
     }

--- a/e2e/rstudio/actions/chat_pane.actions.ts
+++ b/e2e/rstudio/actions/chat_pane.actions.ts
@@ -101,46 +101,37 @@ export class ChatPaneActions {
   }
 
   async dismissSetupPrompts(): Promise<void> {
-    // Short timeouts: if these prompts exist, they're visible almost immediately.
-    // Using 1500ms instead of 5000ms saves ~10s when no prompts are present.
-    try {
-      await this.chatPane.installBtn.click({ timeout: 1500 });
-      console.log('Clicked Install button — waiting for installation...');
+    // These prompts are visible immediately when present; absence is the common
+    // case. Gate each click on isVisible() (snapshot) so we don't burn the full
+    // click({ timeout }) auto-wait when the button is missing.
+    if (await this.chatPane.installBtn.isVisible()) {
+      await this.chatPane.installBtn.click();
+      console.log('Clicked Install button -- waiting for installation...');
       await expect(this.chatPane.chatRoot).toBeVisible({ timeout: 60000 });
       await expect(this.chatPane.chatTextarea).toBeVisible({ timeout: 30000 });
       return;
-    } catch {
-      // No Install button
     }
 
-    try {
-      await this.chatPane.updateBtn.click({ timeout: 1500 });
-      console.log('Clicked Update on update prompt — updating Posit Assistant');
+    if (await this.chatPane.updateBtn.isVisible()) {
+      await this.chatPane.updateBtn.click();
+      console.log('Clicked Update on update prompt -- updating Posit Assistant');
       await expect(this.chatPane.chatRoot).toBeVisible({ timeout: 30000 });
       return;
-    } catch {
-      // No update prompt, or pane is stale after update via Options
     }
 
-    // Dismiss "Trust this directory?" prompt if present
-    try {
-      const trustBtn = this.chatPane.frame.locator("button:has-text('Trust'), button:has-text('trust')");
-      await trustBtn.first().click({ timeout: 1500 });
+    const trustBtn = this.chatPane.frame
+      .locator("button:has-text('Trust'), button:has-text('trust')")
+      .first();
+    if (await trustBtn.isVisible()) {
+      await trustBtn.click();
       console.log('Dismissed directory trust prompt');
-    } catch {
-      // No trust prompt
     }
-
   }
 
   async clickAllowOnceIfPresent(): Promise<void> {
-    try {
-      // click() already polls for actionability within its own timeout, so
-      // there's no need to pre-sleep waiting for the dialog to appear.
-      await this.chatPane.allowBtn.click({ timeout: 3000 });
+    if (await this.chatPane.allowBtn.isVisible()) {
+      await this.chatPane.allowBtn.click();
       console.log('Clicked "Allow" permission button');
-    } catch {
-      // No permission dialog
     }
   }
 
@@ -261,10 +252,11 @@ export class ChatPaneActions {
   }
 
   async getPositAssistantVersion(): Promise<string> {
+    if (!(await this.chatPane.moreBtn.isVisible())) {
+      return 'unknown';
+    }
     try {
-      await this.chatPane.moreBtn.click({ timeout: 5000 });
-      // .first().click() polls for the menu item, replacing the
-      // previous post-click sleep.
+      await this.chatPane.moreBtn.click();
       await this.chatPane.aboutItem.first().click();
 
       await this.chatPane.dialogOverlay.waitFor({ state: 'visible', timeout: 5000 });

--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -391,86 +391,95 @@ export async function launchRStudio(existingConfigRoot?: string): Promise<Deskto
 
   // If anything fails after CDP connect, kill the process to avoid orphaning RStudio.
   try {
-    // The splash screen briefly holds its own page that gets replaced by the
-    // main GWT window. In GWT super dev mode there is also a transient
-    // "Compiling RStudio" page that briefly exposes window.rstudio just
-    // before the codeserver redirects to the compiled app. To avoid
-    // latching onto either of those, poll for a page whose automation
-    // bridge stays installed on the *same* page across consecutive polls.
+    // Gated diagnostic for the post-CDP wait. Helps compare what the test
+    // fixture is waiting on against what's visible in the UI. Enabled by
+    // PW_DEBUG_LAUNCH=1, same flag as attachLaunchDebug above.
+    const launchDebug =
+      process.env.PW_DEBUG_LAUNCH === '1' || process.env.PW_DEBUG_LAUNCH === 'true';
+    const launchT0 = Date.now();
+    const logLaunchStep = (label: string): void => {
+      if (launchDebug) {
+        console.log(`[launch-timing] +${(Date.now() - launchT0).toString().padStart(5, ' ')}ms ${label}`);
+      }
+    };
+    logLaunchStep('CDP connected; polling for window.rstudio.ready');
+
+    // The splash screen and (in GWT super dev mode) a transient "Compiling
+    // RStudio" page both flash before the real app loads, and the compiling
+    // page briefly exposes window.rstudio. Polling for window.rstudio.ready
+    // === true cuts through both: ApplicationAutomation initializes ready to
+    // false and only flips it on DeferredInitCompletedEvent, so the transient
+    // page never matches and we proceed exactly when R-to-GWT roundtrips are
+    // safe (no separate stability window needed).
     const pageDeadline = Date.now() + 30000;
-    const requiredStableMs = 1000;
     let page: Page | undefined;
-    let stablePage: Page | undefined;
-    let stableSince = 0;
+    let bridgeFirstSeen = false;
 
     while (Date.now() < pageDeadline && !page) {
-      let foundPage: Page | undefined;
       for (const ctx of browser.contexts()) {
         for (const candidate of ctx.pages()) {
           if (candidate.isClosed()) continue;
           try {
-            const hasBridge = await candidate.evaluate(
-              'typeof window.rstudio?.commands?.activateConsole === "function"',
-            );
-            if (hasBridge === true) {
-              foundPage = candidate;
+            const state = await candidate.evaluate(() => {
+              const r = window.rstudio;
+              return {
+                hasBridge: typeof r?.commands?.activateConsole === 'function',
+                ready: r?.ready === true,
+              };
+            });
+            if (state.hasBridge && !bridgeFirstSeen) {
+              bridgeFirstSeen = true;
+              logLaunchStep('window.rstudio bridge installed (ready=false)');
+            }
+            if (state.hasBridge && state.ready) {
+              page = candidate;
               break;
             }
           } catch {
             // Page may be navigating or closing during splash -> main transition.
           }
         }
-        if (foundPage) break;
+        if (page) break;
       }
-
-      if (foundPage && foundPage === stablePage) {
-        if (Date.now() - stableSince >= requiredStableMs) {
-          page = stablePage;
-          break;
-        }
-      } else {
-        // Either no page has the bridge right now, or a different page does
-        // than the one we were tracking. Restart the stability window.
-        stablePage = foundPage;
-        stableSince = foundPage ? Date.now() : 0;
-      }
-
+      if (page) break;
       await sleep(250);
     }
     if (!page) {
-      throw new Error('GWT app did not finish loading within 30s (no stable page with window.rstudio bridge)');
+      throw new Error('GWT app did not finish loading within 30s (window.rstudio.ready never became true)');
     }
+    logLaunchStep('window.rstudio.ready === true');
 
-    // Dismiss any "save changes" modal from a previous interrupted run
-    try {
-      const dontSaveBtn = page.locator("button:has-text('Don\\'t Save'), button:has-text('Do not Save'), #rstudio_dlg_no");
-      await dontSaveBtn.click({ timeout: 3000 });
+    // Dismiss any "save changes" modal from a previous interrupted run.
+    // Use isVisible() (snapshot, no wait) to gate the click -- the prior
+    // form passed timeout: 3000 to click(), which spends the full 3s waiting
+    // when no dialog exists (the common case with a fresh per-spec sandbox).
+    const dontSaveBtn = page.locator(
+      "button:has-text('Don\\'t Save'), button:has-text('Do not Save'), #rstudio_dlg_no",
+    ).first();
+    if (await dontSaveBtn.isVisible()) {
+      await dontSaveBtn.click();
       console.log('Dismissed save dialog from previous session');
       await sleep(1000);
-    } catch {
-      // No dialog, continue normally
     }
 
-    // Dismiss any other modal overlay (e.g. update notification, options dialog)
-    try {
-      const overlay = page.locator('.gwt-PopupPanelGlass');
-      if (await overlay.isVisible({ timeout: 1000 })) {
-        await page.keyboard.press('Escape');
-        console.log('Dismissed modal overlay during startup');
-        await sleep(1000);
-      }
-    } catch {
-      // No overlay
+    // Dismiss any other modal overlay (e.g. update notification, options dialog).
+    const overlay = page.locator('.gwt-PopupPanelGlass').first();
+    if (await overlay.isVisible()) {
+      await page.keyboard.press('Escape');
+      console.log('Dismissed modal overlay during startup');
+      await sleep(1000);
     }
 
     // Activate console (makes it visible without zooming)
     await executeCommand(page, 'activateConsole');
+    logLaunchStep('activateConsole dispatched');
 
     // Wait for the console input to be visible AND R to be idle (no
     // rstudio-console-busy class on #rstudio_console_input). The latter is
     // what GWT sets while R is executing -- visibility alone can occur a
     // beat before R is ready to accept input.
     await page.waitForSelector(CONSOLE_INPUT, { state: 'visible', timeout: TIMEOUTS.consoleReady });
+    logLaunchStep('console input visible');
     await page.waitForFunction(
       () => {
         const el = document.getElementById('rstudio_console_input');
@@ -479,6 +488,7 @@ export async function launchRStudio(existingConfigRoot?: string): Promise<Deskto
       null,
       { timeout: TIMEOUTS.consoleReady, polling: 100 },
     );
+    logLaunchStep('console input not busy');
     console.log('RStudio console is ready');
 
     return { page, browser, rstudioProcess, configRoot };

--- a/e2e/rstudio/fixtures/server.fixture.ts
+++ b/e2e/rstudio/fixtures/server.fixture.ts
@@ -246,13 +246,16 @@ export async function launchServer(): Promise<ServerSession> {
   await page.waitForSelector(CONSOLE_INPUT, { state: 'visible', timeout: loginTimeout });
   console.log('RStudio console is ready');
 
-  try {
-    const dontSaveBtn = page.locator("button:has-text('Don\\'t Save'), button:has-text('Do not Save'), #rstudio_dlg_no");
-    await dontSaveBtn.click({ timeout: 2000 });
+  // Dismiss any "save changes" modal from a previous interrupted run.
+  // Use isVisible() (snapshot, no wait) to gate the click -- click({ timeout })
+  // would spend the full timeout when no dialog exists.
+  const dontSaveBtn = page.locator(
+    "button:has-text('Don\\'t Save'), button:has-text('Do not Save'), #rstudio_dlg_no",
+  ).first();
+  if (await dontSaveBtn.isVisible()) {
+    await dontSaveBtn.click();
     console.log('Dismissed save dialog from previous session');
     await sleep(500);
-  } catch {
-    // No dialog present
   }
 
   await page.getByRole('tab', { name: 'Files' }).click({ timeout: 120_000 });

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -36,12 +36,12 @@ const allProjects = [
   {
     name: 'desktop',
     use: { mode: 'desktop' as const },
-    grepInvert: new RegExp(['@server_only', ...desktopOsExclusions, ...editionExclusions].join('|')),
+    grepInvert: new RegExp(['@server_only', '@smoke', ...desktopOsExclusions, ...editionExclusions].join('|')),
   },
   {
     name: 'server',
     use: { mode: 'server' as const },
-    grepInvert: new RegExp(['@desktop_only', ...serverOsExclusions, ...editionExclusions].join('|')),
+    grepInvert: new RegExp(['@desktop_only', '@smoke', ...serverOsExclusions, ...editionExclusions].join('|')),
   },
 ];
 

--- a/e2e/rstudio/tests/panes/console/console_output.test.ts
+++ b/e2e/rstudio/tests/panes/console/console_output.test.ts
@@ -12,7 +12,7 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { AceEditorElement } from '@utils/ace';
 import { writeAndOpenFile, closeAndDeleteSandboxFiles } from '@utils/files';
-import { executeCommand } from '@utils/commands';
+import { clearPref, executeCommand, setPref } from '@utils/commands';
 import { sleep, TIMEOUTS } from '@utils/constants';
 import { heredoc } from '@utils/heredoc';
 
@@ -73,9 +73,7 @@ test.describe('Console output and annotation', () => {
   });
 
   test('errors are highlighted when consoleHighlightConditions is set', async ({ rstudioPage: page }) => {
-    await consoleActions.executeInConsole(
-      '.rs.uiPrefs$consoleHighlightConditions$set("errors_warnings_messages")',
-    );
+    await setPref(page, 'console_highlight_conditions', 'errors_warnings_messages');
     try {
       await consoleActions.executeInConsole('stop("This is an error.")');
       await expect(consoleActions.consolePane.consoleOutput)
@@ -87,14 +85,12 @@ test.describe('Console output and annotation', () => {
       await expect.poll(() => consoleSpanTexts(page))
         .toEqual(expect.arrayContaining(['Error']));
     } finally {
-      await consoleActions.executeInConsole('.rs.uiPrefs$consoleHighlightConditions$clear()');
+      await clearPref(page, 'console_highlight_conditions');
     }
   });
 
   test('warnings are highlighted with options(warn = 0) and options(warn = 1)', async ({ rstudioPage: page }) => {
-    await consoleActions.executeInConsole(
-      '.rs.uiPrefs$consoleHighlightConditions$set("errors_warnings_messages")',
-    );
+    await setPref(page, 'console_highlight_conditions', 'errors_warnings_messages');
     try {
       // warn = 0 defers warnings -- the prefix is "Warning message" once R
       // surfaces them at the prompt.
@@ -111,7 +107,7 @@ test.describe('Console output and annotation', () => {
         .toEqual(expect.arrayContaining(['Warning']));
     } finally {
       await consoleActions.executeInConsole('options(warn = 0)');
-      await consoleActions.executeInConsole('.rs.uiPrefs$consoleHighlightConditions$clear()');
+      await clearPref(page, 'console_highlight_conditions');
     }
   });
 
@@ -161,8 +157,8 @@ test.describe('Console output and annotation', () => {
     }).toBe('M2');
   });
 
-  test('long lines are truncated when consoleLineLengthLimit is reduced', async () => {
-    await consoleActions.executeInConsole('.rs.uiPrefs$consoleLineLengthLimit$set(10L)');
+  test('long lines are truncated when consoleLineLengthLimit is reduced', async ({ rstudioPage: page }) => {
+    await setPref(page, 'console_line_length_limit', 10);
     try {
       await consoleActions.executeInConsole(
         'cat(paste(rep.int("a", 1E4), collapse = ""), sep = "\\n")',
@@ -170,8 +166,9 @@ test.describe('Console output and annotation', () => {
       await expect(consoleActions.consolePane.consoleOutput)
         .toContainText('aaaaaaaaaa ... <truncated>');
     } finally {
-      // Restore the default so the pref doesn't bleed into later tests.
-      await consoleActions.executeInConsole('.rs.uiPrefs$consoleLineLengthLimit$set(2000L)');
+      // Restore the default (schema default is 2000) so the pref doesn't
+      // bleed into later tests.
+      await clearPref(page, 'console_line_length_limit');
     }
   });
 });

--- a/e2e/rstudio/tests/panes/data-viewer/pagination-sorting.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/pagination-sorting.test.ts
@@ -1,9 +1,8 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
-import { sleep } from '@utils/constants';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePane } from '@pages/source_pane.page';
 import { DataViewerPane } from '@pages/data_viewer.page';
-import { executeCommand } from '@utils/commands';
+import { resetSourcePaneState } from '@utils/commands';
 
 // Tests from: electron-tests/EditorPane/test_desktop_DataViewer.py
 // Issues: https://github.com/rstudio/rstudio/issues/13220
@@ -22,19 +21,24 @@ test.describe('Data Viewer', () => {
   });
 
   test.afterEach(async ({ rstudioPage: page }) => {
-    // Close the data viewer tab after each test
-    await executeCommand(page, 'closeSourceDoc');
-    await sleep(1000);
+    // resetToUntitled (vs closeSourceDoc) leaves a single Untitled tab
+    // behind, which keeps the Source pane open across tests. Without that,
+    // the pane closes when the last data viewer tab is closed and re-opens
+    // when the next test's View(df) lands -- and the toolbar can get stuck
+    // hidden in the open-then-close-then-reopen window (#17738-ish).
+    await resetSourcePaneState(page);
+    await expect(sourcePane.selectedTab).toContainText('Untitled', { timeout: 5000 });
   });
 
   // -----------------------------------------------------------------------
-  // Issue 13220 — Large data frame navigation
+  // Issue 13220 - Large data frame navigation
   // -----------------------------------------------------------------------
-  test('large data frame - navigation arrows and column pagination', async ({ rstudioPage: page }) => {
-    await consoleActions.executeInConsole('df <- data.frame(matrix(1:1000000, nrow=100000, ncol=500))');
-    await sleep(2000);
+  test('large data frame - navigation arrows and column pagination', async () => {
+    await consoleActions.executeInConsole(
+      'df <- data.frame(matrix(1:1000000, nrow=100000, ncol=500))',
+      { wait: true },
+    );
     await consoleActions.executeInConsole('View(df)');
-    await sleep(3000);
 
     await expect(sourcePane.selectedTab).toContainText('df');
 
@@ -49,17 +53,14 @@ test.describe('Data Viewer', () => {
 
     // Navigate forward one page
     await dataViewer.rightArrow.click();
-    await sleep(1000);
     await expect(dataViewer.columnNumberInput).toHaveValue('201 - 400');
 
     // Jump to last page
     await dataViewer.rightDoubleArrow.click();
-    await sleep(1000);
     await expect(dataViewer.columnNumberInput).toHaveValue('301 - 500');
 
     // Jump back to first page
     await dataViewer.leftDoubleArrow.click();
-    await sleep(1000);
     await expect(dataViewer.columnNumberInput).toHaveValue('1 - 200');
 
     // Verify grid info inside iframe (visible row count depends on pane height)
@@ -69,23 +70,24 @@ test.describe('Data Viewer', () => {
   // -----------------------------------------------------------------------
   // Odd-numbered columns (edge case for pagination)
   // -----------------------------------------------------------------------
-  test('odd-numbered column count - pagination edge case', async ({ rstudioPage: page }) => {
-    await consoleActions.executeInConsole('df <- data.frame(matrix(1:1000000, nrow=1000, ncol=227))');
-    await sleep(2000);
+  test('odd-numbered column count - pagination edge case', async () => {
+    await consoleActions.executeInConsole(
+      'df <- data.frame(matrix(1:1000000, nrow=1000, ncol=227))',
+      { wait: true },
+    );
     await consoleActions.executeInConsole('View(df)');
-    await sleep(3000);
 
     await expect(sourcePane.selectedTab).toContainText('df');
     await expect(dataViewer.columnNumberInput).toHaveValue('1 - 200');
 
-    // Jump to last page -- viewer slides the 200-column window to end at column 227
+    // The viewer's column-number input renders before the navigation
+    // arrows do; wait for the specific arrow to be visible before clicking.
+    await expect(dataViewer.rightDoubleArrow).toBeVisible();
     await dataViewer.rightDoubleArrow.click();
-    await sleep(1000);
     await expect(dataViewer.columnNumberInput).toHaveValue('28 - 227');
 
     // Jump back to first page
     await dataViewer.leftDoubleArrow.click();
-    await sleep(1000);
     await expect(dataViewer.columnNumberInput).toHaveValue('1 - 200');
 
     // Verify grid info (visible row count depends on pane height)
@@ -95,15 +97,16 @@ test.describe('Data Viewer', () => {
   // -----------------------------------------------------------------------
   // Sorting
   // -----------------------------------------------------------------------
-  test('column sorting - descending order', async ({ rstudioPage: page }) => {
-    await consoleActions.executeInConsole('df <- data.frame(matrix(1:1000000, nrow=100000, ncol=500))');
-    await sleep(2000);
+  test('column sorting - descending order', async () => {
+    await consoleActions.executeInConsole(
+      'df <- data.frame(matrix(1:1000000, nrow=100000, ncol=500))',
+      { wait: true },
+    );
     await consoleActions.executeInConsole('View(df)');
-    await sleep(3000);
 
     await expect(sourcePane.selectedTab).toContainText('df');
 
-    // First row cells: [rowNum, X1, X2, X3, ...] — X2 is td:nth-child(3).
+    // First row cells: [rowNum, X1, X2, X3, ...] -- X2 is td:nth-child(3).
     // tbody starts with a virtual-scroll spacer row; select the first data
     // row by its data-row attribute instead of :first-child.
     const firstRowX2 = dataViewer.frame.locator('#rsGridData tbody tr[data-row="0"] td:nth-child(3)');
@@ -112,33 +115,29 @@ test.describe('Data Viewer', () => {
     // Click column 2 header twice for descending sort
     await dataViewer.columnHeader(2).click();
     await dataViewer.columnHeader(2).click();
-    await sleep(2000);
 
     // After descending sort, first row of X2 should be 200000 (max value)
     await expect(firstRowX2).toContainText('200000');
   });
 
   // -----------------------------------------------------------------------
-  // Issue 13328 — Sorting with many columns after navigating
+  // Issue 13328 - Sorting with many columns after navigating
   // -----------------------------------------------------------------------
-  test('sorting after navigating to later columns (#13328)', async ({ rstudioPage: page }) => {
+  test('sorting after navigating to later columns (#13328)', async () => {
     // Create a 10-row x 400-column data frame with shifted values
     await consoleActions.executeInConsole('data <- replicate(400, 0:9, simplify = FALSE)');
-    await sleep(1000);
-    await consoleActions.executeInConsole('for (i in seq_along(data)) { data[[i]] <- (data[[i]] + i) %% 10 }');
-    await sleep(1000);
+    await consoleActions.executeInConsole(
+      'for (i in seq_along(data)) { data[[i]] <- (data[[i]] + i) %% 10 }',
+    );
     await consoleActions.executeInConsole('names(data) <- paste0("V", 1:400)');
-    await sleep(500);
-    await consoleActions.executeInConsole('df <- as.data.frame(data)');
-    await sleep(500);
+    await consoleActions.executeInConsole('df <- as.data.frame(data)', { wait: true });
     await consoleActions.executeInConsole('View(df)');
-    await sleep(3000);
 
     await expect(dataViewer.columnNumberInput).toHaveValue('1 - 200');
 
-    // Navigate to second page of columns
+    // Wait for the navigation arrow to render before clicking it.
+    await expect(dataViewer.rightArrow).toBeVisible();
     await dataViewer.rightArrow.click();
-    await sleep(1000);
     await expect(dataViewer.columnNumberInput).toHaveValue('201 - 400');
 
     // Column 201 is the first data column on page 2: td:nth-child(2).
@@ -148,7 +147,6 @@ test.describe('Data Viewer', () => {
     // Sort column 201 descending (click twice)
     await dataViewer.columnHeader(201).click();
     await dataViewer.columnHeader(201).click();
-    await sleep(2000);
 
     // After descending sort, first row of column 201 should be 9
     await expect(firstRowCol201).toContainText('9');

--- a/e2e/rstudio/tests/panes/debugger/debugger.test.ts
+++ b/e2e/rstudio/tests/panes/debugger/debugger.test.ts
@@ -3,9 +3,10 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { DebuggerActions } from '@actions/debugger.actions';
 import { EnvironmentPane } from '@pages/environment_pane.page';
 import { useSuiteSandbox } from '@utils/sandbox';
-import { TIMEOUTS, sleep } from '@utils/constants';
+import { TIMEOUTS } from '@utils/constants';
 import { executeCommand } from '@utils/commands';
 import { heredoc } from '@utils/heredoc';
+import { waitForConsoleIdle } from '@pages/console_pane.page';
 
 const sandbox = useSuiteSandbox();
 
@@ -27,10 +28,22 @@ async function writeAndOpen(fileName: string, content: string): Promise<void> {
   // string-escape rules (\\, \", \n, \t, \uXXXX) match R's, so JSON.stringify
   // each line and join with commas to produce a valid R argument list.
   const lines = content.split('\n').map(l => JSON.stringify(l)).join(', ');
-  await consoleActions.executeInConsole(`writeLines(c(${lines}), "${fullPath}")`);
-  await sleep(TIMEOUTS.settleDelay);
+
+  // wait:true so file.edit doesn't race the writeLines completion.
+  await consoleActions.executeInConsole(
+    `writeLines(c(${lines}), "${fullPath}")`,
+    { wait: true },
+  );
+
   await consoleActions.executeInConsole(`file.edit("${fullPath}")`);
-  await sleep(TIMEOUTS.fileEditSettle);
+  // file.edit returns quickly on the R side but the editor opens
+  // asynchronously on the GWT side. Wait for the file's tab to actually
+  // be the selected one -- a deterministic signal that the buffer is
+  // ready to drive.
+  const selectedTab = consoleActions.page.locator(
+    "[class*='rstudio_source_panel'] [class*='PanelTab-selected']",
+  );
+  await expect(selectedTab).toContainText(fileName, { timeout: TIMEOUTS.fileOpen });
 }
 
 async function resetAfterTest(): Promise<void> {
@@ -120,7 +133,7 @@ test.describe('R debugger', () => {
       // click produces an ACTIVE (.ace_breakpoint) marker rather than a
       // pending / inactive one that wouldn't satisfy our locator.
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
-      await sleep(TIMEOUTS.settleDelay);
+      await waitForConsoleIdle(consoleActions.page);
 
       // Set breakpoint on the brace-expression line (line 3).
       await debuggerActions.setBreakpoint(3);
@@ -154,7 +167,7 @@ test.describe('R debugger', () => {
       await writeAndOpen(fileName, content);
       // Source so the toggled breakpoint becomes ACTIVE rather than INACTIVE.
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
-      await sleep(TIMEOUTS.settleDelay);
+      await waitForConsoleIdle(consoleActions.page);
 
       // Place the cursor on line 2 via the goToLine command.
       await consoleActions.goToLine(2);
@@ -203,7 +216,7 @@ test.describe('R debugger', () => {
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
-      await sleep(TIMEOUTS.settleDelay);
+      await waitForConsoleIdle(consoleActions.page);
       await debuggerActions.setBreakpoint(2);
       await consoleActions.executeInConsole('step_next_fn()');
 
@@ -231,7 +244,7 @@ test.describe('R debugger', () => {
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
-      await sleep(TIMEOUTS.settleDelay);
+      await waitForConsoleIdle(consoleActions.page);
       // Breakpoint on the line that calls inner() (line 5).
       await debuggerActions.setBreakpoint(5);
       await consoleActions.executeInConsole('outer()');
@@ -274,7 +287,7 @@ test.describe('R debugger', () => {
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
-      await sleep(TIMEOUTS.settleDelay);
+      await waitForConsoleIdle(consoleActions.page);
       await debuggerActions.setBreakpoint(2);
       await consoleActions.executeInConsole('step_finish_fn()');
 
@@ -301,7 +314,7 @@ test.describe('R debugger', () => {
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
-      await sleep(TIMEOUTS.settleDelay);
+      await waitForConsoleIdle(consoleActions.page);
       await debuggerActions.setBreakpoint(2);
       await debuggerActions.setBreakpoint(5);
       await consoleActions.executeInConsole('step_continue_fn()');
@@ -330,7 +343,7 @@ test.describe('R debugger', () => {
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
-      await sleep(TIMEOUTS.settleDelay);
+      await waitForConsoleIdle(consoleActions.page);
       await debuggerActions.setBreakpoint(2);
       await consoleActions.executeInConsole('step_stop_fn()');
 
@@ -356,7 +369,7 @@ test.describe('R debugger', () => {
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
-      await sleep(TIMEOUTS.settleDelay);
+      await waitForConsoleIdle(consoleActions.page);
       for (const line of [2, 3, 4, 5, 6, 7]) {
         await debuggerActions.setBreakpoint(line);
       }
@@ -415,7 +428,7 @@ test.describe('R debugger', () => {
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
-      await sleep(TIMEOUTS.settleDelay);
+      await waitForConsoleIdle(consoleActions.page);
       await consoleActions.executeInConsole('browser_entry_fn()');
 
       await debuggerActions.waitForDebugMode();
@@ -439,7 +452,7 @@ test.describe('R debugger', () => {
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
-      await sleep(TIMEOUTS.settleDelay);
+      await waitForConsoleIdle(consoleActions.page);
       await consoleActions.executeInConsole('browser_continue_fn()');
 
       await debuggerActions.waitForDebugMode();
@@ -466,7 +479,7 @@ test.describe('R debugger', () => {
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
-      await sleep(TIMEOUTS.settleDelay);
+      await waitForConsoleIdle(consoleActions.page);
       await consoleActions.executeInConsole('rerun_fn()');
 
       // The error widget — and the "Rerun with Debug" link inside it —
@@ -504,7 +517,7 @@ test.describe('R debugger', () => {
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
-      await sleep(TIMEOUTS.settleDelay);
+      await waitForConsoleIdle(consoleActions.page);
       await consoleActions.executeInConsole('env_locals_fn()');
 
       await debuggerActions.waitForDebugMode();
@@ -526,7 +539,7 @@ test.describe('R debugger', () => {
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
-      await sleep(TIMEOUTS.settleDelay);
+      await waitForConsoleIdle(consoleActions.page);
       await consoleActions.executeInConsole('tb_f()');
 
       await debuggerActions.waitForDebugMode();
@@ -563,7 +576,7 @@ test.describe('R debugger', () => {
 
       await writeAndOpen(fileName, content);
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
-      await sleep(TIMEOUTS.settleDelay);
+      await waitForConsoleIdle(consoleActions.page);
       await consoleActions.executeInConsole('fr_f()');
 
       await debuggerActions.waitForDebugMode();

--- a/e2e/rstudio/tests/panes/editor/air_formatting.test.ts
+++ b/e2e/rstudio/tests/panes/editor/air_formatting.test.ts
@@ -34,7 +34,7 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePaneActions } from '@actions/source_pane.actions';
 import { sleep } from '@utils/constants';
 import { useSuiteSandbox } from '@utils/sandbox';
-import { executeCommand } from '@utils/commands';
+import { executeCommand, setPref } from '@utils/commands';
 import { createAndOpenProject } from '@utils/project';
 
 // --- Test data (from issue #16721) ---
@@ -118,8 +118,9 @@ async function setAirPrefs(
 
 /** Reset Air-related preferences programmatically (for setup/cleanup, not the test itself). */
 async function resetAirPrefs(consoleActions: ConsolePaneActions): Promise<void> {
-  await consoleActions.executeInConsole('{ .rs.uiPrefs$codeFormatter$set("none"); .rs.uiPrefs$useAirFormatter$set(FALSE); .rs.uiPrefs$reformatOnSave$set(FALSE) }');
-  await sleep(1000);
+  await setPref(consoleActions.page, 'code_formatter', 'none');
+  await setPref(consoleActions.page, 'use_air_formatter', false);
+  await setPref(consoleActions.page, 'reformat_on_save', false);
 }
 
 /** Create an Air config file in the working directory. */

--- a/e2e/rstudio/tests/panes/editor/code-folding.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code-folding.test.ts
@@ -4,6 +4,7 @@ import { SourcePaneActions } from '@actions/source_pane.actions';
 import { AceEditor } from '@pages/ace_editor.page';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { writeAndOpenFile, closeAndDeleteSandboxFiles } from '@utils/files';
+import { clearPref, setPref } from '@utils/commands';
 
 test.describe('Code folding', () => {
   const sandbox = useSuiteSandbox();
@@ -17,13 +18,13 @@ test.describe('Code folding', () => {
   });
 
   test.afterEach(async ({ rstudioPage: page }) => {
-    await consoleActions.executeInConsole('.rs.uiPrefs$hierarchicalSectionFolding$clear()');
+    await clearPref(page, 'hierarchical_section_folding');
     await closeAndDeleteSandboxFiles(page, sandbox.dir, ['code_folding.R']);
   });
 
   // https://github.com/rstudio/rstudio/issues/16541
   test('hierarchical section folding respects heading depth', async ({ rstudioPage: page }) => {
-    await consoleActions.executeInConsole('.rs.uiPrefs$hierarchicalSectionFolding$set(TRUE)');
+    await setPref(page, 'hierarchical_section_folding', true);
 
     const content = `# Section 1 ----
 code_1 <- 1
@@ -65,7 +66,7 @@ code_2 <- 4
 
   // https://github.com/rstudio/rstudio/issues/16541
   test('flat section folding stops at any section header', async ({ rstudioPage: page }) => {
-    await consoleActions.executeInConsole('.rs.uiPrefs$hierarchicalSectionFolding$set(FALSE)');
+    await setPref(page, 'hierarchical_section_folding', false);
 
     const content = `# Section 1 ----
 code_1 <- 1

--- a/e2e/rstudio/tests/panes/editor/editor.test.ts
+++ b/e2e/rstudio/tests/panes/editor/editor.test.ts
@@ -5,7 +5,7 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { AceEditor } from '@pages/ace_editor.page';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { writeAndOpenFile, closeAndDeleteSandboxFiles } from '@utils/files';
-import { executeCommand } from '@utils/commands';
+import { executeCommand, saveDocument } from '@utils/commands';
 import { sleep, TIMEOUTS } from '@utils/constants';
 
 // Both the console and the active editor mount a FindReplaceBar that shares
@@ -53,11 +53,9 @@ test.describe('Editor', () => {
       await editor.gotoLine(4);
       await editor.insert('# comment 4   ');
 
-      await executeCommand(page, 'saveSourceDoc');
+      await saveDocument(page);
 
-      await expect.poll(async () => {
-        return (await editor.getValue()).trim();
-      }).toBe('# comment 1\n# comment 2\n# comment 3\n# comment 4');
+      expect((await editor.getValue()).trim()).toBe('# comment 1\n# comment 2\n# comment 3\n# comment 4');
     } finally {
       await consoleActions.executeInConsole('.rs.uiPrefs$stripTrailingWhitespace$clear()');
     }

--- a/e2e/rstudio/tests/panes/editor/editor.test.ts
+++ b/e2e/rstudio/tests/panes/editor/editor.test.ts
@@ -5,7 +5,7 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { AceEditor } from '@pages/ace_editor.page';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { writeAndOpenFile, closeAndDeleteSandboxFiles } from '@utils/files';
-import { executeCommand, saveDocument } from '@utils/commands';
+import { clearPref, executeCommand, saveDocument, setPref } from '@utils/commands';
 import { sleep, TIMEOUTS } from '@utils/constants';
 
 // Both the console and the active editor mount a FindReplaceBar that shares
@@ -42,7 +42,10 @@ test.describe('Editor', () => {
   });
 
   test('trailing whitespace is trimmed on save when pref is enabled', async ({ rstudioPage: page }) => {
-    await consoleActions.executeInConsole('.rs.uiPrefs$stripTrailingWhitespace$set(TRUE)');
+    // setPref goes through the bridge (synchronous to GWT) -- using
+    // executeInConsole here would race the save below, since the R-side
+    // pref update isn't necessarily visible to the editor's save flow yet.
+    await setPref(page, 'strip_trailing_whitespace', true);
     try {
       const content = '# comment 1  \n# comment 2 \n# comment 3   \n';
       await writeAndOpenFile(page, sandbox.dir, 'editor_whitespace.R', content);
@@ -57,7 +60,7 @@ test.describe('Editor', () => {
 
       expect((await editor.getValue()).trim()).toBe('# comment 1\n# comment 2\n# comment 3\n# comment 4');
     } finally {
-      await consoleActions.executeInConsole('.rs.uiPrefs$stripTrailingWhitespace$clear()');
+      await clearPref(page, 'strip_trailing_whitespace');
     }
   });
 

--- a/e2e/rstudio/tests/panes/editor/multiline_chunk_execution.test.ts
+++ b/e2e/rstudio/tests/panes/editor/multiline_chunk_execution.test.ts
@@ -8,7 +8,7 @@ import { sleep } from '@utils/constants';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePaneActions } from '@actions/source_pane.actions';
 import { useSuiteSandbox } from '@utils/sandbox';
-import { executeCommand } from '@utils/commands';
+import { executeCommand, saveDocument } from '@utils/commands';
 
 test.describe('Multiline chunk execution', { tag: ['@parallel_safe'] }, () => {
   // Sets cwd to a per-spec sandbox; relative paths used by createAndOpenFile
@@ -48,8 +48,7 @@ test.describe('Multiline chunk execution', { tag: ['@parallel_safe'] }, () => {
     await expect(sourceActions.sourcePane.selectedTab).toContainText(fileName, { timeout: 20000 });
 
     // Save so it's on disk
-    await executeCommand(page, 'saveSourceDoc');
-    await sleep(1000);
+    await saveDocument(page);
 
     // --- Chunk 1: incomplete expression (1 +\n2) ---
     await consoleActions.clearConsole();

--- a/e2e/rstudio/tests/panes/editor/notebook_save_during_execution.test.ts
+++ b/e2e/rstudio/tests/panes/editor/notebook_save_during_execution.test.ts
@@ -8,7 +8,7 @@ import { sleep } from '@utils/constants';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePaneActions } from '@actions/source_pane.actions';
 import { useSuiteSandbox } from '@utils/sandbox';
-import { executeCommand } from '@utils/commands';
+import { executeCommand, saveDocument } from '@utils/commands';
 
 test.describe('Notebook save during execution', { tag: ['@parallel_safe'] }, () => {
   // Sets cwd to a per-spec sandbox; relative paths used by createAndOpenFile
@@ -59,8 +59,7 @@ test.describe('Notebook save during execution', { tag: ['@parallel_safe'] }, () 
     await expect(sourceActions.sourcePane.selectedTab).toContainText(fileName, { timeout: 20000 });
 
     // Save the file first so it's on disk
-    await executeCommand(page, 'saveSourceDoc');
-    await sleep(1000);
+    await saveDocument(page);
 
     // Make an edit so the file has unsaved changes — Ctrl+S during execution
     // must actually trigger a save for the bug to manifest

--- a/e2e/rstudio/tests/panes/editor/reformat.test.ts
+++ b/e2e/rstudio/tests/panes/editor/reformat.test.ts
@@ -9,7 +9,7 @@ import { AceEditor } from '@pages/ace_editor.page';
 import { SourcePane } from '@pages/source_pane.page';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { writeAndOpenFile, closeAndDeleteSandboxFiles } from '@utils/files';
-import { executeCommand } from '@utils/commands';
+import { clearPref, executeCommand, setPref } from '@utils/commands';
 import {
   createAndOpenProject,
   closeProjectIfOpen,
@@ -78,13 +78,13 @@ test.describe.serial('styler reformat on save', () => {
     projectDir = await createAndOpenProject(page, sandbox.dir, 'reformat-styler-project');
     await waitForConsoleIdle(page);
 
-    await consoleActions.executeInConsole('.rs.uiPrefs$reformatOnSave$set(TRUE)');
-    await consoleActions.executeInConsole('.rs.uiPrefs$codeFormatter$set("styler")');
+    await setPref(page, 'reformat_on_save', true);
+    await setPref(page, 'code_formatter', 'styler');
   });
 
   test.afterAll(async ({ rstudioPage: page }) => {
-    await consoleActions.executeInConsole('.rs.uiPrefs$reformatOnSave$clear()');
-    await consoleActions.executeInConsole('.rs.uiPrefs$codeFormatter$clear()');
+    await clearPref(page, 'reformat_on_save');
+    await clearPref(page, 'code_formatter');
     await consoleActions.closeAllBuffersWithoutSaving();
     await waitForConsoleIdle(page);
     await closeProjectIfOpen(page);
@@ -140,14 +140,14 @@ test.describe('styler reformat #17471 (Windows)', { tag: ['@windows_only'] }, ()
   });
 
   test.afterEach(async ({ rstudioPage: page }) => {
-    await consoleActions.executeInConsole('.rs.uiPrefs$codeFormatter$clear()');
+    await clearPref(page, 'code_formatter');
     await closeAndDeleteSandboxFiles(page, sandbox.dir, [FILE_STYLER_DOC, FILE_STYLER_SEL]);
   });
 
   test('Reformat Document does not add extra newlines', async ({ rstudioPage: page }) => {
     test.skip(missingPackages.length > 0, `styler not available: ${missingPackages.join(', ')}`);
 
-    await consoleActions.executeInConsole('.rs.uiPrefs$codeFormatter$set("styler")');
+    await setPref(page, 'code_formatter', 'styler');
 
     const initial = 'print("test")\nprint("test")\n\n';
     const expected = 'print("test")\nprint("test")\n';
@@ -163,7 +163,7 @@ test.describe('styler reformat #17471 (Windows)', { tag: ['@windows_only'] }, ()
   test('Reformat Code (selection) does not add extra newlines', async ({ rstudioPage: page }) => {
     test.skip(missingPackages.length > 0, `styler not available: ${missingPackages.join(', ')}`);
 
-    await consoleActions.executeInConsole('.rs.uiPrefs$codeFormatter$set("styler")');
+    await setPref(page, 'code_formatter', 'styler');
 
     const initial = '1+1; 2+2\n3+3; 4+4\n';
     const expected = '1 + 1\n2 + 2\n3 + 3\n4 + 4\n';

--- a/e2e/rstudio/tests/panes/editor/rmarkdown.test.ts
+++ b/e2e/rstudio/tests/panes/editor/rmarkdown.test.ts
@@ -10,7 +10,7 @@ import {
 import { clearWorkspace } from '@pages/environment_pane.page';
 import { CONSOLE_INPUT } from '@pages/console_pane.page';
 import { useSuiteSandbox } from '@utils/sandbox';
-import { executeCommand, setPref } from '@utils/commands';
+import { executeCommand, saveDocument, setPref } from '@utils/commands';
 
 test.describe('RMarkdown', () => {
   // Sets cwd to a per-spec sandbox; all relative file paths used by
@@ -75,7 +75,7 @@ test.describe('RMarkdown', () => {
     await expect(sourceActions.sourcePane.selectedTab).toContainText(fileName, { timeout: 20000 });
 
     // Save the file
-    await executeCommand(page, 'saveSourceDoc');
+    await saveDocument(page);
 
     // Run all chunks via restart R. The 5s lead-in guards against the
     // not.toBeVisible check below succeeding before the interrupt button has

--- a/e2e/rstudio/tests/panes/editor/rmarkdown_chunks.test.ts
+++ b/e2e/rstudio/tests/panes/editor/rmarkdown_chunks.test.ts
@@ -17,7 +17,7 @@ import type { Page } from 'playwright';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePaneActions } from '@actions/source_pane.actions';
 import { useSuiteSandbox } from '@utils/sandbox';
-import { executeCommand, isCommandEnabled } from '@utils/commands';
+import { executeCommand, isCommandEnabled, saveDocument } from '@utils/commands';
 
 /**
  * Run a labeled chunk and wait for `signal` to appear in the console
@@ -385,7 +385,7 @@ test.describe.serial('R Markdown chunks', { tag: ['@serial'] }, () => {
     await sourceActions.goToEnd();
     await page.keyboard.press('Enter');
     await expect.poll(() => isCommandEnabled(page, 'saveSourceDoc'), { timeout: 5000 }).toBe(true);
-    await executeCommand(page, 'saveSourceDoc');
+    await saveDocument(page);
 
     // RStudio writes nb.html on save; poll the filesystem for it.
     await expect.poll(() => fs.existsSync(nbHtmlPath), { timeout: 30000, intervals: [500] }).toBe(true);

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
@@ -42,9 +42,12 @@ test.describe.serial('R Shiny Tip Calculator via Posit Assistant', { tag: ['@ai'
     await executeCommand(page, 'viewerClearAll');
     await sleep(1000);
 
-    // Dismiss the "Clear Viewer" confirmation dialog if it appears
+    // Dismiss the "Clear Viewer" confirmation dialog if it appears. The
+    // sleep(1000) after viewerClearAll above settles the dialog state, so a
+    // snapshot isVisible() is sufficient -- no need to burn 2s polling for
+    // absence in the common case.
     const clearViewerYes = page.locator('role=alertdialog >> button:has-text("Yes")');
-    if (await clearViewerYes.isVisible({ timeout: 2000 }).catch(() => false)) {
+    if (await clearViewerYes.isVisible()) {
       await clearViewerYes.click();
       await sleep(500);
     }

--- a/e2e/rstudio/tests/projects/create_projects.test.ts
+++ b/e2e/rstudio/tests/projects/create_projects.test.ts
@@ -221,15 +221,14 @@ test.describe.serial('Create Projects in New Directory', () => {
   });
 
   test.beforeAll(async ({ rstudioPage: page }) => {
-    // Dismiss any leftover dialog from a prior failed run
+    // Dismiss any leftover dialog from a prior failed run. The sleep(1000)
+    // below settles after each Escape, so a snapshot isVisible() is enough --
+    // a timeout here would just waste 2s per loop when no dialog is left.
     for (let i = 0; i < 3; i++) {
-      const overlay = page.locator('.gwt-PopupPanelGlass, [role="alertdialog"]');
-      if (await overlay.first().isVisible({ timeout: 2000 }).catch(() => false)) {
-        await page.keyboard.press('Escape');
-        await sleep(1000);
-      } else {
-        break;
-      }
+      const overlay = page.locator('.gwt-PopupPanelGlass, [role="alertdialog"]').first();
+      if (!(await overlay.isVisible())) break;
+      await page.keyboard.press('Escape');
+      await sleep(1000);
     }
 
     // Close any open project from a prior run

--- a/e2e/rstudio/tests/projects/project_trust_dialog.test.ts
+++ b/e2e/rstudio/tests/projects/project_trust_dialog.test.ts
@@ -222,20 +222,15 @@ test.describe.serial('Project Trust Dialog (#17231)', { tag: ['@server_only', '@
   let originalDefaultProjectLocation = '';
 
   test.beforeAll(async ({ rstudioPage: page }) => {
-    // Dismiss any leftover dialog/overlay from a prior failed run.
-    // Try Escape multiple times to handle trust dialogs, save prompts, etc.
+    // Dismiss any leftover dialog/overlay from a prior failed run. The
+    // sleep(1000) below settles after each Escape, so a snapshot isVisible()
+    // is enough -- a timeout here would just waste 2s per loop when no
+    // dialog is left.
     for (let i = 0; i < 3; i++) {
-      try {
-        const overlay = page.locator('.gwt-PopupPanelGlass, [role="alertdialog"]');
-        if (await overlay.first().isVisible({ timeout: 2000 })) {
-          await page.keyboard.press('Escape');
-          await sleep(1000);
-        } else {
-          break;
-        }
-      } catch {
-        break;
-      }
+      const overlay = page.locator('.gwt-PopupPanelGlass, [role="alertdialog"]').first();
+      if (!(await overlay.isVisible())) break;
+      await page.keyboard.press('Escape');
+      await sleep(1000);
     }
 
     // Capture original load_workspace preference for restoration

--- a/e2e/rstudio/tests/smoke/startup.test.ts
+++ b/e2e/rstudio/tests/smoke/startup.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { CONSOLE_INPUT } from '@pages/console_pane.page';
 
-test.describe('Startup smoke test', () => {
+test.describe('Startup smoke test', { tag: ['@smoke'] }, () => {
   test('RStudio starts and stays alive for 30 seconds', async ({ rstudioPage: page }) => {
     // Verify console is ready
     await expect(page.locator(CONSOLE_INPUT)).toBeVisible({ timeout: 30000 });

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -40,10 +40,25 @@ type VersionInfo = {
   r: string;
 };
 
+type ActiveDocument = {
+  id: string;
+  /** Absolute file path, or null for an untitled document. */
+  path: string | null;
+  /** True when the document has unsaved changes in the editor model. */
+  dirty: boolean;
+};
+
+type Documents = {
+  closeAllNoSave(): void;
+  resetToUntitled(): void;
+  /** Info on the focused source document, or null when no editor is active. */
+  active(): ActiveDocument | null;
+};
+
 type RStudioBridge = {
   commands: { [id: string]: CommandEntry } & { list: string[] };
   prefs: { [name: string]: PrefEntry };
-  documents: { closeAllNoSave(): void; resetToUntitled(): void };
+  documents: Documents;
   project: ProjectInfo;
   version: VersionInfo;
   /**
@@ -113,6 +128,28 @@ export async function isCommandEnabled(page: Page, commandId: string): Promise<b
       throw new Error(`Unknown command: ${id}`);
     return cmd.isEnabled();
   }, commandId);
+}
+
+/**
+ * Save the active source document and wait for it to be marked clean.
+ *
+ * Polls `window.rstudio.documents.active().dirty` -- the pure dirty bit
+ * from the editing target's model, distinct from `saveSourceDoc.isEnabled()`
+ * which stays true for source-on-save / reformat-on-save / untitled docs
+ * regardless of dirty state. Pre-save transforms (trim-trailing-whitespace,
+ * styler, Air) update the model before the dirty bit clears, so reading the
+ * editor's value after this returns reflects the final on-disk content.
+ */
+export async function saveDocument(page: Page, timeout = 5000): Promise<void> {
+  await executeCommand(page, 'saveSourceDoc');
+  await page.waitForFunction(
+    () => {
+      const doc = window.rstudio?.documents.active() ?? null;
+      return doc !== null && !doc.dirty;
+    },
+    null,
+    { timeout, polling: 100 },
+  );
 }
 
 /**

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -27,7 +27,9 @@ import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.prefs.model.Prefs;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
+import org.rstudio.studio.client.workbench.views.source.SourceColumnManager;
 
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
@@ -52,6 +54,7 @@ import com.google.inject.Singleton;
  *
  *   window.rstudio.documents.closeAllNoSave()
  *   window.rstudio.documents.resetToUntitled() // close everything but a single untitled tab
+ *   window.rstudio.documents.active()          // { id, path, dirty } for the focused doc, or null
  *
  *   window.rstudio.project.path()       // active project file path, or null
  *   window.rstudio.project.name()       // active project display name, or null
@@ -74,12 +77,14 @@ public class ApplicationAutomation
    public ApplicationAutomation(Commands commands,
                                 EventBus eventBus,
                                 Session session,
-                                UserPrefs userPrefs)
+                                UserPrefs userPrefs,
+                                SourceColumnManager sourceColumnManager)
    {
       commands_ = commands;
       eventBus_ = eventBus;
       session_ = session;
       userPrefs_ = userPrefs;
+      sourceColumnManager_ = sourceColumnManager;
    }
 
    public final boolean isAutomationAgent()
@@ -279,6 +284,22 @@ public class ApplicationAutomation
       eventBus_.dispatchEvent(new DocumentResetToUntitledEvent());
    }
 
+   // Returns null when no editor is active so callers can distinguish "no doc"
+   // from "doc exists but is clean".
+   private JavaScriptObject getActiveDocument()
+   {
+      if (!sourceColumnManager_.hasActiveEditor())
+         return null;
+      return makeActiveDocumentJso(
+         sourceColumnManager_.getActiveDocId(),
+         sourceColumnManager_.getActiveDocPath(),
+         sourceColumnManager_.isActiveDocDirty());
+   }
+
+   private native JavaScriptObject makeActiveDocumentJso(String id, String path, boolean dirty) /*-{
+      return { id: id, path: path, dirty: dirty };
+   }-*/;
+
    // Always read through session_.getSessionInfo() rather than capturing a
    // reference at install time -- a session restart (e.g. close-project)
    // replaces the SessionInfo JSO, and we want callers to see the live state.
@@ -363,6 +384,9 @@ public class ApplicationAutomation
       $wnd.rstudio.documents.resetToUntitled = $entry(function() {
          self.@org.rstudio.studio.client.application.ApplicationAutomation::dispatchResetToUntitled()();
       });
+      $wnd.rstudio.documents.active = $entry(function() {
+         return self.@org.rstudio.studio.client.application.ApplicationAutomation::getActiveDocument()();
+      });
    }-*/;
 
    private native final void registerProjectObject() /*-{
@@ -392,6 +416,7 @@ public class ApplicationAutomation
    private final EventBus eventBus_;
    private final Session session_;
    private final UserPrefs userPrefs_;
+   private final SourceColumnManager sourceColumnManager_;
    private boolean isAutomationAgent_ = false;
    private boolean readinessHandlersRegistered_ = false;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -628,6 +628,14 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       return null;
    }
 
+   public boolean isActiveDocDirty()
+   {
+      if (!hasActiveEditor())
+         return false;
+      Boolean dirty = activeColumn_.getActiveEditor().dirtyState().getValue();
+      return dirty != null && dirty;
+   }
+
    /**
     * Get selections from the active editor as a JSON array.
     * Format: [{ "startLine": n, "startCharacter": n, "endLine": n, "endCharacter": n, "text": "..." }, ...]

--- a/src/node/desktop/src/main/main.ts
+++ b/src/node/desktop/src/main/main.ts
@@ -22,7 +22,7 @@ import { Application } from './application';
 import { initI18n } from './i18n-manager';
 import { ElectronDesktopOptions } from './preferences/electron-desktop-options';
 import { parseStatus } from './program-status';
-import { createStandaloneErrorDialog, isAutomated } from './utils';
+import { createStandaloneErrorDialog } from './utils';
 import { Xdg } from '../core/xdg';
 import { existsSync, readFileSync } from 'fs';
 import path from 'path';
@@ -127,15 +127,6 @@ class RStudioMain {
     setApplication(rstudio);
 
     this.initializeAppConfig();
-
-    // In automation mode the app should not pull focus from whatever the
-    // user (or test runner) is doing. showInactive() handles the per-window
-    // side of this, but on macOS the OS also activates the app on launch.
-    // 'accessory' keeps the dock icon and menu bar present but tells the OS
-    // not to auto-activate, so the test driver's terminal keeps focus.
-    if (process.platform === 'darwin' && isAutomated()) {
-      app.setActivationPolicy('accessory');
-    }
 
     if (!parseStatus(await rstudio.beforeAppReady())) {
       return;

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -41,8 +41,9 @@ export function getAppPath(): string {
 /**
  * True when rsession is launched with --automation-agent (the flag the
  * Playwright fixture passes). Use this to gate test-only behaviors such as
- * `showInactive` over `show` and the macOS 'accessory' activation policy --
- * the goal is to keep the app from stealing focus from the test driver.
+ * `showInactive` over `show` -- the goal is to keep windows from leaping to
+ * the front while leaving the app visible in the dock / Cmd+Tab so the user
+ * can still find and focus it manually.
  */
 export function isAutomated(): boolean {
   return app.commandLine.hasSwitch('automation-agent');


### PR DESCRIPTION
## Summary

A grab-bag of related improvements to the Playwright e2e test suite, primarily aimed at making tests faster and less flaky:

- **`saveDocument` helper + `window.rstudio.documents.active()` bridge.** Exposes the pure dirty-state bit (separate from the conflated `saveSourceDoc.isEnabled()`, which stays true for source-on-save / reformat-on-save / untitled docs). `saveDocument(page)` fires save and waits for `dirty=false`, so reading the editor's value right after returns the post-transform content. Converted the five existing `executeCommand(page, 'saveSourceDoc')` call sites.
- **Bridge-level `setPref` / `clearPref` over `.rs.uiPrefs$X$set(...)`.** The R-side form was raced by subsequent steps (executeInConsole was fire-and-forget without `wait:true`), surfaced most visibly as `editor.test.ts:44` going flaky. Converted offenders in editor / reformat / console_output / code-folding / air_formatting tests.
- **Stop using `click({ timeout })` / `isVisible({ timeout })` as absence probes.** That pattern burns the full timeout when the target is absent (the common case for dialog-dismissal). Snapshot `isVisible()` returns instantly. Touched both fixtures (`desktop`, `server`), `chat_pane.actions`, `assistant_options.actions`, and the leftover-dialog cleanup loops in `create_projects` / `project_trust_dialog` / `shiny-app-r`. Saves ~3s per Desktop launch and ~2s per Server launch.
- **Replace blind sleeps in `debugger.test.ts` and `pagination-sorting.test.ts` with state-based waits.** `writeAndOpen` -> `{ wait: true }` + selectedTab assertion; 14 `sourceActiveDocument + sleep` pairs -> `waitForConsoleIdle`; pagination tests -> `expect.toBeVisible` / `{ wait: true }` and `resetSourcePaneState` in `afterEach` to keep the Source pane open across tests. `brace_fn` went from "failing entirely" to 2.2s; `Step Next` from a 27.7s failure to 3.2s; pagination-sorting from ~38s to 20.5s.
- **Revert `app.setActivationPolicy('accessory')` on macOS automation.** That policy hides the app from the dock and from Cmd+Tab -- the comment that introduced it described the opposite behavior. `showInactive()` on the splash and main window (already in place) is enough to keep windows from pulling focus.
- **Tag the 30s startup smoke test `@smoke` and exclude it by default.** Every one of the other 250 tests already exercises launch + console readiness, so the dedicated stay-alive smoke was pure duplication. Opt back in with `--grep @smoke`.

A `PW_DEBUG_LAUNCH=1` timing tracer in the Desktop launch path (bridge installed -> ready -> activateConsole -> console visible -> not busy) is also included; useful for correlating fixture waits with what's visible in the UI.

## Test plan

- [x] `editor.test.ts:44` (the original flake) passes consistently with `saveDocument` + bridge-level setPref
- [x] Full non-AI suite re-run: 229 / 4 / 9 / 7 (passed / failed / skipped / didn't run), with the 4 failures known and 3 of them flakes (`Step Next`, `paged-table`, `bp_brace`) -- `bp_brace` confirmed real and addressed via blind-sleep cleanup in `writeAndOpen`
- [x] `pagination-sorting.test.ts` 4/4 pass after `resetSourcePaneState` fix (was 2/4 with naive cleanup)
- [x] Debugger tests `:118` (`bp_brace`) and `:206` (`Step Next`) both pass after the writeAndOpen sleep cleanup
- [x] Typechecks pass after every change (`npx tsc --noEmit` + `ant javac`)
- [ ] Verify on macOS that test instances now appear in Cmd+Tab and that windows still don't grab focus at launch
- [ ] Spot-check that the converted setPref sites behave correctly when run interleaved with other tests in full-suite mode

## Follow-up

Roughly ~270 blind sleeps remain across ~25 test files; a local audit list lives at `e2e/rstudio/TODO-blind-sleeps.local.md` (gitignored) and will be addressed in a follow-up sweep. Common patterns to apply:
- `executeInConsole + sleep` -> `executeInConsole({ wait: true })`
- `sleep` before an `expect(...)` -> drop (auto-wait covers it)
- `closeSourceDoc + sleep` in `afterEach` -> `resetSourcePaneState` (keeps Source pane stable)
- CSS-animation buffers -> wait for the specific final-state class/transform