### PR TITLE
fix comment shortcut losing indent on empty indented lines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@
 - ([#17810](https://github.com/rstudio/rstudio/issues/17810)): Fix the "Run Tests" button modifying the active test file's timestamp even when the file had no unsaved changes.
 - ([#17735](https://github.com/rstudio/rstudio/issues/17735)): Hide the redundant column-summary sidebar in the data frame preview shown in the Help pane.
 - ([#17066](https://github.com/rstudio/rstudio/issues/17066)): Fix the Assistant preferences pane showing a stale code-assistant account after switching back and forth between GitHub Copilot and Posit Assistant.
+- ([#17493](https://github.com/rstudio/rstudio/issues/17493)): Fix the comment/uncomment shortcut inserting the comment character at the start of an empty indented line instead of after the indent.
 
 ### Dependencies
 - Ace 1.43.5

--- a/e2e/rstudio/pages/ace_editor.page.ts
+++ b/e2e/rstudio/pages/ace_editor.page.ts
@@ -104,6 +104,10 @@ export class AceEditor extends PageObject {
     return this.run((editor) => editor.getValue());
   }
 
+  /**
+   * Moves the cursor to `line` (1-indexed, matching Ace's own gotoLine and the
+   * editor's gutter), distinct from the 0-indexed row taken by getLine et al.
+   */
   async gotoLine(line: number, column = 0): Promise<void> {
     await this.run(
       (editor, pos: { line: number; column: number }) => editor.gotoLine(pos.line, pos.column),

--- a/e2e/rstudio/tests/panes/editor/editor.test.ts
+++ b/e2e/rstudio/tests/panes/editor/editor.test.ts
@@ -175,7 +175,8 @@ test.describe('Editor', () => {
     await expect.poll(() => editor.getValue()).toContain('f <- function()');
 
     // Put the cursor on the empty body line and indent it, mirroring the user
-    // pressing Tab on a fresh line inside the function.
+    // pressing Tab on a fresh line inside the function. gotoLine(2) and
+    // getLine(1) below both target this line (1-indexed vs 0-indexed).
     await editor.gotoLine(2);
     await editor.insert('  ');
 

--- a/e2e/rstudio/tests/panes/editor/editor.test.ts
+++ b/e2e/rstudio/tests/panes/editor/editor.test.ts
@@ -38,6 +38,7 @@ test.describe('Editor', () => {
       'editor_whole_word.R',
       'editor_shortcuts.R',
       'editor_find_from_selection.R',
+      'editor_comment_indent.R',
     ]);
   });
 
@@ -163,5 +164,24 @@ test.describe('Editor', () => {
     // keyboard focus being on the bar.
     await page.locator(CLOSE_FIND_BAR).click();
     await expect(page.locator(FIND_INPUT)).toHaveCount(0, { timeout: 5000 });
+  });
+
+  // https://github.com/rstudio/rstudio/issues/17493
+  test('comment shortcut preserves indent on an empty indented line', async ({ rstudioPage: page }) => {
+    const content = 'f <- function() {\n\n}\n';
+    await writeAndOpenFile(page, sandbox.dir, 'editor_comment_indent.R', content);
+
+    const editor = new AceEditor(page, 'f <- function()');
+    await expect.poll(() => editor.getValue()).toContain('f <- function()');
+
+    // Put the cursor on the empty body line and indent it, mirroring the user
+    // pressing Tab on a fresh line inside the function.
+    await editor.gotoLine(2);
+    await editor.insert('  ');
+
+    await executeCommand(page, 'commentUncomment');
+
+    // The comment character must land after the indent, not at column zero.
+    await expect.poll(() => editor.getLine(1)).toMatch(/^  #/);
   });
 });

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -495,9 +495,16 @@ public class StringUtil
    {
       if (skipWhitespaceOnlyLines)
       {
-         lines = lines.stream()
+         // Drop whitespace-only lines only when at least one line with content
+         // remains. If every line is whitespace-only, keep them so callers can
+         // still recover the common indent (e.g. commenting an empty indented
+         // line -- https://github.com/rstudio/rstudio/issues/17493).
+         List<String> filtered = lines.stream()
             .filter(line -> !line.trim().isEmpty())
             .collect(Collectors.toList());
+
+         if (!filtered.isEmpty())
+            lines = filtered;
       }
 
       if (lines.size() == 0)

--- a/src/gwt/test/org/rstudio/core/client/StringUtilTests.java
+++ b/src/gwt/test/org/rstudio/core/client/StringUtilTests.java
@@ -378,6 +378,31 @@ public class StringUtilTests extends GWTTestCase
       );
    }
 
+   // https://github.com/rstudio/rstudio/issues/17493
+   public void testCommonPrefixWhitespaceOnlyLines()
+   {
+      // A single whitespace-only line should still report its own indent as the
+      // common prefix when skipWhitespaceOnlyLines is enabled; otherwise the
+      // comment shortcut loses the indent and inserts "#" at column zero.
+      assertEquals(
+         "    ",
+         StringUtil.getCommonPrefix(new String[] { "    " }, true, true)
+      );
+
+      // When every line is whitespace-only, fall back to comparing them rather
+      // than collapsing the prefix to the empty string.
+      assertEquals(
+         "  ",
+         StringUtil.getCommonPrefix(new String[] { "  ", "    " }, false, true)
+      );
+
+      // With at least one content line, whitespace-only lines are still skipped.
+      assertEquals(
+         "  ",
+         StringUtil.getCommonPrefix(new String[] { "  x", "", "  y" }, false, true)
+      );
+   }
+
    // -- StringUtil.htmlUnescape tests ----------------------------------------
 
    public void testHtmlUnescapeNullAndEmpty()

--- a/src/gwt/test/org/rstudio/core/client/StringUtilTests.java
+++ b/src/gwt/test/org/rstudio/core/client/StringUtilTests.java
@@ -383,14 +383,25 @@ public class StringUtilTests extends GWTTestCase
    {
       // A single whitespace-only line should still report its own indent as the
       // common prefix when skipWhitespaceOnlyLines is enabled; otherwise the
-      // comment shortcut loses the indent and inserts "#" at column zero.
+      // comment shortcut loses the indent and inserts "#" at column zero. The
+      // allowPhantomWhitespace argument is irrelevant here: the single-line case
+      // returns the line verbatim before any prefix comparison happens.
       assertEquals(
          "    ",
          StringUtil.getCommonPrefix(new String[] { "    " }, true, true)
       );
 
+      // Tabs are a realistic indent for the comment shortcut, and must be
+      // preserved the same way as spaces.
+      assertEquals(
+         "\t",
+         StringUtil.getCommonPrefix(new String[] { "\t" }, true, true)
+      );
+
       // When every line is whitespace-only, fall back to comparing them rather
-      // than collapsing the prefix to the empty string.
+      // than collapsing the prefix to the empty string. allowPhantomWhitespace
+      // must be false so the shorter line bounds the common prefix at "  ";
+      // with phantom whitespace the prefix would extend to the longer indent.
       assertEquals(
          "  ",
          StringUtil.getCommonPrefix(new String[] { "  ", "    " }, false, true)


### PR DESCRIPTION
## Intent

Fixes #17493.

## Problem

When using the comment/uncomment shortcut (`Cmd+Shift+C` / `Ctrl+Shift+C`) on an
empty but indented line -- e.g. after pressing Tab on a fresh line inside a
function -- the comment character was inserted at column 0 instead of after the
indent. Typing `#` manually was unaffected; only the shortcut misbehaved.

This was a regression introduced in #16646, and first shipped in 2026.01.0
(2025.09.2 was fine).

## Root cause

`doCommentUncomment` derives where to place the comment character from the common
indent of the selected lines, via `StringUtil.getCommonPrefix(..., skipWhitespaceOnlyLines = true)`.

The rewrite of `getCommonPrefix` in #16646 moved the `skipWhitespaceOnlyLines`
filter to the top of the function, ahead of the single-line shortcut. On an
empty-but-indented line, the only line is whitespace-only, so it was filtered
out entirely, the list became empty, and the function returned `""`. The common
indent was then empty and the `#` landed at column 0.

## Fix

Only drop whitespace-only lines when at least one line with content remains. If
every line is whitespace-only, keep them so the common indent is still
recoverable. This preserves the #4163 behavior (blank lines inside a multi-line
selection don't collapse the prefix) while fixing the all-whitespace edge case.

## Testing

- New unit test `StringUtilTests.testCommonPrefixWhitespaceOnlyLines` covering
  the single whitespace line, the all-whitespace fallback, and the
  still-skip-when-content-present case. All 499 GWT unit tests pass.
- New Playwright test in the `Editor` suite, `comment shortcut preserves indent
  on an empty indented line`, which indents an empty function-body line, runs
  the `commentUncomment` command, and asserts the comment character lands after
  the indent. Passes against a dev desktop build.
