### PR TITLE
Guard minimal window close against an already-destroyed window

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@
 - ([#17868](https://github.com/rstudio/rstudio/issues/17868)): Restrict the Python help URL handler (`/python/`) to valid help-topic names, accepting only plain dotted qualified names.
 - ([#17833](https://github.com/rstudio/rstudio/issues/17833)): Fix saving a file silently appearing to succeed when the write actually failed (for example, when the disk is full or a disk quota is exceeded); such failures are now reported and the document keeps its unsaved state.
 - ([#17845](https://github.com/rstudio/rstudio/issues/17845)): Fix Find in Files "Replace All" overwriting a source file with truncated or empty contents when the write failed (for example, when the disk is full or a disk quota is exceeded); the replacement is now written atomically and durably, so on failure the original file is left untouched and the error is reported.
+- ([#17870](https://github.com/rstudio/rstudio/issues/17870)): Fix an uncaught "Object has been destroyed" error in RStudio Desktop when quitting with a plot zoom (or other child) window still open.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/node/desktop/src/main/minimal-window.ts
+++ b/src/node/desktop/src/main/minimal-window.ts
@@ -59,7 +59,13 @@ class MinimalWindow extends DesktopBrowserWindow {
   }
 
   parentWindowDestroyed(): void {
-    this.window.close();
+    // The parent listener is removed on this window's 'close' event, but a
+    // shutdown-ordering race can fire WINDOW_DESTROYED after this window's
+    // BrowserWindow is already destroyed. Guard against closing a dead window
+    // to avoid an uncaught "Object has been destroyed" error (rstudio#17870).
+    if (!this.window.isDestroyed()) {
+      this.window.close();
+    }
   }
 }
 

--- a/src/node/desktop/test/unit/main/minimal-window.test.ts
+++ b/src/node/desktop/test/unit/main/minimal-window.test.ts
@@ -15,6 +15,7 @@
 
 import { describe } from 'mocha';
 import { assert } from 'chai';
+import sinon from 'sinon';
 
 import { isWindowsDocker } from '../unit-utils';
 import { openMinimalWindow } from '../../../src/main/minimal-window';
@@ -42,6 +43,21 @@ if (!isWindowsDocker()) {
       const gwtWindow = new TestMinimalGwtWindow({ name: '' });
       const minWin = openMinimalWindow(gwtWindow, 'test-win', 'about:blank', 640, 480);
       assert.isObject(minWin);
+      minWin.close();
+    });
+
+    it('closes a live child window when the parent is destroyed', () => {
+      const gwtWindow = new TestMinimalGwtWindow({ name: '' });
+      const minWin = openMinimalWindow(gwtWindow, 'test-win', 'about:blank', 640, 480);
+      const closeSpy = sinon.spy(minWin.window, 'close');
+
+      // The normal case: the child is still alive when the parent is
+      // destroyed, so parentWindowDestroyed() takes the guard's true branch
+      // and closes the child.
+      gwtWindow.emit(DesktopBrowserWindow.WINDOW_DESTROYED);
+
+      assert.isTrue(closeSpy.calledOnce);
+      closeSpy.restore();
       minWin.close();
     });
 

--- a/src/node/desktop/test/unit/main/minimal-window.test.ts
+++ b/src/node/desktop/test/unit/main/minimal-window.test.ts
@@ -20,6 +20,7 @@ import { isWindowsDocker } from '../unit-utils';
 import { openMinimalWindow } from '../../../src/main/minimal-window';
 import { clearApplicationSingleton, setApplication } from '../../../src/main/app-state';
 import { Application } from '../../../src/main/application';
+import { DesktopBrowserWindow } from '../../../src/main/desktop-browser-window';
 import { GwtWindow } from '../../../src/main/gwt-window';
 
 class TestMinimalGwtWindow extends GwtWindow {
@@ -42,6 +43,22 @@ if (!isWindowsDocker()) {
       const minWin = openMinimalWindow(gwtWindow, 'test-win', 'about:blank', 640, 480);
       assert.isObject(minWin);
       minWin.close();
+    });
+
+    it('does not throw when the parent is destroyed after the child window', () => {
+      const gwtWindow = new TestMinimalGwtWindow({ name: '' });
+      const minWin = openMinimalWindow(gwtWindow, 'test-win', 'about:blank', 640, 480);
+
+      // Simulate the shutdown-ordering race from rstudio#17870: the child's
+      // underlying window is already destroyed when the parent emits
+      // WINDOW_DESTROYED. destroy() (unlike close()) does not fire the child's
+      // 'close' event, so the parent listener that would normally be removed is
+      // still registered and parentWindowDestroyed() runs on a dead window.
+      minWin.window.destroy();
+
+      assert.doesNotThrow(() => {
+        gwtWindow.emit(DesktopBrowserWindow.WINDOW_DESTROYED);
+      });
     });
   });
 }


### PR DESCRIPTION
### Summary

Closing RStudio Desktop while a child window (e.g. the Plots pane zoom window) is open raised an uncaught `TypeError: Object has been destroyed` in the Electron main process.

`MinimalWindow.parentWindowDestroyed()` called `this.window.close()` with no guard. The listener that removes this handler is detached only on the child's own `close` event, but on shutdown the child's `BrowserWindow` can be destroyed (via `destroy()`, which does not emit `close`) before the parent emits `WINDOW_DESTROYED`. The stale handler then called `close()` on a destroyed window.

This guards the close with `isDestroyed()`, matching the existing pattern in `DesktopBrowserWindow.removeMenu()`.

### Testing

Added a unit test in `minimal-window.test.ts` that destroys the child window and then emits the parent's `WINDOW_DESTROYED`. Without the fix it reproduces the reported stack trace (`parentWindowDestroyed` ← `emit` ← the BrowserWindow `closed` handler); with the fix it passes. Full desktop unit suite passes; `npm run lint` and `npm run typecheck` are clean.

Fixes #17870