### PR TITLE
Install pkgconf and libuv via Homebrew on macOS

### DIFF
--- a/dependencies/osx/install-dependencies-osx-arch
+++ b/dependencies/osx/install-dependencies-osx-arch
@@ -46,10 +46,12 @@ FORMULAS=(
    krb5
    libpq
    libtool
+   libuv
    openjdk@17
    openssl
    ninja
    pidof
+   pkgconf
    postgresql@14
    r
 )


### PR DESCRIPTION
## Intent

Fix `install-dependencies-osx` failing on a clean Apple Silicon machine when renv installs `fs` 2.1.0 (and the rmarkdown / testthat / sass / bslib / pkgload chain that depends on it).

## Summary

- The macOS dependency script did not install `pkgconf` or `libuv` via Homebrew.
- `fs` 2.1.0 builds against system libuv and locates it with `pkg-config`. On a clean machine, the x86_64 brew prefix had neither, so PATH fell through to `/opt/homebrew/bin/pkg-config` (arm64), which reported arm64 libuv paths. The x86_64 build then tried to link an arm64 `libuv.dylib`, ld discarded it, and the link failed with `_uv_default_loop` unresolved.
- Adding `libuv` and `pkgconf` to `FORMULAS` installs them into both brew prefixes (the script runs once per arch), so each arch pass resolves `pkg-config` and libuv from its own brew tree.

## Test plan

- [ ] On a clean Apple Silicon Mac, run `./dependencies/osx/install-dependencies-osx` and confirm `fs` installs from CRAN binary or builds cleanly from source for the x86_64 R library.
- [ ] Confirm `/usr/local/bin/pkg-config --variable=pcfiledir libuv` resolves to a `/usr/local/...` path after the script completes.
- [ ] On an existing dev machine, re-run the script and confirm it is a no-op for the new formulae when they are already present (alias `/opt/homebrew/opt/pkgconf` is detected by the existing `-d ${HOMEBREW_PREFIX}/opt/${FORMULA}` check).