### PR TITLE
add metadata for license tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ AGENTS.md
 GEMINI.md
 spec/
 .positai
+
+# Non-persistent Mole caches
+.mole.web_cache
+.mole.rust_cache

--- a/dependencies/metadata/bins-windows.txt
+++ b/dependencies/metadata/bins-windows.txt
@@ -1,0 +1,39 @@
+dependency(LLVM
+   DEPNAME      "libclang"
+   REPOSITORY   "https://github.com/llvm/llvm-project"
+   REVISION     "main"
+   LICENSE      "Apache-2.0 WITH LLVM-Exceptions"
+   LICENSE_PATH "LICENSE.TXT"
+)
+
+dependency(DIFFUTILS
+   DEPNAME      "diffutils"
+   REPOSITORY   "https://cgit.git.savannah.gnu.org/cgit/diffutils.git/plain"
+   LICENSE_PATH "spdx://GPL-3.0"
+)
+
+dependency(GREP
+   DEPNAME      "grep"
+   REPOSITORY   "https://cgit.git.savannah.gnu.org/cgit/grep.git/plain"
+   LICENSE_PATH "spdx://GPL-3.0"
+)
+
+dependency(SUMATRAPDF
+   DEPNAME      "SumatraPDF"
+   REPOSITORY   "https://github.com/sumatrapdfreader/sumatrapdf"
+   ATTRIBUTION  "Copyright SumatraPDF project authors"
+)
+
+dependency(WINUTILS
+   DEPNAME      "Hadoop Winutils"
+   REPOSITORY   "https://github.com/apache/hadoop/tree/master/hadoop-common-project/hadoop-common/src/main/winutils"
+   LICENSE      "Apache-2.0"
+   AUTHOR       "Apache Software Foundation"
+)
+
+dependency(NSIS
+   DEPNAME      "Nullsoft Scriptable Install System"
+   HOMEPAGE     "https://sourceforge.net/projects/nsis/"
+   LICENSE      "zlib AND bzip2 AND CPL-1.0"
+   LICENSE_PATH "https://github.com/kichik/nsis/blob/master/COPYING"
+)

--- a/dependencies/metadata/bins.txt
+++ b/dependencies/metadata/bins.txt
@@ -1,0 +1,12 @@
+dependency(QUARTO
+   DEPNAME      "Quarto"
+   REPOSITORY   "https://github.com/quarto-dev/quarto-cli"
+)
+
+dependency(PANDOC
+   DEPNAME      "pandoc"
+   REPOSITORY   "https://github.com/jgm/pandoc"
+   REVISION     "main"
+   LICENSE      "GPL-2.0-or-later"
+   LICENSE_PATH "COPYRIGHT"
+)

--- a/dependencies/metadata/desktop.txt
+++ b/dependencies/metadata/desktop.txt
@@ -1,0 +1,11 @@
+# TODO: verify
+dependency(OPENBSM
+   DEPNAME      "OpenBSM"
+   REPOSITORY   "https://github.com/openbsm/openbsm"
+   LICENSE      "BSD-2-Clause"
+)
+
+dependency(JSCUSTOMBADGE
+   DEPNAME      "JSCustomBadge"
+   REPOSITORY   "https://github.com/jessesquires/JSCustomBadge"
+)

