### PR TITLE
use curl binary for air downloads when available

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@
 - ([#17729](https://github.com/rstudio/rstudio/issues/17729)): Show distinct copy in the Posit Assistant chat pane and preferences install prompt when the recommended Posit Assistant version is older than the installed one.
 - ([#17738](https://github.com/rstudio/rstudio/issues/17738)): Fix `file.edit()` (and other Source pane open events) silently dropping when invoked during an in-flight `closeAllSourceDocs`.
 - ([#17745](https://github.com/rstudio/rstudio/issues/17745)): Fix the bundled `air` formatter being copied without the `.exe` extension on Windows, which prevented format-on-save with Air from working.
+- ([#17746](https://github.com/rstudio/rstudio/issues/17746)): Fix the automatic download of the Air formatter failing on slow connections. The download now uses the `curl` binary when available, which only times out on inactivity rather than on total download time; when `curl` is unavailable, the `download.file()` fallback raises R's download timeout to at least 300 seconds for this download.
 - ([#17737](https://github.com/rstudio/rstudio/issues/17737)): Restore the "Show .Last.value in environment listing" preference, which had stopped surfacing `.Last.value` in the Environment pane.
 - ([#17743](https://github.com/rstudio/rstudio/issues/17743)): Fix the debugger failing to capture the browser environment for functions loaded by the `box` package.
 - ([#17712](https://github.com/rstudio/rstudio/issues/17712)): Fix Quarto rendering failing on Windows when the user's home folder path contains an ampersand.

--- a/src/cpp/session/modules/SessionAir.R
+++ b/src/cpp/session/modules/SessionAir.R
@@ -13,16 +13,61 @@
 #
 #
 
+.rs.addFunction("air.downloadFile", function(url, destfile)
+{
+   # Prefer the curl binary when available -- unlike download.file(), it can
+   # time out on inactivity rather than on total download time, so a slow but
+   # active download is not killed prematurely.
+   # https://github.com/rstudio/rstudio/issues/17746
+   curl <- Sys.which("curl")
+   if (nzchar(curl))
+      return(.rs.air.downloadFileWithCurl(curl, url, destfile))
+
+   # Otherwise, fall back to download.file(). The 'timeout' option caps the
+   # total download time for a single file, and the 60-second default has
+   # proven too short for slow connections, so bump it for this download.
+   timeout <- getOption("timeout", default = 60L)
+   options(timeout = max(300L, timeout))
+   on.exit(options(timeout = timeout), add = TRUE)
+
+   download.file(url, destfile = destfile, quiet = TRUE, mode = "wb")
+
+   invisible(destfile)
+})
+
+.rs.addFunction("air.downloadFileWithCurl", function(curl, url, destfile)
+{
+   args <- c(
+      "--fail", "--location", "--silent", "--show-error",
+      "--connect-timeout", "60",
+      "--speed-limit", "1",
+      "--speed-time", "60",
+      "--output", shQuote(destfile),
+      shQuote(url)
+   )
+
+   output <- suppressWarnings(system2(curl, args, stdout = TRUE, stderr = TRUE))
+
+   status <- attr(output, "status")
+   if (!is.null(status) && status != 0L)
+   {
+      fmt <- "Error downloading '%s' [exit code %d]:\n%s"
+      stop(sprintf(fmt, url, status, paste(output, collapse = "\n")))
+   }
+
+   invisible(destfile)
+})
+
 .rs.addFunction("air.defaultVersion", function()
 {
    version <- getOption("rstudio.air.version")
    if (!is.null(version))
       return(version)
-   
+
    url <- "https://api.github.com/repos/posit-dev/air/releases/latest"
    destfile <- tempfile(fileext = ".json")
-   download.file(url, destfile = destfile, quiet = TRUE)
-   
+   .rs.air.downloadFile(url, destfile)
+
    contents <- readLines(destfile, warn = FALSE)
    response <- .rs.fromJSON(contents)
    response[["tag_name"]]
@@ -88,7 +133,7 @@
       fmt <- "https://github.com/posit-dev/air/releases/download/%s/air-%s-pc-windows-msvc.zip"
       url <- sprintf(fmt, version, R.version$arch)
       destfile <- basename(url)
-      download.file(url, destfile = destfile, mode = "wb")
+      .rs.air.downloadFile(url, destfile)
       unzip(destfile)
    }
    else if (.rs.platform.isMacos)
@@ -96,7 +141,7 @@
       fmt <- "https://github.com/posit-dev/air/releases/download/%s/air-%s-apple-darwin.tar.gz"
       url <- sprintf(fmt, version, R.version$arch)
       destfile <- basename(url)
-      download.file(url, destfile = destfile)
+      .rs.air.downloadFile(url, destfile)
       untar(destfile)
    }
    else
@@ -104,7 +149,7 @@
       fmt <- "https://github.com/posit-dev/air/releases/download/%s/air-%s-unknown-linux-gnu.tar.gz"
       url <- sprintf(fmt, version, R.version$arch)
       destfile <- basename(url)
-      download.file(url, destfile = destfile)
+      .rs.air.downloadFile(url, destfile)
       untar(destfile)
    }
    


### PR DESCRIPTION
## Summary

The automatic download of the Air formatter could fail on slow connections, because `download.file()` enforces R's `timeout` option (default 60 seconds) as an absolute cap on total download time -- a slow but actively progressing download is killed at the deadline.

This PR changes `SessionAir.R` to:

- Prefer the system `curl` binary for all Air downloads (release metadata and platform binaries). Curl is configured with `--speed-limit 1 --speed-time 60`, so it only aborts after 60 seconds of effective inactivity; an active download is never killed regardless of how long it takes. A nonzero exit raises an R error that includes curl's stderr. All flags used are available since curl 7.7 (2001), so any curl shipped on Windows 10+, macOS, or Linux qualifies.
- Fall back to `download.file()` when curl is not on the PATH, with the `timeout` option raised to `max(300, getOption("timeout"))` for the duration of the call, as requested in the issue.

## Testing

- Exercised the curl helper standalone via Rscript: release metadata download succeeds, a 404 raises an R error, and a real release asset (which redirects through `objects.githubusercontent.com`) downloads and extracts correctly.
- R linter test suite passes (79 PASS, 0 FAIL).
- Manual verification of the in-IDE download path is still advisable on a clean machine.

Addresses #17746.