### PR TITLE
test(e2e): expose active ace editor via automation bridge

### DIFF
--- a/e2e/rstudio/actions/source_pane.actions.ts
+++ b/e2e/rstudio/actions/source_pane.actions.ts
@@ -6,7 +6,7 @@ import { clickConfirmIfVisible } from '../pages/modals.page';
 import { TIMEOUTS, sleep } from '../utils/constants';
 import { rStringLiteral } from '../utils/r';
 import { executeCommand } from '../utils/commands';
-import { openExistingFile } from '../utils/files';
+import { openFile } from '../utils/files';
 import { Ace, AceEditorElement } from '../utils/ace';
 
 export class SourcePaneActions {
@@ -36,7 +36,7 @@ export class SourcePaneActions {
       { wait: true },
     );
 
-    await openExistingFile(this.page, fileName);
+    await openFile(this.page, fileName);
   }
 
   async closeSourceAndDeleteFile(fileName: string): Promise<void> {

--- a/e2e/rstudio/actions/source_pane.actions.ts
+++ b/e2e/rstudio/actions/source_pane.actions.ts
@@ -6,6 +6,7 @@ import { clickConfirmIfVisible } from '../pages/modals.page';
 import { TIMEOUTS, sleep } from '../utils/constants';
 import { rStringLiteral } from '../utils/r';
 import { executeCommand } from '../utils/commands';
+import { openExistingFile } from '../utils/files';
 import { Ace, AceEditorElement } from '../utils/ace';
 
 export class SourcePaneActions {
@@ -35,9 +36,7 @@ export class SourcePaneActions {
       { wait: true },
     );
 
-    await this.consolePaneActions.executeInConsole(`file.edit(${rStringLiteral(fileName)})`);
-
-    await expect(this.sourcePane.selectedTab).toContainText(fileName, { timeout: TIMEOUTS.fileOpen });
+    await openExistingFile(this.page, fileName);
   }
 
   async closeSourceAndDeleteFile(fileName: string): Promise<void> {
@@ -189,17 +188,18 @@ export class SourcePaneActions {
   }
 
   /**
-   * Get the full text content of the active source editor via Ace API.
+   * Get the full text content of the active source editor via the
+   * automation bridge. `window.rstudio.documents.activeEditor()` returns
+   * the same native Ace instance the GWT side already tracks as "the
+   * active doc," so there's no DOM scan and no chance of landing on the
+   * console scroll panel, dialog editors, or stale source editors that
+   * linger in the DOM after a tab close.
    */
   async getEditorContent(): Promise<string> {
     return await this.page.evaluate(() => {
-      const editors = document.querySelectorAll('.ace_editor');
-      for (let i = 0; i < editors.length; i++) {
-        if (editors[i].closest('#rstudio_console_input')) continue;
-        const editor = (editors[i] as unknown as AceEditorElement).env?.editor;
-        if (editor) return editor.getValue();
-      }
-      throw new Error('No active source editor found');
+      const editor = window.rstudio?.documents.activeEditor() ?? null;
+      if (!editor) throw new Error('No active source editor');
+      return editor.getValue();
     });
   }
 

--- a/e2e/rstudio/tests/panes/editor/air_formatting.test.ts
+++ b/e2e/rstudio/tests/panes/editor/air_formatting.test.ts
@@ -34,6 +34,7 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePaneActions } from '@actions/source_pane.actions';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { executeCommand, saveDocument, setPref } from '@utils/commands';
+import { openExistingFile } from '@utils/files';
 import { closeProjectIfOpen, createAndOpenProject } from '@utils/project';
 
 // --- Test data (from issue #16721) ---
@@ -190,8 +191,12 @@ async function openTestFile(
     `writeLines(c("x<-1+2+3", "y<-list(a=1,b=2,c=3)"), "${TEST_FILE}")`,
     { wait: true },
   );
-  await consoleActions.executeInConsole(`file.edit("${TEST_FILE}")`);
-  await expect(sourceActions.sourcePane.selectedTab).toContainText(TEST_FILE, { timeout: 10000 });
+  // openExistingFile waits for the source-pane Ace instance to be reachable,
+  // not just for the tab title to render. Without that wait, downstream
+  // getEditorContent() can read the editor before its document body has
+  // loaded and the failure surfaces as a confusing reformatCode timeout
+  // instead of "file never finished loading."
+  await openExistingFile(sourceActions.page, TEST_FILE);
 }
 
 /** Click the editor content area to make sure it has focus. */
