### PR TITLE
recognize unicode dashes as r code section delimiters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 ## RStudio 2026.06.0 "Blue Plumbago" Release Notes
 
 ### New
--
+- ([#17734](https://github.com/rstudio/rstudio/issues/17734)): Support em dashes and box-drawing characters as native R code section delimiters.
 
 ### Fixed
 - ([#14202](https://github.com/rstudio/rstudio/issues/14202)): Fixed an issue where RStudio Desktop could hang on startup when offline or on an unreliable network connection.

--- a/e2e/rstudio/tests/panes/editor/code-folding.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code-folding.test.ts
@@ -93,11 +93,15 @@ code_2 <- 4
     await expect.poll(() => editor.getValue()).toContain('code_issue_example');
 
     // Each section header row should be tokenized as comment.sectionhead
-    // (drives the outline) and have a fold-widget start (drives folding).
+    // (drives the outline), have a fold-widget start, and yield a valid
+    // fold range (the range computation has its own delimiter regex that
+    // must stay in sync with the tokenizer).
     for (const row of [0, 2, 4, 6, 8]) {
       const tokens = await editor.getTokens(row);
       expect(tokens[0]?.type, `row ${row} token`).toBe('comment.sectionhead');
       expect(await editor.getFoldWidget(row), `row ${row} fold widget`).toBe('start');
+      const range = await editor.getFoldWidgetRange(row);
+      expect(range?.end.row, `row ${row} fold range end`).toBe(row + 1);
     }
   });
 

--- a/e2e/rstudio/tests/panes/editor/code-folding.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code-folding.test.ts
@@ -4,6 +4,7 @@ import { SourcePaneActions } from '@actions/source_pane.actions';
 import { AceEditor } from '@pages/ace_editor.page';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { writeAndOpenFile, closeAndDeleteSandboxFiles } from '@utils/files';
+import { heredoc } from '@utils/heredoc';
 import { clearPref, setPref } from '@utils/commands';
 
 test.describe('Code folding', () => {
@@ -62,6 +63,42 @@ code_2 <- 4
     // '# Section 2' is the last section; folds to end of document (row 8).
     range = await editor.getFoldWidgetRange(6);
     expect(range?.end.row).toBe(8);
+  });
+
+  // https://github.com/rstudio/rstudio/issues/17734
+  test('em dashes and box-drawing chars are recognized as section delimiters', async ({ rstudioPage: page }) => {
+    // U+2014 em dash, U+2013 en dash,
+    // U+2500 box drawings light horizontal, U+2501 box drawings heavy horizontal.
+    const EM = '\u2014';
+    const EN = '\u2013';
+    const BOX_L = '\u2500';
+    const BOX_H = '\u2501';
+
+    const content = heredoc`
+      # Em dash section ${EM.repeat(4)}
+      code_em <- 1
+      # En dash section ${EN.repeat(4)}
+      code_en <- 2
+      # Box light section ${BOX_L.repeat(4)}
+      code_box_l <- 3
+      # Box heavy section ${BOX_H.repeat(4)}
+      code_box_h <- 4
+      # ${BOX_L.repeat(2)} 1. Load Data ${BOX_L.repeat(20)}
+      code_issue_example <- 5
+    `;
+
+    await writeAndOpenFile(page, sandbox.dir, 'code_folding.R', content);
+
+    const editor = new AceEditor(page, 'code_issue_example');
+    await expect.poll(() => editor.getValue()).toContain('code_issue_example');
+
+    // Each section header row should be tokenized as comment.sectionhead
+    // (drives the outline) and have a fold-widget start (drives folding).
+    for (const row of [0, 2, 4, 6, 8]) {
+      const tokens = await editor.getTokens(row);
+      expect(tokens[0]?.type, `row ${row} token`).toBe('comment.sectionhead');
+      expect(await editor.getFoldWidget(row), `row ${row} fold widget`).toBe('start');
+    }
   });
 
   // https://github.com/rstudio/rstudio/issues/16541

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -23,6 +23,15 @@ var Utils = require("mode/utils");
 var $verticallyAlignFunctionArgs = false;
 var $hierarchicalSectionFolding = true;
 
+// Regexes for R section header parsing, derived from the same delimiter class
+// the tokenizer uses (see mode/r_highlight_rules). Kept in sync so a line
+// recognized as a sectionhead also yields a label and a fold range.
+var reSectionDelimChars = require("mode/r_highlight_rules").reSectionDelimChars;
+var reSectionLabelStart = new RegExp("[^" + reSectionDelimChars + "\\s]", "u");
+var reSectionLabelTail = new RegExp("\\s*[" + reSectionDelimChars + "]+\\s*$", "u");
+var reSectionDelimsOnly = new RegExp("^\\s*[" + reSectionDelimChars + "]+\\s*$", "u");
+var reSectionTrailingTail = new RegExp("[" + reSectionDelimChars + "]+\\s*$", "u");
+
 function comparePoints(pos1, pos2)
 {
    if (pos1.row != pos2.row)
@@ -1004,10 +1013,10 @@ var RCodeModel = function(session, tokenizer,
             //
             // is accepted for folding purposes.
             var label = "(Untitled)";
-            var matchStart = /[^#=-\s]/.exec(value);
+            var matchStart = reSectionLabelStart.exec(value);
             if (matchStart) {
                label = value.substr(matchStart.index);
-               label = label.replace(/\s*[#=-]+\s*$/, "");
+               label = label.replace(reSectionLabelTail, "");
             }
 
             // Detect Markdown-style headers, of the form
@@ -1432,10 +1441,10 @@ var RCodeModel = function(session, tokenizer,
          // Otherwise, consume the '----' tail of the section
          // header as well.
          var index;
-         if (/^\s*[#=-]+\s*$/.test(line)) {
+         if (reSectionDelimsOnly.test(line)) {
             index = line.length;
          } else {
-            var match = /[#=-]+\s*$/.exec(line);
+            var match = reSectionTrailingTail.exec(line);
             if (!match)
                return;
             index = match.index;

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -233,9 +233,10 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
     // full rule states.
     rules["#comment"] = [
       {
-        token : "comment.sectionhead",
-        regex : "#+(?!').*(?:----|====|####)\\s*$",
-        next  : "start"
+        token   : "comment.sectionhead",
+        regex   : "#+(?!').*(?:[\\p{Pd}\u2500\u2501#=-]{4,})\\s*$",
+        next    : "start",
+        unicode : true
       },
       {
         // Begin Roxygen with todo

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -41,6 +41,12 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
   var reLhsBracket = "[[({]";
   var reRhsBracket = "[\\])}]";
 
+  // Body of the character class (no surrounding brackets) for the trailing
+  // delimiter of an R section header: \p{Pd} dashes, box-drawing horizontals,
+  // '#', '=', '-'. Used by both the tokenizer below and r_code_model.js for
+  // label trimming and fold-range computation; must be used with the 'u' flag.
+  var reSectionDelimChars = "-\\p{Pd}\\u2500\\u2501#=";
+
   var RoxygenHighlightRules = function()
   {
     var rules = {};
@@ -234,7 +240,7 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
     rules["#comment"] = [
       {
         token   : "comment.sectionhead",
-        regex   : "#+(?!').*(?:[\\p{Pd}\u2500\u2501#=-]{4,})\\s*$",
+        regex   : "#+(?!').*(?:[" + reSectionDelimChars + "]{4,})\\s*$",
         next    : "start",
         unicode : true
       },
@@ -590,6 +596,7 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
   oop.inherits(RHighlightRules, TextHighlightRules);
 
   exports.RHighlightRules = RHighlightRules;
+  exports.reSectionDelimChars = reSectionDelimChars;
   exports.setHighlightRFunctionCalls = function(value) {
     $colorFunctionCalls = value;
   };

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -45,7 +45,7 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
   // delimiter of an R section header: \p{Pd} dashes, box-drawing horizontals,
   // '#', '=', '-'. Used by both the tokenizer below and r_code_model.js for
   // label trimming and fold-range computation; must be used with the 'u' flag.
-  var reSectionDelimChars = "-\\p{Pd}\\u2500\\u2501#=";
+  var reSectionDelimChars = "\\p{Pd}\\u0023\\u002d\\u003d\\u2500\\u2501";
 
   var RoxygenHighlightRules = function()
   {


### PR DESCRIPTION
## Intent

Addresses #17734.

## Summary

- Extend the R highlight-rules section-head pattern to accept Unicode dash characters (`\p{Pd}`, which covers em dash, en dash, hyphen, etc.) and box-drawing horizontals (`─`, `━`) as delimiters, in addition to the existing `-` / `=` / `#` triplets.
- Adds a Playwright test covering em dash, en dash, light/heavy box-drawing, and the exact example from the issue. Each row is asserted to tokenize as `comment.sectionhead` (drives the Outline pane) and to produce a fold-widget `start` (drives code folding).

## Test plan

- [x] `npm run test:desktop-dev -- code-folding -g "em dashes"` passes locally.
- [ ] Open an R file with `# -- 1. Load Data --------` (using U+2500 box-drawing chars) and confirm the line shows up in the Outline pane and folds.