### PR TITLE
fix command injection in filename-driven render/preview handlers

### DIFF
--- a/e2e/rstudio/tests/panes/editor/custom_knit_confirm.test.ts
+++ b/e2e/rstudio/tests/panes/editor/custom_knit_confirm.test.ts
@@ -1,0 +1,112 @@
+// Confirmation prompt before running a document-specified custom render
+// command. An R Markdown document can set a `knit:` field in its YAML front
+// matter; RStudio evaluates that value as R code when rendering, so opening an
+// untrusted document and clicking Knit could run arbitrary code with no
+// warning. RStudio now confirms first. See rstudio/rstudio-pro#10989.
+
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { useSuiteSandbox } from '@utils/sandbox';
+import { writeAndOpenFile, closeAndDeleteSandboxFiles } from '@utils/files';
+import { executeCommand } from '@utils/commands';
+import { heredoc } from '@utils/heredoc';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// showYesNoMessage renders a GWT dialog with these stable button IDs; the
+// confirmation prompt is the only yes/no dialog this test can raise.
+const YES_BTN = '#rstudio_dlg_yes';
+const NO_BTN = '#rstudio_dlg_no';
+
+test.describe('Custom knit render confirmation', () => {
+  const sandbox = useSuiteSandbox();
+  let consoleActions: ConsolePaneActions;
+  let missingPackages: string[] = [];
+  let fileName = '';
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+    await consoleActions.resetSourcePane();
+
+    // The Knit command routes through withRMarkdownPackage before our gate,
+    // so rmarkdown must be installed or the test would stall on an install
+    // prompt. Skip cleanly if it (or its transitive deps) can't be installed.
+    missingPackages = await consoleActions.ensurePackages(['rmarkdown'], 180_000);
+    await consoleActions.clearConsole();
+  });
+
+  test.beforeEach(() => {
+    test.skip(
+      missingPackages.length > 0,
+      `required R package(s) not available: ${missingPackages.join(', ')}`,
+    );
+  });
+
+  test.afterEach(async ({ rstudioPage: page }) => {
+    if (fileName)
+      await closeAndDeleteSandboxFiles(page, sandbox.dir, [fileName, 'knit_ran.txt']);
+  });
+
+  test('prompts before running a custom knit: command, and remembers approval', async ({ rstudioPage: page }) => {
+    fileName = `custom_knit_${Date.now()}.Rmd`;
+    const markerPath = path.join(sandbox.dir, 'knit_ran.txt');
+
+    // The knit: field is a custom function that writes a marker file next to
+    // the document. RStudio evaluates it when rendering, so it must be
+    // confirmed -- and the marker proves whether it actually ran.
+    const rmd = heredoc`
+      ---
+      title: "Custom knit"
+      knit: "(function(input, ...) writeLines('ran', file.path(dirname(input), 'knit_ran.txt')))"
+      ---
+
+      Body.
+    `;
+    await writeAndOpenFile(page, sandbox.dir, fileName, rmd);
+
+    // The confirmation dialog is the gwt-DialogBox carrying the yes button.
+    const dialog = page.locator('.gwt-DialogBox').filter({ has: page.locator(YES_BTN) });
+
+    // 1) Knit -> confirmation appears, shows the command, and declining it
+    //    runs nothing.
+    await executeCommand(page, 'knitDocument');
+    await expect(dialog).toBeVisible({ timeout: 20000 });
+    await expect(dialog).toContainText('Run Custom Render Command?');
+    await expect(dialog).toContainText('writeLines');
+
+    await page.locator(NO_BTN).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+    // Give a declined render a chance to (erroneously) run; the marker must
+    // not appear. This is a negative assertion, so a short bounded wait is
+    // unavoidable.
+    await page.waitForTimeout(2000);
+    expect(fs.existsSync(markerPath)).toBe(false);
+
+    // 2) Knit again -> the prompt re-appears (declining did not remember the
+    //    file); accepting runs the command.
+    await executeCommand(page, 'knitDocument');
+    await expect(dialog).toBeVisible({ timeout: 20000 });
+    await page.locator(YES_BTN).click();
+    await expect.poll(() => fs.existsSync(markerPath), { timeout: 30000 }).toBe(true);
+
+    // The custom function returns no output file, so RStudio may surface a
+    // render error; clear any such modal before continuing.
+    await page.keyboard.press('Escape');
+    fs.rmSync(markerPath, { force: true });
+
+    // 3) Knit again -> the approval is remembered for the session, so no
+    //    prompt appears and the command runs without a click. Re-issue knit
+    //    until the marker reappears (the prior async render may still be
+    //    running, in which case the backend drops the extra request), and
+    //    fail loudly if the confirmation dialog ever shows.
+    await expect.poll(async () => {
+      if (await dialog.isVisible())
+        throw new Error('confirmation dialog reappeared for an already-approved document');
+      if (fs.existsSync(markerPath))
+        return true;
+      await executeCommand(page, 'knitDocument');
+      return fs.existsSync(markerPath);
+    }, { timeout: 45000, intervals: [2000] }).toBe(true);
+  });
+});

--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -558,6 +558,46 @@ std::string singleQuotedStrEscape(const std::string& str)
    return escape(escapes, subs, str);
 }
 
