### PR TITLE
clear pane maximize state in e2e resets; isolate per-spec data homes

### DIFF
--- a/e2e/rstudio/CLAUDE.md
+++ b/e2e/rstudio/CLAUDE.md
@@ -11,7 +11,7 @@ The `window.rstudio` surface includes:
 - `window.rstudio.project` -- `path()`, `name()`, `isActive()`, `open(path)`.
 - `window.rstudio.version` -- `{ rstudio, r }` version strings.
 - `window.rstudio.dialogs` -- `numShowing()`, `dismissAll()`.
-- `window.rstudio.layout.reset()` -- end any active pane/column zoom.
+- `window.rstudio.layout.reset()` -- end any active pane/column zoom or pane maximize.
 
 Commands and prefs are enumerated up front at agent init, so a missing-by-name lookup is a genuine "doesn't exist" rather than "not yet touched by GWT code".
 

--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -28,7 +28,11 @@ function sandboxRoot(): string {
   }
   return s;
 }
-const sharedDataHome = () => path.join(sandboxRoot(), 'data-home');
+// Sandbox-level data-home: NOT used as RSTUDIO_DATA_HOME for Desktop launches
+// (each launch gets its own data home under its config root -- see
+// createTempConfig), only as the source of the seeded Posit Assistant build
+// (data-home/pai, populated by sandbox-setup.ts when PW_SEED_PAI is set).
+const sandboxDataHome = () => path.join(sandboxRoot(), 'data-home');
 const sharedUserHome = () => path.join(sandboxRoot(), 'user-home');
 
 function readPrefsFile(filePath: string, sourceLabel: string): Record<string, unknown> {
@@ -164,6 +168,7 @@ interface TempConfig {
   configHome: string;
   configDir: string;
   electronUserData: string;
+  dataHome: string;
 }
 
 /**
@@ -171,7 +176,9 @@ interface TempConfig {
  * built by merging fixtures/base-prefs.jsonc with an optional override
  * from PW_RSTUDIO_PREFS_OVERRIDE. Plumbed into RStudio via
  * RSTUDIO_CONFIG_* env vars at spawn time so the user's real profile
- * is untouched.
+ * is untouched. Also carries a per-spec data home (RSTUDIO_DATA_HOME)
+ * so persisted client state -- window layout, pane sizes, source docs --
+ * can't leak between specs or workers.
  *
  * Desktop only -- Server mode doesn't spawn RStudio, so this mechanism
  * doesn't apply directly. See https://github.com/rstudio/rstudio/issues/17520
@@ -182,9 +189,11 @@ function createTempConfig(): TempConfig {
   const configHome = path.join(root, 'config-home');
   const configDir = path.join(root, 'config-dir');
   const electronUserData = path.join(root, 'electron-userdata');
-  for (const d of [configHome, configDir, electronUserData]) {
+  const dataHome = path.join(root, 'data-home');
+  for (const d of [configHome, configDir, electronUserData, dataHome]) {
     fs.mkdirSync(d, { recursive: true });
   }
+  seedPaiIntoDataHome(dataHome);
 
   const basePrefs = readPrefsFile(BASE_PREFS_PATH, 'base');
   const overridePath = process.env[OVERRIDE_PREFS_ENV];
@@ -215,7 +224,28 @@ function createTempConfig(): TempConfig {
     ),
   );
 
-  return { root, configHome, configDir, electronUserData };
+  return { root, configHome, configDir, electronUserData, dataHome };
+}
+
+/**
+ * Link the seeded Posit Assistant build (sandbox data-home/pai, populated by
+ * sandbox-setup.ts when PW_SEED_PAI is set) into a per-spec data home so the
+ * session under test finds it at RSTUDIO_DATA_HOME/pai. A symlink (junction
+ * on Windows, which needs no elevation) avoids copying the install once per
+ * spec. The uninstall flow deletes pai via boost::filesystem::remove_all,
+ * which removes the link itself without following it, so an uninstall test
+ * can't destroy the shared seed. Writes into pai (e.g. manifest-check.json)
+ * do go through the link to the seed -- same exposure as the previous fully
+ * shared data home, now scoped to pai only. No-op when nothing was seeded or
+ * the link already exists (config-root reuse across a restart).
+ */
+function seedPaiIntoDataHome(dataHome: string): void {
+  const seed = path.join(sandboxDataHome(), 'pai');
+  const dest = path.join(dataHome, 'pai');
+  if (!fs.existsSync(seed) || fs.existsSync(dest)) {
+    return;
+  }
+  fs.symlinkSync(seed, dest, process.platform === 'win32' ? 'junction' : 'dir');
 }
 
 // Cold CI runners can take longer than a developer machine to clear the
@@ -304,11 +334,13 @@ async function launchRStudioOnce(existingConfigRoot?: string): Promise<DesktopSe
       configHome: path.join(existingConfigRoot, 'config-home'),
       configDir: path.join(existingConfigRoot, 'config-dir'),
       electronUserData: path.join(existingConfigRoot, 'electron-userdata'),
+      dataHome: path.join(existingConfigRoot, 'data-home'),
     };
     // Defensively recreate child dirs in case anything cleared them between runs
