### PR TITLE
tweak CLAUDE.md and scope ASCII rule to R sources

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -70,11 +70,13 @@ R code lives in several places and serves different purposes:
 
 Each backend feature is implemented as a session module. Modules follow a consistent pattern:
 
+
 ### File naming convention
 
     src/cpp/session/modules/SessionXxx.cpp   # C++ implementation
     src/cpp/session/modules/SessionXxx.hpp   # C++ header (if needed)
     src/cpp/session/modules/SessionXxx.R     # R-side logic (if needed)
+
 
 ### Module structure
 
@@ -109,6 +111,7 @@ Error initialize()
 } // namespace rstudio
 ```
 
+
 ### Key module infrastructure
 
 - `src/cpp/session/include/session/SessionModuleContext.hpp` -- module registration API (`registerRpcMethod`, `registerAsyncRpcMethod`, `sourceModuleRFile`, `enqueClientEvent`, etc.)
@@ -118,6 +121,7 @@ Error initialize()
 ## Client-Server Communication
 
 The frontend and backend communicate via JSON-RPC over HTTP. Understanding this flow is essential for most feature work.
+
 
 ### RPC (Frontend → Backend)
 
@@ -141,6 +145,7 @@ The frontend and backend communicate via JSON-RPC over HTTP. Understanding this 
 
 3. **Frontend** calls it from a presenter or view via the injected server operations interface.
 
+
 ### Client Events (Backend → Frontend)
 
 1. **Backend** fires an event using `module_context::enqueClientEvent()`:
@@ -157,6 +162,7 @@ The frontend and backend communicate via JSON-RPC over HTTP. Understanding this 
 
 ## GWT Frontend Patterns
 
+
 ### Dependency Injection (GIN)
 
 The GWT frontend uses GIN (GWT INjection, based on Guice) for dependency injection.
@@ -164,6 +170,7 @@ The GWT frontend uses GIN (GWT INjection, based on Guice) for dependency injecti
 - `RStudioGinModule.java` -- binds interfaces to implementations
 - `RStudioGinjector.java` -- provides access to injected singletons
 - Use `@Inject` on constructors to wire dependencies
+
 
 ### MVP Pattern
 
@@ -173,9 +180,11 @@ Views follow Model-View-Presenter separation:
 - **View interface** (e.g. `ChatPresenter.Display`) -- defines the UI contract
 - **View implementation** (e.g. `ChatPane.java`) -- implements the widget and UI
 
+
 ### EventBus
 
 Components communicate through a central `EventBus` using typed events. Fire events with `eventBus_.fireEvent()` and handle them by implementing the corresponding `Handler` interface.
+
 
 ### Server Operations
 
@@ -238,8 +247,7 @@ To produce runnable code (GWT transpile to JavaScript, draft/debug mode):
 
     cd src/gwt && ant draft
 
-Use `ant draft` after making changes you need to test in the browser. Use `ant javac` as a fast
-check when iterating on Java code.
+Use `ant draft` after making changes you need to test in the browser. Use `ant javac` as a fast check when iterating on Java code.
 
 If you modify JavaScript components (e.g. in `src/gwt/acesupport`), also run:
 
@@ -268,16 +276,26 @@ To build the Electron application / desktop components, you can use:
 
 ## Writing Automated Tests
 
-End-to-end tests are written in TypeScript with Playwright, under `e2e/rstudio/`.
-The rsession is started with `--automation-agent` so that `window.rstudioCallbacks`
-is exposed for the Playwright command bridge in `e2e/rstudio/utils/commands.ts`.
+End-to-end tests are written in TypeScript with Playwright, under `e2e/rstudio/`. The rsession is started with `--automation-agent`, which causes the GWT frontend to install a JS automation bridge at `window.rstudio` (see `ApplicationAutomation.java`). The Playwright command helpers in `e2e/rstudio/utils/commands.ts` drive the IDE through this bridge instead of the R console, avoiding the focus-shift and pane-collapse pitfalls of the console path.
 
-See `.claude/skills/rstudio-create-playwright-tests/SKILL.md` for detailed guidance
-on writing Playwright tests, and `.claude/skills/rstudio-run-playwright-tests/SKILL.md`
-for how to run them.
+The `window.rstudio` surface includes:
+
+- `window.rstudio.ready` -- boolean flipped to `true` once R's deferred init has run; the canonical "automation can start" signal (reset to `false` on restart or project open/close).
+- `window.rstudio.commands.<commandId>()` -- execute an AppCommand; `.isChecked()` / `.isEnabled()` query its state. `commands.list` is the array of all command ids.
+- `window.rstudio.prefs.<camelCaseName>.get()` / `.set(value)` / `.clear()` -- `set` and `clear` return a Promise that resolves once the `setUserPrefs` RPC has landed server-side.
+- `window.rstudio.documents` -- `active()`, `activeEditor()` (native Ace editor), `open(path, opts?)`, `closeAllNoSave()`, `resetToUntitled()`.
+- `window.rstudio.project` -- `path()`, `name()`, `isActive()`, `open(path)`.
+- `window.rstudio.version` -- `{ rstudio, r }` version strings.
+- `window.rstudio.dialogs` -- `numShowing()`, `dismissAll()`.
+- `window.rstudio.layout.reset()` -- end any active pane/column zoom.
+
+Commands and prefs are enumerated up front at agent init, so a missing-by-name lookup is a genuine "doesn't exist" rather than "not yet touched by GWT code".
+
+See `.claude/skills/rstudio-create-playwright-tests/SKILL.md` for detailed guidance on writing Playwright tests, and `.claude/skills/rstudio-run-playwright-tests/SKILL.md` for how to run them.
 
 
 ## Testing
+
 
 ### C++ Tests
 
@@ -292,8 +310,7 @@ where `<scope>` is one of `core`, `rserver`, `rsession`, or `r`.
 
     cd src/gwt && ant unittest
 
-The standalone HTML test pages in `src/gwt/test/` (autoindent, highlight)
-are exercised in headless chromium via:
+The standalone HTML test pages in `src/gwt/test/` (autoindent, highlight) are exercised in headless chromium via:
 
     cd src/gwt && ant testpage
 
@@ -306,22 +323,16 @@ are exercised in headless chromium via:
     cd src/node/desktop && npm run lint      # ESLint
     cd src/node/desktop && npm run typecheck # TypeScript type checking (tsc --noEmit)
 
-Run all three before committing changes to `src/node/desktop/`. Note that `npm run lint` only runs
-ESLint — it does not catch type errors that the webpack build will reject.
+Run all three before committing changes to `src/node/desktop/`. Note that `npm run lint` only runs ESLint — it does not catch type errors that the webpack build will reject.
 
 
 ## Code Style
 
+
 ### Non-ASCII Characters
 
-Avoid using non-ASCII characters (e.g. `·`, `—`, smart quotes) in source files,
-including comments. Use ASCII equivalents instead (e.g. `-`, `--`, `"`, `'`).
-Non-ASCII characters can cause portability issues across platforms, and the
-test in `src/cpp/tests/testthat/test-linter.R` will fail if any `.R` file
-under `src/cpp` contains them.
+In R source files (`.R`) under `src/cpp`, use only ASCII characters -- including in comments. Replace non-ASCII characters with ASCII equivalents (e.g. `-` for `·`, `--` for `—`, straight `'`/`"` for smart quotes). This is enforced: the test in `src/cpp/tests/testthat/test-linter.R` fails if any such file contains non-ASCII characters.
 
