### PR TITLE
Add URL::clientHost and core::system::ScopedUMask helpers

### DIFF
--- a/src/cpp/core/include/core/http/URL.hpp
+++ b/src/cpp/core/include/core/http/URL.hpp
@@ -121,7 +121,23 @@ public:
    {
       return protocol + "://" + formatHostPort(host, port);
    }
-   
+
+   // Map a bind address to a client-reachable host. Empty, "0.0.0.0", "::",
+   // and the bracketed "[::]" are wildcards used for binding but aren't valid
+   // as connect targets; map them to "localhost" so callers on the same host
+   // can reach the service.
+   static std::string clientHost(const std::string& bindAddress)
+   {
+      if (bindAddress.empty() ||
+          bindAddress == "0.0.0.0" ||
+          bindAddress == "::" ||
+          bindAddress == "[::]")
+      {
+         return std::string("localhost");
+      }
+      return bindAddress;
+   }
+
    void split(std::string* pBaseURL, std::string* pQueryParams) const;
    
    bool operator < (const URL& other) const

--- a/src/cpp/core/include/core/system/PosixSystem.hpp
+++ b/src/cpp/core/include/core/system/PosixSystem.hpp
@@ -25,6 +25,8 @@
 
 // typedefs (in case we need indirection on these for porting)
 #include <sys/resource.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 typedef pid_t PidType;
 typedef rlim_t RLimitType;
 
@@ -51,6 +53,21 @@ enum UMask
    OthersNoneMask        // S_IWGRP | S_IRWXO
 };
 void setUMask(UMask mask);
+
+// RAII wrapper that sets the calling thread's umask for its lifetime and
+// restores the previous value on destruction. Use when a block of code needs
+// child files born with stricter mode bits (e.g. so an atomic-rename target
+// is never world-readable before a follow-up chmod).
+class ScopedUMask
+{
+public:
+   explicit ScopedUMask(mode_t mask) : previous_(::umask(mask)) {}
+   ~ScopedUMask() { ::umask(previous_); }
+   ScopedUMask(const ScopedUMask&) = delete;
+   ScopedUMask& operator=(const ScopedUMask&) = delete;
+private:
+   mode_t previous_;
+};
 
 
 // resource limits


### PR DESCRIPTION
## Summary

Companion to rstudio-pro PR [#11174](https://github.com/rstudio/rstudio-pro/pull/11174) (Chronicle supervision). Both helpers are introduced here so the Pro overlay can call into them without diverging from OSS.

- **`URL::clientHost(bindAddress)`** — Maps wildcard bind addresses (empty, `"0.0.0.0"`, `"::"`, `"[::]"`) to `"localhost"` so loopback callers on the same host can use the result as a connect target. Non-wildcard values pass through unchanged.
- **`core::system::ScopedUMask`** — RAII wrapper that sets the calling thread's umask for its lifetime and restores the previous value on destruction. Use when a block of code needs child files born with stricter mode bits (e.g. so an atomic-rename target is never world-readable before a follow-up `chmod`).

Both are header-only additions; no OSS call sites in this commit. They are consumed by the Pro-side Chronicle init path in the companion PR.

## Test plan

- [ ] Build OSS rserver to confirm headers compile.
- [ ] Verify Pro overlay still builds against this OSS branch.