### PR TITLE
Fix core database tests on Windows CI

### DIFF
--- a/src/cpp/core/DatabaseTests.cpp
+++ b/src/cpp/core/DatabaseTests.cpp
@@ -246,49 +246,56 @@ TEST(DatabaseTest, CanUseConnectionPool)
    SqliteConnectionOptions options;
    options.file = dbPath.getAbsolutePath();
 
-   boost::shared_ptr<ConnectionPool> connectionPool;
-   Error error = createConnectionPool(5, options, &connectionPool);
-   ASSERT_FALSE(error) << "Failed to create connection pool: " << error.getMessage();
-   boost::shared_ptr<IConnection> connection = connectionPool->getConnection();
-   ASSERT_TRUE(connection) << "Failed to get connection from pool";
-
-   Query query = connection->query("create table Test(id int, text varchar(255))");
-   error = connection->execute(query);
-   ASSERT_FALSE(error) << "Failed to create Test table in fixture: " << error.getMessage();
-
-   // Insert some data into the Test table
-   for (int id = 0; id < 100; ++id)
+   // Scope the pool, connections, and queries so they are all destroyed - and their
+   // SQLite handles closed - before the database file is removed. The Query objects
+   // hold prepared statements that keep the connection open, so they must go out of
+   // scope too; otherwise the file handle is still open and, on Windows, the delete
+   // fails silently and orphans the random temp file.
    {
-      std::string text = "Test text " + core::safe_convert::numberToString(id);
-      query = connection->query("insert into Test(id, text) values(:id, :text)")
-            .withInput(id)
-            .withInput(text);
+      boost::shared_ptr<ConnectionPool> connectionPool;
+      Error error = createConnectionPool(5, options, &connectionPool);
+      ASSERT_FALSE(error) << "Failed to create connection pool: " << error.getMessage();
+      boost::shared_ptr<IConnection> connection = connectionPool->getConnection();
+      ASSERT_TRUE(connection) << "Failed to get connection from pool";
+
+      Query query = connection->query("create table Test(id int, text varchar(255))");
       error = connection->execute(query);
-      ASSERT_FALSE(error) << "Failed to insert row " << id << ": " << error.getMessage();
+      ASSERT_FALSE(error) << "Failed to create Test table in fixture: " << error.getMessage();
+
+      // Insert some data into the Test table
+      for (int id = 0; id < 100; ++id)
+      {
+         std::string text = "Test text " + core::safe_convert::numberToString(id);
+         query = connection->query("insert into Test(id, text) values(:id, :text)")
+               .withInput(id)
+               .withInput(text);
+         error = connection->execute(query);
+         ASSERT_FALSE(error) << "Failed to insert row " << id << ": " << error.getMessage();
+      }
+
+      int rowId;
+      std::string rowText;
+      query = connection->query("select id, text from Test where id = 50")
+         .withOutput(rowId)
+         .withOutput(rowText);
+
+      bool dataReturned = false;
+      error = connection->execute(query, &dataReturned);
+      ASSERT_FALSE(error) << "Failed to execute query from pool connection: " << error.getMessage();
+      ASSERT_TRUE(dataReturned) << "Expected data to be returned but none was";
+
+      boost::shared_ptr<IConnection> connection2 = connectionPool->getConnection();
+      ASSERT_TRUE(connection2) << "Failed to get second connection from pool";
+
+      Query query2 = connection2->query("select id, text from Test where id = 25")
+         .withOutput(rowId)
+         .withOutput(rowText);
+
+      dataReturned = false;
+      error = connection2->execute(query2, &dataReturned);
+      ASSERT_FALSE(error) << "Failed to execute query from second pool connection: " << error.getMessage();
+      ASSERT_TRUE(dataReturned) << "Expected data to be returned from second query but none was";
    }
-
-   int rowId;
-   std::string rowText;
-   query = connection->query("select id, text from Test where id = 50")
-      .withOutput(rowId)
-      .withOutput(rowText);
-
-   bool dataReturned = false;
-   error = connection->execute(query, &dataReturned);
-   ASSERT_FALSE(error) << "Failed to execute query from pool connection: " << error.getMessage();
-   ASSERT_TRUE(dataReturned) << "Expected data to be returned but none was";
-
-   boost::shared_ptr<IConnection> connection2 = connectionPool->getConnection();
-   ASSERT_TRUE(connection2) << "Failed to get second connection from pool";
-
-   Query query2 = connection2->query("select id, text from Test where id = 25")
-      .withOutput(rowId)
-      .withOutput(rowText);
-
-   dataReturned = false;
-   error = connection2->execute(query2, &dataReturned);
-   ASSERT_FALSE(error) << "Failed to execute query from second pool connection: " << error.getMessage();
-   ASSERT_TRUE(dataReturned) << "Expected data to be returned from second query but none was";
 
    dbPath.removeIfExists();
 }

--- a/src/cpp/core/DatabaseTests.cpp
+++ b/src/cpp/core/DatabaseTests.cpp
@@ -48,7 +48,7 @@ protected:
 
    void SetUp() override
    {
-      dbPath = FilePath("/tmp/rstudio-test-db");
+      ASSERT_FALSE(FilePath::tempFilePath(dbPath));
       dbPath.removeIfExists();
 
       SqliteConnectionOptions options;
@@ -239,7 +239,8 @@ TEST_F(DatabaseTestsFixture, CanBulkInsert)
 
 TEST(DatabaseTest, CanUseConnectionPool)
 {
-   FilePath dbPath = FilePath("/tmp/rstudio-test-db-pool");
+   FilePath dbPath;
+   ASSERT_FALSE(FilePath::tempFilePath(dbPath));
    dbPath.removeIfExists();
 
    SqliteConnectionOptions options;
@@ -834,7 +835,7 @@ protected:
 
    void SetUp() override
    {
-      dbPath = FilePath("/tmp/rstudio-test-db-pool");
+      ASSERT_FALSE(FilePath::tempFilePath(dbPath));
       dbPath.removeIfExists();
 
       SqliteConnectionOptions options;


### PR DESCRIPTION
## Summary

The `core` unit tests re-enabled on Windows in #17824 failed in the overnight CI
build: the SQLite database tests could not open their database file.

The test fixtures and the connection-pool tests hardcoded a POSIX `/tmp/...` path
for the SQLite file. On Windows that resolves to a drive-relative `C:\tmp`, which
SQLite cannot open unless the directory already exists -- it does not create parent
directories. The tests passed on dev machines that happen to have a `C:\tmp` but
failed in the clean CI container.

This also explains the skip-count difference between local and CI runs.
`DatabaseTestsFixture.CanUpdateSchemas` calls `GTEST_SKIP()` inside the test body,
but the fixture `SetUp()` failed first in CI, so the test was reported as failed
instead of skipped.

## Changes

- Replace the hardcoded `/tmp/...` paths with `FilePath::tempFilePath()`, which uses
  the OS temp directory. This matches the idiom already used by `CanUpdateSchemas`.
- Scope the pool, connections, and `Query` objects in `CanUseConnectionPool` so their
  SQLite handles close before the database file is removed. The `Query` objects hold
  prepared statements, so without this `sqlite3_close()` returns `SQLITE_BUSY`, the
  file handle stays open, and the delete fails silently on Windows -- which, combined
  with the new random temp path, orphaned a db/-wal/-shm fileset on every run.

## Testing

Built `rstudio-core-tests` and ran the database and connection-pool tests on Windows:
11 passed, 3 skipped (Postgres), and 0 temp files left behind.