-    for (const d of [tempConfig.configHome, tempConfig.configDir, tempConfig.electronUserData]) {
+    for (const d of [tempConfig.configHome, tempConfig.configDir, tempConfig.electronUserData, tempConfig.dataHome]) {
       fs.mkdirSync(d, { recursive: true });
     }
+    seedPaiIntoDataHome(tempConfig.dataHome);
   } else {
     tempConfig = createTempConfig();
   }
@@ -357,7 +389,14 @@ async function launchRStudioOnce(existingConfigRoot?: string): Promise<DesktopSe
       RSTUDIO_CONFIG_DIR: tempConfig.configDir,
       RSTUDIO_CONFIG_HOME: tempConfig.configHome,
       RSTUDIO_CONFIG_ROOT: tempConfig.root,
-      RSTUDIO_DATA_HOME: sharedDataHome(),
+      // Per-spec, not shared: RSTUDIO_DATA_HOME is where the session persists
+      // client state (data-home/pcs/*.pper -- window layout, pane sizes,
+      // source docs, ...). Sharing it across workers let one spec's leaked
+      // state (e.g. a maximized Viewer pane from a notebook preview) poison
+      // every later launch in the run, including fresh retry workers. Tied to
+      // the config root so a deliberate quit-and-restart (which reuses the
+      // config root) still sees its persisted state.
+      RSTUDIO_DATA_HOME: tempConfig.dataHome,
       RSTUDIO_DISABLE_WHATS_NEW: '1',
       // Under PW_DEBUG, have the launched app open Chromium DevTools on
       // startup so the renderer's Performance profiler is ready before

--- a/e2e/rstudio/fixtures/sandbox-setup.ts
+++ b/e2e/rstudio/fixtures/sandbox-setup.ts
@@ -8,10 +8,12 @@ import { launchRStudio, shutdownRStudio } from './desktop.fixture';
  * Create a per-invocation sandbox directory and export its path as PW_SANDBOX.
  *
  * The sandbox is the single rooted tree under which every test-side artifact
