### PR TITLE
Vary "Posit Assistant Not Installed" message based on a manifest flag

### DIFF
--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -3629,8 +3629,9 @@ struct UpdateState
    bool unsupportedInstalledVersion;
    bool unsupportedProtocol;
    bool manifestUnavailable;
-   // Whether the manifest entry for our protocol advertises additional
-   // (non-default) providers, used to vary the not-installed view's copy.
+   // Whether the manifest entry for our protocol opts into the bring-your-own-key
+   // provider set (its "providers" array contains "byok"), used to vary the
+   // not-installed view's copy.
    bool additionalProvidersAvailable;
    std::string currentVersion;
    std::string newVersion;
@@ -4599,11 +4600,9 @@ void onUpdateCheckComplete(const Error& fetchError, const json::Object& manifest
       return;
    }
 
-   // The manifest's "providers" array marks the protocol entry as advertising an
-   // additional provider set beyond the default; the not-installed view varies its
-   // copy when that set is offered.
-   additionalProvidersAvailable =
-      std::find(providers.begin(), providers.end(), "byok") != providers.end();
+   // When the manifest opts this build into the bring-your-own-key provider set,
+   // the not-installed view appends a sentence about it.
+   additionalProvidersAvailable = integrity::advertisesByokProvider(providers);
 
    // Compare versions - offer install if versions differ (upgrade or downgrade).
    if (shouldInstallVersion(installedVersion, packageVersion))

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -3629,6 +3629,9 @@ struct UpdateState
    bool unsupportedInstalledVersion;
    bool unsupportedProtocol;
    bool manifestUnavailable;
+   // Whether the manifest entry for our protocol advertises additional
+   // (non-default) providers, used to vary the not-installed view's copy.
+   bool additionalProvidersAvailable;
    std::string currentVersion;
    std::string newVersion;
    std::string downloadUrl;
@@ -3654,6 +3657,7 @@ struct UpdateState
         unsupportedInstalledVersion(false),
         unsupportedProtocol(false),
         manifestUnavailable(false),
+        additionalProvidersAvailable(false),
         installStatus(Status::Idle)
    {
    }