+std::string heredoc(const std::string& str)
+{
+   std::vector<std::string> lines;
+   boost::algorithm::split(lines, str, boost::algorithm::is_any_of("\n"));
+
+   // drop a single leading blank line, so that text may begin on the line
+   // following the opening delimiter
+   if (!lines.empty() && trimWhitespace(lines.front()).empty())
+      lines.erase(lines.begin());
+
+   // drop a single trailing blank line, so that the closing delimiter may sit
+   // on its own line
+   if (!lines.empty() && trimWhitespace(lines.back()).empty())
+      lines.pop_back();
+
+   // determine the common leading indentation shared by all non-blank lines
+   std::size_t commonIndent = std::string::npos;
+   for (const std::string& line : lines)
+   {
+      // blank lines do not contribute to the common indentation
+      std::size_t indent = line.find_first_not_of(" \t");
+      if (indent != std::string::npos)
+         commonIndent = std::min(commonIndent, indent);
+   }
+
+   if (commonIndent == std::string::npos)
+      commonIndent = 0;
+
+   // strip the common indentation from each line
+   for (std::string& line : lines)
+   {
+      if (line.size() >= commonIndent)
+         line = line.substr(commonIndent);
+      else
+         line.clear();
+   }
+
+   return boost::algorithm::join(lines, "\n");
+}
+
 std::string filterControlChars(const std::string& str)
 {
    // Delete control chars, which can cause errors in JSON parsing (especially

--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -589,7 +589,11 @@ std::string heredoc(const std::string& str)
    // strip the common indentation from each line
    for (std::string& line : lines)
    {
-      if (line.size() >= commonIndent)
+      // blank lines collapse to empty, even when they are indented more deeply
+      // than the common indentation (so they leave no trailing whitespace)
+      if (line.find_first_not_of(" \t") == std::string::npos)
+         line.clear();
+      else if (line.size() >= commonIndent)
          line = line.substr(commonIndent);
       else
          line.clear();

--- a/src/cpp/core/StringUtilsTests.cpp
+++ b/src/cpp/core/StringUtilsTests.cpp
@@ -374,6 +374,29 @@ TEST(StringTest, HeredocHandlesEmptyInput)
    EXPECT_EQ(std::string(""), heredoc(""));
 }
 
+TEST(StringTest, SingleQuotedStrEscapeLeavesPlainTextUnchanged)
+{
+   EXPECT_EQ(std::string("hello"), singleQuotedStrEscape("hello"));
+   EXPECT_EQ(std::string(""), singleQuotedStrEscape(""));
+}
+
+TEST(StringTest, SingleQuotedStrEscapeEscapesQuotesAndBackslashes)
+{
+   // a single quote is escaped so it cannot terminate the enclosing literal
+   EXPECT_EQ(std::string("it\\'s"), singleQuotedStrEscape("it's"));
+
+   // a backslash is doubled so it cannot escape the following character
+   EXPECT_EQ(std::string("a\\\\b"), singleQuotedStrEscape("a\\b"));
+}
+
+TEST(StringTest, SingleQuotedStrEscapeNeutralizesInjectionPayload)
+{
+   // a filename crafted to break out of a single-quoted R literal and inject
+   // code has every quote escaped, so the payload cannot close the literal
+   EXPECT_EQ(std::string("\\'); system(\\'rm -rf /\\'); #"),
+             singleQuotedStrEscape("'); system('rm -rf /'); #"));
+}
+
 } // end namespace string_utils
 } // end namespace core
 } // end namespace rstudio

--- a/src/cpp/core/StringUtilsTests.cpp
+++ b/src/cpp/core/StringUtilsTests.cpp
@@ -335,6 +335,45 @@ TEST(StringTest, PositionCanBeComputedForMultiLineString)
    EXPECT_EQ(7u, pos.column);
 }
 
+TEST(StringTest, HeredocStripsCommonIndent)
+{
+   std::string text = heredoc(R"(
+      library(knitr)
+      knit('example.Rmd')
+   )");
+   EXPECT_EQ(std::string("library(knitr)\nknit('example.Rmd')"), text);
+}
+
+TEST(StringTest, HeredocPreservesRelativeIndent)
+{
+   std::string text = heredoc(R"(
+      if (x) {
+         f()
+      }
+   )");
+   EXPECT_EQ(std::string("if (x) {\n   f()\n}"), text);
+}
+
+TEST(StringTest, HeredocHandlesBlankInteriorLines)
+{
+   std::string text = heredoc(R"(
+      a
+
+      b
+   )");
+   EXPECT_EQ(std::string("a\n\nb"), text);
+}
+
+TEST(StringTest, HeredocLeavesUnindentedTextUnchanged)
+{
+   EXPECT_EQ(std::string("a\nb"), heredoc("a\nb"));
+}
+
+TEST(StringTest, HeredocHandlesEmptyInput)
+{
+   EXPECT_EQ(std::string(""), heredoc(""));
+}
+
 } // end namespace string_utils
 } // end namespace core
 } // end namespace rstudio

--- a/src/cpp/core/include/core/StringUtils.hpp
+++ b/src/cpp/core/include/core/StringUtils.hpp
@@ -116,6 +116,20 @@ std::string jsonLiteralUnescape(const std::string& str);
 std::string jsonHtmlEscape(const std::string& str);
 std::string singleQuotedStrEscape(const std::string& str);
 
+// Removes the common leading indentation shared by all non-blank lines, and
+// drops a single leading and trailing blank line. This allows multi-line raw
+// string literals to be indented to match the surrounding source code while
+// still producing cleanly-formatted (un-indented) output -- useful for
+// embedding inline R code, scripts, or other text. For example:
+//
+//    std::string code = heredoc(R"(
+//       library(knitr)
+//       knit('example.Rmd')
+//    )");
+//
+// produces "library(knitr)\nknit('example.Rmd')".
+std::string heredoc(const std::string& str);
+
 Error jsonLiteralUnescape(const std::string& string,
                           std::string* pEscaped);
 

--- a/src/cpp/session/modules/SessionHTMLPreview.cpp
+++ b/src/cpp/session/modules/SessionHTMLPreview.cpp
@@ -26,6 +26,8 @@
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/bind/bind.hpp>
 
+#include <fmt/format.h>
+
 #include <shared_core/Error.hpp>
 #include <core/Exec.hpp>
 #include <core/FileSerializer.hpp>
@@ -219,27 +221,38 @@ private:
          return;
       }
 
