### PR TITLE
write find-in-files replace results atomically and durably

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 - ([#17735](https://github.com/rstudio/rstudio/issues/17735)): Hide the redundant column-summary sidebar in the data frame preview shown in the Help pane.
 - ([#17066](https://github.com/rstudio/rstudio/issues/17066)): Fix the Assistant preferences pane showing a stale code-assistant account after switching back and forth between GitHub Copilot and Posit Assistant.
 - ([#17833](https://github.com/rstudio/rstudio/issues/17833)): Fix saving a file silently appearing to succeed when the write actually failed (for example, when the disk is full or a disk quota is exceeded); such failures are now reported and the document keeps its unsaved state.
+- ([#17845](https://github.com/rstudio/rstudio/issues/17845)): Fix Find in Files "Replace All" overwriting a source file with truncated or empty contents when the write failed (for example, when the disk is full or a disk quota is exceeded); the replacement is now written atomically and durably, so on failure the original file is left untouched and the error is reported.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/cpp/core/FileSerializer.cpp
+++ b/src/cpp/core/FileSerializer.cpp
@@ -466,7 +466,8 @@ bool isDiskSpaceError(const Error& error)
 
 Error writeStringToFileAtomic(const FilePath& filePath,
                               const std::string& str,
-                              string_utils::LineEnding lineEnding)
+                              string_utils::LineEnding lineEnding,
+                              bool preservePermissions)
 {
    // generate a unique temporary file in the same directory
    FilePath tmpFile;
@@ -488,6 +489,29 @@ Error writeStringToFileAtomic(const FilePath& filePath,
       tmpFile.removeIfExists();
       return error;
    }
+
+   // when replacing an existing file, carry its permission bits over to the
+   // temporary file so the rename does not reset the mode to the temporary
+   // file's defaults (no-op on Windows, which manages permissions differently)
+#ifndef _WIN32
+   if (preservePermissions && filePath.exists())
+   {
+      struct stat st;
+      if (::stat(filePath.getAbsolutePath().c_str(), &st) != 0)
+      {
+         error = fileError(errno, filePath, ERROR_LOCATION);
+         tmpFile.removeIfExists();
+         return error;
+      }
+
+      if (::chmod(tmpFile.getAbsolutePath().c_str(), st.st_mode & 07777) != 0)
+      {
+         error = fileError(errno, tmpFile, ERROR_LOCATION);
+         tmpFile.removeIfExists();
+         return error;
+      }
+   }
+#endif
 
    // atomically rename into place
    error = tmpFile.move(filePath, FilePath::MoveDirect);

--- a/src/cpp/core/FileSerializerTests.cpp
+++ b/src/cpp/core/FileSerializerTests.cpp
@@ -23,6 +23,7 @@
 # include <windows.h>
 #else
 # include <cerrno>
+# include <sys/stat.h>
 #endif
 
 namespace rstudio {
@@ -199,6 +200,43 @@ TEST(FileSerializerTest, WriteStringAtomicRoundTrips)
 
    filePath.removeIfExists();
 }
+
+// When overwriting an existing file with preservePermissions set, the renamed
+// replacement must carry the original file's permission bits rather than the
+// temporary file's defaults. Used by Find in Files "Replace All" so a replace
+// does not silently change a source file's mode. POSIX-only (Windows manages
+// permissions differently).
+#ifndef _WIN32
+TEST(FileSerializerTest, WriteStringAtomicPreservesPermissions)
+{
+   FilePath filePath;
+   ASSERT_FALSE(FilePath::tempFilePath(filePath));
+
+   // create the file with a distinctive, non-default mode
+   Error error = writeStringToFile(filePath, "original\n");
+   ASSERT_FALSE(error);
+   ASSERT_EQ(0, ::chmod(filePath.getAbsolutePath().c_str(), 0640));
+
+   // overwrite it atomically, asking to preserve permissions
+   error = writeStringToFileAtomic(filePath,
+                                   "replaced\n",
+                                   string_utils::LineEndingPassthrough,
+                                   true /* preservePermissions */);
+   EXPECT_FALSE(error);
+
+   // the new contents are present and the original mode is intact
+   std::string readback;
+   error = readStringFromFile(filePath, &readback);
+   EXPECT_FALSE(error);
+   EXPECT_EQ("replaced\n", readback);
+
+   struct stat st;
+   ASSERT_EQ(0, ::stat(filePath.getAbsolutePath().c_str(), &st));
+   EXPECT_EQ(0640, static_cast<int>(st.st_mode & 07777));
+
+   filePath.removeIfExists();
+}
+#endif
 
 // Regression test for #17833: a write that fails (e.g. a full disk or an
 // exceeded disk quota) must be reported as an error rather than silently

--- a/src/cpp/core/include/core/FileSerializer.hpp
+++ b/src/cpp/core/include/core/FileSerializer.hpp
@@ -315,9 +315,16 @@ Error writeStringToFile(const core::FilePath& filePath,
 
 // Writes a string to a file atomically by first writing to a temporary file
 // in the same directory and then renaming it into place.
+//
+// preservePermissions, when true and filePath already exists, copies the
+// existing file's permission bits onto the temporary file before renaming so
+// that an atomic overwrite does not silently reset the file's mode to the
+// temporary file's defaults. No-op on Windows. Defaults off so existing
+// callers (which create new files) are unaffected.
 Error writeStringToFileAtomic(const core::FilePath& filePath,
                               const std::string& str,
-                              string_utils::LineEnding lineEnding = string_utils::LineEndingPassthrough);
+                              string_utils::LineEnding lineEnding = string_utils::LineEndingPassthrough,
+                              bool preservePermissions = false);
 
 // Returns true if the given error indicates that a write failed because the
 // disk is full (ENOSPC) or a disk quota was exceeded (EDQUOT), including the

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -24,6 +24,7 @@
 #include <boost/bind/bind.hpp>
 
 #include <core/Exec.hpp>
+#include <core/FileSerializer.hpp>
 #include <core/StringUtils.hpp>
 #include <core/system/Environment.hpp>
 #include <core/system/Process.hpp>
@@ -518,45 +519,6 @@ private:
       }
    }
 
-// permissions getter/setter (only applicable to Unix platforms)
-#ifndef _WIN32
-   Error setPermissions(const std::string& filePath, boost::filesystem::perms permissions)
-   {
-      boost::filesystem::path path(filePath);
-      try
-      {
-         boost::filesystem::permissions(path, permissions);
-      }
-      catch (const boost::filesystem::filesystem_error& e)
-      {
-         return Error(e.code(), ERROR_LOCATION);
-      }
-
-      return Success();
-   }
-
-   Error getPermissions(const std::string& filePath, boost::filesystem::perms* pPerms)
-   {
-      *pPerms = boost::filesystem::no_perms;
-
-      boost::filesystem::path path(filePath);
-      try
-      {
-         boost::filesystem::file_status fileStatus = status(path);
-         *pPerms = fileStatus.permissions();
-      }
-      catch (const boost::filesystem::filesystem_error& e)
-      {
-         return (Error(
-                  errc::findCategory(),
-                  errc::PermissionsError,
-                  "A permissions error occurred during replace operation.",
-                  ERROR_LOCATION));
-      }
-      return Success();
-   }
-#endif
-
    void adjustForPreview(std::string* contents, json::Array* pMatchOn, json::Array* pMatchOff)
    {
       size_t maxPreviewLength = 300;
@@ -594,52 +556,49 @@ private:
 
    Error completeFileReplace(std::set<std::string>* pErrorMessage)
    {
-      if (fileSuccess_)
+      if (fileSuccess_ && !currentFile_.empty() && !findResults().preview())
       {
-         if (!currentFile_.empty() &&
-             !tempReplaceFile_.getAbsolutePath().empty() &&
-             outputStream_->good())
-         {
-             Error error;
+         Error error;
 // For Windows we ignore this additional safety check
 // it will always fail because we have inputStream_ reading the file
 #ifndef _WIN32
-            error = FilePath(currentFile_).testWritePermissions();
-            if (error)
-            {
-               json::Array replaceMatchOn, replaceMatchOff;
-               addReplaceErrorMessage(error.asString(), pErrorMessage, &replaceMatchOn,
-                  &replaceMatchOff, &fileSuccess_);
-               return error;
-            }
+         error = FilePath(currentFile_).testWritePermissions();
+         if (error)
+         {
+            json::Array replaceMatchOn, replaceMatchOff;
+            addReplaceErrorMessage(error.asString(), pErrorMessage, &replaceMatchOn,
+               &replaceMatchOff, &fileSuccess_);
+            return error;
+         }
 #endif
-            std::string line;
-            while (std::getline(*inputStream_, line))
-            {
-               addNewLine(line);
-               outputStream_->write(line.c_str(), line.size());
-            }
-            outputStream_->flush();
-            inputStream_.reset();
-            outputStream_.reset();
+         // append any lines following the final match unchanged
+         std::string line;
+         while (std::getline(*inputStream_, line))
+         {
+            addNewLine(line);
+            outputContents_.append(line);
+         }
+         inputStream_.reset();
 
-// Unnecessary on Windows because this only sets write permissions which we
-// already know are correct if we are writing.
-// This needs to happen after outputStream is flushed
-#ifndef _WIN32
-            error = setPermissions(tempReplaceFile_.getAbsolutePath(), filePermissions_);
-#endif
-            if (!error)
-               error = tempReplaceFile_.move(FilePath(currentFile_), FilePath::MoveType::MoveCrossDevice, true);
+         // Write the replacement atomically: writeStringToFileAtomic writes to a
+         // temporary file in the same directory, flushes it durably (so a full
+         // disk or exceeded quota surfaces as an error rather than a silently
+         // truncated write), preserves the original file's permissions, and only
+         // then renames it into place. On failure the original file is left
+         // untouched.
+         error = writeStringToFileAtomic(FilePath(currentFile_),
+                                         outputContents_,
+                                         string_utils::LineEndingPassthrough,
+                                         true /* preservePermissions */);
+         outputContents_.clear();
+         currentFile_.clear();
 
-            currentFile_.clear();
-            if (error)
-            {
-               json::Array replaceMatchOn, replaceMatchOff;
-               addReplaceErrorMessage(error.asString(), pErrorMessage, &replaceMatchOn,
-                  &replaceMatchOff, &fileSuccess_);
-               return error;
-            }
+         if (error)
+         {
+            json::Array replaceMatchOn, replaceMatchOff;
+            addReplaceErrorMessage(error.asString(), pErrorMessage, &replaceMatchOn,
+               &replaceMatchOff, &fileSuccess_);
+            return error;
          }
       }
       return Success();
@@ -709,27 +668,16 @@ private:
       if (error)
          return error;
 
-      if (!findResults().preview())
-      {
-         tempReplaceFile_ =  module_context::tempFile("replace", "txt");
-         error = tempReplaceFile_.openForWrite(outputStream_);
-         if (error)
-            return error;
-      }
-      
+      // accumulate the replaced contents in memory; completeFileReplace writes
+      // them out atomically once the whole file has been processed
+      outputContents_.clear();
+
       lineEnding_ = string_utils::LineEndingNative;
       string_utils::detectLineEndings(file, &lineEnding_);
 
       error = file.openForRead(inputStream_);
       if (error)
          return error;
-
-      // boost only acknowledges write permissions on Windows which we already know exist
-#ifndef _WIN32
-      error = getPermissions(file.getAbsolutePath(), &filePermissions_);
-      if (error)
-         return (error);
-#endif
 
       fileSuccess_ = true;
       inputLineNum_ = 0;
@@ -754,7 +702,7 @@ private:
          subtractOffsetIntegerToJsonArray(value, offset, pJsonArray);
    }
 
-   Error writeToFile(
+   void writeToFile(
          const std::string& line,
          const std::string& lineLeftContents,
          const std::string& lineRightContents)
@@ -764,19 +712,8 @@ private:
       newLine.insert(newLine.length(), lineRightContents);
       addNewLine(newLine);
 
-      Error error;
-      
-      try
-      {
-         outputStream_->write(newLine.c_str(), newLine.size());
-         outputStream_->flush();
-      }
-      catch (const std::ios_base::failure& e)
-      {
-         error = systemError(errno, e.what(), ERROR_LOCATION);
-      }
-      
-      return error;
+      // buffer the replaced line; it is written to disk in completeFileReplace
+      outputContents_.append(newLine);
    }
 
    void cleanLineAndGetMatches(std::string* pEncodedLine,
@@ -845,7 +782,7 @@ private:
             if (!findResults().preview())
             {
                addNewLine(line);
-               outputStream_->write(line.c_str(), line.size());
+               outputContents_.append(line);
             }
          }
          else // perform replace
@@ -947,14 +884,13 @@ private:
                }
                pos--;
             }
-            // write the new line to file
+            // buffer the new line; it is written to disk in completeFileReplace
             if (!findResults().preview())
             {
-               Error error = writeToFile(pLineInfo->encodedContents,
-                     pLineInfo->leadingWhitespace, pLineInfo->trailingWhitespace);
-               if (error)
-                  addReplaceErrorMessage(error.asString(), pErrorMessage, pReplaceMatchOn,
-                     pReplaceMatchOff, &lineSuccess);
+               writeToFile(
+                     pLineInfo->encodedContents,
+                     pLineInfo->leadingWhitespace,
+                     pLineInfo->trailingWhitespace);
             }
          }
       }
@@ -1219,12 +1155,8 @@ private:
    bool firstDecodeError_;
    std::string stdOutBuf_;
    std::string currentFile_;
-   FilePath tempReplaceFile_;
    std::shared_ptr<std::istream> inputStream_;
-   std::shared_ptr<std::ostream> outputStream_;
-#ifndef _WIN32
-   boost::filesystem::perms filePermissions_;
-#endif
+   std::string outputContents_;
    int inputLineNum_;
    bool fileSuccess_;
    string_utils::LineEnding lineEnding_;


### PR DESCRIPTION
### Summary

Find in Files "Replace All" could overwrite a user's saved source file with truncated or empty contents when the write failed (full disk / exceeded quota), reporting success.

`GrepOperation` streamed the replaced contents to a temp file via a `std::ostream` and then moved it over the original, without surfacing write errors: no exception mask, an unchecked `flush()`, a close error swallowed in the stream destructor, and an unconditional move. The temp also lived on the system temp filesystem and was moved cross-device (a copy onto the original), so even an error-checked temp write would still truncate the original during the copy.

### Changes

- Buffer the replaced contents in memory and write them via `writeStringToFileAtomic`, which writes to a same-directory temp, fsyncs it durably (so `ENOSPC`/`EDQUOT` surface, building on #17844), and only then renames it into place. On failure the original file is left untouched and the error is reported.
- Extend `writeStringToFileAtomic` with an opt-in `preservePermissions` flag that carries the existing file's mode onto the replacement before the rename (POSIX; no-op on Windows). Defaults off, so the two existing callers (`SessionLists`, `SessionTrust`, which create internal state files) are unaffected.
- Drop the now-redundant local `getPermissions`/`setPermissions` helpers and the stream/temp-file members in `SessionFind`.

### Testing

- Added `FileSerializerTest.WriteStringAtomicPreservesPermissions` (POSIX).
- Built `rstudio-core`, `rsession`, and `rstudio-core-tests`; all `FileSerializerTest` cases pass (the `/dev/full` durable-failure test skips on macOS).

The full file-to-disk replace path (`GrepOperation`) is anonymous-namespace and coupled to a live grep + session, so it has no unit-test seam; coverage sits at the `writeStringToFileAtomic` level where the correctness-critical logic now lives.

Fixes #17845.