### PR TITLE
Add preference to disable mouse-wheel editor tab switching

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ### New
 - ([#15830](https://github.com/rstudio/rstudio/issues/15830)): Add a Code menu and command-palette entry to re-enable the editor's missing-package banner for a file after dismissing it, and rename the banner's dismissal label to "Don't show for this file" to make the per-file scope explicit.
 - ([#17734](https://github.com/rstudio/rstudio/issues/17734)): Support em dashes and box-drawing characters as native R code section delimiters.
-- ([#8541](https://github.com/rstudio/rstudio/issues/8541)): Add a "Change active editor tab with mouse-wheel" preference (General > Basic > Other) to disable switching the active editor tab by scrolling the mouse wheel over the tab bar.
+- ([#8541](https://github.com/rstudio/rstudio/issues/8541)): Add a "Change active editor tab with mouse wheel" preference (General > Basic > Other) to disable switching the active editor tab by scrolling the mouse wheel over the tab bar.
 
 ### Fixed
 - ([#14202](https://github.com/rstudio/rstudio/issues/14202)): Fixed an issue where RStudio Desktop could hang on startup when offline or on an unreliable network connection.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ### New
 - ([#15830](https://github.com/rstudio/rstudio/issues/15830)): Add a Code menu and command-palette entry to re-enable the editor's missing-package banner for a file after dismissing it, and rename the banner's dismissal label to "Don't show for this file" to make the per-file scope explicit.
 - ([#17734](https://github.com/rstudio/rstudio/issues/17734)): Support em dashes and box-drawing characters as native R code section delimiters.
+- ([#8541](https://github.com/rstudio/rstudio/issues/8541)): Add a "Change active editor tab with mouse-wheel" preference (General > Basic > Other) to disable switching the active editor tab by scrolling the mouse wheel over the tab bar.
 
 ### Fixed
 - ([#14202](https://github.com/rstudio/rstudio/issues/14202)): Fixed an issue where RStudio Desktop could hang on startup when offline or on an unreliable network connection.

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -306,6 +306,7 @@ namespace prefs {
 #define kLatexPreviewOnCursorIdleInlineOnly "inline_only"
 #define kLatexPreviewOnCursorIdleAlways "always"
 #define kWrapTabNavigation "wrap_tab_navigation"
+#define kMousewheelChangesEditorTab "mousewheel_changes_editor_tab"
 #define kGlobalTheme "global_theme"
 #define kGlobalThemeDefault "default"
 #define kGlobalThemeAlternate "alternate"
@@ -1526,6 +1527,12 @@ public:
     */
    bool wrapTabNavigation();
    core::Error setWrapTabNavigation(bool val);
+
+   /**
+    * Whether scrolling the mouse wheel over the editor tab bar changes the active editor tab.
+    */
+   bool mousewheelChangesEditorTab();
+   core::Error setMousewheelChangesEditorTab(bool val);
 
    /**
     * The theme to use for the main RStudio user interface.

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -1605,6 +1605,16 @@
    clear = function() { .rs.clearUserPref("wrap_tab_navigation") }
 )
 
+# Change active editor tab with mouse-wheel
+#
+# Whether scrolling the mouse wheel over the editor tab bar changes the active
+# editor tab.
+.rs.uiPrefs$mousewheelChangesEditorTab <- list(
+   get = function() { .rs.getUserPref("mousewheel_changes_editor_tab") },
+   set = function(value) { .rs.setUserPref("mousewheel_changes_editor_tab", value) },
+   clear = function() { .rs.clearUserPref("mousewheel_changes_editor_tab") }
+)
+
 # Global theme
 #
 # The theme to use for the main RStudio user interface.

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -1605,7 +1605,7 @@
    clear = function() { .rs.clearUserPref("wrap_tab_navigation") }
 )
 
-# Change active editor tab with mouse-wheel
+# Change active editor tab with mouse wheel
 #
 # Whether scrolling the mouse wheel over the editor tab bar changes the active
 # editor tab.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2247,6 +2247,19 @@ core::Error UserPrefValues::setWrapTabNavigation(bool val)
 }
 
 /**
+ * Whether scrolling the mouse wheel over the editor tab bar changes the active editor tab.
+ */
+bool UserPrefValues::mousewheelChangesEditorTab()
+{
+   return readPref<bool>("mousewheel_changes_editor_tab");
+}
+
+core::Error UserPrefValues::setMousewheelChangesEditorTab(bool val)
+{
+   return writePref("mousewheel_changes_editor_tab", val);
+}
+
+/**
  * The theme to use for the main RStudio user interface.
  */
 std::string UserPrefValues::globalTheme()
@@ -3967,6 +3980,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kDocOutlineShow,
       kLatexPreviewOnCursorIdle,
       kWrapTabNavigation,
+      kMousewheelChangesEditorTab,
       kGlobalTheme,
       kUseDarkThemeModalDialogs,
       kGitDiffIgnoreWhitespace,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1198,7 +1198,7 @@
         "mousewheel_changes_editor_tab": {
             "type": "boolean",
             "default": true,
-            "title": "Change active editor tab with mouse-wheel",
+            "title": "Change active editor tab with mouse wheel",
             "description": "Whether scrolling the mouse wheel over the editor tab bar changes the active editor tab."
         },
         "global_theme": {

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1195,6 +1195,12 @@
             "title": "Wrap around when going to previous/next tab",
             "description": "Whether to wrap around when going to the previous or next editor tab."
         },
+        "mousewheel_changes_editor_tab": {
+            "type": "boolean",
+            "default": true,
+            "title": "Change active editor tab with mouse-wheel",
+            "description": "Whether scrolling the mouse wheel over the editor tab bar changes the active editor tab."
+        },
         "global_theme": {
             "type": "string",
             "default": "default",

--- a/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
@@ -607,6 +607,12 @@ public class DocTabLayoutPanel
          else if (event.getType() == "wheel" ||
                   event.getType() == "mousewheel")
          {
+            // only translate wheel scroll into tab selection when the user
+            // has left this behavior enabled
+            if (!RStudioGinjector.INSTANCE.getUserPrefs()
+                  .mousewheelChangesEditorTab().getValue())
+               return;
+
             // extract the delta from the wheel event (note that this could be
             // zero)
             JsObject evt = event.cast();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -215,6 +215,7 @@ public class UserPrefsAccessor extends Prefs
    public static final String DOC_OUTLINE_SHOW = "doc_outline_show";
    public static final String LATEX_PREVIEW_ON_CURSOR_IDLE = "latex_preview_on_cursor_idle";
    public static final String WRAP_TAB_NAVIGATION = "wrap_tab_navigation";
+   public static final String MOUSEWHEEL_CHANGES_EDITOR_TAB = "mousewheel_changes_editor_tab";
    public static final String GLOBAL_THEME = "global_theme";
    public static final String USE_DARK_THEME_MODAL_DIALOGS = "use_dark_theme_modal_dialogs";
    public static final String GIT_DIFF_IGNORE_WHITESPACE = "git_diff_ignore_whitespace";
@@ -2777,6 +2778,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Whether scrolling the mouse wheel over the editor tab bar changes the active editor tab.
+    */
+   public PrefValue<Boolean> mousewheelChangesEditorTab()
+   {
+      return bool(
+         "mousewheel_changes_editor_tab",
+         _constants.mousewheelChangesEditorTabTitle(), 
+         _constants.mousewheelChangesEditorTabDescription(), 
+         true);
+   }
+
+   /**
     * The theme to use for the main RStudio user interface.
     */
    public PrefValue<String> globalTheme()
@@ -4820,6 +4833,8 @@ public class UserPrefsAccessor extends Prefs
          latexPreviewOnCursorIdle().setValue(layer, source.getString("latex_preview_on_cursor_idle"));
       if (source.hasKey("wrap_tab_navigation"))
          wrapTabNavigation().setValue(layer, source.getBool("wrap_tab_navigation"));
+      if (source.hasKey("mousewheel_changes_editor_tab"))
+         mousewheelChangesEditorTab().setValue(layer, source.getBool("mousewheel_changes_editor_tab"));
       if (source.hasKey("global_theme"))
          globalTheme().setValue(layer, source.getString("global_theme"));
       if (source.hasKey("use_dark_theme_modal_dialogs"))
@@ -5233,6 +5248,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(docOutlineShow());
       prefs.add(latexPreviewOnCursorIdle());
       prefs.add(wrapTabNavigation());
+      prefs.add(mousewheelChangesEditorTab());
       prefs.add(globalTheme());
       prefs.add(useDarkThemeModalDialogs());
       prefs.add(gitDiffIgnoreWhitespace());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -1450,7 +1450,7 @@ public interface UserPrefsAccessorConstants extends Constants {
    /**
     * Whether scrolling the mouse wheel over the editor tab bar changes the active editor tab.
     */
-   @DefaultStringValue("Change active editor tab with mouse-wheel")
+   @DefaultStringValue("Change active editor tab with mouse wheel")
    String mousewheelChangesEditorTabTitle();
    @DefaultStringValue("Whether scrolling the mouse wheel over the editor tab bar changes the active editor tab.")
    String mousewheelChangesEditorTabDescription();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -1448,6 +1448,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String wrapTabNavigationDescription();
 
    /**
+    * Whether scrolling the mouse wheel over the editor tab bar changes the active editor tab.
+    */
+   @DefaultStringValue("Change active editor tab with mouse-wheel")
+   String mousewheelChangesEditorTabTitle();
+   @DefaultStringValue("Whether scrolling the mouse wheel over the editor tab bar changes the active editor tab.")
+   String mousewheelChangesEditorTabDescription();
+
+   /**
     * The theme to use for the main RStudio user interface.
     */
    @DefaultStringValue("Global theme")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -730,7 +730,7 @@ wrapTabNavigationTitle = Wrap around when going to previous/next tab
 wrapTabNavigationDescription = Whether to wrap around when going to the previous or next editor tab.
 
 # Whether scrolling the mouse wheel over the editor tab bar changes the active editor tab.
-mousewheelChangesEditorTabTitle = Change active editor tab with mouse-wheel
+mousewheelChangesEditorTabTitle = Change active editor tab with mouse wheel
 mousewheelChangesEditorTabDescription = Whether scrolling the mouse wheel over the editor tab bar changes the active editor tab.
 
 # The theme to use for the main RStudio user interface.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -729,6 +729,10 @@ latexPreviewOnCursorIdleDescription = When to preview LaTeX mathematical equatio
 wrapTabNavigationTitle = Wrap around when going to previous/next tab
 wrapTabNavigationDescription = Whether to wrap around when going to the previous or next editor tab.
 
+# Whether scrolling the mouse wheel over the editor tab bar changes the active editor tab.
+mousewheelChangesEditorTabTitle = Change active editor tab with mouse-wheel
+mousewheelChangesEditorTabDescription = Whether scrolling the mouse wheel over the editor tab bar changes the active editor tab.
+
 # The theme to use for the main RStudio user interface.
 globalThemeTitle = Global theme
 globalThemeDescription = The theme to use for the main RStudio user interface.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
@@ -689,6 +689,10 @@ latexPreviewOnCursorIdleDescription= Quand prévisualiser les équations mathém
 wrapTabNavigationTitle= Retournement lors du passage à l'onglet précédent/suivant
 wrapTabNavigationDescription= Indiquer ou non, s'il faut envelopper le document lors du passage à l'onglet précédent ou suivant de l'éditeur.
 
+# Whether scrolling the mouse wheel over the editor tab bar changes the active editor tab.
+mousewheelChangesEditorTabTitle= Changer l'onglet actif de l'éditeur avec la molette de la souris
+mousewheelChangesEditorTabDescription= Indiquer si le défilement de la molette de la souris sur la barre d'onglets de l'éditeur change l'onglet actif de l'éditeur.
+
 # The theme to use for the main RStudio user interface.
 globalThemeTitle= Thème global
 globalThemeDescription= Le thème à utiliser pour l'interface utilisateur principale de RStudio.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -218,6 +218,8 @@ public class GeneralPreferencesPane extends PreferencesPane
          basic.add(enableMouseWheelZoom);
       }
 
+      basic.add(checkboxPref(prefs_.mousewheelChangesEditorTab()));
+
       VerticalTabPanel graphics = new VerticalTabPanel(ElementIds.GENERAL_GRAPHICS_PREFS);
 
       initializeGraphicsBackendWidget();


### PR DESCRIPTION
## Intent

Closes #8541.

## Changes

Adds a boolean user preference `mousewheel_changes_editor_tab` (default `true`, preserving current behavior). It appears as a checkbox labeled "Change active editor tab with mouse wheel" in General > Basic > Other, below all existing settings.

When the preference is unchecked, scrolling the mouse wheel over the editor tab bar no longer switches the active editor tab. The wheel handler in `DocTabLayoutPanel` reads the preference and skips tab selection when it is disabled.

The preference and its accessors were generated from the schema with `scripts/generate-prefs.R`. The French translation in `UserPrefsAccessorConstants_fr.properties` was added by hand, as the generator does not write that file.

## Screenshot

<img width="663" height="687" alt="editor-tab-mouse-wheel-setting screenshot" src="https://github.com/user-attachments/assets/e808aac1-834f-4cad-9f17-891a3ae603bf" />

Note: changing to drop the "-" in "mouse-wheel" for consistency with pre-existing settings. Not updating the screenshot.
