### PR TITLE
move PPM vulnerability download off the R main thread

### DIFF
--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -222,6 +222,7 @@ const int kShowMessage = 204;
 const int kNotebookRenderCompleted = 205;
 const int kConsoleReadCompleted = 206;
 const int kRStudioAPIShowMenu = 207;
+const int kPackageVulnerabilitiesReady = 208;
 
 }
 
@@ -622,6 +623,8 @@ std::string ClientEvent::typeName() const
          return "console_read_completed";
       case client_events::kRStudioAPIShowMenu:
          return "rstudioapi_show_menu";
+      case client_events::kPackageVulnerabilitiesReady:
+         return "package_vulnerabilities_ready";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " +
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -223,6 +223,7 @@ extern const int kChatBackendExit;
 extern const int kNotebookRenderCompleted;
 extern const int kConsoleReadCompleted;
 extern const int kRStudioAPIShowMenu;
+extern const int kPackageVulnerabilitiesReady;
 
 }
    

--- a/src/cpp/session/modules/SessionPPM.R
+++ b/src/cpp/session/modules/SessionPPM.R
@@ -16,6 +16,12 @@
 .rs.setVar("ppm.vulns", new.env(parent = emptyenv()))
 .rs.setVar("ppm.metadataCache", new.env(parent = emptyenv()))
 
+# per-repo set of "name==version" keys we've asked the C++ backend to fetch
+# but haven't yet recorded a response for; keyed by repository URL. The fetch
+# itself happens asynchronously in C++ (see SessionPPM.cpp), so this is how the
+# request plan communicates the requested keys to the response handler.
+.rs.setVar("ppm.pending", new.env(parent = emptyenv()))
+
 # once-per-session flags for noisy diagnostics we don't want to repeat
 # on every package-list refresh
 .rs.setVar("ppm.warnings", new.env(parent = emptyenv()))
@@ -30,53 +36,23 @@
    .Call("rs_ppmMetadataColumnEnabled", PACKAGE = "(embedding)")
 })
 
-.rs.addFunction("ppm.getVulnerabilityInformation", function(repos = NULL)
+.rs.addFunction("ppm.installedPackageKeys", function()
 {
-   # For each available repository, ask it for vulnerability information,
-   # then merge that all together.
-   repos <- .rs.nullCoalesce(repos, getOption("repos"))
-
    # PPM's filter/packages endpoint defaults to the current snapshot's latest
    # version of each package, so a vuln that only affects an older installed
-   # version is silently dropped. Ask explicitly for the installed (name,
-   # version) pairs instead.
+   # version is silently dropped. We key everything on the installed (name,
+   # version) pairs instead so older versions still get checked.
    db <- as.data.frame(
       installed.packages(priority = "NA"),
       stringsAsFactors = FALSE
    )
-   pkgKeys <- paste(db[["Package"]], db[["Version"]], sep = "==")
-
-   lapply(repos, function(repoUrl)
-   {
-      tryCatch(
-         .rs.ppm.getVulnerabilityInformationImpl(repoUrl, pkgKeys),
-         error = function(cnd)
-         {
-            # outer-catch: a fetch/parse path with a known failure mode
-            # would have logged and returned NULL already, so an exception
-            # here is unexpected. the caller receives an empty list, which
-            # is indistinguishable from "no vulns" -- the log is the only
-            # signal that something went wrong.
-            .rs.logErrorMessage(sprintf(
-               "unexpected error fetching PPM vulnerability information for %s: %s",
-               repoUrl, conditionMessage(cnd)
-            ))
-            structure(list(), names = character())
-         }
-      )
-   })
+   paste(db[["Package"]], db[["Version"]], sep = "==")
 })
 
-.rs.addFunction("ppm.getVulnerabilityInformationImpl", function(repoUrl, pkgKeys)
+.rs.addFunction("ppm.repoVulnCache", function(repoUrl)
 {
-   empty <- structure(list(), names = character())
-
-   # nothing to ask about
-   if (length(pkgKeys) == 0L)
-      return(empty)
-
-   # Per-repo cache lives in an environment keyed by "name==version" so we
-   # can request only newly-installed (or upgraded) packages on subsequent
+   # Per-repo cache lives in an environment keyed by "name==version" so we can
+   # request only newly-installed (or upgraded) packages on subsequent
    # refreshes. Stale "old==version" entries linger in the cache but are
    # filtered out at aggregation by pkgKeys.
    cache <- .rs.ppm.vulns[[repoUrl]]
@@ -85,63 +61,72 @@
       cache <- new.env(parent = emptyenv())
       assign(repoUrl, cache, envir = .rs.ppm.vulns)
    }
-
-   # only ask PPM about (name, version) pairs we haven't seen this session
-   cachedKeys <- ls(envir = cache, all.names = TRUE)
-   newKeys <- setdiff(pkgKeys, cachedKeys)
-   if (length(newKeys) > 0L)
-   {
-      fetched <- .rs.ppm.fetchVulnerabilityInformation(repoUrl, newKeys)
-
-      # NULL means the request failed; skip the cache update so the next
-      # refresh can retry rather than masking vulns with empty entries
-      if (is.null(fetched))
-         return(.rs.ppm.aggregateVulnsByName(cache, pkgKeys))
-
-      # record every requested key (empty list for the ones PPM didn't
-      # report on) so we don't keep re-querying packages with no vulns
-      for (key in newKeys)
-      {
-         entry <- fetched[[key]]
-         assign(key, if (is.null(entry)) list() else entry, envir = cache)
-      }
-   }
-
-   .rs.ppm.aggregateVulnsByName(cache, pkgKeys)
+   cache
 })
 
-.rs.addFunction("ppm.fetchVulnerabilityInformation", function(repoUrl, pkgKeys)
+# Build the request plan for an asynchronous vulnerability refresh. The actual
+# network request is performed by the C++ backend (off the main thread); this
+# helper only inspects local, already-installed state to decide *what* to
+# request and how to authenticate. It returns one entry per PPM repository that
+# has packages we haven't yet checked this session:
+#
+#   list(repoUrl, endpoint, authHeader, body)
+#
+# and records the requested (name==version) keys in .rs.ppm.pending so the
+# response handler (ppm.recordVulnerabilityResponse) knows which keys the
+# response covers.
+.rs.addFunction("ppm.getVulnerabilityRequestPlan", function(repos = NULL)
 {
-   ppmUrl <- .rs.ppm.fromRepositoryUrl(repoUrl)
-   if (length(ppmUrl) == 0L)
-      return(NULL)
+   if (!.rs.ppm.isIntegrationEnabled())
+      return(list())
 
-   if (!requireNamespace("curl", quietly = TRUE))
+   repos <- .rs.nullCoalesce(repos, getOption("repos"))
+   if (length(repos) == 0L)
+      return(list())
+
+   pkgKeys <- .rs.ppm.installedPackageKeys()
+   if (length(pkgKeys) == 0L)
+      return(list())
+
+   plan <- list()
+   for (repoUrl in repos)
    {
-      # Without curl every refresh will hit this path and silently return,
-      # so we'd lose vulnerability badges with no diagnostic trail. Log
-      # once per session and return NULL so callers can still use any
-      # cached entries instead of poisoning the cache with empty markers.
-      if (is.null(.rs.ppm.warnings$curlMissing))
-      {
-         .rs.logErrorMessage(
-            "cannot fetch PPM vulnerability information: the 'curl' package is not installed"
-         )
-         .rs.ppm.warnings$curlMissing <- TRUE
-      }
-      return(NULL)
+      ppmUrl <- .rs.ppm.fromRepositoryUrl(repoUrl)
+      if (length(ppmUrl) == 0L)
+         next
+
+      # only ask PPM about (name, version) pairs we haven't seen this session
+      cache <- .rs.ppm.repoVulnCache(repoUrl)
+      cachedKeys <- ls(envir = cache, all.names = TRUE)
+      newKeys <- setdiff(pkgKeys, cachedKeys)
+      if (length(newKeys) == 0L)
+         next
+
+      # the legacy /repos/{repo}/vulns endpoint was effectively anonymous;
+      # filter/packages requires auth on locked-down PPM instances, so compute
+      # a Basic auth header from the user's .netrc when one is configured
+      endpoint <- file.path(ppmUrl[["root"]], "__api__/filter/packages")
+      authHeader <- .rs.computeAuthorizationHeader(endpoint)
+
+      # remember which keys this request covers so the response handler can
+      # mark them (including the ones with no vulns) as checked
+      assign(repoUrl, newKeys, envir = .rs.ppm.pending)
+
+      plan[[length(plan) + 1L]] <- list(
+         repoUrl    = .rs.scalar(repoUrl),
+         endpoint   = .rs.scalar(endpoint),
+         authHeader = .rs.scalar(authHeader),
+         body       = .rs.scalar(.rs.ppm.buildVulnerabilityRequestBody(ppmUrl[["repos"]], newKeys))
+      )
    }
 
-   # build a curl handle for the request
-   verbose <- isTRUE(as.logical(Sys.getenv("PWB_PPM_CURL_VERBOSE", unset = "FALSE")))
-   handle <- curl::new_handle(verbose = verbose)
+   plan
+})
 
-   headers <- list("Content-Type" = "application/json")
-   curl::handle_setheaders(handle, .list = headers)
-
-   # ask PPM for vulnerability info on each requested (name, version)
+.rs.addFunction("ppm.buildVulnerabilityRequestBody", function(reposName, pkgKeys)
+{
    data <- list(
-      repo                 = ppmUrl[["repos"]],
+      repo                 = reposName,
       names                = as.list(pkgKeys),
       has_vulns            = TRUE,
       omit_dependencies    = TRUE,
@@ -149,59 +134,72 @@
       omit_package_details = TRUE
    )
 
-   json <- .rs.toJSON(data, unbox = TRUE)
+   .rs.toJSON(data, unbox = TRUE)
+})
 
-   curl::handle_setopt(
-      handle     = handle,
-      post       = TRUE,
-      postfields = json
-   )
+# Record the response to an asynchronous vulnerability request. Called by the
+# C++ backend on the main thread once the network request for 'repoUrl' has
+# completed successfully; 'body' is the raw (NDJSON) response payload. Updates
+# the per-repo cache and returns the full, aggregated vulnerability map for all
+# configured repositories (the same shape the synchronous path used to return)
+# so the backend can forward it to the client.
+.rs.addFunction("ppm.recordVulnerabilityResponse", function(repoUrl, body)
+{
+   newKeys <- .rs.ppm.pending[[repoUrl]]
+   if (is.null(newKeys))
+      newKeys <- character()
 
-   # the legacy /repos/{repo}/vulns endpoint was effectively anonymous;
-   # filter/packages requires auth on locked-down PPM instances, so wire
-   # up netrc when the user has one configured
-   netrcFile <- .rs.netrcPath()
-   if (file.exists(netrcFile))
+   fetched <- .rs.ppm.parseVulnerabilityResponse(body)
+
+   # NULL means the server reported an error on one of its records; leave the
+   # cache (and the pending keys) untouched so a later refresh retries rather
+   # than masking vulns with empty entries
+   if (!is.null(fetched))
    {
-      curl::handle_setopt(
-         handle     = handle,
-         httpauth   = 1L,         # CURLAUTH_BASIC
-         netrc      = 1L,
-         netrc_file = path.expand(netrcFile)
-      )
+      cache <- .rs.ppm.repoVulnCache(repoUrl)
+
+      # record every requested key (empty list for the ones PPM didn't report
+      # on) so we don't keep re-querying packages with no vulns
+      for (key in newKeys)
+      {
+         entry <- fetched[[key]]
+         assign(key, if (is.null(entry)) list() else entry, envir = cache)
+      }
+
+      if (!is.null(.rs.ppm.pending[[repoUrl]]))
+         rm(list = repoUrl, envir = .rs.ppm.pending)
    }
 
-   endpoint <- file.path(ppmUrl[["root"]], "__api__/filter/packages")
-   response <- tryCatch(
-      curl::curl_fetch_memory(endpoint, handle = handle),
-      error = identity
-   )
+   .rs.ppm.getCachedVulnerabilities()
+})
 
-   if (inherits(response, "condition"))
+# Aggregate the cached vulnerability data for all configured repositories,
+# without performing any network access. Returns a list (one element per repo)
+# of package-name -> vulnerability lists.
+.rs.addFunction("ppm.getCachedVulnerabilities", function(repos = NULL)
+{
+   repos <- .rs.nullCoalesce(repos, getOption("repos"))
+   pkgKeys <- .rs.ppm.installedPackageKeys()
+
+   lapply(repos, function(repoUrl)
    {
-      .rs.logErrorMessage(sprintf(
-         "PPM vulnerability request to %s failed: %s",
-         endpoint, conditionMessage(response)
-      ))
-      return(NULL)
-   }
+      cache <- .rs.ppm.vulns[[repoUrl]]
+      if (is.null(cache))
+         return(structure(list(), names = character()))
 
-   if (response$status_code < 200L || response$status_code >= 300L)
-   {
-      .rs.logErrorMessage(sprintf(
-         "PPM vulnerability request to %s returned HTTP %d",
-         endpoint, response$status_code
-      ))
-      return(NULL)
-   }
-
-   contents <- enc2utf8(rawToChar(response$content))
-   .rs.ppm.parseVulnerabilityResponse(contents)
+      .rs.ppm.aggregateVulnsByName(cache, pkgKeys)
+   })
 })
 
 .rs.addFunction("ppm.parseVulnerabilityResponse", function(contents)
 {
    empty <- structure(list(), names = character())
+
+   # an empty (or missing) body has no records to parse. Guarding here also
+   # avoids a "subscript out of bounds" error from strsplit(character(0), ...),
+   # which returns an empty list with no [[1L]] element.
+   if (length(contents) == 0L || !any(nzchar(contents)))
+      return(empty)
 
    # tolerate CRLF in case a proxy or PPM build rewrites line endings
    contents <- gsub("\r", "", contents, fixed = TRUE)

--- a/src/cpp/session/modules/SessionPPM.R
+++ b/src/cpp/session/modules/SessionPPM.R
@@ -64,6 +64,20 @@
    cache
 })
 
+.rs.addFunction("ppm.repoMetadataCache", function(repoUrl)
+{
+   # Per-repo metadata cache, keyed by "name==version" like the vuln cache and
+   # populated from the same response (see ppm.recordVulnerabilityResponse). Read
+   # cache-only by ppm.getMetadata; no network access happens at read time.
+   cache <- .rs.ppm.metadataCache[[repoUrl]]
+   if (is.null(cache))
+   {
+      cache <- new.env(parent = emptyenv())
+      assign(repoUrl, cache, envir = .rs.ppm.metadataCache)
+   }
+   cache
+})
+
 # Build the request plan for an asynchronous vulnerability refresh. The actual
 # network request is performed by the C++ backend (off the main thread); this
 # helper only inspects local, already-installed state to decide *what* to
@@ -125,10 +139,18 @@
 
 .rs.addFunction("ppm.buildVulnerabilityRequestBody", function(reposName, pkgKeys)
 {
+   # NOTE: we intentionally do NOT set has_vulns. has_vulns is a server-side
+   # *filter* (true => only vulnerable packages); omitting it returns a record
+   # for every requested package, each carrying both its vulns array (when the
+   # package is vulnerable) and its custom metadata. That lets this single
+   # request feed both the vulnerability badges and the PPM metadata column --
+   # see ppm.recordVulnerabilityResponse, which folds both out of one response.
+   #
+   # omit_package_details drops the heavier package-detail fields but does NOT
+   # suppress the custom metadata array, so we keep it for a leaner response.
    data <- list(
       repo                 = reposName,
       names                = as.list(pkgKeys),
-      has_vulns            = TRUE,
       omit_dependencies    = TRUE,
       omit_downloads       = TRUE,
       omit_package_details = TRUE
@@ -137,38 +159,48 @@
    .rs.toJSON(data, unbox = TRUE)
 })
 
-# Record the response to an asynchronous vulnerability request. Called by the
+# Record the response to an asynchronous filter/packages request. Called by the
 # C++ backend on the main thread once the network request for 'repoUrl' has
-# completed successfully; 'body' is the raw (NDJSON) response payload. Folds the
-# response into the per-repo cache. The backend publishes the aggregated result
-# (via .rs.ppm.getCachedVulnerabilities) once the whole batch of requests has
-# drained, so this only needs to update the cache.
+# completed successfully; 'body' is the raw (NDJSON) response payload. A single
+# response carries both vulnerability and custom-metadata data, so this folds
+# both into their per-repo caches. The backend publishes the aggregated vulns
+# (via .rs.ppm.getCachedVulnerabilities) and re-delivers the package list (for
+# the metadata column) once the whole batch of requests has drained, so this
+# only needs to update the caches.
 .rs.addFunction("ppm.recordVulnerabilityResponse", function(repoUrl, body)
 {
    newKeys <- .rs.ppm.pending[[repoUrl]]
    if (is.null(newKeys))
       newKeys <- character()
 
-   fetched <- .rs.ppm.parseVulnerabilityResponse(body)
+   records <- .rs.ppm.parsePackageRecords(body)
 
-   # NULL means the server reported an error on one of its records; leave the
-   # cache (and the pending keys) untouched so a later refresh retries rather
-   # than masking vulns with empty entries
-   if (!is.null(fetched))
+   # NULL means the request failed (an empty body, or the server reported an
+   # error on one of its records); leave the caches (and the pending keys)
+   # untouched so a later refresh retries rather than masking vulns or metadata
+   # with empty entries
+   if (is.null(records))
+      return(invisible(NULL))
+
+   vulnsByKey <- .rs.ppm.vulnsByKey(records)
+   metadataByKey <- .rs.ppm.metadataByKey(records)
+
+   vulnCache <- .rs.ppm.repoVulnCache(repoUrl)
+   metaCache <- .rs.ppm.repoMetadataCache(repoUrl)
+
+   # record every requested key (an empty/NA marker for the ones PPM didn't
+   # report on) so we don't keep re-querying packages with no vulns or metadata
+   for (key in newKeys)
    {
-      cache <- .rs.ppm.repoVulnCache(repoUrl)
+      vulnEntry <- vulnsByKey[[key]]
+      assign(key, if (is.null(vulnEntry)) list() else vulnEntry, envir = vulnCache)
 
-      # record every requested key (empty list for the ones PPM didn't report
-      # on) so we don't keep re-querying packages with no vulns
-      for (key in newKeys)
-      {
-         entry <- fetched[[key]]
-         assign(key, if (is.null(entry)) list() else entry, envir = cache)
-      }
-
-      if (!is.null(.rs.ppm.pending[[repoUrl]]))
-         rm(list = repoUrl, envir = .rs.ppm.pending)
+      metaEntry <- metadataByKey[[key]]
+      assign(key, if (is.null(metaEntry)) NA_character_ else metaEntry, envir = metaCache)
    }
+
+   if (!is.null(.rs.ppm.pending[[repoUrl]]))
+      rm(list = repoUrl, envir = .rs.ppm.pending)
 
    invisible(NULL)
 })
@@ -203,21 +235,27 @@
    })
 })
 
