### PR TITLE
ci: build RStudio Desktop from source for macOS e2e, plus robustness

### DIFF
--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       rstudio_installer_url:
-        description: "URL to a Desktop installer (.deb on Ubuntu, .rpm on RHEL/Fedora, .exe on Windows, .dmg on macOS). Leave empty to auto-resolve the latest daily for this workflow's platform. To pin a specific build, paste its full URL from dailies.rstudio.com."
+        description: "Optional .dmg URL to test against (e.g. a specific daily from dailies.rstudio.com). Leave empty to build RStudio Desktop from this branch's source on the runner."
         type: string
         default: ""
       r_version:
@@ -63,7 +63,91 @@ on:
         default: ""
 
 jobs:
+  # Builds RStudio Desktop from this PR's source on the same runner image as
+  # the e2e job below, then uploads RStudio.app as an artifact for the e2e
+  # job to consume. Skipped when rstudio_installer_url is set, in which case
+  # the e2e job downloads the dmg from that URL instead (existing override
+  # path -- useful for testing against a specific daily).
+  build:
+    if: inputs.rstudio_installer_url == ''
+    runs-on: macos-26
+    timeout-minutes: 90
+    env:
+      # The dependency / package scripts default RSTUDIO_TOOLS_ROOT to /opt,
+      # which isn't writable on hosted runners without sudo. Redirect to a
+      # workspace-local path that we can also cache.
+      RSTUDIO_TOOLS_ROOT: ${{ github.workspace }}/opt/rstudio-tools/arm64
+      SCCACHE_ENABLED: '1'
+      SCCACHE_DIR: ${{ github.workspace }}/.sccache
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pre-built tool deps (Boost, SOCI, pandoc, quarto, GWT, node, panmirror,
+      # copilot-language-server, etc.) all land under RSTUDIO_TOOLS_ROOT.
+      # Caching this directory turns the install-common step from ~5-10 min
+      # of downloads into a no-op on warm runs.
+      - name: Cache rstudio-tools deps
+        id: tools-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.RSTUDIO_TOOLS_ROOT }}
+          key: rstudio-tools-arm64-${{ hashFiles('dependencies/common/install-*', 'dependencies/osx/install-*', 'dependencies/tools/rstudio-tools.sh') }}
+          restore-keys: |
+            rstudio-tools-arm64-
+
+      # sccache local cache for the C++ build. Keyed on the commit SHA for
+      # uniqueness; restore-keys pulls the most recent cache as a starting
+      # point so incremental builds get hits even when the SHA changed.
+      - name: Cache sccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: sccache-arm64-${{ github.sha }}
+          restore-keys: |
+            sccache-arm64-
+
+      # install-dependencies-osx (the entry-point script) builds both arm64
+      # and x86_64 dependencies on an M1 Mac, which we don't need. Call the
+      # per-arch script directly to install only arm64 brew formulae; that
+      # script also chains into dependencies/common/install-common at the
+      # end, so this single step covers brew formulae + Boost + SOCI + GWT
+      # + node + pandoc/quarto + panmirror + copilot-language-server +
+      # sccache + dictionaries + mathjax.
+      - name: Install build dependencies
+        working-directory: dependencies/osx
+        run: ./install-dependencies-osx-arch
+
+      - name: Build RStudio Desktop (arm64)
+        working-directory: package/osx
+        env:
+          RSTUDIO_VERSION_MAJOR: '99'
+          RSTUDIO_VERSION_MINOR: '9'
+          RSTUDIO_VERSION_PATCH: '9'
+          RSTUDIO_VERSION_SUFFIX: "-pr+${{ github.run_number }}"
+        run: ./make-package --arch=arm64 --build-dmg=0 --use-creds=0
+
+      # tar (not zip) to preserve symlinks and executable permissions in the
+      # bundle. upload-artifact would otherwise zip the directory tree itself
+      # and break codesigned binaries on the way back out.
+      - name: Package RStudio.app
+        working-directory: package/osx/install
+        run: tar -czf "${{ github.workspace }}/RStudio.app.tar.gz" RStudio.app
+
+      - name: Upload RStudio.app artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rstudio-app-macos-arm64
+          path: RStudio.app.tar.gz
+          retention-days: 7
+
   e2e-desktop-macos:
