### PR TITLE
add a clear-sort button to the data viewer status bar

### DIFF
--- a/e2e/rstudio/pages/data_viewer.page.ts
+++ b/e2e/rstudio/pages/data_viewer.page.ts
@@ -14,6 +14,8 @@ export class DataViewerPane extends PageObject {
 
   // Elements inside the iframe
   public gridInfo: Locator;
+  public sortStatus: Locator;
+  public clearSortButton: Locator;
   public viewport: Locator;
   public horizontalScrollbar: Locator;
 
@@ -30,6 +32,10 @@ export class DataViewerPane extends PageObject {
     // The data grid renders inside an iframe
     this.frame = page.frameLocator('[title="Data Browser"]');
     this.gridInfo = this.frame.locator('#rsGridData_info');
+    // "Sorted by: <col>" status at the right of the info bar, with its
+    // clear-sort button (hidden while no sort is active).
+    this.sortStatus = this.frame.locator('#rsGridData_info_sort');
+    this.clearSortButton = this.frame.locator('#rsGridData_info_sort_clear');
     this.viewport = this.frame.locator('#gridViewport');
     // Custom auto-hide overlay scrollbar for the horizontal axis. Carries the
     // "visible" class while shown; the class is removed when it fades out.

--- a/e2e/rstudio/tests/panes/data-viewer/pagination-sorting.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/pagination-sorting.test.ts
@@ -4,6 +4,8 @@ import { SourcePane } from '@pages/source_pane.page';
 import { DataViewerPane } from '@pages/data_viewer.page';
 import { resetSourcePaneState } from '@utils/commands';
 
+const VIEWER_FRAME = '#rstudio_data_viewer_frame';
+
 // Tests from: electron-tests/EditorPane/test_desktop_DataViewer.py
 // Issues: https://github.com/rstudio/rstudio/issues/13220
 //         https://github.com/rstudio/rstudio/issues/13328
@@ -128,7 +130,7 @@ test.describe('Data Viewer', () => {
   // -----------------------------------------------------------------------
   // Clear-sort button in the status bar
   // -----------------------------------------------------------------------
-  test('clear-sort button in the status bar resets the sort', async () => {
+  test('clear-sort button in the status bar resets the sort', async ({ rstudioPage: page }) => {
     // Values chosen so no cell text is a substring of another -- a stale
     // sort can't false-pass a toContainText assertion.
     await consoleActions.executeInConsole(
@@ -156,6 +158,27 @@ test.describe('Data Viewer', () => {
     // Clicking the clear button restores the natural row order, clears the
     // status text, hides the button, and resets the header indicator.
     await dataViewer.clearSortButton.click();
+    await expect(firstRowA).toContainText('20');
+    await expect(dataViewer.sortStatus).not.toContainText('Sorted by');
+    await expect(dataViewer.clearSortButton).toBeHidden();
+    await expect(dataViewer.columnHeader(1)).not.toHaveClass(/sorting_asc|sorting_desc/);
+    await expect(dataViewer.columnHeader(1)).toHaveAttribute('aria-sort', 'none');
+
+    // The cleared sort must also persist: clearSort() saves sort: null, and a
+    // restore-path regression that re-applied the stale sort on reload (the
+    // filter analogue was #17950) would pass everything above. refreshData()
+    // synchronously clears the grid DOM, then re-fetches and re-applies the
+    // persisted state, so the reappearing first row gates the assertions.
+    await page.evaluate((sel: string) => {
+      const f = document.querySelector(sel) as HTMLIFrameElement | null;
+      const w = f?.contentWindow as unknown as { refreshData?: () => void } | undefined;
+      if (!w?.refreshData)
+        throw new Error('refreshData() not available on data viewer iframe');
+      w.refreshData();
+    }, VIEWER_FRAME);
+
+    // The rebuilt grid comes back unsorted: natural row order, no status
+    // text, no clear button, and a reset header indicator.
     await expect(firstRowA).toContainText('20');
     await expect(dataViewer.sortStatus).not.toContainText('Sorted by');
     await expect(dataViewer.clearSortButton).toBeHidden();

--- a/e2e/rstudio/tests/panes/data-viewer/pagination-sorting.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/pagination-sorting.test.ts
@@ -126,6 +126,44 @@ test.describe('Data Viewer', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Clear-sort button in the status bar
+  // -----------------------------------------------------------------------
+  test('clear-sort button in the status bar resets the sort', async () => {
+    // Values chosen so no cell text is a substring of another -- a stale
+    // sort can't false-pass a toContainText assertion.
+    await consoleActions.executeInConsole(
+      'df <- data.frame(a = c(20, 10, 30))',
+      { wait: true },
+    );
+    await consoleActions.executeInConsole('View(df)');
+
+    await expect(sourcePane.selectedTab).toContainText('df');
+
+    // First row cells are [rowNum, a]; skip the virtual-scroll spacer row.
+    const firstRowA = dataViewer.frame.locator('#rsGridData tbody tr[data-row="0"] td:nth-child(2)');
+    await expect(firstRowA).toContainText('20');
+
+    // No sort active: the clear button is hidden.
+    await expect(dataViewer.clearSortButton).toBeHidden();
+
+    // Sort column 1 descending (click twice).
+    await dataViewer.columnHeader(1).click();
+    await dataViewer.columnHeader(1).click();
+    await expect(firstRowA).toContainText('30');
+    await expect(dataViewer.sortStatus).toContainText('Sorted by: a (descending)');
+    await expect(dataViewer.clearSortButton).toBeVisible();
+
+    // Clicking the clear button restores the natural row order, clears the
+    // status text, hides the button, and resets the header indicator.
+    await dataViewer.clearSortButton.click();
+    await expect(firstRowA).toContainText('20');
+    await expect(dataViewer.sortStatus).not.toContainText('Sorted by');
+    await expect(dataViewer.clearSortButton).toBeHidden();
+    await expect(dataViewer.columnHeader(1)).not.toHaveClass(/sorting_asc|sorting_desc/);
+    await expect(dataViewer.columnHeader(1)).toHaveAttribute('aria-sort', 'none');
+  });
+
+  // -----------------------------------------------------------------------
   // Issue 17863 - Clicking a list-column header must not error
   // -----------------------------------------------------------------------
   test('list columns are not sortable and clicking the header does not error (#17863)', async () => {

--- a/src/cpp/session/resources/grid/DataViewer.css
+++ b/src/cpp/session/resources/grid/DataViewer.css
@@ -668,6 +668,25 @@ th.columnClickable div {
    float: right;
 }
 
+/* Hidden by default; shown (inline-block) while a sort is active. Uses the
+   same inline-SVG X icon as .clearFilter. */
+#rsGridData_info_sort_clear {
+   display: none;
+   width: 11px;
+   height: 11px;
+   margin-left: 5px;
+   padding: 0;
+   border: none;
+   vertical-align: -1px;
+   cursor: pointer;
+   opacity: 0.5;
+   background: transparent url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11'%3E%3Cpath d='M2 2L9 9M9 2L2 9' stroke='%23666' stroke-width='1.5'/%3E%3C/svg%3E") no-repeat center;
+}
+
+#rsGridData_info_sort_clear:hover {
+   opacity: 1;
+}
+
 #rsGridData_info_text {
    overflow: hidden;
 }

--- a/src/cpp/session/resources/grid/DataViewer.css
+++ b/src/cpp/session/resources/grid/DataViewer.css
@@ -595,14 +595,18 @@ th.columnClickable div {
    opacity: 1;
 }
 
-/* Clear filter icon as inline SVG */
+/* Clear filter icon as an inline-SVG mask so the color follows the theme
+   foreground */
 .clearFilter::after {
    content: '';
    display: block;
    width: 11px;
    height: 11px;
-   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11'%3E%3Cpath d='M2 2L9 9M9 2L2 9' stroke='%23666' stroke-width='1.5'/%3E%3C/svg%3E");
-   background-repeat: no-repeat;
+   background-color: var(--grid-fg);
+   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11'%3E%3Cpath d='M2 2L9 9M9 2L2 9' stroke='%23000' stroke-width='1.5'/%3E%3C/svg%3E");
+   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11'%3E%3Cpath d='M2 2L9 9M9 2L2 9' stroke='%23000' stroke-width='1.5'/%3E%3C/svg%3E");
+   -webkit-mask-repeat: no-repeat;
+   mask-repeat: no-repeat;
 }
 
 
@@ -669,7 +673,8 @@ th.columnClickable div {
 }
 
 /* Hidden by default; shown (inline-block) while a sort is active. Uses the
-   same inline-SVG X icon as .clearFilter. */
+   same X icon as .clearFilter, via mask-image so the color follows the
+   theme foreground. */
 #rsGridData_info_sort_clear {
    display: none;
    width: 11px;
@@ -680,7 +685,13 @@ th.columnClickable div {
    vertical-align: -1px;
    cursor: pointer;
    opacity: 0.5;
-   background: transparent url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11'%3E%3Cpath d='M2 2L9 9M9 2L2 9' stroke='%23666' stroke-width='1.5'/%3E%3C/svg%3E") no-repeat center;
+   background-color: var(--grid-fg);
+   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11'%3E%3Cpath d='M2 2L9 9M9 2L2 9' stroke='%23000' stroke-width='1.5'/%3E%3C/svg%3E");
+   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11'%3E%3Cpath d='M2 2L9 9M9 2L2 9' stroke='%23000' stroke-width='1.5'/%3E%3C/svg%3E");
+   -webkit-mask-repeat: no-repeat;
+   -webkit-mask-position: center;
+   mask-repeat: no-repeat;
+   mask-position: center;
 }
 
 #rsGridData_info_sort_clear:hover {

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -1092,7 +1092,9 @@ var clearSort = function() {
    // we don't re-highlight a different row at the old coordinate.
    clearActiveCell();
 
-   // Reset the header arrows, and aria-sort on whichever header was sorted.
+   // Reset the header arrows. applySortIndicators() only updates the arrow
+   // classes, so aria-sort must be cleared separately on every sortable
+   // header (mirroring handleSortClick).
    applySortIndicators();
    var thead = document.getElementById("data_cols");
    if (thead) {

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -1080,6 +1080,36 @@ var handleSortClick = function(colIdx, th) {
    saveState();
 };
 
+// Clear the active sort, restoring the frame's natural row order. Wired to
+// the info bar's clear-sort button at startup.
+var clearSort = function() {
+   if (sortColumn < 0 && !sortDirection) return;
+
+   sortColumn = -1;
+   sortDirection = "";
+
+   // Sort changes row identity at every index; clear the active cell so
+   // we don't re-highlight a different row at the old coordinate.
+   clearActiveCell();
+
+   // Reset the header arrows, and aria-sort on whichever header was sorted.
+   applySortIndicators();
+   var thead = document.getElementById("data_cols");
+   if (thead) {
+      for (var i = 0; i < thead.children.length; i++) {
+         if (thead.children[i].hasAttribute("aria-sort"))
+            thead.children[i].setAttribute("aria-sort", "none");
+      }
+   }
+
+   // Re-fetch data
+   invalidateCache();
+   fetchRows(0, FETCH_SIZE, function() {
+      scrollToTop();
+   });
+   saveState();
+};
+
 // ==========================================================================
 // Column Pinning
 // ==========================================================================
@@ -2471,6 +2501,17 @@ var updateAriaRowCount = function() {
    }
 };
 
+// Update the "Sorted by" portion of the info bar. The text span and the
+// clear-sort button are static elements from gridviewer.html; toggle the
+// button's visibility rather than rebuilding it so the click listener
+// wired at startup survives updates.
+var setSortStatus = function(text) {
+   var textEl = document.getElementById("rsGridData_info_sort_text");
+   if (textEl) textEl.textContent = text;
+   var clearEl = document.getElementById("rsGridData_info_sort_clear");
+   if (clearEl) clearEl.style.display = text ? "inline-block" : "none";
+};
+
 var updateInfoBar = function() {
    updateAriaRowCount();
 
@@ -2482,18 +2523,17 @@ var updateInfoBar = function() {
    var info = document.getElementById("rsGridData_info");
    if (!info) return;
    var textEl = document.getElementById("rsGridData_info_text");
-   var sortEl = document.getElementById("rsGridData_info_sort");
 
    if (statusTextOverride) {
       if (textEl) textEl.textContent = statusTextOverride;
-      if (sortEl) sortEl.textContent = "";
+      setSortStatus("");
       return;
    }
 
    var activeRows = filteredRows;
    if (totalRows === 0) {
       if (textEl) textEl.textContent = "";
-      if (sortEl) sortEl.textContent = "";
+      setSortStatus("");
       return;
    }
 
@@ -2556,7 +2596,7 @@ var updateInfoBar = function() {
          sortText = "Sorted by: " + cols[sortPos].col_name + " (" + dirText + ")";
       }
    }
-   if (sortEl) sortEl.textContent = sortText;
+   setSortStatus(sortText);
 };
 
 var buildRow = function(r) {
@@ -4667,8 +4707,7 @@ var destroyGrid = function() {
 
    var infoText = document.getElementById("rsGridData_info_text");
    if (infoText) infoText.textContent = "";
-   var infoSort = document.getElementById("rsGridData_info_sort");
-   if (infoSort) infoSort.textContent = "";
+   setSortStatus("");
 
    var viewport = document.getElementById("gridViewport");
    if (viewport) {
@@ -5107,6 +5146,12 @@ var loc = parseLocationUrl();
 var dataMode = loc.dataSource || "server";
 
 document.addEventListener("DOMContentLoaded", function() {
+   // #rsGridData_info_sort_clear is a static element that survives
+   // re-bootstraps, so wire its listener once here rather than per-grid.
+   var sortClear = document.getElementById("rsGridData_info_sort_clear");
+   if (sortClear)
+      sortClear.addEventListener("click", clearSort);
+
    if (dataMode === "server") {
       bootstrap();
    }

--- a/src/cpp/session/resources/grid/gridviewer.html
+++ b/src/cpp/session/resources/grid/gridviewer.html
@@ -24,7 +24,9 @@
                 </table>
             </div>
             <div id="rsGridData_info" aria-live="polite" aria-atomic="true">
-                <div id="rsGridData_info_sort"></div>
+                <div id="rsGridData_info_sort">
+                    <span id="rsGridData_info_sort_text"></span><button type="button" id="rsGridData_info_sort_clear" title="Clear sort" aria-label="Clear sort"></button>
+                </div>
                 <div id="rsGridData_info_text"></div>
             </div>
         </div>

--- a/src/gwt/src/org/rstudio/core/client/ScrollUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/ScrollUtil.java
@@ -34,34 +34,44 @@ public class ScrollUtil
             if (retries_ > MAX_SCROLL_RETRIES)
                return false;
 
-            // wait for a document to become available in the frame
-            if (frame.getIFrame() == null)
-               return true;
-            
-            if (frame.getIFrame().getContentDocument() == null)
-               return true;
+            try
+            {
+               // wait for a document to become available in the frame
+               if (frame.getIFrame() == null)
+                  return true;
 
-            // wait for the document to finish loading
-            Document doc = frame.getIFrame().getContentDocument();
-            String readyState = getDocumentReadyState(doc);
-            if (readyState == null)
-               return true;
-            
-            if (!readyState.equals("complete"))
-               return true;
-            
-            // wait for a real document to load (about:blank may be intermediate)
-            if (doc.getScrollTop() > 0)
-               return true;
+               if (frame.getIFrame().getContentDocument() == null)
+                  return true;
 
-            if (doc.getURL() == URIConstants.ABOUT_BLANK)
-               return true;
-            
-            // restore scroll position
-            if (scrollPosition > 0)
-               doc.setScrollTop(scrollPosition);
+               // wait for the document to finish loading
+               Document doc = frame.getIFrame().getContentDocument();
+               String readyState = getDocumentReadyState(doc);
+               if (readyState == null)
+                  return true;
 
-            return false;
+               if (!readyState.equals("complete"))
+                  return true;
+
+               // wait for a real document to load (about:blank may be intermediate)
+               if (doc.getScrollTop() > 0)
+                  return true;
+
+               if (doc.getURL() == URIConstants.ABOUT_BLANK)
+                  return true;
+
+               // restore scroll position
+               if (scrollPosition > 0)
+                  doc.setScrollTop(scrollPosition);
+
+               return false;
+            }
+            catch (Exception e)
+            {
+               // reading the frame's document can throw (e.g. the browser
+               // considers the frame a different origin while a navigation
+               // is in flight); treat it as not loaded yet and keep polling
+               return true;
+            }
          }
          
          private int retries_ = 0;


### PR DESCRIPTION
When a column sort is active, the "Sorted by: <column> (<direction>)" status at the right of the data viewer's info bar now includes a small X button that clears the sort, restoring the frame's natural row order.

Implementation notes:

- The sort status element is split into a text span plus a persistent `<button>`, so the button's click listener (wired once at `DOMContentLoaded`, like the sidebar toggle) survives info-bar updates; a `setSortStatus()` helper updates the text and toggles button visibility everywhere the status used to be written directly.
- `clearSort()` mirrors `handleSortClick`'s unsort path: it resets the sort state, clears the active cell, resets header arrows and `aria-sort`, re-fetches from the top, and saves state so the cleared sort persists.
- The button reuses the same inline-SVG X icon styling as the column filter's clear affordance.

Includes an e2e test covering: sort applied -> status text and button visible -> click -> natural order restored, status cleared, button hidden, header indicator and `aria-sort` reset.

No NEWS.md entry since the sort status bar is part of the unreleased data viewer rework.

Fixes #17959.

---

Also tags along an unrelated e2e-stability fix (45d2a49e06): `ScrollUtil.setScrollPositionOnLoad` polled the rmd preview frame's document without a try/catch, so a transiently cross-origin frame raised an uncaught `SecurityError` from the 50ms timer -- killing the scroll restore and (since #17956) failing whichever e2e test was running, as seen with `create new rmarkdown and knit to HTML` in [run #240](https://github.com/rstudio/rstudio/actions/runs/27429548185). A throw is now treated like the other not-ready cases and polling continues, matching the guarded versions of the same access in `RmdOutputFramePane`.
