### PR TITLE
test(e2e): pin desktop window size; route AceEditor through activeEditor

### DIFF
--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -195,6 +195,25 @@ function createTempConfig(): TempConfig {
     JSON.stringify(prefs, null, 2),
   );
 
+  // Pre-seed electron-store's config.json with explicit windowBounds. The
+  // schema default (1200x900) gets clamped by positionAndEnsureVisible to the
+  // workArea of whatever display is attached -- on macOS GH Actions runners
+  // that's around 1024x645, which is small enough that the left column's
+  // source pane drops under DualWindowLayoutPanel's 60px snap threshold and
+  // the Console gets promoted to MAXIMIZE state. Locking the renderer at
+  // 1400x900 keeps both panes comfortably above the snap threshold.
+  // Requested bounds that intersect any display.workArea are used as-is
+  // (window-utils.ts:191), so a 1400x900 rect at the origin sticks even on
+  // narrower virtual displays.
+  fs.writeFileSync(
+    path.join(electronUserData, 'config.json'),
+    JSON.stringify(
+      { view: { windowBounds: { x: 0, y: 0, width: 1400, height: 900, maximized: false } } },
+      null,
+      2,
+    ),
+  );
+
   return { root, configHome, configDir, electronUserData };
 }
 

--- a/e2e/rstudio/pages/ace_editor.page.ts
+++ b/e2e/rstudio/pages/ace_editor.page.ts
@@ -1,4 +1,4 @@
-import type { Page } from 'playwright';
+import type { Page, JSHandle } from 'playwright';
 import { PageObject } from './page_object_base_classes';
 import { Ace, AceEditorElement } from '../utils/ace';
 
@@ -46,62 +46,78 @@ export class AceEditor extends PageObject {
   }
 
   /**
-   * Reconstructs `fn` in the browser context, locates the editor (active doc
-   * when marker is empty, marker-substring match otherwise), and invokes
-   * `fn(editor, ...args)`. Args must be structured-clone serializable.
+   * Resolve the target editor in the browser and return a JSHandle to it.
+   * Pairs with `run()` below, which disposes the handle when done.
    */
