### PR TITLE
Fix intermittent Posit Assistant Connection Error on Windows

### DIFF
--- a/src/cpp/session/modules/SessionChat.R
+++ b/src/cpp/session/modules/SessionChat.R
@@ -968,8 +968,11 @@
    # status and stop() before reading the file -- the manifest subprocess
    # contract is that a download failure surfaces as a non-zero exit status, not
    # a clean exit with a partial/empty body on stdout.
+   # cat() with the default sep = " " would replace newlines with spaces; use
+   # sep = "\n" so the downloaded body round-trips verbatim on stdout rather than
+   # relying on JSON tolerating that substitution.
    sprintf(
-      "{ options(timeout = 30L); tmp <- tempfile(); status <- download.file(%s); if (!isTRUE(status == 0)) stop(paste('download.file failed, status', status)); cat(readLines(tmp, warn = FALSE)) }",
+      "{ options(timeout = 30L); tmp <- tempfile(); status <- download.file(%s); if (!isTRUE(status == 0)) stop(paste('download.file failed, status', status)); cat(readLines(tmp, warn = FALSE), sep = '\\n') }",
       paste(args, collapse = ", ")
    )
 })

--- a/src/cpp/session/modules/SessionChat.R
+++ b/src/cpp/session/modules/SessionChat.R
@@ -940,3 +940,36 @@
 
    plotData
 })
+
+#' Build the R command run in a --vanilla child process to fetch the manifest.
+#'
+#' The parent session has already resolved download.file.* options (profile +
+#' runtime), so capture them here and inject them so the vanilla child reproduces
+#' the parent's proxy/method configuration. options(timeout = 30L) is the
+#' documented transfer-timeout knob; download.file() has no timeout argument.
+#'
+#' @param url The manifest URL to download.
+.rs.addFunction("chat.manifestDownloadCommand", function(url)
+{
+   serialize <- function(value) paste(deparse(value), collapse = " ")
+
+   args <- c(serialize(url), "destfile = tmp", "quiet = TRUE")
+
+   method <- getOption("download.file.method")
+   if (!is.null(method))
+      args <- c(args, sprintf("method = %s", serialize(method)))
+
+   extra <- getOption("download.file.extra")
+   if (!is.null(extra))
+      args <- c(args, sprintf("extra = %s", serialize(extra)))
+
+   # Propagate download failures as a non-zero process exit. Some methods return
+   # a non-zero status with only a warning (rather than erroring), so capture the
+   # status and stop() before reading the file -- the manifest subprocess
+   # contract is that a download failure surfaces as a non-zero exit status, not
+   # a clean exit with a partial/empty body on stdout.
+   sprintf(
+      "{ options(timeout = 30L); tmp <- tempfile(); status <- download.file(%s); if (!isTRUE(status == 0)) stop(paste('download.file failed, status', status)); cat(readLines(tmp, warn = FALSE)) }",
+      paste(args, collapse = ", ")
+   )
+})

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -25,6 +25,7 @@
 #include "chat/ChatStaticFiles.hpp"
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <map>
 #include <queue>