- * lives: per-spec config trees, R workdirs, the shared data-home
- * (RSTUDIO_DATA_HOME), and the shared user home (HOME/USERPROFILE). The
- * companion sandbox-teardown removes the subtree once the run finishes
- * (unless preserved by the rules in that file).
+ * lives: per-spec config trees (each carrying its own RSTUDIO_DATA_HOME --
+ * see desktop.fixture's createTempConfig), R workdirs, the sandbox-level
+ * data-home (the seeded-pai source; Desktop sessions do not use it as their
+ * data home), and the shared user home (HOME/USERPROFILE). The companion
+ * sandbox-teardown removes the subtree once the run finishes (unless
+ * preserved by the rules in that file).
  *
  * Env vars (all optional):
  *   PW_SANDBOX_ROOT                Parent dir for the sandbox subtree. Defaults
@@ -23,7 +25,8 @@ import { launchRStudio, shutdownRStudio } from './desktop.fixture';
  *                                  (e.g. ~/.local/share/rstudio/pai, as
  *                                  produced by the assistant repo's
  *                                  `npm run deploy:rstudio`). Copied into the
- *                                  sandbox data-home so tests run against
+ *                                  sandbox data-home, from where each per-spec
+ *                                  data home links it, so tests run against
  *                                  that local build instead of downloading
  *                                  the official package. Only the install
  *                                  shape (bin/package.json present) is
@@ -87,7 +90,9 @@ export default async function globalSetup() {
   fs.mkdirSync(path.join(sandbox, 'data-home'), { recursive: true });
 
   // Seed a locally built Posit Assistant into the sandbox data-home so tests
-  // exercise it instead of downloading the official package.
+  // exercise it instead of downloading the official package. Desktop launches
+  // use per-spec data homes; each links data-home/pai from here (see
+  // desktop.fixture's seedPaiIntoDataHome).
   const seedPai = process.env.PW_SEED_PAI;
   if (seedPai) {
     if (!fs.existsSync(path.join(seedPai, 'bin', 'package.json'))) {

--- a/e2e/rstudio/tests/panes/layout/tabs.test.ts
+++ b/e2e/rstudio/tests/panes/layout/tabs.test.ts
@@ -156,4 +156,28 @@ test.describe('Workbench tabs', () => {
     // triggering the HIDE-animation race (#17738) that breaks the next test.
     await resetSourcePaneState(page);
   });
+
+  // A pane can also be maximized at the WindowFrame level -- the pane header
+  // min/max buttons, or EnsureHeightEvent.MAXIMIZED fired when e.g. an R
+  // Notebook preview opens in the Viewer. That state is invisible to
+  // PaneManager's zoom tracking and persists across sessions via client state
+  // (windowlayoutstate), so a leak here once poisoned every later launch in a
+  // CI run: TabSet1 came up minimized with its real tab elements hidden, and
+  // every environment-pane test failed clicking a "not visible" tab.
+  // layout.reset (and with it the per-test reset) must clear it.
+  test('layout.reset clears a WindowFrame-level pane maximize', async ({ rstudioPage: page }) => {
+    const envTab = page.locator(TAB_ENVIRONMENT);
+
+    // Maximize TabSet2 (Files/Plots/Viewer/...); its sibling TabSet1 minimizes
+    // to a facsimile header strip, hiding the real Environment tab element.
+    await executeCommand(page, 'maximizeTabSet2');
+    await expect(envTab).toBeHidden();
+
+    await resetLayoutZoom(page);
+
+    // The real tab strip is back and clickable.
+    await expect(envTab).toBeVisible();
+    await envTab.click();
+    await expect(page.locator(ENV_PANEL)).toBeVisible();
+  });
 });

--- a/e2e/rstudio/tests/sandbox.test.ts
+++ b/e2e/rstudio/tests/sandbox.test.ts
@@ -19,6 +19,8 @@ test.describe('sandbox layout', { tag: ['@desktop_only'] }, () => {
   test('Desktop launch populates electron-userdata and creates data-home/user-home', async ({ rstudioPage }) => {
     void rstudioPage; // Triggers the worker-scoped launch.
 
+    // Sandbox-level dirs: user-home is shared; data-home is only the
+    // seeded-pai source (Desktop sessions get per-spec data homes below).
     expect(fs.existsSync(path.join(SANDBOX!, 'data-home'))).toBe(true);
     expect(fs.existsSync(path.join(SANDBOX!, 'user-home'))).toBe(true);
 
@@ -49,7 +51,25 @@ test.describe('sandbox layout', { tag: ['@desktop_only'] }, () => {
         () => fs.existsSync(path.join(electronData, 'Local State')),
         { message: `${dir}: expected electron-userdata/Local State to exist` },
       ).toBe(true);
+
+      // Each config root carries its own isolated data home; a shared one
+      // let leaked client state (e.g. a maximized pane) poison every later
+      // launch in the run.
+      expect(
+        fs.existsSync(path.join(configRoot, 'data-home')),
+        `${dir}: expected per-spec data-home to exist`,
+      ).toBe(true);
     }
+
+    // The session persists its state under RSTUDIO_DATA_HOME; at least the
+    // current worker's launch must have written there. Catches the session
+    // relocating state writes off RSTUDIO_DATA_HOME (the rest of this suite
+    // would then silently lose its cross-restart persistence coverage).
+    await expect.poll(
+      () => configDirs.some(dir =>
+        fs.existsSync(path.join(SANDBOX!, dir, 'data-home', 'rstudio-desktop.json'))),
+      { message: 'expected at least one per-spec data-home to contain rstudio-desktop.json' },
+    ).toBe(true);
   });
 });
 

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -245,22 +245,25 @@ export async function isCommandEnabled(page: Page, commandId: string): Promise<b
 }
 
 /**
- * End any active pane/column zoom, restoring the default layout.
+ * End any active pane/column zoom or pane maximize, restoring the default
+ * layout.
  *
  * The automation session is worker-scoped, so a test that zooms a pane (e.g.
  * layoutZoomEnvironment) and fails before toggling it back off leaves the
  * layout maximized -- which squeezes every other pane to near-zero and makes
- * the next test's targets unclickable / invisible. This breaks the cascade by
- * ending any active zoom.
+ * the next test's targets unclickable / invisible. The same applies to a
+ * WindowFrame-level maximize (the pane header min/max buttons, or an R
+ * Notebook preview maximizing the Viewer), which additionally persists via
+ * client state. This breaks the cascade by ending either state.
  *
  * Delegates to the GWT bridge (window.rstudio.layout.reset), which decides
- * based on the live PaneManager state: it un-zooms only when something is
- * actually zoomed (so a non-zoomed layout keeps its column widths) and covers
- * both pane/window zoom and column zoom. The bridge returns a Promise that
- * resolves once the relayout has settled (the restore flushes on a later
- * animation frame even under reduced_motion), so awaiting this leaves the
- * layout stable before the caller measures or clicks panes. A no-op when the
- * bridge is absent.
+ * based on the live PaneManager state: it restores only when something is
+ * actually zoomed or maximized (so a normal layout keeps its column widths)
+ * and covers pane/window zoom, column zoom, and WindowFrame maximize. The
+ * bridge returns a Promise that resolves once the relayout has settled (the
+ * restore flushes on a later animation frame even under reduced_motion), so
+ * awaiting this leaves the layout stable before the caller measures or clicks
+ * panes. A no-op when the bridge is absent.
  */
 export async function resetLayoutZoom(page: Page): Promise<void> {
   await page.evaluate(() => window.rstudio?.layout?.reset());

--- a/e2e/rstudio/utils/test-reset.ts
+++ b/e2e/rstudio/utils/test-reset.ts
@@ -42,10 +42,12 @@ const DEBUG_STOP_BTN = `${DEBUG_TOOLBAR} [title^="Stop"]`;
  *     against a stale state and getActiveDebugLineRow throws because the
  *     debug marker is in a hidden editor tab. Click Stop on the debug
  *     toolbar when it's visible.
- *   - **Pane zoom.** A previous test that maximized a pane (layoutZoom*) and
- *     failed before toggling it back leaves the layout zoomed, squeezing every
- *     other pane to near-zero so the next test can't click its targets. End the
- *     zoom when one is active (see resetLayoutZoom).
+ *   - **Pane zoom / maximize.** A previous test that zoomed a pane
+ *     (layoutZoom*) or left one maximized at the WindowFrame level (the pane
+ *     header min/max buttons, or a notebook preview maximizing the Viewer)
+ *     squeezes other panes to near-zero or hides their tab strips entirely,
+ *     so the next test can't click its targets. End either state when active
+ *     (see resetLayoutZoom).
  *   - **Source pane buffers.** Collapse to a single Untitled tab via the
  *     `resetToUntitled` bridge (kept-or-created untitled + close everything
  *     else). resetSourcePaneState specifically -- NOT closeAllSourceDocs --
@@ -138,13 +140,14 @@ export async function resetForNextTest(page: Page): Promise<void> {
     }
   }
 
-  // 3. End any active pane zoom. The session is worker-scoped, so a prior test
-  //    that zoomed a pane (e.g. layoutZoomEnvironment) and failed before
-  //    toggling it back off leaves the layout maximized -- which squeezes every
-  //    other pane to near-zero, so the next test's locator clicks land on a
-  //    zero-size element and time out as "not visible". resetLayoutZoom reads
-  //    the live zoom state and is a no-op (preserving any custom column widths)
-  //    when nothing is zoomed.
+  // 3. End any active pane zoom or pane maximize. The session is worker-scoped,
+  //    so a prior test that zoomed a pane (e.g. layoutZoomEnvironment) or left
+  //    one maximized at the WindowFrame level (e.g. an R Notebook preview
+  //    maximizes the Viewer, minimizing TabSet1 and hiding its tab strip)
+  //    leaves the next test's locator clicks landing on a zero-size or hidden
+  //    element, timing out as "not visible". resetLayoutZoom reads the live
+  //    layout state and is a no-op (preserving any custom column widths) when
+  //    nothing is zoomed or maximized.
   await resetLayoutZoom(page);
 
   // 4. Collapse source pane to a single Untitled tab. resetSourcePaneState

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -81,8 +81,9 @@ import com.google.inject.Singleton;
  *   window.rstudio.dialogs.numShowing()  // count of open modal dialogs
  *   window.rstudio.dialogs.dismissAll()  // hide every open modal dialog
  *
- *   window.rstudio.layout.reset()        // end any active pane/column zoom;
- *                                        // Promise resolves once layout settles
+ *   window.rstudio.layout.reset()        // end any active pane/column zoom or
+ *                                        // pane maximize; Promise resolves once
+ *                                        // layout settles
  * </pre>
  *
  * <h2>Why enumerate everything up front</h2>
@@ -251,10 +252,10 @@ public class ApplicationAutomation
       registerLayoutObject();
    }
 