-  private async runOnEditor<TArgs extends unknown[], TResult>(
-    fn: (editor: Ace.Editor, ...args: TArgs) => TResult,
-    ...args: TArgs
-  ): Promise<TResult> {
-    return this.page.evaluate(
-      ({ marker, fnSource, args }) => {
-        // Reconstruct the function passed by the test from its source.
-        // Input is trusted: it comes from our own .toString() in the caller.
-        const op = (0, eval)('(' + fnSource + ')') as (editor: Ace.Editor, ...args: unknown[]) => unknown;
-
-        if (marker === '') {
-          const editor = window.rstudio?.documents.activeEditor() ?? null;
-          if (!editor) {
-            throw new Error(
-              'AceEditor(\'\'): no active source editor (window.rstudio.documents.activeEditor() returned null)',
-            );
-          }
-          return op(editor, ...args);
+  private editorHandle(): Promise<JSHandle<Ace.Editor>> {
+    return this.page.evaluateHandle((marker: string): Ace.Editor => {
+      if (marker === '') {
+        const editor = window.rstudio?.documents.activeEditor() ?? null;
+        if (!editor) {
+          throw new Error(
+            'AceEditor(\'\'): no active source editor (window.rstudio.documents.activeEditor() returned null)',
+          );
         }
-
-        const editors = document.querySelectorAll('.ace_editor');
-        for (let i = 0; i < editors.length; i++) {
-          if (editors[i].closest('#rstudio_console_input')) continue;
-          const env = (editors[i] as unknown as AceEditorElement).env;
-          if (env?.editor && env.editor.getValue().indexOf(marker) !== -1) {
-            return op(env.editor, ...args);
-          }
+        return editor;
+      }
+      const editors = document.querySelectorAll('.ace_editor');
+      for (let i = 0; i < editors.length; i++) {
+        if (editors[i].closest('#rstudio_console_input')) continue;
+        const env = (editors[i] as unknown as AceEditorElement).env;
+        if (env?.editor && env.editor.getValue().indexOf(marker) !== -1) {
+          return env.editor;
         }
-        throw new Error('No Ace editor found containing marker: ' + marker);
-      },
-      { marker: this.marker, fnSource: fn.toString(), args: args as unknown[] }
-    ) as Promise<TResult>;
+      }
+      throw new Error('No Ace editor found containing marker: ' + marker);
+    }, this.marker);
+  }
+
+  /**
+   * Resolve the editor, run `fn(editor, arg)` against it in the browser, and
+   * return the result. Playwright serializes `fn` natively, so closures over
+   * Node-side state don't work -- pass everything through `arg`, which must
+   * be structured-clone serializable.
+   */
+  private async run<R>(fn: (editor: Ace.Editor) => R): Promise<R>;
+  private async run<A, R>(fn: (editor: Ace.Editor, arg: A) => R, arg: A): Promise<R>;
+  private async run<A, R>(
+    fn: ((editor: Ace.Editor) => R) | ((editor: Ace.Editor, arg: A) => R),
+    arg?: A,
+  ): Promise<R> {
+    const handle = await this.editorHandle();
+    try {
+      // Playwright's PageFunctionOn types wrap the arg in Unboxed<A>, which
+      // can't be reconciled with our open A from the public overloads. The
+      // overloads above keep call sites type-safe; the cast here just lets
+      // the bridge call through.
+      const handleEvaluate = handle.evaluate.bind(handle) as (
+        f: typeof fn,
+        a?: A,
+      ) => Promise<R>;
+      return arguments.length === 1 ? await handleEvaluate(fn) : await handleEvaluate(fn, arg);
+    } finally {
+      await handle.dispose();
+    }
   }
 
   async getValue(): Promise<string> {
-    return this.runOnEditor((editor) => editor.getValue());
+    return this.run((editor) => editor.getValue());
   }
 
   async gotoLine(line: number, column = 0): Promise<void> {
-    await this.runOnEditor(
-      (editor, l: number, c: number) => editor.gotoLine(l, c),
-      line, column
+    await this.run(
+      (editor, pos: { line: number; column: number }) => editor.gotoLine(pos.line, pos.column),
+      { line, column },
     );
   }
 
   /** Returns "start", "end", or "" depending on whether the row has a fold widget. */
   async getFoldWidget(row: number): Promise<string> {
-    return this.runOnEditor((editor, r: number) => editor.session.getFoldWidget(r), row);
+    return this.run((editor, r: number) => editor.session.getFoldWidget(r), row);
   }
 
   async getFoldWidgetRange(row: number): Promise<Ace.Range | null> {
-    return this.runOnEditor((editor, r: number) => {
+    return this.run((editor, r: number) => {
       const range = editor.session.getFoldWidgetRange(r);
       if (!range) return null;
       return {
@@ -113,26 +129,27 @@ export class AceEditor extends PageObject {
 
   /** Returns the raw text of `row` (0-indexed), excluding the trailing newline. */
   async getLine(row: number): Promise<string> {
-    return this.runOnEditor((editor, r: number) => editor.session.getLine(r), row);
+    return this.run((editor, r: number) => editor.session.getLine(r), row);
   }
 
   async getTokens(row: number): Promise<AceToken[]> {
-    return this.runOnEditor(
+    return this.run(
       (editor, r: number) => editor.session.getTokens(r) as AceToken[],
-      row
+      row,
     );
   }
 
   async getTokenAt(row: number, column: number): Promise<AceToken | null> {
-    return this.runOnEditor(
-      (editor, r: number, c: number) => editor.session.getTokenAt(r, c) as AceToken | null,
-      row, column
+    return this.run(
+      (editor, pos: { row: number; column: number }) =>
+        editor.session.getTokenAt(pos.row, pos.column) as AceToken | null,
+      { row, column },
     );
   }
 
   /** Returns all Ace markers on the session, normalized to plain objects. */
   async getMarkers(): Promise<AceMarker[]> {
-    return this.runOnEditor((editor) => {
+    return this.run((editor) => {
       const markers = editor.session.getMarkers() as Record<string, AceMarker>;
       return Object.values(markers).map((m) => ({
         range: m.range
@@ -148,7 +165,7 @@ export class AceEditor extends PageObject {
   }
 
   async getState(row: number): Promise<string> {
-    return this.runOnEditor((editor, r: number) => editor.session.getState(r), row);
+    return this.run((editor, r: number) => editor.session.getState(r), row);
   }
 
   /**
@@ -157,7 +174,7 @@ export class AceEditor extends PageObject {
    * cursor on every matching occurrence.
    */
   async getSelectionRanges(): Promise<Ace.Range[]> {
-    return this.runOnEditor((editor) => {
+    return this.run((editor) => {
       const ranges = editor.selection.rangeList.ranges;
       return ranges.map((r) => ({
         start: { row: r.start.row, column: r.start.column },
@@ -167,7 +184,7 @@ export class AceEditor extends PageObject {
   }
 
   async getCursorPosition(): Promise<Ace.Position> {
-    return this.runOnEditor((editor) => {
+    return this.run((editor) => {
       const pos = editor.getCursorPosition();
       return { row: pos.row, column: pos.column };
     });
@@ -175,7 +192,7 @@ export class AceEditor extends PageObject {
 
   /** Equivalent to Ace's editor.find(needle): selects the first match and scrolls to it. */
   async find(needle: string): Promise<void> {
-    await this.runOnEditor((editor, n: string) => editor.find(n), needle);
+    await this.run((editor, n: string) => editor.find(n), needle);
   }
 
   /**
@@ -183,16 +200,16 @@ export class AceEditor extends PageObject {
    * Useful when typed-key delivery is hard to time (e.g. right after a save).
    */
   async insert(text: string): Promise<void> {
-    await this.runOnEditor((editor, t: string) => editor.insert(t), text);
+    await this.run((editor, t: string) => editor.insert(t), text);
   }
 
   /** Move cursor to the end of the current line (Ace's editor.navigateLineEnd). */
   async navigateLineEnd(): Promise<void> {
-    await this.runOnEditor((editor) => editor.navigateLineEnd());
+    await this.run((editor) => editor.navigateLineEnd());
   }
 
   /** Move focus to the editor textarea so subsequent page.keyboard input routes here. */
   async focus(): Promise<void> {
-    await this.runOnEditor((editor) => editor.focus());
+    await this.run((editor) => editor.focus());
   }
 }

--- a/e2e/rstudio/pages/ace_editor.page.ts
+++ b/e2e/rstudio/pages/ace_editor.page.ts
@@ -21,9 +21,21 @@ export interface AceMarker {
 /**
  * Drives an Ace editor instance from Playwright via page.evaluate.
  *
- * Identifies the target editor by a content marker -- a substring guaranteed
- * to appear in its current value. Editors inside #rstudio_console_input are
- * skipped so the source editor is found even when the console is focused.
+ * Two ways to identify the target editor:
+ *
+ *   - Empty marker (`new AceEditor(page, '')`): the active source editor,
+ *     resolved through `window.rstudio.documents.activeEditor()`. Prefer this
+ *     when there's only one tab open, or when "the editor the user is looking
+ *     at" is what the test means.
+ *   - Non-empty marker: a `.ace_editor` element whose current value contains
+ *     the marker substring. Use this to target a *non-active* tab (e.g. a
+ *     hidden buffer left open in another tab). Editors inside
+ *     #rstudio_console_input are skipped so the source editor is still found
+ *     when the console happens to come first in DOM order.
+ *
+ * The marker-substring path is a DOM walk and can land on stale editors left
+ * in the DOM after a tab close (see ad175dccd1 / #17775 and #17784). Empty
+ * marker avoids that entirely.
  */
 export class AceEditor extends PageObject {
   private readonly marker: string;
@@ -34,9 +46,9 @@ export class AceEditor extends PageObject {
   }
 
   /**
-   * Reconstructs `fn` in the browser context, locates the editor whose value
-   * contains the marker, and invokes `fn(editor, ...args)`. Args must be
-   * structured-clone serializable.
+   * Reconstructs `fn` in the browser context, locates the editor (active doc
+   * when marker is empty, marker-substring match otherwise), and invokes
+   * `fn(editor, ...args)`. Args must be structured-clone serializable.
    */
   private async runOnEditor<TArgs extends unknown[], TResult>(
     fn: (editor: Ace.Editor, ...args: TArgs) => TResult,
@@ -44,14 +56,25 @@ export class AceEditor extends PageObject {
   ): Promise<TResult> {
     return this.page.evaluate(
       ({ marker, fnSource, args }) => {
+        // Reconstruct the function passed by the test from its source.
+        // Input is trusted: it comes from our own .toString() in the caller.
+        const op = (0, eval)('(' + fnSource + ')') as (editor: Ace.Editor, ...args: unknown[]) => unknown;
+
+        if (marker === '') {
+          const editor = window.rstudio?.documents.activeEditor() ?? null;
+          if (!editor) {
+            throw new Error(
+              'AceEditor(\'\'): no active source editor (window.rstudio.documents.activeEditor() returned null)',
+            );
+          }
+          return op(editor, ...args);
+        }
+
         const editors = document.querySelectorAll('.ace_editor');
         for (let i = 0; i < editors.length; i++) {
           if (editors[i].closest('#rstudio_console_input')) continue;
           const env = (editors[i] as unknown as AceEditorElement).env;
           if (env?.editor && env.editor.getValue().indexOf(marker) !== -1) {
-            // Reconstruct the function passed by the test from its source.
-            // Input is trusted: it comes from our own .toString() in the caller.
-            const op = (0, eval)('(' + fnSource + ')') as (editor: Ace.Editor, ...args: unknown[]) => unknown;
             return op(env.editor, ...args);
           }
         }


### PR DESCRIPTION
## Summary

Two related fixes for flakes surfaced by the full e2e run on #17785 (3 unique edit_suggestions failures on macOS GH Actions).

- **Pin Electron window to 1400x900** in `desktop.fixture.ts`. The schema default (1200x900) gets clamped by `positionAndEnsureVisible` to the runner's small virtual display (~1024x645), which drops the left column's source pane under `DualWindowLayoutPanel`'s 60px snap threshold. The layout then promotes the Console to MAXIMIZE state and the source pane visually disappears, breaking any test that types into it. `positionAndEnsureVisible` accepts requested bounds that intersect any display.workArea as-is, so 1400x900 at the origin sticks even on narrow virtual displays.
- **Route empty-marker `AceEditor` through the `window.rstudio.documents.activeEditor()` bridge.** Same stale-editor bug fixed for `openFile`/`getEditorContent` (ad175dccd1 / #17775) and `getCompletionsInEditor` (#17784). Empty marker would trivially match any editor's value, so the DOM walk could land on a stale editor left in the DOM after a tab close. Non-empty markers keep the DOM-walk path (still needed for targeting non-active tabs).
- **Drop the `eval`-based `runOnEditor`** while in there. The previous shape stringified the user callback via `fn.toString()` and reconstituted it in the browser with `(0, eval)('(' + fnSource + ')')` to work around `page.evaluate`'s single-arg signature. Replace with `page.evaluateHandle` + `handle.evaluate`, which serializes the function natively.

## Test plan

- [ ] Re-run macOS desktop e2e suite; confirm the three previously failing tests pass:
  - `panes/editor/edit_suggestions.test.ts >> ghost text suggestions can be prefix-matched`
  - `panes/editor/edit_suggestions.test.ts >> ghost text moves on document edit`
  - `panes/editor/edit_suggestions.test.ts >> ghost text is cleared from old row when newline inserted above`
- [ ] Confirm `panes/layout/panes.test.ts` ratio-based width assertions still pass with a wider viewport (10% tolerance).
- [ ] Spot-check other `new AceEditor(page, '')` callers in `tests/panes/editor/reformat.test.ts` and `tests/panes/editor/rmarkdown.test.ts`.
- [ ] `npm run typecheck` passes locally.