### PR TITLE
Migrate EnvironmentPane, terminal, PlotsPane, and GlobalPrefs tests to Playwright

### DIFF
--- a/.claude/skills/rstudio-migrate-tests-selenium-to-playwright/SKILL.md
+++ b/.claude/skills/rstudio-migrate-tests-selenium-to-playwright/SKILL.md
@@ -16,11 +16,11 @@ The user provides one or more targets:
 
 ## Hard Rules
 
-1. **Load skills first** — Always load `rstudio-create-playwright-tests` before doing any conversion work.
+1. **Load skills and the README first** — Before doing any conversion work, always: (a) load `rstudio-create-playwright-tests`; (b) read `e2e/rstudio/README.md` in full, the suite's primary reference (read it fresh for each migration; don't assume it was read earlier in the session); (c) load `rstudio-run-playwright-tests`, whose run protocol governs the verification in Hard Rule 5.
 2. **Check MIGRATION_FROM_SELENIUM_PROGRESS.md** — Before starting, verify the file hasn't already been converted or partially converted. Located at `e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md`.
-4. **Tests must work on Desktop and Server** — Use the unified fixture (`@fixtures/rstudio.fixture`). Don't hardcode Desktop-only patterns.
-5. **No Claude dependency** — All test infrastructure must be runnable from terminal, CI, and GitHub Actions. Claude subagents are a convenience layer, not a requirement.
-6. **A test isn't migrated until it passes.** Run the converted TypeScript test against a live RStudio instance (Desktop or Server, depending on target). Retry up to 3 times. If it still fails, mark it `test.fixme()` with a blocker note and track it as Fixme in `MIGRATION_FROM_SELENIUM_PROGRESS.md`. Do not list a fixme test as migrated in summaries, PR descriptions, or progress tracking.
+3. **Tests must work on Desktop and Server, and on Windows, macOS, and Linux** — Use the unified fixture (`@fixtures/rstudio.fixture`). Don't hardcode Desktop-only or OS-specific patterns; use cross-platform shortcuts (`ControlOrMeta` where appropriate) and `process.platform` guards, or tag mode/OS-specific tests (`@desktop_only`, `@windows_only`, etc.).
+4. **No Claude dependency** — All test infrastructure must be runnable from terminal, CI, and GitHub Actions. Claude subagents are a convenience layer, not a requirement.
+5. **A test isn't migrated until it passes.** Run the converted TypeScript test against a live RStudio instance (Desktop or Server, depending on target). Retry up to 3 times. If it still fails, mark it `test.fixme()` with a blocker note and track it as Fixme in `MIGRATION_FROM_SELENIUM_PROGRESS.md`. Do not list a fixme test as migrated in summaries, PR descriptions, or progress tracking.
 
 ## Steps
 
@@ -33,6 +33,8 @@ The user provides one or more targets:
 ### Step 2: Read reference materials
 
 - Load `rstudio-create-playwright-tests` skill
+- Read `e2e/rstudio/README.md` in full -- the suite's primary reference; read it fresh for each migration, don't assume it was read earlier in the session
+- Load `rstudio-run-playwright-tests` skill -- its run protocol governs the verification gate (Hard Rule 5)
 - Check `rstudio-ide-automation/rstudio_server_pro/electron-tests/` for other Selenium/Selene electron tests covering the same functionality — useful for test logic, assertions, and expected values
 - Check `rstudio-ide-automation/rstudio_server_pro/tests/` for Selenium/Selene server tests covering the same functionality — useful for test logic, assertions, and expected values
 - Check `rstudio-pro/e2e/` for Workbench e2e patterns (examples include `.or()` locator chaining, `clickIfVisible()` helpers, input fill with retry, reload-on-hang recovery) -- look for anything else reusable
@@ -84,7 +86,7 @@ If the test needs locators or methods not yet available:
 
 ### Step 6: Run the test
 
-**Hard gate (Hard Rule 6):** a test doesn't count as migrated until it passes here.
+**Hard gate (Hard Rule 5):** a test doesn't count as migrated until it passes here.
 
 Defer to the `rstudio-run-playwright-tests` skill for the canonical run commands (Desktop and Server). Present the command and wait for user approval before executing.
 
@@ -154,7 +156,7 @@ Present the assessed findings with recommendations. Wait for approval before edi
 - Fix Low findings only if they're real bugs or silent failures
 - Skip cosmetic Lows and "add tests for simple scripts" suggestions
 
-Apply fixes manually. **Do not invoke `roborev-fix`** -- Ron prefers manual fixes through the migration flow. Re-run the test (Hard Rule 6 still applies). Commit per Step 9. Re-run `roborev-review` on the new commit. Repeat until no actionable findings remain.
+Apply fixes manually. **Do not invoke `roborev-fix`** -- Ron prefers manual fixes through the migration flow. Re-run the test (Hard Rule 5 still applies). Commit per Step 9. Re-run `roborev-review` on the new commit. Repeat until no actionable findings remain.
 
 Close reviewed findings via the `roborev-respond` skill once they're addressed.
 

--- a/.claude/skills/rstudio-migrate-tests-selenium-to-playwright/SKILL.md
+++ b/.claude/skills/rstudio-migrate-tests-selenium-to-playwright/SKILL.md
@@ -40,6 +40,7 @@ The user provides one or more targets:
 - Check `rstudio-pro/e2e/` for Workbench e2e patterns (examples include `.or()` locator chaining, `clickIfVisible()` helpers, input fill with retry, reload-on-hang recovery) -- look for anything else reusable
 - Read relevant existing Playwright page objects in `e2e/rstudio/pages/`
 - Read relevant existing Playwright actions in `e2e/rstudio/actions/`
+- Read relevant existing Playwright test specs in `e2e/rstudio/tests/` -- BRAT is retired; anything that was in BRAT is now in the Playwright suite
 
 **For large files or batch migrations:** if the source has many methods (say 10+) or you're migrating a directory, consider launching a general-purpose subagent to analyze the Python source(s) and return a brief covering: test methods to convert, pytest markers / skip reasons, fixtures used, page objects referenced, parallel safety hints, and any unusual patterns. This keeps the main context lean for the writing and running phases. For typical single-file migrations with a handful of methods, do the analysis inline.
 

--- a/.claude/skills/rstudio-migrate-tests-selenium-to-playwright/SKILL.md
+++ b/.claude/skills/rstudio-migrate-tests-selenium-to-playwright/SKILL.md
@@ -116,11 +116,26 @@ Present proposed improvements to the user. Only apply if approved. Re-run after 
 
 ### Step 8: Update progress tracking
 
-Edit `e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md`:
+Two records to update -- the progress doc (this repo) and the migrated marker
+on the Selenium source (the `rstudio-ide-automation` repo).
+
+**Progress doc** -- edit `e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md`:
 - Update the file's status (Complete, Partial, or Fixme)
 - Add the Playwright target path and test count
 - Add notes if relevant
 - Add any fixme tests to the Fixme Tests table with blocker description
+
+**Mark the Selenium source as migrated** -- in `rstudio-ide-automation`, add
+`@pytest.mark.migratedToTypeScript` so the Python suite records which tests are
+ported. Follow that repo's `migrate-test` skill, Step 15:
+- Mark **each individual test method** that passed verification. **Never mark
+  at the class level** -- a class may be only partially migrated, and class-level
+  marking would wrongly imply every method is done.
+- Module-level `pytestmark = [pytest.mark.migratedToTypeScript, ...]` is
+  acceptable only when the file has no class and every method passed.
+- Never mark a method that ended up `test.fixme()` in Playwright.
+- This is a separate repo, so it needs its own `test/ron/` branch, commit, and
+  PR -- don't fold it into the rstudio PR.
 
 ### Step 9: Commit and submit
 

--- a/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
+++ b/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
@@ -9,9 +9,9 @@ Target: `e2e/rstudio/tests/`
 |--------|-------|
 | Total electron test files | 32 |
 | Total electron test methods | 115 |
-| Files fully converted | 15 |
+| Files fully converted | 16 |
 | Files partially converted | 0 |
-| Files not started | 17 |
+| Files not started | 16 |
 
 ## Conversion Status
 
@@ -22,7 +22,7 @@ Target: `e2e/rstudio/tests/`
 | test_desktop_Citations.py | 17 | — | Not started | |
 | test_desktop_Command_Palette.py | 2 | panes/misc/command-palette.test.ts (2) | Complete | |
 | test_desktop_console.py | 11 | panes/console/console_pane.test.ts (8), panes/console/console_command_effects.test.ts (7), panes/console/execute_from_editor.test.ts (1) | Complete | Split by theme; added Find in Console coverage (3 new tests) and upgraded `help.start()` to verify help-pane contents |
