### PR TITLE
initial PR and scheduled mac os automation

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "src/**"
+      - "dependencies/**"
       - "e2e/rstudio/**"
       - ".github/actions/e2e-deps/**"
       - ".github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml"
@@ -15,6 +16,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   run-macos-26:
@@ -24,3 +26,4 @@ jobs:
       r_version: "4.5.3"
       # Skip @ai-tagged tests on PRs for now.
       grep_invert: "@ai"
+      post_pr_comment: true

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
@@ -21,10 +21,8 @@ permissions:
 jobs:
   run-macos-26:
     uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
-    # TODO: uncomment once CONNECT_API_KEY is added to rstudio/rstudio repo secrets
-    # and declared under on.workflow_call.secrets in the called workflow.
-    # secrets:
-    #   CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
     with:
       project: desktop
       r_version: "4.5.3"

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
@@ -21,6 +21,10 @@ permissions:
 jobs:
   run-macos-26:
     uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+    # Forward repo secrets (CONNECT_API_KEY) into the reusable workflow so the
+    # E2E Test Insights reporter can post on PR runs. Fork PRs receive no
+    # secrets, so the reporter no-ops there.
+    secrets: inherit
     with:
       project: desktop
       r_version: "4.5.3"

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
@@ -24,7 +24,8 @@ jobs:
     # Forward repo secrets (CONNECT_API_KEY) into the reusable workflow so the
     # E2E Test Insights reporter can post on PR runs. Fork PRs receive no
     # secrets, so the reporter no-ops there.
-    secrets: inherit
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
     with:
       project: desktop
       r_version: "4.5.3"

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-pr.yml
@@ -21,11 +21,10 @@ permissions:
 jobs:
   run-macos-26:
     uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
-    # Forward repo secrets (CONNECT_API_KEY) into the reusable workflow so the
-    # E2E Test Insights reporter can post on PR runs. Fork PRs receive no
-    # secrets, so the reporter no-ops there.
-    secrets:
-      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+    # TODO: uncomment once CONNECT_API_KEY is added to rstudio/rstudio repo secrets
+    # and declared under on.workflow_call.secrets in the called workflow.
+    # secrets:
+    #   CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
     with:
       project: desktop
       r_version: "4.5.3"

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-scheduled.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-scheduled.yml
@@ -2,7 +2,7 @@ name: "Test: E2E Playwright RStudio (Desktop, macOS 26 ARM64, Open Source, Sched
 
 on:
   schedule:
-    # Mon–Fri at 02:00 UTC — daily run against latest source on main.
+    # Mon-Fri at 02:00 UTC -- daily run against latest source on main.
     - cron: '0 2 * * 1-5'
   workflow_dispatch:
 
@@ -12,6 +12,8 @@ permissions:
 jobs:
   run-macos-26:
     uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
     with:
       project: desktop
       r_version: "release"

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-scheduled.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-scheduled.yml
@@ -1,0 +1,18 @@
+name: "Test: E2E Playwright RStudio (Desktop, macOS 26 ARM64, Open Source, Scheduled)"
+
+on:
+  schedule:
+    # Mon–Fri at 02:00 UTC — daily run against latest source on main.
+    - cron: '0 2 * * 1-5'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  run-macos-26:
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+    with:
+      project: desktop
+      r_version: "release"
+      grep_invert: "@ai"

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -336,9 +336,10 @@ jobs:
           # Tells playwright.config.ts to switch to blob reporter for this shard.
           PW_SHARD: ${{ matrix.shard }}
           # E2E Test Insights reporter: posts per-shard results to the dashboard
-          # API. SHARD_NAME makes each shard's S3 run id unique so shards don't
-          # overwrite each other. CONNECT_API_KEY is empty on fork PRs, where the
-          # reporter no-ops (warns, never fails the run).
+          # API. SHARD_NAME makes each shard's run id unique so shards don't
+          # overwrite each other. CONNECT_API_KEY is empty on fork PRs; the
+          # reporter still runs but its uploads fail with warnings (never fails
+          # the run).
           CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
           SHARD_NAME: desktop-mac-${{ matrix.shard }}
           # Print the GWT launch timeline so the next launch failure shows
@@ -368,7 +369,7 @@ jobs:
         with:
           name: playwright-blob-report-${{ matrix.shard }}
           path: e2e/rstudio/blob-report/
-          if-no-files-found: ignore
+          if-no-files-found: warn
           retention-days: 1
 
       - name: Upload test results
@@ -404,7 +405,8 @@ jobs:
           if-no-files-found: ignore
 
   # Merge per-shard blob reports into a single HTML report, parse aggregated
