### PR TITLE
test(e2e): expose dialogs.dismissAll automation bridge

### DIFF
--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import stripJsonComments from 'strip-json-comments';
 import { TIMEOUTS, RSTUDIO_EXTRA_ARGS, sleep } from '../utils/constants';
 import { CONSOLE_INPUT, executeInConsole } from '../pages/console_pane.page';
-import { documentCloseAllNoSave, executeCommand } from '../utils/commands';
+import { dismissAllModals, documentCloseAllNoSave, executeCommand } from '../utils/commands';
 import { rLibsUserTemplate } from './r-libs-setup';
 
 const BASE_PREFS_PATH = path.join(__dirname, 'base-prefs.jsonc');
@@ -623,6 +623,16 @@ function getRStudioPids(): Set<number> {
  */
 export async function shutdownRStudio(session: DesktopSession): Promise<void> {
   const { page, browser, rstudioProcess } = session;
+
+  // Dismiss any modal dialogs the test left open. An open GWT modal (Global
+  // Options, Import Dataset, ...) blocks the Electron close path: the
+  // renderer's quit confirmation prompts queue behind the existing modal and
+  // q(save="no") never gets a chance to cascade to a full quit (#17790).
+  try {
+    await dismissAllModals(page);
+  } catch {
+    // Page context may already be gone; we still force-kill below.
+  }
 
   // Close all source files without prompting to save. If a test left the page
   // in the middle of a navigation (e.g. opening a project triggers a session

--- a/e2e/rstudio/tests/panes/misc/dismiss_modals_bridge.test.ts
+++ b/e2e/rstudio/tests/panes/misc/dismiss_modals_bridge.test.ts
@@ -1,0 +1,54 @@
+// Regression test for https://github.com/rstudio/rstudio/issues/17790
+//
+// An open GWT modal dialog blocks the Electron close path: the renderer's
+// quit confirmation prompts queue behind the existing modal, leaving the
+// window in a half-shut-down state until the user manually dismisses it.
+// The automation bridge exposes window.rstudio.dialogs.dismissAll() so test
+// teardown can clear the modal stack before the harness closes the app.
+//
+// This test exercises the bridge directly (open a modal, dismiss it via the
+// bridge, verify the stack is empty and the IDE remains responsive).
+// fixtures/desktop.fixture.ts also calls dismissAllModals() in
+// shutdownRStudio(), so every Desktop test run exercises the cleanup path.
+
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { CONSOLE_INPUT } from '@pages/console_pane.page';
+import {
+  dismissAllModals,
+  executeCommand,
+  numModalsShowing,
+} from '@utils/commands';
+
+const OPTIONS_OK = '#rstudio_preferences_confirm';
+const DIALOG_BOX = '.gwt-DialogBox';
+
+test.describe('Modal dismiss bridge (#17790)', { tag: ['@parallel_safe'] }, () => {
+  test('dismissAll clears an open Global Options dialog', async ({ rstudioPage: page }) => {
+    // Sanity check: no modals at start.
+    expect(await numModalsShowing(page)).toBe(0);
+
+    // Open Tools > Global Options. The OK button ID is the most stable
+    // post-condition that the dialog has actually mounted (the dialog box
+    // class alone matches before the inner content is rendered).
+    await executeCommand(page, 'showOptions');
+    await page.waitForSelector(OPTIONS_OK, { timeout: 15000 });
+    await expect.poll(() => numModalsShowing(page), { timeout: 5000 }).toBe(1);
+
+    // Dismiss via the automation bridge.
+    await dismissAllModals(page);
+
+    // Modal stack and DOM should both report empty.
+    await expect.poll(() => numModalsShowing(page), { timeout: 5000 }).toBe(0);
+    await expect(page.locator(DIALOG_BOX)).toHaveCount(0);
+
+    // Console should still be responsive after the bridge-driven dismissal.
+    await expect(page.locator(CONSOLE_INPUT)).toBeVisible();
+  });
+
+  test('dismissAll is a no-op when no modals are showing', async ({ rstudioPage: page }) => {
+    expect(await numModalsShowing(page)).toBe(0);
+    await dismissAllModals(page);
+    expect(await numModalsShowing(page)).toBe(0);
+    await expect(page.locator(CONSOLE_INPUT)).toBeVisible();
+  });
+});

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -133,12 +133,26 @@ type ChatBridge = {
   setUpdateCheckOverride(override: Record<string, unknown> | null): Promise<void>;
 };
 
+type DialogsBridge = {
+  /** Count of modal dialogs currently in the GWT modal stack. */
+  numShowing(): number;
+  /**
+   * Hide every modal dialog currently in the stack. Useful in test teardown
+   * so a forgotten Tools > Global Options / Import Dataset dialog does not
+   * block the Electron close path -- the renderer's quit confirmation
+   * prompts queue behind an existing modal and the window can end up in a
+   * half-shut-down state.
+   */
+  dismissAll(): void;
+};
+
 type RStudioBridge = {
   commands: { [id: string]: CommandEntry } & { list: string[] };
   prefs: { [name: string]: PrefEntry };
   documents: Documents;
   project: ProjectInfo;
   version: VersionInfo;
+  dialogs: DialogsBridge;
   /** Chat-pane state surface (populated lazily by ChatPresenter). */
   chat?: ChatBridge;
   /**
@@ -391,6 +405,34 @@ export async function clearPref(page: Page, name: string): Promise<void> {
         throw new Error(`Unknown user preference: ${prefName}`);
       await entry.clear();
     }, camel);
+  });
+}
+
+/**
+ * Count of modal dialogs currently in the GWT modal stack.
+ */
+export async function numModalsShowing(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const r = window.rstudio;
+    if (!r)
+      throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
+    return r.dialogs.numShowing();
+  });
+}
+
+/**
+ * Hide every modal dialog currently in the GWT modal stack. Use in test
+ * teardown to keep a leftover dialog (Global Options, Import Dataset, etc.)
+ * from blocking the Electron close path.
+ */
+export async function dismissAllModals(page: Page): Promise<void> {
+  await withBridgeLog('dismissAllModals', '', async () => {
+    await page.evaluate(() => {
+      const r = window.rstudio;
+      if (!r)
+        throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
+      r.dialogs.dismissAll();
+    });
   });
 }
 

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogTracker.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogTracker.java
@@ -75,6 +75,28 @@ public class ModalDialogTracker
    }
 
    /**
+    * Hide every modal dialog currently in the stack. Used during application
+    * shutdown so an open modal cannot prevent the quit path from completing.
+    */
+   public static void dismissAllModalDialogs()
+   {
+      // Iterate over a copy: hide() triggers onUnload() which calls onHide()
+      // and mutates dialogStack_.
+      List<PopupPanel> dialogs = new ArrayList<>(dialogStack_);
+      for (PopupPanel dialog : dialogs)
+      {
+         try
+         {
+            dialog.hide();
+         }
+         catch (Exception e)
+         {
+            Debug.logException(e);
+         }
+      }
+   }
+
+   /**
     * Attempt to dispatch an aria-live message to the topmost popup that supports it, if any.
     * 
     * @param message message to announce

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import org.rstudio.core.client.FilePosition;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.files.FileSystemItem;
+import org.rstudio.core.client.widget.ModalDialogTracker;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.DeferredInitCompletedEvent;
 import org.rstudio.studio.client.application.events.EventBus;
@@ -72,6 +73,9 @@ import com.google.inject.Singleton;
  *   window.rstudio.project.name()       // active project display name, or null
  *   window.rstudio.project.isActive()   // boolean
  *   window.rstudio.project.open(path)   // fire SwitchToProjectEvent; resets ready
+ *
+ *   window.rstudio.dialogs.numShowing()  // count of open modal dialogs
+ *   window.rstudio.dialogs.dismissAll()  // hide every open modal dialog
  * </pre>
  *
  * <h2>Why enumerate everything up front</h2>
@@ -117,6 +121,7 @@ public class ApplicationAutomation
       registerProject();
       registerVersion();
       registerChat();
+      registerDialogs();
       registerReadinessHandlers();
    }
 
@@ -204,6 +209,21 @@ public class ApplicationAutomation
    private void registerChat()
    {
       registerChatObject();
+   }
+
+   private void registerDialogs()
+   {
+      registerDialogsObject();
+   }
+
+   private int numModalsShowing()
+   {
+      return ModalDialogTracker.numModalsShowing();
+   }
+
+   private void dismissAllModals()
+   {
+      ModalDialogTracker.dismissAllModalDialogs();
    }
 
    private void setChatUpdateCheckOverride(JavaScriptObject override,
@@ -548,6 +568,23 @@ public class ApplicationAutomation
          rstudio: rstudio,
          r: r,
       };
+   }-*/;
+
+   // Open modal dialogs block the Electron close path: the renderer's quit
+   // confirmation prompts queue behind the existing modal and the window
+   // ends up in a half-shut-down state until a human dismisses things. Tests
+   // can call dialogs.dismissAll() from afterEach / teardown to clear the
+   // stack before the harness closes the app. numShowing() lets tests assert
+   // that earlier steps left the dialog stack clean.
+   private native final void registerDialogsObject() /*-{
+      var self = this;
+      $wnd.rstudio.dialogs = $wnd.rstudio.dialogs || {};
+      $wnd.rstudio.dialogs.numShowing = $entry(function() {
+         return self.@org.rstudio.studio.client.application.ApplicationAutomation::numModalsShowing()();
+      });
+      $wnd.rstudio.dialogs.dismissAll = $entry(function() {
+         self.@org.rstudio.studio.client.application.ApplicationAutomation::dismissAllModals()();
+      });
    }-*/;
 
    private native final void registerChatObject() /*-{


### PR DESCRIPTION
## Intent

Addresses #17790.

The user-facing bug -- Cmd-Q / File > Quit silently stalling while a GWT modal
(Tools > Global Options, Import Dataset, ...) is open -- is left for a
separate change. This PR scopes the fix to the automation bridge so the
Playwright harness can clean up reliably.

## Summary

- `ModalDialogTracker.dismissAllModalDialogs()` hides every modal in the
  stack (iterating over a copy since `hide()` mutates the stack via
  `onHide()`).
- `ApplicationAutomation` registers a new `dialogs` namespace, exposing
  `window.rstudio.dialogs.numShowing()` and `dialogs.dismissAll()`. Gated to
  `--automation-agent` like the rest of the bridge.
- TS helpers `numModalsShowing(page)` / `dismissAllModals(page)` in
  `e2e/rstudio/utils/commands.ts`.
- `desktop.fixture.ts` `shutdownRStudio()` calls `dismissAllModals` before
  `documentCloseAllNoSave` / `q("no")`, so a forgotten modal no longer blocks
  the Electron close path that the existing comment already called out.
- New regression test `tests/panes/misc/dismiss_modals_bridge.test.ts`:
  opens Tools > Global Options, asserts the bridge clears the stack + DOM,
  and verifies the no-op path.

## Test plan

- [x] `cd src/gwt && ant javac` -- clean
- [x] `cd src/gwt && ant draft` -- clean
- [x] `cd e2e/rstudio && npx tsc --noEmit` -- clean
- [x] `cd e2e/rstudio && npm run test:desktop-dev -- tests/panes/misc/dismiss_modals_bridge.test.ts` -- both tests pass; teardown log shows `dismissAllModals ok 0ms` firing on shutdown so every Desktop test now exercises the cleanup path.