### PR TITLE
Make ResolveAliasedPathWithEnv test portable on Windows

### DIFF
--- a/src/cpp/shared_core/FilePathTests.cpp
+++ b/src/cpp/shared_core/FilePathTests.cpp
@@ -457,7 +457,12 @@ TEST(SharedCoreTest, ResolveAliasedPath)
 TEST(SharedCoreTest, ResolveAliasedPathWithEnv)
 {
    std::string userName = "testuser";
-   FilePath userHome("/mnt/home/testuser");
+
+   // Use createPath() so the paths carry the current drive letter on Windows,
+   // where resolveAliasedPath() completes a driveless absolute path against the
+   // current directory (e.g. "/data/..." -> "C:/data/..."). On POSIX createPath()
+   // is the identity, so the expectations are unchanged there.
+   FilePath userHome = createPath("/mnt/home/testuser");
 
    FilePath resolved = FilePath::resolveAliasedPath("$HOME", userHome, userName);
    EXPECT_EQ(userHome, resolved);
@@ -472,10 +477,10 @@ TEST(SharedCoreTest, ResolveAliasedPathWithEnv)
    EXPECT_EQ(userHome.completeChildPath("projects"), resolved);
 
    resolved = FilePath::resolveAliasedPath("/data/$USER/projects", userHome, userName);
-   EXPECT_EQ(FilePath("/data/testuser/projects"), resolved);
+   EXPECT_EQ(createPath("/data/testuser/projects"), resolved);
 
    resolved = FilePath::resolveAliasedPath("/data/${USER}/projects", userHome, userName);
-   EXPECT_EQ(FilePath("/data/testuser/projects"), resolved);
+   EXPECT_EQ(createPath("/data/testuser/projects"), resolved);
 }
 
 TEST(SharedCoreTest, CreateAliasedPath)


### PR DESCRIPTION
## Summary

`SharedCoreTest.ResolveAliasedPathWithEnv` fails on Windows, 100% of the time, when run locally. It is not caught in CI because Windows CI runs fewer unit test scopes than Linux/macOS (#17825), so this has gone unnoticed.

## Cause

This is a test portability bug, not a production defect. `FilePath::resolveAliasedPath()` completes a driveless absolute path against the current directory, which on Windows prepends the current drive (e.g. `/data/...` -> `C:/data/...`). The test built its expected paths with the raw `FilePath("/...")` constructor (no drive), so the expectations never matched the drive-completed results:

```
  userHome           Which is: /mnt/home/testuser
  resolved           Which is: C:/mnt/home/testuser
```

## Fix

Route the test's paths through the existing `createPath()` helper, exactly as the sibling `ResolveAliasedPath` test (which passes) already does. `createPath()` prepends the current drive on Windows and is the identity on POSIX, so Linux/macOS behavior is unchanged.

## Verification

`ResolveAliasedPathWithEnv` and `ResolveAliasedPath` both pass on Windows, and the full shared-core test suite (12 tests) is green.

No NEWS.md entry: test-only change with no user-facing behavior difference.