### PR TITLE
use native pipe operator by default

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -446,8 +446,8 @@ Exceptions — do NOT add a NEWS.md entry for:
 ## Pull Requests
 
 - Pull requests should be associated with a GitHub issue.
-- Pull requests that fix an existing issue, and also include tests, should include "Fixes #<issue>" in their body.
-- Pull requests that only partially address an issue, or require manual verification, should include "Addresses #<issue>" in their body.
+- Pull requests that fix an existing issue, and also include tests, should include "Fixes #<issue>." in their body.
+- Pull requests that only partially address an issue, or require manual verification, should include "Addresses #<issue>." in their body.
 - When generating a pull request, set the Milestone of the pull request to match contents of @version/RELEASE, if there is a matching milestone already defined. Never create a new milestone.
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - ([#17734](https://github.com/rstudio/rstudio/issues/17734)): Support em dashes and box-drawing characters as native R code section delimiters.
 - ([#8541](https://github.com/rstudio/rstudio/issues/8541)): Add a "Change active editor tab with mouse wheel" preference (General > Basic > Other) to disable switching the active editor tab by scrolling the mouse wheel over the tab bar.
 - ([#2350](https://github.com/rstudio/rstudio/issues/2350)): Add an Appearance pane to Project Options for setting a project-specific editor theme; leaving it at "(Default)" uses the global theme.
+- ([#14965](https://github.com/rstudio/rstudio/issues/14965)): The Insert Pipe Operator command (Ctrl+Shift+M / Cmd+Shift+M) now inserts the native R pipe operator `|>` by default; the magrittr pipe `%>%` can be restored via the "Use R's native pipe operator, |>" preference.
 
 ### Fixed
 - ([#17900](https://github.com/rstudio/rstudio/issues/17900)): Fix Find in Files (and project code search) returning no results in a Quarto or R Markdown website project whose output directory is set to the project directory itself (for example `output-dir: .` in `_quarto.yml`); the project root is no longer treated as ignored output content.

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1719,7 +1719,7 @@
             "description": "Whether the Insert Pipe Operator command should use the native R pipe operator, |>",
             "title": "Use R's native pipe operator, |>",
             "type": "boolean",
-            "default": false
+            "default": true
         },
         "command_palette_mru": {
             "description": "Whether to keep track of recently used commands in the Command Palette",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -3858,7 +3858,7 @@ public class UserPrefsAccessor extends Prefs
          "insert_native_pipe_operator",
          _constants.insertNativePipeOperatorTitle(), 
          _constants.insertNativePipeOperatorDescription(), 
-         false);
+         true);
    }
 
    /**


### PR DESCRIPTION
Make the Insert Pipe Operator command (Ctrl+Shift+M / Cmd+Shift+M) insert the native R pipe operator `|>` by default instead of the magrittr pipe `%>%`. Users who prefer `%>%` can restore it via the "Use R's native pipe operator, |>" preference.

This flips the default value of the `insert_native_pipe_operator` user preference from `false` to `true` (in both the schema and the generated `UserPrefsAccessor`).

Addresses #14965