### PR TITLE
Raise CMake minimum required version to 3.19.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 #
 #
 
-cmake_minimum_required(VERSION 3.6.3)
+cmake_minimum_required(VERSION 3.19.8)
 
 # initialize
 include(cmake/init.cmake)

--- a/package/osx/cmake/codesign-package.cmake
+++ b/package/osx/cmake/codesign-package.cmake
@@ -13,7 +13,7 @@
 #
 #
 
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.19.8)
 
 # CMake's message is suppressed during install stage so just use echo here
 function(echo MESSAGE)

--- a/package/osx/cmake/prepare-package.cmake
+++ b/package/osx/cmake/prepare-package.cmake
@@ -13,7 +13,7 @@
 #
 #
 
-cmake_minimum_required(VERSION 3.6.3)
+cmake_minimum_required(VERSION 3.19.8)
 
 # CMake's message is suppressed during install stage so just use echo here
 function(echo MESSAGE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,7 @@
 #
 
 # set minimum version
-cmake_minimum_required(VERSION 3.6.3)
+cmake_minimum_required(VERSION 3.19.8)
 
 # don't add gwt for special 32-bit binary builds on windows (since
 # we've already got it from the 64-bit build), for development mode

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 
 # set minimum version
-cmake_minimum_required(VERSION 3.6.3)
+cmake_minimum_required(VERSION 3.19.8)
 
 # initialize
 include("${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/init.cmake")

--- a/src/gwt/CMakeLists.txt
+++ b/src/gwt/CMakeLists.txt
@@ -13,7 +13,7 @@
 #
 #
 
-cmake_minimum_required(VERSION 3.6.3)
+cmake_minimum_required(VERSION 3.19.8)
 project (RSTUDIO_GWT)
 
 # define output dirs

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -12,7 +12,7 @@
 #
 
 # set minimum version
-cmake_minimum_required(VERSION 3.6.3)
+cmake_minimum_required(VERSION 3.19.8)
 
 # don't add electron for development mode (since faster to work
 # iteratively using "npm start" and so forth)

--- a/src/node/desktop/CMakeLists.txt
+++ b/src/node/desktop/CMakeLists.txt
@@ -13,7 +13,7 @@
 #
 #
 
-cmake_minimum_required(VERSION 3.6.3)
+cmake_minimum_required(VERSION 3.19.8)
 project(ELECTRON_DESKTOP)
 
 if (LINUX)


### PR DESCRIPTION
## Summary

Raises `cmake_minimum_required` from `3.6.3` to `3.19.8` across the project's
CMake files, clearing the deprecation warning emitted by recent CMake versions:

> Compatibility with CMake < 3.10 will be removed from a future version of CMake.

`3.19.8` matches the documented minimum in `dependencies/linux/README`
("CMake 3.19.8 or newer"), so the declared requirement and the docs stay in
sync. It is satisfied by every cmake the project installs: the Jenkins build
images source-build `3.25.2` via `package/linux/install-dependencies`, and the
package-manager paths in the per-distro setup scripts (EL8 yum `3.20.2`, Ubuntu
noble `3.28`) are all >= `3.19.8`.

Files updated:
- `CMakeLists.txt`
- `src/CMakeLists.txt`
- `src/cpp/CMakeLists.txt`
- `src/gwt/CMakeLists.txt`
- `src/node/CMakeLists.txt`
- `src/node/desktop/CMakeLists.txt`
- `package/osx/cmake/prepare-package.cmake`
- `package/osx/cmake/codesign-package.cmake` (was `3.19`)

## Testing

Reconfigured the backend build; no RStudio-owned CMake deprecation warnings
remain. The only warnings left come from vendored dependencies under
`build/_deps/` (gsl-lite, libgit2, yaml-cpp), which are not RStudio source.
