### PR TITLE
run shiny help examples in the console instead of locking up

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -297,13 +297,19 @@ See `.claude/skills/rstudio-create-playwright-tests/SKILL.md` for detailed guida
 ## Testing
 
 
-### C++ Tests
+### C++ and R Tests
 
-C++ tests use Google Test. Run them with:
+Both are run through `rstudio-tests`:
 
     ./rstudio-tests --scope <scope> --filter <pattern>
 
-where `<scope>` is one of `core`, `rserver`, `rsession`, or `r`.
+The `core`, `rserver`, and `rsession` scopes run the C++ Google Test suites.
+The `r` scope runs the R `testthat` suite under `src/cpp/tests/testthat/`
+(e.g. `test-help.R`). `--filter` matches the test *file* basename, so an R
+`testthat` file is reached with `--scope r --filter <basename>` (for example
+`--scope r --filter help` for `test-help.R`) -- NOT with `--scope rsession`,
+which only runs C++ tests and ignores the testthat files. Rebuild first so the
+staged R copies under `build/src/cpp/session/modules/R/` are current.
 
 
 ### GWT Tests

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -305,11 +305,12 @@ Both are run through `rstudio-tests`:
 
 The `core`, `rserver`, and `rsession` scopes run the C++ Google Test suites.
 The `r` scope runs the R `testthat` suite under `src/cpp/tests/testthat/`