+    needs: build
+    # build is skipped when rstudio_installer_url is set; allow this job to
+    # run in that case too. needs.build.result is "success" on a normal run
+    # and "skipped" on the override path.
+    if: |
+      always() &&
+      (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: macos-26
     timeout-minutes: 120
     env:
@@ -102,44 +186,47 @@ jobs:
           rig ls
           mkdir -p "$R_LIBS_USER"
 
+      # PR-built artifact path (default). Pulled in when no installer URL is
+      # provided -- the build job above produced RStudio.app.tar.gz for us.
+      - name: Download RStudio.app artifact
+        if: inputs.rstudio_installer_url == ''
+        uses: actions/download-artifact@v4
+        with:
+          name: rstudio-app-macos-arm64
+          path: ${{ github.workspace }}
+
+      - name: Install RStudio from artifact
+        if: inputs.rstudio_installer_url == ''
+        run: |
+          tar -xzf "${{ github.workspace }}/RStudio.app.tar.gz" -C "${{ github.workspace }}"
+          sudo rm -rf /Applications/RStudio.app
+          sudo cp -R "${{ github.workspace }}/RStudio.app" /Applications/
+          sudo xattr -cr /Applications/RStudio.app
+          ls -la /Applications/RStudio.app/Contents/MacOS/RStudio
+
+      # Override path: use a specific .dmg URL when rstudio_installer_url is
+      # set. Useful for testing against a specific daily / past release.
       - name: Resolve RStudio .dmg URL
+        if: inputs.rstudio_installer_url != ''
         id: resolve
         env:
           INSTALLER_URL: ${{ inputs.rstudio_installer_url }}
         run: |
           URL="$INSTALLER_URL"
-          SHA=""
-          FILENAME=""
-          if [ -z "$URL" ]; then
-            MANIFEST=$(curl -fsSL https://dailies.rstudio.com/rstudio/latest/index.json)
-            URL=$(echo "$MANIFEST" | jq -er '.products.electron.platforms.macos.link')
-            SHA=$(echo "$MANIFEST" | jq -er '.products.electron.platforms.macos.sha256')
-            FILENAME=$(echo "$MANIFEST" | jq -er '.products.electron.platforms.macos.filename')
-            echo "Auto-resolved latest macos daily:"
-            echo "  URL:      $URL"
-            echo "  SHA-256:  $SHA"
-            echo "  Filename: $FILENAME"
-          else
-            FILENAME=$(basename "$URL")
-            echo "Using override URL: $URL (SHA-256 verification skipped)"
-          fi
+          FILENAME=$(basename "$URL")
+          echo "Using override URL: $URL (SHA-256 verification skipped)"
           echo "url=$URL" >> "$GITHUB_OUTPUT"
-          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
           echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
 
       - name: Download RStudio .dmg
+        if: inputs.rstudio_installer_url != ''
         run: |
           curl -fsSL --retry 3 --retry-delay 5 \
             -o "${{ steps.resolve.outputs.filename }}" \
             "${{ steps.resolve.outputs.url }}"
 
-      - name: Verify SHA-256
-        if: steps.resolve.outputs.sha256 != ''
-        run: |
-          echo "${{ steps.resolve.outputs.sha256 }}  ${{ steps.resolve.outputs.filename }}" \
-            | shasum -a 256 -c -
-
-      - name: Install RStudio
+      - name: Install RStudio from .dmg
+        if: inputs.rstudio_installer_url != ''
         run: |
           MOUNT=$(hdiutil attach -nobrowse -readonly "${{ steps.resolve.outputs.filename }}" | grep -oE '/Volumes/.*' | tail -1)
           if [ -z "$MOUNT" ]; then

--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -68,6 +68,12 @@ jobs:
     timeout-minutes: 120
     env:
       R_LIBS_USER: ${{ github.workspace }}/R-libs
+      # Pin the sandbox parent so the upload-artifact step below knows where
+      # rsession logs / preserved per-spec config trees end up after a failed
+      # run. globalSetup honors this and auto-creates the directory
+      # (PW_SANDBOX_ROOT_CREATE=1).
+      PW_SANDBOX_ROOT: ${{ github.workspace }}/pw-sandbox
+      PW_SANDBOX_ROOT_CREATE: '1'
 
     steps:
       - uses: actions/checkout@v4
@@ -75,6 +81,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
 
       - name: Install rig
         run: |
@@ -174,6 +182,14 @@ jobs:
         working-directory: e2e/rstudio
         run: npm ci
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/ms-playwright
+          key: ${{ runner.os }}-pw-${{ hashFiles('e2e/rstudio/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-pw-
+
       - name: Install Playwright browsers
         working-directory: e2e/rstudio
         run: npx playwright install --with-deps chromium
@@ -188,6 +204,10 @@ jobs:
           PW_TEST_SELECTOR: ${{ inputs.test_selector }}
           PW_TEST_IGNORE: ${{ inputs.test_ignore }}
           PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
+          # Print the GWT launch timeline so the next launch failure shows
+          # which phase exceeded the deadline (CDP-connect vs. bridge-installed
+          # vs. ready-flag vs. console-visible).
+          PW_DEBUG_LAUNCH: '1'
         run: |
           ARGS=()
           if [ -n "$PW_TEST_SELECTOR" ]; then
@@ -218,4 +238,28 @@ jobs:
         with:
           name: test-results
           path: e2e/rstudio/test-results/
+          if-no-files-found: ignore
+
+      # Preserved per-spec sandbox tree on failure -- includes rsession logs,
+      # the spec's RStudio config / data home, and per-test working dirs.
+      # globalTeardown leaves this in place when any test failed; if every
+      # test passed the directory is gone and `if-no-files-found: ignore`
+      # silently skips upload.
+      - name: Upload PW sandbox (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pw-sandbox
+          path: ${{ github.workspace }}/pw-sandbox/
+          if-no-files-found: ignore
+
+      # macOS writes Electron / rsession crash reports here; useful when a
+      # launch fails because the renderer or session process aborted before
+      # the GWT-ready handshake.
+      - name: Upload macOS diagnostic reports (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-diagnostic-reports
+          path: ~/Library/Logs/DiagnosticReports/
           if-no-files-found: ignore

--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -198,13 +198,46 @@ function createTempConfig(): TempConfig {
   return { root, configHome, configDir, electronUserData };
 }
 
+// Cold CI runners can take longer than a developer machine to clear the
+// GWT-ready check (JS download/parse, R session boot, ApplicationAutomation
+// init, DeferredInitCompletedEvent). PW_GWT_READY_TIMEOUT_MS overrides
+// explicitly; otherwise default to 60s under CI and the previous 30s locally.
+const PAGE_READY_TIMEOUT_MS =
+  Number(process.env.PW_GWT_READY_TIMEOUT_MS) ||
+  (process.env.CI ? 60000 : 30000);
+
 /**
  * Launch RStudio with CDP, connect Playwright, and return the session.
  *
  * `existingConfigRoot` lets relaunchAfterRestart reuse the same config
  * directory across a quit-and-restart so prefs/state persist.
+ *
+ * Retries the underlying launch once on failure. A cold-cache flake during
+ * the GWT-ready phase is the dominant failure mode on CI runners, and the
+ * post-CDP catch already tears the process tree down on failure, so a
+ * second attempt is safe and cheap. Set PW_LAUNCH_ATTEMPTS to override the
+ * attempt count (default 2 -- one retry).
  */
 export async function launchRStudio(existingConfigRoot?: string): Promise<DesktopSession> {
+  const maxAttempts = Math.max(1, Number(process.env.PW_LAUNCH_ATTEMPTS) || 2);
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await launchRStudioOnce(existingConfigRoot);
+    } catch (err) {
+      lastError = err;
+      const msg = (err as Error)?.message ?? String(err);
+      if (attempt < maxAttempts) {
+        console.warn(`[launch] attempt ${attempt}/${maxAttempts} failed: ${msg} -- retrying`);
+      } else {
+        console.warn(`[launch] attempt ${attempt}/${maxAttempts} failed: ${msg} -- giving up`);
+      }
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+async function launchRStudioOnce(existingConfigRoot?: string): Promise<DesktopSession> {
   // Clean up any existing RStudio on our specific CDP port. The port is
   // random per worker (9231-9299), so a collision is rare -- only happens
   // when an orphaned process from a prior interrupted run is still bound.
@@ -411,7 +444,7 @@ export async function launchRStudio(existingConfigRoot?: string): Promise<Deskto
     // false and only flips it on DeferredInitCompletedEvent, so the transient
     // page never matches and we proceed exactly when R-to-GWT roundtrips are
     // safe (no separate stability window needed).
-    const pageDeadline = Date.now() + 30000;
+    const pageDeadline = Date.now() + PAGE_READY_TIMEOUT_MS;
     let page: Page | undefined;
     let bridgeFirstSeen = false;
 
@@ -445,7 +478,9 @@ export async function launchRStudio(existingConfigRoot?: string): Promise<Deskto
       await sleep(250);
     }
     if (!page) {
-      throw new Error('GWT app did not finish loading within 30s (window.rstudio.ready never became true)');
+      throw new Error(
+        `GWT app did not finish loading within ${PAGE_READY_TIMEOUT_MS}ms (window.rstudio.ready never became true)`,
+      );
     }
     logLaunchStep('window.rstudio.ready === true');
 

--- a/e2e/rstudio/fixtures/sandbox-setup.ts
+++ b/e2e/rstudio/fixtures/sandbox-setup.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { prepareRLibs } from './r-libs-setup';
+import { launchRStudio, shutdownRStudio } from './desktop.fixture';
 
 /**
  * Create a per-invocation sandbox directory and export its path as PW_SANDBOX.
@@ -164,4 +165,33 @@ export default async function globalSetup() {
   // test. Pre-populating here is idempotent -- a warm cache is a fast
   // installed.packages() check with no install call.
   await prepareRLibs();
+
+  // Warmup launch: workers are recycled between spec files, so each new file
+  // pays the cold-launch cost. Booting once here populates dyld/page caches
+  // before any worker tries, dropping subsequent launches well under the
+  // GWT-ready deadline. Skipped on Server mode (no IDE binary to warm) and
+  // when PW_WARMUP_LAUNCH explicitly opts out. Default on under CI only --
+  // a developer running locally has warm caches already.
+  const mode = (process.env.PW_RSTUDIO_MODE ?? 'desktop').toLowerCase();
+  const warmupOverride = process.env.PW_WARMUP_LAUNCH?.toLowerCase();
+  const shouldWarmup =
+    mode === 'desktop' &&
+    (warmupOverride === '1' || warmupOverride === 'true' ||
+     (warmupOverride !== '0' && warmupOverride !== 'false' && !!process.env.CI));
+  if (shouldWarmup) {
+    console.log('[sandbox] warmup launch (populates RStudio launch caches)');
+    const t0 = Date.now();
+    try {
+      const session = await launchRStudio();
+      await shutdownRStudio(session);
+      console.log(`[sandbox] warmup launch complete in ${Date.now() - t0}ms`);
+    } catch (err) {
+      // A warmup failure is not fatal -- the first real test will retry the
+      // launch via the in-fixture retry. Log it so a persistent failure mode
+      // is visible without burning a whole test slot to surface it.
+      console.warn(
+        `[sandbox] warmup launch failed after ${Date.now() - t0}ms (continuing): ${(err as Error).message}`,
+      );
+    }
+  }
 }

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -36,12 +36,12 @@ const allProjects = [
   {
     name: 'desktop',
     use: { mode: 'desktop' as const },
-    grepInvert: new RegExp(['@server_only', '@smoke', ...desktopOsExclusions, ...editionExclusions].join('|')),
+    grepInvert: new RegExp(['@server_only', ...desktopOsExclusions, ...editionExclusions].join('|')),
   },
   {
     name: 'server',
     use: { mode: 'server' as const },
-    grepInvert: new RegExp(['@desktop_only', '@smoke', ...serverOsExclusions, ...editionExclusions].join('|')),
+    grepInvert: new RegExp(['@desktop_only', ...serverOsExclusions, ...editionExclusions].join('|')),
   },
 ];
 

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -85,7 +85,10 @@ export default defineConfig<{}, ProjectOptions>({
   fullyParallel: false,
   workers: 1,
   timeout: 300000,
-  retries: 0,
+  // On CI a single transient launch flake (e.g. GWT app slow to reach
+  // ready under cold disk caches on a fresh runner) can otherwise turn
+  // the whole suite red. One retry absorbs that without rerunning by hand.
+  retries: process.env.CI ? 1 : 0,
   reporter: [['html'], ['list'], ['./fixtures/sandbox-reporter.ts']],
   globalSetup: './fixtures/sandbox-setup.ts',
   globalTeardown: './fixtures/sandbox-teardown.ts',

--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -308,7 +308,10 @@ if [ -n "$SCCACHE_ENABLED" ]; then
         export SCCACHE_BUCKET="rstudio-build-cache"
     else
         echo "No valid AWS SSO session, using only local build cache"
-        export SCCACHE_DIR=$(pwd)/object_file_cache
+        # Honor an externally-set SCCACHE_DIR (e.g. when a CI runner has
+        # already restored a cache to a known path) instead of always
+        # rooting the cache under the package dir.
+        export SCCACHE_DIR="${SCCACHE_DIR:-$(pwd)/object_file_cache}"
         mkdir -p $SCCACHE_DIR
     fi
 fi

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -757,11 +757,23 @@ if(NOT RSTUDIO_SESSION_WIN32 AND NOT RSESSION_ALTERNATE_BUILD)
    install(DIRECTORY "${RSTUDIO_DEPENDENCIES_MATHJAX_DIR}"
            DESTINATION "${RSTUDIO_INSTALL_SUPPORTING}/resources")
 
-   # install node
+   # install node -- on Apple arm64-only builds, install-npm-dependencies
+   # only creates "-arm64-installed"; universal builds also have the
+   # un-suffixed "-installed" from the x86_64 primary install. Prefer the
+   # un-suffixed folder when present so universal-build behavior is
+   # unchanged.
+   set(_RSTUDIO_INSTALLED_NODE_SRC
+       "${RSTUDIO_DEPENDENCIES_DIR}/common/node/${RSTUDIO_INSTALLED_NODE_VERSION}-installed")
+   if(APPLE AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64"
+              AND NOT EXISTS "${_RSTUDIO_INSTALLED_NODE_SRC}")
+      set(_RSTUDIO_INSTALLED_NODE_SRC
+          "${RSTUDIO_DEPENDENCIES_DIR}/common/node/${RSTUDIO_INSTALLED_NODE_VERSION}-arm64-installed")
+   endif()
    install(
-      DIRECTORY "${RSTUDIO_DEPENDENCIES_DIR}/common/node/${RSTUDIO_INSTALLED_NODE_VERSION}-installed/"
+      DIRECTORY "${_RSTUDIO_INSTALLED_NODE_SRC}/"
       DESTINATION "${RSTUDIO_INSTALL_BIN}/node"
       USE_SOURCE_PERMISSIONS)
+   unset(_RSTUDIO_INSTALLED_NODE_SRC)
 
    # install quarto (or pandoc if quarto disabled)
    if(QUARTO_ENABLED)


### PR DESCRIPTION
## Intent

Two related changes to the macOS 26 ARM64 Playwright workflow:

1. **Make CI actually test the PR's source.** Today the workflow downloads "the latest daily" from `dailies.rstudio.com`. That means a PR's source changes are not under test (only the last-promoted daily is), and re-runs of the same PR race against newly-promoted dailies producing different results. The fix is to build RStudio Desktop from the PR's source on the runner and feed the resulting `RStudio.app` into the E2E job.

2. **Make the launch path more robust to runner flakes**, with diagnostics for the next failure. Original failure mode that started this work was sporadic "GWT app did not finish loading within 30s" on the first test of a spec file; investigation found a hardcoded 30s deadline, no retries, no logs collected on failure, and worker recycling between spec files multiplying any single launch flake into a red suite.

## Changes

### Build RStudio Desktop in CI (new in this push)

`.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml`:

- Adds a `build` job that runs first on the same `macos-26` ARM64 runner, calls `dependencies/osx/install-dependencies-osx-arch` (which chains into `install-common`), then `package/osx/make-package --arch=arm64 --build-dmg=0 --use-creds=0`, then tars `RStudio.app` and uploads it as an artifact (`rstudio-app-macos-arm64`).
- The existing `e2e-desktop-macos` job now `needs: build` and downloads the artifact instead of curling a `.dmg` from dailies. The dmg-from-URL path stays available as a manual override via the `rstudio_installer_url` workflow input -- when that input is set, the build job is skipped and e2e downloads from the URL.
- Caches `RSTUDIO_TOOLS_ROOT` (Boost/SOCI/pandoc/quarto/GWT/node/etc.) and the sccache C++ object cache so warm-cache builds stay in the single-digit-minutes range.

`package/osx/make-package`: honors a pre-set `SCCACHE_DIR` (e.g. CI cache restore path) instead of always rooting it under the package dir. Unchanged behavior when `SCCACHE_DIR` is unset.

### Fixture / config (earlier commit on this branch)

- `playwright.config.ts`: `retries: 1` under CI (0 locally) so a single flake doesn't red the suite.
- `desktop.fixture.ts`: GWT-ready deadline is now 60s under CI and overridable via `PW_GWT_READY_TIMEOUT_MS` (30s locally unchanged). `launchRStudio` retries once internally on failure via a small wrapper around the existing body (`PW_LAUNCH_ATTEMPTS` overrides). Error message now includes the actual deadline so the next failure isn't ambiguous about which timeout fired.
- `fixtures/sandbox-setup.ts`: opt-in warmup launch in `globalSetup`; default on under CI, gated by `PW_WARMUP_LAUNCH`. Boots RStudio once before any worker so dyld/page caches are warm. Failure is non-fatal (logged + skipped).

### Workflow diagnostics (earlier commit)

- `actions/setup-node` `cache: 'npm'` + a Playwright-browser cache step (`~/Library/Caches/ms-playwright`).
- Pin `PW_SANDBOX_ROOT` to `${{ github.workspace }}/pw-sandbox` so the preserved-on-failure sandbox lands at a known path.
- `PW_DEBUG_LAUNCH=1` permanently on. The next launch failure logs which phase exceeded the deadline (CDP-connect / bridge-installed / ready-flag / console-visible).
- Upload `pw-sandbox/` and `~/Library/Logs/DiagnosticReports/` as artifacts on failure.

## Out of scope

- Building on Linux / Windows / x86_64. Just `macos-26 arm64` for now; other platforms follow the same pattern when there's appetite.
- Adding `dependencies/**` and `package/**` to the PR-trigger workflow's path filter. Changes to those won't auto-trigger CI yet -- can be added in a follow-up.
- Wiring this into the broader Jenkins migration. This is a self-contained step that lets us validate "Actions can build RStudio Desktop reliably" without committing to the rest.

## Test plan

- [ ] CI passes on this PR (the workflow now tests itself end-to-end).
- [ ] Build job completes in <90 minutes cold, faster warm.
- [ ] `cd e2e/rstudio && npm run typecheck` is clean. (Confirmed locally.)
- [ ] Local `npm run test:desktop` still works -- warmup off by default locally, retries off, 30s deadline unchanged.
- [ ] `rstudio_installer_url` override path still works: dispatch the workflow with a `.dmg` URL and verify the build job is skipped and the e2e job uses the URL.
- [ ] If a launch failure recurs, the `[launch-timing]` + `[launch] attempt 1/2 failed: ...` lines are visible, and the `pw-sandbox` / `macos-diagnostic-reports` artifacts are uploaded.