### PR TITLE
grant pull-requests: write to all callers to fix startup_failure

### DIFF
--- a/.github/workflows/os-cache-seed-e2e-macos-26-arm64.yml
+++ b/.github/workflows/os-cache-seed-e2e-macos-26-arm64.yml
@@ -34,6 +34,12 @@ concurrency:
 
 permissions:
   contents: read
+  # Required so this workflow can pass pull-requests: write to the called
+  # workflow's e2e-merge job (GitHub validates ALL job-level permissions in the
+  # called workflow at call time). The e2e-merge job is skipped when
+  # build_only=true (the only mode the cache seeder uses), so this permission
+  # is never exercised here — it's declared only to satisfy the validator.
+  pull-requests: write
 
 jobs:
   seed:

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-scheduled.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-scheduled.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   run-macos-26:

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -411,10 +411,6 @@ jobs:
     if: always() && needs.e2e-desktop-macos.result != 'skipped'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions:
-      contents: read
-      pull-requests: write
-
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -414,6 +414,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -411,6 +411,9 @@ jobs:
     if: always() && needs.e2e-desktop-macos.result != 'skipped'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
<!-- include an entry in NEWS.md if required -->

### Intent

Follow-up to #17878. Two callers of the reusable macOS workflow continued failing with `startup_failure` after #17878 merged: the cache seeder (`os-cache-seed-e2e-macos-26-arm64.yml`) and the scheduled runner (`os-test-e2e-rstudio-desktop-os-macos-26-arm64-scheduled.yml`).

Both were missing from the original #17839 fix — `pull-requests: write` was added to the PR caller but not to these two.

GitHub validates all job-level `permissions:` declared in a called workflow against the caller's grants **at startup** — before any `if:` conditions are evaluated. The `e2e-merge` job in the main workflow declares `pull-requests: write`, so every caller must be able to grant that permission or GitHub rejects the run at startup.

### Approach

Add `pull-requests: write` to the workflow-level `permissions:` block of both affected callers:

- **Cache seeder** (`os-cache-seed-e2e-macos-26-arm64.yml`): passes `build_only: true`, so `e2e-desktop-macos` is skipped and `e2e-merge` never runs — the permission is declared only to satisfy GitHub's startup validator.
- **Scheduled runner** (`os-test-e2e-rstudio-desktop-os-macos-26-arm64-scheduled.yml`): does run `e2e-merge` but with `post_pr_comment: false` (default), so the sticky-comment step is skipped. The permission is still required because the `e2e-merge` job's `permissions:` block is validated at startup regardless.

All three callers now consistently declare `pull-requests: write`:

| Caller | Trigger | `pull-requests: write` |
|---|---|---|
| `...-pr.yml` | `pull_request` | ✓ (since #17839) |
| `...-scheduled.yml` | `schedule` / `workflow_dispatch` | ✓ (this PR) |
| `os-cache-seed-....yml` | `push` / `schedule` | ✓ (this PR) |

### Automated Tests

No tests needed — CI workflow fix. Verified by both workflows succeeding after merge.

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests