### PR TITLE
test(e2e): use activeEditor bridge in autocomplete actions

### DIFF
--- a/e2e/rstudio/actions/autocomplete.actions.ts
+++ b/e2e/rstudio/actions/autocomplete.actions.ts
@@ -103,39 +103,29 @@ export class AutocompleteActions {
     await this.sourceActions.sourcePane.aceTextInput.click({ force: true });
     await sleep(300);
 
-    // Position cursor in the source editor (skip console editor)
-    if (cursorLine !== undefined && cursorCol !== undefined) {
-      await this.page.evaluate(`
-        var editors = document.querySelectorAll('.ace_editor');
-        for (var i = 0; i < editors.length; i++) {
-          if (editors[i].closest('#rstudio_console_input')) continue;
-          var env = editors[i].env;
-          if (env && env.editor) {
-            env.editor.focus();
-            env.editor.gotoLine(${cursorLine}, ${cursorCol});
-            break;
-          }
+    // Position cursor in the source editor via the automation bridge.
+    // A DOM scan with `.ace_editor` here would pick stale editors left in
+    // the DOM after a tab close (ad175dccd1 / #17775) -- the chosen empty
+    // editor would silently receive focus + gotoLine, and Ctrl+Space then
+    // fires against an editor with no content to complete on.
+    await this.page.evaluate(
+      ({ line, col }: { line: number | null; col: number | null }) => {
+        const editor = window.rstudio?.documents.activeEditor() ?? null;
+        if (!editor) throw new Error('No active source editor');
+        editor.focus();
+        if (line !== null && col !== null) {
+          editor.gotoLine(line, col);
+        } else {
+          // Default: end of last non-empty line.
+          const session = editor.session;
+          let lastRow = session.getLength() - 1;
+          while (lastRow > 0 && session.getLine(lastRow).trim() === '') lastRow--;
+          const lastCol = session.getLine(lastRow).length;
+          editor.gotoLine(lastRow + 1, lastCol);
         }
-      `);
-    } else {
-      // Default: end of last non-empty line
-      await this.page.evaluate(`
-        var editors = document.querySelectorAll('.ace_editor');
-        for (var i = 0; i < editors.length; i++) {
-          if (editors[i].closest('#rstudio_console_input')) continue;
-          var env = editors[i].env;
-          if (env && env.editor) {
-            var editor = env.editor;
-            editor.focus();
-            var lastRow = editor.session.getLength() - 1;
-            while (lastRow > 0 && editor.session.getLine(lastRow).trim() === '') lastRow--;
-            var lastCol = editor.session.getLine(lastRow).length;
-            editor.gotoLine(lastRow + 1, lastCol);
-            break;
-          }
-        }
-      `);
-    }
+      },
+      { line: cursorLine ?? null, col: cursorCol ?? null },
+    );
     await sleep(500);
 
     // If autocomplete already appeared (e.g. after typing $ or (), use it;

--- a/e2e/rstudio/utils/ace.ts
+++ b/e2e/rstudio/utils/ace.ts
@@ -27,6 +27,7 @@ export namespace Ace {
   // Methods on the EditSession (editor.session). Ace exposes many more --
   // restrict to the ones tests actually need to keep the surface obvious.
   export interface Session {
+    getLength(): number;
     getLine(row: number): string;
     getFoldWidget(row: number): string;
     getFoldWidgetRange(row: number): Range | null;


### PR DESCRIPTION
## Summary
- `AutocompleteActions.getCompletionsInEditor` was iterating `document.querySelectorAll('.ace_editor')` and focusing the first non-console match. On the failing autocomplete_extras tests the scan landed on a stale empty source editor at DOM index 0 instead of the live editor at index 1, so `gotoLine` + `focus` moved into the empty editor and the subsequent `Ctrl+Space` fired with nothing for the completer to anchor to. This is the same class of bug ad175dccd1 (#17775) fixed for `getEditorContent` / `openFile`.
- Replace both the explicit-cursor and default-cursor branches with `window.rstudio.documents.activeEditor()`, which maps through `SourceColumnManager.getActiveNativeEditor` and reliably returns the active doc's editor.
- Add `Session.getLength()` to `utils/ace.ts` so the default-cursor branch can stay typed.

Diagnostic output from a failing run before the fix (cursor placed at row 0 / column 0 in an empty editor, while the actual active editor held the test content):

```
editors[0]: not-in-console, valueLength=0   <- chosen
editors[1]: not-in-console, valueLength=30  <- real one
chosen: 0
finalContent: ""
activeEditorMatch: false
activeEditorContentLength: 30
```

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test:desktop-dev -- autocomplete_extras` -- 11/11 passed
- [x] `npm run test:desktop-dev -- tests/panes/misc/autocomplete.test.ts` -- 14/14 passed