### PR TITLE
ci(e2e): improve caching across the e2e Playwright workflows

### DIFF
--- a/.github/actions/e2e-deps/action.yml
+++ b/.github/actions/e2e-deps/action.yml
@@ -1,0 +1,92 @@
+name: "E2E test dependencies"
+description: >
+  Install and cache the dependencies shared by every RStudio e2e Playwright
+  workflow: R packages (via pak), npm modules, and Playwright browsers. All
+  steps run in bash, which is available on the Linux, macOS, and Windows
+  hosted runners alike, so a single implementation covers every platform.
+
+inputs:
+  r-version:
+    description: "R version label, used only to namespace the R library cache key."
+    required: true
+  r-libs-user:
+    description: "Absolute path to R_LIBS_USER (the per-job R library tree to cache)."
+    required: true
+  working-directory:
+    description: "Directory containing the Playwright project (package.json / DESCRIPTION)."
+    required: false
+    default: "e2e/rstudio"
+
+runs:
+  using: "composite"
+  steps:
+    # Pin Playwright's browser download dir and pak's cache dir to fixed,
+    # workspace-local paths so the cache `path:` is identical on every OS
+    # (the platform defaults differ). PLAYWRIGHT_BROWSERS_PATH is exported to
+    # GITHUB_ENV so the later "Run Playwright tests" step in the calling
+    # workflow finds the cached browsers. R_USER_CACHE_DIR is honored by
+    # tools::R_user_dir(), which pak/pkgcache use to locate their download
+    # cache, so only the install step below needs it.
+    - name: Configure dependency cache paths
+      shell: bash
+      run: |
+        echo "PLAYWRIGHT_BROWSERS_PATH=${{ github.workspace }}/ms-playwright" >> "$GITHUB_ENV"
+
+    - name: Cache R packages (pak download cache)
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/.r-pkg-cache
+        key: ${{ runner.os }}-pak-${{ inputs.r-version }}-${{ hashFiles(format('{0}/DESCRIPTION', inputs.working-directory)) }}
+        restore-keys: |
+          ${{ runner.os }}-pak-${{ inputs.r-version }}-
+          ${{ runner.os }}-pak-
+
+    - name: Cache R library
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.r-libs-user }}
+        key: ${{ runner.os }}-r-${{ inputs.r-version }}-${{ hashFiles(format('{0}/DESCRIPTION', inputs.working-directory)) }}
+        restore-keys: |
+          ${{ runner.os }}-r-${{ inputs.r-version }}-
+
+    - name: Install R packages from DESCRIPTION
+      shell: bash
+      env:
+        E2E_ROOT: ${{ inputs.working-directory }}
+        R_USER_CACHE_DIR: ${{ github.workspace }}/.r-pkg-cache
+      run: |
+        if [ "$RUNNER_OS" = "Linux" ]; then
+          export PKG_REPO="https://packagemanager.posit.co/cran/__linux__/noble/latest"
+        else
+          export PKG_REPO="https://packagemanager.posit.co/cran/latest"
+        fi
+        SCRIPT="$(mktemp -t install-deps.XXXXXX.R)"
+        cat > "$SCRIPT" <<'EOF'
+        options(repos = c(P3M = Sys.getenv("PKG_REPO")))
+        if (!requireNamespace("pak", quietly = TRUE))
+          install.packages("pak")
+        pak::local_install_dev_deps(
+          root = Sys.getenv("E2E_ROOT"),
+          ask = FALSE,
+          upgrade = FALSE
+        )
+        EOF
+        Rscript "$SCRIPT"
+
+    - name: Install npm dependencies
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: npm ci
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/ms-playwright
+        key: ${{ runner.os }}-pw-${{ hashFiles(format('{0}/package-lock.json', inputs.working-directory)) }}
+        restore-keys: |
+          ${{ runner.os }}-pw-
+
+    - name: Install Playwright browsers
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: npx playwright install --with-deps chromium

--- a/.github/actions/e2e-deps/action.yml
+++ b/.github/actions/e2e-deps/action.yml
@@ -6,9 +6,6 @@ description: >
   hosted runners alike, so a single implementation covers every platform.
 
 inputs:
