### PR TITLE
ci: cache build-time R packages in macos-26 desktop e2e workflow

### DIFF
--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -77,6 +77,11 @@ jobs:
       # which isn't writable on hosted runners without sudo. Redirect to a
       # workspace-local path that we can also cache.
       RSTUDIO_TOOLS_ROOT: ${{ github.workspace }}/opt/rstudio-tools/arm64
+      # Pin R's user library to a workspace-local path so we can cache it.
+      # R expands %p/%v at startup to the platform triple and major.minor
+      # version (e.g. aarch64-apple-darwin20/4.5), which keeps libraries
+      # built for different R versions / platforms in separate subtrees.
+      R_LIBS_USER: ${{ github.workspace }}/R-libs/%p/%v
       SCCACHE_ENABLED: '1'
       SCCACHE_DIR: ${{ github.workspace }}/.sccache
     steps:
@@ -94,6 +99,18 @@ jobs:
           key: rstudio-tools-arm64-${{ hashFiles('dependencies/common/install-*', 'dependencies/osx/install-*', 'dependencies/tools/rstudio-tools.sh') }}
           restore-keys: |
             rstudio-tools-arm64-
+
+      # The "Install build dependencies" step below calls install-packages,
+      # which renv::install()s digest/purrr/rmarkdown/testthat/xml2/yaml into
+      # R_LIBS_USER. Cache the whole R-libs tree -- R's %p/%v subpaths keep
+      # different versions / platforms isolated automatically.
+      - name: Cache build-time R packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/R-libs
+          key: rstudio-build-rlibs-arm64-${{ hashFiles('dependencies/common/install-packages', 'dependencies/common/lockfiles/**/renv.lock') }}
+          restore-keys: |
+            rstudio-build-rlibs-arm64-
 
       # sccache local cache for the C++ build. Keyed on the commit SHA for
       # uniqueness; restore-keys pulls the most recent cache as a starting


### PR DESCRIPTION
## Summary

- The `Install build dependencies` step in the macOS-26 desktop e2e build job calls `install-packages`, which `renv::install()`s `digest`, `purrr`, `rmarkdown`, `testthat`, `xml2`, `yaml` from CRAN into `R_LIBS_USER`. That directory wasn't covered by any cache path, so every build re-downloaded and re-compiled those packages.
- Pin `R_LIBS_USER` to a workspace-local path (with R's `%p/%v` expansion so different R versions / platforms stay in their own subtrees) and cache the whole tree, keyed off the `install-packages` script and any `renv.lock` files.

## Test plan

- [ ] First run: cache miss, R packages install as before, cache gets saved.
- [ ] Second run on same SHA / unchanged `install-packages`: cache hit, "Install build dependencies" R-package phase skips download + compile.
- [ ] Touch `dependencies/common/install-packages` -- cache key changes, `restore-keys` falls back to the most recent cache and re-installs only what's missing.