### PR TITLE
test(e2e): fix Posit Assistant chat test reliability

### DIFF
--- a/e2e/rstudio/actions/chat_pane.actions.ts
+++ b/e2e/rstudio/actions/chat_pane.actions.ts
@@ -99,14 +99,19 @@ export class ChatPaneActions {
         continue;
       }
 
-      if (await this.chatPane.signInBtn.first().isVisible().catch(() => false)) {
-        throw new Error(
-          'Posit Assistant requires sign-in despite seeded credentials. ' +
-          'Sign in on the host (~/.positai) and re-run.'
-        );
-      }
-
       await sleep(500);
+    }
+
+    // Deadline expired -- pick the most actionable error message.
+    // The Sign-In affordance can flash briefly during backend startup while
+    // credentials are still being loaded from ~/.positai/store, so we only
+    // treat it as a hard failure when it's still visible at the end of the
+    // polling window.
+    if (await this.chatPane.signInBtn.first().isVisible().catch(() => false)) {
+      throw new Error(
+        'Posit Assistant requires sign-in despite seeded credentials. ' +
+        'Sign in on the host (~/.positai) and re-run.'
+      );
     }
 
     throw new Error(

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
@@ -8,7 +8,7 @@ import { ChatPaneActions } from '@actions/chat_pane.actions';
 import { ChatPane } from '@pages/chat_pane.page';
 import type { EnvironmentVersions } from '@pages/console_pane.page';
 import { useSuiteSandbox } from '@utils/sandbox';
-import { createAndOpenProject } from '@utils/project';
+import { closeProjectIfOpen, createAndOpenProject } from '@utils/project';
 import { setPref } from '@utils/commands';
 import { createChatActions, annotateVersions } from './_chat-setup';
 
@@ -190,7 +190,7 @@ test.describe.serial('User-Added Skills', { tag: ['@ai', '@serial'] }, () => {
     annotateVersions(versions);
   });
 
-  test.afterAll(async () => {
+  test.afterAll(async ({ rstudioPage: page }) => {
     // The project-level skill lives inside the sandbox project; the sandbox
     // afterAll (registered by useSuiteSandbox) removes the entire sandbox
     // tree, so no explicit cleanup is needed for it here.
@@ -200,6 +200,10 @@ test.describe.serial('User-Added Skills', { tag: ['@ai', '@serial'] }, () => {
       `unlink("${userSkillDir()}", recursive = TRUE)`,
       { wait: true },
     );
+
+    // Close the project we opened in beforeAll so subsequent test files start
+    // from a no-project workbench (per the convention in utils/test-reset.ts).
+    await closeProjectIfOpen(page);
   });
 
   test('both custom skills are discovered by assistant', async () => {

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
@@ -269,6 +269,6 @@ test.describe.serial('User-Added Skills', { tag: ['@ai', '@serial'] }, () => {
     const lastMessage = chatPane.messageItem.last();
     const responseText = await lastMessage.innerText();
 
-    expect(responseText).toContain(`skill: ${USER_SKILL_NAME}`);
+    expect(responseText).toMatch(new RegExp(`skill:\\s*${USER_SKILL_NAME}`));
   });
 });


### PR DESCRIPTION
## Summary

Three small fixes to the Playwright suite for Posit Assistant chat tests, prompted by a full-suite run against Posit Assistant 0.3.9.

- **Adapt skill test to the 0.3.9 tool-header DOM.** PR posit-dev/assistant#1397 split the tool name and caption into separate flex siblings, replacing the literal space text node between them with a CSS gap. Chromium's `innerText` now returns `skill:\ncustom-code-review` instead of `skill: custom-code-review`. Switched the assertion to a regex that allows any (or no) whitespace between the header label and the skill name, so it works against both old and new versions.
- **Defer the Sign-In check in `waitForChatReady`.** The Sign-In affordance can flash briefly in the chat iframe during backend startup while credentials are still loading from `~/.positai/store`. The old loop threw on first sight of the button, turning a transient render into a hard failure in full runs (where prior backend restarts slow credential loading on the next launch) but not in isolation. The check is now consulted only after the polling deadline expires, so the "needs sign-in" diagnostic is preserved for the genuinely-stuck case without false positives.
- **Close the project in `chat-user-skills` `afterAll`.** `beforeAll` opens `user_skills_test_project` via `createAndOpenProject` but `afterAll` never closed it, leaving every later test file executing inside that project. On Desktop this also leaked a visible orphan RStudio process (the `SwitchToProjectEvent` path relaunches Electron under a new PID, and `shutdownRStudio` only kills the original PID it spawned). The cleanup matches the policy comment in `utils/test-reset.ts` ("Files that open a project must close it in their own afterAll"). The fixture's PID-tracking is a separate, larger fix.

## Test plan

- [ ] `npm run test:desktop -- tests/panes/posit-assistant-chat/` passes end-to-end with seeded `~/.positai/` credentials
- [ ] No leftover RStudio Desktop process showing `user_skills_test_project` after the suite finishes
- [ ] `chat-user-skills.test.ts` "user-level skill is selected when its description matches the prompt" passes against 0.3.9
- [ ] `open-chat-pane.test.ts` "open chat pane with activateChat command" passes when run as part of the full suite (not just in isolation)