-  r-version:
-    description: "R version label, used only to namespace the R library cache key."
-    required: true
   r-libs-user:
     description: "Absolute path to R_LIBS_USER (the per-job R library tree to cache)."
     required: true
@@ -32,22 +29,37 @@ runs:
       run: |
         echo "PLAYWRIGHT_BROWSERS_PATH=${{ github.workspace }}/ms-playwright" >> "$GITHUB_ENV"
 
+    # Resolve the *installed* R version (major.minor) and fold it into the
+    # cache keys below. Installed packages and pak's binary downloads are only
+    # compatible within an R major.minor series, so when an alias like
+    # "release" rolls forward to a new R the keys must change -- otherwise a
+    # library built for the old R would be restored into the new one. Keying
+    # on the resolved version (rather than the requested alias, which never
+    # changes) handles that, and scoping restore-keys to the same version
+    # stops a prefix-match fallback from pulling a stale-version library in.
+    - name: Resolve R version
+      id: r_version
+      shell: bash
+      run: |
+        VERSION=$(Rscript -e 'cat(R.version$major, sub("[.].*", "", R.version$minor), sep=".")')
+        echo "Resolved R version (major.minor): $VERSION"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
     - name: Cache R packages (pak download cache)
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/.r-pkg-cache
-        key: ${{ runner.os }}-pak-${{ inputs.r-version }}-${{ hashFiles(format('{0}/DESCRIPTION', inputs.working-directory)) }}
+        key: ${{ runner.os }}-pak-${{ steps.r_version.outputs.version }}-${{ hashFiles(format('{0}/DESCRIPTION', inputs.working-directory)) }}
         restore-keys: |
-          ${{ runner.os }}-pak-${{ inputs.r-version }}-
-          ${{ runner.os }}-pak-
+          ${{ runner.os }}-pak-${{ steps.r_version.outputs.version }}-
 
     - name: Cache R library
       uses: actions/cache@v4
       with:
         path: ${{ inputs.r-libs-user }}
-        key: ${{ runner.os }}-r-${{ inputs.r-version }}-${{ hashFiles(format('{0}/DESCRIPTION', inputs.working-directory)) }}
+        key: ${{ runner.os }}-r-${{ steps.r_version.outputs.version }}-${{ hashFiles(format('{0}/DESCRIPTION', inputs.working-directory)) }}
         restore-keys: |
-          ${{ runner.os }}-r-${{ inputs.r-version }}-
+          ${{ runner.os }}-r-${{ steps.r_version.outputs.version }}-
 
     - name: Install R packages from DESCRIPTION
       shell: bash

--- a/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
@@ -146,11 +146,15 @@ jobs:
           "sha256=$sha"        | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           "filename=$filename" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
-      # Daily filenames embed the version + build number, so the file content
-      # is immutable per name -- safe to key the cache on the filename alone.
-      # New dailies miss (different name); same-day reruns hit and skip the
-      # download. The SHA-256 check below still runs on the auto-resolve path.
+      # Cache the installer keyed on its resolved filename. On the daily
+      # auto-resolve path the filename embeds the version + build number, so
+      # the content is immutable per name: a new daily misses and downloads, a
+      # same-day rerun hits and skips the download (SHA-256 still verified
+      # below). Skip caching on the override path -- a user-supplied URL has no
+      # immutability guarantee and its SHA check is skipped, so a reused
+      # basename could otherwise serve stale, unverified bytes.
       - name: Cache RStudio installer
+        if: inputs.rstudio_installer_url == ''
         id: installer-cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
@@ -146,7 +146,19 @@ jobs:
           "sha256=$sha"        | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           "filename=$filename" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
+      # Daily filenames embed the version + build number, so the file content
+      # is immutable per name -- safe to key the cache on the filename alone.
+      # New dailies miss (different name); same-day reruns hit and skip the
+      # download. The SHA-256 check below still runs on the auto-resolve path.
+      - name: Cache RStudio installer
+        id: installer-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.resolve.outputs.filename }}
+          key: rstudio-installer-${{ steps.resolve.outputs.filename }}
+
       - name: Download RStudio .exe
+        if: steps.installer-cache.outputs.cache-hit != 'true'
         env:
           DOWNLOAD_URL: ${{ steps.resolve.outputs.url }}
           DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}

