### PR TITLE
remove the 'new' label from issue templates

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -459,7 +459,6 @@ For branch naming:
 
 ## Issues
 
-- When opening an issue, always add the label `new`
 - If the issue describes a bug, add the label `bug`
 - If the issue is for a new feature or enhancements to an existing feature, add the label `enhancement`
 - These labels apply to issues only, not to pull requests

--- a/.github/ISSUE_TEMPLATE/1_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report a bug in RStudio.
 title: ''
-labels: ['bug', 'new']
+labels: ['bug']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/2_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2_feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Request a new feature.
 title: ''
-labels: ['enhancement', 'new']
+labels: ['enhancement']
 assignees: ''
 
 ---


### PR DESCRIPTION
## Summary

The bug report and feature request issue templates automatically applied a `new` label (alongside `bug` / `enhancement`) to every issue opened through them. In practice we weren't making any use of the `new` label for triage or filtering, so it was just noise on incoming issues.

This removes `new` from both templates:

- `1_bug_report.md`: `labels: ['bug', 'new']` -> `labels: ['bug']`
- `2_feature_request.md`: `labels: ['enhancement', 'new']` -> `labels: ['enhancement']`

It also drops the now-obsolete "always add the label `new`" instruction from the project `CLAUDE.md` so the guidance stays consistent with the templates.

The backport and documentation templates were never applying `new` and are untouched.