### PR TITLE
run per-test e2e resets via auto fixture; capture client exceptions; pin test geometry

### DIFF
--- a/e2e/rstudio/CLAUDE.md
+++ b/e2e/rstudio/CLAUDE.md
@@ -12,6 +12,7 @@ The `window.rstudio` surface includes:
 - `window.rstudio.version` -- `{ rstudio, r }` version strings.
 - `window.rstudio.dialogs` -- `numShowing()`, `dismissAll()`.
 - `window.rstudio.layout.reset()` -- end any active pane/column zoom or pane maximize.
+- `window.rstudio.errors` -- `list()` / `clear()` the uncaught client exceptions recorded by the agent (message + stack); `simulate(msg)` raises a real one (harness self-test only). The per-test fixture drains this and fails the test that raised an exception (opt out with `PW_IGNORE_CLIENT_EXCEPTIONS=1`).
 
 Commands and prefs are enumerated up front at agent init, so a missing-by-name lookup is a genuine "doesn't exist" rather than "not yet touched by GWT code".
 

--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -205,20 +205,21 @@ function createTempConfig(): TempConfig {
     JSON.stringify(prefs, null, 2),
   );
 
-  // Pre-seed electron-store's config.json with explicit windowBounds. The
-  // schema default (1200x900) gets clamped by positionAndEnsureVisible to the
-  // workArea of whatever display is attached -- on macOS GH Actions runners
-  // that's around 1024x645, which is small enough that the left column's
-  // source pane drops under DualWindowLayoutPanel's 60px snap threshold and
-  // the Console gets promoted to MAXIMIZE state. Locking the renderer at
-  // 1400x900 keeps both panes comfortably above the snap threshold.
-  // Requested bounds that intersect any display.workArea are used as-is
-  // (window-utils.ts:191), so a 1400x900 rect at the origin sticks even on
-  // narrower virtual displays.
+  // Pre-seed electron-store's config.json with explicit windowBounds, pinned
+  // to ONE geometry that both local machines and CI render identically:
+  // 1024x645, the macOS GH Actions runner's display workArea. Asking for
+  // anything taller is silently clamped to that on CI (macOS constrains
+  // windows to the visible frame regardless of the requested rect), so the
+  // previous 1400x900 request meant local runs tested a different layout
+  // than CI -- and geometry-sensitive bugs (the Viewer's ensure-height
+  // escalating to a pane maximize, the Plots-pane ImageFrame TypeError)
+  // surfaced only on CI. 800x600 was evaluated and rejected: it genuinely
+  // cramps layouts (fewer data-viewer columns visible, the Import Dataset
+  // dialog doesn't fit) and broke 7 tests.
   fs.writeFileSync(
     path.join(electronUserData, 'config.json'),
     JSON.stringify(
-      { view: { windowBounds: { x: 0, y: 0, width: 1400, height: 900, maximized: false } } },
+      { view: { windowBounds: { x: 0, y: 0, width: 1024, height: 645, maximized: false } } },
       null,
       2,
     ),

--- a/e2e/rstudio/fixtures/rstudio.fixture.ts
+++ b/e2e/rstudio/fixtures/rstudio.fixture.ts
@@ -2,6 +2,7 @@ import { test as base, type Page } from '@playwright/test';
 import { launchRStudio, shutdownRStudio } from './desktop.fixture';
 import { launchServer, shutdownServer } from './server.fixture';
 import { getEnvironmentVersions, clearConsole } from '../pages/console_pane.page';
+import { drainClientExceptions } from '../utils/commands';
 import { resetForNextTest } from '../utils/test-reset';
 import { waitForUserConsoleInput } from '../utils/debug';
 
@@ -20,7 +21,7 @@ async function logVersions(page: Page): Promise<void> {
  * The `mode` option is set per-project in playwright.config.ts; select with
  * `--project=desktop` (default) or `--project=server`.
  */
-export const test = base.extend<{}, { mode: Mode; rstudioPage: Page }>({
+export const test = base.extend<{ perTestReset: void }, { mode: Mode; rstudioPage: Page }>({
   mode: ['desktop', { option: true, scope: 'worker' }],
   rstudioPage: [async ({ mode }, use) => {
     if (mode === 'server') {
@@ -41,18 +42,65 @@ export const test = base.extend<{}, { mode: Mode; rstudioPage: Page }>({
       await shutdownRStudio(session);
     }
   }, { scope: 'worker' }],
-});
 
-// Reset the IDE to a clean per-test starting state. See utils/test-reset.ts
-// for what's covered and what's deliberately not. Each step short-circuits
-// when its trigger isn't present, so on a clean session this is cheap.
-test.beforeEach(async ({ rstudioPage: page }, testInfo) => {
-  await resetForNextTest(page);
+  // Reset the IDE to a clean per-test starting state. See utils/test-reset.ts
+  // for what's covered and what's deliberately not. Each step short-circuits
+  // when its trigger isn't present, so on a clean session this is cheap.
+  //
+  // This is an auto FIXTURE, not a module-scope test.beforeEach, very much on
+  // purpose. Hooks registered at the top level of this (imported) module are
+  // only attached to the suite of the FIRST spec file that loads the module
+  // in each worker process -- Node caches the module, so its top-level
+  // statements never re-run for the next spec file, and every later file in
+  // the worker silently ran without any per-test reset. That is exactly how a
+  // leaked pane maximize from one spec (an R Notebook preview maximizing the
+  // Viewer on a short display) survived into the next spec's first test and
+  // hid the Environment tab (#17952). Auto fixtures are part of the test type
+  // itself, so they run for every test in every file regardless of module
+  // caching.
+  perTestReset: [async ({ rstudioPage: page }, use, testInfo) => {
+    // Drain exceptions that arrived BEFORE this test (a previous test's
+    // teardown, the gap between specs). They can't be attributed to the
+    // upcoming test, so log them rather than fail it.
+    const leftovers = await drainClientExceptions(page);
+    for (const e of leftovers) {
+      console.warn(
+        `[client-exception] recorded between tests (not attributed): ${e.message}\n${e.stack}`,
+      );
+    }
 
-  // Debug-only: park the test (IDE clean and idle) so a human can arm
-  // DevTools before the test body drives its scenario. Prompts in the
-  // RStudio Console pane. No-op unless PW_DEBUG is set. See utils/debug.ts.
-  await waitForUserConsoleInput(page, `run: ${testInfo.title}`);
+    await resetForNextTest(page);
+
+    // Debug-only: park the test (IDE clean and idle) so a human can arm
+    // DevTools before the test body drives its scenario. Prompts in the
+    // RStudio Console pane. No-op unless PW_DEBUG is set. See utils/debug.ts.
+    await waitForUserConsoleInput(page, `run: ${testInfo.title}`);
+
+    await use();
+
+    // Any uncaught client exception raised while this test ran fails the
+    // test, with the recorded stack in the failure output. The product
+    // swallows these behind an "Error" dialog (message only), which the
+    // next reset would silently dismiss -- a real product bug (like the
+    // Plots-pane ImageFrame TypeError on short displays) could otherwise
+    // hide behind passing tests indefinitely. PW_IGNORE_CLIENT_EXCEPTIONS=1
+    // downgrades to a warning if a known benign exception must be tolerated
+    // while a fix lands.
+    const raised = await drainClientExceptions(page);
+    if (raised.length > 0) {
+      const detail = raised.map((e) => `${e.message}\n${e.stack}`).join('\n---\n');
+      const ignore = ['1', 'true'].includes(
+        (process.env.PW_IGNORE_CLIENT_EXCEPTIONS ?? '').toLowerCase(),
+      );
+      if (ignore) {
+        console.warn(`[client-exception] during "${testInfo.title}" (ignored by env):\n${detail}`);
+      } else {
+        throw new Error(
+          `${raised.length} uncaught client exception(s) during "${testInfo.title}":\n${detail}`,
+        );
+      }
+    }
+  }, { auto: true }],
 });
 
 export { expect } from '@playwright/test';

--- a/e2e/rstudio/tests/harness/client_exceptions.test.ts
+++ b/e2e/rstudio/tests/harness/client_exceptions.test.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { dismissAllModals } from '@utils/commands';
+
+/**
+ * Harness self-test for uncaught-client-exception capture (#17952 follow-up).
+ *
+ * The automation agent wraps GWT's uncaught-exception handler and records
+ * {message, stack, time} into window.rstudio.errors; the per-test fixture
+ * drains the record after every test and fails the test that raised one.
+ * `errors.simulate()` throws from a scheduled ($entry-wrapped) context, so
+ * the exception takes the real uncaught-handler path -- the same one a
+ * product bug (e.g. the Plots-pane ImageFrame TypeError) takes.
+ */
+test.describe('client exception capture', () => {
+  test('simulated uncaught exceptions are recorded with a stack', async ({ rstudioPage: page }) => {
+    await page.evaluate(() => window.rstudio!.errors.simulate('automation capture probe'));
+
+    // The simulated throw is scheduled; poll until the recorder sees it.
+    await expect.poll(
+      () => page.evaluate(
+        () => window.rstudio!.errors.list().map((e) => e.message).join('|'),
+      ),
+    ).toContain('automation capture probe');
+
+    const errors = await page.evaluate(() => window.rstudio!.errors.list());
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    // Stack content varies by build (Java names in draft, obfuscated when
+    // optimized); assert presence, not shape.
+    expect(typeof errors[0].stack).toBe('string');
+
+    // Clean up: clear the record so the per-test drain doesn't fail this
+    // test, and dismiss the Error dialog the (delegated-to) default handler
+    // showed for the simulated exception.
+    await page.evaluate(() => window.rstudio!.errors.clear());
+    await dismissAllModals(page);
+  });
+
+  test('an uncaught client exception fails the test that raised it', async ({ rstudioPage: page }) => {
+    // The per-test fixture's drain is expected to fail this test in its
+    // teardown; test.fail() inverts that into the passing outcome, so a
+    // regression in the fail-on-exception machinery surfaces as "expected
+    // to fail, but passed".
+    test.fail();
+
+    await page.evaluate(() => window.rstudio!.errors.simulate('deliberate failure probe'));
+    await expect.poll(
+      () => page.evaluate(() => window.rstudio!.errors.list().length),
+    ).toBeGreaterThan(0);
+
+    // Dismiss the dialog but deliberately do NOT clear the record.
+    await dismissAllModals(page);
+  });
+});

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -163,6 +163,27 @@ type LayoutBridge = {
   reset(): Promise<void>;
 };
 
+/** One uncaught client exception recorded by the automation agent. */
+export type ClientException = {
+  message: string;
+  /**
+   * Cause chain + frames. Java names in draft / super-dev builds; best-effort
+   * (obfuscated) in optimized builds, where the message still identifies the
+   * failure.
+   */
+  stack: string;
+  /** Date.now() at record time. */
+  time: number;
+};
+
+type ErrorsBridge = {
+  /** Uncaught client exceptions recorded since the last clear(). */
+  list(): ClientException[];
+  clear(): void;
+  /** Raise a real uncaught exception from a scheduled context (self-test only). */
+  simulate(message: string): void;
+};
+
 type RStudioBridge = {
   commands: { [id: string]: CommandEntry } & { list: string[] };
   prefs: { [name: string]: PrefEntry };
@@ -171,6 +192,7 @@ type RStudioBridge = {
   version: VersionInfo;
   dialogs: DialogsBridge;
   layout: LayoutBridge;
+  errors: ErrorsBridge;
   /** Chat-pane state surface (populated lazily by ChatPresenter). */
   chat?: ChatBridge;
   /**
@@ -267,6 +289,27 @@ export async function isCommandEnabled(page: Page, commandId: string): Promise<b
  */
 export async function resetLayoutZoom(page: Page): Promise<void> {
   await page.evaluate(() => window.rstudio?.layout?.reset());
+}
+
+/**
+ * Read and clear the uncaught-client-exception record kept by the automation
+ * agent (window.rstudio.errors). Returns [] when the bridge is absent (e.g.
+ * mid-restart) -- callers treat that as "nothing recorded" because a dead
+ * session fails loudly elsewhere.
+ *
+ * The per-test fixture drains this after every test and fails the test that
+ * produced exceptions; a leftover drained before the next test is logged but
+ * not attributed (it may belong to teardown or the gap between tests).
+ */
+export async function drainClientExceptions(page: Page): Promise<ClientException[]> {
+  return page.evaluate(() => {
+    const errors = window.rstudio?.errors;
+    if (!errors)
+      return [];
+    const items = errors.list();
+    errors.clear();
+    return items;
+  }).catch(() => []);
 }
 
 /**

--- a/e2e/rstudio/utils/test-reset.ts
+++ b/e2e/rstudio/utils/test-reset.ts
@@ -102,6 +102,29 @@ export async function resetForNextTest(page: Page): Promise<void> {
   //    whole GWT modal stack (handles stacked + OK-only dialogs a single
   //    button click can't); it hides rather than answers, so a dirty doc's
   //    changes are discarded by resetSourcePaneState's revert in step 3.
+  //
+  //    Capture each dialog's contents BEFORE hiding it: a leaked modal is
+  //    often the only visible artifact of a real product error (e.g. the
+  //    uncaught-exception "Error" dialog GWT raises), and dismissing it
+  //    silently would bury the evidence -- the test that *caused* it can
+  //    pass, and the dialog only blocks some later test. The warning puts
+  //    the dialog text in the test output where CI failures can be triaged.
+  const leakedDialogs = await page.evaluate(() => {
+    const visible = (el: Element) => {
+      const r = el.getBoundingClientRect();
+      return r.width > 0 && r.height > 0;
+    };
+    return Array.from(document.querySelectorAll('.gwt-DialogBox'))
+      .filter(visible)
+      .map((el) => {
+        const label = el.getAttribute('aria-label') ?? 'dialog';
+        const text = ((el as HTMLElement).innerText ?? '').replace(/\s+/g, ' ').trim();
+        return `[${label}] ${text.slice(0, 400)}`;
+      });
+  }).catch(() => [] as string[]);
+  for (const dialog of leakedDialogs) {
+    console.warn(`[test-reset] dismissing leaked modal dialog -- ${dialog}`);
+  }
   await dismissAllModals(page);
   // Sentinel -1 (not 0) on a failed read: 0 would masquerade as "no modals
   // left" and suppress the very warning this block exists to emit.

--- a/src/gwt/src/org/rstudio/core/client/widget/ImageFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ImageFrame.java
@@ -71,7 +71,12 @@ public class ImageFrame extends Frame
    }
 
    private native final boolean replaceLocation(Element el, String url) /*-{
-      if (!el.contentWindow.document)
+      // contentWindow itself is null while the iframe is detached or being
+      // re-parented (e.g. a pane-layout quadrant swap moves the Plots pane),
+      // and dereferencing it raises an uncaught TypeError that surfaces as an
+      // error dialog. Report not-ready instead; the caller's retry timer
+      // re-attempts once the frame has a window again.
+      if (!el.contentWindow || !el.contentWindow.document)
          return false;
       var img = el.contentWindow.document.getElementById('img');
       if (!img)

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.application;
 import java.util.Map;
 
 import org.rstudio.core.client.FilePosition;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.ModalDialogTracker;
@@ -41,7 +42,9 @@ import org.rstudio.studio.client.workbench.ui.PaneManager;
 import org.rstudio.studio.client.workbench.views.chat.server.ChatServerOperations;
 import org.rstudio.studio.client.workbench.views.source.SourceColumnManager;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -84,6 +87,13 @@ import com.google.inject.Singleton;
  *   window.rstudio.layout.reset()        // end any active pane/column zoom or
  *                                        // pane maximize; Promise resolves once
  *                                        // layout settles
+ *
+ *   window.rstudio.errors.list()         // uncaught client exceptions recorded
+ *                                        // since the last clear(): message,
+ *                                        // stack, time
+ *   window.rstudio.errors.clear()        // empty the record
+ *   window.rstudio.errors.simulate(msg)  // raise a real uncaught exception
+ *                                        // (harness self-test only)
  * </pre>
  *
  * <h2>Why enumerate everything up front</h2>
@@ -136,6 +146,7 @@ public class ApplicationAutomation
       registerChat();
       registerDialogs();
       registerLayout();
+      registerErrors();
       registerReadinessHandlers();
    }
 
@@ -250,6 +261,70 @@ public class ApplicationAutomation
    private void registerLayout()
    {
       registerLayoutObject();
+   }
+
+   // Record uncaught client exceptions where the automation harness can see
+   // them. The default ApplicationUncaughtExceptionHandler shows an "Error"
+   // dialog (message only -- no stack) and best-effort logs to the server,
+   // neither of which a test run can reliably observe or attribute. Wrap the
+   // current handler with one that first records {message, stack, time} into
+   // window.rstudio.errors, then delegates so the existing dialog/server
+   // behavior is unchanged. The harness drains the buffer after every test
+   // and fails the test that produced an exception, with the stack in the
+   // failure output.
+   private void registerErrors()
+   {
+      registerErrorsObject();
+
+      final GWT.UncaughtExceptionHandler previousHandler =
+            GWT.getUncaughtExceptionHandler();
+
+      GWT.setUncaughtExceptionHandler((e) ->
+      {
+         try
+         {
+            recordClientException(StringUtil.notNull(e.toString()), stackString(e));
+         }
+         catch (Throwable ignored)
+         {
+            // never let recording break the real handler
+         }
+
+         if (previousHandler != null)
+            previousHandler.onUncaughtException(e);
+      });
+   }
+
+   // Render the throwable (and its cause chain) as a readable stack string.
+   // In draft / super-dev builds the frames carry Java names; in optimized
+   // builds they are best-effort (obfuscated JS identifiers), but the
+   // message and cause chain still identify the failure.
+   private static String stackString(Throwable e)
+   {
+      StringBuilder sb = new StringBuilder();
+      for (Throwable t = e; t != null; t = t.getCause())
+      {
+         if (t != e)
+            sb.append("Caused by: ");
+         sb.append(t.toString()).append("\n");
+
+         StackTraceElement[] stack = t.getStackTrace();
+         int limit = Math.min(stack.length, 50);
+         for (int i = 0; i < limit; i++)
+            sb.append("    at ").append(stack[i]).append("\n");
+      }
+      return sb.toString();
+   }
+
+   // Throw from a scheduled (i.e. $entry-wrapped) context so the exception
+   // takes the real uncaught-handler path. Exists so the harness can
+   // regression-test the capture chain end-to-end; not for product use.
+   private void simulateUncaughtException(String message)
+   {
+      Scheduler.get().scheduleDeferred(() ->
+      {
+         throw new RuntimeException(message);
+      });
    }
 
    // End any pane/column zoom or WindowFrame-level pane maximize a prior test
@@ -657,6 +732,32 @@ public class ApplicationAutomation
    // resolves once the relayout has settled (the restore flushes on a later
    // animation frame even under reduced_motion), so callers can await a stable
    // layout before measuring or clicking panes.
+   // window.rstudio.errors: a drainable record of uncaught client exceptions.
+   //   list()           -> [{ message, stack, time }] (copy)
+   //   clear()          -> empty the record
+   //   simulate(message)-> throw an uncaught exception from a scheduled
+   //                       context (harness self-test only)
+   private native final void registerErrorsObject() /*-{
+      var self = this;
+      $wnd.rstudio.errors = $wnd.rstudio.errors || {};
+      $wnd.rstudio.errors._items = [];
+      $wnd.rstudio.errors.list = $entry(function() {
+         return $wnd.rstudio.errors._items.slice();
+      });
+      $wnd.rstudio.errors.clear = $entry(function() {
+         $wnd.rstudio.errors._items = [];
+      });
+      $wnd.rstudio.errors.simulate = $entry(function(message) {
+         self.@org.rstudio.studio.client.application.ApplicationAutomation::simulateUncaughtException(Ljava/lang/String;)(message);
+      });
+   }-*/;
+
+   private native void recordClientException(String message, String stack) /*-{
+      var errors = $wnd.rstudio && $wnd.rstudio.errors;
+      if (errors && errors._items)
+         errors._items.push({ message: message, stack: stack, time: Date.now() });
+   }-*/;
+
    private native final void registerLayoutObject() /*-{
       var self = this;
       $wnd.rstudio.layout = $wnd.rstudio.layout || {};


### PR DESCRIPTION
Fixes #17954. Fixes #17955.

Follow-ups from validating #17953 -- the residual environment-pane flake turned out to be a deeper harness defect, and chasing it surfaced a product bug.

### Product fix (#17954)

`ImageFrame.replaceLocation` (Plots pane) dereferenced `el.contentWindow` unconditionally; during pane re-parenting (quadrant swaps, snap-to-minimize churn on short windows) it is null, and the read raised an uncaught TypeError shown to the user as an error dialog. Now reports not-ready, feeding the existing `onLoad` retry. Verified: `pane_layout.test.ts` goes from 15/16 to 16/16 at 1024x640.

### Harness fixes (#17955)

- **Per-test reset as an auto fixture.** The module-scope `test.beforeEach` only attached to the first spec file loaded per worker (Node module caching), so every later file ran without resets -- the actual mechanism behind the environment-pane first-test flake. Auto fixtures run for every test in every file. Verified: three files in one worker, resets fire for each file, all green at the geometry that previously reproduced the flake.
- **Uncaught client exceptions fail the test that raised them.** The automation agent wraps the uncaught-exception handler and records message + stack into `window.rstudio.errors`; the fixture drains it after every test (failing with the stack in the output; `PW_IGNORE_CLIENT_EXCEPTIONS=1` downgrades to warnings), and warns with contents for any leaked modal the reset dismisses. New harness self-test exercises the chain end-to-end via `errors.simulate()` (a real throw from a `$entry` context), including a `test.fail()`-inverted check that the fail-on-exception machinery actually fails tests.
- **Pinned window geometry: 1024x645 for local and CI.** macOS clamps windows to the visible frame, so CI was already running at its 1024x645 workArea while local ran 1400x900 -- geometry-sensitive bugs surfaced only on CI. 800x600 was evaluated and rejected (genuinely cramps layouts: data-viewer column tests, Import Dataset dialog; 7 failures).

### Verification

87 tests green locally at the pinned geometry in one run: `tests/harness`, `rnotebook` + `environment_pane` (the CI failure sequence, same worker), all of `tests/panes/layout`, and all of `tests/panes/data-viewer`. `ant javac` and the e2e typecheck pass.