### PR TITLE
Add ServerDatabase.cpp changes

### DIFF
--- a/src/cpp/server_core/ServerDatabase.cpp
+++ b/src/cpp/server_core/ServerDatabase.cpp
@@ -69,24 +69,21 @@ FilePath getDatabaseFilePath(const std::string& databaseConfigFile)
    return optionsFile;
 }
 
-void setAutoCreateDatabaseOption(Settings& settings, const std::string& databaseProvider, const std::string& optionsFilePath)
+void warnIfAutoCreateSetForPostgresql(const Settings& settings, const std::string& databaseProvider, const std::string& optionsFilePath)
 {
-   if (boost::iequals(databaseProvider, kDatabaseProviderSqlite))
+   if (boost::iequals(databaseProvider, kDatabaseProviderPostgresql))
    {
-      // We create the internal database by default for SQLite
-      if (!settings.contains(kAutoCreateDatabase))
-      {
-         settings.set(kAutoCreateDatabase, true);
-      }
-   }
-   else if (boost::iequals(databaseProvider, kDatabaseProviderPostgresql))
-   {
-      // We never create the internal database automatically for PostgreSQL
       if (settings.getBool(kAutoCreateDatabase, false))
       {
-         LOG_INFO_MESSAGE("The internal database cannot be created automatically for PostgreSQL. \"" + std::string(kAutoCreateDatabase) + "\" in " + optionsFilePath + " will be ignored. To remove this warning, remove this setting and verify the database already exists in the PostgreSQL server.");
+         LOG_WARNING_MESSAGE("The internal database cannot be created automatically for PostgreSQL. \"" + std::string(kAutoCreateDatabase) + "\" in " + optionsFilePath + " will be ignored. To remove this warning, remove this setting and verify the database already exists in the PostgreSQL server.");
       }
-      settings.set(kAutoCreateDatabase, false);
+   }
+   else if (boost::iequals(databaseProvider, kDatabaseProviderSqlite))
+   {
+      if (!settings.getBool(kAutoCreateDatabase, true))
+      {
+         LOG_INFO_MESSAGE("\"" + std::string(kAutoCreateDatabase) + "\" is set to 0 for SQLite in " + optionsFilePath + ". The database will not be created automatically on first start. Ensure the database file already exists before starting rstudio-rserver.");
+      }
    }
 }
 
@@ -115,7 +112,7 @@ core::database::Driver getConfiguredDriver(const std::string& databaseConfigFile
    // If the database provider is not specified, use the default provider
    std::string databaseProvider = settings.get(kDatabaseProvider, kDatabaseProviderSqlite);
 
-   setAutoCreateDatabaseOption(settings, databaseProvider, optionsFile.getAbsolutePath());
+   warnIfAutoCreateSetForPostgresql(settings, databaseProvider, optionsFile.getAbsolutePath());
 
    // Translate the Settings object to a database::ConnectionOptions object
    error = utils::applyOptionsFromSettings(settings, &options, defaultDatabaseName, databaseProvider);
@@ -165,7 +162,7 @@ Error readOptions(const std::string& databaseConfigFile,
    if (!forceDatabaseProvider.empty())
       databaseProvider = forceDatabaseProvider;
    
-   setAutoCreateDatabaseOption(settings, databaseProvider, optionsFile.getAbsolutePath());
+   warnIfAutoCreateSetForPostgresql(settings, databaseProvider, optionsFile.getAbsolutePath());
 
    // Translate the Settings object to a database::ConnectionOptions object
    error = utils::applyOptionsFromSettings(settings, pOptions, defaultDatabaseName, databaseProvider);


### PR DESCRIPTION
<!-- include an entry in NEWS.md if required -->

### Intent

Open source companion to https://github.com/rstudio/rstudio-pro/pull/11085/

### Approach

There are pro changes to post install scripts ([see Debian's here](https://github.com/rstudio/rstudio-pro/blob/fe605b898e7d76927b7c25b951cc514d09ffb045/package/linux/debian-control/postinst.in#L52) vs [the current open source approach](https://github.com/rstudio/rstudio/blob/88935a4b80d539bd825dac9ab9fd10fcd3f5d552/package/linux/debian-control/postinst.in#L21)), but they bring in pro-centric options for a default [`rsession.conf`](https://github.com/rstudio/rstudio-pro/blob/samcofer/default-config-files/src/cpp/server/extras/conf/rsession.conf) and [`repos.conf`](https://github.com/rstudio/rstudio-pro/blob/samcofer/default-config-files/src/cpp/server/extras/conf/repos.conf) so I've elected to leave them out.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Ensure you have updated the QA Notes in the original issue.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