-      // args
+      // args -- note that paths are escaped before being interpolated into the
+      // R command, so that a filename containing a single quote cannot break
+      // out of the string literal and inject arbitrary R code
       std::string cmd;
       if (!knitrOutputFile_.isEmpty())
       {
-         boost::format fmt;
+         std::string code = string_utils::heredoc(R"RCODE(
+            require(knitr)
+            knit('{0}', encoding = '{1}')
+         )RCODE");
 
-         fmt = boost::format("require(knitr); "
-                              "knit('%2%', encoding='%1%');");
-
-         cmd = boost::str(fmt % encoding % targetFile_.getFilename());
+         cmd = fmt::format(
+            fmt::runtime(code),
+            string_utils::singleQuotedStrEscape(targetFile_.getFilename()),
+            string_utils::singleQuotedStrEscape(encoding));
       }
       else
       {
          std::string tempFilePath = string_utils::utf8ToSystem(
             outputFileTempFile.getAbsolutePath());
-         boost::format fmt;
-         fmt = boost::format("require(knitr); "
-                             "knit('%2%', encoding='%1%'); "
-                             "cat(o, file='%3%');");
-         cmd = boost::str(fmt % encoding % targetFile_.getFilename() %
-                          tempFilePath);
+
+         std::string code = string_utils::heredoc(R"RCODE(
+            require(knitr)
+            knit('{0}', encoding = '{1}')
+            cat(o, file = '{2}')
+         )RCODE");
+
+         cmd = fmt::format(
+            fmt::runtime(code),
+            string_utils::singleQuotedStrEscape(targetFile_.getFilename()),
+            string_utils::singleQuotedStrEscape(encoding),
+            string_utils::singleQuotedStrEscape(tempFilePath));
       }
 
       outputPathTempFile_ = outputFileTempFile;

--- a/src/cpp/session/modules/SessionPlumberViewer.cpp
+++ b/src/cpp/session/modules/SessionPlumberViewer.cpp
@@ -15,11 +15,13 @@
 
 #include "SessionPlumberViewer.hpp"
 
-#include <boost/format.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+
+#include <fmt/format.h>
 
 #include <shared_core/Error.hpp>
 #include <core/Exec.hpp>
+#include <core/StringUtils.hpp>
 
 #include <r/RSexp.hpp>
 #include <r/RRoutines.hpp>
