### PR TITLE
deps: detect and fail loudly on incomplete Windows dependency installs

### DIFF
--- a/dependencies/tools/rstudio-tools.cmd
+++ b/dependencies/tools/rstudio-tools.cmd
@@ -352,13 +352,8 @@ if not defined _LABEL (
 )
 
 if exist %_FOLDER% (
-  set _FOLDER_HAS_CONTENTS=
-  for /f "delims=" %%I in ('dir /b "%_FOLDER%" 2^>nul') do set _FOLDER_HAS_CONTENTS=1
-  if defined _FOLDER_HAS_CONTENTS (
-    echo -- !_LABEL! is already installed.
-    goto :eof
-  )
-  rmdir /s /q "%_FOLDER%" 2>nul
+  echo -- !_LABEL! is already installed.
+  goto :eof
 )
 
 echo -- Installing !_LABEL!

--- a/dependencies/tools/rstudio-tools.cmd
+++ b/dependencies/tools/rstudio-tools.cmd
@@ -352,8 +352,13 @@ if not defined _LABEL (
 )
 
 if exist %_FOLDER% (
-  echo -- !_LABEL! is already installed.
-  goto :eof
+  set _FOLDER_HAS_CONTENTS=
+  for /f "delims=" %%I in ('dir /b "%_FOLDER%" 2^>nul') do set _FOLDER_HAS_CONTENTS=1
+  if defined _FOLDER_HAS_CONTENTS (
+    echo -- !_LABEL! is already installed.
+    goto :eof
+  )
+  rmdir /s /q "%_FOLDER%" 2>nul
 )
 
 echo -- Installing !_LABEL!

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -164,6 +164,15 @@ if exist quarto\bin\quarto.exe (
     )
   )
 )
+REM If a quarto directory exists but quarto.exe is missing, a previous install was incomplete; remove it so the install can retry.
+if exist quarto if not exist quarto\bin\quarto.exe (
+  echo -- Removing incomplete quarto directory from a prior failed install
+  rmdir /s /q quarto
+  if exist quarto (
+    echo ^^!^^! ERROR: Could not remove incomplete quarto directory. Close any process holding files in it and retry.
+    exit /b 1
+  )
+)
 %RUN% install QUARTO
 if not exist quarto\bin\quarto.exe (
   echo ^^!^^! ERROR: Quarto install failed: quarto\bin\quarto.exe not found.

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -157,10 +157,18 @@ if exist quarto\bin\quarto.exe (
     if not "%%v" == "%QUARTO_VERSION%" (
       echo -- Quarto version mismatch: found %%v, expected %QUARTO_VERSION%
       rmdir /s /q quarto
+      if exist quarto (
+        echo ^^!^^! ERROR: Could not remove old quarto directory. Close any process holding files in it and retry.
+        exit /b 1
+      )
     )
   )
 )
 %RUN% install QUARTO
+if not exist quarto\bin\quarto.exe (
+  echo ^^!^^! ERROR: Quarto install failed: quarto\bin\quarto.exe not found.
+  exit /b 1
+)
 
 REM Always remove any existing copilot-language-server installations to ensure latest version
 if exist copilot-language-server (


### PR DESCRIPTION
## Summary

When updating Quarto on a Windows developer workstation, the installer could leave `dependencies/common/quarto/` as an empty directory with no error reported. The next CMake configure then failed, far from the actual cause.

Root cause is a two-part silent failure in the Quarto path:

1. The version-mismatch path runs `rmdir /s /q quarto`. On Windows, that can leave the directory itself behind when a file inside is briefly locked (e.g. Defender re-scanning `quarto.exe` after the `--version` probe that immediately precedes the rmdir). Files get deleted, the directory does not.
2. The generic `:install` helper then sees `if exist quarto` and prints "quarto X.Y.Z is already installed" without checking for content. Download and extract are skipped.

The result is no visible error from the installer and a broken `quarto/` that CMake later trips over.

## Changes

Guards added to the Quarto block in `dependencies/windows/install-dependencies.cmd`:

- After the version-mismatch rmdir, verify the directory is actually gone; exit with a clear error if it isn't.
- Before invoking `install QUARTO`, if `quarto/` exists but `quarto\bin\quarto.exe` does not, treat that as an incomplete prior install and remove the stale directory so the install can retry.
- After `%RUN% install QUARTO`, verify `quarto\bin\quarto.exe` exists.

These are Quarto-specific. The generic `:install` helper in `dependencies/tools/rstudio-tools.cmd` is unchanged — making it inspect target-folder contents broke boost, whose zip extracts into siblings of `_FOLDER` and leaves `boost-1.90.0-win-msvc143/` as an intentionally empty marker.

The locked-file / empty-folder scenario does not occur in the Jenkins Windows container build (clean base image, no prior install, no Defender real-time scanning), so the rmdir-verify and incomplete-folder-recovery branches are inert in CI under normal conditions. The post-install existence check would only fire in CI on an actual install failure, surfacing it earlier than the eventual CMake configure error.

## Test plan

- [ ] On Windows, with an older Quarto already installed, bump `QUARTO_VERSION` and run `dependencies/windows/install-dependencies.cmd`. Confirm the new version is downloaded and extracted normally.
- [ ] On Windows, manually create an empty `dependencies/common/quarto/` directory and run the installer. Confirm it is removed and Quarto is re-downloaded and extracted.
- [ ] Re-run the installer with all dependencies already installed. Confirm boost is not re-downloaded.
- [ ] Confirm the Jenkins Windows image still builds end-to-end.