### PR TITLE
Migrate test_desktop_EnvironmentPane.py to Playwright

### DIFF
--- a/.claude/skills/rstudio-migrate-tests-selenium-to-playwright/SKILL.md
+++ b/.claude/skills/rstudio-migrate-tests-selenium-to-playwright/SKILL.md
@@ -16,11 +16,11 @@ The user provides one or more targets:
 
 ## Hard Rules
 
-1. **Load skills first** — Always load `rstudio-create-playwright-tests` before doing any conversion work.
+1. **Load skills and the README first** — Before doing any conversion work, always: (a) load `rstudio-create-playwright-tests`; (b) read `e2e/rstudio/README.md` in full, the suite's primary reference (read it fresh for each migration; don't assume it was read earlier in the session); (c) load `rstudio-run-playwright-tests`, whose run protocol governs the verification in Hard Rule 5.
 2. **Check MIGRATION_FROM_SELENIUM_PROGRESS.md** — Before starting, verify the file hasn't already been converted or partially converted. Located at `e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md`.
-4. **Tests must work on Desktop and Server** — Use the unified fixture (`@fixtures/rstudio.fixture`). Don't hardcode Desktop-only patterns.
-5. **No Claude dependency** — All test infrastructure must be runnable from terminal, CI, and GitHub Actions. Claude subagents are a convenience layer, not a requirement.
-6. **A test isn't migrated until it passes.** Run the converted TypeScript test against a live RStudio instance (Desktop or Server, depending on target). Retry up to 3 times. If it still fails, mark it `test.fixme()` with a blocker note and track it as Fixme in `MIGRATION_FROM_SELENIUM_PROGRESS.md`. Do not list a fixme test as migrated in summaries, PR descriptions, or progress tracking.
+3. **Tests must work on Desktop and Server, and on Windows, macOS, and Linux** — Use the unified fixture (`@fixtures/rstudio.fixture`). Don't hardcode Desktop-only or OS-specific patterns; use cross-platform shortcuts (`ControlOrMeta` where appropriate) and `process.platform` guards, or tag mode/OS-specific tests (`@desktop_only`, `@windows_only`, etc.).
+4. **No Claude dependency** — All test infrastructure must be runnable from terminal, CI, and GitHub Actions. Claude subagents are a convenience layer, not a requirement.
+5. **A test isn't migrated until it passes.** Run the converted TypeScript test against a live RStudio instance (Desktop or Server, depending on target). Retry up to 3 times. If it still fails, mark it `test.fixme()` with a blocker note and track it as Fixme in `MIGRATION_FROM_SELENIUM_PROGRESS.md`. Do not list a fixme test as migrated in summaries, PR descriptions, or progress tracking.
 
 ## Steps
 
@@ -33,6 +33,8 @@ The user provides one or more targets:
 ### Step 2: Read reference materials
 
 - Load `rstudio-create-playwright-tests` skill
+- Read `e2e/rstudio/README.md` in full -- the suite's primary reference; read it fresh for each migration, don't assume it was read earlier in the session
+- Load `rstudio-run-playwright-tests` skill -- its run protocol governs the verification gate (Hard Rule 5)
 - Check `rstudio-ide-automation/rstudio_server_pro/electron-tests/` for other Selenium/Selene electron tests covering the same functionality — useful for test logic, assertions, and expected values
 - Check `rstudio-ide-automation/rstudio_server_pro/tests/` for Selenium/Selene server tests covering the same functionality — useful for test logic, assertions, and expected values
 - Check `rstudio-pro/e2e/` for Workbench e2e patterns (examples include `.or()` locator chaining, `clickIfVisible()` helpers, input fill with retry, reload-on-hang recovery) -- look for anything else reusable
@@ -84,7 +86,7 @@ If the test needs locators or methods not yet available:
 
 ### Step 6: Run the test
 
-**Hard gate (Hard Rule 6):** a test doesn't count as migrated until it passes here.
+**Hard gate (Hard Rule 5):** a test doesn't count as migrated until it passes here.
 
 Defer to the `rstudio-run-playwright-tests` skill for the canonical run commands (Desktop and Server). Present the command and wait for user approval before executing.
 
@@ -154,7 +156,7 @@ Present the assessed findings with recommendations. Wait for approval before edi
 - Fix Low findings only if they're real bugs or silent failures
 - Skip cosmetic Lows and "add tests for simple scripts" suggestions
 
-Apply fixes manually. **Do not invoke `roborev-fix`** -- Ron prefers manual fixes through the migration flow. Re-run the test (Hard Rule 6 still applies). Commit per Step 9. Re-run `roborev-review` on the new commit. Repeat until no actionable findings remain.
+Apply fixes manually. **Do not invoke `roborev-fix`** -- Ron prefers manual fixes through the migration flow. Re-run the test (Hard Rule 5 still applies). Commit per Step 9. Re-run `roborev-review` on the new commit. Repeat until no actionable findings remain.
 
 Close reviewed findings via the `roborev-respond` skill once they're addressed.
 

--- a/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
+++ b/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
@@ -9,9 +9,9 @@ Target: `e2e/rstudio/tests/`
 |--------|-------|
 | Total electron test files | 32 |
 | Total electron test methods | 115 |
-| Files fully converted | 15 |
+| Files fully converted | 16 |
 | Files partially converted | 0 |
-| Files not started | 17 |
+| Files not started | 16 |
 
 ## Conversion Status
 
@@ -22,7 +22,7 @@ Target: `e2e/rstudio/tests/`
 | test_desktop_Citations.py | 17 | — | Not started | |
 | test_desktop_Command_Palette.py | 2 | panes/misc/command-palette.test.ts (2) | Complete | |
 | test_desktop_console.py | 11 | panes/console/console_pane.test.ts (8), panes/console/console_command_effects.test.ts (7), panes/console/execute_from_editor.test.ts (1) | Complete | Split by theme; added Find in Console coverage (3 new tests) and upgraded `help.start()` to verify help-pane contents |
-| test_desktop_EnvironmentPane.py | 5 | — | Not started | |
+| test_desktop_EnvironmentPane.py | 5 | panes/environment/environment_pane.test.ts (5) | Complete | Toolbar elements, the import-dataset/object-view/environment-list dropdowns, and memory-pie growth + usage-report modal. No Desktop-only assumptions; the Selenium maximize/restore workaround was dropped. |
 | test_desktop_FindInFiles.py | 3 | panes/misc/find-in-files.test.ts (3) | Complete | |
 | test_desktop_Package_Installation.py | 1 | — | Not started | |
 | test_desktop_PlotsPane.py | 11 | — | Not started | |