-   // End any pane/column zoom a prior test left active. No-op when nothing is
-   // zoomed, so a non-zoomed layout keeps its current column widths. onCompleted
-   // fires once the relayout has settled (see PaneManager.endZoomIfActive) so
-   // the JS side can await it.
+   // End any pane/column zoom or WindowFrame-level pane maximize a prior test
+   // left active. No-op when nothing is zoomed or maximized, so a normal layout
+   // keeps its current column widths. onCompleted fires once the relayout has
+   // settled (see PaneManager.endZoomIfActive) so the JS side can await it.
    private void resetLayoutZoom(JavaScriptObject onCompleted)
    {
       pPaneManager_.get().endZoomIfActive(() -> invokeCallback(onCompleted));
@@ -649,13 +650,13 @@ public class ApplicationAutomation
       });
    }-*/;
 
-   // End any pane/column zoom left active by a prior test (no-op otherwise).
-   // Lets a per-test reset clear leaked zoom state without reverse-engineering
-   // it from command checked-states -- PaneManager decides based on the live
-   // layout state it owns. Returns a Promise that resolves once the relayout
-   // has settled (the restore flushes on a later animation frame even under
-   // reduced_motion), so callers can await a stable layout before measuring or
-   // clicking panes.
+   // End any pane/column zoom or pane maximize left active by a prior test
+   // (no-op otherwise). Lets a per-test reset clear leaked zoom/maximize state
+   // without reverse-engineering it from command checked-states -- PaneManager
+   // decides based on the live layout state it owns. Returns a Promise that
+   // resolves once the relayout has settled (the restore flushes on a later
+   // animation frame even under reduced_motion), so callers can await a stable
+   // layout before measuring or clicking panes.
    private native final void registerLayoutObject() /*-{
       var self = this;
       $wnd.rstudio.layout = $wnd.rstudio.layout || {};

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -730,6 +730,17 @@ public class PaneManager
     * maximizedWindow_ / maximizedTab_; column zoom is reflected by
     * getZoomedColumn().
     *
+    * Quadrants can also be maximized without PaneManager's zoom tracking ever
+    * knowing: the pane-header min/max buttons and EnsureHeightEvent.MAXIMIZED
+    * (fired e.g. when an R Notebook preview opens in the Viewer) drive the
+    * WindowFrame state machine in DualWindowLayoutPanel directly, and that
+    * state persists across sessions via client state (windowlayoutstate). So
+    * when no tracked zoom is active, restore any MAXIMIZE-state quadrant to
+    * NORMAL -- which also restores its MINIMIZE-state sibling (see
+    * DualWindowLayoutPanel.WindowStateChangeManager). HIDE/EXCLUSIVE pairs are
+    * left alone; they encode the empty-source-pane layout owned by the
+    * source-document count logic.
+    *
     * The onComplete callback lets the bridge expose a Promise that resolves
     * only once the relayout has finished -- the relayout flushes on a later
     * animation frame (panel_.animate) even under reduced_motion, so a
@@ -742,10 +753,29 @@ public class PaneManager
           getZoomedColumn() != null)
       {
          restoreLayout(onComplete);
+         return;
       }
-      else if (onComplete != null)
+
+      boolean restored = false;
+      for (LogicalWindow window : panes_)
       {
-         onComplete.execute();
+         if (window.getState() == WindowState.MAXIMIZE)
+         {
+            window.onWindowStateChange(
+                  new WindowStateChangeEvent(WindowState.NORMAL, true));
+            restored = true;
+         }
+      }
+
+      if (onComplete != null)
+      {
+         // The DualWindowLayoutPanel defers its relayout (and the client
+         // state persist) to a scheduled command, so chain the callback
+         // behind that rather than firing it synchronously.
+         if (restored)
+            Scheduler.get().scheduleDeferred(onComplete::execute);
+         else
+            onComplete.execute();
       }
    }
 


### PR DESCRIPTION
Fixes #17952.

Two fixes for the environment-pane e2e failures where `#rstudio_workbench_tab_environment` resolved as selected but stayed "not visible" for the rest of a CI run:

### `layout.reset()` now clears WindowFrame-level pane maximize

`PaneManager.endZoomIfActive` (backing `window.rstudio.layout.reset()`, which the per-test reset calls) only checked PaneManager's zoom tracking. A quadrant maximized through the WindowFrame state machine -- the pane-header min/max buttons, or `EnsureHeightEvent` escalating to MAXIMIZE when the requested height doesn't fit (the R Notebook preview on ~645px-tall CI displays) -- was invisible to it, leaving TabSet1 minimized with its real tab elements hidden. When no tracked zoom is active, the reset now restores any MAXIMIZE-state quadrant to NORMAL, which also restores its minimized sibling; HIDE/EXCLUSIVE pairs (the empty-source-pane layout) are left alone.

### Per-spec `RSTUDIO_DATA_HOME` in the desktop e2e fixture

All workers shared one data home, so the maximize persisted via client state (`data-home/pcs/windowlayoutstate.pper`) and every subsequent launch -- including fresh retry workers -- restored the broken layout at startup. Each launch now gets its own data home under its per-spec config root (still reused across deliberate quit-and-restart flows, so persistence tests keep working), and the seeded Posit Assistant build is symlinked into each per-spec data home. The uninstall flow deletes pai via `boost::filesystem::remove_all`, which removes the link without following it, so the shared seed survives.

### Tests

- New regression test in `tabs.test.ts`: maximizes TabSet2 via `maximizeTabSet2` (the same WindowState path the notebook preview takes), confirms the Environment tab is hidden, and verifies `layout.reset()` restores it. Passes against the dev build.
- `environment_pane.test.ts` passes locally when run after main's `rnotebook.test.ts` in the same worker (the CI failure sequence).
- `sandbox.test.ts` updated for (and verifying) the per-spec data home, including that the session writes `rstudio-desktop.json` there.
- `pane_location_persistence.test.ts` (config-root reuse across restart) passes.