### PR TITLE
fix terminal directory-listing test flake from narrow-terminal line wrapping

### DIFF
--- a/e2e/rstudio/tests/panes/terminal/terminal.test.ts
+++ b/e2e/rstudio/tests/panes/terminal/terminal.test.ts
@@ -140,15 +140,22 @@ test.describe.serial('Terminal pane', () => {
     await killAllTerminals(page);
     await openTerminal(page);
 
-    // Use an absolute sandbox path so the file is cleaned up by globalTeardown
-    // regardless of the terminal's working directory. Require the filename to
-    // appear at least twice in the buffer: once in the echoed touch command and
-    // once in the ls output. A single match would pass even if touch failed
-    // (the filename appears in the echoed command regardless).
+    // cd into the absolute sandbox path first, then create and list the file
+    // using a short name. The file is cleaned up by globalTeardown regardless
+    // of the terminal's working directory. We deliberately keep the touch/ls
+    // arguments short rather than passing the absolute path: a narrow terminal
+    // wraps a long path across physical lines, and terminalBuffer() returns one
+    // entry per physical line, which would split "ztestfile.txt" across a wrap
+    // boundary and break the grep below. Require the filename to appear at least
+    // twice in the buffer: once in the echoed touch command and once in the ls
+    // output. A single match would pass even if touch failed (the filename
+    // appears in the echoed command regardless).
     const sandboxDir = sandbox.dir.replace(/\\/g, '/');
-    await page.keyboard.type(`touch ${sandboxDir}/ztestfile.txt`);
+    await page.keyboard.type(`cd ${sandboxDir}`);
     await page.keyboard.press('Enter');
-    await page.keyboard.type(`ls ${sandboxDir}`);
+    await page.keyboard.type('touch ztestfile.txt');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('ls');
     await page.keyboard.press('Enter');
 
     await expect.poll(


### PR DESCRIPTION
## Summary

Fixes a flaky failure in the `e2e` test `Terminal pane > a file created in the terminal appears in a directory listing` (desktop project), surfaced from a CI run that failed on both the initial attempt and the retry.

## Root cause

The test typed an absolute sandbox path into the terminal:

```
touch <long-absolute-path>/ztestfile.txt
ls <long-absolute-path>
```

and then asserted that `ztestfile.txt` appeared on at least two lines of the terminal buffer (once in the echoed `touch` command, once in the `ls` output).

On the failing CI run the terminal was only ~31 columns wide, so the long path wrapped across physical lines and split the filename across a wrap boundary:

```
guardrail_paths_project runner$
 touch /Users/runner/work/rstud
io/rstudio/pw-sandbox/pw_sandbo
x_r4OqyZ/workdir_9fb47e7b196/zt
estfile.txt
```

`rstudioapi::terminalBuffer()` returns one entry per *physical* (wrapped) line, so `grep("ztestfile.txt", ...)` never matched the echoed command (`...zt` / `estfile.txt`). Only the `ls` output line matched, giving 1 match < 2, and the poll stayed `FALSE` for the full timeout. The keystrokes landed and `touch` ran fine -- the failure was purely an artifact of buffer line-wrapping, which depends on the terminal's column count at creation time (an xterm fit race), making it intermittent.

## Fix

`cd` into the sandbox first and use a short filename, so the asserted token (`ztestfile.txt`, 13 chars) and the echoed `touch ztestfile.txt` both fit on their own physical rows regardless of terminal width. The long path remains only on the `cd` line, which the assertion never inspects. This keeps the original `>= 2` guard intact (the echoed `touch` command + the `ls` output), so a silently-failed `touch` would still be caught.

## Testing

Ran the full serial terminal suite locally with repeats (`--repeat-each`), all green; the directory-listing test passed every iteration. The failure did not reproduce locally because the local terminal is wide enough that the original long path did not wrap.

Test-only change; no `NEWS.md` entry.