### PR TITLE
Don't request AI completions in visual mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@
 - ([#17810](https://github.com/rstudio/rstudio/issues/17810)): Fix the "Run Tests" button modifying the active test file's timestamp even when the file had no unsaved changes.
 - ([#17735](https://github.com/rstudio/rstudio/issues/17735)): Hide the redundant column-summary sidebar in the data frame preview shown in the Help pane.
 - ([#17066](https://github.com/rstudio/rstudio/issues/17066)): Fix the Assistant preferences pane showing a stale code-assistant account after switching back and forth between GitHub Copilot and Posit Assistant.
+- ([#17327](https://github.com/rstudio/rstudio/issues/17327)): Stop requesting code completions and next-edit suggestions while editing in visual mode, where suggestions aren't shown, so document contents are no longer sent to the completion backend for suggestions there.
 
 ### Dependencies
 - Ace 1.43.5

--- a/e2e/rstudio/actions/source_pane.actions.ts
+++ b/e2e/rstudio/actions/source_pane.actions.ts
@@ -268,20 +268,15 @@ export class SourcePaneActions {
    * Ensures the editor is in source mode. If already in source mode, does nothing.
    */
   async ensureSourceMode(): Promise<void> {
-    const proseMirror = this.page.locator('.ProseMirror');
-
-    // Already in source mode? The visual editor mounts a .ProseMirror surface;
-    // its absence means we're already in source mode (or the file type has no
-    // visual mode at all).
-    if (!(await proseMirror.first().isVisible().catch(() => false))) return;
-
-    await this.sourcePane.visualMdToggle.click();
-
-    // Wait for the visual editor -- and the embedded chunk/YAML Ace editors it
-    // mounts -- to tear down before returning. Converting a document with
-    // chunks back to source syncs through pandoc, which takes longer than a
-    // fixed sleep can safely cover; returning early leaves multiple Ace editors
-    // mounted and makes the source aceTextInput locator ambiguous for callers.
-    await proseMirror.first().waitFor({ state: 'hidden', timeout: 15000 });
+    const toggle = this.sourcePane.visualMdToggle;
+    try {
+      const ariaPressed = await toggle.getAttribute('aria-pressed', { timeout: 3000 });
+      if (ariaPressed === 'true') {
+        await toggle.click();
+        await sleep(1000);
+      }
+    } catch {
+      // Toggle not found — already in source mode
+    }
   }
 }

--- a/e2e/rstudio/actions/source_pane.actions.ts
+++ b/e2e/rstudio/actions/source_pane.actions.ts
@@ -268,15 +268,20 @@ export class SourcePaneActions {
    * Ensures the editor is in source mode. If already in source mode, does nothing.
    */
   async ensureSourceMode(): Promise<void> {
-    const toggle = this.sourcePane.visualMdToggle;
-    try {
-      const ariaPressed = await toggle.getAttribute('aria-pressed', { timeout: 3000 });
-      if (ariaPressed === 'true') {
-        await toggle.click();
-        await sleep(1000);
-      }
-    } catch {
-      // Toggle not found — already in source mode
-    }
+    const proseMirror = this.page.locator('.ProseMirror');
+
+    // Already in source mode? The visual editor mounts a .ProseMirror surface;
+    // its absence means we're already in source mode (or the file type has no
+    // visual mode at all).
+    if (!(await proseMirror.first().isVisible().catch(() => false))) return;
+
+    await this.sourcePane.visualMdToggle.click();
+
+    // Wait for the visual editor -- and the embedded chunk/YAML Ace editors it
+    // mounts -- to tear down before returning. Converting a document with
+    // chunks back to source syncs through pandoc, which takes longer than a
+    // fixed sleep can safely cover; returning early leaves multiple Ace editors
+    // mounted and makes the source aceTextInput locator ambiguous for callers.
+    await proseMirror.first().waitFor({ state: 'hidden', timeout: 15000 });
   }
 }

--- a/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
@@ -644,8 +644,8 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
       const fileName = `${prefix}_visual_no_completions.qmd`;
 
       // A Quarto doc with prose and an R chunk. Visual mode is only offered for
-      // markdown documents; the chunk gives the source-mode self-validation
-      // step below a place to trigger a real completion.
+      // markdown documents; the chunk also makes the visual editor mount an
+      // embedded Ace editor, exercising the teardown path on the way back.
       const fileContent =
         '---\n' +
         'title: "Visual Mode Completions"\n' +
@@ -675,38 +675,47 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
       await sourceActions.createAndOpenFile(fileName, fileContent);
       await sleep(1000);
 
-      // --- Visual mode: editing must not trigger a completion request ---
-      await sourceActions.ensureVisualMode();
-      const proseMirror = page.locator('.ProseMirror').first();
-      // Fail loudly if visual mode didn't actually activate, rather than
-      // silently exercising source mode and passing for the wrong reason.
-      await expect(proseMirror).toBeVisible({ timeout: 15000 });
+      try {
+        // --- Visual mode: editing must not trigger a completion request ---
+        await sourceActions.ensureVisualMode();
+        const proseMirror = page.locator('.ProseMirror').first();
+        // Fail loudly if visual mode didn't actually activate, rather than
+        // silently exercising source mode and passing for the wrong reason.
+        await expect(proseMirror).toBeVisible({ timeout: 15000 });
 
-      await proseMirror.click();
-      await page.keyboard.type('Typing in the visual editor.');
-      await page.keyboard.press('Enter');
-      await page.keyboard.press('Enter');
+        await proseMirror.click();
+        await page.keyboard.type('Typing in the visual editor.');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
 
-      // Give the visual editor's sync-on-idle, the completion delay, and a
-      // backend round-trip ample time to fire a request, so a regression
-      // (request sent in visual mode) reliably surfaces the status message.
-      await sleep(10000);
+        // Give the visual editor's sync-on-idle, the completion delay, and a
+        // backend round-trip ample time to fire a request, so a regression
+        // (request sent in visual mode) reliably surfaces the status message.
+        await sleep(10000);
 
-      await expect(completionStatus).toHaveCount(0);
-      console.log('  No completion status surfaced in visual mode');
+        await expect(completionStatus).toHaveCount(0);
+        console.log('  No completion status surfaced in visual mode');
 
-      // --- Source mode: completions resume (guards against a false pass and
-      // confirms suppression is scoped to visual mode) ---
-      await sourceActions.ensureSourceMode();
-      await sourceActions.navigateToChunkByIndex(1);
-      await page.keyboard.press('End');
-      await page.keyboard.press('Enter');
-      await page.keyboard.type('y <- fun');
+        // --- Source mode: completions resume (guards against a false pass and
+        // confirms suppression is scoped to visual mode) ---
+        await sourceActions.ensureSourceMode();
+        // The visual editor's embedded chunk/YAML editors must be gone before
+        // we drive the source editor, otherwise aceTextInput is ambiguous.
+        await expect(sourcePane.aceTextInput).toHaveCount(1, { timeout: 15000 });
 
-      await expect(completionStatus.first()).toBeVisible({ timeout: TIMEOUTS.ghostText });
-      console.log('  Completion status surfaced again in source mode');
+        await sourceActions.goToEnd();
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('y <- fun');
 
-      await sourceActions.closeSourceAndDeleteFile(fileName);
+        await expect(completionStatus.first()).toBeVisible({ timeout: TIMEOUTS.ghostText });
+        console.log('  Completion status surfaced again in source mode');
+      } finally {
+        // Never leave the shared (worker-scoped) IDE in visual mode: a lingering
+        // visual editor keeps embedded Ace editors mounted, which makes the
+        // source aceTextInput locator ambiguous and fails every later test.
+        await sourceActions.ensureSourceMode().catch(() => {});
+        await sourceActions.closeSourceAndDeleteFile(fileName).catch(() => {});
+      }
     });
 
     test.afterAll(async ({ rstudioPage: page }) => {

--- a/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
@@ -1,3 +1,4 @@
+import type { Request } from 'playwright';
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { TIMEOUTS, sleep, CODE_SUGGESTION_PROVIDERS } from '@utils/constants';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
@@ -661,58 +662,67 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
         '\n' +
         'Closing prose.\n';
 
-      // The assistant posts a status-bar message for every completion/NES
-      // request: "Waiting for completions..." when the request is sent, then
-      // "Completion response received." / "No completions available." once it
-      // resolves. None of these auto-hide, so such a message in the active
-      // editor's footer after an edit is a reliable signal that a request was
-      // sent. Scope to the visible tab's footer (footerTable) -- a page-wide
-      // match would also pick up a stale status left in a background editor,
-      // e.g. the suite's persistent Untitled tab.
-      const completionStatus = sourcePane.footerTable.locator('.gwt-Label', {
-        hasText: /Waiting for completions|Completion response received|No completions available/,
-      });
+      // The fix suppresses the actual requests to the completion backend, so
+      // assert on the RPC itself rather than the status bar: the status bar's
+      // last message lingers across a source->visual switch (it never
+      // auto-hides), which makes it a misleading proxy. These are the two RPCs
+      // the editor issues for inline completions and next-edit suggestions.
+      const completionRpc = /\/rpc\/(assistant_generate_completions|assistant_next_edit_suggestions)/;
 
       await sourceActions.createAndOpenFile(fileName, fileContent);
       await sleep(1000);
 
       try {
-        // --- Visual mode: editing must not trigger a completion request ---
+        // --- Visual mode: editing must not issue a completion request ---
         await sourceActions.ensureVisualMode();
         const proseMirror = page.locator('.ProseMirror').first();
         // Fail loudly if visual mode didn't actually activate, rather than
         // silently exercising source mode and passing for the wrong reason.
         await expect(proseMirror).toBeVisible({ timeout: 15000 });
 
-        await proseMirror.click();
-        await page.keyboard.type('Typing in the visual editor.');
-        await page.keyboard.press('Enter');
-        await page.keyboard.press('Enter');
+        // Start watching only after visual mode is active, so requests from
+        // opening the document or the source->visual sync don't count.
+        let visualCompletionRpc: string | null = null;
+        const onVisualRequest = (request: Request) => {
+          if (completionRpc.test(request.url())) visualCompletionRpc = request.url();
+        };
+        page.on('request', onVisualRequest);
 
-        // Give the visual editor's sync-on-idle, the completion delay, and a
-        // backend round-trip ample time to fire a request, so a regression
-        // (request sent in visual mode) reliably surfaces the status message.
-        await sleep(10000);
+        try {
+          await proseMirror.click();
+          await page.keyboard.type('Typing in the visual editor.');
+          await page.keyboard.press('Enter');
+          await page.keyboard.press('Enter');
 
-        // Confirm the visual editor's footer is present, so the count-0 check
-        // below is meaningful rather than vacuously matching an absent footer.
-        await expect(sourcePane.footerTable.first()).toBeVisible({ timeout: 15000 });
-        await expect(completionStatus).toHaveCount(0);
-        console.log('  No completion status surfaced in visual mode');
+          // Give the visual editor's sync-on-idle, the completion delay, and a
+          // backend round-trip ample time, so a regression (request issued in
+          // visual mode) reliably shows up.
+          await sleep(10000);
 
-        // --- Source mode: completions resume (guards against a false pass and
-        // confirms suppression is scoped to visual mode) ---
+          expect(
+            visualCompletionRpc,
+            `unexpected completion request in visual mode: ${visualCompletionRpc}`,
+          ).toBeNull();
+          console.log('  No completion request issued in visual mode');
+        } finally {
+          page.off('request', onVisualRequest);
+        }
+
+        // --- Source mode: completions resume. Guards against a false pass,
+        // confirms suppression is scoped to visual mode, and proves the request
+        // monitoring above actually observes these RPCs. ---
         await sourceActions.ensureSourceMode();
         // The visual editor's embedded chunk/YAML editors must be gone before
         // we drive the source editor, otherwise aceTextInput is ambiguous.
         await expect(sourcePane.aceTextInput).toHaveCount(1, { timeout: 15000 });
 
+        // Arm the wait before typing so a fast request isn't missed.
+        const sourceRequest = page.waitForRequest(completionRpc, { timeout: TIMEOUTS.ghostText });
         await sourceActions.goToEnd();
         await page.keyboard.press('Enter');
         await page.keyboard.type('y <- fun');
-
-        await expect(completionStatus.first()).toBeVisible({ timeout: TIMEOUTS.ghostText });
-        console.log('  Completion status surfaced again in source mode');
+        await sourceRequest;
+        console.log('  Completion request issued again in source mode');
       } finally {
         // Never leave the shared (worker-scoped) IDE in visual mode: a lingering
         // visual editor keeps embedded Ace editors mounted, which makes the

--- a/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
@@ -50,6 +50,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
         `${prefix}_nes_leak_a.R`,
         `${prefix}_nes_leak_b.R`,
         `${prefix}_statusbar_nav.R`,
+        `${prefix}_visual_no_completions.qmd`,
       ];
       const unlinkExpr = testFiles.map(f => `"${f}"`).join(', ');
       await consoleActions.executeInConsole(`for (f in c(${unlinkExpr})) unlink(f)`);
@@ -641,6 +642,75 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
       await sourceActions.closeSourceAndDeleteFile(fileName);
     });
 
+    test('no completion requests in visual mode', async ({ rstudioPage: page }) => {
+      const fileName = `${prefix}_visual_no_completions.qmd`;
+
+      // A Quarto doc with prose and an R chunk. Visual mode is only offered for
+      // markdown documents; the chunk gives the source-mode self-validation
+      // step below a place to trigger a real completion.
+      const fileContent =
+        '---\n' +
+        'title: "Visual Mode Completions"\n' +
+        '---\n' +
+        '\n' +
+        '## Section\n' +
+        '\n' +
+        'Some introductory prose.\n' +
+        '\n' +
+        '```{r}\n' +
+        'x <- 1\n' +
+        '```\n' +
+        '\n' +
+        'Closing prose.\n';
+
+      // The assistant posts a status-bar message for every completion/NES
+      // request: "Waiting for completions..." when the request is sent, then
+      // "Completion response received." / "No completions available." once it
+      // resolves. None of these auto-hide, so their presence after an edit is a
+      // reliable signal that a request was sent to the backend. Matched
+      // page-wide (not scoped to the editor footer) so the check holds in
+      // visual mode too.
+      const completionStatus = page.locator('.gwt-Label', {
+        hasText: /Waiting for completions|Completion response received|No completions available/,
+      });
+
+      await sourceActions.createAndOpenFile(fileName, fileContent);
+      await sleep(1000);
+
+      // --- Visual mode: editing must not trigger a completion request ---
+      await sourceActions.ensureVisualMode();
+      const proseMirror = page.locator('.ProseMirror').first();
+      // Fail loudly if visual mode didn't actually activate, rather than
+      // silently exercising source mode and passing for the wrong reason.
+      await expect(proseMirror).toBeVisible({ timeout: 15000 });
+
+      await proseMirror.click();
+      await page.keyboard.type('Typing in the visual editor.');
+      await page.keyboard.press('Enter');
+      await page.keyboard.press('Enter');
+
+      // Give the visual editor's sync-on-idle, the completion delay, and a
+      // backend round-trip ample time to fire a request, so a regression
+      // (request sent in visual mode) reliably surfaces the status message.
+      await sleep(10000);
+
+      await expect(completionStatus).toHaveCount(0);
+      console.log('  No completion status surfaced in visual mode');
+
+      // --- Source mode: completions resume (guards against a false pass and
+      // confirms suppression is scoped to visual mode) ---
+      await sourceActions.ensureSourceMode();
+      await sourceActions.navigateToChunkByIndex(1);
+      await page.keyboard.press('End');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('y <- fun');
+
+      await expect(completionStatus.first()).toBeVisible({ timeout: TIMEOUTS.ghostText });
+      console.log('  Completion status surfaced again in source mode');
+
+      await sourceActions.closeSourceAndDeleteFile(fileName);
+    });
+
     test.afterAll(async ({ rstudioPage: page }) => {
       // Post-suite cleanup: discard any open buffers and delete artifacts.
       // Don't save -- the sandbox is about to be unlinked by useSuiteSandbox's
@@ -663,6 +733,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
         `${prefix}_nes_leak_a.R`,
         `${prefix}_nes_leak_b.R`,
         `${prefix}_statusbar_nav.R`,
+        `${prefix}_visual_no_completions.qmd`,
       ];
       const unlinkExpr = testFiles.map(f => `"${f}"`).join(', ');
       await consoleActions.executeInConsole(`for (f in c(${unlinkExpr})) unlink(f)`);

--- a/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
@@ -664,11 +664,12 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
       // The assistant posts a status-bar message for every completion/NES
       // request: "Waiting for completions..." when the request is sent, then
       // "Completion response received." / "No completions available." once it
-      // resolves. None of these auto-hide, so their presence after an edit is a
-      // reliable signal that a request was sent to the backend. Matched
-      // page-wide (not scoped to the editor footer) so the check holds in
-      // visual mode too.
-      const completionStatus = page.locator('.gwt-Label', {
+      // resolves. None of these auto-hide, so such a message in the active
+      // editor's footer after an edit is a reliable signal that a request was
+      // sent. Scope to the visible tab's footer (footerTable) -- a page-wide
+      // match would also pick up a stale status left in a background editor,
+      // e.g. the suite's persistent Untitled tab.
+      const completionStatus = sourcePane.footerTable.locator('.gwt-Label', {
         hasText: /Waiting for completions|Completion response received|No completions available/,
       });
 
@@ -693,6 +694,9 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
         // (request sent in visual mode) reliably surfaces the status message.
         await sleep(10000);
 
+        // Confirm the visual editor's footer is present, so the count-0 check
+        // below is meaningful rather than vacuously matching an absent footer.
+        await expect(sourcePane.footerTable.first()).toBeVisible({ timeout: 15000 });
         await expect(completionStatus).toHaveCount(0);
         console.log('  No completion status surfaced in visual mode');
 

--- a/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
@@ -52,6 +52,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
         `${prefix}_nes_leak_b.R`,
         `${prefix}_statusbar_nav.R`,
         `${prefix}_visual_no_completions.qmd`,
+        `${prefix}_visual_source_probe.R`,
       ];
       const unlinkExpr = testFiles.map(f => `"${f}"`).join(', ');
       await consoleActions.executeInConsole(`for (f in c(${unlinkExpr})) unlink(f)`);
@@ -642,11 +643,37 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
     });
 
     test('no completion requests in visual mode', async ({ rstudioPage: page }) => {
-      const fileName = `${prefix}_visual_no_completions.qmd`;
+      const qmdFile = `${prefix}_visual_no_completions.qmd`;
+      const rFile = `${prefix}_visual_source_probe.R`;
 
-      // A Quarto doc with prose and an R chunk. Visual mode is only offered for
-      // markdown documents; the chunk also makes the visual editor mount an
-      // embedded Ace editor, exercising the teardown path on the way back.
+      // The two RPCs the editor issues for inline completions and next-edit
+      // suggestions. The fix suppresses these in visual mode, so assert on the
+      // RPC itself -- the status bar's last message lingers across a mode switch
+      // (it never auto-hides) and is a misleading proxy.
+      const completionRpc = /\/rpc\/(assistant_generate_completions|assistant_next_edit_suggestions)/;
+
+      // --- Source mode (plain R file): a completion request IS issued, and the
+      // request monitoring observes it. This guards the visual-mode check below
+      // against a false pass (completions or monitoring silently broken). A
+      // fresh R file is always a single editor, avoiding the ambiguous editor
+      // state a document leaves behind after visual mode. ---
+      await sourceActions.createAndOpenFile(rFile, 'x <- 1\n');
+      try {
+        await sleep(1000);
+        // Arm the wait before typing so a fast request isn't missed.
+        const sourceRequest = page.waitForRequest(completionRpc, { timeout: TIMEOUTS.ghostText });
+        await sourceActions.goToEnd();
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('y <- fun');
+        await sourceRequest;
+        console.log('  Completion request issued in source mode');
+      } finally {
+        await sourceActions.closeSourceAndDeleteFile(rFile).catch(() => {});
+      }
+
+      // --- Visual mode (Quarto doc): editing must not issue a completion
+      // request. Visual mode is only offered for markdown documents; the chunk
+      // makes the visual editor mount an embedded Ace editor as well. ---
       const fileContent =
         '---\n' +
         'title: "Visual Mode Completions"\n' +
@@ -662,18 +689,9 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
         '\n' +
         'Closing prose.\n';
 
-      // The fix suppresses the actual requests to the completion backend, so
-      // assert on the RPC itself rather than the status bar: the status bar's
-      // last message lingers across a source->visual switch (it never
-      // auto-hides), which makes it a misleading proxy. These are the two RPCs
-      // the editor issues for inline completions and next-edit suggestions.
-      const completionRpc = /\/rpc\/(assistant_generate_completions|assistant_next_edit_suggestions)/;
-
-      await sourceActions.createAndOpenFile(fileName, fileContent);
-      await sleep(1000);
-
+      await sourceActions.createAndOpenFile(qmdFile, fileContent);
       try {
-        // --- Visual mode: editing must not issue a completion request ---
+        await sleep(1000);
         await sourceActions.ensureVisualMode();
         const proseMirror = page.locator('.ProseMirror').first();
         // Fail loudly if visual mode didn't actually activate, rather than
@@ -707,28 +725,12 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
         } finally {
           page.off('request', onVisualRequest);
         }
-
-        // --- Source mode: completions resume. Guards against a false pass,
-        // confirms suppression is scoped to visual mode, and proves the request
-        // monitoring above actually observes these RPCs. ---
-        await sourceActions.ensureSourceMode();
-        // The visual editor's embedded chunk/YAML editors must be gone before
-        // we drive the source editor, otherwise aceTextInput is ambiguous.
-        await expect(sourcePane.aceTextInput).toHaveCount(1, { timeout: 15000 });
-
-        // Arm the wait before typing so a fast request isn't missed.
-        const sourceRequest = page.waitForRequest(completionRpc, { timeout: TIMEOUTS.ghostText });
-        await sourceActions.goToEnd();
-        await page.keyboard.press('Enter');
-        await page.keyboard.type('y <- fun');
-        await sourceRequest;
-        console.log('  Completion request issued again in source mode');
       } finally {
-        // Never leave the shared (worker-scoped) IDE in visual mode: a lingering
-        // visual editor keeps embedded Ace editors mounted, which makes the
-        // source aceTextInput locator ambiguous and fails every later test.
-        await sourceActions.ensureSourceMode().catch(() => {});
-        await sourceActions.closeSourceAndDeleteFile(fileName).catch(() => {});
+        // Closing the tab tears down the visual editor entirely. Prefer this to
+        // toggling back to source mode, which only hides the panmirror and
+        // leaves its embedded Ace editors mounted -- that makes the source
+        // aceTextInput locator ambiguous for later tests in the shared IDE.
+        await sourceActions.closeSourceAndDeleteFile(qmdFile).catch(() => {});
       }
     });
 
@@ -755,6 +757,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
         `${prefix}_nes_leak_b.R`,
         `${prefix}_statusbar_nav.R`,
         `${prefix}_visual_no_completions.qmd`,
+        `${prefix}_visual_source_probe.R`,
       ];
       const unlinkExpr = testFiles.map(f => `"${f}"`).join(', ');
       await consoleActions.executeInConsole(`for (f in c(${unlinkExpr})) unlink(f)`);

--- a/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
@@ -648,8 +648,8 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
 
       // The two RPCs the editor issues for inline completions and next-edit
       // suggestions. The fix suppresses these in visual mode, so assert on the
-      // RPC itself -- the status bar's last message lingers across a mode switch
-      // (it never auto-hides) and is a misleading proxy.
+      // RPC itself -- the status bar can retain its last message across a mode
+      // switch, which makes it a misleading proxy.
       const completionRpc = /\/rpc\/(assistant_generate_completions|assistant_next_edit_suggestions)/;
 
       // --- Source mode (plain R file): a completion request IS issued, and the
@@ -672,13 +672,10 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
       }
 
       // --- Visual mode (Quarto doc): editing must not issue a completion
-      // request. Visual mode is only offered for markdown documents; the chunk
-      // makes the visual editor mount an embedded Ace editor as well. ---
+      // request -- neither in prose nor inside the code chunk's embedded editor.
+      // Visual mode is only offered for markdown documents. No YAML header, so
+      // the R chunk is the only embedded editor (simplifies targeting it). ---
       const fileContent =
-        '---\n' +
-        'title: "Visual Mode Completions"\n' +
-        '---\n' +
-        '\n' +
         '## Section\n' +
         '\n' +
         'Some introductory prose.\n' +
@@ -711,6 +708,17 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
           await page.keyboard.type('Typing in the visual editor.');
           await page.keyboard.press('Enter');
           await page.keyboard.press('Enter');
+
+          // Also type inside the code chunk's embedded Ace editor -- where a
+          // user writes code and where completions would normally fire. Its
+          // edits reach completions through the same source documentChanged
+          // handler the guard sits on. Force-click because an ace_content
+          // overlay intercepts normal clicks on the hidden textarea.
+          const chunkInput = page.locator('.ProseMirror textarea.ace_text-input').first();
+          await chunkInput.click({ force: true });
+          await page.keyboard.press('End');
+          await page.keyboard.press('Enter');
+          await page.keyboard.type('y <- fun');
 
           // Give the visual editor's sync-on-idle, the completion delay, and a
           // backend round-trip ample time, so a regression (request issued in

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetAssistantHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetAssistantHelper.java
@@ -1327,6 +1327,12 @@ public class TextEditingTargetAssistantHelper
             if (assistantDisabledInThisDocument_)
                return;
 
+            // Completions aren't surfaced in visual mode, so don't request them
+            // (which would needlessly exchange document contents with the
+            // completion backend). See issue #17327.
+            if (target_.isVisualEditorActive())
+               return;
+
             target_.withSavedDoc(() ->
             {
                requestId_ += 1;
@@ -1956,6 +1962,12 @@ public class TextEditingTargetAssistantHelper
          return;
 
       if (completionRequestsSuspended_)
+         return;
+
+      // Suggestions aren't surfaced in visual mode, so don't request them
+      // (which would needlessly exchange document contents with the
+      // completion backend). See issue #17327.
+      if (target_.isVisualEditorActive())
          return;
 
       target_.withSavedDoc(() ->


### PR DESCRIPTION
## Intent

Fixes #17327.

## Description

In visual mode the editor doesn't surface inline completions or next-edit suggestions. However, edits in the visual editor are synced back to the hidden source editor, and that sync was still triggering `assistantGenerateCompletions` and `assistantNextEditSuggestions` requests. As a result, document contents were sent to the completion backend (GitHub Copilot / Posit AI) and the status bar showed "waiting for completions" even though no suggestion would appear.

This guards both completion request funnels in `TextEditingTargetAssistantHelper` on `isVisualEditorActive()`:

- the inline-completion timer (`assistantGenerateCompletions`)
- `requestNextEditSuggestions()` (`assistantNextEditSuggestions`)

These two funnels cover every trigger path (auto-on-edit, manual command, and the Copilot NES fallback), so no completion or next-edit request is made while visual mode is active. Both guards run before the `COMPLETION_REQUESTED` event fires, so the "waiting for completions" status is suppressed as well. Requests resume normally on return to source mode.

The `textDocument/didChange` document sync and `textDocument/didFocus` notification are intentionally left in place. They keep the language server's document model current so completions are correct immediately on return to source mode, and they are not themselves suggestion requests.

## Testing

- `cd src/gwt && ant javac` compiles the change; `npx tsc --noEmit` passes for the e2e project.
- Added a `no completion requests in visual mode` case to `e2e/rstudio/tests/panes/editor/code_suggestions.test.ts`, under the existing `@ai`-gated provider loop (GitHub Copilot and Posit AI). Rather than the status bar (whose last message lingers across a mode switch and is a misleading proxy), it watches the actual RPCs the editor issues to the completion backend -- `assistant_generate_completions` and `assistant_next_edit_suggestions`:
  - Opens a Quarto document, switches to visual mode, types, and asserts neither RPC fires.
  - Opens a plain R file, types, and confirms one of those RPCs does fire -- guarding against a false pass and proving the request monitoring observes these calls.
- Verified the test passes against this branch and fails against a build without the fix (a completion RPC fires in visual mode), confirming it catches the regression.