### PR TITLE
test(e2e): add waitFor helpers for debugger line readers

### DIFF
--- a/e2e/rstudio/actions/debugger.actions.ts
+++ b/e2e/rstudio/actions/debugger.actions.ts
@@ -121,6 +121,32 @@ export class DebuggerActions {
     await expect(this.debuggerPage.debugToolbar).not.toBeVisible({ timeout: TIMEOUTS.fileOpen });
   }
 
+  /** Wait until the active debug line marker is visible in the editor and
+   *  return its 0-indexed editor row. Prefer this over the bare
+   *  {@link getActiveDebugLineRow} in test code: after `waitForDebugMode`
+   *  the R debugger may take a beat to surface the marker, and a bare
+   *  read would throw before it appears. */
+  async waitForActiveDebugLineRow(timeout: number = TIMEOUTS.fileOpen): Promise<number> {
+    await this.debuggerPage.activeDebugLine.first().waitFor({
+      state: 'visible',
+      timeout,
+    });
+    return this.getActiveDebugLineRow();
+  }
+
+  /** Wait until the active debug line lands on `row` (0-indexed). Retries
+   *  through transient throws from {@link getActiveDebugLineRow} while the
+   *  marker is rendering. */
+  async waitForActiveDebugLineRowToBe(
+    row: number,
+    timeout: number = TIMEOUTS.fileOpen,
+  ): Promise<void> {
+    await expect.poll(
+      () => this.getActiveDebugLineRow().catch(() => -1),
+      { timeout },
+    ).toBe(row);
+  }
+
   /** Read the editor row (0-indexed) of the active debug line via Ace's
    *  pixel→screen mapping.
    *
@@ -131,9 +157,10 @@ export class DebuggerActions {
    *  first one that's actually rendered, then walk up to its containing
    *  .ace_editor for the pixel→screen mapping.
    *
-   *  Throws if no visibly-rendered active debug line is found — callers
-   *  that need to poll should wrap the call in `expect.poll`, which retries
-   *  on thrown errors. */
+   *  Throws if no visibly-rendered active debug line is found. Most test
+   *  code should use {@link waitForActiveDebugLineRow} instead; this raw
+   *  variant is reserved for the step methods that explicitly want to
+   *  capture "no marker yet" as a null via `.catch(() => null)`. */
   async getActiveDebugLineRow(): Promise<number> {
     const row = await this.page.evaluate(`(function() {
       var candidates = document.querySelectorAll('.ace_active_debug_line');
@@ -160,11 +187,14 @@ export class DebuggerActions {
     return row;
   }
 
-  /** Read the gutter row label of the cell that currently displays the
-   *  executing-line icon. Returns the line number text (e.g., "3"). */
-  async getExecutingLineGutterText(): Promise<string> {
+  /** Wait until the executing-line gutter cell is rendered, then return
+   *  its row label (e.g., "3"). The wait covers the gap between
+   *  `waitForDebugMode` returning and the gutter icon actually painting. */
+  async waitForExecutingLineGutterText(
+    timeout: number = TIMEOUTS.fileOpen,
+  ): Promise<string> {
     const el = this.debuggerPage.executingLineGutter.first();
-    await el.waitFor({ state: 'visible', timeout: TIMEOUTS.fileOpen });
+    await el.waitFor({ state: 'visible', timeout });
     return (await el.innerText()).trim();
   }
 }

--- a/e2e/rstudio/actions/debugger.actions.ts
+++ b/e2e/rstudio/actions/debugger.actions.ts
@@ -21,17 +21,20 @@ export class DebuggerActions {
   }
 
   /** Click the breakpoint area of the gutter cell for `line` (1-indexed).
-   *  Waits until any breakpoint marker (active / pending / inactive) appears
-   *  on the cell — the test caller can assert further on which class shows
-   *  up if a specific state matters. */
+   *  Waits until the marker on that line reaches a settled state -- either
+   *  active (`ace_breakpoint`, R registered the trace) or inactive
+   *  (`ace_inactive-breakpoint`, function not in scope yet). The transient
+   *  `ace_pending-breakpoint` state only means GWT created the breakpoint
+   *  object, not that R has finished processing; returning on pending lets
+   *  a follow-up `setBreakpoint` race the first one's RPC and leave R with
+   *  only one trace registered. See {@link DebuggerPage.settledBreakpointMarker}. */
   async setBreakpoint(line: number): Promise<void> {
-    const before = await this.debuggerPage.anyBreakpointMarker.count();
     const cell = this.debuggerPage.gutterCellForLine(line);
     await cell.waitFor({ state: 'visible', timeout: TIMEOUTS.fileOpen });
     await cell.click({ position: GUTTER_BREAKPOINT_HIT_AREA });
-    await expect.poll(() => this.debuggerPage.anyBreakpointMarker.count(), {
-      timeout: TIMEOUTS.fileOpen,
-    }).toBeGreaterThan(before);
+    await expect(
+      this.debuggerPage.settledBreakpointForLine(line),
+    ).toBeVisible({ timeout: TIMEOUTS.fileOpen });
   }
 
   /** Toggle the breakpoint at the cursor's current position via Shift+F9

--- a/e2e/rstudio/pages/debugger.page.ts
+++ b/e2e/rstudio/pages/debugger.page.ts
@@ -38,6 +38,13 @@ export class DebuggerPage extends PageObject {
   // settling on active or inactive depending on whether the function is in
   // scope at click time.
   public anyBreakpointMarker: Locator;
+  // Matches breakpoints in their settled (post-RPC) states: active or
+  // inactive. Excludes the transient `ace_pending-breakpoint` decoration
+  // that GWT applies between the gutter click and R's response. Use this
+  // when waiting for `setBreakpoint` to be fully processed -- a pending
+  // marker only means the breakpoint object exists in GWT, not that R
+  // has registered the trace.
+  public settledBreakpointMarker: Locator;
   public activeDebugLine: Locator;
   public executingLineGutter: Locator;
 
@@ -64,6 +71,10 @@ export class DebuggerPage extends PageObject {
       ` or contains(@class,'ace_pending-breakpoint')` +
       ` or contains(@class,'ace_inactive-breakpoint')]`,
     );
+    this.settledBreakpointMarker = page.locator(
+      `${ACTIVE_EDITOR}//*[contains(@class,'ace_breakpoint')` +
+      ` or contains(@class,'ace_inactive-breakpoint')]`,
+    );
     this.activeDebugLine = page.locator(`${ACTIVE_EDITOR}//*[contains(@class,'ace_active_debug_line')]`);
     this.executingLineGutter = page.locator(`${ACTIVE_EDITOR}//*[contains(@class,'ace_executing-line')]`);
 
