### PR TITLE
stabilize layoutZoomEnvironment e2e test and break the zoom cascade

### DIFF
--- a/e2e/rstudio/tests/panes/layout/tabs.test.ts
+++ b/e2e/rstudio/tests/panes/layout/tabs.test.ts
@@ -2,7 +2,7 @@
 // Sidebar-width-when-adding-tabs scenarios are exercised by panes.test.ts.
 
 import { test, expect } from '@fixtures/rstudio.fixture';
-import { executeCommand, isCommandChecked, resetSourcePaneState } from '@utils/commands';
+import { executeCommand, isCommandChecked, resetLayoutZoom, resetSourcePaneState } from '@utils/commands';
 import type { Page } from 'playwright';
 
 const WORKBENCH_TABS = [
@@ -42,6 +42,17 @@ async function getAriaSelected(page: Page, selector: string): Promise<boolean> {
 }
 
 test.describe('Workbench tabs', () => {
+  // layoutZoomEnvironment mutates global, worker-scoped layout state. If the
+  // zoom test fails before toggling the zoom back off, the maximized pane
+  // squeezes every other pane to near-zero and poisons the next spec in this
+  // worker (workers=1) -- the Packages pane collapses and its checkbox clicks
+  // time out as "not visible". Guarantee the layout is restored after every
+  // test here regardless of where it failed. resetLayoutZoom is a no-op when
+  // nothing is zoomed, and the per-test reset re-runs it before the next spec.
+  test.afterEach(async ({ rstudioPage: page }) => {
+    await resetLayoutZoom(page);
+  });
+
   test('all core tabs are present and visible', async ({ rstudioPage: page }) => {
     for (const selector of WORKBENCH_TABS) {
       const tab = page.locator(selector);
@@ -75,6 +86,17 @@ test.describe('Workbench tabs', () => {
   // layoutZoomEnvironment is a separate command from layoutZoomLeftColumn /
   // layoutZoomRightColumn (covered by panes.test.ts) -- it expands just the
   // environment panel rather than a whole column.
+  //
+  // Asserts the zoom *invariants* -- the deterministic command-checked state,
+  // the other panes collapsing, and a tolerance-based restore -- rather than a
+  // growth ratio. An earlier version polled `envWidth > initialEnvWidth * 1.5`,
+  // which couples the assertion to the default column proportions: on a CI
+  // display where the Source/Console column starts narrow (the snap-threshold
+  // case the 1400x900 window-bounds pin in desktop.fixture.ts guards against),
+  // the Environment column is already wide, so zooming it grows < 1.5x and the
+  // poll never satisfies. The collapse of the Console / TabSet2 panes is what
+  // "Environment is zoomed" actually means and holds regardless of the starting
+  // proportions (matching how panes.test.ts verifies its column-zoom tests).
   test('layoutZoomEnvironment zooms the environment pane and toggles back', async ({ rstudioPage: page }) => {
     const initialEnvWidth = await getOffsetWidth(page, ENV_PANEL);
     const initialEnvHeight = await getOffsetHeight(page, ENV_PANEL);
@@ -82,37 +104,44 @@ test.describe('Workbench tabs', () => {
     const initialTabSet2Width = await getOffsetWidth(page, TABSET2_PANE);
     const initialTabSet2Height = await getOffsetHeight(page, TABSET2_PANE);
 
-    expect(initialEnvWidth).toBeGreaterThan(0);
-    expect(initialEnvHeight).toBeGreaterThan(0);
-    expect(initialConsoleWidth).toBeGreaterThan(0);
-    expect(initialTabSet2Width).toBeGreaterThan(0);
+    // Precondition: a real (non-collapsed) default layout. Toggle-off restores
+    // the *pre-zoom* widths, so a Console that starts collapsed would make the
+    // restore checks below fail in a confusing way -- assert it loudly here
+    // instead. The per-test reset un-zooms any leaked zoom before we get here.
+    expect(initialEnvWidth, 'Environment panel should have a real width').toBeGreaterThan(50);
+    expect(initialEnvHeight, 'Environment panel should have a real height').toBeGreaterThan(50);
+    expect(initialConsoleWidth, 'Console should start as a non-collapsed column').toBeGreaterThan(50);
+    expect(initialTabSet2Width, 'TabSet2 should have a real width').toBeGreaterThan(50);
 
     await executeCommand(page, 'layoutZoomEnvironment');
 
+    // Zoomed: command is checked and the Console column (different column from
+    // Environment) has collapsed. Poll the command state -- the deterministic
+    // signal -- alongside the collapse so we wait on the relayout settling.
     await expect.poll(
-      async () => (await getOffsetWidth(page, ENV_PANEL)) > initialEnvWidth * 1.5
+      async () => (await isCommandChecked(page, 'layoutZoomEnvironment'))
         && (await getOffsetWidth(page, CONSOLE_PANE)) < 50,
       { timeout: 5000 },
     ).toBe(true);
 
-    await expect.poll(() => isCommandChecked(page, 'layoutZoomEnvironment')).toBe(true);
+    // The Environment panel took the freed space: strictly larger than before
+    // (no ratio -- the magnitude depends on the starting proportions).
+    expect(await getOffsetWidth(page, ENV_PANEL)).toBeGreaterThan(initialEnvWidth);
+    expect(await getOffsetHeight(page, ENV_PANEL)).toBeGreaterThan(initialEnvHeight);
 
-    const zoomedEnvHeight = await getOffsetHeight(page, ENV_PANEL);
-    expect(zoomedEnvHeight).toBeGreaterThan(initialEnvHeight * 1.5);
-
+    // TabSet2 (same column as Environment, stacked below it) collapsed.
     const zoomedTabSet2Width = await getOffsetWidth(page, TABSET2_PANE);
     const zoomedTabSet2Height = await getOffsetHeight(page, TABSET2_PANE);
     expect(zoomedTabSet2Width < 50 || zoomedTabSet2Height < 50).toBe(true);
 
     await executeCommand(page, 'layoutZoomEnvironment');
 
+    // Restored: command unchecked and the Console column is back.
     await expect.poll(
-      async () => (await getOffsetWidth(page, ENV_PANEL)) < initialEnvWidth * 1.5
+      async () => !(await isCommandChecked(page, 'layoutZoomEnvironment'))
         && (await getOffsetWidth(page, CONSOLE_PANE)) > 50,
       { timeout: 5000 },
     ).toBe(true);
-
-    await expect.poll(() => isCommandChecked(page, 'layoutZoomEnvironment')).toBe(false);
 
     const tol = (actual: number, expected: number) => Math.abs(actual - expected) / expected < 0.1;
     expect(tol(await getOffsetWidth(page, ENV_PANEL), initialEnvWidth)).toBe(true);

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -146,6 +146,16 @@ type DialogsBridge = {
   dismissAll(): void;
 };
 
+type LayoutBridge = {
+  /**
+   * End any active pane/window or column zoom, restoring the default layout;
+   * a no-op when nothing is zoomed. The returned Promise resolves once the
+   * relayout has settled (the restore flushes on a later animation frame even
+   * under reduced_motion).
+   */
+  reset(): Promise<void>;
+};
+
 type RStudioBridge = {
   commands: { [id: string]: CommandEntry } & { list: string[] };
   prefs: { [name: string]: PrefEntry };
@@ -153,6 +163,7 @@ type RStudioBridge = {
   project: ProjectInfo;
   version: VersionInfo;
   dialogs: DialogsBridge;
+  layout: LayoutBridge;
   /** Chat-pane state surface (populated lazily by ChatPresenter). */
   chat?: ChatBridge;
   /**
@@ -224,6 +235,28 @@ export async function isCommandEnabled(page: Page, commandId: string): Promise<b
       throw new Error(`Unknown command: ${id}`);
     return cmd.isEnabled();
   }, commandId);
+}
+
+/**
+ * End any active pane/column zoom, restoring the default layout.
+ *
+ * The automation session is worker-scoped, so a test that zooms a pane (e.g.
+ * layoutZoomEnvironment) and fails before toggling it back off leaves the
+ * layout maximized -- which squeezes every other pane to near-zero and makes
+ * the next test's targets unclickable / invisible. This breaks the cascade by
+ * ending any active zoom.
+ *
+ * Delegates to the GWT bridge (window.rstudio.layout.reset), which decides
+ * based on the live PaneManager state: it un-zooms only when something is
+ * actually zoomed (so a non-zoomed layout keeps its column widths) and covers
+ * both pane/window zoom and column zoom. The bridge returns a Promise that
+ * resolves once the relayout has settled (the restore flushes on a later
+ * animation frame even under reduced_motion), so awaiting this leaves the
+ * layout stable before the caller measures or clicks panes. A no-op when the
+ * bridge is absent.
+ */
+export async function resetLayoutZoom(page: Page): Promise<void> {
+  await page.evaluate(() => window.rstudio?.layout?.reset());
 }
 
 /**

--- a/e2e/rstudio/utils/test-reset.ts
+++ b/e2e/rstudio/utils/test-reset.ts
@@ -3,6 +3,7 @@ import {
   dismissAllModals,
   executeCommand,
   numModalsShowing,
+  resetLayoutZoom,
   resetSourcePaneState,
 } from './commands';
 
@@ -20,8 +21,9 @@ const DEBUG_STOP_BTN = `${DEBUG_TOOLBAR} [title^="Stop"]`;
  *
  * Each step short-circuits cheaply when its trigger isn't present, so on a
  * clean session this adds only the cost of an already-satisfied readiness
- * check, two `isVisible()` snapshots, and a bridge call to
- * resetSourcePaneState (typically tens of ms total).
+ * check, two `isVisible()` snapshots, a layout-zoom reset (a no-op bridge call
+ * when nothing is zoomed), and a bridge call to resetSourcePaneState
+ * (typically tens of ms total).
  *
  * What we reset:
  *
@@ -40,6 +42,10 @@ const DEBUG_STOP_BTN = `${DEBUG_TOOLBAR} [title^="Stop"]`;
  *     against a stale state and getActiveDebugLineRow throws because the
  *     debug marker is in a hidden editor tab. Click Stop on the debug
  *     toolbar when it's visible.
+ *   - **Pane zoom.** A previous test that maximized a pane (layoutZoom*) and
+ *     failed before toggling it back leaves the layout zoomed, squeezing every
+ *     other pane to near-zero so the next test can't click its targets. End the
+ *     zoom when one is active (see resetLayoutZoom).
  *   - **Source pane buffers.** Collapse to a single Untitled tab via the
  *     `resetToUntitled` bridge (kept-or-created untitled + close everything
  *     else). resetSourcePaneState specifically -- NOT closeAllSourceDocs --
@@ -59,10 +65,12 @@ const DEBUG_STOP_BTN = `${DEBUG_TOOLBAR} [title^="Stop"]`;
  *   - **Working directory.** `useSuiteSandbox` already scopes cwd; tests
  *     that need a specific cwd set it themselves.
  *
- * Error handling: the debug-exit step (2) is incidental cleanup and is fully
- * guarded -- it never throws. Steps 1, 3, and 4 (modal dismissal, source-pane
- * reset, console focus) are structural and call the automation bridge; they
- * will throw if `window.rstudio` is gone. That is intentional -- a missing
+ * Error handling: the debug-exit (2) and zoom-reset (3) steps are incidental
+ * cleanup and are fully guarded -- they never throw (resetLayoutZoom treats a
+ * missing bridge as "nothing zoomed"). Steps 1, 4, and 5 (modal dismissal,
+ * source-pane reset, console focus) are structural and call the automation
+ * bridge; they will throw if `window.rstudio` is gone. That is intentional --
+ * a missing
  * bridge means the session is unusable and every following test would fail
  * anyway, so failing here (named clearly) beats swallowing the error and
  * letting the next test fail on a mystery first action. Guarding the
@@ -130,13 +138,22 @@ export async function resetForNextTest(page: Page): Promise<void> {
     }
   }
 
-  // 3. Collapse source pane to a single Untitled tab. resetSourcePaneState
+  // 3. End any active pane zoom. The session is worker-scoped, so a prior test
+  //    that zoomed a pane (e.g. layoutZoomEnvironment) and failed before
+  //    toggling it back off leaves the layout maximized -- which squeezes every
+  //    other pane to near-zero, so the next test's locator clicks land on a
+  //    zero-size element and time out as "not visible". resetLayoutZoom reads
+  //    the live zoom state and is a no-op (preserving any custom column widths)
+  //    when nothing is zoomed.
+  await resetLayoutZoom(page);
+
+  // 4. Collapse source pane to a single Untitled tab. resetSourcePaneState
   //    waits for the async close chain to drain before returning, so lingering
   //    tabs (and their hidden Ace editors) can't bleed state into the next
   //    test -- stale `.ace_active_debug_line` markers, gutter breakpoints, etc.
   await resetSourcePaneState(page);
 
-  // 4. Restore focus to the console so tests start from a deterministic
+  // 5. Restore focus to the console so tests start from a deterministic
   //    focus state. resetToUntitled's handler moves focus to the kept /
   //    newly-created Untitled tab; without this, the first test action
   //    that needs console focus (e.g. clearConsole, executeInConsole) has

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -37,11 +37,14 @@ import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.prefs.model.Prefs;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
+import org.rstudio.studio.client.workbench.ui.PaneManager;
 import org.rstudio.studio.client.workbench.views.chat.server.ChatServerOperations;
 import org.rstudio.studio.client.workbench.views.source.SourceColumnManager;
 
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import com.google.inject.Singleton;
 
 /**
@@ -76,6 +79,9 @@ import com.google.inject.Singleton;
  *
  *   window.rstudio.dialogs.numShowing()  // count of open modal dialogs
  *   window.rstudio.dialogs.dismissAll()  // hide every open modal dialog
+ *
+ *   window.rstudio.layout.reset()        // end any active pane/column zoom;
+ *                                        // Promise resolves once layout settles
  * </pre>
  *
  * <h2>Why enumerate everything up front</h2>
@@ -96,7 +102,8 @@ public class ApplicationAutomation
                                 Session session,
                                 UserPrefs userPrefs,
                                 SourceColumnManager sourceColumnManager,
-                                ChatServerOperations chatServer)
+                                ChatServerOperations chatServer,
+                                Provider<PaneManager> pPaneManager)
    {
       commands_ = commands;
       eventBus_ = eventBus;
@@ -104,6 +111,10 @@ public class ApplicationAutomation
       userPrefs_ = userPrefs;
       sourceColumnManager_ = sourceColumnManager;
       chatServer_ = chatServer;
+      // Provider, not a direct injection: PaneManager is constructed later in
+      // the workbench lifecycle than this early-initialized agent, so resolve
+      // it lazily (mirrors WorkbenchScreen / PaneLayoutPreferencesPane).
+      pPaneManager_ = pPaneManager;
    }
 
    public final boolean isAutomationAgent()
@@ -122,6 +133,7 @@ public class ApplicationAutomation
       registerVersion();
       registerChat();
       registerDialogs();
+      registerLayout();
       registerReadinessHandlers();
    }
 
@@ -215,6 +227,24 @@ public class ApplicationAutomation
    {
       registerDialogsObject();
    }
+
+   private void registerLayout()
+   {
+      registerLayoutObject();
+   }
+
+   // End any pane/column zoom a prior test left active. No-op when nothing is
+   // zoomed, so a non-zoomed layout keeps its current column widths. onCompleted
+   // fires once the relayout has settled (see PaneManager.endZoomIfActive) so
+   // the JS side can await it.
+   private void resetLayoutZoom(JavaScriptObject onCompleted)
+   {
+      pPaneManager_.get().endZoomIfActive(() -> invokeCallback(onCompleted));
+   }
+
+   private native void invokeCallback(JavaScriptObject cb) /*-{
+      if (cb) cb();
+   }-*/;
 
    private int numModalsShowing()
    {
@@ -587,6 +617,24 @@ public class ApplicationAutomation
       });
    }-*/;
 
+   // End any pane/column zoom left active by a prior test (no-op otherwise).
+   // Lets a per-test reset clear leaked zoom state without reverse-engineering
+   // it from command checked-states -- PaneManager decides based on the live
+   // layout state it owns. Returns a Promise that resolves once the relayout
+   // has settled (the restore flushes on a later animation frame even under
+   // reduced_motion), so callers can await a stable layout before measuring or
+   // clicking panes.
+   private native final void registerLayoutObject() /*-{
+      var self = this;
+      $wnd.rstudio.layout = $wnd.rstudio.layout || {};
+      $wnd.rstudio.layout.reset = $entry(function() {
+         return new $wnd.Promise(function(resolve) {
+            var cb = $entry(function() { resolve(); });
+            self.@org.rstudio.studio.client.application.ApplicationAutomation::resetLayoutZoom(*)(cb);
+         });
+      });
+   }-*/;
+
    private native final void registerChatObject() /*-{
       var self = this;
       $wnd.rstudio.chat = $wnd.rstudio.chat || {};
@@ -612,6 +660,7 @@ public class ApplicationAutomation
    private final UserPrefs userPrefs_;
    private final SourceColumnManager sourceColumnManager_;
    private final ChatServerOperations chatServer_;
+   private final Provider<PaneManager> pPaneManager_;
    private boolean isAutomationAgent_ = false;
    private boolean readinessHandlersRegistered_ = false;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -714,6 +714,41 @@ public class PaneManager
       restoreLayout();
    }
 
+   /**
+    * End any active pane/window or column zoom, restoring the default layout;
+    * no-op when nothing is zoomed. Runs {@code onComplete} once the restore has
+    * settled (after the relayout animation completes), or immediately when
+    * nothing was zoomed.
+    *
+    * Exposed for the automation bridge (window.rstudio.layout.reset). The
+    * worker-scoped automation session means a test that zooms a pane and fails
+    * before toggling it back leaves the layout maximized, squeezing the other
+    * panes to near-zero so the next test can't reach its targets. The guard
+    * matters because restoreLayout() resets column widths to default when no
+    * window is maximized, so firing it unconditionally would clobber any custom
+    * widths a non-zoomed test set up. Pane/window zoom is tracked by
+    * maximizedWindow_ / maximizedTab_; column zoom is reflected by
+    * getZoomedColumn().
+    *
+    * The onComplete callback lets the bridge expose a Promise that resolves
+    * only once the relayout has finished -- the relayout flushes on a later
+    * animation frame (panel_.animate) even under reduced_motion, so a
+    * fire-and-forget reset would otherwise return before the panes settle.
+    */
+   public void endZoomIfActive(Command onComplete)
+   {
+      if (maximizedWindow_ != null ||
+          maximizedTab_ != null ||
+          getZoomedColumn() != null)
+      {
+         restoreLayout(onComplete);
+      }
+      else if (onComplete != null)
+      {
+         onComplete.execute();
+      }
+   }
+
    @Handler
    public void onLayoutConsoleOnLeft()
    {
@@ -1532,13 +1567,18 @@ public class PaneManager
 
    private void restoreLayout()
    {
+      restoreLayout(null);
+   }
+
+   private void restoreLayout(Command afterComplete)
+   {
       // If we're currently zoomed, then use that to provide the previous
       // 'non-zoom' state.
       if (maximizedWindow_ != null &&
           leftList_.size() == leftWidgetSizePriorToZoom_.size())
-         restoreSavedLayout();
+         restoreSavedLayout(afterComplete);
       else
-         restorePaneLayout();
+         restorePaneLayout(afterComplete);
    }
 
    private void invalidateSavedLayoutState(boolean enableSplitter)
@@ -1555,8 +1595,21 @@ public class PaneManager
 
    private void restorePaneLayout()
    {
+      restorePaneLayout(null);
+   }
+
+   private void restorePaneLayout(Command afterComplete)
+   {
       restorePaneStateToDefault();
       restoreColumnLayout();
+
+      // restoreColumnLayout applies column widths via setWidgetSize without an
+      // explicit animate(), so there's no animation callback to hook here --
+      // the sizes are already applied by the time we return. Run afterComplete
+      // directly. (The pane/window-zoom path goes through restoreSavedLayout,
+      // which does animate and threads afterComplete into onAnimationComplete.)
+      if (afterComplete != null)
+         afterComplete.execute();
    }
 
    private Double getValidColumnWidth(Widget w, boolean set)
@@ -1635,7 +1688,7 @@ public class PaneManager
       invalidateSavedLayoutState(true);
    }
 
-   private void restoreSavedLayout()
+   private void restoreSavedLayout(Command afterComplete)
    {
       restorePaneStateToDefault();
 
@@ -1661,14 +1714,14 @@ public class PaneManager
       if ((sidebarOnRight || sidebarOnLeft) && sidebarSizePriorToZoom_ >= 0)
       {
          if (sidebarOnRight)
-            resizeHorizontallyWithSidebarOnRight(widgetSizePriorToZoom_, leftTargets, sidebarSizePriorToZoom_, null);
+            resizeHorizontallyWithSidebarOnRight(widgetSizePriorToZoom_, leftTargets, sidebarSizePriorToZoom_, afterComplete);
          else
-            resizeHorizontallyWithSidebarOnLeft(widgetSizePriorToZoom_, leftTargets, sidebarSizePriorToZoom_, null);
+            resizeHorizontallyWithSidebarOnLeft(widgetSizePriorToZoom_, leftTargets, sidebarSizePriorToZoom_, afterComplete);
       }
       else
       {
          // No sidebar or sidebar wasn't saved - use original behavior
-         resizeHorizontally(widgetSizePriorToZoom_, leftTargets);
+         resizeHorizontally(widgetSizePriorToZoom_, leftTargets, afterComplete);
       }
 
       invalidateSavedLayoutState(true);


### PR DESCRIPTION
## Intent

Stabilize the `layoutZoomEnvironment` Playwright spec and stop it from
poisoning later specs in the same worker. Three desktop e2e failures were
observed together:

- `tabs.test.ts` -> layoutZoomEnvironment zoom/toggle poll timeout
- `packages_pane.test.ts` -> checkbox click timeout ("not visible")
- `packages_pane.test.ts` -> initial checkbox state

There is no tracking issue; this addresses CI flakiness only. No product
behavior changes for users -- the only product-side addition is an
automation-only bridge surface (`window.rstudio.layout.reset()`), active just
under `--automation-agent`.

## Root cause

The Playwright suite runs with `workers: 1` and a **worker-scoped**
`rstudioPage`, so every spec shares one RStudio window. `resetForNextTest`
reset modals, debug mode, and the source pane, but **never cleared pane
zoom**. When the `layoutZoomEnvironment` spec failed before toggling the zoom
back off, the Environment pane stayed maximized -- which collapses the
Packages pane (same right column) to <50px. The following `packages_pane`
specs then ran against a zero-size checkbox, so `click()` / `toBeVisible()`
timed out. The three failures were one cascade, not three bugs.

Separately, the `layoutZoomEnvironment` assertions themselves were fragile:
`envWidth > initialEnvWidth * 1.5` couples the assertion to the default column
proportions. On a CI display where the Source/Console column starts narrow
(the snap-threshold case the `1400x900` window-bounds pin guards against), the
Environment column is already wide, so zooming grows < 1.5x and the poll's
predicate is simply never true. `PaneManager` has not changed since this test
last passed, so this is a test-assertion issue, not a product regression.

## Changes

- **Bridge**: add `window.rstudio.layout.reset()` (in `ApplicationAutomation`).
  It delegates to `PaneManager.endZoomIfActive`, which ends any active
  pane/window or column zoom **only when something is zoomed** (a non-zoomed
  layout keeps its custom column widths). It returns a Promise that resolves
  once the relayout has settled -- the restore flushes on a later animation
  frame even under `reduced_motion` -- by threading a completion callback
  through `restoreLayout` -> `restoreSavedLayout` / `restorePaneLayout`.
- **Reset**: `resetForNextTest` now un-zooms via the bridge, and `tabs.test.ts`
  un-zooms in an `afterEach`, so a failed zoom spec can't poison the next one.
- **Assertions**: rewrite the `layoutZoomEnvironment` test to verify the zoom
  invariants -- the deterministic command-checked state, the collapse of the
  Console / TabSet2 panes, and a tolerance-based restore -- instead of a growth
  ratio (matching how `panes.test.ts` verifies its column-zoom tests). Adds a
  loud precondition so a contaminated/too-small starting layout fails clearly
  at setup rather than as a mystery poll timeout.

## Validation

- `tsc --noEmit` clean (e2e)
- `ant javac` clean (GWT)
- End-to-end run of the affected specs deferred to CI (the bridge change needs
  a GWT + desktop build to exercise).