@@ -3673,20 +3674,25 @@ void fetchManifestAsync(
    // Single-completion guard shared by the normal completion and the deadline.
    // The AsyncRProcess completion can fire on the offline-service background
    // thread (processSupervisor().poll() runs there while R occupies the main
-   // thread), so marshal the body onto the main thread before touching pDone or
-   // the single-flight state, and before onReady -> onUpdateCheckComplete drains
-   // queued completions (which may run R, e.g. performInstall). executeOnMainThread
-   // runs inline when already on the main thread (the deadline path below), so it
-   // adds no latency there.
-   boost::shared_ptr<bool> pDone = boost::make_shared<bool>(false);
+   // thread), so pDone is claimed atomically the instant either event occurs.
+   // Claiming before we schedule means a subprocess that finishes before the
+   // deadline always wins, even if R stays busy and the main thread only drains
+   // both scheduled tasks (the deadline and this completion) afterwards -- the
+   // deadline's complete() then no-ops instead of overwriting a real result with a
+   // timeout. The winner's body is marshalled onto the main thread so onReady ->
+   // onUpdateCheckComplete (and any queued completions it runs, e.g. performInstall,
+   // which execute R) never touch the single-flight state off-thread.
+   // executeOnMainThread runs inline when already on the main thread (the deadline
+   // path below), so it adds no latency there.
+   boost::shared_ptr<std::atomic<bool>> pDone =
+      boost::make_shared<std::atomic<bool>>(false);
    boost::function<void(const core::system::ProcessResult&)> complete =
       [onReady, pDone](const core::system::ProcessResult& result)
       {
-         module_context::executeOnMainThread([onReady, pDone, result]()
+         if (pDone->exchange(true))
+            return;
+         module_context::executeOnMainThread([onReady, result]()
          {
-            if (*pDone)
-               return;
-            *pDone = true;
             json::Object manifest;
             Error err = integrity::manifestFromDownloadResult(result, &manifest);
             onReady(err, manifest);
@@ -3698,10 +3704,11 @@ void fetchManifestAsync(
    pProc->start(command.c_str(), FilePath(), async_r::R_PROCESS_VANILLA);
 
    // Wall-clock deadline. terminate() only sends a soft interrupt, so a child
-   // wedged in DNS/connect may not die promptly. Resolve the waiting callers
-   // immediately under the single-completion guard (bounding how long they wait)
-   // and free the single-flight, then best-effort terminate the child; its
-   // eventual onCompleted re-enters complete() and no-ops.
+   // wedged in DNS/connect may not die promptly. complete() no-ops if the fetch
+   // already finished (pDone claimed); otherwise it resolves the waiting callers
+   // with a timeout (bounding how long they wait) and frees the single-flight,
+   // then we best-effort terminate the child; its eventual onCompleted re-enters
+   // complete() and no-ops.
    //
    // Intentional tradeoff: a wedged child can briefly outlive the deadline, so a
    // retry in that window could spawn a second fetch. This is bounded and
@@ -3714,10 +3721,8 @@ void fetchManifestAsync(
    boost::weak_ptr<ManifestDownload> wProc(pProc);
    module_context::scheduleDelayedWork(
       boost::posix_time::seconds(kManifestDeadlineSeconds),
-      [wProc, pDone, complete]()
+      [wProc, complete]()
       {
-         if (*pDone)
-            return;
          core::system::ProcessResult timeout;
          timeout.exitStatus = 1;
          timeout.stdErr = "manifest download timed out";

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -3509,9 +3509,13 @@ const char* const kManifestTestUrl = "https://cdn.posit.co/posit-ai/manifest-tes
 // check fails (manifestUnavailable) after this long.
 const int kManifestDeadlineSeconds = 30;
 
-// Single-flight state for manifest update checks. Main-thread-only: the async
-// subprocess completion and the RPC handlers all run on the main thread, so no
-// lock is needed here (s_updateState keeps its own mutex for cross-thread reads).
+// Single-flight state for manifest update checks. All access happens on the main
+// thread, so no lock is needed here (s_updateState keeps its own mutex for
+// cross-thread reads): the two RPC handlers are not offlineable (so they run on
+// the main thread), the scheduled startup and deadline work run on the main
+// thread, and the async subprocess completion is explicitly marshalled onto the
+// main thread by fetchManifestAsync -- its process callbacks can otherwise fire
+// on the offline-service background thread while R is busy.
 // s_pendingCompletions holds the actions to run once the in-flight check
 // finishes (each RPC caller queues one); s_checkIncludesStartup records whether
 // any caller in the current batch is the startup check (which also runs the
@@ -3520,9 +3524,8 @@ bool s_checkInProgress = false;
 bool s_checkIncludesStartup = false;
 std::vector<boost::function<void()>> s_pendingCompletions;
 
-// Defined further below (at the former doUpdateCheck site, after the manifest
-// parse/check helpers); forward-declared here so onDeferredInit's startup
-// kickoff can reference startUpdateCheck.
+// Defined further below (after the manifest parse/check helpers); forward-declared
+// here so onDeferredInit's startup kickoff can reference startUpdateCheck.
 void startUpdateCheck(bool isStartup, boost::function<void()> onComplete);
 void onUpdateCheckComplete(const Error& fetchError, const json::Object& manifest);
 
@@ -3668,16 +3671,26 @@ void fetchManifestAsync(
    }
 
    // Single-completion guard shared by the normal completion and the deadline.
+   // The AsyncRProcess completion can fire on the offline-service background
+   // thread (processSupervisor().poll() runs there while R occupies the main
+   // thread), so marshal the body onto the main thread before touching pDone or
+   // the single-flight state, and before onReady -> onUpdateCheckComplete drains
+   // queued completions (which may run R, e.g. performInstall). executeOnMainThread
+   // runs inline when already on the main thread (the deadline path below), so it
+   // adds no latency there.
    boost::shared_ptr<bool> pDone = boost::make_shared<bool>(false);
    boost::function<void(const core::system::ProcessResult&)> complete =
       [onReady, pDone](const core::system::ProcessResult& result)
       {
-         if (*pDone)
-            return;
-         *pDone = true;
-         json::Object manifest;
-         Error err = integrity::manifestFromDownloadResult(result, &manifest);
-         onReady(err, manifest);
+         module_context::executeOnMainThread([onReady, pDone, result]()
+         {
+            if (*pDone)
+               return;
+            *pDone = true;
+            json::Object manifest;
+            Error err = integrity::manifestFromDownloadResult(result, &manifest);
+            onReady(err, manifest);
+         });
       };
 
    boost::shared_ptr<ManifestDownload> pProc =
@@ -4213,13 +4226,13 @@ Error installPackage(const FilePath& packagePath)
    return Success();
 }
 
-// Runs on the main thread once a manifest fetch completes (success or failure).
-// Computes the new update state from the manifest, writes s_updateState in one
-// atomic locked update (no reset-at-start window), stops the agent when the
-// installed version/protocol is unsupported or the manifest is unavailable, runs
-// the startup-only recommended-RStudio-version warning, then drains any queued
-// single-flight completions. Replaces the old (synchronous) doUpdateCheck /
-// checkForUpdatesOnStartup, whose bodies were ~identical apart from the warning.
+// Runs on the main thread (fetchManifestAsync marshals the subprocess completion
+// there) once a manifest fetch completes (success or failure). Computes the new
+// update state from the manifest, writes s_updateState in one atomic locked update
+// (no reset-at-start window), stops the agent when the installed version/protocol
+// is unsupported or the manifest is unavailable, runs the startup-only
+// recommended-RStudio-version warning, then drains any queued single-flight
+// completions.
 void onUpdateCheckComplete(const Error& fetchError, const json::Object& manifest)
 {
    bool wasStartup = s_checkIncludesStartup;

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -3663,6 +3663,10 @@ void fetchManifestAsync(
 
    // Build the child command in the parent session so the --vanilla child
    // reproduces the parent's resolved download.file.method/extra and timeout.
+   // --vanilla implies --no-environ, so the child does not itself re-read
+   // .Renviron; proxy config still applies because the child inherits the parent's
+   // process environment (the parent read .Renviron at startup) and the
+   // method/extra options are injected explicitly into the command.
    std::string command;
    Error error = r::exec::RFunction(".rs.chat.manifestDownloadCommand", url).call(&command);
    if (error)
@@ -3703,7 +3707,10 @@ void fetchManifestAsync(
       boost::make_shared<ManifestDownload>(complete);
    pProc->start(command.c_str(), FilePath(), async_r::R_PROCESS_VANILLA);
 
-   // Wall-clock deadline. terminate() only sends a soft interrupt, so a child
+   // Deadline (bounded by main-thread availability: like the completion, it fires
+   // when the main thread next services its scheduled-work queue, so a main thread
+   // wedged in a long synchronous R computation defers both -- no worse than the
+   // old in-process download). terminate() only sends a soft interrupt, so a child
    // wedged in DNS/connect may not die promptly. complete() no-ops if the fetch
    // already finished (pDone claimed); otherwise it resolves the waiting callers
    // with a timeout (bounding how long they wait) and frees the single-flight,
@@ -3733,7 +3740,7 @@ void fetchManifestAsync(
                pClient->terminate();
          }
       },
-      false);  // not idleOnly: a real wall-clock deadline
+      false);  // not idleOnly: fire even while R is busy (not only when idle)
 }
 
 
@@ -5219,6 +5226,7 @@ void performInstall(const json::JsonRpcFunctionContinuation& cont)
       setErrorResponse(systemError(boost::system::errc::operation_not_permitted,
                                    "No update available", ERROR_LOCATION),
                        &response);
+      lock.unlock();  // don't hold the state lock across the continuation
       cont(Success(), &response);
       return;
    }
@@ -5231,6 +5239,7 @@ void performInstall(const json::JsonRpcFunctionContinuation& cont)
       setErrorResponse(systemError(boost::system::errc::operation_in_progress,
                                    "Update already in progress", ERROR_LOCATION),
                        &response);
+      lock.unlock();  // don't hold the state lock across the continuation
       cont(Success(), &response);
       return;
    }

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -36,9 +36,11 @@
 #include <boost/asio.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/make_shared.hpp>
 #include <boost/optional.hpp>
 #include <boost/regex.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/weak_ptr.hpp>
 
 #include <core/AnsiEscapes.hpp>
 #include <core/Exec.hpp>
@@ -72,6 +74,7 @@
 #include <session/SessionSourceDatabase.hpp>
 #include <session/SessionUrlPorts.hpp>
 #include <session/SessionScopes.hpp>
+#include <session/SessionAsyncRProcess.hpp>
 #include <session/prefs/UserPrefs.hpp>
 #include <session/prefs/UserState.hpp>
 #include <session/projects/SessionProjects.hpp>
@@ -3498,6 +3501,31 @@ struct UpdateState
 UpdateState s_updateState;
 boost::mutex s_updateStateMutex;
 
+// Posit Assistant manifest endpoints (prod + opt-in test manifest).
+const char* const kManifestUrl     = "https://cdn.posit.co/posit-ai/manifest.json";
+const char* const kManifestTestUrl = "https://cdn.posit.co/posit-ai/manifest-test.json";
+
+// Wall-clock bound for a manifest fetch; a stalled child is terminated and the
+// check fails (manifestUnavailable) after this long.
+const int kManifestDeadlineSeconds = 30;
+
+// Single-flight state for manifest update checks. Main-thread-only: the async
+// subprocess completion and the RPC handlers all run on the main thread, so no
+// lock is needed here (s_updateState keeps its own mutex for cross-thread reads).
+// s_pendingCompletions holds the actions to run once the in-flight check
+// finishes (each RPC caller queues one); s_checkIncludesStartup records whether
+// any caller in the current batch is the startup check (which also runs the
+// recommended-RStudio-version warning).
+bool s_checkInProgress = false;
+bool s_checkIncludesStartup = false;
+std::vector<boost::function<void()>> s_pendingCompletions;
+
+// Defined further below (at the former doUpdateCheck site, after the manifest
+// parse/check helpers); forward-declared here so onDeferredInit's startup
+// kickoff can reference startUpdateCheck.
+void startUpdateCheck(bool isStartup, boost::function<void()> onComplete);
+void onUpdateCheckComplete(const Error& fetchError, const json::Object& manifest);
+
 // Automation-only override for chatCheckForUpdates. When set (via the
 // chat_set_update_check_override RPC), the next chatCheckForUpdates returns
 // this object verbatim instead of running an actual manifest fetch + parse,
@@ -3518,66 +3546,107 @@ bool isHttpsUrl(const std::string& url)
    return boost::starts_with(url, "https://");
 }
 
-Error downloadManifest(json::Object* pManifest)
-{
-   if (!pManifest)
-      return systemError(boost::system::errc::invalid_argument, ERROR_LOCATION);
-
 #ifndef NDEBUG
-   // DEBUG builds only: Support local manifest file for testing
+// DEBUG builds only: read a local manifest file (RSTUDIO_CHAT_DEBUG_MANIFEST)
+// for testing. Returns Success() and populates *pManifest, or an error.
+Error readDebugManifest(const std::string& debugManifestPath, json::Object* pManifest)
+{
+   // Validate path ends with manifest.json
+   if (!boost::algorithm::ends_with(debugManifestPath, "manifest.json"))
+   {
+      return systemError(
+         boost::system::errc::invalid_argument,
+         "RSTUDIO_CHAT_DEBUG_MANIFEST must end with 'manifest.json': " + debugManifestPath,
+         ERROR_LOCATION);
+   }
+
+   FilePath debugManifestFile(debugManifestPath);
+   if (!debugManifestFile.exists())
+   {
+      return systemError(
+         boost::system::errc::no_such_file_or_directory,
+         "Debug manifest file not found: " + debugManifestPath,
+         ERROR_LOCATION);
+   }
+
+   DLOG("DEBUG: Using local manifest file: {}", debugManifestPath);
+
+   std::string manifestContent;
+   Error error = core::readStringFromFile(debugManifestFile, &manifestContent);
+   if (error)
+   {
+      WLOG("Failed to read debug manifest file: {}", error.getMessage());
+      return error;
+   }
+
+   json::Value manifestValue;
+   if (manifestValue.parse(manifestContent))
+   {
+      WLOG("Failed to parse debug manifest JSON");
+      return systemError(boost::system::errc::protocol_error,
+                         "Invalid JSON in debug manifest", ERROR_LOCATION);
+   }
+
+   if (!manifestValue.isObject())
+   {
+      return systemError(boost::system::errc::protocol_error,
+                         "Debug manifest must be a JSON object", ERROR_LOCATION);
+   }
+
+   *pManifest = manifestValue.getObject();
+   DLOG("Successfully loaded and parsed debug manifest");
+   return Success();
+}
+#endif
+
+// Collects a manifest-download subprocess's stdout/stderr and reports a
+// ProcessResult to a completion callback. Mirrors AsyncDownloadFile
+// (SessionAsyncDownloadFile.cpp), but is local so the child can run --vanilla
+// (clean stdout) with injected download.file.* options for proxy parity
+// (see .rs.chat.manifestDownloadCommand).
+class ManifestDownload : public async_r::AsyncRProcess
+{
+public:
+   explicit ManifestDownload(
+      const boost::function<void(const core::system::ProcessResult&)>& onCompleted)
+      : onCompleted_(onCompleted)
+   {
+   }
+
+   void onStdout(const std::string& output) override { stdOut_ += output; }
+   void onStderr(const std::string& output) override { stdErr_ += output; }
+
+   void onCompleted(int exitStatus) override
+   {
+      core::system::ProcessResult result;
+      result.exitStatus = exitStatus;
+      result.stdOut = stdOut_;
+      result.stdErr = stdErr_;
+      onCompleted_(result);
+   }
+
+private:
+   std::string stdOut_;
+   std::string stdErr_;
+   boost::function<void(const core::system::ProcessResult&)> onCompleted_;
+};
+
+// Fetch the manifest off the main thread via an async R subprocess. onReady runs
+// on the main thread with either an error (mapped to manifestUnavailable
+// upstream) or the parsed manifest object. Running the download in a child
+// process -- so rsession never reads its own temp file -- is what eliminates the
+// Windows ERROR_SHARING_VIOLATION (#17891).
+void fetchManifestAsync(
+   const boost::function<void(const Error&, const json::Object&)>& onReady)
+{
+#ifndef NDEBUG
    std::string debugManifestPath = core::system::getenv("RSTUDIO_CHAT_DEBUG_MANIFEST");
    if (!debugManifestPath.empty())
    {
-      // Validate path ends with manifest.json
-      if (!boost::algorithm::ends_with(debugManifestPath, "manifest.json"))
-      {
-         return systemError(
-            boost::system::errc::invalid_argument,
-            "RSTUDIO_CHAT_DEBUG_MANIFEST must end with 'manifest.json': " +
-               debugManifestPath,
-            ERROR_LOCATION);
-      }
-
-      FilePath debugManifestFile(debugManifestPath);
-      if (!debugManifestFile.exists())
-      {
-         return systemError(
-            boost::system::errc::no_such_file_or_directory,
-            "Debug manifest file not found: " + debugManifestPath,
-            ERROR_LOCATION);
-      }
-
-      DLOG("DEBUG: Using local manifest file: {}", debugManifestPath);
-
-      // Read and parse JSON from local file
-      std::string manifestContent;
-      Error error = core::readStringFromFile(debugManifestFile, &manifestContent);
-      if (error)
-      {
-         WLOG("Failed to read debug manifest file: {}", error.getMessage());
-         return error;
-      }
-
-      // Parse JSON
-      json::Value manifestValue;
-      if (manifestValue.parse(manifestContent))
-      {
-         WLOG("Failed to parse debug manifest JSON");
-         return systemError(boost::system::errc::protocol_error,
-                           "Invalid JSON in debug manifest",
-                           ERROR_LOCATION);
-      }
-
-      if (!manifestValue.isObject())
-      {
-         return systemError(boost::system::errc::protocol_error,
-                           "Debug manifest must be a JSON object",
-                           ERROR_LOCATION);
-      }
-
-      *pManifest = manifestValue.getObject();
-      DLOG("Successfully loaded and parsed debug manifest");
-      return Success();
+      json::Object manifest;
+      Error error = readDebugManifest(debugManifestPath, &manifest);
+      onReady(error, manifest);
+      return;
    }
 #endif
 
@@ -3585,63 +3654,68 @@ Error downloadManifest(json::Object* pManifest)
    // command-line/session option or the user preference.
    bool useTestManifest = options().positAssistantTestManifest() ||
                           prefs::userPrefs().positAssistantTestManifest();
-   std::string downloadUri = useTestManifest
-      ? "https://cdn.posit.co/posit-ai/manifest-test.json"
-      : "https://cdn.posit.co/posit-ai/manifest.json";
+   std::string url = useTestManifest ? kManifestTestUrl : kManifestUrl;
+   DLOG("Fetching manifest from: {}", url);
 
-   DLOG("Downloading manifest from: {}", downloadUri);
-
-   // Create temp file for download
-   FilePath tempFile = module_context::tempFile("manifest", "json");
-
-   // Use R's download.file() function with timeout protection.
-   // Do not hardcode the download method -- let R use whatever method the
-   // user/admin has configured via options(download.file.method).  Corporate
-   // proxy environments typically set method = "curl" with a --cacert option
-   // in download.file.extra to trust the proxy's CA certificate.
-   r::exec::RFunction downloadFunc("download.file");
-   downloadFunc.addParam("url", downloadUri);
-   downloadFunc.addParam("destfile", tempFile.getAbsolutePath());
-   downloadFunc.addParam("quiet", true);
-   downloadFunc.addParam("timeout", 30);  // 30 second timeout
-
-   Error error = downloadFunc.call();
+   // Build the child command in the parent session so the --vanilla child
+   // reproduces the parent's resolved download.file.method/extra and timeout.
+   std::string command;
+   Error error = r::exec::RFunction(".rs.chat.manifestDownloadCommand", url).call(&command);
    if (error)
    {
-      WLOG("Failed to download manifest: {}", error.getMessage());
-      return error;
+      onReady(error, json::Object());
+      return;
    }
 
-   // Read and parse JSON
-   std::string manifestContent;
-   error = core::readStringFromFile(tempFile, &manifestContent);
-   if (error)
-   {
-      WLOG("Failed to read manifest file: {}", error.getMessage());
-      return error;
-   }
+   // Single-completion guard shared by the normal completion and the deadline.
+   boost::shared_ptr<bool> pDone = boost::make_shared<bool>(false);
+   boost::function<void(const core::system::ProcessResult&)> complete =
+      [onReady, pDone](const core::system::ProcessResult& result)
+      {
+         if (*pDone)
+            return;
+         *pDone = true;
+         json::Object manifest;
+         Error err = integrity::manifestFromDownloadResult(result, &manifest);
+         onReady(err, manifest);
+      };
 
-   // Parse JSON
-   json::Value manifestValue;
-   if (manifestValue.parse(manifestContent))
-   {
-      WLOG("Failed to parse manifest JSON");
-      return systemError(boost::system::errc::protocol_error,
-                        "Invalid JSON in manifest",
-                        ERROR_LOCATION);
-   }
+   boost::shared_ptr<ManifestDownload> pProc =
+      boost::make_shared<ManifestDownload>(complete);
+   pProc->start(command.c_str(), FilePath(), async_r::R_PROCESS_VANILLA);
 
-   if (!manifestValue.isObject())
-   {
-      return systemError(boost::system::errc::protocol_error,
-                        "Manifest must be a JSON object",
-                        ERROR_LOCATION);
-   }
-
-   *pManifest = manifestValue.getObject();
-   DLOG("Successfully downloaded and parsed manifest");
-
-   return Success();
+   // Wall-clock deadline. terminate() only sends a soft interrupt, so a child
+   // wedged in DNS/connect may not die promptly. Resolve the waiting callers
+   // immediately under the single-completion guard (bounding how long they wait)
+   // and free the single-flight, then best-effort terminate the child; its
+   // eventual onCompleted re-enters complete() and no-ops.
+   //
+   // Intentional tradeoff: a wedged child can briefly outlive the deadline, so a
+   // retry in that window could spawn a second fetch. This is bounded and
+   // acceptable -- the manifest check is infrequent and user-paced (not auto-
+   // retried), and a stuck child self-exits when the OS DNS lookup / download
+   // timeout gives up (~tens of seconds). Holding the single-flight until the
+   // child exited was tried, but created a worse failure mode (callers arriving
+   // after the deadline could hang until the child died), so freeing the
+   // single-flight at the deadline is preferred.
+   boost::weak_ptr<ManifestDownload> wProc(pProc);
+   module_context::scheduleDelayedWork(
+      boost::posix_time::seconds(kManifestDeadlineSeconds),
+      [wProc, pDone, complete]()
+      {
+         if (*pDone)
+            return;
+         core::system::ProcessResult timeout;
+         timeout.exitStatus = 1;
+         timeout.stdErr = "manifest download timed out";
+         complete(timeout);
+         if (boost::shared_ptr<ManifestDownload> pClient = wProc.lock())
+         {
+            if (pClient->isRunning())
+               pClient->terminate();
+         }
+      },
+      false);  // not idleOnly: a real wall-clock deadline
 }
 
 
@@ -3726,6 +3800,21 @@ void onDeferredInit(bool)
        prefs::userPrefs().positAssistantTestManifest())
    {
       showTestManifestWarning();
+   }
+
+   // Kick off the startup manifest check, deferred off the critical startup
+   // path. The fetch is async, but spawning the --vanilla child R process still
+   // has a cost (process creation + R DLL load, often AV-scanned on Windows), so
+   // we wait for an idle moment rather than spawning it during session startup.
+   // isStartup=true so the recommended-RStudio-version warning fires (once,
+   // startup-only). Guarded by isPositAssistantWanted() so non-PAI sessions never
+   // spawn the fetch.
+   if (isPositAssistantWanted())
+   {
+      module_context::scheduleDelayedWork(
+         boost::posix_time::seconds(1),
+         []() { startUpdateCheck(true, boost::function<void()>()); },
+         true);  // idleOnly: run after R becomes idle (post client attach)
    }
 }
 
@@ -3966,8 +4055,10 @@ Error downloadPackage(const std::string& url, const FilePath& destPath)
 
    DLOG("Downloading package from: {} to: {}", url, destPath.getAbsolutePath());
 
-   // Use R's download.file() function with timeout protection.
-   // Do not hardcode the download method -- see downloadManifest() comment.
+   // Use R's download.file() function with timeout protection. Do not hardcode
+   // the download method -- let R use whatever the user/admin configured via
+   // options(download.file.method) (corporate proxies often set method = "curl"
+   // with a --cacert in download.file.extra to trust the proxy's CA).
    r::exec::RFunction downloadFunc("download.file");
    downloadFunc.addParam("url", url);
    downloadFunc.addParam("destfile", destPath.getAbsolutePath());
@@ -4122,13 +4213,17 @@ Error installPackage(const FilePath& packagePath)
    return Success();
 }
 
-// Performs the actual update check logic (must be called with mutex NOT held)
-// This populates s_updateState with current version info and available updates
-void doUpdateCheck()
+// Runs on the main thread once a manifest fetch completes (success or failure).
+// Computes the new update state from the manifest, writes s_updateState in one
+// atomic locked update (no reset-at-start window), stops the agent when the
+// installed version/protocol is unsupported or the manifest is unavailable, runs
+// the startup-only recommended-RStudio-version warning, then drains any queued
+// single-flight completions. Replaces the old (synchronous) doUpdateCheck /
+// checkForUpdatesOnStartup, whose bodies were ~identical apart from the warning.
+void onUpdateCheckComplete(const Error& fetchError, const json::Object& manifest)
 {
-   DLOG("Performing update check");
+   bool wasStartup = s_checkIncludesStartup;
 
-   // Get installed version
    std::string installedVersion = getInstalledVersion();
    if (installedVersion.empty())
    {
@@ -4136,337 +4231,195 @@ void doUpdateCheck()
       installedVersion = "0.0.0";
    }
 
-   // Reset blocking flags from any previous check before starting fresh
-   {
-      boost::mutex::scoped_lock lock(s_updateStateMutex);
-      s_updateState.currentVersion = installedVersion;
-      s_updateState.updateAvailable = false;
-      s_updateState.isDowngrade = false;
-      s_updateState.noCompatibleVersion = false;
-      s_updateState.unsupportedInstalledVersion = false;
-      s_updateState.unsupportedProtocol = false;
-      s_updateState.manifestUnavailable = false;
-      s_updateState.errorMessage.clear();
-   }
-
-   // Download manifest
-   json::Object manifest;
-   Error error = downloadManifest(&manifest);
-   if (error)
-   {
-      WLOG("Failed to download manifest: {}", error.getMessage());
-      {
-         boost::mutex::scoped_lock lock(s_updateStateMutex);
-         s_updateState.manifestUnavailable = true;
-         s_updateState.errorMessage = error.getMessage();
-      }
-      assistant::stopAgentForUpdate();
-      return;
-   }
-
-   // Check for unsupported versions/protocols
-   UnsupportedInfo unsupportedInfo;
-   error = getUnsupportedInfo(manifest, &unsupportedInfo);
-   if (error)
-   {
-      // Malformed unsupported info — fail closed to be safe
-      WLOG("Failed to parse unsupported info (blocking Posit Assistant): {}",
-           error.getMessage());
-      {
-         boost::mutex::scoped_lock lock(s_updateStateMutex);
-         s_updateState.manifestUnavailable = true;
-         s_updateState.errorMessage = error.getMessage();
-      }
-      assistant::stopAgentForUpdate();
-      return;
-   }
-
-   // Check for protocol mismatch (file I/O, done outside the lock)
-   bool protocolMismatch = hasProtocolMismatch(installedVersion);
-
-   {
-      boost::mutex::scoped_lock lock(s_updateStateMutex);
-      s_updateState.unsupportedProtocol = isProtocolUnsupported(unsupportedInfo);
-      s_updateState.unsupportedInstalledVersion =
-         isVersionUnsupported(installedVersion, unsupportedInfo) ||
-         protocolMismatch;
-
-      DLOG("Unsupported check: protocol={}, installedVersion={}",
-           s_updateState.unsupportedProtocol,
-           s_updateState.unsupportedInstalledVersion);
-   }
-
-   // Stop Posit Assistant agent if version/protocol is unsupported or manifest unavailable
-   if (isPositAssistantUnsupported())
-   {
-      assistant::stopAgentForUpdate();
-   }
-
-   // Get package info for our protocol version
-   std::string packageVersion;
+   // Check-related fields, computed into locals and written once at the end so a
+   // concurrent reader never sees a half-updated (reset) state.
+   bool manifestUnavailable = false;
+   std::string errorMessage;
+   bool unsupportedProtocol = false;
+   bool unsupportedInstalledVersion = false;
+   bool noCompatibleVersion = false;
+   bool updateAvailable = false;
+   bool isDowngrade = false;
+   std::string newVersion;
    std::string downloadUrl;
-   std::string sha256;
-   error = integrity::getPackageInfoFromManifest(manifest, kProtocolVersion, &packageVersion, &downloadUrl, &sha256);
-   if (error)
-   {
-      WLOG("Failed to get package info from manifest: {}", error.getMessage());
+   std::string expectedSha256;
+   bool showVersionWarning = false;
+   std::string recommendedVersion;
+   std::string downloadPageUrl;
 
-      // Check if this is specifically a "protocol not found" error
-      if (error.getCode() == boost::system::errc::protocol_not_supported)
+   // Apply the computed state + side effects, then drain waiters. Runs on exactly
+   // one exit path.
+   auto finish = [&]()
+   {
       {
          boost::mutex::scoped_lock lock(s_updateStateMutex);
-         // Only block if there's no installed version to fall back on
-         if (installedVersion == "0.0.0")
-         {
-            s_updateState.noCompatibleVersion = true;
-         }
-         s_updateState.updateAvailable = false;
-      }
-      return;
-   }
-
-   // Compare versions - offer install if versions differ (upgrade or downgrade)
-   boost::mutex::scoped_lock lock(s_updateStateMutex);
-   if (shouldInstallVersion(installedVersion, packageVersion))
-   {
-      // Don't offer an update if the available version is also unsupported
-      if (isVersionUnsupported(packageVersion, unsupportedInfo))
-      {
-         WLOG("Available version {} is also unsupported (minimum: {}), "
-              "no compatible version available",
-              packageVersion, unsupportedInfo.minimumPackageVersion);
-         s_updateState.noCompatibleVersion = true;
-         s_updateState.updateAvailable = false;
-      }
-      else
-      {
-         bool isDowngrade = isVersionDowngrade(installedVersion, packageVersion);
-         DLOG("{} available: {} -> {}",
-              isDowngrade ? "Downgrade" : "Update",
-              installedVersion, packageVersion);
-         s_updateState.updateAvailable = true;
+         s_updateState.currentVersion = installedVersion;
+         s_updateState.manifestUnavailable = manifestUnavailable;
+         s_updateState.errorMessage = errorMessage;
+         s_updateState.unsupportedProtocol = unsupportedProtocol;
+         s_updateState.unsupportedInstalledVersion = unsupportedInstalledVersion;
+         s_updateState.noCompatibleVersion = noCompatibleVersion;
+         s_updateState.updateAvailable = updateAvailable;
          s_updateState.isDowngrade = isDowngrade;
-         s_updateState.newVersion = packageVersion;
+         s_updateState.newVersion = newVersion;
          s_updateState.downloadUrl = downloadUrl;
-         s_updateState.expectedSha256 = sha256;
+         s_updateState.expectedSha256 = expectedSha256;
       }
-   }
-   else
+
+      if (manifestUnavailable || isPositAssistantUnsupported())
+         assistant::stopAgentForUpdate();
+
+      if (showVersionWarning)
+         showRStudioVersionWarning(recommendedVersion, downloadPageUrl);
+
+      // Reset single-flight state and run queued completions. Swap first so a
+      // completion that kicks a fresh check sees a clean queue.
+      s_checkInProgress = false;
+      s_checkIncludesStartup = false;
+      std::vector<boost::function<void()>> completions;
+      completions.swap(s_pendingCompletions);
+      for (boost::function<void()>& completion : completions)
+         completion();
+   };
+
+   if (fetchError)
    {
-      DLOG("No update needed (installed: {}, available: {})", installedVersion, packageVersion);
-      s_updateState.updateAvailable = false;
-   }
-}
-
-// Called during session initialization to check for updates
-Error checkForUpdatesOnStartup()
-{
-   if (!isPositAssistantWanted())
-   {
-      DLOG("Update check skipped: posit not selected for chat or assistant");
-      return Success();
+      WLOG("Failed to download manifest: {}", fetchError.getMessage());
+      manifestUnavailable = true;
+      errorMessage = fetchError.getMessage();
+      finish();
+      return;
    }
 
-   DLOG("Checking for updates on startup");
-
-   // Get installed version
-   std::string installedVersion = getInstalledVersion();
-   if (installedVersion.empty())
-   {
-      DLOG("No installation found, checking for initial install");
-      installedVersion = "0.0.0";
-   }
-
-   // Reset blocking flags from any previous check before starting fresh
-   {
-      boost::mutex::scoped_lock lock(s_updateStateMutex);
-      s_updateState.currentVersion = installedVersion;
-      s_updateState.updateAvailable = false;
-      s_updateState.isDowngrade = false;
-      s_updateState.noCompatibleVersion = false;
-      s_updateState.unsupportedInstalledVersion = false;
-      s_updateState.unsupportedProtocol = false;
-      s_updateState.manifestUnavailable = false;
-      s_updateState.errorMessage.clear();
-   }
-
-   // Download manifest
-   json::Object manifest;
-   Error error = downloadManifest(&manifest);
-   if (error)
-   {
-      WLOG("Failed to download manifest: {}", error.getMessage());
-      {
-         boost::mutex::scoped_lock lock(s_updateStateMutex);
-         s_updateState.manifestUnavailable = true;
-         s_updateState.errorMessage = error.getMessage();
-      }
-      assistant::stopAgentForUpdate();
-      return Success();
-   }
-
-   // Manifest succeeded — clear the failure flag
-   {
-      boost::mutex::scoped_lock lock(s_updateStateMutex);
-      s_updateState.manifestUnavailable = false;
-      s_updateState.errorMessage.clear();
-   }
-
-   // Check for unsupported versions/protocols
+   // Parse the optional "unsupported" constraints; malformed -> fail closed.
    UnsupportedInfo unsupportedInfo;
-   error = getUnsupportedInfo(manifest, &unsupportedInfo);
+   Error error = getUnsupportedInfo(manifest, &unsupportedInfo);
    if (error)
    {
-      // Malformed unsupported info — fail closed to be safe
       WLOG("Failed to parse unsupported info (blocking Posit Assistant): {}",
            error.getMessage());
-      {
-         boost::mutex::scoped_lock lock(s_updateStateMutex);
-         s_updateState.manifestUnavailable = true;
-         s_updateState.errorMessage = error.getMessage();
-      }
-      assistant::stopAgentForUpdate();
-      return Success();
+      manifestUnavailable = true;
+      errorMessage = error.getMessage();
+      finish();
+      return;
    }
 
-   // Check for protocol mismatch (file I/O, done outside the lock)
+   // Protocol mismatch (file I/O, no lock held).
    bool protocolMismatch = hasProtocolMismatch(installedVersion);
+   unsupportedProtocol = isProtocolUnsupported(unsupportedInfo);
+   unsupportedInstalledVersion =
+      isVersionUnsupported(installedVersion, unsupportedInfo) || protocolMismatch;
+   DLOG("Unsupported check: protocol={}, installedVersion={}",
+        unsupportedProtocol, unsupportedInstalledVersion);
 
-   {
-      boost::mutex::scoped_lock lock(s_updateStateMutex);
-      s_updateState.unsupportedProtocol = isProtocolUnsupported(unsupportedInfo);
-      s_updateState.unsupportedInstalledVersion =
-         isVersionUnsupported(installedVersion, unsupportedInfo) ||
-         protocolMismatch;
-
-      DLOG("Unsupported check: protocol={}, installedVersion={}",
-           s_updateState.unsupportedProtocol,
-           s_updateState.unsupportedInstalledVersion);
-   }
-
-   // Stop Posit Assistant agent if version/protocol is unsupported or manifest unavailable
-   if (isPositAssistantUnsupported())
-   {
-      assistant::stopAgentForUpdate();
-   }
-
-   // Get package info for our protocol version
+   // Get package info for our protocol version.
    std::string packageVersion;
-   std::string downloadUrl;
+   std::string pkgDownloadUrl;
    std::string sha256;
-   error = integrity::getPackageInfoFromManifest(manifest, kProtocolVersion, &packageVersion, &downloadUrl, &sha256);
+   error = integrity::getPackageInfoFromManifest(
+      manifest, kProtocolVersion, &packageVersion, &pkgDownloadUrl, &sha256);
    if (error)
    {
       WLOG("Failed to get package info from manifest: {}", error.getMessage());
-      WLOG("Error code: {}, Expected: {}", error.getCode(),
-           static_cast<int>(boost::system::errc::protocol_not_supported));
 
-      // Check if this is specifically a "protocol not found" error
-      if (error.getCode() == boost::system::errc::protocol_not_supported)
+      // Protocol version not in manifest: only block if there's no installed
+      // version to fall back on. Other errors leave the installed version
+      // running (updateAvailable stays false).
+      if (error.getCode() == boost::system::errc::protocol_not_supported &&
+          installedVersion == "0.0.0")
       {
-         boost::mutex::scoped_lock lock(s_updateStateMutex);
-         // Protocol version not in manifest - only block if there's no installed
-         // version to fall back on
-         if (installedVersion == "0.0.0")
-         {
-            s_updateState.noCompatibleVersion = true;
-         }
-         s_updateState.updateAvailable = false;
+         noCompatibleVersion = true;
       }
-
-      // For non-protocol errors (e.g. missing fields), allow the installed
-      // version to continue running if one exists
-      return Success();
+      finish();
+      return;
    }
 
-   // Compare versions - offer install if versions differ (upgrade or downgrade)
+   // Compare versions - offer install if versions differ (upgrade or downgrade).
    if (shouldInstallVersion(installedVersion, packageVersion))
    {
-      // Don't offer an update if the available version is also unsupported
+      // Don't offer an update if the available version is also unsupported.
       if (isVersionUnsupported(packageVersion, unsupportedInfo))
       {
          WLOG("Available version {} is also unsupported (minimum: {}), "
               "no compatible version available",
               packageVersion, unsupportedInfo.minimumPackageVersion);
-         {
-            boost::mutex::scoped_lock lock(s_updateStateMutex);
-            s_updateState.noCompatibleVersion = true;
-            s_updateState.updateAvailable = false;
-         }
+         noCompatibleVersion = true;
       }
       else
       {
-         bool isDowngrade = isVersionDowngrade(installedVersion, packageVersion);
+         isDowngrade = isVersionDowngrade(installedVersion, packageVersion);
          DLOG("{} available: {} -> {}",
-              isDowngrade ? "Downgrade" : "Update",
-              installedVersion, packageVersion);
-
-         {
-            boost::mutex::scoped_lock lock(s_updateStateMutex);
-            s_updateState.updateAvailable = true;
-            s_updateState.isDowngrade = isDowngrade;
-            s_updateState.newVersion = packageVersion;
-            s_updateState.downloadUrl = downloadUrl;
-            s_updateState.expectedSha256 = sha256;
-         }
+              isDowngrade ? "Downgrade" : "Update", installedVersion, packageVersion);
+         updateAvailable = true;
+         newVersion = packageVersion;
+         downloadUrl = pkgDownloadUrl;
+         expectedSha256 = sha256;
       }
    }
    else
    {
-      DLOG("No update needed (installed: {}, available: {})", installedVersion, packageVersion);
-      {
-         boost::mutex::scoped_lock lock(s_updateStateMutex);
-         s_updateState.updateAvailable = false;
-      }
+      DLOG("No update needed (installed: {}, available: {})",
+           installedVersion, packageVersion);
    }
 
-   // Check for recommended RStudio version
-   std::string recommendedVersion, downloadPageUrl;
-   Error versionError = getRecommendedRStudioVersion(manifest, &recommendedVersion, &downloadPageUrl);
-   if (!versionError)
+   // Startup-only: warn about an out-of-date prerelease RStudio build. Computed
+   // here, fired in finish() (after the state write); never on a pane-open/Retry
+   // check (wasStartup is false for those).
+   if (wasStartup)
    {
-      core::Version current(RSTUDIO_VERSION);
-      core::Version recommended(recommendedVersion);
-
-      // Validate version parsed successfully (non-empty with at least major version)
-      if (recommended.empty())
+      Error versionError =
+         getRecommendedRStudioVersion(manifest, &recommendedVersion, &downloadPageUrl);
+      if (!versionError)
       {
-         WLOG("Failed to parse recommended RStudio version: {}", recommendedVersion);
-      }
-      else
-      {
-         std::string versionStr(RSTUDIO_VERSION);
-         bool isDailyBuild = versionStr.find("-daily") != std::string::npos;
-         bool isHourlyBuild = versionStr.find("-hourly") != std::string::npos;
-         bool isPrereleaseBuild = isDailyBuild || isHourlyBuild;
-         bool forceCheck = !core::system::getenv("RSTUDIO_FORCE_DEV_UPDATE_CHECK").empty();
-
-         DLOG("RStudio version check: current={}, recommended={}, isPrerelease={}",
-              RSTUDIO_VERSION, recommendedVersion, isPrereleaseBuild);
-
-         // Skip if Posit Assistant not installed (user hasn't completed beta signup)
-         if (installedVersion == "0.0.0")
+         core::Version current(RSTUDIO_VERSION);
+         core::Version recommended(recommendedVersion);
+         if (recommended.empty())
          {
-            DLOG("  Skipping version warning (Posit Assistant not installed)");
-         }
-         // Only check for prerelease builds (daily/hourly) unless overridden
-         else if (!isPrereleaseBuild && !forceCheck)
-         {
-            DLOG("  Skipping version warning (release build)");
-         }
-         else if (current < recommended)
-         {
-            DLOG("  Showing version warning");
-            showRStudioVersionWarning(recommendedVersion, downloadPageUrl);
+            WLOG("Failed to parse recommended RStudio version: {}", recommendedVersion);
          }
          else
          {
-            DLOG("  No warning needed (version is current or newer)");
+            std::string versionStr(RSTUDIO_VERSION);
+            bool isPrereleaseBuild =
+               versionStr.find("-daily") != std::string::npos ||
+               versionStr.find("-hourly") != std::string::npos;
+            bool forceCheck =
+               !core::system::getenv("RSTUDIO_FORCE_DEV_UPDATE_CHECK").empty();
+
+            DLOG("RStudio version check: current={}, recommended={}, isPrerelease={}",
+                 RSTUDIO_VERSION, recommendedVersion, isPrereleaseBuild);
+
+            if (installedVersion == "0.0.0")
+               DLOG("  Skipping version warning (Posit Assistant not installed)");
+            else if (!isPrereleaseBuild && !forceCheck)
+               DLOG("  Skipping version warning (release build)");
+            else if (current < recommended)
+               showVersionWarning = true;
+            else
+               DLOG("  No warning needed (version is current or newer)");
          }
       }
    }
 
-   return Success();
+   finish();
+}
+
+// Begin (or join) a manifest update check. onComplete (may be empty) runs once
+// the check finishes; overlapping callers (startup + pane-open + Retry) share a
+// single fetch. Ordering invariant: enqueue the completion BEFORE starting the
+// fetch, so the synchronous DEBUG-manifest path still drains it. Main-thread only.
+void startUpdateCheck(bool isStartup, boost::function<void()> onComplete)
+{
+   if (onComplete)
+      s_pendingCompletions.push_back(onComplete);
+   if (isStartup)
+      s_checkIncludesStartup = true;
+
+   if (s_checkInProgress)
+      return;
+
+   s_checkInProgress = true;
+   fetchManifestAsync(&onUpdateCheckComplete);
 }
 
 // ============================================================================
@@ -5098,8 +5051,41 @@ Error chatGetVersion(const json::JsonRpcRequest& request,
    return Success();
 }
 
-Error chatCheckForUpdates(const json::JsonRpcRequest& request,
-                          json::JsonRpcResponse* pResponse)
+// Build the client-facing update-state result (under the state lock).
+void buildUpdateStateResult(json::Object* pResult)
+{
+   boost::mutex::scoped_lock lock(s_updateStateMutex);
+   (*pResult)["updateAvailable"] = s_updateState.updateAvailable;
+   (*pResult)["isDowngrade"] = s_updateState.isDowngrade;
+   (*pResult)["noCompatibleVersion"] = s_updateState.noCompatibleVersion;
+   (*pResult)["unsupportedInstalledVersion"] = s_updateState.unsupportedInstalledVersion;
+   (*pResult)["unsupportedProtocol"] = s_updateState.unsupportedProtocol;
+   (*pResult)["manifestUnavailable"] = s_updateState.manifestUnavailable;
+   (*pResult)["errorMessage"] = s_updateState.errorMessage;
+   (*pResult)["currentVersion"] = s_updateState.currentVersion;
+   (*pResult)["newVersion"] = s_updateState.newVersion;
+   (*pResult)["downloadUrl"] = s_updateState.downloadUrl;
+   (*pResult)["isInitialInstall"] = (s_updateState.currentVersion == "0.0.0");
+}
+
+// Resolve an async chat_check_for_updates continuation with the current state.
+void resolveWithUpdateState(const json::JsonRpcFunctionContinuation& cont)
+{
+   json::Object result;
+   buildUpdateStateResult(&result);
+
+   DLOG("chatCheckForUpdates resolving with current update state");
+
+   json::JsonRpcResponse response;
+   response.setResult(result);
+   cont(Success(), &response);
+}
+
+// Async RPC: the manifest fetch is off-thread, so the continuation resolves once
+// the (possibly already in-flight) check completes -- preserving the frontend's
+// existing per-call callback contract with no client changes.
+void chatCheckForUpdates(const json::JsonRpcRequest& request,
+                         const json::JsonRpcFunctionContinuation& cont)
 {
    // Honor any automation-test override before doing real work. This is set
    // via chat_set_update_check_override and lets Playwright tests force the
@@ -5113,8 +5099,10 @@ Error chatCheckForUpdates(const json::JsonRpcRequest& request,
       {
          json::Object override = *s_updateCheckOverride;
          s_updateCheckOverride.reset();
-         pResponse->setResult(override);
-         return Success();
+         json::JsonRpcResponse response;
+         response.setResult(override);
+         cont(Success(), &response);
+         return;
       }
    }
 
@@ -5124,48 +5112,36 @@ Error chatCheckForUpdates(const json::JsonRpcRequest& request,
    {
       Error error = json::readParam(request.params, 0, &forceRecheck);
       if (error)
-         return error;
-   }
-
-   // Perform on-demand update check if state hasn't been populated yet,
-   // or if the caller explicitly requested a recheck.
-   // This happens when user selects Posit Assistant in Preferences before the pref is saved.
-   // We allow the check regardless of isPositAssistantWanted() since checking for available
-   // updates doesn't require the preference - only actual installation does.
-   {
-      boost::mutex::scoped_lock lock(s_updateStateMutex);
-      if (s_updateState.currentVersion.empty() || forceRecheck)
       {
-         DLOG("Update state not populated or recheck forced, performing on-demand check");
-         lock.unlock();
-         doUpdateCheck();
+         json::JsonRpcResponse response;
+         setErrorResponse(error, &response);
+         cont(Success(), &response);
+         return;
       }
    }
 
-   boost::mutex::scoped_lock lock(s_updateStateMutex);
+   // Return cached state immediately only when it's populated, no recheck was
+   // forced, AND no check is in flight. If a check is running (e.g. a forced
+   // Retry from another caller), fall through and join it via startUpdateCheck so
+   // we return fresh state rather than a stale snapshot. (s_checkInProgress is
+   // main-thread-only, like this handler, so it's safe to read without a lock.)
+   // Checking doesn't require isPositAssistantWanted() -- the pref only gates
+   // actual installation, and the pane/Preferences may check before it is saved.
+   bool haveState = false;
+   {
+      boost::mutex::scoped_lock lock(s_updateStateMutex);
+      haveState = !s_updateState.currentVersion.empty();
+   }
 
-   // Return cached/computed check result
-   json::Object result;
-   result["updateAvailable"] = s_updateState.updateAvailable;
-   result["isDowngrade"] = s_updateState.isDowngrade;
-   result["noCompatibleVersion"] = s_updateState.noCompatibleVersion;
-   result["unsupportedInstalledVersion"] = s_updateState.unsupportedInstalledVersion;
-   result["unsupportedProtocol"] = s_updateState.unsupportedProtocol;
-   result["manifestUnavailable"] = s_updateState.manifestUnavailable;
-   result["errorMessage"] = s_updateState.errorMessage;
-   result["currentVersion"] = s_updateState.currentVersion;
-   result["newVersion"] = s_updateState.newVersion;
-   result["downloadUrl"] = s_updateState.downloadUrl;
-   result["isInitialInstall"] = (s_updateState.currentVersion == "0.0.0");
+   if (haveState && !forceRecheck && !s_checkInProgress)
+   {
+      resolveWithUpdateState(cont);
+      return;
+   }
 
-   DLOG("chatCheckForUpdates returning: updateAvailable={}, noCompatibleVersion={}, "
-        "unsupportedVersion={}, unsupportedProtocol={}, manifestUnavailable={}",
-        s_updateState.updateAvailable, s_updateState.noCompatibleVersion,
-        s_updateState.unsupportedInstalledVersion, s_updateState.unsupportedProtocol,
-        s_updateState.manifestUnavailable);
-
-   pResponse->setResult(result);
-   return Success();
+   // Otherwise kick (or join) an async check and resolve once it completes.
+   DLOG("Update state not populated or recheck forced, performing async check");
+   startUpdateCheck(false, boost::bind(resolveWithUpdateState, cont));
 }
 
 // Test-only: install (or clear) a one-shot override for chatCheckForUpdates.
@@ -5208,36 +5184,25 @@ Error chatSetUpdateCheckOverride(const json::JsonRpcRequest& request,
    return Success();
 }
 
-Error chatInstallUpdate(const json::JsonRpcRequest& request,
-                        json::JsonRpcResponse* pResponse)
+// Download + install the available update using the current state, then resolve
+// the continuation. The download/install is synchronous (the client polls
+// chat_get_update_status for progress); only the preceding update check is
+// async, so this is unchanged from the previous behavior apart from resolving a
+// continuation instead of returning a response.
+void performInstall(const json::JsonRpcFunctionContinuation& cont)
 {
-   if (!isPositAssistantWanted())
-   {
-      return systemError(boost::system::errc::operation_not_permitted,
-                        "Posit not selected for chat or assistant",
-                        ERROR_LOCATION);
-   }
-
-   // Check if we need to perform an update check first
-   // This happens when the user selects Posit Assistant after session startup
-   {
-      boost::mutex::scoped_lock lock(s_updateStateMutex);
-      if (s_updateState.currentVersion.empty())
-      {
-         DLOG("Update state not populated, performing on-demand check");
-         lock.unlock();
-         doUpdateCheck();
-      }
-   }
+   json::JsonRpcResponse response;
 
    boost::mutex::scoped_lock lock(s_updateStateMutex);
 
    // Check if update is available
    if (!s_updateState.updateAvailable)
    {
-      return systemError(boost::system::errc::operation_not_permitted,
-                        "No update available",
-                        ERROR_LOCATION);
+      setErrorResponse(systemError(boost::system::errc::operation_not_permitted,
+                                   "No update available", ERROR_LOCATION),
+                       &response);
+      cont(Success(), &response);
+      return;
    }
 
    // Check if already in progress
@@ -5245,16 +5210,18 @@ Error chatInstallUpdate(const json::JsonRpcRequest& request,
        s_updateState.installStatus != UpdateState::Status::Complete &&
        s_updateState.installStatus != UpdateState::Status::Error)
    {
-      return systemError(boost::system::errc::operation_in_progress,
-                        "Update already in progress",
-                        ERROR_LOCATION);
+      setErrorResponse(systemError(boost::system::errc::operation_in_progress,
+                                   "Update already in progress", ERROR_LOCATION),
+                       &response);
+      cont(Success(), &response);
+      return;
    }
 
-   // Start update process (async would be better, but doing sync for simplicity)
+   // Start update process (the download/install below is synchronous)
    s_updateState.installStatus = UpdateState::Status::Downloading;
    s_updateState.installMessage = "Downloading update...";
 
-   // Capture values before unlocking — a concurrent doUpdateCheck() could
+   // Capture values before unlocking — a concurrent update check could
    // reset s_updateState while we're downloading
    std::string downloadUrl = s_updateState.downloadUrl;
    std::string newVersion = s_updateState.newVersion;
@@ -5298,8 +5265,9 @@ Error chatInstallUpdate(const json::JsonRpcRequest& request,
       if (cleanupError)
          WLOG("Failed to remove temp package after download failure: {}", cleanupError.getMessage());
 
-      pResponse->setResult(json::Value());
-      return Success();
+      response.setResult(json::Value());
+      cont(Success(), &response);
+      return;
    }
 
    // Verify SHA-256 integrity of the downloaded package
@@ -5318,8 +5286,9 @@ Error chatInstallUpdate(const json::JsonRpcRequest& request,
          WLOG("Failed to remove temp package after missing hash: {}",
               cleanupError.getMessage());
 
-      pResponse->setResult(json::Value());
-      return Success();
+      response.setResult(json::Value());
+      cont(Success(), &response);
+      return;
    }
 
    error = integrity::verifyPackageSha256(tempPackage, expectedSha256);
@@ -5336,8 +5305,9 @@ Error chatInstallUpdate(const json::JsonRpcRequest& request,
          WLOG("Failed to remove temp package after integrity failure: {}",
               cleanupError.getMessage());
 
-      pResponse->setResult(json::Value());
-      return Success();
+      response.setResult(json::Value());
+      cont(Success(), &response);
+      return;
    }
 
    // Install package
@@ -5389,8 +5359,9 @@ Error chatInstallUpdate(const json::JsonRpcRequest& request,
             WLOG("Failed to clean up backup directory after failed install: {}", prevCleanup.getMessage());
       }
 
-      pResponse->setResult(json::Value());
-      return Success();
+      response.setResult(json::Value());
+      cont(Success(), &response);
+      return;
    }
 
    // Success - ensure backup is cleaned up
@@ -5415,8 +5386,46 @@ Error chatInstallUpdate(const json::JsonRpcRequest& request,
       s_updateState.currentVersion = newVersion;
    }
 
-   pResponse->setResult(json::Value());
-   return Success();
+   response.setResult(json::Value());
+   cont(Success(), &response);
+}
+
+// Async RPC. Installs the available update; if the update state hasn't been
+// populated yet (e.g. user selected Posit Assistant after startup), run an async
+// check first, then install. The install body itself is unchanged and the
+// client still polls chat_get_update_status for progress.
+void chatInstallUpdate(const json::JsonRpcRequest& request,
+                       const json::JsonRpcFunctionContinuation& cont)
+{
+   if (!isPositAssistantWanted())
+   {
+      json::JsonRpcResponse response;
+      setErrorResponse(systemError(boost::system::errc::operation_not_permitted,
+                                   "Posit not selected for chat or assistant",
+                                   ERROR_LOCATION),
+                       &response);
+      cont(Success(), &response);
+      return;
+   }
+
+   // Install from current state only when it's populated and no check is in
+   // flight; if a check is running, wait for it (join the single-flight queue)
+   // so we install against fresh state rather than a stale snapshot.
+   bool haveState = false;
+   {
+      boost::mutex::scoped_lock lock(s_updateStateMutex);
+      haveState = !s_updateState.currentVersion.empty();
+   }
+
+   if (haveState && !s_checkInProgress)
+   {
+      performInstall(cont);
+   }
+   else
+   {
+      DLOG("Update state not populated, performing async check before install");
+      startUpdateCheck(false, boost::bind(performInstall, cont));
+   }
 }
 
 Error chatGetUpdateStatus(const json::JsonRpcRequest& request,
@@ -5917,9 +5926,9 @@ Error initialize()
       (bind(registerRpcMethod, "chat_get_backend_url", chatGetBackendUrl))
       (bind(registerRpcMethod, "chat_get_backend_status", chatGetBackendStatus))
       (bind(registerRpcMethod, "chat_get_version", chatGetVersion))
-      (bind(registerRpcMethod, "chat_check_for_updates", chatCheckForUpdates))
+      (bind(registerAsyncRpcMethod, "chat_check_for_updates", chatCheckForUpdates))
       (bind(registerRpcMethod, "chat_set_update_check_override", chatSetUpdateCheckOverride))
-      (bind(registerRpcMethod, "chat_install_update", chatInstallUpdate))
+      (bind(registerAsyncRpcMethod, "chat_install_update", chatInstallUpdate))
       (bind(registerRpcMethod, "chat_get_update_status", chatGetUpdateStatus))
       (bind(registerRpcMethod, "chat_uninstall_posit_assistant", chatUninstallPositAssistant))
       (bind(registerRpcMethod, "chat_doc_focused", chatDocFocused))
@@ -5935,20 +5944,10 @@ Error initialize()
       return error;
    }
 
-   // Defer the update check off the synchronous init path. downloadManifest()
-   // blocks on R's download.file(), whose transfer timeout doesn't bound DNS
-   // resolution -- offline or flaky networks can stall it long enough to
-   // prevent rsession's HTTP listener from starting, leaving the GWT client
-   // stuck on the splash with empty menus. See rstudio/rstudio#14202.
-   module_context::scheduleDelayedWork(
-      boost::posix_time::seconds(1),
-      []()
-      {
-         Error error = checkForUpdatesOnStartup();
-         if (error)
-            WLOG("Update check failed: {}", error.getMessage());
-      },
-      true);  // idleOnly: run after R becomes idle (post client attach)
+   // The startup manifest check is kicked from onDeferredInit now. The fetch is
+   // async (subprocess), so it no longer needs the scheduleDelayedWork(idleOnly)
+   // workaround that previously kept the blocking download.file() off the
+   // critical startup path (see rstudio/rstudio#14202).
 
    DLOG("SessionChat module initialized successfully, URI handler registered for /ai-chat");
    return Success();

--- a/src/cpp/session/modules/chat/ChatIntegrity.cpp
+++ b/src/cpp/session/modules/chat/ChatIntegrity.cpp
@@ -17,10 +17,13 @@
 #include "ChatLogging.hpp"
 #include "ChatTypes.hpp"
 
+#include <cstdlib>
+
 #include <boost/algorithm/string.hpp>
 
 #include <core/FileSerializer.hpp>
 #include <core/system/Crypto.hpp>
+#include <core/system/Process.hpp>
 
 using namespace rstudio::core;
 using namespace rstudio::session::modules::chat::types;
@@ -36,6 +39,42 @@ namespace {
 bool isHttpsUrl(const std::string& url)
 {
    return boost::starts_with(url, "https://");
+}
+
+// Index just past the first balanced top-level {...} in `s` (string-literal
+// aware), or std::string::npos if there is no complete top-level object. Used
+// to detect trailing content after a parsed manifest object, which
+// json::Value::parse (kParseStopWhenDoneFlag) would otherwise accept silently.
+std::string::size_type endOfFirstJsonObject(const std::string& s)
+{
+   int depth = 0;
+   bool inString = false;
+   bool escaped = false;
+   bool started = false;
+   for (std::string::size_type i = 0; i < s.size(); ++i)
+   {
+      char c = s[i];
+      if (inString)
+      {
+         if (escaped)
+            escaped = false;
+         else if (c == '\\')
+            escaped = true;
+         else if (c == '"')
+            inString = false;
+         continue;
+      }
+      if (c == '"')
+         inString = true;
+      else if (c == '{')
+      {
+         ++depth;
+         started = true;
+      }
+      else if (c == '}' && started && --depth == 0)
+         return i + 1;
+   }
+   return std::string::npos;
 }
 
 } // anonymous namespace
@@ -207,6 +246,51 @@ Error verifyPackageSha256(const FilePath& packagePath,
    }
 
    DLOG("SHA-256 verification passed: {}", actualSha256);
+   return Success();
+}
+
+Error manifestFromDownloadResult(const core::system::ProcessResult& result,
+                                 json::Object* pManifest)
+{
+   if (pManifest == nullptr)
+      return systemError(boost::system::errc::invalid_argument, ERROR_LOCATION);
+
+   if (result.exitStatus != EXIT_SUCCESS)
+   {
+      // Locale-independent: stderr is only folded into the message for the log,
+      // never parsed to decide behavior. Any non-zero exit is "unavailable".
+      std::string detail = boost::algorithm::trim_copy(result.stdErr);
+      std::string message = "Manifest download failed";
+      if (!detail.empty())
+         message += ": " + detail;
+      return systemError(boost::system::errc::io_error, message, ERROR_LOCATION);
+   }
+
+   std::string body = boost::algorithm::trim_copy(result.stdOut);
+   if (body.empty())
+      return systemError(boost::system::errc::io_error,
+                         "Manifest download produced no output", ERROR_LOCATION);
+
+   // json::Value::parse returns a (truthy) Error on failure.
+   json::Value value;
+   if (value.parse(body))
+      return systemError(boost::system::errc::protocol_error,
+                         "Manifest is not valid JSON", ERROR_LOCATION);
+
+   if (!value.isObject())
+      return systemError(boost::system::errc::protocol_error,
+                         "Manifest must be a JSON object", ERROR_LOCATION);
+
+   // json::Value::parse uses kParseStopWhenDoneFlag and would accept a valid
+   // object followed by trailing content (e.g. "{...}\nwarning"). The body is
+   // already trimmed, so anything past the top-level object's close brace is
+   // non-whitespace junk -- reject it; the manifest must be exactly one object.
+   if (endOfFirstJsonObject(body) != body.size())
+      return systemError(boost::system::errc::protocol_error,
+                         "Manifest has unexpected content after the JSON object",
+                         ERROR_LOCATION);
+
+   *pManifest = value.getObject();
    return Success();
 }
 