--- a/dependencies/metadata/desktop.txt
+++ b/dependencies/metadata/desktop.txt
@@ -1,10 +1,3 @@
-# TODO: verify
-dependency(OPENBSM
-   DEPNAME      "OpenBSM"
-   REPOSITORY   "https://github.com/openbsm/openbsm"
-   LICENSE      "BSD-2-Clause"
-)
-
 dependency(JSCUSTOMBADGE
    DEPNAME      "JSCustomBadge"
    REPOSITORY   "https://github.com/jessesquires/JSCustomBadge"

--- a/dependencies/metadata/general-js.txt
+++ b/dependencies/metadata/general-js.txt
@@ -1,0 +1,79 @@
+dependency(ACE
+   DEPNAME      "Ajax.org Code Editor"
+   PATH         "src/gwt/acesupport"
+   LICENSE      "AGPL-3.0"
+   ATTRIBUTION  "Copyright (C) 2010 Ajax.org B.V."
+)
+
+dependency(STAN_ACE
+   DEPNAME      "Stan Highlight Rules"
+   PATH         "src/gwt/acesupport/acemode/stan_highlight_rules.js"
+   LICENSE      "LGPL-2.1-or-later"
+   LICENSE_PATH "https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt"
+   ATTRIBUTION  "Copyright (C) 2014 Jeffrey Arnold"
+)
+
+dependency(RSAJS
+   DEPNAME      "RSA.js"
+   REPOSITORY   "http://www-cs-students.stanford.edu/~tjw/jsbn/"
+   LICENSE_PATH "http://www-cs-students.stanford.edu/~tjw/jsbn/LICENSE"
+   ATTRIBUTION  "Copyright (c) 2005 Tom Wu"
+)
+
+dependency(SHOWDOWNJS
+   DEPNAME      "Showdown"
+   REPOSITORY   "https://github.com/showdownjs/showdown"
+)
+
+dependency(MATHJAX
+   DEPNAME      "MathJax"
+   REPOSITORY   "https://github.com/mathjax/MathJax"
+   VERSION      "2.7.9"
+   ATTRIBUTION  "Copyright (c) 2009-2020 The MathJax Consortium"
+)
+
+dependency(BOOTSTRAP
+   DEPNAME      "Bootstrap"
+   REPOSITORY   "https://github.com/twbs/bootstrap"
+)
+
+dependency(JQUERY
+   DEPNAME      "jQuery"
+   VERSION      "2.1.0"
+   REPOSITORY   "https://github.com/jquery/jquery"
+)
+
+dependency(ZOCIAL
+   DEPNAME      "Zocial Buttons"
+   REPOSITORY   "https://github.com/adamstac/zocial"
+   LICENSE      "MIT"
+   ATTRIBUTION  "Copyright (c) 2011 Sam Collins (@smcllns) and Adam Stacoviak (@adamstac)"
+)
+
+dependency(ICOMOON
+   DEPNAME      "IcoMoon Free"
+   REPOSITORY   "https://icomoon.io/"
+   LICENSE      "CC-BY-4.0"
+   ATTRIBUTION  "Designed by Keyamoon"
+   LICENSE_PATH "https://creativecommons.org/licenses/by/4.0/legalcode.txt"
+)
+
+dependency(GZLOG
+   DEPNAME      "gzlog"
+   VERSION      "1.3.1"
+   REPOSITORY   "https://github.com/madler/zlib/blob/develop/examples/gzlog.c"
+   LICENSE      "ZLIB"
+   LICENSE_PATH "https://github.com/madler/zlib/blob/develop/LICENSE"
+)
+
+dependency(CURL
+   DEPNAME      "curl"
+   REPOSITORY   "https://github.com/curl/curl"
+   LICENSE      "curl"
+)
+
+dependency(JSDIFF
+   DEPNAME      "jsdiff"
+   REPOSITORY   "https://github.com/kpdecker/jsdiff"
+   VERSION      "v8.0.2"
+)

--- a/dependencies/metadata/general.txt
+++ b/dependencies/metadata/general.txt
@@ -1,0 +1,87 @@
+dependency(BOOST
+   DEPNAME      "Boost"
+   VERSION      "1.87.0"
+   REPOSITORY   "https://github.com/boostorg/boost"
+   REVISION     "boost-1.87.0"
+   LICENSE_PATH "LICENSE_1_0.txt"
+   AUTHOR       "Boost.org"
+)
+
+dependency(MSINTTYPES
+   DEPNAME      "msinttypes"
+   REPOSITORY   "https://github.com/Tencent/rapidjson"
+   LICENSE      "MIT"
+   LICENSE_PATH "license.txt"
+)
+
+dependency(OPENSSL
+   DEPNAME      "OpenSSL"
+   REPOSITORY   "https://github.com/openssl/openssl"
+   LICENSE_PATH "LICENSE.txt"
+)
+
+dependency(SYNCTEX
+   DEPNAME      "SyncTeX"
+   REPOSITORY   "https://github.com/jlaurens/synctex/"
+)
+
+dependency(PCRE2
+   DEPNAME      "PCRE2"
+   REPOSITORY   "https://github.com/PCRE2Project/pcre2"
+   LICENSE      "BSD-3-Clause WITH PCRE2-exception"
+   LICENSE_PATH "LICENCE.md"
+)
+
+dependency(NODEJS
+   DEPNAME      "Node.js"
+   REPOSITORY   "https://github.com/nodejs/node"
+   LICENSE      "MIT-with-additional"
+   ATTRIBUTION  "Copyright Node.js contributors"
+)
+
+dependency(SUNDOWN
+   DEPNAME      "Sundown"
+   PATH         "src/cpp/core/markdown/sundown"
+   LICENSE      "ISC"
+)
+
+dependency(PROMETHEUS_CPP
+   DEPNAME      "Prometheus Client Library for Modern C++"
+   PATH         "src/cpp/ext/prometheus-cpp"
+)
+
+dependency(TREE_HH
+   DEPNAME      "tree.hh"
+   PATH         "src/cpp/core/include/core/collection/Tree.hpp"
+   LICENSE      "GPL-3.0"
+   LICENSE_PATH "spdx://GPL-3.0"
+   ATTRIBUTION  "Derived from tree.hh, copyright (C) 2001-2024 Kasper Peeters"
+)
+
+dependency(RAPIDXML
+   DEPNAME      "RapidXML"
+   PATH         "src/cpp/core/include/core/rapidxml"
+   LICENSE_PATH "license.txt"
+   LICENSE      "BSL-1.0 OR MIT"
+   ATTRIBUTION  "Copyright (C) 2006, 2009 Marcin Kalicinski"
+)
+
+dependency(CATCH2
+   DEPNAME      "Catch2"
+   PATH         "src/cpp/tests/cpp/tests/vendor/catch.hpp"
+   LICENSE      "BSL-1.0"
+   ATTRIBUTION  "Copyright (c) 2022 Two Blue Cubes Ltd."
+)
+
+dependency(LIBUUID
+   DEPNAME      "libuuid"
+   REPOSITORY   "https://github.com/util-linux/util-linux/tree/master/libuuid"
+   ATTRIBUTION  "Copyright (C) 1996, 1997, 1998 Theodore Ts'o"
+)
+
+dependency(LIBR
+   DEPNAME      "libR"
+   HOMEPAGE     "https://www.r-project.org/"
+   LICENSE      "GPL-2.0-or-later"
+   ATTRIBUTION  "Copyright © 1998–2020 Kurt Hornik\nCopyright © 2021–2025 R Core Team"
+)

--- a/dependencies/metadata/gwt.txt
+++ b/dependencies/metadata/gwt.txt
@@ -1,0 +1,22 @@
+dependency(GWT
+   DEPNAME      "Google Web Toolkit"
+   REPOSITORY   "https://github.com/gwtproject/gwt"
+   VERSION      "2.12.2"
+)
+
+dependency(ELEMENTAL2
+   DEPNAME      "Elemental2"
+   REPOSITORY   "https://github.com/google/elemental2"
+   VERSION      "1.2.3"
+)
+
+dependency(GWTWEBSOCKETS
+   DEPNAME      "gwt-websockets"
+   REPOSITORY   "https://github.com/sksamuel/gwt-websockets"
+)
+
+dependency(JSINTEROPBASE
+   DEPNAME      "JsInterop Base"
+   REPOSITORY   "https://github.com/google/jsinterop-base"
+   VERSION      "1.0.3"
+)

--- a/dependencies/metadata/rstudio.txt
+++ b/dependencies/metadata/rstudio.txt
@@ -1,0 +1,11 @@
+dependency(GWT
+   DEPNAME      "Google Web Toolkit"
+   REPOSITORY   "https://github.com/gwtproject/gwt"
+   LICENSE      "Apache-2.0"
+   ATTRIBUTION  "Copyright Google, Inc."
+)
+
+dependency(GWTWEBSOCKETS
+   DEPNAME      "gwt-websockets"
+   PATH         "src/gwt/src/com/sksamuel/gwt/"
+)

--- a/dependencies/metadata/server.txt
+++ b/dependencies/metadata/server.txt
@@ -1,0 +1,18 @@
+dependency(LIBPQ
+   DEPNAME      "PostgreSQL Client Library"
+   REPOSITORY   "https://github.com/postgres/postgres"
+   LICENSE      "PostgreSQL"
+)
+
+dependency(SOCI
+   DEPNAME      "SOCI"
+   REPOSITORY   "https://github.com/SOCI/soci"
+   LICENSE_PATH "LICENSE_1_0.txt"
+)
+
+dependency(SQLITE
+   DEPNAME      "SQLite"
+   HOMEPAGE     "https://sqlite.org/"
+   LICENSE      "SQLite Blessing"
+   ATTRIBUTION  "Dedicated to the public domain"
+)

--- a/package/osx/scripts/package.json
+++ b/package/osx/scripts/package.json
@@ -1,4 +1,7 @@
 {
+  "name": "osx-packaging",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "@electron/universal": "3.0.4"
   }

--- a/src/cpp/ext/CMakeLists.txt
+++ b/src/cpp/ext/CMakeLists.txt
@@ -30,22 +30,39 @@ set(CMAKE_WARN_DEPRECATED FALSE)
 #
 # This function accepts the following single-value arguments:
 #
-# COMMENT:     A one-line description of the dependency, usually from the dependency itself.
-# VERSION:     The version of the dependency to be used.
-# REPOSITORY:  The (git) repository to be used when retrieving the dependency.
-# REVISION:    The (git) revision / commit hash to be used when retrieving the dependency.
-# CUSTOM:      Optional; when TRUE, the project is retrieved but not automatically added to the build.
-# PLATFORMS:   Optional; a list of platforms for which this dependency should be retrieved and built.
+# COMMENT:      A one-line description of the dependency, usually from the dependency itself.
+# VERSION:      The version of the dependency to be used.
+# REPOSITORY:   The (git) repository to be used when retrieving the dependency.
+# REVISION:     The (git) revision / commit hash to be used when retrieving the dependency.
+# CUSTOM:       Optional; when TRUE, the project is retrieved but not automatically added to the build.
+# PLATFORMS:    Optional; a list of platforms for which this dependency should be retrieved and built.
+#
+# This function also accepts and ignores these optional single-value arguments, which are used to render
+# the third-party license notice files (NOTICE, NOTICE-SUPPLEMENT, docs/server/licenses/index.qmd):
+#
+# DEPNAME:      The human-readable name of the dependency.
+# PATH:         Only for vendored dependencies; the path to the dependency within this repo.
+#               **Do not use in CMakeLists.txt, only in dependencies/metadata/*.txt.**
+# HOMEPAGE:     The URL to the dependency's homepage.
+# LICENSE:      An SPDX identifier for the dependency's license.
+# LICENSE_PATH: A comma-separated list of URLs or paths to the text of the dependency's license.
+#               Paths are interpreted relative to REPOSITORY or PATH.
+# AUTHOR:       The dependency's author, maintainer, or packager.
+# ATTRIBUTION:  A line of copyright attribution. If present, AUTHOR is ignored.
 #
 # Use the CUSTOM argument when you want to fetch an external dependency, but need to manually
 # set up a build target based on that package's sources. This is mainly useful for projects which
 # don't provide the requisite CMake infrastructure, or for projects which define a CMakeLists.txt
 # which we want or need to ignore.
 #
+# Files in dependencies/metadata/*.txt follow this same format but do not automatically cause
+# the dependency to be downloaded or compiled. These files are only used for rendering the third-party
+# license notice files.
+#
 function(dependency)
 
    set(_NAME "${ARGV0}")
-   cmake_parse_arguments(PARSE_ARGV 1 "" "" "COMMENT;CUSTOM;VERSION;REPOSITORY;REVISION;CXXFLAGS" "PLATFORMS")
+   cmake_parse_arguments(PARSE_ARGV 1 "" "" "COMMENT;CUSTOM;VERSION;REPOSITORY;REVISION;CXXFLAGS;DEPNAME;HOMEPAGE;LICENSE;LICENSE_PATH;AUTHOR;ATTRIBUTION" "PLATFORMS")
 
    set(${_NAME}_VERSION    "${_VERSION}"    CACHE INTERNAL "")
    set(${_NAME}_REPOSITORY "${_REPOSITORY}" CACHE INTERNAL "")
@@ -193,6 +210,7 @@ endfunction()
 
 # dtl
 dependency(DTL
+   DEPNAME    "dtl"
    COMMENT    "dtl provides the functions for comparing two sequences have arbitrary type."
    VERSION    "1.21"
    REPOSITORY "https://github.com/cubicdaiya/dtl"
@@ -203,6 +221,7 @@ dependency(DTL
 
 # fmt
 dependency(FMT
+   DEPNAME    "{fmt}"
    COMMENT    "{fmt} is an open-source formatting library providing a fast and safe alternative to C stdio and C++ iostreams."
    VERSION    "11.1.4"
    REPOSITORY "https://github.com/fmtlib/fmt"
@@ -214,7 +233,9 @@ set(FMT_INSTALL OFF)
 
 # libgit2
 dependency(LIBGIT2
+   DEPNAME    "libgit2"
    COMMENT    "libgit2 is a portable, pure C implementation of the Git core methods."
+   LICENSE    "GPL-2.0 WITH linking-exception"
    VERSION    "1.9.2"
    REPOSITORY "https://github.com/libgit2/libgit2"
    REVISION   "ca225744b992bf2bf24e9a2eb357ddef78179667" # pragma: allowlist secret
@@ -266,6 +287,7 @@ endif()
 
 # gsl-lite
 dependency(GSL_LITE
+   DEPNAME    "gsl-lite"
    COMMENT    "gsl-lite is an implementation of the C++ Core Guidelines Support Library originally based on Microsoft GSL."
    VERSION    "0.42.0"
    REPOSITORY "https://github.com/gsl-lite/gsl-lite"
@@ -275,6 +297,7 @@ dependency(GSL_LITE
 
 # gtest and gmock
 dependency(GTEST
+   DEPNAME    "GoogleTest"
    COMMENT    "Google Test is a C++ test framework based on the xUnit architecture."
    VERSION    "1.17.0"
    REPOSITORY "https://github.com/google/googletest"
@@ -293,6 +316,7 @@ endif()
 
 # hunspell
 dependency(HUNSPELL
+   DEPNAME    "Hunspell"
    COMMENT    "Hunspell is a free spell checker and morphological analyzer library and command-line tool, licensed under LGPL/GPL/MPL tri-license."
    VERSION    "1.7.2"
    REPOSITORY "https://github.com/hunspell/hunspell"
@@ -303,6 +327,7 @@ dependency(HUNSPELL
 
 # rapidjson
 dependency(RAPIDJSON
+   DEPNAME    "RapidJSON"
    COMMENT    "A fast JSON parser/generator for C++ with both SAX/DOM style API"
    VERSION    "1.1.0"
    REPOSITORY "https://github.com/Tencent/rapidjson"
@@ -313,6 +338,7 @@ dependency(RAPIDJSON
 
 # tl-expected
 dependency(TL_EXPECTED
+   DEPNAME    "tl::expected"
    COMMENT    "Single header implementation of std::expected with functional-style extensions."
    VERSION    "1.1.0"
    REPOSITORY "https://github.com/TartanLlama/expected"
@@ -324,6 +350,7 @@ set(EXPECTED_BUILD_TESTS OFF)
 
 # utfcpp
 dependency(UTFCPP
+   DEPNAME    "UTF8-CPP"
    COMMENT    "UTF8-CPP: UTF-8 with C++ in a Portable Way"
    VERSION    "4.0.8"
    REPOSITORY "https://github.com/nemtrif/utfcpp"
@@ -334,6 +361,7 @@ dependency(UTFCPP
 
 # websocketpp
 dependency(WEBSOCKETPP
+   DEPNAME    "WebSocket++"
    COMMENT    "WebSocket++ is a header only C++ library that implements RFC6455 The WebSocket Protocol."
    VERSION    "0.8.3"
    REPOSITORY "https://github.com/amini-allight/websocketpp"
@@ -344,6 +372,7 @@ dependency(WEBSOCKETPP
 
 # yaml-cpp
 dependency(YAML_CPP
+   DEPNAME    "yaml-cpp"
    COMMENT    "yaml-cpp is a YAML parser and emitter in C++ matching the YAML 1.2 spec."
    VERSION    "0.8.0"
    REPOSITORY "https://github.com/jbeder/yaml-cpp"
@@ -362,6 +391,7 @@ endif()
 # a target name collision with the 'zlib' OBJECT target that libgit2 creates
 # from its own bundled deps/zlib when find_package(ZLIB) fails on Windows.
 dependency(ZLIB
+   DEPNAME    "zlib"
    COMMENT    "zlib is a general purpose data compression library."
    VERSION    "1.3.1"
    REPOSITORY "https://github.com/madler/zlib"
@@ -403,17 +433,17 @@ if(EXISTS "${_LIBGIT2_GIT2_H}")
 endif()
 
 fetch(
-   dtl          DTL
-   fmt          FMT
-   gsl-lite     GSL_LITE
-   libgit2      LIBGIT2
-   gtest        GTEST
-   hunspell     HUNSPELL
-   rapidjson    RAPIDJSON
-   tl-expected  TL_EXPECTED
-   utfcpp       UTFCPP
-   websocketpp  WEBSOCKETPP
-   yaml-cpp     YAML_CPP)
+   dtl                   DTL
+   fmt                   FMT
+   gsl-lite              GSL_LITE
+   libgit2               LIBGIT2
+   gtest                 GTEST
+   hunspell              HUNSPELL
+   rapidjson             RAPIDJSON
+   tl-expected           TL_EXPECTED
+   utfcpp                UTFCPP
+   websocketpp           WEBSOCKETPP
+   yaml-cpp              YAML_CPP)
 
 if(EXISTS "${_LIBGIT2_GIT2_H}.prev")
    if(EXISTS "${_LIBGIT2_GIT2_H}")


### PR DESCRIPTION
### Intent

To keep the NOTICE file up-to-date, it will be very helpful to maintain machine-readable dependency licensing metadata.

### Approach

The NOTICE file is generated by [license-mole](https://github.com/posit-dev/license-mole), which has a function that can read `dependency()` blocks like the ones we use in our CMakeLists files. This PR creates such blocks for all of the dependencies that can't be automatically detected.

Additionally, the OSX package.json file is marked as "private", because it isn't intended to be deployed to npm.

### Automated Tests

This change requires no automated testing. However, the generated NOTICE file is already covered by an automated test for link validity.

### QA Notes

N/A

### Documentation

This updates the Licenses page in the Posit docs.

### Checklist

- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
