### PR TITLE
hide data-preview summary sidebar in the help popup and import/output previews

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 - ([#17777](https://github.com/rstudio/rstudio/issues/17777)): Fix "Import Dataset" from the Environment pane failing with "could not find function '.rs.digest'" when previewing a CSV (or other readr/readxl/haven source).
 - ([#17800](https://github.com/rstudio/rstudio/issues/17800)): Fix the data viewer's horizontal scrollbar staying hidden after returning to the tab, and fix Ctrl+C/Cmd+C copying only the active cell instead of the user's multi-cell text selection.
 - ([#17810](https://github.com/rstudio/rstudio/issues/17810)): Fix the "Run Tests" button modifying the active test file's timestamp even when the file had no unsaved changes.
+- ([#17735](https://github.com/rstudio/rstudio/issues/17735)): Hide the redundant column-summary sidebar in the data frame preview shown in the Help pane.
 
 ### Dependencies
 - Ace 1.43.5

--- a/e2e/rstudio/tests/panes/data-viewer/help_popup_data_preview.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/help_popup_data_preview.test.ts
@@ -1,11 +1,17 @@
 // Data-frame preview in the autocompletion help popup -- #17735.
 //
-// When you autocomplete a data frame, the help popup renders the shared grid
-// viewer (grid_resource/gridviewer.html) as a preview. That host should hide
-// the column-summary sidebar: it is redundant with the help text and crowds
-// out the rows the preview exists to surface. SessionHelp.R (getHelpDataFrame)
-// now passes show_summary=0 for this host; the standalone Data Viewer still
-// honors the data_viewer_show_summary preference.
+// Completing a data frame that is a list member (`object$df`) renders the
+// shared grid viewer (grid_resource/gridviewer.html) as a preview in the
+// completion help popup: the completion has type DATAFRAME, so HelpStrategy
+// routes to getHelpDataFrame, which resolves `object$df` via .rs.getAnywhere
+// and embeds the preview. (A bare top-level data-frame symbol does not surface
+// this preview, so the test drives the list-member `$` path the feature
+// actually uses.)
+//
+// That host should hide the column-summary sidebar: it is redundant with the
+// help text and crowds out the rows the preview exists to surface.
+// SessionHelp.R (getHelpDataFrame) now passes show_summary=0 for this host;
+// the standalone Data Viewer still honors the data_viewer_show_summary pref.
 //
 // The grid viewer always renders #sidebarPanel; it carries the "expanded"
 // class only while the summary is shown, and #sidebarToggle mirrors that in
@@ -15,12 +21,13 @@
 
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { COMPLETION_POPUP } from '@actions/autocomplete.actions';
 import { TIMEOUTS } from '@utils/constants';
 
 // No data viewer is open in this test, so the gridviewer iframe matched here
 // is unambiguously the help-popup preview.
 const GRID_FRAME = 'iframe[src*="grid_resource/gridviewer.html"]';
-const DF_NAME = 'df_17735_preview';
+const LIST_NAME = 'list_17735_preview';
 
 test.describe('Help popup data preview - #17735', () => {
   let consoleActions: ConsolePaneActions;
@@ -33,20 +40,23 @@ test.describe('Help popup data preview - #17735', () => {
     // executeInConsole replaces the input via setValue, so any partial
     // completion text left in the buffer can't corrupt this cleanup.
     await new ConsolePaneActions(page).executeInConsole(
-      `if (exists("${DF_NAME}", envir = .GlobalEnv)) rm(list = "${DF_NAME}", envir = .GlobalEnv)`,
+      `if (exists("${LIST_NAME}", envir = .GlobalEnv)) rm(list = "${LIST_NAME}", envir = .GlobalEnv)`,
       { wait: true },
     );
   });
 
   test('the autocompletion help popup hides the column-summary sidebar', async ({ rstudioPage: page }) => {
-    // A data frame in the global env so the completion resolves to the
-    // DATAFRAME help path (getHelpDataFrame), which embeds the preview.
-    await consoleActions.executeInConsole(`${DF_NAME} <- head(mtcars)`, { wait: true });
+    // A list whose `df` member is a data frame: completing `<list>$df` routes
+    // to the DATAFRAME help path (getHelpDataFrame) that embeds the preview.
+    await consoleActions.executeInConsole(`${LIST_NAME} <- list(df = head(mtcars))`, { wait: true });
 
-    // Type the name and trigger autocomplete; the selected completion's help
-    // (the data preview) renders alongside the completion popup.
-    await consoleActions.typeInConsole(DF_NAME);
-    await page.keyboard.press('Control+Space');
+    // Type up to the `$` and trigger member completion. The selected member's
+    // help (the data preview) renders alongside the completion popup.
+    await consoleActions.typeInConsole(`${LIST_NAME}$`);
+    if (!(await page.locator(COMPLETION_POPUP).isVisible())) {
+      await page.keyboard.press('Control+Space');
+    }
+    await expect(page.locator(COMPLETION_POPUP)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
 
     // The preview iframe is the shared grid viewer in server mode (env/obj).
     const previewFrame = page.frameLocator(GRID_FRAME);

--- a/e2e/rstudio/tests/panes/data-viewer/help_popup_data_preview.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/help_popup_data_preview.test.ts
@@ -1,0 +1,68 @@
+// Data-frame preview in the autocompletion help popup -- #17735.
+//
+// When you autocomplete a data frame, the help popup renders the shared grid
+// viewer (grid_resource/gridviewer.html) as a preview. That host should hide
+// the column-summary sidebar: it is redundant with the help text and crowds
+// out the rows the preview exists to surface. SessionHelp.R (getHelpDataFrame)
+// now passes show_summary=0 for this host; the standalone Data Viewer still
+// honors the data_viewer_show_summary preference.
+//
+// The grid viewer always renders #sidebarPanel; it carries the "expanded"
+// class only while the summary is shown, and #sidebarToggle mirrors that in
+// aria-expanded. Asserting the panel is collapsed is the behavioral check for
+// the fix -- pre-fix this host defaulted show_summary to true and the sidebar
+// was expanded.
+
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { TIMEOUTS } from '@utils/constants';
+
+// No data viewer is open in this test, so the gridviewer iframe matched here
+// is unambiguously the help-popup preview.
+const GRID_FRAME = 'iframe[src*="grid_resource/gridviewer.html"]';
+const DF_NAME = 'df_17735_preview';
+
+test.describe('Help popup data preview - #17735', () => {
+  let consoleActions: ConsolePaneActions;
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+  });
+
+  test.afterAll(async ({ rstudioPage: page }) => {
+    // executeInConsole replaces the input via setValue, so any partial
+    // completion text left in the buffer can't corrupt this cleanup.
+    await new ConsolePaneActions(page).executeInConsole(
+      `if (exists("${DF_NAME}", envir = .GlobalEnv)) rm(list = "${DF_NAME}", envir = .GlobalEnv)`,
+      { wait: true },
+    );
+  });
+
+  test('the autocompletion help popup hides the column-summary sidebar', async ({ rstudioPage: page }) => {
+    // A data frame in the global env so the completion resolves to the
+    // DATAFRAME help path (getHelpDataFrame), which embeds the preview.
+    await consoleActions.executeInConsole(`${DF_NAME} <- head(mtcars)`, { wait: true });
+
+    // Type the name and trigger autocomplete; the selected completion's help
+    // (the data preview) renders alongside the completion popup.
+    await consoleActions.typeInConsole(DF_NAME);
+    await page.keyboard.press('Control+Space');
+
+    // The preview iframe is the shared grid viewer in server mode (env/obj).
+    const previewFrame = page.frameLocator(GRID_FRAME);
+
+    // Wait for the grid to bootstrap (first data column header). initSidebar
+    // runs during bootstrap, so the sidebar's collapsed/expanded state is
+    // settled once the header is visible.
+    await expect(previewFrame.locator('th[data-col-idx="1"]'))
+      .toBeVisible({ timeout: TIMEOUTS.fileOpen });
+
+    // The fix: the summary sidebar is collapsed in this host.
+    await expect(previewFrame.locator('#sidebarPanel')).not.toHaveClass(/\bexpanded\b/);
+    await expect(previewFrame.locator('#sidebarToggle')).toHaveAttribute('aria-expanded', 'false');
+
+    // Dismiss the completion + help popups.
+    await page.keyboard.press('Escape');
+    await page.keyboard.press('Escape');
+  });
+});

--- a/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
+++ b/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
@@ -1,15 +1,21 @@
-// Import Dataset (readr) end-to-end test for #17777.
+// Import Dataset (readr) end-to-end tests.
 //
-// preview_data_import_async spawns a --vanilla R subprocess that sources
-// only Tools.R + a handful of session modules. Before the fix, .rs.digest
-// lived in SessionRUtil.R (not sourced in that subprocess) and was backed
-// by a .Call into the embedding (also not available there), so the CSV
-// preview failed with "Is this a valid CSV file? could not find function
-// '.rs.digest'". .rs.digest is now a pure-base-R Adler-32 in Tools.R,
-// which the subprocess already sources -- this test asserts the dialog
-// renders a successful preview end to end.
+// - #17777: the readr CSV preview must render without an .rs.digest lookup
+//   error. preview_data_import_async spawns a --vanilla R subprocess that
+//   sources only Tools.R + a handful of session modules. Before the fix,
+//   .rs.digest lived in SessionRUtil.R (not sourced there) and was backed by
+//   a .Call into the embedding (also unavailable), so the preview failed with
+//   "Is this a valid CSV file? could not find function '.rs.digest'".
+//   .rs.digest is now a pure-base-R Adler-32 in Tools.R, which the subprocess
+//   already sources.
+// - #17735: the import preview is a GridViewerFrame, which runs the shared
+//   grid viewer in data_source=data mode (data pushed in client-side, no
+//   server-side cached frame). The column-summary sidebar fetches stats from
+//   the grid_data endpoint and so has nothing to summarize in this host; it
+//   must be hidden. GridViewerFrame now requests show_summary=0.
 
 import { test, expect } from '@fixtures/rstudio.fixture';
+import type { Page, FrameLocator, Locator } from 'playwright';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { executeCommand } from '@utils/commands';
 import { installDepIfPrompted } from '@pages/modals.page';
@@ -23,6 +29,57 @@ const IMPORT_DIALOG = '.gwt-DialogBox[aria-label="Import Text Data"]';
 // The preview iframe is a GridViewerFrame titled with constants_.dataPreview().
 const PREVIEW_FRAME = 'iframe[title="Data Preview"]';
 
+// Open Import Dataset > From Text (readr) for the given CSV path and drive the
+// dialog until the preview iframe is up. Returns the dialog + preview frame so
+// each test can assert on the rendered preview. The caller cancels the dialog.
+async function openReadrCsvPreview(
+  page: Page,
+  consoleActions: ConsolePaneActions,
+  csvPath: string,
+): Promise<{ dialog: Locator; previewFrame: FrameLocator }> {
+  // Write the CSV via the R session so the path is valid on the rsession host
+  // (matters for Server mode where runner and session can be on different
+  // machines).
+  await consoleActions.executeInConsole(
+    `writeLines(c("a,b,c","1,2,3","4,5,6"), "${csvPath}")`,
+    { wait: true },
+  );
+
+  // The presenter wraps the dialog in a dependency check; accept the install
+  // prompt if readr (or a transitive dep) isn't already on the library path.
+  await executeCommand(page, 'importDatasetFromCsvUsingReadr');
+  await installDepIfPrompted(page);
+
+  const dialog = page.locator(IMPORT_DIALOG);
+  await expect(dialog).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+
+  // Set the path on the file chooser TextBox in one shot. The chooser polls
+  // for value changes every 250ms (DataImportFileChooser.checkForTextBoxChange)
+  // and flips the action button from "Browse..." to "Update" when the textbox
+  // transitions empty -> non-empty -- we wait on that flip below rather than
+  // racing the poll per keystroke.
+  //
+  // The textbox's class is the obfuscated form of `modelTextBox` (set via
+  // styleName= in DataImportFileChooser.ui.xml, which replaces the default
+  // .gwt-TextBox), so target it by ARIA name instead -- "File/URL:" comes from
+  // the label-association in DataImport.ui.xml.
+  const fileInput = dialog.getByRole('textbox', { name: 'File/URL:' });
+  await expect(fileInput).toBeVisible({ timeout: 5000 });
+  await fileInput.fill(csvPath);
+
+  // Click "Update" to commit the path and kick off preview_data_import_async.
+  // The textbox value change alone does not trigger the preview -- it has to go
+  // through the action button's click handler (DataImportFileChooser.
+  // actionButton_). The button's aria-label flips from "Browse for File/URL"
+  // to "Update for File/URL" via switchToUpdateMode() once the polling timer
+  // notices the new value.
+  const updateBtn = dialog.getByRole('button', { name: 'Update for File/URL' });
+  await expect(updateBtn).toBeVisible({ timeout: 5000 });
+  await updateBtn.click();
+
+  return { dialog, previewFrame: dialog.frameLocator(PREVIEW_FRAME) };
+}
+
 test.describe('Import Dataset (readr)', () => {
   const sandbox = useSuiteSandbox();
   let consoleActions: ConsolePaneActions;
@@ -33,47 +90,9 @@ test.describe('Import Dataset (readr)', () => {
 
   // https://github.com/rstudio/rstudio/issues/17777
   test('CSV preview renders without an .rs.digest lookup error', async ({ rstudioPage: page }) => {
-    // Write a tiny CSV via the R session so the path is valid on the
-    // rsession host (matters for Server mode where the runner and session
-    // can be on different machines).
-    const csvPath = `${sandbox.dir}/sample.csv`;
-    await consoleActions.executeInConsole(
-      `writeLines(c("a,b,c","1,2,3","4,5,6"), "${csvPath}")`,
-      { wait: true },
+    const { dialog, previewFrame } = await openReadrCsvPreview(
+      page, consoleActions, `${sandbox.dir}/sample.csv`,
     );
-
-    // Open Import Dataset > From Text (readr). The presenter wraps the
-    // dialog in a dependency check; accept the install prompt if readr
-    // (or one of its transitive deps) isn't already on the library path.
-    await executeCommand(page, 'importDatasetFromCsvUsingReadr');
-    await installDepIfPrompted(page);
-
-    const dialog = page.locator(IMPORT_DIALOG);
-    await expect(dialog).toBeVisible({ timeout: TIMEOUTS.fileOpen });
-
-    // Set the path on the file chooser TextBox in one shot. The chooser
-    // polls for value changes every 250ms (DataImportFileChooser.
-    // checkForTextBoxChange) and flips the action button from "Browse..."
-    // to "Update" when the textbox transitions empty -> non-empty -- we
-    // wait on that flip below rather than racing the poll per keystroke.
-    //
-    // The textbox's class is the obfuscated form of `modelTextBox` (set via
-    // styleName= in DataImportFileChooser.ui.xml, which replaces the default
-    // .gwt-TextBox), so target it by ARIA name instead -- "File/URL:" comes
-    // from the label-association in DataImport.ui.xml.
-    const fileInput = dialog.getByRole('textbox', { name: 'File/URL:' });
-    await expect(fileInput).toBeVisible({ timeout: 5000 });
-    await fileInput.fill(csvPath);
-
-    // Click "Update" to commit the path and kick off
-    // preview_data_import_async. The textbox value change alone does not
-    // trigger the preview -- it has to go through the action button's
-    // click handler (DataImportFileChooser.actionButton_). The button's
-    // aria-label flips from "Browse for File/URL" to "Update for File/URL"
-    // via switchToUpdateMode() once the polling timer notices the new value.
-    const updateBtn = dialog.getByRole('button', { name: 'Update for File/URL' });
-    await expect(updateBtn).toBeVisible({ timeout: 5000 });
-    await updateBtn.click();
 
     // Preview iframe should populate with the CSV's three columns. Pre-fix
     // this never landed because the subprocess errored out before returning
@@ -81,7 +100,6 @@ test.describe('Import Dataset (readr)', () => {
     // CSV file?" error prefix instead. The grid renders each header as
     // "<name>(<type>)" once column inference completes; anchor on the name
     // prefix so the assertion doesn't depend on the inferred type string.
-    const previewFrame = dialog.frameLocator(PREVIEW_FRAME);
     await expect(previewFrame.locator('th[data-col-idx="1"]'))
       .toHaveText(/^a/, { timeout: TIMEOUTS.fileOpen });
     await expect(previewFrame.locator('th[data-col-idx="2"]')).toHaveText(/^b/);
@@ -93,6 +111,29 @@ test.describe('Import Dataset (readr)', () => {
     await expect(dialog).not.toContainText('valid CSV file');
 
     // Cancel out -- we don't want to actually run the import.
+    await dialog.locator('#rstudio_dlg_cancel').click();
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+  });
+
+  // https://github.com/rstudio/rstudio/issues/17735
+  test('preview hides the column-summary sidebar', async ({ rstudioPage: page }) => {
+    const { dialog, previewFrame } = await openReadrCsvPreview(
+      page, consoleActions, `${sandbox.dir}/summary.csv`,
+    );
+
+    // Gate on the preview being up (first data column header). initSidebar
+    // runs during the grid's data-mode bootstrap, so the sidebar's
+    // collapsed/expanded state is settled by the time the header is visible.
+    await expect(previewFrame.locator('th[data-col-idx="1"]'))
+      .toHaveText(/^a/, { timeout: TIMEOUTS.fileOpen });
+
+    // The fix: GridViewerFrame requests show_summary=0, so the panel never
+    // gains the "expanded" class and the toggle reports collapsed. Pre-fix the
+    // host defaulted show_summary to true and the (non-functional in data
+    // mode) summary sidebar was expanded.
+    await expect(previewFrame.locator('#sidebarPanel')).not.toHaveClass(/\bexpanded\b/);
+    await expect(previewFrame.locator('#sidebarToggle')).toHaveAttribute('aria-expanded', 'false');
+
     await dialog.locator('#rstudio_dlg_cancel').click();
     await expect(dialog).not.toBeVisible({ timeout: 5000 });
   });

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -578,10 +578,16 @@ options(help_type = "html")
    maxDisplayColumns <- .rs.readUiPref("data_viewer_max_columns")
 
    # build a uri
+   #
+   # The column-summary sidebar is hidden in the help preview: the help
+   # document already describes the data frame, so the summary is redundant
+   # here and would crowd out the rows the preview is meant to surface. Other
+   # hosts (the standalone Data Viewer) continue to honor the user preference.
    attrs <- c(
-      obj       = title,
-      max_rows  = 1000,
-      max_cols  = maxDisplayColumns
+      obj          = title,
+      max_rows     = 1000,
+      max_cols     = maxDisplayColumns,
+      show_summary = 0
    )
    
    # only include env if we didn't find the data from "anywhere"

--- a/src/gwt/src/org/rstudio/core/client/widget/GridViewerFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/GridViewerFrame.java
@@ -31,7 +31,11 @@ public class GridViewerFrame extends RStudioThemedFrame
    {
       super(
          title,
-         "grid_resource/gridviewer.html?data_source=data&max_cols=-1",
+         // show_summary=0: this frame runs in data_source=data mode (data is
+         // pushed in client-side, with no server-side cached frame), so the
+         // column-summary sidebar -- which fetches stats from the grid_data
+         // endpoint -- has nothing to summarize here. Hide it.
+         "grid_resource/gridviewer.html?data_source=data&max_cols=-1&show_summary=0",
          false,
          null, 
          GridViewerStyles.getCustomStyle(),


### PR DESCRIPTION
## Intent

Addresses #17735.

The shared grid viewer (`grid_resource/gridviewer.html`) renders a
column-summary sidebar controlled by a `show_summary` query parameter. Two
hosts that embed the grid viewer as a small preview never set it, so it
defaulted to `true` and showed the sidebar:

- **Autocompletion help popup** for a data frame (`getHelpDataFrame` in
  `SessionHelp.R`). The summary is redundant with the help text and crowds out
  the rows the preview exists to surface.
- **Data Import dialog + Data Output pane** (`GridViewerFrame`). These run the
  grid viewer in `data_source=data` mode -- data is pushed in client-side with
  no server-side cached frame -- so the summary's `grid_data` fetch has nothing
  to summarize there at all.

This is a per-host toggle, not removal: the standalone Data Viewer continues to
honor the `data_viewer_show_summary` user preference.

## Changes

- `SessionHelp.R`: pass `show_summary=0` in the help-popup preview URI.
- `GridViewerFrame.java`: request `show_summary=0` for the import/output preview.
- Playwright coverage for both hosts, asserting the summary sidebar is
  collapsed (`#sidebarPanel` lacks `expanded`, `#sidebarToggle` reports
  `aria-expanded=false`):
  - `help_popup_data_preview.test.ts` -- drives the list-member `$` path
    (`object$df`) that actually surfaces the help preview.
  - `import_dataset.test.ts` -- new case alongside the existing #17777 test.

## Testing

`npm run test:desktop-dev -- help_popup_data_preview import_dataset` -- all
three tests pass:

- help popup preview collapses the sidebar
- CSV import preview renders (#17777, unchanged)
- import preview collapses the sidebar (#17735)
