### PR TITLE
store project mru paths in canonical (absolute) form

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 - ([#17743](https://github.com/rstudio/rstudio/issues/17743)): Fix the debugger failing to capture the browser environment for functions loaded by the `box` package.
 - ([#17712](https://github.com/rstudio/rstudio/issues/17712)): Fix Quarto rendering failing on Windows when the user's home folder path contains an ampersand.
 - ([#17669](https://github.com/rstudio/rstudio/issues/17669)): Avoid re-scanning the watched directory on every Files pane notification on macOS by enabling FSEvents per-file event reporting for non-recursive watches.
+- ([#17225](https://github.com/rstudio/rstudio/issues/17225)): Fix duplicate entries appearing in the recent projects list when the same project was recorded under both aliased (`~/...`) and absolute path forms.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/cpp/session/modules/SessionLists.cpp
+++ b/src/cpp/session/modules/SessionLists.cpp
@@ -17,6 +17,7 @@
 #include "SessionLists.hpp"
 
 #include <map>
+#include <set>
 
 #include <boost/utility.hpp>
 #include <boost/circular_buffer.hpp>
@@ -140,7 +141,66 @@ std::string removeCustomProjectName(const std::string& str)
    else
       return str;
 }
- 
+
+// Split a project_name_mru entry into (path, name). Returns an empty name
+// when the entry has no separator.
+std::pair<std::string, std::string> splitProjectMruEntry(const std::string& entry)
+{
+   std::size_t pos = entry.find(kProjectNameSepChar);
+   if (pos == std::string::npos)
+      return std::make_pair(entry, std::string());
+   return std::make_pair(entry.substr(0, pos), entry.substr(pos + 1));
+}
+
+// Join a (path, name) pair back into the on-disk MRU entry form.
+std::string joinProjectMruEntry(const std::string& path, const std::string& name)
+{
+   if (name.empty())
+      return path;
+   return path + kProjectNameSepChar + name;
+}
+
+// Canonicalize the path portion of a project_name_mru entry. Aliased paths
+// (~/...) are resolved to their absolute form so the on-disk representation
+// is invariant under changes in how the home directory is resolved.
+std::string canonicalizeProjectMruEntry(const std::string& entry)
+{
+   auto parts = splitProjectMruEntry(entry);
+   if (parts.first.empty() || !FilePath::isAliasedPath(parts.first))
+      return entry;
+   std::string absolutePath =
+      module_context::resolveAliasedPath(parts.first).getAbsolutePath();
+   return joinProjectMruEntry(absolutePath, parts.second);
+}
+
+// Alias the path portion of a project_name_mru entry for delivery to the
+// client. Paths within the user's home directory are rewritten to ~ form;
+// paths already aliased or outside the home directory pass through.
+std::string aliasProjectMruEntry(const std::string& entry)
+{
+   auto parts = splitProjectMruEntry(entry);
+   if (parts.first.empty() || FilePath::isAliasedPath(parts.first))
+      return entry;
+   std::string aliasedPath =
+      module_context::createAliasedPath(FilePath(parts.first));
+   return joinProjectMruEntry(aliasedPath, parts.second);
+}
+
+// Serialize a named list's contents to JSON, aliasing project_name_mru paths
+// so the client sees ~ form when paths are within the user's home directory.
+// Other lists pass through unchanged.
+json::Array listContentsToJson(const std::string& name,
+                               const std::list<std::string>& contents)
+{
+   if (name != kProjectNameMru)
+      return listToJson(contents);
+
+   json::Array jsonArray;
+   for (const std::string& val : contents)
+      jsonArray.push_back(aliasProjectMruEntry(val));
+   return jsonArray;
+}
+
 Error syncLegacyProjectMru()
 {
    // read the current project mru list (project_name_mru)
@@ -150,13 +210,59 @@ Error syncLegacyProjectMru()
       return error;
 
    // write out the legacy list (project_mru) without the custom names
-   error = writeCollectionToFile<std::list<std::string>>(listPath(kProjectMru), 
+   error = writeCollectionToFile<std::list<std::string>>(listPath(kProjectMru),
                                                          list->contents(),
                                                          removeCustomProjectName);
    if (error)
       return error;
 
    return Success();
+}
+
+// One-time migration: convert any aliased paths in the on-disk
+// project_name_mru file to absolute form and drop the duplicates that
+// resulted from the same project being recorded under both aliased and
+// absolute representations (see rstudio/rstudio#17225). After this runs
+// the file is canonical: every entry is an absolute path, optionally
+// followed by a name suffix. New additions are kept canonical by
+// canonicalizeProjectMruEntry on the RPC path.
+Error normalizeProjectMru()
+{
+   FilePath mruPath = listPath(kProjectNameMru);
+   if (!mruPath.exists())
+      return Success();
+
+   std::list<std::string> entries;
+   Error error = readCollectionFromFile<std::list<std::string>>(
+      mruPath, &entries, parseString);
+   if (error)
+      return error;
+
+   std::list<std::string> normalized;
+   std::set<std::string> seenPaths;
+   bool changed = false;
+   for (const std::string& entry : entries)
+   {
+      std::string canonical = canonicalizeProjectMruEntry(entry);
+      if (canonical != entry)
+         changed = true;
+
+      // dedupe by path, preserving the first occurrence's ordering and name
+      std::string path = splitProjectMruEntry(canonical).first;
+      if (!seenPaths.insert(path).second)
+      {
+         changed = true;
+         continue;
+      }
+      normalized.push_back(canonical);
+   }
+
+   if (!changed)
+      return Success();
+
+   LOG_INFO_MESSAGE("Normalizing project MRU list to canonical (absolute) paths");
+   return writeCollectionToFile<std::list<std::string>>(
+      mruPath, normalized, stringifyString);
 }
 
 void onListsFileChanged(const core::system::FileChangeEvent& fileChange)
@@ -198,7 +304,7 @@ void onListsFileChanged(const core::system::FileChangeEvent& fileChange)
 
    json::Object eventJson;
    eventJson["name"] = name;
-   eventJson["list"] = listToJson(list->contents());
+   eventJson["list"] = listContentsToJson(name, list->contents());
 
    ClientEvent event(client_events::kListChanged, eventJson);
    module_context::enqueClientEvent(event);
@@ -243,7 +349,7 @@ Error listGet(const json::JsonRpcRequest& request,
    if (error)
       return error;
 
-   pResponse->setResult(listToJson(list->contents()));
+   pResponse->setResult(listContentsToJson(name, list->contents()));
 
    return Success();
 }
@@ -257,6 +363,8 @@ Error listSetContents(const json::JsonRpcRequest& request,
    if (error)
       return error;
 
+   bool isProjectMru = (name == kProjectNameMru);
+
    std::list<std::string> list;
    for (const json::Value& val : jsonList)
    {
@@ -266,7 +374,10 @@ Error listSetContents(const json::JsonRpcRequest& request,
          continue;
       }
 
-      list.push_back(val.getString());
+      std::string entry = val.getString();
+      if (isProjectMru)
+         entry = canonicalizeProjectMruEntry(entry);
+      list.push_back(entry);
    }
 
    return writeCollectionToFile<std::list<std::string> >(listPath(name), list, stringifyString);
@@ -285,6 +396,11 @@ Error listInsertItem(bool prepend,
    error = json::readParam(request.params, 1, &value);
    if (error)
       return error;
+
+   // project paths are stored canonically (absolute) so that aliased and
+   // non-aliased forms of the same path don't produce duplicate entries
+   if (name == kProjectNameMru)
+      value = canonicalizeProjectMruEntry(value);
 
    // do the insert
    if (prepend)
@@ -324,6 +440,9 @@ Error listUpdateItemExtraData(const json::JsonRpcRequest& request,
    if (error)
       return error;
 
+   if (name == kProjectNameMru)
+      value = canonicalizeProjectMruEntry(value);
+
    list->updateExtraData(value);
 
    return Success();
@@ -343,6 +462,9 @@ Error listRemoveItem(const json::JsonRpcRequest& request,
    // get value to remove
    std::string value;
    error = json::readParam(request.params, 1, &value);
+
+   if (name == kProjectNameMru)
+      value = canonicalizeProjectMruEntry(value);
 
    // remove it
    list->remove(value);
@@ -400,7 +522,7 @@ json::Object allListsAsJson()
       if (error)
          LOG_ERROR(error);
 
-      allListsJson[it->first] = listToJson(list->contents());
+      allListsJson[it->first] = listContentsToJson(it->first, list->contents());
    }
 
    return allListsJson;
@@ -425,6 +547,10 @@ Error initialize()
    Error error = migrateLegacyProjectMru();
    if (error)
       return error;
+
+   error = normalizeProjectMru();
+   if (error)
+      LOG_ERROR(error);
 
    using boost::bind;
    using namespace module_context;

--- a/src/cpp/session/modules/SessionLists.cpp
+++ b/src/cpp/session/modules/SessionLists.cpp
@@ -18,6 +18,7 @@
 
 #include <map>
 #include <set>
+#include <sstream>
 
 #include <boost/utility.hpp>
 #include <boost/circular_buffer.hpp>
@@ -34,9 +35,9 @@ using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {
-namespace modules { 
+namespace modules {
 namespace lists {
-   
+
 namespace {
 
 using namespace collection;
@@ -52,6 +53,12 @@ const char * const kCommandPaletteMru = "command_palette_mru";
 
 // path to lists dir
 FilePath s_listsPath;
+
+// When normalizeProjectMru() rewrites the project_name_mru file at startup,
+// the file watcher would otherwise fire a kListChanged event carrying the
+// same contents the client already received via allListsAsJson(). This holds
+// the path whose next change event should be suppressed.
+FilePath s_suppressNextChange;
 
 // registered lists
 typedef std::map<std::string, std::size_t> Lists;
@@ -142,48 +149,18 @@ std::string removeCustomProjectName(const std::string& str)
       return str;
 }
 
-// Split a project_name_mru entry into (path, name). Returns an empty name
-// when the entry has no separator.
-std::pair<std::string, std::string> splitProjectMruEntry(const std::string& entry)
-{
-   std::size_t pos = entry.find(kProjectNameSepChar);
-   if (pos == std::string::npos)
-      return std::make_pair(entry, std::string());
-   return std::make_pair(entry.substr(0, pos), entry.substr(pos + 1));
-}
+// File-local wrappers for the detail helpers. These pull the home path
+// from module_context so callers in this file don't need to thread it
+// through. The tested overloads in detail:: take an explicit homePath.
 
-// Join a (path, name) pair back into the on-disk MRU entry form.
-std::string joinProjectMruEntry(const std::string& path, const std::string& name)
-{
-   if (name.empty())
-      return path;
-   return path + kProjectNameSepChar + name;
-}
-
-// Canonicalize the path portion of a project_name_mru entry. Aliased paths
-// (~/...) are resolved to their absolute form so the on-disk representation
-// is invariant under changes in how the home directory is resolved.
 std::string canonicalizeProjectMruEntry(const std::string& entry)
 {
-   auto parts = splitProjectMruEntry(entry);
-   if (parts.first.empty() || !FilePath::isAliasedPath(parts.first))
-      return entry;
-   std::string absolutePath =
-      module_context::resolveAliasedPath(parts.first).getAbsolutePath();
-   return joinProjectMruEntry(absolutePath, parts.second);
+   return detail::canonicalizeProjectMruEntry(entry, module_context::userHomePath());
 }
 
-// Alias the path portion of a project_name_mru entry for delivery to the
-// client. Paths within the user's home directory are rewritten to ~ form;
-// paths already aliased or outside the home directory pass through.
 std::string aliasProjectMruEntry(const std::string& entry)
 {
-   auto parts = splitProjectMruEntry(entry);
-   if (parts.first.empty() || FilePath::isAliasedPath(parts.first))
-      return entry;
-   std::string aliasedPath =
-      module_context::createAliasedPath(FilePath(parts.first));
-   return joinProjectMruEntry(aliasedPath, parts.second);
+   return detail::aliasProjectMruEntry(entry, module_context::userHomePath());
 }
 
 // Serialize a named list's contents to JSON, aliasing project_name_mru paths
@@ -247,8 +224,11 @@ Error normalizeProjectMru()
       if (canonical != entry)
          changed = true;
 
-      // dedupe by path, preserving the first occurrence's ordering and name
-      std::string path = splitProjectMruEntry(canonical).first;
+      // Dedupe by the canonical path; canonicalizeProjectMruEntry has
+      // already resolved aliased forms and normalized separators, so a
+      // string match here collapses the duplicates that motivated this
+      // pass.
+      std::string path = detail::splitProjectMruEntry(canonical).first;
       if (!seenPaths.insert(path).second)
       {
          changed = true;
@@ -261,8 +241,29 @@ Error normalizeProjectMru()
       return Success();
 
    LOG_INFO_MESSAGE("Normalizing project MRU list to canonical (absolute) paths");
-   return writeCollectionToFile<std::list<std::string>>(
-      mruPath, normalized, stringifyString);
+
+   // Serialize and write atomically: writeCollectionToFile truncates on
+   // open, so a crash mid-write would leave the MRU empty. Build the
+   // payload in memory and use the atomic helper instead.
+   std::ostringstream out;
+   for (const std::string& entry : normalized)
+      out << stringifyString(entry) << "\n";
+
+   // Suppress the kListChanged event that would otherwise fire from the
+   // monitor as a result of this rewrite; the contents we'd send are
+   // identical to what the client receives via allListsAsJson() on init.
+   s_suppressNextChange = mruPath;
+
+   error = writeStringToFileAtomic(mruPath, out.str());
+   if (error)
+   {
+      // clear the suppression flag so a subsequent legitimate change
+      // is not eaten
+      s_suppressNextChange = FilePath();
+      return error;
+   }
+
+   return Success();
 }
 
 void onListsFileChanged(const core::system::FileChangeEvent& fileChange)
@@ -279,7 +280,14 @@ void onListsFileChanged(const core::system::FileChangeEvent& fileChange)
    FilePath filePath(fileChange.fileInfo().absolutePath());
    std::string name = filePath.getFilename();
 
-   // ignore changes to the legacy project_mru file; we write to it whenever project_name_mru is 
+   // swallow the single change event triggered by normalizeProjectMru()
+   if (!s_suppressNextChange.isEmpty() && filePath == s_suppressNextChange)
+   {
+      s_suppressNextChange = FilePath();
+      return;
+   }
+
+   // ignore changes to the legacy project_mru file; we write to it whenever project_name_mru is
    // written, but never read it; it's kept updated so user doesn't lose their Projects MRU if
    // they downgrade to an older version of RStudio
    if (name == kProjectMru)
@@ -397,8 +405,9 @@ Error listInsertItem(bool prepend,
    if (error)
       return error;
 
-   // project paths are stored canonically (absolute) so that aliased and
-   // non-aliased forms of the same path don't produce duplicate entries
+   // project paths are stored canonically (absolute, separator-normalized)
+   // so that aliased and non-aliased forms of the same path don't produce
+   // duplicate entries -- see rstudio/rstudio#17225
    if (name == kProjectNameMru)
       value = canonicalizeProjectMruEntry(value);
 
@@ -440,6 +449,7 @@ Error listUpdateItemExtraData(const json::JsonRpcRequest& request,
    if (error)
       return error;
 
+   // project paths are stored canonically (see canonicalizeProjectMruEntry)
    if (name == kProjectNameMru)
       value = canonicalizeProjectMruEntry(value);
 
@@ -462,7 +472,10 @@ Error listRemoveItem(const json::JsonRpcRequest& request,
    // get value to remove
    std::string value;
    error = json::readParam(request.params, 1, &value);
+   if (error)
+      return error;
 
+   // project paths are stored canonically (see canonicalizeProjectMruEntry)
    if (name == kProjectNameMru)
       value = canonicalizeProjectMruEntry(value);
 
@@ -512,6 +525,58 @@ Error listClear(const json::JsonRpcRequest& request,
 } // anonymous namespace
 
 
+namespace detail {
+
+std::pair<std::string, std::string> splitProjectMruEntry(const std::string& entry)
+{
+   std::size_t pos = entry.find(kProjectNameSepChar);
+   if (pos == std::string::npos)
+      return std::make_pair(entry, std::string());
+   return std::make_pair(entry.substr(0, pos), entry.substr(pos + 1));
+}
+
+std::string joinProjectMruEntry(const std::string& path, const std::string& name)
+{
+   if (name.empty())
+      return path;
+   return path + kProjectNameSepChar + name;
+}
+
+std::string canonicalizeProjectMruEntry(const std::string& entry,
+                                        const FilePath& homePath)
+{
+   auto parts = splitProjectMruEntry(entry);
+   if (parts.first.empty())
+      return entry;
+
+   // Resolve aliased paths against the supplied home path; treat any
+   // other input as already absolute (or relative-to-cwd, which the
+   // MRU path should never be in practice).
+   FilePath resolved = FilePath::isAliasedPath(parts.first)
+      ? FilePath::resolveAliasedPath(parts.first, homePath)
+      : FilePath(parts.first);
+
+   // getLexicallyNormalPath() returns the generic (forward-slash) form
+   // on all platforms and collapses .. components, so the result is
+   // invariant under Windows native vs. generic separator differences.
+   std::string canonical = resolved.getLexicallyNormalPath();
+   return joinProjectMruEntry(canonical, parts.second);
+}
+
+std::string aliasProjectMruEntry(const std::string& entry,
+                                 const FilePath& homePath)
+{
+   auto parts = splitProjectMruEntry(entry);
+   if (parts.first.empty() || FilePath::isAliasedPath(parts.first))
+      return entry;
+   std::string aliasedPath =
+      FilePath::createAliasedPath(FilePath(parts.first), homePath);
+   return joinProjectMruEntry(aliasedPath, parts.second);
+}
+
+} // namespace detail
+
+
 json::Object allListsAsJson()
 {
    json::Object allListsJson;
@@ -529,7 +594,7 @@ json::Object allListsAsJson()
 }
 
 Error initialize()
-{  
+{
    // register lists / max sizes
    s_lists[kFileMru] = 15;
    s_lists[kProjectMru] = 15; // legacy, kept in sync with kProjectNameMru
@@ -550,7 +615,7 @@ Error initialize()
 
    error = normalizeProjectMru();
    if (error)
-      LOG_ERROR(error);
+      return error;
 
    using boost::bind;
    using namespace module_context;
@@ -565,7 +630,7 @@ Error initialize()
       (bind(registerRpcMethod, "list_clear", listClear));
    return initBlock.execute();
 }
-   
+
 
 
 } // namespace lists

--- a/src/cpp/session/modules/SessionLists.cpp
+++ b/src/cpp/session/modules/SessionLists.cpp
@@ -374,6 +374,7 @@ Error listSetContents(const json::JsonRpcRequest& request,
    bool isProjectMru = (name == kProjectNameMru);
 
    std::list<std::string> list;
+   std::set<std::string> seenPaths;
    for (const json::Value& val : jsonList)
    {
       if (!json::isType<std::string>(val))
@@ -384,7 +385,16 @@ Error listSetContents(const json::JsonRpcRequest& request,
 
       std::string entry = val.getString();
       if (isProjectMru)
+      {
+         // canonicalize, then drop any later entries that resolve to the
+         // same project path -- mirrors the dedup pass in normalizeProjectMru
+         // so callers can't reintroduce the duplicates from #17225 through
+         // this RPC path
          entry = canonicalizeProjectMruEntry(entry);
+         std::string path = detail::splitProjectMruEntry(entry).first;
+         if (!seenPaths.insert(path).second)
+            continue;
+      }
       list.push_back(entry);
    }
 

--- a/src/cpp/session/modules/SessionLists.hpp
+++ b/src/cpp/session/modules/SessionLists.hpp
@@ -16,23 +16,55 @@
 #ifndef SESSION_LISTS_HPP
 #define SESSION_LISTS_HPP
 
+#include <string>
+#include <utility>
+
 #include <shared_core/json/Json.hpp>
 
 namespace rstudio {
 namespace core {
    class Error;
+   class FilePath;
 }
 }
- 
+
 namespace rstudio {
 namespace session {
-namespace modules { 
+namespace modules {
 namespace lists {
-   
+
 core::json::Object allListsAsJson();
 
 core::Error initialize();
-                       
+
+// Helpers for project_name_mru entry manipulation. Exposed via the header
+// only so they can be exercised by SessionListsTests; production code in
+// SessionLists.cpp uses the file-local wrappers that pull the home path
+// from module_context::userHomePath().
+namespace detail {
+
+// Split a project_name_mru entry into (path, name). Returns an empty name
+// when the entry has no separator.
+std::pair<std::string, std::string> splitProjectMruEntry(const std::string& entry);
+
+// Join a (path, name) pair back into the on-disk MRU entry form.
+std::string joinProjectMruEntry(const std::string& path, const std::string& name);
+
+// Canonicalize the path portion of a project_name_mru entry against the
+// given home path. Aliased forms (~/...) are resolved to absolute form,
+// and separators are normalized so aliased and non-aliased representations
+// of the same project produce identical strings (see rstudio/rstudio#17225).
+std::string canonicalizeProjectMruEntry(const std::string& entry,
+                                        const core::FilePath& homePath);
+
+// Alias the path portion of a project_name_mru entry against the given
+// home path. Paths within the home directory are rewritten to ~ form;
+// paths already aliased or outside the home directory pass through.
+std::string aliasProjectMruEntry(const std::string& entry,
+                                 const core::FilePath& homePath);
+
+} // namespace detail
+
 } // namespace lists
 } // namespace modules
 } // namespace session

--- a/src/cpp/session/modules/SessionListsTests.cpp
+++ b/src/cpp/session/modules/SessionListsTests.cpp
@@ -1,0 +1,207 @@
+/*
+ * SessionListsTests.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <shared_core/FilePath.hpp>
+#include <session/SessionConstants.hpp>
+
+#include "SessionLists.hpp"
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace lists {
+namespace {
+
+using core::FilePath;
+
+const char kSep = kProjectNameSepChar;
+
+std::string withName(const std::string& path, const std::string& name)
+{
+   return path + kSep + name;
+}
+
+#ifdef _WIN32
+FilePath fakeHome()
+{
+   return FilePath("C:/Users/test");
+}
+#else
+FilePath fakeHome()
+{
+   return FilePath("/home/test");
+}
+#endif
+
+TEST(SessionListsTest, SplitEntry_PathOnly)
+{
+   auto parts = detail::splitProjectMruEntry("/home/test/foo/foo.Rproj");
+   EXPECT_EQ("/home/test/foo/foo.Rproj", parts.first);
+   EXPECT_EQ("", parts.second);
+}
+
+TEST(SessionListsTest, SplitEntry_PathWithName)
+{
+   auto parts = detail::splitProjectMruEntry(withName("/home/test/foo/foo.Rproj", "My Project"));
+   EXPECT_EQ("/home/test/foo/foo.Rproj", parts.first);
+   EXPECT_EQ("My Project", parts.second);
+}
+
+TEST(SessionListsTest, SplitEntry_Empty)
+{
+   auto parts = detail::splitProjectMruEntry("");
+   EXPECT_EQ("", parts.first);
+   EXPECT_EQ("", parts.second);
+}
+
+TEST(SessionListsTest, JoinEntry_NoName)
+{
+   EXPECT_EQ("/home/test/foo/foo.Rproj",
+             detail::joinProjectMruEntry("/home/test/foo/foo.Rproj", ""));
+}
+
+TEST(SessionListsTest, JoinEntry_WithName)
+{
+   EXPECT_EQ(withName("/home/test/foo/foo.Rproj", "My Project"),
+             detail::joinProjectMruEntry("/home/test/foo/foo.Rproj", "My Project"));
+}
+
+TEST(SessionListsTest, SplitJoin_RoundTrips)
+{
+   const std::string entries[] = {
+      "/home/test/foo/foo.Rproj",
+      withName("/home/test/foo/foo.Rproj", "Display Name"),
+      "",
+   };
+
+   for (const std::string& entry : entries)
+   {
+      auto parts = detail::splitProjectMruEntry(entry);
+      EXPECT_EQ(entry, detail::joinProjectMruEntry(parts.first, parts.second));
+   }
+}
+
+TEST(SessionListsTest, Canonicalize_ResolvesTildePath)
+{
+   FilePath home = fakeHome();
+   std::string aliased = "~/foo/foo.Rproj";
+   std::string canonical = detail::canonicalizeProjectMruEntry(aliased, home);
+
+   // After canonicalize, the path is no longer aliased.
+   EXPECT_FALSE(FilePath::isAliasedPath(detail::splitProjectMruEntry(canonical).first));
+
+   // Aliasing the canonical form against the same home returns the
+   // original aliased entry, so the transformation is reversible.
+   EXPECT_EQ(aliased, detail::aliasProjectMruEntry(canonical, home));
+}
+
+TEST(SessionListsTest, Canonicalize_PreservesProjectName)
+{
+   FilePath home = fakeHome();
+   std::string entry = withName("~/foo/foo.Rproj", "My Project");
+   std::string canonical = detail::canonicalizeProjectMruEntry(entry, home);
+
+   auto parts = detail::splitProjectMruEntry(canonical);
+   EXPECT_FALSE(FilePath::isAliasedPath(parts.first));
+   EXPECT_EQ("My Project", parts.second);
+}
+
+TEST(SessionListsTest, Canonicalize_PreservesPathsOutsideHome)
+{
+#ifdef _WIN32
+   const std::string outside = "D:/projects/foo/foo.Rproj";
+#else
+   const std::string outside = "/opt/projects/foo/foo.Rproj";
+#endif
+   FilePath home = fakeHome();
+   std::string canonical = detail::canonicalizeProjectMruEntry(outside, home);
+   EXPECT_EQ(outside, detail::splitProjectMruEntry(canonical).first);
+}
+
+TEST(SessionListsTest, Canonicalize_PassesThroughEmpty)
+{
+   FilePath home = fakeHome();
+   EXPECT_EQ("", detail::canonicalizeProjectMruEntry("", home));
+}
+
+TEST(SessionListsTest, Canonicalize_AliasedAndAbsoluteMatch)
+{
+   // Same project recorded both ways should produce the same canonical form
+   // so the dedup pass in normalizeProjectMru collapses them.
+   FilePath home = fakeHome();
+   std::string aliased = "~/foo/foo.Rproj";
+   std::string absolute = home.getAbsolutePath() + "/foo/foo.Rproj";
+
+   EXPECT_EQ(detail::canonicalizeProjectMruEntry(aliased, home),
+             detail::canonicalizeProjectMruEntry(absolute, home));
+}
+
+#ifdef _WIN32
+TEST(SessionListsTest, Canonicalize_NormalizesWindowsSeparators)
+{
+   // The same project with native vs. generic separators must canonicalize
+   // identically -- this is what the dedup pass relies on for the duplicate
+   // entries reported in rstudio/rstudio#17225 on Windows.
+   FilePath home = fakeHome();
+   std::string native = "C:\\Users\\test\\foo\\foo.Rproj";
+   std::string generic = "C:/Users/test/foo/foo.Rproj";
+
+   EXPECT_EQ(detail::canonicalizeProjectMruEntry(native, home),
+             detail::canonicalizeProjectMruEntry(generic, home));
+}
+#endif
+
+TEST(SessionListsTest, Alias_RewritesPathsInsideHome)
+{
+   FilePath home = fakeHome();
+   std::string absolute = home.getAbsolutePath() + "/foo/foo.Rproj";
+   std::string aliased = detail::aliasProjectMruEntry(absolute, home);
+   EXPECT_EQ("~/foo/foo.Rproj", aliased);
+}
+
+TEST(SessionListsTest, Alias_PreservesProjectName)
+{
+   FilePath home = fakeHome();
+   std::string entry = withName(home.getAbsolutePath() + "/foo/foo.Rproj", "My Project");
+   std::string aliased = detail::aliasProjectMruEntry(entry, home);
+   EXPECT_EQ(withName("~/foo/foo.Rproj", "My Project"), aliased);
+}
+
+TEST(SessionListsTest, Alias_PassesThroughExternalPaths)
+{
+#ifdef _WIN32
+   const std::string outside = "D:/projects/foo/foo.Rproj";
+#else
+   const std::string outside = "/opt/projects/foo/foo.Rproj";
+#endif
+   FilePath home = fakeHome();
+   EXPECT_EQ(outside, detail::aliasProjectMruEntry(outside, home));
+}
+
+TEST(SessionListsTest, Alias_PassesThroughAlreadyAliased)
+{
+   FilePath home = fakeHome();
+   EXPECT_EQ("~/foo", detail::aliasProjectMruEntry("~/foo", home));
+}
+
+} // anonymous namespace
+} // namespace lists
+} // namespace modules
+} // namespace session
+} // namespace rstudio


### PR DESCRIPTION
## Intent

Addresses #17225.

The project MRU dedupes entries by exact string equality. The same
project can end up recorded twice -- once under its aliased form
(`~/minigit/minigit.Rproj`) and once under its absolute form
(`C:/Users/RonBlum/minigit/minigit.Rproj`) -- whenever `userHomePath()`
resolves differently between sessions (which is easy to trigger on
Windows, where `~` typically means `Documents` but the project lives one
level up in the OS home). The aliased entry then fails to open in any
session where `~` no longer resolves to the directory it did when the
entry was first recorded.

## Summary

- Store `project_name_mru` entries canonically (absolute paths) on disk;
  alias them only on the way out to the client.
- Canonicalize incoming MRU paths in the four RPC handlers that mutate
  the list (`list_prepend_item`, `list_append_item`,
  `list_set_contents`, `list_update_extra`, `list_remove_item`) so the
  on-disk form is always absolute.
- Alias outbound entries in the three places that send MRU contents to
  the client (`listGet`, `onListsFileChanged`, `allListsAsJson`) so the
  UI continues to display `~/...` where appropriate.
- Add a one-time `normalizeProjectMru()` pass during module init that
  rewrites any existing aliased entries to absolute form and drops the
  duplicates that already snuck into users' MRU files.

The change is gated to `project_name_mru` -- other lists (`file_mru`,
`help_history_links`, etc.) pass through unchanged.

## Test plan

- [ ] Open a project in `~/<something>` on Windows where `~` is
      `Documents`; confirm the MRU shows a single entry with the
      expected `~/...` label.
- [ ] Open a project under `C:\Users\<name>\` (a sibling of Documents)
      and confirm a single entry, no `minigit -- ~` duplicate.
- [ ] Start RStudio with a pre-existing MRU file containing both
      `~/foo/foo.Rproj` and `C:/Users/<name>/foo/foo.Rproj`; verify
      `normalizeProjectMru` collapses them to one absolute entry
      (`Normalizing project MRU list...` log line should appear once).
- [ ] On Linux/macOS, confirm the MRU still shows aliased labels for
      projects inside `$HOME` and absolute paths for projects outside.
- [ ] Set a custom project name, close + reopen the project, and
      confirm the name still round-trips through the MRU.