### PR TITLE
Set automation ready flag on re-join after page reload

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -151,7 +151,13 @@ public class ApplicationAutomation
    //     the actual suspend-for-restart, covering .rs.restartR / restartR
    //     command (kSuspendAndRestart on the server side).
    //   - DeferredInitCompletedEvent: fires once R's deferred init has run for
-   //     each session, signalling that R-to-GWT roundtrips are safe.
+   //     each session, signalling that R-to-GWT roundtrips are safe. NOTE this
+   //     is enqueued once per R *session* (SessionMain::rSessionInitHook), not
+   //     per client connect, so it does NOT re-fire on a re-join -- a page
+   //     reload that reconnects to an R session which already finished deferred
+   //     init (e.g. restoreDefaultPaneAndTabLayoutNoPrompt, which saves prefs
+   //     then WindowEx.reload()s). The re-join is covered separately below by
+   //     reading sessionInfo.deferred_init_completed (mirroring Packages.java).
    //   - OpenProjectErrorEvent: server-emitted client event when a project
    //     open/switch fails before reaching quit. Bridge callers preemptively
    //     reset ready in project.open() to close the kQuit-arrival window;
@@ -177,6 +183,17 @@ public class ApplicationAutomation
             setReadyFlag(false);
       });
       eventBus_.addHandler(OpenProjectErrorEvent.TYPE, event -> setReadyFlag(true));
+
+      // Re-join: a reload that reconnects to a still-running R session which has
+      // already completed its deferred init. kDeferredInitCompleted fired once
+      // for that session and won't fire again (see the event note above), so the
+      // handler is registered for the fresh-start / suspend-resume case while we
+      // recognize the re-join here from sessionInfo. Without this, ready would
+      // stay false forever after such a reload and any test gating on it in a
+      // beforeEach would time out. On a fresh start / suspend-resume the flag is
+      // still false at this point, so the event handler does the work as before.
+      if (session_.getSessionInfo().getDeferredInitCompleted())
+         setReadyFlag(true);
 
       readinessHandlersRegistered_ = true;
    }


### PR DESCRIPTION
## Summary

The `--automation-agent` bridge sets `window.rstudio.ready` to `true` only from the `DeferredInitCompletedEvent` handler. That client event (`kDeferredInitCompleted`) is enqueued once per R session in `SessionMain::rSessionInitHook`, not once per client connect, so it does not re-fire on a re-join: a renderer reload that reconnects to a still-running R session which already finished its deferred init. `restoreDefaultPaneAndTabLayoutNoPrompt` is exactly that path -- it saves preferences and then calls `WindowEx.reload()`.

After such a reload `ready` stayed `false` indefinitely, because `ApplicationAutomation` listened for the event but never read the re-join signal. Any Playwright test whose `beforeEach` gates on `window.rstudio.ready` after a reload then timed out (observed in `pane_layout.test.ts`: the first test whose reset runs after a preceding test's `resetUILayout` reload).

## Change

In `registerReadinessHandlers`, after wiring the event handlers, set the ready flag immediately when `sessionInfo.deferred_init_completed` is already `true`. This mirrors how `Packages.java` already handles the re-join case. `initializeAgent` runs inside the post-`ClientInit` callback, so `sessionInfo` is populated at that point.

Fresh start and suspend/resume are unchanged: `deferred_init_completed` is still `false` at this point, so the new check is a no-op and the event handler does the work as before. The change is therefore confined to the re-join path and cannot affect the paths that already work.

Only the automation bridge (`--automation-agent`) is touched; there is no user-facing behavior change, so no NEWS entry.

## Verification

- `cd src/gwt && ant javac` passes.
- roborev review: no issues found.