--- a/src/cpp/session/modules/chat/ChatIntegrity.cpp
+++ b/src/cpp/session/modules/chat/ChatIntegrity.cpp
@@ -255,31 +255,33 @@ Error manifestFromDownloadResult(const core::system::ProcessResult& result,
    if (pManifest == nullptr)
       return systemError(boost::system::errc::invalid_argument, ERROR_LOCATION);
 
+   // Non-empty stderr (rare with --vanilla + quiet) is appended to every failure
+   // message for diagnostics -- the human message becomes the error's description,
+   // surfaced when the error is logged in full. It is never parsed to decide
+   // behavior, so the error mapping stays locale-independent. Any non-zero exit,
+   // and any empty / invalid / non-object / trailing-content body, is treated as
+   // "unavailable".
+   std::string detail = boost::algorithm::trim_copy(result.stdErr);
+   std::string suffix = detail.empty() ? std::string() : (": " + detail);
+
    if (result.exitStatus != EXIT_SUCCESS)
-   {
-      // Locale-independent: stderr is only folded into the message for the log,
-      // never parsed to decide behavior. Any non-zero exit is "unavailable".
-      std::string detail = boost::algorithm::trim_copy(result.stdErr);
-      std::string message = "Manifest download failed";
-      if (!detail.empty())
-         message += ": " + detail;
-      return systemError(boost::system::errc::io_error, message, ERROR_LOCATION);
-   }
+      return systemError(boost::system::errc::io_error,
+                         "Manifest download failed" + suffix, ERROR_LOCATION);
 
    std::string body = boost::algorithm::trim_copy(result.stdOut);
    if (body.empty())
       return systemError(boost::system::errc::io_error,
-                         "Manifest download produced no output", ERROR_LOCATION);
+                         "Manifest download produced no output" + suffix, ERROR_LOCATION);
 
    // json::Value::parse returns a (truthy) Error on failure.
    json::Value value;
    if (value.parse(body))
       return systemError(boost::system::errc::protocol_error,
-                         "Manifest is not valid JSON", ERROR_LOCATION);
+                         "Manifest is not valid JSON" + suffix, ERROR_LOCATION);
 
    if (!value.isObject())
       return systemError(boost::system::errc::protocol_error,
-                         "Manifest must be a JSON object", ERROR_LOCATION);
+                         "Manifest must be a JSON object" + suffix, ERROR_LOCATION);
 
    // json::Value::parse uses kParseStopWhenDoneFlag and would accept a valid
    // object followed by trailing content (e.g. "{...}\nwarning"). The body is