-.rs.addFunction("ppm.parseVulnerabilityResponse", function(contents)
+# Parse a filter/packages NDJSON body into a list of per-package records.
+# Returns:
+#   - an empty list for a missing body (character(0)): "nothing to record"
+#   - NULL for a failure: an empty/whitespace-only 2xx body, or a body in which
+#     the server reported an error on any line. NULL is the "request failed"
+#     signal that tells callers to leave their caches untouched and retry on a
+#     later refresh rather than caching every package as "checked, nothing".
+#   - otherwise, the parsed records (lines that aren't valid JSON are skipped)
+.rs.addFunction("ppm.parsePackageRecords", function(contents)
 {
-   empty <- structure(list(), names = character())
-
    # a missing body (character(0)) has no records to parse. Guarding here also
    # avoids a "subscript out of bounds" error from strsplit(character(0), ...),
    # which returns an empty list with no [[1L]] element. Treat this as "nothing
    # to record" rather than an error, matching the crash-guard intent.
    if (length(contents) == 0L)
-      return(empty)
+      return(list())
 
    # a 2xx with an empty or whitespace-only body tells us nothing about the
    # packages we asked about. Return NULL (the "request failed" signal) so the
    # caller leaves the cache untouched and retries on a later refresh, rather
-   # than caching every requested package as "checked, no vulns" and silently
+   # than caching every requested package as "checked, nothing" and silently
    # clearing any badges. trimws() is needed here because nzchar() considers a
    # whitespace-only string non-empty.
    if (!any(nzchar(trimws(contents))))
@@ -230,7 +268,7 @@
    records <- lapply(splat, .rs.fromJSON)
 
    # bail out if the server reported an error on any line. Returning NULL
-   # (rather than empty) lets the caller distinguish "no vulns" from
+   # (rather than empty) lets the caller distinguish "nothing reported" from
    # "request failed" and skip the cache, so a transient failure doesn't
    # mask vulns for the rest of the session.
    for (record in records)
@@ -246,18 +284,23 @@
       }
    }
 
-   # group vulns by "name==version" so cached entries can be invalidated
-   # individually when a specific installed version is upgraded
-   byKey <- empty
+   records
+})
+
+# Group the vulns out of a parsed record list, keyed by "name==version" so a
+# cached entry can be invalidated individually when an installed version is
+# upgraded. Records missing a name/version, or with no vulns, are skipped.
+.rs.addFunction("ppm.vulnsByKey", function(records)
+{
+   byKey <- structure(list(), names = character())
    for (record in records)
    {
       name <- record[["name"]]
       version <- record[["version"]]
       pkgVulns <- record[["vulns"]]
 
-      # name or version missing means PPM emitted something we can't key
-      # on -- warn once per session if it ever happens (the get-impl
-      # cache-fill below prevents us from re-querying), then move on
+      # name or version missing means PPM emitted something we can't key on --
+      # warn once per session if it ever happens, then move on
       if (is.null(name) || is.null(version))
       {
          if (is.null(.rs.ppm.warnings$malformedRecord))
@@ -278,6 +321,38 @@
    }
 
    .rs.markScalars(byKey)
+})
+
+# Pull the custom metadata out of a parsed record list, keyed by "name==version"
+# to match the vuln cache. A record with no metadata maps to NA so the response
+# handler can still mark the key as checked (avoiding a re-query).
+.rs.addFunction("ppm.metadataByKey", function(records)
+{
+   byKey <- list()
+   for (record in records)
+   {
+      name <- record[["name"]]
+      version <- record[["version"]]
+      if (is.null(name) || is.null(version))
+         next
+
+      key <- paste(name, version, sep = "==")
+      metadata <- record[["metadata"]]
+      byKey[[key]] <- if (is.null(metadata)) NA_character_ else metadata
+   }
+
+   byKey
+})
+
+# Thin wrapper retained for callers/tests that only care about vulnerability
+# data. Returns the by-"name==version" vuln map, or NULL on request failure.
+.rs.addFunction("ppm.parseVulnerabilityResponse", function(contents)
+{
+   records <- .rs.ppm.parsePackageRecords(contents)
+   if (is.null(records))
+      return(NULL)
+
+   .rs.ppm.vulnsByKey(records)
 })
 
 .rs.addFunction("ppm.aggregateVulnsByName", function(cache, pkgKeys)
@@ -348,127 +423,21 @@
    .rs.ppm.fromRepositoryUrl(repos[[1L]])
 })
 
