### PR TITLE
Trim manifest-fetch child to utils to cut R startup latency

### DIFF
--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -3722,9 +3722,19 @@ void fetchManifestAsync(
          });
       };
 
+   // Trim the child's startup to the packages the download command actually uses.
+   // download.file lives in utils; everything else in the command (options,
+   // tempfile, readLines, cat) is base. --vanilla still loads R's full default
+   // package set; forcing R_DEFAULT_PACKAGES=utils skips the rest of it
+   // (methods/stats/graphics/grDevices/datasets) -- the bulk of cold R
+   // startup -- cutting spawn latency
+   // (the dominant cost of this fetch -- the manifest itself is tiny).
+   core::system::Options childEnv;
+   core::system::setenv(&childEnv, "R_DEFAULT_PACKAGES", "utils");
+
    boost::shared_ptr<ManifestDownload> pProc =
       boost::make_shared<ManifestDownload>(complete);
-   pProc->start(command.c_str(), FilePath(), async_r::R_PROCESS_VANILLA);
+   pProc->start(command.c_str(), childEnv, FilePath(), async_r::R_PROCESS_VANILLA);
 
    // Deadline (bounded by main-thread availability: like the completion, it fires
    // when the main thread next services its scheduled-work queue, so a main thread


### PR DESCRIPTION
## What

Follow-up to #17891 / #17896. That work moved the Posit Assistant manifest download into an async `R --vanilla` subprocess to eliminate the Windows `ERROR_SHARING_VIOLATION`. Spawning a fresh R process is now the dominant cost of the fetch: `--vanilla` still loads R's full default package set (`methods`/`stats`/`graphics`/`grDevices`/`datasets`), while the manifest download itself is tiny.

The generated download command only uses `download.file` (from `utils`) plus base builtins (`options`, `tempfile`, `readLines`, `cat`). This forces `R_DEFAULT_PACKAGES=utils` in the child's environment so it skips loading the rest. `utils` is the complete dependency set regardless of the user's `download.file.method` (the external `wget`/`curl` methods shell out; `libcurl`/`internal`/`wininet` live in base/utils).

## Changes

- `SessionChat.cpp` (`fetchManifestAsync`): pass an environment with `R_DEFAULT_PACKAGES=utils` to the manifest-download child via the existing `AsyncRProcess::start` environment overload. The child still inherits the parent process environment (proxy vars, `R_LIBS`, etc.); only the default-package list is overridden.

## Measurements

Local Linux, R 4.6.0, full download-command shape using a local `file://` source to isolate spawn cost from network time:

| | mean spawn (n=20) |
|---|---|
| default packages | 148.3 ms |
| `R_DEFAULT_PACKAGES=utils` | 55.8 ms |

About a 62% reduction in the per-fetch fixed cost. The absolute saving is expected to be larger on Windows, where the skipped package loads are antivirus-scanned. This trims the fixed spawn cost only; it does not change network/DNS/TLS time.

## Testing

- Full backend build (`ninja`) links cleanly.
- Verified end-to-end against `https://cdn.posit.co/posit-ai/manifest.json` with `R_DEFAULT_PACKAGES=utils`: `download.file` is available, only `utils`/`base`/`compiler` load, and the manifest is returned with exit status 0.

Addresses #17891.