### PR TITLE
fix: improve skill score for rstudio-run-playwright-tests

### DIFF
--- a/.claude/skills/rstudio-run-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-run-playwright-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rstudio-run-playwright-tests
-description: How to run RStudio Playwright tests in Desktop and Server modes. Use this skill whenever the user asks to run, execute, or launch Playwright tests against RStudio - whether on Desktop (local) or Server (remote). Also use when the user asks about the test command, environment variables, or how to point tests at a server URL. Trigger on phrases like "run the test", "execute on server", "run it on desktop", "run against <IP>", or any request involving npx playwright test for the RStudio test suite.
+description: "Run RStudio Playwright tests in Desktop and Server modes. Use when running, executing, or launching Playwright tests against RStudio on Desktop (local) or Server (remote), configuring test environment variables, or pointing tests at a server URL. Also covers npm run test:desktop, npm run test:server, and npx playwright test commands for the RStudio e2e test suite."
 ---
 
 # Running RStudio Playwright Tests
@@ -45,3 +45,13 @@ directly; don't prompt for approval before kicking off the run. Prefer
 
 After the first run, don't re-ask to re-run the same file in the same mode --
 just go. Switching modes (not files) warrants a fresh mode-pick.
+
+## Verifying results
+
+Check the Playwright exit code: 0 means all tests passed. On failure, read the
+test output for assertion errors or timeouts. Re-run a single failing test in
+isolation before investigating further:
+
+```bash
+npm run test:desktop -- tests/path/to/failing.test.ts --reporter=list
+```


### PR DESCRIPTION
Hey @kevinushey 👋

thats truly impressive. 5k stars on an IDE that's been central to the R community for years. The breadth of features from Sweave support to server mode shows a real commitment to making R accessible across setups.

also ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| rstudio-run-playwright-tests | 18% | 100% | +82% |

<details>
<summary>Changes made</summary>

- **Fixed description validation**: Removed `<IP>` XML tag that caused deterministic validation failure, replaced with a cleaner quoted-string description
- **Improved trigger term coverage**: Added explicit `npm run test:desktop`, `npm run test:server`, and `npx playwright test` references to the description for better skill matching
- **Added verification section**: Brief guidance on checking exit codes and re-running failing tests in isolation - addresses the one content gap the evaluator flagged

</details>

---

quick honest disclosure. I work at https://github.com/tesslio where we build tooling around skills like these. Not a pitch, just saw room for improvement and wanted to contribute.

If you want to self-improve your skills, or define your own scenarios to pressure test, just ask your agent (Claude Code, Codex, etc.) to evaluate and optimize your skill with Tessl. Ping me [@yogesh-tessl](https://github.com/yogesh-tessl), if you hit any snags.