--- a/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
@@ -201,7 +201,6 @@ jobs:
       - name: Install e2e test dependencies
         uses: ./.github/actions/e2e-deps
         with:
-          r-version: ${{ inputs.r_version || 'release' }}
           r-libs-user: ${{ env.R_LIBS_USER }}
 
       - name: Run Playwright tests

--- a/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
@@ -84,6 +84,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
 
       - name: Install rig
         run: |
@@ -184,40 +186,11 @@ jobs:
           }
           Get-Item $exe | Format-List FullName, Length, LastWriteTime
 
-      - name: Restore R library cache
-        if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
-        id: r-cache
-        uses: actions/cache/restore@v4
+      - name: Install e2e test dependencies
+        uses: ./.github/actions/e2e-deps
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-v1-${{ inputs.r_version || 'release' }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
-          restore-keys: |
-            ${{ runner.os }}-r-v1-${{ inputs.r_version || 'release' }}-
-
-      - name: Install R packages from DESCRIPTION
-        if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
-        shell: bash
-        run: |
-          Rscript -e '
-            options(repos = c(P3M = "https://packagemanager.posit.co/cran/latest"))
-            if (!requireNamespace("pak", quietly = TRUE)) install.packages("pak")
-            pak::local_install_dev_deps(root = "e2e/rstudio", ask = FALSE, upgrade = FALSE)
-          '
-
-      - name: Save R library cache
-        if: hashFiles('e2e/rstudio/DESCRIPTION') != '' && steps.r-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-v1-${{ inputs.r_version || 'release' }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
-
-      - name: Install npm dependencies
-        working-directory: e2e/rstudio
-        run: npm ci
-
-      - name: Install Playwright browsers
-        working-directory: e2e/rstudio
-        run: npx playwright install --with-deps chromium
+          r-version: ${{ inputs.r_version || 'release' }}
+          r-libs-user: ${{ env.R_LIBS_USER }}
 
       - name: Run Playwright tests
         working-directory: e2e/rstudio

--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "src/**"
       - "e2e/rstudio/**"
+      - ".github/actions/e2e-deps/**"
       - ".github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml"
       - ".github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml"
 

--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -84,6 +84,13 @@ jobs:
       R_LIBS_USER: ${{ github.workspace }}/R-libs/%p/%v
       SCCACHE_ENABLED: '1'
       SCCACHE_DIR: ${{ github.workspace }}/.sccache
+      # Bound the on-disk cache so each per-SHA cache entry stays small. The
+      # sccache cache key includes github.sha (see below), so every commit
+      # writes a fresh entry; without a cap a handful of large entries can
+      # blow past the repo's 10 GB Actions cache budget and LRU-evict the
+      # rstudio-tools / R-libs caches. 5G comfortably holds a full C++ object
+      # cache; tune it down once "Show sccache stats" reports the real size.
+      SCCACHE_CACHE_SIZE: '5G'
     steps:
       - uses: actions/checkout@v4
 
@@ -134,6 +141,12 @@ jobs:
         working-directory: dependencies/osx
         run: ./install-dependencies-osx-arch
 
+      # Reset the hit/miss counters so the post-build stats reflect only this
+      # run. sccache lands on PATH (/usr/local/bin) via install-sccache above;
+      # tolerate its absence so a packaging change can't fail the build here.
+      - name: Zero sccache stats
+        run: sccache --zero-stats || true
+
       - name: Build RStudio Desktop (arm64)
         working-directory: package/osx
         env:
@@ -142,6 +155,13 @@ jobs:
           RSTUDIO_VERSION_PATCH: '9'
           RSTUDIO_VERSION_SUFFIX: "-pr+${{ github.run_number }}"
         run: ./make-package --arch=arm64 --build-dmg=0 --use-creds=0
+
+      # Surfaces the compile cache hit rate and on-disk size so we can tell
+      # whether the warm-cache path is actually working and tune
+      # SCCACHE_CACHE_SIZE. Runs even when the build fails.
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats || true
 
       # tar (not zip) to preserve symlinks and executable permissions in the
       # bundle. upload-artifact would otherwise zip the directory tree itself

--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -88,8 +88,9 @@ jobs:
       # sccache cache key includes github.sha (see below), so every commit
       # writes a fresh entry; without a cap a handful of large entries can
       # blow past the repo's 10 GB Actions cache budget and LRU-evict the
-      # rstudio-tools / R-libs caches. 5G comfortably holds a full C++ object
-      # cache; tune it down once "Show sccache stats" reports the real size.
+      # rstudio-tools / R-libs caches. 5G is a starting estimate for a full
+      # C++ object cache; tune it once "Show sccache stats" reports the real
+      # size.
       SCCACHE_CACHE_SIZE: '5G'
     steps:
       - uses: actions/checkout@v4
@@ -142,8 +143,10 @@ jobs:
         run: ./install-dependencies-osx-arch
 
       # Reset the hit/miss counters so the post-build stats reflect only this
-      # run. sccache lands on PATH (/usr/local/bin) via install-sccache above;
-      # tolerate its absence so a packaging change can't fail the build here.
+      # run. install-sccache (via install-common above) installs sccache to
+      # /usr/local/bin when writable, else $HOME/opt/bin, which may not be on
+      # PATH; the `|| true` tolerates sccache being absent or off-PATH so a
+      # packaging / runner change can't fail the build here.
       - name: Zero sccache stats
         run: sccache --zero-stats || true
 

--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -279,7 +279,6 @@ jobs:
       - name: Install e2e test dependencies
         uses: ./.github/actions/e2e-deps
         with:
-          r-version: ${{ inputs.r_version }}
           r-libs-user: ${{ env.R_LIBS_USER }}
 
       - name: Run Playwright tests

--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -256,47 +256,11 @@ jobs:
           sudo xattr -cr /Applications/RStudio.app
           ls -la /Applications/RStudio.app/Contents/MacOS/RStudio
 
-      - name: Restore R library cache
-        if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
-        id: r-cache
-        uses: actions/cache/restore@v4
+      - name: Install e2e test dependencies
+        uses: ./.github/actions/e2e-deps
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ inputs.r_version }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
-          restore-keys: |
-            ${{ runner.os }}-r-${{ inputs.r_version }}-
-
-      - name: Install R packages from DESCRIPTION
-        if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
-        run: |
-          Rscript -e '
-            options(repos = c(P3M = "https://packagemanager.posit.co/cran/latest"))
-            if (!requireNamespace("pak", quietly = TRUE)) install.packages("pak")
-            pak::local_install_dev_deps(root = "e2e/rstudio", ask = FALSE, upgrade = FALSE)
-          '
-
-      - name: Save R library cache
-        if: hashFiles('e2e/rstudio/DESCRIPTION') != '' && steps.r-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ inputs.r_version }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
-
-      - name: Install npm dependencies
-        working-directory: e2e/rstudio
-        run: npm ci
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/Library/Caches/ms-playwright
-          key: ${{ runner.os }}-pw-${{ hashFiles('e2e/rstudio/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-pw-
-
-      - name: Install Playwright browsers
-        working-directory: e2e/rstudio
-        run: npx playwright install --with-deps chromium
+          r-version: ${{ inputs.r_version }}
+          r-libs-user: ${{ env.R_LIBS_USER }}
 
       - name: Run Playwright tests
         working-directory: e2e/rstudio

--- a/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -122,11 +122,15 @@ jobs:
           echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
           echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
 
-      # Daily filenames embed the version + build number, so the file content
-      # is immutable per name -- safe to key the cache on the filename alone.
-      # New dailies miss (different name); same-day reruns hit and skip the
-      # download. The SHA-256 check below still runs on the auto-resolve path.
+      # Cache the installer keyed on its resolved filename. On the daily
+      # auto-resolve path the filename embeds the version + build number, so
+      # the content is immutable per name: a new daily misses and downloads, a
+      # same-day rerun hits and skips the download (SHA-256 still verified
+      # below). Skip caching on the override path -- a user-supplied URL has no
+      # immutability guarantee and its SHA check is skipped, so a reused
+      # basename could otherwise serve stale, unverified bytes.
       - name: Cache RStudio installer
+        if: inputs.rstudio_installer_url == ''
         id: installer-cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -154,7 +154,6 @@ jobs:
       - name: Install e2e test dependencies
         uses: ./.github/actions/e2e-deps
         with:
-          r-version: ${{ inputs.r_version }}
           r-libs-user: ${{ env.R_LIBS_USER }}
 
       - name: Run Playwright tests

--- a/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -75,6 +75,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
 
       - name: Install OS dependencies
         run: |
@@ -137,39 +139,11 @@ jobs:
           sudo apt-get install -y "./${{ steps.resolve.outputs.filename }}"
           ls -la /usr/bin/rstudio
 
-      - name: Restore R library cache
-        if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
-        id: r-cache
-        uses: actions/cache/restore@v4
+      - name: Install e2e test dependencies
+        uses: ./.github/actions/e2e-deps
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ inputs.r_version }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
-          restore-keys: |
-            ${{ runner.os }}-r-${{ inputs.r_version }}-
-
-      - name: Install R packages from DESCRIPTION
-        if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
-        run: |
-          Rscript -e '
-            options(repos = c(P3M = "https://packagemanager.posit.co/cran/__linux__/noble/latest"))
-            if (!requireNamespace("pak", quietly = TRUE)) install.packages("pak")
-            pak::local_install_dev_deps(root = "e2e/rstudio", ask = FALSE, upgrade = FALSE)
-          '
-
-      - name: Save R library cache
-        if: hashFiles('e2e/rstudio/DESCRIPTION') != '' && steps.r-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ inputs.r_version }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
-
-      - name: Install npm dependencies
-        working-directory: e2e/rstudio
-        run: npm ci
-
-      - name: Install Playwright browsers
-        working-directory: e2e/rstudio
-        run: npx playwright install --with-deps chromium
+          r-version: ${{ inputs.r_version }}
+          r-libs-user: ${{ env.R_LIBS_USER }}
 
       - name: Run Playwright tests
         working-directory: e2e/rstudio

--- a/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -122,7 +122,19 @@ jobs:
           echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
           echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
 
+      # Daily filenames embed the version + build number, so the file content
+      # is immutable per name -- safe to key the cache on the filename alone.
+      # New dailies miss (different name); same-day reruns hit and skip the
+      # download. The SHA-256 check below still runs on the auto-resolve path.
+      - name: Cache RStudio installer
+        id: installer-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.resolve.outputs.filename }}
+          key: rstudio-installer-${{ steps.resolve.outputs.filename }}
+
       - name: Download RStudio .deb
