### PR TITLE
Update macOS packaging brace-expansion lockfile entry

### DIFF
--- a/package/osx/scripts/package-lock.json
+++ b/package/osx/scripts/package-lock.json
@@ -134,9 +134,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
<!-- include an entry in NEWS.md if required -->

### Intent

Update the macOS packaging scripts lockfile entry for `brace-expansion` from 5.0.5 to 5.0.6. This clears the npm audit finding for GHSA-jxxr-4gwj-5jf2 in `package/osx/scripts`.

### Approach

This is a scoped lockfile-only update. `package.json` remains unchanged; the transitive `brace-expansion` resolution in `package/osx/scripts/package-lock.json` moves to 5.0.6.

### Automated Tests

From `package/osx/scripts`:

```text
npm audit --omit=dev
# found 0 vulnerabilities
```

Also verified with:

```text
npm install --package-lock-only --ignore-scripts
npm ls brace-expansion --package-lock-only
```

### QA Notes

No manual QA expected; this only updates a macOS packaging scripts dependency lockfile entry.

### Documentation

No documentation changes. This is a dependency lockfile maintenance update.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
