### PR TITLE
Fix stale assistant account info when switching code assistants

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
 - ([#17278](https://github.com/rstudio/rstudio/issues/17278)): Fix a `data.table` returned invisibly from a `:=` update (e.g. `dt[, x := y]`) being auto-printed in notebook chunks, when its output should be suppressed as it is in the console.
 - ([#17810](https://github.com/rstudio/rstudio/issues/17810)): Fix the "Run Tests" button modifying the active test file's timestamp even when the file had no unsaved changes.
 - ([#17735](https://github.com/rstudio/rstudio/issues/17735)): Hide the redundant column-summary sidebar in the data frame preview shown in the Help pane.
+- ([#17066](https://github.com/rstudio/rstudio/issues/17066)): Fix the Assistant preferences pane showing a stale code-assistant account after switching back and forth between GitHub Copilot and Posit Assistant.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AssistantPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AssistantPreferencesPane.java
@@ -444,14 +444,19 @@ public class AssistantPreferencesPane extends PreferencesPane
                         @Override
                         public void onResponseReceived(Boolean isInstalled)
                         {
+                           // Ignore the result if the user switched away while
+                           // the verify call was in flight
+                           if (isStaleStatusResult(UserPrefsAccessor.ASSISTANT_POSIT))
+                              return;
+
                            if (event == null)
                            {
-                              // Panel just loaded, not a user action — just refresh
+                              // Panel just loaded, not a user action -- just refresh
                               refresh(UserPrefsAccessor.ASSISTANT_POSIT);
                            }
                            else
                            {
-                              // User changed the selection — check for
+                              // User changed the selection -- check for
                               // install, update, or unsupported status
                               checkPositAssistantInstallation(/* forAssistant= */ true);
                            }
@@ -460,6 +465,9 @@ public class AssistantPreferencesPane extends PreferencesPane
                         @Override
                         public void onError(ServerError error)
                         {
+                           if (isStaleStatusResult(UserPrefsAccessor.ASSISTANT_POSIT))
+                              return;
+
                            Debug.logError(error);
                            lblAssistantStatus_.setText(constants_.assistantStartupError());
                         }
@@ -503,6 +511,11 @@ public class AssistantPreferencesPane extends PreferencesPane
                         @Override
                         public void onResponseReceived(Boolean isInstalled)
                         {
+                           // Ignore the result if the user switched away while
+                           // the verify call was in flight
+                           if (isStaleStatusResult(UserPrefsAccessor.ASSISTANT_COPILOT))
+                              return;
+
                            if (isInstalled)
                            {
                               // Copilot is installed - refresh status by passing assistantType
@@ -518,6 +531,9 @@ public class AssistantPreferencesPane extends PreferencesPane
                         @Override
                         public void onError(ServerError error)
                         {
+                           if (isStaleStatusResult(UserPrefsAccessor.ASSISTANT_COPILOT))
+                              return;
+
                            Debug.logError(error);
                            lblAssistantStatus_.setText(constants_.assistantStartupError());
                         }
@@ -749,17 +765,36 @@ public class AssistantPreferencesPane extends PreferencesPane
       });
    }
 
+   /**
+    * Returns true when an async status result for the given assistant type
+    * should be ignored because the user has since selected a different
+    * assistant. The status label and buttons are shared across panels, so a
+    * late callback for a no-longer-selected assistant must not overwrite the
+    * current panel's status.
+    */
+   private boolean isStaleStatusResult(String assistantType)
+   {
+      return !assistantType.equals(selAssistant_.getValue());
+   }
+
    private void refresh(String assistantType)
    {
       imgRefreshSpinner_.setVisible(true);
       reset();
 
-      // Use overloaded method to pass assistantType if provided
+      // Resolve to the current preference when no explicit type was provided
+      final String type = assistantType.isEmpty() ? prefs_.assistant().getGlobalValue() : assistantType;
+
       ServerRequestCallback<AssistantStatusResponse> callback = new ServerRequestCallback<AssistantStatusResponse>()
       {
          @Override
          public void onResponseReceived(AssistantStatusResponse response)
          {
+            // Ignore a result for an assistant the user has since switched
+            // away from; the now-current panel owns the shared status UI
+            if (isStaleStatusResult(type))
+               return;
+
             imgRefreshSpinner_.setVisible(false);
             hideButtons();
 
@@ -773,7 +808,7 @@ public class AssistantPreferencesPane extends PreferencesPane
                {
                   // Assistant still starting up, so wait a second and refresh again
                   SingleShotTimer.fire(1000, () -> {
-                     refresh(assistantType);
+                     refresh(type);
                   });
                }
                else if (response.error != null && response.error.getCode() != AssistantConstants.ErrorCodes.AGENT_SHUT_DOWN)
@@ -792,11 +827,11 @@ public class AssistantPreferencesPane extends PreferencesPane
                else if (AssistantResponseTypes.AssistantAgentNotRunningReason.isError(response.reason))
                {
                   int reason = (int) response.reason.valueOf();
-                  lblAssistantStatus_.setText(AssistantResponseTypes.AssistantAgentNotRunningReason.reasonToString(reason, Assistant.getDisplayName(assistantType)));
+                  lblAssistantStatus_.setText(AssistantResponseTypes.AssistantAgentNotRunningReason.reasonToString(reason, Assistant.getDisplayName(type)));
 
                   // Show Install button for Posit Assistant when not installed
                   if (reason == AssistantResponseTypes.AssistantAgentNotRunningReason.NotInstalled &&
-                      assistantType.equals(UserPrefsAccessor.ASSISTANT_POSIT))
+                      type.equals(UserPrefsAccessor.ASSISTANT_POSIT))
                   {
                      showButtons(btnInstall_, btnRefresh_);
                   }
@@ -808,7 +843,7 @@ public class AssistantPreferencesPane extends PreferencesPane
                else if (projectOptions_ != null &&
                         UserPrefsAccessor.ASSISTANT_NONE.equals(projectOptions_.getAssistantOptions().assistant))
                {
-                  lblAssistantStatus_.setText(constants_.assistantDisabledInProject(Assistant.getDisplayName(assistantType)));
+                  lblAssistantStatus_.setText(constants_.assistantDisabledInProject(Assistant.getDisplayName(type)));
                   showButtons(btnProjectOptions_);
                }
                else
@@ -843,6 +878,9 @@ public class AssistantPreferencesPane extends PreferencesPane
          @Override
          public void onError(ServerError error)
          {
+            if (isStaleStatusResult(type))
+               return;
+
             Debug.logError(error);
             hideButtons();
             lblAssistantStatus_.setText(constants_.assistantUnexpectedError());
@@ -850,8 +888,6 @@ public class AssistantPreferencesPane extends PreferencesPane
          }
       };
 
-      // If no assistantType specified, use current preference
-      String type = assistantType.isEmpty() ? prefs_.assistant().getGlobalValue() : assistantType;
       server_.assistantStatus(type, callback);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AssistantPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AssistantPreferencesPane.java
@@ -882,6 +882,7 @@ public class AssistantPreferencesPane extends PreferencesPane
             if (isStaleStatusResult(type))
                return;
 
+            imgRefreshSpinner_.setVisible(false);
             Debug.logError(error);
             hideButtons();
             lblAssistantStatus_.setText(constants_.assistantUnexpectedError());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AssistantPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AssistantPreferencesPane.java
@@ -408,6 +408,9 @@ public class AssistantPreferencesPane extends PreferencesPane
                assistantDetailsPanel_.setWidget(nonePanel_);
                copilotTosPanel_.setVisible(false);
                disableCopilot(UserPrefsAccessor.ASSISTANT_NONE);
+
+               // Reset both flags so each panel re-queries its status when next shown
+               copilotRefreshed_ = false;
                positAiRefreshed_ = false;
             }
             else if (value.equals(UserPrefsAccessor.ASSISTANT_POSIT))
@@ -420,6 +423,9 @@ public class AssistantPreferencesPane extends PreferencesPane
                assistantDetailsPanel_.setWidget(positAiPanel_);
                copilotTosPanel_.setVisible(false);
                disableCopilot(UserPrefsAccessor.ASSISTANT_POSIT);
+
+               // Reset the Copilot flag so it re-queries its status when next shown
+               copilotRefreshed_ = false;
 
                // Refresh Posit Assistant status when panel is shown
                if (!positAiRefreshed_)
@@ -849,7 +855,6 @@ public class AssistantPreferencesPane extends PreferencesPane
          prefs_.copilotEnabled().setGlobalValue(false);
          prefs_.assistant().setGlobalValue(newAssistant);
          prefs_.writeUserPrefs((completed) -> {});
-         copilotRefreshed_ = false;
       }
    }
 
@@ -1141,6 +1146,9 @@ public class AssistantPreferencesPane extends PreferencesPane
    private void reset()
    {
       assistantStartupError_ = null;
+      // Clear the shared status label so a previous assistant's account info
+      // is not shown while the new status is being fetched
+      lblAssistantStatus_.setText("");
       hideButtons();
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AssistantPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AssistantPreferencesPane.java
@@ -779,8 +779,9 @@ public class AssistantPreferencesPane extends PreferencesPane
 
    private void refresh(String assistantType)
    {
-      imgRefreshSpinner_.setVisible(true);
+      // Clear any prior status, then show the spinner for this request
       reset();
+      imgRefreshSpinner_.setVisible(true);
 
       // Resolve to the current preference when no explicit type was provided
       final String type = assistantType.isEmpty() ? prefs_.assistant().getGlobalValue() : assistantType;
@@ -1190,8 +1191,9 @@ public class AssistantPreferencesPane extends PreferencesPane
    private void reset()
    {
       assistantStartupError_ = null;
-      // Clear the shared status label so a previous assistant's account info
-      // is not shown while the new status is being fetched
+      // Clear the shared status UI so a previous assistant's account info and
+      // loading spinner are not shown while the new status is being fetched
+      imgRefreshSpinner_.setVisible(false);
       lblAssistantStatus_.setText("");
       hideButtons();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AssistantPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AssistantPreferencesPane.java
@@ -779,12 +779,19 @@ public class AssistantPreferencesPane extends PreferencesPane
 
    private void refresh(String assistantType)
    {
+      // Resolve to the current preference when no explicit type was provided
+      final String type = assistantType.isEmpty() ? prefs_.assistant().getGlobalValue() : assistantType;
+
+      // A queued or late refresh for a no-longer-selected assistant must not
+      // touch the shared status UI: it would clear the current panel and, since
+      // the callback below early-returns, leave the spinner running. This guards
+      // invocation paths such as the retry timer and the sign-in/out callbacks.
+      if (isStaleStatusResult(type))
+         return;
+
       // Clear any prior status, then show the spinner for this request
       reset();
       imgRefreshSpinner_.setVisible(true);
-
-      // Resolve to the current preference when no explicit type was provided
-      final String type = assistantType.isEmpty() ? prefs_.assistant().getGlobalValue() : assistantType;
 
       ServerRequestCallback<AssistantStatusResponse> callback = new ServerRequestCallback<AssistantStatusResponse>()
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AssistantPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AssistantPreferencesPane.java
@@ -432,6 +432,10 @@ public class AssistantPreferencesPane extends PreferencesPane
                {
                   positAiRefreshed_ = true;
 
+                  // Clear the shared status UI now so the previous assistant's
+                  // account is not shown during the async install/status checks
+                  reset();
+
                   // Check if Posit Assistant is installed
                   server_.assistantVerifyInstalled(
                      UserPrefsAccessor.ASSISTANT_POSIT,
@@ -485,6 +489,10 @@ public class AssistantPreferencesPane extends PreferencesPane
                if (!copilotRefreshed_)
                {
                   copilotRefreshed_ = true;
+
+                  // Clear the shared status UI now so the previous assistant's
+                  // account is not shown during the async install/status checks
+                  reset();
 
                   // Check if Copilot is installed (passing assistantType so backend knows
                   // which language server to check, even if preference isn't saved yet)


### PR DESCRIPTION
## Intent

Addresses #17066.

## Summary

The Assistant preferences pane reuses a single status panel (the "Signed in:" label and its buttons) across the GitHub Copilot and Posit Assistant panels. Switching the "Use code assistant" selector back and forth could leave the previously selected assistant's account shown under the newly selected one.

There were two causes:

- The `copilotRefreshed_` guard was only reset inside `disableCopilot()`, gated on `copilot_enabled` being true. After the first switch away from Copilot that preference becomes false, so the guard stayed set, and returning to Copilot skipped the status query -- leaving the previously displayed Posit account in the shared label. The `positAiRefreshed_` guard was already reset unconditionally, so the Posit panel did not have this problem. This change resets `copilotRefreshed_` unconditionally when leaving Copilot, matching the Posit behavior, and removes the now-redundant reset from `disableCopilot()`.

- Even with the guard fixed, the status query runs behind an async `assistantVerifyInstalled()` call -- and for Posit, behind any install/update prompt -- while the shared status panel is moved into the newly shown panel right away. During that window the old account stayed visible. The shared status UI is now cleared inside the refresh guard block, before the async checks, so it is empty the moment the panel is shown and is repopulated by the subsequent refresh or status text.

The shared status UI (label, buttons, and loading spinner) is also hardened against rapid switching: async `assistantVerifyInstalled()` and status results for a no-longer-selected assistant are ignored (`isStaleStatusResult()`), and the spinner is cleared on panel switch and at request start, hidden on success and error, and not shown for a stale `refresh()` invocation, so it can no longer be stranded.

## Testing

- `cd src/gwt && ant javac` compiles.
