### PR TITLE
fix find in files in website projects with output-dir set to project root

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - ([#8541](https://github.com/rstudio/rstudio/issues/8541)): Add a "Change active editor tab with mouse wheel" preference (General > Basic > Other) to disable switching the active editor tab by scrolling the mouse wheel over the tab bar.
 
 ### Fixed
+- ([#17900](https://github.com/rstudio/rstudio/issues/17900)): Fix Find in Files (and project code search) returning no results in a Quarto or R Markdown website project whose output directory is set to the project directory itself (for example `output-dir: .` in `_quarto.yml`); the project root is no longer treated as ignored output content.
 - ([#14202](https://github.com/rstudio/rstudio/issues/14202)): Fixed an issue where RStudio Desktop could hang on startup when offline or on an unreliable network connection.
 - ([#17701](https://github.com/rstudio/rstudio/issues/17701)): Honor newline characters in `rstudioapi::showDialog()` and `rstudioapi::showPrompt()` messages.
 - ([#17729](https://github.com/rstudio/rstudio/issues/17729)): Show distinct copy in the Posit Assistant chat pane and preferences install prompt when the recommended Posit Assistant version is older than the installed one.

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -3124,21 +3124,32 @@ std::vector<FilePath> ignoreContentDirs()
       if (quartoConf.is_project)
       {
          FilePath quartoProjDir = module_context::resolveAliasedPath(quartoConf.project_dir);
-         
+
          std::string quartoOutputDir = quartoConf.project_output_dir;
          if (!quartoOutputDir.empty())
-            ignoreDirs.push_back(quartoProjDir.completeChildPath(quartoOutputDir));
-         
+         {
+            // don't ignore an output dir that resolves to the project directory
+            // itself (e.g. 'output-dir: .'), as that would ignore all project content
+            FilePath outputDirPath = quartoProjDir.completeChildPath(quartoOutputDir);
+            if (outputDirPath.getLexicallyNormalPath() != quartoProjDir.getLexicallyNormalPath())
+               ignoreDirs.push_back(outputDirPath);
+         }
+
          ignoreDirs.push_back(quartoProjDir.completeChildPath("_freeze"));
       }
-      
+
       // rmarkdown site output dir
       if (module_context::isWebsiteProject())
       {
          FilePath buildTargetPath = projects::projectContext().buildTargetPath();
          std::string outputDir = module_context::websiteOutputDir();
          if (!outputDir.empty())
-            ignoreDirs.push_back(buildTargetPath.completeChildPath(outputDir));
+         {
+            // as above, don't ignore an output dir that is the project directory itself
+            FilePath outputDirPath = buildTargetPath.completeChildPath(outputDir);
+            if (outputDirPath.getLexicallyNormalPath() != buildTargetPath.getLexicallyNormalPath())
+               ignoreDirs.push_back(outputDirPath);
+         }
       }
    }
    

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -3110,31 +3110,40 @@ void checkXcodeLicense()
 #endif
 }
 
+bool shouldIgnoreOutputDir(const FilePath& base, const std::string& outputDir)
+{
+   if (outputDir.empty())
+      return false;
+
+   // Compare by filesystem identity rather than lexically-normal string: a
+   // configured 'output-dir: .' resolves to base, but 'base/.' does not
+   // normalize to 'base' as a string. Ignoring base would drop all project
+   // content, leaving Find in Files with no results (#17900).
+   FilePath outputDirPath = base.completeChildPath(outputDir);
+   return !outputDirPath.isEquivalentTo(base);
+}
+
 std::vector<FilePath> ignoreContentDirs()
 {
    std::vector<FilePath> ignoreDirs;
-   
+
    if (projects::projectContext().hasProject())
    {
       // python virtual environments
       ignoreDirs = projects::projectContext().pythonEnvs();
       quarto::QuartoConfig quartoConf = quarto::quartoConfig();
-      
+
+      auto addOutputDir = [&ignoreDirs](const FilePath& base, const std::string& outputDir)
+      {
+         if (shouldIgnoreOutputDir(base, outputDir))
+            ignoreDirs.push_back(base.completeChildPath(outputDir));
+      };
+
       // quarto site output dir
       if (quartoConf.is_project)
       {
          FilePath quartoProjDir = module_context::resolveAliasedPath(quartoConf.project_dir);
-
-         std::string quartoOutputDir = quartoConf.project_output_dir;
-         if (!quartoOutputDir.empty())
-         {
-            // don't ignore an output dir that resolves to the project directory
-            // itself (e.g. 'output-dir: .'), as that would ignore all project content
-            FilePath outputDirPath = quartoProjDir.completeChildPath(quartoOutputDir);
-            if (outputDirPath.getLexicallyNormalPath() != quartoProjDir.getLexicallyNormalPath())
-               ignoreDirs.push_back(outputDirPath);
-         }
-
+         addOutputDir(quartoProjDir, quartoConf.project_output_dir);
          ignoreDirs.push_back(quartoProjDir.completeChildPath("_freeze"));
       }
 
@@ -3142,14 +3151,7 @@ std::vector<FilePath> ignoreContentDirs()
       if (module_context::isWebsiteProject())
       {
          FilePath buildTargetPath = projects::projectContext().buildTargetPath();
-         std::string outputDir = module_context::websiteOutputDir();
-         if (!outputDir.empty())
-         {
-            // as above, don't ignore an output dir that is the project directory itself
-            FilePath outputDirPath = buildTargetPath.completeChildPath(outputDir);
-            if (outputDirPath.getLexicallyNormalPath() != buildTargetPath.getLexicallyNormalPath())
-               ignoreDirs.push_back(outputDirPath);
-         }
+         addOutputDir(buildTargetPath, module_context::websiteOutputDir());
       }
    }
    

--- a/src/cpp/session/SessionModuleContextTests.cpp
+++ b/src/cpp/session/SessionModuleContextTests.cpp
@@ -264,6 +264,79 @@ TEST(CreateFileUrlTest, HomeFileRoundTripSkipsAudit)
       << " should skip audit via the ?show=1 marker";
 }
 
+// --- shouldIgnoreOutputDir --------------------------------------------------
+//
+// Regression coverage for #17900: a website 'output-dir' that resolves to the
+// project directory itself (e.g. 'output-dir: .') must NOT be added to the
+// ignore list, or Find in Files / code search drops every result. The decision
+// compares by filesystem identity, so '.', './', and 'sub/..' -- all naming the
+// project root -- are recognized even though they do not normalize to the base
+// path as strings (the bug in the original fix: lexically_normal("base/.") is
+// "base/.", not "base").
+
+class ShouldIgnoreOutputDirTest : public ::testing::Test
+{
+protected:
+   void SetUp() override
+   {
+      // Create a unique temp directory to stand in for the project root.
+      core::Error error = core::FilePath::tempFilePath(baseDir_);
+      ASSERT_FALSE(error) << error.asString();
+      error = baseDir_.removeIfExists();
+      ASSERT_FALSE(error) << error.asString();
+      error = baseDir_.ensureDirectory();
+      ASSERT_FALSE(error) << error.asString();
+   }
+
+   void TearDown() override
+   {
+      baseDir_.removeIfExists();
+   }
+
+   core::FilePath baseDir_;
+};
+
+TEST_F(ShouldIgnoreOutputDirTest, EmptyOutputDirIsNotIgnored)
+{
+   EXPECT_FALSE(shouldIgnoreOutputDir(baseDir_, ""));
+}
+
+TEST_F(ShouldIgnoreOutputDirTest, DotResolvesToBaseAndIsNotIgnored)
+{
+   // 'output-dir: .' -- the exact #17900 repro.
+   EXPECT_FALSE(shouldIgnoreOutputDir(baseDir_, "."));
+}
+
+TEST_F(ShouldIgnoreOutputDirTest, DotSlashResolvesToBaseAndIsNotIgnored)
+{
+   EXPECT_FALSE(shouldIgnoreOutputDir(baseDir_, "./"));
+}
+
+TEST_F(ShouldIgnoreOutputDirTest, SubdirParentResolvesToBaseAndIsNotIgnored)
+{
+   // 'sub/..' names the project root; boost::filesystem::equivalent needs the
+   // intermediate 'sub' to exist on disk to resolve the path.
+   core::Error error = baseDir_.completeChildPath("sub").ensureDirectory();
+   ASSERT_FALSE(error) << error.asString();
+   EXPECT_FALSE(shouldIgnoreOutputDir(baseDir_, "sub/.."));
+}
+
+TEST_F(ShouldIgnoreOutputDirTest, RealSubdirIsIgnored)
+{
+   // A genuine output dir (e.g. a built '_site') is distinct from the project
+   // root and must still be ignored.
+   core::Error error = baseDir_.completeChildPath("_site").ensureDirectory();
+   ASSERT_FALSE(error) << error.asString();
+   EXPECT_TRUE(shouldIgnoreOutputDir(baseDir_, "_site"));
+}
+
+TEST_F(ShouldIgnoreOutputDirTest, UnbuiltSubdirIsIgnored)
+{
+   // A not-yet-built output dir does not exist on disk; it must still be
+   // ignored (isEquivalentTo returns false when a path is missing).
+   EXPECT_TRUE(shouldIgnoreOutputDir(baseDir_, "_site_not_built"));
+}
+
 } // namespace tests
 } // namespace module_context
 } // namespace session

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -1050,6 +1050,14 @@ bool navigateToRenderPreviewError(const core::FilePath& previewFile,
                                   const std::string& output,
                                   const std::string& allOutput);
 
+// Returns true if a website's output directory (outputDir, resolved relative
+// to base) should be excluded from Find in Files / code search. Returns false
+// when outputDir is empty, or when it resolves to base itself (e.g.
+// 'output-dir: .') -- ignoring base would drop all project content (#17900).
+// The comparison is by filesystem identity (boost::filesystem::equivalent via
+// FilePath::isEquivalentTo), so 'base/.' is recognized as base even though it
+// differs from base as a lexically-normal string.
+bool shouldIgnoreOutputDir(const core::FilePath& base, const std::string& outputDir);
 std::vector<core::FilePath> ignoreContentDirs();
 bool isIgnoredContent(const core::FilePath& filePath, const std::vector<core::FilePath>& ignoreDirs);
 

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -1449,6 +1449,14 @@ bool FilePath::isSymlink() const
 
 bool FilePath::isWithin(const FilePath& in_scopePath) const
 {
+   // Caveat: because the component loop below stops at a "." element (see the
+   // comment there), a scope path that ends in "." -- e.g. "/proj/." -- matches
+   // ALL paths, since only the "/" and "proj" components are compared before the
+   // "." terminates the loop. Lexical normalization does not strip a trailing "."
+   // (getLexicallyNormalPath: "/proj/." stays "/proj/."), so this can happen with
+   // a path built via completeChildPath("."). Guard such cases at the call site
+   // (e.g. with isEquivalentTo) rather than relying on isWithin to reject them.
+
    // Technically, we contain ourselves.
    if (*this == in_scopePath)
       return true;

--- a/src/cpp/shared_core/include/shared_core/FilePath.hpp
+++ b/src/cpp/shared_core/include/shared_core/FilePath.hpp
@@ -552,6 +552,13 @@ public:
     * @brief Gets the lexically normal representation of this file path, with . and ..
     *    components resolved and/or removed.
     *
+    * This is a purely lexical (string) operation: it does not touch the filesystem
+    * or resolve symlinks. Note that a trailing "." is NOT removed -- "/proj/."
+    * normalizes to "/proj/.", not "/proj" (only the "sub/.." spelling collapses
+    * back to the parent). Do NOT use this to test path equality: two paths that
+    * refer to the same directory can have different normal forms. Use
+    * isEquivalentTo() to test whether two paths refer to the same entity.
+    *
     * @return The lexically normal representation of this file path.
     */
    std::string getLexicallyNormalPath() const;

--- a/src/cpp/shared_core/include/shared_core/FilePath.hpp
+++ b/src/cpp/shared_core/include/shared_core/FilePath.hpp
@@ -555,8 +555,13 @@ public:
     * This is a purely lexical (string) operation: it does not touch the filesystem
     * or resolve symlinks. Note that a trailing "." is NOT removed -- "/proj/."
     * normalizes to "/proj/.", not "/proj" (only the "sub/.." spelling collapses
-    * back to the parent). Do NOT use this to test path equality: two paths that
-    * refer to the same directory can have different normal forms. Use
+    * back to the parent). This is by design: normalization removes each "."
+    * along with its immediately following separator, so an interior "." in
+    * "a/./b" vanishes, but a trailing "." has no following separator and is kept
+    * as a directory-ness marker (a bare trailing separator "a/" likewise yields
+    * "a/."). At most one trailing "." survives -- interior repeats like "a/././."
+    * still collapse to "a/.". Do NOT use this to test path equality: two paths
+    * that refer to the same directory can have different normal forms. Use
     * isEquivalentTo() to test whether two paths refer to the same entity.
     *
     * @return The lexically normal representation of this file path.


### PR DESCRIPTION
### Summary

Fix Find in Files (and project code search) returning "(No results found)" in a Quarto or R Markdown website project whose output directory resolves to the project directory itself, e.g. `output-dir: .` in `_quarto.yml`.

### Root cause

`module_context::ignoreContentDirs()` excludes a website's output directory from Find in Files / code search results so that generated HTML isn't matched. When the configured output dir is `.`, `quartoProjDir.completeChildPath(".")` resolves to the project root, so the entire project gets added to the ignore list. Every grep hit is then dropped by `isIgnoredContent()` (`filePath.isWithin(ignoreDir)` is true for all files), producing no results.

This matched all of the reporter's observations: `grep`/`system2` work directly (the filtering happens after, in result processing), a no-project instance finds results, and subfolders within the project also return nothing.

### Fix

In `ignoreContentDirs()`, skip an output directory that resolves to the project/build directory itself (comparing lexically-normal paths, since `projDir/.` differs from `projDir` as a raw string). Applied to both the Quarto and R Markdown website branches.

Trade-off: with `output-dir: .`, generated `.html` files are now searchable (they can no longer be distinguished from sources), matching the no-project behavior. This is strictly better than the project being entirely unsearchable.

### Testing

Manually verified the resolution against the repro project from the issue (`output-dir: .`). No automated test added, as `ignoreContentDirs()` depends on live project/Quarto config state.

Addresses #17900
