### PR TITLE
backport .rs.digest move to Tools.R and adler32 rewrite

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1077,6 +1077,67 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    contents
 })
 
+# Adler-32 fingerprint of an R value. Not cryptographic -- this is for
+# stable, bounded identity tokens (e.g. the data viewer's column-names
+# fingerprint), where a hypothetical collision means reapplying saved
+# UI state to the wrong frame, not a security boundary.
+#
+# Raw vectors hash directly; everything else goes through serialize() so
+# element boundaries are encoded unambiguously and we don't have to
+# invent our own framing -- a delimiter-joined string can collide on
+# names that contain the delimiter.
+#
+# We pin serialize(version = 2L) and zero out bytes 7-10 (the writer's R
+# version field) so the hash is stable across R upgrades. Otherwise the
+# colsFingerprint persisted alongside the data viewer's saved UI state
+# would silently invalidate after every R upgrade. Version 2 has been
+# the stable archival format since R 1.4.0; version 3 additionally
+# embeds the native encoding name in the header, which can vary by
+# platform.
+#
+# The modulus 65521 is the largest prime below 2^16, per the spec.
+# Each loop iteration evaluates
+#   b + k*a + sum_{i=1..k} (k+1-i) * chunk[i]
+# before the %% reduction. Worst case (a, b near 65520; chunk[i] = 255)
+# bounds at 65520*(k+1) + 255*k*(k+1)/2; staying within R's signed
+# 32-bit integer range gives k <= 3854, so chunk size 1024 has plenty
+# of headroom.
+.rs.addFunction("digest", function(x)
+{
+   if (is.raw(x))
+   {
+      bytes <- x
+   }
+   else
+   {
+      bytes <- serialize(x, connection = NULL, ascii = FALSE, version = 2L)
+      bytes[7:10] <- as.raw(0L)
+   }
+
+   n <- length(bytes)
+   a <- 1L
+   b <- 0L
+   size <- 1024L
+
+   pos <- 1L
+   while (pos <= n)
+   {
+      end <- min(pos + size - 1L, n)
+      k <- end - pos + 1L
+      chunk <- as.integer(bytes[pos:end])
+
+      s1 <- sum(chunk)
+      weighted <- sum(seq.int(k, 1L) * chunk)
+
+      b <- (b + k * a + weighted) %% 65521L
+      a <- (a + s1) %% 65521L
+
+      pos <- end + 1L
+   }
+
+   sprintf("%04x%04x", b, a)
+})
+
 .rs.addFunction("fromJSON", function(string)
 {
    .Call("rs_fromJSON", string)

--- a/src/cpp/session/modules/SessionRUtil.R
+++ b/src/cpp/session/modules/SessionRUtil.R
@@ -226,27 +226,3 @@
 {
    .Call("rs_getSessionOverlayOption", as.character(key), PACKAGE = "(embedding)")
 })
-
-# SHA-256 hex digest of an R value. Avoids pulling in the digest package
-# for the small set of internal places where we need a stable, bounded
-# identity token for an in-memory value.
-#
-# Raw vectors are hashed directly. Everything else (including character
-# vectors) goes through serialize() so element boundaries are encoded
-# unambiguously -- any hand-rolled framing of a character vector via a
-# delimiter can collide on strings that happen to contain that delimiter.
-#
-# Returns NA_character_ if the C++ hash call fails (e.g. crypto init issue).
-.rs.addFunction("digest", function(x)
-{
-   bytes <- if (is.raw(x))
-      x
-   else
-      serialize(x, connection = NULL, ascii = FALSE)
-
-   hash <- .Call("rs_sha256", bytes, PACKAGE = "(embedding)")
-   if (is.null(hash))
-      NA_character_
-   else
-      hash
-})

--- a/src/cpp/session/modules/SessionRUtil.cpp
+++ b/src/cpp/session/modules/SessionRUtil.cpp
@@ -27,7 +27,6 @@
 
 #include <core/Log.hpp>
 #include <core/Exec.hpp>
-#include <core/system/Crypto.hpp>
 #include <core/system/Xdg.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/Macros.hpp>
@@ -390,35 +389,6 @@ SEXP rs_userDataDir()
    return r::sexp::createUtf8(userDataDir, &protect);
 }
 
