### PR TITLE
fix run tests button modifying clean test file timestamp

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 - ([#17225](https://github.com/rstudio/rstudio/issues/17225)): Fix duplicate entries appearing in the recent projects list when the same project was recorded under both aliased (`~/...`) and absolute path forms.
 - ([#17777](https://github.com/rstudio/rstudio/issues/17777)): Fix "Import Dataset" from the Environment pane failing with "could not find function '.rs.digest'" when previewing a CSV (or other readr/readxl/haven source).
 - ([#17800](https://github.com/rstudio/rstudio/issues/17800)): Fix the data viewer's horizontal scrollbar staying hidden after returning to the tab, and fix Ctrl+C/Cmd+C copying only the active cell instead of the user's multi-cell text selection.
+- ([#17810](https://github.com/rstudio/rstudio/issues/17810)): Fix the "Run Tests" button modifying the active test file's timestamp even when the file had no unsaved changes.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -9419,7 +9419,11 @@ public class TextEditingTarget implements
             @Override
             public void execute()
             {
-               save(new Command()
+               // Save any unsaved documents before running tests. We use
+               // withSaveFilesBeforeCommand (rather than an unconditional save)
+               // so that unmodified documents are not re-written to disk, which
+               // would needlessly update their timestamps. See #17810.
+               source_.withSaveFilesBeforeCommand(new Command()
                {
                   @Override
                   public void execute()
@@ -9439,7 +9443,9 @@ public class TextEditingTarget implements
                         }
                      });
                   }
-               });
+               },
+               () -> {},
+               "Run Tests");
             }
          },
          true
@@ -9457,7 +9463,11 @@ public class TextEditingTarget implements
             @Override
             public void execute()
             {
-               save(new Command()
+               // Save any unsaved documents before running tests. We use
+               // withSaveFilesBeforeCommand (rather than an unconditional save)
+               // so that unmodified documents are not re-written to disk, which
+               // would needlessly update their timestamps. See #17810.
+               source_.withSaveFilesBeforeCommand(new Command()
                {
                   @Override
                   public void execute()
@@ -9477,7 +9487,9 @@ public class TextEditingTarget implements
                         }
                      });
                   }
-               });
+               },
+               () -> {},
+               "Run Tests");
             }
          },
          false


### PR DESCRIPTION
## Intent

Addresses #17810.

The "Run Tests" button modified the active test file's timestamp on every
click, even when the file had no unsaved changes.

## Root cause

`onTestTestthatFile()` (and its sibling `onTestShinytestFile()`) in
`TextEditingTarget.java` called `save(...)` unconditionally before starting
the build. `save()` flushes the document with a real path, which bypasses the
"no changes" short-circuit in `DocUpdateSentinel.doSaveImpl()` -- that guard
only applies when `path == null` (the autosave route). As a result the backend
always rewrote the file via `writeStringToFile`, bumping its modification time.

`Ctrl+Shift+T` (Test Package) was unaffected because it goes through
`Source.withSaveFilesBeforeCommand`, which saves only dirty documents.

## Fix

Both handlers now use `source_.withSaveFilesBeforeCommand(...)` -- the same
helper already used by Test Package, `runShinyApp()`, and `runPlumberAPI()`. It
flushes only unsaved documents to disk (so tests still run against current
editor content) and leaves clean files untouched, so their timestamps are no
longer modified.

`DocUpdateSentinel.withSavedDoc()` was considered but rejected: when a document
is dirty it saves via the `path == null` route, which only updates the source
database and keeps the document dirty without writing the file -- so
`testthat::test_file()` would read stale on-disk content.

## Behavior note

"Run Tests" now saves all unsaved documents (matching Test Package) rather than
just the active one, and may show the standard unsaved-changes prompt depending
on the `saveFilesBeforeBuild` preference.

## Testing

- `cd src/gwt && ant javac` passes.
- Manually: create a package, `usethis::use_testthat()`, `usethis::use_test("example")`,
  click "Run Tests" on the clean `test-example.R` tab, and confirm the file's
  timestamp in the Files pane is unchanged across repeated clicks.
