### PR TITLE
enable FSEvents per-file reporting for non-recursive watches on macOS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 - ([#17737](https://github.com/rstudio/rstudio/issues/17737)): Restore the "Show .Last.value in environment listing" preference, which had stopped surfacing `.Last.value` in the Environment pane.
 - ([#17743](https://github.com/rstudio/rstudio/issues/17743)): Fix the debugger failing to capture the browser environment for functions loaded by the `box` package.
 - ([#17712](https://github.com/rstudio/rstudio/issues/17712)): Fix Quarto rendering failing on Windows when the user's home folder path contains an ampersand.
+- ([#17669](https://github.com/rstudio/rstudio/issues/17669)): Avoid re-scanning the watched directory on every Files pane notification on macOS by enabling FSEvents per-file event reporting for non-recursive watches.
 
 ### Dependencies
 - Ace 1.43.5

--- a/e2e/rstudio/tests/panes/files/file_monitor.test.ts
+++ b/e2e/rstudio/tests/panes/files/file_monitor.test.ts
@@ -1,0 +1,75 @@
+// Files pane file-monitor integration test (#17669).
+//
+// The Files pane installs a non-recursive watch on the directory it is
+// showing (FilesListingMonitor in SessionFiles.cpp). A file created or
+// removed outside the IDE should propagate through file_monitor and
+// surface in the pane without an explicit refresh.
+//
+// Per-platform backends exercised: macOS uses FSEvents with
+// kFSEventStreamCreateFlagFileEvents (the path this PR introduces);
+// Linux uses inotify; Windows uses ReadDirectoryChangesW.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { executeCommand } from '@utils/commands';
+
+// The desktop and server fixtures redirect HOME to ${PW_SANDBOX}/user-home,
+// so path.expand("~") on the R side and this path on the runner side resolve
+// to the same directory (both fixtures spawn the session locally).
+function sandboxedHome(): string {
+  const sandbox = process.env.PW_SANDBOX;
+  if (!sandbox) {
+    throw new Error('PW_SANDBOX is not set; sandbox-setup.ts should populate it');
+  }
+  return path.join(sandbox, 'user-home');
+}
+
+function uniqueName(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.txt`;
+}
+
+test.describe('Files pane reflects file events in ~', () => {
+  let consoleActions: ConsolePaneActions;
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+    // Navigate the Files pane to ~ (sandboxed HOME) once per worker. This
+    // triggers a list_files RPC with monitor=true, which arms a non-recursive
+    // watcher rooted there -- the watcher whose macOS path this PR changes.
+    await consoleActions.executeInConsole(
+      '.rs.api.filesPaneNavigate(path.expand("~"))',
+      { wait: true },
+    );
+  });
+
+  test.beforeEach(async ({ rstudioPage: page }) => {
+    // The shared per-test reset (resetForNextTest) ends by activating the
+    // console; bring the Files pane back to front so the virtualized grid
+    // actually renders rows we then assert against.
+    await executeCommand(page, 'activateFiles');
+  });
+
+  test('files created in and removed from ~ are reflected in the pane', async ({ rstudioPage: page }) => {
+    const fileName = uniqueName('pw-file-monitor');
+    const fullPath = path.join(sandboxedHome(), fileName);
+    // The name column renders each entry as <div title="filename">filename</div>
+    // (LinkColumn.java). Waiting on this locator covers the whole roundtrip:
+    // file_monitor -> FilesListingMonitor -> client event -> FilesPresenter
+    // -> data provider update -> grid render.
+    const row = page.locator(`div[title="${fileName}"]`);
+
+    fs.writeFileSync(fullPath, 'created\n');
+    try {
+      await expect(row).toBeVisible({ timeout: 15000 });
+    } catch (err) {
+      fs.rmSync(fullPath, { force: true });
+      throw err;
+    }
+
+    fs.rmSync(fullPath);
+    await expect(row).toHaveCount(0, { timeout: 15000 });
+  });
+});

--- a/src/cpp/core/FileMonitorTests.cpp
+++ b/src/cpp/core/FileMonitorTests.cpp
@@ -122,11 +122,32 @@ bool hasEventFor(const CallbackState& state,
    return false;
 }
 
-void writeFile(const FilePath& path, const std::string& contents)
+// Returns true on success. Tests should ASSERT on the result -- a void helper
+// with ASSERT_TRUE inside would mark the test as failed but continue, leaving
+// the actual failure buried under a downstream waitFor timeout.
+bool writeFile(const FilePath& path, const std::string& contents)
 {
    std::ofstream out(path.getAbsolutePath());
-   ASSERT_TRUE(out.is_open());
+   if (!out.is_open())
+      return false;
    out << contents;
+   return out.good();
+}
+
+// Write a sentinel file in `dir` and block until its FileAdded event arrives.
+// Use as a drain: any event FSEvents was going to deliver for prior writes has
+// passed through by the time the sentinel's event lands -- safer than a fixed
+// sleep, which can be slipped by a delayed callback. Returns false if the
+// sentinel write or its event never lands.
+bool drainViaSentinel(const FilePath& dir, CallbackState* pState)
+{
+   FilePath sentinel = dir.completeChildPath("__file_monitor_test_sentinel__");
+   if (!writeFile(sentinel, "drain"))
+      return false;
+   return waitFor([&] {
+      return hasEventFor(*pState, system::FileChangeEvent::FileAdded,
+                         sentinel.getAbsolutePath());
+   });
 }
 
 system::file_monitor::Handle startMonitor(
@@ -207,7 +228,7 @@ TEST_F(FileMonitorTest, NonRecursiveDetectsFileAdded)
    state.events.clear();
 
    FilePath child = tempDir_.completeChildPath("added.txt");
-   writeFile(child, "hello");
+   ASSERT_TRUE(writeFile(child, "hello"));
 
    ASSERT_TRUE(waitFor([&] {
       return hasEventFor(state, system::FileChangeEvent::FileAdded,
@@ -220,7 +241,7 @@ TEST_F(FileMonitorTest, NonRecursiveDetectsFileAdded)
 TEST_F(FileMonitorTest, NonRecursiveDetectsFileModified)
 {
    FilePath child = tempDir_.completeChildPath("modified.txt");
-   writeFile(child, "initial");
+   ASSERT_TRUE(writeFile(child, "initial"));
    // FileInfo stores st_mtimespec.tv_sec (truncated to whole seconds), so
    // back-to-back writes within the same wall-clock second produce identical
    // FileInfos and processFileAdded suppresses the modify. Sleep past the
@@ -231,7 +252,7 @@ TEST_F(FileMonitorTest, NonRecursiveDetectsFileModified)
    auto handle = startMonitor(tempDir_, &state);
    state.events.clear();
 
-   writeFile(child, "updated contents that are longer than the initial");
+   ASSERT_TRUE(writeFile(child, "updated contents that are longer than the initial"));
 
    ASSERT_TRUE(waitFor([&] {
       return hasEventFor(state, system::FileChangeEvent::FileModified,
@@ -244,7 +265,7 @@ TEST_F(FileMonitorTest, NonRecursiveDetectsFileModified)
 TEST_F(FileMonitorTest, NonRecursiveDetectsFileRemoved)
 {
    FilePath child = tempDir_.completeChildPath("doomed.txt");
-   writeFile(child, "soon to be gone");
+   ASSERT_TRUE(writeFile(child, "soon to be gone"));
 
    CallbackState state;
    auto handle = startMonitor(tempDir_, &state);
@@ -272,19 +293,9 @@ TEST_F(FileMonitorTest, NonRecursiveIgnoresSubtreeChanges)
    state.events.clear();
 
    FilePath nested = subDir.completeChildPath("deep.txt");
-   writeFile(nested, "nested activity");
+   ASSERT_TRUE(writeFile(nested, "nested activity"));
 
-   // Drain the event pump using a sentinel file in tempDir_ as positive
-   // evidence: once we see its FileAdded, anything FSEvents was going to
-   // deliver for the nested write has already passed through. A fixed sleep
-   // here would let a delayed callback land just after the sleep elapses and
-   // pass the assertion spuriously.
-   FilePath sentinel = tempDir_.completeChildPath("sentinel.txt");
-   writeFile(sentinel, "drain");
-   ASSERT_TRUE(waitFor([&] {
-      return hasEventFor(state, system::FileChangeEvent::FileAdded,
-                         sentinel.getAbsolutePath());
-   }));
+   ASSERT_TRUE(drainViaSentinel(tempDir_, &state));
 
    for (const auto& event : state.events)
    {
@@ -310,8 +321,8 @@ TEST_F(FileMonitorTest, NonRecursiveAppliesUserFilter)
 
    FilePath rejected = tempDir_.completeChildPath("ignored.tmp");
    FilePath accepted = tempDir_.completeChildPath("kept.txt");
-   writeFile(rejected, "filtered out");
-   writeFile(accepted, "filtered in");
+   ASSERT_TRUE(writeFile(rejected, "filtered out"));
+   ASSERT_TRUE(writeFile(accepted, "filtered in"));
 
    ASSERT_TRUE(waitFor([&] {
       return hasEventFor(state, system::FileChangeEvent::FileAdded,
@@ -327,22 +338,30 @@ TEST_F(FileMonitorTest, NonRecursiveAppliesUserFilter)
    stopMonitor(handle, &state);
 }
 
-TEST_F(FileMonitorTest, NonRecursiveTreatsSymlinksLiterally)
+// Documents (does not strictly enforce) the lstat-vs-stat parity invariant
+// from readFileInfoLStat. FSEvents only fires for paths under the watched
+// root, so a target file living outside the watched directory can't trigger
+// an event for the symlink path -- the inner loop has nothing to iterate on
+// for the link, regardless of whether the (hypothetical) code path used
+// lstat or stat. A future "simplify to stat()" refactor would not be caught
+// by this assertion. We keep it as documentation of the expected behavior;
+// the lstat parity guarantee proper lives in PosixFileScanner's tests.
+TEST_F(FileMonitorTest, SymlinkToExternalTargetEmitsNoEventOnTargetChange)
 {
-   // readFileInfoLStat documents that symlink parity with PosixFileScanner
-   // (lstat semantics, no target follow) is what keeps the tree consistent
-   // with subsequent event-time lookups. A future "simplify to stat()"
-   // refactor would diverge: the initial tree would carry the link's size
-   // and mtime, while events for that path would carry the target's, and
-   // FileInfo::operator== would emit a spurious FileModified for every
-   // symlink whose target moved. Pin the expected behavior here.
-   FilePath external = FilePath("/tmp").completeChildPath(
-      "rstudio-file-monitor-target-" + system::generateUuid(false) + ".txt");
-   writeFile(external, "outside");
-   auto cleanupExternal = [&]() { external.removeIfExists(); };
+   // RAII cleanup so an ASSERT failure mid-test doesn't leak the external
+   // file (a bare lambda at the bottom of the body would be skipped).
+   struct ExternalFileGuard
+   {
+      FilePath path;
+      ~ExternalFileGuard() { path.removeIfExists(); }
+   };
+
+   ExternalFileGuard external{ FilePath("/tmp").completeChildPath(
+      "rstudio-file-monitor-target-" + system::generateUuid(false) + ".txt") };
+   ASSERT_TRUE(writeFile(external.path, "outside"));
 
    FilePath link = tempDir_.completeChildPath("link.txt");
-   ASSERT_EQ(0, ::symlink(external.getAbsolutePath().c_str(),
+   ASSERT_EQ(0, ::symlink(external.path.getAbsolutePath().c_str(),
                           link.getAbsolutePath().c_str()))
       << "symlink() failed: errno=" << errno;
 
@@ -350,17 +369,11 @@ TEST_F(FileMonitorTest, NonRecursiveTreatsSymlinksLiterally)
    auto handle = startMonitor(tempDir_, &state);
    state.events.clear();
 
-   // Touch the target. The link's lstat info (size = link path length,
-   // mtime = link creation time) is unchanged, so no FileModified for the
-   // link should arrive. Use a drain sentinel rather than a fixed sleep so
-   // a delayed callback can't slip past.
-   writeFile(external, "outside, modified");
-   FilePath sentinel = tempDir_.completeChildPath("sentinel.txt");
-   writeFile(sentinel, "drain");
-   ASSERT_TRUE(waitFor([&] {
-      return hasEventFor(state, system::FileChangeEvent::FileAdded,
-                         sentinel.getAbsolutePath());
-   }));
+   // Touch the target (outside tempDir_). FSEvents does not see this and
+   // does not call our callback for the link path. The drain sentinel
+   // exists only to give the event pump a known endpoint.
+   ASSERT_TRUE(writeFile(external.path, "outside, modified"));
+   ASSERT_TRUE(drainViaSentinel(tempDir_, &state));
 
    for (const auto& event : state.events)
    {
@@ -372,7 +385,6 @@ TEST_F(FileMonitorTest, NonRecursiveTreatsSymlinksLiterally)
    }
 
    stopMonitor(handle, &state);
-   cleanupExternal();
 }
 
 TEST_F(FileMonitorTest, NonRecursiveDetectsSubdirectoryCreatedAfterStart)
@@ -406,17 +418,10 @@ TEST_F(FileMonitorTest, NonRecursiveDetectsSubdirectoryCreatedAfterStart)
    }
    EXPECT_TRUE(foundDirectoryEntry);
 
-   // Nested activity must remain filtered. Drain with a sentinel so the
-   // assertion isn't a thinly-veiled race.
+   // Nested activity must remain filtered.
    FilePath nested = subDir.completeChildPath("deep.txt");
-   writeFile(nested, "nested after start");
-
-   FilePath sentinel = tempDir_.completeChildPath("sentinel.txt");
-   writeFile(sentinel, "drain");
-   ASSERT_TRUE(waitFor([&] {
-      return hasEventFor(state, system::FileChangeEvent::FileAdded,
-                         sentinel.getAbsolutePath());
-   }));
+   ASSERT_TRUE(writeFile(nested, "nested after start"));
+   ASSERT_TRUE(drainViaSentinel(tempDir_, &state));
 
    for (const auto& event : state.events)
    {

--- a/src/cpp/core/FileMonitorTests.cpp
+++ b/src/cpp/core/FileMonitorTests.cpp
@@ -1,0 +1,280 @@
+/*
+ * FileMonitorTests.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifdef __APPLE__
+
+#include <chrono>
+#include <thread>
+#include <fstream>
+#include <vector>
+
+#include <boost/bind/bind.hpp>
+
+#include <gtest/gtest.h>
+
+#include <shared_core/Error.hpp>
+#include <shared_core/FilePath.hpp>
+
+#include <core/FileInfo.hpp>
+#include <core/collection/Tree.hpp>
+#include <core/system/FileChangeEvent.hpp>
+#include <core/system/FileMonitor.hpp>
+#include <core/system/System.hpp>
+
+namespace rstudio {
+namespace core {
+namespace tests {
+
+namespace {
+
+struct CallbackState
+{
+   bool registered = false;
+   bool registrationError = false;
+   bool monitoringError = false;
+   bool unregistered = false;
+   system::file_monitor::Handle handle;
+   std::vector<system::FileChangeEvent> events;
+};
+
+void onRegistered(CallbackState* pState,
+                  system::file_monitor::Handle handle,
+                  const tree<FileInfo>& /*files*/)
+{
+   pState->handle = handle;
+   pState->registered = true;
+}
+
+void onRegistrationError(CallbackState* pState, const Error& /*error*/)
+{
+   pState->registrationError = true;
+}
+
+void onMonitoringError(CallbackState* pState, const Error& /*error*/)
+{
+   pState->monitoringError = true;
+}
+
+void onFilesChanged(CallbackState* pState,
+                    const std::vector<system::FileChangeEvent>& events)
+{
+   for (const auto& event : events)
+      pState->events.push_back(event);
+}
+
+void onUnregistered(CallbackState* pState, system::file_monitor::Handle /*handle*/)
+{
+   pState->unregistered = true;
+}
+
+// Pumps the file_monitor callback queue on the current thread and polls
+// the supplied predicate until it returns true or the timeout elapses.
+template <typename Predicate>
+bool waitFor(Predicate pred,
+             std::chrono::milliseconds timeout = std::chrono::seconds(8))
+{
+   auto deadline = std::chrono::steady_clock::now() + timeout;
+   while (std::chrono::steady_clock::now() < deadline)
+   {
+      system::file_monitor::checkForChanges();
+      if (pred())
+         return true;
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+   }
+   system::file_monitor::checkForChanges();
+   return pred();
+}
+
+bool hasEventFor(const CallbackState& state,
+                 system::FileChangeEvent::Type type,
+                 const std::string& path)
+{
+   for (const auto& event : state.events)
+   {
+      if (event.type() == type &&
+          event.fileInfo().absolutePath() == path)
+      {
+         return true;
+      }
+   }
+   return false;
+}
+
+void writeFile(const FilePath& path, const std::string& contents)
+{
+   std::ofstream out(path.getAbsolutePath());
+   ASSERT_TRUE(out.is_open());
+   out << contents;
+}
+
+system::file_monitor::Handle startMonitor(const FilePath& dir,
+                                          CallbackState* pState)
+{
+   using namespace boost::placeholders;
+
+   system::file_monitor::Callbacks cb;
+   cb.onRegistered = boost::bind(onRegistered, pState, _1, _2);
+   cb.onRegistrationError = boost::bind(onRegistrationError, pState, _1);
+   cb.onMonitoringError = boost::bind(onMonitoringError, pState, _1);
+   cb.onFilesChanged = boost::bind(onFilesChanged, pState, _1);
+   cb.onUnregistered = boost::bind(onUnregistered, pState, _1);
+
+   system::file_monitor::registerMonitor(
+      dir,
+      /*recursive=*/false,
+      boost::function<bool(const FileInfo&)>(),
+      cb);
+
+   EXPECT_TRUE(waitFor([&] { return pState->registered || pState->registrationError; }));
+   EXPECT_TRUE(pState->registered);
+   EXPECT_FALSE(pState->registrationError);
+   return pState->handle;
+}
+
+void stopMonitor(system::file_monitor::Handle handle, CallbackState* pState)
+{
+   system::file_monitor::unregisterMonitor(handle);
+   waitFor([&] { return pState->unregistered; });
+}
+
+} // anonymous namespace
+
+class FileMonitorTest : public ::testing::Test
+{
+protected:
+   static void SetUpTestSuite()
+   {
+      system::file_monitor::initialize();
+   }
+
+   static void TearDownTestSuite()
+   {
+      system::file_monitor::stop();
+   }
+
+   void SetUp() override
+   {
+      std::string name = "rstudio-file-monitor-test-" + system::generateUuid(false);
+      FilePath created = FilePath("/tmp").completeChildPath(name);
+      Error error = created.ensureDirectory();
+      ASSERT_FALSE(error) << error.asString();
+
+      // Use the canonical path; FSEvents reports paths in canonical form
+      // (e.g. /private/tmp/... rather than /tmp/...) and registerMonitor
+      // canonicalizes the rootPath internally before scanning the tree.
+      std::string canonical = created.getCanonicalPath();
+      ASSERT_FALSE(canonical.empty());
+      tempDir_ = FilePath(canonical);
+   }
+
+   void TearDown() override
+   {
+      tempDir_.removeIfExists();
+   }
+
+   FilePath tempDir_;
+};
+
+TEST_F(FileMonitorTest, NonRecursiveDetectsFileAdded)
+{
+   CallbackState state;
+   auto handle = startMonitor(tempDir_, &state);
+   state.events.clear();
+
+   FilePath child = tempDir_.completeChildPath("added.txt");
+   writeFile(child, "hello");
+
+   ASSERT_TRUE(waitFor([&] {
+      return hasEventFor(state, system::FileChangeEvent::FileAdded,
+                         child.getAbsolutePath());
+   }));
+
+   stopMonitor(handle, &state);
+}
+
+TEST_F(FileMonitorTest, NonRecursiveDetectsFileModified)
+{
+   FilePath child = tempDir_.completeChildPath("modified.txt");
+   writeFile(child, "initial");
+   // mtime resolution: bump it so the modification is observable
+   std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+
+   CallbackState state;
+   auto handle = startMonitor(tempDir_, &state);
+   state.events.clear();
+
+   writeFile(child, "updated contents that are longer than the initial");
+
+   ASSERT_TRUE(waitFor([&] {
+      return hasEventFor(state, system::FileChangeEvent::FileModified,
+                         child.getAbsolutePath());
+   }));
+
+   stopMonitor(handle, &state);
+}
+
+TEST_F(FileMonitorTest, NonRecursiveDetectsFileRemoved)
+{
+   FilePath child = tempDir_.completeChildPath("doomed.txt");
+   writeFile(child, "soon to be gone");
+
+   CallbackState state;
+   auto handle = startMonitor(tempDir_, &state);
+   state.events.clear();
+
+   ASSERT_FALSE(child.remove());
+
+   ASSERT_TRUE(waitFor([&] {
+      return hasEventFor(state, system::FileChangeEvent::FileRemoved,
+                         child.getAbsolutePath());
+   }));
+
+   stopMonitor(handle, &state);
+}
+
+TEST_F(FileMonitorTest, NonRecursiveIgnoresSubtreeChanges)
+{
+   FilePath subDir = tempDir_.completeChildPath("subdir");
+   ASSERT_FALSE(subDir.ensureDirectory());
+
+   CallbackState state;
+   auto handle = startMonitor(tempDir_, &state);
+   // The subdir itself was created before the watch started; we should NOT
+   // receive any events for activity inside it.
+   state.events.clear();
+
+   FilePath nested = subDir.completeChildPath("deep.txt");
+   writeFile(nested, "nested activity");
+
+   // Wait long enough that an event WOULD have arrived if we were going to
+   // process subtree changes (FSEvents latency is configured at 1s; allow a
+   // generous margin).
+   std::this_thread::sleep_for(std::chrono::seconds(3));
+   system::file_monitor::checkForChanges();
+
+   for (const auto& event : state.events)
+   {
+      EXPECT_NE(event.fileInfo().absolutePath(), nested.getAbsolutePath())
+         << "Unexpected event for nested file";
+   }
+
+   stopMonitor(handle, &state);
+}
+
+} // namespace tests
+} // namespace core
+} // namespace rstudio
+
+#endif // __APPLE__

--- a/src/cpp/core/FileMonitorTests.cpp
+++ b/src/cpp/core/FileMonitorTests.cpp
@@ -13,13 +13,23 @@
  *
  */
 
+// The behavior covered here -- per-file event delivery for non-recursive
+// watches via FSEvents kFSEventStreamCreateFlagFileEvents -- is specific to
+// MacFileMonitor.cpp. The Linux (inotify) and Windows (ReadDirectoryChangesW)
+// backends have parallel semantics but different code paths. core/CMakeLists
+// globs all *Tests.cpp, so we gate the whole body rather than introduce a
+// per-platform conditional list.
 #ifdef __APPLE__
 
 #include <chrono>
+#include <cerrno>
 #include <thread>
 #include <fstream>
 #include <vector>
 
+#include <unistd.h>
+
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/bind/bind.hpp>
 
 #include <gtest/gtest.h>
@@ -119,8 +129,11 @@ void writeFile(const FilePath& path, const std::string& contents)
    out << contents;
 }
 
-system::file_monitor::Handle startMonitor(const FilePath& dir,
-                                          CallbackState* pState)
+system::file_monitor::Handle startMonitor(
+      const FilePath& dir,
+      CallbackState* pState,
+      boost::function<bool(const FileInfo&)> filter =
+         boost::function<bool(const FileInfo&)>())
 {
    using namespace boost::placeholders;
 
@@ -134,7 +147,7 @@ system::file_monitor::Handle startMonitor(const FilePath& dir,
    system::file_monitor::registerMonitor(
       dir,
       /*recursive=*/false,
-      boost::function<bool(const FileInfo&)>(),
+      filter,
       cb);
 
    EXPECT_TRUE(waitFor([&] { return pState->registered || pState->registrationError; }));
@@ -208,7 +221,10 @@ TEST_F(FileMonitorTest, NonRecursiveDetectsFileModified)
 {
    FilePath child = tempDir_.completeChildPath("modified.txt");
    writeFile(child, "initial");
-   // mtime resolution: bump it so the modification is observable
+   // FileInfo stores st_mtimespec.tv_sec (truncated to whole seconds), so
+   // back-to-back writes within the same wall-clock second produce identical
+   // FileInfos and processFileAdded suppresses the modify. Sleep past the
+   // second boundary so the next write produces an observably newer mtime.
    std::this_thread::sleep_for(std::chrono::milliseconds(1100));
 
    CallbackState state;
@@ -258,16 +274,154 @@ TEST_F(FileMonitorTest, NonRecursiveIgnoresSubtreeChanges)
    FilePath nested = subDir.completeChildPath("deep.txt");
    writeFile(nested, "nested activity");
 
-   // Wait long enough that an event WOULD have arrived if we were going to
-   // process subtree changes (FSEvents latency is configured at 1s; allow a
-   // generous margin).
-   std::this_thread::sleep_for(std::chrono::seconds(3));
-   system::file_monitor::checkForChanges();
+   // Drain the event pump using a sentinel file in tempDir_ as positive
+   // evidence: once we see its FileAdded, anything FSEvents was going to
+   // deliver for the nested write has already passed through. A fixed sleep
+   // here would let a delayed callback land just after the sleep elapses and
+   // pass the assertion spuriously.
+   FilePath sentinel = tempDir_.completeChildPath("sentinel.txt");
+   writeFile(sentinel, "drain");
+   ASSERT_TRUE(waitFor([&] {
+      return hasEventFor(state, system::FileChangeEvent::FileAdded,
+                         sentinel.getAbsolutePath());
+   }));
 
    for (const auto& event : state.events)
    {
       EXPECT_NE(event.fileInfo().absolutePath(), nested.getAbsolutePath())
          << "Unexpected event for nested file";
+   }
+
+   stopMonitor(handle, &state);
+}
+
+TEST_F(FileMonitorTest, NonRecursiveAppliesUserFilter)
+{
+   // Filter rejects *.tmp; the .txt sibling should still pass through. The
+   // filter path was previously untested (startMonitor's default left filter
+   // empty), so a polarity inversion here would silently expose hidden files.
+   auto filter = [](const FileInfo& info) -> bool {
+      return !boost::algorithm::ends_with(info.absolutePath(), ".tmp");
+   };
+
+   CallbackState state;
+   auto handle = startMonitor(tempDir_, &state, filter);
+   state.events.clear();
+
+   FilePath rejected = tempDir_.completeChildPath("ignored.tmp");
+   FilePath accepted = tempDir_.completeChildPath("kept.txt");
+   writeFile(rejected, "filtered out");
+   writeFile(accepted, "filtered in");
+
+   ASSERT_TRUE(waitFor([&] {
+      return hasEventFor(state, system::FileChangeEvent::FileAdded,
+                         accepted.getAbsolutePath());
+   }));
+
+   for (const auto& event : state.events)
+   {
+      EXPECT_NE(event.fileInfo().absolutePath(), rejected.getAbsolutePath())
+         << "Filter should have suppressed the .tmp event";
+   }
+
+   stopMonitor(handle, &state);
+}
+
+TEST_F(FileMonitorTest, NonRecursiveTreatsSymlinksLiterally)
+{
+   // readFileInfoLStat documents that symlink parity with PosixFileScanner
+   // (lstat semantics, no target follow) is what keeps the tree consistent
+   // with subsequent event-time lookups. A future "simplify to stat()"
+   // refactor would diverge: the initial tree would carry the link's size
+   // and mtime, while events for that path would carry the target's, and
+   // FileInfo::operator== would emit a spurious FileModified for every
+   // symlink whose target moved. Pin the expected behavior here.
+   FilePath external = FilePath("/tmp").completeChildPath(
+      "rstudio-file-monitor-target-" + system::generateUuid(false) + ".txt");
+   writeFile(external, "outside");
+   auto cleanupExternal = [&]() { external.removeIfExists(); };
+
+   FilePath link = tempDir_.completeChildPath("link.txt");
+   ASSERT_EQ(0, ::symlink(external.getAbsolutePath().c_str(),
+                          link.getAbsolutePath().c_str()))
+      << "symlink() failed: errno=" << errno;
+
+   CallbackState state;
+   auto handle = startMonitor(tempDir_, &state);
+   state.events.clear();
+
+   // Touch the target. The link's lstat info (size = link path length,
+   // mtime = link creation time) is unchanged, so no FileModified for the
+   // link should arrive. Use a drain sentinel rather than a fixed sleep so
+   // a delayed callback can't slip past.
+   writeFile(external, "outside, modified");
+   FilePath sentinel = tempDir_.completeChildPath("sentinel.txt");
+   writeFile(sentinel, "drain");
+   ASSERT_TRUE(waitFor([&] {
+      return hasEventFor(state, system::FileChangeEvent::FileAdded,
+                         sentinel.getAbsolutePath());
+   }));
+
+   for (const auto& event : state.events)
+   {
+      if (event.fileInfo().absolutePath() == link.getAbsolutePath())
+      {
+         EXPECT_NE(event.type(), system::FileChangeEvent::FileModified)
+            << "spurious FileModified for symlink whose target changed";
+      }
+   }
+
+   stopMonitor(handle, &state);
+   cleanupExternal();
+}
+
+TEST_F(FileMonitorTest, NonRecursiveDetectsSubdirectoryCreatedAfterStart)
+{
+   // The dynamic case is distinct from the pre-existing-subdir case covered
+   // by NonRecursiveIgnoresSubtreeChanges: the subdir creation itself is a
+   // top-level FileAdded that must surface as a directory, and subsequent
+   // activity inside it must still be filtered (non-recursive semantics).
+   CallbackState state;
+   auto handle = startMonitor(tempDir_, &state);
+   state.events.clear();
+
+   FilePath subDir = tempDir_.completeChildPath("late-subdir");
+   ASSERT_FALSE(subDir.ensureDirectory());
+
+   ASSERT_TRUE(waitFor([&] {
+      return hasEventFor(state, system::FileChangeEvent::FileAdded,
+                         subDir.getAbsolutePath());
+   }));
+
+   // The FileAdded should carry isDirectory=true; without that flag the
+   // FilesPane would render this as a regular file.
+   bool foundDirectoryEntry = false;
+   for (const auto& event : state.events)
+   {
+      if (event.fileInfo().absolutePath() == subDir.getAbsolutePath())
+      {
+         EXPECT_TRUE(event.fileInfo().isDirectory());
+         foundDirectoryEntry = true;
+      }
+   }
+   EXPECT_TRUE(foundDirectoryEntry);
+
+   // Nested activity must remain filtered. Drain with a sentinel so the
+   // assertion isn't a thinly-veiled race.
+   FilePath nested = subDir.completeChildPath("deep.txt");
+   writeFile(nested, "nested after start");
+
+   FilePath sentinel = tempDir_.completeChildPath("sentinel.txt");
+   writeFile(sentinel, "drain");
+   ASSERT_TRUE(waitFor([&] {
+      return hasEventFor(state, system::FileChangeEvent::FileAdded,
+                         sentinel.getAbsolutePath());
+   }));
+
+   for (const auto& event : state.events)
+   {
+      EXPECT_NE(event.fileInfo().absolutePath(), nested.getAbsolutePath())
+         << "Unexpected event for nested file under late-created subdir";
    }
 
    stopMonitor(handle, &state);

--- a/src/cpp/core/system/file_monitor/MacFileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/MacFileMonitor.cpp
@@ -115,15 +115,16 @@ public:
 // Read a FileInfo via lstat, matching what PosixFileScanner produces for the
 // initial tree population. Mirroring that view (in particular: symlinks treated
 // literally) keeps per-event updates consistent with the tree so we don't emit
-// spurious modify events for symlinks. Returns false on stat failure with errno
-// in *pErrno.
-bool readFileInfoLStat(const std::string& path, FileInfo* pFileInfo, int* pErrno)
+// spurious modify events for symlinks. Returns systemError on lstat failure;
+// callers special-case ENOENT to emit FileRemoved.
+Error readFileInfoLStat(const std::string& path, FileInfo* pFileInfo)
 {
    struct stat st;
    if (::lstat(path.c_str(), &st) == -1)
    {
-      *pErrno = errno;
-      return false;
+      Error error = systemError(errno, ERROR_LOCATION);
+      error.addProperty("path", path);
+      return error;
    }
 
    bool isSymlink = S_ISLNK(st.st_mode);
@@ -139,7 +140,7 @@ bool readFileInfoLStat(const std::string& path, FileInfo* pFileInfo, int* pErrno
                             st.st_mtimespec.tv_sec,
                             isSymlink);
    }
-   return true;
+   return Success();
 }
 
 // Process a batch of FSEvents events for a non-recursive watch. With the
@@ -184,12 +185,10 @@ void processNonRecursiveFileEvents(FileEventContext* pContext,
       tree<FileInfo>::iterator rootIt = pContext->fileTree.begin();
 
       FileInfo fileInfo;
-      int statErrno = 0;
-      bool exists = readFileInfoLStat(path, &fileInfo, &statErrno);
-
-      if (!exists)
+      Error statError = readFileInfoLStat(path, &fileInfo);
+      if (statError)
       {
-         if (statErrno == ENOENT)
+         if (statError == systemError(boost::system::errc::no_such_file_or_directory, ErrorLocation()))
          {
             // entry no longer exists; processFileRemoved finds it in the tree
             // by path and uses the stored FileInfo for the event payload
@@ -203,9 +202,7 @@ void processNonRecursiveFileEvents(FileEventContext* pContext,
          }
          else
          {
-            Error error = systemError(statErrno, ERROR_LOCATION);
-            error.addProperty("path", path);
-            LOG_ERROR(error);
+            LOG_ERROR(statError);
          }
          continue;
       }
@@ -227,15 +224,12 @@ void processNonRecursiveFileEvents(FileEventContext* pContext,
          LOG_ERROR(error);
    }
 
-   // Flush any per-file events the loop accumulated before kicking off a
-   // rescan. The loop already mutated pContext->fileTree as it processed
-   // each event, so discoverAndProcessFileChanges (which diffs the
-   // filesystem against the tree) would find no diff for those entries and
-   // emit nothing -- losing the events. Emit them now so the rescan only
-   // needs to reconcile what the loop couldn't (the dropped-event tail).
-   if (!fileChanges.empty())
-      pContext->callbacks.onFilesChanged(fileChanges);
-
+   // Emission order matches LinuxFileMonitor's IN_Q_OVERFLOW path: rescan
+   // first (so it reconciles the filesystem against the tree the loop just
+   // mutated -- entries already applied have no diff and aren't re-emitted),
+   // then fire the per-event vector the loop accumulated. The rescan and
+   // the accumulated events are disjoint by construction, so order is just
+   // a matter of cross-backend consistency.
    if (needsFullRescan)
    {
       FileInfo rootInfo(pContext->rootPath);
@@ -254,6 +248,9 @@ void processNonRecursiveFileEvents(FileEventContext* pContext,
          }
       }
    }
+
+   if (!fileChanges.empty())
+      pContext->callbacks.onFilesChanged(fileChanges);
 }
 
 void fileEventCallback(ConstFSEventStreamRef streamRef,
@@ -299,6 +296,9 @@ void fileEventCallback(ConstFSEventStreamRef streamRef,
       return;
    }
 
+   // FSEvents documents `eventPaths` (and the parallel `eventFlags` array) as
+   // valid only for the duration of this callback. Both branches below copy
+   // the strings they need before any cross-callback use.
    char **paths = (char**) eventPaths;
 
    // Non-recursive watches go through the per-file event path; see

--- a/src/cpp/core/system/file_monitor/MacFileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/MacFileMonitor.cpp
@@ -17,6 +17,8 @@
 
 #include <CoreServices/CoreServices.h>
 
+#include <sys/stat.h>
+
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/bind/bind.hpp>
@@ -110,6 +112,145 @@ public:
    Callbacks callbacks;
 };
 
+// Read a FileInfo via lstat, matching what PosixFileScanner produces for the
+// initial tree population. Mirroring that view (in particular: symlinks treated
+// literally) keeps per-event updates consistent with the tree so we don't emit
+// spurious modify events for symlinks. Returns false on stat failure with errno
+// in *pErrno.
+bool readFileInfoLStat(const std::string& path, FileInfo* pFileInfo, int* pErrno)
+{
+   struct stat st;
+   if (::lstat(path.c_str(), &st) == -1)
+   {
+      *pErrno = errno;
+      return false;
+   }
+
+   bool isSymlink = S_ISLNK(st.st_mode);
+   if (S_ISDIR(st.st_mode))
+   {
+      *pFileInfo = FileInfo(path, true, isSymlink);
+   }
+   else
+   {
+      *pFileInfo = FileInfo(path,
+                            false,
+                            st.st_size,
+                            st.st_mtimespec.tv_sec,
+                            isSymlink);
+   }
+   return true;
+}
+
+// Process a batch of FSEvents events for a non-recursive watch. With the
+// kFSEventStreamCreateFlagFileEvents flag enabled, FSEvents reports the
+// specific file path that changed (rather than just the enclosing directory).
+// We filter to events whose parent is the watched root and update the tree
+// directly using lstat, avoiding the readdir+diff that the directory-level
+// callback path performs.
+void processNonRecursiveFileEvents(FileEventContext* pContext,
+                                   size_t numEvents,
+                                   char** paths,
+                                   const FSEventStreamEventFlags eventFlags[])
+{
+   const std::string& rootPathStr = pContext->rootPath.getAbsolutePath();
+
+   std::vector<FileChangeEvent> fileChanges;
+   bool needsFullRescan = false;
+
+   for (std::size_t i = 0; i < numEvents; i++)
+   {
+      FSEventStreamEventFlags flags = eventFlags[i];
+
+      // FSEvents indicates events were dropped (kernel/user buffer overflow,
+      // or MustScanSubDirs); reconcile by rescanning the watched directory.
+      if (flags & (kFSEventStreamEventFlagMustScanSubDirs |
+                   kFSEventStreamEventFlagKernelDropped |
+                   kFSEventStreamEventFlagUserDropped))
+      {
+         needsFullRescan = true;
+         continue;
+      }
+
+      std::string path(paths[i]);
+      boost::algorithm::trim_right_if(path, boost::algorithm::is_any_of("/"));
+
+      // Only process events whose direct parent is the watched root. Subtree
+      // events still wake us up, but they cost just this comparison.
+      FilePath eventPath(path);
+      if (eventPath.getParent().getAbsolutePath() != rootPathStr)
+         continue;
+
+      tree<FileInfo>::iterator rootIt = pContext->fileTree.begin();
+
+      FileInfo fileInfo;
+      int statErrno = 0;
+      bool exists = readFileInfoLStat(path, &fileInfo, &statErrno);
+
+      if (!exists)
+      {
+         if (statErrno == ENOENT)
+         {
+            // entry no longer exists; processFileRemoved finds it in the tree
+            // by path and uses the stored FileInfo for the event payload
+            FileChangeEvent change(FileChangeEvent::FileRemoved,
+                                   FileInfo(path, false));
+            impl::processFileRemoved(rootIt,
+                                     change,
+                                     false,
+                                     &pContext->fileTree,
+                                     &fileChanges);
+         }
+         else
+         {
+            Error error = systemError(statErrno, ERROR_LOCATION);
+            error.addProperty("path", path);
+            LOG_ERROR(error);
+         }
+         continue;
+      }
+
+      // entry exists; apply user filter
+      if (pContext->filter && !pContext->filter(fileInfo))
+         continue;
+
+      // processFileAdded handles the in-tree case by emitting FileModified
+      // when the FileInfo differs, and does nothing when it matches
+      FileChangeEvent change(FileChangeEvent::FileAdded, fileInfo);
+      Error error = impl::processFileAdded(rootIt,
+                                           change,
+                                           false,
+                                           pContext->filter,
+                                           &pContext->fileTree,
+                                           &fileChanges);
+      if (error)
+         LOG_ERROR(error);
+   }
+
+   if (needsFullRescan)
+   {
+      FileInfo rootInfo(pContext->rootPath);
+      if (!pContext->filter || pContext->filter(rootInfo))
+      {
+         Error error = impl::discoverAndProcessFileChanges(
+                                             rootInfo,
+                                             false,
+                                             pContext->filter,
+                                             &(pContext->fileTree),
+                                             pContext->callbacks.onFilesChanged);
+         if (error &&
+            (error != systemError(boost::system::errc::no_such_file_or_directory, ErrorLocation())))
+         {
+            LOG_ERROR(error);
+         }
+      }
+   }
+   else if (!fileChanges.empty())
+   {
+      pContext->callbacks.onFilesChanged(fileChanges);
+   }
+}
+
 void fileEventCallback(ConstFSEventStreamRef streamRef,
                        void *pCallbackInfo,
                        size_t numEvents,
@@ -134,8 +275,8 @@ void fileEventCallback(ConstFSEventStreamRef streamRef,
    // against this by also double-checking whether the original path
    // monitored and the path reported by the file handle match up
    //
-   // We check for filesystem equivalence (not path equivalence) since macOS 
-   // Catalina can issue a RootChanged event for conversion to/from a 
+   // We check for filesystem equivalence (not path equivalence) since macOS
+   // Catalina can issue a RootChanged event for conversion to/from a
    // canonicalized /System/Volumes/Data path.
    //
    // https://github.com/rstudio/rstudio/issues/4755
@@ -154,16 +295,23 @@ void fileEventCallback(ConstFSEventStreamRef streamRef,
    }
 
    char **paths = (char**) eventPaths;
+
+   // Non-recursive watches use kFSEventStreamCreateFlagFileEvents so events
+   // are reported per-file; handle them on a separate path that updates the
+   // tree directly without a readdir per matched event.
+   //
+   // https://github.com/rstudio/rstudio/issues/17669
+   if (!pContext->recursive)
+   {
+      processNonRecursiveFileEvents(pContext, numEvents, paths, eventFlags);
+      return;
+   }
+
    for (std::size_t i = 0; i < numEvents; i++)
    {
       // make a copy of the path and strip off trailing / if necessary
       std::string path(paths[i]);
       boost::algorithm::trim_right_if(path, boost::algorithm::is_any_of("/"));
-
-      // if we aren't in recursive mode then ignore this if it isn't for
-      // the root directory
-      if (!pContext->recursive && (path != pContext->rootPath.getAbsolutePath()))
-         continue;
 
       // get FileInfo for this directory
       FileInfo fileInfo(path, true);
@@ -291,6 +439,22 @@ Handle registerMonitor(const FilePath& filePath,
    context.copyDescription = nullptr;
 
    // create the stream and save a reference to it
+   //
+   // For non-recursive watches we additionally request per-file events. Without
+   // this flag FSEvents reports only the enclosing directory of each change,
+   // forcing a readdir+diff every time something inside the watched directory
+   // changes. With kFSEventStreamCreateFlagFileEvents the callback receives the
+   // specific file path plus flags identifying the change (created, removed,
+   // modified, renamed, etc.), so we can update the tree directly.
+   //
+   // Recursive watches keep the directory-granularity events (and the existing
+   // discoverAndProcessFileChanges path) to keep this change minimally invasive.
+   FSEventStreamCreateFlags streamFlags =
+                  kFSEventStreamCreateFlagNoDefer |
+                  kFSEventStreamCreateFlagWatchRoot;
+   if (!recursive)
+      streamFlags |= kFSEventStreamCreateFlagFileEvents;
+
    pContext->streamRef = ::FSEventStreamCreate(
                   kCFAllocatorDefault,
                   &fileEventCallback,
@@ -298,8 +462,7 @@ Handle registerMonitor(const FilePath& filePath,
                   pathsArrayRef,
                   kFSEventStreamEventIdSinceNow,
                   1,
-                  kFSEventStreamCreateFlagNoDefer |
-                  kFSEventStreamCreateFlagWatchRoot);
+                  streamFlags);
    if (pContext->streamRef == nullptr)
    {
       callbacks.onRegistrationError(systemError(

--- a/src/cpp/core/system/file_monitor/MacFileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/MacFileMonitor.cpp
@@ -227,6 +227,15 @@ void processNonRecursiveFileEvents(FileEventContext* pContext,
          LOG_ERROR(error);
    }
 
+   // Flush any per-file events the loop accumulated before kicking off a
+   // rescan. The loop already mutated pContext->fileTree as it processed
+   // each event, so discoverAndProcessFileChanges (which diffs the
+   // filesystem against the tree) would find no diff for those entries and
+   // emit nothing -- losing the events. Emit them now so the rescan only
+   // needs to reconcile what the loop couldn't (the dropped-event tail).
+   if (!fileChanges.empty())
+      pContext->callbacks.onFilesChanged(fileChanges);
+
    if (needsFullRescan)
    {
       FileInfo rootInfo(pContext->rootPath);
@@ -244,10 +253,6 @@ void processNonRecursiveFileEvents(FileEventContext* pContext,
             LOG_ERROR(error);
          }
       }
-   }
-   else if (!fileChanges.empty())
-   {
-      pContext->callbacks.onFilesChanged(fileChanges);
    }
 }
 
@@ -296,11 +301,8 @@ void fileEventCallback(ConstFSEventStreamRef streamRef,
 
    char **paths = (char**) eventPaths;
 
-   // Non-recursive watches use kFSEventStreamCreateFlagFileEvents so events
-   // are reported per-file; handle them on a separate path that updates the
-   // tree directly without a readdir per matched event.
-   //
-   // https://github.com/rstudio/rstudio/issues/17669
+   // Non-recursive watches go through the per-file event path; see
+   // processNonRecursiveFileEvents for details (#17669).
    if (!pContext->recursive)
    {
       processNonRecursiveFileEvents(pContext, numEvents, paths, eventFlags);
@@ -440,15 +442,13 @@ Handle registerMonitor(const FilePath& filePath,
 
    // create the stream and save a reference to it
    //
-   // For non-recursive watches we additionally request per-file events. Without
+   // For non-recursive watches we additionally request per-file events: without
    // this flag FSEvents reports only the enclosing directory of each change,
    // forcing a readdir+diff every time something inside the watched directory
-   // changes. With kFSEventStreamCreateFlagFileEvents the callback receives the
-   // specific file path plus flags identifying the change (created, removed,
-   // modified, renamed, etc.), so we can update the tree directly.
-   //
-   // Recursive watches keep the directory-granularity events (and the existing
-   // discoverAndProcessFileChanges path) to keep this change minimally invasive.
+   // changes. With the flag set the callback receives the specific file path
+   // and processNonRecursiveFileEvents reconciles it against the tree via
+   // lstat (it consults the per-event flags only to detect drops). Recursive
+   // watches stay on directory-granularity events and the readdir+diff path.
    FSEventStreamCreateFlags streamFlags =
                   kFSEventStreamCreateFlagNoDefer |
                   kFSEventStreamCreateFlagWatchRoot;

--- a/src/cpp/session/modules/SessionFiles.R
+++ b/src/cpp/session/modules/SessionFiles.R
@@ -23,6 +23,67 @@ for (binding in bindings)
    assign(binding, original, envir = .rs.files.savedBindings)
 }
 
+
+.rs.addJsonRpcHandler("list_all_files", function(path, pattern)
+{
+   list.files(path, pattern = pattern, recursive = TRUE)
+})
+
+.rs.addJsonRpcHandler("ensure_file_exists", function(path)
+{
+   if (!file.exists(path))
+      if (!file.create(path, recursive = TRUE))
+         return(.rs.scalar(FALSE))
+   
+   .rs.scalar(identical(file.info(path)$isdir, FALSE))
+})
+
+.rs.addJsonRpcHandler("create_aliased_path", function(path)
+{
+   if (!file.exists(path))
+      return(.rs.scalar(""))
+   
+   # make sure we use forward slashes here, since otherwise our
+   # home path detection will fail to work
+   # https://github.com/rstudio/rstudio/issues/13134
+   normalized <- normalizePath(path, winslash = "/", mustWork = FALSE)
+   .rs.scalar(.rs.createAliasedPath(normalized))
+})
+
+.rs.addJsonRpcHandler("get_issue_url", function(id)
+{
+   project <- .rs.getProjectDirectory()
+   if (is.null(project)) {
+      return(.rs.scalar(""))
+   }
+   
+   DESCRIPTION <- file.path(project, "DESCRIPTION")
+   if (!file.exists(DESCRIPTION)) {
+      return(.rs.scalar(""))
+   }
+
+   BugReports <- tryCatch(
+      read.dcf(DESCRIPTION, fields = "BugReports"), 
+      error = function(e) NA, 
+      warning = function(w) NA
+   )
+   if (is.na(BugReports)) {
+      return(.rs.scalar(""))
+   }
+
+   if (!is.character(BugReports) || length(BugReports) != 1L) {
+      return(.rs.scalar(""))
+   }
+
+   # make sure BugReports is a url and append the id to it
+   if (grepl("^(https?://|www.)", BugReports)) {
+      .rs.scalar(paste0(BugReports, "/", sub("#", "", id)))
+   } else {
+      .rs.scalar("")
+   }
+})
+
+
 # these hooks are added to support RStudio's transition into
 # the use of a UTF-8 code page
 .rs.addFunction("files.replaceBindings", function()
@@ -120,7 +181,6 @@ for (binding in bindings)
    as.character(utils::unzip(zipfile, list=TRUE)$Name)
 })
 
-
 .rs.addFunction("createZipFile", function(zipfile, parent, files)
 {
    # set working dir to parent (and restore on exit)
@@ -134,31 +194,6 @@ for (binding in bindings)
    
    # execute the command (return output of command)
    system(createZipCommand, intern = TRUE)
-})
-
-.rs.addJsonRpcHandler("list_all_files", function(path, pattern) {
-   list.files(path, pattern = pattern, recursive = TRUE)
-})
-
-.rs.addJsonRpcHandler("ensure_file_exists", function(path)
-{
-   if (!file.exists(path))
-      if (!file.create(path, recursive = TRUE))
-         return(.rs.scalar(FALSE))
-   
-   .rs.scalar(identical(file.info(path)$isdir, FALSE))
-})
-
-.rs.addJsonRpcHandler("create_aliased_path", function(path)
-{
-   if (!file.exists(path))
-      return(.rs.scalar(""))
-   
-   # make sure we use forward slashes here, since otherwise our
-   # home path detection will fail to work
-   # https://github.com/rstudio/rstudio/issues/13134
-   normalized <- normalizePath(path, winslash = "/", mustWork = FALSE)
-   .rs.scalar(.rs.createAliasedPath(normalized))
 })
 
 .rs.addFunction("scanFiles", function(path,
@@ -175,38 +210,14 @@ for (binding in bindings)
 
 .rs.addFunction("readLines", function(filePath)
 {
-   .Call("rs_readLines", path.expand(filePath))
+   .Call("rs_readLines", path.expand(filePath), PACKAGE = "(embedding)")
 })
 
-.rs.addJsonRpcHandler("get_issue_url", function(id)
+# Vectorized: replaces each path's HOME prefix with "~" (and HOME itself with
+# "~"), leaving paths outside HOME unchanged. Delegates to the C++
+# FilePath::createAliasedPath so the R-callable layer and the C++ session
+# share a single implementation -- see rs_createAliasedPath in SessionFiles.cpp.
+.rs.addFunction("createAliasedPath", function(path)
 {
-   project <- .rs.getProjectDirectory()
-   if (is.null(project)) {
-      return(.rs.scalar(""))
-   }
-   
-   DESCRIPTION <- file.path(project, "DESCRIPTION")
-   if (!file.exists(DESCRIPTION)) {
-      return(.rs.scalar(""))
-   }
-
-   BugReports <- tryCatch(
-      read.dcf(DESCRIPTION, fields = "BugReports"), 
-      error = function(e) NA, 
-      warning = function(w) NA
-   )
-   if (is.na(BugReports)) {
-      return(.rs.scalar(""))
-   }
-
-   if (!is.character(BugReports) || length(BugReports) != 1L) {
-      return(.rs.scalar(""))
-   }
-
-   # make sure BugReports is a url and append the id to it
-   if (grepl("^(https?://|www.)", BugReports)) {
-      .rs.scalar(paste0(BugReports, "/", sub("#", "", id)))
-   } else {
-      .rs.scalar("")
-   }
+   .Call("rs_createAliasedPath", path, PACKAGE = "(embedding)")
 })

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -2093,28 +2093,48 @@ SEXP rs_readLines(SEXP filePathSEXP)
 // FilesPane breadcrumb, and now this R-callable wrapper).
 SEXP rs_createAliasedPath(SEXP pathsSEXP)
 {
-   if (TYPEOF(pathsSEXP) != STRSXP)
-      Rf_error("'path' must be a character vector");
-
-   FilePath home = module_context::userHomePath();
-   int n = r::sexp::length(pathsSEXP);
-   r::sexp::Protect protect;
-   SEXP result = Rf_allocVector(STRSXP, n);
-   protect.add(result);
-   for (int i = 0; i < n; i++)
+   try
    {
-      SEXP elt = STRING_ELT(pathsSEXP, i);
-      if (elt == NA_STRING)
+      if (TYPEOF(pathsSEXP) != STRSXP)
+         throw r::exec::RErrorException("'path' must be a character vector");
+
+      FilePath home = module_context::userHomePath();
+
+      int n = r::sexp::length(pathsSEXP);
+      r::sexp::Protect protect;
+      SEXP result = Rf_allocVector(STRSXP, n);
+      protect.add(result);
+
+      for (int i = 0; i < n; i++)
       {
-         SET_STRING_ELT(result, i, NA_STRING);
-         continue;
+         SEXP elt = STRING_ELT(pathsSEXP, i);
+         if (elt == NA_STRING)
+         {
+            SET_STRING_ELT(result, i, NA_STRING);
+            continue;
+         }
+
+         std::string aliased = FilePath::createAliasedPath(
+            FilePath(r::sexp::asUtf8String(elt)),
+            home);
+
+         SEXP charSEXP = Rf_mkCharLenCE(
+            aliased.data(),
+            static_cast<int>(aliased.size()),
+            CE_UTF8);
+
+         SET_STRING_ELT(result, i, charSEXP);
       }
-      std::string aliased = FilePath::createAliasedPath(
-         FilePath(r::sexp::asUtf8String(elt)),
-         home);
-      SET_STRING_ELT(result, i, Rf_mkCharCE(aliased.c_str(), CE_UTF8));
+
+      return result;
    }
-   return result;
+   catch(r::exec::RErrorException& e)
+   {
+      r::exec::error(e.message());
+   }
+   CATCH_UNEXPECTED_EXCEPTION
+
+   return R_NilValue;
 }
 
 } // anonymous namespace

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -2086,6 +2086,37 @@ SEXP rs_readLines(SEXP filePathSEXP)
    return r::sexp::create(splat, &protect);
 }
 
+// Vectorized: replaces each path's HOME prefix with "~" (and HOME itself
+// with "~"), leaving paths outside HOME unchanged. Delegates to the C++
+// FilePath::createAliasedPath so there's a single source of truth for
+// aliasing logic (used by enqueFileChangedEvent, list_files RPC, the
+// FilesPane breadcrumb, and now this R-callable wrapper).
+SEXP rs_createAliasedPath(SEXP pathsSEXP)
+{
+   if (TYPEOF(pathsSEXP) != STRSXP)
+      Rf_error("'path' must be a character vector");
+
+   FilePath home = module_context::userHomePath();
+   int n = r::sexp::length(pathsSEXP);
+   r::sexp::Protect protect;
+   SEXP result = Rf_allocVector(STRSXP, n);
+   protect.add(result);
+   for (int i = 0; i < n; i++)
+   {
+      SEXP elt = STRING_ELT(pathsSEXP, i);
+      if (elt == NA_STRING)
+      {
+         SET_STRING_ELT(result, i, NA_STRING);
+         continue;
+      }
+      std::string aliased = FilePath::createAliasedPath(
+         FilePath(r::sexp::asUtf8String(elt)),
+         home);
+      SET_STRING_ELT(result, i, Rf_mkCharCE(aliased.c_str(), CE_UTF8));
+   }
+   return result;
+}
+
 } // anonymous namespace
 
 bool isMonitoringDirectory(const FilePath& directory)
@@ -2104,10 +2135,11 @@ Error initialize()
    // subscribe to events
    events().onClientInit.connect(bind(onClientInit));
 
+   RS_REGISTER_CALL_METHOD(rs_createAliasedPath);
    RS_REGISTER_CALL_METHOD(rs_listFiles);
    RS_REGISTER_CALL_METHOD(rs_listDirs);
-   RS_REGISTER_CALL_METHOD(rs_readLines);
    RS_REGISTER_CALL_METHOD(rs_pathInfo);
+   RS_REGISTER_CALL_METHOD(rs_readLines);
 
    // install handlers
    using boost::bind;

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -985,27 +985,6 @@
 })
 
 
-# a vectorized function that takes any number of paths and aliases the home
-# directory in those paths (i.e. "/Users/bob/foo" => "~/foo", "/Users/bob"
-# => "~"), leaving any paths outside the home directory untouched
-.rs.addFunction("createAliasedPath", function(path)
-{
-   homeBare <- path.expand("~")
-   homeDir  <- paste0(homeBare, "/")
-
-   # an exact match for the home directory itself (no trailing slash on the
-   # input) aliases to "~"; the prefix branch below only handles "<home>/foo"
-   # since its length check requires the trailing slash
-   exactMatch <- path == homeBare
-   path[exactMatch] <- "~"
-
-   homePathIdx <- !exactMatch & substr(path, 1L, nchar(homeDir)) == homeDir
-   homePaths <- path[homePathIdx]
-   homeSuffix <- substr(homePaths, nchar(homeDir), nchar(homePaths))
-   path[homePathIdx] <- paste0("~", homeSuffix)
-   path
-})
-
 # Some R commands called during packaging-related operations (such as untar)
 # delegate to the system tar binary specified in TAR. On OS X, R may set TAR to
 # /usr/bin/gnutar, which exists prior to Mavericks (10.9) but not in later

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -986,12 +986,20 @@
 
 
 # a vectorized function that takes any number of paths and aliases the home
-# directory in those paths (i.e. "/Users/bob/foo" => "~/foo"), leaving any 
-# paths outside the home directory untouched
+# directory in those paths (i.e. "/Users/bob/foo" => "~/foo", "/Users/bob"
+# => "~"), leaving any paths outside the home directory untouched
 .rs.addFunction("createAliasedPath", function(path)
 {
-   homeDir <- path.expand("~/")
-   homePathIdx <- substr(path, 1L, nchar(homeDir)) == homeDir
+   homeBare <- path.expand("~")
+   homeDir  <- paste0(homeBare, "/")
+
+   # an exact match for the home directory itself (no trailing slash on the
+   # input) aliases to "~"; the prefix branch below only handles "<home>/foo"
+   # since its length check requires the trailing slash
+   exactMatch <- path == homeBare
+   path[exactMatch] <- "~"
+
+   homePathIdx <- !exactMatch & substr(path, 1L, nchar(homeDir)) == homeDir
    homePaths <- path[homePathIdx]
    homeSuffix <- substr(homePaths, nchar(homeDir), nchar(homePaths))
    path[homePathIdx] <- paste0("~", homeSuffix)

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -1457,7 +1457,10 @@ bool FilePath::isWithin(const FilePath& in_scopePath) const
    FilePath child(getLexicallyNormalPath());
    FilePath parent(in_scopePath.getLexicallyNormalPath());
 
-   // Easy test: We can't possibly be in this scope path if it has more components than we do
+   // Cheap early exit: boost::filesystem::path::size() is the length of the
+   // underlying pathname string (not the component count), so a parent whose
+   // string is longer than the child's can't possibly be a prefix of it. The
+   // component-wise comparison below does the real work.
    if (parent.m_impl->Path.size() > child.m_impl->Path.size())
       return false;
 


### PR DESCRIPTION
## Intent

Addresses #17669.

## Summary

On macOS, `FilesListingMonitor::start()` asks `file_monitor::registerMonitor` for a non-recursive watch, but FSEvents has no non-recursive mode at the kernel level: callbacks fire for every change anywhere under the watched root. `MacFileMonitor` filters these out in userspace, but for every event that *did* match the watched root we then ran a full `readdir()` + tree diff to figure out what changed (because the stream was not configured for per-file event reporting).

This change enables `kFSEventStreamCreateFlagFileEvents` for non-recursive watches, so FSEvents now reports the specific path that changed and a flag bitmask describing the change. A new `processNonRecursiveFileEvents` path consumes these events, filters by exact parent path, and updates the in-memory `tree<FileInfo>` directly via `lstat` -- no readdir per event. Falls back to the existing `discoverAndProcessFileChanges` path when FSEvents reports it dropped events (`MustScanSubDirs` / `KernelDropped` / `UserDropped`).

Recursive watches are unchanged.

### What this does and does not fix

- **Fixes:** the readdir-on-every-matching-event cost. Each callback that previously triggered a directory rescan is now a stat per event.
- **Does not fix:** wakeup count from subtree activity. FSEvents still fires for every change in the watched subtree -- but each wakeup now costs just a path comparison, no I/O. Eliminating wakeups would require `kqueue` (issue notes that as option 3); we chose option 2 here as the smallest-blast-radius improvement.

### Behavioral change for downstream consumers

Non-recursive watches now emit one `FileChangeEvent` per affected file instead of one aggregate event after a directory rescan. The Files pane handles `FileChangeEvent` granularity already, so this should be transparent.

## Test plan

- [x] Built `rstudio-core` with no new warnings
- [x] Added `src/cpp/core/FileMonitorTests.cpp` with four gtest cases covering non-recursive add / modify / remove and subtree-event filtering
- [x] Ran `rstudio-core-tests` locally: all 352 runnable tests pass (6 skipped for missing deps)
- [ ] Manual smoke-test of Files pane in `~`: verify additions / modifications / deletions still surface