### PR TITLE
playwright: add documents.open bridge + paper-trail logging

### DIFF
--- a/e2e/rstudio/docs/ANTIPATTERN_CLEANUP.md
+++ b/e2e/rstudio/docs/ANTIPATTERN_CLEANUP.md
@@ -1,0 +1,265 @@
+# E2E Anti-Pattern Cleanup
+
+Tracking cleanup of anti-patterns surfaced by the 2026-05-24 scan of
+`e2e/rstudio/` (102 TypeScript files across `tests/`, `utils/`, `pages/`,
+`actions/`, `fixtures/`).
+
+Items are grouped into three tiers:
+
+- **Must** -- documented project rules; every occurrence is a violation.
+- **Should** -- structural fixes that pay back across many tests.
+- **Nice** -- stylistic polish; address opportunistically.
+
+Initial counts are recorded so progress can be checked against the scan
+baseline.
+
+## Initial baseline
+
+| Category                                   | Count           |
+|--------------------------------------------|-----------------|
+| Blind sleeps (`waitForTimeout` + `sleep`)  | 4 + ~150        |
+| Console-based `.rs.*` RPC                  | 8 sites         |
+| Focused / unexplained tests                | 0 `.only`; 1 bare `test.skip` |
+| Inline `timeout: NNNN`                     | 371 (50 are 30000 / 60000)    |
+| XPath / deep CSS selectors                 | 0               |
+| `force: true` clicks                       | 16              |
+| `page.evaluate` driving UI                 | 72 (4 = desktopHooks command palette) |
+| `toBe(true|false)` on locator booleans     | ~200            |
+| In-test `try/catch` swallowing             | 9               |
+| `console.log` leftovers                    | ~150            |
+| `if (await ...)` branches in tests         | 24+             |
+
+---
+
+## Must -- rule violations
+
+### Blind sleeps
+
+Project rule: wait for a measurable condition, not a fixed duration. See
+memory `feedback_avoid_blind_sleeps.md`.
+
+Hot-spot test files:
+
+- [ ] `tests/panes/editor/code_suggestions.test.ts` -- 38 `await sleep()`
+      calls; 22 are `sleep(5000)`. Single highest-leverage file.
+- [ ] `tests/panes/layout/panes.test.ts` -- 21 `sleep(TIMEOUTS.layoutSettle)`
+      calls. See the "layout-settle signal" item under **Should**.
+- [ ] `tests/panes/misc/s4_unloaded_package.test.ts:168` -- `sleep(5000)`
+      after `restartR`; comment notes "replace once restartR has a
+      confirmable post-condition".
+- [ ] `tests/panes/misc/python_completions.test.ts:56,59` -- `sleep(3000)` /
+      `sleep(500)` around Python REPL typing.
+- [ ] `tests/panes/posit-assistant-chat/uninstall-posit-ai.test.ts:74,119`
+- [ ] `tests/panes/posit-assistant-chat/chat-pane-persistence.test.ts:27,78`
+- [ ] `tests/panes/debugger/debugger_extras.test.ts:89` -- `sleep(300)`
+
+Shared infrastructure (each removal cascades through many tests):
+
+- [ ] `actions/chat_pane.actions.ts` -- 15 sleeps in lines 90-230
+- [ ] `actions/console_pane.actions.ts` -- 10 sleeps
+      (150, 158, 170, 179, 182, 197, 221, 240, 298, 316)
+- [ ] `actions/assistant_options.actions.ts` -- 11 sleeps in lines 37-116
+- [ ] `actions/autocomplete.actions.ts` -- 9 sleeps
+- [ ] `actions/source_pane.actions.ts` -- 5 sleeps (line 242: `sleep(2000)`)
+- [ ] `fixtures/desktop.fixture.ts` -- 10 sleeps; worst at line 529
+      (`sleep(5000)`) and line 551 (`sleep(3000)`)
+- [ ] `fixtures/server.fixture.ts` -- 7 sleeps (line 288: `sleep(2000)`;
+      line 300 manual race timeout may be OK)
+- [ ] `pages/console_pane.page.ts` -- 6 sleeps in `typeInConsole`,
+      `clearConsole`, `goToLine`, `closeAllBuffersWithoutSaving`
+- [ ] `pages/modals.page.ts:21,33` -- `sleep(5000)` then `sleep(1000)`
+- [ ] `pages/environment_pane.page.ts:65,67`
+- [ ] `utils/project.ts` -- 6 sleeps (3000, 2000, 1500, others)
+
+`waitForTimeout` sites (4):
+
+- [ ] `tests/smoke/startup.test.ts:10` -- 30s "stay alive" body; consider
+      replacing with an actual readiness assertion
+- [ ] `tests/panes/files/files.test.ts:133` -- 1500ms mtime granularity
+      guard; has comment, may stay
+- [ ] `tests/panes/posit-assistant-chat/chat-user-skills.test.ts:130` --
+      5000ms; comment "no bridge-exposed signal for backend shutdown"
+- [ ] `tests/panes/posit-assistant-chat/readline-notification.test.ts:60` --
+      1000ms absence-of-event window
+
+### Console-based `.rs.*` RPC
+
+Project rule: use `executeCommand(page, ...)` / bridge helpers instead of
+typing `.rs.api.*` into the console. See memory
+`feedback_executecommand_over_console_api.md`.
+
+Ported:
+
+- [x] `tests/projects/shinytest2.test.ts:78` -- `.rs.api.openProject` ->
+      `openProject(page, '${dir}/${basename}.Rproj')`
+- [x] `tests/panes/misc/build_pane_testthat.test.ts:69` -- same as above
+- [x] `tests/panes/editor/syntax-highlighting.test.ts:62,89` --
+      `.rs.writeUserPref("rainbow_fenced_divs", ...)` -> `setPref`
+- [x] `tests/projects/project_trust_dialog.test.ts:239,248` --
+      `.rs.api.readRStudioPreference(...)` via `captureResult` -> `getPref`
+- [x] `tests/projects/shinytest2.test.ts:87` and
+      `tests/panes/misc/build_pane_testthat.test.ts:82` --
+      `.rs.api.documentOpen(...)` -> `documentOpen(page, path)` via new
+      `window.rstudio.documents.open(path, opts?)` bridge method.
+
+Intentionally kept as console RPC (no bridge equivalent or testing the API
+itself); each site has an inline comment explaining the reason:
+
+- `tests/projects/shinytest2.test.ts` -- `.rs.api.initializeProject` writes
+  the .Rproj file; no bridge for project initialization.
+- `tests/panes/misc/session_restart.test.ts` -- the test specifically
+  exercises `.rs.api.restartSession`'s `afterRestart` parameter, which the
+  `restartR` AppCommand does not expose.
+
+Follow-up: adding `project.initialize(path)` to the automation bridge would
+close out the initializeProject site.
+
+### Lone unexplained `test.skip`
+
+- [ ] `tests/panes/editor/rmarkdown.test.ts:211` -- bare
+      `test.skip('visual mode go to next and prev chunk', ...)` with no
+      comment or linked issue. Either explain, link an issue, or restore.
+
+---
+
+## Should -- structural fixes
+
+### Build a measurable layout-settle signal
+
+`tests/panes/layout/panes.test.ts` has 21 `sleep(TIMEOUTS.layoutSettle)`
+calls (and `pane_layout.test.ts` has more). A real signal -- mutation
+observer on the pane container, a `data-layout-settled` attribute, or a
+busy-class watcher -- would let us strike all of them at once and stop
+papering over real races.
+
+- [ ] Design a layout-settle signal in the GWT layout code (or expose an
+      existing one through the automation bridge)
+- [ ] Replace `sleep(layoutSettle)` calls in `panes.test.ts` and
+      `pane_layout.test.ts`
+
+### Clean up `code_suggestions.test.ts`
+
+Single worst file in the suite (38 sleeps, ~40 `console.log` calls, several
+`if (await ...)` branches, two `force: true` clicks). Worth a dedicated
+pass.
+
+- [ ] Replace sleeps with measurable waits
+- [ ] Strip step-narration `console.log` calls (lines 84, 137, 143, 176,
+      226, 229, 270, 286, 289, 329, 340, 343, 346, 373, 384, 419, 433, 469,
+      483, 486, 518, 536, 538, 587, 593, 597, 619, 628, 634)
+- [ ] Collapse `if (await ...)` branches at lines 136, 269, 328, 584
+      (especially line 137 which logs a WARNING for a stale gutter icon
+      instead of failing -- file the bug or assert it)
+- [ ] Document or remove `force: true` click at line 630
+
+### Strip `console.log` debugging leftovers
+
+~150 occurrences total; cleanup hooks that log cleanup errors are fine,
+but step-narration inside test bodies should go. Worst (outside
+`code_suggestions.test.ts`):
+
+- [ ] `tests/panes/editor/quarto.test.ts:68-83` -- 7 "Checking ..." logs
+- [ ] `tests/projects/project_trust_dialog.test.ts:240,311,327,328`
+- [ ] `tests/panes/misc/s4_unloaded_package.test.ts:79,180,196,199,212`
+- [ ] `tests/panes/layout/pane_location_persistence.test.ts:133,138,141,148`
+
+### Move conditional cleanup out of test bodies
+
+Tests should follow a single deterministic path; conditional cleanup logic
+belongs in `afterEach`.
+
+- [ ] `tests/panes/posit-assistant-chat/shiny-app-r.test.ts:48,64,76,89` --
+      four conditional cleanup branches in the test body
+- [ ] `tests/panes/posit-assistant-chat/open-chat-pane.test.ts:39,57` --
+      `chatIframe.isVisible()` branching
+- [ ] `tests/panes/layout/panes.test.ts:73,85,228` -- sidebar-presence
+      branches
+- [ ] `tests/panes/layout/pane_location_persistence.test.ts:38,51,65,74`
+- [ ] `tests/panes/console/console_pane.test.ts:141,170` -- find-bar state
+      branches
+- [ ] `tests/panes/editor/air_formatting.test.ts:120` -- modal-handling
+      branch
+- [ ] `tests/panes/misc/rstudioapi_show_dialog.test.ts:69` -- iterating
+      buttons with `.isVisible().catch(() => false)`
+- [ ] `tests/projects/project_id.test.ts:45` -- pre-existing-modal close
+- [ ] Eliminate the `.isVisible().catch(() => false)` swallow pattern in
+      chat / dialog tests -- it can't distinguish "not present" from
+      "selector broke"
+
+### Document or remove undocumented `force: true` clicks
+
+16 sites; the comment at `actions/chat_pane.actions.ts:294` is a good
+template ("GWT console DOM elements report overlapping coordinates").
+
+- [ ] `tests/panes/debugger/debugger_extras.test.ts:51`
+- [ ] `tests/panes/editor/code_suggestions.test.ts:630` -- on
+      `statusBarCompletionReceived`
+- [ ] `tests/panes/console/console_pane.test.ts:38,76`
+- [ ] `utils/project.ts:109`
+- [ ] `pages/console_pane.page.ts:277,284`
+- [ ] `actions/source_pane.actions.ts:114,121,144`
+- [ ] `actions/autocomplete.actions.ts:103`
+- [ ] `fixtures/server.fixture.ts:268`
+
+### Stop bypassing the command bridge for the command palette
+
+- [ ] `tests/panes/posit-assistant-chat/uninstall-posit-ai.test.ts:42,73,87,99`
+      -- `page.evaluate("window.desktopHooks.invokeCommand('showCommandPalette')")`
+      should be `executeCommand(page, 'showCommandPalette')`
+
+---
+
+## Nice -- stylistic polish
+
+### Replace inline `timeout: NNNN` with named constants
+
+371 occurrences; 50 are exactly `30000` or `60000` and map to existing
+`TIMEOUTS.*` entries (`rstudioStartup`, `sessionRestart`, etc.). The two
+`timeout: 120000` cases need a new constant.
+
+- [ ] Add a long-operation timeout constant (e.g. `TIMEOUTS.longOperation`)
+- [ ] Sweep call sites; worst files: `panes.test.ts` (47),
+      `project_trust_dialog.test.ts` (26), `rmarkdown.test.ts` (25),
+      `code_suggestions.test.ts` (24), `chat_pane.actions.ts` (21),
+      `create_projects.test.ts` (17), `pane_layout.test.ts` (15)
+
+### Prefer auto-retrying matchers over `toBe(true|false)` on locator booleans
+
+~200 sites. Most are `expect(await isTabChecked(...)).toBe(true)` style in
+`tests/panes/layout/pane_layout.test.ts`; `toBeChecked()` or `expect.poll`
+would auto-retry and give a better failure message.
+
+- [ ] Audit `pane_layout.test.ts`
+- [ ] Audit the rest of `tests/panes/layout/`
+
+### Use specific matchers instead of `toBeTruthy`
+
+- [ ] `tests/panes/misc/s4_unloaded_package.test.ts:42` -- regex match
+- [ ] `tests/panes/misc/rs_value_contents.test.ts:28,120`
+
+### Remove in-test `try/catch` swallows
+
+9 sites where catches inside tests hide failure modes (cleanup-hook
+catches are fine and excluded):
+
+- [ ] `tests/panes/misc/autocomplete_extras.test.ts:132`
+- [ ] `tests/panes/data-viewer/data_viewer.test.ts:165,207,239`
+- [ ] `tests/panes/posit-assistant-chat/chat-websocket-url.test.ts:39`
+- [ ] `tests/panes/editor/code_suggestions.test.ts:215`
+- [ ] `tests/panes/console/console_output.test.ts:77,94,162`
+- [ ] `tests/panes/editor/syntax-highlighting.test.ts:63`
+- [ ] `tests/panes/editor/editor.test.ts:49`
+- [ ] `tests/panes/editor/air_formatting.test.ts:104`
+
+---
+
+## Verified clean (no action needed)
+
+- `test.only` / `describe.only` -- none committed.
+- XPath selectors -- none.
+- `debugger;` statements -- none.
+- `noWaitAfter: true` -- none.
+- `#rstudio_*` GWT id selectors (43) -- these are stable, project-preferred
+  handles; not a smell.
+- Recorded `test.skip` / `test.fixme` -- all but `rmarkdown.test.ts:211`
+  have explanations or linked issues.

