### PR TITLE
seed macos arm64 build caches on main

### DIFF
--- a/.github/workflows/cache-seed-e2e-macos-26-arm64.yml
+++ b/.github/workflows/cache-seed-e2e-macos-26-arm64.yml
@@ -1,0 +1,36 @@
+name: "Cache: Seed macOS 26 ARM64 build caches"
+
+# Seeds the build caches (rstudio-tools, build-time R packages, and sccache)
+# on the default branch so that PR builds start warm. GitHub Actions caches
+# are scoped per-branch: a cache can only be restored from the same branch,
+# the PR's base branch, or the default branch. Sibling branches / PRs cannot
+# see each other's caches. By running the build job on main, the caches it
+# saves land in main's scope, which every PR (based on main) can then restore
+# via the restore-keys prefixes (rstudio-tools-arm64-, etc.). Without this,
+# every new PR branch starts 100% cold on its first build.
+on:
+  # Re-seed when the dependency scripts / lockfiles change -- those feed the
+  # rstudio-tools and R-libs cache keys, so a change there invalidates the
+  # existing main cache and a fresh one needs to be saved.
+  push:
+    branches: [main]
+    paths:
+      - "dependencies/**"
+      - ".github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml"
+      - ".github/workflows/cache-seed-e2e-macos-26-arm64.yml"
+  # Nightly re-seed keeps the sccache object cache (keyed per-commit, restored
+  # by prefix) recent on main so PR builds get a high compile-cache hit rate.
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+# Don't stack expensive macOS builds; the latest seed run wins.
+concurrency:
+  group: cache-seed-macos-26-arm64
+  cancel-in-progress: true
+
+jobs:
+  seed:
+    uses: ./.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+    with:
+      build_only: true

--- a/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -35,6 +35,10 @@ on:
         description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS."
         type: string
         default: ""
+      build_only:
+        description: "Run only the build job (to seed the rstudio-tools / R-libs / sccache caches) and skip the e2e job."
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       rstudio_installer_url:
@@ -61,6 +65,9 @@ on:
       rstudio_extra_args:
         type: string
         default: ""
+      build_only:
+        type: boolean
+        default: false
 
 jobs:
   # Builds RStudio Desktop from this PR's source on the same runner image as
@@ -184,9 +191,11 @@ jobs:
     needs: build
     # build is skipped when rstudio_installer_url is set; allow this job to
     # run in that case too. needs.build.result is "success" on a normal run
-    # and "skipped" on the override path.
+    # and "skipped" on the override path. build_only seeds the build caches
+    # (rstudio-tools / R-libs / sccache) without running e2e, so skip here.
     if: |
       always() &&
+      inputs.build_only != true &&
       (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: macos-26
     timeout-minutes: 120


### PR DESCRIPTION
## Intent

The macOS 26 ARM64 e2e build caches (`rstudio-tools-arm64-`, `rstudio-build-rlibs-arm64-`, `sccache-arm64-`) effectively never warmed up: every new PR started a 100% cold build.

GitHub Actions caches are scoped per-branch. A run can only restore caches created by its own ref, its PR base branch, or the default branch -- sibling branches/PRs can't see each other's caches. The only universally-shared scope is `main`. But the cache-bearing `build` job only runs in the PR-triggered workflow, and `main` never ran a successful build, so there was no shared baseline for PRs to restore from.

(The caching mechanism itself works fine within a single PR's re-runs -- confirmed via the logs, where a second build on the same branch hit all three caches cleanly.)

## Changes

- Add a `build_only` input to the reusable workflow (`test-e2e-rstudio-desktop-os-macos-26-arm64.yml`). When set, the `e2e-desktop-macos` job is skipped and only the cache-saving `build` job runs.
- Add a seed workflow (`cache-seed-e2e-macos-26-arm64.yml`) that calls the reusable workflow with `build_only: true` on:
  - **push to `main`**, path-filtered to `dependencies/**` and the workflow files (the inputs to the rstudio-tools / R-libs cache keys),
  - a **nightly schedule** (keeps the per-commit sccache object cache recent on `main`),
  - **`workflow_dispatch`** (seed on demand).

This puts the caches in `main`'s scope, so each PR's first build restores them via its `restore-keys` prefixes instead of building from scratch.

## Notes

- The first seed run still builds cold (nothing to restore yet); subsequent PRs warm up after it saves.
- The push path filter uses `dependencies/**` (slightly broader than the exact `hashFiles` globs) so a re-seed triggers eagerly rather than missing a relevant dependency change.
- No NEWS.md entry: CI infrastructure change, not user-facing.