### PR TITLE
fix data viewer remembering filters and sorts across close/reopen

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,7 @@
 - ([#17872](https://github.com/rstudio/rstudio/issues/17872)): Fix a newly added file appearing at the bottom of the Files pane instead of in its sorted position when the pane is sorted by a column.
 - ([#17865](https://github.com/rstudio/rstudio/issues/17865)): Fix project paths on a mapped network drive (e.g. `S:`) being resolved to their UNC target (e.g. `\\server\share`) on Windows, which caused functions such as `here::here()` and `getwd()` to report the UNC path instead of the mapped drive.
 - ([#17870](https://github.com/rstudio/rstudio/issues/17870)): Fix an uncaught "Object has been destroyed" error in RStudio Desktop when quitting with a plot zoom (or other child) window still open.
+- ([#17830](https://github.com/rstudio/rstudio/issues/17830)): Fix the data viewer not clearing a data set's saved sorts and filters when its tab is explicitly closed, so reopening the data set no longer restores stale filters; the saved state still persists across a session suspend/restore or a page reload. Restored filters now also reveal the filter row, instead of being applied with no visible filter UI.
 
 ### Dependencies
 - Ace 1.43.5

--- a/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
@@ -318,6 +318,17 @@ test.describe('Data Viewer', () => {
   // tab must discard it, so reopening the data set starts fresh -- the clear
   // runs host-side because the iframe is already detached by the time the close
   // reaches us.
+  //
+  // NOTE: the complementary half of this invariant -- that MOVING the tab
+  // between source columns must PRESERVE the saved state -- is deliberately not
+  // covered here. The gate lives in DataEditingTarget.onDismiss, which clears
+  // only on DISMISS_TYPE_CLOSE and not on DISMISS_TYPE_MOVE. A cross-column tab
+  // move is a drag-and-drop layout operation with no AppCommand to drive it
+  // from the automation bridge, so it can't be exercised reliably from
+  // Playwright. If a future refactor drops that dismissType guard (or clears
+  // unconditionally), a column move would silently wipe the user's sorts and
+  // filters and this suite would stay green -- so guard the invariant at the
+  // source, not just here.
   test('explicitly closing the viewer clears its saved sorts and filters (#17830)', async ({ rstudioPage: page }) => {
     await consoleActions.executeInConsole(
       '{ .rs.close_clear_df <- mtcars; View(.rs.close_clear_df) }',

--- a/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
@@ -11,7 +11,7 @@ import { test, expect } from '@fixtures/rstudio.fixture';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePane } from '@pages/source_pane.page';
 import { DataViewerPane } from '@pages/data_viewer.page';
-import { resetSourcePaneState } from '@utils/commands';
+import { resetSourcePaneState, executeCommand } from '@utils/commands';
 import { TIMEOUTS } from '@utils/constants';
 
 const VIEWER_FRAME = '#rstudio_data_viewer_frame';
@@ -309,6 +309,111 @@ test.describe('Data Viewer', () => {
       await consoleActions.executeInConsole(
         'rm(".rs.persist_test_df", envir = .GlobalEnv)',
       );
+    }
+  });
+
+  // https://github.com/rstudio/rstudio/issues/17830
+  // Saved per-object UI state lives in localStorage (shared same-origin between
+  // the host page and the data viewer iframe). Explicitly closing the viewer
+  // tab must discard it, so reopening the data set starts fresh -- the clear
+  // runs host-side because the iframe is already detached by the time the close
+  // reaches us.
+  test('explicitly closing the viewer clears its saved sorts and filters (#17830)', async ({ rstudioPage: page }) => {
+    await consoleActions.executeInConsole(
+      '{ .rs.close_clear_df <- mtcars; View(.rs.close_clear_df) }',
+    );
+    try {
+      await waitForViewer(dataViewer);
+
+      // Sort col 1 ascending -- this writes per-object state to localStorage.
+      const col1 = dataViewer.frame.locator('th[data-col-idx="1"]');
+      await col1.click();
+      await expect.poll(() => colHeaderClass(dataViewer, 1)).toMatch(/sorting_asc/);
+
+      // The saved-state entry for this object is readable from the host page,
+      // which both confirms the write landed and proves the host/iframe share
+      // localStorage (the assumption the host-side clear relies on).
+      const savedKey = () => page.evaluate(() =>
+        Object.keys(window.localStorage).find(
+          (k) => k.startsWith('rstudio.dataViewer:') && k.includes('close_clear_df')) ?? null);
+      await expect.poll(savedKey, { timeout: TIMEOUTS.fileOpen }).not.toBeNull();
+
+      // Explicitly close the data viewer tab (DISMISS_TYPE_CLOSE).
+      await executeCommand(page, 'closeSourceDoc');
+      await expect(sourcePane.selectedTab).toContainText('Untitled', { timeout: 5000 });
+
+      // The saved state must be gone, so a later View() of the same object
+      // would start unsorted/unfiltered.
+      await expect.poll(savedKey, { timeout: TIMEOUTS.fileOpen }).toBeNull();
+    } finally {
+      await consoleActions.executeInConsole('rm(".rs.close_clear_df", envir = .GlobalEnv)');
+    }
+  });
+
+  // https://github.com/rstudio/rstudio/issues/17830
+  // A saved filter is restored on open, but it must also reveal the filter row
+  // so it's visible and editable -- before the fix the rows were filtered with
+  // no filter UI shown. A page/iframe reload preserves saved state (it's not a
+  // close), so it exercises the restore path.
+  test('restored filters reveal the filter row after a reload (#17830)', async ({ rstudioPage: page }) => {
+    // A character first column gives a simple text-box filter to drive.
+    await consoleActions.executeInConsole(
+      '{ .rs.restore_filter_df <- data.frame(x = letters, stringsAsFactors = FALSE); View(.rs.restore_filter_df) }',
+    );
+    try {
+      await waitForViewer(dataViewer);
+
+      const filterToggle = page.locator('#data_editing_toolbar .rstudio_dt_filter_toggle');
+
+      // Reveal the filter row and apply a text filter to column 1. Mirrors the
+      // open-and-type retry from the #17806 test (the editor auto-dismisses if
+      // it blurs while empty, so the open + type has to land as a unit).
+      await page.locator('#data_editing_toolbar').getByText('Filter', { exact: true }).click();
+      const col1Filter = dataViewer.frame.locator('th[data-col-idx="1"] .colFilter');
+      await expect(col1Filter).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+
+      const filterInput = dataViewer.frame.locator('th[data-col-idx="1"] .textFilterBox');
+      const allLabel = col1Filter.getByText('All');
+      await expect(async () => {
+        if ((await filterInput.count()) === 0) {
+          await allLabel.click();
+          await filterInput.waitFor({ state: 'visible', timeout: 2000 });
+        }
+        await filterInput.fill('');
+        await filterInput.pressSequentially('a');
+        await expect(filterInput).toHaveValue('a', { timeout: 2000 });
+      }).toPass({ timeout: TIMEOUTS.fileOpen });
+      await expect(dataViewer.gridInfo)
+        .toContainText('filtered from', { timeout: TIMEOUTS.fileOpen });
+
+      // Reload only the data viewer iframe: a reload preserves saved state (it's
+      // not a close), so the filter must come back -- and reveal its row.
+      await page.evaluate((sel: string) => {
+        const f = document.querySelector(sel) as HTMLIFrameElement | null;
+        if (!f?.contentWindow) throw new Error('data viewer iframe not accessible');
+        f.contentWindow.location.reload();
+      }, VIEWER_FRAME);
+
+      await waitForViewer(dataViewer);
+
+      // The filter row is shown automatically (no manual toolbar click) and
+      // still carries the active value -- the core of the bug.
+      const col1FilterAfter = dataViewer.frame.locator('th[data-col-idx="1"] .colFilter');
+      await expect(col1FilterAfter).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      await expect(col1FilterAfter).toHaveClass(/filtered/);
+      await expect(dataViewer.frame.locator('th[data-col-idx="1"] .textFilterBox'))
+        .toHaveValue('a');
+
+      // The toolbar funnel reflects the restored filter state (aria-pressed is
+      // set by the LatchingToolbarButton when filterStateCallback latches it).
+      await expect(filterToggle)
+        .toHaveAttribute('aria-pressed', 'true', { timeout: TIMEOUTS.fileOpen });
+
+      // ...and the data is still filtered.
+      await expect(dataViewer.gridInfo)
+        .toContainText('filtered from', { timeout: TIMEOUTS.fileOpen });
+    } finally {
+      await consoleActions.executeInConsole('rm(".rs.restore_filter_df", envir = .GlobalEnv)');
     }
   });
 

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -195,6 +195,11 @@ var postInitActions = {};
 // Sidebar state
 var sidebarVisible = true;
 
+// Marker class for the injected per-column filter widgets. Shared by
+// setFilterUIVisible (which injects them) and isFilterUIVisible (which reads
+// the recorded postInitActions entry keyed by this marker).
+var FILTER_UI_MARKER = "filter-injected-ui";
+
 // In-flight column-summary fetches; the shared sidebar spinner only
 // hides when this drops back to zero so partial completion doesn't yank
 // it out from under still-pending fetches.
@@ -4033,6 +4038,21 @@ var initGrid = function(resCols, data) {
    // been registered before bootstrap ran with a different default.
    if (window.sidebarStateCallback) window.sidebarStateCallback(sidebarVisible);
 
+   // Reveal the filter row when saved state restored active per-column filters,
+   // so they're visible and editable instead of being applied with no UI
+   // (#17830). Filter-row visibility itself isn't persisted -- it's derived
+   // from whether any filter values came back. setFilterUIVisible records a
+   // post-init action, so this also survives column-pagination re-bootstraps;
+   // the replay loop below applies it once the headers are built.
+   if (Object.keys(cachedFilterValues).length > 0) {
+      window.setFilterUIVisible(true);
+   }
+
+   // Sync the host's filter latch with the resolved filter-row visibility,
+   // mirroring the sidebar callback above. The callback may have been
+   // registered before bootstrap resolved the restored filters.
+   if (window.filterStateCallback) window.filterStateCallback(isFilterUIVisible());
+
    // Run post-init actions
    for (var actionName in postInitActions) {
       if (postInitActions[actionName]) {
@@ -4523,6 +4543,13 @@ var columnNav = function(newOffset) {
 // Window API Exports
 // ==========================================================================
 
+// True when the filter row is shown. Reads the recorded postInitActions entry
+// (the source of truth that survives column-pagination re-bootstraps) rather
+// than the live DOM, so it stays correct before headers are rebuilt.
+var isFilterUIVisible = function() {
+   return !!postInitActions["setHeaderUIVisible:" + FILTER_UI_MARKER];
+};
+
 window.setFilterUIVisible = function(visible) {
    return setHeaderUIVisible(
       visible,
@@ -4544,7 +4571,7 @@ window.setFilterUIVisible = function(visible) {
             saveState();
          }
       },
-      "filter-injected-ui"
+      FILTER_UI_MARKER
    );
 };
 
@@ -4637,8 +4664,11 @@ window.onDeactivate = function() {
 };
 
 // Called from GWT when the data viewer tab is being closed (dismissType
-// CLOSE, not MOVE). Discard the saved state so it doesn't accumulate in
-// localStorage past the lifetime of the tab.
+// CLOSE, not MOVE). Discards the saved state so it doesn't accumulate in
+// localStorage past the lifetime of the tab. This is best-effort only: the
+// iframe is usually already detached by the time a close reaches us, so the
+// host clears the same key directly via the stateKeyCallback path (#17830).
+// Kept for the rare case where the frame is still live at dismiss.
 window.onDismiss = function() {
    clearSavedState();
 };
@@ -4676,6 +4706,23 @@ window.setOption = function(option, value) {
          // callback typically registers after bootstrap has already
          // resolved sidebarVisible from URL params + saved state.
          value(sidebarVisible);
+         break;
+      case "filterStateCallback":
+         window.filterStateCallback = value;
+         // Sync immediately, then again at the end of bootstrap once saved
+         // filters have been resolved (mirrors sidebarStateCallback).
+         value(isFilterUIVisible());
+         break;
+      case "stateKeyCallback":
+         window.stateKeyCallback = value;
+         // Report the localStorage key for this object's saved UI state so the
+         // host can clear it on explicit close. The host has to do the clearing
+         // because by the time the close reaches us the data viewer iframe is
+         // already detached (TabClosedEvent fires after the widget is removed),
+         // so an in-frame clear would no-op (#17830). The key derives only from
+         // the iframe URL (env+obj), which is available as soon as the frame
+         // loads, so this does not need to wait for bootstrap.
+         value(stateKey());
          break;
    }
 };

--- a/src/gwt/src/org/rstudio/studio/client/dataviewer/DataTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/dataviewer/DataTable.java
@@ -22,6 +22,7 @@ import org.rstudio.core.client.ClassIds;
 import org.rstudio.core.client.CommandWith2Args;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.ShortcutManager;
@@ -430,6 +431,34 @@ public class DataTable
       });
    }
 
+   public void setFilterStateCallback()
+   {
+      // JS owns whether the filter row is shown. It can become visible without
+      // a toolbar click -- restoring saved per-column filters reveals the row
+      // so they aren't applied invisibly (#17830). The callback fires on
+      // registration and again at the end of bootstrap, keeping filtered_ and
+      // the funnel latch in sync, mirroring the sidebar pattern above.
+      setFilterStateCallback(getWindow(), new CommandWithArg<Boolean>() {
+         public void execute(Boolean visible) {
+            filtered_ = visible != null && visible;
+            if (filterButton_ != null)
+               filterButton_.setLatched(filtered_);
+         }
+      });
+   }
+
+   public void setStateKeyCallback()
+   {
+      // JS reports the localStorage key holding this object's saved UI state.
+      // We stash it so onDismiss can clear it host-side on an explicit close;
+      // see clearSavedStateHostSide for why the host (not the iframe) clears.
+      setStateKeyCallback(getWindow(), new CommandWithArg<String>() {
+         public void execute(String key) {
+            stateKey_ = key;
+         }
+      });
+   }
+
    public void refreshData()
    {
       filtered_= false;
@@ -474,6 +503,14 @@ public class DataTable
    {
       try
       {
+         // Authoritative clear: the iframe is usually already detached by the
+         // time an explicit close reaches us (TabClosedEvent fires after the
+         // tab widget is removed from the DOM), so getWindow() is null and the
+         // in-frame onDismiss below no-ops. Clearing host-side works regardless
+         // (#17830).
+         clearSavedStateHostSide();
+
+         // Best-effort in-frame clear for the rare case the frame is still live.
          onDismiss(getWindow());
       }
       catch(Exception e)
@@ -482,6 +519,18 @@ public class DataTable
          // log so failures show up in dev/diagnostics output.
          Debug.logException(e);
       }
+   }
+
+   private void clearSavedStateHostSide()
+   {
+      // The data viewer iframe is same-origin with the host page, so they share
+      // localStorage. That lets us remove the saved-state entry the frame
+      // reported (via stateKeyCallback) even after the frame is gone -- the
+      // frame can't do it itself once detached.
+      if (StringUtil.isNullOrEmpty(stateKey_))
+         return;
+
+      removeLocalStorageItem(stateKey_);
    }
 
    private boolean isLimitedColumnFrame() { return isLimitedColumnFrame(getWindow()); }
@@ -654,6 +703,31 @@ public class DataTable
             sidebarStateCallback.@org.rstudio.core.client.CommandWithArg::execute(*)(@java.lang.Boolean::valueOf(Z)(!!visible));
          }));
    }-*/;
+
+   private static final native void setFilterStateCallback(WindowEx frame, CommandWithArg<Boolean> filterStateCallback) /*-{
+      frame.setOption(
+         "filterStateCallback",
+         $entry(function(visible) {
+            filterStateCallback.@org.rstudio.core.client.CommandWithArg::execute(*)(@java.lang.Boolean::valueOf(Z)(!!visible));
+         }));
+   }-*/;
+
+   private static final native void setStateKeyCallback(WindowEx frame, CommandWithArg<String> stateKeyCallback) /*-{
+      frame.setOption(
+         "stateKeyCallback",
+         $entry(function(key) {
+            stateKeyCallback.@org.rstudio.core.client.CommandWithArg::execute(*)(key);
+         }));
+   }-*/;
+
+   private static final native void removeLocalStorageItem(String key) /*-{
+      try {
+         $wnd.localStorage.removeItem(key);
+      } catch (e) {
+         // localStorage may be unavailable (private mode / blocked); nothing
+         // to clear in that case.
+      }
+   }-*/;
    private Host host_;
    private LatchingToolbarButton filterButton_;
    private LatchingToolbarButton sidebarButton_;
@@ -667,6 +741,10 @@ public class DataTable
    private ArrayList<SimpleButton> columnViewButtons_;
    private SearchWidget searchWidget_;
    private boolean filtered_ = false;
+
+   // localStorage key for this object's persisted UI state, reported by the
+   // iframe via stateKeyCallback; used to clear it host-side on close (#17830).
+   private String stateKey_ = null;
 
    private static String COLUMN_VIEW_BUTTONS[] = {
       "<i class=\"icon-angle-double-left \"></i>",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTargetWidget.java
@@ -155,7 +155,9 @@ public class DataEditingTargetWidget extends Composite
          table_.setListViewerCallback(callback);
          table_.setColumnFrameCallback();
          table_.setSidebarStateCallback();
-         
+         table_.setFilterStateCallback();
+         table_.setStateKeyCallback();
+
       });
 
       Widget mainWidget;


### PR DESCRIPTION
## Summary

The data viewer rewrite (#17382) persists per-object UI state (sorts, filters, pinned columns) to `localStorage`. This fixes two problems with how that state is restored and cleared, reported in #17830.

### Saved state survived an explicit close

Closing a data viewer tab is supposed to discard its saved state, but it didn't: the clear ran inside the iframe via `window.onDismiss`, which is driven by `TabClosedEvent` -- and that fires *after* the tab widget (and its iframe) has already been detached from the DOM (`DocTabLayoutPanel.remove` calls `super.remove` before firing the event). So `getWindow()` was null and the in-frame clear silently no-oped, leaving the entry in `localStorage`. Reopening the data set then restored stale filters/sorts.

The close-vs-move distinction is only known post-detach (`DISMISS_TYPE_CLOSE`), so a pre-detach clear isn't an option. Instead, the iframe now reports its `localStorage` key on load (`stateKeyCallback`), and on an explicit close the host clears that key directly via shared same-origin `localStorage` -- which works even though the frame is gone. An explicit close is the only teardown that clears; a session suspend/restore or a page reload still preserves state (which is the intended behavior).

### Restored filters were applied with no visible filter UI

Restoring a saved filter sent it to the server (the rows were filtered) but left the filter row hidden, so the filter was active with no visible UI to see or edit it. Bootstrap now reveals the filter row when restored filters are non-empty (recorded as a post-init action so it survives column pagination), and a new `filterStateCallback` keeps the toolbar funnel latch in sync -- mirroring the existing `sidebarStateCallback`.

## Tests

Adds two Playwright regression tests to `data_viewer.test.ts`:

- **explicitly closing the viewer clears its saved sorts and filters** -- sorts a column, confirms the saved-state key is readable from the host page (proving the host/iframe share `localStorage`), closes the tab, and asserts the key is gone.
- **restored filters reveal the filter row after a reload** -- applies a filter, reloads the iframe, and asserts the filter row auto-reveals with its value, the toolbar funnel reports `aria-pressed=true`, and the data is still filtered.

All 18 tests in the file pass (16 existing + 2 new).

Fixes #17830