-// SHA-256 hex digest of a raw or character SEXP. Used by .rs.digest as a
-// dependency-free alternative to digest::digest for the (small) set of
-// places we need a stable hash of in-memory R values.
-SEXP rs_sha256(SEXP inputSEXP)
-{
-   std::string input;
-   if (TYPEOF(inputSEXP) == RAWSXP)
-   {
-      input.assign(
-            reinterpret_cast<const char*>(RAW(inputSEXP)),
-            static_cast<std::size_t>(Rf_xlength(inputSEXP)));
-   }
-   else
-   {
-      input = r::sexp::asString(inputSEXP);
-   }
-
-   std::string hashHex;
-   Error error = core::system::crypto::sha256Hex(input, &hashHex);
-   if (error)
-   {
-      LOG_ERROR(error);
-      return R_NilValue;
-   }
-
-   r::sexp::Protect protect;
-   return r::sexp::create(hashHex, &protect);
-}
-
 } // anonymous namespace
 
 Error initialize()
@@ -435,7 +405,6 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_utf8ToSystem);
    RS_REGISTER_CALL_METHOD(rs_getSessionOverlayOption);
    RS_REGISTER_CALL_METHOD(rs_userDataDir);
-   RS_REGISTER_CALL_METHOD(rs_sha256);
 
    using boost::bind;
    using namespace module_context;


### PR DESCRIPTION
## Intent

Addresses #17777. Backports the minimal `.rs.digest` changes from #17789 to `rel-golden-wattle`.

`preview_data_import_async` (in `SessionData.cpp`) spawns a `--vanilla` R subprocess to run the preview off the main session. That subprocess sources only `Tools.R` plus a handful of session modules and has no RStudio embedding registered. The SHA-256-backed `.rs.digest` added in #17595 lived in `SessionRUtil.R` (not sourced there) and called into `rs_sha256` via the embedding (also not available), so any CSV/readr/readxl/haven preview failed with:

> Is this a valid CSV file?  could not find function ".rs.digest"

The data viewer fingerprint just needs a stable, bounded identity token for collision detection, not a cryptographic hash. This change:

- Moves `.rs.digest` from `SessionRUtil.R` to `Tools.R` (already sourced by the subprocess).
- Reimplements it as a vectorized Adler-32 in pure base R. Processed in 1024-byte chunks so every intermediate sum stays within R's signed 32-bit integer range; the result is exact and identical across platforms regardless of input size.
- Pins `serialize(version = 2L)` and zeros out bytes 7-10 (the writer's R version field) so the hash is stable across R upgrades. v2 chosen over v3 because v3 additionally embeds the native encoding name in the header, which can vary by platform.
- Drops the now-unused `rs_sha256` C++ helper and its `Crypto.hpp` include.

`.rs.digest` keeps the same API (raw or arbitrary R value in, fixed-size hex string out), so existing callers work unchanged.

## Scope

This is the minimal `.rs.digest`-focused subset of #17789. The adjacent cleanups bundled into that PR (the `rs_fromJSON` PACKAGE qualifier, the dead `INTEGER_OR_NULL` dlopen removal, the `rstudio-tests` TTY auto-wrap, the Playwright test hardening, and the new E2E test) are intentionally not included here.

## Upgrade note

The fingerprint format changes from `n:sha256` (#17595) to `n:adler32`. Any saved per-object data-viewer state (pin/width/sort/filter) carrying the old anchor will mismatch on first launch and get discarded -- a one-time UI-state reset, no data loss. Since #17595 is still in the open Golden Wattle milestone, no released build is affected.
