### PR TITLE
jenkins: silence 'forgot def' warning on checks script field

### DIFF
--- a/jenkins/utils.groovy
+++ b/jenkins/utils.groovy
@@ -1,5 +1,7 @@
 // Utility methods for Jenkins pipelines
 
+import groovy.transform.Field
+
 /**
   * Returns true if branch has changes in the specified path with the target branch.
   * If invertMatch is true, returns true if branch has changes that do not match the specified path.
@@ -443,7 +445,8 @@ def checkRunsRequestWithRetry(String method, String payload = "", String url = p
   return lastResponse
 }
 
-checks = [:]
+@Field
+def checks = [:]
 
 /**
   * Posts a review check to the GitHub /check-runs API with the specified args.


### PR DESCRIPTION
## Summary

Every Jenkins build prints this Groovy compiler warning, repeated many times across stages:

```
Did you forget the `def` keyword? Script1 seems to be setting a field
named checks (to a value of type LinkedHashMap) which could lead to
memory leaks or other issues.
```

The source is the bare script-level assignment `checks = [:]` in `jenkins/utils.groovy`. Because `utils.groovy` is loaded via `load()` (it ends in `return this`), an undeclared assignment becomes an implicit field on the script binding rather than a properly declared field — which is exactly what the warning is calling out.

This PR annotates the declaration with `@Field` (from `groovy.transform.Field`), making `checks` an explicit instance field of the loaded script. The behavior is unchanged: both `postReviewCheck()` and `finishReviewChecks()` already read and mutate `checks` as shared state across calls, which is what `@Field` semantically expresses.

## Background

The `checks` map was introduced on 2024-06-13 in commit cb55d0be3d ("Sync Jenkinsfile pull request changes from Pro"), when the PR check-runs machinery (`postReviewCheck` / `finishReviewChecks`) was first added to `utils.groovy`. The warning has been emitted on every Jenkins build since.

## Test plan

- [ ] Trigger a Jenkins build and confirm the `Did you forget the \`def\` keyword?` warning for `checks` no longer appears in the logs
- [ ] Confirm PR check-runs still post correctly (queued -> in_progress -> success/failure) on a sample PR build