### PR TITLE
show column count and close glyph in summary sidebar header

### DIFF
--- a/e2e/rstudio/tests/panes/data-viewer/pagination-sorting.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/pagination-sorting.test.ts
@@ -51,6 +51,13 @@ test.describe('Data Viewer', () => {
     // Check initial column range
     await expect(dataViewer.columnNumberInput).toHaveValue('1 - 200');
 
+    // The summary sidebar header counts the loaded page against the frame
+    // total; both sides must exclude the rowname column, so a miscount on
+    // either would surface here as an off-by-one (e.g. "201 of 500").
+    await expect(dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-label')).toHaveText(
+      '200 of 500 columns',
+    );
+
     // Navigate forward one page
     await dataViewer.rightArrow.click();
     await expect(dataViewer.columnNumberInput).toHaveValue('201 - 400');

--- a/src/cpp/session/resources/grid/DataViewer.css
+++ b/src/cpp/session/resources/grid/DataViewer.css
@@ -719,6 +719,9 @@ th.columnClickable div {
 }
 
 .sidebar-toggle-label {
+   /* min-width: 0 lets this flex child shrink below its content size when
+      the panel is narrow; without it the ellipsis can never trigger. */
+   min-width: 0;
    overflow: hidden;
    text-overflow: ellipsis;
 }

--- a/src/cpp/session/resources/grid/DataViewer.css
+++ b/src/cpp/session/resources/grid/DataViewer.css
@@ -718,6 +718,26 @@ th.columnClickable div {
    background-color: var(--grid-hover-bg);
 }
 
+.sidebar-toggle-label {
+   overflow: hidden;
+   text-overflow: ellipsis;
+}
+
+/* Right-aligned close affordance; purely visual (clicks bubble to
+   #sidebarToggle, which is the accessible control). */
+.sidebar-toggle-close {
+   margin-left: auto;
+   padding-left: 8px;
+   font-size: 14px;
+   font-weight: normal;
+   line-height: 1;
+   opacity: 0.6;
+}
+
+#sidebarToggle:hover .sidebar-toggle-close {
+   opacity: 1;
+}
+
 #sidebarContent {
    flex: 1;
    overflow-y: auto;

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -3140,7 +3140,8 @@ var initSidebar = function() {
    var toggleLabel = document.createElement("span");
    toggleLabel.className = "sidebar-toggle-label";
    if (totalCols > shownCols) {
-      // Column pagination is active; the sidebar lists the current page only.
+      // Fewer columns are loaded than the frame contains (e.g. only the
+      // current page of a paginated frame); the sidebar lists those only.
       toggleLabel.textContent = shownCols.toLocaleString() + " of " +
          totalCols.toLocaleString() + " columns";
    } else {

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -3129,8 +3129,24 @@ var initSidebar = function() {
    toggle.setAttribute("aria-controls", "sidebarContent");
    toggle.setAttribute("aria-expanded", sidebarVisible ? "true" : "false");
    toggle.setAttribute("aria-label", "Toggle column summary panel");
+   // The host toolbar's Summary button already names the panel, so the
+   // header shows the column count instead of repeating "Summary".
+   var shownCols = 0;
+   for (var ci = 0; ci < cols.length; ci++) {
+      if (!isRownameColumn(cols[ci]))
+         shownCols++;
+   }
+
    var toggleLabel = document.createElement("span");
-   toggleLabel.textContent = "Summary";
+   toggleLabel.className = "sidebar-toggle-label";
+   if (totalCols > shownCols) {
+      // Column pagination is active; the sidebar lists the current page only.
+      toggleLabel.textContent = shownCols.toLocaleString() + " of " +
+         totalCols.toLocaleString() + " columns";
+   } else {
+      toggleLabel.textContent = shownCols.toLocaleString() +
+         (shownCols === 1 ? " column" : " columns");
+   }
    toggle.appendChild(toggleLabel);
 
    var toggleSpinner = document.createElement("span");
@@ -3138,6 +3154,14 @@ var initSidebar = function() {
    toggleSpinner.style.display = "none";
    toggleSpinner.id = "sidebarSpinner";
    toggle.appendChild(toggleSpinner);
+
+   // Decorative close glyph; clicks bubble to the toggle, which remains the
+   // panel's single accessible control.
+   var toggleClose = document.createElement("span");
+   toggleClose.className = "sidebar-toggle-close";
+   toggleClose.setAttribute("aria-hidden", "true");
+   toggleClose.textContent = "\u00D7";
+   toggle.appendChild(toggleClose);
 
    toggle.addEventListener("click", onSidebarToggleActivate);
    toggle.addEventListener("keydown", onSidebarToggleKeyDown);


### PR DESCRIPTION
## Summary

When the data viewer's Summary sidebar is open, its header strip repeated the word "Summary" directly below the toolbar's Summary toggle button, which already names (and latches for) the panel.

The header strip itself still earns its place -- it visually caps the panel in line with the grid's column-header row, hosts the shared column-summary fetch spinner, and acts as an in-panel close control -- so rather than removing it:

- The label now shows the column count (e.g. "12 columns"), or "50 of 5,000 columns" when column pagination means the sidebar lists only the current page.
- A right-aligned close glyph was added as a visual affordance. It is `aria-hidden` and has no handler of its own; clicks bubble to `#sidebarToggle`, which remains the panel's single accessible control with its existing `aria-label`/`aria-expanded` wiring.

No NEWS.md entry since the Summary sidebar is unreleased (2026.06.0).

## Testing

- `node --check` passes on `DataViewer.js`; the file remains ASCII-only (the glyph is written as a `\u00D7` escape).
- Ran the Summary sidebar e2e tests against the dev build: `npm run test:desktop-dev -- tests/panes/data-viewer/data_viewer.test.ts -g "Summary"` -- 2 passed ("dismissed summary sidebar stays dismissed when a column is added", "the in-grid Summary toggle still works after a data refresh").
