### PR TITLE
avoid silently accepting code suggestions off-screen

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 - ([#14965](https://github.com/rstudio/rstudio/issues/14965)): The Insert Pipe Operator command (Ctrl+Shift+M / Cmd+Shift+M) now inserts the native R pipe operator `|>` by default; the magrittr pipe `%>%` can be restored via the "Use R's native pipe operator, |>" preference.
 
 ### Fixed
+- ([#17147](https://github.com/rstudio/rstudio/issues/17147)): Fix code suggestions being silently accepted off-screen. Inline (at-cursor) ghost text is now dismissed when the cursor moves elsewhere; accepting a next edit suggestion that is scrolled out of view first navigates to it, with a second key press accepting it; an arrow indicator pinned to the edge of the gutter now points toward an active off-screen suggestion, and clicking it navigates there.
 - ([#17900](https://github.com/rstudio/rstudio/issues/17900)): Fix Find in Files (and project code search) returning no results in a Quarto or R Markdown website project whose output directory is set to the project directory itself (for example `output-dir: .` in `_quarto.yml`); the project root is no longer treated as ignored output content.
 - ([#14202](https://github.com/rstudio/rstudio/issues/14202)): Fixed an issue where RStudio Desktop could hang on startup when offline or on an unreliable network connection.
 - ([#17701](https://github.com/rstudio/rstudio/issues/17701)): Honor newline characters in `rstudioapi::showDialog()` and `rstudioapi::showPrompt()` messages.

--- a/e2e/rstudio/pages/source_pane.page.ts
+++ b/e2e/rstudio/pages/source_pane.page.ts
@@ -16,6 +16,7 @@ export class SourcePane extends PageObject {
   public nesDeletionMarker: Locator;
   public nesDiscard: Locator;
   public nesGutter: Locator;
+  public nesOffscreenGutter: Locator;
   public publishBtn: Locator;
   public formatOptions: Locator;
   public viewerPaneOption: Locator;
@@ -43,6 +44,9 @@ export class SourcePane extends PageObject {
     this.nesDiscard = page.locator("xpath=//*[text()='Discard']");
     this.nesDeletionMarker = page.locator('[class*=ace_next-edit-suggestion-deletion]');
     this.nesGutter = page.locator("xpath=//div[@role='tabpanel' and not(contains(@style, 'display: none'))]//*[starts-with(@id,'rstudio_source_text_editor')]//*[contains(@class,'ace_nes-gutter')]");
+    // Edge-pinned arrow shown in the gutter while an active suggestion is
+    // scrolled out of view; clicking it navigates to the suggestion.
+    this.nesOffscreenGutter = page.locator("xpath=//div[@role='tabpanel' and not(contains(@style, 'display: none'))]//*[starts-with(@id,'rstudio_source_text_editor')]//*[contains(@class,'ace_nes-offscreen-gutter')]");
     // The toolbar locators below scope to the visible tabpanel (same pattern as
     // contentPane / aceTextInput above). Each open editor tab renders its own
     // copy of these buttons; a plain page-wide locator triggers Playwright's

--- a/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
@@ -46,6 +46,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
         `${prefix}_nes_multiline_diff.R`,
         `${prefix}_nes_multiline_apply.R`,
         `${prefix}_ghost_dismiss.R`,
+        `${prefix}_ghost_cursor_dismiss.R`,
         `${prefix}_nes_dismiss.R`,
         `${prefix}_nes_persist.R`,
         `${prefix}_nes_leak_a.R`,
@@ -389,6 +390,46 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
         await expect(sourcePane.ghostText).toHaveCount(0, { timeout: 1000 });
       }).toPass({ timeout: 15000 });
       console.log('  Ghost text dismissed with Escape');
+
+      await sourceActions.closeSourceAndDeleteFile(fileName);
+    });
+
+    test('ghost text dismissed when cursor moves away', async ({ rstudioPage: page }) => {
+      const fileName = `${prefix}_ghost_cursor_dismiss.R`;
+
+      const fileContent =
+        'calculate_total <- function(price, tax_rate) {\n' +
+        '  total <- price + (price * tax_rate)\n' +
+        '  return(total)\n' +
+        '}\n' +
+        '\n' +
+        'result <- calculate_total(100, 0.08)\n';
+
+      await sourceActions.createAndOpenFile(fileName, fileContent);
+      await sleep(1000);
+
+      await sourcePane.contentPane.click();
+      await sleep(500);
+
+      await page.keyboard.type('x <- func');
+
+      await expect(sourcePane.ghostText.first()).toBeVisible({ timeout: TIMEOUTS.ghostText });
+      console.log('  Ghost text visible — moving cursor away');
+
+      // Moving the cursor away from the completion point should dismiss the
+      // ghost text (https://github.com/rstudio/rstudio/issues/17147). As in
+      // the Escape test above, gate on no in-flight completion request so a
+      // late response can't re-render ghost text after we check.
+      await expect(async () => {
+        await page.keyboard.press('ArrowLeft');
+        await expect(sourcePane.statusBarCompletionPending).toHaveCount(0, { timeout: 1000 });
+        await expect(sourcePane.ghostText).toHaveCount(0, { timeout: 1000 });
+      }).toPass({ timeout: 15000 });
+      console.log('  Ghost text dismissed by cursor movement');
+
+      // The typed text is intact and the suggestion was not inserted
+      const content = await sourceActions.getEditorContent();
+      expect(content).toContain('x <- func');
 
       await sourceActions.closeSourceAndDeleteFile(fileName);
     });
@@ -759,6 +800,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
         `${prefix}_nes_multiline_diff.R`,
         `${prefix}_nes_multiline_apply.R`,
         `${prefix}_ghost_dismiss.R`,
+        `${prefix}_ghost_cursor_dismiss.R`,
         `${prefix}_nes_dismiss.R`,
         `${prefix}_nes_persist.R`,
         `${prefix}_nes_leak_a.R`,

--- a/e2e/rstudio/tests/panes/editor/edit_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/edit_suggestions.test.ts
@@ -10,6 +10,7 @@
 
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { SourcePaneActions } from '@actions/source_pane.actions';
 import { AceEditor } from '@pages/ace_editor.page';
 import { SourcePane } from '@pages/source_pane.page';
 import { useSuiteSandbox } from '@utils/sandbox';
@@ -18,19 +19,35 @@ import { typeSlowly } from '@utils/constants';
 
 const FILE_PREFIX = 'es_';
 const FILES = {
-  prefix:        `${FILE_PREFIX}prefix.R`,
-  mutate:        `${FILE_PREFIX}mutate.R`,
-  move:          `${FILE_PREFIX}move.R`,
-  clearOldRow:   `${FILE_PREFIX}clear_old_row.R`,
-  inline:        `${FILE_PREFIX}inline.R`,
+  prefix:          `${FILE_PREFIX}prefix.R`,
+  mutate:          `${FILE_PREFIX}mutate.R`,
+  move:            `${FILE_PREFIX}move.R`,
+  clearOldRow:     `${FILE_PREFIX}clear_old_row.R`,
+  inline:          `${FILE_PREFIX}inline.R`,
+  offscreenAbove:  `${FILE_PREFIX}offscreen_above.R`,
+  offscreenBelow:  `${FILE_PREFIX}offscreen_below.R`,
+  offscreenClick:  `${FILE_PREFIX}offscreen_click.R`,
 } as const;
+
+// A file long enough that the editor must scroll: the suggestion target line
+// and the cursor can't both be in the viewport at once.
+function longFileContents(): string {
+  const lines: string[] = ['# Create a 3D point.'];
+  for (let i = 2; i < 100; i++) {
+    lines.push(`value_${i} <- ${i}`);
+  }
+  lines.push('point <- function(x, y, z) {}');
+  return lines.join('\n');
+}
 
 test.describe('Edit suggestions (showEditSuggestion injection)', () => {
   const sandbox = useSuiteSandbox();
   let consoleActions: ConsolePaneActions;
+  let sourceActions: SourcePaneActions;
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
+    sourceActions = new SourcePaneActions(page, consoleActions);
     await consoleActions.resetSourcePane();
   });
 
@@ -173,5 +190,98 @@ test.describe('Edit suggestions (showEditSuggestion injection)', () => {
       const tokens = await editor.getTokens(0);
       return tokens[0]?.value;
     }).toBe('# Create a 4D point.');
+  });
+
+  // --- Off-screen suggestion handling (#17147) ---
+  //
+  // A suggestion whose range is scrolled out of view must not be accepted
+  // blindly: while it is off-screen an edge-pinned gutter arrow points toward
+  // it, the first accept keypress navigates to it, and only a subsequent
+  // accept inserts the edit.
+
+  test('accepting an off-screen pending suggestion navigates first', async ({ rstudioPage: page }) => {
+    await writeAndOpenFile(page, sandbox.dir, FILES.offscreenAbove, longFileContents());
+
+    const editor = new AceEditor(page, '# Create');
+    const sourcePane = new SourcePane(page);
+
+    // Move to the bottom of the file so row 0 is scrolled out of view
+    await editor.gotoLine(100);
+    await expect.poll(() => sourceActions.getFirstVisibleRow()).toBeGreaterThan(50);
+
+    // The suggestion starts before the cursor, so it shows as a pending
+    // (gutter-only) suggestion on row 0 -- off-screen.
+    await consoleActions.executeInConsole(
+      '.rs.api.showEditSuggestion(c(1, 12, 1, 14), "4D")',
+    );
+
+    // The edge-pinned indicator points toward the off-screen suggestion
+    await expect(sourcePane.nesOffscreenGutter.first()).toBeVisible();
+
+    await sourcePane.contentPane.click();
+    await editor.focus();
+
+    // First accept navigates to the suggestion without applying it
+    await page.keyboard.press('ControlOrMeta+;');
+    await expect.poll(() => sourceActions.getFirstVisibleRow()).toBeLessThan(5);
+    await expect(sourcePane.nesOffscreenGutter).toHaveCount(0);
+    expect(await editor.getLine(0)).toBe('# Create a 3D point.');
+
+    // Second accept applies it
+    await page.keyboard.press('ControlOrMeta+;');
+    await expect.poll(() => editor.getLine(0)).toBe('# Create a 4D point.');
+  });
+
+  test('accepting an off-screen revealed suggestion navigates first', async ({ rstudioPage: page }) => {
+    await writeAndOpenFile(page, sandbox.dir, FILES.offscreenBelow, longFileContents());
+
+    const editor = new AceEditor(page, '# Create');
+    const sourcePane = new SourcePane(page);
+
+    // Keep the cursor at the top; the suggestion lands on the last row,
+    // after the cursor, so it autoshows (as ghost text) -- off-screen.
+    await editor.gotoLine(1);
+    await consoleActions.executeInConsole(
+      '.rs.api.showEditSuggestion(c(100, 1, 100, 1), "# ")',
+    );
+
+    await expect(sourcePane.nesOffscreenGutter.first()).toBeVisible();
+
+    await sourcePane.contentPane.click();
+    await editor.focus();
+
+    // First accept navigates to the suggestion without applying it
+    await page.keyboard.press('ControlOrMeta+;');
+    await expect.poll(() => sourceActions.getFirstVisibleRow()).toBeGreaterThan(50);
+    await expect(sourcePane.nesOffscreenGutter).toHaveCount(0);
+    expect(await editor.getLine(99)).toBe('point <- function(x, y, z) {}');
+
+    // Second accept applies it
+    await page.keyboard.press('ControlOrMeta+;');
+    await expect.poll(() => editor.getLine(99)).toBe('# point <- function(x, y, z) {}');
+  });
+
+  test('clicking the off-screen indicator navigates to the suggestion', async ({ rstudioPage: page }) => {
+    await writeAndOpenFile(page, sandbox.dir, FILES.offscreenClick, longFileContents());
+
+    const editor = new AceEditor(page, '# Create');
+    const sourcePane = new SourcePane(page);
+
+    await editor.gotoLine(100);
+    await expect.poll(() => sourceActions.getFirstVisibleRow()).toBeGreaterThan(50);
+
+    await consoleActions.executeInConsole(
+      '.rs.api.showEditSuggestion(c(1, 12, 1, 14), "4D")',
+    );
+
+    await expect(sourcePane.nesOffscreenGutter.first()).toBeVisible();
+    await sourcePane.nesOffscreenGutter.first().click({ force: true });
+
+    // Navigates without accepting; the suggestion's own gutter icon is now
+    // visible and the document text is unchanged.
+    await expect.poll(() => sourceActions.getFirstVisibleRow()).toBeLessThan(5);
+    await expect(sourcePane.nesOffscreenGutter).toHaveCount(0);
+    await expect(sourcePane.nesGutter.first()).toBeVisible();
+    expect(await editor.getLine(0)).toBe('# Create a 3D point.');
   });
 });

--- a/e2e/rstudio/tests/panes/editor/edit_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/edit_suggestions.test.ts
@@ -24,6 +24,7 @@ const FILES = {
   move:            `${FILE_PREFIX}move.R`,
   clearOldRow:     `${FILE_PREFIX}clear_old_row.R`,
   inline:          `${FILE_PREFIX}inline.R`,
+  cursorDismiss:   `${FILE_PREFIX}cursor_dismiss.R`,
   offscreenAbove:  `${FILE_PREFIX}offscreen_above.R`,
   offscreenBelow:  `${FILE_PREFIX}offscreen_below.R`,
   offscreenClick:  `${FILE_PREFIX}offscreen_click.R`,
@@ -190,6 +191,28 @@ test.describe('Edit suggestions (showEditSuggestion injection)', () => {
       const tokens = await editor.getTokens(0);
       return tokens[0]?.value;
     }).toBe('# Create a 4D point.');
+  });
+
+  test('at-cursor ghost text is dismissed when the cursor moves away', async ({ rstudioPage: page }) => {
+    await writeAndOpenFile(page, sandbox.dir, FILES.cursorDismiss, '# abc\n\n\n');
+
+    const editor = new AceEditor(page, '# abc');
+    const sourcePane = new SourcePane(page);
+
+    // A zero-width suggestion at the cursor position is treated as an
+    // inline (at-cursor) completion, like real provider ghost text.
+    await editor.gotoLine(1, 5);
+    await consoleActions.executeInConsole(
+      '.rs.api.showEditSuggestion(c(1, 6, 1, 6), " def")',
+    );
+
+    await expect(sourcePane.ghostText.first()).toBeVisible();
+
+    // Moving the cursor away dismisses the ghost text without inserting it
+    // (https://github.com/rstudio/rstudio/issues/17147)
+    await editor.gotoLine(3);
+    await expect(sourcePane.ghostText).toHaveCount(0);
+    expect(await editor.getLine(0)).toBe('# abc');
   });
 
   // --- Off-screen suggestion handling (#17147) ---

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -8,6 +8,7 @@
 @external ace_chunk-queued-line, ace_chunk-executed-line, ace_chunk-resting-line, ace_chunk-error-line;
 @external ace_active_debug_line, ace_next-edit-suggestion-background, ace_next-edit-suggestion-highlight, ace_next-edit-suggestion-deletion, ace_next-edit-suggestion-deletion-bounds, ace_deletion-clickable, ace_insertion_preview, ace_next-edit-suggestion-insertion-bounds, ace_insertion-clickable, ace_replacement_deletion, ace_next-edit-suggestion-replacement-bounds, ace_replacement-clickable;
 @external ace_nes-gutter, ace_nes-gutter-background, ace_nes-gutter-highlight, ace_nes-gutter-deletion, ace_nes-gutter-insertion, ace_nes-gutter-replacement;
+@external ace_nes-offscreen-gutter, ace_nes-offscreen-gutter-up, ace_nes-offscreen-gutter-down;
 @external ace_diff-added, ace_diff-removed;
 @external visual_chunk-queued-line, visual_chunk-executed-line, visual_chunk-resting-line, visual_chunk-error-line;
 @external ace_sb;
@@ -498,6 +499,46 @@ pre {
    background-image:
       radial-gradient(circle 1.5px at 12px 12px, #888888 100%, transparent 100%),
       radial-gradient(circle 2.5px at 12px 12px, #000000 100%, transparent 100%);
+}
+
+/* Edge-pinned gutter indicator pointing toward an off-screen suggestion */
+.ace_nes-offscreen-gutter .ace_gutter_annotation {
+   position: relative;
+   cursor: pointer;
+}
+
+.ace_nes-offscreen-gutter .ace_gutter_annotation::before {
+   content: '';
+   position: absolute;
+   left: 1px;
+   top: 50%;
+   transform: translateY(-50%);
+   width: 16px;
+   height: 16px;
+   border-radius: 3px;
+   cursor: pointer;
+   background-color: #1E77BC;
+}
+
+.ace_nes-offscreen-gutter .ace_gutter_annotation::after {
+   content: '';
+   position: absolute;
+   left: 5px;
+   top: 50%;
+   transform: translateY(-50%);
+   width: 0;
+   height: 0;
+   border-left: 4px solid transparent;
+   border-right: 4px solid transparent;
+   cursor: pointer;
+}
+
+.ace_nes-offscreen-gutter-up .ace_gutter_annotation::after {
+   border-bottom: 5px solid white;
+}
+
+.ace_nes-offscreen-gutter-down .ace_gutter_annotation::after {
+   border-top: 5px solid white;
 }
 
 .ace_next-edit-suggestion-highlight {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorGutterStyles.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorGutterStyles.java
@@ -31,4 +31,10 @@ public class AceEditorGutterStyles
    // NES gutter background style (darker blue background for all NES gutter cells)
    public static final String NES_GUTTER_BACKGROUND  = "ace_nes-gutter-background";
 
+   // Edge-pinned indicator pointing toward an active suggestion outside the viewport.
+   // Uses a distinct base class (not NES_GUTTER) so clicks navigate instead of accepting.
+   public static final String NES_GUTTER_OFFSCREEN      = "ace_nes-offscreen-gutter";
+   public static final String NES_GUTTER_OFFSCREEN_UP   = "ace_nes-offscreen-gutter ace_nes-offscreen-gutter-up";
+   public static final String NES_GUTTER_OFFSCREEN_DOWN = "ace_nes-offscreen-gutter ace_nes-offscreen-gutter-down";
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetAssistantHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetAssistantHelper.java
@@ -490,6 +490,11 @@ public class TextEditingTargetAssistantHelper
       {
          // Ghost text at cursor position
          setEditSuggestion(normalized, SuggestionType.GHOST_TEXT, null);
+
+         // A zero-width insertion at the cursor behaves like a regular inline
+         // completion, including dismissal when the cursor moves away
+         editSuggestion_.isInlineCompletion = suggestionStart.isEqualTo(cursorPosition);
+
          if (autoshow)
             renderEditSuggestion();
          else

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetAssistantHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetAssistantHelper.java
@@ -156,6 +156,10 @@ public class TextEditingTargetAssistantHelper
       // Whether the suggestion is currently being displayed (ghost text or diff visible)
       public boolean isRevealed;
 
+      // Whether this is a regular inline completion shown at the cursor position,
+      // as opposed to a next edit suggestion (which may be elsewhere in the document)
+      public boolean isInlineCompletion;
+
       // Anchors that track the suggestion position as the document changes
       // These must be set externally via setAnchors() since they require display_ access
       public Anchor startAnchor;
@@ -629,6 +633,9 @@ public class TextEditingTargetAssistantHelper
             // Perform the actual replacement
             display_.replaceRange(range, replacementText);
 
+            // Make sure the accepted edit is visible to the user
+            display_.ensureCursorVisible();
+
             // Notify server that completion was accepted
             if (command != null)
                server_.assistantDidAcceptCompletion(command, new VoidServerRequestCallback());
@@ -743,6 +750,9 @@ public class TextEditingTargetAssistantHelper
       // Move cursor to start of range, then perform the edit
       display_.setCursorPosition(range.getStart());
       display_.replaceRange(range, editSuggestion_.insertText);
+
+      // Make sure the accepted edit is visible to the user
+      display_.ensureCursorVisible();
 
       // Notify server that completion was accepted
       if (editSuggestion_.command != null)
@@ -1087,6 +1097,8 @@ public class TextEditingTargetAssistantHelper
    {
       pendingGutterRow_ = row;
       pendingGutterRegistration_ = display_.addGutterItem(row, gutterClass);
+
+      updateOffscreenIndicator();
    }
 
    /**
@@ -1170,6 +1182,8 @@ public class TextEditingTargetAssistantHelper
          default:
             break;
       }
+
+      updateOffscreenIndicator();
    }
 
    /**
@@ -1236,6 +1250,8 @@ public class TextEditingTargetAssistantHelper
          pendingGutterRegistration_ = null;
       }
       pendingGutterRow_ = -1;
+
+      removeOffscreenIndicator();
    }
 
    /**
@@ -1483,6 +1499,7 @@ public class TextEditingTargetAssistantHelper
                            editSuggestion_ = new EditSuggestion(normalized);
                            editSuggestion_.type = SuggestionType.GHOST_TEXT;
                            editSuggestion_.isRevealed = true;
+                           editSuggestion_.isInlineCompletion = true;
                            createSuggestionAnchors(
                               editSuggestion_.startLine,
                               editSuggestion_.startCharacter,
@@ -1622,6 +1639,38 @@ public class TextEditingTargetAssistantHelper
    {
       registrations_.add(
 
+               // Inline (at-cursor) ghost text completions are dismissed when the
+               // cursor moves away, rather than lingering invisibly where they could
+               // later be accepted off-screen. Next edit suggestions are excluded, as
+               // those are intentionally persistent and may be far from the cursor.
+               // https://github.com/rstudio/rstudio/issues/17147
+               display_.addCursorChangedHandler((event) ->
+               {
+                  if (editSuggestion_ == null || !editSuggestion_.isInlineCompletion)
+                     return;
+
+                  if (!editSuggestion_.isRevealed || editSuggestion_.startAnchor == null)
+                     return;
+
+                  // Ignore cursor motion caused by our own programmatic edits
+                  // (accepting a completion, partial word acceptance)
+                  if (ignoreNextDocumentChangeEvents_)
+                     return;
+
+                  Position cursorPos = display_.getCursorPosition();
+                  if (!cursorPos.isEqualTo(editSuggestion_.startAnchor.getPosition()))
+                  {
+                     sendSuggestionFeedback("ignored");
+                     resetSuggestion();
+                  }
+               }),
+
+               // Keep the off-screen suggestion indicator in sync as the user scrolls
+               display_.addScrollYHandler((event) ->
+               {
+                  updateOffscreenIndicator();
+               }),
+
                // click handler for next edit suggestion gutter icon. we use a capturing
                // event handler here so we can intercept the event before Ace does.
                DomUtils.addEventListener(display_.getElement(), "mousedown", true, (event) ->
@@ -1630,6 +1679,19 @@ public class TextEditingTargetAssistantHelper
                      return;
 
                   Element target = event.getEventTarget().cast();
+
+                  // Check for clicks on the off-screen suggestion indicator;
+                  // these navigate to the suggestion rather than accepting it
+                  Element offscreenGutterEl = DomUtils.findParentElement(target, true, (el) ->
+                     el.hasClassName(AceEditorGutterStyles.NES_GUTTER_OFFSCREEN));
+
+                  if (offscreenGutterEl != null && hasActiveSuggestion())
+                  {
+                     event.stopPropagation();
+                     event.preventDefault();
+                     navigateToSuggestionIfOffscreen();
+                     return;
+                  }
 
                   // Check for clicks on any NES gutter icon (uses base class)
                   Element nesGutterEl = DomUtils.findParentElement(target, true, (el) ->
@@ -1850,6 +1912,7 @@ public class TextEditingTargetAssistantHelper
                         {
                            event.stopPropagation();
                            event.preventDefault();
+                           navigateToSuggestionIfOffscreen();
                            showPendingSuggestionDetails();
                            return;
                         }
@@ -1870,7 +1933,8 @@ public class TextEditingTargetAssistantHelper
                         {
                            event.stopPropagation();
                            event.preventDefault();
-                           diffView_.apply();
+                           if (!navigateToSuggestionIfOffscreen())
+                              diffView_.apply();
                            return;
                         }
                      }
@@ -1882,7 +1946,8 @@ public class TextEditingTargetAssistantHelper
                         {
                            event.stopPropagation();
                            event.preventDefault();
-                           acceptEditSuggestion();
+                           if (!navigateToSuggestionIfOffscreen())
+                              acceptEditSuggestion();
                            return;
                         }
                         else if (event.getKeyCode() == KeyCodes.KEY_ESCAPE)
@@ -1932,7 +1997,8 @@ public class TextEditingTargetAssistantHelper
                      {
                         event.stopPropagation();
                         event.preventDefault();
-                        acceptEditSuggestion();
+                        if (!navigateToSuggestionIfOffscreen())
+                           acceptEditSuggestion();
                      }
                      else if (event.getKeyCode() == KeyCodes.KEY_ESCAPE)
                      {
@@ -2150,9 +2216,15 @@ public class TextEditingTargetAssistantHelper
       // If we have a pending suggestion that hasn't been revealed, reveal it first
       if (hasPendingUnrevealedSuggestion())
       {
+         navigateToSuggestionIfOffscreen();
          showPendingSuggestionDetails();
          return;
       }
+
+      // If the suggestion is off-screen, navigate to it first so the user can
+      // see what would be accepted; a second invocation will then accept it
+      if (hasActiveSuggestion() && navigateToSuggestionIfOffscreen())
+         return;
 
       // Apply the appropriate suggestion type
       if (diffView_ != null)
@@ -2424,6 +2496,117 @@ public class TextEditingTargetAssistantHelper
    }
 
    /**
+    * Returns the document row associated with the active suggestion,
+    * or -1 if there is no active suggestion.
+    */
+   private int activeSuggestionRow()
+   {
+      if (editSuggestion_ != null)
+      {
+         return editSuggestion_.startAnchor != null
+            ? editSuggestion_.startAnchor.getRow()
+            : editSuggestion_.startLine;
+      }
+
+      if (pendingGutterRow_ != -1)
+         return pendingGutterRow_;
+
+      return -1;
+   }
+
+   /**
+    * If the active suggestion lies outside the visible viewport, move the cursor
+    * to the suggestion and scroll it into view, so the user can see what would
+    * be accepted. Returns true if navigation occurred.
+    * https://github.com/rstudio/rstudio/issues/17147
+    */
+   private boolean navigateToSuggestionIfOffscreen()
+   {
+      int row = activeSuggestionRow();
+      if (row == -1)
+         return false;
+
+      boolean visible =
+         row >= display_.getFirstVisibleRow() &&
+         row <= display_.getLastVisibleRow();
+      if (visible)
+         return false;
+
+      Position position = (editSuggestion_ != null && editSuggestion_.startAnchor != null)
+         ? editSuggestion_.startAnchor.getPosition()
+         : Position.create(row, 0);
+
+      display_.setCursorPosition(position);
+      display_.moveCursorNearTop();
+
+      updateOffscreenIndicator();
+      return true;
+   }
+
+   /**
+    * Shows or hides the edge-pinned gutter indicator that points toward an
+    * active suggestion lying outside the visible viewport.
+    */
+   private void updateOffscreenIndicator()
+   {
+      int row = activeSuggestionRow();
+      if (row == -1)
+      {
+         removeOffscreenIndicator();
+         return;
+      }
+
+      // Pin the indicator one row inside the viewport edges: the first and
+      // last visible rows are often only partially visible (clipped by the
+      // toolbar or the bottom edge), which would leave the indicator mostly
+      // hidden and unclickable.
+      int indicatorRow;
+      String indicatorStyle;
+      if (row < display_.getFirstVisibleRow())
+      {
+         indicatorRow = display_.getFirstVisibleRow() + 1;
+         indicatorStyle = AceEditorGutterStyles.NES_GUTTER_OFFSCREEN_UP;
+      }
+      else if (row > display_.getLastVisibleRow())
+      {
+         indicatorRow = display_.getLastVisibleRow() - 1;
+         indicatorStyle = AceEditorGutterStyles.NES_GUTTER_OFFSCREEN_DOWN;
+      }
+      else
+      {
+         removeOffscreenIndicator();
+         return;
+      }
+
+      // Avoid churn if the indicator is already in the right place
+      if (offscreenGutterRegistration_ != null &&
+          offscreenGutterRow_ == indicatorRow &&
+          StringUtil.equals(offscreenGutterStyle_, indicatorStyle))
+      {
+         return;
+      }
+
+      removeOffscreenIndicator();
+      offscreenGutterRegistration_ = display_.addGutterItem(indicatorRow, indicatorStyle);
+      offscreenGutterRow_ = indicatorRow;
+      offscreenGutterStyle_ = indicatorStyle;
+   }
+
+   /**
+    * Removes the off-screen suggestion gutter indicator, if showing.
+    */
+   private void removeOffscreenIndicator()
+   {
+      if (offscreenGutterRegistration_ != null)
+      {
+         offscreenGutterRegistration_.removeHandler();
+         offscreenGutterRegistration_ = null;
+      }
+      offscreenGutterRow_ = -1;
+      offscreenGutterStyle_ = null;
+   }
+
+   /**
     * Re-renders tokens for all rows that have positions in the given list.
     * This efficiently handles multiple positions on the same row by only
     * rendering each affected row once. Also removes synthetic tokens for
@@ -2653,6 +2836,11 @@ public class TextEditingTargetAssistantHelper
    private int pendingGutterRow_ = -1;
    private HandlerRegistration pendingGutterRegistration_;
    private boolean pendingSuggestionRevealed_ = false;
+
+   // Edge-pinned gutter indicator for off-screen suggestions
+   private HandlerRegistration offscreenGutterRegistration_;
+   private int offscreenGutterRow_ = -1;
+   private String offscreenGutterStyle_;
 
    // Injected ----
    private Assistant assistant_;


### PR DESCRIPTION
## Summary

A code suggestion whose range had scrolled out of view could be silently accepted with Ctrl-;/Cmd-; (or Tab), inserting text the user couldn't see. This PR addresses that in four ways:

- **Inline ghost text is dismissed when the cursor moves away.** At-cursor completions (the classic Copilot ghost text) no longer linger invisibly after clicking or navigating elsewhere, matching the behavior of other editors. Inline completions are classified behaviorally -- a zero-width insertion shown at the cursor -- so suggestions injected via `.rs.api.showEditSuggestion` behave the same as provider ghost text. Next edit suggestions elsewhere in the document are unaffected; those are intentionally persistent.
- **Two-stage accept for off-screen suggestions.** If an active suggestion (NES or scrolled-away ghost text) lies outside the viewport, the first accept key press navigates to it and reveals it; a second press accepts it. This mirrors VS Code's next-edit-suggestion behavior.
- **Edge-pinned gutter indicator.** While an active suggestion is off-screen, an arrow indicator pinned just inside the gutter's viewport edge points toward it (up or down), updating as the user scrolls. Clicking the indicator navigates to the suggestion.
- **Safety net.** Accepted edits are always scrolled into view after insertion (`ensureCursorVisible()`), covering any remaining accept path -- this is also the behavior originally proposed in the issue.

## Tests

- Four new injection-based Playwright tests in `edit_suggestions.test.ts` (no AI credentials required) cover ghost text dismissal on cursor movement, the two-stage accept (pending suggestion above the viewport, revealed ghost text below it), and indicator-click navigation; all pass locally against the dev build, along with the rest of the spec.
- A new provider-driven test in `code_suggestions.test.ts` (`@ai`-tagged) additionally covers dismissal of real provider ghost text on cursor movement.

Fixes #17147.