@@ -199,16 +204,54 @@ async function focusEditor(sourceActions: SourcePaneActions): Promise<void> {
   await sourceActions.sourcePane.contentPane.click();
   // Wait until focus has actually landed on a source-pane Ace textarea --
   // click() resolves before the focus event has propagated.
-  await sourceActions.page.waitForFunction(
-    () => {
-      const el = document.activeElement;
-      if (!el) return false;
-      if (el.closest('#rstudio_console_input')) return false;
-      return el.classList?.contains('ace_text-input') ?? false;
-    },
-    null,
-    { timeout: 2000, polling: 50 },
-  );
+  try {
+    await sourceActions.page.waitForFunction(
+      () => {
+        const el = document.activeElement;
+        if (!el) return false;
+        if (el.closest('#rstudio_console_input')) return false;
+        return el.classList?.contains('ace_text-input') ?? false;
+      },
+      null,
+      { timeout: 2000, polling: 50 },
+    );
+  } catch (err) {
+    // The bare waitForFunction timeout reads as an opaque "Timeout exceeded
+    // while waiting on the predicate" -- which makes it impossible to tell
+    // whether focus drifted to the console, the source pane has no editor
+    // at all (file load failed), or something stranger. Capture the actual
+    // active-element state and re-raise.
+    const diag = await sourceActions.page.evaluate(() => {
+      const el = document.activeElement as HTMLElement | null;
+      const describe = (e: Element | null): string => {
+        if (!e) return 'null';
+        const tag = e.tagName.toLowerCase();
+        const id = e.id ? `#${e.id}` : '';
+        const className = typeof (e as HTMLElement).className === 'string'
+          ? (e as HTMLElement).className
+          : '';
+        const cls = className
+          ? '.' + className.split(/\s+/).filter(Boolean).join('.')
+          : '';
+        return `${tag}${id}${cls}`;
+      };
+      const sourceAceCount = document.querySelectorAll(
+        "[class*='rstudio_source_panel'] textarea.ace_text-input",
+      ).length;
+      return {
+        active: describe(el),
+        inConsole: !!(el && el.closest('#rstudio_console_input')),
+        inSourcePanel: !!(el && el.closest("[class*='rstudio_source_panel']")),
+        sourceAceCount,
+      };
+    });
+    throw new Error(
+      `focusEditor: focus did not land on a source-pane ace_text-input ` +
+      `(active=${diag.active}, inConsole=${diag.inConsole}, ` +
+      `inSourcePanel=${diag.inSourcePanel}, sourceAceCount=${diag.sourceAceCount}). ` +
+      `Original: ${(err as Error).message}`,
+    );
+  }
 }
 
 /** Select all code in the editor, then reformat via Cmd+Shift+A / Ctrl+Shift+A. */

--- a/e2e/rstudio/tests/panes/editor/air_formatting.test.ts
+++ b/e2e/rstudio/tests/panes/editor/air_formatting.test.ts
@@ -34,7 +34,7 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePaneActions } from '@actions/source_pane.actions';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { executeCommand, saveDocument, setPref } from '@utils/commands';
-import { openExistingFile } from '@utils/files';
+import { openFile } from '@utils/files';
 import { closeProjectIfOpen, createAndOpenProject } from '@utils/project';
 
 // --- Test data (from issue #16721) ---
@@ -191,12 +191,12 @@ async function openTestFile(
     `writeLines(c("x<-1+2+3", "y<-list(a=1,b=2,c=3)"), "${TEST_FILE}")`,
     { wait: true },
   );
