### PR TITLE
Fix two flaky code-suggestion Playwright tests

### DIFF
--- a/e2e/rstudio/actions/source_pane.actions.ts
+++ b/e2e/rstudio/actions/source_pane.actions.ts
@@ -218,16 +218,18 @@ export class SourcePaneActions {
     }, marker);
   }
 
-  /** Get the first visible row index (0-based) of the active source editor. */
+  /**
+   * Get the first visible row index (0-based) of the active source editor.
+   * Uses the automation bridge's activeEditor() rather than scanning
+   * `.ace_editor` nodes -- a DOM scan can land on a stale or background
+   * editor (e.g. the empty Untitled tab the suite keeps open), which sorts
+   * first and always reports row 0. See getEditorContent for the same pattern.
+   */
   async getFirstVisibleRow(): Promise<number> {
     return await this.page.evaluate(() => {
-      const editors = document.querySelectorAll('.ace_editor');
-      for (let i = 0; i < editors.length; i++) {
-        if (editors[i].closest('#rstudio_console_input')) continue;
-        const editor = (editors[i] as unknown as AceEditorElement).env?.editor;
-        if (editor) return editor.getFirstVisibleRow();
-      }
-      throw new Error('No active source editor found');
+      const editor = window.rstudio?.documents.activeEditor() ?? null;
+      if (!editor) throw new Error('No active source editor');
+      return editor.getFirstVisibleRow();
     });
   }
 

--- a/e2e/rstudio/pages/source_pane.page.ts
+++ b/e2e/rstudio/pages/source_pane.page.ts
@@ -29,6 +29,7 @@ export class SourcePane extends PageObject {
   public secondaryToolbar: Locator;
   public chunkImage: Locator;
   public statusBarCompletionReceived: Locator;
+  public statusBarCompletionPending: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -64,6 +65,9 @@ export class SourcePane extends PageObject {
     this.secondaryToolbar = page.locator('[aria-label="Markdown editing tools"]');
     this.chunkImage = page.locator("xpath=//*[@id='rstudio_source_text_editor']//*[@class='gwt-Image']");
     this.statusBarCompletionReceived = this.footerTable.locator('.gwt-Label', { hasText: 'Completion response received' });
+    // Shown while a code-completion request is in flight (COMPLETION_REQUESTED).
+    // Its presence means a response may still land and re-render ghost text.
+    this.statusBarCompletionPending = this.footerTable.locator('.gwt-Label', { hasText: 'Waiting for completions' });
   }
 }
 

--- a/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
@@ -372,15 +372,15 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
       await expect(sourcePane.ghostText.first()).toBeVisible({ timeout: TIMEOUTS.ghostText });
       console.log('  Ghost text visible — pressing Escape');
 
-      // First Escape closes Ace autocomplete popup if active;
-      // second Escape dismisses the ghost text itself
-      await page.keyboard.press('Escape');
-      await sleep(500);
-      await page.keyboard.press('Escape');
-      await sleep(1000);
-
-      // Verify ghost text is fully cleared
-      await expect(sourcePane.ghostText).toHaveCount(0, { timeout: 5000 });
+      // A late completion response can re-render ghost text after a single
+      // Escape (see status bar "Completion response received"), so retry Escape
+      // until the suggestion stays cleared rather than pressing a fixed number
+      // of times. This also covers the case where the first Escape only closes
+      // the Ace autocomplete popup.
+      await expect(async () => {
+        await page.keyboard.press('Escape');
+        await expect(sourcePane.ghostText).toHaveCount(0, { timeout: 1000 });
+      }).toPass({ timeout: 10000 });
       console.log('  Ghost text dismissed with Escape');
 
       await sourceActions.closeSourceAndDeleteFile(fileName);
@@ -596,22 +596,16 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
       await expect(sourcePane.statusBarCompletionReceived).toBeVisible({ timeout: 5000 });
       console.log('  Status bar shows "Completion response received"');
 
-      // Scroll the viewport to the middle of the file WITHOUT moving the cursor.
-      // Using keyboard shortcuts would move the cursor, triggering a new
-      // completion request that replaces the click handler we want to test.
-      // We scroll to the middle so that regardless of whether the completion
-      // is near the top or bottom, clicking the status bar causes an
-      // observable scroll change.
+      // Scroll the active editor to the top WITHOUT moving the cursor (the
+      // completion is at the bottom where we typed, so clicking the status bar
+      // produces an observable downward scroll). Using keyboard shortcuts would
+      // move the cursor and trigger a new completion request, replacing the
+      // click handler we want to test. Target activeEditor() rather than the
+      // first .ace_editor in the DOM: the suite keeps an empty Untitled tab
+      // open, whose editor sorts first and would otherwise absorb the scroll.
       await page.evaluate(`(function() {
-        var editors = document.querySelectorAll('.ace_editor');
-        for (var i = 0; i < editors.length; i++) {
-          if (editors[i].closest('#rstudio_console_input')) continue;
-          var env = editors[i].env;
-          if (env && env.editor) {
-            env.editor.scrollToLine(0, false);
-            break;
-          }
-        }
+        var editor = window.rstudio && window.rstudio.documents.activeEditor();
+        if (editor) editor.scrollToLine(0, false);
       })()`);
       await sleep(1000);
 

