### PR TITLE
ignore version/PATCH when merging release branches

### DIFF
--- a/scripts/merge-release-branch.sh
+++ b/scripts/merge-release-branch.sh
@@ -67,6 +67,7 @@ RELEASE_ONLY_FILES=(
     version/BUILDTYPE
     version/RELEASE
     version/CALENDAR_VERSION
+    version/PATCH
 )
 
 # Directories whose contents should always retain main's value after a


### PR DESCRIPTION
Adds `version/PATCH` to the `RELEASE_ONLY_FILES` set in `scripts/merge-release-branch.sh`, so it is reset to main's value after a rel-branch merge along with the other version files (`BUILDTYPE`, `RELEASE`, `CALENDAR_VERSION`).