### PR TITLE
add e2e test for find-in-files replace all

### DIFF
--- a/e2e/rstudio/tests/panes/misc/find_in_files_replace.test.ts
+++ b/e2e/rstudio/tests/panes/misc/find_in_files_replace.test.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import * as fs from 'fs';
+import * as path from 'path';
+import { executeCommand } from '@utils/commands';
+import { createAndOpenProject, closeProjectIfOpen } from '@utils/project';
+import { useSuiteSandbox } from '@utils/sandbox';
+import { TIMEOUTS } from '@utils/constants';
+
+// -- Selectors ----------------------------------------------------------------
+
+// Find in Files results pane (workbench_panel_ + idSafeString("Find in Files")).
+const FIND_PANE = '#rstudio_workbench_panel_find_in_files';
+// Search-pattern box in the Find in Files dialog (ElementIds.FIND_FILES_TEXT).
+const SEARCH_INPUT = '#rstudio_find_files_text';
+// Replace-mode toggle, replace box, and Replace All button in the find pane
+// (ElementIds.FIND_REPLACE_MODE_TOGGLE / FIND_REPLACE_TEXT / FIND_REPLACE_ALL).
+const REPLACE_MODE_TOGGLE = '#rstudio_find_replace_mode_toggle';
+const REPLACE_INPUT = '#rstudio_find_replace_text';
+const REPLACE_ALL_BTN = '#rstudio_find_replace_all';
+// Standard modal buttons (pages/modals.page.ts).
+const FIND_OK_BTN = '#rstudio_dlg_ok';
+const CONFIRM_YES_BTN = '#rstudio_dlg_yes';
+
+const sandbox = useSuiteSandbox();
+
+// Regression test for #17845: a Find in Files "Replace All" must rewrite the
+// file with every match replaced -- and must not leave it truncated/emptied.
+// The disk-full failure mode that caused the truncation can't be reproduced
+// here, so this guards the streaming -> buffered-atomic-write refactor by
+// driving a real replace end to end and asserting the on-disk result.
+//
+// @desktop_only: the assertion reads the project file straight off disk via
+// Node fs, which only sees the rsession's filesystem when they're co-located.
+test.describe('Find in Files: Replace All', { tag: ['@desktop_only'] }, () => {
+  test.afterAll(async ({ rstudioPage: page }) => {
+    await closeProjectIfOpen(page);
+  });
+
+  test('replaces every match and writes the result to disk', async ({ rstudioPage: page }) => {
+    // Open a project so the Find in Files dialog defaults its search scope to
+    // the project directory (no need to drive the read-only directory chooser).
+    const projectDir = await createAndOpenProject(page, sandbox.dir, 'find_replace_project');
+
+    // Create hello.txt on disk inside the project, with three matches.
+    const helloPath = path.join(projectDir, 'hello.txt');
+    fs.writeFileSync(helloPath, 'hello hello hello\n');
+
+    // Find "hello" across the project.
+    await executeCommand(page, 'findInFiles');
+    const searchInput = page.locator(SEARCH_INPUT);
+    await searchInput.waitFor({ state: 'visible', timeout: TIMEOUTS.fileOpen });
+    await searchInput.click();
+    await searchInput.pressSequentially('hello');
+    await page.locator(FIND_OK_BTN).click();
+
+    // Wait for the results to include our file before switching to replace.
+    const findPane = page.locator(FIND_PANE);
+    await expect(findPane).toContainText('hello.txt', { timeout: TIMEOUTS.fileOpen });
+
+    // Switch to Replace mode, enter the replacement, and Replace All.
+    await page.locator(REPLACE_MODE_TOGGLE).click();
+    const replaceInput = page.locator(REPLACE_INPUT);
+    await replaceInput.waitFor({ state: 'visible', timeout: TIMEOUTS.fileOpen });
+    await replaceInput.click();
+    await replaceInput.pressSequentially('goodbye');
+
+    await page.locator(REPLACE_ALL_BTN).click();
+    await page.locator(CONFIRM_YES_BTN).click();
+
+    // The file is rewritten with every match replaced -- and, crucially, not
+    // truncated or emptied (the #17845 regression).
+    await expect
+      .poll(() => fs.readFileSync(helloPath, 'utf8').trim(), { timeout: TIMEOUTS.fileOpen })
+      .toBe('goodbye goodbye goodbye');
+  });
+});