-.rs.addFunction("ppm.updateMetadataCache", function(packages)
-{
-   # get the active ppm repository
-   parts <- .rs.ppm.getActiveRepository()
-   if (length(parts) == 0L)
-      return(new.env(parent = emptyenv()))
-   
-   # check and see if we've already cached results for these packages
-   url <- parts[["url"]]
-   cache <- .rs.ppm.metadataCache[[url]] <- .rs.nullCoalesce(
-      .rs.ppm.metadataCache[[url]],
-      new.env(parent = emptyenv())
-   )
-   
-   # update only packages which haven't yet been cached
-   keys <- ls(envir = cache, all.names = TRUE)
-   packages <- setdiff(packages, keys)
-   if (length(packages) == 0L)
-      return(cache)
-   
-   # one or more packages have not yet been cached; try to update them
-   # make a request to the active PPM instance for available metadata
-   
-   # set some dummy values in our local cache, so we can avoid re-querying
-   # packages which have no metadata available (or for queries that fail)
-   for (package in packages)
-      assign(package, list(), envir = cache)
-   
-   # TODO: can we avoid the curl requirement?
-   if (!requireNamespace("curl", quietly = TRUE))
-      return(cache)
-   
-   # begin building a curl handle
-   verbose <- isTRUE(as.logical(Sys.getenv("PWB_PPM_CURL_VERBOSE", unset = "FALSE")))
-   handle <- curl::new_handle(verbose = verbose)
-   
-   # set headers for request
-   headers <- list("Content-Type" = "application/json")
-   curl::handle_setheaders(handle, .list = headers)
-   
-   # start building POST options
-   data <- list(
-      repo                 = parts[["repos"]],
-      snapshot             = parts[["snapshot"]],
-      names                = as.list(packages),
-      metadata             = TRUE,
-      vulns                = TRUE,
-      omit_dependencies    = TRUE,
-      omit_downloads       = TRUE,
-      omit_package_details = TRUE
-   )
-   
-   json <- .rs.toJSON(data, unbox = TRUE)
-   
-   # get netrc file path
-   curl::handle_setopt(
-      handle     = handle,
-      post       = TRUE,
-      postfields = json
-   )
-   
-   # use netrc if available
-   netrcFile <- .rs.netrcPath()
-   if (file.exists(netrcFile))
-   {
-      curl::handle_setopt(
-         handle     = handle,
-         httpauth   = 1L,
-         netrc      = 1L,
-         netrc_file = path.expand(netrcFile)
-      )
-   }
-   
-   # make the request, collect the response
-   endpoint <- file.path(parts[["root"]], "__api__/filter/packages")
-   response <- curl::curl_fetch_memory(endpoint, handle = handle)
-   contents <- enc2utf8(rawToChar(response$content))
-   splat <- strsplit(contents, "\n", fixed = TRUE)[[1L]]
-   data <- lapply(splat, .rs.fromJSON)
-   
-   # handle errors
-   for (i in seq_along(data))
-   {
-      error <- data[[i]][["error"]]
-      if (!is.character(error))
-         next
-      
-      code <- .rs.nullCoalesce(data[[i]][["code"]], "unknown")
-      fmt <- "error requesting package metadata; %s [error code %s]"
-      msg <- sprintf(fmt, error, as.character(code))
-      warning(msg, call. = FALSE)
-      return(cache)
-   }
-   
-   # pull out the metadata from each response
-   metadata <- lapply(data, `[[`, "metadata")
-   if (length(metadata) == 0L)
-      return(cache)
-   
-   names(metadata) <- vapply(data, function(datum) {
-      paste(datum[["name"]], datum[["version"]], sep = "==")
-   }, FUN.VALUE = character(1))
-   
-   # add these results to the cache
-   list2env(metadata, envir = cache)
-   
-   # use NA for any requests which had no metadata available
-   for (package in setdiff(packages, names(metadata)))
-      if (is.null(cache[[package]]))
-         cache[[package]] <- NA_character_
-   
-   # we're done
-   cache
-   
-})
-
 .rs.addFunction("ppm.getMetadataKey", function()
 {
    .Call("rs_ppmMetadataKey", PACKAGE = "(embedding)")
 })
 
+#' Read cached PPM metadata for the active repository.
+#'
+#' Returns a (package-name -> value) map for the requested metadata key, drawn
+#' entirely from the local cache. The cache is populated off the main thread by
+#' the asynchronous filter/packages refresh (see ppm.recordVulnerabilityResponse
+#' in this file and ppm::refreshVulnerabilitiesAsync in SessionPPM.cpp), so this
+#' performs NO network access -- a slow or unreachable PPM can never block the
+#' package list (and therefore the IDE) here. Packages with no cached metadata
+#' yet (or none available) map to "".
+#'
 #' @param key The name of the metadata key which should be pulled.
 .rs.addFunction("ppm.getMetadata", function(key = NULL)
 {
@@ -478,21 +447,16 @@
 
    # figure out what metadata key should be used
    key <- .rs.nullCoalesce(key, .rs.ppm.getMetadataKey())
-   
-   # figure out the packages for which we need to request metadata
-   db <- as.data.frame(
-      installed.packages(priority = "NA"),
-      stringsAsFactors = FALSE
-   )
-   
-   packages <- paste(db[["Package"]], db[["Version"]], sep = "==")
-   
-   # update the metadata cache
-   cache <- .rs.ppm.updateMetadataCache(packages)
+
+   # read whatever the asynchronous refresh has cached for the active repo
+   cache <- .rs.ppm.metadataCache[[parts[["url"]]]]
+   if (is.null(cache))
+      return(list())
+
    metadata <- as.list.environment(cache, all.names = TRUE)
    if (length(metadata) == 0L)
       return(list())
-   
+
    # filter to requested metadata key
    result <- lapply(metadata, function(data) {
       for (datum in data)
@@ -501,8 +465,7 @@
       ""
    })
    names(result) <- names(metadata)
-   
+
    # return sorted metadata
    result[order(names(result))]
-   
 })

--- a/src/cpp/session/modules/SessionPPM.R
+++ b/src/cpp/session/modules/SessionPPM.R
@@ -183,11 +183,23 @@
 
    lapply(repos, function(repoUrl)
    {
+      empty <- structure(list(), names = character())
+
       cache <- .rs.ppm.vulns[[repoUrl]]
       if (is.null(cache))
-         return(structure(list(), names = character()))
+         return(empty)
 
-      .rs.ppm.aggregateVulnsByName(cache, pkgKeys)
+      # isolate per-repo failures so one repo's malformed cache entry can't take
+      # down the aggregation (and therefore the client update) for every repo
+      tryCatch(
+         .rs.ppm.aggregateVulnsByName(cache, pkgKeys),
+         error = function(e) {
+            .rs.logWarningMessage(paste(
+               "error aggregating PPM vulnerabilities for", repoUrl, "-", conditionMessage(e)
+            ))
+            empty
+         }
+      )
    })
 })
 
@@ -195,11 +207,21 @@
 {
    empty <- structure(list(), names = character())
 
-   # an empty (or missing) body has no records to parse. Guarding here also
+   # a missing body (character(0)) has no records to parse. Guarding here also
    # avoids a "subscript out of bounds" error from strsplit(character(0), ...),
-   # which returns an empty list with no [[1L]] element.
-   if (length(contents) == 0L || !any(nzchar(contents)))
+   # which returns an empty list with no [[1L]] element. Treat this as "nothing
+   # to record" rather than an error, matching the crash-guard intent.
+   if (length(contents) == 0L)
       return(empty)
+
+   # a 2xx with an empty or whitespace-only body tells us nothing about the
+   # packages we asked about. Return NULL (the "request failed" signal) so the
+   # caller leaves the cache untouched and retries on a later refresh, rather
+   # than caching every requested package as "checked, no vulns" and silently
+   # clearing any badges. trimws() is needed here because nzchar() considers a
+   # whitespace-only string non-empty.
+   if (!any(nzchar(trimws(contents))))
+      return(NULL)
 
    # tolerate CRLF in case a proxy or PPM build rewrites line endings
    contents <- gsub("\r", "", contents, fixed = TRUE)

--- a/src/cpp/session/modules/SessionPPM.R
+++ b/src/cpp/session/modules/SessionPPM.R
@@ -139,10 +139,10 @@
 
 # Record the response to an asynchronous vulnerability request. Called by the
 # C++ backend on the main thread once the network request for 'repoUrl' has
-# completed successfully; 'body' is the raw (NDJSON) response payload. Updates
-# the per-repo cache and returns the full, aggregated vulnerability map for all
-# configured repositories (the same shape the synchronous path used to return)
-# so the backend can forward it to the client.
+# completed successfully; 'body' is the raw (NDJSON) response payload. Folds the
+# response into the per-repo cache. The backend publishes the aggregated result
+# (via .rs.ppm.getCachedVulnerabilities) once the whole batch of requests has
+# drained, so this only needs to update the cache.
 .rs.addFunction("ppm.recordVulnerabilityResponse", function(repoUrl, body)
 {
    newKeys <- .rs.ppm.pending[[repoUrl]]
@@ -170,7 +170,7 @@
          rm(list = repoUrl, envir = .rs.ppm.pending)
    }
 
-   .rs.ppm.getCachedVulnerabilities()
+   invisible(NULL)
 })
 
 # Aggregate the cached vulnerability data for all configured repositories,

--- a/src/cpp/session/modules/SessionPPM.cpp
+++ b/src/cpp/session/modules/SessionPPM.cpp
@@ -25,6 +25,7 @@
 #include <core/Exec.hpp>
 #include <core/http/Request.hpp>
 #include <core/http/Response.hpp>
+#include <core/http/TcpIpAsyncClient.hpp>
 #include <core/http/TcpIpAsyncClientSsl.hpp>
 #include <core/http/URL.hpp>
 
@@ -128,47 +129,47 @@ int s_activeRequests = 0;
 bool s_refreshPending = false;
 
 void startVulnerabilityRequests();
+void enqueCachedVulnerabilities();
 
 // Runs on the main thread once a single repo's request has completed (whether
-// it succeeded or failed). On success, hand the response body back to R to fold
-// into the cache and forward the aggregated result to the client.
+// it succeeded or failed). On success, fold the response body into the per-repo
+// cache. We publish the aggregated result to the client once the whole batch
+// drains (see below) rather than per response, so that even a batch where every
+// request fails still produces a deterministic update -- otherwise the Packages
+// pane could keep showing stale badges after a repo/package change whose fetch
+// failed.
 void onVulnerabilityRequestComplete(const std::string& repoUrl,
                                     bool succeeded,
                                     const std::string& body)
 {
    if (succeeded)
    {
-      r::sexp::Protect protect;
-      SEXP vulnsSEXP = R_NilValue;
       Error error = r::exec::RFunction(".rs.ppm.recordVulnerabilityResponse")
                        .addParam(repoUrl)
                        .addParam(body)
-                       .call(&vulnsSEXP, &protect);
+                       .call();
       if (error)
-      {
          LOG_ERROR(error);
-      }
-      else
-      {
-         json::Value vulnsJson;
-         error = r::json::jsonValueFromObject(vulnsSEXP, &vulnsJson);
-         if (error)
-            LOG_ERROR(error);
-         else
-            module_context::enqueClientEvent(
-               ClientEvent(client_events::kPackageVulnerabilitiesReady, vulnsJson));
-      }
    }
 
-   // this request is done; if it was the last one and another refresh came in
-   // while we were busy, run it now so we don't drop the latest state
    if (s_activeRequests > 0)
       s_activeRequests--;
 
-   if (s_activeRequests == 0 && s_refreshPending)
+   // not done yet -- wait for the remaining requests in this batch
+   if (s_activeRequests > 0)
+      return;
+
+   // the batch has drained; if another refresh came in while we were busy run
+   // it now, otherwise publish the (possibly unchanged) cached set so the UI is
+   // always updated deterministically -- including when every request failed
+   if (s_refreshPending)
    {
       s_refreshPending = false;
       startVulnerabilityRequests();
+   }
+   else
+   {
+      enqueCachedVulnerabilities();
    }
 }
 
@@ -199,7 +200,7 @@ void onVulnerabilityError(const std::string& repoUrl,
       boost::bind(onVulnerabilityRequestComplete, repoUrl, false, std::string()));
 }
 
-// Issue one async HTTPS POST for a single repo's request-plan entry.
+// Issue one async POST for a single repo's request-plan entry.
 void sendVulnerabilityRequest(const json::Object& entry)
 {
    std::string repoUrl, endpoint, authHeader, body;
@@ -214,10 +215,14 @@ void sendVulnerabilityRequest(const json::Object& entry)
       return;
    }
 
+   // https is the norm, but the legacy curl path also worked against http PPM
+   // deployments, so keep supporting both rather than silently dropping vuln
+   // checks for an http-configured repository
    http::URL url(endpoint);
-   if (!url.isValid() || url.protocol() != "https")
+   bool useSsl = url.protocol() == "https";
+   if (!url.isValid() || (!useSsl && url.protocol() != "http"))
    {
-      LOG_ERROR_MESSAGE("PPM vulnerability endpoint is not a valid https URL: " + endpoint);
+      LOG_ERROR_MESSAGE("PPM vulnerability endpoint is not a valid http(s) URL: " + endpoint);
       return;
    }
 
@@ -231,13 +236,23 @@ void sendVulnerabilityRequest(const json::Object& entry)
       request.setHeader("Authorization", authHeader);
    request.setBody(body);
 
-   boost::shared_ptr<http::TcpIpAsyncClientSsl> pClient(
-      new http::TcpIpAsyncClientSsl(server_rpc::ioContext(),
-                                    url.hostname(),
-                                    url.portStr(),
-                                    true, // verify certificates
-                                    std::string(), // certificate authority
-                                    kConnectionTimeout));
+   boost::shared_ptr<http::IAsyncClient> pClient;
+   if (useSsl)
+   {
+      pClient.reset(new http::TcpIpAsyncClientSsl(server_rpc::ioContext(),
+                                                  url.hostname(),
+                                                  url.portStr(),
+                                                  true, // verify certificates
+                                                  std::string(), // cert authority
+                                                  kConnectionTimeout));
+   }
+   else
+   {
+      pClient.reset(new http::TcpIpAsyncClient(server_rpc::ioContext(),
+                                               url.hostname(),
+                                               url.portStr(),
+                                               kConnectionTimeout));
+   }
 
    pClient->request().assign(request);
 

