### PR TITLE
[Golden Wattle] drive ppm vulnerability display off the session repositories, not env vars

### DIFF
--- a/src/cpp/session/modules/SessionPPM.R
+++ b/src/cpp/session/modules/SessionPPM.R
@@ -91,11 +91,24 @@
 # response covers.
 .rs.addFunction("ppm.getVulnerabilityRequestPlan", function(repos = NULL)
 {
-   if (!.rs.ppm.isIntegrationEnabled())
-      return(list())
-
+   # NOTE: enablement is driven by whether the session's repositories point at a
+   # Posit Package Manager instance -- NOT by .rs.ppm.isIntegrationEnabled() (the
+   # PWB_PPM_* env vars). Vulnerability display is intentionally not opt-in: it
+   # is shown whenever a PPM repo is in use, including open-source / desktop
+   # RStudio. The env-var gate is reserved for the Workbench-only metadata column
+   # (.rs.ppm.isMetadataColumnEnabled). See 88778df845 "always try to provide vuln
+   # info if available"; an async rewrite had briefly re-applied the env-var gate
+   # here, which regressed that behavior.
    repos <- .rs.nullCoalesce(repos, getOption("repos"))
    if (length(repos) == 0L)
+      return(list())
+
+   # bail out early -- before the potentially-expensive installed.packages() call
+   # below -- if none of the configured repositories is a PPM instance
+   isPpmRepo <- vapply(repos, function(url) {
+      length(.rs.ppm.fromRepositoryUrl(url)) > 0L
+   }, logical(1))
+   if (!any(isPpmRepo))
       return(list())
 
    pkgKeys <- .rs.ppm.installedPackageKeys()

--- a/src/cpp/session/modules/SessionPPM.R
+++ b/src/cpp/session/modules/SessionPPM.R
@@ -95,10 +95,10 @@
    # Posit Package Manager instance -- NOT by .rs.ppm.isIntegrationEnabled() (the
    # PWB_PPM_* env vars). Vulnerability display is intentionally not opt-in: it
    # is shown whenever a PPM repo is in use, including open-source / desktop
-   # RStudio. The env-var gate is reserved for the Workbench-only metadata column
-   # (.rs.ppm.isMetadataColumnEnabled). See 88778df845 "always try to provide vuln
-   # info if available"; an async rewrite had briefly re-applied the env-var gate
-   # here, which regressed that behavior.
+   # RStudio. The env-var gate gates the Workbench-only metadata column
+   # (.rs.ppm.isMetadataColumnEnabled), not vulnerabilities. See 88778df845
+   # "always try to provide vuln info if available"; an async rewrite had briefly
+   # re-applied the env-var gate here, which regressed that behavior.
    repos <- .rs.nullCoalesce(repos, getOption("repos"))
    if (length(repos) == 0L)
       return(list())
@@ -389,6 +389,14 @@
 
 .rs.addFunction("ppm.fromRepositoryUrl", function(url)
 {
+   # guard against non-string / NA repo entries before .rs.regexMatches: a
+   # gregexpr-driven substring() on NA throws "invalid substring arguments",
+   # which would abort the whole vulnerability plan. getOption("repos") can
+   # legitimately carry an NA entry (e.g. an unset named repo), and this is now
+   # scanned unconditionally for every session, so handle it here.
+   if (!is.character(url) || length(url) != 1L || is.na(url))
+      return(NULL)
+
    pattern <- paste0(
       "^",                                  # start of url
       "(?<root>",                           # start of root of url

--- a/src/cpp/session/modules/SessionPPM.cpp
+++ b/src/cpp/session/modules/SessionPPM.cpp
@@ -454,8 +454,16 @@ SEXP rs_ppmMetadataKey()
 
 void refreshVulnerabilitiesAsync()
 {
-   if (!isPpmIntegrationEnabled())
-      return;
+   // NOTE: do NOT gate this on isPpmIntegrationEnabled(). Vulnerability display
+   // is intentionally not opt-in: we surface vulns whenever the session is using
+   // a Posit Package Manager repository, including open-source / desktop RStudio
+   // (the env-var-driven isPpmIntegrationEnabled() gate is for the Workbench-only
+   // metadata column, not for vulnerabilities). This mirrors the deliberate
+   // decision in 88778df845 "always try to provide vuln info if available", which
+   // an earlier async rewrite had inadvertently reverted. Whether any repository
+   // actually qualifies is decided downstream by .rs.ppm.getVulnerabilityRequestPlan,
+   // which inspects getOption("repos"); a non-PPM session simply yields an empty
+   // plan and publishes the (empty) cached set.
 
    // coalesce: if requests are still in flight, defer until they drain so the
    // refresh reflects the latest installed-package / repo state

--- a/src/cpp/tests/testthat/test-ppm.R
+++ b/src/cpp/tests/testthat/test-ppm.R
@@ -318,7 +318,6 @@ test_that("getVulnerabilityRequestPlan asks PPM only about uncached keys", {
    assign("pkgA==1.0.0", list(list(id = "V1")), envir = cache)
    assign(.rs.testPpm$repoUrl, cache, envir = .rs.ppm.vulns)
 
-   withMockFunction(".rs.ppm.isIntegrationEnabled", function() TRUE)
    withMockFunction(".rs.ppm.installedPackageKeys", function() c("pkgA==1.0.0", "pkgB==2.0.0"))
    withMockFunction(".rs.computeAuthorizationHeader", function(url) "")
 
@@ -338,7 +337,6 @@ test_that("getVulnerabilityRequestPlan skips repos with no uncached keys", {
    assign("pkgA==1.0.0", list(list(id = "V1")), envir = cache)
    assign(.rs.testPpm$repoUrl, cache, envir = .rs.ppm.vulns)
 
-   withMockFunction(".rs.ppm.isIntegrationEnabled", function() TRUE)
    withMockFunction(".rs.ppm.installedPackageKeys", function() "pkgA==1.0.0")
 
    plan <- .rs.ppm.getVulnerabilityRequestPlan(repos = c(CRAN = .rs.testPpm$repoUrl))
@@ -347,17 +345,25 @@ test_that("getVulnerabilityRequestPlan skips repos with no uncached keys", {
    expect_false(exists(.rs.testPpm$repoUrl, envir = .rs.ppm.pending, inherits = FALSE))
 })
 
-test_that("getVulnerabilityRequestPlan returns nothing when integration is disabled", {
+test_that("getVulnerabilityRequestPlan ignores the integration-enabled flag", {
+   # Regression guard: vulnerability display is intentionally NOT opt-in. It is
+   # driven by whether a PPM repository is configured (see the PPM-URL check
+   # below), NOT by the PWB_PPM_* env vars (.rs.ppm.isIntegrationEnabled, which
+   # gates only the Workbench metadata column). A plan must still be built for a
+   # PPM repo even when integration reports "disabled". See 88778df845 "always
+   # try to provide vuln info if available"; an async rewrite once re-applied the
+   # env-var gate here and suppressed vulns for sessions that set repos by hand.
    clearVulnsState()
    withMockFunction(".rs.ppm.isIntegrationEnabled", function() FALSE)
+   withMockFunction(".rs.ppm.installedPackageKeys", function() "pkgA==1.0.0")
+   withMockFunction(".rs.computeAuthorizationHeader", function(url) "")
 
    plan <- .rs.ppm.getVulnerabilityRequestPlan(repos = c(CRAN = .rs.testPpm$repoUrl))
-   expect_length(plan, 0L)
+   expect_length(plan, 1L)
 })
 
 test_that("getVulnerabilityRequestPlan skips non-PPM repositories", {
    clearVulnsState()
-   withMockFunction(".rs.ppm.isIntegrationEnabled", function() TRUE)
    withMockFunction(".rs.ppm.installedPackageKeys", function() "pkgA==1.0.0")
 
    plan <- .rs.ppm.getVulnerabilityRequestPlan(repos = c(CRAN = "https://cran.rstudio.com"))
@@ -366,7 +372,6 @@ test_that("getVulnerabilityRequestPlan skips non-PPM repositories", {
 
 test_that("getVulnerabilityRequestPlan returns nothing when no packages are installed", {
    clearVulnsState()
-   withMockFunction(".rs.ppm.isIntegrationEnabled", function() TRUE)
    withMockFunction(".rs.ppm.installedPackageKeys", function() character())
 
    plan <- .rs.ppm.getVulnerabilityRequestPlan(repos = c(CRAN = .rs.testPpm$repoUrl))
@@ -375,7 +380,6 @@ test_that("getVulnerabilityRequestPlan returns nothing when no packages are inst
 
 test_that("getVulnerabilityRequestPlan includes the computed auth header and endpoint", {
    clearVulnsState()
-   withMockFunction(".rs.ppm.isIntegrationEnabled", function() TRUE)
    withMockFunction(".rs.ppm.installedPackageKeys", function() "pkgA==1.0.0")
    # mock the header explicitly so the assertion doesn't depend on the test
    # runner's real ~/.netrc
@@ -398,7 +402,6 @@ test_that("getVulnerabilityRequestPlan emits one entry per PPM repo with uncache
    assign("pkgA==1.0.0", list(), envir = cacheA)
    assign(repoA, cacheA, envir = .rs.ppm.vulns)
 
-   withMockFunction(".rs.ppm.isIntegrationEnabled", function() TRUE)
    withMockFunction(".rs.ppm.installedPackageKeys", function() c("pkgA==1.0.0", "pkgB==2.0.0"))
    withMockFunction(".rs.computeAuthorizationHeader", function(url) "")
 

--- a/src/cpp/tests/testthat/test-ppm.R
+++ b/src/cpp/tests/testthat/test-ppm.R
@@ -370,6 +370,45 @@ test_that("getVulnerabilityRequestPlan skips non-PPM repositories", {
    expect_length(plan, 0L)
 })
 
+test_that("getVulnerabilityRequestPlan keeps the PPM repo when a non-PPM repo is mixed in", {
+   # the cheap any() pre-filter only decides whether to bail; the per-repo loop
+   # does the real filtering, so a non-PPM repo alongside a PPM one must not
+   # suppress the PPM plan entry
+   clearVulnsState()
+   withMockFunction(".rs.ppm.installedPackageKeys", function() "pkgA==1.0.0")
+   withMockFunction(".rs.computeAuthorizationHeader", function(url) "")
+
+   plan <- .rs.ppm.getVulnerabilityRequestPlan(
+      repos = c(CRAN = "https://cran.rstudio.com", PPM = .rs.testPpm$repoUrl)
+   )
+   expect_length(plan, 1L)
+   expect_equal(as.character(plan[[1L]]$repoUrl), .rs.testPpm$repoUrl)
+})
+
+test_that("getVulnerabilityRequestPlan skips installed.packages() for non-PPM sessions", {
+   # the PPM-URL pre-filter exists to avoid the expensive installed.packages()
+   # call when no repo qualifies; this locks in that ordering
+   clearVulnsState()
+   withMockFunction(".rs.ppm.installedPackageKeys", function() stop("should not be called"))
+
+   plan <- .rs.ppm.getVulnerabilityRequestPlan(repos = c(CRAN = "https://cran.rstudio.com"))
+   expect_length(plan, 0L)
+})
+
+test_that("getVulnerabilityRequestPlan tolerates an NA repo entry", {
+   # getOption("repos") can carry an NA entry (e.g. an unset named repo); the
+   # plan must not abort on it (.rs.regexMatches would otherwise throw)
+   clearVulnsState()
+   withMockFunction(".rs.ppm.installedPackageKeys", function() "pkgA==1.0.0")
+   withMockFunction(".rs.computeAuthorizationHeader", function(url) "")
+
+   plan <- .rs.ppm.getVulnerabilityRequestPlan(
+      repos = c(BIOC = NA_character_, PPM = .rs.testPpm$repoUrl)
+   )
+   expect_length(plan, 1L)
+   expect_equal(as.character(plan[[1L]]$repoUrl), .rs.testPpm$repoUrl)
+})
+
 test_that("getVulnerabilityRequestPlan returns nothing when no packages are installed", {
    clearVulnsState()
    withMockFunction(".rs.ppm.installedPackageKeys", function() character())
@@ -449,6 +488,34 @@ test_that("buildVulnerabilityRequestBody keeps a single package name as a JSON a
    body <- .rs.ppm.buildVulnerabilityRequestBody("cran", "pkgA==1.0.0")
    expect_match(body, '"names"[[:space:]]*:[[:space:]]*\\[')
    expect_true(grepl("pkgA==1.0.0", body, fixed = TRUE))
+})
+
+test_that("fromRepositoryUrl classifies a plain PPM repo URL", {
+   parts <- .rs.ppm.fromRepositoryUrl("https://packagemanager.posit.co/cran/latest")
+   expect_equal(parts[["root"]], "https://packagemanager.posit.co")
+   expect_equal(parts[["repos"]], "cran")
+   expect_equal(parts[["snapshot"]], "latest")
+   expect_false(nzchar(parts[["binary"]]))
+})
+
+test_that("fromRepositoryUrl extracts the optional binary / platform parts", {
+   parts <- .rs.ppm.fromRepositoryUrl(
+      "https://packagemanager.posit.co/cran/__linux__/jammy/2024-01-01"
+   )
+   expect_equal(parts[["repos"]], "cran")
+   expect_equal(parts[["binary"]], "__linux__")
+   expect_equal(parts[["platform"]], "jammy")
+   expect_equal(parts[["snapshot"]], "2024-01-01")
+})
+
+test_that("fromRepositoryUrl returns NULL for non-PPM and non-string inputs", {
+   # the common desktop entries -- "@CRAN@" and "" -- are not PPM URLs, and an
+   # NA entry must be tolerated rather than throwing from .rs.regexMatches
+   expect_null(.rs.ppm.fromRepositoryUrl("@CRAN@"))
+   expect_null(.rs.ppm.fromRepositoryUrl(""))
+   expect_null(.rs.ppm.fromRepositoryUrl(NA_character_))
+   expect_null(.rs.ppm.fromRepositoryUrl(NULL))
+   expect_null(.rs.ppm.fromRepositoryUrl(character()))
 })
 
 test_that("recordVulnerabilityResponse caches vulns and empty markers for requested keys", {

--- a/version/news/os/NEWS-2026.05.1-golden-wattle.md
+++ b/version/news/os/NEWS-2026.05.1-golden-wattle.md
@@ -6,6 +6,7 @@
 - ([#17737](https://github.com/rstudio/rstudio/issues/17737)): Restore the "Show .Last.value in environment listing" preference, which had stopped surfacing `.Last.value` in the Environment pane.
 - ([#17777](https://github.com/rstudio/rstudio/issues/17777)): Fix "Import Dataset" from the Environment pane failing with "could not find function '.rs.digest'" when previewing a CSV (or other readr/readxl/haven source).
 - ([#17807](https://github.com/rstudio/rstudio/issues/17807)): Fix 60 second startup delay on Posit Package Manager vulnerability check.
+- ([#17822](https://github.com/rstudio/rstudio/pull/17822)): Fix Posit Package Manager vulnerability badges no longer appearing in the Packages pane for sessions that point `options(repos)` at a PPM instance without Workbench PPM integration configured.
 
 ### Dependencies
 


### PR DESCRIPTION
## Intent

Backport of #17822 to `rel-golden-wattle`.

Fixes a regression introduced by #17808, which is present on this release branch. That PR moved the PPM vulnerability download off the R main thread (addressing the startup delay in #17807), but in the rewrite it reintroduced an `isPpmIntegrationEnabled()` gate on the vulnerability path -- in both `refreshVulnerabilitiesAsync()` (C++) and `getVulnerabilityRequestPlan()` (R).

`isPpmIntegrationEnabled()` is satisfied only by the Workbench-injected `PWB_PPM_*` environment variables. So any session that points `options(repos)` at a Posit Package Manager instance by hand -- without Workbench PPM integration configured -- stopped showing vulnerability badges in the Packages pane entirely.

Vulnerability display is intentionally **not** opt-in. This was made an explicit decision in `88778df845` ("always try to provide vuln info if available"), which removed an env-var gate that had been applied incidentally when the metadata column landed. The env-var gate is meant only for the Workbench-only metadata column.

## Changes

- **`SessionPPM.cpp`**: remove the `isPpmIntegrationEnabled()` early-return in `refreshVulnerabilitiesAsync()`.
- **`SessionPPM.R`**: remove the `isIntegrationEnabled()` gate at the top of `getVulnerabilityRequestPlan()`; enablement is again driven by detecting a PPM URL in `getOption("repos")` (the per-repo `fromRepositoryUrl` check already in the loop). A cheap PPM-URL pre-filter is added so `installed.packages()` is still skipped for non-PPM sessions.
- Both call sites carry comments recording the motivation (and the `88778df845` reference).
- **`test-ppm.R`**: replace the now-obsolete "returns nothing when integration is disabled" test with a regression guard ("ignores the integration-enabled flag"); drop the now-dead `isIntegrationEnabled()=TRUE` mocks from the other plan tests.

The metadata column remains gated by `isPpmMetadataColumnEnabled()` exactly as before.

## Testing

Cherry-picked cleanly from #17822; the resulting diff is byte-identical, and the `SessionPPM` files on this branch match `main` at the changed locations. Verified on the equivalent `main` change:

- `cmake --build . --target rsession` -- compiles and links cleanly.
- `rstudio-tests --scope r --filter ppm` -- `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 69 ]`.
- `rstudio-tests --scope rsession --filter ppm` -- 231 passed, 0 failed.

## Notes

- No `NEWS.md` entry: the regression was reintroduced by #17808 (2026-06-01) and has not shipped in an official release.