@@ -287,7 +289,7 @@ Error manifestFromDownloadResult(const core::system::ProcessResult& result,
    // non-whitespace junk -- reject it; the manifest must be exactly one object.
    if (endOfFirstJsonObject(body) != body.size())
       return systemError(boost::system::errc::protocol_error,
-                         "Manifest has unexpected content after the JSON object",
+                         "Manifest has unexpected content after the JSON object" + suffix,
                          ERROR_LOCATION);
 
    *pManifest = value.getObject();

--- a/src/cpp/session/modules/chat/ChatIntegrity.hpp
+++ b/src/cpp/session/modules/chat/ChatIntegrity.hpp
@@ -21,6 +21,11 @@
 #include <shared_core/FilePath.hpp>
 #include <shared_core/json/Json.hpp>
 
+// forward declaration -- the signature below takes ProcessResult by reference,
+// so the full definition (<core/system/Process.hpp>) is only needed in the
+// .cpp and tests, not in every includer of this header.
+namespace rstudio { namespace core { namespace system { struct ProcessResult; } } }
+
 namespace rstudio {
 namespace session {
 namespace modules {
@@ -56,6 +61,22 @@ core::Error getPackageInfoFromManifest(
  */
 core::Error verifyPackageSha256(const core::FilePath& packagePath,
                                 const std::string& expectedSha256);
+
+/**
+ * Map a manifest download subprocess result to a parsed manifest object.
+ *
+ * The manifest body is expected on the subprocess's stdout. Any failure --
+ * non-zero exit, empty output, invalid JSON, or a JSON root that is not an
+ * object -- is returned as an error (the caller treats that as the manifest
+ * being unavailable). Error mapping is locale-independent: stderr text is only
+ * folded into the message for diagnostics, never used to decide behavior.
+ *
+ * @param result The completed download subprocess result.
+ * @param pManifest Output: the parsed manifest object (set only on success).
+ * @return Success(), or an error describing the failure.
+ */
+core::Error manifestFromDownloadResult(const core::system::ProcessResult& result,
+                                       core::json::Object* pManifest);
 
 } // namespace integrity
 } // namespace chat

--- a/src/cpp/session/modules/chat/ChatIntegrityTests.cpp
+++ b/src/cpp/session/modules/chat/ChatIntegrityTests.cpp
@@ -94,6 +94,55 @@ TEST(ChatIntegrity, ManifestFromResultAcceptsNestedObject)
    EXPECT_FALSE(error);
 }
 
+TEST(ChatIntegrity, ManifestFromResultAcceptsEscapedQuoteInString)
+{
+   // A backslash-escaped quote must not end the string early, so the braces that
+   // follow it stay inside the string and are ignored by the brace scan.
+   json::Object manifest;
+   Error error = manifestFromDownloadResult(
+      downloadResult(EXIT_SUCCESS, "{\"note\":\"a \\\" b {c}\"}"), &manifest);
+   EXPECT_FALSE(error);
+}
+
+TEST(ChatIntegrity, ManifestFromResultAcceptsBraceInsideString)
+{
+   // A closing brace inside a top-level string must not be mistaken for the end
+   // of the object.
+   json::Object manifest;
+   Error error = manifestFromDownloadResult(
+      downloadResult(EXIT_SUCCESS, "{\"a\":\"}\"}"), &manifest);
+   EXPECT_FALSE(error);
+}
+
+TEST(ChatIntegrity, ManifestFromResultRejectsExtraTrailingBrace)
+{
+   // json::Value::parse stops after the first object; a stray trailing '}' is
+   // content past the object's close brace and must be rejected.
+   json::Object manifest;
+   EXPECT_TRUE(manifestFromDownloadResult(
+      downloadResult(EXIT_SUCCESS, "{\"a\":1}}"), &manifest) != Success());
+}
+
+TEST(ChatIntegrity, ManifestFromResultRejectsNonZeroExitWithEmptyStderr)
+{
+   // A non-zero exit with no stderr is still "unavailable" (the mapping does not
+   // depend on stderr being present).
+   json::Object manifest;
+   EXPECT_TRUE(manifestFromDownloadResult(downloadResult(1, "", ""), &manifest) != Success());
+}
+
+TEST(ChatIntegrity, ManifestFromResultFoldsStderrIntoMessage)
+{
+   // Non-empty stderr is appended to the failure message for diagnostics. The
+   // human message is stored as the error's description (getMessage() returns the
+   // generic errno text), so assert on the full diagnostic string.
+   json::Object manifest;
+   Error error = manifestFromDownloadResult(
+      downloadResult(1, "", "cannot resolve host name"), &manifest);
+   EXPECT_TRUE(error != Success());
+   EXPECT_NE(error.asString().find("cannot resolve host name"), std::string::npos);
+}
+
 // ============================================================================
 // verifyPackageSha256 tests
 // ============================================================================

--- a/src/cpp/session/modules/chat/ChatIntegrityTests.cpp
+++ b/src/cpp/session/modules/chat/ChatIntegrityTests.cpp
@@ -15,11 +15,84 @@
 
 #include "ChatIntegrity.hpp"
 
+#include <cstdlib>
+
 #include <gtest/gtest.h>
 #include <core/FileSerializer.hpp>
+#include <core/system/Process.hpp>
 
 using namespace rstudio::core;
 using namespace rstudio::session::modules::chat::integrity;
+
+// NOTE: fully qualify ProcessResult -- this file has `using namespace
+// rstudio::core;` (not `rstudio`), so the bare name `core` is not in scope here.
+namespace {
+rstudio::core::system::ProcessResult downloadResult(int exitStatus,
+                                                    const std::string& out,
+                                                    const std::string& err = std::string())
+{
+   rstudio::core::system::ProcessResult result;
+   result.exitStatus = exitStatus;
+   result.stdOut = out;
+   result.stdErr = err;
+   return result;
+}
+} // anonymous namespace
+
+TEST(ChatIntegrity, ManifestFromResultParsesValidObject)
+{
+   json::Object manifest;
+   Error error = manifestFromDownloadResult(downloadResult(EXIT_SUCCESS, "{\"version\":\"1.0\"}"), &manifest);
+   EXPECT_FALSE(error);
+}
+
+TEST(ChatIntegrity, ManifestFromResultRejectsNonObjectJson)
+{
+   json::Object manifest;
+   EXPECT_TRUE(manifestFromDownloadResult(downloadResult(EXIT_SUCCESS, "[]"), &manifest) != Success());
+}
+
+TEST(ChatIntegrity, ManifestFromResultRejectsInvalidJson)
+{
+   json::Object manifest;
+   EXPECT_TRUE(manifestFromDownloadResult(downloadResult(EXIT_SUCCESS, "not json"), &manifest) != Success());
+}
+
+TEST(ChatIntegrity, ManifestFromResultRejectsEmptyOutput)
+{
+   json::Object manifest;
+   EXPECT_TRUE(manifestFromDownloadResult(downloadResult(EXIT_SUCCESS, "   \n"), &manifest) != Success());
+}
+
+TEST(ChatIntegrity, ManifestFromResultRejectsNonZeroExit)
+{
+   json::Object manifest;
+   EXPECT_TRUE(manifestFromDownloadResult(downloadResult(1, "", "cannot resolve host name"), &manifest) != Success());
+}
+
+TEST(ChatIntegrity, ManifestFromResultRejectsLeadingNonJson)
+{
+   // Defends the parse contract even though --vanilla keeps the child's stdout clean.
+   json::Object manifest;
+   EXPECT_TRUE(manifestFromDownloadResult(downloadResult(EXIT_SUCCESS, "startup msg\n{\"v\":1}"), &manifest) != Success());
+}
+
+TEST(ChatIntegrity, ManifestFromResultRejectsTrailingContent)
+{
+   // json::Value::parse stops at the first value, so a valid object followed by
+   // junk (e.g. a warning line) must be rejected, not silently accepted.
+   json::Object manifest;
+   EXPECT_TRUE(manifestFromDownloadResult(downloadResult(EXIT_SUCCESS, "{\"version\":\"1.0\"}\nwarning: stuff"), &manifest) != Success());
+}
+
+TEST(ChatIntegrity, ManifestFromResultAcceptsNestedObject)
+{
+   // The brace scan must handle nested objects and strings containing braces.
+   json::Object manifest;
+   Error error = manifestFromDownloadResult(
+      downloadResult(EXIT_SUCCESS, "{\"versions\":{\"1.0\":{\"url\":\"https://x/{y}\"}}}"), &manifest);
+   EXPECT_FALSE(error);
+}
 
 // ============================================================================
 // verifyPackageSha256 tests

--- a/src/cpp/tests/testthat/test-chat.R
+++ b/src/cpp/tests/testthat/test-chat.R
@@ -62,3 +62,17 @@ test_that("manifestDownloadCommand errors when download.file reports a non-zero 
    env$download.file <- function(...) 1L  # non-zero status, no file written
    expect_error(eval(parse(text = cmd), envir = env), "download.file failed")
 })
+
+test_that("manifestDownloadCommand emits the downloaded body with newlines intact", {
+   # cat() defaults to sep = " "; the command uses sep = "\n" so a multi-line body
+   # round-trips verbatim rather than having its line breaks collapsed to spaces.
+   cmd <- .rs.chat.manifestDownloadCommand("https://example.test/m.json")
+
+   env <- new.env()
+   env$download.file <- function(url, destfile, ...) {
+      writeLines(c("{", '  "v": 1', "}"), destfile)
+      0L
+   }
+   out <- paste(capture.output(eval(parse(text = cmd), envir = env)), collapse = "\n")
+   expect_identical(out, "{\n  \"v\": 1\n}")
+})

--- a/src/cpp/tests/testthat/test-chat.R
+++ b/src/cpp/tests/testthat/test-chat.R
@@ -1,0 +1,58 @@
+#
+# test-chat.R
+#
+# Copyright (C) 2026 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+context("chat")
+
+test_that("manifestDownloadCommand sets a 30s timeout and downloads to a temp file", {
+   cmd <- .rs.chat.manifestDownloadCommand("https://cdn.posit.co/posit-ai/manifest.json")
+   expect_true(grepl("options(timeout = 30L)", cmd, fixed = TRUE))
+   expect_true(grepl("tempfile()", cmd, fixed = TRUE))
+   expect_true(grepl("download.file(", cmd, fixed = TRUE))
+   expect_true(grepl("cat(readLines(", cmd, fixed = TRUE))
+   # the URL is deparsed (quoted) into the command
+   expect_true(grepl("https://cdn.posit.co/posit-ai/manifest.json", cmd, fixed = TRUE))
+})
+
+test_that("manifestDownloadCommand injects download.file.method when set", {
+   withr::with_options(list(download.file.method = "libcurl"), {
+      cmd <- .rs.chat.manifestDownloadCommand("https://example.test/m.json")
+      expect_true(grepl("method = \"libcurl\"", cmd, fixed = TRUE))
+   })
+})
+
+test_that("manifestDownloadCommand injects download.file.extra when set", {
+   withr::with_options(list(download.file.extra = c("--cacert", "/etc/ca.pem")), {
+      cmd <- .rs.chat.manifestDownloadCommand("https://example.test/m.json")
+      expect_true(grepl("extra = ", cmd, fixed = TRUE))
+      expect_true(grepl("--cacert", cmd, fixed = TRUE))
+   })
+})
+
+test_that("manifestDownloadCommand omits method/extra when unset", {
+   withr::with_options(list(download.file.method = NULL, download.file.extra = NULL), {
+      cmd <- .rs.chat.manifestDownloadCommand("https://example.test/m.json")
+      expect_false(grepl("method = ", cmd, fixed = TRUE))
+      expect_false(grepl("extra = ", cmd, fixed = TRUE))
+   })
+})
+
+test_that("manifestDownloadCommand propagates download failures as a non-zero exit", {
+   # Some download.file methods return a non-zero status with only a warning, so
+   # the command must check the status and stop() -- otherwise a failed download
+   # would exit 0 with a partial/empty body and be parsed as a valid manifest.
+   cmd <- .rs.chat.manifestDownloadCommand("https://example.test/m.json")
+   expect_true(grepl("status <- download.file(", cmd, fixed = TRUE))
+   expect_true(grepl("stop(paste(", cmd, fixed = TRUE))
+})

--- a/src/cpp/tests/testthat/test-chat.R
+++ b/src/cpp/tests/testthat/test-chat.R
@@ -48,11 +48,17 @@ test_that("manifestDownloadCommand omits method/extra when unset", {
    })
 })
 
