### PR TITLE
guard the python help url handler against code injection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@
 - ([#17810](https://github.com/rstudio/rstudio/issues/17810)): Fix the "Run Tests" button modifying the active test file's timestamp even when the file had no unsaved changes.
 - ([#17735](https://github.com/rstudio/rstudio/issues/17735)): Hide the redundant column-summary sidebar in the data frame preview shown in the Help pane.
 - ([#17066](https://github.com/rstudio/rstudio/issues/17066)): Fix the Assistant preferences pane showing a stale code-assistant account after switching back and forth between GitHub Copilot and Posit Assistant.
+- Fixed a security issue where the Python help URL handler (`/python/`) evaluated the requested help topic as a Python expression, allowing arbitrary code execution; the handler now accepts only plain dotted help-topic names.
 
 ### Dependencies
 - Ace 1.43.5

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,7 @@
 - ([#17810](https://github.com/rstudio/rstudio/issues/17810)): Fix the "Run Tests" button modifying the active test file's timestamp even when the file had no unsaved changes.
 - ([#17735](https://github.com/rstudio/rstudio/issues/17735)): Hide the redundant column-summary sidebar in the data frame preview shown in the Help pane.
 - ([#17066](https://github.com/rstudio/rstudio/issues/17066)): Fix the Assistant preferences pane showing a stale code-assistant account after switching back and forth between GitHub Copilot and Posit Assistant.
-- Fixed a security issue where the Python help URL handler (`/python/`) evaluated the requested help topic as a Python expression, allowing arbitrary code execution; the handler now accepts only plain dotted help-topic names.
+- ([#17868](https://github.com/rstudio/rstudio/issues/17868)): Restrict the Python help URL handler (`/python/`) to valid help-topic names, accepting only plain dotted qualified names.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -1099,6 +1099,17 @@ void handlePythonHelpRequest(const http::Request& request,
       return;
    }
 
+   // the requested topic is evaluated as a Python expression when help is
+   // generated, so reject anything that isn't a plain dotted name (e.g.
+   // 'numpy', 'os.path', 'pandas.DataFrame.html') to guard against code
+   // injection. the R side performs stricter validation as well.
+   static const boost::regex rePythonHelpTopic("^[A-Za-z_][A-Za-z0-9_.]*$");
+   if (!boost::regex_match(code, rePythonHelpTopic))
+   {
+      pResponse->setNotFoundError(request);
+      return;
+   }
+
    // construct HTML help file from requested object
    std::string path;
    Error error = r::exec::RFunction(".rs.python.generateHtmlHelp")

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -1232,13 +1232,32 @@
    }, numeric(1))
 })
 
+.rs.addFunction("python.isHelpTopicValid", function(code)
+{
+   # a valid Python help topic is a simple qualified name; that is, a
+   # sequence of identifiers joined by dots (e.g. 'numpy', 'os.path',
+   # 'pandas.DataFrame'). the topic is evaluated as a Python expression
+   # when generating help, so anything that isn't a plain dotted name is
+   # rejected to guard against code injection.
+   pattern <- "^[A-Za-z_][A-Za-z0-9_]*([.][A-Za-z_][A-Za-z0-9_]*)*$"
+   grepl(pattern, code, perl = TRUE)
+})
+
 .rs.addFunction("python.generateHtmlHelp", function(code)
 {
    Encoding(code) <- "UTF-8"
-   
+
    # remove a '.html' suffix if present
    code <- sub("[.]html$", "", code)
-   
+
+   # validate the requested topic before attempting to resolve it; the
+   # topic is otherwise evaluated as a Python expression below, so an
+   # invalid topic could be used to inject and execute arbitrary code
+   if (!.rs.python.isHelpTopicValid(code)) {
+      warning(sprintf("'%s' is not a valid Python help topic", code), call. = FALSE)
+      return("")
+   }
+
    # check for pre-existing generated HTML
    dir <- file.path(tempdir(), "reticulate-python-help")
    if (!.rs.ensureDirectory(dir)) {

--- a/src/cpp/tests/testthat/test-reticulate.R
+++ b/src/cpp/tests/testthat/test-reticulate.R
@@ -30,3 +30,28 @@ test_that("RETICULATE_PYTHON environment variable is respected", {
    # we expect that since we set a custom value it'll be reflected
    expect_equal(python, Sys.getenv("RETICULATE_PYTHON"))
 })
+
+test_that("Python help topics accept only plain dotted names", {
+
+   # legitimate help topics resolve to valid qualified names
+   expect_true(.rs.python.isHelpTopicValid("numpy"))
+   expect_true(.rs.python.isHelpTopicValid("os.path"))
+   expect_true(.rs.python.isHelpTopicValid("pandas.DataFrame"))
+   expect_true(.rs.python.isHelpTopicValid("_private.member"))
+
+})
+
+test_that("Python help topics reject code injection payloads", {
+
+   # these would otherwise be evaluated as Python expressions
+   expect_false(.rs.python.isHelpTopicValid("open('pwned.txt','w').write('RCE')"))
+   expect_false(.rs.python.isHelpTopicValid("__import__('os').system('id')"))
+   expect_false(.rs.python.isHelpTopicValid("os.system('id')"))
+   expect_false(.rs.python.isHelpTopicValid("numpy.array(1)"))
+   expect_false(.rs.python.isHelpTopicValid("a;b"))
+   expect_false(.rs.python.isHelpTopicValid("a b"))
+   expect_false(.rs.python.isHelpTopicValid("1abc"))
+   expect_false(.rs.python.isHelpTopicValid(".leadingdot"))
+   expect_false(.rs.python.isHelpTopicValid(""))
+
+})


### PR DESCRIPTION
## Intent

Addresses rstudio/rstudio-pro#11306.

## Overview

The Help pane serves Python help topics through the `/python/` help endpoint. When generating one of these pages, the backend passed the topic taken from the URL straight to `reticulate::py_eval()`, which evaluates it as a Python expression. As a result a crafted help URL could cause the session to run code instead of just displaying documentation. Because these are ordinary GET URLs, a browser could be made to open one (for example via a redirect), so this could be triggered without the user's intent -- most significant in server deployments.

## Changes

- `SessionReticulate.R`: add `.rs.python.isHelpTopicValid()` and validate the requested topic in `python.generateHtmlHelp()` before resolving it. Only plain dotted help-topic names (e.g. `numpy`, `os.path`, `pandas.DataFrame`) are accepted; anything else returns no help.
- `SessionHelp.cpp`: as defense in depth, the `/python/` handler now rejects topics containing characters outside a dotted-name set before invoking R.
- `test-reticulate.R`: regression tests covering valid topics and rejected payloads.
- `NEWS.md`: changelog entry.

## Testing

`./rstudio-tests --scope r --filter reticulate` passes (`FAIL 0 | PASS 14`). Legitimate "Go to Help" for Python objects continues to work, since real topics are dotted names.