-| test_desktop_EnvironmentPane.py | 5 | — | Not started | |
+| test_desktop_EnvironmentPane.py | 5 | panes/environment/environment_pane.test.ts (5) | Complete | Toolbar elements, the import-dataset/object-view/environment-list dropdowns, and memory-pie growth + usage-report modal. No Desktop-only assumptions; the Selenium maximize/restore workaround was dropped. |
 | test_desktop_FindInFiles.py | 3 | panes/misc/find-in-files.test.ts (3) | Complete | |
 | test_desktop_Package_Installation.py | 1 | — | Not started | |
 | test_desktop_PlotsPane.py | 11 | — | Not started | |

--- a/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
+++ b/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
@@ -9,9 +9,9 @@ Target: `e2e/rstudio/tests/`
 |--------|-------|
 | Total electron test files | 32 |
 | Total electron test methods | 115 |
-| Files fully converted | 21 |
+| Files fully converted | 30 |
 | Files partially converted | 0 |
-| Files not started | 11 |
+| Files not started | 6 |
 
 ## Conversion Status
 
@@ -50,16 +50,16 @@ Target: `e2e/rstudio/tests/`
 
 | Electron Source | Methods | Playwright Target | Status | Notes |
 |----------------|---------|-------------------|--------|-------|
-| test_desktop_GlobalPrefAccessibility.py | 6 | — | Not started | |
-| test_desktop_GlobalPrefAppearance.py | 1 | — | Not started | |
-| test_desktop_GlobalPrefCode.py | 2 | — | Not started | |
-| test_desktop_GlobalPrefGeneral.py | 3 | — | Not started | |
-| test_desktop_GlobalPrefPackages.py | 2 | — | Not started | |
-| test_desktop_GlobalPrefPaneLayout.py | 1 | — | Not started | |
-| test_desktop_GlobalPrefRMarkdown.py | 1 | — | Not started | |
-| test_desktop_GlobalPrefSpelling.py | 1 | — | Not started | |
-| test_desktop_GlobalPrefSweave.py | 1 | — | Not started | |
-| test_desktop_GlobalPrefTerminal.py | 1 | — | Not started | |
+| test_desktop_GlobalPrefAccessibility.py | 6 | — | Not started | Keyboard focus/tab-wrap navigation tests; medium complexity |
+| test_desktop_GlobalPrefAppearance.py | 1 | preferences/global_prefs_panels.test.ts (1) | Complete | |
+| test_desktop_GlobalPrefCode.py | 2 | preferences/global_prefs_panels.test.ts (2) | Complete | |
+| test_desktop_GlobalPrefGeneral.py | 3 | preferences/global_prefs_panels.test.ts (1) | Complete | 2 WIP methods were commented out in the Python source; not migrated |
+| test_desktop_GlobalPrefPackages.py | 2 | preferences/global_prefs_panels.test.ts (1) | Complete | 1 method was commented out in the Python source; not migrated |
+| test_desktop_GlobalPrefPaneLayout.py | 1 | preferences/global_prefs_panels.test.ts (1) | Complete | |
+| test_desktop_GlobalPrefRMarkdown.py | 1 | preferences/global_prefs_panels.test.ts (1) | Complete | |
+| test_desktop_GlobalPrefSpelling.py | 1 | preferences/global_prefs_panels.test.ts (1) | Complete | |
+| test_desktop_GlobalPrefSweave.py | 1 | preferences/global_prefs_panels.test.ts (1) | Complete | |
+| test_desktop_GlobalPrefTerminal.py | 1 | preferences/global_prefs_panels.test.ts (1) | Complete | Also includes 2 new tests (Python panel, Assistant panel) with no Selenium equivalent |
 
 ### Licensing (4 files, 9 methods)
 

--- a/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
+++ b/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
@@ -9,9 +9,9 @@ Target: `e2e/rstudio/tests/`
 |--------|-------|
 | Total electron test files | 32 |
 | Total electron test methods | 115 |
-| Files fully converted | 19 |
+| Files fully converted | 20 |
 | Files partially converted | 0 |
-| Files not started | 13 |
+| Files not started | 12 |
 
 ## Conversion Status
 
@@ -28,7 +28,7 @@ Target: `e2e/rstudio/tests/`
 | test_desktop_PlotsPane.py | 11 | — | Not started | |
 | test_desktop_R.py | 1 | panes/editor/r_execution.test.ts (1) | Complete | |
 | test_desktop_R_Session_Restart.py | 1 | panes/console/r_session_restart.test.ts (1) | Complete | |
-| test_desktop_terminal.py | 4 | — | Not started | |
+| test_desktop_terminal.py | 4 | panes/terminal/terminal.test.ts (4) | Complete | Added to existing terminal spec: toolbar next/previous buttons, R --version output, file create and ls, Shift+Backspace character deletion (@desktop_only). Uses rstudioapi::terminalBuffer for all output assertions. |
 | test_desktop_ViewerPane.py | 1 | panes/viewer/htmlwidgets.test.ts (1) | Complete | |
 
 ### EditorPane (10 files, 37 methods)

--- a/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
+++ b/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
@@ -9,9 +9,9 @@ Target: `e2e/rstudio/tests/`
 |--------|-------|
 | Total electron test files | 32 |
 | Total electron test methods | 115 |
-| Files fully converted | 20 |
+| Files fully converted | 21 |
 | Files partially converted | 0 |
-| Files not started | 12 |
+| Files not started | 11 |
 
 ## Conversion Status
 
@@ -25,7 +25,7 @@ Target: `e2e/rstudio/tests/`
 | test_desktop_EnvironmentPane.py | 5 | panes/environment/environment_pane.test.ts (5) | Complete | Toolbar elements, the import-dataset/object-view/environment-list dropdowns, and memory-pie growth + usage-report modal. No Desktop-only assumptions; the Selenium maximize/restore workaround was dropped. |
 | test_desktop_FindInFiles.py | 3 | panes/misc/find-in-files.test.ts (3) | Complete | |
 | test_desktop_Package_Installation.py | 1 | panes/console/package_installation.test.ts (1) | Complete | |
-| test_desktop_PlotsPane.py | 11 | — | Not started | |
+| test_desktop_PlotsPane.py | 11 | panes/plots/plots_pane.test.ts (11) | Complete | All 11 tests including the 3 that were commented out in the desktop source (export dropdown, save as image, save as PDF). Two-step save flow (OK + GWT file chooser) with R file-exists verification. Zoom and resize tests are @desktop_only. |
 | test_desktop_R.py | 1 | panes/editor/r_execution.test.ts (1) | Complete | |
 | test_desktop_R_Session_Restart.py | 1 | panes/console/r_session_restart.test.ts (1) | Complete | |
 | test_desktop_terminal.py | 4 | panes/terminal/terminal.test.ts (4) | Complete | Added to existing terminal spec: toolbar next/previous buttons, R --version output, file create and ls, Shift+Backspace character deletion (@desktop_only). Uses rstudioapi::terminalBuffer for all output assertions. |