-test_that("manifestDownloadCommand propagates download failures as a non-zero exit", {
+test_that("manifestDownloadCommand errors when download.file reports a non-zero status", {
    # Some download.file methods return a non-zero status with only a warning, so
    # the command must check the status and stop() -- otherwise a failed download
    # would exit 0 with a partial/empty body and be parsed as a valid manifest.
+   # Exercise the behavior (the command throws), not the command text. cmd is the
+   # trusted output of the function under test, evaluated in a sandbox env whose
+   # download.file is stubbed to report failure -- this is how the generated R
+   # command is meant to be run.
    cmd <- .rs.chat.manifestDownloadCommand("https://example.test/m.json")
-   expect_true(grepl("status <- download.file(", cmd, fixed = TRUE))
-   expect_true(grepl("stop(paste(", cmd, fixed = TRUE))
+
+   env <- new.env()
+   env$download.file <- function(...) 1L  # non-zero status, no file written
+   expect_error(eval(parse(text = cmd), envir = env), "download.file failed")
 })


### PR DESCRIPTION
## What

The Posit Assistant update check downloaded its manifest with R's `download.file()` to a temp file and read it back in-process (`downloadManifest()`). On Windows the read intermittently failed with `ERROR_SHARING_VIOLATION` ("The process cannot access the file because it is being used by another process"), shown in the pane as "Connection Error / Unable to verify Posit Assistant compatibility"; a retry succeeded. The trigger was #17686 deferring the startup check into an idle event-loop callback, where R's libcurl `download.file`, run re-entrantly there, left the destfile write handle open in rsession when it returned.

The manifest is now fetched in an async R subprocess: a `--vanilla` child runs `download.file` and returns the body on stdout. rsession never reads its own temp file, so the sharing violation cannot occur, and the fetch runs off the main thread.

## Changes

All backend; no GWT/frontend changes.

- `chat/ChatIntegrity.{hpp,cpp}` (+ tests): `manifestFromDownloadResult()` maps a subprocess result to a parsed manifest object, treating a non-zero exit, empty output, non-object JSON, or trailing content after the object as a failure.
- `SessionChat.R` (+ `tests/testthat/test-chat.R`): `.rs.chat.manifestDownloadCommand()` builds the child command, injecting the session's `download.file.method`/`extra` and `options(timeout = 30L)`, and propagating a non-zero `download.file` status as a non-zero process exit.
- `SessionChat.cpp`:
  - `fetchManifestAsync()` replaces `downloadManifest()` and runs the `--vanilla` child, with a wall-clock deadline that maps a stalled fetch to `manifestUnavailable`.
  - `doUpdateCheck()` and `checkForUpdatesOnStartup()` are consolidated into `onUpdateCheckComplete()` (one atomic state update) behind a single-flight queue that coalesces overlapping checks.
  - `chat_check_for_updates` and `chat_install_update` become async RPCs; the existing frontend callback contract is unchanged.
  - The startup check is kicked from `onDeferredInit`, deferred off the critical startup path, replacing the previous `scheduleDelayedWork` workaround.

The startup-only recommended-RStudio-version warning is preserved. Proxy configuration is honored via profile/`.Renviron`/environment plus the injected `download.file.method`/`extra`.

No NEWS.md entry: this fixes a regression in the still-in-development Posit Assistant feature (the temp-file race was introduced by the unreleased #17686).

## Testing

- C++: `manifestFromDownloadResult` unit tests (`./rstudio-tests --scope rsession`, `ChatIntegrity`).
- R: `.rs.chat.manifestDownloadCommand` tests (`test-chat.R`).
- Manual on Windows Desktop: launching with the Posit Assistant sidebar shown at startup no longer produces the Connection Error; the rsession log shows the manifest fetched with `manifestUnavailable=false`.

Fixes #17891.