--- a/e2e/rstudio/docs/ANTIPATTERN_CLEANUP.md
+++ b/e2e/rstudio/docs/ANTIPATTERN_CLEANUP.md
@@ -207,21 +207,45 @@ template ("GWT console DOM elements report overlapping coordinates").
       -- `page.evaluate("window.desktopHooks.invokeCommand('showCommandPalette')")`
       should be `executeCommand(page, 'showCommandPalette')`
 
+### Remove the `TIMEOUTS` object; wait on observable state
+
+`utils/constants.ts` exports `TIMEOUTS` (`sessionRestart: 30000`,
+`fileOpen: 20000`, `consoleReady: 15000`, `settleDelay: 1000`, etc.). Its
+existence implies that long blind timeouts on assertions are an acceptable
+substitute for waiting on observable state -- they aren't. The right
+pattern is to poll a bridge-state predicate
+(`window.rstudio.project.path()`, `documents.active()`, the `console-busy`
+class, etc.) and let the assertion run at Playwright's default short
+timeout. Each `TIMEOUTS` entry callers reach for is a missing or
+under-exposed bridge signal.
+
+PR #17761 demonstrates the pattern: `openProject` polls
+`window.rstudio.project.path()` against the requested .Rproj, so the
+follow-up `expect(PROJECT_MENU).toContainText(...)` runs at the default
+5s timeout instead of the previous 30s `TIMEOUTS.sessionRestart` blind
+wait.
+
+Goal: shrink `TIMEOUTS` to only the legitimate non-wait constants
+(`pollInterval`, `slowKeystroke`) and remove the rest.
+
+- [ ] Audit each `TIMEOUTS.*` use site and identify the observable
+      post-condition it's papering over (e.g. `consoleReady` ->
+      `#rstudio_console_input` visible + not `.rstudio-console-busy`).
+- [ ] Surface the underlying signal in the automation bridge if not
+      already exposed.
+- [ ] Convert each call site to poll the signal; the assertion that
+      follows can run at Playwright's default.
+- [ ] Delete the entry from `TIMEOUTS` once all sites are gone.
+
+Volume to chase: 371 inline `timeout: NNNN` occurrences in test code; 50
+of them are the 30000 / 60000 cases. Worst files: `panes.test.ts` (47),
+`project_trust_dialog.test.ts` (26), `rmarkdown.test.ts` (25),
+`code_suggestions.test.ts` (24), `chat_pane.actions.ts` (21),
+`create_projects.test.ts` (17), `pane_layout.test.ts` (15).
+
 ---
 
 ## Nice -- stylistic polish