--- a/e2e/rstudio/pages/environment_pane.page.ts
+++ b/e2e/rstudio/pages/environment_pane.page.ts
@@ -63,8 +63,7 @@ export class EnvironmentPane extends PageObject {
     this.refreshWorkspaceBtn = page.locator('#rstudio_tb_refreshenvironment');
     this.loadWorkspaceBtn = page.locator('#rstudio_tb_loadworkspace');
     this.saveWorkspaceBtn = page.locator('#rstudio_tb_saveworkspace');
-    // The pie-crust div carries the stable id; the adjacent button is the menu.
-    this.memoryPieBtn = page.locator('#rstudio_memory_pie_mini + button');
+    this.memoryPieBtn = page.locator('#rstudio_memory_dropdown');
 
     this.importDatasetMenu = page.locator('#rstudio_mb_import_dataset');
     this.viewMenu = page.locator('#rstudio_mb_object_list_view');

--- a/e2e/rstudio/pages/environment_pane.page.ts
+++ b/e2e/rstudio/pages/environment_pane.page.ts
@@ -19,12 +19,74 @@ export class EnvironmentPane extends PageObject {
   public clearWorkspaceBtn: Locator;
   public objectGridRows: Locator;
 
+  // Toolbar buttons.
+  public searchBar: Locator;
+  public refreshWorkspaceBtn: Locator;
+  public loadWorkspaceBtn: Locator;
+  public saveWorkspaceBtn: Locator;
+  public memoryPieBtn: Locator;
+
+  // Toolbar menu buttons (each opens a dropdown menu).
+  public importDatasetMenu: Locator;
+  public viewMenu: Locator;
+  public envListMenu: Locator;
+
+  // Import Dataset menu items.
+  public datasetTextBase: Locator;
+  public datasetTextReadr: Locator;
+  public datasetExcel: Locator;
+  public datasetSpss: Locator;
+  public datasetSas: Locator;
+  public datasetStata: Locator;
+
+  // Object-view menu items.
+  public listViewOption: Locator;
+  public gridViewOption: Locator;
+
+  // Environment-list menu items.
+  public globalEnvOption: Locator;
+  public packageStats: Locator;
+  public packageGraphics: Locator;
+  public packageGrDevices: Locator;
+  public packageUtils: Locator;
+  public packageMethods: Locator;
+  public packageBase: Locator;
+
   constructor(page: Page) {
     super(page);
     this.panel = page.locator(ENV_PANEL);
     this.tab = page.locator(ENV_TAB);
     this.clearWorkspaceBtn = page.locator(CLEAR_WORKSPACE_BTN);
     this.objectGridRows = this.panel.locator('table tr');
+
+    this.searchBar = page.locator('#rstudio_sw_environment');
+    this.refreshWorkspaceBtn = page.locator('#rstudio_tb_refreshenvironment');
+    this.loadWorkspaceBtn = page.locator('#rstudio_tb_loadworkspace');
+    this.saveWorkspaceBtn = page.locator('#rstudio_tb_saveworkspace');
+    // The pie-crust div carries the stable id; the adjacent button is the menu.
+    this.memoryPieBtn = page.locator('#rstudio_memory_pie_mini + button');
+
+    this.importDatasetMenu = page.locator('#rstudio_mb_import_dataset');
+    this.viewMenu = page.locator('#rstudio_mb_object_list_view');
+    this.envListMenu = page.locator('#rstudio_mb_environment_list');
+
+    this.datasetTextBase = page.locator('#rstudio_label_from_text_base_command');
+    this.datasetTextReadr = page.locator('#rstudio_label_from_text_readr_command');
+    this.datasetExcel = page.locator('#rstudio_label_from_excel_command');
+    this.datasetSpss = page.locator('#rstudio_label_from_spss_command');
+    this.datasetSas = page.locator('#rstudio_label_from_sas_command');
+    this.datasetStata = page.locator('#rstudio_label_from_stata_command');
+
+    this.listViewOption = page.locator('#rstudio_label_list_command');
+    this.gridViewOption = page.locator('#rstudio_label_grid_command');
+
+    this.globalEnvOption = page.locator('#rstudio_label_global_environment_command');
+    this.packageStats = page.locator('#rstudio_label_package_stats_command');
+    this.packageGraphics = page.locator('#rstudio_label_package_graphics_command');
+    this.packageGrDevices = page.locator('#rstudio_label_package_grdevices_command');
+    this.packageUtils = page.locator('#rstudio_label_package_utils_command');
+    this.packageMethods = page.locator('#rstudio_label_package_methods_command');
+    this.packageBase = page.locator('#rstudio_label_package_base_command');
   }
 
   async getPanelText(): Promise<string> {
@@ -56,6 +118,28 @@ export class EnvironmentPane extends PageObject {
    *  whole-panel level rather than the call-frame region itself. */
   callFrameByText(frameLabel: string, exact = false): Locator {
     return this.panel.getByText(frameLabel, { exact });
+  }
+
+  /** Read the memory figure on the Environment pane's memory-pie button and
+   *  normalize it to MiB. MemUsageWidget.formatBigMemory renders the text as
+   *  "<n> MiB" or "<x.yy> GiB" (and "Memory" before the first usage sample
+   *  arrives), so this returns null when no numeric value is present yet --
+   *  callers can poll. Normalizing the unit avoids the cross-environment bug
+   *  where stripping non-digits compares "1.2 GiB" (-> 12) against
+   *  "850 MiB" (-> 850). */
+  async getMemoryMiB(): Promise<number | null> {
+    const text = (await this.memoryPieBtn.innerText()).trim();
+    const match = text.match(/([\d.,]+)\s*(KiB|MiB|GiB|TiB)/i);
+    if (!match) return null;
+    const value = parseFloat(match[1].replace(/,/g, ''));
+    if (Number.isNaN(value)) return null;
+    const factorToMiB: Record<string, number> = {
+      kib: 1 / 1024,
+      mib: 1,
+      gib: 1024,
+      tib: 1024 * 1024,
+    };
+    return value * factorToMiB[match[2].toLowerCase()];
   }
 }
 

--- a/e2e/rstudio/pages/global_options.page.ts
+++ b/e2e/rstudio/pages/global_options.page.ts
@@ -1,0 +1,91 @@
+import type { Page } from 'playwright';
+import { executeCommand } from '@utils/commands';
+
+// Dialog chrome
+export const GLOBAL_OPTIONS_DIALOG = '#rstudio_dialog_global_prefs';
+export const DIALOG_BOX = '.gwt-DialogBox';
+export const OPTIONS_OK = '#rstudio_preferences_confirm';
+export const OPTIONS_CANCEL = '#rstudio_dlg_cancel';
+export const OPTIONS_APPLY = '#rstudio_dlg_apply';
+
+// Appearance
+export const APPEARANCE_TAB = '#rstudio_label_appearance_options';
+export const APPEARANCE_PANEL = '#rstudio_label_appearance_options_panel';
+export const APPEARANCE_PREVIEW = 'iframe[title="Editor Theme Preview"]';
+
+// Code
+export const CODE_TAB = '#rstudio_label_code_options';
+export const CODE_PANEL = '#rstudio_label_code_options_panel';
+export const CODE_EDITING_TAB = '#rstudio_edit_editing_prefs_tab';
+export const CODE_EDITING_PANEL = '#rstudio_edit_editing_prefs_panel';
+export const CODE_DISPLAY_TAB = '#rstudio_edit_display_prefs_tab';
+export const CODE_DISPLAY_PANEL = '#rstudio_edit_display_prefs_panel';
+export const CODE_SAVING_TAB = '#rstudio_edit_saving_prefs_tab';
+export const CODE_SAVING_PANEL = '#rstudio_edit_saving_prefs_panel';
+export const CODE_CHANGE_ENCODING_BTN = '#rstudio_tbb_button_text_encoding';
+export const CODE_CHANGE_ENCODING_MODAL = 'div.gwt-DialogBox[aria-label="Choose Encoding"]';
+export const CODE_COMPLETION_TAB = '#rstudio_editing_completion_prefs_tab';
+export const CODE_COMPLETION_PANEL = '#rstudio_editing_completion_prefs_panel';
+export const CODE_DIAGNOSTICS_TAB = '#rstudio_editing_diagnostics_prefs_tab';
+export const CODE_DIAGNOSTICS_PANEL = '#rstudio_editing_diagnostics_prefs_panel';
+
+// General
+export const GENERAL_TAB = '#rstudio_label_general_options';
+export const GENERAL_PANEL = '#rstudio_label_general_options_panel';
+export const GENERAL_ADVANCED_TAB = '#rstudio_general_advanced_prefs_tab';
+export const GENERAL_ADVANCED_PANEL = '#rstudio_general_advanced_prefs_panel';
+
+// Packages
+export const PACKAGES_TAB = '#rstudio_label_packages_options';
+export const PACKAGES_PANEL = '#rstudio_label_packages_options_panel';
+export const PACKAGES_MANAGEMENT_TAB = '#rstudio_package_management_prefs_tab';
+export const PACKAGES_MANAGEMENT_PANEL = '#rstudio_package_management_prefs_panel';
+export const PACKAGES_DEVELOPMENT_TAB = '#rstudio_package_development_prefs_tab';
+export const PACKAGES_DEVELOPMENT_PANEL = '#rstudio_package_development_prefs_panel';
+
+// Pane Layout
+export const PANE_LAYOUT_TAB = '#rstudio_label_pane_layout_options';
+export const PANE_LAYOUT_PANEL = '#rstudio_label_pane_layout_options_panel';
+
+// R Markdown
+export const RMARKDOWN_TAB = '#rstudio_label_r_markdown_options';
+export const RMARKDOWN_PANEL = '#rstudio_label_r_markdown_options_panel';
+
+// Spelling
+export const SPELLING_TAB = '#rstudio_label_spelling_options';
+export const SPELLING_PANEL = '#rstudio_label_spelling_options_panel';
+
+// Sweave
+export const SWEAVE_TAB = '#rstudio_label_sweave_options';
+export const SWEAVE_PANEL = '#rstudio_label_sweave_options_panel';
+
+// Terminal
+export const TERMINAL_TAB = '#rstudio_label_terminal_options';
+export const TERMINAL_PANEL = '#rstudio_label_terminal_options_panel';
+export const TERMINAL_GENERAL_TAB = '#rstudio_terminal_general_prefs_tab';
+export const TERMINAL_GENERAL_PANEL = '#rstudio_terminal_general_prefs_panel';
+export const TERMINAL_CLOSING_TAB = '#rstudio_terminal_closing_prefs_tab';
+export const TERMINAL_CLOSING_PANEL = '#rstudio_terminal_closing_prefs_panel';
+
+// Python
+export const PYTHON_TAB = '#rstudio_label_python_options';
+export const PYTHON_PANEL = '#rstudio_label_python_options_panel';
+export const PYTHON_INTERPRETER_PATH = '#rstudio_tbb_text_python_path';
+export const PYTHON_INTERPRETER_SELECT_BTN = '#rstudio_tbb_button_python_path';
+export const PYTHON_INTERPRETERS_MODAL = '[aria-label="Python Interpreters"]';
+
+// Assistant (code assistant / GitHub Copilot configuration)
+export const ASSISTANT_TAB = '#rstudio_label_assistant_options';
+export const ASSISTANT_PANEL = '#rstudio_label_assistant_options_panel';
+export const ASSISTANT_LABEL = 'Use code assistant:';
+
+// Actions
+export async function openGlobalOptions(page: Page): Promise<void> {
+  await executeCommand(page, 'showOptions');
+  await page.waitForSelector(OPTIONS_OK, { timeout: 15000 });
+}
+
+export async function closeGlobalOptions(page: Page): Promise<void> {
+  await page.locator(OPTIONS_CANCEL).click();
+  await page.waitForSelector(DIALOG_BOX, { state: 'detached', timeout: 10000 });
+}

--- a/e2e/rstudio/pages/global_options.page.ts
+++ b/e2e/rstudio/pages/global_options.page.ts
@@ -75,6 +75,8 @@ export const PYTHON_INTERPRETER_SELECT_BTN = '#rstudio_tbb_button_python_path';
 export const PYTHON_INTERPRETERS_MODAL = '[aria-label="Python Interpreters"]';
 
 // Assistant (code assistant / GitHub Copilot configuration)
+// ASSISTANT_TAB/ASSISTANT_PANEL and OPTIONS_OK mirror selectors in
+// pages/assistant_options.page.ts; keep both in sync if these IDs change.
 export const ASSISTANT_TAB = '#rstudio_label_assistant_options';
 export const ASSISTANT_PANEL = '#rstudio_label_assistant_options_panel';
 export const ASSISTANT_LABEL = 'Use code assistant:';
@@ -87,5 +89,5 @@ export async function openGlobalOptions(page: Page): Promise<void> {
 
 export async function closeGlobalOptions(page: Page): Promise<void> {
   await page.locator(OPTIONS_CANCEL).click();
-  await page.waitForSelector(DIALOG_BOX, { state: 'detached', timeout: 10000 });
+  await page.waitForSelector(GLOBAL_OPTIONS_DIALOG, { state: 'detached', timeout: 10000 });
 }

--- a/e2e/rstudio/pages/plots_pane.page.ts
+++ b/e2e/rstudio/pages/plots_pane.page.ts
@@ -1,0 +1,55 @@
+import type { Page, Locator } from 'playwright';
+import { PageObject } from './page_object_base_classes';
+
+export const PLOTS_TAB = '#rstudio_workbench_tab_plots';
+export const PLOT_IMAGE_FRAME = '#rstudio_plot_image_frame';
+
+export class PlotsPane extends PageObject {
+  public tab: Locator;
+  public plotImage: Locator;
+
+  // Toolbar buttons
+  public zoomPlotBtn: Locator;
+  public removePlotBtn: Locator;
+  public clearPlotsBtn: Locator;
+  public refreshPlotBtn: Locator;
+  public publishBtn: Locator;
+  public nextPlotBtn: Locator;
+  public previousPlotBtn: Locator;
+
+  // Export menu button and its items
+  public exportMenu: Locator;
+  public saveAsImageItem: Locator;
+  public saveAsPdfItem: Locator;
+  public copyToClipboardItem: Locator;
+
+  // Export dialogs (identified by stable aria-labels from the GWT ModalDialog ctors)
+  public saveAsImageDialog: Locator;
+  public saveAsPdfDialog: Locator;
+  public copyToClipboardDialog: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.tab = page.locator(PLOTS_TAB);
+    this.plotImage = page.locator(PLOT_IMAGE_FRAME);
+
+    this.zoomPlotBtn = page.locator('#rstudio_tb_zoomplot');
+    this.removePlotBtn = page.locator('#rstudio_tb_removeplot');
+    this.clearPlotsBtn = page.locator('#rstudio_tb_clearplots');
+    this.refreshPlotBtn = page.locator('#rstudio_tb_refreshplot');
+    this.publishBtn = page.locator('#rstudio_publish_item_plots_pane');
+    this.nextPlotBtn = page.locator('#rstudio_tb_nextplot');
+    this.previousPlotBtn = page.locator('#rstudio_tb_previousplot');
+
+    this.exportMenu = page.locator('#rstudio_mb_plots_export');
+    this.saveAsImageItem = page.locator('#rstudio_label_save_as_image_command');
+    this.saveAsPdfItem = page.locator('#rstudio_label_save_as_pdf_command');
+    this.copyToClipboardItem = page.locator('#rstudio_label_copy_to_clipboard_command');
+
+    // getByRole('dialog') excludes aria-hidden ghost dialogs that GWT keeps in
+    // the DOM after closing, avoiding strict-mode violations from two matches.
+    this.saveAsImageDialog = page.getByRole('dialog', { name: 'Save Plot as Image' });
+    this.saveAsPdfDialog = page.getByRole('dialog', { name: 'Save Plot as PDF' });
+    this.copyToClipboardDialog = page.getByRole('dialog', { name: 'Copy Plot to Clipboard' });
+  }
+}

--- a/e2e/rstudio/tests/panes/environment/environment_pane.test.ts
+++ b/e2e/rstudio/tests/panes/environment/environment_pane.test.ts
@@ -1,0 +1,110 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { EnvironmentPane, clearWorkspace } from '@pages/environment_pane.page';
+import { CONFIRM_BTN } from '@pages/modals.page';
+import { executeCommand } from '@utils/commands';
+import { TIMEOUTS } from '@utils/constants';
+
+let envPane: EnvironmentPane;
+let consoleActions: ConsolePaneActions;
+
+test.describe('Environment pane', () => {
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    envPane = new EnvironmentPane(page);
+    consoleActions = new ConsolePaneActions(page);
+    await consoleActions.resetSourcePane();
+  });
+
+  test.beforeEach(async () => {
+    // Every test operates on the Environment tab; make it active first.
+    await envPane.tab.click();
+  });
+
+  test('toolbar elements are displayed', async () => {
+    await expect(envPane.panel).toBeVisible();
+    await expect(envPane.searchBar).toBeVisible();
+    await expect(envPane.refreshWorkspaceBtn).toBeVisible();
+    await expect(envPane.memoryPieBtn).toBeVisible();
+    await expect(envPane.clearWorkspaceBtn).toBeVisible();
+    await expect(envPane.loadWorkspaceBtn).toBeVisible();
+    await expect(envPane.saveWorkspaceBtn).toBeVisible();
+  });
+
+  test('import dataset dropdown lists every source', async ({ rstudioPage: page }) => {
+    await envPane.importDatasetMenu.click();
+
+    await expect(envPane.datasetTextBase).toBeVisible();
+    await expect(envPane.datasetTextReadr).toBeVisible();
+    await expect(envPane.datasetExcel).toBeVisible();
+    await expect(envPane.datasetSpss).toBeVisible();
+    await expect(envPane.datasetSas).toBeVisible();
+    await expect(envPane.datasetStata).toBeVisible();
+
+    await page.keyboard.press('Escape');
+  });
+
+  test('object-view dropdown shows list and grid views', async ({ rstudioPage: page }) => {
+    await envPane.viewMenu.click();
+
+    await expect(envPane.listViewOption).toBeVisible();
+    await expect(envPane.gridViewOption).toBeVisible();
+
+    await page.keyboard.press('Escape');
+  });
+
+  test('environment-list dropdown shows the global environment and packages', async ({
+    rstudioPage: page,
+  }) => {
+    await envPane.envListMenu.click();
+
+    await expect(envPane.globalEnvOption).toBeVisible();
+    await expect(envPane.packageStats).toBeVisible();
+    await expect(envPane.packageGraphics).toBeVisible();
+    await expect(envPane.packageGrDevices).toBeVisible();
+    await expect(envPane.packageUtils).toBeVisible();
+    await expect(envPane.packageMethods).toBeVisible();
+    await expect(envPane.packageBase).toBeVisible();
+
+    await page.keyboard.press('Escape');
+  });
+
+  test('memory pie grows with allocation and the usage report opens', async ({
+    rstudioPage: page,
+  }) => {
+    // Start from a clean workspace so the only Values row is the one we add.
+    await clearWorkspace(page);
+    await consoleActions.clearConsole();
+
+    // Wait for the pie to report a concrete positive figure (it reads "Memory"
+    // until the first usage sample arrives), then capture the baseline in MiB.
+    await expect.poll(() => envPane.getMemoryMiB(), { timeout: TIMEOUTS.memoryUsageUpdate })
+      .toBeGreaterThan(0);
+    const before = (await envPane.getMemoryMiB())!;
+
+    // Allocate ~76 MiB (1e7 doubles) -- well above the pie's 1 MiB resolution.
+    await consoleActions.executeInConsole('bigval <- runif(1e7)');
+    await expect(envPane.panel).toContainText('bigval');
+
+    // The pie samples on an interval, so poll for the increase rather than
+    // reading once. Unit-normalized comparison (MiB) avoids the GiB/MiB trap.
+    await expect
+      .poll(
+        async () => {
+          const after = await envPane.getMemoryMiB();
+          return after !== null && after > before;
+        },
+        { timeout: TIMEOUTS.memoryUsageUpdate, message: 'memory pie did not grow after allocation' },
+      )
+      .toBe(true);
+
+    // The memory-usage report opens as a modal titled "Memory Usage Report".
+    await executeCommand(page, 'showMemoryUsageReport');
+    const dialog = page.locator('.gwt-DialogBox').filter({ hasText: 'Memory Usage' });
+    await expect(dialog).toBeVisible();
+    await page.locator(CONFIRM_BTN).click();
+    await expect(dialog).toBeHidden();
+
+    // Free the big vector so the shared session doesn't carry ~76 MiB onward.
+    await consoleActions.executeInConsole('rm(bigval)');
+  });
+});

--- a/e2e/rstudio/tests/panes/plots/plots_pane.test.ts
+++ b/e2e/rstudio/tests/panes/plots/plots_pane.test.ts
@@ -109,10 +109,11 @@ test.describe.serial('Plots pane', { tag: ['@serial'] }, () => {
     await expect(plotsPane.saveAsImageDialog).toBeHidden();
 
     // Verify a file was actually written -- the dialog closing alone doesn't
-    // confirm a successful save.
+    // confirm a successful save. Match the extension so a pre-existing Rplot.pdf
+    // from a later test can't satisfy this assertion vacuously.
     await expect.poll(
       () => consoleActions.evalRLogical(
-        `length(list.files(getwd(), pattern = "Rplot")) > 0`,
+        `length(list.files(getwd(), pattern = "Rplot.*\\\\.png$")) > 0`,
       ),
       { timeout: TIMEOUTS.fileOpen },
     ).toBe(true);
@@ -128,9 +129,11 @@ test.describe.serial('Plots pane', { tag: ['@serial'] }, () => {
     await page.locator(FILE_ACCEPT_SAVE).click();
     await expect(plotsPane.saveAsPdfDialog).toBeHidden();
 
+    // RStudio increments the filename (Rplot01.pdf, Rplot02.pdf, ...) when a
+    // previous export already exists in the directory. Match any Rplot*.pdf.
     await expect.poll(
       () => consoleActions.evalRLogical(
-        `length(list.files(getwd(), pattern = "Rplot")) > 0`,
+        `length(list.files(getwd(), pattern = "Rplot.*\\\\.pdf$")) > 0`,
       ),
       { timeout: TIMEOUTS.fileOpen },
     ).toBe(true);

--- a/e2e/rstudio/tests/panes/plots/plots_pane.test.ts
+++ b/e2e/rstudio/tests/panes/plots/plots_pane.test.ts
@@ -173,6 +173,15 @@ test.describe.serial('Plots pane', { tag: ['@serial'] }, () => {
       ]);
       await expect(popup.locator('#plot')).toBeVisible({ timeout: TIMEOUTS.fileOpen });
 
+      // Confirm a resize actually drives the popup window before stressing it --
+      // otherwise a silent setViewportSize no-op would leave the loop below
+      // exercising nothing. innerWidth must track the requested size.
+      await popup.setViewportSize({ width: 640, height: 480 });
+      const widthSmall = await popup.evaluate(() => window.innerWidth);
+      await popup.setViewportSize({ width: 1280, height: 900 });
+      const widthLarge = await popup.evaluate(() => window.innerWidth);
+      expect(widthLarge).toBeGreaterThan(widthSmall);
+
       for (let i = 0; i < 8; i++) {
         await popup.setViewportSize({ width: 1280, height: 900 });
         await popup.setViewportSize({ width: 640, height: 480 });
@@ -181,10 +190,10 @@ test.describe.serial('Plots pane', { tag: ['@serial'] }, () => {
 
       await popup.close();
 
-      // The real point: R is still responsive after the resize storm.
-      await consoleActions.clearConsole();
-      await consoleActions.executeInConsole("cat('alive')");
-      await expect(consoleActions.consolePane.consoleOutput).toContainText('alive');
+      // The real point: R is still responsive after the resize storm. evalRLogical
+      // reads R's "[1] TRUE" output -- a token the echoed console input can't
+      // contain -- so this proves a genuine round-trip, not just an echo match.
+      expect(await consoleActions.evalRLogical('TRUE')).toBe(true);
     },
   );
 });

--- a/e2e/rstudio/tests/panes/plots/plots_pane.test.ts
+++ b/e2e/rstudio/tests/panes/plots/plots_pane.test.ts
@@ -1,0 +1,187 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { PlotsPane } from '@pages/plots_pane.page';
+import { CONFIRM_BTN, CANCEL_BTN, YES_BTN } from '@pages/modals.page';
+import { useSuiteSandbox } from '@utils/sandbox';
+import { TIMEOUTS } from '@utils/constants';
+import type { Page } from 'playwright';
+
+// GWT file-chooser accept button. base-prefs.jsonc sets native_file_dialogs=false
+// suite-wide, so export flows always use the GWT file chooser (never a native OS
+// dialog). The two-step save flow is: OK on the format dialog, then this button
+// on the file chooser to accept the default path.
+const FILE_ACCEPT_SAVE = '#rstudio_file_accept_save';
+
+// Sandbox working directory for file-export tests so saved files are cleaned
+// up by globalTeardown automatically.
+useSuiteSandbox();
+
+let consoleActions: ConsolePaneActions;
+let plotsPane: PlotsPane;
+
+// Creates a minimal base-graphics plot and waits for the Plots pane to show it.
+async function createPlot(page: Page): Promise<void> {
+  await consoleActions.executeInConsole('plot(1, 1)');
+  await plotsPane.tab.click();
+  await expect(plotsPane.plotImage).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+}
+
+test.describe.serial('Plots pane', { tag: ['@serial'] }, () => {
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+    plotsPane = new PlotsPane(page);
+    await consoleActions.resetSourcePane();
+  });
+
+  test.afterEach(async () => {
+    // Close all open graphics devices to reset plot history between tests
+    // without needing to interact with the confirmation dialog.
+    await consoleActions.executeInConsole('try(while (dev.cur() > 1) dev.off(), silent = TRUE)');
+  });
+
+  test(
+    'zoom in plot opens a popup containing the plot image',
+    { tag: ['@desktop_only'] },
+    async ({ rstudioPage: page }) => {
+      await createPlot(page);
+
+      const [popup] = await Promise.all([
+        page.context().waitForEvent('page'),
+        plotsPane.zoomPlotBtn.click(),
+      ]);
+      await expect(popup.locator('#plot')).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      await popup.close();
+    },
+  );
+
+  test('removing a plot clears the plots pane', async ({ rstudioPage: page }) => {
+    await createPlot(page);
+
+    await plotsPane.removePlotBtn.click();
+    await page.locator(YES_BTN).click();
+    // When no plots remain the toolbar buttons are disabled -- the iframe
+    // stays in the DOM (src="about:blank") so visibility is not a useful signal.
+    await expect(plotsPane.removePlotBtn).toBeDisabled();
+  });
+
+  test('clearing all plots clears the plots pane', async ({ rstudioPage: page }) => {
+    await createPlot(page);
+
+    await plotsPane.clearPlotsBtn.click();
+    await page.locator(YES_BTN).click();
+    await expect(plotsPane.clearPlotsBtn).toBeDisabled();
+  });
+
+  test('publish button is visible in the plots toolbar', async ({ rstudioPage: page }) => {
+    await createPlot(page);
+    await expect(plotsPane.publishBtn).toBeVisible();
+  });
+
+  test('refreshing a plot leaves the plot image visible', async ({ rstudioPage: page }) => {
+    await createPlot(page);
+
+    await plotsPane.refreshPlotBtn.click();
+    await expect(plotsPane.plotImage).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+  });
+
+  test('export dropdown lists save-image, save-PDF, and copy-to-clipboard options', async ({
+    rstudioPage: page,
+  }) => {
+    await createPlot(page);
+
+    await plotsPane.exportMenu.click();
+    await expect(plotsPane.saveAsImageItem).toBeVisible();
+    await expect(plotsPane.saveAsPdfItem).toBeVisible();
+    await expect(plotsPane.copyToClipboardItem).toBeVisible();
+    await page.keyboard.press('Escape');
+  });
+
+  test('save plot as image dialog opens and accepts the save', async ({ rstudioPage: page }) => {
+    await createPlot(page);
+
+    await plotsPane.exportMenu.click();
+    await plotsPane.saveAsImageItem.click();
+    await expect(plotsPane.saveAsImageDialog).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+    // Two-step save: OK confirms format/size, then the GWT file chooser appears
+    // and FILE_ACCEPT_SAVE accepts the default path.
+    await page.locator(CONFIRM_BTN).click();
+    await page.locator(FILE_ACCEPT_SAVE).click();
+    await expect(plotsPane.saveAsImageDialog).toBeHidden();
+
+    // Verify a file was actually written -- the dialog closing alone doesn't
+    // confirm a successful save.
+    await expect.poll(
+      () => consoleActions.evalRLogical(
+        `length(list.files(getwd(), pattern = "Rplot")) > 0`,
+      ),
+      { timeout: TIMEOUTS.fileOpen },
+    ).toBe(true);
+  });
+
+  test('save plot as PDF dialog opens and accepts the save', async ({ rstudioPage: page }) => {
+    await createPlot(page);
+
+    await plotsPane.exportMenu.click();
+    await plotsPane.saveAsPdfItem.click();
+    await expect(plotsPane.saveAsPdfDialog).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+    await page.locator(CONFIRM_BTN).click();
+    await page.locator(FILE_ACCEPT_SAVE).click();
+    await expect(plotsPane.saveAsPdfDialog).toBeHidden();
+
+    await expect.poll(
+      () => consoleActions.evalRLogical(
+        `length(list.files(getwd(), pattern = "Rplot")) > 0`,
+      ),
+      { timeout: TIMEOUTS.fileOpen },
+    ).toBe(true);
+  });
+
+  test('copy plot to clipboard dialog opens and can be cancelled', async ({
+    rstudioPage: page,
+  }) => {
+    await createPlot(page);
+
+    await plotsPane.exportMenu.click();
+    await plotsPane.copyToClipboardItem.click();
+    await expect(plotsPane.copyToClipboardDialog).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+    await page.locator(CANCEL_BTN).click();
+    await expect(plotsPane.copyToClipboardDialog).toBeHidden();
+  });
+
+  test('grid graphics renders a plot without crashing R', async ({ rstudioPage: page }) => {
+    await consoleActions.executeInConsole('grid::grid.newpage()');
+    await plotsPane.tab.click();
+    await expect(plotsPane.plotImage).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+  });
+
+  test(
+    'resizing the zoomed plot popup does not crash R',
+    { tag: ['@desktop_only'] },
+    async ({ rstudioPage: page }) => {
+      await createPlot(page);
+
+      // Guards against rstudio/rstudio#14697 (crash on repeated resize of the
+      // zoomed-plot popup). We drive viewport resizes on the popup page rather
+      // than OS-level window.resizeTo(), which exercises the same resize-event
+      // handlers without requiring Electron-specific JS evaluation.
+      const [popup] = await Promise.all([
+        page.context().waitForEvent('page'),
+        plotsPane.zoomPlotBtn.click(),
+      ]);
+      await expect(popup.locator('#plot')).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+
+      for (let i = 0; i < 8; i++) {
+        await popup.setViewportSize({ width: 1280, height: 900 });
+        await popup.setViewportSize({ width: 640, height: 480 });
+        await popup.setViewportSize({ width: 960, height: 720 });
+      }
+
+      await popup.close();
+
+      // The real point: R is still responsive after the resize storm.
+      await consoleActions.clearConsole();
+      await consoleActions.executeInConsole("cat('alive')");
+      await expect(consoleActions.consolePane.consoleOutput).toContainText('alive');
+    },
+  );
+});

--- a/e2e/rstudio/tests/panes/terminal/terminal.test.ts
+++ b/e2e/rstudio/tests/panes/terminal/terminal.test.ts
@@ -4,7 +4,7 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { executeInConsole, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { AceEditor } from '@pages/ace_editor.page';
 import { rStringLiteral } from '@utils/r';
-import { executeCommand, setPref } from '@utils/commands';
+import { executeCommand } from '@utils/commands';
 import { useSuiteSandbox } from '@utils/sandbox';
 import type { Page } from 'playwright';
 
@@ -53,13 +53,6 @@ test.describe.serial('Terminal pane', () => {
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
-    // Force the DOM renderer so the xterm widget renders correctly in
-    // headless/software-rasterized environments (default is canvas).
-    await setPref(page, 'terminal_renderer', 'dom');
-  });
-
-  test.afterAll(async ({ rstudioPage: page }) => {
-    await setPref(page, 'terminal_renderer', 'canvas');
   });
 
   test.afterEach(async ({ rstudioPage: page }) => {
@@ -148,7 +141,10 @@ test.describe.serial('Terminal pane', () => {
     await openTerminal(page);
 
     // Use an absolute sandbox path so the file is cleaned up by globalTeardown
-    // regardless of the terminal's working directory.
+    // regardless of the terminal's working directory. Require the filename to
+    // appear at least twice in the buffer: once in the echoed touch command and
+    // once in the ls output. A single match would pass even if touch failed
+    // (the filename appears in the echoed command regardless).
     const sandboxDir = sandbox.dir.replace(/\\/g, '/');
     await page.keyboard.type(`touch ${sandboxDir}/ztestfile.txt`);
     await page.keyboard.press('Enter');
@@ -159,7 +155,8 @@ test.describe.serial('Terminal pane', () => {
       () => captureResult(
         page,
         '{ ids <- rstudioapi::terminalList(); ' +
-        'length(ids) > 0 && any(grepl("ztestfile.txt", rstudioapi::terminalBuffer(ids[[1]]))) }',
+        'buf <- paste(rstudioapi::terminalBuffer(ids[[1]]), collapse = "\\n"); ' +
+        'length(ids) > 0 && length(grep("ztestfile.txt", unlist(strsplit(buf, "\\n")))) >= 2 }',
       ),
       { timeout: TIMEOUTS.consoleReady },
     ).toBe('TRUE');

--- a/e2e/rstudio/tests/panes/terminal/terminal.test.ts
+++ b/e2e/rstudio/tests/panes/terminal/terminal.test.ts
@@ -4,7 +4,8 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { executeInConsole, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { AceEditor } from '@pages/ace_editor.page';
 import { rStringLiteral } from '@utils/r';
-import { executeCommand } from '@utils/commands';
+import { executeCommand, setPref } from '@utils/commands';
+import { useSuiteSandbox } from '@utils/sandbox';
 import type { Page } from 'playwright';
 
 const TERMINAL_TAB = '#rstudio_workbench_tab_terminal';
@@ -43,11 +44,22 @@ async function openTerminal(page: Page): Promise<void> {
   });
 }
 
+// Sandbox for file-creation test (terminal cwd is its own shell, so we
+// pass the absolute sandbox path directly to the shell command).
+const sandbox = useSuiteSandbox();
+
 test.describe.serial('Terminal pane', () => {
   let consoleActions: ConsolePaneActions;
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
+    // Force the DOM renderer so the xterm widget renders correctly in
+    // headless/software-rasterized environments (default is canvas).
+    await setPref(page, 'terminal_renderer', 'dom');
+  });
+
+  test.afterAll(async ({ rstudioPage: page }) => {
+    await setPref(page, 'terminal_renderer', 'canvas');
   });
 
   test.afterEach(async ({ rstudioPage: page }) => {
@@ -103,4 +115,79 @@ test.describe.serial('Terminal pane', () => {
       { timeout: TIMEOUTS.fileOpen },
     ).toContain('expr 1 + 1\n2\n');
   });
+
+  test('toolbar shows next and previous terminal buttons', async ({ rstudioPage: page }) => {
+    await killAllTerminals(page);
+    await openTerminal(page);
+
+    await expect(page.locator('#rstudio_tb_nextterminal')).toBeVisible();
+    await expect(page.locator('#rstudio_tb_previousterminal')).toBeVisible();
+  });
+
+  test('R --version runs in the terminal', async ({ rstudioPage: page }) => {
+    await killAllTerminals(page);
+    await openTerminal(page);
+
+    await page.keyboard.type('R --version');
+    await page.keyboard.press('Enter');
+
+    await expect.poll(
+      () => captureResult(
+        page,
+        '{ ids <- rstudioapi::terminalList(); ' +
+        'length(ids) > 0 && any(grepl("R version", rstudioapi::terminalBuffer(ids[[1]]))) }',
+      ),
+      { timeout: TIMEOUTS.consoleReady },
+    ).toBe('TRUE');
+  });
+
+  test('a file created in the terminal appears in a directory listing', async ({
+    rstudioPage: page,
+  }) => {
+    await killAllTerminals(page);
+    await openTerminal(page);
+
+    // Use an absolute sandbox path so the file is cleaned up by globalTeardown
+    // regardless of the terminal's working directory.
+    const sandboxDir = sandbox.dir.replace(/\\/g, '/');
+    await page.keyboard.type(`touch ${sandboxDir}/ztestfile.txt`);
+    await page.keyboard.press('Enter');
+    await page.keyboard.type(`ls ${sandboxDir}`);
+    await page.keyboard.press('Enter');
+
+    await expect.poll(
+      () => captureResult(
+        page,
+        '{ ids <- rstudioapi::terminalList(); ' +
+        'length(ids) > 0 && any(grepl("ztestfile.txt", rstudioapi::terminalBuffer(ids[[1]]))) }',
+      ),
+      { timeout: TIMEOUTS.consoleReady },
+    ).toBe('TRUE');
+  });
+
+  test(
+    'Shift+Backspace deletes the last character before submission',
+    { tag: ['@desktop_only'] },
+    async ({ rstudioPage: page }) => {
+      await killAllTerminals(page);
+      await openTerminal(page);
+
+      await page.keyboard.type('echo hello');
+      await page.keyboard.press('Shift+Backspace');
+      await page.keyboard.press('Enter');
+
+      // "echo hell" must appear AND "echo hello" must not -- if Shift+Backspace
+      // had no effect the full word would be present and the test would pass
+      // vacuously on the substring match alone.
+      await expect.poll(
+        () => captureResult(
+          page,
+          '{ ids <- rstudioapi::terminalList(); ' +
+          'buf <- paste(rstudioapi::terminalBuffer(ids[[1]]), collapse = "\\n"); ' +
+          'grepl("echo hell", buf) && !grepl("echo hello", buf) }',
+        ),
+        { timeout: TIMEOUTS.consoleReady },
+      ).toBe('TRUE');
+    },
+  );
 });

--- a/e2e/rstudio/tests/preferences/global_prefs_panels.test.ts
+++ b/e2e/rstudio/tests/preferences/global_prefs_panels.test.ts
@@ -81,7 +81,9 @@ test.describe('Global Options panels', () => {
     await expect(page.locator(CODE_DIAGNOSTICS_TAB)).toBeVisible();
 
     await expect(page.locator(CODE_EDITING_PANEL)).toBeVisible();
-    await expect(page.getByLabel('Auto-detect code indentation')).not.toBeChecked();
+    const autoDetect = page.getByLabel('Auto-detect code indentation');
+    await expect(autoDetect).toBeVisible();
+    await expect(autoDetect).not.toBeChecked();
 
     await page.locator(CODE_DISPLAY_TAB).click();
     await expect(page.locator(CODE_DISPLAY_PANEL)).toBeVisible();
@@ -130,33 +132,23 @@ test.describe('Global Options panels', () => {
     await closeGlobalOptions(page);
   });
 
-  test('Pane Layout panel is accessible', async ({ rstudioPage: page }) => {
-    await openGlobalOptions(page);
-    await page.locator(PANE_LAYOUT_TAB).click();
-    await expect(page.locator(PANE_LAYOUT_PANEL)).toBeVisible();
-    await closeGlobalOptions(page);
-  });
+  // Panels that are a plain open -> click tab -> verify panel visible. Each row
+  // generates its own named test so a failure still points at one panel.
+  const SIMPLE_PANELS = [
+    { name: 'Pane Layout', tab: PANE_LAYOUT_TAB, panel: PANE_LAYOUT_PANEL },
+    { name: 'R Markdown', tab: RMARKDOWN_TAB, panel: RMARKDOWN_PANEL },
+    { name: 'Spelling', tab: SPELLING_TAB, panel: SPELLING_PANEL },
+    { name: 'Sweave', tab: SWEAVE_TAB, panel: SWEAVE_PANEL },
+  ];
 
-  test('R Markdown panel is accessible', async ({ rstudioPage: page }) => {
-    await openGlobalOptions(page);
-    await page.locator(RMARKDOWN_TAB).click();
-    await expect(page.locator(RMARKDOWN_PANEL)).toBeVisible();
-    await closeGlobalOptions(page);
-  });
-
-  test('Spelling panel is accessible', async ({ rstudioPage: page }) => {
-    await openGlobalOptions(page);
-    await page.locator(SPELLING_TAB).click();
-    await expect(page.locator(SPELLING_PANEL)).toBeVisible();
-    await closeGlobalOptions(page);
-  });
-
-  test('Sweave panel is accessible', async ({ rstudioPage: page }) => {
-    await openGlobalOptions(page);
-    await page.locator(SWEAVE_TAB).click();
-    await expect(page.locator(SWEAVE_PANEL)).toBeVisible();
-    await closeGlobalOptions(page);
-  });
+  for (const { name, tab, panel } of SIMPLE_PANELS) {
+    test(`${name} panel is accessible`, async ({ rstudioPage: page }) => {
+      await openGlobalOptions(page);
+      await page.locator(tab).click();
+      await expect(page.locator(panel)).toBeVisible();
+      await closeGlobalOptions(page);
+    });
+  }
 
   test('Terminal sub-panels are accessible', async ({ rstudioPage: page }) => {
     await openGlobalOptions(page);

--- a/e2e/rstudio/tests/preferences/global_prefs_panels.test.ts
+++ b/e2e/rstudio/tests/preferences/global_prefs_panels.test.ts
@@ -1,0 +1,192 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { dismissAllModals } from '@utils/commands';
+import {
+  DIALOG_BOX,
+  openGlobalOptions,
+  closeGlobalOptions,
+  APPEARANCE_TAB,
+  APPEARANCE_PANEL,
+  APPEARANCE_PREVIEW,
+  CODE_TAB,
+  CODE_EDITING_TAB,
+  CODE_EDITING_PANEL,
+  CODE_DISPLAY_TAB,
+  CODE_DISPLAY_PANEL,
+  CODE_SAVING_TAB,
+  CODE_SAVING_PANEL,
+  CODE_CHANGE_ENCODING_BTN,
+  CODE_CHANGE_ENCODING_MODAL,
+  CODE_COMPLETION_TAB,
+  CODE_COMPLETION_PANEL,
+  CODE_DIAGNOSTICS_TAB,
+  CODE_DIAGNOSTICS_PANEL,
+  GENERAL_TAB,
+  GENERAL_PANEL,
+  GENERAL_ADVANCED_TAB,
+  GENERAL_ADVANCED_PANEL,
+  PACKAGES_TAB,
+  PACKAGES_PANEL,
+  PACKAGES_MANAGEMENT_TAB,
+  PACKAGES_MANAGEMENT_PANEL,
+  PACKAGES_DEVELOPMENT_TAB,
+  PACKAGES_DEVELOPMENT_PANEL,
+  PANE_LAYOUT_TAB,
+  PANE_LAYOUT_PANEL,
+  RMARKDOWN_TAB,
+  RMARKDOWN_PANEL,
+  SPELLING_TAB,
+  SPELLING_PANEL,
+  SWEAVE_TAB,
+  SWEAVE_PANEL,
+  TERMINAL_TAB,
+  TERMINAL_PANEL,
+  TERMINAL_GENERAL_TAB,
+  TERMINAL_GENERAL_PANEL,
+  TERMINAL_CLOSING_TAB,
+  TERMINAL_CLOSING_PANEL,
+  PYTHON_TAB,
+  PYTHON_PANEL,
+  PYTHON_INTERPRETER_PATH,
+  PYTHON_INTERPRETER_SELECT_BTN,
+  PYTHON_INTERPRETERS_MODAL,
+  ASSISTANT_TAB,
+  ASSISTANT_PANEL,
+  ASSISTANT_LABEL,
+} from '@pages/global_options.page';
+
+test.describe('Global Options panels', () => {
+  test.afterEach(async ({ rstudioPage: page }) => {
+    if (await page.locator(DIALOG_BOX).count() > 0) {
+      await dismissAllModals(page);
+      await page.waitForSelector(DIALOG_BOX, { state: 'detached', timeout: 10000 });
+    }
+  });
+
+  test('Appearance panel displays editor theme preview', async ({ rstudioPage: page }) => {
+    await openGlobalOptions(page);
+    await page.locator(APPEARANCE_TAB).click();
+    await expect(page.locator(APPEARANCE_PANEL)).toBeVisible();
+    await expect(page.locator(APPEARANCE_PREVIEW)).toBeVisible();
+    await closeGlobalOptions(page);
+  });
+
+  test('Code sub-panels are all accessible', async ({ rstudioPage: page }) => {
+    await openGlobalOptions(page);
+    await page.locator(CODE_TAB).click();
+
+    await expect(page.locator(CODE_EDITING_TAB)).toBeVisible();
+    await expect(page.locator(CODE_DISPLAY_TAB)).toBeVisible();
+    await expect(page.locator(CODE_SAVING_TAB)).toBeVisible();
+    await expect(page.locator(CODE_COMPLETION_TAB)).toBeVisible();
+    await expect(page.locator(CODE_DIAGNOSTICS_TAB)).toBeVisible();
+
+    await expect(page.locator(CODE_EDITING_PANEL)).toBeVisible();
+    await expect(page.getByLabel('Auto-detect code indentation')).not.toBeChecked();
+
+    await page.locator(CODE_DISPLAY_TAB).click();
+    await expect(page.locator(CODE_DISPLAY_PANEL)).toBeVisible();
+
+    await page.locator(CODE_SAVING_TAB).click();
+    await expect(page.locator(CODE_SAVING_PANEL)).toBeVisible();
+
+    await page.locator(CODE_COMPLETION_TAB).click();
+    await expect(page.locator(CODE_COMPLETION_PANEL)).toBeVisible();
+
+    await page.locator(CODE_DIAGNOSTICS_TAB).click();
+    await expect(page.locator(CODE_DIAGNOSTICS_PANEL)).toBeVisible();
+
+    await closeGlobalOptions(page);
+  });
+
+  test('Code saving change encoding modal opens', async ({ rstudioPage: page }) => {
+    await openGlobalOptions(page);
+    await page.locator(CODE_TAB).click();
+    await page.locator(CODE_SAVING_TAB).click();
+    await expect(page.locator(CODE_CHANGE_ENCODING_BTN)).toBeVisible();
+    await page.locator(CODE_CHANGE_ENCODING_BTN).click();
+    await expect(page.locator(CODE_CHANGE_ENCODING_MODAL)).toBeVisible();
+    await page.keyboard.press('Escape');
+    await page.waitForSelector(CODE_CHANGE_ENCODING_MODAL, { state: 'detached', timeout: 10000 });
+    await closeGlobalOptions(page);
+  });
+
+  test('General panel and Advanced sub-panel are accessible', async ({ rstudioPage: page }) => {
+    await openGlobalOptions(page);
+    await page.locator(GENERAL_TAB).click();
+    await expect(page.locator(GENERAL_PANEL)).toBeVisible();
+    await page.locator(GENERAL_ADVANCED_TAB).click();
+    await expect(page.locator(GENERAL_ADVANCED_PANEL)).toBeVisible();
+    await closeGlobalOptions(page);
+  });
+
+  test('Packages sub-panels are accessible', async ({ rstudioPage: page }) => {
+    await openGlobalOptions(page);
+    await page.locator(PACKAGES_TAB).click();
+    await expect(page.locator(PACKAGES_PANEL)).toBeVisible();
+    await page.locator(PACKAGES_MANAGEMENT_TAB).click();
+    await expect(page.locator(PACKAGES_MANAGEMENT_PANEL)).toBeVisible();
+    await page.locator(PACKAGES_DEVELOPMENT_TAB).click();
+    await expect(page.locator(PACKAGES_DEVELOPMENT_PANEL)).toBeVisible();
+    await closeGlobalOptions(page);
+  });
+
+  test('Pane Layout panel is accessible', async ({ rstudioPage: page }) => {
+    await openGlobalOptions(page);
+    await page.locator(PANE_LAYOUT_TAB).click();
+    await expect(page.locator(PANE_LAYOUT_PANEL)).toBeVisible();
+    await closeGlobalOptions(page);
+  });
+
+  test('R Markdown panel is accessible', async ({ rstudioPage: page }) => {
+    await openGlobalOptions(page);
+    await page.locator(RMARKDOWN_TAB).click();
+    await expect(page.locator(RMARKDOWN_PANEL)).toBeVisible();
+    await closeGlobalOptions(page);
+  });
+
+  test('Spelling panel is accessible', async ({ rstudioPage: page }) => {
+    await openGlobalOptions(page);
+    await page.locator(SPELLING_TAB).click();
+    await expect(page.locator(SPELLING_PANEL)).toBeVisible();
+    await closeGlobalOptions(page);
+  });
+
+  test('Sweave panel is accessible', async ({ rstudioPage: page }) => {
+    await openGlobalOptions(page);
+    await page.locator(SWEAVE_TAB).click();
+    await expect(page.locator(SWEAVE_PANEL)).toBeVisible();
+    await closeGlobalOptions(page);
+  });
+
+  test('Terminal sub-panels are accessible', async ({ rstudioPage: page }) => {
+    await openGlobalOptions(page);
+    await page.locator(TERMINAL_TAB).click();
+    await expect(page.locator(TERMINAL_PANEL)).toBeVisible();
+    await page.locator(TERMINAL_GENERAL_TAB).click();
+    await expect(page.locator(TERMINAL_GENERAL_PANEL)).toBeVisible();
+    await page.locator(TERMINAL_CLOSING_TAB).click();
+    await expect(page.locator(TERMINAL_CLOSING_PANEL)).toBeVisible();
+    await closeGlobalOptions(page);
+  });
+
+  test('Python panel and interpreter selector are accessible', async ({ rstudioPage: page }) => {
+    await openGlobalOptions(page);
+    await page.locator(PYTHON_TAB).click();
+    await expect(page.locator(PYTHON_PANEL)).toBeVisible();
+    await expect(page.locator(PYTHON_INTERPRETER_PATH)).toBeVisible();
+    await expect(page.locator(PYTHON_INTERPRETER_SELECT_BTN)).toBeVisible();
+    await page.locator(PYTHON_INTERPRETER_SELECT_BTN).click();
+    await expect(page.locator(PYTHON_INTERPRETERS_MODAL)).toBeVisible({ timeout: 15000 });
+    await page.keyboard.press('Escape');
+    await page.waitForSelector(PYTHON_INTERPRETERS_MODAL, { state: 'detached', timeout: 10000 });
+    await closeGlobalOptions(page);
+  });
+
+  test('Assistant panel displays code assistant configuration', async ({ rstudioPage: page }) => {
+    await openGlobalOptions(page);
+    await page.locator(ASSISTANT_TAB).click();
+    await expect(page.locator(ASSISTANT_PANEL)).toBeVisible();
+    await expect(page.locator(ASSISTANT_PANEL).getByText(ASSISTANT_LABEL)).toBeVisible();
+    await closeGlobalOptions(page);
+  });
+});

--- a/e2e/rstudio/utils/constants.ts
+++ b/e2e/rstudio/utils/constants.ts
@@ -3,6 +3,9 @@ export const TIMEOUTS = {
   rstudioStartup: 30000,
   consoleReady: 15000,
   sessionRestart: 30000,
+  // The Environment pane requeries memory stats every memory_query_interval_seconds
+  // (default 10s), so a memory-pie change can take a full interval to surface.
+  memoryUsageUpdate: 30000,
   settleDelay: 1000,
   pollInterval: 500,
   fileOpen: 20000,


### PR DESCRIPTION
## Summary

Migrates Selenium desktop test files to the Playwright e2e suite:

- `test_desktop_EnvironmentPane.py` -> `tests/panes/environment/environment_pane.test.ts` (5 tests)
  - Toolbar elements, import-dataset/object-view/environment-list dropdowns,
    memory-pie growth with unit-normalized MiB comparison, and usage-report modal.

- `test_desktop_terminal.py` -> `tests/panes/terminal/terminal.test.ts` (4 tests added)
  - Toolbar next/previous buttons, R --version output, file create and ls,
    and Shift+Backspace character deletion (@desktop_only). All output assertions
    use rstudioapi::terminalBuffer.

- `test_desktop_PlotsPane.py` -> `tests/panes/plots/plots_pane.test.ts` (11 tests)
  - Zoom popup, remove/clear, publish, refresh, export dropdown, save as image,
    save as PDF, copy to clipboard, grid graphics, and resize-crash guard
    (rstudio/rstudio#14697). Includes the 3 tests that were commented out in
    the Selenium source. Save flows use the two-step GWT file chooser with R
    file-exists verification. Zoom and resize tests are @desktop_only.

- `GlobalPrefs/test_desktop_GlobalPref*.py` (9 files) -> `tests/preferences/global_prefs_panels.test.ts` (12 tests)
  - Panel visibility smoke tests for Appearance, Code, General, Packages, Pane Layout,
    R Markdown, Spelling, Sweave, and Terminal. Includes 2 new tests (Python panel,
    Assistant panel) with no Selenium equivalent. Also adds `pages/global_options.page.ts`
    page object.

Also adds new page objects (EnvironmentPane extensions, PlotsPane), a
memoryUsageUpdate timeout constant, and tightens the migration skill hard
rules (README and run-skill loads required, cross-platform requirement added,
rules renumbered, BRAT retired in favor of the Playwright suite).