--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -228,6 +228,11 @@ public class ElementIds
    public final static String FIND_FILES_EXCLUDE_CUSTOM = "find_files_exclude_custom";
    public static String getExcludeCustom() { return getElementId(FIND_FILES_EXCLUDE_CUSTOM); }
 
+   // FindOutputPane (Find in Files results / replace toolbar)
+   public final static String FIND_REPLACE_MODE_TOGGLE = "find_replace_mode_toggle";
+   public final static String FIND_REPLACE_TEXT = "find_replace_text";
+   public final static String FIND_REPLACE_ALL = "find_replace_all";
+
    // ImportFileSettingsDialog
    public final static String IMPORT_FILE_NAME = "import_file_name";
    public static String getImportFileName() { return getElementId(IMPORT_FILE_NAME); }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPane.java
@@ -28,6 +28,7 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.rstudio.core.client.CodeNavigationTarget;
 import org.rstudio.core.client.DebouncedCommand;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.events.EnsureVisibleEvent;
 import org.rstudio.core.client.events.SelectionCommitEvent;
@@ -77,6 +78,7 @@ public class FindOutputPane extends WorkbenchPane
       setStopSearchButtonVisible(false);
 
       showFindButton_ = new LeftRightToggleButton(constants_.findLabel(), constants_.replaceLabel(), true);
+      ElementIds.assignElementId(showFindButton_, ElementIds.FIND_REPLACE_MODE_TOGGLE);
       showFindButton_.addClickHandler(new ClickHandler() {
          @Override
          public void onClick(ClickEvent event)
@@ -109,6 +111,7 @@ public class FindOutputPane extends WorkbenchPane
       replaceMode_ = true;
 
       replaceTextBox_ = new TextBox();
+      ElementIds.assignElementId(replaceTextBox_, ElementIds.FIND_REPLACE_TEXT);
       replaceTextBox_.addKeyUpHandler(new KeyUpHandler()
       {
          public void onKeyUp(KeyUpEvent event)
@@ -128,6 +131,7 @@ public class FindOutputPane extends WorkbenchPane
       setStopReplaceButtonVisible(false);
 
       replaceAllButton_ = new ToolbarButton(constants_.replaceAllText(), constants_.replaceAllText(), null);
+      ElementIds.assignElementId(replaceAllButton_, ElementIds.FIND_REPLACE_ALL);
       replaceToolbar.addRightWidget(replaceAllButton_);
 
       replaceProgress_ = new ProgressBar();


### PR DESCRIPTION
### Summary

Follow-up to #17864 (already merged), which reworked Find in Files "Replace All" to write back atomically and durably so a failed write can't truncate the user's file. That PR landed before this test coverage was committed; this PR adds it.

### Changes

- **E2E test** (`e2e/rstudio/tests/panes/misc/find_in_files_replace.test.ts`): drives Replace All through the real UI -- open a project, create `hello.txt` with `hello hello hello`, Find in Files for `hello`, toggle to Replace mode, replace with `goodbye`, confirm -- and asserts the on-disk file becomes `goodbye goodbye goodbye` (every match replaced, not truncated). Tagged `@desktop_only` because the assertion reads the project file directly off disk.
- **Stable element IDs** (`ElementIds.java`, `FindOutputPane.java`): assigns IDs to the replace-mode toggle, replace text box, and Replace All button so the test targets `#rstudio_*` selectors rather than `gwt-uid` or localized button text.

### Testing

- `ant javac`, `tsc --noEmit`, and `ant draft` all clean.
- The test passes against the in-tree dev build (`npm run test:desktop-dev`).

The disk-full failure mode from the original report can't be reproduced in Playwright, so this is a happy-path regression guard for the write-back rewrite; the durable-failure path is covered by the `writeStringToFileAtomic` unit tests added in #17864.

Addresses #17845.