### PR TITLE
use 127.0.0.1 instead of localhost for viewer pane urls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,7 @@
 - ([#17810](https://github.com/rstudio/rstudio/issues/17810)): Fix the "Run Tests" button modifying the active test file's timestamp even when the file had no unsaved changes.
 - ([#17735](https://github.com/rstudio/rstudio/issues/17735)): Hide the redundant column-summary sidebar in the data frame preview shown in the Help pane.
 - ([#17066](https://github.com/rstudio/rstudio/issues/17066)): Fix the Assistant preferences pane showing a stale code-assistant account after switching back and forth between GitHub Copilot and Posit Assistant.
+- ([#17579](https://github.com/rstudio/rstudio/issues/17579)): On RStudio Desktop, serve Viewer pane content via `127.0.0.1` instead of `localhost`, so HTML files and htmlwidgets display on systems where `localhost` does not resolve to the IPv4 loopback address that R's help server binds to.
 - ([#17327](https://github.com/rstudio/rstudio/issues/17327)): Stop requesting code completions and next-edit suggestions while editing in visual mode, where suggestions aren't shown, so document contents are no longer sent to the completion backend for suggestions there.
 - ([#17493](https://github.com/rstudio/rstudio/issues/17493)): Fix the comment/uncomment shortcut inserting the comment character at the start of an empty indented line instead of after the indent.
 - ([#17868](https://github.com/rstudio/rstudio/issues/17868)): Restrict the Python help URL handler (`/python/`) to valid help-topic names, accepting only plain dotted qualified names.

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -18,6 +18,8 @@
 #include <atomic>
 #include <vector>
 
+#include <fmt/format.h>
+
 #include <boost/assert.hpp>
 #include <boost/utility.hpp>
 #include <boost/format.hpp>
@@ -2798,13 +2800,15 @@ std::string sessionTempDirUrl(const std::string& sessionTempPath)
 
    if (useRHelpServer)
    {
-      boost::format fmt("http://localhost:%1%/session/%2%");
-      return boost::str(fmt % rLocalHelpPort() % sessionTempPath);
+      // use the loopback IP address rather than 'localhost' here, since R's
+      // help server binds explicitly to 127.0.0.1 -- on machines where
+      // 'localhost' resolves elsewhere (e.g. only to '::1'), connections
+      // to the help server would otherwise fail (#17579)
+      return fmt::format("http://127.0.0.1:{}/session/{}", rLocalHelpPort(), sessionTempPath);
    }
    else
    {
-      boost::format fmt("session/%1%");
-      return boost::str(fmt % sessionTempPath);
+      return fmt::format("session/{}", sessionTempPath);
    }
 }
 


### PR DESCRIPTION
On RStudio Desktop, the Viewer pane serves session temporary files (plain HTML files and htmlwidgets) directly from R's internal help server, via a URL of the form `http://localhost:<port>/session/<file>`. However, R's help server binds explicitly to the IPv4 loopback address (`Rhttpd.c` calls `startHTTPD("127.0.0.1", port)`), and R's own help URLs use `http://127.0.0.1:<port>/...`.

On systems where `localhost` does not resolve to `127.0.0.1` (e.g. resolves only to `::1`, or loopback traffic is intercepted), the Viewer pane's iframe fails to connect and renders blank, while the Help pane continues to work since it is served in-process by the rsession. This change uses `127.0.0.1` directly, matching the URLs R itself generates.

Notes for reviewers:

- `isLocalURL()` in `SessionHelp.cpp` already checks the `127.0.0.1` prefix (before `localhost`), so `browseURL()` interception of help-server URLs is unaffected.
- `url_ports::mapUrlPorts()` is a passthrough in desktop mode, and this code path is desktop-only (`isUsingRHelpServer()` returns false in server mode).
- Also switched the function from `boost::format` to `fmt::format`.

Requires manual verification on a machine where `localhost` resolution is broken; I was unable to reproduce the original failure locally.

Addresses #17579.