### PR TITLE
Add option to ignore project-specific appearance settings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 - ([#15830](https://github.com/rstudio/rstudio/issues/15830)): Add a Code menu and command-palette entry to re-enable the editor's missing-package banner for a file after dismissing it, and rename the banner's dismissal label to "Don't show for this file" to make the per-file scope explicit.
 - ([#17734](https://github.com/rstudio/rstudio/issues/17734)): Support em dashes and box-drawing characters as native R code section delimiters.
 - ([#8541](https://github.com/rstudio/rstudio/issues/8541)): Add a "Change active editor tab with mouse wheel" preference (General > Basic > Other) to disable switching the active editor tab by scrolling the mouse wheel over the tab bar.
-- ([#2350](https://github.com/rstudio/rstudio/issues/2350)): Add an Appearance pane to Project Options for setting a project-specific editor theme; leaving it at "(Default)" uses the global theme.
+- ([#2350](https://github.com/rstudio/rstudio/issues/2350)): Add an Appearance pane to Project Options for setting a project-specific editor theme; leaving it at "(Default)" uses the global theme. A new "Ignore project-specific appearance settings" option (Global Options > Appearance) keeps the global editor theme even when a project sets its own.
 
 ### Fixed
 - ([#14202](https://github.com/rstudio/rstudio/issues/14202)): Fixed an issue where RStudio Desktop could hang on startup when offline or on an unreliable network connection.

--- a/e2e/rstudio/tests/projects/ignore_project_appearance.test.ts
+++ b/e2e/rstudio/tests/projects/ignore_project_appearance.test.ts
@@ -1,0 +1,202 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import {
+  executeCommand,
+  dismissAllModals,
+  numModalsShowing,
+  getPref,
+  setPref,
+  clearPref,
+} from '@utils/commands';
+import { createAndOpenProject, closeProjectIfOpen } from '@utils/project';
+import { useSuiteSandbox } from '@utils/sandbox';
+import type { Locator, Page } from 'playwright';
+
+// "Ignore project-specific appearance settings" (Global Options > Appearance)
+// makes RStudio apply the global editor theme even when the active project sets
+// its own. Toggling the checkbox changes nothing until OK/Apply; on Apply the
+// pane updates immediately (the project-override indicator gives way to the
+// theme selector) and the live editor theme reverts to the global one.
+
+// -- Selectors ----------------------------------------------------------------
+
+const GLOBAL_OPTIONS_DIALOG = '.gwt-DialogBox[aria-label="Options"]';
+const PROJECT_OPTIONS_DIALOG = '.gwt-DialogBox[aria-label="Project Options"]';
+const APPEARANCE_TAB = '#rstudio_label_appearance_options';
+
+const GLOBAL_THEME_SELECT = '#rstudio_appearance_editor_theme';
+const GLOBAL_THEME_OVERRIDE = '#rstudio_appearance_editor_theme_project_override';
+const PROJECT_THEME_SELECT = '#rstudio_project_editor_theme';
+
+// ModalDialogBase assigns these via ElementIds.assignElementId, disambiguating
+// with a numeric suffix when another dialog already holds the base id (the
+// project dialog can open on top of the global one). Match by id prefix.
+const PREFERENCES_OK = '[id^="rstudio_preferences_confirm"]';
+const PREFERENCES_APPLY = '[id^="rstudio_dlg_apply"]';
+const DIALOG_CANCEL = '[id^="rstudio_dlg_cancel"]';
+
+// GWT CheckBox renders an <input type="checkbox"> associated with its label, so
+// the checkbox resolves by accessible name (PrefsConstants.ignoreProjectAppearanceLabel).
+const IGNORE_CHECKBOX_LABEL = 'Ignore project-specific appearance settings';
+
+// The 'Cobalt' theme ships with RStudio; its stylesheet href is
+// "theme/default/cobalt.rstheme". 'Textmate (default)' is the out-of-the-box
+// global theme and its href contains "textmate". Pinning the global theme to
+// Textmate makes the "reverted to the global theme" assertion meaningful.
+const PROJECT_THEME = 'Cobalt';
+const GLOBAL_THEME = 'Textmate (default)';
+
+// ID on the <link> AceThemes.java injects to apply the active editor theme CSS.
+const ACE_THEME_LINK = '#rstudio-acethemes-linkelement';
+const THEME_POLL = { timeout: 15000, intervals: [200, 500, 1000] };
+
+// -- Helpers ------------------------------------------------------------------
+
+/** Read the href of the active Ace theme stylesheet link from the DOM. */
+async function getActiveThemeHref(page: Page): Promise<string> {
+  return page.evaluate(
+    (id) => document.querySelector(id)?.getAttribute('href') ?? '',
+    ACE_THEME_LINK,
+  );
+}
+
+/** Open the project Appearance tab, select a theme, then save and wait for close. */
+async function setProjectEditorTheme(page: Page, themeLabel: string): Promise<void> {
+  await executeCommand(page, 'projectOptions');
+  const dialog = page.locator(PROJECT_OPTIONS_DIALOG);
+  await expect(dialog).toBeVisible({ timeout: 15000 });
+  await dialog.locator(APPEARANCE_TAB).click();
+
+  const select = dialog.locator(PROJECT_THEME_SELECT);
+  await expect(select).toBeVisible({ timeout: 5000 });
+  // Wait for the async theme list to land before selecting.
+  await expect(select.locator('option', { hasText: themeLabel })).toHaveCount(1, {
+    timeout: 15000,
+  });
+
+  await select.selectOption({ label: themeLabel });
+  // onApply reads the DOM <select>; fire change explicitly so the pane observes it.
+  await select.dispatchEvent('change');
+
+  await dialog.locator(PREFERENCES_OK).click();
+  await expect(dialog).not.toBeVisible({ timeout: 10000 });
+}
+
+/** Open global Options and switch to its Appearance tab. */
+async function openGlobalAppearance(page: Page): Promise<Locator> {
+  await executeCommand(page, 'showOptions');
+  const dialog = page.locator(GLOBAL_OPTIONS_DIALOG);
+  await expect(dialog).toBeVisible({ timeout: 15000 });
+  await dialog.locator(APPEARANCE_TAB).click();
+  return dialog;
+}
+
+/** Cancel out of a still-open dialog without persisting further changes. */
+async function cancelDialog(page: Page, dialogSelector: string): Promise<void> {
+  const dialog = page.locator(dialogSelector);
+  await dialog.locator(DIALOG_CANCEL).click();
+  await expect(dialog).not.toBeVisible({ timeout: 10000 });
+}
+
+// -- Test suite ---------------------------------------------------------------
+
+test.describe.serial('Ignore project appearance settings', () => {
+  const sandbox = useSuiteSandbox();
+
+  // Original global editor_theme, restored in afterAll.
+  let originalTheme: string | null = null;
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    originalTheme = (await getPref(page, 'editor_theme')) as string | null;
+
+    // Pin the global theme so the override (Cobalt) and the revert target
+    // (Textmate) are distinct. setPref alone doesn't re-theme mid-session, but
+    // opening the project below rebuilds the session and applies it.
+    await setPref(page, 'editor_theme', GLOBAL_THEME);
+
+    // The override indicator (and the project theme) only exist inside a project.
+    await createAndOpenProject(page, sandbox.dir, 'IgnoreAppearance');
+    await setProjectEditorTheme(page, PROJECT_THEME);
+  });
+
+  test.afterAll(async ({ rstudioPage: page }) => {
+    // Reset the new pref so it can't leak into other suites in this worker.
+    try {
+      await clearPref(page, 'ignore_project_appearance');
+    } catch (err) {
+      console.warn('[ignore_project_appearance] afterAll clearPref failed:', err);
+    }
+
+    try {
+      if ((await numModalsShowing(page)) > 0) {
+        await dismissAllModals(page);
+      }
+    } catch (err) {
+      console.warn('[ignore_project_appearance] afterAll dismissAllModals failed:', err);
+    }
+
+    // Restore the original global editor_theme.
+    try {
+      if (originalTheme !== null) {
+        await setPref(page, 'editor_theme', originalTheme);
+      } else {
+        await clearPref(page, 'editor_theme');
+      }
+    } catch (err) {
+      console.warn('[ignore_project_appearance] afterAll theme restore failed:', err);
+    }
+
+    // Closing the project rebuilds the session, dropping the project pref layer
+    // and re-applying the restored global theme via syncThemePrefs.
+    try {
+      await closeProjectIfOpen(page);
+    } catch (err) {
+      console.warn('[ignore_project_appearance] afterAll closeProjectIfOpen failed:', err);
+    }
+  });
+
+  test('reverts to the global theme on Apply, and restores the override when cleared', async ({
+    rstudioPage: page,
+  }) => {
+    const dialog = await openGlobalAppearance(page);
+
+    // Precondition: the project override is active -- indicator shown, selector
+    // hidden, and the live editor theme is the project's Cobalt.
+    const overridePanel = dialog.locator(GLOBAL_THEME_OVERRIDE);
+    await expect(overridePanel).toBeVisible({ timeout: 15000 });
+    await expect(dialog.locator(GLOBAL_THEME_SELECT)).not.toBeVisible();
+    await expect.poll(() => getActiveThemeHref(page), THEME_POLL).toMatch(/cobalt/i);
+
+    const ignoreCheckbox = dialog.getByRole('checkbox', { name: IGNORE_CHECKBOX_LABEL });
+    await expect(ignoreCheckbox).toBeVisible();
+
+    // Checking the box alone must not change the pane or the live theme; the
+    // change takes effect only on Apply/OK.
+    await ignoreCheckbox.check();
+    await expect(overridePanel).toBeVisible();
+    expect(await getActiveThemeHref(page)).toMatch(/cobalt/i);
+
+    // Apply: the pane updates immediately -- the override indicator gives way to
+    // the theme selector -- and the live theme reverts to the global Textmate.
+    await dialog.locator(PREFERENCES_APPLY).click();
+    await expect(overridePanel).not.toBeVisible({ timeout: 10000 });
+    await expect(dialog.locator(GLOBAL_THEME_SELECT)).toBeVisible({ timeout: 10000 });
+    await expect.poll(() => getActiveThemeHref(page), THEME_POLL).toMatch(/textmate/i);
+
+    // Clearing the option (uncheck + Apply) restores the project override live.
+    await ignoreCheckbox.uncheck();
+    await dialog.locator(PREFERENCES_APPLY).click();
+    await expect(overridePanel).toBeVisible({ timeout: 10000 });
+    await expect(dialog.locator(GLOBAL_THEME_SELECT)).not.toBeVisible({ timeout: 10000 });
+    await expect.poll(() => getActiveThemeHref(page), THEME_POLL).toMatch(/cobalt/i);
+
+    // A stray "Install Posit Assistant" modal (if the assistant pane regresses)
+    // would sit on top of the global dialog and intercept the cancel click.
+    if ((await numModalsShowing(page)) > 1) {
+      await dismissAllModals(page);
+      await expect(dialog).not.toBeVisible({ timeout: 10000 });
+      return;
+    }
+
+    await cancelDialog(page, GLOBAL_OPTIONS_DIALOG);
+  });
+});

--- a/e2e/rstudio/tests/projects/ignore_project_appearance.test.ts
+++ b/e2e/rstudio/tests/projects/ignore_project_appearance.test.ts
@@ -38,6 +38,10 @@ const DIALOG_CANCEL = '[id^="rstudio_dlg_cancel"]';
 // the checkbox resolves by accessible name (PrefsConstants.ignoreProjectAppearanceLabel).
 const IGNORE_CHECKBOX_LABEL = 'Ignore project-specific appearance settings';
 
+// Leading, quote-free substring of the project Appearance pane note
+// (StudioClientProjectConstants.appearanceIgnoredByGlobalText).
+const PROJECT_IGNORED_NOTE = 'Project appearance settings are currently ignored';
+
 // The 'Cobalt' theme ships with RStudio; its stylesheet href is
 // "theme/default/cobalt.rstheme". 'Textmate (default)' is the out-of-the-box
 // global theme and its href contains "textmate". Pinning the global theme to
@@ -198,5 +202,49 @@ test.describe.serial('Ignore project appearance settings', () => {
     }
 
     await cancelDialog(page, GLOBAL_OPTIONS_DIALOG);
+  });
+
+  test('the project Appearance pane shows the ignored note when the option is on', async ({
+    rstudioPage: page,
+  }) => {
+    // Enable the option out-of-band; the note is rendered when the project
+    // Appearance pane is constructed (on dialog open).
+    await setPref(page, 'ignore_project_appearance', true);
+    try {
+      await executeCommand(page, 'projectOptions');
+      const dialog = page.locator(PROJECT_OPTIONS_DIALOG);
+      await expect(dialog).toBeVisible({ timeout: 15000 });
+      await dialog.locator(APPEARANCE_TAB).click();
+
+      await expect(
+        dialog.getByText(PROJECT_IGNORED_NOTE, { exact: false }),
+      ).toBeVisible({ timeout: 10000 });
+
+      await cancelDialog(page, PROJECT_OPTIONS_DIALOG);
+    } finally {
+      // Restore the default so the override (and the next test) behave normally.
+      await setPref(page, 'ignore_project_appearance', false);
+    }
+  });
+
+  test('enabling the option and clicking OK reverts the live theme to the global one', async ({
+    rstudioPage: page,
+  }) => {
+    const dialog = await openGlobalAppearance(page);
+
+    // Precondition: the project override is active and Cobalt is applied live.
+    const overridePanel = dialog.locator(GLOBAL_THEME_OVERRIDE);
+    await expect(overridePanel).toBeVisible({ timeout: 15000 });
+    await expect.poll(() => getActiveThemeHref(page), THEME_POLL).toMatch(/cobalt/i);
+
+    // Enable the option and confirm with OK (which closes the dialog) -- a
+    // different code path than Apply, which keeps it open.
+    await dialog.getByRole('checkbox', { name: IGNORE_CHECKBOX_LABEL }).check();
+    await dialog.locator(PREFERENCES_OK).click();
+    await expect(dialog).not.toBeVisible({ timeout: 10000 });
+
+    // The live editor theme still reverts to the global Textmate even though the
+    // dialog closed: onApply persisted the pref and re-resolved the applied theme.
+    await expect.poll(() => getActiveThemeHref(page), THEME_POLL).toMatch(/textmate/i);
   });
 });

--- a/e2e/rstudio/tests/projects/project_editor_theme.test.ts
+++ b/e2e/rstudio/tests/projects/project_editor_theme.test.ts
@@ -44,6 +44,14 @@ test.describe.serial('Project-level EditorTheme in .Rproj', () => {
   });
 
   test.afterAll(async ({ rstudioPage: page }) => {
+    // Defensively clear the ignore-project-appearance opt-out so a failing test
+    // can't leak it into other suites in this worker.
+    try {
+      await clearPref(page, 'ignore_project_appearance');
+    } catch (err) {
+      console.warn('[project_editor_theme] afterAll clearPref(ignore) failed:', err);
+    }
+
     // Restore the original global editor_theme pref first.
     try {
       if (originalTheme !== null) {
@@ -230,6 +238,67 @@ test.describe.serial('Project-level EditorTheme in .Rproj', () => {
 
     // Clean up.
     await closeProjectIfOpen(page);
+    await executeInConsole(
+      page,
+      `unlink(${rPathLiteral(projectDir)}, recursive = TRUE)`,
+    );
+    await waitForConsoleIdle(page);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 3: A project's EditorTheme is NOT applied when the user has globally
+  // opted to ignore project appearance settings; the global theme stays active.
+  // This exercises the backend syncThemePrefs() path (project layer excluded),
+  // complementing the live Global Options toggle in
+  // ignore_project_appearance.test.ts.
+  // ---------------------------------------------------------------------------
+  test('project EditorTheme is not applied when project appearance settings are ignored', async ({
+    rstudioPage: page,
+  }) => {
+    // Globally ignore project appearance settings, and pin the global theme so
+    // the "stayed on the global theme" assertion is deterministic.
+    await setPref(page, 'ignore_project_appearance', true);
+    await setPref(page, 'editor_theme', THEME_DEFAULT);
+
+    const parentDir = sandbox.dir.replace(/\\/g, '/');
+    const name = 'ignored_theme_project';
+    const projectDir = `${parentDir}/${name}`;
+    const rprojPath = `${projectDir}/${name}.Rproj`;
+    const rprojLit = rPathLiteral(rprojPath);
+
+    // Write a .Rproj that sets EditorTheme: Cobalt -- which would normally
+    // override the global theme on open.
+    await executeInConsole(
+      page,
+      `{ dir.create(${rPathLiteral(projectDir)}); ` +
+        `writeLines(c(` +
+        `"Version: 1.0", "", ` +
+        `"RestoreWorkspace: Default", ` +
+        `"SaveWorkspace: Default", ` +
+        `"EditorTheme: ${THEME_WITH_OVERRIDE}"` +
+        `), ${rprojLit}) }`,
+    );
+    await waitForConsoleIdle(page);
+
+    await openProject(page, rprojPath);
+
+    // syncThemePrefs() excludes the project layer while the opt-out is on, so the
+    // global Textmate remains applied even though the .Rproj sets Cobalt.
+    await expect
+      .poll(
+        () => getActiveThemeHref(page),
+        {
+          message: `Expected ace theme link href to stay "textmate" (project Cobalt ignored)`,
+          timeout: 15000,
+          intervals: [200, 500, 1000],
+        },
+      )
+      .toMatch(/textmate/i);
+    expect(await getActiveThemeHref(page)).not.toMatch(/cobalt/i);
+
+    // Clean up: close the project (rebuilds the session), stop ignoring, remove dir.
+    await closeProjectIfOpen(page);
+    await clearPref(page, 'ignore_project_appearance');
     await executeInConsole(
       page,
       `unlink(${rPathLiteral(projectDir)}, recursive = TRUE)`,

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -185,6 +185,7 @@ namespace prefs {
 #define kEnableMousewheelZoom "enable_mousewheel_zoom"
 #define kMousewheelZoomDebounceMs "mousewheel_zoom_debounce_ms"
 #define kEditorTheme "editor_theme"
+#define kIgnoreProjectAppearance "ignore_project_appearance"
 #define kServerEditorFontEnabled "server_editor_font_enabled"
 #define kServerEditorFont "server_editor_font"
 #define kDefaultEncoding "default_encoding"
@@ -1084,6 +1085,12 @@ public:
     */
    std::string editorTheme();
    core::Error setEditorTheme(std::string val);
+
+   /**
+    * Whether to ignore appearance settings (such as the editor theme) configured at the project level, always using the global settings instead.
+    */
+   bool ignoreProjectAppearance();
+   core::Error setIgnoreProjectAppearance(bool val);
 
    /**
     * Whether to use a custom editor font in RStudio Server.

--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -650,9 +650,10 @@ Error syncThemePrefs()
    // Effective editor theme (project layer wins if set), unless the user has
    // opted to ignore project-level appearance settings -- then the project
    // layer is excluded and the global theme is applied.
-   std::string effectiveName = prefs::userPrefs().ignoreProjectAppearance()
-      ? globalName
-      : prefs::userPrefs().editorTheme();
+   std::string effectiveName = chooseEffectiveThemeName(
+      prefs::userPrefs().ignoreProjectAppearance(),
+      prefs::userPrefs().editorTheme(),
+      globalName);
 
    // Installed themes and the built-in default name.
    ThemeMap themes = getAllThemes();
@@ -755,6 +756,13 @@ std::string chooseAppliedThemeName(const std::string& effectiveName,
    if (availableThemes.count(globalName))
       return globalName;
    return defaultName;
+}
+
+std::string chooseEffectiveThemeName(bool ignoreProjectAppearance,
+                                     const std::string& projectEffectiveName,
+                                     const std::string& globalName)
+{
+   return ignoreProjectAppearance ? globalName : projectEffectiveName;
 }
 
 Error initialize()

--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -637,9 +637,6 @@ Error syncThemePrefs()
 {
    Error err;
 
-   // Effective editor theme (project layer wins if set).
-   std::string effectiveName = prefs::userPrefs().editorTheme();
-
    // Global editor theme: the effective value with the project layer excluded.
    std::string globalName = resolveGlobalThemeName(
       [](const std::string& layer) -> boost::optional<std::string> {
@@ -649,6 +646,13 @@ Error syncThemePrefs()
             return v->getString();
          return boost::none;
       });
+
+   // Effective editor theme (project layer wins if set), unless the user has
+   // opted to ignore project-level appearance settings -- then the project
+   // layer is excluded and the global theme is applied.
+   std::string effectiveName = prefs::userPrefs().ignoreProjectAppearance()
+      ? globalName
+      : prefs::userPrefs().editorTheme();
 
    // Installed themes and the built-in default name.
    ThemeMap themes = getAllThemes();

--- a/src/cpp/session/modules/SessionThemes.hpp
+++ b/src/cpp/session/modules/SessionThemes.hpp
@@ -60,6 +60,13 @@ std::string chooseAppliedThemeName(const std::string& effectiveName,
                                    const std::set<std::string>& availableThemes,
                                    const std::string& defaultName);
 
+// Returns the editor theme name to treat as "effective": the global theme when
+// the user is ignoring project appearance settings (project layer excluded),
+// otherwise the project-effective value (which already reflects a project override).
+std::string chooseEffectiveThemeName(bool ignoreProjectAppearance,
+                                     const std::string& projectEffectiveName,
+                                     const std::string& globalName);
+
 core::Error initialize();
 
 } // namespace themes

--- a/src/cpp/session/modules/SessionThemesTests.cpp
+++ b/src/cpp/session/modules/SessionThemesTests.cpp
@@ -68,6 +68,21 @@ TEST(SessionThemesTests, ChooseAppliedThemeNameUninstalledOverrideEmptyGlobalRes
              "Textmate (default)");
 }
 
+TEST(SessionThemesTests, ChooseEffectiveThemeNameUsesProjectWhenNotIgnoring)
+{
+   // Not ignoring: the project-effective value (a project override here) wins.
+   EXPECT_EQ(chooseEffectiveThemeName(false, "Cobalt", "Textmate (default)"),
+             "Cobalt");
+}
+
+TEST(SessionThemesTests, ChooseEffectiveThemeNameUsesGlobalWhenIgnoring)
+{
+   // Ignoring project appearance settings: the project layer is excluded and the
+   // global theme is used even when a project names its own.
+   EXPECT_EQ(chooseEffectiveThemeName(true, "Cobalt", "Textmate (default)"),
+             "Textmate (default)");
+}
+
 TEST(SessionThemesTests, ResolveGlobalThemeNameSkipsPresentButEmptyUserLayer)
 {
    // A present-but-empty user-layer value falls through to a lower layer

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -917,6 +917,16 @@
    clear = function() { .rs.clearUserPref("editor_theme") }
 )
 
+# Ignore project-specific appearance settings
+#
+# Whether to ignore appearance settings (such as the editor theme) configured at
+# the project level, always using the global settings instead.
+.rs.uiPrefs$ignoreProjectAppearance <- list(
+   get = function() { .rs.getUserPref("ignore_project_appearance") },
+   set = function(value) { .rs.setUserPref("ignore_project_appearance", value) },
+   clear = function() { .rs.clearUserPref("ignore_project_appearance") }
+)
+
 # Enable editor fonts on RStudio Server
 #
 # Whether to use a custom editor font in RStudio Server.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -1285,6 +1285,19 @@ core::Error UserPrefValues::setEditorTheme(std::string val)
 }
 
 /**
+ * Whether to ignore appearance settings (such as the editor theme) configured at the project level, always using the global settings instead.
+ */
+bool UserPrefValues::ignoreProjectAppearance()
+{
+   return readPref<bool>("ignore_project_appearance");
+}
+
+core::Error UserPrefValues::setIgnoreProjectAppearance(bool val)
+{
+   return writePref("ignore_project_appearance", val);
+}
+
+/**
  * Whether to use a custom editor font in RStudio Server.
  */
 bool UserPrefValues::serverEditorFontEnabled()
@@ -3919,6 +3932,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kEnableMousewheelZoom,
       kMousewheelZoomDebounceMs,
       kEditorTheme,
+      kIgnoreProjectAppearance,
       kServerEditorFontEnabled,
       kServerEditorFont,
       kDefaultEncoding,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -708,6 +708,12 @@
             "title": "Theme",
             "description": "The name of the color theme to apply to the text editor in RStudio."
         },
+        "ignore_project_appearance": {
+            "type": "boolean",
+            "default": false,
+            "title": "Ignore project-specific appearance settings",
+            "description": "Whether to ignore appearance settings (such as the editor theme) configured at the project level, always using the global settings instead."
+        },
         "server_editor_font_enabled": {
             "type": "boolean",
             "default": false,

--- a/src/gwt/src/org/rstudio/studio/client/projects/StudioClientProjectConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/StudioClientProjectConstants.java
@@ -201,6 +201,7 @@ public interface StudioClientProjectConstants extends com.google.gwt.i18n.client
     String rMarkdownText();
     String appearanceText();
     String editorThemeFormLabel();
+    String appearanceIgnoredByGlobalText();
     String sharingText();
     String vcsSelectLabel();
     String originLabel();

--- a/src/gwt/src/org/rstudio/studio/client/projects/StudioClientProjectConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/projects/StudioClientProjectConstants_en.properties
@@ -183,6 +183,7 @@ visualModeZoteroCaption=Visual Mode: Zotero
 rMarkdownText=R Markdown
 appearanceText=Appearance
 editorThemeFormLabel=Editor theme:
+appearanceIgnoredByGlobalText=Project appearance settings are currently ignored because "Ignore project-specific appearance settings" is enabled in Global Options.
 sharingText=Sharing
 vcsSelectLabel=Version control system:
 originLabel=Origin: 

--- a/src/gwt/src/org/rstudio/studio/client/projects/StudioClientProjectConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/projects/StudioClientProjectConstants_fr.properties
@@ -177,6 +177,7 @@ visualModeZoteroCaption=Mode visuel : Zotero
 rMarkdownText=R Markdown
 appearanceText=Apparence
 editorThemeFormLabel=Thème de l''éditeur :
+appearanceIgnoredByGlobalText=Les paramètres d''apparence du projet sont actuellement ignorés car l''option « Ignorer les paramètres d''apparence spécifiques au projet » est activée dans les options globales.
 sharingText=Partage de
 vcsSelectLabel=Système de contrôle de version :
 originLabel=Origine : 

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectAppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectAppearancePreferencesPane.java
@@ -35,6 +35,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceT
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.resources.client.TextResource;
@@ -105,6 +106,8 @@ public class ProjectAppearancePreferencesPane extends ProjectPreferencesPane
          Label ignoredNote = new Label(constants_.appearanceIgnoredByGlobalText());
          ignoredNote.addStyleName(PreferencesDialogBaseResources.INSTANCE.styles().infoLabel());
          ignoredNote.setWidth("100%");
+         // Separate the note from the theme controls below it.
+         ignoredNote.getElement().getStyle().setMarginBottom(8, Unit.PX);
          add(ignoredNote);
       }
 
@@ -232,8 +235,9 @@ public class ProjectAppearancePreferencesPane extends ProjectPreferencesPane
    private static final int PREVIEW_VERTICAL_MARGIN = 38;
    private static final int THEME_LABEL_HEIGHT = 24;
    // Vertical space (px) reserved for the "settings ignored" note when the user
-   // is globally ignoring project appearance settings (the note wraps to ~2 lines).
-   private static final int IGNORED_NOTE_HEIGHT = 48;
+   // is globally ignoring project appearance settings (the note wraps to ~2
+   // lines, plus a little space below it).
+   private static final int IGNORED_NOTE_HEIGHT = 56;
    private static final int VISIBLE_ITEM_COUNT = 20;
 
    private String initialEditorTheme_ = "";

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectAppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectAppearancePreferencesPane.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.prefs.PreferencesDialogBaseResources;
 import org.rstudio.core.client.prefs.RestartRequirement;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.FormLabel;
@@ -39,6 +40,7 @@ import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.resources.client.TextResource;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.inject.Inject;
@@ -59,7 +61,13 @@ public class ProjectAppearancePreferencesPane extends ProjectPreferencesPane
             - PreferencesDialogConstants.SECTION_CHOOSER_PADDING;
       int paneHeight = PreferencesDialogConstants.PROJECT_PANEL_CONTAINER_HEIGHT;
 
-      int previewHeight = paneHeight - PREVIEW_VERTICAL_MARGIN;
+      // When the user is globally ignoring project appearance settings, reserve
+      // room above the two columns for a note explaining that anything chosen
+      // here has no effect until that option is turned off.
+      boolean ignoringAppearance = userPrefs_.ignoreProjectAppearance().getGlobalValue();
+
+      int previewHeight = paneHeight - PREVIEW_VERTICAL_MARGIN
+            - (ignoringAppearance ? IGNORED_NOTE_HEIGHT : 0);
       int previewWidth = paneWidth - LEFT_COLUMN_WIDTH;
 
       // Editor-theme list: a multi-row listbox (not a dropdown) that fills the
@@ -91,6 +99,15 @@ public class ProjectAppearancePreferencesPane extends ProjectPreferencesPane
       hpanel.add(leftPanel);
       hpanel.setCellWidth(leftPanel, LEFT_COLUMN_WIDTH + "px");
       hpanel.add(previewPanel);
+
+      if (ignoringAppearance)
+      {
+         Label ignoredNote = new Label(constants_.appearanceIgnoredByGlobalText());
+         ignoredNote.addStyleName(PreferencesDialogBaseResources.INSTANCE.styles().infoLabel());
+         ignoredNote.setWidth("100%");
+         add(ignoredNote);
+      }
+
       add(hpanel);
    }
 
@@ -173,11 +190,14 @@ public class ProjectAppearancePreferencesPane extends ProjectPreferencesPane
 
    // Applied-theme resolution rule: effective if installed, else global, else the
    // built-in default. Returns null only when the theme list is unavailable
-   // (not yet loaded or empty).
+   // (not yet loaded or empty). When the user is ignoring project appearance
+   // settings, the project override is excluded so the global theme is applied.
    public AceTheme resolveAppliedTheme(UserPrefs uiPrefs)
    {
-      return AceTheme.resolveApplied(themeList_,
-         uiPrefs.editorTheme().getValue(),
+      String preferred = uiPrefs.ignoreProjectAppearance().getGlobalValue()
+         ? uiPrefs.editorTheme().getGlobalValue()
+         : uiPrefs.editorTheme().getValue();
+      return AceTheme.resolveApplied(themeList_, preferred,
          uiPrefs.editorTheme().getGlobalValue());
    }
 
@@ -211,6 +231,9 @@ public class ProjectAppearancePreferencesPane extends ProjectPreferencesPane
    private static final int LEFT_COLUMN_PADDING = 12;
    private static final int PREVIEW_VERTICAL_MARGIN = 38;
    private static final int THEME_LABEL_HEIGHT = 24;
+   // Vertical space (px) reserved for the "settings ignored" note when the user
+   // is globally ignoring project appearance settings (the note wraps to ~2 lines).
+   private static final int IGNORED_NOTE_HEIGHT = 48;
    private static final int VISIBLE_ITEM_COUNT = 20;
 
    private String initialEditorTheme_ = "";

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectAppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectAppearancePreferencesPane.java
@@ -235,9 +235,12 @@ public class ProjectAppearancePreferencesPane extends ProjectPreferencesPane
    private static final int PREVIEW_VERTICAL_MARGIN = 38;
    private static final int THEME_LABEL_HEIGHT = 24;
    // Vertical space (px) reserved for the "settings ignored" note when the user
-   // is globally ignoring project appearance settings (the note wraps to ~2
-   // lines, plus a little space below it).
-   private static final int IGNORED_NOTE_HEIGHT = 56;
+   // is globally ignoring project appearance settings. The pane is ~413px wide
+   // (PROJECT_PANEL_CONTAINER_WIDTH - SECTION_CHOOSER_WIDTH - padding), where the
+   // note wraps to ~2 lines in English but more in longer locales (French is
+   // ~30% longer). Budget ~4 lines at the info font (~16px each) plus the 8px
+   // bottom margin so the note never overlaps the theme controls below it.
+   private static final int IGNORED_NOTE_HEIGHT = 72;
    private static final int VISIBLE_ITEM_COUNT = 20;
 
    private String initialEditorTheme_ = "";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants.java
@@ -96,6 +96,7 @@ public interface PrefsConstants extends com.google.gwt.i18n.client.Messages {
     String appearanceEditorLineHeightLabel();
     String appearanceEditorThemeLabel();
     String appearanceEditorThemeProjectOverrideText();
+    String ignoreProjectAppearanceLabel();
     String addThemeButtonLabel();
     String addThemeButtonCaption();
     String removeThemeButtonLabel();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants_en.properties
@@ -77,6 +77,7 @@ appearanceEditorFontLabel=Editor font:
 appearanceEditorFontSizeLabel=Editor font size:
 appearanceEditorThemeLabel=Editor theme:
 appearanceEditorThemeProjectOverrideText=The editor theme is overridden by project settings.
+ignoreProjectAppearanceLabel=Ignore project-specific appearance settings
 addThemeButtonLabel=Add...
 addThemeButtonCaption=Theme Files (*.tmTheme *.rstheme)
 removeThemeButtonLabel=Remove

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants_fr.properties
@@ -77,6 +77,7 @@ appearanceEditorFontLabel=Police de l''éditeur :
 appearanceEditorFontSizeLabel=Taille de la police de l''éditeur :
 appearanceEditorThemeLabel=Thème de l''éditeur :
 appearanceEditorThemeProjectOverrideText=Le thème de l''éditeur est remplacé par les paramètres du projet.
+ignoreProjectAppearanceLabel=Ignorer les paramètres d''apparence spécifiques au projet
 addThemeButtonLabel=Ajouter...
 addThemeButtonCaption=Fichiers de thème (*.tmTheme *.rstheme)
 removeThemeButtonLabel=Supprimer

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -141,6 +141,7 @@ public class UserPrefsAccessor extends Prefs
    public static final String ENABLE_MOUSEWHEEL_ZOOM = "enable_mousewheel_zoom";
    public static final String MOUSEWHEEL_ZOOM_DEBOUNCE_MS = "mousewheel_zoom_debounce_ms";
    public static final String EDITOR_THEME = "editor_theme";
+   public static final String IGNORE_PROJECT_APPEARANCE = "ignore_project_appearance";
    public static final String SERVER_EDITOR_FONT_ENABLED = "server_editor_font_enabled";
    public static final String SERVER_EDITOR_FONT = "server_editor_font";
    public static final String DEFAULT_ENCODING = "default_encoding";
@@ -1740,6 +1741,18 @@ public class UserPrefsAccessor extends Prefs
          _constants.editorThemeTitle(), 
          _constants.editorThemeDescription(), 
          "Textmate (default)");
+   }
+
+   /**
+    * Whether to ignore appearance settings (such as the editor theme) configured at the project level, always using the global settings instead.
+    */
+   public PrefValue<Boolean> ignoreProjectAppearance()
+   {
+      return bool(
+         "ignore_project_appearance",
+         _constants.ignoreProjectAppearanceTitle(), 
+         _constants.ignoreProjectAppearanceDescription(), 
+         false);
    }
 
    /**
@@ -4698,6 +4711,8 @@ public class UserPrefsAccessor extends Prefs
          mousewheelZoomDebounceMs().setValue(layer, source.getInteger("mousewheel_zoom_debounce_ms"));
       if (source.hasKey("editor_theme"))
          editorTheme().setValue(layer, source.getString("editor_theme"));
+      if (source.hasKey("ignore_project_appearance"))
+         ignoreProjectAppearance().setValue(layer, source.getBool("ignore_project_appearance"));
       if (source.hasKey("server_editor_font_enabled"))
          serverEditorFontEnabled().setValue(layer, source.getBool("server_editor_font_enabled"));
       if (source.hasKey("server_editor_font"))
@@ -5189,6 +5204,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(enableMousewheelZoom());
       prefs.add(mousewheelZoomDebounceMs());
       prefs.add(editorTheme());
+      prefs.add(ignoreProjectAppearance());
       prefs.add(serverEditorFontEnabled());
       prefs.add(serverEditorFont());
       prefs.add(defaultEncoding());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -846,6 +846,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String editorThemeDescription();
 
    /**
+    * Whether to ignore appearance settings (such as the editor theme) configured at the project level, always using the global settings instead.
+    */
+   @DefaultStringValue("Ignore project-specific appearance settings")
+   String ignoreProjectAppearanceTitle();
+   @DefaultStringValue("Whether to ignore appearance settings (such as the editor theme) configured at the project level, always using the global settings instead.")
+   String ignoreProjectAppearanceDescription();
+
+   /**
     * Whether to use a custom editor font in RStudio Server.
     */
    @DefaultStringValue("Enable editor fonts on RStudio Server")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -428,6 +428,10 @@ mousewheelZoomDebounceMsDescription = A delay in milliseconds to wait before app
 editorThemeTitle = Theme
 editorThemeDescription = The name of the color theme to apply to the text editor in RStudio.
 
+# Whether to ignore appearance settings (such as the editor theme) configured at the project level, always using the global settings instead.
+ignoreProjectAppearanceTitle = Ignore project-specific appearance settings
+ignoreProjectAppearanceDescription = Whether to ignore appearance settings (such as the editor theme) configured at the project level, always using the global settings instead.
+
 # Whether to use a custom editor font in RStudio Server.
 serverEditorFontEnabledTitle = Enable editor fonts on RStudio Server
 serverEditorFontEnabledDescription = Whether to use a custom editor font in RStudio Server.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
@@ -402,6 +402,10 @@ mousewheelZoomDebounceMsDescription = Un délai en millisecondes à attendre ava
 editorThemeTitle= Thème
 editorThemeDescription= Le nom du thème de couleur à appliquer à l'éditeur de texte dans RStudio.
 
+# Whether to ignore appearance settings (such as the editor theme) configured at the project level, always using the global settings instead.
+ignoreProjectAppearanceTitle= Ignorer les paramètres d'apparence spécifiques au projet
+ignoreProjectAppearanceDescription= Indique s'il faut ignorer les paramètres d'apparence (tels que le thème de l'éditeur) configurés au niveau du projet, en utilisant toujours les paramètres globaux à la place.
+
 # Whether to use a custom editor font in RStudio Server.
 serverEditorFontEnabledTitle= Activer les polices de l'éditeur sur le serveur RStudio
 serverEditorFontEnabledDescription= Si on doit utiliser une police d'éditeur personnalisée dans le serveur RStudio.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -1185,7 +1185,9 @@ public class AppearancePreferencesPane extends PreferencesPane
    private final static String DEFAULT_FONT_VALUE = "__default__";
 
    // Vertical space (px) reserved below the two columns for the
-   // "ignore project appearance" checkbox row, including the spacer above it.
+   // "ignore project appearance" checkbox: 8px spacer above + ~28px for the
+   // single-line checkbox row. The label spans the full pane width, so it stays
+   // on one line in every locale -- no wrap headroom is needed here.
    private final static int IGNORE_APPEARANCE_ROW_HEIGHT = 36;
    
    private final static PrefsConstants constants_ = GWT.create(PrefsConstants.class);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -76,6 +76,7 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.resources.client.TextResource;
+import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
@@ -438,7 +439,9 @@ public class AppearancePreferencesPane extends PreferencesPane
       FlowPanel previewPanel = new FlowPanel();
 
       int previewWidth = PreferencesDialogConstants.PANEL_CONTAINER_WIDTH - 312;
-      int previewHeight = PreferencesDialogConstants.PANEL_CONTAINER_HEIGHT - 38;
+      // Reserve room below the two columns for the "ignore project appearance"
+      // checkbox so it fits without overflowing the pane.
+      int previewHeight = PreferencesDialogConstants.PANEL_CONTAINER_HEIGHT - 38 - IGNORE_APPEARANCE_ROW_HEIGHT;
       previewPanel.setSize("100%", "100%");
       preview_ = new AceEditorPreview(RES.codeSample().getText());
       preview_.setWidth(previewWidth + "px");
@@ -456,6 +459,18 @@ public class AppearancePreferencesPane extends PreferencesPane
       hpanel.add(previewPanel);
 
       add(hpanel);
+
+      // "Ignore project-specific appearance settings" -- a global opt-out that
+      // makes RStudio always use the global editor theme even when the active
+      // project sets its own. checkboxPref persists the value in the base
+      // onApply(); the visible effect (reverting the applied theme, restoring
+      // the selector) is handled in this pane's onApply(), so toggling the box
+      // alone changes nothing until OK/Apply.
+      ignoreProjectAppearance_ = checkboxPref(
+            constants_.ignoreProjectAppearanceLabel(),
+            userPrefs_.ignoreProjectAppearance());
+      initialIgnoreProjectAppearance_ = userPrefs_.ignoreProjectAppearance().getGlobalValue();
+      add(ignoreProjectAppearance_);
 
       // Themes are retrieved asynchronously, so we have to update the theme list and preview panel
       // asynchronously too. We also need to wait until the next event cycle so that the progress
@@ -663,6 +678,13 @@ public class AppearancePreferencesPane extends PreferencesPane
    private boolean isProjectThemeOverrideActive()
    {
       if (!hasActiveProject_)
+         return false;
+
+      // When the user has opted to ignore project appearance settings, the
+      // project's editor theme is not applied, so there is no override to show.
+      // Read the persisted pref (not the checkbox) so that merely toggling the
+      // checkbox doesn't change the pane until OK/Apply persists it.
+      if (userPrefs_.ignoreProjectAppearance().getGlobalValue())
          return false;
 
       return userPrefs_.editorTheme().hasProjectValue() &&
@@ -900,19 +922,40 @@ public class AppearancePreferencesPane extends PreferencesPane
          initialEditorFontSize_ = helpFontSize;
       }
 
-      // themeList_ is populated asynchronously from setThemes(); if the user
-      // clicks OK before that lands, the dropdown is empty and the user can't
-      // have made a selection -- so there's nothing to apply.
-      if (themeList_ != null &&
-          !StringUtil.equals(theme_.getValue(), userPrefs_.editorTheme().getGlobalValue()))
-      {
-         // persist the user's global editor theme
+      // The editor-theme selector is only meaningful when visible; an active
+      // project override hides it. themeList_ is populated asynchronously from
+      // setThemes(), so if the user clicks OK before that lands there's nothing
+      // to apply.
+      boolean globalThemeChanged =
+         themeList_ != null &&
+         theme_.isVisible() &&
+         !StringUtil.equals(theme_.getValue(), userPrefs_.editorTheme().getGlobalValue());
+      if (globalThemeChanged)
          userPrefs_.editorTheme().setGlobalValue(theme_.getValue(), false);
 
-         // apply the *effective* theme: a project override (if active and installed)
-         // must win, so changing the global theme does not replace it
-         AceTheme applied = AceTheme.resolveApplied(themeList_,
-            userPrefs_.editorTheme().getValue(),
+      // "Ignore project appearance settings" was already persisted by
+      // super.onApply(); detect whether it changed since the pane was seeded so
+      // we can re-resolve the applied theme (e.g. revert a project override back
+      // to the global theme) and refresh the pane to match.
+      boolean ignoreChanged =
+         userPrefs_.ignoreProjectAppearance().getGlobalValue() != initialIgnoreProjectAppearance_;
+      initialIgnoreProjectAppearance_ = userPrefs_.ignoreProjectAppearance().getGlobalValue();
+
+      if (themeList_ != null && (globalThemeChanged || ignoreChanged))
+      {
+         // Reflect the (possibly new) override state in the pane -- show the
+         // selector vs. the override indicator and point the preview at the
+         // applied theme. On Apply this updates the still-visible pane
+         // immediately; on OK it refreshes a pane that is about to close.
+         updateProjectThemeOverride();
+
+         // Apply the *effective* theme: a project override wins only while it is
+         // active (the project sets a theme and it isn't being ignored);
+         // otherwise the global selection applies.
+         String preferred = isProjectThemeOverrideActive()
+            ? userPrefs_.editorTheme().getValue()
+            : userPrefs_.editorTheme().getGlobalValue();
+         AceTheme applied = AceTheme.resolveApplied(themeList_, preferred,
             userPrefs_.editorTheme().getGlobalValue());
          if (applied != null)
             userState_.theme().setGlobalValue(applied);
@@ -1081,6 +1124,8 @@ public class AppearancePreferencesPane extends PreferencesPane
    private ThemedButton removeThemeButton_;
    private HorizontalPanel themeButtonsPanel_;
    private VerticalPanel projectThemeOverridePanel_;
+   private CheckBox ignoreProjectAppearance_;
+   private boolean initialIgnoreProjectAppearance_;
    private final AceEditorPreview preview_;
    private SelectWidget fontFace_;
    private String initialFontFace_;
@@ -1100,6 +1145,10 @@ public class AppearancePreferencesPane extends PreferencesPane
 
    private final static String DEFAULT_FONT_NAME = "(Default)";
    private final static String DEFAULT_FONT_VALUE = "__default__";
+
+   // Vertical space (px) reserved below the two columns for the
+   // "ignore project appearance" checkbox row.
+   private final static int IGNORE_APPEARANCE_ROW_HEIGHT = 28;
    
    private final static PrefsConstants constants_ = GWT.create(PrefsConstants.class);
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -667,6 +667,17 @@ public class AppearancePreferencesPane extends PreferencesPane
             // Toggle the project-override UI and point the preview at the theme
             // that is actually in effect (the project's theme when overriding).
             updateProjectThemeOverride();
+
+            // If the user changed a theme-affecting setting (e.g. toggled
+            // "ignore project appearance") and applied it before this list
+            // loaded, onApply couldn't resolve a live theme then; do it now.
+            if (pendingThemeApply_)
+            {
+               pendingThemeApply_ = false;
+               initialIgnoreProjectAppearance_ =
+                  userPrefs_.ignoreProjectAppearance().getGlobalValue();
+               applyEffectiveThemeLive();
+            }
          },
          getProgressIndicator());
    }
@@ -725,6 +736,25 @@ public class AppearancePreferencesPane extends PreferencesPane
 
       if (theme != null)
          preview_.setTheme(theme.getUrl());
+   }
+
+   // Resolve the effective editor theme (the project override when active, else
+   // the global selection) and apply it to the live editor via user state.
+   // Requires the theme list to be loaded; updating the preview and the
+   // selector vs. override-indicator UI is the caller's job (via
+   // updateProjectThemeOverride()).
+   private void applyEffectiveThemeLive()
+   {
+      if (themeList_ == null)
+         return;
+
+      String preferred = isProjectThemeOverrideActive()
+         ? userPrefs_.editorTheme().getValue()
+         : userPrefs_.editorTheme().getGlobalValue();
+      AceTheme applied = AceTheme.resolveApplied(themeList_, preferred,
+         userPrefs_.editorTheme().getGlobalValue());
+      if (applied != null)
+         userState_.theme().setGlobalValue(applied);
    }
 
    private void updateThemes(String focusedThemeName, AceThemes themes)
@@ -925,7 +955,7 @@ public class AppearancePreferencesPane extends PreferencesPane
       // The editor-theme selector is only meaningful when visible; an active
       // project override hides it. themeList_ is populated asynchronously from
       // setThemes(), so if the user clicks OK before that lands there's nothing
-      // to apply.
+      // in the dropdown to apply.
       boolean globalThemeChanged =
          themeList_ != null &&
          theme_.isVisible() &&
@@ -939,26 +969,28 @@ public class AppearancePreferencesPane extends PreferencesPane
       // to the global theme) and refresh the pane to match.
       boolean ignoreChanged =
          userPrefs_.ignoreProjectAppearance().getGlobalValue() != initialIgnoreProjectAppearance_;
-      initialIgnoreProjectAppearance_ = userPrefs_.ignoreProjectAppearance().getGlobalValue();
 
-      if (themeList_ != null && (globalThemeChanged || ignoreChanged))
+      if (globalThemeChanged || ignoreChanged)
       {
-         // Reflect the (possibly new) override state in the pane -- show the
-         // selector vs. the override indicator and point the preview at the
-         // applied theme. On Apply this updates the still-visible pane
-         // immediately; on OK it refreshes a pane that is about to close.
-         updateProjectThemeOverride();
+         if (themeList_ != null)
+         {
+            initialIgnoreProjectAppearance_ = userPrefs_.ignoreProjectAppearance().getGlobalValue();
 
-         // Apply the *effective* theme: a project override wins only while it is
-         // active (the project sets a theme and it isn't being ignored);
-         // otherwise the global selection applies.
-         String preferred = isProjectThemeOverrideActive()
-            ? userPrefs_.editorTheme().getValue()
-            : userPrefs_.editorTheme().getGlobalValue();
-         AceTheme applied = AceTheme.resolveApplied(themeList_, preferred,
-            userPrefs_.editorTheme().getGlobalValue());
-         if (applied != null)
-            userState_.theme().setGlobalValue(applied);
+            // Reflect the (possibly new) override state in the pane -- show the
+            // selector vs. the override indicator and point the preview at the
+            // applied theme. On Apply this updates the still-visible pane
+            // immediately; on OK it refreshes a pane that is about to close.
+            updateProjectThemeOverride();
+            applyEffectiveThemeLive();
+         }
+         else
+         {
+            // The theme list hasn't loaded, so the AceTheme (url/isDark) can't be
+            // resolved yet. Defer the live re-resolution to setThemes(), which
+            // runs once the list arrives. initialIgnoreProjectAppearance_ is left
+            // unchanged so the change is still seen as pending.
+            pendingThemeApply_ = true;
+         }
       }
 
      if (!StringUtil.equals(initialFontFace_, fontFace_.getValue()))
@@ -1126,6 +1158,9 @@ public class AppearancePreferencesPane extends PreferencesPane
    private VerticalPanel projectThemeOverridePanel_;
    private CheckBox ignoreProjectAppearance_;
    private boolean initialIgnoreProjectAppearance_;
+   // Set when a theme-affecting setting is applied before the async theme list
+   // loads; setThemes() resolves and applies the live theme once it arrives.
+   private boolean pendingThemeApply_ = false;
    private final AceEditorPreview preview_;
    private SelectWidget fontFace_;
    private String initialFontFace_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -470,6 +470,9 @@ public class AppearancePreferencesPane extends PreferencesPane
             constants_.ignoreProjectAppearanceLabel(),
             userPrefs_.ignoreProjectAppearance());
       initialIgnoreProjectAppearance_ = userPrefs_.ignoreProjectAppearance().getGlobalValue();
+      // Breathe a little above the checkbox so it isn't cramped against the
+      // two-column area.
+      add(new VerticalSpacer("8px"));
       add(ignoreProjectAppearance_);
 
       // Themes are retrieved asynchronously, so we have to update the theme list and preview panel
@@ -1182,8 +1185,8 @@ public class AppearancePreferencesPane extends PreferencesPane
    private final static String DEFAULT_FONT_VALUE = "__default__";
 
    // Vertical space (px) reserved below the two columns for the
-   // "ignore project appearance" checkbox row.
-   private final static int IGNORE_APPEARANCE_ROW_HEIGHT = 28;
+   // "ignore project appearance" checkbox row, including the spacer above it.
+   private final static int IGNORE_APPEARANCE_ROW_HEIGHT = 36;
    
    private final static PrefsConstants constants_ = GWT.create(PrefsConstants.class);
    


### PR DESCRIPTION
Adds an "Ignore project-specific appearance settings" option to Global Options > Appearance (off by default). When enabled, RStudio uses the global editor theme even when the active project sets its own. This extends the project-level editor theme added in #2350.

## Behavior
- New `ignore_project_appearance` user preference.
- `syncThemePrefs()` excludes the project preference layer when the option is on, so opening a project whose `.Rproj` sets `EditorTheme:` keeps the global theme.
- Global Options > Appearance shows the normal theme selector instead of the project-override indicator while the option is on. Toggling the checkbox changes nothing until OK/Apply; on Apply the pane updates immediately and the applied theme is re-resolved live. If a change is applied before the asynchronous theme list has loaded, it is deferred and applied once the list arrives.
- Project Options > Appearance shows a note when the option is on, explaining the project's appearance settings are currently ignored, and saving a project theme no longer applies it live in that state.

## Screenshots

### New option in Global Options
<img width="666" height="688" alt="global-options-checkbox" src="https://github.com/user-attachments/assets/45bec97e-4806-42a7-acf1-ed7946edc1eb" />

### Warning in Project Options when overriden by the new setting
<img width="591" height="545" alt="project-override" src="https://github.com/user-attachments/assets/6744ee22-8db2-4d24-a09f-0d1885fef559" />

## Testing
- C++ unit tests for the effective-theme-name selection (both branches of the ignore decision).
- e2e: the live Global Options round-trip (Apply and OK), the project-open `syncThemePrefs` path, and the project-pane note. The deferred-apply path (apply within the sub-second async theme-list load window) is covered by reasoning rather than a timing-dependent test.

Verified: `ant javac`, `rsession` build, and the e2e `tsc` typecheck.

Addresses #2350