-  # counts, and post a sticky PR comment with pass/fail/skip totals.
+  # counts, and post a sticky PR comment with pass/fail/skip totals
+  # (when post_pr_comment is set).
   e2e-merge:
     needs: [e2e-desktop-macos]
     if: always() && needs.e2e-desktop-macos.result != 'skipped'
@@ -435,9 +437,8 @@ jobs:
         working-directory: e2e/rstudio
         run: |
           if [ -z "$(ls -A all-blob-reports 2>/dev/null)" ]; then
-            echo "::warning::No blob reports found; skipping merge"
-            mkdir -p playwright-report
-            exit 0
+            echo "::error::No blob reports found — both shards failed to produce artifacts"
+            exit 1
           fi
           cat > merge.config.ts <<'EOF'
           import { defineConfig } from '@playwright/test';
@@ -456,10 +457,18 @@ jobs:
         run: |
           FILE="e2e/rstudio/playwright-report/test-results.json"
           if [ -f "$FILE" ]; then
-            PASSED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == true and (.tests[0].status // "expected") != "flaky" and (.tests[0].status // "expected") != "skipped")] | length' "$FILE" || echo 0)
-            FAILED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == false)] | length' "$FILE" || echo 0)
-            SKIPPED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "skipped")] | length' "$FILE" || echo 0)
-            FLAKY=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "flaky")] | length' "$FILE" || echo 0)
+            if ! PASSED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == true and (.tests[0].status // "expected") != "flaky" and (.tests[0].status // "expected") != "skipped")] | length' "$FILE"); then
+              echo "::error::Failed to parse test-results.json (PASSED)"; exit 1
+            fi
+            if ! FAILED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == false)] | length' "$FILE"); then
+              echo "::error::Failed to parse test-results.json (FAILED)"; exit 1
+            fi
+            if ! SKIPPED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "skipped")] | length' "$FILE"); then
+              echo "::error::Failed to parse test-results.json (SKIPPED)"; exit 1
+            fi
+            if ! FLAKY=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "flaky")] | length' "$FILE"); then
+              echo "::error::Failed to parse test-results.json (FLAKY)"; exit 1
+            fi
           else
             PASSED=0; FAILED=0; SKIPPED=0; FLAKY=0
           fi
@@ -468,7 +477,9 @@ jobs:
             RATE=$(( (PASSED * 100) / TOTAL ))
             FILLED=$(( (RATE * 20) / 100 ))
             EMPTY=$(( 20 - FILLED ))
-            BAR=$(printf '█%.0s' $(seq 1 $FILLED) 2>/dev/null)$(printf '░%.0s' $(seq 1 $EMPTY) 2>/dev/null)
+            BAR=""
+            [ "$FILLED" -gt 0 ] && BAR=$(printf '█%.0s' $(seq 1 $FILLED))
+            [ "$EMPTY"  -gt 0 ] && BAR="${BAR}$(printf '░%.0s' $(seq 1 $EMPTY))"
           else
             RATE=0; BAR="░░░░░░░░░░░░░░░░░░░░"
           fi
@@ -490,8 +501,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Post E2E results to PR
-        if: always() && inputs.post_pr_comment == true
-        continue-on-error: true
+        if: always() && inputs.post_pr_comment == true && github.event.pull_request.head.repo.fork == false
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: e2e-macos-arm64-results

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -334,6 +334,12 @@ jobs:
           PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
           # Tells playwright.config.ts to switch to blob reporter for this shard.
           PW_SHARD: ${{ matrix.shard }}
+          # E2E Test Insights reporter: posts per-shard results to the dashboard
+          # API. SHARD_NAME makes each shard's S3 run id unique so shards don't
+          # overwrite each other. CONNECT_API_KEY is empty on fork PRs, where the
+          # reporter no-ops (warns, never fails the run).
+          CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+          SHARD_NAME: desktop-mac-${{ matrix.shard }}
           # Print the GWT launch timeline so the next launch failure shows
           # which phase exceeded the deadline (CDP-connect vs. bridge-installed
           # vs. ready-flag vs. console-visible).

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -452,10 +452,10 @@ jobs:
         run: |
           FILE="e2e/rstudio/playwright-report/test-results.json"
           if [ -f "$FILE" ]; then