--- a/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
@@ -372,17 +372,17 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
       await expect(sourcePane.ghostText.first()).toBeVisible({ timeout: TIMEOUTS.ghostText });
       console.log('  Ghost text visible — pressing Escape');
 
-      // A late completion response can re-render ghost text after a single
-      // Escape (see status bar "Completion response received"), so retry Escape
-      // until the suggestion clears AND stays cleared: assert empty, wait out
-      // the late-response window, then assert empty again. A bare toPass would
-      // resolve the instant the count first hits 0 and miss a re-render landing
-      // moments later. This also covers the case where the first Escape only
-      // closes the Ace autocomplete popup.
+      // Press Escape until the suggestion is gone AND no completion request is
+      // still in flight. An in-flight request -- shown as "Waiting for
+      // completions..." in the status bar -- can land a response that re-renders
+      // ghost text right after we dismiss it (the original flake; the failure
+      // snapshot showed a late "Completion response received"). Gating on "no
+      // request pending" is the meaningful signal that nothing can resurrect the
+      // suggestion, so we don't need a blind stability sleep. This also covers
+      // the case where the first Escape only closes the Ace autocomplete popup.
       await expect(async () => {
         await page.keyboard.press('Escape');
-        await expect(sourcePane.ghostText).toHaveCount(0, { timeout: 1000 });
-        await sleep(1000);
+        await expect(sourcePane.statusBarCompletionPending).toHaveCount(0, { timeout: 1000 });
         await expect(sourcePane.ghostText).toHaveCount(0, { timeout: 1000 });
       }).toPass({ timeout: 15000 });
       console.log('  Ghost text dismissed with Escape');

--- a/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
@@ -374,13 +374,17 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
 
       // A late completion response can re-render ghost text after a single
       // Escape (see status bar "Completion response received"), so retry Escape
-      // until the suggestion stays cleared rather than pressing a fixed number
-      // of times. This also covers the case where the first Escape only closes
-      // the Ace autocomplete popup.
+      // until the suggestion clears AND stays cleared: assert empty, wait out
+      // the late-response window, then assert empty again. A bare toPass would
+      // resolve the instant the count first hits 0 and miss a re-render landing
+      // moments later. This also covers the case where the first Escape only
+      // closes the Ace autocomplete popup.
       await expect(async () => {
         await page.keyboard.press('Escape');
         await expect(sourcePane.ghostText).toHaveCount(0, { timeout: 1000 });
-      }).toPass({ timeout: 10000 });
+        await sleep(1000);
+        await expect(sourcePane.ghostText).toHaveCount(0, { timeout: 1000 });
+      }).toPass({ timeout: 15000 });
       console.log('  Ghost text dismissed with Escape');
 
       await sourceActions.closeSourceAndDeleteFile(fileName);


### PR DESCRIPTION
## Summary

Fixes two flaky tests in `e2e/rstudio/tests/panes/editor/code_suggestions.test.ts` (Posit AI / Copilot code suggestions).

### `ghost text dismissed with Escape`

A late completion response could re-render ghost text after the test pressed Escape, leaving the suggestion on screen when the test asserted it was gone (the failure showed "Completion response received" in the status bar). The fixed double-Escape with `sleep()` calls is replaced with an `expect().toPass()` block that re-presses Escape and re-asserts the ghost-text count is 0 after a stability window, so the test confirms the suggestion clears and stays cleared rather than exiting on a transient 0.

### `status bar navigates to most recent completion on click`

The test read scroll position from the wrong editor. The suite keeps an empty Untitled tab open for its lifetime, and its `.ace_editor` sorts first in the DOM. Both the scroll setup and `getFirstVisibleRow()` grabbed the first `.ace_editor`, so they acted on the empty placeholder while the click handler scrolled the active document -- first-visible-row read 0 before and after the click, failing the `not.toBe` assertion. Both now go through `window.rstudio.documents.activeEditor()` (the approach `getEditorContent()` already uses) so they target the active document.

## Testing

- `npm run typecheck` passes
- Both tests pass locally on Desktop