### PR TITLE
fix import dataset preview by removing embedding dependency from .rs.digest

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 - ([#17712](https://github.com/rstudio/rstudio/issues/17712)): Fix Quarto rendering failing on Windows when the user's home folder path contains an ampersand.
 - ([#17669](https://github.com/rstudio/rstudio/issues/17669)): Avoid re-scanning the watched directory on every Files pane notification on macOS by enabling FSEvents per-file event reporting for non-recursive watches.
 - ([#17225](https://github.com/rstudio/rstudio/issues/17225)): Fix duplicate entries appearing in the recent projects list when the same project was recorded under both aliased (`~/...`) and absolute path forms.
+- ([#17777](https://github.com/rstudio/rstudio/issues/17777)): Fix "Import Dataset" from the Environment pane failing with "could not find function '.rs.digest'" when previewing a CSV (or other readr/readxl/haven source).
 
 ### Dependencies
 - Ace 1.43.5

--- a/e2e/rstudio/README.md
+++ b/e2e/rstudio/README.md
@@ -225,7 +225,7 @@ test.describe('Feature name', () => {
 
 - **Parallel safety**: Default to `test.describe()`. Use `test.describe.serial()` only when tests share state (e.g., multi-turn chat conversations).
 - **Failing tests**: Use `test.fixme()` — never comment tests out.
-- **Cleanup**: prefer a `beforeAll` calling `consoleActions.closeAllBuffersWithoutSaving()` over per-test cleanup. Use `saveAllSourceDocs` → `closeAllSourceDocs` only when the test must flush in-editor edits to disk.
+- **Cleanup**: prefer a `beforeAll` calling `consoleActions.resetSourcePane()` over per-test cleanup. That helper leaves the source pane in a single-Untitled-tab state -- it avoids the no-tabs/has-tabs HIDE animation race (#17738) that `closeAllBuffersWithoutSaving` triggers, and gives every test a known starting state. Use `saveAllSourceDocs` → `closeAllSourceDocs` only when the test must flush in-editor edits to disk.
 - **File naming**: Test files use snake_case: `feature_name.test.ts`.
 - **Temporary files**: Use timestamps (`test_${Date.now()}.R`) to avoid collisions.
 

--- a/e2e/rstudio/actions/source_pane.actions.ts
+++ b/e2e/rstudio/actions/source_pane.actions.ts
@@ -42,11 +42,13 @@ export class SourcePaneActions {
   async closeSourceAndDeleteFile(fileName: string): Promise<void> {
     await executeCommand(this.page, 'saveAllSourceDocs');
     await sleep(1000);
-    await executeCommand(this.page, 'closeAllSourceDocs');
-
-    // Wait for the editor to detach before unlinking the file.
-    await expect(this.sourcePane.aceTextInput).toHaveCount(0, { timeout: 5000 }).catch(() => {});
-
+    // resetSourcePane closes every tab except a single Untitled placeholder,
+    // so the source pane never transits through the zero-tab HIDE state
+    // (#17738) and the next test starts from a known good state. The previous
+    // closeAllSourceDocs + toHaveCount(0) wait left the pane briefly empty,
+    // and the auto-spawned Untitled1 that filled the gap collided with the
+    // new file the next test opened (two publishBtns -> strict-mode error).
+    await this.consolePaneActions.resetSourcePane();
     await this.consolePaneActions.executeInConsole(`unlink("${fileName}")`, { wait: true });
   }
 

--- a/e2e/rstudio/pages/source_pane.page.ts
+++ b/e2e/rstudio/pages/source_pane.page.ts
@@ -41,15 +41,21 @@ export class SourcePane extends PageObject {
     this.nesDiscard = page.locator("xpath=//*[text()='Discard']");
     this.nesDeletionMarker = page.locator('[class*=ace_next-edit-suggestion-deletion]');
     this.nesGutter = page.locator("xpath=//div[@role='tabpanel' and not(contains(@style, 'display: none'))]//*[starts-with(@id,'rstudio_source_text_editor')]//*[contains(@class,'ace_nes-gutter')]");
-    this.publishBtn = page.locator("[id*='rstudio_publish_item_editor']");
-    this.formatOptions = page.locator('[aria-label="Edit the R Markdown format options for the current file"]');
+    // The toolbar locators below scope to the visible tabpanel (same pattern as
+    // contentPane / aceTextInput above). Each open editor tab renders its own
+    // copy of these buttons; a plain page-wide locator triggers Playwright's
+    // strict-mode "multiple elements" error as soon as a second tab exists
+    // (e.g. the Untitled placeholder left by resetSourcePaneState plus a test-
+    // opened file). Scoping picks the one belonging to the active tab.
+    this.publishBtn = page.locator("xpath=//div[@role='tabpanel' and not(contains(@style, 'display: none'))]//*[starts-with(@id,'rstudio_publish_item_editor')]");
+    this.formatOptions = page.locator("xpath=//div[@role='tabpanel' and not(contains(@style, 'display: none'))]//*[@aria-label='Edit the R Markdown format options for the current file']");
     this.viewerPaneOption = page.locator('#rstudio_label_preview_in_viewer_pane_command');
-    this.knitOptions = page.locator('[aria-label="Knit options"]');
+    this.knitOptions = page.locator("xpath=//div[@role='tabpanel' and not(contains(@style, 'display: none'))]//*[@aria-label='Knit options']");
     this.knitHtml = page.locator('#rstudio_label_knit_to_html_command');
     this.previewBtn = page.locator("xpath=//*[contains(@title,'Preview') and not(contains(@style, 'display: none'))]");
-    this.saveBtn = page.locator("[class*='rstudio_source_panel'] [title*='Save current doc']");
+    this.saveBtn = page.locator("xpath=//div[@role='tabpanel' and not(contains(@style, 'display: none'))]//*[contains(@title,'Save current doc')]");
     this.footerTable = page.locator("xpath=//*[contains(@class, 'rstudio_source_panel')]//div[@role='tabpanel' and not(contains(@style, 'display: none'))]//*[contains(@class, 'rstudio-themes-background')]");
-    this.visualMdToggle = page.locator('.rstudio_visual_md_on');
+    this.visualMdToggle = page.locator("xpath=//div[@role='tabpanel' and not(contains(@style, 'display: none'))]//*[contains(concat(' ', normalize-space(@class), ' '), ' rstudio_visual_md_on ')]");
     this.secondaryToolbar = page.locator('[aria-label="Markdown editing tools"]');
     this.chunkImage = page.locator("xpath=//*[@id='rstudio_source_text_editor']//*[@class='gwt-Image']");
     this.statusBarCompletionReceived = this.footerTable.locator('.gwt-Label', { hasText: 'Completion response received' });

--- a/e2e/rstudio/tests/panes/console/console_output.test.ts
+++ b/e2e/rstudio/tests/panes/console/console_output.test.ts
@@ -184,7 +184,7 @@ test.describe('Error output after caught try()', () => {
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
   });
 
   test.afterEach(async ({ rstudioPage: page }) => {

--- a/e2e/rstudio/tests/panes/console/execute_from_editor.test.ts
+++ b/e2e/rstudio/tests/panes/console/execute_from_editor.test.ts
@@ -3,7 +3,7 @@ import { TIMEOUTS } from '@utils/constants';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePaneActions } from '@actions/source_pane.actions';
 import { useSuiteSandbox } from '@utils/sandbox';
-import { documentCloseAllNoSave, waitForActiveDocument } from '@utils/commands';
+import { resetSourcePaneState, waitForActiveDocument } from '@utils/commands';
 
 test.describe('Run Line button', () => {
   const sandbox = useSuiteSandbox();
@@ -17,7 +17,7 @@ test.describe('Run Line button', () => {
 
   test('submits queued lines to the console in document order', async ({ rstudioPage: page }) => {
     await consoleActions.clearConsole();
-    await documentCloseAllNoSave(page);
+    await resetSourcePaneState(page);
 
     const sandboxR = sandbox.dir.replace(/\\/g, '/');
     const filePath = `${sandboxR}/submit_order_${Date.now()}.R`;
@@ -39,6 +39,6 @@ test.describe('Run Line button', () => {
       timeout: 15000,
     });
 
-    await documentCloseAllNoSave(page);
+    await resetSourcePaneState(page);
   });
 });

--- a/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
@@ -50,7 +50,7 @@ test.describe('Data Viewer', () => {
     consoleActions = new ConsolePaneActions(page);
     sourcePane = new SourcePane(page);
     dataViewer = new DataViewerPane(page);
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
   });
 
   test.afterEach(async ({ rstudioPage: page }) => {

--- a/e2e/rstudio/tests/panes/data-viewer/pagination-sorting.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/pagination-sorting.test.ts
@@ -17,7 +17,7 @@ test.describe('Data Viewer', () => {
     consoleActions = new ConsolePaneActions(page);
     sourcePane = new SourcePane(page);
     dataViewer = new DataViewerPane(page);
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
   });
 
   test.afterEach(async ({ rstudioPage: page }) => {

--- a/e2e/rstudio/tests/panes/editor/air_formatting.test.ts
+++ b/e2e/rstudio/tests/panes/editor/air_formatting.test.ts
@@ -254,19 +254,30 @@ async function focusEditor(sourceActions: SourcePaneActions): Promise<void> {
   }
 }
 
-/** Select all code in the editor, then reformat via Cmd+Shift+A / Ctrl+Shift+A. */
+/** Select all code in the editor, then dispatch the reformat command. */
 async function reformatCode(page: Page, sourceActions: SourcePaneActions): Promise<void> {
-  // Snapshot the content before the keystroke so we can poll for the diff
+  // Snapshot the content before the command so we can poll for the diff
   // to land. The reformat command (whether server-side Air or client-side
   // built-in) applies its diff asynchronously and exposes no per-command
   // signal; every caller of this helper expects the content to *change*,
   // so a content-change poll is a precise readiness signal. Callers that
   // need to assert "no change" should use saveFile (which polls dirty=false
   // via saveDocument) instead.
+  //
+  // Drive select-all and reformat through the window.rstudio bridge rather
+  // than Cmd+A / Cmd+Shift+A keyboard presses. The keyboard path lost the
+  // race on slow CI: focus could drift off the source pane between the two
+  // keystrokes (or between the keystroke and the command dispatch), at
+  // which point Cmd+Shift+A landed on a different focus target and the
+  // reformat never fired -- the failure surfaced as a 10s opaque timeout
+  // because *nothing happened* to the buffer.
   const before = await sourceActions.getEditorContent();
-  await focusEditor(sourceActions);
-  await page.keyboard.press('ControlOrMeta+a'); // select all
-  await page.keyboard.press('ControlOrMeta+Shift+a'); // reformat selection
+  await page.evaluate(() => {
+    const editor = window.rstudio?.documents.activeEditor();
+    if (!editor) throw new Error('reformatCode: no active source editor');
+    editor.selectAll();
+  });
+  await executeCommand(page, 'reformatCode');
   await expect.poll(
     () => sourceActions.getEditorContent(),
     { timeout: 10000 },
@@ -337,11 +348,29 @@ test.describe('Air Formatting (#16721)', { tag: ['@parallel_safe'] }, () => {
     await createAndOpenProject(page, sandbox.dir, 'air_formatting');
     consoleActions = new ConsolePaneActions(page);
     sourceActions = new SourcePaneActions(page, consoleActions);
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
     await consoleActions.clearConsole();
     // Start clean — programmatic reset (not the thing being tested)
     await removeAirConfig(consoleActions);
     await resetAirPrefs(consoleActions);
+
+    // Smoke probe: exercise the reformat machinery once with the simplest
+    // configuration (built-in formatter, no Air, no config). If the command
+    // bridge, source pane, or built-in formatter is wedged, every test below
+    // would fail with a 10-second opaque "content never changed" timeout --
+    // surface that here as a single beforeAll failure with the actual buffer
+    // we saw, so the cause is recognizable instead of a wall of identical
+    // reformatCode timeouts.
+    await openTestFile(consoleActions, sourceActions);
+    await reformatCode(page, sourceActions);
+    const probeContent = await sourceActions.getEditorContent();
+    if (!probeContent.includes('x <- 1 + 2 + 3')) {
+      throw new Error(
+        'Air suite smoke probe failed: built-in reformat did not produce ' +
+        `expected output. Got:\n${probeContent}`,
+      );
+    }
+    await sourceActions.closeSourceAndDeleteFile(TEST_FILE);
   });
 
   test.afterEach(async () => {

--- a/e2e/rstudio/tests/panes/editor/close_open_race.test.ts
+++ b/e2e/rstudio/tests/panes/editor/close_open_race.test.ts
@@ -28,7 +28,7 @@ test.describe('Source pane open during close race', () => {
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
   });
 
   test('file.edit immediately after closeAllSourceDocs still opens the tab', async ({ rstudioPage: page }) => {

--- a/e2e/rstudio/tests/panes/editor/code-folding.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code-folding.test.ts
@@ -15,7 +15,7 @@ test.describe('Code folding', () => {
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
     sourceActions = new SourcePaneActions(page, consoleActions);
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
   });
 
   test.afterEach(async ({ rstudioPage: page }) => {

--- a/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
@@ -5,7 +5,7 @@ import { AssistantOptionsActions } from '@actions/assistant_options.actions';
 import { SourcePaneActions } from '@actions/source_pane.actions';
 import { SourcePane } from '@pages/source_pane.page';
 import { useSuiteSandbox } from '@utils/sandbox';
-import { documentCloseAllNoSave } from '@utils/commands';
+import { resetSourcePaneState } from '@utils/commands';
 import { requireAiCredentials } from '@utils/ai-credentials';
 
 for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
@@ -32,7 +32,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
       // a save here would race a now-gone sandbox path from an earlier aborted
       // run and surface an ENOENT "Save File" dialog whose popup-glass blocks
       // every subsequent click.
-      await documentCloseAllNoSave(page);
+      await resetSourcePaneState(page);
       await sleep(1000);
 
       // Delete all possible test files in a single R command
@@ -519,7 +519,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
 
       // Close File A without saving -- the file is in the per-suite sandbox
       // and a save here would race that sandbox's later teardown.
-      await documentCloseAllNoSave(page);
+      await resetSourcePaneState(page);
       await sleep(2000);
 
       // --- File B: same original code, no edits ---
@@ -646,7 +646,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
       // Don't save -- the sandbox is about to be unlinked by useSuiteSandbox's
       // afterAll, so saving races the directory removal and surfaces an
       // "Error Saving File" dialog whose popup-glass blocks the shutdown.
-      await documentCloseAllNoSave(page);
+      await resetSourcePaneState(page);
       await sleep(1000);
 
       const testFiles = [

--- a/e2e/rstudio/tests/panes/editor/edit_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/edit_suggestions.test.ts
@@ -31,7 +31,7 @@ test.describe('Edit suggestions (showEditSuggestion injection)', () => {
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
   });
 
   test.afterEach(async ({ rstudioPage: page }) => {

--- a/e2e/rstudio/tests/panes/editor/editor.test.ts
+++ b/e2e/rstudio/tests/panes/editor/editor.test.ts
@@ -29,7 +29,7 @@ test.describe('Editor', () => {
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
   });
 
   test.afterEach(async ({ rstudioPage: page }) => {

--- a/e2e/rstudio/tests/panes/editor/missing_packages_banner.test.ts
+++ b/e2e/rstudio/tests/panes/editor/missing_packages_banner.test.ts
@@ -32,7 +32,7 @@ test.describe('Missing-package banner', () => {
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
     // discoverPackageDependencies filters to CRAN packages that aren't on
     // disk, so if a prior run or the shared R_LIBS_USER cache already has
     // the package the banner won't appear. Force a clean slate -- assert

--- a/e2e/rstudio/tests/panes/editor/multiline_chunk_execution.test.ts
+++ b/e2e/rstudio/tests/panes/editor/multiline_chunk_execution.test.ts
@@ -20,7 +20,7 @@ test.describe('Multiline chunk execution', { tag: ['@parallel_safe'] }, () => {
     consoleActions = new ConsolePaneActions(page);
     sourceActions = new SourcePaneActions(page, consoleActions);
 
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
     await consoleActions.clearConsole();
   });
 

--- a/e2e/rstudio/tests/panes/editor/notebook_save_during_execution.test.ts
+++ b/e2e/rstudio/tests/panes/editor/notebook_save_during_execution.test.ts
@@ -21,7 +21,7 @@ test.describe('Notebook save during execution', { tag: ['@parallel_safe'] }, () 
     consoleActions = new ConsolePaneActions(page);
     sourceActions = new SourcePaneActions(page, consoleActions);
 
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
     await consoleActions.clearConsole();
 
     missingPackages = await consoleActions.ensurePackages(['ggplot2', 'nycflights13'], 120000);

--- a/e2e/rstudio/tests/panes/editor/quarto.test.ts
+++ b/e2e/rstudio/tests/panes/editor/quarto.test.ts
@@ -20,7 +20,7 @@ test.describe('Quarto', () => {
     sourceActions = new SourcePaneActions(page, consoleActions);
 
     // Clean up leftover source files
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
 
     await consoleActions.ensurePackages(['rmarkdown']);
 

--- a/e2e/rstudio/tests/panes/editor/reformat.test.ts
+++ b/e2e/rstudio/tests/panes/editor/reformat.test.ts
@@ -50,7 +50,7 @@ test.describe('Built-in code reformat', () => {
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
   });
 
   test.afterEach(async ({ rstudioPage: page }) => {
@@ -84,7 +84,7 @@ test.describe.serial('styler reformat on save', () => {
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
     missingPackages = await consoleActions.ensurePackages(['styler'], 180_000);
 
     projectDir = await createAndOpenProject(page, sandbox.dir, 'reformat-styler-project');
@@ -97,7 +97,7 @@ test.describe.serial('styler reformat on save', () => {
   test.afterAll(async ({ rstudioPage: page }) => {
     await clearPref(page, 'reformat_on_save');
     await clearPref(page, 'code_formatter');
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
     await waitForConsoleIdle(page);
     await closeProjectIfOpen(page);
   });
@@ -154,7 +154,7 @@ test.describe('styler reformat #17471 (Windows)', { tag: ['@windows_only'] }, ()
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
     missingPackages = await consoleActions.ensurePackages(['styler'], 180_000);
   });
 

--- a/e2e/rstudio/tests/panes/editor/rmarkdown.test.ts
+++ b/e2e/rstudio/tests/panes/editor/rmarkdown.test.ts
@@ -17,16 +17,37 @@ test.describe('RMarkdown', () => {
   useSuiteSandbox();
   let consoleActions: ConsolePaneActions;
   let sourceActions: SourcePaneActions;
+  let missingPackages: string[] = [];
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
     sourceActions = new SourcePaneActions(page, consoleActions);
 
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
 
-    await consoleActions.ensurePackages(['rmarkdown', 'remotes']);
+    // Bumped from the default 60s -- on slow CI runners rmarkdown's transitive
+    // install (knitr, markdown, etc.) regularly outlasts a minute. The previous
+    // call discarded the return value; if install timed out, every test below
+    // would then fail with an opaque knit/template/spellcheck timeout 60+
+    // seconds later. Capture failures and surface them as a clear test.skip
+    // in each test so the cause is visible in one place.
+    missingPackages = await consoleActions.ensurePackages(
+      ['rmarkdown', 'remotes'],
+      180_000,
+    );
 
     await consoleActions.clearConsole();
+  });
+
+  // Every test in this suite drives at least one .rmd path (knit, chunk run,
+  // spellcheck, templates) that needs rmarkdown installed. Skipping at the
+  // beforeEach level keeps the report honest -- a missing dep shows up as
+  // "skipped: rmarkdown not available", not as 4-6 different opaque timeouts.
+  test.beforeEach(() => {
+    test.skip(
+      missingPackages.length > 0,
+      `required R package(s) not available: ${missingPackages.join(', ')}`,
+    );
   });
 
   test('create new rmarkdown and knit to HTML', async ({ rstudioPage: page }) => {
@@ -116,7 +137,7 @@ test.describe('RMarkdown', () => {
     await page.keyboard.press('Enter');
     await expect(sourceActions.sourcePane.contentPane).toHaveText('# Section');
 
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
     await consoleActions.executeInConsole(`unlink("${rmdFileName}")`, { wait: true });
 
     // Check that an R file DOES insert a comment on newline
@@ -205,7 +226,7 @@ test.describe('RMarkdown', () => {
     await expect(page.locator('.ProseMirror')).toContainText('Theming with bslib and thematic', { timeout: 10000 });
 
     // Cleanup
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
   });
 
   test.skip('visual mode go to next and prev chunk', async ({ rstudioPage: page }) => {
@@ -256,6 +277,6 @@ test.describe('RMarkdown', () => {
     await expect(consoleOutput).not.toContainText('plot(pressure)');
 
     // Cleanup
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
   });
 });

--- a/e2e/rstudio/tests/panes/editor/rmarkdown_chunks.test.ts
+++ b/e2e/rstudio/tests/panes/editor/rmarkdown_chunks.test.ts
@@ -70,11 +70,24 @@ test.describe.serial('R Markdown chunks', { tag: ['@serial'] }, () => {
   const sandbox = useSuiteSandbox();
   let consoleActions: ConsolePaneActions;
   let sourceActions: SourcePaneActions;
+  let missingPackages: string[] = [];
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
     sourceActions = new SourcePaneActions(page, consoleActions);
+    // Every test in this file drives chunks or saves a notebook, both of
+    // which need rmarkdown loadable. Without this check, a missing dep
+    // surfaces as an opaque chunk/save timeout deep inside a test; capture
+    // the failure once here and let test.beforeEach skip with a clear reason.
+    missingPackages = await consoleActions.ensurePackages(['rmarkdown'], 180_000);
     await consoleActions.clearConsole();
+  });
+
+  test.beforeEach(() => {
+    test.skip(
+      missingPackages.length > 0,
+      `required R package(s) not available: ${missingPackages.join(', ')}`,
+    );
   });
 
   test('the warn option is preserved when running chunks', async ({ rstudioPage: page }) => {

--- a/e2e/rstudio/tests/panes/editor/sweave.test.ts
+++ b/e2e/rstudio/tests/panes/editor/sweave.test.ts
@@ -13,7 +13,7 @@ test.describe('Sweave', () => {
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
     sourceActions = new SourcePaneActions(page, consoleActions);
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
   });
 
   test.afterEach(async ({ rstudioPage: page }) => {

--- a/e2e/rstudio/tests/panes/editor/syntax-highlighting.test.ts
+++ b/e2e/rstudio/tests/panes/editor/syntax-highlighting.test.ts
@@ -14,7 +14,7 @@ test.describe('Syntax Highlighting', () => {
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
     sourceActions = new SourcePaneActions(page, consoleActions);
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
   });
 
   test.afterEach(async ({ rstudioPage: page }) => {

--- a/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
+++ b/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
@@ -51,10 +51,11 @@ test.describe('Import Dataset (readr)', () => {
     const dialog = page.locator(IMPORT_DIALOG);
     await expect(dialog).toBeVisible({ timeout: TIMEOUTS.fileOpen });
 
-    // Type the CSV path into the file chooser TextBox. The chooser polls
-    // for value changes every 250ms (DataImportFileChooser.checkForTextBoxChange)
-    // and flips the action button from "Browse..." to "Update" when the
-    // textbox transitions empty -> non-empty.
+    // Set the path on the file chooser TextBox in one shot. The chooser
+    // polls for value changes every 250ms (DataImportFileChooser.
+    // checkForTextBoxChange) and flips the action button from "Browse..."
+    // to "Update" when the textbox transitions empty -> non-empty -- we
+    // wait on that flip below rather than racing the poll per keystroke.
     //
     // The textbox's class is the obfuscated form of `modelTextBox` (set via
     // styleName= in DataImportFileChooser.ui.xml, which replaces the default
@@ -62,8 +63,7 @@ test.describe('Import Dataset (readr)', () => {
     // from the label-association in DataImport.ui.xml.
     const fileInput = dialog.getByRole('textbox', { name: 'File/URL:' });
     await expect(fileInput).toBeVisible({ timeout: 5000 });
-    await fileInput.click();
-    await fileInput.pressSequentially(csvPath);
+    await fileInput.fill(csvPath);
 
     // Click "Update" to commit the path and kick off
     // preview_data_import_async. The textbox value change alone does not

--- a/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
+++ b/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
@@ -1,0 +1,99 @@
+// Import Dataset (readr) end-to-end test for #17777.
+//
+// preview_data_import_async spawns a --vanilla R subprocess that sources
+// only Tools.R + a handful of session modules. Before the fix, .rs.digest
+// lived in SessionRUtil.R (not sourced in that subprocess) and was backed
+// by a .Call into the embedding (also not available there), so the CSV
+// preview failed with "Is this a valid CSV file? could not find function
+// '.rs.digest'". .rs.digest is now a pure-base-R Adler-32 in Tools.R,
+// which the subprocess already sources -- this test asserts the dialog
+// renders a successful preview end to end.
+
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { executeCommand } from '@utils/commands';
+import { installDepIfPrompted } from '@pages/modals.page';
+import { useSuiteSandbox } from '@utils/sandbox';
+import { TIMEOUTS } from '@utils/constants';
+
+// The dialog's aria-label comes from the caption passed to the
+// ModalDialog ctor in DataImportPresenter (constants_.importTextData()).
+const IMPORT_DIALOG = '.gwt-DialogBox[aria-label="Import Text Data"]';
+
+// The preview iframe is a GridViewerFrame titled with constants_.dataPreview().
+const PREVIEW_FRAME = 'iframe[title="Data Preview"]';
+
+test.describe('Import Dataset (readr)', () => {
+  const sandbox = useSuiteSandbox();
+  let consoleActions: ConsolePaneActions;
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+  });
+
+  // https://github.com/rstudio/rstudio/issues/17777
+  test('CSV preview renders without an .rs.digest lookup error', async ({ rstudioPage: page }) => {
+    // Write a tiny CSV via the R session so the path is valid on the
+    // rsession host (matters for Server mode where the runner and session
+    // can be on different machines).
+    const csvPath = `${sandbox.dir}/sample.csv`;
+    await consoleActions.executeInConsole(
+      `writeLines(c("a,b,c","1,2,3","4,5,6"), "${csvPath}")`,
+      { wait: true },
+    );
+
+    // Open Import Dataset > From Text (readr). The presenter wraps the
+    // dialog in a dependency check; accept the install prompt if readr
+    // (or one of its transitive deps) isn't already on the library path.
+    await executeCommand(page, 'importDatasetFromCsvUsingReadr');
+    await installDepIfPrompted(page);
+
+    const dialog = page.locator(IMPORT_DIALOG);
+    await expect(dialog).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+
+    // Type the CSV path into the file chooser TextBox. The chooser polls
+    // for value changes every 250ms (DataImportFileChooser.checkForTextBoxChange)
+    // and flips the action button from "Browse..." to "Update" when the
+    // textbox transitions empty -> non-empty.
+    //
+    // The textbox's class is the obfuscated form of `modelTextBox` (set via
+    // styleName= in DataImportFileChooser.ui.xml, which replaces the default
+    // .gwt-TextBox), so target it by ARIA name instead -- "File/URL:" comes
+    // from the label-association in DataImport.ui.xml.
+    const fileInput = dialog.getByRole('textbox', { name: 'File/URL:' });
+    await expect(fileInput).toBeVisible({ timeout: 5000 });
+    await fileInput.click();
+    await fileInput.pressSequentially(csvPath);
+
+    // Click "Update" to commit the path and kick off
+    // preview_data_import_async. The textbox value change alone does not
+    // trigger the preview -- it has to go through the action button's
+    // click handler (DataImportFileChooser.actionButton_). The button's
+    // aria-label flips from "Browse for File/URL" to "Update for File/URL"
+    // via switchToUpdateMode() once the polling timer notices the new value.
+    const updateBtn = dialog.getByRole('button', { name: 'Update for File/URL' });
+    await expect(updateBtn).toBeVisible({ timeout: 5000 });
+    await updateBtn.click();
+
+    // Preview iframe should populate with the CSV's three columns. Pre-fix
+    // this never landed because the subprocess errored out before returning
+    // column data, and DataImport.java would render the "Is this a valid
+    // CSV file?" error prefix instead. The grid renders each header as
+    // "<name>(<type>)" once column inference completes; anchor on the name
+    // prefix so the assertion doesn't depend on the inferred type string.
+    const previewFrame = dialog.frameLocator(PREVIEW_FRAME);
+    await expect(previewFrame.locator('th[data-col-idx="1"]'))
+      .toHaveText(/^a/, { timeout: TIMEOUTS.fileOpen });
+    await expect(previewFrame.locator('th[data-col-idx="2"]')).toHaveText(/^b/);
+    await expect(previewFrame.locator('th[data-col-idx="3"]')).toHaveText(/^c/);
+
+    // Defensive: ensure the #17777 error prefix is not anywhere in the
+    // dialog (would catch a regression where the iframe also happens to
+    // render correct-looking headers from some unrelated source).
+    await expect(dialog).not.toContainText('valid CSV file');
+
+    // Cancel out -- we don't want to actually run the import.
+    await dialog.locator('#rstudio_dlg_cancel').click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+});

--- a/e2e/rstudio/tests/panes/files/files.test.ts
+++ b/e2e/rstudio/tests/panes/files/files.test.ts
@@ -11,7 +11,7 @@ import { SourcePane } from '@pages/source_pane.page';
 import { AceEditor } from '@pages/ace_editor.page';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { TIMEOUTS, typeSlowly } from '@utils/constants';
-import { executeCommand, documentCloseAllNoSave, setPref, clearPref } from '@utils/commands';
+import { executeCommand, resetSourcePaneState, setPref, clearPref } from '@utils/commands';
 
 const MODAL_DIALOG = '.rstudio_modal_dialog';
 // The Open File dialog renders a virtualized file list as a `<table
@@ -28,12 +28,12 @@ test.describe('Open File dialog (virtualized)', { tag: ['@server_only'] }, () =>
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
   });
 
   test.afterEach(async ({ rstudioPage: page }) => {
     // Clean up any stub files and close opened source docs.
-    await documentCloseAllNoSave(page);
+    await resetSourcePaneState(page);
     await consoleActions.executeInConsole(`unlink(list.files(${JSON.stringify(sandbox.dir)}, pattern = "\\\\.R$", full.names = TRUE))`);
   });
 
@@ -88,7 +88,7 @@ test.describe('Autosave on blur', () => {
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
   });
 
   // https://github.com/rstudio/rstudio/issues/16329
@@ -142,7 +142,7 @@ test.describe('Autosave on blur', () => {
       );
     } finally {
       await clearPref(page, 'auto_save_on_blur');
-      await documentCloseAllNoSave(page);
+      await resetSourcePaneState(page);
       await consoleActions.executeInConsole(
         `{ unlink(file.path(${JSON.stringify(sandbox.dir)}, "autosave.R")); rm(list = ls(pattern = "^\\\\.rs_autosave", envir = globalenv()), envir = globalenv()) }`,
       );

--- a/e2e/rstudio/tests/panes/layout/panes.test.ts
+++ b/e2e/rstudio/tests/panes/layout/panes.test.ts
@@ -48,6 +48,31 @@ async function getLeft(page: Page, selector: string): Promise<number> {
   return await page.locator(selector).evaluate(el => el.getBoundingClientRect().left);
 }
 
+// Wait until a pane's offsetWidth has settled: two consecutive samples agree
+// and the width is at least `min`. The offsetWidth observation is the most
+// direct DOM signal we have for "GWT has finished laying out this pane" --
+// the previous pattern (sleep(layoutSettle) + immediate read) lost races on
+// slow CI because relayout regularly outlasts the 300ms wait. Returns the
+// settled width.
+async function waitForStableWidth(
+  page: Page,
+  selector: string,
+  options: { min?: number; timeout?: number } = {},
+): Promise<number> {
+  const { min = 1, timeout = 5000 } = options;
+  let prev = -1;
+  await expect.poll(
+    async () => {
+      const w = await getOffsetWidth(page, selector);
+      const settled = w >= min && w === prev;
+      prev = w;
+      return settled;
+    },
+    { timeout, intervals: [50, 100, 150] },
+  ).toBe(true);
+  return prev;
+}
+
 async function elementExists(page: Page, selector: string): Promise<boolean> {
   return (await page.locator(selector).count()) > 0;
 }
@@ -195,7 +220,13 @@ async function toggleTab(page: Page, container: string, tabLabel: string): Promi
 // Tests
 // ---------------------------------------------------------------------------
 
-test.describe.serial('Pane and column management', { tag: ['@serial'] }, () => {
+// Dropped `.describe.serial` here: the per-test `afterEach(resetUILayout)`
+// below already restores the layout between tests, and serial mode was
+// turning one flaky test failure into a cascade of skipped sibling tests
+// (then re-running the whole block on retry). Without serial, only the
+// failed test retries -- failures stay actionable instead of producing
+// 17-test noise dumps.
+test.describe('Pane and column management', () => {
   test.beforeAll(async ({ rstudioPage: page }) => {
     const consoleActions = new ConsolePaneActions(page);
     // Normalize the source pane to a single Untitled tab instead of
@@ -431,11 +462,12 @@ test.describe.serial('Pane and column management', { tag: ['@serial'] }, () => {
     expect(await getOffsetWidth(page, TABSET2_PANE)).toBeLessThan(50);
 
     await executeCommand(page, 'layoutZoomLeftColumn');
-    await expect.poll(
-      async () => (await getOffsetWidth(page, CONSOLE_PANE)) < zoomedConsoleWidth * 0.75
-        && (await getOffsetWidth(page, TABSET1_PANE)) > 50,
-      { timeout: 5000 }
-    ).toBe(true);
+    // Wait for the un-zoom relayout to settle on each pane before reading
+    // widths -- the previous `> 50 && < 0.75 * zoomed` threshold passed mid-
+    // animation, so expectWidthClose would see in-flight values.
+    await waitForStableWidth(page, CONSOLE_PANE, { min: 100 });
+    await waitForStableWidth(page, TABSET1_PANE, { min: 50 });
+    await waitForStableWidth(page, TABSET2_PANE, { min: 50 });
 
     expectWidthClose(await getOffsetWidth(page, CONSOLE_PANE), initialConsoleWidth, 0.1, 'restored Console');
     expectWidthClose(await getOffsetWidth(page, TABSET1_PANE), initialTabSet1Width, 0.1, 'restored TabSet1');
@@ -471,12 +503,10 @@ test.describe.serial('Pane and column management', { tag: ['@serial'] }, () => {
     expect(await getOffsetWidth(page, SIDEBAR_PANE)).toBeLessThan(50);
 
     await executeCommand(page, 'layoutZoomLeftColumn');
-    await expect.poll(
-      async () => (await getOffsetWidth(page, CONSOLE_PANE)) < zoomedConsoleWidth * 0.75
-        && (await getOffsetWidth(page, TABSET1_PANE)) > 50
-        && (await getOffsetWidth(page, SIDEBAR_PANE)) > 50,
-      { timeout: 5000 }
-    ).toBe(true);
+    await waitForStableWidth(page, CONSOLE_PANE, { min: 100 });
+    await waitForStableWidth(page, TABSET1_PANE, { min: 50 });
+    await waitForStableWidth(page, TABSET2_PANE, { min: 50 });
+    await waitForStableWidth(page, SIDEBAR_PANE, { min: 50 });
 
     expectWidthClose(await getOffsetWidth(page, CONSOLE_PANE), initialConsoleWidth, 0.1, 'restored Console');
     expectWidthClose(await getOffsetWidth(page, TABSET1_PANE), initialTabSet1Width, 0.1, 'restored TabSet1');
@@ -510,11 +540,9 @@ test.describe.serial('Pane and column management', { tag: ['@serial'] }, () => {
     expect(await getOffsetWidth(page, CONSOLE_PANE)).toBeLessThan(50);
 
     await executeCommand(page, 'layoutZoomRightColumn');
-    await expect.poll(
-      async () => (await getOffsetWidth(page, TABSET1_PANE)) < zoomedTabSet1Width * 0.75
-        && (await getOffsetWidth(page, CONSOLE_PANE)) > 50,
-      { timeout: 5000 }
-    ).toBe(true);
+    await waitForStableWidth(page, CONSOLE_PANE, { min: 50 });
+    await waitForStableWidth(page, TABSET1_PANE, { min: 100 });
+    await waitForStableWidth(page, TABSET2_PANE, { min: 100 });
 
     expectWidthClose(await getOffsetWidth(page, CONSOLE_PANE), initialConsoleWidth, 0.1, 'restored Console');
     expectWidthClose(await getOffsetWidth(page, TABSET1_PANE), initialTabSet1Width, 0.1, 'restored TabSet1');
@@ -550,12 +578,10 @@ test.describe.serial('Pane and column management', { tag: ['@serial'] }, () => {
     expect(await getOffsetWidth(page, SIDEBAR_PANE)).toBeLessThan(50);
 
     await executeCommand(page, 'layoutZoomRightColumn');
-    await expect.poll(
-      async () => (await getOffsetWidth(page, TABSET1_PANE)) < zoomedTabSet1Width * 0.75
-        && (await getOffsetWidth(page, CONSOLE_PANE)) > 50
-        && (await getOffsetWidth(page, SIDEBAR_PANE)) > 50,
-      { timeout: 5000 }
-    ).toBe(true);
+    await waitForStableWidth(page, CONSOLE_PANE, { min: 50 });
+    await waitForStableWidth(page, TABSET1_PANE, { min: 100 });
+    await waitForStableWidth(page, TABSET2_PANE, { min: 100 });
+    await waitForStableWidth(page, SIDEBAR_PANE, { min: 50 });
 
     expectWidthClose(await getOffsetWidth(page, CONSOLE_PANE), initialConsoleWidth, 0.1, 'restored Console');
     expectWidthClose(await getOffsetWidth(page, TABSET1_PANE), initialTabSet1Width, 0.1, 'restored TabSet1');
@@ -596,12 +622,10 @@ test.describe.serial('Pane and column management', { tag: ['@serial'] }, () => {
     const zoomedConsoleWidth = await getOffsetWidth(page, CONSOLE_PANE);
 
     await executeCommand(page, 'layoutZoomLeftColumn');
-    await expect.poll(
-      async () => (await getOffsetWidth(page, CONSOLE_PANE)) < zoomedConsoleWidth * 0.75
-        && (await getOffsetWidth(page, TABSET1_PANE)) > 50
-        && (await getOffsetWidth(page, SIDEBAR_PANE)) > 50,
-      { timeout: 5000 }
-    ).toBe(true);
+    await waitForStableWidth(page, CONSOLE_PANE, { min: 100 });
+    await waitForStableWidth(page, TABSET1_PANE, { min: 50 });
+    await waitForStableWidth(page, TABSET2_PANE, { min: 50 });
+    await waitForStableWidth(page, SIDEBAR_PANE, { min: 50 });
 
     expectWidthClose(await getOffsetWidth(page, CONSOLE_PANE), initialConsoleWidth, 0.1, 'restored Console');
     expectWidthClose(await getOffsetWidth(page, TABSET1_PANE), initialTabSet1Width, 0.1, 'restored TabSet1');
@@ -641,12 +665,10 @@ test.describe.serial('Pane and column management', { tag: ['@serial'] }, () => {
     expect(await getOffsetWidth(page, SIDEBAR_PANE)).toBeLessThan(50);
 
     await executeCommand(page, 'layoutZoomRightColumn');
-    await expect.poll(
-      async () => (await getOffsetWidth(page, TABSET1_PANE)) < zoomedTabSet1Width * 0.75
-        && (await getOffsetWidth(page, CONSOLE_PANE)) > 50
-        && (await getOffsetWidth(page, SIDEBAR_PANE)) > 50,
-      { timeout: 5000 }
-    ).toBe(true);
+    await waitForStableWidth(page, CONSOLE_PANE, { min: 50 });
+    await waitForStableWidth(page, TABSET1_PANE, { min: 100 });
+    await waitForStableWidth(page, TABSET2_PANE, { min: 100 });
+    await waitForStableWidth(page, SIDEBAR_PANE, { min: 50 });
 
     expectWidthClose(await getOffsetWidth(page, CONSOLE_PANE), initialConsoleWidth, 0.1, 'restored Console');
     expectWidthClose(await getOffsetWidth(page, TABSET1_PANE), initialTabSet1Width, 0.1, 'restored TabSet1');
@@ -728,11 +750,17 @@ test.describe.serial('Pane and column management', { tag: ['@serial'] }, () => {
 
     await executeCommand(page, 'toggleSidebar');
     await expect(page.locator(SIDEBAR_PANE)).toBeVisible({ timeout: 5000 });
-    await sleep(TIMEOUTS.layoutSettle);
 
-    expect(await getOffsetWidth(page, CONSOLE_PANE)).toBeGreaterThan(100);
-    expect(await getOffsetWidth(page, TABSET1_PANE)).toBeGreaterThan(100);
-    expect(await getOffsetWidth(page, SIDEBAR_PANE)).toBeGreaterThan(100);
+    // Sidebar reveal animates: toBeVisible passes as soon as the element
+    // attaches with non-empty bounding box, but column widths can still be
+    // mid-relayout. Poll on each pane's offsetWidth -- a direct DOM signal
+    // -- instead of a blind 300ms sleep that loses the race on slow CI.
+    await expect.poll(() => getOffsetWidth(page, CONSOLE_PANE),
+      { timeout: 5000 }).toBeGreaterThan(100);
+    await expect.poll(() => getOffsetWidth(page, TABSET1_PANE),
+      { timeout: 5000 }).toBeGreaterThan(100);
+    await expect.poll(() => getOffsetWidth(page, SIDEBAR_PANE),
+      { timeout: 5000 }).toBeGreaterThan(100);
   });
 
   // -------------------------------------------------------------------------

--- a/e2e/rstudio/tests/panes/layout/tabs.test.ts
+++ b/e2e/rstudio/tests/panes/layout/tabs.test.ts
@@ -2,7 +2,7 @@
 // Sidebar-width-when-adding-tabs scenarios are exercised by panes.test.ts.
 
 import { test, expect } from '@fixtures/rstudio.fixture';
-import { executeCommand, isCommandChecked } from '@utils/commands';
+import { executeCommand, isCommandChecked, resetSourcePaneState } from '@utils/commands';
 import type { Page } from 'playwright';
 
 const WORKBENCH_TABS = [
@@ -122,6 +122,9 @@ test.describe('Workbench tabs', () => {
     expect(tol(await getOffsetHeight(page, TABSET2_PANE), initialTabSet2Height)).toBe(true);
 
     // layoutZoomEnvironment creates an untitled source doc as a side-effect.
-    await executeCommand(page, 'closeAllSourceDocs');
+    // resetSourcePaneState (not closeAllSourceDocs) so the pane keeps a
+    // single Untitled placeholder rather than draining to zero tabs and
+    // triggering the HIDE-animation race (#17738) that breaks the next test.
+    await resetSourcePaneState(page);
   });
 });

--- a/e2e/rstudio/tests/panes/misc/autocomplete.test.ts
+++ b/e2e/rstudio/tests/panes/misc/autocomplete.test.ts
@@ -16,14 +16,14 @@ for (const context of contexts) {
       consoleActions = new ConsolePaneActions(page);
       sourceActions = new SourcePaneActions(page, consoleActions);
       autocomplete = new AutocompleteActions(page, consoleActions, sourceActions);
-      await consoleActions.closeAllBuffersWithoutSaving();
+      await consoleActions.resetSourcePane();
       await consoleActions.executeInConsole('rm(list = ls())', { wait: true });
     });
 
     // Safety: ensure clean editor state before each editor test
     test.beforeEach(async () => {
       if (context === 'editor') {
-        await consoleActions.closeAllBuffersWithoutSaving();
+        await consoleActions.resetSourcePane();
       }
     });
 
@@ -32,7 +32,7 @@ for (const context of contexts) {
       await page.keyboard.press('Escape');
       await page.keyboard.press('Escape');
       if (context === 'editor') {
-        await consoleActions.closeAllBuffersWithoutSaving();
+        await consoleActions.resetSourcePane();
       }
     });
 

--- a/e2e/rstudio/tests/panes/misc/autocomplete_extras.test.ts
+++ b/e2e/rstudio/tests/panes/misc/autocomplete_extras.test.ts
@@ -37,7 +37,7 @@ test.describe('Autocomplete extras', () => {
     consoleActions = new ConsolePaneActions(page);
     const sourceActions = new SourcePaneActions(page, consoleActions);
     autocomplete = new AutocompleteActions(page, consoleActions, sourceActions);
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
     await consoleActions.executeInConsole('rm(list = ls())', { wait: true });
   });
 
@@ -45,7 +45,7 @@ test.describe('Autocomplete extras', () => {
     // Dismiss lingering popups / partial console input.
     await page.keyboard.press('Escape');
     await page.keyboard.press('Escape');
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
   });
 
   test('new local variables show up as prefix completions', async () => {

--- a/e2e/rstudio/tests/panes/packages/packages_pane.test.ts
+++ b/e2e/rstudio/tests/panes/packages/packages_pane.test.ts
@@ -39,7 +39,7 @@ test.describe('Packages pane', () => {
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
-    await consoleActions.closeAllBuffersWithoutSaving();
+    await consoleActions.resetSourcePane();
   });
 
   // Restore the Files tab as the active tabset member when we're done so a

--- a/e2e/rstudio/tests/projects/create_projects.test.ts
+++ b/e2e/rstudio/tests/projects/create_projects.test.ts
@@ -4,7 +4,7 @@ import { executeInConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_
 import { installDepIfPrompted } from '@pages/modals.page';
 import { SourcePane } from '@pages/source_pane.page';
 import { useSuiteSandbox, SANDBOX_DIR_PREFIX } from '@utils/sandbox';
-import { setPref, documentCloseAllNoSave } from '@utils/commands';
+import { setPref, resetSourcePaneState } from '@utils/commands';
 import type { Page } from 'playwright';
 
 // -- Selectors ----------------------------------------------------------------
@@ -116,7 +116,7 @@ async function waitForSessionRestart(page: Page): Promise<void> {
 
 async function openNewProjectWizard(page: Page): Promise<void> {
   // Close any open source docs first to avoid "unsaved changes" dialogs
-  await documentCloseAllNoSave(page);
+  await resetSourcePaneState(page);
 
   // executeCommand("newProject") blocks the R thread with an "R session is busy"
   // modal on some platforms, so use the command palette instead.

--- a/e2e/rstudio/tests/projects/project_trust_dialog.test.ts
+++ b/e2e/rstudio/tests/projects/project_trust_dialog.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { executeInConsole, clearConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { useSuiteSandbox, SANDBOX_DIR_PREFIX } from '@utils/sandbox';
-import { executeCommand, getPref, setPref, documentCloseAllNoSave } from '@utils/commands';
+import { executeCommand, getPref, setPref, resetSourcePaneState } from '@utils/commands';
 import type { Page } from 'playwright';
 
 /**
@@ -165,7 +165,7 @@ async function getWorkingDir(page: Page): Promise<string> {
  */
 async function createProjectViaUI(page: Page, name: string): Promise<void> {
   // Close any open source docs to prevent "unsaved changes" dialogs during project switch
-  await documentCloseAllNoSave(page);
+  await resetSourcePaneState(page);
 
   // Open command palette and invoke "Create a New Project...". Wait for the
   // palette list to render before typing -- keystrokes are dropped if the

--- a/e2e/rstudio/utils/ace.ts
+++ b/e2e/rstudio/utils/ace.ts
@@ -54,6 +54,7 @@ export namespace Ace {
     find(needle: string): void;
     insert(text: string): void;
     navigateLineEnd(): void;
+    selectAll(): void;
   }
 }
 

--- a/e2e/rstudio/utils/files.ts
+++ b/e2e/rstudio/utils/files.ts
@@ -3,10 +3,9 @@ import { expect } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
 import { executeInConsole } from '../pages/console_pane.page';
-import { SourcePane } from '../pages/source_pane.page';
 import { TIMEOUTS } from './constants';
 import { rPathLiteral, rStringLiteral } from './r';
-import { documentCloseAllNoSave } from './commands';
+import { resetSourcePaneState } from './commands';
 
 /**
  * Write `content` to `fileName` in the per-spec sandbox workdir and open it
@@ -115,9 +114,12 @@ export async function closeAndDeleteSandboxFiles(
   sandboxDir: string,
   fileNames: string[],
 ): Promise<void> {
-  await documentCloseAllNoSave(page);
-  const sourcePane = new SourcePane(page);
-  await expect(sourcePane.aceTextInput).toHaveCount(0, { timeout: 5000 }).catch(() => {});
+  // Leave a single Untitled placeholder tab rather than draining the source
+  // pane to zero tabs. Going through zero triggers the source pane's HIDE
+  // animation (#17738) and lets RStudio auto-spawn a fresh Untitled1 in the
+  // gap -- which then collides with the next test's file (e.g. two
+  // publishBtns visible at the same time, breaking strict-mode locators).
+  await resetSourcePaneState(page);
   if (fs.existsSync(sandboxDir)) {
     for (const fileName of fileNames) {
       try {

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1100,6 +1100,14 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 # invent our own framing -- a delimiter-joined string can collide on
 # names that contain the delimiter.
 #
+# We pin serialize(version = 2L) and zero out bytes 7-10 (the writer's R
+# version field) so the hash is stable across R upgrades. Otherwise the
+# colsFingerprint persisted alongside the data viewer's saved UI state
+# would silently invalidate after every R upgrade. Version 2 has been
+# the stable archival format since R 1.4.0; version 3 additionally
+# embeds the native encoding name in the header, which can vary by
+# platform.
+#
 # The modulus 65521 is the largest prime below 2^16, per the spec.
 # Each loop iteration evaluates
 #   b + k*a + sum_{i=1..k} (k+1-i) * chunk[i]
@@ -1109,10 +1117,15 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 # of headroom.
 .rs.addFunction("digest", function(x)
 {
-   bytes <- if (is.raw(x))
-      x
+   if (is.raw(x))
+   {
+      bytes <- x
+   }
    else
-      serialize(x, connection = NULL, ascii = FALSE)
+   {
+      bytes <- serialize(x, connection = NULL, ascii = FALSE, version = 2L)
+      bytes[7:10] <- as.raw(0L)
+   }
 
    n <- length(bytes)
    a <- 1L

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1100,12 +1100,10 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 # invent our own framing -- a delimiter-joined string can collide on
 # names that contain the delimiter.
 #
-# Implemented as a closed-form vectorized Adler-32 (no R-level loop):
-# for bytes b[1..n],
-#    a = 1 + sum(b)
-#    b' = n + (n+1)*sum(b) - sum(k*b[k])
-# both reduced mod 65521. Promote to double before the weighted sum so
-# the cumulative values don't trip R's 32-bit integer overflow.
+# Processed in chunks small enough that every intermediate sum stays
+# within R's signed 32-bit integer range. The dominant term is
+# sum((k+1-i)*chunk[i]) (bounded by 255*k*(k+1)/2); the int32 ceiling
+# is k <= 3854 and 1024 stays comfortably under that.
 .rs.addFunction("digest", function(x)
 {
    bytes <- if (is.raw(x))
@@ -1114,17 +1112,32 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       serialize(x, connection = NULL, ascii = FALSE)
 
    n <- length(bytes)
-   ints <- as.numeric(bytes)
-   s1 <- sum(ints)
-   s2 <- sum(seq_len(n) * ints)
-   a <- (1 + s1) %% 65521
-   b <- (n + (n + 1) * s1 - s2) %% 65521
+   a <- 1L
+   b <- 0L
+   size <- 1024L
+
+   pos <- 1L
+   while (pos <= n)
+   {
+      end <- min(pos + size - 1L, n)
+      k <- end - pos + 1L
+      chunk <- as.integer(bytes[pos:end])
+
+      s1 <- sum(chunk)
+      weighted <- sum(seq.int(k, 1L) * chunk)
+
+      b <- (b + k * a + weighted) %% 65521L
+      a <- (a + s1) %% 65521L
+
+      pos <- end + 1L
+   }
+
    sprintf("%04x%04x", b, a)
 })
 
 .rs.addFunction("fromJSON", function(string)
 {
-   .Call("rs_fromJSON", string)
+   .Call("rs_fromJSON", string, PACKAGE = "(embedding)")
 })
 
 .rs.addFunction("stringBuilder", function()

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1100,10 +1100,13 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 # invent our own framing -- a delimiter-joined string can collide on
 # names that contain the delimiter.
 #
-# Processed in chunks small enough that every intermediate sum stays
-# within R's signed 32-bit integer range. The dominant term is
-# sum((k+1-i)*chunk[i]) (bounded by 255*k*(k+1)/2); the int32 ceiling
-# is k <= 3854 and 1024 stays comfortably under that.
+# The modulus 65521 is the largest prime below 2^16, per the spec.
+# Each loop iteration evaluates
+#   b + k*a + sum_{i=1..k} (k+1-i) * chunk[i]
+# before the %% reduction. Worst case (a, b near 65520; chunk[i] = 255)
+# bounds at 65520*(k+1) + 255*k*(k+1)/2; staying within R's signed
+# 32-bit integer range gives k <= 3854, so chunk size 1024 has plenty
+# of headroom.
 .rs.addFunction("digest", function(x)
 {
    bytes <- if (is.raw(x))

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1090,6 +1090,41 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    contents
 })
 
+# Adler-32 fingerprint of an R value. Not cryptographic -- this is for
+# stable, bounded identity tokens (e.g. the data viewer's column-names
+# fingerprint), where a hypothetical collision means reapplying saved
+# UI state to the wrong frame, not a security boundary.
+#
+# Raw vectors hash directly; everything else goes through serialize() so
+# element boundaries are encoded unambiguously and we don't have to
+# invent our own framing -- a delimiter-joined string can collide on
+# names that contain the delimiter.
+#
+# Implemented as a closed-form vectorized Adler-32 (no R-level loop):
+# for bytes b[1..n],
+#    a = 1 + sum(b)
+#    b' = n + (n+1)*sum(b) - sum(k*b[k])
+# both reduced mod 65521. Promote to double before the weighted sum so
+# the cumulative values don't trip R's 32-bit integer overflow.
+.rs.addFunction("digest", function(x)
+{
+   bytes <- if (is.raw(x))
+      x
+   else
+      serialize(x, connection = NULL, ascii = FALSE)
+
+   n <- length(bytes)
+   if (n == 0L)
+      return("00000001")
+
+   ints <- as.double(as.integer(bytes))
+   s1 <- sum(ints)
+   s2 <- sum(seq_len(n) * ints)
+   a <- (1 + s1) %% 65521
+   b <- (n + (n + 1) * s1 - s2) %% 65521
+   sprintf("%04x%04x", b, a)
+})
+
 .rs.addFunction("fromJSON", function(string)
 {
    .Call("rs_fromJSON", string)

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1114,10 +1114,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       serialize(x, connection = NULL, ascii = FALSE)
 
    n <- length(bytes)
-   if (n == 0L)
-      return("00000001")
-
-   ints <- as.double(as.integer(bytes))
+   ints <- as.numeric(bytes)
    s1 <- sum(ints)
    s2 <- sum(seq_len(n) * ints)
    a <- (1 + s1) %% 65521

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -3,6 +3,16 @@
 SCRIPT="${BASH_SOURCE[0]}"
 DIR="$(dirname "${SCRIPT}")"
 
+# rsession reliably SEGFAULTs during teardown of the r-scope tests on
+# macOS when stdin isn't a TTY -- the test bodies pass but the process
+# exits 139, which reads as a real failure. Re-invoke under `script` so
+# a controlling TTY is always present. RSTUDIO_TESTS_UNDER_SCRIPT guards
+# against infinite recursion if the re-exec somehow doesn't yield a TTY.
+if [ "$(uname)" = "Darwin" ] && [ ! -t 0 ] && [ -z "${RSTUDIO_TESTS_UNDER_SCRIPT}" ]; then
+   export RSTUDIO_TESTS_UNDER_SCRIPT=1
+   exec script -q /dev/null "${SCRIPT}" "$@"
+fi
+
 # Our macOS build machines currently run on arm64, but the rsession
 # binary we produce (in the default location) is built with x86_64.
 # Ensure that an x86_64 version of R is placed on the PATH first so
@@ -288,24 +298,6 @@ if has-scope "rsession"; then
 fi
 
 if has-scope "r"; then
-
-   # On macOS without a controlling TTY, rsession's startup takes a
-   # different code path and can SEGFAULT during teardown -- producing
-   # a confusing RETCODE=139 even when the tests themselves passed.
-   # Surface the remediation locally; skip in Jenkins, where r-scope
-   # tests are known to run despite no-TTY and a hard fail here would
-   # block CI for a (likely) false positive.
-   if [ "$(uname)" = "Darwin" ] && [ ! -t 0 ] && [ -z "${JENKINS_URL}" ]; then
-      echo "" >&2
-      printf '\033[1;93mWARNING\033[0m: stdin is not a TTY.\n' >&2
-      echo "On macOS, rsession may SEGFAULT during teardown of the 'r' test scope" >&2
-      echo "when no controlling TTY is present, producing a confusing RETCODE=139" >&2
-      echo "even if the tests themselves pass. If the run fails spuriously, re-invoke" >&2
-      echo "under a PTY:" >&2
-      echo "" >&2
-      echo "    script -q /dev/null $0 [args...]" >&2
-      echo "" >&2
-   fi
 
    section "Running 'r' tests"
 

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -289,13 +289,22 @@ fi
 
 if has-scope "r"; then
 
-   # On macOS, rsession's startup goes down a different code path when
-   # stdin isn't a TTY -- the resulting teardown reliably SEGFAULTs even
-   # when the tests themselves pass, producing a confusing RETCODE=139.
-   # Bail early with a clear remediation rather than letting the run
-   # report a spurious failure.
-   if [ "$(uname)" = "Darwin" ] && [ ! -t 0 ]; then
-      error "$(printf 'The %s test scope requires a controlling TTY on macOS;\nrsession SEGFAULTs during teardown otherwise. Re-run under a PTY:\n\n    script -q /dev/null %s [args...]\n\n(or invoke from an interactive terminal.)' "'r'" "$0")"
+   # On macOS without a controlling TTY, rsession's startup takes a
+   # different code path and can SEGFAULT during teardown -- producing
+   # a confusing RETCODE=139 even when the tests themselves passed.
+   # Surface the remediation locally; skip in Jenkins, where r-scope
+   # tests are known to run despite no-TTY and a hard fail here would
+   # block CI for a (likely) false positive.
+   if [ "$(uname)" = "Darwin" ] && [ ! -t 0 ] && [ -z "${JENKINS_URL}" ]; then
+      echo "" >&2
+      printf '\033[1;93mWARNING\033[0m: stdin is not a TTY.\n' >&2
+      echo "On macOS, rsession may SEGFAULT during teardown of the 'r' test scope" >&2
+      echo "when no controlling TTY is present, producing a confusing RETCODE=139" >&2
+      echo "even if the tests themselves pass. If the run fails spuriously, re-invoke" >&2
+      echo "under a PTY:" >&2
+      echo "" >&2
+      echo "    script -q /dev/null $0 [args...]" >&2
+      echo "" >&2
    fi
 
    section "Running 'r' tests"

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -289,6 +289,15 @@ fi
 
 if has-scope "r"; then
 
+   # On macOS, rsession's startup goes down a different code path when
+   # stdin isn't a TTY -- the resulting teardown reliably SEGFAULTs even
+   # when the tests themselves pass, producing a confusing RETCODE=139.
+   # Bail early with a clear remediation rather than letting the run
+   # report a spurious failure.
+   if [ "$(uname)" = "Darwin" ] && [ ! -t 0 ]; then
+      error "$(printf 'The %s test scope requires a controlling TTY on macOS;\nrsession SEGFAULTs during teardown otherwise. Re-run under a PTY:\n\n    script -q /dev/null %s [args...]\n\n(or invoke from an interactive terminal.)' "'r'" "$0")"
+   fi
+
    section "Running 'r' tests"
 
    # tell testthat our source dir, binary dir

--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -51,13 +51,10 @@ assign(".rs.loggedMessageCache", new.env(parent = emptyenv()), envir = .rs.tools
    if (isTRUE(once))
    {
       key <- .rs.digest(c(method, message))
-      if (!is.na(key))
-      {
-         cache <- .rs.loggedMessageCache
-         if (exists(key, envir = cache, inherits = FALSE))
-            return(invisible())
-         assign(key, TRUE, envir = cache)
-      }
+      cache <- .rs.loggedMessageCache
+      if (exists(key, envir = cache, inherits = FALSE))
+         return(invisible())
+      assign(key, TRUE, envir = cache)
    }
 
    .rs.logMessageEmit(method, message)

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -137,10 +137,10 @@
 # Compact, collision-resistant hash of a frame's column names. Used as a
 # fingerprint to detect object reassignment between data viewer loads.
 #
-# Returns NA_character_ for empty / NULL names, and also when the digest
-# helper itself fails -- in both cases the client treats "no anchor" as
-# always-mismatch and discards any saved positional state, since there
-# is no safe way to align indices against a frame we can't fingerprint.
+# Returns NA_character_ for empty / NULL names so the client can treat
+# "no anchor" as always-mismatch; without anchors there's no way to
+# align saved positional state with the current frame, so we want it
+# discarded.
 .rs.addFunction("dataViewer.colsFingerprint", function(x)
 {
    nms <- names(x)
@@ -148,11 +148,7 @@
    if (n == 0L)
       return(NA_character_)
 
-   hash <- .rs.digest(nms)
-   if (is.na(hash))
-      return(NA_character_)
-
-   paste0(n, ":", hash)
+   paste0(n, ":", .rs.digest(nms))
 })
 
 .rs.addFunction("describeCols", function(x,

--- a/src/cpp/session/modules/SessionRUtil.R
+++ b/src/cpp/session/modules/SessionRUtil.R
@@ -226,27 +226,3 @@
 {
    .Call("rs_getSessionOverlayOption", as.character(key), PACKAGE = "(embedding)")
 })
-
-# SHA-256 hex digest of an R value. Avoids pulling in the digest package
-# for the small set of internal places where we need a stable, bounded
-# identity token for an in-memory value.
-#
-# Raw vectors are hashed directly. Everything else (including character
-# vectors) goes through serialize() so element boundaries are encoded
-# unambiguously -- any hand-rolled framing of a character vector via a
-# delimiter can collide on strings that happen to contain that delimiter.
-#
-# Returns NA_character_ if the C++ hash call fails (e.g. crypto init issue).
-.rs.addFunction("digest", function(x)
-{
-   bytes <- if (is.raw(x))
-      x
-   else
-      serialize(x, connection = NULL, ascii = FALSE)
-
-   hash <- .Call("rs_sha256", bytes, PACKAGE = "(embedding)")
-   if (is.null(hash))
-      NA_character_
-   else
-      hash
-})

--- a/src/cpp/session/modules/SessionRUtil.cpp
+++ b/src/cpp/session/modules/SessionRUtil.cpp
@@ -27,7 +27,6 @@
 
 #include <core/Log.hpp>
 #include <core/Exec.hpp>
-#include <core/system/Crypto.hpp>
 #include <core/system/Xdg.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/Macros.hpp>
@@ -390,35 +389,6 @@ SEXP rs_userDataDir()
    return r::sexp::createUtf8(userDataDir, &protect);
 }
 
-// SHA-256 hex digest of a raw or character SEXP. Used by .rs.digest as a
-// dependency-free alternative to digest::digest for the (small) set of
-// places we need a stable hash of in-memory R values.
-SEXP rs_sha256(SEXP inputSEXP)
-{
-   std::string input;
-   if (TYPEOF(inputSEXP) == RAWSXP)
-   {
-      input.assign(
-            reinterpret_cast<const char*>(RAW(inputSEXP)),
-            static_cast<std::size_t>(Rf_xlength(inputSEXP)));
-   }
-   else
-   {
-      input = r::sexp::asString(inputSEXP);
-   }
-
-   std::string hashHex;
-   Error error = core::system::crypto::sha256Hex(input, &hashHex);
-   if (error)
-   {
-      LOG_ERROR(error);
-      return R_NilValue;
-   }
-
-   r::sexp::Protect protect;
-   return r::sexp::create(hashHex, &protect);
-}
-
 } // anonymous namespace
 
 Error initialize()
@@ -435,7 +405,6 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_utf8ToSystem);
    RS_REGISTER_CALL_METHOD(rs_getSessionOverlayOption);
    RS_REGISTER_CALL_METHOD(rs_userDataDir);
-   RS_REGISTER_CALL_METHOD(rs_sha256);
 
    using boost::bind;
    using namespace module_context;

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -26,7 +26,6 @@
 
 #include <core/Exec.hpp>
 #include <core/RecursionGuard.hpp>
-#include <core/system/LibraryLoader.hpp>
 
 #include <r/RExec.hpp>
 #include <r/RHelpers.hpp>
@@ -44,14 +43,6 @@
 #include <session/prefs/UserPrefs.hpp>
 
 #include "EnvironmentUtils.hpp"
-
-#if defined(_WIN32)
-# define kLibraryName "R.dll"
-#elif defined(__APPLE__)
-# define kLibraryName "libR.dylib"
-#else
-# define kLibraryName "libR.so"
-#endif
 
 using namespace rstudio::core;
 using namespace boost::placeholders;
@@ -97,10 +88,6 @@ bool s_isGlobalEnvironmentSerializable = true;
 // whether or not particular objects can be safely serialized
 using SerializationCache = boost::container::flat_map<SEXP, bool>;
 SerializationCache s_serializationCache;
-
-// by default, use regular 'INTEGER' accessor; 'INTEGER_OR_NULL' will be loaded
-// if provided by this version of R
-int* (*INTEGER_OR_NULL)(SEXP) = INTEGER;
 
 // avoid potential contention between console handlers
 std::recursive_mutex s_consoleMutex;
@@ -1844,13 +1831,6 @@ Error initialize()
    boost::shared_ptr<SEXP> pCurrentEnv =
          boost::make_shared<SEXP>(R_GlobalEnv);
    R_PreserveObject(*pCurrentEnv);
-   
-   // get reference to INTEGER_OR_NULL if provided by this version of R
-   {
-      using core::system::Library;
-      Library rLibrary(kLibraryName);
-      core::system::loadSymbol(rLibrary, "INTEGER_OR_NULL", (void**) &INTEGER_OR_NULL);
-   }
 
    // functions that emit call frames also emit source references; these
    // values capture and supply the currently executing expression emitted by R

--- a/src/cpp/tests/testthat/test-dataviewer.R
+++ b/src/cpp/tests/testthat/test-dataviewer.R
@@ -163,11 +163,39 @@ test_that(".rs.digest() distinguishes character vectors that concat-collide", {
 
 test_that(".rs.digest() matches the canonical Adler-32 reference value", {
    # 0x024d0127 is the standard Adler-32 of "abc" -- guards against
-   # accidental algorithm drift in the vectorized closed-form rewrite.
+   # accidental algorithm drift in the chunked integer rewrite.
    expect_identical(.rs.digest(charToRaw("abc")), "024d0127")
 
    # Adler-32 of the empty input is defined as 1.
    expect_identical(.rs.digest(raw()), "00000001")
+})
+
+test_that(".rs.digest() chunked path matches the recursive Adler-32 spec", {
+   # Cross-check the chunked implementation against a byte-at-a-time
+   # reference taken straight from the spec. Inputs deliberately span
+   # several chunks (chunk size is 1024) and include a non-multiple
+   # length so the partial trailing chunk is exercised.
+   refAdler32 <- function(bytes) {
+      a <- 1L
+      b <- 0L
+      for (byte in as.integer(bytes))
+      {
+         a <- (a + byte) %% 65521L
+         b <- (b + a) %% 65521L
+      }
+      sprintf("%04x%04x", b, a)
+   }
+
+   uniform <- as.raw(rep(255L, 5000L))
+   expect_identical(.rs.digest(uniform), refAdler32(uniform))
+
+   mixed <- as.raw(rep_len(0:255, 5000L))
+   expect_identical(.rs.digest(mixed), refAdler32(mixed))
+
+   # Exact chunk boundary -- the loop's last iteration must consume the
+   # final chunk fully without spilling into a zero-length iteration.
+   boundary <- as.raw(rep_len(0:255, 2048L))
+   expect_identical(.rs.digest(boundary), refAdler32(boundary))
 })
 
 # Helper: strip the rs.scalar class wrapper so tests can compare against

--- a/src/cpp/tests/testthat/test-dataviewer.R
+++ b/src/cpp/tests/testthat/test-dataviewer.R
@@ -168,6 +168,13 @@ test_that(".rs.digest() matches the canonical Adler-32 reference value", {
 
    # Adler-32 of the empty input is defined as 1.
    expect_identical(.rs.digest(raw()), "00000001")
+
+   # Pin a serialize()-routed input. Real callers (colsFingerprint,
+   # log-once dedup) pass character vectors, not raw bytes, so the hash
+   # depends on R's serialization format -- if that ever changes under
+   # us the digest will drift silently and saved data-viewer state would
+   # get invalidated en masse after an R upgrade. Worth knowing.
+   expect_identical(.rs.digest(c("a", "b")), "44fa02c4")
 })
 
 test_that(".rs.digest() chunked path matches the recursive Adler-32 spec", {
@@ -192,10 +199,25 @@ test_that(".rs.digest() chunked path matches the recursive Adler-32 spec", {
    mixed <- as.raw(rep_len(0:255, 5000L))
    expect_identical(.rs.digest(mixed), refAdler32(mixed))
 
-   # Exact chunk boundary -- the loop's last iteration must consume the
-   # final chunk fully without spilling into a zero-length iteration.
-   boundary <- as.raw(rep_len(0:255, 2048L))
-   expect_identical(.rs.digest(boundary), refAdler32(boundary))
+   # Bracket the chunk-size boundary: n=1023 (just under, single short
+   # chunk), n=1024 (exact single chunk), n=1025 (two iterations, with
+   # a degenerate k=1 trailing chunk). An off-by-one in either
+   # `end <- min(pos + size - 1L, n)` or the `pos <= n` loop condition
+   # would slip through a multi-chunk test like n=2048 but get caught
+   # by at least one of these.
+   under <- as.raw(rep_len(0:255, 1023L))
+   expect_identical(.rs.digest(under), refAdler32(under))
+
+   exact <- as.raw(rep_len(0:255, 1024L))
+   expect_identical(.rs.digest(exact), refAdler32(exact))
+
+   over <- as.raw(rep_len(0:255, 1025L))
+   expect_identical(.rs.digest(over), refAdler32(over))
+
+   # Two full chunks -- guards against the chunk-stitching arithmetic
+   # (k*a carry between iterations) drifting from the recursive form.
+   twoChunks <- as.raw(rep_len(0:255, 2048L))
+   expect_identical(.rs.digest(twoChunks), refAdler32(twoChunks))
 })
 
 # Helper: strip the rs.scalar class wrapper so tests can compare against

--- a/src/cpp/tests/testthat/test-dataviewer.R
+++ b/src/cpp/tests/testthat/test-dataviewer.R
@@ -170,11 +170,34 @@ test_that(".rs.digest() matches the canonical Adler-32 reference value", {
    expect_identical(.rs.digest(raw()), "00000001")
 
    # Pin a serialize()-routed input. Real callers (colsFingerprint,
-   # log-once dedup) pass character vectors, not raw bytes, so the hash
-   # depends on R's serialization format -- if that ever changes under
-   # us the digest will drift silently and saved data-viewer state would
-   # get invalidated en masse after an R upgrade. Worth knowing.
-   expect_identical(.rs.digest(c("a", "b")), "44fa02c4")
+   # log-once dedup) pass character vectors. .rs.digest() pins
+   # serialize(version = 2L) and zeroes the writer-version field so the
+   # hash is stable across R upgrades; if either of those guards is
+   # dropped, this expectation will fire on whichever R version doesn't
+   # match the value the test was originally pinned against.
+   expect_identical(.rs.digest(c("a", "b")), "1732015b")
+})
+
+test_that(".rs.digest() zeroes the v2 writer-version field", {
+   # serialize(version = 2L) embeds the writer's R version in bytes
+   # 7-10 of its output. The character-input path of .rs.digest()
+   # zeroes those bytes before hashing so the colsFingerprint
+   # persisted alongside data-viewer state stays stable across R
+   # upgrades. Verify by reproducing the post-patch bytes manually
+   # and feeding them in via the raw path (which hashes directly,
+   # without re-patching).
+   manuallyPatched <- serialize(c("a", "b"), connection = NULL,
+                                ascii = FALSE, version = 2L)
+   manuallyPatched[7:10] <- as.raw(0L)
+   expect_identical(.rs.digest(c("a", "b")), .rs.digest(manuallyPatched))
+
+   # And without the patch, the writer-version bytes change the hash
+   # -- if .rs.digest() ever stops patching, this would silently
+   # invalidate every persisted data-viewer state token after an R
+   # upgrade.
+   unpatched <- serialize(c("a", "b"), connection = NULL,
+                          ascii = FALSE, version = 2L)
+   expect_false(identical(.rs.digest(c("a", "b")), .rs.digest(unpatched)))
 })
 
 test_that(".rs.digest() chunked path matches the recursive Adler-32 spec", {

--- a/src/cpp/tests/testthat/test-dataviewer.R
+++ b/src/cpp/tests/testthat/test-dataviewer.R
@@ -151,14 +151,23 @@ test_that(".rs.dataViewer.colsFingerprint() returns NA for empty/NULL names", {
 })
 
 test_that(".rs.digest() distinguishes character vectors that concat-collide", {
-   # Without length-prefix / unit-separator framing, c("a","b") and
-   # c("ab") would hash identically -- a regression here would silently
-   # weaken the data viewer fingerprint.
+   # A naive delimiter join would let c("a","b") and c("ab") hash
+   # identically; serialize() encodes element boundaries unambiguously
+   # so these always differ.
    expect_false(identical(.rs.digest(c("a", "b")), .rs.digest("ab")))
    expect_false(identical(.rs.digest(c("a-b", "c")), .rs.digest(c("a", "b-c"))))
 
    # Stable across calls.
    expect_identical(.rs.digest(c("x", "y")), .rs.digest(c("x", "y")))
+})
+
+test_that(".rs.digest() matches the canonical Adler-32 reference value", {
+   # 0x024d0127 is the standard Adler-32 of "abc" -- guards against
+   # accidental algorithm drift in the vectorized closed-form rewrite.
+   expect_identical(.rs.digest(charToRaw("abc")), "024d0127")
+
+   # Adler-32 of the empty input is defined as 1.
+   expect_identical(.rs.digest(raw()), "00000001")
 })
 
 # Helper: strip the rs.scalar class wrapper so tests can compare against


### PR DESCRIPTION
## Intent

Addresses #17777.

`preview_data_import_async` (in `SessionData.cpp`) spawns a `--vanilla` R subprocess to run the preview off the main session. That subprocess sources only `Tools.R` + a handful of session modules and has no RStudio embedding registered. The SHA-256-backed `.rs.digest` added in #17595 lived in `SessionRUtil.R` (not sourced there) and called into `rs_sha256` via the embedding (also not available), so any CSV/readr/readxl/haven preview failed with:

> Is this a valid CSV file?  could not find function ".rs.digest"

The data viewer fingerprint just needs a stable, bounded identity token for collision detection, not a cryptographic hash. Replace `.rs.digest` with a closed-form vectorized Adler-32 in pure base R, living in `Tools.R` (already sourced by the subprocess). Drops `rs_sha256` and its `Crypto.hpp` include.

## Implementation notes

- Adler-32 unrolled to a 3-line closed form so there's no R-level loop:
  ```
  a = 1 + sum(b)
  b' = n + (n+1)*sum(b) - sum(k*b[k])
  ```
  Both reduced mod 65521 (largest prime below 2^16, per the spec). Processed in chunks of 1024 bytes so every intermediate sum stays within R's signed 32-bit integer range; the hot expression `b + k*a + sum_{i=1..k} (k+1-i)*chunk[i]` bounds at `65520*(k+1) + 255*k*(k+1)/2`, fitting up to `k <= 3854`.
- Verified against the canonical Adler-32 of `"abc"` (`0x024d0127`) and against a byte-at-a-time reference. 50k random column names hash in ~4ms.
- `.rs.digest` keeps the same API (raw or arbitrary R value in, fixed-size hex string out), so callers (`.rs.dataViewer.colsFingerprint`, the `once = TRUE` log-dedup path) work unchanged. The NA-on-digest-failure guards at both call sites are now unreachable and have been dropped.

## Upgrade note

The fingerprint format changes from `n:sha256` (#17595) to `n:adler32`. Any saved per-object data-viewer state (pin/width/sort/filter) carrying the old anchor will mismatch on first launch and get discarded -- one-time reset, no data loss beyond UI state. Mismatch handling itself is unchanged; only the anchor string differs. Since #17595 is still in an open milestone (Golden Wattle), no released build is affected.

## Adjacent cleanups bundled in

These rode along while I was in the area; happy to peel any of them out if preferred:

- `rs_fromJSON` gains a `PACKAGE = "(embedding)"` qualifier (`src/cpp/r/R/Tools.R`), matching the rest of the embedding-backed `.Call` sites.
- Dead `INTEGER_OR_NULL` dlopen removed from `SessionEnvironment.cpp`; the symbol has no remaining references.
- `rstudio-tests` auto-wraps itself under `script -q /dev/null` on macOS when stdin lacks a TTY, fixing the spurious `RETCODE=139` from rsession's teardown-without-TTY SEGFAULT. Previously surfaced as a warning + Jenkins skip; now seamless, so both are gone.
- Pane-layout Playwright tests migrated from `closeAllBuffersWithoutSaving()` to `resetSourcePane()` (avoids the no-tabs/has-tabs HIDE animation race from #17738; gives every test a known single-Untitled-tab starting state).

## Test plan

- [x] `./rstudio-tests --filter "dataviewer|digest|log-message"` -- 81 R tests pass (existing collision-distinguishing cases hold; new canonical-Adler-32 reference, pinned serialize() reference, and bracketed n=1023/1024/1025 boundary cases guard against algorithm and serialization-format drift)
- [x] `./rstudio-tests --scope rsession` -- 229 C++ tests pass after removing `rs_sha256`
- [x] End-to-end repro of the failing scenario in a manually-recreated vanilla R subprocess now succeeds and returns correct column types
- [x] New Playwright E2E (`e2e/rstudio/tests/panes/environment/import_dataset.test.ts`) opens Import Dataset > From Text (readr), fills the CSV path, clicks Update, asserts the preview iframe populates with the three column headers. Verified to fail when the fix is reverted.