--- a/e2e/rstudio/pages/environment_pane.page.ts
+++ b/e2e/rstudio/pages/environment_pane.page.ts
@@ -19,12 +19,74 @@ export class EnvironmentPane extends PageObject {
   public clearWorkspaceBtn: Locator;
   public objectGridRows: Locator;
 
+  // Toolbar buttons.
+  public searchBar: Locator;
+  public refreshWorkspaceBtn: Locator;
+  public loadWorkspaceBtn: Locator;
+  public saveWorkspaceBtn: Locator;
+  public memoryPieBtn: Locator;
+
+  // Toolbar menu buttons (each opens a dropdown menu).
+  public importDatasetMenu: Locator;
+  public viewMenu: Locator;
+  public envListMenu: Locator;
+
+  // Import Dataset menu items.
+  public datasetTextBase: Locator;
+  public datasetTextReadr: Locator;
+  public datasetExcel: Locator;
+  public datasetSpss: Locator;
+  public datasetSas: Locator;
+  public datasetStata: Locator;
+
+  // Object-view menu items.
+  public listViewOption: Locator;
+  public gridViewOption: Locator;
+
+  // Environment-list menu items.
+  public globalEnvOption: Locator;
+  public packageStats: Locator;
+  public packageGraphics: Locator;
+  public packageGrDevices: Locator;
+  public packageUtils: Locator;
+  public packageMethods: Locator;
+  public packageBase: Locator;
+
   constructor(page: Page) {
     super(page);
     this.panel = page.locator(ENV_PANEL);
     this.tab = page.locator(ENV_TAB);
     this.clearWorkspaceBtn = page.locator(CLEAR_WORKSPACE_BTN);
     this.objectGridRows = this.panel.locator('table tr');
+
+    this.searchBar = page.locator('#rstudio_sw_environment');
+    this.refreshWorkspaceBtn = page.locator('#rstudio_tb_refreshenvironment');
+    this.loadWorkspaceBtn = page.locator('#rstudio_tb_loadworkspace');
+    this.saveWorkspaceBtn = page.locator('#rstudio_tb_saveworkspace');
+    // The pie-crust div carries the stable id; the adjacent button is the menu.
+    this.memoryPieBtn = page.locator('#rstudio_memory_pie_mini + button');
+
+    this.importDatasetMenu = page.locator('#rstudio_mb_import_dataset');
+    this.viewMenu = page.locator('#rstudio_mb_object_list_view');
+    this.envListMenu = page.locator('#rstudio_mb_environment_list');
+
+    this.datasetTextBase = page.locator('#rstudio_label_from_text_base_command');
+    this.datasetTextReadr = page.locator('#rstudio_label_from_text_readr_command');
+    this.datasetExcel = page.locator('#rstudio_label_from_excel_command');
+    this.datasetSpss = page.locator('#rstudio_label_from_spss_command');
+    this.datasetSas = page.locator('#rstudio_label_from_sas_command');
+    this.datasetStata = page.locator('#rstudio_label_from_stata_command');
+
+    this.listViewOption = page.locator('#rstudio_label_list_command');
+    this.gridViewOption = page.locator('#rstudio_label_grid_command');
+
+    this.globalEnvOption = page.locator('#rstudio_label_global_environment_command');
+    this.packageStats = page.locator('#rstudio_label_package_stats_command');
+    this.packageGraphics = page.locator('#rstudio_label_package_graphics_command');
+    this.packageGrDevices = page.locator('#rstudio_label_package_grdevices_command');
+    this.packageUtils = page.locator('#rstudio_label_package_utils_command');
+    this.packageMethods = page.locator('#rstudio_label_package_methods_command');
+    this.packageBase = page.locator('#rstudio_label_package_base_command');
   }
 
   async getPanelText(): Promise<string> {
@@ -56,6 +118,28 @@ export class EnvironmentPane extends PageObject {
    *  whole-panel level rather than the call-frame region itself. */
   callFrameByText(frameLabel: string, exact = false): Locator {
     return this.panel.getByText(frameLabel, { exact });
+  }
+
+  /** Read the memory figure on the Environment pane's memory-pie button and
+   *  normalize it to MiB. MemUsageWidget.formatBigMemory renders the text as
+   *  "<n> MiB" or "<x.yy> GiB" (and "Memory" before the first usage sample
+   *  arrives), so this returns null when no numeric value is present yet --
+   *  callers can poll. Normalizing the unit avoids the cross-environment bug
+   *  where stripping non-digits compares "1.2 GiB" (-> 12) against
+   *  "850 MiB" (-> 850). */
+  async getMemoryMiB(): Promise<number | null> {
+    const text = (await this.memoryPieBtn.innerText()).trim();
+    const match = text.match(/([\d.,]+)\s*(KiB|MiB|GiB|TiB)/i);
+    if (!match) return null;
+    const value = parseFloat(match[1].replace(/,/g, ''));
+    if (Number.isNaN(value)) return null;
+    const factorToMiB: Record<string, number> = {
+      kib: 1 / 1024,
+      mib: 1,
+      gib: 1024,
+      tib: 1024 * 1024,
+    };
+    return value * factorToMiB[match[2].toLowerCase()];
   }
 }
 

--- a/e2e/rstudio/tests/panes/environment/environment_pane.test.ts
+++ b/e2e/rstudio/tests/panes/environment/environment_pane.test.ts
@@ -1,0 +1,110 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { EnvironmentPane, clearWorkspace } from '@pages/environment_pane.page';
+import { CONFIRM_BTN } from '@pages/modals.page';
+import { executeCommand } from '@utils/commands';
+import { TIMEOUTS } from '@utils/constants';
+
+let envPane: EnvironmentPane;
+let consoleActions: ConsolePaneActions;
+
+test.describe('Environment pane', () => {
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    envPane = new EnvironmentPane(page);
+    consoleActions = new ConsolePaneActions(page);
+    await consoleActions.resetSourcePane();
+  });
+
+  test.beforeEach(async () => {
+    // Every test operates on the Environment tab; make it active first.
+    await envPane.tab.click();
+  });
+
+  test('toolbar elements are displayed', async () => {
+    await expect(envPane.panel).toBeVisible();
+    await expect(envPane.searchBar).toBeVisible();
+    await expect(envPane.refreshWorkspaceBtn).toBeVisible();
+    await expect(envPane.memoryPieBtn).toBeVisible();
+    await expect(envPane.clearWorkspaceBtn).toBeVisible();
+    await expect(envPane.loadWorkspaceBtn).toBeVisible();
+    await expect(envPane.saveWorkspaceBtn).toBeVisible();
+  });
+
+  test('import dataset dropdown lists every source', async ({ rstudioPage: page }) => {
+    await envPane.importDatasetMenu.click();
+
+    await expect(envPane.datasetTextBase).toBeVisible();
+    await expect(envPane.datasetTextReadr).toBeVisible();
+    await expect(envPane.datasetExcel).toBeVisible();
+    await expect(envPane.datasetSpss).toBeVisible();
+    await expect(envPane.datasetSas).toBeVisible();
+    await expect(envPane.datasetStata).toBeVisible();
+
+    await page.keyboard.press('Escape');
+  });
+
+  test('object-view dropdown shows list and grid views', async ({ rstudioPage: page }) => {
+    await envPane.viewMenu.click();
+
+    await expect(envPane.listViewOption).toBeVisible();
+    await expect(envPane.gridViewOption).toBeVisible();
+
+    await page.keyboard.press('Escape');
+  });
+
+  test('environment-list dropdown shows the global environment and packages', async ({
+    rstudioPage: page,
+  }) => {
+    await envPane.envListMenu.click();
+
+    await expect(envPane.globalEnvOption).toBeVisible();
+    await expect(envPane.packageStats).toBeVisible();
+    await expect(envPane.packageGraphics).toBeVisible();
+    await expect(envPane.packageGrDevices).toBeVisible();
+    await expect(envPane.packageUtils).toBeVisible();
+    await expect(envPane.packageMethods).toBeVisible();
+    await expect(envPane.packageBase).toBeVisible();
+
+    await page.keyboard.press('Escape');
+  });
+
+  test('memory pie grows with allocation and the usage report opens', async ({
+    rstudioPage: page,
+  }) => {
+    // Start from a clean workspace so the only Values row is the one we add.
+    await clearWorkspace(page);
+    await consoleActions.clearConsole();
+
+    // Wait for the pie to report a concrete positive figure (it reads "Memory"
+    // until the first usage sample arrives), then capture the baseline in MiB.
+    await expect.poll(() => envPane.getMemoryMiB(), { timeout: TIMEOUTS.memoryUsageUpdate })
+      .toBeGreaterThan(0);
+    const before = (await envPane.getMemoryMiB())!;
+
+    // Allocate ~76 MiB (1e7 doubles) -- well above the pie's 1 MiB resolution.
+    await consoleActions.executeInConsole('bigval <- runif(1e7)');
+    await expect(envPane.panel).toContainText('bigval');
+
+    // The pie samples on an interval, so poll for the increase rather than
+    // reading once. Unit-normalized comparison (MiB) avoids the GiB/MiB trap.
+    await expect
+      .poll(
+        async () => {
+          const after = await envPane.getMemoryMiB();
+          return after !== null && after > before;
+        },
+        { timeout: TIMEOUTS.memoryUsageUpdate, message: 'memory pie did not grow after allocation' },
+      )
+      .toBe(true);
+
+    // The memory-usage report opens as a modal titled "Memory Usage Report".
+    await executeCommand(page, 'showMemoryUsageReport');
+    const dialog = page.locator('.gwt-DialogBox').filter({ hasText: 'Memory Usage' });
+    await expect(dialog).toBeVisible();
+    await page.locator(CONFIRM_BTN).click();
+    await expect(dialog).toBeHidden();
+
+    // Free the big vector so the shared session doesn't carry ~76 MiB onward.
+    await consoleActions.executeInConsole('rm(bigval)');
+  });
+});

