### PR TITLE
Backport: Restore .Last.value in environment listing (#17759)

### DIFF
--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -414,16 +414,66 @@ void listEnvironment(SEXP env,
    // add in .Last.value if it exists
    if (!includeAll && includeLastDotValue)
    {
-      SEXP lastValueSEXP = findVarInFrame(env, Rf_install(".Last.value"));
+      // R stores .Last.value in baseenv (SET_SYMVALUE on R_LastvalueSymbol).
+      // Use a chain walk so we only surface it for environments where it's
+      // actually reachable -- i.e. envs that inherit from baseenv (globalenv,
+      // package envs, function frames). Custom envs whose chain bypasses
+      // baseenv (e.g. parent = emptyenv()) intentionally don't see it.
+      // .Last.value is never a promise, so forcing in the findVar wrapper
+      // is a no-op here.
+      SEXP lastValueSEXP = findVar(R_LastvalueSymbol, env);
       if (lastValueSEXP != nullptr)
          pNames->push_back(".Last.value");
    }
 }
 
+namespace {
+
+// Walk env's parent chain to find the first env whose frame binds sym.
+// Mirrors Rf_findVar's traversal so we can classify or retrieve a binding
+// in the env that actually contains it, even when the chain doesn't end
+// in baseenv. Returns R_EmptyEnv when sym isn't reachable.
+//
+// Uses runtime::getBindingType for frame-presence checks because it's
+// non-evaluating -- a value lookup via findVarInFrame would invoke an
+// active binding's getter, which we must avoid while merely inspecting
+// where the binding lives.
+SEXP findBindingFrame(SEXP sym, SEXP env)
+{
+   while (env != R_EmptyEnv)
+   {
+      int bt = runtime::getBindingType(sym, env);
+      if (bt != runtime::kBindingTypeNotFound &&
+          bt != runtime::kBindingTypeUnbound)
+      {
+         return env;
+      }
+      env = getParentEnv(env);
+   }
+   return R_EmptyEnv;
+}
+
+} // anonymous namespace
+
 BindingType getBindingType(const std::string& name, SEXP env)
 {
    SEXP sym = Rf_install(name.c_str());
    int bt = runtime::getBindingType(sym, env);
+
+   // .Last.value lives in baseenv (SET_SYMVALUE on R_LastvalueSymbol), not
+   // in any user env's frame. If env doesn't shadow it but a binding is
+   // reachable via the parent chain, classify it against the env that
+   // actually contains the binding -- which is usually baseenv, but may be
+   // an intermediate env if a user has shadowed .Last.value (in which case
+   // classifying via baseenv would mis-report the binding's type).
+   if (sym == R_LastvalueSymbol &&
+       (bt == runtime::kBindingTypeUnbound || bt == runtime::kBindingTypeNotFound))
+   {
+      SEXP bindingEnv = findBindingFrame(sym, env);
+      if (bindingEnv != R_EmptyEnv)
+         bt = runtime::getBindingType(sym, bindingEnv);
+   }
+
    switch (bt)
    {
    case runtime::kBindingTypeActive:
@@ -448,8 +498,19 @@ SEXP getBindingIdentity(const std::string& name, SEXP env, BindingType type)
    {
    case BindingType::Normal:
    {
-      // value is already evaluated; safe to retrieve via public API
-      return findVarInFrame(env, sym);
+      // value is already evaluated; safe to retrieve via public API.
+      // .Last.value lives in baseenv (see getBindingType): if the queried
+      // env doesn't shadow it, retrieve from the env in the parent chain
+      // that actually contains the binding (matches the env getBindingType
+      // classified against).
+      SEXP value = findVarInFrame(env, sym);
+      if (value == nullptr && sym == R_LastvalueSymbol)
+      {
+         SEXP bindingEnv = findBindingFrame(sym, env);
+         if (bindingEnv != R_EmptyEnv)
+            value = findVarInFrame(bindingEnv, sym);
+      }
+      return value;
    }
 
    case BindingType::Promise:

--- a/src/cpp/tests/testthat/test-environment.R
+++ b/src/cpp/tests/testthat/test-environment.R
@@ -77,6 +77,89 @@ test_that("environment object listings are correct", {
    expect_true(!exists("obj6", globalenv()))
 })
 
+test_that(".Last.value appears in environment listing when enabled", {
+   # https://github.com/rstudio/rstudio/issues/17737
+   # Regression test: ensure the "Show .Last.value" preference works.
+   # .Last.value is stored on R_LastvalueSymbol via SET_SYMVALUE (it lives
+   # in baseenv, not in globalenv's frame), so a frame-only lookup misses it.
+   lastValue <- .rs.api.readRStudioPreference("show_last_dot_value")
+   on.exit(.rs.api.writeRStudioPreference("show_last_dot_value", lastValue), add = TRUE)
+   .rs.api.writeRStudioPreference("show_last_dot_value", TRUE)
+
+   # .Last.value's binding in baseenv is locked; unlock to set a known value
+   # then relock (and restore) so we don't leak state to other tests.
+   prev <- .Last.value
+   unlockBinding(".Last.value", baseenv())
+   on.exit({
+      assign(".Last.value", prev, envir = baseenv())
+      lockBinding(".Last.value", baseenv())
+   }, add = TRUE)
+   assign(".Last.value", 42L, envir = baseenv())
+
+   .rs.invokeRpc("set_environment", "R_GlobalEnv")
+   contents <- .rs.invokeRpc("list_environment")
+
+   names <- vapply(contents, function(x) x[["name"]], character(1))
+   expect_true(".Last.value" %in% names)
+
+   lastVal <- contents[[which(names == ".Last.value")]]
+   # binding-type classification must resolve via baseenv (not "unknown")
+   expect_false(identical(lastVal[["type"]], "unknown"))
+   expect_equal(lastVal[["value"]], "42L")
+})
+
+test_that("ancestor-shadowed .Last.value is classified at the shadowing env", {
+   # https://github.com/rstudio/rstudio/issues/17737
+   # When a parent env in the search path shadows .Last.value (e.g. with an
+   # active binding), the binding-type cascade must classify it against the
+   # shadowing env, not against R_BaseEnv. This also exercises the
+   # non-evaluating chain walk in findBindingFrame: the active binding's
+   # getter must fire only once (during the existence check in listEnvironment),
+   # not again while we locate the binding's frame for type classification.
+   lastValue <- .rs.api.readRStudioPreference("show_last_dot_value")
+   on.exit(.rs.api.writeRStudioPreference("show_last_dot_value", lastValue), add = TRUE)
+   .rs.api.writeRStudioPreference("show_last_dot_value", TRUE)
+
+   # Attach an empty env first, then add the active binding directly to the
+   # env on the search path. attach(env) on R < 4.6 copies contents via get(),
+   # which would fire the active binding during the copy and demote it to a
+   # regular value -- defeating the test.
+   attach(NULL, name = "rstudio-17737-shadow", warn.conflicts = FALSE)
+   on.exit(detach("rstudio-17737-shadow"), add = TRUE)
+   shadow <- as.environment("rstudio-17737-shadow")
+
+   counter <- 0L
+   makeActiveBinding(".Last.value", function() {
+      counter <<- counter + 1L
+      42L
+   }, env = shadow)
+
+   .rs.invokeRpc("set_environment", "R_GlobalEnv")
+   contents <- .rs.invokeRpc("list_environment")
+
+   names <- vapply(contents, function(x) x[["name"]], character(1))
+   expect_true(".Last.value" %in% names)
+
+   lastVal <- contents[[which(names == ".Last.value")]]
+   expect_equal(lastVal[["type"]], "active binding")
+   # Getter ran only for the existence-check value lookup; the chain walk
+   # used to identify the shadowing env must not have re-fired it.
+   expect_equal(counter, 1L)
+})
+
+test_that(".Last.value is hidden when preference is disabled", {
+   # https://github.com/rstudio/rstudio/issues/17737
+   lastValue <- .rs.api.readRStudioPreference("show_last_dot_value")
+   on.exit(.rs.api.writeRStudioPreference("show_last_dot_value", lastValue), add = TRUE)
+   .rs.api.writeRStudioPreference("show_last_dot_value", FALSE)
+
+   .rs.invokeRpc("set_environment", "R_GlobalEnv")
+   contents <- .rs.invokeRpc("list_environment")
+
+   names <- vapply(contents, function(x) x[["name"]], character(1))
+   expect_false(".Last.value" %in% names)
+})
+
 test_that("flag must be specified when removing objects", {
    expect_error(.rs.invokeRpc("remove_all_objects"))
 })

--- a/version/news/os/NEWS-2026.05.1-golden-wattle.md
+++ b/version/news/os/NEWS-2026.05.1-golden-wattle.md
@@ -1,0 +1,9 @@
+## RStudio 2026.05.1 "Golden Wattle" Release Notes
+
+### New
+
+### Fixed
+- ([#17737](https://github.com/rstudio/rstudio/issues/17737)): Restore the "Show .Last.value in environment listing" preference, which had stopped surfacing `.Last.value` in the Environment pane.
+
+### Dependencies
+


### PR DESCRIPTION
## Intent

Addresses #17737.

Backport of #17759 from `main` into `rel-golden-wattle` for the 2026.05 patch release.

## Summary

The R API compliance rewrite (#17276) changed the `.Last.value` existence check in `r::sexp::listEnvironment` from `Rf_findVar` (walks parent chain) to `findVarInFrame` (frame only). R stores `.Last.value` in baseenv via `SET_SYMVALUE` on `R_LastvalueSymbol`, not in any user environment's frame, so the check always missed it and the "Show .Last.value" preference silently did nothing.

- Use a parent-chain walk (`findVar`) in `listEnvironment` so `.Last.value` is surfaced when it's reachable through the queried env's ancestors (globalenv, package envs, function frames). Custom envs whose chain bypasses baseenv intentionally stay clean.
- Add a `findBindingFrame` helper that walks the parent chain via `runtime::getBindingType` (non-evaluating, won't trigger active bindings or force promises) to locate the env actually containing `.Last.value`.
- Update `getBindingType` and `getBindingIdentity` to classify/retrieve `.Last.value` against that ancestor env, so the cascade through `varToJson` renders the real value instead of `"unknown"` -- and correctly reports the binding type when an ancestor shadows `.Last.value`.

## Test plan

- [ ] `./build/src/cpp/rstudio-tests --scope r --filter environment` passes.