-
-### Replace inline `timeout: NNNN` with named constants
-
-371 occurrences; 50 are exactly `30000` or `60000` and map to existing
-`TIMEOUTS.*` entries (`rstudioStartup`, `sessionRestart`, etc.). The two
-`timeout: 120000` cases need a new constant.
-
-- [ ] Add a long-operation timeout constant (e.g. `TIMEOUTS.longOperation`)
-- [ ] Sweep call sites; worst files: `panes.test.ts` (47),
-      `project_trust_dialog.test.ts` (26), `rmarkdown.test.ts` (25),
-      `code_suggestions.test.ts` (24), `chat_pane.actions.ts` (21),
-      `create_projects.test.ts` (17), `pane_layout.test.ts` (15)
 
 ### Prefer auto-retrying matchers over `toBe(true|false)` on locator booleans
 

--- a/e2e/rstudio/tests/panes/editor/syntax-highlighting.test.ts
+++ b/e2e/rstudio/tests/panes/editor/syntax-highlighting.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@fixtures/rstudio.fixture';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePaneActions } from '@actions/source_pane.actions';
 import { AceEditor } from '@pages/ace_editor.page';
+import { setPref } from '@utils/commands';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { writeAndOpenFile, closeAndDeleteSandboxFiles } from '@utils/files';
 
