### PR TITLE
Don't init the monitor when running the rsession tests

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2028,7 +2028,16 @@ void initMonitorClient()
    // we handle monitor calls in a separate thread to ensure that calls
    // to the monitor (which are likely across machines and thus very expensive)
    // do not hamper the liveliness of the session as a whole
-   core::thread::safeLaunchThread(monitorWorkerThreadFunc);
+   //
+   // but do not start it when running unit tests: there is no rserver-monitor to
+   // connect to, so every async log/event would fail-fast and race the worker
+   // thread against the initiating thread on the same socket. The worker thread
+   // also never gets stopped on the test path (R exits via exit()), so it would
+   // race static destruction of s_monitorIoContext at process exit. Both produce
+   // intermittent SIGSEGVs. The client object is still initialized above so that
+  // monitor::client() stays valid; queued async ops are simply never processed.
+   if (!options().runTests())
+      core::thread::safeLaunchThread(monitorWorkerThreadFunc);
 }
 
 void beforeResume()
@@ -2302,7 +2311,7 @@ int main(int argc, char * const argv[])
       BOOST_SCOPE_EXIT_END
 
       // register monitor log writer (but not in standalone or verify installation mode)
-      if (!options.standalone() && !options.verifyInstallation())
+      if (!options.standalone() && !options.verifyInstallation() && !options.runTests())
       {
          core::log::addLogDestination(
             monitor::client().createLogDestination(core::system::generateShortenedUuid(), log::LogLevel::WARN, options.programIdentity()));


### PR DESCRIPTION
It has an intermittent bug where it can crash when an error is logged.  This only affects the unit tests and so the unit tests should effectively test the fix. 
