### PR TITLE
ensure sendPing onCompleted fires exactly once

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionOpener.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionOpener.java
@@ -212,10 +212,16 @@ public class SessionOpener
                return false;
             }
             
-            // if we hit our retry count, give up
+            // if we hit our retry count, give up -- but still signal completion
+            // so callers (e.g. the restart flow) don't get stuck waiting forever
             if (retries_++ > maxRetries)
             {
                Debug.logWarning("Error connecting with session.");
+               pingDelivered_ = true;
+
+               if (onCompleted != null)
+                  onCompleted.execute();
+
                return false;
             }
             
@@ -244,11 +250,15 @@ public class SessionOpener
                   protected void onFailure()
                   {
                      pingInFlight_ = false;
-                     
-                     // if the ping was already handled separately, discard this
+
+                     // if completion was already delivered, discard this
                      if (pingDelivered_)
                         return;
-                     
+
+                     // treat a failed ping as completion as well, but mark
+                     // ourselves delivered so onCompleted fires only once
+                     pingDelivered_ = true;
+
                      if (onCompleted != null)
                         onCompleted.execute();
                   }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionOpener.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionOpener.java
@@ -200,14 +200,14 @@ public class SessionOpener
       Scheduler.get().scheduleFixedDelay(new RepeatingCommand()
       {
          private int retries_ = 0;
-         private boolean pingDelivered_ = false;
+         private boolean completed_ = false;
          private boolean pingInFlight_ = false;
          
          @Override
          public boolean execute()
          {
-            // if we've already delivered the ping, return false
-            if (pingDelivered_)
+            // if we've already completed, return false
+            if (completed_)
             {
                return false;
             }
@@ -217,7 +217,7 @@ public class SessionOpener
             if (retries_++ > maxRetries)
             {
                Debug.logWarning("Error connecting with session.");
-               pingDelivered_ = true;
+               completed_ = true;
 
                if (onCompleted != null)
                   onCompleted.execute();
@@ -235,11 +235,11 @@ public class SessionOpener
                   {
                      pingInFlight_ = false;
                      
-                     // if the ping was already handled separately, discard this
-                     if (pingDelivered_)
+                     // if completion was already signaled, discard this
+                     if (completed_)
                         return;
-                     
-                     pingDelivered_ = true;
+
+                     completed_ = true;
                      pEventBus_.get().fireEvent(new ConsoleRestartRCompletedEvent());
                      
                      if (onCompleted != null)
@@ -251,13 +251,13 @@ public class SessionOpener
                   {
                      pingInFlight_ = false;
 
-                     // if completion was already delivered, discard this
-                     if (pingDelivered_)
+                     // if completion was already signaled, discard this
+                     if (completed_)
                         return;
 
                      // treat a failed ping as completion as well, but mark
-                     // ourselves delivered so onCompleted fires only once
-                     pingDelivered_ = true;
+                     // ourselves completed so onCompleted fires only once
+                     completed_ = true;
 
                      if (onCompleted != null)
                         onCompleted.execute();
@@ -265,7 +265,7 @@ public class SessionOpener
                });
             }
             
-            // keep trying until the ping is delivered
+            // keep trying until completion is signaled
             return true;
          }
          


### PR DESCRIPTION
## Summary

In `SessionOpener.sendPing()`, the `onCompleted` callback was never invoked when the ping loop exhausted its `maxRetries`. The loop logged a warning and returned `false` without signaling completion, so the restart flow's `onRestartComplete` (`ApplicationQuit`) never ran:

- `suspendingAndRestarting_` stayed `true` permanently, suppressing nested restart detection.
- `RestartStatusEvent.RESTART_COMPLETED` was never fired, leaving listeners in stale state.
- The progress indicator was never dismissed.

While re-evaluating, the `onFailure` path had a related defect: it called `onCompleted` without marking the loop as delivered and kept returning `true`, so repeated ping failures could invoke `onCompleted` -- and re-fire `RESTART_COMPLETED` -- multiple times.

## Fix

Make `pingDelivered_` a single fire-once guard, set on all three exit paths (success, failure, retry exhaustion) before invoking `onCompleted`. This:

- Calls `onCompleted` on retry exhaustion so the restart flow always completes.
- Ensures `onCompleted` fires exactly once across all paths, including the case where a hung in-flight ping returns after exhaustion.

## Testing

- `cd src/gwt && ant javac` (clean compile).
- No automated test: the loop is a `Scheduler`-driven `RepeatingCommand` against a live `ping` RPC, which is not readily exercised by the GWT unit suite. The retry-exhaustion path triggers only when a ping neither succeeds nor fails for the full retry window, which is difficult to reproduce deterministically.

Addresses #17143.