@@ -59,7 +60,7 @@ Goodbye, world!
 :::
 `;
 
-    await consoleActions.executeInConsole('.rs.writeUserPref("rainbow_fenced_divs", TRUE)');
+    await setPref(page, 'rainbow_fenced_divs', true);
     try {
       await writeAndOpenFile(page, sandbox.dir, 'syntax_highlight.Rmd', content);
 
@@ -86,7 +87,7 @@ Goodbye, world!
 
       expect(await editor.getState(5)).toBe('start');
     } finally {
-      await consoleActions.executeInConsole('.rs.writeUserPref("rainbow_fenced_divs", FALSE)');
+      await setPref(page, 'rainbow_fenced_divs', false);
     }
   });
 

--- a/e2e/rstudio/tests/panes/misc/build_pane_testthat.test.ts
+++ b/e2e/rstudio/tests/panes/misc/build_pane_testthat.test.ts
@@ -70,11 +70,7 @@ test.describe('Build pane', () => {
       `.rs.rpc.package_skeleton(packageName = ${projectNameLit}, packageDirectory = ${projectDirLit}, sourceFiles = character(), usingRcpp = FALSE)`,
     );
     await openProject(page, `${projectDir}/${projectName}.Rproj`);
-    // Match the long timeout shinytest2's port uses -- openProject's
-    // ready-flag wait can land before the project-menu label updates.
-    await expect(page.locator(PROJECT_MENU)).toContainText(projectName, {
-      timeout: TIMEOUTS.sessionRestart,
-    });
+    await expect(page.locator(PROJECT_MENU)).toContainText(projectName);
 
     // Write a trivial testthat test file via Node fs and open it -- testTestthatFile
     // runs the active document, so the file has to be the current source tab.

--- a/e2e/rstudio/tests/panes/misc/build_pane_testthat.test.ts
+++ b/e2e/rstudio/tests/panes/misc/build_pane_testthat.test.ts
@@ -4,7 +4,7 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { installDepIfPrompted } from '@pages/modals.page';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { rPathLiteral, rStringLiteral } from '@utils/r';
-import { executeCommand, waitForActiveDocument } from '@utils/commands';
+import { documentOpen, executeCommand, openProject } from '@utils/commands';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { Page } from 'playwright';
@@ -56,21 +56,25 @@ test.describe('Build pane', () => {
     const testFile = path.join(projectDir, 'tests', 'testthat', 'test-example.R');
     const projectNameLit = rStringLiteral(projectName);
     const projectDirLit = rPathLiteral(projectDir);
-    const testFileLit = rPathLiteral(testFile);
 
     test.setTimeout(180000);
 
     // Create the package skeleton and open the project. openProject restarts R,
     // so wait for both the project label to update and the console to be idle
     // before continuing.
+    // package_skeleton writes ${projectDir}/${projectName}.Rproj; the bridge's
+    // project.open dispatches SwitchToProjectEvent directly and needs that
+    // .Rproj path (the R-side .rs.api.openProject accepts a dir and re-derives
+    // it, but the bridge does not).
     await consoleActions.executeInConsole(
       `.rs.rpc.package_skeleton(packageName = ${projectNameLit}, packageDirectory = ${projectDirLit}, sourceFiles = character(), usingRcpp = FALSE)`,
     );
-    await consoleActions.executeInConsole(`.rs.api.openProject(${projectDirLit})`);
+    await openProject(page, `${projectDir}/${projectName}.Rproj`);
+    // Match the long timeout shinytest2's port uses -- openProject's
+    // ready-flag wait can land before the project-menu label updates.
     await expect(page.locator(PROJECT_MENU)).toContainText(projectName, {
       timeout: TIMEOUTS.sessionRestart,
     });
-    await waitForConsoleIdle(page);
 
     // Write a trivial testthat test file via Node fs and open it -- testTestthatFile
     // runs the active document, so the file has to be the current source tab.
@@ -79,8 +83,7 @@ test.describe('Build pane', () => {
       testFile,
       'test_that("we can run a test", {\n  expect_equal(2 + 2, 4)\n})\n',
     );
-    await consoleActions.executeInConsole(`.rs.api.documentOpen(${testFileLit})`);
-    await waitForActiveDocument(page, testFile, TIMEOUTS.fileOpen);
+    await documentOpen(page, testFile);
 
     await executeCommand(page, 'testTestthatFile');
 

--- a/e2e/rstudio/tests/panes/misc/session_restart.test.ts
+++ b/e2e/rstudio/tests/panes/misc/session_restart.test.ts
@@ -12,6 +12,9 @@ test.describe('Session restart', () => {
 
   test('variables defined before restart are visible to the after-restart command', async () => {
     await consoleActions.executeInConsole('x <- 1; y <- 2');
+    // Test specifically exercises .rs.api.restartSession's afterRestart
+    // parameter -- the restartR AppCommand has no equivalent way to schedule
+    // a command for the post-restart session, so this stays in console.
     await consoleActions.executeInConsole(".rs.api.restartSession('print(x + y)')");
 
     await expect(consoleActions.consolePane.consoleOutput).toContainText('[1] 3', {

--- a/e2e/rstudio/tests/projects/project_trust_dialog.test.ts
+++ b/e2e/rstudio/tests/projects/project_trust_dialog.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { executeInConsole, clearConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { useSuiteSandbox, SANDBOX_DIR_PREFIX } from '@utils/sandbox';
-import { executeCommand, setPref, documentCloseAllNoSave } from '@utils/commands';
+import { executeCommand, getPref, setPref, documentCloseAllNoSave } from '@utils/commands';
 import type { Page } from 'playwright';
 
 /**
@@ -219,7 +219,7 @@ test.describe.serial('Project Trust Dialog (#17231)', { tag: ['@server_only', '@
   const sandbox = useSuiteSandbox();
   let projectDir = '';
   let trustEnabled = true;
-  let originalLoadWorkspace = 'FALSE';
+  let originalLoadWorkspace = false;
   let originalDefaultProjectLocation = '';
 
   test.beforeAll(async ({ rstudioPage: page }) => {
@@ -235,8 +235,7 @@ test.describe.serial('Project Trust Dialog (#17231)', { tag: ['@server_only', '@
     }
 
     // Capture original load_workspace preference for restoration
-    originalLoadWorkspace = await captureResult(page,
-      '.rs.api.readRStudioPreference("load_workspace")');
+    originalLoadWorkspace = await getPref(page, 'load_workspace') as boolean;
     console.log(`Original load_workspace: ${originalLoadWorkspace}`);
 
     // Redirect the New Project Wizard's parent-directory field into the
@@ -244,8 +243,7 @@ test.describe.serial('Project Trust Dialog (#17231)', { tag: ['@server_only', '@
     // field itself is read-only, so setting the pref is the only way.
     // If a prior crashed run left our sandbox path in the pref, treat it
     // as leftover state and restore to the schema default on afterAll.
-    const current = await captureResult(page,
-      '.rs.api.readRStudioPreference("default_project_location")');
+    const current = await getPref(page, 'default_project_location') as string;
     const basename = current.split(/[/\\]/).pop() || '';
     originalDefaultProjectLocation = basename.startsWith(SANDBOX_DIR_PREFIX) ? '' : current;
 
@@ -263,7 +261,7 @@ test.describe.serial('Project Trust Dialog (#17231)', { tag: ['@server_only', '@
       }
 
       // Restore preferences
-      await setPref(page, 'load_workspace', originalLoadWorkspace === 'TRUE');
+      await setPref(page, 'load_workspace', originalLoadWorkspace);
       await setPref(page, 'default_project_location', originalDefaultProjectLocation);
     } catch (err) {
       console.warn('project_trust_dialog afterAll cleanup failed:', err);

--- a/e2e/rstudio/tests/projects/shinytest2.test.ts
+++ b/e2e/rstudio/tests/projects/shinytest2.test.ts
@@ -5,7 +5,7 @@ import { CONFIRM_BTN } from '@pages/modals.page';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { executeInConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { rPathLiteral } from '@utils/r';
-import { executeCommand, waitForActiveDocument } from '@utils/commands';
+import { documentOpen, executeCommand, openProject } from '@utils/commands';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { Page } from 'playwright';
@@ -72,20 +72,28 @@ async function scaffoldShinytest2Project(
 
   const projectDirLit = rPathLiteral(projectDir);
   const appPathLit = rPathLiteral(`${projectDir}/app.R`);
-  const testPathLit = rPathLiteral(testFilePath);
 
+  // initializeProject writes ${dir}/${basename(dir)}.Rproj; no bridge
+  // equivalent for project init yet, so stays in console. The bridge's
+  // project.open then dispatches SwitchToProjectEvent directly and needs
+  // that .Rproj path (the R-side .rs.api.openProject accepts a dir and
+  // re-derives it, but the bridge does not). projectName mirrors
+  // basename(projectDir) here, so we can build the .Rproj path locally
+  // without a second R round-trip.
   await consoleActions.executeInConsole(`.rs.api.initializeProject(${projectDirLit})`);
-  await consoleActions.executeInConsole(`.rs.api.openProject(${projectDirLit})`);
+  await openProject(page, `${projectDir}/${projectName}.Rproj`);
+  // openProject waits on window.rstudio.ready, but the GWT project-menu label
+  // can lag that signal between two open-in-a-row tests (the local
+  // closeProjectIfOpen doesn't wait for the no-project session's bridge to
+  // re-settle). Keep the long timeout so the assertion also acts as the wait.
   await expect(page.locator(PROJECT_MENU)).toContainText(projectName, {
     timeout: TIMEOUTS.sessionRestart,
   });
-  await waitForConsoleIdle(page);
 
   await consoleActions.executeInConsole(
     `file.copy(file.path(system.file("examples", package = "shiny"), "01_hello", "app.R"), ${appPathLit}, overwrite = TRUE)`,
   );
-  await consoleActions.executeInConsole(`.rs.api.documentOpen(${testPathLit})`);
-  await waitForActiveDocument(page, testFilePath, TIMEOUTS.fileOpen);
+  await documentOpen(page, testFilePath);
 }
 
 test.describe('shinytest2 integration', () => {

--- a/e2e/rstudio/tests/projects/shinytest2.test.ts
+++ b/e2e/rstudio/tests/projects/shinytest2.test.ts
@@ -82,13 +82,7 @@ async function scaffoldShinytest2Project(
   // without a second R round-trip.
   await consoleActions.executeInConsole(`.rs.api.initializeProject(${projectDirLit})`);
   await openProject(page, `${projectDir}/${projectName}.Rproj`);
-  // openProject waits on window.rstudio.ready, but the GWT project-menu label
-  // can lag that signal between two open-in-a-row tests (the local
-  // closeProjectIfOpen doesn't wait for the no-project session's bridge to
-  // re-settle). Keep the long timeout so the assertion also acts as the wait.
-  await expect(page.locator(PROJECT_MENU)).toContainText(projectName, {
-    timeout: TIMEOUTS.sessionRestart,
-  });
+  await expect(page.locator(PROJECT_MENU)).toContainText(projectName);
 
   await consoleActions.executeInConsole(
     `file.copy(file.path(system.file("examples", package = "shiny"), "01_hello", "app.R"), ${appPathLit}, overwrite = TRUE)`,

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test';
 import { waitForConsoleIdle } from '../pages/console_pane.page';
+import { withBridgeLog, withBridgeLogResult } from './log';
 
 // `window.rstudio` is registered when rsession runs with --automation-agent
 // (the Desktop fixture forwards that flag). The bridge lets tests trigger and
@@ -61,11 +62,26 @@ type ActiveDocument = {
   dirty: boolean;
 };
 
+type DocumentOpenOptions = {
+  /** 1-indexed line to navigate to after opening. Omit (or <0) to skip navigation. */
+  line?: number;
+  /** 1-indexed column. Defaults to 1 when `line` is set. */
+  col?: number;
+  /** Whether to move the cursor to the position (true) or just scroll there (false). Defaults to true. */
+  moveCursor?: boolean;
+};
+
 type Documents = {
   closeAllNoSave(): void;
   resetToUntitled(): void;
   /** Info on the focused source document, or null when no editor is active. */
   active(): ActiveDocument | null;
+  /**
+   * Open the file at `path` in the source pane. Fires OpenSourceFileEvent
+   * directly; the caller must ensure the file exists on disk (the bridge
+   * skips the ensureFileExists RPC that .rs.api.documentOpen does).
+   */
+  open(path: string, opts?: DocumentOpenOptions): void;
 };
 
 /**
@@ -140,21 +156,23 @@ function snakeToCamel(s: string): string {
 
 /** Run an AppCommand by id (no console roundtrip). */
 export async function executeCommand(page: Page, commandId: string): Promise<void> {
-  // The bridge is transiently absent during session restarts (project open
-  // /close, Restart R). Wait for the specific command to land before
-  // dispatching so callers don't have to manage that themselves. When the
-  // bridge is already up, the condition is true on the first poll, so this
-  // adds no measurable latency to the steady-state path.
-  await page.waitForFunction(
-    (id) => typeof (window.rstudio?.commands as Record<string, unknown> | undefined)?.[id] === 'function',
-    commandId,
-    { timeout: 10000, polling: 50 },
-  );
-  await page.evaluate((id) => {
-    const r = window.rstudio!;
-    const cmd = r.commands[id];
-    cmd();
-  }, commandId);
+  await withBridgeLog('executeCommand', commandId, async () => {
+    // The bridge is transiently absent during session restarts (project open
+    // /close, Restart R). Wait for the specific command to land before
+    // dispatching so callers don't have to manage that themselves. When the
+    // bridge is already up, the condition is true on the first poll, so this
+    // adds no measurable latency to the steady-state path.
+    await page.waitForFunction(
+      (id) => typeof (window.rstudio?.commands as Record<string, unknown> | undefined)?.[id] === 'function',
+      commandId,
+      { timeout: 10000, polling: 50 },
+    );
+    await page.evaluate((id) => {
+      const r = window.rstudio!;
+      const cmd = r.commands[id];
+      cmd();
+    }, commandId);
+  });
 }
 
 /** True when the named AppCommand reports `isChecked` (e.g. an active layout zoom). */
@@ -194,15 +212,17 @@ export async function isCommandEnabled(page: Page, commandId: string): Promise<b
  * editor's value after this returns reflects the final on-disk content.
  */
 export async function saveDocument(page: Page, timeout = 5000): Promise<void> {
-  await executeCommand(page, 'saveSourceDoc');
-  await page.waitForFunction(
-    () => {
-      const doc = window.rstudio?.documents.active() ?? null;
-      return doc !== null && !doc.dirty;
-    },
-    null,
-    { timeout, polling: 100 },
-  );
+  await withBridgeLog('saveDocument', '', async () => {
+    await executeCommand(page, 'saveSourceDoc');
+    await page.waitForFunction(
+      () => {
+        const doc = window.rstudio?.documents.active() ?? null;
+        return doc !== null && !doc.dirty;
+      },
+      null,
+      { timeout, polling: 100 },
+    );
+  });
 }
 
 /**
@@ -211,11 +231,44 @@ export async function saveDocument(page: Page, timeout = 5000): Promise<void> {
  * round trip (and therefore the "session is busy" dialog risk).
  */
 export async function documentCloseAllNoSave(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    const r = window.rstudio;
-    if (!r)
-      throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
-    r.documents.closeAllNoSave();
+  await withBridgeLog('documentCloseAllNoSave', '', async () => {
+    await page.evaluate(() => {
+      const r = window.rstudio;
+      if (!r)
+        throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
+      r.documents.closeAllNoSave();
+    });
+  });
+}
+
+/**
+ * Open the file at `path` in the source pane via the automation bridge, and
+ * wait until it is the active document.
+ *
+ * Mirrors `.rs.api.documentOpen(path, line, col, moveCursor)` but skips the
+ * R round-trip and the ensureFileExists RPC; the caller is responsible for
+ * ensuring the file exists on disk.
+ *
+ * The event dispatch is synchronous; the actual open is async (file load,
+ * editor create), so this also polls `documents.active()` until the path
+ * matches -- equivalent to following the open with `waitForActiveDocument`.
+ *
+ * `line` is 1-indexed; omit (or pass <0) to open without navigating.
+ */
+export async function documentOpen(
+  page: Page,
+  path: string,
+  opts: DocumentOpenOptions = {},
+  timeout = 20000,
+): Promise<void> {
+  await withBridgeLog('documentOpen', path, async () => {
+    await page.evaluate(({ docPath, options }) => {
+      const r = window.rstudio;
+      if (!r)
+        throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
+      r.documents.open(docPath, options);
+    }, { docPath: path, options: opts });
+    await waitForActiveDocument(page, path, timeout);
   });
 }
 
@@ -228,11 +281,13 @@ export async function documentCloseAllNoSave(page: Page): Promise<void> {
  * cross-test resets where a following file.edit / newDoc is imminent.
  */
 export async function resetSourcePaneState(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    const r = window.rstudio;
-    if (!r)
-      throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
-    r.documents.resetToUntitled();
+  await withBridgeLog('resetSourcePaneState', '', async () => {
+    await page.evaluate(() => {
+      const r = window.rstudio;
+      if (!r)
+        throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
+      r.documents.resetToUntitled();
+    });
   });
 }
 
@@ -267,14 +322,20 @@ export async function waitForActiveDocument(
  * unknown.
  */
 export async function getPref(page: Page, name: string): Promise<PrefValue | null> {
-  const camel = snakeToCamel(name);
-  return page.evaluate((prefName) => {
-    const r = window.rstudio;
-    if (!r)
-      throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
-    const entry = r.prefs[prefName];
-    return entry ? entry.get() : null;
-  }, camel);
+  return withBridgeLogResult(
+    'getPref',
+    (result) => `${name}=${JSON.stringify(result)}`,
+    async () => {
+      const camel = snakeToCamel(name);
+      return page.evaluate((prefName) => {
+        const r = window.rstudio;
+        if (!r)
+          throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
+        const entry = r.prefs[prefName];
+        return entry ? entry.get() : null;
+      }, camel);
+    },
+  );
 }
 
 /**
@@ -288,16 +349,18 @@ export async function getPref(page: Page, name: string): Promise<PrefValue | nul
  * pref change is observable in R / the session-side cache when this resolves.
  */
 export async function setPref(page: Page, name: string, value: PrefValue): Promise<void> {
-  const camel = snakeToCamel(name);
-  await page.evaluate(async ({ prefName, prefValue }) => {
-    const r = window.rstudio;
-    if (!r)
-      throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
-    const entry = r.prefs[prefName];
-    if (!entry)
-      throw new Error(`Unknown user preference: ${prefName}`);
-    await entry.set(prefValue);
-  }, { prefName: camel, prefValue: value });
+  await withBridgeLog('setPref', `${name}=${JSON.stringify(value)}`, async () => {
+    const camel = snakeToCamel(name);
+    await page.evaluate(async ({ prefName, prefValue }) => {
+      const r = window.rstudio;
+      if (!r)
+        throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
+      const entry = r.prefs[prefName];
+      if (!entry)
+        throw new Error(`Unknown user preference: ${prefName}`);
+      await entry.set(prefValue);
+    }, { prefName: camel, prefValue: value });
+  });
 }
 
 /**
@@ -306,16 +369,18 @@ export async function setPref(page: Page, name: string, value: PrefValue): Promi
  * server-side before returning.
  */
 export async function clearPref(page: Page, name: string): Promise<void> {
-  const camel = snakeToCamel(name);
-  await page.evaluate(async (prefName) => {
-    const r = window.rstudio;
-    if (!r)
-      throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
-    const entry = r.prefs[prefName];
-    if (!entry)
-      throw new Error(`Unknown user preference: ${prefName}`);
-    await entry.clear();
-  }, camel);
+  await withBridgeLog('clearPref', name, async () => {
+    const camel = snakeToCamel(name);
+    await page.evaluate(async (prefName) => {
+      const r = window.rstudio;
+      if (!r)
+        throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
+      const entry = r.prefs[prefName];
+      if (!entry)
+        throw new Error(`Unknown user preference: ${prefName}`);
+      await entry.clear();
+    }, camel);
+  });
 }
 
 /**
@@ -344,14 +409,20 @@ export async function setChatUpdateCheckOverride(
   page: Page,
   override: Record<string, unknown> | null,
 ): Promise<void> {
-  await page.evaluate(async (o) => {
-    if (!window.rstudio?.chat?.setUpdateCheckOverride) {
-      throw new Error(
-        'window.rstudio.chat.setUpdateCheckOverride missing; launch RStudio with --automation-agent',
-      );
-    }
-    await window.rstudio.chat.setUpdateCheckOverride(o);
-  }, override);
+  await withBridgeLog(
+    'setChatUpdateCheckOverride',
+    override === null ? 'null' : JSON.stringify(override),
+    async () => {
+      await page.evaluate(async (o) => {
+        if (!window.rstudio?.chat?.setUpdateCheckOverride) {
+          throw new Error(
+            'window.rstudio.chat.setUpdateCheckOverride missing; launch RStudio with --automation-agent',
+          );
+        }
+        await window.rstudio.chat.setUpdateCheckOverride(o);
+      }, override);
+    },
+  );
 }
 
 /**
@@ -372,29 +443,31 @@ export async function openProject(
   projectFilePath: string,
   timeout = 60000,
 ): Promise<void> {
-  await page.evaluate((p) => {
-    const r = window.rstudio;
-    if (!r)
-      throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
-    r.project.open(p);
-  }, projectFilePath);
+  await withBridgeLog('openProject', projectFilePath, async () => {
+    await page.evaluate((p) => {
+      const r = window.rstudio;
+      if (!r)
+        throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
+      r.project.open(p);
+    }, projectFilePath);
 
-  // The Server mode page may navigate as part of the project switch; let it
-  // settle before polling the bridge. On Desktop this is a no-op.
-  await page.waitForLoadState('load', { timeout: 30000 }).catch(() => {});
+    // The Server mode page may navigate as part of the project switch; let it
+    // settle before polling the bridge. On Desktop this is a no-op.
+    await page.waitForLoadState('load', { timeout: 30000 }).catch(() => {});
 
-  await page.waitForFunction(
-    () => window.rstudio?.ready === true,
-    null,
-    { timeout, polling: 50 },
-  );
+    await page.waitForFunction(
+      () => window.rstudio?.ready === true,
+      null,
+      { timeout, polling: 50 },
+    );
 
-  // ready=true tells us GWT's workbench is wired up, but the console-busy
-  // class can still be set briefly while the post-switch prompt transition
-  // completes (same gap restartSessionWithSentinel guards against in
-  // project.ts). Without this wait callers can issue a console action into
-  // a still-busy session.
-  await waitForConsoleIdle(page);
+    // ready=true tells us GWT's workbench is wired up, but the console-busy
+    // class can still be set briefly while the post-switch prompt transition
+    // completes (same gap restartSessionWithSentinel guards against in
+    // project.ts). Without this wait callers can issue a console action into
+    // a still-busy session.
+    await waitForConsoleIdle(page);
+  });
 }
 
 /** Read the RStudio + R version info installed on the automation bridge. */

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -461,11 +461,25 @@ export async function openProject(
       { timeout, polling: 50 },
     );
 
-    // ready=true tells us GWT's workbench is wired up, but the console-busy
-    // class can still be set briefly while the post-switch prompt transition
-    // completes (same gap restartSessionWithSentinel guards against in
-    // project.ts). Without this wait callers can issue a console action into
-    // a still-busy session.
+    // ready=true tells us the workbench is wired up, but SessionInfo can
+    // still report the previous project's path for a beat -- and the project
+    // menu UI lags that. Poll project.path() against the requested file so
+    // the helper's post-condition is "the bridge agrees this project is
+    // active" rather than "ready flipped true." Case-insensitive to match
+    // waitForActiveDocument's handling of HFS+ / NTFS.
+    await page.waitForFunction(
+      (target) => {
+        const path = window.rstudio?.project.path() ?? null;
+        return path !== null && path.toLowerCase() === target.toLowerCase();
+      },
+      projectFilePath,
+      { timeout, polling: 100 },
+    );
+
+    // The console-busy class can still be set briefly while the post-switch
+    // prompt transition completes (same gap restartSessionWithSentinel
+    // guards against in project.ts). Without this wait callers can issue a
+    // console action into a still-busy session.
     await waitForConsoleIdle(page);
   });
 }

--- a/e2e/rstudio/utils/log.ts
+++ b/e2e/rstudio/utils/log.ts
@@ -1,0 +1,93 @@
+import { test } from '@playwright/test';
+
+/**
+ * Paper-trail logging for automation bridge actions.
+ *
+ * Emits one log line per bridge call, capturing the high-level action label,
+ * its arguments, success or failure, and elapsed time. The timestamp is
+ * captured at call start (when the action was initiated, not when it
+ * returned) so concurrent flows interleave in initiation order.
+ *
+ * Format:
+ *
+ *     [<iso8601-timestamp>] [<test-title-or-fallback>] <action> <details> <status> <ms>ms
+ *
+ * Example:
+ *
+ *     [2026-05-24T08:50:42.123Z] [shinytest2 toolbar] setPref rainbow_fenced_divs=true ok 23ms
+ *     [2026-05-24T08:50:42.146Z] [shinytest2 toolbar] openProject /tmp/sandbox/foo.Rproj ok 1842ms
+ *     [2026-05-24T08:50:43.988Z] [shinytest2 toolbar] documentOpen /tmp/sandbox/test.R FAILED 20012ms
+ *
+ * Only used by the helpers in `commands.ts`. Tests should not call these
+ * functions directly; calling a bridge helper produces the log entry.
+ */
+
+function activeTestTitle(): string {
+  try {
+    return test.info().title;
+  } catch {
+    // Outside the test-runner context (e.g. a helper called from a worker
+    // setup hook before any test has started).
+    return '[no-test]';
+  }
+}
+
+function emit(
+  startedAt: string,
+  action: string,
+  details: string,
+  status: 'ok' | 'FAILED',
+  durationMs: number,
+): void {
+  const detailPart = details ? ` ${details}` : '';
+  // eslint-disable-next-line no-console
+  console.log(`[${startedAt}] [${activeTestTitle()}] ${action}${detailPart} ${status} ${durationMs}ms`);
+}
+
+/**
+ * Run `fn` and emit one paper-trail log line. The line includes the action
+ * label, the details string, ok/FAILED status, and elapsed milliseconds.
+ *
+ * Captures the timestamp at call start. On thrown error the entry is logged
+ * before the error is re-thrown so a trace-less failure still produces "the
+ * last thing that was tried" in the log.
+ */
+export async function withBridgeLog<T>(
+  action: string,
+  details: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const startedAt = new Date().toISOString();
+  const startMs = Date.now();
+  try {
+    const result = await fn();
+    emit(startedAt, action, details, 'ok', Date.now() - startMs);
+    return result;
+  } catch (err) {
+    emit(startedAt, action, details, 'FAILED', Date.now() - startMs);
+    throw err;
+  }
+}
+
+/**
+ * Variant of `withBridgeLog` for read calls that resolve to a value the
+ * paper trail should record. The detail string for the log entry is built
+ * from the resolved value via `formatResult`, so the log can include the
+ * value that was observed (useful for `getPref` etc.).
+ */
+export async function withBridgeLogResult<T>(
+  action: string,
+  formatResult: (result: T) => string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const startedAt = new Date().toISOString();
+  const startMs = Date.now();
+  try {
+    const result = await fn();
+    emit(startedAt, action, formatResult(result), 'ok', Date.now() - startMs);
+    return result;
+  } catch (err) {
+    emit(startedAt, action, '<unresolved>', 'FAILED', Date.now() - startMs);
+    throw err;
+  }
+}

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -16,11 +16,18 @@ package org.rstudio.studio.client.application;
 
 import java.util.Map;
 
+import org.rstudio.core.client.FilePosition;
 import org.rstudio.core.client.command.AppCommand;
+import org.rstudio.core.client.files.FileSystemItem;
+import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.DeferredInitCompletedEvent;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.QuitEvent;
 import org.rstudio.studio.client.application.events.RestartStatusEvent;
+import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
+import org.rstudio.studio.client.common.filetypes.TextFileType;
+import org.rstudio.studio.client.common.filetypes.events.OpenSourceFileEvent;
+import org.rstudio.studio.client.common.filetypes.model.NavigationMethods;
 import org.rstudio.studio.client.projects.events.OpenProjectErrorEvent;
 import org.rstudio.studio.client.projects.events.SwitchToProjectEvent;
 import org.rstudio.studio.client.server.model.DocumentCloseAllNoSaveEvent;
@@ -58,6 +65,7 @@ import com.google.inject.Singleton;
  *   window.rstudio.documents.closeAllNoSave()
  *   window.rstudio.documents.resetToUntitled() // close everything but a single untitled tab
  *   window.rstudio.documents.active()          // { id, path, dirty } for the focused doc, or null
+ *   window.rstudio.documents.open(path, opts?) // open file at path; opts: { line?, col?, moveCursor? }
  *
  *   window.rstudio.project.path()       // active project file path, or null
  *   window.rstudio.project.name()       // active project display name, or null
@@ -331,6 +339,23 @@ public class ApplicationAutomation
       eventBus_.dispatchEvent(new DocumentResetToUntitledEvent());
    }
 
+   // Equivalent to .rs.api.documentOpen(path, line, col, moveCursor) but skips
+   // the ensureFileExists RPC that columnManager_.editFile would do -- tests
+   // pass known-existing paths, and OpenSourceFileEvent is the same event the
+   // GWT side ultimately fires from the R-API path. line is 1-indexed; pass
+   // line < 0 to open without navigating.
+   private void dispatchDocumentOpen(String path, int line, int col, boolean moveCursor)
+   {
+      FileSystemItem file = FileSystemItem.createFile(path);
+      FileTypeRegistry registry = RStudioGinjector.INSTANCE.getFileTypeRegistry();
+      TextFileType fileType = registry.getTextTypeForFile(file);
+      FilePosition position = line >= 0
+         ? FilePosition.create(line, Math.max(col, 1))
+         : null;
+      eventBus_.dispatchEvent(new OpenSourceFileEvent(
+         file, position, fileType, moveCursor, NavigationMethods.DEFAULT));
+   }
+
    // Returns null when no editor is active so callers can distinguish "no doc"
    // from "doc exists but is clean".
    private JavaScriptObject getActiveDocument()
@@ -459,6 +484,17 @@ public class ApplicationAutomation
       });
       $wnd.rstudio.documents.active = $entry(function() {
          return self.@org.rstudio.studio.client.application.ApplicationAutomation::getActiveDocument()();
+      });
+      // opts: { line?: number (1-indexed; omit/<0 = don't navigate),
+      //         col?: number (1-indexed; defaults to 1),
+      //         moveCursor?: boolean (defaults to true) }.
+      $wnd.rstudio.documents.open = $entry(function(path, opts) {
+         opts = opts || {};
+         var line = (typeof opts.line === 'number') ? opts.line : -1;
+         var col = (typeof opts.col === 'number') ? opts.col : 1;
+         var moveCursor = (opts.moveCursor !== false);
+         self.@org.rstudio.studio.client.application.ApplicationAutomation::dispatchDocumentOpen(*)(
+            path, line, col, moveCursor);
       });
    }-*/;
 


### PR DESCRIPTION
## Summary

- Adds `window.rstudio.documents.open(path, opts?)` to the automation bridge in `ApplicationAutomation.java` (fires `OpenSourceFileEvent` directly, skipping the `ensureFileExists` RPC roundtrip `columnManager_.editFile` does). Exposes a `documentOpen(page, path)` helper in `utils/commands.ts` that also waits for the file to become the active document.
- Adds `utils/log.ts` with `withBridgeLog` / `withBridgeLogResult` and wraps every state-changing bridge helper (`executeCommand`, `saveDocument`, `documentCloseAllNoSave`, `documentOpen`, `resetSourcePaneState`, `setPref`, `getPref`, `clearPref`, `setChatUpdateCheckOverride`, `openProject`). Each call emits one line:

      [<iso8601-start>] [<test-title or fallback>] <action> <details> ok|FAILED <ms>ms

- Ports six of eight `.rs.api.*` console sites surfaced by an e2e anti-pattern scan:
  - `syntax-highlighting.test.ts` two `.rs.writeUserPref` -> `setPref`
  - `project_trust_dialog.test.ts` two `.rs.api.readRStudioPreference` via `captureResult` -> `getPref` (with downstream comparison simplified from string `=== 'TRUE'` to direct boolean)
  - `shinytest2.test.ts` + `build_pane_testthat.test.ts` `.rs.api.openProject(dir)` -> `openProject(page, '${dir}/${basename}.Rproj')` (bridge needs the .Rproj path directly; `initializeProject`/`package_skeleton` write the predictable name)
  - `shinytest2.test.ts` + `build_pane_testthat.test.ts` `.rs.api.documentOpen` -> the new `documentOpen` helper
- Leaves four sites intentionally in-console with inline comments explaining the reason: `.rs.api.initializeProject` (no bridge equivalent for project init), `.rs.api.restartSession('print(x + y)')` in `session_restart.test.ts` (the test specifically exercises the `afterRestart` parameter, which the `restartR` AppCommand does not expose).
- Adds `e2e/rstudio/docs/ANTIPATTERN_CLEANUP.md` as a tracking doc for the broader anti-pattern cleanup. The console-RPC item is the first category to be addressed.

## Test plan

- [x] `npm run typecheck` (e2e/rstudio) clean
- [x] `cd src/gwt && ant javac` clean
- [x] `cd src/gwt && ant draft` clean (required since `ApplicationAutomation.java` changed)
- [x] `npm run test:desktop-dev -- --grep-invert @ai` -- 243 passed, 10 skipped, 0 failures after restoring a `PROJECT_MENU` long-timeout assertion that the original code had.