### PR TITLE
Point chat e2e input selector at TipTap composer (PAI 0.4.6+)

### DIFF
--- a/e2e/rstudio/actions/chat_pane.actions.ts
+++ b/e2e/rstudio/actions/chat_pane.actions.ts
@@ -35,23 +35,23 @@ export class ChatPaneActions {
       await this.chatPane.installBtn.click();
       console.log('Clicked Install button -- waiting for installation...');
       await expect(this.chatPane.chatRoot).toBeVisible({ timeout: 60000 });
-      await expect(this.chatPane.chatTextarea).toBeVisible({ timeout: 30000 });
+      await expect(this.chatPane.chatInput).toBeVisible({ timeout: 30000 });
     } else if (await this.chatPane.updateBtn.isVisible()) {
       await this.chatPane.updateBtn.click();
       console.log('Clicked Update on update prompt -- updating Posit Assistant');
       await expect(this.chatPane.chatRoot).toBeVisible({ timeout: 30000 });
     }
 
-    // The TrustOverlay and the chat textarea both render asynchronously after
+    // The TrustOverlay and the chat input both render asynchronously after
     // the iframe loads; waitForChatReady polls for either path through the
-    // workspace-trust dialog or a clean ready textarea, so callers don't need
-    // to handle it themselves.
+    // workspace-trust dialog or a clean editable composer, so callers don't
+    // need to handle it themselves.
     await this.waitForChatReady();
   }
 
   /**
-   * Wait until the chat pane is actually usable -- i.e., the message textarea
-   * is enabled. Until that point, sending a message is a guaranteed failure
+   * Wait until the chat pane is actually usable -- i.e., the message composer
+   * is editable. Until that point, sending a message is a guaranteed failure
    * even when chatRoot is visible, so this is the only real "ready" signal.
    *
    * Polls (a) clicking through any trust dialog that appears late and (b)
@@ -60,7 +60,7 @@ export class ChatPaneActions {
    * The host's Posit Assistant rotates the refresh token in ~/.positai/store,
    * so seeded copies can be invalidated between globalSetup and test
    * execution; surfacing that as "sign in on the host and re-run" is more
-   * useful than the cryptic "textarea disabled after 15s" downstream timeout
+   * useful than the cryptic "input not editable after 15s" downstream timeout
    * each test would otherwise hit.
    *
    * The TrustOverlay component in databot renders as a role="dialog" with the
@@ -78,8 +78,8 @@ export class ChatPaneActions {
     while (Date.now() < deadline) {
       iter += 1;
 
-      if (await this.chatPane.chatTextarea.isEnabled().catch(() => false)) {
-        if (iter > 1) console.log(`waitForChatReady: textarea enabled after ${iter} iterations`);
+      if (await this.chatPane.isChatInputReady()) {
+        if (iter > 1) console.log(`waitForChatReady: input editable after ${iter} iterations`);
         return;
       }
 
@@ -115,7 +115,7 @@ export class ChatPaneActions {
     }
 
     throw new Error(
-      `waitForChatReady: chat textarea still disabled after ${timeout}ms ` +
+      `waitForChatReady: chat input still not editable after ${timeout}ms ` +
       `(no Sign-In button, no Trust dialog). Chat pane initialization may ` +
       `have stalled.`
     );
@@ -189,9 +189,10 @@ export class ChatPaneActions {
   }
 
   async sendChatMessage(text: string): Promise<void> {
-    await expect(this.chatPane.chatTextarea).toBeVisible({ timeout: 15000 });
-    await expect(this.chatPane.chatTextarea).toBeEnabled({ timeout: 15000 });
-    await this.chatPane.chatTextarea.fill(text);
+    await expect(this.chatPane.chatInput).toBeVisible({ timeout: 15000 });
+    await expect(this.chatPane.chatInput)
+      .toHaveAttribute('contenteditable', 'true', { timeout: 15000 });
+    await this.chatPane.typeMessage(text);
 
     await expect(this.chatPane.sendBtn).toBeVisible({ timeout: 15000 });
     await this.chatPane.sendBtn.click();

--- a/e2e/rstudio/pages/chat_pane.page.ts
+++ b/e2e/rstudio/pages/chat_pane.page.ts
@@ -11,7 +11,7 @@ const CHAT_FRAME_SELECTOR = "iframe[title='Posit Assistant']";
 export class ChatPane extends FramePageObject {
   // Inside the chat iframe
   public chatRoot: Locator;
-  public chatTextarea: Locator;
+  public chatInput: Locator;
   public messageItem: Locator;
   public allowBtn: Locator;
   public allowDropdownTrigger: Locator;
@@ -45,7 +45,10 @@ export class ChatPane extends FramePageObject {
     super(page, CHAT_FRAME_SELECTOR);
 
     this.chatRoot = this.frame.locator('#root');
-    this.chatTextarea = this.frame.locator('textarea');
+    // PAI 0.4.6 (#1495) rebuilt the composer on TipTap/ProseMirror: the chat
+    // input is now a contenteditable <div class="tiptap-input-editor">, not a
+    // <textarea>. editor.setEditable() toggles its contenteditable attribute.
+    this.chatInput = this.frame.locator('.tiptap-input-editor');
     this.messageItem = this.frame.locator('[data-message-id]');
     this.allowBtn = this.frame.locator("button:has-text('Allow')");
     this.allowDropdownTrigger = this.frame.locator('button.rounded-l-none:has(svg.lucide-chevron-down)');
@@ -89,6 +92,29 @@ export class ChatPane extends FramePageObject {
 
   async isAllowDropdownVisible(): Promise<boolean> {
     return await this.allowDropdownTrigger.isVisible().catch(() => false);
+  }
+
+  /**
+   * The chat composer is ready when it's visible and editable. TipTap reflects
+   * its editable state via the contenteditable attribute (toggled by
+   * editor.setEditable), so we check that rather than isEnabled() -- a
+   * contenteditable <div> is not a form control and always reports "enabled".
+   */
+  async isChatInputReady(): Promise<boolean> {
+    if (!(await this.chatInput.isVisible().catch(() => false))) {
+      return false;
+    }
+    return (await this.chatInput.getAttribute('contenteditable').catch(() => null)) === 'true';
+  }
+
+  /**
+   * Type into the chat composer. Playwright's fill() is unreliable on a
+   * ProseMirror contenteditable (it bypasses the editor's input handling), so
+   * focus the editor and dispatch real key events instead.
+   */
+  async typeMessage(text: string): Promise<void> {
+    await this.chatInput.click();
+    await this.chatInput.pressSequentially(text);
   }
 
   /**

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/deprecate-pai-blocking.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/deprecate-pai-blocking.test.ts
@@ -76,7 +76,7 @@ test.describe.serial('Deprecate old Posit AI builds -- #17145', { tag: ['@ai', '
     // Let Posit Assistant load normally first
     await chatActions.openChatPane();
     await chatActions.dismissSetupPrompts();
-    await expect(chatPane.chatTextarea).toBeVisible({ timeout: 60000 });
+    await expect(chatPane.chatInput).toBeVisible({ timeout: 60000 });
     await consoleActions.clearConsole();
   });
 

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/readline-notification.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/readline-notification.test.ts
@@ -49,7 +49,7 @@ test.describe.serial('Readline Notification in Chat Pane', { tag: ['@ai', '@seri
 
     // --- Step 5: Type a message in chat and press Enter -- nothing should happen ---
     const messageCountBefore = await chatPane.getMessageCount();
-    await chatPane.chatTextarea.fill('This should not go through');
+    await chatPane.typeMessage('This should not go through');
     await chatPane.sendBtn.click({ timeout: 2000 }).catch(() => {
       // Send button may be disabled or unresponsive -- that's expected
     });

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/uninstall-posit-ai.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/uninstall-posit-ai.test.ts
@@ -130,7 +130,7 @@ base.describe.serial('Uninstall Posit Assistant - #17322', { tag: ['@ai', '@seri
     await chatActions.dismissSetupPrompts();
 
     await expect(chatActions.chatPane.chatRoot).toBeVisible({ timeout: 30000 });
-    await expect(chatActions.chatPane.chatTextarea).toBeVisible({ timeout: 15000 });
+    await expect(chatActions.chatPane.chatInput).toBeVisible({ timeout: 15000 });
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Posit Assistant 0.4.6 (assistant PR #1495, "TipTap input rebuild") rebuilt the chat composer on TipTap/ProseMirror, replacing the `<textarea>` with a `contenteditable` `<div class="tiptap-input-editor">`. The Playwright page object located the composer with `frame.locator('textarea')`, so against PAI 0.4.6+ (e.g. the pre-release 0.4.8 served by the test manifest) `waitForChatReady` never detected readiness, timed out at 30s, and the fallback sign-in check reported a misleading "Posit Assistant requires sign-in despite seeded credentials" error. The backend had authenticated normally (the seeded credentials were valid; `positai.log` showed a successful model fetch).

## Changes

- `pages/chat_pane.page.ts`: rename `chatTextarea` -> `chatInput`, locate `.tiptap-input-editor`. Add `isChatInputReady()` (visible and `contenteditable="true"`, since a `<div>` is not a form control and always reports enabled) and `typeMessage()` (`click()` + `pressSequentially()`, since `fill()` bypasses ProseMirror's input handling).
- `actions/chat_pane.actions.ts`: readiness check uses `isChatInputReady()` instead of `isEnabled()`; `sendChatMessage` asserts `contenteditable="true"` and types via `typeMessage()`. Updated stale comments and timeout messages.
- Update the three specs that referenced the locator directly: `deprecate-pai-blocking`, `readline-notification`, `uninstall-posit-ai`.

## Verification

- `npm run typecheck` (in `e2e/rstudio`) passes.
- The `@ai` chat suite passed against the pre-release (0.4.8) test manifest:
  `PW_RSTUDIO_PREFS_OVERRIDE=.prefs.local.json npm run test:desktop -- tests/panes/posit-assistant-chat/chat-guardrails.test.ts`