### PR TITLE
Skip e2e-merge and PR comment posting when shards were cancelled or produced no results

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -408,7 +408,7 @@ jobs:
   # (when post_pr_comment is set).
   e2e-merge:
     needs: [e2e-desktop-macos]
-    if: always() && needs.e2e-desktop-macos.result != 'skipped'
+    if: always() && needs.e2e-desktop-macos.result != 'skipped' && needs.e2e-desktop-macos.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -503,7 +503,11 @@ jobs:
           if-no-files-found: ignore
 
       - name: Post E2E results to PR
-        if: always() && inputs.post_pr_comment == true && github.event.pull_request.head.repo.fork == false
+        if: |
+          always() &&
+          inputs.post_pr_comment == true &&
+          github.event.pull_request.head.repo.fork == false &&
+          (steps.summary.outputs.passed != '0' || steps.summary.outputs.failed != '0' || steps.summary.outputs.skipped != '0')
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: e2e-macos-arm64-results

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -507,7 +507,7 @@ jobs:
           always() &&
           inputs.post_pr_comment == true &&
           github.event.pull_request.head.repo.fork == false &&
-          (steps.summary.outputs.passed != '0' || steps.summary.outputs.failed != '0' || steps.summary.outputs.skipped != '0')
+          (steps.summary.outputs.passed != '0' || steps.summary.outputs.failed != '0' || steps.summary.outputs.skipped != '0' || steps.summary.outputs.flaky != '0')
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: e2e-macos-arm64-results


### PR DESCRIPTION
<!-- include an entry in NEWS.md if required -->

### Intent

Fixes a misleading all-zeros test report being posted to PRs when a CI run is cancelled mid-way (e.g. because a newer push triggered a higher-priority run). The e2e-merge job was running even on cancelled shard runs, finding no blob reports, and posting a comment showing 0 passed / 0 failed / 0 skipped — making it look like something went wrong when nothing actually ran.

### Approach

Two guards added to os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml:                                                                                                                              
   
  - e2e-merge job condition: added && needs.e2e-desktop-macos.result != 'cancelled' — skips the entire merge job when shards were cancelled, so no comment is posted at all.                          
  - Post E2E results to PR step condition: added a check that at least one of passed/failed/skipped is non-zero — safety net for other edge cases where the merge job runs but no tests produced results (e.g. both shards crash before writing their blob report).                                                                         

### Automated Tests

No new unit tests — CI infrastructure only. Will be verified by observing that cancelled runs no longer post all-zeros comments.                                                                

### QA Notes

No product behavior changes. CI-only.

### Documentation

No documentation changes needed.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
