### PR TITLE
report write errors when saving files on a full disk or over quota

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
 - ([#17810](https://github.com/rstudio/rstudio/issues/17810)): Fix the "Run Tests" button modifying the active test file's timestamp even when the file had no unsaved changes.
 - ([#17735](https://github.com/rstudio/rstudio/issues/17735)): Hide the redundant column-summary sidebar in the data frame preview shown in the Help pane.
 - ([#17066](https://github.com/rstudio/rstudio/issues/17066)): Fix the Assistant preferences pane showing a stale code-assistant account after switching back and forth between GitHub Copilot and Posit Assistant.
+- ([#17833](https://github.com/rstudio/rstudio/issues/17833)): Fix saving a file silently appearing to succeed when the write actually failed (for example, when the disk is full or a disk quota is exceeded); such failures are now reported and the document keeps its unsaved state.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/cpp/core/FileSerializer.cpp
+++ b/src/cpp/core/FileSerializer.cpp
@@ -65,24 +65,28 @@ Error fileError(int code, const FilePath& filePath, const ErrorLocation& locatio
    return error;
 }
 
-// Write the given contents to filePath, flushing all the way to durable storage
-// before returning so that a failed write (most importantly a full disk,
-// ENOSPC, or an exceeded disk quota, EDQUOT) is reported rather than silently
-// discarded.
+// Write the given contents to filePath.
 //
 // We deliberately work directly against the operating system's file APIs rather
 // than a std::ostream. A stream defers the actual write until its buffer is
 // flushed, and its destructor (which must not throw) swallows any error from
 // that final flush -- which is how a save onto a full disk could appear to
-// succeed. Going through the OS directly also lets us flush to physical storage
-// (fsync / FlushFileBuffers): with delayed allocation (ext4, btrfs, XFS) a small
-// write into the page cache succeeds even on a full disk, and the ENOSPC /
-// EDQUOT failure only becomes visible when those pages are flushed.
+// succeed. Going through the OS directly lets us check the write and the close
+// for errors instead.
+//
+// When durable is true we additionally flush all the way to physical storage
+// (fsync / FlushFileBuffers) before returning. This is required to reliably
+// surface a full disk (ENOSPC) or an exceeded quota (EDQUOT): with delayed
+// allocation (ext4, btrfs, XFS) a small write into the page cache succeeds even
+// on a full disk, and the failure only becomes visible when those pages are
+// flushed. It is also relatively expensive, so callers that do not need their
+// write to survive a crash (the great majority) leave it off.
 #ifdef _WIN32
 
 Error writeContentsToFile(const FilePath& filePath,
                           const std::string& contents,
-                          bool truncate)
+                          bool truncate,
+                          bool durable)
 {
    HANDLE hFile = ::CreateFileW(
       filePath.getAbsolutePathW().c_str(),
@@ -123,9 +127,9 @@ Error writeContentsToFile(const FilePath& filePath,
       remaining -= written;
    }
 
-   // flush to durable storage; this is the point at which a full disk or an
-   // exceeded quota is reliably reported
-   if (!::FlushFileBuffers(hFile))
+   // when durability is requested, flush to physical storage; this is the point
+   // at which a full disk or an exceeded quota is reliably reported
+   if (durable && !::FlushFileBuffers(hFile))
    {
       Error error = LAST_SYSTEM_ERROR();
       (void) ::CloseHandle(hFile);
@@ -147,7 +151,8 @@ Error writeContentsToFile(const FilePath& filePath,
 
 Error writeContentsToFile(const FilePath& filePath,
                           const std::string& contents,
-                          bool truncate)
+                          bool truncate,
+                          bool durable)
 {
    // open the file, retrying only on EINTR (there are no sharing violations on
    // POSIX, so the higher-level retry loop runs this exactly once)
@@ -182,38 +187,42 @@ Error writeContentsToFile(const FilePath& filePath,
       remaining -= static_cast<std::size_t>(written);
    }
 
-   // flush to durable storage; on macOS plain fsync() does not push data to the
-   // physical platter, so we prefer F_FULLFSYNC and fall back to fsync() when
-   // the filesystem does not support it
-   int rc = -1;
+   // when durability is requested, flush to physical storage; this is the point
+   // at which a full disk or an exceeded quota is reliably reported. On macOS
+   // plain fsync() does not push data to the physical platter, so we prefer
+   // F_FULLFSYNC and fall back to fsync() when the filesystem does not support it.
+   if (durable)
+   {
+      int rc = -1;
 #ifdef __APPLE__
-   do
-   {
-      rc = ::fcntl(fd, F_FULLFSYNC, 0);
-   }
-   while (rc == -1 && errno == EINTR);
+      do
+      {
+         rc = ::fcntl(fd, F_FULLFSYNC, 0);
+      }
+      while (rc == -1 && errno == EINTR);
 
-   if (rc == -1 && (errno == ENOTSUP || errno == ENOTTY || errno == EINVAL))
-   {
+      if (rc == -1 && (errno == ENOTSUP || errno == ENOTTY || errno == EINVAL))
+      {
+         do
+         {
+            rc = ::fsync(fd);
+         }
+         while (rc == -1 && errno == EINTR);
+      }
+#else
       do
       {
          rc = ::fsync(fd);
       }
       while (rc == -1 && errno == EINTR);
-   }
-#else
-   do
-   {
-      rc = ::fsync(fd);
-   }
-   while (rc == -1 && errno == EINTR);
 #endif
 
-   if (rc == -1)
-   {
-      int code = errno;
-      (void) ::close(fd);
-      return fileError(code, filePath, ERROR_LOCATION);
+      if (rc == -1)
+      {
+         int code = errno;
+         (void) ::close(fd);
+         return fileError(code, filePath, ERROR_LOCATION);
+      }
    }
 
    // close the file; a close() that returns EINTR has still closed the
@@ -235,7 +244,8 @@ Error writeContentsToFile(const FilePath& filePath,
 Error writeContentsToFileWithRetry(const FilePath& filePath,
                                    const std::string& contents,
                                    bool truncate,
-                                   int maxOpenRetrySeconds)
+                                   int maxOpenRetrySeconds,
+                                   bool durable)
 {
    using namespace boost::posix_time;
 
@@ -249,7 +259,7 @@ Error writeContentsToFileWithRetry(const FilePath& filePath,
 
    while (true)
    {
-      Error error = writeContentsToFile(filePath, contents, truncate);
+      Error error = writeContentsToFile(filePath, contents, truncate, durable);
 
       // success and all non-sharing-violation errors are returned immediately
       if (!isFileLockedError(error))
@@ -395,16 +405,17 @@ Error writeStringToFile(const FilePath& filePath,
                         string_utils::LineEnding lineEnding,
                         bool truncate,
                         int maxOpenRetrySeconds,
-                        bool logError)
+                        bool logError,
+                        bool durable)
 {
    // normalize line endings up front
    std::string contents = str;
    string_utils::convertLineEndings(&contents, lineEnding);
 
-   // write the contents, flushing all the way to durable storage so that
-   // deferred write failures (a full disk or an exceeded quota) are reported
-   // rather than silently discarded
-   Error error = writeContentsToFileWithRetry(filePath, contents, truncate, maxOpenRetrySeconds);
+   // write the contents; when durable is set we flush all the way to physical
+   // storage so that deferred write failures (a full disk or an exceeded quota)
+   // are reported rather than silently discarded
+   Error error = writeContentsToFileWithRetry(filePath, contents, truncate, maxOpenRetrySeconds, durable);
    if (error && logError)
       LOG_ERROR(error);
 
@@ -421,8 +432,15 @@ Error writeStringToFileAtomic(const FilePath& filePath,
    if (error)
       return error;
 
-   // write to the temporary file
-   error = writeStringToFile(tmpFile, str, lineEnding);
+   // write to the temporary file, flushing it to physical storage so the
+   // contents are durable before we rename it into place
+   error = writeStringToFile(tmpFile,
+                             str,
+                             lineEnding,
+                             true /* truncate */,
+                             0 /* maxOpenRetrySeconds */,
+                             true /* logError */,
+                             true /* durable */);
    if (error)
    {
       tmpFile.removeIfExists();

--- a/src/cpp/core/FileSerializer.cpp
+++ b/src/cpp/core/FileSerializer.cpp
@@ -17,6 +17,7 @@
 
 #include <utility>
 #include <iostream>
+#include <fstream>
 #include <sstream>
 #include <algorithm>
 #include <gsl/gsl-lite.hpp>
@@ -25,6 +26,11 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/iostreams/copy.hpp>
 #include <boost/thread.hpp>
+
+#ifdef _WIN32
+# include <boost/iostreams/device/file_descriptor.hpp>
+# include <boost/iostreams/stream.hpp>
+#endif
 
 #include <shared_core/FilePath.hpp>
 #include <core/DateTime.hpp>
@@ -93,6 +99,37 @@ Error openFileForWritingWithRetry(const FilePath& filePath,
       LOG_ERROR(lastError);
 
    return lastError;
+}
+
+// Flush and close an output stream opened by openFileForWritingWithRetry,
+// surfacing any deferred write errors (e.g. a full disk or an exceeded disk
+// quota) as exceptions rather than letting them be silently swallowed when the
+// stream is destroyed.
+//
+// Stream destructors must not throw, so the std::ostream destructor closes the
+// underlying file and discards any error reported by the final flush. For small
+// writes the buffered data is not actually written to disk until that point, so
+// without an explicit flush and close the caller can observe success even though
+// nothing was durably written. Note that on some filesystems (for example NFS)
+// write errors are reported only when the file is closed, not when written, so
+// we must close here too rather than relying on the flush alone.
+//
+// The concrete stream type is platform-specific (a std::ofstream on POSIX, a
+// boost file-descriptor sink stream on Windows), so we downcast to invoke the
+// appropriate close(). The exception mask set by the caller ensures both flush()
+// and close() throw on failure.
+void closeFileForWriting(const std::shared_ptr<std::ostream>& pOfs)
+{
+   pOfs->flush();
+
+#ifdef _WIN32
+   typedef boost::iostreams::stream<boost::iostreams::file_descriptor_sink> FileStream;
+#else
+   typedef std::ofstream FileStream;
+#endif
+
+   if (FileStream* pStream = dynamic_cast<FileStream*>(pOfs.get()))
+      pStream->close();
 }
 
 } // anonymous namespace
@@ -208,7 +245,12 @@ Error writeStringToFile(const FilePath& filePath,
       string_utils::convertLineEndings(&normalized, lineEnding);
       std::istringstream istr(normalized);
       boost::iostreams::copy(istr, *pOfs);
-      
+
+      // explicitly flush and close so that write errors (e.g. a full disk or
+      // an exceeded disk quota) are reported here rather than being silently
+      // discarded when the stream is destroyed
+      closeFileForWriting(pOfs);
+
       // return success
       return Success();
    }

--- a/src/cpp/core/FileSerializer.cpp
+++ b/src/cpp/core/FileSerializer.cpp
@@ -17,7 +17,6 @@
 
 #include <utility>
 #include <iostream>
-#include <fstream>
 #include <sstream>
 #include <algorithm>
 #include <gsl/gsl-lite.hpp>
@@ -28,8 +27,12 @@
 #include <boost/thread.hpp>
 
 #ifdef _WIN32
-# include <boost/iostreams/device/file_descriptor.hpp>
-# include <boost/iostreams/stream.hpp>
+# include <windows.h>
+#else
+# include <cerrno>
+# include <fcntl.h>
+# include <sys/stat.h>
+# include <unistd.h>
 #endif
 
 #include <shared_core/FilePath.hpp>
@@ -52,85 +55,252 @@ bool isFileLockedError(const Error& error)
 #endif
 }
 
-Error openFileForWritingWithRetry(const FilePath& filePath,
-                                  bool truncate,
-                                  int maxOpenRetrySeconds,
-                                  bool logError,
-                                  std::shared_ptr<std::ostream>* pOfs)
+// Build an Error describing a failed file operation, annotated with the path.
+// The code is captured by the caller immediately after the failing syscall so
+// that it is not clobbered by any intervening cleanup (close, etc.).
+Error fileError(int code, const FilePath& filePath, const ErrorLocation& location)
+{
+   Error error = systemError(code, location);
+   error.addProperty("path", filePath.getAbsolutePath());
+   return error;
+}
+
+// Write the given contents to filePath, flushing all the way to durable storage
+// before returning so that a failed write (most importantly a full disk,
+// ENOSPC, or an exceeded disk quota, EDQUOT) is reported rather than silently
+// discarded.
+//
+// We deliberately work directly against the operating system's file APIs rather
+// than a std::ostream. A stream defers the actual write until its buffer is
+// flushed, and its destructor (which must not throw) swallows any error from
+// that final flush -- which is how a save onto a full disk could appear to
+// succeed. Going through the OS directly also lets us flush to physical storage
+// (fsync / FlushFileBuffers): with delayed allocation (ext4, btrfs, XFS) a small
+// write into the page cache succeeds even on a full disk, and the ENOSPC /
+// EDQUOT failure only becomes visible when those pages are flushed.
+#ifdef _WIN32
+
+Error writeContentsToFile(const FilePath& filePath,
+                          const std::string& contents,
+                          bool truncate)
+{
+   HANDLE hFile = ::CreateFileW(
+      filePath.getAbsolutePathW().c_str(),
+      truncate ? GENERIC_WRITE : FILE_APPEND_DATA,
+      0, // exclusive access (matches FilePath::openForWrite)
+      nullptr,
+      truncate ? CREATE_ALWAYS : OPEN_ALWAYS,
+      FILE_ATTRIBUTE_NORMAL,
+      nullptr);
+
+   if (hFile == INVALID_HANDLE_VALUE)
+   {
+      Error error = LAST_SYSTEM_ERROR();
+      error.addProperty("path", filePath.getAbsolutePath());
+      return error;
+   }
+
+   // write all of the bytes, looping in case WriteFile performs a partial write
+   const char* data = contents.data();
+   std::size_t remaining = contents.size();
+   while (remaining > 0)
+   {
+      // WriteFile takes a DWORD count; cap each call well within its range
+      const std::size_t kMaxWrite = 0x7fffffff;
+      DWORD toWrite = (remaining > kMaxWrite) ? static_cast<DWORD>(kMaxWrite)
+                                              : static_cast<DWORD>(remaining);
+
+      DWORD written = 0;
+      if (!::WriteFile(hFile, data, toWrite, &written, nullptr))
+      {
+         Error error = LAST_SYSTEM_ERROR();
+         (void) ::CloseHandle(hFile);
+         error.addProperty("path", filePath.getAbsolutePath());
+         return error;
+      }
+
+      data += written;
+      remaining -= written;
+   }
+
+   // flush to durable storage; this is the point at which a full disk or an
+   // exceeded quota is reliably reported
+   if (!::FlushFileBuffers(hFile))
+   {
+      Error error = LAST_SYSTEM_ERROR();
+      (void) ::CloseHandle(hFile);
+      error.addProperty("path", filePath.getAbsolutePath());
+      return error;
+   }
+
+   if (!::CloseHandle(hFile))
+   {
+      Error error = LAST_SYSTEM_ERROR();
+      error.addProperty("path", filePath.getAbsolutePath());
+      return error;
+   }
+
+   return Success();
+}
+
+#else
+
+Error writeContentsToFile(const FilePath& filePath,
+                          const std::string& contents,
+                          bool truncate)
+{
+   // open the file, retrying only on EINTR (there are no sharing violations on
+   // POSIX, so the higher-level retry loop runs this exactly once)
+   int flags = O_WRONLY | O_CREAT | (truncate ? O_TRUNC : O_APPEND);
+   int fd = -1;
+   do
+   {
+      fd = ::open(filePath.getAbsolutePath().c_str(), flags, 0666);
+   }
+   while (fd == -1 && errno == EINTR);
+
+   if (fd == -1)
+      return fileError(errno, filePath, ERROR_LOCATION);
+
+   // write all of the bytes, handling partial writes and EINTR
+   const char* data = contents.data();
+   std::size_t remaining = contents.size();
+   while (remaining > 0)
+   {
+      ssize_t written = ::write(fd, data, remaining);
+      if (written < 0)
+      {
+         if (errno == EINTR)
+            continue;
+
+         int code = errno;
+         (void) ::close(fd);
+         return fileError(code, filePath, ERROR_LOCATION);
+      }
+
+      data += written;
+      remaining -= static_cast<std::size_t>(written);
+   }
+
+   // flush to durable storage; on macOS plain fsync() does not push data to the
+   // physical platter, so we prefer F_FULLFSYNC and fall back to fsync() when
+   // the filesystem does not support it
+   int rc = -1;
+#ifdef __APPLE__
+   do
+   {
+      rc = ::fcntl(fd, F_FULLFSYNC, 0);
+   }
+   while (rc == -1 && errno == EINTR);
+
+   if (rc == -1 && (errno == ENOTSUP || errno == ENOTTY || errno == EINVAL))
+   {
+      do
+      {
+         rc = ::fsync(fd);
+      }
+      while (rc == -1 && errno == EINTR);
+   }
+#else
+   do
+   {
+      rc = ::fsync(fd);
+   }
+   while (rc == -1 && errno == EINTR);
+#endif
+
+   if (rc == -1)
+   {
+      int code = errno;
+      (void) ::close(fd);
+      return fileError(code, filePath, ERROR_LOCATION);
+   }
+
+   // close the file; a close() that returns EINTR has still closed the
+   // descriptor on Linux, so we must not retry it (that could close an
+   // unrelated fd that was opened in the meantime)
+   if (::close(fd) == -1 && errno != EINTR)
+      return fileError(errno, filePath, ERROR_LOCATION);
+
+   return Success();
+}
+
+#endif
+
+// Write the given contents to filePath. On Windows, openForWrite requests
+// exclusive access, so a file held open by another process (commonly backup
+// software) fails with a sharing violation; maxOpenRetrySeconds asks us to keep
+// retrying for that long before giving up. A sharing violation occurs before
+// any data is written, so retrying the whole operation is safe.
+Error writeContentsToFileWithRetry(const FilePath& filePath,
+                                   const std::string& contents,
+                                   bool truncate,
+                                   int maxOpenRetrySeconds)
 {
    using namespace boost::posix_time;
-
-   ptime startTime = second_clock::universal_time();
-   Error lastError;
 
    // do not allow negative values - regular signed int was chosen here for
    // easier integration with other parts of the codebase
    if (maxOpenRetrySeconds < 0)
       maxOpenRetrySeconds = 0;
 
+   ptime startTime = second_clock::universal_time();
    int numTries = 0;
+
    while (true)
    {
-      lastError = filePath.openForWrite(*pOfs, truncate);
+      Error error = writeContentsToFile(filePath, contents, truncate);
 
-      // if the error is a non file lock error, then we should just return it
-      if (!isFileLockedError(lastError))
-      {
-         if (lastError && logError)
-            LOG_ERROR(lastError);
+      // success and all non-sharing-violation errors are returned immediately
+      if (!isFileLockedError(error))
+         return error;
 
-         return lastError;
-      }
-
-      lastError.addOrUpdateProperty("open-attempts", ++numTries);
+      error.addOrUpdateProperty("open-attempts", ++numTries);
 
       // stop retrying if we've spent more than the requested amount of time
       if ((second_clock::universal_time() - startTime) >= seconds(maxOpenRetrySeconds))
       {
-         lastError.addProperty("description", "Timed out while attempting to reopen the file");
-         break;
+         error.addProperty("description", "Timed out while attempting to reopen the file");
+         return error;
       }
 
       // wait a moment before retrying
       boost::this_thread::sleep(milliseconds(500));
    }
-
-   if (lastError && logError)
-      LOG_ERROR(lastError);
-
-   return lastError;
 }
 
-// Flush and close an output stream opened by openFileForWritingWithRetry,
-// surfacing any deferred write errors (e.g. a full disk or an exceeded disk
-// quota) as exceptions rather than letting them be silently swallowed when the
-// stream is destroyed.
-//
-// Stream destructors must not throw, so the std::ostream destructor closes the
-// underlying file and discards any error reported by the final flush. For small
-// writes the buffered data is not actually written to disk until that point, so
-// without an explicit flush and close the caller can observe success even though
-// nothing was durably written. Note that on some filesystems (for example NFS)
-// write errors are reported only when the file is closed, not when written, so
-// we must close here too rather than relying on the flush alone.
-//
-// The concrete stream type is platform-specific (a std::ofstream on POSIX, a
-// boost file-descriptor sink stream on Windows), so we downcast to invoke the
-// appropriate close(). The exception mask set by the caller ensures both flush()
-// and close() throw on failure.
-void closeFileForWriting(const std::shared_ptr<std::ostream>& pOfs)
+#ifndef _WIN32
+// Flush a directory so that a newly created or renamed entry within it survives
+// a crash. This is a POSIX-only durability optimization (Windows has no portable
+// equivalent) and is best-effort: the rename has already completed and is
+// visible, so a failure here only affects crash durability, not correctness.
+void syncDirectory(const FilePath& dirPath)
 {
-   pOfs->flush();
-
-#ifdef _WIN32
-   typedef boost::iostreams::stream<boost::iostreams::file_descriptor_sink> FileStream;
-#else
-   typedef std::ofstream FileStream;
+   int flags = O_RDONLY;
+#ifdef O_DIRECTORY
+   flags |= O_DIRECTORY;
 #endif
 
-   if (FileStream* pStream = dynamic_cast<FileStream*>(pOfs.get()))
-      pStream->close();
+   int fd = -1;
+   do
+   {
+      fd = ::open(dirPath.getAbsolutePath().c_str(), flags);
+   }
+   while (fd == -1 && errno == EINTR);
+
+   if (fd == -1)
+      return;
+
+   int rc;
+   do
+   {
+      rc = ::fsync(fd);
+   }
+   while (rc == -1 && errno == EINTR);
+
+   (void) ::close(fd);
 }
+#endif
 
 } // anonymous namespace
 
@@ -227,41 +397,18 @@ Error writeStringToFile(const FilePath& filePath,
                         int maxOpenRetrySeconds,
                         bool logError)
 {
-   using namespace boost::system::errc;
-   
-   // open file
-   std::shared_ptr<std::ostream> pOfs;
-   Error error = openFileForWritingWithRetry(filePath, truncate, maxOpenRetrySeconds, logError, &pOfs);
-   if (error)
-      return error;
+   // normalize line endings up front
+   std::string contents = str;
+   string_utils::convertLineEndings(&contents, lineEnding);
 
-   try
-   {
-      // set exception mask (required for proper reporting of errors)
-      pOfs->exceptions(std::ostream::failbit | std::ostream::badbit);
-      
-      // copy string to file
-      std::string normalized = str;
-      string_utils::convertLineEndings(&normalized, lineEnding);
-      std::istringstream istr(normalized);
-      boost::iostreams::copy(istr, *pOfs);
+   // write the contents, flushing all the way to durable storage so that
+   // deferred write failures (a full disk or an exceeded quota) are reported
+   // rather than silently discarded
+   Error error = writeContentsToFileWithRetry(filePath, contents, truncate, maxOpenRetrySeconds);
+   if (error && logError)
+      LOG_ERROR(error);
 
-      // explicitly flush and close so that write errors (e.g. a full disk or
-      // an exceeded disk quota) are reported here rather than being silently
-      // discarded when the stream is destroyed
-      closeFileForWriting(pOfs);
-
-      // return success
-      return Success();
-   }
-   catch(const std::exception& e)
-   {
-      Error error = systemError(boost::system::errc::io_error, 
-                                ERROR_LOCATION);
-      error.addProperty("what", e.what());
-      error.addProperty("path", filePath.getAbsolutePath());
-      return error;
-   }
+   return error;
 }
 
 Error writeStringToFileAtomic(const FilePath& filePath,
@@ -289,6 +436,13 @@ Error writeStringToFileAtomic(const FilePath& filePath,
       tmpFile.removeIfExists();
       return error;
    }
+
+   // the temporary file's contents were already flushed to disk by
+   // writeStringToFile; flush the parent directory as well so that the rename
+   // itself is durable across a crash (best-effort, POSIX only)
+#ifndef _WIN32
+   syncDirectory(filePath.getParent());
+#endif
 
    return Success();
 }

--- a/src/cpp/core/FileSerializer.cpp
+++ b/src/cpp/core/FileSerializer.cpp
@@ -439,6 +439,31 @@ Error writeStringToFile(const FilePath& filePath,
    return error;
 }
 
+bool isDiskSpaceError(const Error& error)
+{
+   if (!error)
+      return false;
+
+   // ENOSPC / EDQUOT (and the Windows equivalents) are reported in the system
+   // category: errno on POSIX, the Win32 error code on Windows
+   if (error.getName() != boost::system::system_category().name())
+      return false;
+
+   int code = error.getCode();
+
+#ifdef _WIN32
+   return code == ERROR_DISK_FULL || code == ERROR_HANDLE_DISK_FULL;
+#else
+   if (code == ENOSPC)
+      return true;
+# ifdef EDQUOT
+   if (code == EDQUOT)
+      return true;
+# endif
+   return false;
+#endif
+}
+
 Error writeStringToFileAtomic(const FilePath& filePath,
                               const std::string& str,
                               string_utils::LineEnding lineEnding)

--- a/src/cpp/core/FileSerializer.cpp
+++ b/src/cpp/core/FileSerializer.cpp
@@ -88,9 +88,11 @@ Error writeContentsToFile(const FilePath& filePath,
                           bool truncate,
                           bool durable)
 {
+   // request GENERIC_WRITE in both modes: FlushFileBuffers requires it, so an
+   // append handle opened with only FILE_APPEND_DATA would fail at flush time
    HANDLE hFile = ::CreateFileW(
       filePath.getAbsolutePathW().c_str(),
-      truncate ? GENERIC_WRITE : FILE_APPEND_DATA,
+      GENERIC_WRITE,
       0, // exclusive access (matches FilePath::openForWrite)
       nullptr,
       truncate ? CREATE_ALWAYS : OPEN_ALWAYS,
@@ -102,6 +104,21 @@ Error writeContentsToFile(const FilePath& filePath,
       Error error = LAST_SYSTEM_ERROR();
       error.addProperty("path", filePath.getAbsolutePath());
       return error;
+   }
+
+   // in append mode, move to the end of the file before writing -- a GENERIC_WRITE
+   // handle does not auto-append the way a FILE_APPEND_DATA-only handle would
+   if (!truncate)
+   {
+      LARGE_INTEGER offset;
+      offset.QuadPart = 0;
+      if (!::SetFilePointerEx(hFile, offset, nullptr, FILE_END))
+      {
+         Error error = LAST_SYSTEM_ERROR();
+         (void) ::CloseHandle(hFile);
+         error.addProperty("path", filePath.getAbsolutePath());
+         return error;
+      }
    }
 
    // write all of the bytes, looping in case WriteFile performs a partial write

--- a/src/cpp/core/FileSerializerTests.cpp
+++ b/src/cpp/core/FileSerializerTests.cpp
@@ -19,6 +19,12 @@
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
 
+#ifdef _WIN32
+# include <windows.h>
+#else
+# include <cerrno>
+#endif
+
 namespace rstudio {
 namespace core {
 
@@ -215,6 +221,26 @@ TEST(FileSerializerTest, WriteStringReportsFailedWrite)
                                    false /* logError */,
                                    true /* durable */);
    EXPECT_TRUE(error);
+}
+
+// isDiskSpaceError must recognize the full-disk / over-quota error codes (so a
+// raw write failure can be turned into a recovery-oriented message) and must
+// not misclassify unrelated errors or success.
+TEST(FileSerializerTest, IsDiskSpaceErrorClassifies)
+{
+   EXPECT_FALSE(isDiskSpaceError(Success()));
+
+#ifdef _WIN32
+   EXPECT_TRUE(isDiskSpaceError(systemError(ERROR_DISK_FULL, ERROR_LOCATION)));
+   EXPECT_TRUE(isDiskSpaceError(systemError(ERROR_HANDLE_DISK_FULL, ERROR_LOCATION)));
+#else
+   EXPECT_TRUE(isDiskSpaceError(systemError(ENOSPC, ERROR_LOCATION)));
+# ifdef EDQUOT
+   EXPECT_TRUE(isDiskSpaceError(systemError(EDQUOT, ERROR_LOCATION)));
+# endif
+   // an unrelated system error is not a disk-space error
+   EXPECT_FALSE(isDiskSpaceError(systemError(ENOENT, ERROR_LOCATION)));
+#endif
 }
 
 } // namespace core

--- a/src/cpp/core/FileSerializerTests.cpp
+++ b/src/cpp/core/FileSerializerTests.cpp
@@ -1,0 +1,58 @@
+/*
+ * FileSerializerTests.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <core/FileSerializer.hpp>
+#include <shared_core/Error.hpp>
+#include <shared_core/FilePath.hpp>
+
+namespace rstudio {
+namespace core {
+
+TEST(FileSerializerTest, WriteStringRoundTrips)
+{
+   FilePath filePath;
+   ASSERT_FALSE(FilePath::tempFilePath(filePath));
+
+   std::string contents = "hello\nworld\n";
+   Error error = writeStringToFile(filePath, contents);
+   EXPECT_FALSE(error);
+
+   std::string readback;
+   error = readStringFromFile(filePath, &readback);
+   EXPECT_FALSE(error);
+   EXPECT_EQ(contents, readback);
+
+   filePath.removeIfExists();
+}
+
+// Regression test for #17833: a write that fails (e.g. a full disk or an
+// exceeded disk quota) must be reported as an error rather than silently
+// appearing to succeed. We use /dev/full, which always fails writes with
+// ENOSPC, to simulate the condition. The device is only available on Linux,
+// so the test is skipped elsewhere.
+TEST(FileSerializerTest, WriteStringReportsFailedWrite)
+{
+   FilePath devFull("/dev/full");
+   if (!devFull.exists())
+      GTEST_SKIP() << "/dev/full not available on this platform";
+
+   Error error = writeStringToFile(devFull, "this write should fail");
+   EXPECT_TRUE(error);
+}
+
+} // namespace core
+} // namespace rstudio

--- a/src/cpp/core/FileSerializerTests.cpp
+++ b/src/cpp/core/FileSerializerTests.cpp
@@ -152,6 +152,31 @@ TEST(FileSerializerTest, WriteStringAppends)
    filePath.removeIfExists();
 }
 
+// The durable write path additionally flushes to physical storage; confirm a
+// normal round-trip still works through it.
+TEST(FileSerializerTest, WriteStringDurableRoundTrips)
+{
+   FilePath filePath;
+   ASSERT_FALSE(FilePath::tempFilePath(filePath));
+
+   std::string contents = "hello\nworld\n";
+   Error error = writeStringToFile(filePath,
+                                   contents,
+                                   string_utils::LineEndingPassthrough,
+                                   true /* truncate */,
+                                   0 /* maxOpenRetrySeconds */,
+                                   true /* logError */,
+                                   true /* durable */);
+   EXPECT_FALSE(error);
+
+   std::string readback;
+   error = readStringFromFile(filePath, &readback);
+   EXPECT_FALSE(error);
+   EXPECT_EQ(contents, readback);
+
+   filePath.removeIfExists();
+}
+
 TEST(FileSerializerTest, WriteStringAtomicRoundTrips)
 {
    FilePath filePath;
@@ -173,16 +198,22 @@ TEST(FileSerializerTest, WriteStringAtomicRoundTrips)
 // exceeded disk quota) must be reported as an error rather than silently
 // appearing to succeed. We use /dev/full, which always fails writes with
 // ENOSPC, to simulate the condition. The device is only available on Linux,
-// so the test is skipped elsewhere. Because we now write to the file
-// descriptor directly (rather than buffering through a stream), the failure
-// surfaces regardless of payload size.
+// so the test is skipped elsewhere. We exercise the durable path (matching the
+// document-save call site) and disable error logging so the expected failure
+// does not pollute the test output.
 TEST(FileSerializerTest, WriteStringReportsFailedWrite)
 {
    FilePath devFull("/dev/full");
    if (!devFull.exists())
       GTEST_SKIP() << "/dev/full not available on this platform";
 
-   Error error = writeStringToFile(devFull, "this write should fail");
+   Error error = writeStringToFile(devFull,
+                                   "this write should fail",
+                                   string_utils::LineEndingPassthrough,
+                                   true /* truncate */,
+                                   0 /* maxOpenRetrySeconds */,
+                                   false /* logError */,
+                                   true /* durable */);
    EXPECT_TRUE(error);
 }
 

--- a/src/cpp/core/FileSerializerTests.cpp
+++ b/src/cpp/core/FileSerializerTests.cpp
@@ -39,11 +39,143 @@ TEST(FileSerializerTest, WriteStringRoundTrips)
    filePath.removeIfExists();
 }
 
+// An empty write is a real code path (e.g. AdvisoryFileLock) and must both
+// succeed and truncate any prior contents.
+TEST(FileSerializerTest, WriteStringEmptyRoundTrips)
+{
+   FilePath filePath;
+   ASSERT_FALSE(FilePath::tempFilePath(filePath));
+
+   Error error = writeStringToFile(filePath, "initial contents");
+   EXPECT_FALSE(error);
+
+   error = writeStringToFile(filePath, "");
+   EXPECT_FALSE(error);
+
+   std::string readback = "not empty";
+   error = readStringFromFile(filePath, &readback);
+   EXPECT_FALSE(error);
+   EXPECT_EQ("", readback);
+
+   filePath.removeIfExists();
+}
+
+// A payload larger than any internal buffer, to exercise a big write and
+// confirm nothing is truncated or duplicated by the write loop.
+TEST(FileSerializerTest, WriteStringLargeRoundTrips)
+{
+   FilePath filePath;
+   ASSERT_FALSE(FilePath::tempFilePath(filePath));
+
+   std::string contents;
+   contents.reserve(4 * 1024 * 1024);
+   for (std::size_t i = 0; i < 4 * 1024 * 1024; ++i)
+      contents.push_back(static_cast<char>('a' + (i % 26)));
+
+   Error error = writeStringToFile(filePath, contents);
+   EXPECT_FALSE(error);
+
+   std::string readback;
+   error = readStringFromFile(filePath, &readback);
+   EXPECT_FALSE(error);
+   EXPECT_EQ(contents, readback);
+
+   filePath.removeIfExists();
+}
+
+// Content with embedded NUL bytes and high bytes must round-trip exactly: the
+// write is length-based, not NUL-terminated, and we must not convert line
+// endings when passing them through.
+TEST(FileSerializerTest, WriteStringBinaryRoundTrips)
+{
+   FilePath filePath;
+   ASSERT_FALSE(FilePath::tempFilePath(filePath));
+
+   std::string contents;
+   contents.push_back('a');
+   contents.push_back('\0');
+   contents.push_back('b');
+   contents.push_back('\xFF');
+   contents.push_back('\0');
+   contents.push_back('c');
+
+   Error error = writeStringToFile(filePath, contents);
+   EXPECT_FALSE(error);
+
+   std::string readback;
+   error = readStringFromFile(filePath, &readback);
+   EXPECT_FALSE(error);
+   EXPECT_EQ(contents, readback);
+
+   filePath.removeIfExists();
+}
+
+// A truncating write over a longer file must leave only the new (shorter)
+// contents behind, with no trailing remnants of the original.
+TEST(FileSerializerTest, WriteStringTruncatesExisting)
+{
+   FilePath filePath;
+   ASSERT_FALSE(FilePath::tempFilePath(filePath));
+
+   Error error = writeStringToFile(filePath, "a much longer set of contents");
+   EXPECT_FALSE(error);
+
+   error = writeStringToFile(filePath, "short");
+   EXPECT_FALSE(error);
+
+   std::string readback;
+   error = readStringFromFile(filePath, &readback);
+   EXPECT_FALSE(error);
+   EXPECT_EQ("short", readback);
+
+   filePath.removeIfExists();
+}
+
+// A non-truncating write appends to the existing contents.
+TEST(FileSerializerTest, WriteStringAppends)
+{
+   FilePath filePath;
+   ASSERT_FALSE(FilePath::tempFilePath(filePath));
+
+   Error error = writeStringToFile(filePath, "hello");
+   EXPECT_FALSE(error);
+
+   error = writeStringToFile(filePath, " world", string_utils::LineEndingPassthrough,
+                             /* truncate */ false);
+   EXPECT_FALSE(error);
+
+   std::string readback;
+   error = readStringFromFile(filePath, &readback);
+   EXPECT_FALSE(error);
+   EXPECT_EQ("hello world", readback);
+
+   filePath.removeIfExists();
+}
+
+TEST(FileSerializerTest, WriteStringAtomicRoundTrips)
+{
+   FilePath filePath;
+   ASSERT_FALSE(FilePath::tempFilePath(filePath));
+
+   std::string contents = "hello\nworld\n";
+   Error error = writeStringToFileAtomic(filePath, contents);
+   EXPECT_FALSE(error);
+
+   std::string readback;
+   error = readStringFromFile(filePath, &readback);
+   EXPECT_FALSE(error);
+   EXPECT_EQ(contents, readback);
+
+   filePath.removeIfExists();
+}
+
 // Regression test for #17833: a write that fails (e.g. a full disk or an
 // exceeded disk quota) must be reported as an error rather than silently
 // appearing to succeed. We use /dev/full, which always fails writes with
 // ENOSPC, to simulate the condition. The device is only available on Linux,
-// so the test is skipped elsewhere.
+// so the test is skipped elsewhere. Because we now write to the file
+// descriptor directly (rather than buffering through a stream), the failure
+// surfaces regardless of payload size.
 TEST(FileSerializerTest, WriteStringReportsFailedWrite)
 {
    FilePath devFull("/dev/full");

--- a/src/cpp/core/include/core/FileSerializer.hpp
+++ b/src/cpp/core/include/core/FileSerializer.hpp
@@ -319,6 +319,12 @@ Error writeStringToFileAtomic(const core::FilePath& filePath,
                               const std::string& str,
                               string_utils::LineEnding lineEnding = string_utils::LineEndingPassthrough);
 
+// Returns true if the given error indicates that a write failed because the
+// disk is full (ENOSPC) or a disk quota was exceeded (EDQUOT), including the
+// Windows equivalents. Useful for translating a raw write failure into a
+// recovery-oriented message for the user.
+bool isDiskSpaceError(const core::Error& error);
+
 // lineEnding is the type of line ending you want the resulting string to have
 Error readStringFromFile(const core::FilePath& filePath,
                          std::string* pStr,

--- a/src/cpp/core/include/core/FileSerializer.hpp
+++ b/src/cpp/core/include/core/FileSerializer.hpp
@@ -297,12 +297,21 @@ Error readStringVectorFromFile(const core::FilePath& filePath,
 // when it is in use by another process (common when using backup software), and if so
 // how many seconds of elapsed time should we wait for the file to become available
 // note: this only has an effect on Windows
+//
+// durable, when true, flushes the contents all the way to physical storage
+// (fsync / FlushFileBuffers) before returning. This is required to reliably
+// detect a full disk (ENOSPC) or an exceeded quota (EDQUOT) -- with delayed
+// allocation a write into the page cache succeeds even on a full disk, and the
+// failure only surfaces when the pages are flushed -- but it is relatively
+// expensive, so it defaults off. Enable it on paths where a silently dropped
+// write would lose user data (e.g. saving an editor document).
 Error writeStringToFile(const core::FilePath& filePath,
                         const std::string& str,
                         string_utils::LineEnding lineEnding = string_utils::LineEndingPassthrough,
                         bool truncate = true,
                         int maxOpenRetrySeconds = 0,
-                        bool logError = true);
+                        bool logError = true,
+                        bool durable = false);
 
 // Writes a string to a file atomically by first writing to a temporary file
 // in the same directory and then renaming it into place.

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -425,6 +425,7 @@ namespace prefs {
 #define kPythonVersion "python_version"
 #define kPythonPath "python_path"
 #define kSaveRetryTimeout "save_retry_timeout"
+#define kSaveFilesDurably "save_files_durably"
 #define kInsertNativePipeOperator "insert_native_pipe_operator"
 #define kCommandPaletteMru "command_palette_mru"
 #define kShowMemoryUsage "show_memory_usage"
@@ -1976,6 +1977,12 @@ public:
     */
    int saveRetryTimeout();
    core::Error setSaveRetryTimeout(int val);
+
+   /**
+    * Whether to flush saved files all the way to physical storage so that write failures (such as a full disk or an exceeded quota) are reported rather than silently lost. Disabling this can improve save performance on slow or networked filesystems, at the risk of not detecting some failed writes.
+    */
+   bool saveFilesDurably();
+   core::Error setSaveFilesDurably(bool val);
 
    /**
     * Whether the Insert Pipe Operator command should use the native R pipe operator, |>

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -540,12 +540,20 @@ Error saveDocumentCore(const std::string& contents,
       // note whether the file existed prior to writing
       bool newFile = !fullDocPath.exists();
 
-      // write the contents to the file
+      // write the contents to the file; request a durable flush (unless the
+      // user has opted out) so that a write that fails on a full disk or over
+      // quota is reported rather than silently dropped -- which would clear the
+      // editor's unsaved marker and lose the user's work
       int writeTimeout = retryWrite ? session::prefs::userPrefs().saveRetryTimeout() : 0;
-      error = writeStringToFile(fullDocPath, encoded,
-                                module_context::lineEndings(fullDocPath),
-                                true,
-                                writeTimeout);
+      bool durable = session::prefs::userPrefs().saveFilesDurably();
+      error = writeStringToFile(
+            fullDocPath,
+            encoded,
+            module_context::lineEndings(fullDocPath),
+            true /* truncate */,
+            writeTimeout,
+            true /* logError */,
+            durable);
       if (error)
          return error;
 

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -458,6 +458,27 @@ Error openDocument(const json::JsonRpcRequest& request,
    return Success();
 } 
 
+// Translate a low-level save failure into a message the user can act on. The
+// original error (with the precise OS message and errno) has already been
+// logged by writeStringToFile, so this only changes what is surfaced to the
+// user. Non-disk-space errors are returned unchanged.
+Error friendlySaveError(const Error& error)
+{
+   if (isDiskSpaceError(error))
+   {
+      return Error(
+         boost::system::error_code(error.getCode(), boost::system::system_category()),
+         "There is not enough free space to save this file -- the disk may be "
+         "full, or a disk quota may have been exceeded. Free up some disk space "
+         "(or increase your disk quota) and try saving the file again.",
+         ERROR_LOCATION);
+   }
+   else
+   {
+      return error;
+   }
+}
+
 Error saveDocumentCore(const std::string& contents,
                        const json::Value& jsonPath,
                        const json::Value& jsonType,
@@ -555,7 +576,7 @@ Error saveDocumentCore(const std::string& contents,
             true /* logError */,
             durable);
       if (error)
-         return error;
+         return friendlySaveError(error);
 
       // set the new path and contents for the document
       error = pDoc->setPathAndContents(path);

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -2292,6 +2292,18 @@
    clear = function() { .rs.clearUserPref("save_retry_timeout") }
 )
 
+# Use durable writes when saving files
+#
+# Whether to flush saved files all the way to physical storage so that write
+# failures (such as a full disk or an exceeded quota) are reported rather than
+# silently lost. Disabling this can improve save performance on slow or networked
+# filesystems, at the risk of not detecting some failed writes.
+.rs.uiPrefs$saveFilesDurably <- list(
+   get = function() { .rs.getUserPref("save_files_durably") },
+   set = function(value) { .rs.setUserPref("save_files_durably", value) },
+   clear = function() { .rs.clearUserPref("save_files_durably") }
+)
+
 # Use R's native pipe operator, |>
 #
 # Whether the Insert Pipe Operator command should use the native R pipe operator,

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -3222,6 +3222,19 @@ core::Error UserPrefValues::setSaveRetryTimeout(int val)
 }
 
 /**
+ * Whether to flush saved files all the way to physical storage so that write failures (such as a full disk or an exceeded quota) are reported rather than silently lost. Disabling this can improve save performance on slow or networked filesystems, at the risk of not detecting some failed writes.
+ */
+bool UserPrefValues::saveFilesDurably()
+{
+   return readPref<bool>("save_files_durably");
+}
+
+core::Error UserPrefValues::setSaveFilesDurably(bool val)
+{
+   return writePref("save_files_durably", val);
+}
+
+/**
  * Whether the Insert Pipe Operator command should use the native R pipe operator, |>
  */
 bool UserPrefValues::insertNativePipeOperator()
@@ -4042,6 +4055,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kPythonVersion,
       kPythonPath,
       kSaveRetryTimeout,
+      kSaveFilesDurably,
       kInsertNativePipeOperator,
       kCommandPaletteMru,
       kShowMemoryUsage,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1703,6 +1703,12 @@
             "title": "Save Retry Timeout",
             "description": "The maximum amount of seconds of retry for save operations."
         },
+        "save_files_durably": {
+            "type": "boolean",
+            "default": true,
+            "title": "Use durable writes when saving files",
+            "description": "Whether to flush saved files all the way to physical storage so that write failures (such as a full disk or an exceeded quota) are reported rather than silently lost. Disabling this can improve save performance on slow or networked filesystems, at the risk of not detecting some failed writes."
+        },
         "insert_native_pipe_operator": {
             "description": "Whether the Insert Pipe Operator command should use the native R pipe operator, |>",
             "title": "Use R's native pipe operator, |>",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -290,6 +290,7 @@ public class UserPrefsAccessor extends Prefs
    public static final String PYTHON_VERSION = "python_version";
    public static final String PYTHON_PATH = "python_path";
    public static final String SAVE_RETRY_TIMEOUT = "save_retry_timeout";
+   public static final String SAVE_FILES_DURABLY = "save_files_durably";
    public static final String INSERT_NATIVE_PIPE_OPERATOR = "insert_native_pipe_operator";
    public static final String COMMAND_PALETTE_MRU = "command_palette_mru";
    public static final String SHOW_MEMORY_USAGE = "show_memory_usage";
@@ -3824,6 +3825,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Whether to flush saved files all the way to physical storage so that write failures (such as a full disk or an exceeded quota) are reported rather than silently lost. Disabling this can improve save performance on slow or networked filesystems, at the risk of not detecting some failed writes.
+    */
+   public PrefValue<Boolean> saveFilesDurably()
+   {
+      return bool(
+         "save_files_durably",
+         _constants.saveFilesDurablyTitle(), 
+         _constants.saveFilesDurablyDescription(), 
+         true);
+   }
+
+   /**
     * Whether the Insert Pipe Operator command should use the native R pipe operator, |>
     */
    public PrefValue<Boolean> insertNativePipeOperator()
@@ -4970,6 +4983,8 @@ public class UserPrefsAccessor extends Prefs
          pythonPath().setValue(layer, source.getString("python_path"));
       if (source.hasKey("save_retry_timeout"))
          saveRetryTimeout().setValue(layer, source.getInteger("save_retry_timeout"));
+      if (source.hasKey("save_files_durably"))
+         saveFilesDurably().setValue(layer, source.getBool("save_files_durably"));
       if (source.hasKey("insert_native_pipe_operator"))
          insertNativePipeOperator().setValue(layer, source.getBool("insert_native_pipe_operator"));
       if (source.hasKey("command_palette_mru"))
@@ -5308,6 +5323,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(pythonVersion());
       prefs.add(pythonPath());
       prefs.add(saveRetryTimeout());
+      prefs.add(saveFilesDurably());
       prefs.add(insertNativePipeOperator());
       prefs.add(commandPaletteMru());
       prefs.add(showMemoryUsage());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -2058,6 +2058,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String saveRetryTimeoutDescription();
 
    /**
+    * Whether to flush saved files all the way to physical storage so that write failures (such as a full disk or an exceeded quota) are reported rather than silently lost. Disabling this can improve save performance on slow or networked filesystems, at the risk of not detecting some failed writes.
+    */
+   @DefaultStringValue("Use durable writes when saving files")
+   String saveFilesDurablyTitle();
+   @DefaultStringValue("Whether to flush saved files all the way to physical storage so that write failures (such as a full disk or an exceeded quota) are reported rather than silently lost. Disabling this can improve save performance on slow or networked filesystems, at the risk of not detecting some failed writes.")
+   String saveFilesDurablyDescription();
+
+   /**
     * Whether the Insert Pipe Operator command should use the native R pipe operator, |>
     */
    @DefaultStringValue("Use R's native pipe operator, |>")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -1034,6 +1034,10 @@ pythonPathDescription = The path to the default Python interpreter.
 saveRetryTimeoutTitle = Save Retry Timeout
 saveRetryTimeoutDescription = The maximum amount of seconds of retry for save operations.
 
+# Whether to flush saved files all the way to physical storage so that write failures (such as a full disk or an exceeded quota) are reported rather than silently lost. Disabling this can improve save performance on slow or networked filesystems, at the risk of not detecting some failed writes.
+saveFilesDurablyTitle = Use durable writes when saving files
+saveFilesDurablyDescription = Whether to flush saved files all the way to physical storage so that write failures (such as a full disk or an exceeded quota) are reported rather than silently lost. Disabling this can improve save performance on slow or networked filesystems, at the risk of not detecting some failed writes.
+
 # Whether the Insert Pipe Operator command should use the native R pipe operator, |>
 insertNativePipeOperatorTitle = Use R's native pipe operator, |>
 insertNativePipeOperatorDescription = Whether the Insert Pipe Operator command should use the native R pipe operator, |>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CodePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CodePreferencesPane.java
@@ -333,7 +333,8 @@ public class CodePreferencesPane extends PreferencesPane
       savePanel.add(checkboxPref(constants_.savingStripTrailingWhitespaceLabel(), prefs_.stripTrailingWhitespace()));
       savePanel.add(checkboxPref(constants_.savingRestoreSourceDocumentCursorPositionLabel(), prefs_.restoreSourceDocumentCursorPosition()));
       savePanel.add(checkboxPref(prefs_.reformatOnSave()));
-      
+      savePanel.add(checkboxPref(prefs_.saveFilesDurably()));
+
       Label serializationLabel = headerLabel(constants_.editingSerializationLabel());
       serializationLabel.getElement().getStyle().setPaddingTop(14, Unit.PX);
       savePanel.add(serializationLabel);


### PR DESCRIPTION
## Intent

Addresses #17833.

## Problem

When a file save failed because the disk was full or a disk quota was exceeded, RStudio reported success anyway: the editor cleared the unsaved (`*` / red tab) indicator and showed no error, even though nothing was written to disk. Users could keep editing and "saving" while silently losing all of their work.

## Root cause

The bug is in `writeStringToFile` (`src/cpp/core/FileSerializer.cpp`), the low-level helper used by the document-save path (`SessionSource.cpp` -> `saveDocumentCore` -> `writeStringToFile`).

It copied the content into a `std::ofstream` buffer and returned `Success()` immediately:

```cpp
boost::iostreams::copy(istr, *pOfs);
return Success();
```

For a typical edit the content is smaller than the stream's buffer, so nothing is actually written to the file descriptor during the copy. The real flush/close happens later, when the `std::shared_ptr<std::ostream>` is destroyed as the function returns. A stream destructor must not throw, so the `std::ofstream` destructor closes the file and **silently discards** any `ENOSPC` / `EDQUOT` error from the final flush.

Every layer above `writeStringToFile` already handles errors correctly -- `saveDocumentCore` checks the returned `Error`, and the frontend (`DocUpdateSentinel`) only clears the dirty marker on a successful response and shows an error via `SaveFailedEvent` on failure. They were simply never told the write had failed.

## Fix

`writeStringToFile` now writes through the operating system's file APIs directly instead of buffering through a `std::ofstream`:

- **POSIX:** `open` -> `write` loop (handling partial writes and `EINTR`) -> optional flush -> `close`, with the real `errno` captured before any cleanup so it is not clobbered.
- **Windows:** `CreateFileW` -> `WriteFile` loop -> optional `FlushFileBuffers` -> `CloseHandle`.

Both the write and the close are now checked for errors, so a failed write surfaces as an `Error` that propagates up and lights up the existing "save failed" UI while keeping the document marked unsaved -- the in-editor content is preserved and the user can free space and save again.

### Durability is opt-in (`durable` flag)

Surfacing a full-disk failure reliably requires flushing to physical storage: with delayed allocation (ext4/btrfs/XFS) a small write into the page cache succeeds even on a full disk, and `ENOSPC`/`EDQUOT` only becomes visible at `fsync`. That flush (`fsync`/`F_FULLFSYNC`/`FlushFileBuffers`) is comparatively expensive, and `writeStringToFile` has ~150 callers (lock files, client state, prefs, caches, ...) that should not pay for it on every write.

So the flush is gated behind a new `durable` parameter that **defaults to `false`**. Only the paths that would lose user data on a dropped write opt in:

- the document-save path (`SessionSource.cpp`), and
- `writeStringToFileAtomic` (which also `fsync`s the parent directory after the rename, POSIX only, so the rename is crash-durable).

All other callers keep their previous, non-fsync behavior while still benefiting from the new write/close error checking.

On macOS the durable path uses `F_FULLFSYNC` (falling back to `fsync` when the filesystem does not support it), since plain `fsync` does not reach the platter there.

## Testing

Added `src/cpp/core/FileSerializerTests.cpp`:

- Round-trip coverage: empty, large (multi-MB), binary (embedded NULs / high bytes), truncating, append, durable, and atomic writes -- guarding the new write/flush/close path against regressions.
- `WriteStringReportsFailedWrite` -- regression test for this issue, writing to `/dev/full` (which always fails with `ENOSPC`) via the durable path and asserting an error is returned. Runs on Linux (incl. CI); skipped on platforms without `/dev/full`.

Built `rstudio-core-tests` and ran the suite locally (macOS): all round-trip cases pass, the `/dev/full` case skips as expected.

## Note on atomic saves

I considered also switching the document save to a temp-file-plus-rename (atomic) write so a failed save leaves the original file intact rather than truncated. I left that out deliberately: with this fix the editor already retains the unsaved content and reports the failure, so no work is lost, and atomic rename has real side effects on RStudio Server (changes file ownership/permissions, breaks symlinks and hardlinks) that warrant separate consideration. Happy to do it as a follow-up if wanted.
