### PR TITLE
Suppress invisibly-returned data.table auto-print in notebooks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 - ([#17225](https://github.com/rstudio/rstudio/issues/17225)): Fix duplicate entries appearing in the recent projects list when the same project was recorded under both aliased (`~/...`) and absolute path forms.
 - ([#17777](https://github.com/rstudio/rstudio/issues/17777)): Fix "Import Dataset" from the Environment pane failing with "could not find function '.rs.digest'" when previewing a CSV (or other readr/readxl/haven source).
 - ([#17800](https://github.com/rstudio/rstudio/issues/17800)): Fix the data viewer's horizontal scrollbar staying hidden after returning to the tab, and fix Ctrl+C/Cmd+C copying only the active cell instead of the user's multi-cell text selection.
+- ([#17278](https://github.com/rstudio/rstudio/issues/17278)): Fix a `data.table` returned invisibly from a `:=` update (e.g. `dt[, x := y]`) being auto-printed in notebook chunks, when its output should be suppressed as it is in the console.
 
 ### Dependencies
 - Ace 1.43.5

--- a/e2e/rstudio/tests/panes/editor/rmarkdown_chunks.test.ts
+++ b/e2e/rstudio/tests/panes/editor/rmarkdown_chunks.test.ts
@@ -3,8 +3,9 @@
  * `warn` option round-trip when running a chunk, error halts
  * (#16006-adjacent), console-history recall after an errored chunk
  * (#16006), patchwork-style auto-printing (#13470), paged-table
- * representation (#16483), suppression of invisibly-returned data.table
- * auto-printing (#17278), and nb.html generation on save.
+ * representation (#16483), data.table auto-print behavior -- paged for a
+ * normal table, suppressed for an invisible `:=` update (#17278), and
+ * nb.html generation on save.
  *
  * Multiline chunk execution (#17350) is covered by
  * `multiline_chunk_execution.test.ts`; notebook-save-during-execution
@@ -376,26 +377,36 @@ test.describe.serial('R Markdown chunks', { tag: ['@serial'] }, () => {
     await sourceActions.closeSourceAndDeleteFile(fileNamePrint);
   });
 
-  // A data.table returned invisibly from `[.data.table` after a `:=` update
-  // must not be auto-printed -- matching the console, knitr, and rmarkdown
-  // behavior. The notebook print override regressed in 2026.01: on the
-  // suppression signal it fell through to data.table's own print method,
-  // re-triggering data.table's stateful shouldPrint() and dumping the table
-  // into the chunk. https://github.com/rstudio/rstudio/issues/17278
-  test('data.table returned invisibly from := is not auto-printed (#17278)', async ({ rstudioPage: page }) => {
+  // The data.table override is the only one that signals "do not print" (a
+  // NULL override-map result), so the fix touches `print.data.table`
+  // specifically. The #16483/#13470 tests only exercise `print.data.frame`
+  // (via `mtcars`), so cover both sides of the data.table branch here:
+  //   - a normal data.table still renders as a paged table -- guards against
+  //     the fix over-suppressing a legitimate data.table; and
+  //   - a data.table returned invisibly from a `:=` update is not auto-printed,
+  //     matching the console/knitr behavior. This regressed in 2026.01: on the
+  //     suppression signal the override fell through to data.table's own print
+  //     method, re-triggering its stateful shouldPrint() and dumping the table.
+  // https://github.com/rstudio/rstudio/issues/17278
+  test('data.table auto-print: normal renders paged, invisible := is suppressed (#17278)', async ({ rstudioPage: page }) => {
     const missing = await consoleActions.ensurePackages(['data.table'], 180_000);
     test.skip(missing.length > 0, `required R package(s) not available: ${missing.join(', ')}`);
 
-    // Distinctive value for the added column: if the table is (incorrectly)
-    // printed, this string lands in the chunk output, which is what makes the
-    // assertion below non-vacuous. It cannot leak in from the source editor
-    // because the assertion is scoped to the chunk-output element.
+    // Distinctive value for the added column: if the invisible table is
+    // (incorrectly) printed, this string lands in the chunk output, which is
+    // what makes the suppression assertion non-vacuous. It cannot leak in from
+    // the source editor because that assertion is scoped to the chunk-output
+    // element.
     const sentinel = 'NBDTSENTINEL17278';
-    const fileName = `rmarkdown_datatable_invisible_${Date.now()}.Rmd`;
+    const fileName = `rmarkdown_datatable_${Date.now()}.Rmd`;
     const content = [
       '---',
-      'title: data.table Invisible Update',
+      'title: data.table Auto-Print',
       '---',
+      '',
+      '```{r dtnormal}',
+      'data.table::as.data.table(mtcars)',
+      '```',
       '',
       '```{r dtinvisible}',
       `data.table::as.data.table(mtcars)[, foo := '${sentinel}']`,
@@ -404,15 +415,23 @@ test.describe.serial('R Markdown chunks', { tag: ['@serial'] }, () => {
 
     await sourceActions.createAndOpenFile(fileName, content);
 
+    // Positive guard: a normal (visibly-returned) data.table must still render
+    // as a paged table. It's the only paged table on the page at this point
+    // (the #16483 auto-print case closed its document), so the bare
+    // `.pagedtable` locator is unambiguous.
+    await sourceActions.navigateToChunkByLabel('dtnormal');
+    await executeCommand(page, 'executeCurrentChunk');
+    await expect(page.locator('.pagedtable')).toBeVisible({ timeout: 15000 });
+
     // The `:=` update returns invisibly, so a correctly-behaving chunk
     // produces no output -- wait on R's idle state. Run twice; the first run
     // might not surface a stale chunk-output buffer (mirrors the #13470 test).
     await runChunkByLabelAndWaitForIdle(page, sourceActions, 'dtinvisible');
     await runChunkByLabelAndWaitForIdle(page, sourceActions, 'dtinvisible');
 
-    // No chunk-output element for this chunk should contain the table. The
-    // class is `rstudio_chunk_output_<label>` -- ClassIds.assignClassId adds it
-    // as a CSS *class*, so it must be matched with `.`, not `#`. Filtering on
+    // No chunk-output element for the invisible chunk should contain the table.
+    // The class is `rstudio_chunk_output_<label>` -- ClassIds.assignClassId adds
+    // it as a CSS *class*, so it must be matched with `.`, not `#`. Filtering on
     // the sentinel keeps this robust whether or not an empty output frame
     // exists, and only matches when the table was actually printed.
     await expect(

--- a/e2e/rstudio/tests/panes/editor/rmarkdown_chunks.test.ts
+++ b/e2e/rstudio/tests/panes/editor/rmarkdown_chunks.test.ts
@@ -3,7 +3,8 @@
  * `warn` option round-trip when running a chunk, error halts
  * (#16006-adjacent), console-history recall after an errored chunk
  * (#16006), patchwork-style auto-printing (#13470), paged-table
- * representation (#16483), and nb.html generation on save.
+ * representation (#16483), suppression of invisibly-returned data.table
+ * auto-printing (#17278), and nb.html generation on save.
  *
  * Multiline chunk execution (#17350) is covered by
  * `multiline_chunk_execution.test.ts`; notebook-save-during-execution
@@ -373,6 +374,52 @@ test.describe.serial('R Markdown chunks', { tag: ['@serial'] }, () => {
     );
     await expect(page.locator('.pagedtable')).toHaveCount(0);
     await sourceActions.closeSourceAndDeleteFile(fileNamePrint);
+  });
+
+  // A data.table returned invisibly from `[.data.table` after a `:=` update
+  // must not be auto-printed -- matching the console, knitr, and rmarkdown
+  // behavior. The notebook print override regressed in 2026.01: on the
+  // suppression signal it fell through to data.table's own print method,
+  // re-triggering data.table's stateful shouldPrint() and dumping the table
+  // into the chunk. https://github.com/rstudio/rstudio/issues/17278
+  test('data.table returned invisibly from := is not auto-printed (#17278)', async ({ rstudioPage: page }) => {
+    const missing = await consoleActions.ensurePackages(['data.table'], 180_000);
+    test.skip(missing.length > 0, `required R package(s) not available: ${missing.join(', ')}`);
+
+    // Distinctive value for the added column: if the table is (incorrectly)
+    // printed, this string lands in the chunk output, which is what makes the
+    // assertion below non-vacuous. It cannot leak in from the source editor
+    // because the assertion is scoped to the chunk-output element.
+    const sentinel = 'NBDTSENTINEL17278';
+    const fileName = `rmarkdown_datatable_invisible_${Date.now()}.Rmd`;
+    const content = [
+      '---',
+      'title: data.table Invisible Update',
+      '---',
+      '',
+      '```{r dtinvisible}',
+      `data.table::as.data.table(mtcars)[, foo := '${sentinel}']`,
+      '```',
+    ].join('\n');
+
+    await sourceActions.createAndOpenFile(fileName, content);
+
+    // The `:=` update returns invisibly, so a correctly-behaving chunk
+    // produces no output -- wait on R's idle state. Run twice; the first run
+    // might not surface a stale chunk-output buffer (mirrors the #13470 test).
+    await runChunkByLabelAndWaitForIdle(page, sourceActions, 'dtinvisible');
+    await runChunkByLabelAndWaitForIdle(page, sourceActions, 'dtinvisible');
+
+    // No chunk-output element for this chunk should contain the table. The
+    // class is `rstudio_chunk_output_<label>` -- ClassIds.assignClassId adds it
+    // as a CSS *class*, so it must be matched with `.`, not `#`. Filtering on
+    // the sentinel keeps this robust whether or not an empty output frame
+    // exists, and only matches when the table was actually printed.
+    await expect(
+      page.locator('.rstudio_chunk_output_dtinvisible', { hasText: sentinel }),
+    ).toHaveCount(0);
+
+    await sourceActions.closeSourceAndDeleteFile(fileName);
   });
 
   test('saving an R Notebook creates an nb.html file', async ({ rstudioPage: page }) => {

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -122,8 +122,17 @@
         o <- overrideMap(x, options)
         if (!is.null(o))
           return(overridePrint(o$x, o$options, o$className, o$nRow, o$nCol))
+
+        # a NULL override map result signals that this auto-printed object
+        # should not be printed at all -- e.g. a 'data.table' returned
+        # invisibly from '[.data.table' following a ':=' update. suppress the
+        # output rather than falling through to the original print method,
+        # which would re-print the object (and, for data.table, re-trigger its
+        # stateful shouldPrint() check and dump the table).
+        # https://github.com/rstudio/rstudio/issues/17278
+        return(invisible(x))
       }
-      
+
       # otherwise, call the original S3 method. we need to manually manage the
       # lookup here since we inject overrides into the base namespace, which
       # could mask the visibility of certain S3 overrides

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -123,12 +123,17 @@
         if (!is.null(o))
           return(overridePrint(o$x, o$options, o$className, o$nRow, o$nCol))
 
-        # a NULL override map result signals that this auto-printed object
-        # should not be printed at all -- e.g. a 'data.table' returned
-        # invisibly from '[.data.table' following a ':=' update. suppress the
-        # output rather than falling through to the original print method,
-        # which would re-print the object (and, for data.table, re-trigger its
-        # stateful shouldPrint() check and dump the table).
+        # A NULL from overrideMap() is a deliberate "do not print" signal, not a
+        # "no override available" miss: each overrideFun is bound to one class's
+        # map and only runs once S3 dispatch has already selected a registered
+        # override. data.table's map is currently the only one with a NULL branch
+        # -- it returns NULL for a table returned invisibly from a ':=' update,
+        # where data.table:::shouldPrint() returned FALSE. shouldPrint() is
+        # stateful and single-shot, so the overrideMap() call above already
+        # consumed that FALSE; falling through to the original print.data.table
+        # would call it again, get TRUE, and print the table. Return early so no
+        # output is emitted (invisible(x) just follows the print-method
+        # convention of returning its argument invisibly).
         # https://github.com/rstudio/rstudio/issues/17278
         return(invisible(x))
       }


### PR DESCRIPTION
## Intent

Addresses #17278.

## Approach

In notebook chunks, a `data.table` returned invisibly from a `:=` update (e.g. `dt[, x := y]`) was auto-printed as text, even though the same code suppresses output in the R console and in knitr/rmarkdown.

The notebook print override in `NotebookData.R` distinguishes auto-printed objects from explicit `print()` calls. For the `data.table` override, `overrideMap()` consults `data.table:::shouldPrint()` and returns `NULL` to signal "do not print". The auto-print branch returned early only when the override produced output; when `overrideMap()` returned `NULL`, control fell through to the original `print.data.table` method. `shouldPrint()` is stateful -- the first call returns `FALSE` and flips internal state so the next call returns `TRUE` -- so the fall-through invocation re-printed the table.

This change returns early (suppressing output) when the override map signals suppression for an auto-printed object, rather than delegating to the original print method. Explicit `print()` calls are unaffected and still delegate to the real S3 method.

## Automated Tests

Adds a Playwright regression test in `e2e/rstudio/tests/panes/editor/rmarkdown_chunks.test.ts` asserting that a `data.table` returned invisibly from a `:=` update produces no chunk output.

## QA Notes

In an R Notebook with "Chunk Output Inline", run a chunk containing:

    data.table::as.data.table(mtcars)[, foo := 'bar']

No output should appear below the chunk, matching the console and knitr behavior. A normal `data.table` (e.g. `data.table::as.data.table(mtcars)`) should still render as a paged table, and an explicit `print()` should still use `data.table`'s own print method.

## Documentation

N/A
