### PR TITLE
report file monitor events in the registered path form on macos

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,7 +41,7 @@
 - ([#17865](https://github.com/rstudio/rstudio/issues/17865)): Fix project paths on a mapped network drive (e.g. `S:`) being resolved to their UNC target (e.g. `\\server\share`) on Windows, which caused functions such as `here::here()` and `getwd()` to report the UNC path instead of the mapped drive.
 - ([#17870](https://github.com/rstudio/rstudio/issues/17870)): Fix an uncaught "Object has been destroyed" error in RStudio Desktop when quitting with a plot zoom (or other child) window still open.
 - ([#17830](https://github.com/rstudio/rstudio/issues/17830)): Fix the data viewer not clearing a data set's saved sorts and filters when its tab is explicitly closed, so reopening the data set no longer restores stale filters; the saved state still persists across a session suspend/restore or a page reload. Restored filters now also reveal the filter row, instead of being applied with no visible filter UI.
-- ([#17909](https://github.com/rstudio/rstudio/issues/17909)): Fix the Files pane on macOS briefly showing and then emptying the contents of a symlinked directory; file change events are now reported against the path the directory was opened as, rather than its resolved target.
+- ([#17909](https://github.com/rstudio/rstudio/issues/17909)): Fix the Files pane on macOS briefly showing and then emptying the contents of a symlinked directory; file change events are now reported against the path the directory was opened as, rather than its resolved target. Opening a project via a symlinked path on macOS also no longer rewrites the project directory (as reported by `getwd()` and `here::here()`) to the symlink's target.
 
 ### Dependencies
 - Ace 1.43.5

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@
 - ([#17865](https://github.com/rstudio/rstudio/issues/17865)): Fix project paths on a mapped network drive (e.g. `S:`) being resolved to their UNC target (e.g. `\\server\share`) on Windows, which caused functions such as `here::here()` and `getwd()` to report the UNC path instead of the mapped drive.
 - ([#17870](https://github.com/rstudio/rstudio/issues/17870)): Fix an uncaught "Object has been destroyed" error in RStudio Desktop when quitting with a plot zoom (or other child) window still open.
 - ([#17830](https://github.com/rstudio/rstudio/issues/17830)): Fix the data viewer not clearing a data set's saved sorts and filters when its tab is explicitly closed, so reopening the data set no longer restores stale filters; the saved state still persists across a session suspend/restore or a page reload. Restored filters now also reveal the filter row, instead of being applied with no visible filter UI.
+- ([#17909](https://github.com/rstudio/rstudio/issues/17909)): Fix the Files pane on macOS briefly showing and then emptying the contents of a symlinked directory; file change events are now reported against the path the directory was opened as, rather than its resolved target.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/cpp/core/FileMonitorTests.cpp
+++ b/src/cpp/core/FileMonitorTests.cpp
@@ -527,6 +527,16 @@ TEST_F(FileMonitorTest, SymlinkedRootReportsRegisteredPathFormRecursive)
                          nested.getAbsolutePath());
    }));
 
+   // the recursive branch can also emit events for enclosing directories
+   // (e.g. a FileModified for subdir); every event must be in link form
+   std::string linkPrefix = link.getAbsolutePath();
+   for (const auto& event : state.events)
+   {
+      EXPECT_TRUE(boost::algorithm::starts_with(event.fileInfo().absolutePath(),
+                                                linkPrefix + "/"))
+         << "event path not in link form: " << event.fileInfo().absolutePath();
+   }
+
    stopMonitor(handle, &state);
 }
 

--- a/src/cpp/core/FileMonitorTests.cpp
+++ b/src/cpp/core/FileMonitorTests.cpp
@@ -21,6 +21,7 @@
 // per-platform conditional list.
 #ifdef __APPLE__
 
+#include <algorithm>
 #include <chrono>
 #include <cerrno>
 #include <thread>
@@ -56,14 +57,17 @@ struct CallbackState
    bool monitoringError = false;
    bool unregistered = false;
    system::file_monitor::Handle handle;
+   std::vector<std::string> registeredPaths;
    std::vector<system::FileChangeEvent> events;
 };
 
 void onRegistered(CallbackState* pState,
                   system::file_monitor::Handle handle,
-                  const tree<FileInfo>& /*files*/)
+                  const tree<FileInfo>& files)
 {
    pState->handle = handle;
+   for (auto it = files.begin(); it != files.end(); ++it)
+      pState->registeredPaths.push_back(it->absolutePath());
    pState->registered = true;
 }
 
@@ -154,7 +158,8 @@ system::file_monitor::Handle startMonitor(
       const FilePath& dir,
       CallbackState* pState,
       boost::function<bool(const FileInfo&)> filter =
-         boost::function<bool(const FileInfo&)>())
+         boost::function<bool(const FileInfo&)>(),
+      bool recursive = false)
 {
    using namespace boost::placeholders;
 
@@ -167,7 +172,7 @@ system::file_monitor::Handle startMonitor(
 
    system::file_monitor::registerMonitor(
       dir,
-      /*recursive=*/false,
+      recursive,
       filter,
       cb);
 
@@ -205,9 +210,10 @@ protected:
       Error error = created.ensureDirectory();
       ASSERT_FALSE(error) << error.asString();
 
-      // Use the canonical path; FSEvents reports paths in canonical form
-      // (e.g. /private/tmp/... rather than /tmp/...) and registerMonitor
-      // canonicalizes the rootPath internally before scanning the tree.
+      // Use the canonical path so expected paths in most tests are identical
+      // to what FSEvents reports (e.g. /private/tmp/... rather than
+      // /tmp/...). registerMonitor itself preserves whatever path form the
+      // caller passes; the Symlinked* tests below cover that mapping.
       std::string canonical = created.getCanonicalPath();
       ASSERT_FALSE(canonical.empty());
       tempDir_ = FilePath(canonical);
@@ -428,6 +434,98 @@ TEST_F(FileMonitorTest, NonRecursiveDetectsSubdirectoryCreatedAfterStart)
       EXPECT_NE(event.fileInfo().absolutePath(), nested.getAbsolutePath())
          << "Unexpected event for nested file under late-created subdir";
    }
+
+   stopMonitor(handle, &state);
+}
+
+// Repro for #17909: watch a directory through a symlink. The registration
+// snapshot and all change events must come back in the link's path form --
+// the Files pane diffs the snapshot against a listing taken via the link
+// path, and the GWT client drops events whose parent doesn't match the
+// displayed directory. Canonical (target) path forms leaking out of the
+// monitor empty the pane.
+TEST_F(FileMonitorTest, SymlinkedRootReportsRegisteredPathForm)
+{
+   FilePath target = tempDir_.completeChildPath("real_dir");
+   ASSERT_FALSE(target.ensureDirectory());
+   ASSERT_TRUE(writeFile(target.completeChildPath("existing.txt"), "pre-existing"));
+
+   FilePath link = tempDir_.completeChildPath("link_dir");
+   ASSERT_EQ(0, ::symlink(target.getAbsolutePath().c_str(),
+                          link.getAbsolutePath().c_str()))
+      << "symlink() failed: errno=" << errno;
+
+   CallbackState state;
+   auto handle = startMonitor(link, &state);
+
+   // every path in the registration snapshot uses the link form
+   std::string linkPrefix = link.getAbsolutePath();
+   ASSERT_FALSE(state.registeredPaths.empty());
+   for (const auto& path : state.registeredPaths)
+   {
+      EXPECT_TRUE(path == linkPrefix ||
+                  boost::algorithm::starts_with(path, linkPrefix + "/"))
+         << "snapshot path not in link form: " << path;
+   }
+   EXPECT_TRUE(std::count(state.registeredPaths.begin(),
+                          state.registeredPaths.end(),
+                          link.completeChildPath("existing.txt").getAbsolutePath()) == 1);
+
+   // change events arrive in link form too, even though FSEvents reports
+   // them against the canonical target path
+   state.events.clear();
+   FilePath added = link.completeChildPath("added.txt");
+   ASSERT_TRUE(writeFile(added, "hello"));
+
+   ASSERT_TRUE(waitFor([&] {
+      return hasEventFor(state, system::FileChangeEvent::FileAdded,
+                         added.getAbsolutePath());
+   }));
+
+   ASSERT_FALSE(added.remove());
+
+   ASSERT_TRUE(waitFor([&] {
+      return hasEventFor(state, system::FileChangeEvent::FileRemoved,
+                         added.getAbsolutePath());
+   }));
+
+   for (const auto& event : state.events)
+   {
+      EXPECT_TRUE(boost::algorithm::starts_with(event.fileInfo().absolutePath(),
+                                                linkPrefix + "/"))
+         << "event path not in link form: " << event.fileInfo().absolutePath();
+   }
+
+   stopMonitor(handle, &state);
+}
+
+// The recursive branch goes through directory-granularity events and
+// discoverAndProcessFileChanges rather than the per-file path, so the
+// canonical-to-registered mapping needs separate coverage there.
+TEST_F(FileMonitorTest, SymlinkedRootReportsRegisteredPathFormRecursive)
+{
+   FilePath target = tempDir_.completeChildPath("real_dir");
+   FilePath subDir = target.completeChildPath("subdir");
+   ASSERT_FALSE(subDir.ensureDirectory());
+
+   FilePath link = tempDir_.completeChildPath("link_dir");
+   ASSERT_EQ(0, ::symlink(target.getAbsolutePath().c_str(),
+                          link.getAbsolutePath().c_str()))
+      << "symlink() failed: errno=" << errno;
+
+   CallbackState state;
+   auto handle = startMonitor(link, &state,
+                              boost::function<bool(const FileInfo&)>(),
+                              /*recursive=*/true);
+   state.events.clear();
+
+   FilePath nested = link.completeChildPath("subdir/nested.txt");
+   ASSERT_TRUE(writeFile(nested, "nested"));
+
+   ASSERT_TRUE(waitFor([&] {
+      return hasEventFor(state, system::FileChangeEvent::FileAdded,
+                         nested.getAbsolutePath());
+   }));
 
    stopMonitor(handle, &state);
 }

--- a/src/cpp/core/system/file_monitor/MacFileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/MacFileMonitor.cpp
@@ -104,6 +104,7 @@ public:
 
    Handle handle;
    FilePath rootPath;
+   std::string canonicalRootPath;
    DirectoryHandle rootHandle;
    FSEventStreamRef streamRef;
    bool recursive;
@@ -111,6 +112,33 @@ public:
    tree<FileInfo> fileTree;
    Callbacks callbacks;
 };
+
+// FSEvents reports event paths in canonical form (e.g. /private/tmp/foo for
+// a watch registered as /tmp/foo, since /tmp is a symlink on macOS). The file
+// tree and the paths we report to clients use the form the watch was
+// registered with, so map the canonical root prefix back to the registered
+// root before any tree lookup or event emission. Without this, clients that
+// compare reported paths against the path they asked us to monitor (like the
+// Files pane) drop every event (#17909).
+std::string mapEventPath(FileEventContext* pContext, const std::string& path)
+{
+   const std::string& canonicalRoot = pContext->canonicalRootPath;
+   const std::string& registeredRoot = pContext->rootPath.getAbsolutePath();
+   if (canonicalRoot == registeredRoot)
+      return path;
+
+   if (path == canonicalRoot)
+      return registeredRoot;
+
+   if (path.length() > canonicalRoot.length() &&
+       path.compare(0, canonicalRoot.length(), canonicalRoot) == 0 &&
+       path[canonicalRoot.length()] == '/')
+   {
+      return registeredRoot + path.substr(canonicalRoot.length());
+   }
+
+   return path;
+}
 
 // Read a FileInfo via lstat, matching what PosixFileScanner produces for the
 // initial tree population. Mirroring that view (in particular: symlinks treated
@@ -175,6 +203,9 @@ void processNonRecursiveFileEvents(FileEventContext* pContext,
 
       std::string path(paths[i]);
       boost::algorithm::trim_right_if(path, boost::algorithm::is_any_of("/"));
+
+      // map the canonical event path back to the registered path form
+      path = mapEventPath(pContext, path);
 
       // Only process events whose direct parent is the watched root. Subtree
       // events still wake us up, but they cost just this comparison.
@@ -315,6 +346,9 @@ void fileEventCallback(ConstFSEventStreamRef streamRef,
       std::string path(paths[i]);
       boost::algorithm::trim_right_if(path, boost::algorithm::is_any_of("/"));
 
+      // map the canonical event path back to the registered path form
+      path = mapEventPath(pContext, path);
+
       // get FileInfo for this directory
       FileInfo fileInfo(path, true);
 
@@ -386,23 +420,24 @@ Handle registerMonitor(const FilePath& filePath,
 {
    // FSEvents reports event paths in canonical form (e.g. /private/tmp/foo
    // even when we registered /tmp/foo, because /tmp is a symlink on macOS).
-   // Canonicalize up front so the rootPath, the file tree we build during
-   // the initial scan, and the paths reported in change events all agree.
-   // Without this, the tree lookup in discoverAndProcessFileChanges fails
-   // and no FileChangeEvents are dispatched for projects opened via a
-   // symlinked path.
-   FilePath rootPath = filePath;
+   // Register the stream against the canonical path so that the WatchRoot
+   // machinery agrees with what FSEvents reports, but keep the caller's path
+   // form for the rootPath, the file tree built during the initial scan, and
+   // the paths reported to callbacks -- clients compare reported paths
+   // against the path they asked us to monitor (#17909). Event paths arriving
+   // in canonical form are mapped back via mapEventPath.
+   std::string canonicalRootPath = filePath.getAbsolutePath();
    if (filePath.exists())
    {
       std::string canonical = filePath.getCanonicalPath();
       if (!canonical.empty())
-         rootPath = FilePath(canonical);
+         canonicalRootPath = canonical;
    }
 
    // allocate file path
    CFStringRef filePathRef = ::CFStringCreateWithCString(
                                        kCFAllocatorDefault,
-                                       rootPath.getAbsolutePath().c_str(),
+                                       canonicalRootPath.c_str(),
                                        kCFStringEncodingUTF8);
    if (filePathRef == nullptr)
    {
@@ -429,7 +464,8 @@ Handle registerMonitor(const FilePath& filePath,
 
    // create and allocate FileEventContext (create auto-ptr in case we
    // return early, we'll call release later before returning)
-   FileEventContext* pContext = new FileEventContext(rootPath);
+   FileEventContext* pContext = new FileEventContext(filePath);
+   pContext->canonicalRootPath = canonicalRootPath;
    pContext->recursive = recursive;
    pContext->filter = filter;
    std::unique_ptr<FileEventContext> autoPtrContext(pContext);
@@ -492,7 +528,7 @@ Handle registerMonitor(const FilePath& filePath,
    options.recursive = recursive;
    options.yield = true;
    options.filter = filter;
-   Error error = scanFiles(FileInfo(rootPath), options, &pContext->fileTree);
+   Error error = scanFiles(FileInfo(filePath), options, &pContext->fileTree);
    if (error)
    {
        // stop, invalidate, release

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -380,31 +380,16 @@ Error ProjectContext::startup(const FilePath& projectFile,
    }
 
    // initialize members
+   //
+   // NOTE: the project directory is deliberately not canonicalized here.
+   // Canonicalizing rewrote user-visible paths (getwd(), here::here()) for
+   // projects opened via a symlinked path on macOS, and resolved mapped
+   // network drives to their UNC targets on Windows (#17865). The macOS
+   // file monitor maps FSEvents' canonical event paths back to the
+   // registered path form itself (#17909), so file change events compare
+   // equal to directory() without any canonicalization on our side.
    file_ = projectFile;
    directory_ = file_.getParent();
-
-   // Canonicalize the project directory so it matches what the file
-   // monitor will see (FSEvents on macOS reports canonical paths -- e.g.
-   // /private/tmp/foo rather than /tmp/foo). Without this, paths from
-   // file change events won't compare equal to directory() and any
-   // root-anchored matches downstream silently miss.
-   //
-   // This is gated to macOS on purpose. On Windows, getCanonicalPath()
-   // (boost::filesystem::canonical) resolves a mapped network drive back to
-   // its UNC target (e.g. S:/foo -> //server/share/foo), which then becomes
-   // the working directory and surfaces in user-facing paths such as
-   // here::here(); see https://github.com/rstudio/rstudio/issues/17865. R's
-   // own normalizePath deliberately avoids this by preferring the drive-letter
-   // form. The Win32 (GetLongPathName) and inotify file monitors don't report
-   // canonical paths anyway, so the macOS FSEvents mismatch is unique to macOS.
-#ifdef __APPLE__
-   if (directory_.exists())
-   {
-      std::string canonical = directory_.getCanonicalPath();
-      if (!canonical.empty())
-         directory_ = FilePath(canonical);
-   }
-#endif
    scratchPath_ = scratchPath;
    sharedScratchPath_ = sharedScratchPath;
    config_ = projectConfig;


### PR DESCRIPTION
The canonicalization added in #17667 replaced the macOS file monitor's root path with its canonical form, so the registration snapshot and all change events came back in the symlink target's path form. The Files pane diffs that snapshot against a listing taken via the path it was asked to monitor, producing a remove event for every entry (which the client applies) and an add event in the canonical form (which the client drops, because the parent doesn't match the displayed directory) -- emptying the pane whenever a symlinked directory was opened. Refreshing repeated the cycle, giving the flicker-then-empty behavior in the report.

This keeps the caller's path form as authoritative: the FSEvents stream is registered against the canonical path (FSEvents reports canonical paths, and the WatchRoot machinery needs to agree), but the file tree is built from the registered path, and incoming canonical event paths are mapped back to the registered prefix before tree lookups and event emission, in both the per-file (#17772) and directory-granularity callback branches. This preserves the #17667 fix -- events still match the tree for watches registered via symlinked paths -- while reporting paths in the namespace the caller actually uses.

With the monitor handling the path-form mapping itself, the project directory canonicalization in `ProjectContext::initialize` (added in #17667, gated to macOS in #17881 after it resolved mapped network drives to UNC targets on Windows, #17865) is no longer needed, so it is removed entirely. This also stops projects opened via a symlinked path on macOS from reporting the symlink's target from `getwd()` and `here::here()` -- the same class of problem as the Windows UNC issue.

Includes two new FileMonitorTests cases that register a watch on a symlinked directory (non-recursive and recursive) and assert the registration snapshot and change events come back in the link's path form; both fail against the previous behavior. The `ignorefiles` Playwright test (mid-session `.positai` detection via the project file monitor, the scenario that motivated the #17667 canonicalization) and the `file_monitor` Files pane test both pass against this change.

Fixes #17909.

### QA Notes

From a terminal:

    mkdir real_dir
    touch real_dir/test.txt
    ln -s real_dir link_dir

Then in RStudio on macOS, navigate the Files pane to `link_dir`. Before this change the contents appeared briefly and then the pane emptied; the contents should now persist, and file adds/removes inside the directory should live-update.

Additionally, open a project located behind a symlinked path on macOS and confirm `getwd()` reports the symlinked form, and that mid-session file monitoring (e.g. the Files pane updating, `.positai` ignore-file augmentation) still works.