-            PASSED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == true and (.tests[0].status // "expected") != "flaky" and (.tests[0].status // "expected") != "skipped")] | length' "$FILE")
-            FAILED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == false)] | length' "$FILE")
-            SKIPPED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "skipped")] | length' "$FILE")
-            FLAKY=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "flaky")] | length' "$FILE")
+            PASSED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == true and (.tests[0].status // "expected") != "flaky" and (.tests[0].status // "expected") != "skipped")] | length' "$FILE" || echo 0)
+            FAILED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == false)] | length' "$FILE" || echo 0)
+            SKIPPED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "skipped")] | length' "$FILE" || echo 0)
+            FLAKY=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "flaky")] | length' "$FILE" || echo 0)
           else
             PASSED=0; FAILED=0; SKIPPED=0; FLAKY=0
           fi

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -452,14 +452,28 @@ jobs:
             PASSED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == true and (.tests[0].status // "expected") != "flaky" and (.tests[0].status // "expected") != "skipped")] | length' "$FILE")
             FAILED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == false)] | length' "$FILE")
             SKIPPED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "skipped")] | length' "$FILE")
+            FLAKY=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "flaky")] | length' "$FILE")
           else
-            PASSED=0; FAILED=0; SKIPPED=0
+            PASSED=0; FAILED=0; SKIPPED=0; FLAKY=0
+          fi
+          TOTAL=$((PASSED + FAILED))
+          if [ "$TOTAL" -gt 0 ]; then
+            RATE=$(( (PASSED * 100) / TOTAL ))
+            FILLED=$(( (RATE * 20) / 100 ))
+            EMPTY=$(( 20 - FILLED ))
+            BAR=$(printf '█%.0s' $(seq 1 $FILLED) 2>/dev/null)$(printf '░%.0s' $(seq 1 $EMPTY) 2>/dev/null)
+          else
+            RATE=0; BAR="░░░░░░░░░░░░░░░░░░░░"
           fi
           echo "passed=$PASSED" >> "$GITHUB_OUTPUT"
           echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
           echo "skipped=$SKIPPED" >> "$GITHUB_OUTPUT"
+          echo "flaky=$FLAKY" >> "$GITHUB_OUTPUT"
+          echo "rate=$RATE" >> "$GITHUB_OUTPUT"
+          echo "bar=$BAR" >> "$GITHUB_OUTPUT"
 
       - name: Upload merged Playwright report
+        id: upload-report
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -475,18 +489,24 @@ jobs:
         with:
           header: e2e-macos-arm64-results
           message: |
-            ${{ needs.e2e-desktop-macos.result == 'success' && steps.summary.outputs.failed == '0' && ':white_check_mark: macOS E2E tests passed!' || ':x: Some macOS E2E tests failed. Check the report for details.' }}
+            ## 🍎 macOS Desktop E2E · ARM64
 
-            **macOS Desktop E2E Test Results (ARM64)**
-            | :white_check_mark: Passed | :x: Failed | :warning: Skipped |
-            | :---: | :---: | :---: |
-            | ${{ steps.summary.outputs.passed }} | ${{ steps.summary.outputs.failed }} | ${{ steps.summary.outputs.skipped }} |
+            ${{ needs.e2e-desktop-macos.result == 'success' && steps.summary.outputs.failed == '0' && '### ✅ All tests passed!' || format('### ❌ {0} test(s) failed', steps.summary.outputs.failed) }}
 