--- a/e2e/rstudio/utils/constants.ts
+++ b/e2e/rstudio/utils/constants.ts
@@ -3,6 +3,9 @@ export const TIMEOUTS = {
   rstudioStartup: 30000,
   consoleReady: 15000,
   sessionRestart: 30000,
+  // The Environment pane requeries memory stats every memory_query_interval_seconds
+  // (default 10s), so a memory-pie change can take a full interval to surface.
+  memoryUsageUpdate: 30000,
   settleDelay: 1000,
   pollInterval: 500,
   fileOpen: 20000,


### PR DESCRIPTION
## Summary

Migrates `test_desktop_EnvironmentPane.py` to the Playwright e2e suite as
`tests/panes/environment/environment_pane.test.ts` (5 tests):

- Toolbar elements are displayed (search bar, refresh, memory pie,
  clear/load/save workspace)
- Import Dataset dropdown lists all six sources (base text, readr, Excel,
  SPSS, SAS, Stata)
- Object-view dropdown shows list and grid views
- Environment-list dropdown shows the global environment and base packages
- Memory pie grows after allocation and the usage-report modal opens

Extends `EnvironmentPane` page object with toolbar/dropdown/menu-item
locators and a unit-normalized `getMemoryMiB()` helper (avoids the MiB/GiB
comparison trap). Adds a `memoryUsageUpdate` timeout constant (the pie
requeries every 10s by default).

The Selenium maximize/restore workaround was dropped -- all targets have
stable IDs and work without it. Tests are mode-agnostic (no `@desktop_only`),
confirmed by the equivalent Server-mode Selenium test.

Also tightens the migration skill's hard rules: reading `e2e/rstudio/README.md`
and loading `rstudio-run-playwright-tests` are now explicit requirements,
rules are renumbered sequentially, and the cross-platform requirement
(Windows/macOS/Linux) is added alongside Desktop/Server.