+        if: steps.installer-cache.outputs.cache-hit != 'true'
         run: |
           curl -fsSL --retry 3 --retry-delay 5 \
             -o "${{ steps.resolve.outputs.filename }}" \

--- a/.github/workflows/test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -78,6 +78,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
 
       - name: Install rig
         run: |
@@ -161,40 +163,11 @@ jobs:
           }
           Get-Item $exe | Format-List FullName, Length, LastWriteTime
 
-      - name: Restore R library cache
-        if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
-        id: r-cache
-        uses: actions/cache/restore@v4
+      - name: Install e2e test dependencies
+        uses: ./.github/actions/e2e-deps
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ inputs.r_version }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
-          restore-keys: |
-            ${{ runner.os }}-r-${{ inputs.r_version }}-
-
-      - name: Install R packages from DESCRIPTION
-        if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
-        run: |
-          $ErrorActionPreference = 'Stop'
-          Rscript -e @'
-            options(repos = c(P3M = "https://packagemanager.posit.co/cran/latest"))
-            if (!requireNamespace("pak", quietly = TRUE)) install.packages("pak")
-            pak::local_install_dev_deps(root = "e2e/rstudio", ask = FALSE, upgrade = FALSE)
-          '@
-
-      - name: Save R library cache
-        if: hashFiles('e2e/rstudio/DESCRIPTION') != '' && steps.r-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ inputs.r_version }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
-
-      - name: Install npm dependencies
-        working-directory: e2e/rstudio
-        run: npm ci
-
-      - name: Install Playwright browsers
-        working-directory: e2e/rstudio
-        run: npx playwright install --with-deps chromium
+          r-version: ${{ inputs.r_version }}
+          r-libs-user: ${{ env.R_LIBS_USER }}
 
       - name: Run Playwright tests
         working-directory: e2e/rstudio