-            :bar_chart: **View Full HTML Report:**
-            1. Go to the [workflow run page](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            2. Scroll to "Artifacts" section at the bottom
-            3. Click `playwright-report` to download (downloads as .zip)
-            4. Extract the zip file and open `index.html` in a browser
+            `${{ steps.summary.outputs.bar }}` **${{ steps.summary.outputs.rate }}%** pass rate
+
+            | ✅ Passed | ❌ Failed | ⚠️ Skipped | 🔁 Flaky |
+            | :---: | :---: | :---: | :---: |
+            | **${{ steps.summary.outputs.passed }}** | **${{ steps.summary.outputs.failed }}** | **${{ steps.summary.outputs.skipped }}** | **${{ steps.summary.outputs.flaky }}** |
+
+            <details>
+            <summary>📥 Download Playwright report</summary>
+
+            **[⬇️ playwright-report.zip](${{ steps.upload-report.outputs.artifact-url }})** — extract and open `index.html`
+
+            > Includes screenshots, traces, and step-by-step details for every test. Expires in 15 days.
+
+            </details>
 
             ---
-            <sub>Last updated: ${{ github.event.pull_request.head.sha }} | [Workflow run #${{ github.run_number }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})</sub>
+            <sub>2 shards · macos-26 ARM64 · commit <code>${{ github.event.pull_request.head.sha }}</code> · <a href="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}">Run #${{ github.run_number }}</a></sub>

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -1,6 +1,9 @@
 name: "Test: E2E Playwright RStudio (Desktop, macOS 26 ARM64, Open Source)"
 
 on:
+  schedule:
+    # Mon–Fri at 02:00 UTC — daily smoke run against latest source on main.
+    - cron: '0 2 * * 1-5'
   workflow_dispatch:
     inputs:
       rstudio_installer_url:
@@ -28,15 +31,19 @@ on:
         type: string
         default: ""
       grep_invert:
-        description: "Optional Playwright --grep-invert pattern to skip tests by title."
+        description: "Optional Playwright --grep-invert pattern to skip tests by title. Defaults to '@ai' to skip tests that require credentials not available in unattended runs."
         type: string
-        default: ""
+        default: "@ai"
       rstudio_extra_args:
         description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS."
         type: string
         default: ""
       build_only:
         description: "Run only the build job (to seed the rstudio-tools / R-libs / sccache caches) and skip the e2e job."
+        type: boolean
+        default: false
+      post_pr_comment:
+        description: "Post test results as a sticky comment on the PR. Pass true only from PR-triggered callers."
         type: boolean
         default: false
   workflow_call:
@@ -61,16 +68,20 @@ on:
         default: ""
       grep_invert:
         type: string
-        default: ""
+        default: "@ai"
       rstudio_extra_args:
         type: string
         default: ""
       build_only:
         type: boolean
         default: false
+      post_pr_comment:
+        type: boolean
+        default: false
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   # Builds RStudio Desktop from this PR's source on the same runner image as
@@ -206,6 +217,10 @@ jobs:
       always() &&
       inputs.build_only != true &&
       (needs.build.result == 'success' || needs.build.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     runs-on: macos-26
     timeout-minutes: 120
     env:
@@ -317,6 +332,8 @@ jobs:
           PW_TEST_SELECTOR: ${{ inputs.test_selector }}
           PW_TEST_IGNORE: ${{ inputs.test_ignore }}
           PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
+          # Tells playwright.config.ts to switch to blob reporter for this shard.
+          PW_SHARD: ${{ matrix.shard }}
           # Print the GWT launch timeline so the next launch failure shows
           # which phase exceeded the deadline (CDP-connect vs. bridge-installed
           # vs. ready-flag vs. console-visible).
@@ -335,21 +352,23 @@ jobs:
           if [ -n "$PW_GREP_INVERT" ]; then
             ARGS+=(--grep-invert "$PW_GREP_INVERT")
           fi
+          ARGS+=(--shard="${{ matrix.shard }}/2")
           npx playwright test "${ARGS[@]}"
 
-      - name: Upload Playwright report
+      - name: Upload blob report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
-          path: e2e/rstudio/playwright-report/
+          name: playwright-blob-report-${{ matrix.shard }}
+          path: e2e/rstudio/blob-report/
           if-no-files-found: ignore
+          retention-days: 1
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: test-results-${{ matrix.shard }}
           path: e2e/rstudio/test-results/
           if-no-files-found: ignore
 
@@ -362,7 +381,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: pw-sandbox
+          name: pw-sandbox-${{ matrix.shard }}
           path: ${{ github.workspace }}/pw-sandbox/
           if-no-files-found: ignore
 
@@ -373,6 +392,101 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: macos-diagnostic-reports
+          name: macos-diagnostic-reports-${{ matrix.shard }}
           path: ~/Library/Logs/DiagnosticReports/
           if-no-files-found: ignore
+
+  # Merge per-shard blob reports into a single HTML report, parse aggregated
+  # counts, and post a sticky PR comment with pass/fail/skip totals.
+  e2e-merge:
+    needs: [e2e-desktop-macos]
+    if: always() && needs.e2e-desktop-macos.result != 'skipped'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
+
+      - name: Install Playwright
+        working-directory: e2e/rstudio
+        run: npm ci
+
+      - name: Download shard blob reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: playwright-blob-report-*
+          path: e2e/rstudio/all-blob-reports
+          merge-multiple: true
+
+      - name: Merge shard reports
+        working-directory: e2e/rstudio
+        run: |
+          if [ -z "$(ls -A all-blob-reports 2>/dev/null)" ]; then
+            echo "::warning::No blob reports found; skipping merge"
+            mkdir -p playwright-report
+            exit 0
+          fi
+          cat > merge.config.ts <<'EOF'
+          import { defineConfig } from '@playwright/test';
+          export default defineConfig({
+            reporter: [
+              ['html', { outputFolder: 'playwright-report', open: 'never' }],
+              ['json', { outputFile: 'playwright-report/test-results.json' }],
+            ],
+          });
+          EOF
+          npx playwright merge-reports --config merge.config.ts ./all-blob-reports
+
+      - name: Parse aggregated results
+        id: summary
+        if: always()
+        run: |
+          FILE="e2e/rstudio/playwright-report/test-results.json"
+          if [ -f "$FILE" ]; then
+            PASSED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == true and (.tests[0].status // "expected") != "flaky" and (.tests[0].status // "expected") != "skipped")] | length' "$FILE")
+            FAILED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == false)] | length' "$FILE")
+            SKIPPED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "skipped")] | length' "$FILE")
+          else
+            PASSED=0; FAILED=0; SKIPPED=0
+          fi
+          echo "passed=$PASSED" >> "$GITHUB_OUTPUT"
+          echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
+          echo "skipped=$SKIPPED" >> "$GITHUB_OUTPUT"
+
+      - name: Upload merged Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: e2e/rstudio/playwright-report/
+          retention-days: 15
+          if-no-files-found: ignore
+
+      - name: Post E2E results to PR
+        if: always() && inputs.post_pr_comment == true
+        continue-on-error: true
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: e2e-macos-arm64-results
+          message: |
+            ${{ needs.e2e-desktop-macos.result == 'success' && steps.summary.outputs.failed == '0' && ':white_check_mark: macOS E2E tests passed!' || ':x: Some macOS E2E tests failed. Check the report for details.' }}
+
+            **macOS Desktop E2E Test Results (ARM64)**
+            | :white_check_mark: Passed | :x: Failed | :warning: Skipped |
+            | :---: | :---: | :---: |
+            | ${{ steps.summary.outputs.passed }} | ${{ steps.summary.outputs.failed }} | ${{ steps.summary.outputs.skipped }} |
+
+            :bar_chart: **View Full HTML Report:**
+            1. Go to the [workflow run page](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            2. Scroll to "Artifacts" section at the bottom
+            3. Click `playwright-report` to download (downloads as .zip)
+            4. Extract the zip file and open `index.html` in a browser
+
+            ---
+            <sub>Last updated: ${{ github.event.pull_request.head.sha }} | [Workflow run #${{ github.run_number }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})</sub>

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -437,7 +437,7 @@ jobs:
         working-directory: e2e/rstudio
         run: |
           if [ -z "$(ls -A all-blob-reports 2>/dev/null)" ]; then
-            echo "::error::No blob reports found — both shards failed to produce artifacts"
+            echo "::error::No blob reports found -- both shards failed to produce artifacts"
             exit 1
           fi
           cat > merge.config.ts <<'EOF'

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -75,6 +75,10 @@ on:
       post_pr_comment:
         type: boolean
         default: false
+    secrets:
+      CONNECT_API_KEY:
+        description: "Posit Connect API key for the E2E Test Insights reporter"
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -1,9 +1,6 @@
 name: "Test: E2E Playwright RStudio (Desktop, macOS 26 ARM64, Open Source)"
 
 on:
-  schedule:
-    # Mon–Fri at 02:00 UTC — daily smoke run against latest source on main.
-    - cron: '0 2 * * 1-5'
   workflow_dispatch:
     inputs:
       rstudio_installer_url:

--- a/e2e/rstudio/package-lock.json
+++ b/e2e/rstudio/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@estruyf/github-actions-reporter": "^1.12.0",
+        "@midleman/playwright-reporter": "^0.49.0",
         "@types/node": "^25.9.1",
         "cross-env": "^10.1.0",
         "tsx": "^4.20.3",
@@ -59,6 +60,523 @@
       "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.1.tgz",
+      "integrity": "sha512-DFCtlisEuWzw7rESV65jHK7De1QsJZRZgUNJ8ovpmdVaayPrxvmlsAlW8hka9E7f9B31d1T7lHG9oozZf6Bp6w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1061.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1061.0.tgz",
+      "integrity": "sha512-ygyRCIkktaDz4/kNzsxhbZqocLwCJV5absi/k7Xd3LThPOmVkid7Nghm/xTW2Yg+vSQIL0yq99oV7u3T+4ZbAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/credential-provider-node": "^3.972.50",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.20",
+        "@aws-sdk/middleware-expect-continue": "^3.972.16",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.26",
+        "@aws-sdk/middleware-location-constraint": "^3.972.13",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.47",
+        "@aws-sdk/middleware-ssec": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.31",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.17.tgz",
+      "integrity": "sha512-r8o4h2K7j6P9ngno+8ei0aK0U/4JwDb7A2fMMxGVoSqDN8AFlIzSDeZHME9LcVLR2codyhtr1WAAg+/nmkeeMA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.10",
+        "@aws-sdk/xml-builder": "^3.972.27",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.43.tgz",
+      "integrity": "sha512-g0XVQKzaA/4cq1vz1IvCQwYM+1Pkv01J9yHDpCTXekVuGZRDEz0wqBQ1AuYTq7FM6uik4uBGH8Tb5d9YvgeA7g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.45.tgz",
+      "integrity": "sha512-w9PuOoKCt6+xoESvY+zlV0u3PKQ0mVL259PcsVR6a3S/uYJJHnIi4r1NxdJHEcNldUVRIciltWnFMGBR4YEm3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.48.tgz",
+      "integrity": "sha512-+6BQ6Lrnc+EyAGElLRW6j+Sa+RirPHnIJsobvYO6nnyK+oGKmz1ne/ieclbLWyjyDKEU3/JVJWcWY3VLFPvGtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/credential-provider-env": "^3.972.43",
+        "@aws-sdk/credential-provider-http": "^3.972.45",
+        "@aws-sdk/credential-provider-login": "^3.972.47",
+        "@aws-sdk/credential-provider-process": "^3.972.43",
+        "@aws-sdk/credential-provider-sso": "^3.972.47",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.47",
+        "@aws-sdk/nested-clients": "^3.997.15",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.47.tgz",
+      "integrity": "sha512-Iy2ebWVgrZBH05464uJiQYu6HSSiROnwVZptthEFXx2gWjo1ORCxEAFZB5Cr2MdfrSnZ+0QUPkZ1ZpCqpkUrLQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/nested-clients": "^3.997.15",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.50.tgz",
+      "integrity": "sha512-b05Aelq5cqAvCCDQjCYacl0XmR8QhBNSqLbsdISkQmlQBa5oPS66zYPteWcSp5LswbpoIe552EUGjluKiadBig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.43",
+        "@aws-sdk/credential-provider-http": "^3.972.45",
+        "@aws-sdk/credential-provider-ini": "^3.972.48",
+        "@aws-sdk/credential-provider-process": "^3.972.43",
+        "@aws-sdk/credential-provider-sso": "^3.972.47",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.47",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.43.tgz",
+      "integrity": "sha512-GPokLNyvTfCmuaHk+v3GKVs4ZT3cMu5kgS2a+NPkOMt96cq6fSIK0g+mZHpGS6Cd4QGrPKesANEaLUKgOskTzg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.47.tgz",
+      "integrity": "sha512-0AzvLrzlvJs0DzbeWGvNj+bX3Uzd7VNS6vDqCOdZzBlCGKGd78uxctJSW9iK/Rt/nxiJqpTvrYQlVJ4guVM2Dw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/nested-clients": "^3.997.15",
+        "@aws-sdk/token-providers": "3.1060.0",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.47.tgz",
+      "integrity": "sha512-eksfbUErOejUAGWBAcNqaP7IX21oUOEo73d9R56k9Ua4d57qS90NEYkWJsuSGzTXMFulCu17qXJI/qGmM7hvoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/nested-clients": "^3.997.15",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.20.tgz",
+      "integrity": "sha512-D35MfedGvTTzK1oygFPjm7DViSJwj9cuPV26ElHKwZqEz2rWag1hzYeAQ7st0jlCIAAihQgOyQ0/JwmqLOOinw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.47",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.16.tgz",
+      "integrity": "sha512-S52iw+M9zJC+7uxRdvvKeiR0s2PDeYEmbNZQkWE6OJf8upIs+r4WQY0TER+6akVitEMeRdwS0DrBUhKkmpsyng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.47",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.26.tgz",
+      "integrity": "sha512-WndRXQV8wAU/bW3GH8THumEOSV7FpS0AtoluT2M7lYaaDUyG0gOCD+DppB+IWQ4TPmzuTtFcCedh9xCzM4Zv4g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.13.tgz",
+      "integrity": "sha512-Yh0MmpADMsSR7ExRM/2w85D26i/U2aDC/pC7fMwhUpmOl6sebGpmBPoRL/uJRDhqRrwX/tvXWWZrsbsPM/O9FQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.47",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.47.tgz",
+      "integrity": "sha512-fzVBvGib8P1G6RFV3qVTPlXy9bMFAy5nxhdhA7LwyhWjRkJufNfJIPiloZq2mt36YAXSlLsEa4s3Kgcw6cv3+g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.31",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.13.tgz",
+      "integrity": "sha512-M+dDhWp2zv9u92I4/4rgUFdiF8jSIk5PIj5ktyBdhvR/dkmKSYMo07nuh+3g8/59HnizwkcRC3glcLMX5GhyaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.47",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.15.tgz",
+      "integrity": "sha512-Fpri1/PXKMKveORZ7E00VLTlWS5DkfZkW70PUE+bOnpWpAeHAQLoiDHhkzN3kNWbbSsGg64+IZYiq/EZgME3Mg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.31",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.31.tgz",
+      "integrity": "sha512-Kn2up9SlG1KC6wRtwf0d7waTGF6rvp9DxYqB54x6UCKdQ6kyaXCqHL4WGb5vUJga5kS8FxnjhY0LqM28aMvnNQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1060.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1060.0.tgz",
+      "integrity": "sha512-6NZaMKkFhpaNiwLpHi1sZaYjidL/lCJE6ME6NxwA8gv9vQna+Kr0j4OFwVoz6tANRWM3WbGz6jiPsGX/Vkjwow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.17",
+        "@aws-sdk/nested-clients": "^3.997.15",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.10.tgz",
+      "integrity": "sha512-992QrTO7G9qCvKD0fx1rMlqcL14plUcRAbwmqqYVsuF3GrqcvlAL9qxR+baMafarEZ+l7DUQ5lCMmt5mbMhF7g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.27.tgz",
+      "integrity": "sha512-hpsCXCOI436kxWpjtRuIHVvuPP81MOw8f18jzfZeg+UOiiOvlqWcmWChzEhJEu16cOC6+ku4ncBN+7rdt+DZ9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@epic-web/invariant": {
       "version": "1.0.0",
@@ -528,6 +1046,37 @@
         "@playwright/test": "^1.42.1"
       }
     },
+    "node_modules/@midleman/playwright-reporter": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.49.0.tgz",
+      "integrity": "sha512-hhu795HxQFDCUhxp3wG87TFpZytamp2sqOkL1/98h6Vlz24VER1wFh1v7w0JTRVhh6DsUbmUd/DQU7Mp1cDbEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.980.0",
+        "cross-spawn": "^7.0.6",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "e2e-insights": "dist/cli/index.js"
+      },
+      "peerDependencies": {
+        "@playwright/test": ">=1.40.0"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@playwright/test": {
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
@@ -541,6 +1090,135 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.7.tgz",
+      "integrity": "sha512-xj8gq/bjFABAh6qWPSDCYcY3kzQIm4b561C+YnHH4zGq8rOgzQ3Shk+JGlpUxSd41UGiO6FkLdUCtNX1FAeHgg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
+      "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.6.tgz",
+      "integrity": "sha512-3fya8i7GrJilQouk4cZJKdy5k8MWQBpjfXrRNaXDedH8r779tr0jcxyH3+yoTmsluc2+vF4S343yFbnvu8ExDQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@types/node": {
@@ -568,6 +1246,13 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -666,6 +1351,45 @@
         "@esbuild/win32-x64": "0.28.0"
       }
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -698,6 +1422,22 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {
@@ -774,6 +1514,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.22.3",
@@ -864,6 +1624,32 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/e2e/rstudio/package.json
+++ b/e2e/rstudio/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@estruyf/github-actions-reporter": "^1.12.0",
+    "@midleman/playwright-reporter": "^0.49.0",
     "@types/node": "^25.9.1",
     "cross-env": "^10.1.0",
     "tsx": "^4.20.3",

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -129,7 +129,8 @@ if (process.env.GITHUB_ACTIONS)
 // are suppressed per-shard. sandbox-reporter is kept so teardown can still
 // detect failures and preserve sandbox state for artifact upload. The E2E Test
 // Insights reporter rides alongside blob so per-shard results also reach the
-// dashboard; it no-ops without CONNECT_API_KEY (e.g. fork PRs).
+// dashboard. Without CONNECT_API_KEY (e.g. fork PRs) it still runs but
+// its uploads fail with warnings (never fails the run).
 if (process.env.GITHUB_ACTIONS && process.env.PW_SHARD)
   reporters.splice(0, reporters.length, ['blob'], ['./fixtures/sandbox-reporter.ts'], ['@midleman/playwright-reporter', { mode: 'prod' }]);
 

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -124,11 +124,6 @@ if (process.env.GITHUB_ACTIONS)
     showError: true,
   }]);
 