@@ -4446,6 +4450,7 @@ void onUpdateCheckComplete(const Error& fetchError, const json::Object& manifest
    bool unsupportedProtocol = false;
    bool unsupportedInstalledVersion = false;
    bool noCompatibleVersion = false;
+   bool additionalProvidersAvailable = false;
    bool updateAvailable = false;
    bool isDowngrade = false;
    std::string newVersion;
@@ -4470,6 +4475,7 @@ void onUpdateCheckComplete(const Error& fetchError, const json::Object& manifest
          s_updateState.unsupportedProtocol = unsupportedProtocol;
          s_updateState.unsupportedInstalledVersion = unsupportedInstalledVersion;
          s_updateState.noCompatibleVersion = noCompatibleVersion;
+         s_updateState.additionalProvidersAvailable = additionalProvidersAvailable;
          s_updateState.updateAvailable = updateAvailable;
          s_updateState.isDowngrade = isDowngrade;
          s_updateState.newVersion = newVersion;
@@ -4573,8 +4579,10 @@ void onUpdateCheckComplete(const Error& fetchError, const json::Object& manifest
    std::string packageVersion;
    std::string pkgDownloadUrl;
    std::string sha256;
+   std::vector<std::string> providers;
    error = integrity::getPackageInfoFromManifest(
-      manifest, kProtocolVersion, &packageVersion, &pkgDownloadUrl, &sha256);
+      manifest, kProtocolVersion, &packageVersion, &pkgDownloadUrl, &sha256,
+      &providers);
    if (error)
    {
       WLOG("Failed to get package info from manifest: {}", error.getMessage());
@@ -4590,6 +4598,12 @@ void onUpdateCheckComplete(const Error& fetchError, const json::Object& manifest
       finish();
       return;
    }
+
+   // The manifest's "providers" array marks the protocol entry as advertising an
+   // additional provider set beyond the default; the not-installed view varies its
+   // copy when that set is offered.
+   additionalProvidersAvailable =
+      std::find(providers.begin(), providers.end(), "byok") != providers.end();
 
    // Compare versions - offer install if versions differ (upgrade or downgrade).
    if (shouldInstallVersion(installedVersion, packageVersion))
@@ -4715,6 +4729,7 @@ void resolveWithoutManifestFetch()
       s_updateState.unsupportedProtocol = unsupportedProtocol;
       s_updateState.unsupportedInstalledVersion = unsupportedInstalledVersion;
       s_updateState.noCompatibleVersion = false;
+      s_updateState.additionalProvidersAvailable = false;
       s_updateState.updateAvailable = false;
       s_updateState.isDowngrade = false;
       s_updateState.newVersion = "";
@@ -5402,6 +5417,7 @@ void buildUpdateStateResult(json::Object* pResult)
    (*pResult)["unsupportedInstalledVersion"] = s_updateState.unsupportedInstalledVersion;
    (*pResult)["unsupportedProtocol"] = s_updateState.unsupportedProtocol;
    (*pResult)["manifestUnavailable"] = s_updateState.manifestUnavailable;
+   (*pResult)["additionalProvidersAvailable"] = s_updateState.additionalProvidersAvailable;
    (*pResult)["errorMessage"] = s_updateState.errorMessage;
    (*pResult)["currentVersion"] = s_updateState.currentVersion;
    (*pResult)["newVersion"] = s_updateState.newVersion;

--- a/src/cpp/session/modules/chat/ChatIntegrity.cpp
+++ b/src/cpp/session/modules/chat/ChatIntegrity.cpp
@@ -79,12 +79,42 @@ std::string::size_type endOfFirstJsonObject(const std::string& s)
 
 } // anonymous namespace
 
+// Read an optional array-of-strings field into `out`. Absent field -> empty;
+// non-array or non-string entries are skipped with a warning (lenient, matching
+// the manifest's other optional arrays).
+void readStringArray(const json::Object& obj,
+                     const std::string& key,
+                     std::vector<std::string>* out)
+{
+   out->clear();
+   json::Object::Iterator it = obj.find(key);
+   if (it == obj.end())
+      return;
+
+   json::Value value = (*it).getValue();
+   if (!value.isArray())
+   {
+      WLOG("Manifest field '{}' is not an array; ignoring", key);
+      return;
+   }
+
+   json::Array arr = value.getArray();
+   for (const json::Value& entry : arr)
+   {
+      if (entry.isString())
+         out->push_back(entry.getString());
+      else
+         WLOG("Skipping non-string entry in manifest field '{}'", key);
+   }
+}
+
 Error getPackageInfoFromManifest(
     const json::Object& manifest,
     const std::string& protocolVersion,
     std::string* pPackageVersion,
     std::string* pDownloadUrl,
-    std::string* pSha256)
+    std::string* pSha256,
+    std::vector<std::string>* pProviders)
 {
    if (!pPackageVersion || !pDownloadUrl)
       return systemError(boost::system::errc::invalid_argument, ERROR_LOCATION);
@@ -116,6 +146,7 @@ Error getPackageInfoFromManifest(
    std::string bestPackageVersion;
    std::string bestDownloadUrl;
    std::string bestSha256;
+   std::vector<std::string> bestProviders;
    bool foundCompatible = false;
 
    for (const auto& entry : versions)
@@ -175,6 +206,10 @@ Error getPackageInfoFromManifest(
       std::string sha256;
       json::readObject(versionInfo, "sha256", sha256); // ignore error - field is optional
 
+      // Read optional providers field (advertised provider identifiers)
+      std::vector<std::string> providers;
+      readStringArray(versionInfo, "providers", &providers);
+
       // Check if this is the best (highest) protocol version so far
       if (!foundCompatible || manifestProtocolVer > bestProtocol)
       {
@@ -182,6 +217,7 @@ Error getPackageInfoFromManifest(
          bestPackageVersion = packageVersion;
          bestDownloadUrl = downloadUrl;
          bestSha256 = sha256;
+         bestProviders = providers;
          foundCompatible = true;
          DLOG("Found compatible protocol {}.{} with package version {}",
               manifestProtocolVer.major, manifestProtocolVer.minor, packageVersion);
@@ -200,6 +236,8 @@ Error getPackageInfoFromManifest(
    *pDownloadUrl = bestDownloadUrl;
    if (pSha256)
       *pSha256 = bestSha256;
+   if (pProviders)
+      *pProviders = bestProviders;
 
    DLOG("Selected best compatible protocol {}.{}: package version={}, url={}, sha256={}",
         bestProtocol.major, bestProtocol.minor, bestPackageVersion, bestDownloadUrl,

--- a/src/cpp/session/modules/chat/ChatIntegrity.cpp
+++ b/src/cpp/session/modules/chat/ChatIntegrity.cpp
@@ -178,9 +178,13 @@ Error getPackageInfoFromManifest(
       std::string sha256;
       json::readObject(versionInfo, "sha256", sha256); // ignore error - field is optional
 
-      // Read optional providers field (advertised provider identifiers)
+      // Read optional providers field (advertised provider identifiers). On any
+      // error -- absent, not an array, or a non-string element -- treat the entry
+      // as having no providers. readObject appends valid elements before failing
+      // on a bad one, so reset to avoid an order-dependent partial result.
       std::vector<std::string> providers;
-      json::readObject(versionInfo, "providers", providers); // ignore error - field is optional
+      if (json::readObject(versionInfo, "providers", providers))
+         providers.clear();
 
       // Check if this is the best (highest) protocol version so far
       if (!foundCompatible || manifestProtocolVer > bestProtocol)

--- a/src/cpp/session/modules/chat/ChatIntegrity.cpp
+++ b/src/cpp/session/modules/chat/ChatIntegrity.cpp
@@ -17,6 +17,7 @@
 #include "ChatLogging.hpp"
 #include "ChatTypes.hpp"
 
+#include <algorithm>
 #include <cstdlib>
 
 #include <boost/algorithm/string.hpp>
@@ -78,35 +79,6 @@ std::string::size_type endOfFirstJsonObject(const std::string& s)
 }
 
 } // anonymous namespace
-
-// Read an optional array-of-strings field into `out`. Absent field -> empty;
-// non-array or non-string entries are skipped with a warning (lenient, matching
-// the manifest's other optional arrays).
-void readStringArray(const json::Object& obj,
-                     const std::string& key,
-                     std::vector<std::string>* out)
-{
-   out->clear();
-   json::Object::Iterator it = obj.find(key);
-   if (it == obj.end())
-      return;
-
-   json::Value value = (*it).getValue();
-   if (!value.isArray())
-   {
-      WLOG("Manifest field '{}' is not an array; ignoring", key);
-      return;
-   }
-
-   json::Array arr = value.getArray();
-   for (const json::Value& entry : arr)
-   {
-      if (entry.isString())
-         out->push_back(entry.getString());
-      else
-         WLOG("Skipping non-string entry in manifest field '{}'", key);
-   }
-}
 
 Error getPackageInfoFromManifest(
     const json::Object& manifest,
@@ -208,7 +180,7 @@ Error getPackageInfoFromManifest(
 
       // Read optional providers field (advertised provider identifiers)
       std::vector<std::string> providers;
-      readStringArray(versionInfo, "providers", &providers);
+      json::readObject(versionInfo, "providers", providers); // ignore error - field is optional
 
       // Check if this is the best (highest) protocol version so far
       if (!foundCompatible || manifestProtocolVer > bestProtocol)
@@ -244,6 +216,14 @@ Error getPackageInfoFromManifest(
         bestSha256.empty() ? "(none)" : bestSha256);
 
    return Success();
+}
+
+bool advertisesByokProvider(const std::vector<std::string>& providers)
+{
+   // The manifest opts a build's protocol entry into the bring-your-own-key
+   // provider set by listing "byok" among its providers. Other identifiers
+   // (e.g. "pai") do not trip this.
+   return std::find(providers.begin(), providers.end(), "byok") != providers.end();
 }
 
 Error verifyPackageSha256(const FilePath& packagePath,

--- a/src/cpp/session/modules/chat/ChatIntegrity.hpp
+++ b/src/cpp/session/modules/chat/ChatIntegrity.hpp
@@ -17,6 +17,7 @@
 #define SESSION_CHAT_INTEGRITY_HPP
 
 #include <string>
+#include <vector>
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
 #include <shared_core/json/Json.hpp>
@@ -43,6 +44,9 @@ namespace integrity {
  * @param pPackageVersion Output: the package version string
  * @param pDownloadUrl Output: the package download URL
  * @param pSha256 Output: the SHA-256 hash (optional, may be nullptr)
+ * @param pProviders Output: the provider identifiers advertised for the
+ *                   selected protocol entry, or empty when the entry has no
+ *                   "providers" array (optional, may be nullptr)
  * @return Success() or an error if no compatible version is found
  */
 core::Error getPackageInfoFromManifest(
@@ -50,7 +54,8 @@ core::Error getPackageInfoFromManifest(
     const std::string& protocolVersion,
     std::string* pPackageVersion,
     std::string* pDownloadUrl,
-    std::string* pSha256 = nullptr);
+    std::string* pSha256 = nullptr,
+    std::vector<std::string>* pProviders = nullptr);
 
 /**
  * Verify SHA-256 hash of a downloaded package file.

--- a/src/cpp/session/modules/chat/ChatIntegrity.hpp
+++ b/src/cpp/session/modules/chat/ChatIntegrity.hpp
@@ -58,6 +58,19 @@ core::Error getPackageInfoFromManifest(
     std::vector<std::string>* pProviders = nullptr);
 
 /**
+ * Whether a manifest entry's provider identifiers opt the build into the
+ * bring-your-own-key provider set.
+ *
+ * Returns true only when "byok" is present; other identifiers (e.g. "pai")
+ * are ignored. "byok" is a string contract shared with the manifest producer.
+ *
+ * @param providers The provider identifiers from a manifest entry's
+ *                  "providers" array (e.g. as returned via getPackageInfoFromManifest).
+ * @return true if the bring-your-own-key provider is advertised.
+ */
+bool advertisesByokProvider(const std::vector<std::string>& providers);
+
+/**
  * Verify SHA-256 hash of a downloaded package file.
  *
  * @param packagePath Path to the downloaded package file

--- a/src/cpp/session/modules/chat/ChatIntegrityTests.cpp
+++ b/src/cpp/session/modules/chat/ChatIntegrityTests.cpp
@@ -16,6 +16,8 @@
 #include "ChatIntegrity.hpp"
 
 #include <cstdlib>
+#include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 #include <core/FileSerializer.hpp>
@@ -416,4 +418,90 @@ TEST(ChatIntegrity, GetPackageInfoErrorsOnNullPointers)
       manifest, "1.0", nullptr, nullptr);
 
    EXPECT_TRUE(error != Success());
+}
+
+TEST(ChatIntegrity, GetPackageInfoExtractsProviders)
+{
+   json::Object versionInfo;
+   versionInfo["version"] = "2.0.0";
+   versionInfo["url"] = "https://example.com/pkg.zip";
+   versionInfo["providers"] = json::toJsonArray(
+      std::vector<std::string>{"pai", "byok"});
+
+   json::Object versions;
+   versions["1.0"] = versionInfo;
+   json::Object manifest;
+   manifest["versions"] = versions;
+
+   std::string packageVersion, downloadUrl, sha256;
+   std::vector<std::string> providers;
+   Error error = getPackageInfoFromManifest(
+      manifest, "1.0", &packageVersion, &downloadUrl, &sha256, &providers);
+
+   EXPECT_FALSE(error);
+   EXPECT_EQ(providers, (std::vector<std::string>{"pai", "byok"}));
+}
+
+TEST(ChatIntegrity, GetPackageInfoProvidersEmptyWhenAbsent)
+{
+   json::Object manifest = makeManifest(
+      "1.0", "2.0.0", "https://example.com/pkg.zip");
+
+   std::string packageVersion, downloadUrl, sha256;
+   std::vector<std::string> providers{"stale"};
+   Error error = getPackageInfoFromManifest(
+      manifest, "1.0", &packageVersion, &downloadUrl, &sha256, &providers);
+
+   EXPECT_FALSE(error);
+   EXPECT_TRUE(providers.empty());
+}
+
+TEST(ChatIntegrity, GetPackageInfoProvidersFromSelectedProtocol)
+{
+   // Lower minor advertises providers; the selected (highest minor) entry does
+   // not -- the result must reflect the selected entry, not a skipped one.
+   json::Object v10Info;
+   v10Info["version"] = "1.0.0";
+   v10Info["url"] = "https://example.com/pkg-1.0.zip";
+   v10Info["providers"] = json::toJsonArray(std::vector<std::string>{"byok"});
+
+   json::Object v11Info;
+   v11Info["version"] = "1.1.0";
+   v11Info["url"] = "https://example.com/pkg-1.1.zip";
+
+   json::Object versions;
+   versions["1.0"] = v10Info;
+   versions["1.1"] = v11Info;
+   json::Object manifest;
+   manifest["versions"] = versions;
+
+   std::string packageVersion, downloadUrl, sha256;
+   std::vector<std::string> providers{"stale"};
+   Error error = getPackageInfoFromManifest(
+      manifest, "1.0", &packageVersion, &downloadUrl, &sha256, &providers);
+
+   EXPECT_FALSE(error);
+   EXPECT_EQ(packageVersion, "1.1.0");
+   EXPECT_TRUE(providers.empty());
+}
+
+TEST(ChatIntegrity, GetPackageInfoIgnoresNonArrayProviders)
+{
+   json::Object versionInfo;
+   versionInfo["version"] = "2.0.0";
+   versionInfo["url"] = "https://example.com/pkg.zip";
+   versionInfo["providers"] = "byok"; // wrong type -- must be tolerated
+
+   json::Object versions;
+   versions["1.0"] = versionInfo;
+   json::Object manifest;
+   manifest["versions"] = versions;
+
+   std::string packageVersion, downloadUrl, sha256;
+   std::vector<std::string> providers{"stale"};
+   Error error = getPackageInfoFromManifest(
+      manifest, "1.0", &packageVersion, &downloadUrl, &sha256, &providers);
+
+   EXPECT_FALSE(error);
+   EXPECT_TRUE(providers.empty());
 }

--- a/src/cpp/session/modules/chat/ChatIntegrityTests.cpp
+++ b/src/cpp/session/modules/chat/ChatIntegrityTests.cpp
@@ -505,3 +505,11 @@ TEST(ChatIntegrity, GetPackageInfoIgnoresNonArrayProviders)
    EXPECT_FALSE(error);
    EXPECT_TRUE(providers.empty());
 }
+
+TEST(ChatIntegrity, AdvertisesByokProvider)
+{
+   EXPECT_TRUE(advertisesByokProvider({"pai", "byok"}));
+   EXPECT_TRUE(advertisesByokProvider({"byok"}));
+   EXPECT_FALSE(advertisesByokProvider({"pai"}));
+   EXPECT_FALSE(advertisesByokProvider({}));
+}

--- a/src/cpp/session/modules/chat/ChatIntegrityTests.cpp
+++ b/src/cpp/session/modules/chat/ChatIntegrityTests.cpp
@@ -506,6 +506,34 @@ TEST(ChatIntegrity, GetPackageInfoIgnoresNonArrayProviders)
    EXPECT_TRUE(providers.empty());
 }
 
+TEST(ChatIntegrity, GetPackageInfoIgnoresMalformedProviderArray)
+{
+   // A providers array with a non-string element is treated as no providers,
+   // regardless of where the bad element sits (no order-dependent partial read).
+   json::Array bad;
+   bad.push_back("pai");
+   bad.push_back(123);
+   bad.push_back("byok");
+
+   json::Object versionInfo;
+   versionInfo["version"] = "2.0.0";
+   versionInfo["url"] = "https://example.com/pkg.zip";
+   versionInfo["providers"] = bad;
+
+   json::Object versions;
+   versions["1.0"] = versionInfo;
+   json::Object manifest;
+   manifest["versions"] = versions;
+
+   std::string packageVersion, downloadUrl, sha256;
+   std::vector<std::string> providers{"stale"};
+   Error error = getPackageInfoFromManifest(
+      manifest, "1.0", &packageVersion, &downloadUrl, &sha256, &providers);
+
+   EXPECT_FALSE(error);
+   EXPECT_TRUE(providers.empty());
+}
+
 TEST(ChatIntegrity, AdvertisesByokProvider)
 {
    EXPECT_TRUE(advertisesByokProvider({"pai", "byok"}));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AssistantPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AssistantPreferencesPane.java
@@ -1026,8 +1026,11 @@ public class AssistantPreferencesPane extends PreferencesPane
 
          @Override
          public void onUpdateAvailable(String currentVersion, String newVersion,
-                                       boolean isInitialInstall, boolean isDowngrade)
+                                       boolean isInitialInstall, boolean isDowngrade,
+                                       boolean additionalProvidersAvailable)
          {
+            // additionalProvidersAvailable only varies the chat pane's not-installed
+            // view; the preferences install prompt does not show that description.
             showInstallUpdatePrompt(newVersion, isInitialInstall, isDowngrade,
                forAssistant, previousAssistantValue, previousChatProviderValue);
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants.java
@@ -32,6 +32,7 @@ public interface ChatConstants extends com.google.gwt.i18n.client.Messages {
     String chatNotInstalledWithVersionMessage(String version);
     String chatNotInstalledDescription();
     String chatNotInstalledDescriptionWorkbench();
+    String chatNotInstalledAdditionalProviders();
     String chatLearnMore();
     String chatInstallButton();
     String chatInstallTermsOfUse();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants_en.properties
@@ -21,6 +21,7 @@ chatNotInstalledTitle=Posit Assistant Not Installed
 chatNotInstalledWithVersionMessage=Posit Assistant ({0}) is available to install.
 chatNotInstalledDescription=Posit Assistant is powered by the Posit AI service and includes collaborative chat and Next Edit Suggestions that predict your next code change.
 chatNotInstalledDescriptionWorkbench=Posit Assistant is a collaborative chat agent powered by your organization''s model provider.
+chatNotInstalledAdditionalProviders=Bring your own Key support also adds additional enterprise providers.
 chatLearnMore=Learn More
 chatInstallButton=Install Posit Assistant
 chatInstallTermsOfUse=By installing this software, you agree to the <a href=''https://www.rstudio.org/links/posit-ai-client-terms-of-use'' target=''_blank'' rel=''noopener noreferrer'' style=''white-space: nowrap;''>terms of use</a>.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants_fr.properties
@@ -21,6 +21,7 @@ chatNotInstalledTitle=Posit Assistant non installé
 chatNotInstalledWithVersionMessage=Posit Assistant ({0}) est disponible pour installation.
 chatNotInstalledDescription=Posit Assistant est alimenté par le service Posit AI et comprend le chat collaboratif et les suggestions de modification suivante qui prédisent votre prochain changement de code.
 chatNotInstalledDescriptionWorkbench=Posit Assistant est un agent de chat collaboratif alimenté par le fournisseur de modèles de votre organisation.
+chatNotInstalledAdditionalProviders=La prise en charge de votre propre clé ajoute également des fournisseurs d''entreprise supplémentaires.
 chatLearnMore=En savoir plus
 chatInstallButton=Installer Posit Assistant
 chatInstallTermsOfUse=En installant ce logiciel, vous acceptez les <a href=''https://www.rstudio.org/links/posit-ai-client-terms-of-use'' target=''_blank'' rel=''noopener noreferrer'' style=''white-space: nowrap;''>conditions d''utilisation</a>.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPane.java
@@ -682,9 +682,11 @@ public class ChatPane
    }
 
    @Override
-   public void showNotInstalledWithInstall(String newVersion)
+   public void showNotInstalledWithInstall(String newVersion,
+                                           boolean additionalProvidersAvailable)
    {
-      String html = generateNotInstalledWithInstallHTML(newVersion);
+      String html = generateNotInstalledWithInstallHTML(
+         newVersion, additionalProvidersAvailable);
       updateFrameContent(html);
    }
 
@@ -703,11 +705,17 @@ public class ChatPane
              !Desktop.isDesktop();
    }
 
-   private String generateNotInstalledWithInstallHTML(String newVersion)
+   private String generateNotInstalledWithInstallHTML(String newVersion,
+                                                      boolean additionalProvidersAvailable)
    {
       String description = isWorkbench() ?
          constants_.chatNotInstalledDescriptionWorkbench() :
          constants_.chatNotInstalledDescription();
+
+      // The manifest can advertise additional providers for this build; when it
+      // does, extend the description with a sentence about that support.
+      if (additionalProvidersAvailable)
+         description += " " + constants_.chatNotInstalledAdditionalProviders();
 
       String body =
          "<h2>" + constants_.chatNotInstalledTitle() + "</h2>" +
@@ -1143,9 +1151,11 @@ public class ChatPane
    }
 
    @Override
-   public String getNotInstalledWithInstallHTML(String newVersion)
+   public String getNotInstalledWithInstallHTML(String newVersion,
+                                                boolean additionalProvidersAvailable)
    {
-      return generateNotInstalledWithInstallHTML(newVersion);
+      return generateNotInstalledWithInstallHTML(
+         newVersion, additionalProvidersAvailable);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPane.java
@@ -708,14 +708,22 @@ public class ChatPane
    private String generateNotInstalledWithInstallHTML(String newVersion,
                                                       boolean additionalProvidersAvailable)
    {
-      String description = isWorkbench() ?
-         constants_.chatNotInstalledDescriptionWorkbench() :
-         constants_.chatNotInstalledDescription();
+      String description;
+      if (isWorkbench())
+      {
+         description = constants_.chatNotInstalledDescriptionWorkbench();
+      }
+      else
+      {
+         description = constants_.chatNotInstalledDescription();
 
-      // The manifest can advertise additional providers for this build; when it
-      // does, extend the description with a sentence about that support.
-      if (additionalProvidersAvailable)
-         description += " " + constants_.chatNotInstalledAdditionalProviders();
+         // The manifest can advertise additional providers for this build; when
+         // it does, extend the description with a sentence about that support.
+         // Only the open-source (Posit AI) description is extended; the Workbench
+         // variant describes the organization's own provider and is left as-is.
+         if (additionalProvidersAvailable)
+            description += " " + constants_.chatNotInstalledAdditionalProviders();
+      }
 
       String body =
          "<h2>" + constants_.chatNotInstalledTitle() + "</h2>" +

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPresenter.java
@@ -107,7 +107,8 @@ public class ChatPresenter extends BasePresenter
       void setStatus(Status status);
       void showError(String errorMessage);
       void loadUrl(String url);
-      void showNotInstalledWithInstall(String newVersion);
+      void showNotInstalledWithInstall(String newVersion,
+                                       boolean additionalProvidersAvailable);
       void showUpdateAvailableWithVersions(String currentVersion, String newVersion,
                                             boolean isDowngrade);
       void showUpdatingStatus();
@@ -131,7 +132,8 @@ public class ChatPresenter extends BasePresenter
       void showPoppedOutPlaceholder();
       void hidePoppedOutPlaceholder();
 
-      String getNotInstalledWithInstallHTML(String newVersion);
+      String getNotInstalledWithInstallHTML(String newVersion,
+                                            boolean additionalProvidersAvailable);
       String getUpdateAvailableWithVersionsHTML(
          String currentVersion, String newVersion, boolean isDowngrade);
       String getMessageHTML(String message);
@@ -959,7 +961,8 @@ public class ChatPresenter extends BasePresenter
 
          @Override
          public void onUpdateAvailable(String currentVersion, String newVersion,
-                                       boolean isInitialInstall, boolean isDowngrade)
+                                       boolean isInitialInstall, boolean isDowngrade,
+                                       boolean additionalProvidersAvailable)
          {
             // Pausing for user action — do NOT start backend.
             // Backend starts after user clicks "Update/Install Now" and it
@@ -967,8 +970,10 @@ public class ChatPresenter extends BasePresenter
             if (isInitialInstall)
             {
                showInDisplayOrSatellite(
-                  display_.getNotInstalledWithInstallHTML(newVersion),
-                  () -> display_.showNotInstalledWithInstall(newVersion));
+                  display_.getNotInstalledWithInstallHTML(
+                     newVersion, additionalProvidersAvailable),
+                  () -> display_.showNotInstalledWithInstall(
+                     newVersion, additionalProvidersAvailable));
                setAutomationChatState("not-installed", true);
             }
             else

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/PositAiInstallManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/PositAiInstallManager.java
@@ -54,8 +54,9 @@ public class PositAiInstallManager
        * @param isInitialInstall True if this is a fresh install, false if it's an update
        * @param isDowngrade True if the available version is older than the installed version
        *                    (only meaningful when isInitialInstall is false)
-       * @param additionalProvidersAvailable True if the manifest advertises additional
-       *                    providers for this build (only reflected in the initial-install view)
+       * @param additionalProvidersAvailable True if the manifest opts this build into
+       *                    the bring-your-own-key provider set (only reflected in the
+       *                    initial-install view)
        */
       void onUpdateAvailable(String currentVersion, String newVersion,
                              boolean isInitialInstall, boolean isDowngrade,
@@ -199,8 +200,8 @@ public class PositAiInstallManager
             Boolean isDowngradeBoxed = result.getBoolean("isDowngrade");
             boolean isDowngrade = isDowngradeBoxed != null && isDowngradeBoxed;
 
-            // Also default to false when omitted (older rsession or a manifest
-            // entry without a "providers" array).
+            // getBoolean returns null when the field is absent (e.g. an older
+            // rsession); treat that as false. The backend owns what makes it true.
             Boolean additionalProvidersBoxed =
                result.getBoolean("additionalProvidersAvailable");
             boolean additionalProvidersAvailable =

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/PositAiInstallManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/PositAiInstallManager.java
@@ -54,9 +54,12 @@ public class PositAiInstallManager
        * @param isInitialInstall True if this is a fresh install, false if it's an update
        * @param isDowngrade True if the available version is older than the installed version
        *                    (only meaningful when isInitialInstall is false)
+       * @param additionalProvidersAvailable True if the manifest advertises additional
+       *                    providers for this build (only reflected in the initial-install view)
        */
       void onUpdateAvailable(String currentVersion, String newVersion,
-                             boolean isInitialInstall, boolean isDowngrade);
+                             boolean isInitialInstall, boolean isDowngrade,
+                             boolean additionalProvidersAvailable);
 
       /**
        * Called when no compatible version of Posit Assistant is available for this RStudio version.
@@ -196,6 +199,13 @@ public class PositAiInstallManager
             Boolean isDowngradeBoxed = result.getBoolean("isDowngrade");
             boolean isDowngrade = isDowngradeBoxed != null && isDowngradeBoxed;
 
+            // Also default to false when omitted (older rsession or a manifest
+            // entry without a "providers" array).
+            Boolean additionalProvidersBoxed =
+               result.getBoolean("additionalProvidersAvailable");
+            boolean additionalProvidersAvailable =
+               additionalProvidersBoxed != null && additionalProvidersBoxed;
+
             // unsupportedVersion is only true when an actual package is installed
             // (isVersionUnsupported returns false for "0.0.0"/not-installed)
             if (unsupportedVersion)
@@ -219,7 +229,8 @@ public class PositAiInstallManager
                String currentVersion = result.getString("currentVersion");
                String newVersion = result.getString("newVersion");
                callback.onUpdateAvailable(currentVersion, newVersion,
-                                          isInitialInstall, isDowngrade);
+                                          isInitialInstall, isDowngrade,
+                                          additionalProvidersAvailable);
             }
             else
             {


### PR DESCRIPTION
Reads an optional `providers` array from the Posit Assistant manifest entry that matches this build's protocol version, and uses it to vary the copy shown in the "Posit Assistant Not Installed" view.

## What changed
- The manifest parser (`ChatIntegrity`) now also returns the `providers` identifiers advertised for the selected protocol entry, plus a small tested predicate over them.
- The session module surfaces a flag on the `chat_check_for_updates` result based on that array.
- When the flag is set, the chat pane appends a sentence to the open-source "Posit Assistant is powered by the Posit AI service…" description. The Workbench description (shown only for a pro license on the server) is left unchanged.
- When the array is absent — or the field is omitted by an older session — the view is unchanged, so the behavior is backward compatible.
- A malformed `providers` array is treated as empty, deterministically (no dependence on element order).

## Tests
- C++ unit tests in `ChatIntegrityTests.cpp` cover provider extraction from the selected protocol entry, absence, malformed input, and the predicate.

An end-to-end test is intentionally deferred and will be handled separately.

Addresses #17957.