--- a/.github/workflows/test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -131,7 +131,19 @@ jobs:
           "sha256=$sha"        | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           "filename=$filename" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
+      # Daily filenames embed the version + build number, so the file content
+      # is immutable per name -- safe to key the cache on the filename alone.
+      # New dailies miss (different name); same-day reruns hit and skip the
+      # download. The SHA-256 check below still runs on the auto-resolve path.
+      - name: Cache RStudio installer
+        id: installer-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.resolve.outputs.filename }}
+          key: rstudio-installer-${{ steps.resolve.outputs.filename }}
+
       - name: Download RStudio .exe
+        if: steps.installer-cache.outputs.cache-hit != 'true'
         run: |
           $ErrorActionPreference = 'Stop'
           Invoke-WebRequest `

--- a/.github/workflows/test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -178,7 +178,6 @@ jobs:
       - name: Install e2e test dependencies
         uses: ./.github/actions/e2e-deps
         with:
-          r-version: ${{ inputs.r_version }}
           r-libs-user: ${{ env.R_LIBS_USER }}
 
       - name: Run Playwright tests

--- a/.github/workflows/test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -131,11 +131,15 @@ jobs:
           "sha256=$sha"        | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           "filename=$filename" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
-      # Daily filenames embed the version + build number, so the file content
-      # is immutable per name -- safe to key the cache on the filename alone.
-      # New dailies miss (different name); same-day reruns hit and skip the
-      # download. The SHA-256 check below still runs on the auto-resolve path.
+      # Cache the installer keyed on its resolved filename. On the daily
+      # auto-resolve path the filename embeds the version + build number, so
+      # the content is immutable per name: a new daily misses and downloads, a
+      # same-day rerun hits and skips the download (SHA-256 still verified
+      # below). Skip caching on the override path -- a user-supplied URL has no
+      # immutability guarantee and its SHA check is skipped, so a reused
+      # basename could otherwise serve stale, unverified bytes.
       - name: Cache RStudio installer
+        if: inputs.rstudio_installer_url == ''
         id: installer-cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -115,11 +115,15 @@ jobs:
           echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
           echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
 
-      # Daily filenames embed the version + build number, so the file content
-      # is immutable per name -- safe to key the cache on the filename alone.
-      # New dailies miss (different name); same-day reruns hit and skip the
-      # download. The SHA-256 check below still runs on the auto-resolve path.
+      # Cache the installer keyed on its resolved filename. On the daily
+      # auto-resolve path the filename embeds the version + build number, so
+      # the content is immutable per name: a new daily misses and downloads, a
+      # same-day rerun hits and skips the download (SHA-256 still verified
+      # below). Skip caching on the override path -- a user-supplied URL has no
+      # immutability guarantee and its SHA check is skipped, so a reused
+      # basename could otherwise serve stale, unverified bytes.
       - name: Cache RStudio Server installer
+        if: inputs.rstudio_installer_url == ''
         id: installer-cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -188,7 +188,6 @@ jobs:
       - name: Install e2e test dependencies
         uses: ./.github/actions/e2e-deps
         with:
-          r-version: ${{ inputs.r_version }}
           r-libs-user: ${{ env.R_LIBS_USER }}
 
       - name: Run Playwright tests

--- a/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -115,7 +115,19 @@ jobs:
           echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
           echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
 
+      # Daily filenames embed the version + build number, so the file content
+      # is immutable per name -- safe to key the cache on the filename alone.
+      # New dailies miss (different name); same-day reruns hit and skip the
+      # download. The SHA-256 check below still runs on the auto-resolve path.
+      - name: Cache RStudio Server installer
+        id: installer-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.resolve.outputs.filename }}
+          key: rstudio-server-installer-${{ steps.resolve.outputs.filename }}
+
       - name: Download RStudio Server .deb
+        if: steps.installer-cache.outputs.cache-hit != 'true'
         run: |
           curl -fsSL --retry 3 --retry-delay 5 \
             -o "${{ steps.resolve.outputs.filename }}" \

--- a/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -68,6 +68,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
 
       - name: Install OS dependencies
         run: |
@@ -171,39 +173,11 @@ jobs:
           sudo journalctl -u rstudio-server --no-pager -n 200
           exit 1
 
-      - name: Restore R library cache
-        if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
-        id: r-cache
-        uses: actions/cache/restore@v4
+      - name: Install e2e test dependencies
+        uses: ./.github/actions/e2e-deps
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ inputs.r_version }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
-          restore-keys: |
-            ${{ runner.os }}-r-${{ inputs.r_version }}-
-
-      - name: Install R packages from DESCRIPTION
-        if: hashFiles('e2e/rstudio/DESCRIPTION') != ''
-        run: |
-          Rscript -e '
-            options(repos = c(P3M = "https://packagemanager.posit.co/cran/__linux__/noble/latest"))
-            if (!requireNamespace("pak", quietly = TRUE)) install.packages("pak")
-            pak::local_install_dev_deps(root = "e2e/rstudio", ask = FALSE, upgrade = FALSE)
-          '
-
-      - name: Save R library cache
-        if: hashFiles('e2e/rstudio/DESCRIPTION') != '' && steps.r-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ inputs.r_version }}-${{ hashFiles('e2e/rstudio/DESCRIPTION') }}
-
-      - name: Install npm dependencies
-        working-directory: e2e/rstudio
-        run: npm ci
-
-      - name: Install Playwright browsers
-        working-directory: e2e/rstudio
-        run: npx playwright install --with-deps chromium
+          r-version: ${{ inputs.r_version }}
+          r-libs-user: ${{ env.R_LIBS_USER }}
 
       - name: Run Playwright tests
         working-directory: e2e/rstudio


### PR DESCRIPTION
## Intent

Improve the runtime and caching of the E2E Playwright workflows under
`.github/workflows/`. No associated issue -- this is a CI-performance change.

## Summary

Closes the caching gaps in the e2e workflows and removes a large amount of
duplicated setup, without changing what the workflows actually test.

### Composite action (`.github/actions/e2e-deps`)

The per-workflow R-package / npm / Playwright install steps are factored into
a single composite action shared by all five e2e workflows. It runs entirely
in bash, which is available on the Linux, macOS, and Windows runners alike, so
one implementation covers every platform. Alongside the dedup this enables the
caches that previously only the macOS workflow had:

- **npm** -- enable `setup-node`'s npm cache on the four non-macOS workflows.
- **Playwright browsers** -- cache the browser binaries on every workflow by
  pinning `PLAYWRIGHT_BROWSERS_PATH` to a fixed, workspace-local path (the
  platform defaults differ) and exporting it for the test-run step.
- **pak download cache** -- point `R_USER_CACHE_DIR` at a fixed workspace path
  (honored by `tools::R_user_dir`, which pak/pkgcache use) and cache it, so
  partial R-library cache hits no longer re-download every package.

### sccache (macOS build job)

The macOS workflow is the only one that compiles RStudio from source. Added
`sccache --zero-stats` / `--show-stats` around the build so the compile-cache
hit rate and on-disk size are visible in the run log, and capped
`SCCACHE_CACHE_SIZE=5G` so the per-SHA cache entries can't evict the
rstudio-tools / R-libs caches out of the 10 GB repo cache budget.

### Daily installer download cache

The four daily-binary workflows now cache the downloaded installer keyed on
its resolved filename (which embeds version + build number, so it is immutable
per name). New dailies miss and download; same-day reruns hit and skip the
few-hundred-MB download. SHA-256 verification still runs on the auto-resolve
path.

## Deliberately out of scope

- **Test sharding** across runners -- the single biggest wall-clock lever, but
  it multiplies runner-minutes by N. Left for a follow-up once post-cache
  wall-clock is measured.
- **Base-R install caching (`rig add`)** -- caching the root-owned R install
  trees plus rig's registration/PATH state across three OSes is fragile for a
  sub-minute saving. The high-value R caching (package library + pak cache) is
  already covered here.

## Validation

YAML parses on all six files; `actionlint` is clean apart from a stale
`macos-26` runner-label false positive that predates this change. The
workflows can't be exercised locally, so this PR exists to get a CI run going.
