### PR TITLE
Bump Windows build target to Windows 10 1809 for ConPTY

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -145,12 +145,16 @@ else()
    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /bigobj")
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
 
-   # require Windows-7 SP1
+   # require Windows 10 version 1809 (build 17763), the minimum for the
+   # ConPTY pseudoconsole APIs. _WIN32_WINNT/WINVER are per-major-version and
+   # share one value across Windows 10 and 11 (0x0A00); NTDDI_VERSION selects
+   # the specific build (NTDDI_WIN10_RS5 = 1809) that gates the ConPTY headers.
    add_definitions(
       -DNOMINMAX
-      -DWINVER=0x601
-      -D_WIN32_WINNT=0x601
-      -D_WIN32_IE=0x601
+      -DWINVER=0x0A00
+      -D_WIN32_WINNT=0x0A00
+      -D_WIN32_IE=0x0A00
+      -DNTDDI_VERSION=0x0A000006
       -DWIN32_LEAN_AND_MEAN
       -DBOOST_USE_WINDOWS_H)
 

--- a/src/cpp/core/system/Win32ConPty.cpp
+++ b/src/cpp/core/system/Win32ConPty.cpp
@@ -27,13 +27,14 @@ const size_t kOutHighWater    = 1u * 1024 * 1024;  // 1 MiB
 const DWORD  kShutdownTimeout = 4000;              // ms
 const DWORD  kReadChunk       = 4096;
 
-#ifndef PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE
-#define PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE ProcThreadAttributeValue(22, FALSE, TRUE, FALSE)
-#endif
-
-typedef HRESULT (WINAPI *CreatePseudoConsoleFn)(COORD, HANDLE, HANDLE, DWORD, HPCONHANDLE*);
-typedef HRESULT (WINAPI *ResizePseudoConsoleFn)(HPCONHANDLE, COORD);
-typedef void    (WINAPI *ClosePseudoConsoleFn)(HPCONHANDLE);
+// The build targets Windows 10 1809 (NTDDI_WIN10_RS5), so the SDK declares
+// HPCON and the pseudoconsole functions natively. We still resolve them from
+// kernel32 at runtime rather than linking the imports directly: that keeps the
+// binary loadable on older Windows 10 builds (pre-1809), where isAvailable()
+// reports false and callers fall back instead of failing to start.
+typedef HRESULT (WINAPI *CreatePseudoConsoleFn)(COORD, HANDLE, HANDLE, DWORD, HPCON*);
+typedef HRESULT (WINAPI *ResizePseudoConsoleFn)(HPCON, COORD);
+typedef void    (WINAPI *ClosePseudoConsoleFn)(HPCON);
 
 struct ConPtyApi
 {
@@ -464,7 +465,7 @@ void ConPty::teardownLocked()
    std::thread closer;
    if (hPC_)
    {
-      HPCONHANDLE hpc = hPC_;
+      HPCON hpc = hPC_;
       closer = std::thread([hpc] { api().close(hpc); });
    }
 

--- a/src/cpp/core/system/Win32ConPty.cpp
+++ b/src/cpp/core/system/Win32ConPty.cpp
@@ -28,10 +28,11 @@ const DWORD  kShutdownTimeout = 4000;              // ms
 const DWORD  kReadChunk       = 4096;
 
 // The build targets Windows 10 1809 (NTDDI_WIN10_RS5), so the SDK declares
-// HPCON and the pseudoconsole functions natively. We still resolve them from
-// kernel32 at runtime rather than linking the imports directly: that keeps the
-// binary loadable on older Windows 10 builds (pre-1809), where isAvailable()
-// reports false and callers fall back instead of failing to start.
+// HPCON and the pseudoconsole functions natively. 1809 is the supported floor,
+// but we still resolve these from kernel32 at runtime rather than linking the
+// imports directly: if the pseudoconsole entry points are ever missing at
+// runtime, isAvailable() reports false and callers fall back instead of a
+// static import failing the whole process at load.
 typedef HRESULT (WINAPI *CreatePseudoConsoleFn)(COORD, HANDLE, HANDLE, DWORD, HPCON*);
 typedef HRESULT (WINAPI *ResizePseudoConsoleFn)(HPCON, COORD);
 typedef void    (WINAPI *ClosePseudoConsoleFn)(HPCON);

--- a/src/cpp/core/system/Win32ConPty.cpp
+++ b/src/cpp/core/system/Win32ConPty.cpp
@@ -283,7 +283,8 @@ Error ConPty::start(const std::string& exe,
 
    if (!isAvailable())
       return systemError(boost::system::errc::not_supported,
-                         "ConPTY is not available on this version of Windows",
+                         "ConPTY is not available; the terminal requires "
+                         "Windows 10 version 1809 or newer",
                          ERROR_LOCATION);
    // Read hPC_ directly rather than via running(): we already hold stateMutex_.
    if (hPC_ != nullptr)

--- a/src/cpp/core/system/Win32ConPty.hpp
+++ b/src/cpp/core/system/Win32ConPty.hpp
@@ -35,11 +35,6 @@ namespace rstudio {
 namespace core {
 namespace system {
 
-// HPCON is only declared in SDK headers gated behind NTDDI_WIN10_RS5; the build
-// targets _WIN32_WINNT=0x601, so we use our own handle type and resolve the
-// pseudoconsole functions dynamically from kernel32 (see Win32ConPty.cpp).
-typedef VOID* HPCONHANDLE;
-
 // Native Windows pseudoconsole (ConPTY) wrapper. Replaces the winpty-based
 // WinPty class. Owns the pseudoconsole, its input/output pipes, and a reader
 // thread. Output is buffered (bounded, with backpressure) and drained by the
@@ -95,7 +90,7 @@ private:
    void readerLoop();
    void teardownLocked();   // single ordered teardown path; caller holds stateMutex_
 
-   HPCONHANDLE hPC_ = nullptr;
+   HPCON hPC_ = nullptr;
    HANDLE hInputWrite_ = nullptr;    // caller thread writes here (synchronous)
    HANDLE hOutputRead_ = nullptr;    // reader thread reads here
 


### PR DESCRIPTION
## Summary

Raises the Windows compile-time target from Windows 7 (`0x601`) to Windows 10 version 1809 (build 17763), the minimum required by the ConPTY pseudoconsole APIs adopted in the winpty->ConPTY migration (#17814).

## Changes

- `src/cpp/CMakeLists.txt`: set `WINVER`/`_WIN32_WINNT` to `0x0A00` and `NTDDI_VERSION` to `NTDDI_WIN10_RS5` (`0x0A000006`). `_WIN32_WINNT` is per-major-version and shares one value across Windows 10 and 11; `NTDDI_VERSION` selects the specific 1809 build that gates the ConPTY headers.
- `Win32ConPty.{hpp,cpp}`: with the native SDK declarations now available, remove the hand-rolled `HPCONHANDLE` typedef and the manual `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE` define and use the native `HPCON` / attribute. The pseudoconsole functions are still resolved from kernel32 via `GetProcAddress`, so a missing entry point degrades through `isAvailable()` rather than a static-import load failure.
- Name the 1809 requirement in the "ConPTY not available" terminal error message so affected users know what is required.

## Verification

- Full Windows rebuild is clean with no new compiler warnings introduced by the target change.
- Import audit: the static-import set of `rsession.exe` is unchanged versus the previous target (no new load-time OS dependency; nothing requires newer than 1809). `CreatePseudoConsole`/`ResizePseudoConsole`/`ClosePseudoConsole` remain `GetProcAddress`-resolved, not statically imported.

No NEWS.md entry: this supports the unreleased ConPTY migration rather than a shipped feature.