### PR TITLE
gate project directory canonicalization to macOS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@
 - ([#17868](https://github.com/rstudio/rstudio/issues/17868)): Restrict the Python help URL handler (`/python/`) to valid help-topic names, accepting only plain dotted qualified names.
 - ([#17833](https://github.com/rstudio/rstudio/issues/17833)): Fix saving a file silently appearing to succeed when the write actually failed (for example, when the disk is full or a disk quota is exceeded); such failures are now reported and the document keeps its unsaved state.
 - ([#17845](https://github.com/rstudio/rstudio/issues/17845)): Fix Find in Files "Replace All" overwriting a source file with truncated or empty contents when the write failed (for example, when the disk is full or a disk quota is exceeded); the replacement is now written atomically and durably, so on failure the original file is left untouched and the error is reported.
+- ([#17865](https://github.com/rstudio/rstudio/issues/17865)): Fix project paths on a mapped network drive (e.g. `S:`) being resolved to their UNC target (e.g. `\\server\share`) on Windows, which caused functions such as `here::here()` and `getwd()` to report the UNC path instead of the mapped drive.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -388,12 +388,23 @@ Error ProjectContext::startup(const FilePath& projectFile,
    // /private/tmp/foo rather than /tmp/foo). Without this, paths from
    // file change events won't compare equal to directory() and any
    // root-anchored matches downstream silently miss.
+   //
+   // This is gated to macOS on purpose. On Windows, getCanonicalPath()
+   // (boost::filesystem::canonical) resolves a mapped network drive back to
+   // its UNC target (e.g. S:/foo -> //server/share/foo), which then becomes
+   // the working directory and surfaces in user-facing paths such as
+   // here::here(); see https://github.com/rstudio/rstudio/issues/17865. R's
+   // own normalizePath deliberately avoids this by preferring the drive-letter
+   // form. The Win32 (GetLongPathName) and inotify file monitors don't report
+   // canonical paths anyway, so the macOS FSEvents mismatch is unique to macOS.
+#ifdef __APPLE__
    if (directory_.exists())
    {
       std::string canonical = directory_.getCanonicalPath();
       if (!canonical.empty())
          directory_ = FilePath(canonical);
    }
+#endif
    scratchPath_ = scratchPath;
    sharedScratchPath_ = sharedScratchPath;
    config_ = projectConfig;


### PR DESCRIPTION
## Summary

On Windows, opening a project located on a mapped network drive (e.g. `S:`) caused functions like `here::here()` and `getwd()` to report the drive's UNC target (e.g. `\\server\share\...`) instead of the mapped path. This was a regression in 2026.05.0 relative to 2026.04.0.

## Cause

#17667 added canonicalization of the project directory in `ProjectContext::startup` so that paths from file-change events compare equal to `directory()`. That was needed only because **macOS FSEvents reports event paths in canonical form regardless of the path you register** (`MacFileMonitor` already canonicalizes its own root internally). The Win32 and inotify monitors instead report events under the path they were registered with -- which *is* `directory()` -- so registration and matching are already self-consistent there and never needed the canonicalization.

The harm: `getCanonicalPath()` is `boost::filesystem::canonical`, which on Windows resolves a mapped network drive to its UNC target (`S:` -> `\\server\share`). That canonicalized path becomes the working directory and surfaces in user-facing paths. R's own `normalizePath` deliberately avoids this (it prefers the drive-letter form), but boost's `canonical` has no such fallback. On Windows the canonicalization also *diverges* from the drive-letter paths the Win32 monitor actually reports, so it was never helping matching there.

## Fix

Gate the project-directory canonicalization to `__APPLE__`. macOS behavior is unchanged; Windows and Linux revert to the pre-#17667 behavior of leaving `directory()` as-is.

## Testing

No automated test: reproducing the symptom requires a Windows host with a mapped network drive, and there is no cross-platform seam that would exercise the real path rather than just the `#ifdef`. **Needs manual verification on Windows with a mapped network drive** -- confirm `here::here()` / `getwd()` report `S:/...` rather than the UNC path when a project is opened from the mapped drive.

Addresses #17865