### PR TITLE
Suppress invisibly-returned data.table auto-print in notebooks

### DIFF
--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -122,8 +122,22 @@
         o <- overrideMap(x, options)
         if (!is.null(o))
           return(overridePrint(o$x, o$options, o$className, o$nRow, o$nCol))
+
+        # A NULL from overrideMap() is a deliberate "do not print" signal, not a
+        # "no override available" miss: each overrideFun is bound to one class's
+        # map and only runs once S3 dispatch has already selected a registered
+        # override. data.table's map is currently the only one with a NULL branch
+        # -- it returns NULL for a table returned invisibly from a ':=' update,
+        # where data.table:::shouldPrint() returned FALSE. shouldPrint() is
+        # stateful and single-shot, so the overrideMap() call above already
+        # consumed that FALSE; falling through to the original print.data.table
+        # would call it again, get TRUE, and print the table. Return early so no
+        # output is emitted (invisible(x) just follows the print-method
+        # convention of returning its argument invisibly).
+        # https://github.com/rstudio/rstudio/issues/17278
+        return(invisible(x))
       }
-      
+
       # otherwise, call the original S3 method. we need to manually manage the
       # lookup here since we inject overrides into the base namespace, which
       # could mask the visibility of certain S3 overrides

--- a/version/news/os/NEWS-2026.05.1-golden-wattle.md
+++ b/version/news/os/NEWS-2026.05.1-golden-wattle.md
@@ -6,6 +6,7 @@
 - ([#17737](https://github.com/rstudio/rstudio/issues/17737)): Restore the "Show .Last.value in environment listing" preference, which had stopped surfacing `.Last.value` in the Environment pane.
 - ([#17777](https://github.com/rstudio/rstudio/issues/17777)): Fix "Import Dataset" from the Environment pane failing with "could not find function '.rs.digest'" when previewing a CSV (or other readr/readxl/haven source).
 - ([#17807](https://github.com/rstudio/rstudio/issues/17807)): Fix 60 second startup delay on Posit Package Manager vulnerability check.
+- ([#17278](https://github.com/rstudio/rstudio/issues/17278)): Fix a `data.table` returned invisibly from a `:=` update (e.g. `dt[, x := y]`) being auto-printed in notebook chunks, when its output should be suppressed as it is in the console.
 
 ### Dependencies
 


### PR DESCRIPTION
## Intent

Addresses #17278.

Backport of #17811 to `rel-golden-wattle`.

## Approach

In notebook chunks, a `data.table` returned invisibly from a `:=` update (e.g. `dt[, x := y]`) was auto-printed as text, even though the same code suppresses output in the R console and in knitr/rmarkdown.

The notebook print override in `NotebookData.R` distinguishes auto-printed objects from explicit `print()` calls. For the `data.table` override, `overrideMap()` consults `data.table:::shouldPrint()` and returns `NULL` to signal "do not print". The auto-print branch returned early only when the override produced output; when `overrideMap()` returned `NULL`, control fell through to the original `print.data.table` method. `shouldPrint()` is stateful -- the first call returns `FALSE` and flips internal state so the next call returns `TRUE` -- so the fall-through invocation re-printed the table.

This change returns early (suppressing output) when the override map signals suppression for an auto-printed object, rather than delegating to the original print method. Explicit `print()` calls are unaffected and still delegate to the real S3 method.

## Differences from #17811

- The NEWS entry is added to `version/news/os/NEWS-2026.05.1-golden-wattle.md` rather than the top-level `NEWS.md`.
- The Playwright regression test from #17811 is omitted. The test file is new on `main` and depends on test infrastructure absent from this release branch: the `window.rstudio.commands` automation-bridge wrapper (`@utils/commands`) and the `waitForConsoleBusy`/`waitForConsoleIdle` helpers.

## QA Notes

In an R Notebook with "Chunk Output Inline", run a chunk containing:

    data.table::as.data.table(mtcars)[, foo := 'bar']

No output should appear below the chunk, matching the console and knitr behavior. A normal `data.table` (e.g. `data.table::as.data.table(mtcars)`) should still render as a paged table, and an explicit `print()` should still use `data.table`'s own print method.