@@ -167,18 +169,13 @@ Error getPlumberRunCmd(const json::JsonRpcRequest& request,
    if (!isPlumberAttached)
       runCmd = "plumber::";
    
-   if (!hasEntrypointFile)
-   {
-      runCmd.append(R"RCODE(plumb(file=')RCODE");
-      runCmd.append(plumberRunPath);
-      runCmd.append(R"RCODE(')$run())RCODE");
-   } 
-   else
-   {
-      runCmd.append(R"RCODE(plumb(dir=')RCODE");
-      runCmd.append(plumberRunPath);
-      runCmd.append(R"RCODE(')$run())RCODE");
-   }
+   // escape the path before interpolating it into the R command, so that a
+   // filename containing a single quote cannot break out of the string literal
+   // and inject arbitrary R code
+   runCmd += fmt::format(
+      "plumb({} = '{}')$run()",
+      hasEntrypointFile ? "dir" : "file",
+      string_utils::singleQuotedStrEscape(plumberRunPath));
 
    json::Object dataJson;
    dataJson["run_cmd"] = runCmd;

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -1317,15 +1317,20 @@ private:
       cmd << "-s";
       cmd << "-e";
 
+      // escape the paths before interpolating them into the R command, so that
+      // a filename containing a single quote cannot break out of the string
+      // literal and inject arbitrary R code
       if (type == kTestShiny)
       {
-        boost::format fmt("shinytest2::test_app('%1%')");
-        cmd << boost::str(fmt % shinyPath.getAbsolutePath());
+        cmd << fmt::format("shinytest2::test_app('{}')",
+                           string_utils::singleQuotedStrEscape(
+                              string_utils::utf8ToSystem(shinyPath.getAbsolutePath())));
       }
       else if (type == kTestShinyFile)
       {
-        boost::format fmt("testthat::test_file('%1%')");
-        cmd << boost::str(fmt % shinyTestFile);
+        cmd << fmt::format("testthat::test_file('{}')",
+                           string_utils::singleQuotedStrEscape(
+                              string_utils::utf8ToSystem(shinyTestFile)));
       }
       else
       {
@@ -1533,10 +1538,13 @@ private:
          boost::format fmt("rmarkdown::render_site(%1%)");
          std::string format;
          if (options_.websiteOutputFormat != "all")
-            format = "output_format = '" + options_.websiteOutputFormat + "', ";
+            format = "output_format = '" +
+                     string_utils::singleQuotedStrEscape(options_.websiteOutputFormat) +
+                     "', ";
 
          format += ("encoding = '" +
-                    projects::projectContext().defaultEncoding() +
+                    string_utils::singleQuotedStrEscape(
+                       projects::projectContext().defaultEncoding()) +
                     "'");
 
          command = boost::str(fmt % format);

--- a/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
+++ b/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
@@ -19,7 +19,6 @@
 #include <iostream>
 
 #include <boost/utility.hpp>
-#include <boost/format.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/trim.hpp>
@@ -27,8 +26,11 @@
 #include <boost/regex.hpp>
 #include <boost/iostreams/filter/regex.hpp>
 
+#include <fmt/format.h>
+
 #include <core/FileSerializer.hpp>
 #include <core/HtmlUtils.hpp>
+#include <core/StringUtils.hpp>
 #include <core/markdown/Markdown.hpp>
 #include <core/text/TemplateFilter.hpp>
 #include <core/system/Process.hpp>
@@ -314,23 +316,36 @@ bool performKnit(const FilePath& rmdPath,
    args.push_back("--no-restore");
    args.push_back("-s");
    args.push_back("-e");
-   boost::format fmt("library(knitr); "
-                     "opts_chunk$set(cache.path='%1%-cache/', "
-                                    "fig.path='%1%-figure/', "
-                                    "tidy=FALSE, "
-                                    "warning=FALSE, "
-                                    "error=FALSE, "
-                                    "message=FALSE, "
-                                    "comment=NA); "
-                     "render_markdown(); "
-                     "knit('%2%', output = '%3%', encoding='%4%');");
    std::string encoding = projects::projectContext().defaultEncoding();
    if(encoding.empty()) encoding = "UTF-8";
-   std::string cmd = boost::str(
-      fmt % string_utils::utf8ToSystem(rmdPath.getStem())
-          % string_utils::utf8ToSystem(rmdPath.getFilename())
-          % string_utils::utf8ToSystem(mdPath.getFilename())
-          % encoding);
+
+   // escape the paths before interpolating them into the R command, so that a
+   // filename containing a single quote cannot break out of the string literal
+   // and inject arbitrary R code
+   std::string code = string_utils::heredoc(R"RCODE(
+      library(knitr)
+      opts_chunk$set(
+         cache.path = '{0}-cache/',
+         fig.path = '{0}-figure/',
+         tidy = FALSE,
+         warning = FALSE,
+         error = FALSE,
+         message = FALSE,
+         comment = NA
+      )
+      render_markdown()
+      knit('{1}', output = '{2}', encoding = '{3}')
+   )RCODE");
+
+   std::string cmd = fmt::format(
+      fmt::runtime(code),
+      string_utils::singleQuotedStrEscape(
+            string_utils::utf8ToSystem(rmdPath.getStem())),
+      string_utils::singleQuotedStrEscape(
+            string_utils::utf8ToSystem(rmdPath.getFilename())),
+      string_utils::singleQuotedStrEscape(
+            string_utils::utf8ToSystem(mdPath.getFilename())),
+      string_utils::singleQuotedStrEscape(encoding));
    args.push_back(cmd);
 
    // options

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -1208,32 +1208,6 @@ Error getRMarkdownContext(const json::JsonRpcRequest&,
    return Success();
 }
 
-bool requiresRenderConfirmation(const std::string& renderFunc)
-{
-   // A document's `knit:` YAML field is evaluated as R code when the document
-   // is rendered (see RenderRmd::start), so an untrusted document can use it to
-   // run arbitrary code on a single click of the Knit/Preview button. The
-   // values below are either RStudio's own defaults or are derived by RStudio
-   // from the document's runtime/site configuration, so they are known-safe;
-   // anything else originates verbatim from the document's `knit:` field and is
-   // confirmed with the user before it is run.
-   static const std::set<std::string> knownSafe = {
-      "",
-      kStandardRenderFunc,          // rmarkdown::render
-      kShinyRenderFunc,             // rmarkdown::run
-      "rmarkdown::render_site",
-      "blogdown::serve_site",
-      "bookdown::render_book",
-      "bookdown::preview_chapter",
-      "pkgdown::build_site",
-      "xaringan::inf_mr",
-      "quarto serve",
-      "quarto render",
-   };
-
-   return knownSafe.find(renderFunc) == knownSafe.end();
-}
-
 Error getCustomRenderFunction(const json::JsonRpcRequest& request,
                               json::JsonRpcResponse* pResponse)
 {
@@ -1250,12 +1224,24 @@ Error getCustomRenderFunction(const json::JsonRpcRequest& request,
    error = r::exec::RFunction(
       ".rs.getCustomRenderFunction",
       string_utils::utf8ToSystem(targetPath.getAbsolutePath())).call(&renderFunc);
+
+   // fail closed: if we could not determine the document's render function, ask
+   // the client to confirm rather than silently treating it as known-safe. This
+   // is the last line of defense before RenderRmd::start evaluates the function.
+   bool requiresConfirmation;
    if (error)
+   {
       LOG_ERROR(error);
+      requiresConfirmation = true;
+   }
+   else
+   {
+      requiresConfirmation = requiresRenderConfirmation(renderFunc);
+   }
 
    json::Object resultJson;
    resultJson["render_function"] = renderFunc;
-   resultJson["requires_confirmation"] = requiresRenderConfirmation(renderFunc);
+   resultJson["requires_confirmation"] = requiresConfirmation;
    pResponse->setResult(resultJson);
    return Success();
 }
@@ -1366,6 +1352,13 @@ Error renderRmd(const json::JsonRpcRequest& request,
 Error renderRmdSource(const json::JsonRpcRequest& request,
                      json::JsonRpcResponse* pResponse)
 {
+   // NOTE: This renders caller-supplied source text (written to a temp file)
+   // and so does not pass through the client-side custom-render confirmation in
+   // RmdOutput.onRenderRmd, which guards rendering of on-disk documents. This is
+   // currently safe because the only entry point (renderRMarkdownSource) has no
+   // live callers; if that changes, any new caller must apply the same
+   // confirmation before invoking this RPC (or the gate must move to the
+   // RenderRmd::start chokepoint for defense-in-depth).
    std::string source;
    Error error = json::readParams(request.params, &source);
    if (error)
@@ -1875,6 +1868,32 @@ void onResume(const Settings&)
 }
 
 } // anonymous namespace
+
+bool requiresRenderConfirmation(const std::string& renderFunc)
+{
+   // A document's `knit:` YAML field is evaluated as R code when the document
+   // is rendered (see RenderRmd::start), so an untrusted document can use it to
+   // run arbitrary code on a single click of the Knit/Preview button. The
+   // values below are either RStudio's own defaults or are derived by RStudio
+   // from the document's runtime/site configuration, so they are known-safe;
+   // anything else originates verbatim from the document's `knit:` field and is
+   // confirmed with the user before it is run.
+   static const std::set<std::string> knownSafe = {
+      "",
+      kStandardRenderFunc,          // rmarkdown::render
+      kShinyRenderFunc,             // rmarkdown::run
+      "rmarkdown::render_site",
+      "blogdown::serve_site",
+      "bookdown::render_book",
+      "bookdown::preview_chapter",
+      "pkgdown::build_site",
+      "xaringan::inf_mr",
+      "quarto serve",
+      "quarto render",
+   };
+
+   return knownSafe.find(renderFunc) == knownSafe.end();
+}
 
 Error evaluateRmdParams(const std::string& docId)
 {

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -20,6 +20,7 @@
 #include <gsl/gsl-lite.hpp>
 
 #include <optional>
+#include <set>
 
 #include "SessionRmdNotebook.hpp"
 #include "../SessionHTMLPreview.hpp"
@@ -1207,6 +1208,58 @@ Error getRMarkdownContext(const json::JsonRpcRequest&,
    return Success();
 }
 
+bool requiresRenderConfirmation(const std::string& renderFunc)
+{
+   // A document's `knit:` YAML field is evaluated as R code when the document
+   // is rendered (see RenderRmd::start), so an untrusted document can use it to
+   // run arbitrary code on a single click of the Knit/Preview button. The
+   // values below are either RStudio's own defaults or are derived by RStudio
+   // from the document's runtime/site configuration, so they are known-safe;
+   // anything else originates verbatim from the document's `knit:` field and is
+   // confirmed with the user before it is run.
+   static const std::set<std::string> knownSafe = {
+      "",
+      kStandardRenderFunc,          // rmarkdown::render
+      kShinyRenderFunc,             // rmarkdown::run
+      "rmarkdown::render_site",
+      "blogdown::serve_site",
+      "bookdown::render_book",
+      "bookdown::preview_chapter",
+      "pkgdown::build_site",
+      "xaringan::inf_mr",
+      "quarto serve",
+      "quarto render",
+   };
+
+   return knownSafe.find(renderFunc) == knownSafe.end();
+}
+
+Error getCustomRenderFunction(const json::JsonRpcRequest& request,
+                              json::JsonRpcResponse* pResponse)
+{
+   std::string file;
+   Error error = json::readParams(request.params, &file);
+   if (error)
+      return error;
+
+   FilePath targetPath = module_context::resolveAliasedPath(file);
+
+   // note that .rs.getCustomRenderFunction only parses the document's YAML front
+   // matter -- it does not evaluate the `knit:` field, so calling it here is safe
+   std::string renderFunc;
+   error = r::exec::RFunction(
+      ".rs.getCustomRenderFunction",
+      string_utils::utf8ToSystem(targetPath.getAbsolutePath())).call(&renderFunc);
+   if (error)
+      LOG_ERROR(error);
+
+   json::Object resultJson;
+   resultJson["render_function"] = renderFunc;
+   resultJson["requires_confirmation"] = requiresRenderConfirmation(renderFunc);
+   pResponse->setResult(resultJson);
+   return Success();
+}
+
 void doRenderRmd(const std::string& file,
                  int line,
                  const std::string& format,
@@ -1941,6 +1994,7 @@ Error initialize()
    initBlock.addFunctions()
       (bind(registerRpcMethod, "get_rmarkdown_context", getRMarkdownContext))
       (bind(registerRpcMethod, "render_rmd", renderRmd))
+      (bind(registerRpcMethod, "get_custom_render_function", getCustomRenderFunction))
       (bind(registerRpcMethod, "render_rmd_source", renderRmdSource))
       (bind(registerRpcMethod, "terminate_render_rmd", terminateRenderRmd))
       (bind(registerRpcMethod, "create_rmd_from_template", createRmdFromTemplate))

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.hpp
@@ -54,6 +54,12 @@ core::Error evaluateRmdParams(const std::string& docId);
 
 std::string parsableRStudioVersion();
 
+// Returns true if the given document render function (from a document's `knit:`
+// YAML field) must be confirmed with the user before it is run, because it is
+// not one of RStudio's known-safe defaults. See SessionRMarkdown.cpp for
+// details on why a custom render function is treated as untrusted.
+bool requiresRenderConfirmation(const std::string& renderFunc);
+
 core::Error initialize();
 
 } // namespace rmarkdown

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdownTests.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdownTests.cpp
@@ -1,0 +1,59 @@
+/*
+ * SessionRMarkdownTests.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include "SessionRMarkdown.hpp"
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace rmarkdown {
+
+TEST(SessionRMarkdownTest, KnownSafeRenderFunctionsDoNotRequireConfirmation)
+{
+   // RStudio's own defaults and derived render functions are known-safe and
+   // must not prompt the user on every ordinary knit/preview.
+   EXPECT_FALSE(requiresRenderConfirmation(""));
+   EXPECT_FALSE(requiresRenderConfirmation("rmarkdown::render"));
+   EXPECT_FALSE(requiresRenderConfirmation("rmarkdown::run"));
+   EXPECT_FALSE(requiresRenderConfirmation("rmarkdown::render_site"));
+   EXPECT_FALSE(requiresRenderConfirmation("blogdown::serve_site"));
+   EXPECT_FALSE(requiresRenderConfirmation("bookdown::render_book"));
+   EXPECT_FALSE(requiresRenderConfirmation("bookdown::preview_chapter"));
+   EXPECT_FALSE(requiresRenderConfirmation("pkgdown::build_site"));
+   EXPECT_FALSE(requiresRenderConfirmation("xaringan::inf_mr"));
+   EXPECT_FALSE(requiresRenderConfirmation("quarto serve"));
+   EXPECT_FALSE(requiresRenderConfirmation("quarto render"));
+}
+
+TEST(SessionRMarkdownTest, CustomRenderFunctionsRequireConfirmation)
+{
+   // Anything originating verbatim from a document's `knit:` field is treated
+   // as untrusted and must be confirmed before it is evaluated.
+   EXPECT_TRUE(requiresRenderConfirmation("my_custom_render"));
+   EXPECT_TRUE(requiresRenderConfirmation("source('evil.R')"));
+   EXPECT_TRUE(requiresRenderConfirmation("function(input, ...) system('rm -rf /')"));
+
+   // a value that merely resembles a known-safe entry is still not an exact
+   // match, so it must be confirmed
+   EXPECT_TRUE(requiresRenderConfirmation("rmarkdown::render2"));
+   EXPECT_TRUE(requiresRenderConfirmation(" rmarkdown::render"));
+}
+
+} // namespace rmarkdown
+} // namespace modules
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/session/modules/tex/SessionRnwWeave.cpp
+++ b/src/cpp/session/modules/tex/SessionRnwWeave.cpp
@@ -449,7 +449,29 @@ std::string driverForFile(const core::tex::TexMagicComments& magicComments)
       if (boost::algorithm::iequals(mc.scope(), "rnw") &&
           boost::algorithm::iequals(mc.variable(), "driver"))
       {
-         return mc.value();
+         std::string driver = mc.value();
+
+         // The driver is interpolated into the weave command as a bare R
+         // expression (not a quoted string literal), so unlike the file and
+         // encoding we cannot escape it. To keep an untrusted document from
+         // injecting arbitrary R code via a "% !Rnw driver = ..." magic
+         // comment, only accept values that look like a plain, optionally
+         // namespaced function reference -- e.g. "RweaveLatex",
+         // "cacheSweave::cacheSweaveDriver", or "RweaveLatex()". Anything else
+         // is rejected and the default driver is used instead.
+         static const boost::regex driverPattern(
+            "^\\s*"
+            "(?:[a-zA-Z.][a-zA-Z0-9._]*:{2,3})?"   // optional pkg:: or pkg:::
+            "[a-zA-Z.][a-zA-Z0-9._]*"              // function name
+            "\\s*(?:\\(\\s*\\))?"                  // optional empty arg list
+            "\\s*$");
+
+         if (regex_utils::match(driver, driverPattern))
+            return driver;
+
+         WLOGF("Ignoring invalid Sweave driver '{}' specified in magic comment",
+               driver);
+         return std::string();
       }
    }
 

--- a/src/cpp/session/modules/tex/SessionRnwWeave.cpp
+++ b/src/cpp/session/modules/tex/SessionRnwWeave.cpp
@@ -19,7 +19,10 @@
 #include <boost/format.hpp>
 #include <boost/algorithm/string/split.hpp>
 
+#include <fmt/format.h>
+
 #include <core/FileSerializer.hpp>
+#include <core/StringUtils.hpp>
 #include <core/tex/TexLogParser.hpp>
 #include <core/tex/TexMagicComment.hpp>
 
@@ -227,13 +230,19 @@ public:
                                     const std::string& encoding,
                                     const std::string& driver) const
    {
-      std::string cmd = "utils::Sweave('" + file + "'";
+      // escape the path and encoding before interpolating them into the R
+      // command, so that a filename containing a single quote cannot break out
+      // of the string literal and inject arbitrary R code
+      std::string cmd =
+            fmt::format("utils::Sweave('{}'",
+                        string_utils::singleQuotedStrEscape(file));
 
       if (!driver.empty())
-         cmd += ", driver = " + driver + "";
+         cmd += fmt::format(", driver = {}", driver);
 
       if (!encoding.empty())
-         cmd += (", encoding='" + encoding + "'");
+         cmd += fmt::format(", encoding = '{}'",
+                            string_utils::singleQuotedStrEscape(encoding));
 
       cmd += ")";
 
@@ -265,14 +274,18 @@ public:
                                     const std::string& encoding,
                                     const std::string& driver) const
    {
-      std::string format = "require(knitr); ";
+      std::string cmd = "require(knitr); ";
       if (prefs::userPrefs().alwaysEnableRnwConcordance())
-         format += "opts_knit$set(concordance = TRUE); ";
-      format += "knit('%1%'";
-      std::string cmd = boost::str(boost::format(format) % file);
+         cmd += "opts_knit$set(concordance = TRUE); ";
+
+      // escape the path and encoding before interpolating them into the R
+      // command, so that a filename containing a single quote cannot break out
+      // of the string literal and inject arbitrary R code
+      cmd += fmt::format("knit('{}'", string_utils::singleQuotedStrEscape(file));
 
       if (!encoding.empty())
-         cmd += (", encoding='" + encoding + "'");
+         cmd += fmt::format(", encoding = '{}'",
+                            string_utils::singleQuotedStrEscape(encoding));
 
       cmd += ")";
 

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/RMarkdownConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/RMarkdownConstants.java
@@ -40,4 +40,5 @@ public interface RMarkdownConstants extends Messages {
     String locationLabel();
     String customRenderConfirmCaption();
     String customRenderConfirmMessage(String renderFunction);
+    String customRenderConfirmMessageUnknown();
 }

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/RMarkdownConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/RMarkdownConstants.java
@@ -38,4 +38,6 @@ public interface RMarkdownConstants extends Messages {
     String yesAlwaysButtonText();
     String noButtonText();
     String locationLabel();
+    String customRenderConfirmCaption();
+    String customRenderConfirmMessage(String renderFunction);
 }

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/RMarkdownConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/RMarkdownConstants_en.properties
@@ -22,3 +22,4 @@ noButtonText=No
 locationLabel=Location:
 customRenderConfirmCaption=Run Custom Render Command?
 customRenderConfirmMessage=This document specifies a custom render command in its YAML header:\n\n    {0}\n\nRendering will run this command, which can execute arbitrary code. Only continue if you trust this document. Run the command?
+customRenderConfirmMessageUnknown=RStudio could not determine how this document will be rendered. If the document specifies a custom render command in its YAML header, rendering will run that command, which can execute arbitrary code. Only continue if you trust this document. Render the document?

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/RMarkdownConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/RMarkdownConstants_en.properties
@@ -20,3 +20,5 @@ yesOnceButtonText=Yes, Once
 yesAlwaysButtonText=Yes, Always
 noButtonText=No
 locationLabel=Location:
+customRenderConfirmCaption=Run Custom Render Command?
+customRenderConfirmMessage=This document specifies a custom render command in its YAML header:\n\n    {0}\n\nRendering will run this command, which can execute arbitrary code. Only continue if you trust this document. Run the command?

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/RMarkdownConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/RMarkdownConstants_fr.properties
@@ -20,3 +20,5 @@ yesOnceButtonText=Oui, une fois
 yesAlwaysButtonText=Oui, toujours
 noButtonText=Non
 locationLabel=Emplacement:
+customRenderConfirmCaption=Exécuter la commande de rendu personnalisée ?
+customRenderConfirmMessage=Ce document spécifie une commande de rendu personnalisée dans son en-tête YAML :\n\n    {0}\n\nLe rendu exécutera cette commande, qui peut exécuter du code arbitraire. Ne continuez que si vous faites confiance à ce document. Exécuter la commande ?

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/RMarkdownConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/RMarkdownConstants_fr.properties
@@ -22,3 +22,4 @@ noButtonText=Non
 locationLabel=Emplacement:
 customRenderConfirmCaption=Exécuter la commande de rendu personnalisée ?
 customRenderConfirmMessage=Ce document spécifie une commande de rendu personnalisée dans son en-tête YAML :\n\n    {0}\n\nLe rendu exécutera cette commande, qui peut exécuter du code arbitraire. Ne continuez que si vous faites confiance à ce document. Exécuter la commande ?
+customRenderConfirmMessageUnknown=RStudio n''a pas pu déterminer comment ce document sera rendu. Si le document spécifie une commande de rendu personnalisée dans son en-tête YAML, le rendu exécutera cette commande, qui peut exécuter du code arbitraire. Ne continuez que si vous faites confiance à ce document. Rendre le document ?

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/RmdOutput.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/RmdOutput.java
@@ -299,7 +299,10 @@ public class RmdOutput implements RmdRenderStartedEvent.Handler,
                      @Override
                      public void execute()
                      {
-                        // user declined: do not render
+                        // user declined: do not render. RmdRenderPendingEvent
+                        // (fired before we got here) set renderInProgress_, so
+                        // clear it since no render will start.
+                        renderInProgress_ = false;
                      }
                   },
                   false /* yesIsDefault */);

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/RmdOutput.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/RmdOutput.java
@@ -15,9 +15,7 @@
 package org.rstudio.studio.client.rmarkdown;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
@@ -256,11 +254,13 @@ public class RmdOutput implements RmdRenderStartedEvent.Handler,
       // against a malicious document running arbitrary code on a single click
       // of the Knit/Preview button, confirm with the user before honoring a
       // custom render command (see rstudio-pro#10989). Known-safe and
-      // RStudio-derived render functions do not require confirmation, and a
-      // given source file is only confirmed once per session.
+      // RStudio-derived render functions do not require confirmation. A given
+      // custom command is confirmed once per session; we re-query the backend
+      // on every render (it only parses the YAML, it does not evaluate it) and
+      // re-confirm if the command has changed since it was approved (e.g. the
+      // file was replaced on disk after approval).
       final String sourceFile = event.getSourceFile();
-      if (StringUtil.isNullOrEmpty(sourceFile) ||
-          customRenderConfirmed_.contains(sourceFile))
+      if (StringUtil.isNullOrEmpty(sourceFile))
       {
          doRenderRmd(event);
          return;
@@ -274,49 +274,79 @@ public class RmdOutput implements RmdRenderStartedEvent.Handler,
          {
             Boolean requiresConfirmation = response == null ? null :
                response.getBoolean("requires_confirmation");
-            if (requiresConfirmation == null || !requiresConfirmation)
+
+            // fail closed: only skip the prompt when the backend explicitly
+            // reports that confirmation is not required. A null/missing value
+            // means we couldn't determine the render function, so confirm.
+            if (Boolean.FALSE.equals(requiresConfirmation))
             {
                doRenderRmd(event);
                return;
             }
 
-            String renderFunction =
+            String renderFunction = response == null ? "" :
                StringUtil.notNull(response.getString("render_function"));
-            globalDisplay_.showYesNoMessage(
-                  GlobalDisplay.MSG_WARNING,
-                  constants_.customRenderConfirmCaption(),
-                  constants_.customRenderConfirmMessage(renderFunction),
-                  false,
-                  new Operation() {
-                     @Override
-                     public void execute()
-                     {
-                        customRenderConfirmed_.add(sourceFile);
-                        doRenderRmd(event);
-                     }
-                  },
-                  new Operation() {
-                     @Override
-                     public void execute()
-                     {
-                        // user declined: do not render. RmdRenderPendingEvent
-                        // (fired before we got here) set renderInProgress_, so
-                        // clear it since no render will start.
-                        renderInProgress_ = false;
-                     }
-                  },
-                  false /* yesIsDefault */);
+
+            // skip the prompt only if the user already approved this exact
+            // command for this file this session; a changed command re-prompts
+            // (renderFunction is non-null, so this comparison is null-safe)
+            if (renderFunction.equals(customRenderConfirmed_.get(sourceFile)))
+            {
+               doRenderRmd(event);
+               return;
+            }
+
+            confirmCustomRender(event, renderFunction);
          }
 
          @Override
          public void onError(ServerError error)
          {
-            // best-effort check; if we can't read the render function, proceed
-            // with the render rather than blocking the user
+            // fail closed: if we can't read the render function, confirm with
+            // the user rather than silently running a possibly-custom command
             Debug.logError(error);
-            doRenderRmd(event);
+            confirmCustomRender(event, "");
          }
       });
+   }
+
+   private void confirmCustomRender(final RenderRmdEvent event,
+                                    final String renderFunction)
+   {
+      final String sourceFile = event.getSourceFile();
+
+      // when we couldn't determine the specific render command, fall back to a
+      // generic confirmation message rather than naming an empty command
+      String message = StringUtil.isNullOrEmpty(renderFunction)
+            ? constants_.customRenderConfirmMessageUnknown()
+            : constants_.customRenderConfirmMessage(renderFunction);
+
+      globalDisplay_.showYesNoMessage(
+            GlobalDisplay.MSG_WARNING,
+            constants_.customRenderConfirmCaption(),
+            message,
+            false,
+            new Operation() {
+               @Override
+               public void execute()
+               {
+                  // remember the approved command so we don't re-prompt for it,
+                  // but still re-prompt if the command later changes
+                  customRenderConfirmed_.put(sourceFile, renderFunction);
+                  doRenderRmd(event);
+               }
+            },
+            new Operation() {
+               @Override
+               public void execute()
+               {
+                  // user declined: do not render. RmdRenderPendingEvent
+                  // (fired before we got here) set renderInProgress_, so
+                  // clear it since no render will start.
+                  renderInProgress_ = false;
+               }
+            },
+            false /* yesIsDefault */);
    }
 
    private void doRenderRmd(final RenderRmdEvent event)
@@ -890,9 +920,10 @@ public class RmdOutput implements RmdRenderStartedEvent.Handler,
    private boolean livePreviewRenderInProgress_ = false;
    private boolean quitInitiatedAfterLastRender_ = false;
 
-   // source files whose custom render command the user has confirmed this
-   // session (so we only prompt once per file per session)
-   private final Set<String> customRenderConfirmed_ = new HashSet<>();
+   // maps a source file to the custom render command the user has confirmed for
+   // it this session, so we only prompt once per command but re-prompt if the
+   // command changes (e.g. the file is replaced on disk after approval)
+   private final Map<String, String> customRenderConfirmed_ = new HashMap<>();
 
    public final static String NOTEBOOK_EXT = ".nb.html";
 

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/RmdOutput.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/RmdOutput.java
@@ -15,12 +15,16 @@
 package org.rstudio.studio.client.rmarkdown;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.files.FileSystemItem;
+import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -246,6 +250,73 @@ public class RmdOutput implements RmdRenderStartedEvent.Handler,
 
    @Override
    public void onRenderRmd(final RenderRmdEvent event)
+   {
+      // A document can specify a custom render command in its YAML `knit:`
+      // field, which RStudio evaluates as R code when rendering. To protect
+      // against a malicious document running arbitrary code on a single click
+      // of the Knit/Preview button, confirm with the user before honoring a
+      // custom render command (see rstudio-pro#10989). Known-safe and
+      // RStudio-derived render functions do not require confirmation, and a
+      // given source file is only confirmed once per session.
+      final String sourceFile = event.getSourceFile();
+      if (StringUtil.isNullOrEmpty(sourceFile) ||
+          customRenderConfirmed_.contains(sourceFile))
+      {
+         doRenderRmd(event);
+         return;
+      }
+
+      server_.getCustomRenderFunction(sourceFile,
+            new ServerRequestCallback<JsObject>()
+      {
+         @Override
+         public void onResponseReceived(JsObject response)
+         {
+            Boolean requiresConfirmation = response == null ? null :
+               response.getBoolean("requires_confirmation");
+            if (requiresConfirmation == null || !requiresConfirmation)
+            {
+               doRenderRmd(event);
+               return;
+            }
+
+            String renderFunction =
+               StringUtil.notNull(response.getString("render_function"));
+            globalDisplay_.showYesNoMessage(
+                  GlobalDisplay.MSG_WARNING,
+                  constants_.customRenderConfirmCaption(),
+                  constants_.customRenderConfirmMessage(renderFunction),
+                  false,
+                  new Operation() {
+                     @Override
+                     public void execute()
+                     {
+                        customRenderConfirmed_.add(sourceFile);
+                        doRenderRmd(event);
+                     }
+                  },
+                  new Operation() {
+                     @Override
+                     public void execute()
+                     {
+                        // user declined: do not render
+                     }
+                  },
+                  false /* yesIsDefault */);
+         }
+
+         @Override
+         public void onError(ServerError error)
+         {
+            // best-effort check; if we can't read the render function, proceed
+            // with the render rather than blocking the user
+            Debug.logError(error);
+            doRenderRmd(event);
+         }
+      });
+   }
+
+   private void doRenderRmd(final RenderRmdEvent event)
    {
       quitInitiatedAfterLastRender_ = false;
 
@@ -815,6 +886,10 @@ public class RmdOutput implements RmdRenderStartedEvent.Handler,
    private boolean renderInProgress_ = false;
    private boolean livePreviewRenderInProgress_ = false;
    private boolean quitInitiatedAfterLastRender_ = false;
+
+   // source files whose custom render command the user has confirmed this
+   // session (so we only prompt once per file per session)
+   private final Set<String> customRenderConfirmed_ = new HashSet<>();
 
    public final static String NOTEBOOK_EXT = ".nb.html";
 

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
@@ -37,6 +37,9 @@ public interface RMarkdownServerOperations extends CryptoServerOperations
    
    void renderRmdSource(String source,
                         ServerRequestCallback<Boolean> requestCallback);
+
+   void getCustomRenderFunction(String file,
+                        ServerRequestCallback<JsObject> requestCallback);
    
    void maybeCopyWebsiteAsset(String file,
                          ServerRequestCallback<Boolean> requestCallback);

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -5794,6 +5794,13 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, RENDER_RMD_SOURCE, source, requestCallback);
    }
 
+   @Override
+   public void getCustomRenderFunction(String file,
+         ServerRequestCallback<JsObject> requestCallback)
+   {
+      sendRequest(RPC_SCOPE, "get_custom_render_function", file, requestCallback);
+   }
+
 
    @Override
    public void maybeCopyWebsiteAsset(String file,


### PR DESCRIPTION
## Intent

Addresses rstudio/rstudio-pro#10989.

## Summary

Two related changes hardening how RStudio constructs R commands for
filename-driven "run/preview/render" actions.

**1. Escape interpolated paths (filename command injection).**
Several handlers built an R command by concatenating a user-controlled
file path directly into a single-quoted R string literal, so a filename
containing a single quote could break out of the literal and inject R
code. Each interpolated path/stem/encoding is now escaped with
`string_utils::singleQuotedStrEscape()` (already used elsewhere for this
purpose). Covered sites:

- Plumber "Run API" (`SessionPlumberViewer.cpp`)
- R Presentation "Preview" (`presentation/SlideRequestHandler.cpp`)
- HTML/knitr preview (`SessionHTMLPreview.cpp`)
- Sweave and knitr weave (`tex/SessionRnwWeave.cpp`)
- shinytest2 / testthat run and website `render_site` (`build/SessionBuild.cpp`)

While here, these sites were ported from `boost::format`/string
concatenation to `fmt::format`, the generated R is formatted
conventionally (spaces around `=`), and a `string_utils::heredoc()`
helper (with unit tests) was added so multi-line R templates can be
indented to match the surrounding source.

**2. Confirm custom `knit:` render commands.**
A document can specify a custom render command in its YAML `knit:` field,
which RStudio evaluates as R code at render time -- so opening an
untrusted document and clicking Knit/Preview could run arbitrary code
with no warning. This is execution-by-design rather than string
injection, so escaping does not apply. The render chokepoint now asks
the backend (via a new read-only `get_custom_render_function` RPC that
only parses the YAML, it does not evaluate it) whether the document's
render function is custom, and prompts for confirmation before running
it. RStudio's own defaults and derived render functions are known-safe
and skip the prompt; approval is remembered per source file for the
session.

## Testing

- New C++ unit tests for `string_utils::heredoc()` (`StringUtilsTests.cpp`).
- New Playwright test (`e2e/.../custom_knit_confirm.test.ts`) asserting the
  custom-knit confirmation prompts, that declining runs nothing, that
  accepting runs the command, and that approval is remembered.
- `rstudio-core`/`rsession` build and link; GWT compiles; the new e2e test
  passes on desktop.