### PR TITLE
Run unit tests on Windows CI

### DIFF
--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -173,7 +173,7 @@ pipeline {
 
         stage('Tests') {
           steps {
-            bat 'cd package/win32/build/src/cpp && rstudio-tests.bat --scope core'
+            bat 'cd package/win32/build/src/cpp && rstudio-tests.bat core'
           }
         }
 


### PR DESCRIPTION
## Description

The Windows `Tests` stage invoked `rstudio-tests.bat --scope core`, but
the batch script takes positional scope tokens (`core`, `shared_core`,
`rsession`) rather than the `--scope` flag used by the bash script.

Since #14883 (June 2024) added argument parsing that routes any
unrecognized token to the help text and exits 0, `--scope core` caused
the stage to print usage and pass without running any tests.

This passes the `core` scope the script understands, so the core suite
runs on Windows CI again.