-The exception is localization `.properties` files (e.g. `*_fr.properties`),
-which may contain actual accented characters.
 
 ### R
 
@@ -335,6 +346,7 @@ When documenting R code, use Roxygen style for formatting. For example:
     #' @param timeout The maximum amount of time to wait, in seconds.
     work <- function(callback, timeout) { ... }
 
+
 ### C++
 
 C++ code is formatted with clang-format. The configuration is in `src/cpp/.clang-format`. Key settings:
@@ -342,6 +354,7 @@ C++ code is formatted with clang-format. The configuration is in `src/cpp/.clang
 - 3-space indentation
 - Allman brace style
 - No tabs
+
 
 ### TypeScript (Desktop)
 
@@ -390,10 +403,8 @@ When a command is added here, a stub will also need to be added to the file at:
 
     src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
 
-When Commands.cmd.xml is modified in any way, a checksum stored in
-src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml.MD5 MUST be
-updated to match, and that file included in the commit. The MD5 file is updated when the GWT
-code is built using `ant` or `ant draft`.
+When Commands.cmd.xml is modified in any way, a checksum stored in src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml.MD5 MUST be updated to match, and that file included in the commit. The MD5 file is updated when the GWT code is built using `ant` or `ant draft`.
+
 
 ### Command Handlers
 
@@ -422,8 +433,7 @@ possibly with other injected parameters.
 
 ## NEWS.md
 
-When fixing a bug or adding a new feature, add an entry to the appropriate section (`### New`,
-`### Fixed`, etc.) of `NEWS.md`. Follow the existing format:
+When fixing a bug or adding a new feature, add an entry to the appropriate section (`### New`, `### Fixed`, etc.) of `NEWS.md`. Follow the existing format:
 
     - ([#NNNN](https://github.com/rstudio/rstudio/issues/NNNN)): Brief description of the change
 
@@ -435,13 +445,11 @@ Exceptions — do NOT add a NEWS.md entry for:
 
 ## Pull Requests
 
-When generating a pull request that fixes a known issue, please ensure the pull request body includes:
+- Pull requests should be associated with a GitHub issue.
+- Pull requests that fix an existing issue, and also include tests, should include "Fixes #<issue>" in their body.
+- Pull requests that only partially address an issue, or require manual verification, should include "Addresses #<issue>" in their body.
+- When generating a pull request, set the Milestone of the pull request to match contents of @version/RELEASE, if there is a matching milestone already defined. Never create a new milestone.
 
-    ## Intent
-
-    Addresses <issue>.
-
-When generating a pull request, set the Milestone of the pull request to match contents of @version/RELEASE, if there is a matching milestone already defined. Never create a new milestone.
 
 ## Git Conventions
 
@@ -449,13 +457,13 @@ For commit messages:
 
 - Use "Addresses #<issue>" instead of "Fixes #<issue>".
 
-
 For branch naming:
 
 - Use the 'bugfix/' prefix for code changes which fix an existing issue.
 - Use the 'feature/' prefix for code changes that add or extend existing functionality.
 - Use the 'developer/' prefix for code changes that are primarily for developer ergonomics.
 - Use the 'test/' prefix for code changes that are focused on automated tests.
+
 
 ## Issues
 


### PR DESCRIPTION
## Intent

Refresh the project `CLAUDE.md`:

- Document the `window.rstudio` automation bridge in the "Writing Automated Tests" section (the old text referenced the stale `window.rstudioCallbacks`).
- Rewrite the pull-request guidance into a clearer bulleted form (Fixes-with-tests vs. Addresses-partial).
- Narrow the non-ASCII rule so it applies only to `.R` sources under `src/cpp`, matching what the linter (`test-linter.R`) actually enforces.

Docs-only; no functional changes.