--- a/src/cpp/session/modules/SessionPPM.cpp
+++ b/src/cpp/session/modules/SessionPPM.cpp
@@ -13,17 +13,31 @@
  *
  */
 
+#include "SessionPPM.hpp"
+
 #include <functional>
 
+#include <boost/bind/bind.hpp>
+
 #include <shared_core/Error.hpp>
+#include <shared_core/json/Json.hpp>
 
 #include <core/Exec.hpp>
+#include <core/http/Request.hpp>
+#include <core/http/Response.hpp>
+#include <core/http/TcpIpAsyncClientSsl.hpp>
+#include <core/http/URL.hpp>
 
+#include <r/RExec.hpp>
+#include <r/RJson.hpp>
 #include <r/RRoutines.hpp>
+#include <r/RSexp.hpp>
 
 #include <session/SessionModuleContext.hpp>
+#include <session/SessionServerRpc.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 #define kPwbPpmIntegrationEnabled  "PWB_PPM_INTEGRATION_ENABLED"
 #define kPwbPpmRepoUrl             "PWB_PPM_REPO_URL"
@@ -101,6 +115,203 @@ bool isPpmMetadataColumnEnabled()
 
 namespace {
 
+// Cap how long we'll wait to connect to PPM. The whole point of moving this
+// off the main thread is so a slow or unreachable PPM never blocks the IDE;
+// keep the timeout short so a dead endpoint fails fast and quietly.
+const boost::posix_time::time_duration kConnectionTimeout =
+   boost::posix_time::seconds(10);
+
+// Number of vulnerability requests currently in flight, plus a flag noting
+// that another refresh was requested while requests were outstanding. Both are
+// only ever touched on the main thread.
+int s_activeRequests = 0;
+bool s_refreshPending = false;
+
+void startVulnerabilityRequests();
+
+// Runs on the main thread once a single repo's request has completed (whether
+// it succeeded or failed). On success, hand the response body back to R to fold
+// into the cache and forward the aggregated result to the client.
+void onVulnerabilityRequestComplete(const std::string& repoUrl,
+                                    bool succeeded,
+                                    const std::string& body)
+{
+   if (succeeded)
+   {
+      r::sexp::Protect protect;
+      SEXP vulnsSEXP = R_NilValue;
+      Error error = r::exec::RFunction(".rs.ppm.recordVulnerabilityResponse")
+                       .addParam(repoUrl)
+                       .addParam(body)
+                       .call(&vulnsSEXP, &protect);
+      if (error)
+      {
+         LOG_ERROR(error);
+      }
+      else
+      {
+         json::Value vulnsJson;
+         error = r::json::jsonValueFromObject(vulnsSEXP, &vulnsJson);
+         if (error)
+            LOG_ERROR(error);
+         else
+            module_context::enqueClientEvent(
+               ClientEvent(client_events::kPackageVulnerabilitiesReady, vulnsJson));
+      }
+   }
+
+   // this request is done; if it was the last one and another refresh came in
+   // while we were busy, run it now so we don't drop the latest state
+   if (s_activeRequests > 0)
+      s_activeRequests--;
+
+   if (s_activeRequests == 0 && s_refreshPending)
+   {
+      s_refreshPending = false;
+      startVulnerabilityRequests();
+   }
+}
+
+void onVulnerabilityResponse(const std::string& repoUrl,
+                             const std::string& endpoint,
+                             const http::Response& response)
+{
+   bool ok = response.statusCode() >= 200 && response.statusCode() < 300;
+   if (!ok)
+   {
+      LOG_ERROR_MESSAGE("PPM vulnerability request to " + endpoint +
+                        " returned HTTP " +
+                        safe_convert::numberToString(response.statusCode()));
+   }
+
+   std::string body = response.body();
+   module_context::executeOnMainThread(
+      boost::bind(onVulnerabilityRequestComplete, repoUrl, ok, body));
+}
+
+void onVulnerabilityError(const std::string& repoUrl,
+                          const std::string& endpoint,
+                          const Error& error)
+{
+   LOG_ERROR_MESSAGE("PPM vulnerability request to " + endpoint +
+                     " failed: " + error.getSummary());
+   module_context::executeOnMainThread(
+      boost::bind(onVulnerabilityRequestComplete, repoUrl, false, std::string()));
+}
+
+// Issue one async HTTPS POST for a single repo's request-plan entry.
+void sendVulnerabilityRequest(const json::Object& entry)
+{
+   std::string repoUrl, endpoint, authHeader, body;
+   Error error = json::readObject(entry,
+                                  "repoUrl", repoUrl,
+                                  "endpoint", endpoint,
+                                  "authHeader", authHeader,
+                                  "body", body);
+   if (error)
+   {
+      LOG_ERROR(error);
+      return;
+   }
+
+   http::URL url(endpoint);
+   if (!url.isValid() || url.protocol() != "https")
+   {
+      LOG_ERROR_MESSAGE("PPM vulnerability endpoint is not a valid https URL: " + endpoint);
+      return;
+   }
+
+   http::Request request;
+   request.setMethod("POST");
+   request.setUri(url.path());
+   request.setHost(url.hostWithPort());
+   request.setHeader("Connection", "close");
+   request.setContentType("application/json");
+   if (!authHeader.empty())
+      request.setHeader("Authorization", authHeader);
+   request.setBody(body);
+
+   boost::shared_ptr<http::TcpIpAsyncClientSsl> pClient(
+      new http::TcpIpAsyncClientSsl(server_rpc::ioContext(),
+                                    url.hostname(),
+                                    url.portStr(),
+                                    true, // verify certificates
+                                    std::string(), // certificate authority
+                                    kConnectionTimeout));
+
+   pClient->request().assign(request);
+
+   s_activeRequests++;
+   pClient->execute(
+      boost::bind(onVulnerabilityResponse, repoUrl, endpoint, _1),
+      boost::bind(onVulnerabilityError, repoUrl, endpoint, _1));
+}
+
+// Forward the currently-cached vulnerability data to the client without making
+// any network request. Used when there's nothing new to fetch, so that (for
+// example) switching from a PPM repo to a non-PPM repo clears stale badges.
+void enqueCachedVulnerabilities()
+{
+   r::sexp::Protect protect;
+   SEXP vulnsSEXP = R_NilValue;
+   Error error = r::exec::RFunction(".rs.ppm.getCachedVulnerabilities")
+                    .call(&vulnsSEXP, &protect);
+   if (error)
+   {
+      LOG_ERROR(error);
+      return;
+   }
+
+   json::Value vulnsJson;
+   error = r::json::jsonValueFromObject(vulnsSEXP, &vulnsJson);
+   if (error)
+      LOG_ERROR(error);
+   else
+      module_context::enqueClientEvent(
+         ClientEvent(client_events::kPackageVulnerabilitiesReady, vulnsJson));
+}
+
+// Ask R for the request plan (what to fetch + how to authenticate) and fire off
+// an async request for each repo that has uncached packages. Runs on the main
+// thread.
+void startVulnerabilityRequests()
+{
+   r::sexp::Protect protect;
+   SEXP planSEXP = R_NilValue;
+   Error error = r::exec::RFunction(".rs.ppm.getVulnerabilityRequestPlan")
+                    .call(&planSEXP, &protect);
+   if (error)
+   {
+      LOG_ERROR(error);
+      return;
+   }
+
+   json::Value planJson;
+   error = r::json::jsonValueFromObject(planSEXP, &planJson);
+   if (error)
+   {
+      LOG_ERROR(error);
+      return;
+   }
+
+   json::Array plan = planJson.isArray() ? planJson.getArray() : json::Array();
+
+   // nothing new to fetch -- still publish what we have cached so the client
+   // reflects the current repository state (e.g. clears badges after a switch
+   // to a non-PPM repo)
+   if (plan.isEmpty())
+   {
+      enqueCachedVulnerabilities();
+      return;
+   }
+
+   for (const json::Value& entry : plan)
+   {
+      if (entry.isObject())
+         sendVulnerabilityRequest(entry.getObject());
+   }
+}
+
 SEXP rs_ppmIntegrationEnabled()
 {
    return isPpmIntegrationEnabled() ? Rf_ScalarLogical(TRUE) : Rf_ScalarLogical(FALSE);
@@ -118,6 +329,22 @@ SEXP rs_ppmMetadataKey()
 }
 
 } // end anonymous namespace
+
+void refreshVulnerabilitiesAsync()
+{
+   if (!isPpmIntegrationEnabled())
+      return;
+
+   // coalesce: if requests are still in flight, defer until they drain so the
+   // refresh reflects the latest installed-package / repo state
+   if (s_activeRequests > 0)
+   {
+      s_refreshPending = true;
+      return;
+   }
+
+   startVulnerabilityRequests();
+}
 
 Error initialize()
 {

--- a/src/cpp/session/modules/SessionPPM.cpp
+++ b/src/cpp/session/modules/SessionPPM.cpp
@@ -41,6 +41,8 @@
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionServerRpc.hpp>
 
+#include "SessionPackages.hpp"
+
 using namespace rstudio::core;
 using namespace boost::placeholders;
 
@@ -136,10 +138,13 @@ const boost::posix_time::time_duration kConnectionTimeout =
 const std::chrono::seconds kRequestTimeout(30);
 
 // Number of vulnerability requests currently in flight, plus a flag noting
-// that another refresh was requested while requests were outstanding. Both are
-// only ever touched on the main thread.
+// that another refresh was requested while requests were outstanding, plus a
+// flag recording whether any request in the current batch succeeded (used to
+// decide whether the metadata column needs a refreshed package list once the
+// batch drains). All are only ever touched on the main thread.
 int s_activeRequests = 0;
 bool s_refreshPending = false;
+bool s_batchSucceeded = false;
 
 void startVulnerabilityRequests();
 void enqueCachedVulnerabilities();
@@ -163,6 +168,8 @@ void onVulnerabilityRequestComplete(const std::string& repoUrl,
                        .call();
       if (error)
          LOG_ERROR(error);
+      else
+         s_batchSucceeded = true;
    }
 
    if (s_activeRequests > 0)
@@ -173,17 +180,32 @@ void onVulnerabilityRequestComplete(const std::string& repoUrl,
       return;
 
    // the batch has drained; if another refresh came in while we were busy run
-   // it now, otherwise publish the (possibly unchanged) cached set so the UI is
-   // always updated deterministically -- including when every request failed
+   // it now (its own drain will publish), otherwise publish results
    if (s_refreshPending)
    {
       s_refreshPending = false;
       startVulnerabilityRequests();
+      return;
    }
-   else
+
+   // A successful response folds new data into both the vuln cache and the
+   // metadata cache. Vulnerability badges arrive via the kPackageVulnerabilities
+   // Ready event, but metadata rides on the package list (PackageInfo), so when
+   // the metadata column is enabled we re-deliver the package list to fill the
+   // column in. enquePackageStateChanged() also kicks a (now no-op) vuln refresh
+   // that republishes the badges, so it subsumes enqueCachedVulnerabilities().
+   bool delivered = false;
+   if (s_batchSucceeded && isPpmMetadataColumnEnabled())
    {
-      enqueCachedVulnerabilities();
+      packages::enquePackageStateChanged();
+      delivered = true;
    }
+   s_batchSucceeded = false;
+
+   // publish the (possibly unchanged) cached set so the UI is always updated
+   // deterministically -- including when every request failed
+   if (!delivered)
+      enqueCachedVulnerabilities();
 }
 
 // Runs on the server_rpc io thread. A single request has three possible
@@ -365,6 +387,11 @@ void enqueCachedVulnerabilities()
 // thread.
 void startVulnerabilityRequests()
 {
+   // fresh batch: clear the success flag so a prior batch's outcome can't leak
+   // across a coalesced refresh (any cached metadata is re-read on the next
+   // package-list delivery regardless, so deferring delivery here loses nothing)
+   s_batchSucceeded = false;
+
    r::sexp::Protect protect;
    SEXP planSEXP = R_NilValue;
    Error error = r::exec::RFunction(".rs.ppm.getVulnerabilityRequestPlan")

--- a/src/cpp/session/modules/SessionPPM.cpp
+++ b/src/cpp/session/modules/SessionPPM.cpp
@@ -325,6 +325,12 @@ void startVulnerabilityRequests()
       if (entry.isObject())
          sendVulnerabilityRequest(entry.getObject());
    }
+
+   // if no request was actually launched (e.g. every plan entry failed preflight
+   // validation), nothing will drain the batch, so publish the cached set here
+   // to keep every refresh deterministic
+   if (s_activeRequests == 0)
+      enqueCachedVulnerabilities();
 }
 
 SEXP rs_ppmIntegrationEnabled()