@@ -87,6 +98,15 @@ export class DebuggerPage extends PageObject {
    *  doesn't necessarily correspond to source line N+1. */
   gutterCellForLine(line: number): Locator {
     return this.gutterCells.filter({
+      hasText: new RegExp(`^\\s*${line}\\s*$`),
+    });
+  }
+
+  /** Locate a settled (active or inactive) breakpoint marker on `line`.
+   *  See {@link settledBreakpointMarker} for why pending markers are
+   *  excluded. */
+  settledBreakpointForLine(line: number): Locator {
+    return this.settledBreakpointMarker.filter({
       hasText: new RegExp(`^\\s*${line}\\s*$`),
     });
   }

--- a/e2e/rstudio/tests/panes/debugger/debugger.test.ts
+++ b/e2e/rstudio/tests/panes/debugger/debugger.test.ts
@@ -99,16 +99,11 @@ test.describe('R debugger', () => {
       `;
 
       await writeAndOpen(fileName, content);
-
       await debuggerActions.setBreakpoint(2);
-
       await executeCommand(consoleActions.page, 'sourceActiveDocument');
 
       await debuggerActions.waitForDebugMode();
-      await expect.poll(
-        () => debuggerActions.getActiveDebugLineRow(),
-        { timeout: TIMEOUTS.fileOpen },
-      ).toBe(1); // 0-indexed → line 2
+      await debuggerActions.waitForActiveDebugLineRowToBe(1); // 0-indexed → line 2
     });
 
     test('single gutter breakpoint highlights correct row', async () => {
@@ -141,12 +136,9 @@ test.describe('R debugger', () => {
       // Breakpoint on line 3 (the `{` opening the brace block). The active
       // debug line lands on row 2 (= line 3, 0-indexed); the gutter
       // executing-line icon shows "3".
-      await expect.poll(
-        () => debuggerActions.getActiveDebugLineRow(),
-        { timeout: TIMEOUTS.fileOpen },
-      ).toBe(2);
+      await debuggerActions.waitForActiveDebugLineRowToBe(2);
 
-      const gutterText = await debuggerActions.getExecutingLineGutterText();
+      const gutterText = await debuggerActions.waitForExecutingLineGutterText();
       expect(gutterText).toBe('3');
     });
 
@@ -217,14 +209,11 @@ test.describe('R debugger', () => {
       await consoleActions.executeInConsole('step_next_fn()');
 
       await debuggerActions.waitForDebugMode();
-      const startRow = await debuggerActions.getActiveDebugLineRow();
+      const startRow = await debuggerActions.waitForActiveDebugLineRow();
       expect(startRow).toBeGreaterThanOrEqual(0);
 
       await debuggerActions.stepOver();
-      await expect.poll(
-        () => debuggerActions.getActiveDebugLineRow(),
-        { timeout: TIMEOUTS.fileOpen },
-      ).toBe(startRow + 1);
+      await debuggerActions.waitForActiveDebugLineRowToBe(startRow + 1);
     });
 
     test('Step Into descends into a nested function call', async () => {
@@ -248,10 +237,7 @@ test.describe('R debugger', () => {
       await debuggerActions.waitForDebugMode();
 
       // Breakpoint at line 5 (the `inner()` call) → row 4 at debug entry.
-      await expect.poll(
-        () => debuggerActions.getActiveDebugLineRow(),
-        { timeout: TIMEOUTS.fileOpen },
-      ).toBe(4);
+      await debuggerActions.waitForActiveDebugLineRowToBe(4);
 
       await debuggerActions.stepInto();
 
@@ -261,10 +247,10 @@ test.describe('R debugger', () => {
       // (b) it landed inside inner()'s body (rows 0–2). Combined, these
       // distinguish a real descent from "debug exited" or "stepped over".
       await expect.poll(
-        () => debuggerActions.getActiveDebugLineRow(),
+        () => debuggerActions.getActiveDebugLineRow().catch(() => -1),
         { timeout: TIMEOUTS.fileOpen },
       ).not.toBe(4);
-      const after = await debuggerActions.getActiveDebugLineRow();
+      const after = await debuggerActions.waitForActiveDebugLineRow();
       expect(after).toBeGreaterThanOrEqual(0);
       expect(after).toBeLessThanOrEqual(2);
       await expect(debuggerActions.debuggerPage.debugToolbar).toBeVisible();
@@ -316,16 +302,10 @@ test.describe('R debugger', () => {
       await consoleActions.executeInConsole('step_continue_fn()');
 
       await debuggerActions.waitForDebugMode();
-      await expect.poll(
-        () => debuggerActions.getActiveDebugLineRow(),
-        { timeout: TIMEOUTS.fileOpen },
-      ).toBe(1); // 0-indexed → line 2
+      await debuggerActions.waitForActiveDebugLineRowToBe(1); // 0-indexed → line 2
 
       await debuggerActions.continueDebug();
-      await expect.poll(
-        () => debuggerActions.getActiveDebugLineRow(),
-        { timeout: TIMEOUTS.fileOpen },
-      ).toBe(4); // 0-indexed → line 5
+      await debuggerActions.waitForActiveDebugLineRowToBe(4); // 0-indexed → line 5
     });
 
     test('Stop button cleanly exits debug', async () => {
@@ -372,10 +352,7 @@ test.describe('R debugger', () => {
       await consoleActions.executeInConsole('five_continues_fn()');
 
       await debuggerActions.waitForDebugMode();
-      await expect.poll(
-        () => debuggerActions.getActiveDebugLineRow(),
-        { timeout: TIMEOUTS.fileOpen },
-      ).toBe(1); // 0-indexed → line 2
+      await debuggerActions.waitForActiveDebugLineRowToBe(1); // 0-indexed → line 2
 
       // Each Continue lands on the next breakpoint, and the prior
       // assignment becomes visible in the Environment pane.
@@ -388,10 +365,7 @@ test.describe('R debugger', () => {
       ];
       for (const { row, name, value } of stops) {
         await debuggerActions.continueDebug();
-        await expect.poll(
-          () => debuggerActions.getActiveDebugLineRow(),
-          { timeout: TIMEOUTS.fileOpen },
-        ).toBe(row);
+        await debuggerActions.waitForActiveDebugLineRowToBe(row);
         await expect.poll(
           () => envPane.hasVariable(name, value),
           { timeout: TIMEOUTS.fileOpen },
@@ -432,7 +406,7 @@ test.describe('R debugger', () => {
       // (row 1) before advancing. Assert the marker lands on row 1 or row
       // 2 — anywhere inside the function body but not on the function
       // declaration (row 0) or past the closing brace.
-      const row = await debuggerActions.getActiveDebugLineRow();
+      const row = await debuggerActions.waitForActiveDebugLineRow();
       expect(row).toBeGreaterThanOrEqual(1);
       expect(row).toBeLessThanOrEqual(2);
     });

--- a/e2e/rstudio/tests/panes/debugger/debugger_extras.test.ts
+++ b/e2e/rstudio/tests/panes/debugger/debugger_extras.test.ts
@@ -176,6 +176,7 @@ test.describe('R debugger extras', () => {
 
       // Set a breakpoint on line 2.
       await debuggerActions.setBreakpoint(2);
+
       await expect.poll(
         () => debuggerActions.debuggerPage.anyBreakpointMarker.count(),
         { timeout: TIMEOUTS.fileOpen },
@@ -268,7 +269,7 @@ test.describe('R debugger extras', () => {
 
       await debuggerActions.waitForDebugMode();
       await expect.poll(
-        () => debuggerActions.getExecutingLineGutterText(),
+        () => debuggerActions.waitForExecutingLineGutterText(),
         { timeout: TIMEOUTS.fileOpen },
       ).toBe('3');
 


### PR DESCRIPTION
## Summary

- Add `waitForActiveDebugLineRow` and `waitForActiveDebugLineRowToBe` to `DebuggerActions` so test code doesn't need to wrap bare `getActiveDebugLineRow` reads in `expect.poll` themselves — the wait happens against the `.ace_active_debug_line` locator before the row is read.
- Rename `getExecutingLineGutterText` to `waitForExecutingLineGutterText` to match the actual semantics (the method already waits for the gutter cell to be visible).
- Update `debugger.test.ts` and `debugger_extras.test.ts` to use the new helpers in place of bare reads after `waitForDebugMode`, and drop a few `sleep` calls in the affected tests that were standing in for the missing wait.

The raw `getActiveDebugLineRow` stays on the class because the internal step methods (`stepOver`, `stepInto`, etc.) rely on its `throw -> .catch(() => null)` shape to detect "no marker yet" before each step.

## Test plan

- [x] `npm run test:desktop-dev -- panes/debugger/` passes locally (19 passed, 2 skipped in ~44s).