### PR TITLE
persist data viewer scroll position across reloads

### DIFF
--- a/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
@@ -599,6 +599,71 @@ test.describe('Data Viewer', () => {
     }
   });
 
+  // The scroll position is part of the per-object UI state persisted to
+  // localStorage (alongside sorts/filters/pins), so it survives a close/reopen
+  // reload the same way they do. A page/iframe reload preserves saved state
+  // (it's not a close), so it exercises the restore path -- mirroring the
+  // #17830 filter-restore test.
+  test('scroll position is restored after a reload', async ({ rstudioPage: page }) => {
+    await consoleActions.executeInConsole(
+      '{ .rs.scroll_reload_df <- as.data.frame(matrix(0L, nrow = 2000, ncol = 5)); View(.rs.scroll_reload_df) }',
+    );
+    try {
+      await waitForViewer(dataViewer);
+
+      // Scroll well down, then fire scrollend so the settled position is
+      // persisted to localStorage (onScrollEnd -> saveState). Dispatching the
+      // event explicitly removes the timing flake of waiting on the browser to
+      // emit scrollend for a programmatic scroll.
+      const target = await dataViewer.viewport.evaluate((el: HTMLElement) => {
+        el.scrollTop = 20000;
+        el.dispatchEvent(new Event('scrollend'));
+        return el.scrollTop;
+      });
+      expect(target).toBeGreaterThan(0);
+
+      // Confirm the position landed in the shared (host/iframe) localStorage
+      // entry: both a wait gate for the write and proof it was persisted.
+      const savedScrollTop = () => page.evaluate(() => {
+        const key = Object.keys(window.localStorage).find(
+          (k) => k.startsWith('rstudio.dataViewer:') && k.includes('scroll_reload_df'));
+        if (!key)
+          return null;
+        try {
+          const state = JSON.parse(window.localStorage.getItem(key) ?? '');
+          return state && state.scroll ? state.scroll.top : null;
+        } catch (e) {
+          return null;
+        }
+      });
+      await expect.poll(savedScrollTop, { timeout: TIMEOUTS.fileOpen })
+        .toBeGreaterThan(0);
+
+      // Reload only the data viewer iframe: a reload preserves saved state (it's
+      // not a close), so the scroll position must come back.
+      await page.evaluate((sel: string) => {
+        const f = document.querySelector(sel) as HTMLIFrameElement | null;
+        if (!f?.contentWindow) throw new Error('data viewer iframe not accessible');
+        f.contentWindow.location.reload();
+      }, VIEWER_FRAME);
+
+      await waitForViewer(dataViewer);
+      await expect(dataViewer.frame.locator('#gridBody td[data-col-pos]').first())
+        .toBeVisible({ timeout: TIMEOUTS.fileOpen });
+
+      // Position is restored to (about) where it was, not reset to the top.
+      // Allow one ROW_HEIGHT (23px) of slack for rounding.
+      await expect.poll(
+        () => dataViewer.viewport.evaluate((el: HTMLElement) => el.scrollTop),
+        { message: 'scroll position should be restored after a reload' },
+      ).toBeGreaterThan(target - 23);
+    } finally {
+      await consoleActions.executeInConsole(
+        'rm(".rs.scroll_reload_df", envir = .GlobalEnv)',
+      );
+    }
+  });
+
   test('HTML-special cell values render as text, not markup', async () => {
     // textContent encodes <, >, and & but leaves quotes as plain text.
     // The security property is that nothing user-supplied becomes a real

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -2635,6 +2635,11 @@ var onScrollEnd = function() {
    renderVisibleRows(colsChanged);
    updateInfoBar();
    updateCustomScrollbars();
+
+   // Persist the settled scroll position so it survives a close/reopen reload,
+   // alongside pins/sort/filters. scrollend fires once per gesture (including
+   // keyboard-driven scrolls), so this stays cheap.
+   saveState();
 };
 
 // Window resize handler: debounce wrapper is created once here so its
@@ -4214,6 +4219,11 @@ var columnFingerprint = function() {
 var saveState = function() {
    var key = stateKey();
    if (!key) return;
+   // Don't persist before the grid is initialized: columnFingerprint() would
+   // fall back to its missing-data sentinel and totalRows would be stale, so the
+   // entry could never validate on reload. (saveState now also fires from scroll
+   // settling and tab deactivation, either of which can race an early teardown.)
+   if (!cols) return;
    // pinnedColumns/sort/filters are stored by absolute column identity (1-based
    // index in the full frame), so they survive column pagination. manualWidths
    // remains positional within the current window.
@@ -4224,7 +4234,12 @@ var saveState = function() {
       sidebarVisible: sidebarVisible,
       manualWidths: manualWidths.slice(),
       sort: sortColumn >= 0 ? { col: sortColumn, dir: sortDirection } : null,
-      filters: Object.assign({}, cachedFilterValues)
+      filters: Object.assign({}, cachedFilterValues),
+      // Scroll offset, keyed to the unfiltered row count so a frame whose size
+      // changed while closed reopens at the top -- the same guard refreshes use
+      // (see restoreScrollAfterRefresh). lastScroll* is kept current by onScroll/
+      // onScrollEnd/onDeactivate, so it's the live position at any save.
+      scroll: { top: lastScrollTop, left: lastScrollLeft, rows: totalRows }
    };
    try {
       localStorage.setItem(key, JSON.stringify(state));
@@ -4364,6 +4379,25 @@ var applySavedState = function(state) {
          var w = state.manualWidths[i];
          if (typeof w === "number" && w > 0) manualWidths[i] = w;
       }
+   }
+
+   // Restore the saved scroll position through the same path a refresh uses:
+   // restoreScrollAfterRefresh (run after the first row fetch) re-checks the
+   // row count before applying, so a frame whose row count changed while closed
+   // still opens at the top. Defer to a live refresh capture if one already owns
+   // the slot (a refresh-driven rebuild carries a fresher position than the
+   // persisted one), and only when the fingerprint matched -- a mismatch returns
+   // early above without reaching here.
+   if (!activeScrollRestore &&
+       state.scroll &&
+       typeof state.scroll.top === "number" &&
+       typeof state.scroll.left === "number" &&
+       typeof state.scroll.rows === "number") {
+      activeScrollRestore = {
+         top: state.scroll.top,
+         left: state.scroll.left,
+         rows: state.scroll.rows
+      };
    }
 
    return false;
@@ -4661,6 +4695,11 @@ window.onDeactivate = function() {
       lastScrollTop = viewport.scrollTop;
       lastScrollLeft = viewport.scrollLeft;
    }
+
+   // Leaving the tab is a natural persist point: capture the final position to
+   // localStorage in case the gesture that put us here didn't emit a scrollend
+   // (e.g. a programmatic or interrupted scroll).
+   saveState();
 };
 
 // Called from GWT when the data viewer tab is being closed (dismissType


### PR DESCRIPTION
## Summary

The data viewer already persists per-object UI state (pinned columns, sorts, filters, sidebar visibility, column widths) to `localStorage` so it survives a reload / suspend-restore, and clears it on an explicit close. This extends that persisted state to include the **scroll position**, so reopening a data set returns you to where you were scrolled rather than the top.

## What changed

`src/cpp/session/resources/grid/DataViewer.js`:

- **`saveState()`** records `scroll: { top, left, rows }`, keyed to the unfiltered row count so a frame whose size changed while closed reopens at the top (the same guard in-place refreshes use). Also guards against saving before the grid is initialized.
- **`applySavedState()`** seeds the existing `activeScrollRestore` slot from the saved scroll. The restore then flows through `restoreScrollAfterRefresh` after the first row fetch, which re-checks the row count and defers to any live refresh-driven capture. Only runs once the column fingerprint matches.
- **`onScrollEnd` / `onDeactivate`** call `saveState()` so the persisted position stays current.

Clearing on close needs no new code: scroll rides in the same `localStorage` entry the close path already removes (host-side clear + `onDismiss`).

`STATE_VERSION` is intentionally left at 3 -- adding an optional field is backward-compatible, and bumping would have discarded users' existing pins/sorts/filters for a purely additive change.

## Testing

Added an e2e test (`scroll position is restored after a reload`) that scrolls down, confirms the offset persisted to the shared host/iframe `localStorage`, reloads the data viewer iframe, and asserts the position is restored. The full data-viewer Playwright suite (19 tests) passes locally with no regressions.

Follow-on to the data viewer state-persistence work in #17861 and #17886.