--- a/src/cpp/session/modules/SessionPPM.cpp
+++ b/src/cpp/session/modules/SessionPPM.cpp
@@ -15,9 +15,13 @@
 
 #include "SessionPPM.hpp"
 
+#include <chrono>
 #include <functional>
 
+#include <boost/asio/system_timer.hpp>
 #include <boost/bind/bind.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/weak_ptr.hpp>
 
 #include <shared_core/Error.hpp>
 #include <shared_core/json/Json.hpp>
@@ -122,6 +126,15 @@ namespace {
 const boost::posix_time::time_duration kConnectionTimeout =
    boost::posix_time::seconds(10);
 
+// Cap the *entire* request, not just the TCP connect phase. kConnectionTimeout
+// is handed to the connector and only bounds establishing the socket;
+// AsyncClient has no read/handshake deadline of its own. Without this overall
+// deadline, a PPM that completes the TCP handshake but then stalls during TLS
+// negotiation or while streaming the response body would keep its request in
+// flight forever -- s_activeRequests would never return to 0, so every later
+// refresh would be silently dropped for the rest of the session.
+const std::chrono::seconds kRequestTimeout(30);
+
 // Number of vulnerability requests currently in flight, plus a flag noting
 // that another refresh was requested while requests were outstanding. Both are
 // only ever touched on the main thread.
@@ -173,8 +186,32 @@ void onVulnerabilityRequestComplete(const std::string& repoUrl,
    }
 }
 
+// Runs on the server_rpc io thread. A single request has three possible
+// outcomes -- response, low-level error, or timeout -- and we must drive
+// completion from exactly one of them. The io context is single threaded (one
+// worker runs server_rpc::ioContext()), so a plain bool shared between the
+// three paths is sufficient; no lock is needed. Cancels the deadline timer and
+// marshals the result back to the main thread, where the batch bookkeeping
+// lives.
+void settleVulnerabilityRequest(const boost::shared_ptr<bool>& pSettled,
+                                const boost::shared_ptr<boost::asio::system_timer>& pTimer,
+                                const std::string& repoUrl,
+                                bool succeeded,
+                                const std::string& body)
+{
+   if (*pSettled)
+      return;
+   *pSettled = true;
+
+   pTimer->cancel();
+   module_context::executeOnMainThread(
+      boost::bind(onVulnerabilityRequestComplete, repoUrl, succeeded, body));
+}
+
 void onVulnerabilityResponse(const std::string& repoUrl,
                              const std::string& endpoint,
+                             const boost::shared_ptr<bool>& pSettled,
+                             const boost::shared_ptr<boost::asio::system_timer>& pTimer,
                              const http::Response& response)
 {
    bool ok = response.statusCode() >= 200 && response.statusCode() < 300;
@@ -185,19 +222,45 @@ void onVulnerabilityResponse(const std::string& repoUrl,
                         safe_convert::numberToString(response.statusCode()));
    }
 
-   std::string body = response.body();
-   module_context::executeOnMainThread(
-      boost::bind(onVulnerabilityRequestComplete, repoUrl, ok, body));
+   settleVulnerabilityRequest(pSettled, pTimer, repoUrl, ok, response.body());
 }
 
 void onVulnerabilityError(const std::string& repoUrl,
                           const std::string& endpoint,
+                          const boost::shared_ptr<bool>& pSettled,
+                          const boost::shared_ptr<boost::asio::system_timer>& pTimer,
                           const Error& error)
 {
    LOG_ERROR_MESSAGE("PPM vulnerability request to " + endpoint +
                      " failed: " + error.getSummary());
-   module_context::executeOnMainThread(
-      boost::bind(onVulnerabilityRequestComplete, repoUrl, false, std::string()));
+   settleVulnerabilityRequest(pSettled, pTimer, repoUrl, false, std::string());
+}
+
+// Fires when a request overruns kRequestTimeout. Closes the socket so the
+// AsyncClient abandons the stalled read and frees itself; its own error path
+// then sees the socket as already closed and stays quiet, so we drive
+// completion from here.
+void onVulnerabilityTimeout(const std::string& repoUrl,
+                            const std::string& endpoint,
+                            const boost::shared_ptr<bool>& pSettled,
+                            const boost::shared_ptr<boost::asio::system_timer>& pTimer,
+                            const boost::weak_ptr<http::IAsyncClient>& wClient,
+                            const boost::system::error_code& ec)
+{
+   // a normal completion cancels the timer, which delivers operation_aborted;
+   // nothing actually timed out in that case
+   if (ec == boost::asio::error::operation_aborted || *pSettled)
+      return;
+
+   LOG_ERROR_MESSAGE("PPM vulnerability request to " + endpoint +
+                     " timed out after " +
+                     safe_convert::numberToString(kRequestTimeout.count()) +
+                     "s; closing connection");
+
+   if (boost::shared_ptr<http::IAsyncClient> pClient = wClient.lock())
+      pClient->close();
+
+   settleVulnerabilityRequest(pSettled, pTimer, repoUrl, false, std::string());
 }
 
 // Issue one async POST for a single repo's request-plan entry.
@@ -256,10 +319,21 @@ void sendVulnerabilityRequest(const json::Object& entry)
 
    pClient->request().assign(request);
 
+   // arm the overall request deadline (see kRequestTimeout); the timer and the
+   // two completion handlers coordinate through pSettled so the request always
+   // settles exactly once
+   boost::shared_ptr<boost::asio::system_timer> pTimer =
+      boost::make_shared<boost::asio::system_timer>(server_rpc::ioContext(), kRequestTimeout);
+   boost::shared_ptr<bool> pSettled = boost::make_shared<bool>(false);
+
+   boost::weak_ptr<http::IAsyncClient> wClient(pClient);
+   pTimer->async_wait(
+      boost::bind(onVulnerabilityTimeout, repoUrl, endpoint, pSettled, pTimer, wClient, _1));
+
    s_activeRequests++;
    pClient->execute(
-      boost::bind(onVulnerabilityResponse, repoUrl, endpoint, _1),
-      boost::bind(onVulnerabilityError, repoUrl, endpoint, _1));
+      boost::bind(onVulnerabilityResponse, repoUrl, endpoint, pSettled, pTimer, _1),
+      boost::bind(onVulnerabilityError, repoUrl, endpoint, pSettled, pTimer, _1));
 }
 
 // Forward the currently-cached vulnerability data to the client without making

--- a/src/cpp/session/modules/SessionPPM.hpp
+++ b/src/cpp/session/modules/SessionPPM.hpp
@@ -34,6 +34,13 @@ bool isPpmMetadataColumnEnabled();
 std::string getPpmRepositoryUrl();
 std::string getPpmMetadataColumnLabel();
 
+// Kick off an asynchronous refresh of package vulnerability data. The network
+// request is performed off the main thread; results are delivered to the
+// client via the kPackageVulnerabilitiesReady event. Safe to call from the
+// main thread at any time -- it coalesces overlapping refreshes and is a no-op
+// when PPM integration is disabled.
+void refreshVulnerabilitiesAsync();
+
 core::Error initialize();
                        
 } // namespace ppm

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -258,12 +258,11 @@ Error getPackageStateJson(json::Object* pJson)
       LOG_ERROR(error);
    (*pJson)["active_repository"] = activeRepository;
 
-   // Vulnerability information is fetched asynchronously (see
-   // ppm::refreshVulnerabilitiesAsync) so that a slow or unreachable PPM can't
-   // block the package list -- and therefore IDE startup. Start with an empty
-   // map here; the data arrives later via the kPackageVulnerabilitiesReady
+   // NOTE: vulnerability data is intentionally not part of the package state.
+   // It is fetched asynchronously (see ppm::refreshVulnerabilitiesAsync) so that
+   // a slow or unreachable PPM can't block the package list -- and therefore IDE
+   // startup -- and delivered separately via the kPackageVulnerabilitiesReady
    // event.
-   (*pJson)["vulns"] = json::Object();
 
    return Success();
 }
@@ -461,6 +460,15 @@ Error getPackageState(const json::JsonRpcRequest& ,
       LOG_ERROR(error);
    else
       pResponse->setResult(result);
+
+   // The package list returns immediately without vulnerability data, which
+   // arrives later via kPackageVulnerabilitiesReady. This RPC is the only path
+   // for a re-join/reconnect to an already-running session (where onDeferredInit
+   // won't fire again) and for the user-facing Refresh command, so kick off a
+   // refresh here too -- otherwise a reconnected client would show no badges
+   // until some incidental package mutation happened to trigger one.
+   ppm::refreshVulnerabilitiesAsync();
+
    return error;
 }
 

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -258,19 +258,12 @@ Error getPackageStateJson(json::Object* pJson)
       LOG_ERROR(error);
    (*pJson)["active_repository"] = activeRepository;
 
-   // collect vulnerability information as well
-   SEXP vulnsSEXP = R_NilValue;
-   error = r::exec::RFunction(".rs.ppm.getVulnerabilityInformation")
-               .call(&vulnsSEXP, &protect);
-   if (error)
-      LOG_ERROR(error);
-
-   json::Value vulnsJson;
-   error = r::json::jsonValueFromObject(vulnsSEXP, &vulnsJson);
-   if (error)
-      LOG_ERROR(error);
-
-   (*pJson)["vulns"] = vulnsJson;
+   // Vulnerability information is fetched asynchronously (see
+   // ppm::refreshVulnerabilitiesAsync) so that a slow or unreachable PPM can't
+   // block the package list -- and therefore IDE startup. Start with an empty
+   // map here; the data arrives later via the kPackageVulnerabilitiesReady
+   // event.
+   (*pJson)["vulns"] = json::Object();
 
    return Success();
 }
@@ -454,6 +447,9 @@ void onDeferredInit(bool /* newSession */)
    // monitor libPaths for changes
    detectLibPathsChanges();
    module_context::events().onDetectChanges.connect(onDetectChanges);
+
+   // kick off the initial (asynchronous) vulnerability check
+   ppm::refreshVulnerabilitiesAsync();
 }
 
 Error getPackageState(const json::JsonRpcRequest& ,
@@ -487,6 +483,10 @@ void enquePackageStateChanged()
       ClientEvent event(client_events::kPackageStateChanged, pkgState);
       module_context::enqueClientEvent(event);
    }
+
+   // the package set or active repository may have changed; refresh
+   // vulnerability data asynchronously to match
+   ppm::refreshVulnerabilitiesAsync();
 }
 
 Error initialize()

--- a/src/cpp/tests/testthat/test-ppm.R
+++ b/src/cpp/tests/testthat/test-ppm.R
@@ -416,16 +416,26 @@ test_that("getVulnerabilityRequestPlan emits one entry per PPM repo with uncache
    expect_true(grepl("pkgB==2.0.0", planB$body, fixed = TRUE))
 })
 