-  // openExistingFile waits for the source-pane Ace instance to be reachable,
-  // not just for the tab title to render. Without that wait, downstream
+  // openFile waits for the source-pane Ace instance to be reachable, not
+  // just for the tab title to render. Without that wait, downstream
   // getEditorContent() can read the editor before its document body has
   // loaded and the failure surfaces as a confusing reformatCode timeout
   // instead of "file never finished loading."
-  await openExistingFile(sourceActions.page, TEST_FILE);
+  await openFile(sourceActions.page, TEST_FILE);
 }
 
 /** Click the editor content area to make sure it has focus. */

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -1,6 +1,7 @@
 import type { Page } from '@playwright/test';
 import { waitForConsoleIdle } from '../pages/console_pane.page';
 import { withBridgeLog, withBridgeLogResult } from './log';
+import type { Ace } from './ace';
 
 // `window.rstudio` is registered when rsession runs with --automation-agent
 // (the Desktop fixture forwards that flag). The bridge lets tests trigger and
@@ -76,6 +77,16 @@ type Documents = {
   resetToUntitled(): void;
   /** Info on the focused source document, or null when no editor is active. */
   active(): ActiveDocument | null;
+  /**
+   * Native Ace editor instance backing the active source document, or null
+   * when no editor is active (or the active editor isn't Ace-backed -- data
+   * viewer, object explorer, etc.). Call Ace API methods (getValue, setValue,
+   * getSession, ...) on the returned object directly. Prefer this over
+   * iterating `.ace_editor` DOM nodes: the DOM scan can land on the console
+   * scroll panel, dialog editors (IgnoreDialog, ViewFileDialog, ...), or
+   * stale source editors left in the DOM after a tab close.
+   */
+  activeEditor(): Ace.Editor | null;
   /**
    * Open the file at `path` in the source pane. Fires OpenSourceFileEvent
    * directly; the caller must ensure the file exists on disk (the bridge

--- a/e2e/rstudio/utils/files.ts
+++ b/e2e/rstudio/utils/files.ts
@@ -29,16 +29,63 @@ export async function writeAndOpenFile(
   content: string,
 ): Promise<void> {
   const fullPath = path.join(sandboxDir, fileName);
-  const rFullPath = rPathLiteral(fullPath);
   if (fs.existsSync(sandboxDir)) {
     fs.writeFileSync(fullPath, content);
   } else {
-    await executeInConsole(page, `writeLines(${rStringLiteral(content)}, ${rFullPath})`);
+    await executeInConsole(page, `writeLines(${rStringLiteral(content)}, ${rPathLiteral(fullPath)})`);
   }
-  await executeInConsole(page, `file.edit(${rFullPath})`);
-  // The source tab shows the basename, not the full path.
+  await openExistingFile(page, fullPath);
+}
+
+/**
+ * Open an existing file via `file.edit()` and wait until the source editor
+ * is fully hydrated and ready to drive: the tab is selected, the bridge
+ * reports the file as the active document, and a source-pane Ace instance
+ * is reachable.
+ *
+ * Use this instead of bare `file.edit(...)` + `selectedTab` wait. The tab
+ * can be selected before Ace finishes loading the document body; without
+ * the bridge + Ace polls the gap surfaces later as a confusing
+ * `Expected: not ""` timeout from a downstream getEditorContent /
+ * focusEditor call rather than as "file never finished loading."
+ *
+ * `pathOrName` may be a basename, a relative path, or an absolute path --
+ * `file.edit` resolves relative paths against R's cwd, and the active-doc
+ * post-condition compares basenames so the helper does not need to know
+ * what RStudio will normalize the path to.
+ */
+export async function openExistingFile(
+  page: Page,
+  pathOrName: string,
+): Promise<void> {
+  await executeInConsole(page, `file.edit(${rPathLiteral(pathOrName)})`);
+
+  // Compute the basename for both the tab and the bridge check. file.edit
+  // resolves relative paths against R's cwd, which can differ from Node's,
+  // so we don't know the exact absolute path the bridge will report -- but
+  // the basename is invariant.
+  const slash = Math.max(pathOrName.lastIndexOf('/'), pathOrName.lastIndexOf('\\'));
+  const basename = slash >= 0 ? pathOrName.slice(slash + 1) : pathOrName;
+
   const tab = page.locator("[class*='rstudio_source_panel'] [class*='PanelTab-selected']");
-  await expect(tab).toContainText(fileName, { timeout: TIMEOUTS.fileOpen });
+  await expect(tab).toContainText(basename, { timeout: TIMEOUTS.fileOpen });
+
+  await page.waitForFunction(
+    (base: string) => {
+      const doc = window.rstudio?.documents.active() ?? null;
+      if (!doc || !doc.path) return false;
+      const docSlash = Math.max(doc.path.lastIndexOf('/'), doc.path.lastIndexOf('\\'));
+      const docBase = docSlash >= 0 ? doc.path.slice(docSlash + 1) : doc.path;
+      if (docBase.toLowerCase() !== base.toLowerCase()) return false;
+      // Bridge confirms the active doc has a live Ace editor instance --
+      // the same handle the GWT side already tracks as "the active doc."
+      // Returns null when there's no editor or it's not Ace-backed (data
+      // viewer, object explorer, ...) so we don't return prematurely.
+      return window.rstudio?.documents.activeEditor() != null;
+    },
+    basename,
+    { timeout: TIMEOUTS.fileOpen, polling: 50 },
+  );
 }
 
 /**

--- a/e2e/rstudio/utils/files.ts
+++ b/e2e/rstudio/utils/files.ts
@@ -34,14 +34,15 @@ export async function writeAndOpenFile(
   } else {
     await executeInConsole(page, `writeLines(${rStringLiteral(content)}, ${rPathLiteral(fullPath)})`);
   }
-  await openExistingFile(page, fullPath);
+  await openFile(page, fullPath);
 }
 
 /**
- * Open an existing file via `file.edit()` and wait until the source editor
- * is fully hydrated and ready to drive: the tab is selected, the bridge
- * reports the file as the active document, and a source-pane Ace instance
- * is reachable.
+ * Open a file via `file.edit()` and wait until the source editor is fully
+ * hydrated and ready to drive: the tab is selected, the bridge reports
+ * the file as the active document, and a source-pane Ace instance is
+ * reachable. The file must already exist on disk -- `file.edit` resolves
+ * existing paths only.
  *
  * Use this instead of bare `file.edit(...)` + `selectedTab` wait. The tab
  * can be selected before Ace finishes loading the document body; without
@@ -54,7 +55,7 @@ export async function writeAndOpenFile(
  * post-condition compares basenames so the helper does not need to know
  * what RStudio will normalize the path to.
  */
-export async function openExistingFile(
+export async function openFile(
   page: Page,
   pathOrName: string,
 ): Promise<void> {

--- a/e2e/rstudio/utils/files.ts
+++ b/e2e/rstudio/utils/files.ts
@@ -50,10 +50,13 @@ export async function writeAndOpenFile(
  * `Expected: not ""` timeout from a downstream getEditorContent /
  * focusEditor call rather than as "file never finished loading."
  *
- * `pathOrName` may be a basename, a relative path, or an absolute path --
- * `file.edit` resolves relative paths against R's cwd, and the active-doc
- * post-condition compares basenames so the helper does not need to know
- * what RStudio will normalize the path to.
+ * `pathOrName` may be a basename, a relative path, or an absolute path.
+ * When absolute, the active-doc post-condition compares full paths
+ * (case-insensitive, slashes normalized) so two open files that share a
+ * basename can't be confused for one another. When relative or a bare
+ * basename, falls back to basename match -- R resolves the path against
+ * its own cwd, which can differ from Node's, so the absolute form
+ * RStudio reports back is not known to the helper.
  */
 export async function openFile(
   page: Page,
@@ -61,30 +64,38 @@ export async function openFile(
 ): Promise<void> {
   await executeInConsole(page, `file.edit(${rPathLiteral(pathOrName)})`);
 
-  // Compute the basename for both the tab and the bridge check. file.edit
-  // resolves relative paths against R's cwd, which can differ from Node's,
-  // so we don't know the exact absolute path the bridge will report -- but
-  // the basename is invariant.
-  const slash = Math.max(pathOrName.lastIndexOf('/'), pathOrName.lastIndexOf('\\'));
-  const basename = slash >= 0 ? pathOrName.slice(slash + 1) : pathOrName;
+  // rPathLiteral normalizes backslashes to forward slashes for R; mirror
+  // that on the comparison side so platform-specific separators don't
+  // cause spurious mismatches.
+  const requestedSlashes = pathOrName.replace(/\\/g, '/');
+  const slash = requestedSlashes.lastIndexOf('/');
+  const basename = slash >= 0 ? requestedSlashes.slice(slash + 1) : requestedSlashes;
+  const expectedFullPath = path.isAbsolute(pathOrName) ? requestedSlashes : null;
 
   const tab = page.locator("[class*='rstudio_source_panel'] [class*='PanelTab-selected']");
   await expect(tab).toContainText(basename, { timeout: TIMEOUTS.fileOpen });
 
   await page.waitForFunction(
-    (base: string) => {
+    (args: { expectedFullPath: string | null; basename: string }) => {
       const doc = window.rstudio?.documents.active() ?? null;
       if (!doc || !doc.path) return false;
-      const docSlash = Math.max(doc.path.lastIndexOf('/'), doc.path.lastIndexOf('\\'));
-      const docBase = docSlash >= 0 ? doc.path.slice(docSlash + 1) : doc.path;
-      if (docBase.toLowerCase() !== base.toLowerCase()) return false;
+      const docPath = doc.path.replace(/\\/g, '/');
+      if (args.expectedFullPath !== null) {
+        // Full-path match: case-insensitive to tolerate macOS HFS+ /
+        // Windows NTFS, where the filesystem itself folds case.
+        if (docPath.toLowerCase() !== args.expectedFullPath.toLowerCase()) return false;
+      } else {
+        const docSlash = docPath.lastIndexOf('/');
+        const docBase = docSlash >= 0 ? docPath.slice(docSlash + 1) : docPath;
+        if (docBase.toLowerCase() !== args.basename.toLowerCase()) return false;
+      }
       // Bridge confirms the active doc has a live Ace editor instance --
       // the same handle the GWT side already tracks as "the active doc."
       // Returns null when there's no editor or it's not Ace-backed (data
       // viewer, object explorer, ...) so we don't return prematurely.
       return window.rstudio?.documents.activeEditor() != null;
     },
-    basename,
+    { expectedFullPath, basename },
     { timeout: TIMEOUTS.fileOpen, polling: 50 },
   );
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -65,6 +65,7 @@ import com.google.inject.Singleton;
  *   window.rstudio.documents.closeAllNoSave()
  *   window.rstudio.documents.resetToUntitled() // close everything but a single untitled tab
  *   window.rstudio.documents.active()          // { id, path, dirty } for the focused doc, or null
+ *   window.rstudio.documents.activeEditor()    // native Ace editor for the focused doc, or null
  *   window.rstudio.documents.open(path, opts?) // open file at path; opts: { line?, col?, moveCursor? }
  *
  *   window.rstudio.project.path()       // active project file path, or null
@@ -372,6 +373,17 @@ public class ApplicationAutomation
       return { id: id, path: path, dirty: dirty };
    }-*/;
 
+   // Returns the native Ace editor JS instance for the active document, or
+   // null when no active editor is present (or the active editor isn't
+   // Ace-backed). Callers invoke Ace API methods on the returned object
+   // directly -- this is the same JS object exposed via element.env.editor,
+   // but reached deterministically through the GWT-tracked active doc rather
+   // than by scanning the DOM.
+   private JavaScriptObject getActiveNativeEditor()
+   {
+      return sourceColumnManager_.getActiveNativeEditor();
+   }
+
    // Always read through session_.getSessionInfo() rather than capturing a
    // reference at install time -- a session restart (e.g. close-project)
    // replaces the SessionInfo JSO, and we want callers to see the live state.
@@ -484,6 +496,14 @@ public class ApplicationAutomation
       });
       $wnd.rstudio.documents.active = $entry(function() {
          return self.@org.rstudio.studio.client.application.ApplicationAutomation::getActiveDocument()();
+      });
+      // Native Ace editor for the active doc, or null. Lets tests call
+      // Ace API directly (getValue, setValue, getSession, ...) without
+      // walking `.ace_editor` DOM nodes -- which can collide with the
+      // console scroll panel, dialog editors, and stale source editors
+      // left in the DOM after a tab close.
+      $wnd.rstudio.documents.activeEditor = $entry(function() {
+         return self.@org.rstudio.studio.client.application.ApplicationAutomation::getActiveNativeEditor()();
       });
       // opts: { line?: number (1-indexed; omit/<0 = don't navigate),
       //         col?: number (1-indexed; defaults to 1),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -637,6 +637,27 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    }
 
    /**
+    * Native Ace editor instance backing the active source document, or null
+    * when there is no active editor or the active editor is not Ace-backed
+    * (e.g. data viewer, object explorer, code browser). Exposed to JS via
+    * the automation bridge (`window.rstudio.documents.activeEditor()`); tests
+    * call Ace API methods (getValue, getSession, setValue, ...) on it
+    * directly instead of walking the DOM for a `.ace_editor` element.
+    */
+   public JavaScriptObject getActiveNativeEditor()
+   {
+      if (!hasActiveEditor())
+         return null;
+      EditingTarget target = activeColumn_.getActiveEditor();
+      if (!(target instanceof TextEditingTarget))
+         return null;
+      DocDisplay display = ((TextEditingTarget) target).getDocDisplay();
+      if (!(display instanceof AceEditor))
+         return null;
+      return ((AceEditor) display).getWidget().getEditor();
+   }
+
+   /**
     * Get selections from the active editor as a JSON array.
     * Format: [{ "startLine": n, "startCharacter": n, "endLine": n, "endCharacter": n, "text": "..." }, ...]
     * For cursor position (no selection), start and end will be the same position and text will be empty.


### PR DESCRIPTION
## Summary

- New `window.rstudio.documents.activeEditor()` bridge method returning the native Ace JS instance for the active source document (or `null`). Maps through `SourceColumnManager.getActiveNativeEditor` -- same path GWT already uses to track the active doc.
- Refactors `getEditorContent()` and a new `openExistingFile()` helper to use the bridge, eliminating the `.ace_editor` DOM scan that was the proximate cause of 8 consistent `air_formatting` failures.
- `air_formatting.test.ts` `focusEditor` now wraps `waitForFunction` in a diagnostic catch so a future focus-drift failure reports the actual active element rather than an opaque predicate timeout.

## Why the DOM scan was wrong

The bare `.ace_editor` selector also matches:

- ShellWidget's console scroll panel (`ShellWidget.java:279` adds the class for styling)
- Dialog editors: `IgnoreDialog`, `ViewFileDialog`, `EditSnippetsDialog`, `AceEditorPreview`
- Stale source editors left in the DOM after a tab close

Any of those could shadow the real source editor and surface as an empty `getValue()` in `reformatCode`, producing the `Expected: not ""` timeout the 8 failing tests were all hitting.

## Test plan

- [x] `npm run test:desktop-dev -- -g "Air Formatting"` -- 8/8 pass (was 0/8) in 47s, no flakes
- [ ] `npm run test:desktop-dev -- -g "Edit suggestions"` -- the `writeAndOpenFile` path now goes through `openExistingFile` too, worth confirming
- [ ] CI desktop e2e suite