-(e.g. `test-help.R`). `--filter` matches the test *file* basename, so an R
-`testthat` file is reached with `--scope r --filter <basename>` (for example
-`--scope r --filter help` for `test-help.R`) -- NOT with `--scope rsession`,
-which only runs C++ tests and ignores the testthat files. Rebuild first so the
-staged R copies under `build/src/cpp/session/modules/R/` are current.
+(e.g. `test-help.R`). `--filter` is a `testthat::test_dir()` filter: a regular
+expression matched against the test file name after its `test-` prefix and
+`.R` extension are stripped, so `test-help.R` is reached with
+`--scope r --filter help` -- NOT with `--scope rsession`, which only runs C++
+tests and ignores the testthat files. Rebuild first so the staged R copies
+under `build/src/cpp/session/modules/R/` are current.
 
 
 ### GWT Tests

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@
 - ([#17865](https://github.com/rstudio/rstudio/issues/17865)): Fix project paths on a mapped network drive (e.g. `S:`) being resolved to their UNC target (e.g. `\\server\share`) on Windows, which caused functions such as `here::here()` and `getwd()` to report the UNC path instead of the mapped drive.
 - ([#17870](https://github.com/rstudio/rstudio/issues/17870)): Fix an uncaught "Object has been destroyed" error in RStudio Desktop when quitting with a plot zoom (or other child) window still open.
 - ([#17830](https://github.com/rstudio/rstudio/issues/17830)): Fix the data viewer not clearing a data set's saved sorts and filters when its tab is explicitly closed, so reopening the data set no longer restores stale filters; the saved state still persists across a session suspend/restore or a page reload. Restored filters now also reveal the filter row, instead of being applied with no visible filter UI.
+- ([#17178](https://github.com/rstudio/rstudio/issues/17178)): Fix RStudio locking up when clicking "Run examples" in a help page whose examples launch a blocking application such as a Shiny app. Such examples now run in the console (like `example()`) instead of being rendered inline by the help server.
 
 ### Dependencies
 - Ace 1.43.5

--- a/e2e/rstudio/tests/panes/help/run_examples_blocking.test.ts
+++ b/e2e/rstudio/tests/panes/help/run_examples_blocking.test.ts
@@ -1,0 +1,133 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { useSuiteSandbox } from '@utils/sandbox';
+
+// Regression test for issue #17178: clicking "Run examples" on a help page
+// whose examples launch a blocking application (e.g. a Shiny app) used to lock
+// up the session, because R's enhanced HTML help rendered the example inline on
+// the R event loop and a blocking runApp() never returned. We now detect such
+// examples and run them in the console (like example()) instead.
+//
+// To keep the test deterministic and self-contained we install a throwaway
+// package whose example *statically* looks like it launches a Shiny app -- so
+// our detection fires -- but guards the launcher with `if (FALSE)` and prints a
+// marker. That way the example our fix dispatches to the console completes
+// instantly without launching anything (and without needing shiny installed).
+
+const sandbox = useSuiteSandbox();
+
+const PKG = 'lockuptest';
+const MARKER = 'LOCKUP-EXAMPLE-RAN';
+
+let consoleActions: ConsolePaneActions;
+
+function rPath(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
+// Build a `writeLines(c(...), path)` command. Splitting on newlines and
+// JSON.stringify-ing each line yields valid R string literals: JSON's escape
+// rules for \\, \", and \n match R's, so backslash-heavy Rd content survives.
+function writeFileCmd(path: string, content: string): string {
+  const lines = content.split('\n').map((l) => JSON.stringify(l)).join(', ');
+  return `writeLines(c(${lines}), ${JSON.stringify(path)})`;
+}
+
+test.describe('Help "Run examples" for blocking examples', () => {
+  let installed = false;
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+
+    const pkgDir = `${rPath(sandbox.dir)}/${PKG}`;
+
+    const description = [
+      `Package: ${PKG}`,
+      'Type: Package',
+      'Title: Lockup Test',
+      'Version: 0.1.0',
+      'Description: Fixture package for issue 17178.',
+      'License: GPL-3',
+      'Encoding: UTF-8',
+    ].join('\n');
+
+    // String.raw keeps the Rd backslashes literal. The example statically
+    // mentions shiny::runApp/shinyApp (so detection fires) but never runs them.
+    const testfnRd = String.raw`\name{testfn}
+\alias{testfn}
+\title{Test help example}
+\usage{testfn(x)}
+\arguments{\item{x}{An argument.}}
+\description{A test function.}
+\examples{
+if (FALSE) {
+  shiny::runApp(shiny::shinyApp(ui, server))
+}
+cat("${MARKER}\n")
+}`;
+
+    // Build a minimal source package directly from the session so it lands in
+    // the session's library and its help is served by the dynamic help server.
+    await consoleActions.executeInConsole(
+      `unlink(${JSON.stringify(pkgDir)}, recursive = TRUE); ` +
+        `dir.create(${JSON.stringify(`${pkgDir}/R`)}, recursive = TRUE, showWarnings = FALSE); ` +
+        `dir.create(${JSON.stringify(`${pkgDir}/man`)}, recursive = TRUE, showWarnings = FALSE)`,
+      { wait: true },
+    );
+    await consoleActions.executeInConsole(writeFileCmd(`${pkgDir}/DESCRIPTION`, description), {
+      wait: true,
+    });
+    await consoleActions.executeInConsole(writeFileCmd(`${pkgDir}/NAMESPACE`, 'export(testfn)'), {
+      wait: true,
+    });
+    await consoleActions.executeInConsole(
+      writeFileCmd(`${pkgDir}/R/testfn.R`, 'testfn <- function(x) "this is a test"'),
+      { wait: true },
+    );
+    await consoleActions.executeInConsole(writeFileCmd(`${pkgDir}/man/testfn.Rd`, testfnRd), {
+      wait: true,
+    });
+    await consoleActions.executeInConsole(
+      `install.packages(${JSON.stringify(pkgDir)}, repos = NULL, type = "source")`,
+      { wait: true, timeout: 60000 },
+    );
+
+    installed =
+      (await consoleActions.evalRLogical(
+        `"${PKG}" %in% rownames(installed.packages())`,
+      )) === true;
+  });
+
+  test.afterAll(async () => {
+    if (installed)
+      await consoleActions.uninstallPackage(PKG).catch(() => undefined);
+  });
+
+  test('routes a Shiny-launching example to the console instead of locking up', async ({
+    rstudioPage: page,
+  }) => {
+    test.skip(!installed, `Could not install fixture package ${PKG}`);
+
+    await consoleActions.clearConsole();
+    await consoleActions.executeInConsole(`help("testfn", package = "${PKG}")`);
+
+    const helpFrame = page.frameLocator('#rstudio_help_frame');
+    const runExamples = helpFrame.getByRole('link', { name: 'Run examples' });
+    await expect(runExamples).toBeVisible({ timeout: 15000 });
+
+    await runExamples.click();
+
+    // The help server returns our lightweight "running in the console" page
+    // immediately, rather than blocking while it renders the example inline.
+    await expect(helpFrame.locator('body')).toContainText(
+      'Running example testfn in the R console',
+      { timeout: 15000 },
+    );
+
+    // And the example actually ran in the console (the safe path), which we
+    // can see from its marker output.
+    await expect(consoleActions.consolePane.consoleOutput).toContainText(MARKER, {
+      timeout: 15000,
+    });
+  });
+});

--- a/e2e/rstudio/tests/panes/help/run_examples_blocking.test.ts
+++ b/e2e/rstudio/tests/panes/help/run_examples_blocking.test.ts
@@ -17,7 +17,13 @@ import { useSuiteSandbox } from '@utils/sandbox';
 const sandbox = useSuiteSandbox();
 
 const PKG = 'lockuptest';
+
+// The marker the example emits when it actually runs. example() echoes the
+// example *source* into the console before executing it, so the Rd builds the
+// marker from two halves via cat(..., sep = "") -- the joined string below can
+// only ever appear as executed output, never in the echoed source.
 const MARKER = 'LOCKUP-EXAMPLE-RAN';
+const MARKER_CALL = 'cat("LOCKUP-", "EXAMPLE-RAN\\n", sep = "")';
 
 let consoleActions: ConsolePaneActions;
 
@@ -63,7 +69,7 @@ test.describe('Help "Run examples" for blocking examples', () => {
 if (FALSE) {
   shiny::runApp(shiny::shinyApp(ui, server))
 }
-cat("${MARKER}\n")
+${MARKER_CALL}
 }`;
 
     // Build a minimal source package directly from the session so it lands in

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -1105,7 +1105,12 @@ options(help_type = "html")
 
 .rs.addFunction("helpExampleDivertCommand", function(type, package, topic)
 {
-   # Fetch the example (or demo) source without running it.
+   # Fetch the example (or demo) source without running it. Note that
+   # 'give.lines = TRUE' applies the same \dontrun{} / \donttest{} commenting
+   # as a real example() call, so a launcher living only inside \dontrun{}
+   # arrives commented out, doesn't trip detection, and isn't diverted --
+   # consistent with the diverted example() call below, which wouldn't have
+   # run it either.
    code <- tryCatch(
       suppressWarnings(
          if (identical(type, "Demo"))
@@ -1118,7 +1123,15 @@ options(help_type = "html")
                give.lines = TRUE
             )
       ),
-      error = function(e) NULL
+      error = function(e) {
+         # Log before swallowing so a residual lockup stays debuggable.
+         msg <- sprintf(
+            "Error retrieving %s source for %s::%s: %s",
+            tolower(type), package, topic, conditionMessage(e)
+         )
+         .rs.logWarningMessage(msg)
+         NULL
+      }
    )
 
    # If we couldn't read the source, or it doesn't look like it launches a

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -1103,33 +1103,42 @@ options(help_type = "html")
    any(calls %in% launchers)
 })
 
-.rs.addFunction("runExampleInConsoleIfBlocking", function(type, package, topic)
+.rs.addFunction("helpExampleDivertCommand", function(type, package, topic)
 {
    # Fetch the example (or demo) source without running it.
    code <- tryCatch(
-      if (identical(type, "Demo"))
-         readLines(system.file("demo", paste0(topic, ".R"), package = package))
-      else
-         utils::example(
-            topic,
-            package = package,
-            character.only = TRUE,
-            give.lines = TRUE
-         ),
+      suppressWarnings(
+         if (identical(type, "Demo"))
+            readLines(system.file("demo", paste0(topic, ".R"), package = package, mustWork = TRUE))
+         else
+            utils::example(
+               topic,
+               package = package,
+               character.only = TRUE,
+               give.lines = TRUE
+            )
+      ),
       error = function(e) NULL
    )
 
    # If we couldn't read the source, or it doesn't look like it launches a
    # blocking application, let the normal (inline) help server path handle it.
    if (is.null(code) || !.rs.exampleCodeLaunchesApp(code))
-      return(FALSE)
+      return(NULL)
 
-   command <- sprintf(
+   sprintf(
       "%s(%s, package = %s)",
       if (identical(type, "Demo")) "demo" else "example",
       deparse(topic),
       deparse(package)
    )
+})
+
+.rs.addFunction("runExampleInConsoleIfBlocking", function(type, package, topic)
+{
+   command <- .rs.helpExampleDivertCommand(type, package, topic)
+   if (is.null(command))
+      return(FALSE)
 
    .rs.api.sendToConsole(command, echo = TRUE, execute = TRUE, focus = TRUE)
    TRUE

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -1071,3 +1071,66 @@ options(help_type = "html")
    
    paste(lines, collapse = "\n")
 })
+
+.rs.addFunction("exampleCodeLaunchesApp", function(code)
+{
+   # Returns TRUE if the supplied example/demo code appears to launch a blocking
+   # application (e.g. a Shiny app). Such code, when run inline by R's enhanced
+   # HTML help, locks up the session (issue #17178), so we run it in the console
+   # instead. We parse the code and inspect the function calls it makes, so that
+   # comments and strings mentioning these names don't trigger a false positive.
+   exprs <- tryCatch(
+      parse(text = code, keep.source = TRUE),
+      error = function(e) NULL
+   )
+
+   if (is.null(exprs))
+      return(FALSE)
+
+   parseData <- utils::getParseData(exprs)
+   if (is.null(parseData))
+      return(FALSE)
+
+   calls <- parseData$text[parseData$token == "SYMBOL_FUNCTION_CALL"]
+
+   launchers <- c(
+      "runApp", "runExample", "runGadget",
+      "runUrl", "runGist", "runGitHub",
+      "shinyApp", "shinyAppDir", "shinyAppFile",
+      "run_tutorial"
+   )
+
+   any(calls %in% launchers)
+})
+
+.rs.addFunction("runExampleInConsoleIfBlocking", function(type, package, topic)
+{
+   # Fetch the example (or demo) source without running it.
+   code <- tryCatch(
+      if (identical(type, "Demo"))
+         readLines(system.file("demo", paste0(topic, ".R"), package = package))
+      else
+         utils::example(
+            topic,
+            package = package,
+            character.only = TRUE,
+            give.lines = TRUE
+         ),
+      error = function(e) NULL
+   )
+
+   # If we couldn't read the source, or it doesn't look like it launches a
+   # blocking application, let the normal (inline) help server path handle it.
+   if (is.null(code) || !.rs.exampleCodeLaunchesApp(code))
+      return(FALSE)
+
+   command <- sprintf(
+      "%s(%s, package = %s)",
+      if (identical(type, "Demo")) "demo" else "example",
+      deparse(topic),
+      deparse(package)
+   )
+
+   .rs.api.sendToConsole(command, echo = TRUE, execute = TRUE, focus = TRUE)
+   TRUE
+})

--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -998,13 +998,20 @@ void handleHttpdRequest(const std::string& location,
                .addParam(topic)
                .call(&diverted);
          if (error)
+         {
+            error.addProperty("type", type);
+            error.addProperty("package", package);
+            error.addProperty("topic", topic);
             LOG_ERROR(error);
+         }
 
          if (diverted)
          {
-            // for an example, the topic in the URL is the Rd base name, so the
-            // help page we came from is ../html/<topic>.html; for a demo, fall
-            // back to the package index
+            // for an example, the topic in the URL is the Rd file's first
+            // \alias, which usually -- but not always -- matches the Rd base
+            // name used in help page URLs (../html/<topic>.html), so this
+            // back-link is best-effort; for a demo, fall back to the package
+            // index
             std::string label = isExample ? "example" : "demo";
             std::string backUrl = isExample
                   ? "../html/" + http::util::urlEncode(topic) + ".html"

--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -972,6 +972,48 @@ void handleHttpdRequest(const std::string& location,
       return;
    }
 
+   // intercept "Run examples" (and "Run demo") links for examples that launch a
+   // blocking application such as a Shiny app. R's enhanced HTML help renders
+   // these inline by running the example on the R event loop while serving this
+   // request; a blocking runApp() there never returns, locking up the whole
+   // session (see issue #17178). When we detect such an example, run it in the
+   // console instead -- matching the behavior of example()/demo() at the prompt.
+   {
+      static const boost::regex reRunnable("^/library/([^/]+)/(Example|Demo)/(.+)$");
+      boost::smatch match;
+      if (boost::regex_search(path, match, reRunnable))
+      {
+         std::string package = match[1];
+         std::string type = match[2];
+         std::string topic = match[3];
+
+         bool diverted = false;
+         Error error = r::exec::RFunction(".rs.runExampleInConsoleIfBlocking")
+               .addParam(type)
+               .addParam(package)
+               .addParam(topic)
+               .call(&diverted);
+         if (error)
+            LOG_ERROR(error);
+
+         if (diverted)
+         {
+            std::string label = (type == "Demo") ? "demo" : "example";
+            std::string html =
+                  "<!DOCTYPE html>\n"
+                  "<html>\n<head><meta charset=\"utf-8\"></head>\n<body>\n"
+                  "<p>Running " + label + " <code>" +
+                  string_utils::htmlEscape(topic) + "</code> in the R console.</p>\n"
+                  "</body>\n</html>\n";
+
+            pResponse->setContentType("text/html");
+            pResponse->setNoCacheHeaders();
+            pResponse->setBody(html, filter);
+            return;
+         }
+      }
+   }
+
    // evaluate the handler
    r::sexp::Protect rp;
    SEXP httpdSEXP;

--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -979,13 +979,17 @@ void handleHttpdRequest(const std::string& location,
    // session (see issue #17178). When we detect such an example, run it in the
    // console instead -- matching the behavior of example()/demo() at the prompt.
    {
-      static const boost::regex reRunnable("^/library/([^/]+)/(Example|Demo)/(.+)$");
+      // these mirror the URL patterns recognized by tools:::httpd()
+      static const boost::regex reExample("^/library/([^/]+)/Example/(.+)$");
+      static const boost::regex reDemo("^/library/([^/]+)/Demo/([^/]+)$");
+
       boost::smatch match;
-      if (boost::regex_search(path, match, reRunnable))
+      bool isExample = boost::regex_match(path, match, reExample);
+      if (isExample || boost::regex_match(path, match, reDemo))
       {
          std::string package = match[1];
-         std::string type = match[2];
-         std::string topic = match[3];
+         std::string topic = match[2];
+         std::string type = isExample ? "Example" : "Demo";
 
          bool diverted = false;
          Error error = r::exec::RFunction(".rs.runExampleInConsoleIfBlocking")
@@ -998,12 +1002,21 @@ void handleHttpdRequest(const std::string& location,
 
          if (diverted)
          {
-            std::string label = (type == "Demo") ? "demo" : "example";
+            // for an example, the topic in the URL is the Rd base name, so the
+            // help page we came from is ../html/<topic>.html; for a demo, fall
+            // back to the package index
+            std::string label = isExample ? "example" : "demo";
+            std::string backUrl = isExample
+                  ? "../html/" + http::util::urlEncode(topic) + ".html"
+                  : "../html/00Index.html";
+            std::string backLabel = isExample ? "Back to help topic" : "Back to package index";
+
             std::string html =
                   "<!DOCTYPE html>\n"
                   "<html>\n<head><meta charset=\"utf-8\"></head>\n<body>\n"
                   "<p>Running " + label + " <code>" +
                   string_utils::htmlEscape(topic) + "</code> in the R console.</p>\n"
+                  "<p><a href=\"" + backUrl + "\">" + backLabel + "</a></p>\n"
                   "</body>\n</html>\n";
 
             pResponse->setContentType("text/html");

--- a/src/cpp/tests/testthat/test-help.R
+++ b/src/cpp/tests/testthat/test-help.R
@@ -44,8 +44,20 @@ test_that(".rs.exampleCodeLaunchesApp() detects blocking application launchers",
 
     expect_true(.rs.exampleCodeLaunchesApp(shiny_code))
     expect_true(.rs.exampleCodeLaunchesApp("shiny::runApp(app)"))
-    expect_true(.rs.exampleCodeLaunchesApp("runGadget(myGadget())"))
     expect_true(.rs.exampleCodeLaunchesApp("learnr::run_tutorial(\"hello\")"))
+
+    # every launcher in the detection list, bare and namespace-qualified
+    launchers <- c(
+        "runApp", "runExample", "runGadget",
+        "runUrl", "runGist", "runGitHub",
+        "shinyApp", "shinyAppDir", "shinyAppFile",
+        "run_tutorial"
+    )
+
+    for (launcher in launchers) {
+        expect_true(.rs.exampleCodeLaunchesApp(sprintf("%s(x)", launcher)), info = launcher)
+        expect_true(.rs.exampleCodeLaunchesApp(sprintf("pkg::%s(x)", launcher)), info = launcher)
+    }
 })
 
 test_that(".rs.exampleCodeLaunchesApp() ignores launcher names in comments and strings", {
@@ -100,4 +112,124 @@ test_that(".rs.helpExampleDivertCommand() handles demos", {
     # a benign demo, and a missing one, are not diverted
     expect_null(.rs.helpExampleDivertCommand("Demo", "fakepkg", "benign"))
     expect_null(.rs.helpExampleDivertCommand("Demo", "fakepkg", "nosuchdemo"))
+})
+
+test_that(".rs.helpExampleDivertCommand() handles examples", {
+    # build a fake installed package with a help database, in a temporary
+    # library; this mirrors what R CMD INSTALL produces (an Rd lazy-load db
+    # plus an aliases index), which is what example(give.lines = TRUE) reads
+    lib <- tempfile("rstudio-test-lib-")
+    pkg <- file.path(lib, "fakehelppkg")
+    dir.create(file.path(pkg, "help"), recursive = TRUE)
+    on.exit(unlink(lib, recursive = TRUE), add = TRUE)
+
+    writeLines(
+        c("Package: fakehelppkg", "Version: 0.1.0"),
+        file.path(pkg, "DESCRIPTION")
+    )
+
+    blockingRd <- tempfile("blocking-", fileext = ".Rd")
+    writeLines(
+        c(
+            "\\name{blocking}",
+            "\\alias{blocking}",
+            "\\alias{it's \"blocking\"}",
+            "\\title{Blocking}",
+            "\\description{Launches a Shiny app.}",
+            "\\examples{",
+            "ui <- shiny::fluidPage()",
+            "server <- function(input, output, session) {}",
+            "shiny::runApp(shiny::shinyApp(ui, server))",
+            "}"
+        ),
+        blockingRd
+    )
+
+    benignRd <- tempfile("benign-", fileext = ".Rd")
+    writeLines(
+        c(
+            "\\name{benign}",
+            "\\alias{benign}",
+            "\\title{Benign}",
+            "\\description{Just plots.}",
+            "\\examples{",
+            "plot(1:10)",
+            "}"
+        ),
+        benignRd
+    )
+
+    db <- list(
+        blocking = tools::parse_Rd(blockingRd),
+        benign = tools::parse_Rd(benignRd)
+    )
+    tools:::makeLazyLoadDB(db, file.path(pkg, "help", "fakehelppkg"))
+
+    aliases <- c(
+        "blocking" = "blocking",
+        "it's \"blocking\"" = "blocking",
+        "benign" = "benign"
+    )
+    saveRDS(aliases, file.path(pkg, "help", "aliases.rds"))
+
+    libPaths <- .libPaths()
+    .libPaths(c(lib, libPaths))
+    on.exit(.libPaths(libPaths), add = TRUE)
+
+    # an example that launches an app is diverted to the console
+    expect_identical(
+        .rs.helpExampleDivertCommand("Example", "fakehelppkg", "blocking"),
+        "example(\"blocking\", package = \"fakehelppkg\")"
+    )
+
+    # topics needing escaping survive the round-trip through deparse()
+    expect_identical(
+        .rs.helpExampleDivertCommand("Example", "fakehelppkg", "it's \"blocking\""),
+        "example(\"it's \\\"blocking\\\"\", package = \"fakehelppkg\")"
+    )
+
+    # a benign example, and a missing one, are not diverted
+    expect_null(.rs.helpExampleDivertCommand("Example", "fakehelppkg", "benign"))
+    expect_null(.rs.helpExampleDivertCommand("Example", "fakehelppkg", "nosuchtopic"))
+})
+
+test_that(".rs.helpExampleDivertCommand() ignores launchers inside dontrun blocks", {
+    # \dontrun{} code is commented out by example(give.lines = TRUE), exactly
+    # as it would be in the diverted example() call, so it must not divert
+    lib <- tempfile("rstudio-test-lib-")
+    pkg <- file.path(lib, "fakedontrunpkg")
+    dir.create(file.path(pkg, "help"), recursive = TRUE)
+    on.exit(unlink(lib, recursive = TRUE), add = TRUE)
+
+    writeLines(
+        c("Package: fakedontrunpkg", "Version: 0.1.0"),
+        file.path(pkg, "DESCRIPTION")
+    )
+
+    dontrunRd <- tempfile("dontrun-", fileext = ".Rd")
+    writeLines(
+        c(
+            "\\name{dontrun}",
+            "\\alias{dontrun}",
+            "\\title{Dontrun}",
+            "\\description{Launches an app, but only via dontrun.}",
+            "\\examples{",
+            "x <- 1:10",
+            "\\dontrun{",
+            "shiny::runApp(app)",
+            "}",
+            "}"
+        ),
+        dontrunRd
+    )
+
+    db <- list(dontrun = tools::parse_Rd(dontrunRd))
+    tools:::makeLazyLoadDB(db, file.path(pkg, "help", "fakedontrunpkg"))
+    saveRDS(c("dontrun" = "dontrun"), file.path(pkg, "help", "aliases.rds"))
+
+    libPaths <- .libPaths()
+    .libPaths(c(lib, libPaths))
+    on.exit(.libPaths(libPaths), add = TRUE)
+
+    expect_null(.rs.helpExampleDivertCommand("Example", "fakedontrunpkg", "dontrun"))
 })

--- a/src/cpp/tests/testthat/test-help.R
+++ b/src/cpp/tests/testthat/test-help.R
@@ -31,3 +31,35 @@ test_that(".rs.getHelp() handles empty and NULL package", {
     expect_identical(help_rnorm1, help_rnorm5)
     expect_identical(help_rnorm1, help_rnorm6)
 })
+
+test_that(".rs.exampleCodeLaunchesApp() detects blocking application launchers", {
+    shiny_code <- c(
+        "captureVals <- function() {",
+        "  ui <- shiny::fluidPage(shiny::textInput(\"the_text\", \"Enter text\"))",
+        "  server <- function(input, output, session) {}",
+        "  shiny::runApp(shiny::shinyApp(ui, server))",
+        "}",
+        "captureVals()"
+    )
+
+    expect_true(.rs.exampleCodeLaunchesApp(shiny_code))
+    expect_true(.rs.exampleCodeLaunchesApp("shiny::runApp(app)"))
+    expect_true(.rs.exampleCodeLaunchesApp("runGadget(myGadget())"))
+    expect_true(.rs.exampleCodeLaunchesApp("learnr::run_tutorial(\"hello\")"))
+})
+
+test_that(".rs.exampleCodeLaunchesApp() ignores launcher names in comments and strings", {
+    # mentions runApp, but never actually calls it
+    benign_code <- c(
+        "# call shiny::runApp() to launch the app yourself",
+        "x <- 1:10",
+        "msg <- \"use runApp() to start\"",
+        "mean(x)"
+    )
+
+    expect_false(.rs.exampleCodeLaunchesApp(benign_code))
+    expect_false(.rs.exampleCodeLaunchesApp("plot(1:10)"))
+
+    # unparseable input should never error -- it just isn't diverted
+    expect_false(.rs.exampleCodeLaunchesApp("this is not valid R code ("))
+})

--- a/src/cpp/tests/testthat/test-help.R
+++ b/src/cpp/tests/testthat/test-help.R
@@ -63,3 +63,41 @@ test_that(".rs.exampleCodeLaunchesApp() ignores launcher names in comments and s
     # unparseable input should never error -- it just isn't diverted
     expect_false(.rs.exampleCodeLaunchesApp("this is not valid R code ("))
 })
+
+test_that(".rs.helpExampleDivertCommand() handles demos", {
+    # build a fake installed package with demos, in a temporary library
+    lib <- tempfile("rstudio-test-lib-")
+    pkg <- file.path(lib, "fakepkg")
+    dir.create(file.path(pkg, "demo"), recursive = TRUE)
+    on.exit(unlink(lib, recursive = TRUE), add = TRUE)
+
+    writeLines(
+        c("Package: fakepkg", "Version: 0.1.0"),
+        file.path(pkg, "DESCRIPTION")
+    )
+
+    writeLines(
+        c(
+            "ui <- shiny::fluidPage()",
+            "server <- function(input, output, session) {}",
+            "shiny::runApp(shiny::shinyApp(ui, server))"
+        ),
+        file.path(pkg, "demo", "blocking.R")
+    )
+
+    writeLines("plot(1:10)", file.path(pkg, "demo", "benign.R"))
+
+    libPaths <- .libPaths()
+    .libPaths(c(lib, libPaths))
+    on.exit(.libPaths(libPaths), add = TRUE)
+
+    # a demo that launches an app is diverted to the console
+    expect_identical(
+        .rs.helpExampleDivertCommand("Demo", "fakepkg", "blocking"),
+        "demo(\"blocking\", package = \"fakepkg\")"
+    )
+
+    # a benign demo, and a missing one, are not diverted
+    expect_null(.rs.helpExampleDivertCommand("Demo", "fakepkg", "benign"))
+    expect_null(.rs.helpExampleDivertCommand("Demo", "fakepkg", "nosuchdemo"))
+})


### PR DESCRIPTION
### Problem

Clicking "Run examples" on a help page whose examples launch a blocking
application (for example a Shiny app via `shiny::runApp()`) locks up RStudio,
recoverable only by Force Quit (#17178).

R's enhanced HTML help renders "Run examples" inline by knitting the example
code *on the R event loop while serving the help HTTP request*. A blocking
`runApp()` there never returns, so the help response never arrives (blank
window) and the R REPL stays parked (unresponsive console). Running
`example("testfn")` at the prompt works fine because it executes at the REPL
top level, where a blocking app is interruptible and expected.

### Fix

Intercept the `/library/<pkg>/Example/<topic>` (and `Demo`) request in the help
server. If the example's source statically looks like it launches a blocking
application, run it in the console via `example()` / `demo()` -- matching the
behavior users get at the prompt -- and return a lightweight page instead of
blocking the help server. Normal examples are untouched and still render
inline.

Detection parses the example/demo source and matches `SYMBOL_FUNCTION_CALL`
tokens against a conservative launcher list (`runApp`, `runExample`,
`runGadget`, `shinyApp`, `run_tutorial`, ...), so launcher names appearing only
in comments or strings do not trigger a false positive.

### Known limitation

The launcher list is intentionally conservative (Shiny-family plus
`run_tutorial`). Other ways an example can block the help server (`readline()`,
`plumber::pr_run()`, `httpuv::runServer()`, ...) are not detected and would
still wedge the session as before; an undetected case is no worse than current
behavior. The list can grow as such cases are reported.

### Testing

- R unit tests for the detector in `test-help.R` (`--scope r --filter help`).
- A Playwright e2e test that installs a throwaway package whose example
  statically references `shiny::runApp` (guarded by `if (FALSE)` so it does not
  actually launch), clicks the real "Run examples" link, and asserts both the
  console-routing page and that `example()` ran in the console.

Fixes #17178.
