### PR TITLE
fix cache seeder startup failure by adding secrets: inherit to acknowledge CONNECT_API_KEY

### DIFF
--- a/.github/workflows/os-cache-seed-e2e-macos-26-arm64.yml
+++ b/.github/workflows/os-cache-seed-e2e-macos-26-arm64.yml
@@ -38,6 +38,7 @@ permissions:
 jobs:
   seed:
     uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
-    secrets: inherit
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
     with:
       build_only: true

--- a/.github/workflows/os-cache-seed-e2e-macos-26-arm64.yml
+++ b/.github/workflows/os-cache-seed-e2e-macos-26-arm64.yml
@@ -38,5 +38,6 @@ permissions:
 jobs:
   seed:
     uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+    secrets: inherit
     with:
       build_only: true

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -82,7 +82,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   # Builds RStudio Desktop from this PR's source on the same runner image as
@@ -218,6 +217,9 @@ jobs:
       always() &&
       inputs.build_only != true &&
       (needs.build.result == 'success' || needs.build.result == 'skipped')
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -217,9 +217,6 @@ jobs:
       always() &&
       inputs.build_only != true &&
       (needs.build.result == 'success' || needs.build.result == 'skipped')
-    permissions:
-      contents: read
-      pull-requests: write
     strategy:
       fail-fast: false
       matrix:
@@ -414,6 +411,9 @@ jobs:
     if: always() && needs.e2e-desktop-macos.result != 'skipped'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- include an entry in NEWS.md if required -->

### Intent

The macOS cache seeder workflow (os-cache-seed-e2e-macos-26-arm64.yml) started failing with startup_failure after #17839 merged. That PR introduced two issues for the cache seeder:

  1. It added CONNECT_API_KEY to the workflow_call secrets block — GitHub requires all callers to acknowledge declared secrets even when required: false
  2. It added pull-requests: write at the workflow level — a push-triggered workflow is only granted pull-requests: none, causing GitHub to reject the call at startup
  
### Approach

Two fixes:
  - Add an explicit CONNECT_API_KEY secret mapping to the cache seeder (matching the two sibling callers — PR and scheduled workflows — for consistency and least-privilege)
  - Move pull-requests: write from the workflow level to the e2e-merge job level, which is the only job that actually posts PR comments. The build job and all build_only: true callers now only get contents: read

### Automated Tests

No tests needed — this is a CI workflow fix. The fix is verified by the cache seeder run succeeding after merge.      

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
