### PR TITLE
add read-only permission allowlist to claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,19 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(npm run test:desktop-dev)",
+      "Bash(npm run test:desktop-dev *)",
+      "Bash(./build/src/cpp/rstudio-tests *)",
+      "Bash(npm run typecheck)",
+      "Bash(npm run typecheck *)",
+      "Bash(npm run lint)",
+      "Bash(npm run lint *)",
+      "Bash(npm test)",
+      "Bash(npm test *)",
+      "Bash(gh search *)",
+      "Bash(gh run watch *)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## Summary

Adds a `permissions.allow` list to the checked-in `.claude/settings.json`, so Claude Code no longer prompts for common read-only or test-loop commands in this repo.

The entries were derived by scanning recent session transcripts for frequently-prompted commands, keeping only those that are read-only or standard test/check invocations:

- `npm run test:desktop-dev` -- Playwright desktop tests against the dev build
- `./build/src/cpp/rstudio-tests` -- C++ / R test runner
- `npm run typecheck`, `npm run lint`, `npm test` -- desktop checks and unit tests
- `gh search`, `gh run watch` -- read-only GitHub CLI queries

Deliberately excluded: anything mutating (`git push`, `gh pr create`, `gh issue edit`, ...), interpreters and package runners (`Rscript`, `node`, `npx`), and builds (`cmake --build`, `ant draft`). Commands Claude Code already auto-allows (read-only `git`/`gh` subcommands, `grep`, `ls`, etc.) are omitted as redundant.

No NEWS.md entry since this is a developer-tooling change with no user-facing impact.