-// Write a machine-readable summary so CI can parse passed/failed/skipped counts
-// without re-running tests (used by PR comment steps).
-if (process.env.GITHUB_ACTIONS)
-  reporters.push(['json', { outputFile: 'e2e-results.json' }]);
-
 // Sharded CI runs use blob reporter so the merge job can reassemble a single
 // HTML report and accurate counts from all shards. Other human-facing reporters
 // are suppressed per-shard. sandbox-reporter is kept so teardown can still

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -124,6 +124,17 @@ if (process.env.GITHUB_ACTIONS)
     showError: true,
   }]);
 
+// Write a machine-readable summary so CI can parse passed/failed/skipped counts
+// without re-running tests (used by PR comment steps).
+if (process.env.GITHUB_ACTIONS)
+  reporters.push(['json', { outputFile: 'e2e-results.json' }]);
+
+// Sharded CI runs use blob reporter so the merge job can reassemble a single
+// HTML report and accurate counts from all shards. All other reporters are
+// suppressed per-shard to avoid producing N partial HTML reports.
+if (process.env.GITHUB_ACTIONS && process.env.PW_SHARD)
+  reporters.splice(0, reporters.length, ['blob']);
+
 export default defineConfig<{}, ProjectOptions>({
   testDir: './tests',
   testIgnore: testIgnore.length > 0 ? testIgnore : undefined,

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -131,9 +131,11 @@ if (process.env.GITHUB_ACTIONS)
 
 // Sharded CI runs use blob reporter so the merge job can reassemble a single
 // HTML report and accurate counts from all shards. All other reporters are
-// suppressed per-shard to avoid producing N partial HTML reports.
+// suppressed per-shard to avoid producing N partial HTML reports. The E2E Test
+// Insights reporter rides alongside blob so per-shard results also reach the
+// dashboard; it no-ops without CONNECT_API_KEY (e.g. fork PRs).
 if (process.env.GITHUB_ACTIONS && process.env.PW_SHARD)
-  reporters.splice(0, reporters.length, ['blob']);
+  reporters.splice(0, reporters.length, ['blob'], ['@midleman/playwright-reporter', { mode: 'prod' }]);
 
 export default defineConfig<{}, ProjectOptions>({
   testDir: './tests',

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -130,12 +130,13 @@ if (process.env.GITHUB_ACTIONS)
   reporters.push(['json', { outputFile: 'e2e-results.json' }]);
 
 // Sharded CI runs use blob reporter so the merge job can reassemble a single
-// HTML report and accurate counts from all shards. All other reporters are
-// suppressed per-shard to avoid producing N partial HTML reports. The E2E Test
+// HTML report and accurate counts from all shards. Other human-facing reporters
+// are suppressed per-shard. sandbox-reporter is kept so teardown can still
+// detect failures and preserve sandbox state for artifact upload. The E2E Test
 // Insights reporter rides alongside blob so per-shard results also reach the
 // dashboard; it no-ops without CONNECT_API_KEY (e.g. fork PRs).
 if (process.env.GITHUB_ACTIONS && process.env.PW_SHARD)
-  reporters.splice(0, reporters.length, ['blob'], ['@midleman/playwright-reporter', { mode: 'prod' }]);
+  reporters.splice(0, reporters.length, ['blob'], ['./fixtures/sandbox-reporter.ts'], ['@midleman/playwright-reporter', { mode: 'prod' }]);
 
 export default defineConfig<{}, ProjectOptions>({
   testDir: './tests',


### PR DESCRIPTION
<!-- include an entry in NEWS.md if required -->

### Intent
Github issue: https://github.com/rstudio/rstudio-ide-automation/issues/4989

Add automated E2E Playwright test runs for macOS ARM64 Desktop on every PR that touches source or test files. Previously there was no automated E2E feedback for open source contributors -- tests had to be triggered manually. This PR adds:                                                                                                                                                              
  - PR-triggered runs (on changes to src/**, dependencies/**, e2e/rstudio/**)                                                                                     
  - Daily scheduled runs Mon-Fri
  - 2 parallel shards to cut run time (~1hr instead of ~2hr)                                                                                                      
  - Sticky PR comment with pass/fail/skip counts and a link to the merged HTML report       
  
### Approach

Two shards run in parallel on `macos-26`  GitHub-hosted runners. Each shard uploads a Playwright blob report. A lightweight `e2e-merge` job (Ubuntu) downloads both blobs, merges them into a single HTML report, parses the aggregated counts with `jq`, and posts a sticky comment on the PR via `marocchino/sticky-pull-request-comment`.  
                                                                                                                       
`playwright.config.ts` switches to blob-only reporter when `PW_SHARD` is set, so each shard doesn't produce a partial HTML report. The merged report is the single source of truth.
                                                                                                                                                                  
`ai`-tagged tests are excluded by default until credentials are available (1Password setup pending).   

### Automated Tests

This PR is itself the test infrastructure. No unit tests apply - the change is CI configuration only. 

### Notes:
  - @midleman/playwright-reporter is an internal Posit reporter maintained by @mvendettuoli. It posts per-shard results to the E2E Test Insights dashboard and no-ops when CONNECT_API_KEY is absent (e.g. fork PRs).                                                                                                      
  - Fork PRs don't receive a sticky comment or dashboard data - GitHub doesn't expose repository secrets to fork workflows. The comment step uses continue-on-error: true so it fails silently rather than failing the run.