-test_that("buildVulnerabilityRequestBody sets the repo and omit/has_vulns flags", {
+test_that("buildVulnerabilityRequestBody sets the repo and omit flags", {
    parsed <- .rs.fromJSON(
       .rs.ppm.buildVulnerabilityRequestBody("cran", c("pkgA==1.0.0", "pkgB==2.0.0"))
    )
    expect_equal(as.character(parsed$repo), "cran")
-   expect_true(as.logical(parsed$has_vulns))
    expect_true(as.logical(parsed$omit_dependencies))
    expect_true(as.logical(parsed$omit_downloads))
    expect_true(as.logical(parsed$omit_package_details))
    expect_equal(as.character(parsed$names), c("pkgA==1.0.0", "pkgB==2.0.0"))
+})
+
+test_that("buildVulnerabilityRequestBody omits has_vulns so all packages are returned", {
+   # has_vulns is a server-side filter; sending it would drop every non-vulnerable
+   # package from the response, taking its metadata down with it. The single
+   # request must return a record for every requested package so we can feed both
+   # the vulnerability badges and the metadata column from one response.
+   body <- .rs.ppm.buildVulnerabilityRequestBody("cran", "pkgA==1.0.0")
+   parsed <- .rs.fromJSON(body)
+   expect_null(parsed$has_vulns)
+   expect_false(grepl("has_vulns", body, fixed = TRUE))
 })
 
 test_that("buildVulnerabilityRequestBody keeps a single package name as a JSON array", {
@@ -454,6 +464,47 @@ test_that("recordVulnerabilityResponse caches vulns and empty markers for reques
    expect_false(exists(.rs.testPpm$repoUrl, envir = .rs.ppm.pending, inherits = FALSE))
 })
 
+test_that("recordVulnerabilityResponse caches metadata from the same response", {
+   # a single filter/packages response carries both vulns and custom metadata;
+   # recording it must populate the metadata cache too (the metadata column reads
+   # this cache directly, with no network access of its own)
+   clearVulnsState()
+   rm(
+      list = ls(envir = .rs.ppm.metadataCache, all.names = TRUE),
+      envir = .rs.ppm.metadataCache
+   )
+   assign(.rs.testPpm$repoUrl, c("pkgA==1.0.0", "pkgB==2.0.0"), envir = .rs.ppm.pending)
+
+   body <- paste(
+      '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1"}],"metadata":[{"key":"risk-level","value":"low"}]}',
+      '{"name":"pkgB","version":"2.0.0"}',
+      sep = "\n"
+   )
+   .rs.ppm.recordVulnerabilityResponse(.rs.testPpm$repoUrl, body)
+
+   metaCache <- .rs.ppm.metadataCache[[.rs.testPpm$repoUrl]]
+   # pkgA's metadata is cached in the raw [{key,value}] form getMetadata expects
+   expect_equal(
+      get("pkgA==1.0.0", envir = metaCache),
+      list(list(key = "risk-level", value = "low"))
+   )
+   # pkgB reported no metadata -- cache an NA marker so we don't keep re-asking
+   expect_true(is.na(get("pkgB==2.0.0", envir = metaCache)))
+})
+
+test_that("metadataByKey keys metadata by name==version and marks misses with NA", {
+   records <- list(
+      list(name = "pkgA", version = "1.0.0",
+           metadata = list(list(key = "risk-level", value = "high"))),
+      list(name = "pkgB", version = "2.0.0"),
+      list(version = "9.9.9")   # missing name -- skipped entirely
+   )
+   result <- .rs.ppm.metadataByKey(records)
+   expect_equal(result[["pkgA==1.0.0"]], list(list(key = "risk-level", value = "high")))
+   expect_true(is.na(result[["pkgB==2.0.0"]]))
+   expect_false("9.9.9" %in% names(result))
+})
+
 test_that("recordVulnerabilityResponse leaves cache and pending intact on a server error", {
    clearVulnsState()
    assign(.rs.testPpm$repoUrl, "pkgB==2.0.0", envir = .rs.ppm.pending)
@@ -479,6 +530,38 @@ test_that("recordVulnerabilityResponse leaves cache and pending intact on an emp
 
    expect_null(.rs.ppm.vulns[[.rs.testPpm$repoUrl]])
    expect_equal(.rs.ppm.pending[[.rs.testPpm$repoUrl]], "pkgB==2.0.0")
+})
+
+test_that("getMetadata reads the cache for the active repo without any network access", {
+   clearVulnsState()
+   rm(
+      list = ls(envir = .rs.ppm.metadataCache, all.names = TRUE),
+      envir = .rs.ppm.metadataCache
+   )
+
+   # seed the metadata cache as the async refresh would have
+   metaCache <- .rs.ppm.repoMetadataCache(.rs.testPpm$repoUrl)
+   assign("pkgA==1.0.0", list(list(key = "risk-level", value = "low")), envir = metaCache)
+   assign("pkgB==2.0.0", NA_character_, envir = metaCache)
+
+   withMockFunction(".rs.ppm.getActiveRepository", function() list(url = .rs.testPpm$repoUrl))
+   withMockFunction(".rs.ppm.getMetadataKey", function() "risk-level")
+
+   result <- .rs.ppm.getMetadata()
+   # the requested key resolves to its value; the NA-marked package yields ""
+   expect_equal(as.character(result[["pkgA==1.0.0"]]), "low")
+   expect_equal(as.character(result[["pkgB==2.0.0"]]), "")
+})
+
+test_that("getMetadata returns an empty list when the active repo has no cache", {
+   rm(
+      list = ls(envir = .rs.ppm.metadataCache, all.names = TRUE),
+      envir = .rs.ppm.metadataCache
+   )
+   withMockFunction(".rs.ppm.getActiveRepository", function() list(url = .rs.testPpm$repoUrl))
+   withMockFunction(".rs.ppm.getMetadataKey", function() "risk-level")
+
+   expect_equal(.rs.ppm.getMetadata(), list())
 })
 
 test_that("getCachedVulnerabilities aggregates per repo without any network access", {

--- a/src/cpp/tests/testthat/test-ppm.R
+++ b/src/cpp/tests/testthat/test-ppm.R
@@ -266,137 +266,142 @@ test_that("aggregateVulnsByName skips cached entries with empty vuln lists", {
    ))
 })
 
-# Tests for getVulnerabilityInformationImpl swap in a mock
-# fetchVulnerabilityInformation. The helper clears the session-wide cache
-# so each test starts from a known state, then installs the mock and
-# arranges for it to be restored when the test exits.
+# Tests for the asynchronous request-plan / response-recording flow. The
+# network request itself happens in C++ (off the main thread); these tests
+# exercise the R helpers that decide what to request and that fold a response
+# back into the per-repo cache.
 .rs.testPpm <- list(
    repoUrl = "https://example.test/repo/latest"
 )
 
-# Install a mock for .rs.ppm.fetchVulnerabilityInformation that runs the
-# supplied function. Schedules restoration via withr::defer so the swap
-# only lasts for the current test_that() frame. Preserves the closure's
-# lexical environment so <<- captures back into the test scope still work.
-withMockFetch <- function(fn)
+# Swap a tools-env function for the duration of the current test_that() frame.
+# Schedules restoration via withr::defer so the swap only lasts for that frame.
+withMockFunction <- function(name, fn)
 {
    toolsEnv <- .rs.toolsEnv()
-   original <- get(".rs.ppm.fetchVulnerabilityInformation", envir = toolsEnv)
-   assign(".rs.ppm.fetchVulnerabilityInformation", fn, envir = toolsEnv)
+   original <- get(name, envir = toolsEnv)
+   assign(name, fn, envir = toolsEnv)
    withr::defer(
-      assign(".rs.ppm.fetchVulnerabilityInformation", original, envir = toolsEnv),
+      assign(name, original, envir = toolsEnv),
       envir = parent.frame()
    )
 }
 
-# Reset the per-repo cache between tests so nothing leaks between them.
-clearVulnsCache <- function()
+# Reset the per-repo cache and pending-key state between tests so nothing
+# leaks between them.
+clearVulnsState <- function()
 {
    rm(list = ls(envir = .rs.ppm.vulns, all.names = TRUE), envir = .rs.ppm.vulns)
+   rm(list = ls(envir = .rs.ppm.pending, all.names = TRUE), envir = .rs.ppm.pending)
 }
 
-test_that("getVulnerabilityInformationImpl preserves cached vulns when fetch fails", {
-   # Pre-seed the cache for one package, then ask about that package plus
-   # a new one. A fetch failure (mock returns NULL) should leave the cache
-   # alone and still surface the cached vulns at aggregation time.
-   clearVulnsCache()
-   cache <- new.env(parent = emptyenv())
-   assign("pkgA==1.0.0", list(list(id = "V1", summary = "old")), envir = cache)
-   assign(.rs.testPpm$repoUrl, cache, envir = .rs.ppm.vulns)
-
-   withMockFetch(function(repoUrl, pkgKeys) NULL)
-
-   result <- .rs.ppm.getVulnerabilityInformationImpl(
-      .rs.testPpm$repoUrl,
-      c("pkgA==1.0.0", "pkgB==2.0.0")
-   )
-
-   expect_equal(result, expected(
-      pkgA = list(list(id = "V1", summary = "old"))
-   ))
-   # pkgB must not be marked "queried, no vulns" -- the next refresh has
-   # to be free to retry it
-   expect_false(exists("pkgB==2.0.0", envir = cache, inherits = FALSE))
-})
-
-test_that("getVulnerabilityInformationImpl asks PPM only about uncached keys", {
-   clearVulnsCache()
+test_that("getVulnerabilityRequestPlan asks PPM only about uncached keys", {
+   clearVulnsState()
    cache <- new.env(parent = emptyenv())
    assign("pkgA==1.0.0", list(list(id = "V1")), envir = cache)
    assign(.rs.testPpm$repoUrl, cache, envir = .rs.ppm.vulns)
 
-   capturedKeys <- NULL
-   withMockFetch(function(repoUrl, pkgKeys) {
-      capturedKeys <<- pkgKeys
-      structure(list(), names = character())
-   })
+   withMockFunction(".rs.ppm.isIntegrationEnabled", function() TRUE)
+   withMockFunction(".rs.ppm.installedPackageKeys", function() c("pkgA==1.0.0", "pkgB==2.0.0"))
+   withMockFunction(".rs.computeAuthorizationHeader", function(url) "")
 
-   .rs.ppm.getVulnerabilityInformationImpl(
-      .rs.testPpm$repoUrl,
-      c("pkgA==1.0.0", "pkgB==2.0.0")
-   )
+   plan <- .rs.ppm.getVulnerabilityRequestPlan(repos = c(CRAN = .rs.testPpm$repoUrl))
 
-   expect_equal(capturedKeys, "pkgB==2.0.0")
+   expect_length(plan, 1L)
+   # only the uncached key should appear in the request body
+   expect_true(grepl("pkgB==2.0.0", plan[[1L]]$body, fixed = TRUE))
+   expect_false(grepl("pkgA==1.0.0", plan[[1L]]$body, fixed = TRUE))
+   # the requested keys are recorded so the response handler can mark them
+   expect_equal(.rs.ppm.pending[[.rs.testPpm$repoUrl]], "pkgB==2.0.0")
 })
 
-test_that("getVulnerabilityInformationImpl caches empty markers for keys PPM did not return", {
-   # PPM may report vulns for only a subset of requested keys. The impl
-   # caches an empty list for the missing keys so subsequent refreshes
-   # don't keep re-asking.
-   clearVulnsCache()
+test_that("getVulnerabilityRequestPlan skips repos with no uncached keys", {
+   clearVulnsState()
+   cache <- new.env(parent = emptyenv())
+   assign("pkgA==1.0.0", list(list(id = "V1")), envir = cache)
+   assign(.rs.testPpm$repoUrl, cache, envir = .rs.ppm.vulns)
 
-   withMockFetch(function(repoUrl, pkgKeys) {
-      structure(
-         list(list(list(id = "V1"))),
-         names = "pkgA==1.0.0"
-      )
-   })
+   withMockFunction(".rs.ppm.isIntegrationEnabled", function() TRUE)
+   withMockFunction(".rs.ppm.installedPackageKeys", function() "pkgA==1.0.0")
 
-   result <- .rs.ppm.getVulnerabilityInformationImpl(
-      .rs.testPpm$repoUrl,
-      c("pkgA==1.0.0", "pkgB==2.0.0")
-   )
+   plan <- .rs.ppm.getVulnerabilityRequestPlan(repos = c(CRAN = .rs.testPpm$repoUrl))
 
-   expect_equal(result, expected(
-      pkgA = list(list(id = "V1"))
-   ))
+   expect_length(plan, 0L)
+   expect_false(exists(.rs.testPpm$repoUrl, envir = .rs.ppm.pending, inherits = FALSE))
+})
+
+test_that("getVulnerabilityRequestPlan returns nothing when integration is disabled", {
+   clearVulnsState()
+   withMockFunction(".rs.ppm.isIntegrationEnabled", function() FALSE)
+
+   plan <- .rs.ppm.getVulnerabilityRequestPlan(repos = c(CRAN = .rs.testPpm$repoUrl))
+   expect_length(plan, 0L)
+})
+
+test_that("getVulnerabilityRequestPlan skips non-PPM repositories", {
+   clearVulnsState()
+   withMockFunction(".rs.ppm.isIntegrationEnabled", function() TRUE)
+   withMockFunction(".rs.ppm.installedPackageKeys", function() "pkgA==1.0.0")
+
+   plan <- .rs.ppm.getVulnerabilityRequestPlan(repos = c(CRAN = "https://cran.rstudio.com"))
+   expect_length(plan, 0L)
+})
+
+test_that("getVulnerabilityRequestPlan returns nothing when no packages are installed", {
+   clearVulnsState()
+   withMockFunction(".rs.ppm.isIntegrationEnabled", function() TRUE)
+   withMockFunction(".rs.ppm.installedPackageKeys", function() character())
+
+   plan <- .rs.ppm.getVulnerabilityRequestPlan(repos = c(CRAN = .rs.testPpm$repoUrl))
+   expect_length(plan, 0L)
+})
+
+test_that("recordVulnerabilityResponse caches vulns and empty markers for requested keys", {
+   clearVulnsState()
+   assign(.rs.testPpm$repoUrl, c("pkgA==1.0.0", "pkgB==2.0.0"), envir = .rs.ppm.pending)
+
+   # isolate the cache-update behaviour from the session's live repos option
+   withMockFunction(".rs.ppm.getCachedVulnerabilities", function(repos = NULL) list())
+
+   body <- '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1"}]}'
+   .rs.ppm.recordVulnerabilityResponse(.rs.testPpm$repoUrl, body)
 
    cache <- .rs.ppm.vulns[[.rs.testPpm$repoUrl]]
-   expect_equal(get("pkgA==1.0.0", envir = cache), list(list(id = "V1")))
+   # the parser marks leaf values as scalars, so compare against the marked form
+   expect_equal(get("pkgA==1.0.0", envir = cache), expected(list(id = "V1")))
+   # pkgB had no vulns reported -- cache an empty marker so we don't re-ask
    expect_equal(get("pkgB==2.0.0", envir = cache), list())
+   # the pending entry is cleared once recorded
+   expect_false(exists(.rs.testPpm$repoUrl, envir = .rs.ppm.pending, inherits = FALSE))
 })
 
-test_that("getVulnerabilityInformationImpl returns empty without calling PPM when pkgKeys is empty", {
-   clearVulnsCache()
+test_that("recordVulnerabilityResponse leaves cache and pending intact on a server error", {
+   clearVulnsState()
+   assign(.rs.testPpm$repoUrl, "pkgB==2.0.0", envir = .rs.ppm.pending)
 
-   called <- FALSE
-   withMockFetch(function(repoUrl, pkgKeys) {
-      called <<- TRUE
-      structure(list(), names = character())
-   })
+   withMockFunction(".rs.ppm.getCachedVulnerabilities", function(repos = NULL) list())
 
-   result <- .rs.ppm.getVulnerabilityInformationImpl(.rs.testPpm$repoUrl, character())
+   body <- '{"error":"not allowed","code":"403"}'
+   expect_warning(
+      .rs.ppm.recordVulnerabilityResponse(.rs.testPpm$repoUrl, body),
+      "error requesting package vulnerabilities.*not allowed.*403"
+   )
 
-   expect_equal(result, structure(list(), names = character()))
-   expect_false(called)
+   # nothing cached, and the key stays pending so a later refresh retries it
+   expect_null(.rs.ppm.vulns[[.rs.testPpm$repoUrl]])
+   expect_equal(.rs.ppm.pending[[.rs.testPpm$repoUrl]], "pkgB==2.0.0")
 })
 
-test_that("getVulnerabilityInformationImpl skips the fetch when every key is already cached", {
-   clearVulnsCache()
+test_that("getCachedVulnerabilities aggregates per repo without any network access", {
+   clearVulnsState()
    cache <- new.env(parent = emptyenv())
    assign("pkgA==1.0.0", list(list(id = "V1")), envir = cache)
    assign(.rs.testPpm$repoUrl, cache, envir = .rs.ppm.vulns)
 
-   called <- FALSE
-   withMockFetch(function(repoUrl, pkgKeys) {
-      called <<- TRUE
-      structure(list(), names = character())
-   })
+   withMockFunction(".rs.ppm.installedPackageKeys", function() "pkgA==1.0.0")
 
-   result <- .rs.ppm.getVulnerabilityInformationImpl(.rs.testPpm$repoUrl, "pkgA==1.0.0")
-
-   expect_false(called)
-   expect_equal(result, expected(
+   result <- .rs.ppm.getCachedVulnerabilities(repos = c(CRAN = .rs.testPpm$repoUrl))
+   expect_equal(result, list(CRAN = expected(
       pkgA = list(list(id = "V1"))
-   ))
+   )))
 })

--- a/src/cpp/tests/testthat/test-ppm.R
+++ b/src/cpp/tests/testthat/test-ppm.R
@@ -360,9 +360,6 @@ test_that("recordVulnerabilityResponse caches vulns and empty markers for reques
    clearVulnsState()
    assign(.rs.testPpm$repoUrl, c("pkgA==1.0.0", "pkgB==2.0.0"), envir = .rs.ppm.pending)
 
-   # isolate the cache-update behaviour from the session's live repos option
-   withMockFunction(".rs.ppm.getCachedVulnerabilities", function(repos = NULL) list())
-
    body <- '{"name":"pkgA","version":"1.0.0","vulns":[{"id":"V1"}]}'
    .rs.ppm.recordVulnerabilityResponse(.rs.testPpm$repoUrl, body)
 
@@ -378,8 +375,6 @@ test_that("recordVulnerabilityResponse caches vulns and empty markers for reques
 test_that("recordVulnerabilityResponse leaves cache and pending intact on a server error", {
    clearVulnsState()
    assign(.rs.testPpm$repoUrl, "pkgB==2.0.0", envir = .rs.ppm.pending)
-
-   withMockFunction(".rs.ppm.getCachedVulnerabilities", function(repos = NULL) list())
 
    body <- '{"error":"not allowed","code":"403"}'
    expect_warning(

--- a/src/cpp/tests/testthat/test-ppm.R
+++ b/src/cpp/tests/testthat/test-ppm.R
@@ -21,7 +21,8 @@ context("ppm")
 expected <- function(...) .rs.markScalars(list(...))
 
 # Helper: build a cache environment populated with the given keyed entries,
-# matching the layout used by .rs.ppm.getVulnerabilityInformationImpl.
+# matching the per-repo layout produced by .rs.ppm.repoVulnCache and consumed
+# by .rs.ppm.aggregateVulnsByName.
 cacheEnv <- function(...)
 {
    entries <- list(...)
@@ -31,9 +32,25 @@ cacheEnv <- function(...)
    env
 }
 
-test_that("parseVulnerabilityResponse handles an empty body", {
-   result <- .rs.ppm.parseVulnerabilityResponse("")
+test_that("parseVulnerabilityResponse treats a missing body as nothing-to-record", {
+   # character(0) is the crash-guard case: strsplit(character(0), ...) has no
+   # [[1L]] element. We return the empty marker (not NULL) so the response is
+   # recorded as "checked, no vulns" rather than retried forever.
+   result <- .rs.ppm.parseVulnerabilityResponse(character(0))
    expect_equal(result, structure(list(), names = character()))
+})
+
+test_that("parseVulnerabilityResponse returns NULL for an empty server body", {
+   # a 2xx with an empty body tells us nothing about the requested packages, so
+   # we signal failure (NULL) and let a later refresh retry rather than caching
+   # every package as "no vulns" and clearing badges
+   expect_null(.rs.ppm.parseVulnerabilityResponse(""))
+})
+
+test_that("parseVulnerabilityResponse returns NULL for a whitespace-only body", {
+   expect_null(.rs.ppm.parseVulnerabilityResponse("   "))
+   expect_null(.rs.ppm.parseVulnerabilityResponse("\n"))
+   expect_null(.rs.ppm.parseVulnerabilityResponse("\r\n"))
 })
 
 test_that("parseVulnerabilityResponse parses a single record into a name==version key", {
@@ -356,6 +373,71 @@ test_that("getVulnerabilityRequestPlan returns nothing when no packages are inst
    expect_length(plan, 0L)
 })
 
+test_that("getVulnerabilityRequestPlan includes the computed auth header and endpoint", {
+   clearVulnsState()
+   withMockFunction(".rs.ppm.isIntegrationEnabled", function() TRUE)
+   withMockFunction(".rs.ppm.installedPackageKeys", function() "pkgA==1.0.0")
+   # mock the header explicitly so the assertion doesn't depend on the test
+   # runner's real ~/.netrc
+   withMockFunction(".rs.computeAuthorizationHeader", function(url) "Basic dXNlcjpwYXNz")
+
+   plan <- .rs.ppm.getVulnerabilityRequestPlan(repos = c(CRAN = .rs.testPpm$repoUrl))
+   expect_length(plan, 1L)
+   expect_equal(as.character(plan[[1L]]$authHeader), "Basic dXNlcjpwYXNz")
+   expect_match(as.character(plan[[1L]]$endpoint), "/__api__/filter/packages$")
+})
+
+test_that("getVulnerabilityRequestPlan emits one entry per PPM repo with uncached keys", {
+   clearVulnsState()
+
+   repoA <- "https://a.example.test/repo/latest"
+   repoB <- "https://b.example.test/repo/latest"
+
+   # repoA already has pkgA cached; repoB has nothing cached yet
+   cacheA <- new.env(parent = emptyenv())
+   assign("pkgA==1.0.0", list(), envir = cacheA)
+   assign(repoA, cacheA, envir = .rs.ppm.vulns)
+
+   withMockFunction(".rs.ppm.isIntegrationEnabled", function() TRUE)
+   withMockFunction(".rs.ppm.installedPackageKeys", function() c("pkgA==1.0.0", "pkgB==2.0.0"))
+   withMockFunction(".rs.computeAuthorizationHeader", function(url) "")
+
+   plan <- .rs.ppm.getVulnerabilityRequestPlan(repos = c(A = repoA, B = repoB))
+   expect_length(plan, 2L)
+
+   repoUrls <- vapply(plan, function(e) as.character(e$repoUrl), character(1))
+   planA <- plan[[which(repoUrls == repoA)]]
+   planB <- plan[[which(repoUrls == repoB)]]
+
+   # repoA only needs pkgB (pkgA is cached); repoB needs both
+   expect_true(grepl("pkgB==2.0.0", planA$body, fixed = TRUE))
+   expect_false(grepl("pkgA==1.0.0", planA$body, fixed = TRUE))
+   expect_true(grepl("pkgA==1.0.0", planB$body, fixed = TRUE))
+   expect_true(grepl("pkgB==2.0.0", planB$body, fixed = TRUE))
+})
+
+test_that("buildVulnerabilityRequestBody sets the repo and omit/has_vulns flags", {
+   parsed <- .rs.fromJSON(
+      .rs.ppm.buildVulnerabilityRequestBody("cran", c("pkgA==1.0.0", "pkgB==2.0.0"))
+   )
+   expect_equal(as.character(parsed$repo), "cran")
+   expect_true(as.logical(parsed$has_vulns))
+   expect_true(as.logical(parsed$omit_dependencies))
+   expect_true(as.logical(parsed$omit_downloads))
+   expect_true(as.logical(parsed$omit_package_details))
+   expect_equal(as.character(parsed$names), c("pkgA==1.0.0", "pkgB==2.0.0"))
+})
+
+test_that("buildVulnerabilityRequestBody keeps a single package name as a JSON array", {
+   # as.list() prevents unbox = TRUE from collapsing a one-element vector into a
+   # bare string; PPM's filter/packages endpoint requires names to be an array.
+   # fromJSON can't distinguish array-of-one from a scalar, so assert on the
+   # serialized form directly.
+   body <- .rs.ppm.buildVulnerabilityRequestBody("cran", "pkgA==1.0.0")
+   expect_match(body, '"names"[[:space:]]*:[[:space:]]*\\[')
+   expect_true(grepl("pkgA==1.0.0", body, fixed = TRUE))
+})
+
 test_that("recordVulnerabilityResponse caches vulns and empty markers for requested keys", {
    clearVulnsState()
    assign(.rs.testPpm$repoUrl, c("pkgA==1.0.0", "pkgB==2.0.0"), envir = .rs.ppm.pending)
@@ -387,6 +469,18 @@ test_that("recordVulnerabilityResponse leaves cache and pending intact on a serv
    expect_equal(.rs.ppm.pending[[.rs.testPpm$repoUrl]], "pkgB==2.0.0")
 })
 
+test_that("recordVulnerabilityResponse leaves cache and pending intact on an empty body", {
+   # an empty 2xx body parses to NULL (request-failed signal), so nothing should
+   # be cached and the key stays pending for a later retry
+   clearVulnsState()
+   assign(.rs.testPpm$repoUrl, "pkgB==2.0.0", envir = .rs.ppm.pending)
+
+   .rs.ppm.recordVulnerabilityResponse(.rs.testPpm$repoUrl, "")
+
+   expect_null(.rs.ppm.vulns[[.rs.testPpm$repoUrl]])
+   expect_equal(.rs.ppm.pending[[.rs.testPpm$repoUrl]], "pkgB==2.0.0")
+})
+
 test_that("getCachedVulnerabilities aggregates per repo without any network access", {
    clearVulnsState()
    cache <- new.env(parent = emptyenv())
@@ -399,4 +493,36 @@ test_that("getCachedVulnerabilities aggregates per repo without any network acce
    expect_equal(result, list(CRAN = expected(
       pkgA = list(list(id = "V1"))
    )))
+})
+
+test_that("getCachedVulnerabilities isolates a failing repo from the others", {
+   # one repo's aggregation error must not take down the client update for the
+   # rest -- the failing repo yields an empty map while the others succeed
+   clearVulnsState()
+
+   repoA <- "https://a.example.test/repo/latest"   # will fail to aggregate
+   repoB <- "https://b.example.test/repo/latest"   # will aggregate cleanly
+
+   cacheA <- new.env(parent = emptyenv())
+   assign("__boom__", TRUE, envir = cacheA)
+   assign(repoA, cacheA, envir = .rs.ppm.vulns)
+
+   cacheB <- new.env(parent = emptyenv())
+   assign("pkgB==2.0.0", list(list(id = "V2")), envir = cacheB)
+   assign(repoB, cacheB, envir = .rs.ppm.vulns)
+
+   warned <- FALSE
+   withMockFunction(".rs.logWarningMessage", function(message) warned <<- TRUE)
+   withMockFunction(".rs.ppm.installedPackageKeys", function() "pkgB==2.0.0")
+   withMockFunction(".rs.ppm.aggregateVulnsByName", function(cache, pkgKeys)
+   {
+      if (exists("__boom__", envir = cache, inherits = FALSE))
+         stop("boom")
+      .rs.markScalars(list(pkgB = list(list(id = "V2"))))
+   })
+
+   result <- .rs.ppm.getCachedVulnerabilities(repos = c(A = repoA, B = repoB))
+   expect_true(warned)
+   expect_equal(result$A, structure(list(), names = character()))
+   expect_equal(result$B, expected(pkgB = list(list(id = "V2"))))
 })

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -38,6 +38,7 @@ class ClientEvent extends JavaScriptObject
    public static final String PlotsStateChanged = "plots_state_changed";
    public static final String PackageStatusChanged = "package_status_changed";
    public static final String PackageStateChanged = "package_state_changed";
+   public static final String PackageVulnerabilitiesReady = "package_vulnerabilities_ready";
    public static final String Locator = "locator";
    public static final String ConsoleResetHistory = "console_reset_history";
    public static final String SessionSerialization = "session_serialization";

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -215,9 +215,11 @@ import org.rstudio.studio.client.workbench.views.output.sourcecpp.model.SourceCp
 import org.rstudio.studio.client.workbench.views.packages.events.LoadedPackageUpdatesEvent;
 import org.rstudio.studio.client.workbench.views.packages.events.PackageStateChangedEvent;
 import org.rstudio.studio.client.workbench.views.packages.events.PackageStatusChangedEvent;
+import org.rstudio.studio.client.workbench.views.packages.events.PackageVulnerabilitiesReadyEvent;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageProvidedExtensions;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageState;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageStatus;
+import org.rstudio.studio.client.workbench.views.packages.model.PackageVulnerabilityTypes.RepositoryPackageVulnerabilityListMap;
 import org.rstudio.studio.client.workbench.views.plots.events.LocatorEvent;
 import org.rstudio.studio.client.workbench.views.plots.events.PlotsChangedEvent;
 import org.rstudio.studio.client.workbench.views.plots.events.PlotsZoomSizeChangedEvent;
@@ -388,6 +390,11 @@ public class ClientEventDispatcher
          {
             PackageStatus status = event.getData();
             eventBus_.dispatchEvent(new PackageStatusChangedEvent(status));
+         }
+         else if (type == ClientEvent.PackageVulnerabilitiesReady)
+         {
+            RepositoryPackageVulnerabilityListMap vulns = event.getData();
+            eventBus_.dispatchEvent(new PackageVulnerabilitiesReadyEvent(vulns));
          }
          else if (type == ClientEvent.Locator)
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -841,6 +841,13 @@ public class Packages
 
    private void setViewPackageList()
    {
+      // the initial package state may not have loaded yet (e.g. an async
+      // PackageVulnerabilitiesReadyEvent can arrive first); projectContext_ is
+      // null until then, so bail out and let setPackageState() render once it
+      // populates the context
+      if (projectContext_ == null)
+         return;
+
       ArrayList<PackageInfo> packages = null;
 
       // apply filter (if any)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -71,6 +71,7 @@ import org.rstudio.studio.client.workbench.views.help.events.ShowHelpEvent;
 import org.rstudio.studio.client.workbench.views.packages.events.LoadedPackageUpdatesEvent;
 import org.rstudio.studio.client.workbench.views.packages.events.PackageStateChangedEvent;
 import org.rstudio.studio.client.workbench.views.packages.events.PackageStatusChangedEvent;
+import org.rstudio.studio.client.workbench.views.packages.events.PackageVulnerabilitiesReadyEvent;
 import org.rstudio.studio.client.workbench.views.packages.events.RaisePackagePaneEvent;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageInfo;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageInstallContext;
@@ -92,6 +93,9 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+
+import jsinterop.base.Js;
+import jsinterop.base.JsPropertyMap;
 
 public class Packages
       extends BasePresenter
@@ -798,6 +802,14 @@ public class Packages
          updatePackageState(false, false);
    }
 
+   public void onPackageVulnerabilitiesReady(PackageVulnerabilitiesReadyEvent event)
+   {
+      // vulnerability data arrived asynchronously; refresh the table so the
+      // badges render against the current package list
+      vulns_ = event.getVulnerabilities();
+      setViewPackageList();
+   }
+
    @Override
    public void onDeferredInitCompleted(DeferredInitCompletedEvent event)
    {
@@ -1215,7 +1227,12 @@ public class Packages
       // sort the packages
       allPackages_ = new ArrayList<>();
       activeRepository_ = newState.getActiveRepository();
-      vulns_ = newState.getVulnerabilityInfo();
+
+      // NOTE: vulnerability data is intentionally NOT taken from the package
+      // state here. It is fetched asynchronously and delivered via
+      // PackageVulnerabilitiesReadyEvent (see onPackageVulnerabilitiesReady),
+      // so that a slow or unreachable PPM never blocks the package list. The
+      // existing vulns_ is preserved until that event updates it.
 
       JsArray<PackageInfo> serverPackages = newState.getPackageList();
       for (int i = 0; i < serverPackages.length(); i++)
@@ -1271,7 +1288,9 @@ public class Packages
    private final PackratServerOperations packratServer_;
    private final RenvServerOperations renvServer_;
    private ArrayList<PackageInfo> allPackages_ = new ArrayList<>();
-   private RepositoryPackageVulnerabilityListMap vulns_;
+   // starts empty (never null) so the table can render before vulnerability
+   // data arrives asynchronously; replaced wholesale by onPackageVulnerabilitiesReady
+   private RepositoryPackageVulnerabilityListMap vulns_ = Js.uncheckedCast(JsPropertyMap.of());
    private JsObject activeRepository_;
    private ProjectContext projectContext_;
    private String packageFilter_ = new String();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesTab.java
@@ -26,6 +26,7 @@ import org.rstudio.studio.client.workbench.ui.DelayLoadTabShim;
 import org.rstudio.studio.client.workbench.ui.DelayLoadWorkbenchTab;
 import org.rstudio.studio.client.workbench.views.packages.events.LoadedPackageUpdatesEvent;
 import org.rstudio.studio.client.workbench.views.packages.events.PackageStateChangedEvent;
+import org.rstudio.studio.client.workbench.views.packages.events.PackageVulnerabilitiesReadyEvent;
 import org.rstudio.studio.client.workbench.views.packages.events.RaisePackagePaneEvent;
 
 public class PackagesTab extends DelayLoadWorkbenchTab<Packages>
@@ -36,7 +37,8 @@ public class PackagesTab extends DelayLoadWorkbenchTab<Packages>
          extends DelayLoadTabShim<Packages, PackagesTab>
          implements LoadedPackageUpdatesEvent.Handler,
                     RaisePackagePaneEvent.Handler,
-                    PackageStateChangedEvent.Handler
+                    PackageStateChangedEvent.Handler,
+                    PackageVulnerabilitiesReadyEvent.Handler
    {
       @Handler
       public abstract void onInstallPackage();
@@ -57,6 +59,7 @@ public class PackagesTab extends DelayLoadWorkbenchTab<Packages>
       events.addHandler(LoadedPackageUpdatesEvent.TYPE, shim);
       events.addHandler(RaisePackagePaneEvent.TYPE, shim);
       events.addHandler(PackageStateChangedEvent.TYPE, shim);
+      events.addHandler(PackageVulnerabilitiesReadyEvent.TYPE, shim);
       uiPrefs_ = uiPrefs;
       session_ = session;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/events/PackageVulnerabilitiesReadyEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/events/PackageVulnerabilitiesReadyEvent.java
@@ -1,0 +1,59 @@
+/*
+ * PackageVulnerabilitiesReadyEvent.java
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.packages.events;
+
+import org.rstudio.studio.client.workbench.views.packages.model.PackageVulnerabilityTypes.RepositoryPackageVulnerabilityListMap;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+// Fired when package vulnerability information has been fetched asynchronously
+// from Posit Package Manager (see SessionPPM.cpp). The data is delivered
+// separately from the package list so that a slow or unreachable PPM never
+// blocks the package list -- or IDE startup.
+public class PackageVulnerabilitiesReadyEvent extends
+                              GwtEvent<PackageVulnerabilitiesReadyEvent.Handler>
+{
+   public static final Type<Handler> TYPE = new Type<>();
+
+   public interface Handler extends EventHandler
+   {
+      void onPackageVulnerabilitiesReady(PackageVulnerabilitiesReadyEvent event);
+   }
+
+   public PackageVulnerabilitiesReadyEvent(RepositoryPackageVulnerabilityListMap vulns)
+   {
+      vulns_ = vulns;
+   }
+
+   public RepositoryPackageVulnerabilityListMap getVulnerabilities()
+   {
+      return vulns_;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onPackageVulnerabilitiesReady(this);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   private final RepositoryPackageVulnerabilityListMap vulns_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageState.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageState.java
@@ -16,7 +16,6 @@ package org.rstudio.studio.client.workbench.views.packages.model;
 
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.studio.client.workbench.projects.ProjectContext;
-import org.rstudio.studio.client.workbench.views.packages.model.PackageVulnerabilityTypes.RepositoryPackageVulnerabilityListMap;
 
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
@@ -36,10 +35,6 @@ public class PackageState extends JavaScriptObject
          "packrat_context": this.packrat_context,
          "renv_context": this.renv_context
       };
-   }-*/;
-
-   public final native RepositoryPackageVulnerabilityListMap getVulnerabilityInfo() /*-{
-      return this.vulns;
    }-*/;
 
    public final native JsObject getActiveRepository() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -1374,7 +1374,15 @@ public class TextEditingTargetWidget
       syncRainbowParenMode();
       syncRainbowFencedDivs();
 
-      Scheduler.get().scheduleDeferred(() -> manageToolbarSizes());
+      // avoid lambda here (makes gwt devmode sad)
+      Scheduler.get().scheduleDeferred(new ScheduledCommand()
+      {
+         @Override
+         public void execute()
+         {
+            manageToolbarSizes();
+         }
+      });
    }
 
    public void setFontSize(double size)


### PR DESCRIPTION
## Intent

Addresses #17807.

When PPM integration is enabled and the active repo is a PPM URL, RStudio fetched
package vulnerability data on a **blocking** `curl::curl_fetch_memory()` call on the
R main thread, inside the synchronous `get_package_state` path reached at startup. A
slow or unreachable PPM therefore froze the entire IDE for the full TCP timeout
(~60s in the report).

## Changes

- **Stop downloading from R.** Removed all networking from `SessionPPM.R`. It now only
  does fast, local, pure-CPU work: build a request plan (what to fetch + a netrc-derived
  `Authorization` header + the request body), fold an NDJSON response into the per-repo
  cache, and aggregate the cache by package name. Also hardened the NDJSON parser against
  empty bodies (the `subscript out of bounds` case noted in the issue).
- **Fetch asynchronously, governed from C++.** `ppm::refreshVulnerabilitiesAsync()` runs
  the POST off the main thread via `TcpIpAsyncClientSsl`/`TcpIpAsyncClient` on
  `server_rpc::ioContext()`, with an explicit 10s connection timeout, then marshals back
  to the main thread to update the cache and publish results. Supports both `https` and
  `http` endpoints (parity with the old curl path), and honors `https_proxy`.
- **Decoupled delivery.** `get_package_state` no longer carries vulnerability data; the
  package list returns immediately. Vulnerabilities arrive shortly after via a new
  `package_vulnerabilities_ready` client event, applied to the table without rebuilding
  the package list. The event is published when each refresh batch drains (success or
  total failure, including when no request is launched) so the pane is always updated
  deterministically and never shows stale badges.

## Testing

- `rstudio-tests --scope r --filter ppm`: 35/35 pass (reworked request-plan /
  record-response / cached-aggregation coverage).
- GWT `ant javac` and backend `cmake --build` both clean.

No NEWS.md entry: this release branch does not track `NEWS.md`.
