### PR TITLE
fix data viewer multi-cell copy and horizontal scrollbar on tab return

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 - ([#17768](https://github.com/rstudio/rstudio/issues/17768)): Handle the ANSI cursor-movement escape sequences cursor-up (CSI A), cursor-down (CSI B), cursor-next-line (CSI E), cursor-previous-line (CSI F), and cursor-horizontal-absolute (CSI G) in the console so that multiple `cli` progress bars render on separate lines instead of overwriting each other.
 - ([#17225](https://github.com/rstudio/rstudio/issues/17225)): Fix duplicate entries appearing in the recent projects list when the same project was recorded under both aliased (`~/...`) and absolute path forms.
 - ([#17777](https://github.com/rstudio/rstudio/issues/17777)): Fix "Import Dataset" from the Environment pane failing with "could not find function '.rs.digest'" when previewing a CSV (or other readr/readxl/haven source).
+- ([#17800](https://github.com/rstudio/rstudio/issues/17800)): Fix the data viewer's horizontal scrollbar staying hidden after returning to the tab, and fix Ctrl+C/Cmd+C copying only the active cell instead of the user's multi-cell text selection.
 
 ### Dependencies
 - Ace 1.43.5

--- a/e2e/rstudio/pages/data_viewer.page.ts
+++ b/e2e/rstudio/pages/data_viewer.page.ts
@@ -14,6 +14,8 @@ export class DataViewerPane extends PageObject {
 
   // Elements inside the iframe
   public gridInfo: Locator;
+  public viewport: Locator;
+  public horizontalScrollbar: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -28,6 +30,10 @@ export class DataViewerPane extends PageObject {
     // The data grid renders inside an iframe
     this.frame = page.frameLocator('[title="Data Browser"]');
     this.gridInfo = this.frame.locator('#rsGridData_info');
+    this.viewport = this.frame.locator('#gridViewport');
+    // Custom auto-hide overlay scrollbar for the horizontal axis. Carries the
+    // "visible" class while shown; the class is removed when it fades out.
+    this.horizontalScrollbar = this.frame.locator('.custom-scrollbar.horizontal');
   }
 
   /** Get a column header locator by column number (inside iframe). */

--- a/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
@@ -232,6 +232,128 @@ test.describe('Data Viewer', () => {
     }
   });
 
+  // https://github.com/rstudio/rstudio/issues/17800
+  //
+  // The grid intercepts Ctrl/Cmd+C while the viewport is focused to copy the
+  // single active cell. Regression: it did so unconditionally, clobbering a
+  // multi-cell native text selection -- so after clicking a cell the user
+  // could only ever copy that one cell. The fix steps aside when a non-empty
+  // selection exists and lets the browser copy it.
+  //
+  // The test installs a one-shot `copy` listener in the iframe that records
+  // window.getSelection().toString(). When the keystroke is correctly handed
+  // to the browser, that listener fires with the full selection; with the old
+  // behavior the keydown was preventDefault()ed and no `copy` event fired at
+  // all, so the recorded text stays null and the poll below times out.
+  test('Ctrl+C copies a multi-cell text selection, not just the active cell', async ({ rstudioPage: page }) => {
+    await consoleActions.executeInConsole(
+      '{ .rs.copy_test_df <- data.frame(a = c("alpha", "bravo"), b = c("charlie", "delta"), stringsAsFactors = FALSE); View(.rs.copy_test_df) }',
+    );
+    try {
+      await waitForViewer(dataViewer);
+
+      // Click a value cell first: this sets the active cell and focuses the
+      // viewport, which is the precondition for the grid's keydown handler to
+      // intercept Ctrl+C in the first place (and matches the user's report of
+      // "the cell that I initially clicked on").
+      await dataViewer.frame.locator('#gridBody tr[data-row="0"] td.textCell').first().click();
+
+      // Select the whole first data row natively, then arm a copy listener.
+      await page.evaluate((sel: string) => {
+        const f = document.querySelector(sel) as HTMLIFrameElement | null;
+        const win = f?.contentWindow as (Window & { __dvCopyText?: string | null }) | null;
+        const doc = f?.contentDocument;
+        if (!win || !doc) throw new Error('data viewer iframe not accessible');
+        const tr = doc.querySelector('#gridBody tr[data-row="0"]');
+        if (!tr) throw new Error('first data row not rendered');
+        const selection = win.getSelection();
+        if (!selection) throw new Error('no Selection object');
+        selection.removeAllRanges();
+        const range = doc.createRange();
+        range.selectNodeContents(tr);
+        selection.addRange(range);
+        win.__dvCopyText = null;
+        doc.addEventListener(
+          'copy',
+          () => { win.__dvCopyText = win.getSelection()?.toString() ?? ''; },
+          { once: true },
+        );
+      }, VIEWER_FRAME);
+
+      // ControlOrMeta so the platform copy accelerator fires the browser's
+      // native copy (Cmd+C on macOS, Ctrl+C elsewhere); the grid handler
+      // accepts either modifier too.
+      await page.keyboard.press('ControlOrMeta+c');
+
+      // The native copy should have captured both cells from row 0.
+      await expect.poll(
+        () => page.evaluate((sel: string) => {
+          const f = document.querySelector(sel) as HTMLIFrameElement | null;
+          const win = f?.contentWindow as (Window & { __dvCopyText?: string | null }) | null;
+          return win?.__dvCopyText ?? null;
+        }, VIEWER_FRAME),
+        { timeout: TIMEOUTS.fileOpen, message: 'native copy of the multi-cell selection never fired' },
+      ).toContain('alpha');
+
+      const copied = await page.evaluate((sel: string) => {
+        const f = document.querySelector(sel) as HTMLIFrameElement | null;
+        const win = f?.contentWindow as (Window & { __dvCopyText?: string | null }) | null;
+        return win?.__dvCopyText ?? '';
+      }, VIEWER_FRAME);
+      expect(copied).toContain('charlie');
+    } finally {
+      await consoleActions.executeInConsole(
+        'rm(".rs.copy_test_df", envir = .GlobalEnv)',
+      );
+    }
+  });
+
+  // https://github.com/rstudio/rstudio/issues/17800
+  //
+  // The grid uses auto-hide overlay scrollbars that fade after ~1.2s of
+  // inactivity and only reappear on a scroll event. Regression: returning to
+  // the data viewer tab re-ran layout but never re-showed the bars, so the
+  // horizontal scrollbar stayed hidden (and horizontal scrolls rarely happen
+  // via the wheel, so it was effectively gone). The fix calls showScrollbars()
+  // from the tab-activation hook.
+  test('horizontal scrollbar reappears after returning to the data viewer tab', async ({ rstudioPage: page }) => {
+    // 60 columns guarantees the grid overflows its viewport horizontally
+    // regardless of the source pane width in CI.
+    await consoleActions.executeInConsole(
+      '{ .rs.wide_test_df <- as.data.frame(matrix(seq_len(300), nrow = 5, ncol = 60)); View(.rs.wide_test_df) }',
+    );
+    try {
+      await waitForViewer(dataViewer);
+
+      // Precondition: the grid is actually horizontally scrollable.
+      await expect.poll(
+        () => dataViewer.viewport.evaluate(
+          (el: HTMLElement) => el.scrollWidth - el.clientWidth,
+        ),
+        { message: 'wide data frame should overflow the viewport horizontally' },
+      ).toBeGreaterThan(1);
+
+      // Let the initial activity-based show fade out so the next assertion is
+      // meaningful: the bar must be hidden before we switch back to it.
+      await expect(dataViewer.horizontalScrollbar)
+        .not.toHaveClass(/\bvisible\b/, { timeout: 2500 });
+
+      // Switch away to the kept Untitled tab, then back to the viewer tab.
+      // Selecting the viewer tab fires the data viewer's onActivate hook.
+      const sourceTabs = page.locator("[class*='rstudio_source_panel'] .gwt-TabLayoutPanelTab");
+      await sourceTabs.filter({ hasText: 'Untitled' }).first().click();
+      await sourceTabs.filter({ hasText: '.rs.wide_test_df' }).first().click();
+
+      // The bar is shown again on activation (it fades after ~1.2s, but
+      // toHaveClass polls fast enough to observe the visible window).
+      await expect(dataViewer.horizontalScrollbar).toHaveClass(/\bvisible\b/);
+    } finally {
+      await consoleActions.executeInConsole(
+        'rm(".rs.wide_test_df", envir = .GlobalEnv)',
+      );
+    }
+  });
+
   test('HTML-special column names render as text, not markup', async () => {
     await consoleActions.executeInConsole(
       '{ .rs.escape_hdr_df <- data.frame(x = 1, check.names = FALSE); names(.rs.escape_hdr_df) <- "<b>&\\"\'"; View(.rs.escape_hdr_df) }',

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -2018,6 +2018,12 @@ var onResize = debounce(function() {
    renderVisibleRows(true);
    updateInfoBar();
    updateCustomScrollbars();
+
+   // A resize can change whether (and how far) the grid scrolls horizontally
+   // without any scroll event firing; surface the auto-hide scrollbars so the
+   // affordance reflects the new layout. update() above leaves non-scrollable
+   // axes hidden, so this only reveals bars that actually overflow.
+   showScrollbars();
 }, TIMING.resizeDebounce);
 
 // ==========================================================================
@@ -2763,7 +2769,13 @@ var onGridKeyDown = function(evt) {
    }
 
    if (isCopy) {
-      if (copyActiveCell()) evt.preventDefault();
+      // If the user has a non-empty native text selection (e.g. drag-selected
+      // across multiple cells), let the browser copy it. Overriding with the
+      // single active cell here would clobber a multi-cell selection -- the
+      // active-cell copy is only the fallback when nothing is selected.
+      var sel = window.getSelection ? window.getSelection() : null;
+      var hasSelection = sel && !sel.isCollapsed && sel.toString().length > 0;
+      if (!hasSelection && copyActiveCell()) evt.preventDefault();
       return;
    }
 
@@ -3767,6 +3779,13 @@ window.onActivate = function() {
    renderVisibleRows(true);
    updateInfoBar();
    updateCustomScrollbars();
+
+   // Returning to the tab is not a scroll event, so the activity-based fade
+   // would leave the (auto-hide) scrollbars hidden -- briefly show them so
+   // the horizontal scroll affordance is visible again. update() above has
+   // already set display:none on any axis that isn't scrollable, so this
+   // only reveals bars that actually have overflow.
+   showScrollbars();
 };
 
 window.onDeactivate = function() {


### PR DESCRIPTION
## Intent

Addresses #17800.

Two regressions in the vanilla-JS data viewer (introduced by the rewrite in #17382):

1. **Horizontal scrollbar disappears after returning to the tab.** The grid uses auto-hide overlay scrollbars that fade after ~1.2s and only reappear on a scroll event. Returning to the data viewer tab re-ran layout (`onActivate`) but never re-showed the bars, so the horizontal scrollbar stayed hidden -- and since horizontal scrolls rarely happen via the wheel, it was effectively gone until the user arrow-keyed a cell out of view.

2. **Ctrl/Cmd+C only copied the active cell.** While the viewport is focused the grid intercepts copy to grab the single active cell, but it did so unconditionally and `preventDefault()`ed the keystroke -- clobbering any multi-cell native text selection. Copying multiple cells only worked when the viewer was popped out to a separate window (where focus isn't forced onto the viewport).

## Changes

- `DataViewer.js`: call `showScrollbars()` from `onActivate` and `onResize` so the auto-hide bars resurface after a relayout (`update()` still leaves non-scrollable axes hidden).
- `DataViewer.js`: in the copy handler, defer to the browser's native copy when a non-empty selection exists; the single-active-cell copy remains the fallback when nothing is selected.

## Tests

Two Playwright tests added to `e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts` (each fails on the pre-fix code):

- multi-cell selection + Ctrl/Cmd+C fires a native `copy` carrying both cells
- horizontal scrollbar regains its `visible` class after switching away and back to the viewer tab

Full data viewer file is green (9/9) on Desktop; `npm run typecheck` clean.