### PR TITLE
add pin/sort controls, richer summaries, and help dialog to data viewer sidebar

### DIFF
--- a/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
@@ -221,6 +221,144 @@ test.describe('Data Viewer', () => {
     expect((await colOrder(dataViewer)).slice(0, 4)).toEqual(['0', '1', '2', '3']);
   });
 
+  // The summary sidebar mirrors the grid header's pin and sort affordances:
+  // its icons both reflect state changes made in the grid and drive the same
+  // toggle/cycle paths themselves.
+  test('sidebar pin and sort icons mirror and control column state', async () => {
+    await consoleActions.executeInConsole('View(mtcars)');
+    await waitForViewer(dataViewer);
+
+    const sidebarSort = dataViewer.frame
+      .locator('.sidebar-col[data-col-idx="1"] .sidebar-sort-icon');
+    const sidebarPin = dataViewer.frame
+      .locator('.sidebar-col[data-col-idx="3"] .sidebar-pin-icon');
+
+    // Sort from the sidebar: the grid header and the sidebar icon both
+    // step through asc, then desc.
+    await sidebarSort.click();
+    await expect.poll(() => colHeaderClass(dataViewer, 1)).toMatch(/sorting_asc/);
+    await expect(sidebarSort).toHaveClass(/sorting_asc/);
+
+    await sidebarSort.click();
+    await expect.poll(() => colHeaderClass(dataViewer, 1)).toMatch(/sorting_desc/);
+    await expect(sidebarSort).toHaveClass(/sorting_desc/);
+
+    // Clearing the sort from the grid header (third cycle step) syncs back
+    // into the sidebar icon.
+    await dataViewer.frame.locator('th[data-col-idx="1"]').click();
+    await expect(sidebarSort).not.toHaveClass(/sorting_(asc|desc)/);
+
+    // Pin from the sidebar: the column moves to the pinned prefix and the
+    // sidebar icon flips to its pinned state. (The icon is opacity:0 until
+    // hover, but locator clicks land regardless of visibility.)
+    await sidebarPin.click();
+    await expect.poll(() => colHeaderClass(dataViewer, 3)).toMatch(/\bpinned\b/);
+    expect((await colOrder(dataViewer)).slice(0, 3)).toEqual(['0', '3', '1']);
+    await expect(sidebarPin).toHaveClass(/\bpinned\b/);
+    await expect(sidebarPin).toHaveAttribute('aria-pressed', 'true');
+
+    // Unpin from the grid header: the sidebar icon follows.
+    await dataViewer.frame.locator('th[data-col-idx="3"] .pin-icon').click();
+    await expect.poll(() => colHeaderClass(dataViewer, 3)).not.toMatch(/\bpinned\b/);
+    await expect(sidebarPin).not.toHaveClass(/\bpinned\b/);
+    await expect(sidebarPin).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  // The sidebar footer is uniform across entries: numeric columns show the
+  // actual data range on the left (the sparkline has no axis ticks), and
+  // every column shows an NA percentage on the right, dimmed (class "zero")
+  // when the column has no missing values.
+  test('sidebar footer shows the numeric range and a uniform NA stat', async () => {
+    await consoleActions.executeInConsole(
+      '{ .rs.sidebar_footer_df <- data.frame(num = c(1.5, NA, 4.2, 3), chr = letters[1:4]); View(.rs.sidebar_footer_df) }',
+    );
+    try {
+      await waitForViewer(dataViewer);
+
+      const numEntry = dataViewer.frame.locator('.sidebar-col[data-col-idx="1"]');
+      const chrEntry = dataViewer.frame.locator('.sidebar-col[data-col-idx="2"]');
+
+      // Numeric column: finite data range on the left, 25% NA on the right.
+      await expect(numEntry.locator('.sidebar-col-summary')).toHaveText('[1.5, 4.2]');
+      const numNa = numEntry.locator('.sidebar-col-na');
+      await expect(numNa).toHaveText('25% NA');
+      await expect(numNa).not.toHaveClass(/\bzero\b/);
+
+      // Character column: distinct-value count on the left, and the NA stat
+      // is still rendered (uniform footer), dimmed via the "zero" class.
+      await expect(chrEntry.locator('.sidebar-col-summary')).toHaveText('4 unique');
+      const chrNa = chrEntry.locator('.sidebar-col-na');
+      await expect(chrNa).toHaveText('0% NA');
+      await expect(chrNa).toHaveClass(/\bzero\b/);
+    } finally {
+      await consoleActions.executeInConsole(
+        'rm(".rs.sidebar_footer_df", envir = .GlobalEnv)',
+      );
+    }
+  });
+
+  // Low-cardinality factor / character columns get a categorical frequency
+  // sparkline (one bar per distinct value, capped server-side at 24 bars);
+  // above the cutoff the sidebar falls back to a text summary with the
+  // dominant value -- omitted for ID-like columns where every value is
+  // distinct and "top" would be noise.
+  test('sidebar shows category bars below the cutoff and a text summary above it', async () => {
+    await consoleActions.executeInConsole(
+      '{ .rs.sidebar_cat_df <- data.frame(' +
+        'fct = factor(rep(c("aa", "bb", "cc"), each = 10)), ' +
+        'rpt = c(rep("dom", 6), sprintf("v%02d", 1:24)), ' +
+        'ids = sprintf("id%02d", 1:30)); ' +
+        'View(.rs.sidebar_cat_df) }',
+    );
+    try {
+      await waitForViewer(dataViewer);
+
+      const fctEntry = dataViewer.frame.locator('.sidebar-col[data-col-idx="1"]');
+      const rptEntry = dataViewer.frame.locator('.sidebar-col[data-col-idx="2"]');
+      const idsEntry = dataViewer.frame.locator('.sidebar-col[data-col-idx="3"]');
+
+      // 3 levels: frequency bars, with the level count kept in the footer.
+      await expect(fctEntry.locator('.sidebar-sparkline canvas')).toBeVisible();
+      await expect(fctEntry.locator('.sidebar-col-summary')).toHaveText('3 levels');
+
+      // 25 distinct values (> 24): no sparkline; the text summary names the
+      // dominant value with its share of all rows (6 of 30).
+      await expect(rptEntry.locator('.sidebar-sparkline')).toHaveCount(0);
+      await expect(rptEntry.locator('.sidebar-col-summary'))
+        .toHaveText('25 unique \u00b7 top: dom (20%)');
+
+      // All-distinct (ID-like): cardinality only, no "top".
+      await expect(idsEntry.locator('.sidebar-sparkline')).toHaveCount(0);
+      await expect(idsEntry.locator('.sidebar-col-summary')).toHaveText('30 unique');
+    } finally {
+      await consoleActions.executeInConsole(
+        'rm(".rs.sidebar_cat_df", envir = .GlobalEnv)',
+      );
+    }
+  });
+
+  // The sidebar header's "?" opens a dialog explaining the summary entries.
+  // Opening it must not collapse the panel (the icon stops propagation to
+  // the header toggle, unlike the decorative close glyph), and Escape
+  // dismisses it with the panel still expanded.
+  test('sidebar help icon opens the explainer dialog without collapsing the panel', async () => {
+    await consoleActions.executeInConsole('View(mtcars)');
+    await waitForViewer(dataViewer);
+
+    const panel = dataViewer.frame.locator('#sidebarPanel');
+    await expect(panel).toHaveClass(/\bexpanded\b/, { timeout: TIMEOUTS.fileOpen });
+
+    const dialog = dataViewer.frame.locator('.sidebar-help-dialog');
+    await dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-help').click();
+    await expect(dialog).toBeVisible();
+    await expect(panel).toHaveClass(/\bexpanded\b/);
+
+    // The dialog took focus on open, so Escape lands on it and dismisses.
+    await dialog.press('Escape');
+    await expect(dialog).toBeHidden();
+    await expect(panel).toHaveClass(/\bexpanded\b/);
+  });
+
   // https://github.com/rstudio/rstudio/issues/17835
   test('a pinned column stays pinned to its original column across column pagination', async ({ rstudioPage: page }) => {
     // 300 columns exceeds the 200-column page size, so server-side column

--- a/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
@@ -203,8 +203,9 @@ test.describe('Data Viewer', () => {
     // Initial layout: rownames column (0), then mtcars columns 1..n in order.
     expect((await colOrder(dataViewer)).slice(0, 4)).toEqual(['0', '1', '2', '3']);
 
-    // The pin icon is opacity:0 by default; clicking via locator dispatches
-    // a real click regardless of visibility.
+    // The pin icon is opacity:0 by default, which still passes Playwright's
+    // actionability visibility check (only display:none / visibility:hidden
+    // / an empty box fail it), so a locator click lands.
     const pinCol3 = dataViewer.frame.locator('th[data-col-idx="3"] .pin-icon');
     await pinCol3.click();
 
@@ -243,6 +244,11 @@ test.describe('Data Viewer', () => {
     await expect.poll(() => colHeaderClass(dataViewer, 1)).toMatch(/sorting_desc/);
     await expect(sidebarSort).toHaveClass(/sorting_desc/);
 
+    // The sort actually re-fetched the rows, not just flipped the arrows:
+    // mtcars' maximum mpg leads the grid when descending.
+    await expect(dataViewer.frame.locator('#gridBody td[data-col-pos="1"]').first())
+      .toHaveText('33.9');
+
     // Clearing the sort from the grid header (third cycle step) syncs back
     // into the sidebar icon.
     await dataViewer.frame.locator('th[data-col-idx="1"]').click();
@@ -250,7 +256,8 @@ test.describe('Data Viewer', () => {
 
     // Pin from the sidebar: the column moves to the pinned prefix and the
     // sidebar icon flips to its pinned state. (The icon is opacity:0 until
-    // hover, but locator clicks land regardless of visibility.)
+    // hover, which still passes Playwright's actionability visibility
+    // check -- only display:none / visibility:hidden / an empty box fail it.)
     await sidebarPin.click();
     await expect.poll(() => colHeaderClass(dataViewer, 3)).toMatch(/\bpinned\b/);
     expect((await colOrder(dataViewer)).slice(0, 3)).toEqual(['0', '3', '1']);
@@ -262,6 +269,51 @@ test.describe('Data Viewer', () => {
     await expect.poll(() => colHeaderClass(dataViewer, 3)).not.toMatch(/\bpinned\b/);
     await expect(sidebarPin).not.toHaveClass(/\bpinned\b/);
     await expect(sidebarPin).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  // The sidebar sort icon must work for a column whose <th> is virtualized
+  // out of the rendered window: handleSortClick keys off column state, not
+  // the rendered header (which the pre-sidebar implementation required).
+  test('sidebar sorts a column whose header is virtualized out of the grid', async () => {
+    // 300 columns so a full horizontal scroll evicts column 1's header from
+    // the DOM (same harness as the #17806 filter test). V1 holds descending
+    // values so an ascending sort visibly reverses the row order.
+    await consoleActions.executeInConsole(
+      '{ .rs.sidebar_virt_df <- as.data.frame(matrix(1:30000, nrow = 100, ncol = 300)); .rs.sidebar_virt_df[[1]] <- 100:1; View(.rs.sidebar_virt_df) }',
+    );
+    try {
+      await waitForViewer(dataViewer);
+      await expect(dataViewer.gridInfo).toContainText('100', { timeout: TIMEOUTS.fileOpen });
+
+      // Scroll the column window fully right: column 1's header is evicted
+      // from the DOM, but its sidebar entry remains.
+      await dataViewer.viewport.evaluate((el) => { el.scrollLeft = el.scrollWidth; });
+      await expect(dataViewer.frame.locator('th[data-col-idx="1"]'))
+        .toHaveCount(0, { timeout: TIMEOUTS.fileOpen });
+
+      // The column window's right edge (V200; columns past 200 sit on the
+      // next column page) is now in view. Its first-row cell anchors the
+      // row-order assertions: V200 holds 19901..20000 in natural row order.
+      const lastColCell = dataViewer.frame.locator('#gridBody td[data-col-pos="200"]').first();
+      await expect(lastColCell).toHaveText('19901');
+
+      // Sort ascending from the sidebar: the icon reflects the new state
+      // with no <th> for the column in the document, and the rows actually
+      // reorder (V1 descends, so ascending brings the last row to the top).
+      const sidebarSort = dataViewer.frame
+        .locator('.sidebar-col[data-col-idx="1"] .sidebar-sort-icon');
+      await sidebarSort.click();
+      await expect(sidebarSort).toHaveClass(/sorting_asc/);
+      await expect(lastColCell).toHaveText('20000', { timeout: TIMEOUTS.fileOpen });
+
+      // Scroll back: the recreated header carries the sort state.
+      await dataViewer.viewport.evaluate((el) => { el.scrollLeft = 0; });
+      await expect(dataViewer.frame.locator('th[data-col-idx="1"]'))
+        .toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      await expect.poll(() => colHeaderClass(dataViewer, 1)).toMatch(/sorting_asc/);
+    } finally {
+      await consoleActions.executeInConsole('rm(".rs.sidebar_virt_df", envir = .GlobalEnv)');
+    }
   });
 
   // The sidebar footer is uniform across entries: numeric columns show the
@@ -443,6 +495,15 @@ test.describe('Data Viewer', () => {
         const c3 = await colHeaderClass(dataViewer, 3);
         return /sorting_desc/.test(c1) && /\bpinned\b/.test(c3);
       }).toBe(true);
+
+      // The restored state also re-applies to the rebuilt sidebar (the
+      // trailing updateSidebarColumnIndicators call in initSidebar).
+      await expect(dataViewer.frame
+        .locator('.sidebar-col[data-col-idx="1"] .sidebar-sort-icon'))
+        .toHaveClass(/sorting_desc/);
+      await expect(dataViewer.frame
+        .locator('.sidebar-col[data-col-idx="3"] .sidebar-pin-icon'))
+        .toHaveClass(/\bpinned\b/);
     } finally {
       await consoleActions.executeInConsole(
         'rm(".rs.persist_test_df", envir = .GlobalEnv)',

--- a/e2e/rstudio/tests/panes/data-viewer/pagination-sorting.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/pagination-sorting.test.ts
@@ -162,14 +162,21 @@ test.describe('Data Viewer', () => {
     await expect(dataViewer.sortStatus).toContainText('Sorted by: a (descending)');
     await expect(dataViewer.clearSortButton).toBeVisible();
 
+    // The summary sidebar mirrors the sort state on its own icon.
+    const sidebarSort = dataViewer.frame
+      .locator('.sidebar-col[data-col-idx="1"] .sidebar-sort-icon');
+    await expect(sidebarSort).toHaveClass(/sorting_desc/);
+
     // Clicking the clear button restores the natural row order, clears the
-    // status text, hides the button, and resets the header indicator.
+    // status text, hides the button, and resets both the header indicator
+    // and the sidebar icon.
     await dataViewer.clearSortButton.click();
     await expect(firstRowA).toContainText('20');
     await expect(dataViewer.sortStatus).not.toContainText('Sorted by');
     await expect(dataViewer.clearSortButton).toBeHidden();
     await expect(dataViewer.columnHeader(1)).not.toHaveClass(/sorting_asc|sorting_desc/);
     await expect(dataViewer.columnHeader(1)).toHaveAttribute('aria-sort', 'none');
+    await expect(sidebarSort).not.toHaveClass(/sorting_asc|sorting_desc/);
 
     // The cleared sort must also persist: clearSort() saves sort: null, and a
     // restore-path regression that re-applied the stale sort on reload (the
@@ -185,12 +192,13 @@ test.describe('Data Viewer', () => {
     }, VIEWER_FRAME);
 
     // The rebuilt grid comes back unsorted: natural row order, no status
-    // text, no clear button, and a reset header indicator.
+    // text, no clear button, and reset header / sidebar indicators.
     await expect(firstRowA).toContainText('20');
     await expect(dataViewer.sortStatus).not.toContainText('Sorted by');
     await expect(dataViewer.clearSortButton).toBeHidden();
     await expect(dataViewer.columnHeader(1)).not.toHaveClass(/sorting_asc|sorting_desc/);
     await expect(dataViewer.columnHeader(1)).toHaveAttribute('aria-sort', 'none');
+    await expect(sidebarSort).not.toHaveClass(/sorting_asc|sorting_desc/);
   });
 
   // -----------------------------------------------------------------------

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -222,6 +222,14 @@
    # gets a text summary (count of uniques + dominant value) instead.
    maxCategoryBars <- 24L
 
+   # Character columns are only categorized (a full table() hash) when they
+   # have at most this many rows. The option is user-supplied, so validate
+   # it here; a malformed value (NA, wrong length, non-numeric) must not be
+   # able to break the whole describe call.
+   maxCategorizeRows <- getOption("rstudio.dataViewer.maxCategorizeRows", 1e6)
+   if (!is.numeric(maxCategorizeRows) || length(maxCategorizeRows) != 1 || is.na(maxCategorizeRows))
+      maxCategorizeRows <- 1e6
+
    # Cheap upper bound on the displayed character count for a column.
    # Only handles types where the bound is a property of range/levels/type
    # rather than a per-element format() call. Returns NA if the column type
@@ -378,21 +386,41 @@
             # via tabulate() on the underlying integer codes. at most
             # maxCategoryBars bars are drawn (in level order, preserving
             # ordinal structure); above that the sidebar falls back to a
-            # text summary, so only the dominant level is shipped
-            if (length(col_vals) > 0)
+            # text summary, so only the dominant level is shipped.
+            #
+            # gate on the column type, not val: list columns whose first
+            # element is a factor reach this branch, and as.integer() on a
+            # list is an error. the counts are decorative (the client
+            # degrades gracefully without them), so any failure just drops
+            # them instead of failing the whole describe call
+            status <- .rs.tryCatch({
+               if (is.factor(x[[idx]]) && length(col_vals) > 0)
+               {
+                  counts <- tabulate(as.integer(x[[idx]]), nbins = length(col_vals))
+                  if (length(col_vals) <= maxCategoryBars)
+                  {
+                     col_cat_vals <- col_vals
+                     col_cat_counts <- counts
+                  }
+                  else if (any(counts > 0))
+                  {
+                     top <- which.max(counts)
+                     col_top_value <- col_vals[[top]]
+                     col_top_count <- counts[[top]]
+                  }
+               }
+            })
+
+            if (inherits(status, "error"))
             {
-               counts <- tabulate(as.integer(x[[idx]]), nbins = length(col_vals))
-               if (length(col_vals) <= maxCategoryBars)
-               {
-                  col_cat_vals <- col_vals
-                  col_cat_counts <- counts
-               }
-               else if (any(counts > 0))
-               {
-                  top <- which.max(counts)
-                  col_top_value <- col_vals[[top]]
-                  col_top_count <- counts[[top]]
-               }
+               col_cat_vals <- NULL
+               col_cat_counts <- NULL
+               col_top_value <- NULL
+               col_top_count <- NULL
+               .rs.logErrorMessage(
+                  "Error computing level counts for column '%s': %s",
+                  col_name,
+                  conditionMessage(status))
             }
          }
          # for histograms, we support only the base R numeric class and its derivatives;
@@ -433,8 +461,9 @@
                col_breaks <- h$breaks
                col_counts <- h$counts
 
-               # the actual (finite) data range; the histogram breaks are
-               # pretty()-ed and so may extend past it. shown in the column
+               # the actual (finite) data range; the histogram breaks can
+               # extend past it (pretty()-ed for default binning, padded by
+               # 0.5 on each side for integer bins). shown in the column
                # summary sidebar, where the sparkline has no axis ticks
                col_min <- min_v
                col_max <- max_v
@@ -457,24 +486,44 @@
             # maxCategoryBars distinct values draws one bar per value, most
             # frequent first (no natural order to preserve); above that only
             # the text summary fields (count of uniques, dominant value) are
-            # shipped
-            maxCategorize <- getOption("rstudio.dataViewer.maxCategorizeRows", 1e6)
-            if (length(x[[idx]]) <= maxCategorize)
+            # shipped.
+            #
+            # gate on the column type, not val: list columns whose first
+            # element is a character vector reach this branch, and table()
+            # on a list either errors (ragged elements) or counts the wrong
+            # thing. decorative only, so any failure just drops the fields
+            # instead of failing the whole describe call
+            status <- .rs.tryCatch({
+               if (is.character(x[[idx]]) && length(x[[idx]]) <= maxCategorizeRows)
+               {
+                  counts <- table(x[[idx]], useNA = "no")
+                  col_n_unique <- length(counts)
+                  if (col_n_unique > 0 && col_n_unique <= maxCategoryBars)
+                  {
+                     counts <- sort(counts, decreasing = TRUE)
+                     col_cat_vals <- names(counts)
+                     col_cat_counts <- as.integer(counts)
+                  }
+                  else if (col_n_unique > 0)
+                  {
+                     top <- which.max(counts)
+                     col_top_value <- names(counts)[[top]]
+                     col_top_count <- as.integer(counts[[top]])
+                  }
+               }
+            })
+
+            if (inherits(status, "error"))
             {
-               counts <- table(x[[idx]], useNA = "no")
-               col_n_unique <- length(counts)
-               if (col_n_unique > 0 && col_n_unique <= maxCategoryBars)
-               {
-                  counts <- sort(counts, decreasing = TRUE)
-                  col_cat_vals <- names(counts)
-                  col_cat_counts <- as.integer(counts)
-               }
-               else if (col_n_unique > 0)
-               {
-                  top <- which.max(counts)
-                  col_top_value <- names(counts)[[top]]
-                  col_top_count <- as.integer(counts[[top]])
-               }
+               col_cat_vals <- NULL
+               col_cat_counts <- NULL
+               col_n_unique <- NULL
+               col_top_value <- NULL
+               col_top_count <- NULL
+               .rs.logErrorMessage(
+                  "Error computing category counts for column '%s': %s",
+                  col_name,
+                  conditionMessage(status))
             }
          }
          else if (is.logical(val))
@@ -504,8 +553,10 @@
          result$col_max <- .rs.scalar(col_max)
       }
 
-      # category metadata for the sidebar: bar values/counts below the
-      # 24-category cutoff, text-summary fields above it
+      # category metadata for the sidebar: bar values/counts at or below
+      # the maxCategoryBars cutoff, dominant-value fields above it; the
+      # distinct-value count ships whenever it was computed (character
+      # columns within the row gate), regardless of the cutoff
       if (!is.null(col_cat_counts)) {
          result$col_cat_vals <- as.character(col_cat_vals)
          result$col_cat_counts <- as.integer(col_cat_counts)

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -217,6 +217,11 @@
    maxCharsCap <- 200L
    computeMaxChars <- ncol(x) > 0 && ncol(x) <= maxCharsCap
 
+   # Maximum number of distinct values for which the summary sidebar draws
+   # one frequency bar per category; above this, a factor / character column
+   # gets a text summary (count of uniques + dominant value) instead.
+   maxCategoryBars <- 24L
+
    # Cheap upper bound on the displayed character count for a column.
    # Only handles types where the bound is a property of range/levels/type
    # rather than a per-element format() call. Returns NA if the column type
@@ -318,8 +323,15 @@
       col_class <- class(x[[idx]])
       col_breaks <- c()
       col_counts <- c()
+      col_min <- NULL
+      col_max <- NULL
       col_vals <- ""
       col_search_type <- ""
+      col_cat_vals <- NULL
+      col_cat_counts <- NULL
+      col_n_unique <- NULL
+      col_top_value <- NULL
+      col_top_count <- NULL
       
       # extract label, if any, or use global label, if any
       label <- attr(x[[idx]], "label", exact = TRUE)
@@ -361,6 +373,27 @@
             # https://github.com/rstudio/rstudio/issues/14113
             col_search_type <- "factor"
             col_vals <- levels(val)
+
+            # per-level counts for the sidebar's category mini-plot: cheap
+            # via tabulate() on the underlying integer codes. at most
+            # maxCategoryBars bars are drawn (in level order, preserving
+            # ordinal structure); above that the sidebar falls back to a
+            # text summary, so only the dominant level is shipped
+            if (length(col_vals) > 0)
+            {
+               counts <- tabulate(as.integer(x[[idx]]), nbins = length(col_vals))
+               if (length(col_vals) <= maxCategoryBars)
+               {
+                  col_cat_vals <- col_vals
+                  col_cat_counts <- counts
+               }
+               else if (any(counts > 0))
+               {
+                  top <- which.max(counts)
+                  col_top_value <- col_vals[[top]]
+                  col_top_count <- counts[[top]]
+               }
+            }
          }
          # for histograms, we support only the base R numeric class and its derivatives;
          # is.numeric can return true for values that can only be manipulated using
@@ -400,6 +433,12 @@
                col_breaks <- h$breaks
                col_counts <- h$counts
 
+               # the actual (finite) data range; the histogram breaks are
+               # pretty()-ed and so may extend past it. shown in the column
+               # summary sidebar, where the sparkline has no axis ticks
+               col_min <- min_v
+               col_max <- max_v
+
                # record search type
                col_search_type <- "numeric"
             }
@@ -411,6 +450,32 @@
          else if (is.character(val))
          {
             col_search_type <- "character"
+
+            # category counts for the sidebar mini-plot. unlike factors this
+            # costs a full hash of the column (table()), so very long columns
+            # skip it and the sidebar shows no categorical summary. at most
+            # maxCategoryBars distinct values draws one bar per value, most
+            # frequent first (no natural order to preserve); above that only
+            # the text summary fields (count of uniques, dominant value) are
+            # shipped
+            maxCategorize <- getOption("rstudio.dataViewer.maxCategorizeRows", 1e6)
+            if (length(x[[idx]]) <= maxCategorize)
+            {
+               counts <- table(x[[idx]], useNA = "no")
+               col_n_unique <- length(counts)
+               if (col_n_unique > 0 && col_n_unique <= maxCategoryBars)
+               {
+                  counts <- sort(counts, decreasing = TRUE)
+                  col_cat_vals <- names(counts)
+                  col_cat_counts <- as.integer(counts)
+               }
+               else if (col_n_unique > 0)
+               {
+                  top <- which.max(counts)
+                  col_top_value <- names(counts)[[top]]
+                  col_top_count <- as.integer(counts[[top]])
+               }
+            }
          }
          else if (is.logical(val))
          {
@@ -432,6 +497,25 @@
          col_na_count    = .rs.scalar(col_na_count),
          col_index       = .rs.scalar(as.integer(colIndices[idx]))
       )
+
+      # data range, present only for histogram-summarized numeric columns
+      if (!is.null(col_min)) {
+         result$col_min <- .rs.scalar(col_min)
+         result$col_max <- .rs.scalar(col_max)
+      }
+
+      # category metadata for the sidebar: bar values/counts below the
+      # 24-category cutoff, text-summary fields above it
+      if (!is.null(col_cat_counts)) {
+         result$col_cat_vals <- as.character(col_cat_vals)
+         result$col_cat_counts <- as.integer(col_cat_counts)
+      }
+      if (!is.null(col_n_unique))
+         result$col_n_unique <- .rs.scalar(as.integer(col_n_unique))
+      if (!is.null(col_top_value)) {
+         result$col_top_value <- .rs.scalar(col_top_value)
+         result$col_top_count <- .rs.scalar(as.integer(col_top_count))
+      }
 
       # Optionally include a cheap upper bound on displayed character count.
       # The client uses this for initial column width sizing instead of

--- a/src/cpp/session/resources/grid/DataViewer.css
+++ b/src/cpp/session/resources/grid/DataViewer.css
@@ -945,10 +945,11 @@ th.columnClickable div {
 
 /* --- Pin / sort icons (mirroring the grid header) --- */
 
-/* The shared .pin-icon class supplies the mask glyph plus the hidden-until-
-   hover and pinned-state opacities; these rules adapt it to the flex header
-   row. Unlike the grid's pin icon, the sidebar copies are focusable buttons,
-   so reveal them on keyboard focus too. */
+/* The shared .pin-icon class supplies the mask glyph and the pinned-state
+   opacity, but its hover reveal is scoped to th:hover, so the .sidebar-col
+   rule below re-creates it for the sidebar entries; the rest adapts the
+   icon to the flex header row. Unlike the grid's pin icon, the sidebar
+   copies are focusable buttons, so reveal them on keyboard focus too. */
 .sidebar-pin-icon {
    margin-right: 0;
    flex-shrink: 0;

--- a/src/cpp/session/resources/grid/DataViewer.css
+++ b/src/cpp/session/resources/grid/DataViewer.css
@@ -28,6 +28,13 @@
    --grid-na-color: var(--rstudio-disabledForeground, #b0b0b0);
    --grid-focus-border: var(--rstudio-focusBorder, #4d9de0);
 
+   /* Sidebar sparkline bar colors (read from JS when painting the canvas).
+      Numeric histograms follow the theme accent; categorical frequency
+      bars use a deliberately different hue as a visual cue that the
+      x-axis is discrete values, not a numeric range. */
+   --grid-spark-numeric: var(--grid-focus-border);
+   --grid-spark-categorical: #2ba36b;
+
    /* Computed mix shades -- keep these in one place so theme tweaks land
       consistently across hover/stripe rules. */
    --grid-row-hover-bg:  color-mix(in srgb, var(--grid-bg), var(--grid-fg) 10%);
@@ -207,12 +214,13 @@ tbody tr.odd-row td.col-spacer {
    to the toolbar) -- otherwise it would look like keyboard focus is
    in two places.
 
-   Note: th and .pin-icon intentionally have no :focus / :focus-visible
-   styling of their own. Neither element is individually focusable now;
-   the only visible focus indicator inside the grid is the .activeCell /
-   .activeHeader outline below, driven by aria-activedescendant. Adding
-   per-element focus rings here would re-introduce the dual-focus look
-   this design eliminated. */
+   Note: th and the grid header's .pin-icon intentionally have no :focus /
+   :focus-visible styling of their own. Neither element is individually
+   focusable inside the grid; the only visible focus indicator there is
+   the .activeCell / .activeHeader outline below, driven by
+   aria-activedescendant. Adding per-element focus rings here would
+   re-introduce the dual-focus look this design eliminated. (The sidebar
+   reuses .pin-icon on real focusable buttons -- see .sidebar-pin-icon.) */
 #gridViewport:focus-within td.activeCell,
 #gridViewport:focus-within th.activeHeader {
    outline: 2px solid var(--grid-focus-border);
@@ -756,10 +764,31 @@ th.columnClickable div {
    text-overflow: ellipsis;
 }
 
-/* Right-aligned close affordance; purely visual (clicks bubble to
-   #sidebarToggle, which is the accessible control). */
-.sidebar-toggle-close {
+/* Help affordance; owns the auto margin that pushes it (and the close
+   glyph after it) to the right edge. A real button, unlike the decorative
+   close glyph: activating it opens the help dialog rather than collapsing
+   the panel. */
+.sidebar-toggle-help {
    margin-left: auto;
+   width: 13px;
+   height: 12px;
+   opacity: 0.6;
+   font-size: 12px;
+   font-weight: normal;
+   text-align: center;
+   font-family: monospace;
+   cursor: pointer;
+   flex-shrink: 0;
+}
+
+.sidebar-toggle-help:hover,
+.sidebar-toggle-help:focus-visible {
+   opacity: 1;
+}
+
+/* Close affordance; purely visual (clicks bubble to #sidebarToggle, which
+   is the accessible control). */
+.sidebar-toggle-close {
    padding-left: 8px;
    font-size: 14px;
    font-weight: normal;
@@ -769,6 +798,95 @@ th.columnClickable div {
 
 #sidebarToggle:hover .sidebar-toggle-close {
    opacity: 1;
+}
+
+/* ...but not while the help icon is hovered: a click there opens the help
+   dialog instead of reaching the toggle, so the close affordance should
+   not light up as if the header were about to collapse. (The close glyph
+   is a following sibling of the help icon, hence the ~ combinator.) */
+#sidebarToggle .sidebar-toggle-help:hover ~ .sidebar-toggle-close {
+   opacity: 0.6;
+}
+
+/* --- Help dialog --- */
+
+#sidebarHelpOverlay {
+   position: fixed;
+   inset: 0;
+   z-index: 100;
+   display: flex;
+   align-items: center;
+   justify-content: center;
+   background-color: rgba(0, 0, 0, 0.3);
+}
+
+.sidebar-help-dialog {
+   position: relative;
+   width: 340px;
+   max-width: calc(100vw - 40px);
+   max-height: calc(100vh - 40px);
+   overflow-y: auto;
+   padding: 12px 16px 14px;
+   background-color: var(--grid-bg);
+   color: var(--grid-fg);
+   border: 1px solid var(--grid-border);
+   border-radius: 6px;
+   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+   font-size: 12px;
+   line-height: 1.5;
+   /* The dialog takes programmatic focus on open; the dimmed backdrop is
+      indication enough, so suppress the focus ring. */
+   outline: none;
+}
+
+.sidebar-help-title {
+   font-size: 13px;
+   font-weight: bold;
+   margin-bottom: 2px;
+}
+
+.sidebar-help-close {
+   position: absolute;
+   top: 10px;
+   right: 12px;
+   font-size: 14px;
+   line-height: 1;
+   cursor: pointer;
+   opacity: 0.6;
+}
+
+.sidebar-help-close:hover,
+.sidebar-help-close:focus-visible {
+   opacity: 1;
+}
+
+.sidebar-help-section {
+   margin-top: 8px;
+}
+
+.sidebar-help-heading {
+   font-weight: bold;
+}
+
+.sidebar-help-line + .sidebar-help-line {
+   margin-top: 4px;
+}
+
+/* Legend swatches matching the sparkline bar colors. */
+.sidebar-help-swatch {
+   display: inline-block;
+   width: 9px;
+   height: 9px;
+   margin-right: 5px;
+   border-radius: 2px;
+}
+
+.sidebar-help-swatch.numeric {
+   background-color: var(--grid-spark-numeric);
+}
+
+.sidebar-help-swatch.categorical {
+   background-color: var(--grid-spark-categorical);
 }
 
 #sidebarContent {
@@ -825,6 +943,77 @@ th.columnClickable div {
    font-family: monospace;
 }
 
+/* --- Pin / sort icons (mirroring the grid header) --- */
+
+/* The shared .pin-icon class supplies the mask glyph plus the hidden-until-
+   hover and pinned-state opacities; these rules adapt it to the flex header
+   row. Unlike the grid's pin icon, the sidebar copies are focusable buttons,
+   so reveal them on keyboard focus too. */
+.sidebar-pin-icon {
+   margin-right: 0;
+   flex-shrink: 0;
+   align-self: center;
+}
+
+.sidebar-col:hover .pin-icon {
+   opacity: 0.6;
+}
+
+.sidebar-pin-icon:focus-visible {
+   opacity: 0.8;
+}
+
+/* Same arrow glyphs as the th.sorting* rules, as a standalone element
+   rather than a ::after (the icon doubles as a click/keyboard target). */
+.sidebar-sort-icon {
+   width: 10px;
+   height: 10px;
+   /* Keep clear of the floating sidebar scrollbar, which overlays the
+      panel's right edge. */
+   margin-right: 4px;
+   flex-shrink: 0;
+   align-self: center;
+   cursor: pointer;
+   opacity: 0.4;
+   background-color: var(--grid-fg);
+   -webkit-mask-repeat: no-repeat;
+   -webkit-mask-position: center;
+   -webkit-mask-size: contain;
+   mask-repeat: no-repeat;
+   mask-position: center;
+   mask-size: contain;
+   /* Both arrows (unsorted) */
+   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'%3E%3Cpath d='M5 1L8 4H2z'/%3E%3Cpath d='M5 9L2 6h6z'/%3E%3C/svg%3E");
+   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'%3E%3Cpath d='M5 1L8 4H2z'/%3E%3Cpath d='M5 9L2 6h6z'/%3E%3C/svg%3E");
+}
+
+.sidebar-sort-icon:hover,
+.sidebar-sort-icon:focus-visible {
+   opacity: 0.8;
+}
+
+.sidebar-sort-icon.sorting_asc {
+   /* Up arrow */
+   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'%3E%3Cpath d='M5 2L8 6H2z'/%3E%3C/svg%3E");
+   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'%3E%3Cpath d='M5 2L8 6H2z'/%3E%3C/svg%3E");
+   opacity: 0.8;
+}
+
+.sidebar-sort-icon.sorting_desc {
+   /* Down arrow */
+   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'%3E%3Cpath d='M5 8L2 4h6z'/%3E%3C/svg%3E");
+   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'%3E%3Cpath d='M5 8L2 4h6z'/%3E%3C/svg%3E");
+   opacity: 0.8;
+}
+
+/* Inert placeholder for non-sortable (list / data.frame) columns; keeps
+   the type labels right-aligned consistently across entries. */
+.sidebar-sort-icon.disabled {
+   visibility: hidden;
+   cursor: default;
+}
+
+
 /* --- Sparkline histogram --- */
 
 .sidebar-sparkline {
@@ -866,15 +1055,53 @@ th.columnClickable div {
    margin-top: 2px;
 }
 
+/* Extra 2px of breathing room between a sparkline histogram and the
+   summary row below it. Set here rather than as margin-bottom on
+   .sidebar-sparkline, which would collapse into the footer's own
+   margin-top and add nothing. */
+.sidebar-sparkline + .sidebar-col-footer {
+   margin-top: 4px;
+}
+
 .sidebar-col-summary {
    font-size: 10px;
    color: var(--grid-na-color);
+   /* The categorical summary can embed an arbitrary user value ("top: ...");
+      ellipsize rather than wrap or push the NA stat out of the row. */
+   overflow: hidden;
+   text-overflow: ellipsis;
+   white-space: nowrap;
+   min-width: 0;
+}
+
+/* The numeric range carries actual data, so its numbers use the regular
+   foreground -- the muted summary color is hard to read in light themes. */
+.sidebar-col-summary.range {
+   color: var(--grid-fg);
+}
+
+/* The [ , ] adornments of the numeric range read as notation, not data:
+   dimming them (relative to the numbers, whose color they inherit) keeps
+   the numbers prominent and stops a locale's comma thousands separators
+   from blending into the interval's delimiter. */
+.sidebar-col-summary .range-punct {
+   opacity: 0.6;
 }
 
 .sidebar-col-na {
    font-size: 10px;
    color: var(--grid-na-color);
    font-style: italic;
+   flex-shrink: 0;
+   /* Keep clear of the floating sidebar scrollbar, which overlays the
+      panel's right edge (matching .sidebar-sort-icon). */
+   margin-right: 4px;
+}
+
+/* The NA stat is always rendered for a uniform footer; dim the zero case
+   so columns with real missingness stand out when scanning the list. */
+.sidebar-col-na.zero {
+   opacity: 0.5;
 }
 
 /* --- Expand button --- */

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -887,9 +887,18 @@ var hasHistogram = function(col) {
 // sidebar's frequency bars. The server only emits these below its bar
 // cutoff, so presence of the fields is the entire decision.
 var hasCategoryCounts = function(col) {
-   return col.col_cat_vals && col.col_cat_vals.length > 0 &&
-          col.col_cat_counts &&
-          col.col_cat_counts.length === col.col_cat_vals.length;
+   if (!col.col_cat_vals || col.col_cat_vals.length === 0)
+      return false;
+   if (!col.col_cat_counts ||
+       col.col_cat_counts.length !== col.col_cat_vals.length) {
+      // The fields only ship as a pair, so a mismatch means a server-side
+      // bug; leave a trace rather than silently dropping the sparkline.
+      console.warn("category values/counts mismatch for column '" +
+         col.col_name + "': " + col.col_cat_vals.length + " values, " +
+         (col.col_cat_counts ? col.col_cat_counts.length : 0) + " counts");
+      return false;
+   }
+   return true;
 };
 
 // Coarse category used to choose which summary stats to render in the sidebar.
@@ -2997,8 +3006,10 @@ var createSparkline = function(breaks, counts, labels) {
       var headline;
       if (labels) {
          // Categorical bar: the headline is the value itself, truncated so
-         // a long string can't blow the tooltip out to absurd widths.
-         headline = String(labels[bin]);
+         // a long string can't blow the tooltip out to absurd widths. An
+         // explicit NA factor level arrives as JSON null; label it "NA"
+         // rather than rendering the literal string "null".
+         headline = labels[bin] === null ? "NA" : String(labels[bin]);
          if (headline.length > 40)
             headline = headline.substring(0, 40) + "...";
       } else {
@@ -3355,20 +3366,24 @@ var initSidebar = function() {
 
       // Footer row: type-specific summary (left) + NA stat (right). Always
       // rendered so entries keep a uniform shape: the left slot may be empty
-      // (e.g. character columns have no compact summary), and the NA stat is
-      // always present, visually dimmed when the column has nothing missing.
+      // (e.g. Date / logical columns, or character columns too long for the
+      // server to count distinct values), and the NA stat is always
+      // present, visually dimmed when the column has nothing missing.
       var footer = document.createElement("div");
       footer.className = "sidebar-col-footer";
 
       // Type-specific summary (left). For numeric columns this is the actual
       // data range as a closed interval, [min, max], which doubles as the
-      // sparkline's (unticked) axis bounds; col_min/col_max may be absent on
-      // older servers, in which case the slot stays empty. The bracket and
-      // comma adornments are dimmed spans (see .range-punct) so they read
-      // as notation rather than data.
+      // sparkline's (unticked) axis bounds; the col_min/col_max checks are
+      // purely defensive (the fields ship with every histogram), keeping the
+      // slot empty rather than throwing mid-bootstrap if one were missing.
+      // The bracket and comma adornments are dimmed spans (see .range-punct)
+      // so they read as notation rather than data.
       var summaryEl = document.createElement("span");
       summaryEl.className = "sidebar-col-summary";
-      if (hasHistogram(col) && typeof col.col_min === "number") {
+      if (hasHistogram(col) &&
+          typeof col.col_min === "number" &&
+          typeof col.col_max === "number") {
          summaryEl.classList.add("range");
          appendRangePunct(summaryEl, "[");
          summaryEl.appendChild(
@@ -3635,12 +3650,6 @@ var buildSidebarHelpOverlay = function() {
    dialog.setAttribute("aria-modal", "true");
    dialog.setAttribute("aria-labelledby", "sidebarHelpTitle");
    dialog.setAttribute("tabindex", "-1");
-   dialog.addEventListener("keydown", function(evt) {
-      if (evt.key === "Escape") {
-         evt.stopPropagation();
-         hideSidebarHelp();
-      }
-   });
 
    var title = document.createElement("div");
    title.className = "sidebar-help-title";
@@ -3662,6 +3671,19 @@ var buildSidebarHelpOverlay = function() {
       }
    });
    dialog.appendChild(closeBtn);
+
+   dialog.addEventListener("keydown", function(evt) {
+      if (evt.key === "Escape") {
+         evt.stopPropagation();
+         hideSidebarHelp();
+      } else if (evt.key === "Tab") {
+         // Minimal focus trap, as aria-modal promises one: the close glyph
+         // is the dialog's only tabbable element, so park focus there
+         // rather than letting Tab walk into the grid behind the backdrop.
+         evt.preventDefault();
+         closeBtn.focus();
+      }
+   });
 
    var addSection = function(heading) {
       var section = document.createElement("div");
@@ -3707,7 +3729,8 @@ var buildSidebarHelpOverlay = function() {
    addLine(statsSec,
       "The numeric data range as [min, max], or the number of factor " +
       "levels / distinct values -- plus the most frequent value when " +
-      "there are too many to chart. The right-hand side shows the " +
+      "there are too many to chart. Distinct values are not counted for " +
+      "very large character columns. The right-hand side shows the " +
       "percentage of missing values.");
 
    var detailsSec = addSection("Details");

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -883,6 +883,15 @@ var hasHistogram = function(col) {
           col.col_counts && col.col_counts.length > 0;
 };
 
+// Whether a (factor / character) column ships per-category counts for the
+// sidebar's frequency bars. The server only emits these below its bar
+// cutoff, so presence of the fields is the entire decision.
+var hasCategoryCounts = function(col) {
+   return col.col_cat_vals && col.col_cat_vals.length > 0 &&
+          col.col_cat_counts &&
+          col.col_cat_counts.length === col.col_cat_vals.length;
+};
+
 // Coarse category used to choose which summary stats to render in the sidebar.
 // Anything not matched here (Date, POSIXct, ...) falls through to the generic
 // min/max stats in renderColumnStats.
@@ -997,7 +1006,7 @@ var createHeader = function(idx, col) {
       if (evt.target.className === "resizer") return;
       if (evt.target.classList && evt.target.classList.contains("pin-icon")) return;
       if (didResize) { didResize = false; return; }
-      if (sortable) handleSortClick(idx, th);
+      if (sortable) handleSortClick(idx);
       var displayIdx = columnOrder.indexOf(idx);
       if (displayIdx >= 0) setActiveHeader(displayIdx);
       focusGridViewport();
@@ -1021,10 +1030,7 @@ var sortAriaValue = function(dir) {
    return "none";
 };
 
-var handleSortClick = function(colIdx, th) {
-   var thead = document.getElementById("data_cols");
-   var headers = thead.children;
-
+var handleSortClick = function(colIdx) {
    // sortColumn is an absolute column identity, so translate the clicked
    // window position before comparing/storing.
    var absIdx = absColIndex(colIdx);
@@ -1049,28 +1055,11 @@ var handleSortClick = function(colIdx, th) {
    // we don't re-highlight a different row at the old coordinate.
    clearActiveCell();
 
-   // Update header classes and aria-sort. AT users hear "ascending" /
-   // "descending" / "none" in place of the visual arrow cue.
-   for (var i = 0; i < headers.length; i++) {
-      headers[i].classList.remove("sorting_asc", "sorting_desc");
-      if (!headers[i].classList.contains("sorting")) {
-         headers[i].classList.add("sorting");
-      }
-      if (headers[i].hasAttribute("aria-sort")) {
-         headers[i].setAttribute("aria-sort", "none");
-      }
-   }
-   if (newDir === "asc") {
-      th.classList.remove("sorting");
-      th.classList.add("sorting_asc");
-      th.setAttribute("aria-sort", "ascending");
-   } else if (newDir === "desc") {
-      th.classList.remove("sorting");
-      th.classList.add("sorting_desc");
-      th.setAttribute("aria-sort", "descending");
-   } else {
-      th.setAttribute("aria-sort", "none");
-   }
+   // Refresh the arrow classes and aria-sort on every rendered header, and
+   // mirror the new state into the sidebar's sort icons. AT users hear
+   // "ascending" / "descending" / "none" in place of the visual arrow cue.
+   applySortIndicators();
+   updateSidebarColumnIndicators();
 
    // Re-fetch data
    invalidateCache();
@@ -1092,17 +1081,9 @@ var clearSort = function() {
    // we don't re-highlight a different row at the old coordinate.
    clearActiveCell();
 
-   // Reset the header arrows. applySortIndicators() only updates the arrow
-   // classes, so aria-sort must be cleared separately on every sortable
-   // header (mirroring handleSortClick).
+   // Reset the header arrows + aria-sort and the sidebar's sort icons.
    applySortIndicators();
-   var thead = document.getElementById("data_cols");
-   if (thead) {
-      for (var i = 0; i < thead.children.length; i++) {
-         if (thead.children[i].hasAttribute("aria-sort"))
-            thead.children[i].setAttribute("aria-sort", "none");
-      }
-   }
+   updateSidebarColumnIndicators();
 
    // Re-fetch data
    invalidateCache();
@@ -1458,6 +1439,7 @@ var togglePinColumn = function(colIdx) {
    // refresh the custom scrollbars so the thumb size matches before the
    // user scrolls.
    updateCustomScrollbars();
+   updateSidebarColumnIndicators();
    saveState();
    if (headerOrigCol >= 0) {
       var newDisplayIdx = columnOrder.indexOf(headerOrigCol);
@@ -2916,8 +2898,14 @@ var onResize = debounce(TIMING.resizeDebounce, function() {
 // approach put thousands of vector nodes on the page, and repainting them
 // during grid scroll caused multi-second stalls with the summary panel open
 // (#17806). A canvas is one raster element, far cheaper for the compositor.
-var createSparkline = function(breaks, counts) {
-   if (!breaks || !counts || counts.length === 0) return null;
+//
+// Two modes share the renderer: numeric histograms (breaks + counts) and
+// categorical frequency bars (labels + counts, breaks null). Categorical
+// bars draw in an alternate color with per-bar gaps, cueing that the x-axis
+// is a set of discrete values rather than a continuous range.
+var createSparkline = function(breaks, counts, labels) {
+   if (!counts || counts.length === 0) return null;
+   if (!breaks && !labels) return null;
 
    var max = 0;
    var total = 0;
@@ -2952,8 +2940,14 @@ var createSparkline = function(breaks, counts) {
 
    // Resolve the bar color from CSS so theming still applies; a canvas
    // can't pick up the old .sparkline-bar rule on its own.
-   var barColor = getComputedStyle(document.documentElement)
-      .getPropertyValue("--grid-focus-border").trim() || "#4d9de0";
+   var styles = getComputedStyle(document.documentElement);
+   var barColor = labels
+      ? (styles.getPropertyValue("--grid-spark-categorical").trim() || "#2ba36b")
+      : (styles.getPropertyValue("--grid-spark-numeric").trim() || "#4d9de0");
+
+   // Histogram bins tile seamlessly (contiguous ranges); categorical bars
+   // get a small gap so discrete values read as separate bars.
+   var barGap = labels ? Math.max(1, Math.round(dpr)) : 0;
 
    // Redraw all bars, drawing the hovered bar (if any) at full opacity to
    // mimic the per-bar :hover highlight the SVG version had. Cheap to call
@@ -2969,7 +2963,7 @@ var createSparkline = function(breaks, counts) {
          var x0 = Math.round((j / counts.length) * canvas.width);
          var x1 = Math.round(((j + 1) / counts.length) * canvas.width);
          ctx.globalAlpha = (j === highlightBin) ? 1 : 0.6;
-         ctx.fillRect(x0, canvas.height - h, Math.max(1, x1 - x0), h);
+         ctx.fillRect(x0, canvas.height - h, Math.max(1, x1 - x0 - barGap), h);
       }
    };
    drawBars(hoverBin);
@@ -2981,16 +2975,6 @@ var createSparkline = function(breaks, counts) {
    tooltip.className = "sparkline-tooltip";
    tooltip.style.display = "none";
    wrapper.appendChild(tooltip);
-
-   var formatNum = function(n) {
-      // Integer-valued breaks (including 0) render without a fractional
-      // part: "0" rather than "0.00", "5" rather than "5.0".
-      if (Number.isInteger(n)) return n.toLocaleString();
-      if (Math.abs(n) >= 100) return Math.round(n).toLocaleString();
-      if (Math.abs(n) >= 1) return n.toFixed(1);
-      if (Math.abs(n) >= 0.01) return n.toFixed(2);
-      return n.toPrecision(3);
-   };
 
    canvas.addEventListener("mousemove", function(evt) {
       // The canvas has no per-bar nodes, so derive the hovered bin from the
@@ -3007,26 +2991,37 @@ var createSparkline = function(breaks, counts) {
       // Repaint with the hovered bar highlighted when the bin changes.
       if (bin !== hoverBin) { hoverBin = bin; drawBars(hoverBin); }
 
-      // breaks arrive from R as strings (col_breaks is as.character'd
-      // server-side); coerce here so arithmetic doesn't fall into string
-      // concatenation via the `+` operator.
-      var lo = Number(breaks[bin]);
-      var hi = Number(breaks[bin + 1]);
       var count = counts[bin];
       var pct = total > 0 ? ((count / total) * 100).toFixed(1) : "0";
 
-      // For integer-binned histograms (server emits breaks like
-      // 0.5, 1.5, 2.5, ... so each bin holds one integer value), show the
-      // integer rather than the awkward "Range: 0.5 to 1.5".
-      var mid = (lo + hi) / 2;
-      var isIntegerBin = (hi - lo) === 1 && Number.isInteger(mid);
+      var headline;
+      if (labels) {
+         // Categorical bar: the headline is the value itself, truncated so
+         // a long string can't blow the tooltip out to absurd widths.
+         headline = String(labels[bin]);
+         if (headline.length > 40)
+            headline = headline.substring(0, 40) + "...";
+      } else {
+         // breaks arrive from R as strings (col_breaks is as.character'd
+         // server-side); coerce here so arithmetic doesn't fall into string
+         // concatenation via the `+` operator.
+         var lo = Number(breaks[bin]);
+         var hi = Number(breaks[bin + 1]);
+
+         // For integer-binned histograms (server emits breaks like
+         // 0.5, 1.5, 2.5, ... so each bin holds one integer value), show the
+         // integer rather than the awkward "Range: 0.5 to 1.5".
+         var mid = (lo + hi) / 2;
+         var isIntegerBin = (hi - lo) === 1 && Number.isInteger(mid);
+         headline = isIntegerBin
+            ? "Value: " + mid
+            : "Range: " + formatCompactNum(lo) + " to " + formatCompactNum(hi);
+      }
 
       // Build with DOM nodes rather than innerHTML so future format changes
       // can't accidentally interpret data values as markup.
       tooltip.textContent = "";
-      tooltip.appendChild(document.createTextNode(isIntegerBin
-         ? "Value: " + mid
-         : "Range: " + formatNum(lo) + " to " + formatNum(hi)));
+      tooltip.appendChild(document.createTextNode(headline));
       tooltip.appendChild(document.createElement("br"));
       tooltip.appendChild(document.createTextNode(
          "Count: " + count.toLocaleString() + " (" + pct + "%)"));
@@ -3067,6 +3062,28 @@ var typeLabel = function(col) {
       "raw": "raw"
    };
    return map[type] || type;
+};
+
+// Compact formatter for axis-style values (sparkline bin bounds, the
+// footer's min/max range). Integer values (including 0) render without a
+// fractional part: "0" rather than "0.00", "5" rather than "5.0".
+var formatCompactNum = function(n) {
+   if (Number.isInteger(n)) return n.toLocaleString();
+   if (Math.abs(n) >= 100) return Math.round(n).toLocaleString();
+   if (Math.abs(n) >= 1) return n.toFixed(1);
+   if (Math.abs(n) >= 0.01) return n.toFixed(2);
+   return n.toPrecision(3);
+};
+
+// Append one of the range interval's punctuation adornments ("[", ", ",
+// "]") to the footer summary as a dimmed span, visually separating the
+// notation from the numbers themselves (whose locale formatting may
+// include comma thousands separators).
+var appendRangePunct = function(el, text) {
+   var punct = document.createElement("span");
+   punct.className = "range-punct";
+   punct.textContent = text;
+   el.appendChild(punct);
 };
 
 var formatStatValue = function(val) {
@@ -3200,6 +3217,30 @@ var initSidebar = function() {
    toggleSpinner.id = "sidebarSpinner";
    toggle.appendChild(toggleSpinner);
 
+   // Help icon: opens a small dialog explaining the summary entries. Unlike
+   // the close glyph below, activation must NOT reach the toggle -- it opens
+   // the dialog rather than collapsing the panel -- so both handlers stop
+   // propagation. A real button (focusable, labelled), since it does
+   // something other than what the header announces.
+   var toggleHelp = document.createElement("span");
+   toggleHelp.className = "sidebar-toggle-help";
+   toggleHelp.textContent = "?";
+   toggleHelp.setAttribute("role", "button");
+   toggleHelp.setAttribute("tabindex", "0");
+   toggleHelp.setAttribute("aria-label", "About column summaries");
+   toggleHelp.title = "About column summaries";
+   var onToggleHelpActivate = function(evt) {
+      evt.stopPropagation();
+      evt.preventDefault();
+      showSidebarHelp(toggleHelp);
+   };
+   toggleHelp.addEventListener("click", onToggleHelpActivate);
+   toggleHelp.addEventListener("keydown", function(evt) {
+      if (evt.key === "Enter" || evt.key === " ")
+         onToggleHelpActivate(evt);
+   });
+   toggle.appendChild(toggleHelp);
+
    // Decorative close glyph; clicks bubble to the toggle, which remains the
    // panel's single accessible control.
    var toggleClose = document.createElement("span");
@@ -3246,6 +3287,16 @@ var initSidebar = function() {
          "Toggle summary for column " + col.col_name);
       header.appendChild(expandBtn);
 
+      // Pin icon, mirroring the grid header's affordance: hidden until the
+      // entry is hovered, persistent while the column is pinned. State
+      // (pinned class, title, aria) is applied by
+      // updateSidebarColumnIndicators once all entries exist.
+      var pinIcon = document.createElement("span");
+      pinIcon.className = "pin-icon sidebar-pin-icon";
+      pinIcon.setAttribute("role", "button");
+      pinIcon.setAttribute("tabindex", "0");
+      header.appendChild(pinIcon);
+
       var name = document.createElement("span");
       name.className = "sidebar-col-name";
       name.textContent = col.col_name;
@@ -3257,11 +3308,29 @@ var initSidebar = function() {
       type.textContent = "<" + typeLabel(col) + ">";
       header.appendChild(type);
 
+      // Sort icon at the right edge, mirroring the grid header's indicator.
+      // Non-sortable columns (list / data.frame) keep an inert hidden
+      // placeholder so the type labels stay aligned across entries; when
+      // ordering is disabled for the whole grid no icon is created at all.
+      var sortIcon = null;
+      if (ordering) {
+         sortIcon = document.createElement("span");
+         sortIcon.className = "sidebar-sort-icon";
+         if (isColumnSortable(col)) {
+            sortIcon.setAttribute("role", "button");
+            sortIcon.setAttribute("tabindex", "0");
+         } else {
+            sortIcon.classList.add("disabled");
+         }
+         header.appendChild(sortIcon);
+      }
+
       entry.appendChild(header);
 
-      // Sparkline histogram for numeric columns. Create the (empty)
-      // container now but defer drawing the canvas until the panel is
-      // visible -- see renderPendingSparklines.
+      // Sparkline for numeric columns (histogram) and low-cardinality
+      // factor / character columns (per-category frequency bars). Create
+      // the (empty) container now but defer drawing the canvas until the
+      // panel is visible -- see renderPendingSparklines.
       if (hasHistogram(col)) {
          var sparkContainer = document.createElement("div");
          sparkContainer.className = "sidebar-sparkline";
@@ -3269,43 +3338,90 @@ var initSidebar = function() {
          pendingSparklines_.push({
             container: sparkContainer,
             breaks: col.col_breaks,
-            counts: col.col_counts
+            counts: col.col_counts,
+            labels: null
+         });
+      } else if (hasCategoryCounts(col)) {
+         var catContainer = document.createElement("div");
+         catContainer.className = "sidebar-sparkline";
+         entry.appendChild(catContainer);
+         pendingSparklines_.push({
+            container: catContainer,
+            breaks: null,
+            counts: col.col_cat_counts,
+            labels: col.col_cat_vals
          });
       }
 
-      // Footer row: type-specific summary + NA count
+      // Footer row: type-specific summary (left) + NA stat (right). Always
+      // rendered so entries keep a uniform shape: the left slot may be empty
+      // (e.g. character columns have no compact summary), and the NA stat is
+      // always present, visually dimmed when the column has nothing missing.
       var footer = document.createElement("div");
       footer.className = "sidebar-col-footer";
 
-      // Type-specific summary (left)
-      var summaryText = "";
-      if (isFactorColumn(col) && col.col_vals) {
-         summaryText = col.col_vals.length + " levels";
-      } else if (col.col_type === "logical") {
-         summaryText = "logical";
+      // Type-specific summary (left). For numeric columns this is the actual
+      // data range as a closed interval, [min, max], which doubles as the
+      // sparkline's (unticked) axis bounds; col_min/col_max may be absent on
+      // older servers, in which case the slot stays empty. The bracket and
+      // comma adornments are dimmed spans (see .range-punct) so they read
+      // as notation rather than data.
+      var summaryEl = document.createElement("span");
+      summaryEl.className = "sidebar-col-summary";
+      if (hasHistogram(col) && typeof col.col_min === "number") {
+         summaryEl.classList.add("range");
+         appendRangePunct(summaryEl, "[");
+         summaryEl.appendChild(
+            document.createTextNode(formatCompactNum(col.col_min)));
+         appendRangePunct(summaryEl, ", ");
+         summaryEl.appendChild(
+            document.createTextNode(formatCompactNum(col.col_max)));
+         appendRangePunct(summaryEl, "]");
+      } else {
+         // Categorical cardinality: level count for factors, distinct-value
+         // count for characters (absent when the server skipped counting,
+         // e.g. very long columns). Above the server's bar cutoff there is
+         // no category sparkline, so enrich the text with the dominant
+         // value instead -- but not when the top count is 1 (ID-like
+         // columns where every value is distinct, and "top" is noise).
+         var catText = "";
+         if (isFactorColumn(col) && col.col_vals) {
+            catText = col.col_vals.length.toLocaleString() + " levels";
+         } else if (typeof col.col_n_unique === "number") {
+            catText = col.col_n_unique.toLocaleString() + " unique";
+         }
+         if (catText &&
+             typeof col.col_top_count === "number" &&
+             col.col_top_count > 1 &&
+             totalRows > 0) {
+            var topPct = (col.col_top_count / totalRows) * 100;
+            catText += " \u00b7 top: " + col.col_top_value +
+               " (" + (topPct < 1 ? "<1" : Math.round(topPct)) + "%)";
+         }
+         summaryEl.textContent = catText;
+         // The top value is user data of arbitrary length; the summary
+         // ellipsizes, so expose the full text as a tooltip.
+         if (catText)
+            summaryEl.title = catText;
       }
-      if (summaryText) {
-         var summaryEl = document.createElement("span");
-         summaryEl.className = "sidebar-col-summary";
-         summaryEl.textContent = summaryText;
-         footer.appendChild(summaryEl);
-      }
+      footer.appendChild(summaryEl);
 
-      // NA count (right)
+      // NA stat (right)
       var naCount = col.col_na_count || 0;
+      var naEl = document.createElement("span");
+      naEl.className = "sidebar-col-na";
       if (naCount > 0 && totalRows > 0) {
          var naPct = ((naCount / totalRows) * 100);
-         var naText = (naPct < 1 ? "<1" : Math.round(naPct)) + "% NA";
-         var naEl = document.createElement("span");
-         naEl.className = "sidebar-col-na";
-         naEl.textContent = naText;
+         naEl.textContent = (naPct < 1 ? "<1" : Math.round(naPct)) + "% NA";
          naEl.title = naCount.toLocaleString() + " missing values";
-         footer.appendChild(naEl);
+      } else {
+         naEl.textContent = "0% NA";
+         naEl.classList.add("zero");
+         naEl.title = "No missing values";
       }
+      footer.appendChild(naEl);
 
-      if (footer.childNodes.length > 0) {
-         entry.appendChild(footer);
-      }
+      entry.appendChild(footer);
 
       // Stats panel (hidden until expanded)
       var statsPanel = document.createElement("div");
@@ -3313,8 +3429,9 @@ var initSidebar = function() {
       statsPanel.style.display = "none";
       entry.appendChild(statsPanel);
 
-      // Click entry to scroll; click expand button to toggle stats
-      (function(colIdx, statsEl, btnEl, headerEl, colType) {
+      // Click entry to scroll; click expand button to toggle stats; pin and
+      // sort icons route into the same toggle/cycle paths as the grid header.
+      (function(colIdx, statsEl, btnEl, headerEl, pinEl, sortEl, colType) {
          var expanded = false;
          var loaded = false;
 
@@ -3363,6 +3480,28 @@ var initSidebar = function() {
             if (evt.key === "Enter" || evt.key === " ") toggleStats(evt);
          });
 
+         var togglePin = function(evt) {
+            evt.stopPropagation();
+            evt.preventDefault();
+            togglePinColumn(colIdx);
+         };
+         pinEl.addEventListener("click", togglePin);
+         pinEl.addEventListener("keydown", function(evt) {
+            if (evt.key === "Enter" || evt.key === " ") togglePin(evt);
+         });
+
+         if (sortEl && !sortEl.classList.contains("disabled")) {
+            var cycleSort = function(evt) {
+               evt.stopPropagation();
+               evt.preventDefault();
+               handleSortClick(colIdx);
+            };
+            sortEl.addEventListener("click", cycleSort);
+            sortEl.addEventListener("keydown", function(evt) {
+               if (evt.key === "Enter" || evt.key === " ") cycleSort(evt);
+            });
+         }
+
          var scrollToCol = function() { scrollToColumn(colIdx); };
          entry.addEventListener("click", scrollToCol);
          headerEl.addEventListener("keydown", function(evt) {
@@ -3372,10 +3511,14 @@ var initSidebar = function() {
                scrollToCol();
             }
          });
-      })(i, statsPanel, expandBtn, header, statsCategory(col));
+      })(i, statsPanel, expandBtn, header, pinIcon, sortIcon, statsCategory(col));
 
       content.appendChild(entry);
    }
+
+   // Apply the current (possibly restored-from-saved-state) pin and sort
+   // state to the icons just created.
+   updateSidebarColumnIndicators();
 
    // Apply initial sidebar visibility -- toggle authoritatively so a previous
    // "expanded" class from an earlier bootstrap doesn't override saved state.
@@ -3394,6 +3537,188 @@ var initSidebar = function() {
    if (sidebarScrollbar_) sidebarScrollbar_.update();
 };
 
+// Sync the sidebar's pin and sort icons with the module pin/sort state.
+// Called after any pin or sort mutation -- whether it originated from the
+// grid header, the keyboard, or the sidebar icons themselves -- and at the
+// end of initSidebar to apply the initial (possibly restored) state.
+var updateSidebarColumnIndicators = function() {
+   var content = document.getElementById("sidebarContent");
+   if (!content || !cols) return;
+
+   var entries = content.querySelectorAll(".sidebar-col");
+   for (var i = 0; i < entries.length; i++) {
+      var entry = entries[i];
+      var colIdx = parseInt(entry.getAttribute("data-col-idx"), 10);
+      var col = isNaN(colIdx) ? null : cols[colIdx];
+      if (!col) continue;
+
+      var pinEl = entry.querySelector(".sidebar-pin-icon");
+      if (pinEl) {
+         var pinned = pinnedColumns.has(absColIndex(colIdx));
+         pinEl.classList.toggle("pinned", pinned);
+         pinEl.title = pinned ? "Unpin column" : "Pin column";
+         pinEl.setAttribute("aria-pressed", pinned ? "true" : "false");
+         pinEl.setAttribute("aria-label",
+            (pinned ? "Unpin column " : "Pin column ") + col.col_name);
+      }
+
+      var sortEl = entry.querySelector(".sidebar-sort-icon");
+      if (sortEl && !sortEl.classList.contains("disabled")) {
+         var dir = (absColIndex(colIdx) === sortColumn) ? sortDirection : "";
+         sortEl.classList.toggle("sorting_asc", dir === "asc");
+         sortEl.classList.toggle("sorting_desc", dir === "desc");
+
+         // The label announces the next step in the sort cycle.
+         var action;
+         if (dir === "asc") {
+            action = "Sort column " + col.col_name + " descending";
+         } else if (dir === "desc") {
+            action = "Remove sort on column " + col.col_name;
+         } else {
+            action = "Sort column " + col.col_name + " ascending";
+         }
+         sortEl.title = action;
+         sortEl.setAttribute("aria-label", action);
+      }
+   }
+};
+
+// ==========================================================================
+// Sidebar help dialog
+// ==========================================================================
+
+// Element to restore focus to when the help dialog closes (the header's
+// help icon). Module-scoped: the dialog outlives sidebar rebuilds.
+var sidebarHelpReturnFocus_ = null;
+
+// Show the dialog explaining the structure of the sidebar's column
+// summaries, building it on first use. It is appended to <body> rather
+// than the sidebar so a data refresh (which rebuilds the sidebar DOM)
+// can't tear it down mid-read.
+var showSidebarHelp = function(returnFocusEl) {
+   var overlay = document.getElementById("sidebarHelpOverlay");
+   if (!overlay) {
+      overlay = buildSidebarHelpOverlay();
+      document.body.appendChild(overlay);
+   }
+   overlay.style.display = "";
+   sidebarHelpReturnFocus_ = returnFocusEl || null;
+
+   var dialog = overlay.querySelector(".sidebar-help-dialog");
+   if (dialog) dialog.focus();
+};
+
+var hideSidebarHelp = function() {
+   var overlay = document.getElementById("sidebarHelpOverlay");
+   if (overlay) overlay.style.display = "none";
+
+   // Restore focus to the opener if it's still in the document (the
+   // sidebar may have been rebuilt while the dialog was open).
+   if (sidebarHelpReturnFocus_ && sidebarHelpReturnFocus_.isConnected)
+      sidebarHelpReturnFocus_.focus();
+   sidebarHelpReturnFocus_ = null;
+};
+
+var buildSidebarHelpOverlay = function() {
+   var overlay = document.createElement("div");
+   overlay.id = "sidebarHelpOverlay";
+
+   // Dismiss on backdrop click; clicks inside the dialog hit the dialog
+   // node (or its children), not the overlay itself.
+   overlay.addEventListener("mousedown", function(evt) {
+      if (evt.target === overlay) hideSidebarHelp();
+   });
+
+   var dialog = document.createElement("div");
+   dialog.className = "sidebar-help-dialog";
+   dialog.setAttribute("role", "dialog");
+   dialog.setAttribute("aria-modal", "true");
+   dialog.setAttribute("aria-labelledby", "sidebarHelpTitle");
+   dialog.setAttribute("tabindex", "-1");
+   dialog.addEventListener("keydown", function(evt) {
+      if (evt.key === "Escape") {
+         evt.stopPropagation();
+         hideSidebarHelp();
+      }
+   });
+
+   var title = document.createElement("div");
+   title.className = "sidebar-help-title";
+   title.id = "sidebarHelpTitle";
+   title.textContent = "Column summaries";
+   dialog.appendChild(title);
+
+   var closeBtn = document.createElement("span");
+   closeBtn.className = "sidebar-help-close";
+   closeBtn.textContent = "\u00D7";
+   closeBtn.setAttribute("role", "button");
+   closeBtn.setAttribute("tabindex", "0");
+   closeBtn.setAttribute("aria-label", "Close");
+   closeBtn.addEventListener("click", hideSidebarHelp);
+   closeBtn.addEventListener("keydown", function(evt) {
+      if (evt.key === "Enter" || evt.key === " ") {
+         evt.preventDefault();
+         hideSidebarHelp();
+      }
+   });
+   dialog.appendChild(closeBtn);
+
+   var addSection = function(heading) {
+      var section = document.createElement("div");
+      section.className = "sidebar-help-section";
+      var head = document.createElement("div");
+      head.className = "sidebar-help-heading";
+      head.textContent = heading;
+      section.appendChild(head);
+      dialog.appendChild(section);
+      return section;
+   };
+
+   var addLine = function(section, text, swatchClass) {
+      var line = document.createElement("div");
+      line.className = "sidebar-help-line";
+      if (swatchClass) {
+         var swatch = document.createElement("span");
+         swatch.className = "sidebar-help-swatch " + swatchClass;
+         swatch.setAttribute("aria-hidden", "true");
+         line.appendChild(swatch);
+      }
+      line.appendChild(document.createTextNode(text));
+      section.appendChild(line);
+   };
+
+   var headerSec = addSection("Header");
+   addLine(headerSec,
+      "Each entry names a column and its type. Click an entry to scroll " +
+      "the grid to that column; the pin and sort icons work just like " +
+      "their counterparts in the grid header.");
+
+   var plotSec = addSection("Mini-plot");
+   addLine(plotSec,
+      "Numeric columns draw a histogram of their finite values.",
+      "numeric");
+   addLine(plotSec,
+      "Factor and character columns with few distinct values draw one " +
+      "bar per value: factors in level order, characters most frequent " +
+      "first. Hover a bar for details.",
+      "categorical");
+
+   var statsSec = addSection("Summary line");
+   addLine(statsSec,
+      "The numeric data range as [min, max], or the number of factor " +
+      "levels / distinct values -- plus the most frequent value when " +
+      "there are too many to chart. The right-hand side shows the " +
+      "percentage of missing values.");
+
+   var detailsSec = addSection("Details");
+   addLine(detailsSec,
+      "The triangle expands a panel of detailed statistics, computed " +
+      "on demand.");
+
+   overlay.appendChild(dialog);
+   return overlay;
+};
+
 // Draw any sparklines whose canvas hasn't been rendered yet. Idempotent and
 // cheap to call repeatedly -- once drained, subsequent calls are no-ops, so
 // it is safe to invoke on every panel-open.
@@ -3402,7 +3727,7 @@ var renderPendingSparklines = function() {
    var items = pendingSparklines_;
    pendingSparklines_ = [];
    for (var i = 0; i < items.length; i++) {
-      var spark = createSparkline(items[i].breaks, items[i].counts);
+      var spark = createSparkline(items[i].breaks, items[i].counts, items[i].labels);
       if (spark) {
          items[i].container.appendChild(spark);
       } else {
@@ -3778,8 +4103,7 @@ var onGridKeyDown = function(evt) {
       if (key === "Enter" || key === " ") {
          evt.preventDefault();
          if (ordering && isColumnSortable(col)) {
-            var th = getActiveHeaderTh();
-            if (th) handleSortClick(origCol, th);
+            handleSortClick(origCol);
          }
          return;
       }
@@ -4707,9 +5031,10 @@ var applySavedState = function(state) {
    return false;
 };
 
-// Apply asc/desc CSS classes on header cells based on current sort state.
-// Mirrors the inline class manipulation in handleSortClick, but works from
-// the cached sortColumn/sortDirection (used after restoring saved state).
+// Apply asc/desc CSS classes and aria-sort on header cells based on current
+// sort state. The single render path for sort indicators: used by
+// handleSortClick / clearSort and after the header window is rebuilt (e.g.
+// when restoring saved state).
 var applySortIndicators = function() {
    var thead = document.getElementById("data_cols");
    if (!thead) return;
@@ -4719,10 +5044,16 @@ var applySortIndicators = function() {
       // Skip spacer cells (col-spacer) that stand in for off-window columns.
       if (isNaN(colIdx)) continue;
       th.classList.remove("sorting", "sorting_asc", "sorting_desc");
-      if (absColIndex(colIdx) === sortColumn && sortDirection) {
+      var sorted = absColIndex(colIdx) === sortColumn && sortDirection;
+      if (sorted) {
          th.classList.add("sorting_" + sortDirection);
       } else {
          th.classList.add("sorting");
+      }
+      // Only sortable headers carry aria-sort (set in createHeader).
+      if (th.hasAttribute("aria-sort")) {
+         th.setAttribute("aria-sort",
+            sorted ? sortAriaValue(sortDirection) : "none");
       }
    }
 };

--- a/src/cpp/tests/testthat/test-dataviewer.R
+++ b/src/cpp/tests/testthat/test-dataviewer.R
@@ -447,10 +447,10 @@ test_that(".rs.describeCols() handles integer columns whose range overflows", {
 
 test_that(".rs.describeCols() reports the data range for numeric columns", {
    # col_min / col_max carry the actual finite data range (the histogram
-   # breaks are pretty()-ed and may extend past it); the sidebar displays
-   # them under the sparkline, which has no axis ticks. Non-numeric columns
-   # omit the fields entirely, as does a numeric column with too few finite
-   # values to summarize.
+   # breaks can extend past it: pretty()-ed for default binning, padded by
+   # 0.5 for integer bins); the sidebar displays them under the sparkline,
+   # which has no axis ticks. Non-numeric columns omit the fields entirely,
+   # as does a numeric column with too few finite values to summarize.
    df <- data.frame(x = c(1.5, NA, 4.25, 3), y = letters[1:4], z = c(NA, NA, NA, 7))
 
    cols <- .rs.describeCols(df)
@@ -464,6 +464,20 @@ test_that(".rs.describeCols() reports the data range for numeric columns", {
    expect_null(cols[[3L]][["col_max"]])
    expect_null(cols[[4L]][["col_min"]])
    expect_null(cols[[4L]][["col_max"]])
+})
+
+test_that(".rs.describeCols() excludes infinite values from the data range", {
+   # the range is computed over finite values only (matching the histogram);
+   # an Inf endpoint would not survive JSON serialization as a number and
+   # would silently blank the sidebar footer
+   df <- data.frame(x = c(1, 2, Inf), y = c(-Inf, 5, 10))
+
+   cols <- .rs.describeCols(df)
+
+   expect_equal(cols[[2L]][["col_min"]], .rs.scalar(1))
+   expect_equal(cols[[2L]][["col_max"]], .rs.scalar(2))
+   expect_equal(cols[[3L]][["col_min"]], .rs.scalar(5))
+   expect_equal(cols[[3L]][["col_max"]], .rs.scalar(10))
 })
 
 test_that(".rs.describeCols() ships category counts for low-cardinality columns", {
@@ -512,19 +526,95 @@ test_that(".rs.describeCols() falls back to a text summary above the bar cutoff"
    expect_equal(s[["col_top_count"]], .rs.scalar(3L))
 })
 
-test_that(".rs.describeCols() skips character categorization above the row limit", {
-   # table() over a long character column is not free, so categorization is
-   # gated on a row-count limit (default 1e6, here lowered for the test)
-   old <- options(rstudio.dataViewer.maxCategorizeRows = 2L)
+test_that(".rs.describeCols() draws the line at exactly 24 categories", {
+   # the cutoff (maxCategoryBars) is inclusive: exactly 24 distinct values
+   # still get bars, 25 fall back to the text summary
+   vals24 <- c(letters[1:24], letters[1:24])
+   vals25 <- c(letters[1:25], letters[1:25])
+   df24 <- data.frame(f = factor(vals24), s = vals24, stringsAsFactors = FALSE)
+   df25 <- data.frame(f = factor(vals25), s = vals25, stringsAsFactors = FALSE)
+
+   cols24 <- .rs.describeCols(df24)
+   cols25 <- .rs.describeCols(df25)
+
+   expect_equal(cols24[[2L]][["col_cat_vals"]], letters[1:24])
+   expect_equal(cols24[[2L]][["col_cat_counts"]], rep(2L, 24L))
+   expect_length(cols24[[3L]][["col_cat_vals"]], 24L)
+   expect_equal(cols24[[3L]][["col_cat_counts"]], rep(2L, 24L))
+
+   expect_null(cols25[[2L]][["col_cat_counts"]])
+   expect_equal(cols25[[2L]][["col_top_count"]], .rs.scalar(2L))
+   expect_null(cols25[[3L]][["col_cat_counts"]])
+   expect_equal(cols25[[3L]][["col_n_unique"]], .rs.scalar(25L))
+})
+
+test_that(".rs.describeCols() tolerates list columns of character / factor vectors", {
+   # branch selection peeks at the column's first element, so a list column
+   # of character vectors enters the character branch (and a list of factors
+   # the factor branch); the category computation must gate on the column
+   # type, or table() / as.integer() on a ragged list errors and takes the
+   # whole describe call (and thus the grid) down with it
+   df <- data.frame(x = 1:3)
+   df$tokens <- strsplit(c("a b", "c", "d e f"), " ")
+   df$f <- list(factor("a"), factor("b"), factor("c"))
+
+   cols <- .rs.describeCols(df)
+
+   # no category metadata ships for either list column...
+   tokens <- cols[[3L]]
+   expect_null(tokens[["col_cat_counts"]])
+   expect_null(tokens[["col_n_unique"]])
+   expect_null(tokens[["col_top_value"]])
+   f <- cols[[4L]]
+   expect_null(f[["col_cat_counts"]])
+   expect_null(f[["col_top_value"]])
+
+   # ...but the pre-existing branch behavior is preserved
+   expect_equal(tokens$col_search_type, .rs.scalar("character"))
+   expect_equal(f$col_search_type, .rs.scalar("factor"))
+})
+
+test_that(".rs.describeCols() survives a malformed maxCategorizeRows option", {
+   # the option is user-supplied; NA (or any non-scalar / non-numeric value)
+   # must fall back to the default rather than erroring out of describeCols
+   old <- options(rstudio.dataViewer.maxCategorizeRows = NA)
    on.exit(options(old), add = TRUE)
 
    df <- data.frame(s = c("a", "b", "a"), stringsAsFactors = FALSE)
    cols <- .rs.describeCols(df)
 
    s <- cols[[2L]]
+   expect_equal(s[["col_cat_vals"]], c("a", "b"))
+   expect_equal(s[["col_cat_counts"]], c(2L, 1L))
+
+   options(rstudio.dataViewer.maxCategorizeRows = "banana")
+   cols <- .rs.describeCols(df)
+   expect_equal(cols[[2L]][["col_cat_counts"]], c(2L, 1L))
+})
+
+test_that(".rs.describeCols() skips character categorization above the row limit", {
+   # table() over a long character column is not free, so categorization is
+   # gated on a row-count limit (default 1e6, here lowered for the test)
+   old <- options(rstudio.dataViewer.maxCategorizeRows = 2L)
+   on.exit(options(old), add = TRUE)
+
+   df <- data.frame(
+      s = c("a", "b", "a"),
+      f = factor(c("x", "y", "x")),
+      stringsAsFactors = FALSE)
+   cols <- .rs.describeCols(df)
+
+   s <- cols[[2L]]
    expect_null(s[["col_cat_counts"]])
    expect_null(s[["col_n_unique"]])
    expect_null(s[["col_top_value"]])
+
+   # the gate is character-only by design: factor counts come from a cheap
+   # tabulate() over the integer codes, so they survive on frames of any
+   # length
+   f <- cols[[3L]]
+   expect_equal(f[["col_cat_vals"]], c("x", "y"))
+   expect_equal(f[["col_cat_counts"]], c(2L, 1L))
 })
 
 test_that(".rs.describeCols() reports a nested data.frame column faithfully", {

--- a/src/cpp/tests/testthat/test-dataviewer.R
+++ b/src/cpp/tests/testthat/test-dataviewer.R
@@ -445,6 +445,88 @@ test_that(".rs.describeCols() handles integer columns whose range overflows", {
    expect_equal(sum(col$col_counts), 2)
 })
 
+test_that(".rs.describeCols() reports the data range for numeric columns", {
+   # col_min / col_max carry the actual finite data range (the histogram
+   # breaks are pretty()-ed and may extend past it); the sidebar displays
+   # them under the sparkline, which has no axis ticks. Non-numeric columns
+   # omit the fields entirely, as does a numeric column with too few finite
+   # values to summarize.
+   df <- data.frame(x = c(1.5, NA, 4.25, 3), y = letters[1:4], z = c(NA, NA, NA, 7))
+
+   cols <- .rs.describeCols(df)
+
+   x <- cols[[2L]]
+   expect_equal(x[["col_min"]], .rs.scalar(1.5))
+   expect_equal(x[["col_max"]], .rs.scalar(4.25))
+
+   # exact [[ indexing: $col_max would partial-match col_max_chars
+   expect_null(cols[[3L]][["col_min"]])
+   expect_null(cols[[3L]][["col_max"]])
+   expect_null(cols[[4L]][["col_min"]])
+   expect_null(cols[[4L]][["col_max"]])
+})
+
+test_that(".rs.describeCols() ships category counts for low-cardinality columns", {
+   df <- data.frame(
+      f = factor(c("a", "b", "b", NA), levels = c("a", "b", "c")),
+      s = c("x", "y", "y", "y"),
+      stringsAsFactors = FALSE)
+
+   cols <- .rs.describeCols(df)
+
+   # factors: one count per level, in level order (unused levels included,
+   # NA values excluded); col_vals (the filter dropdown's source) unchanged
+   f <- cols[[2L]]
+   expect_equal(f$col_vals, c("a", "b", "c"))
+   expect_equal(f[["col_cat_vals"]], c("a", "b", "c"))
+   expect_equal(f[["col_cat_counts"]], c(1L, 2L, 0L))
+
+   # characters: most frequent first, with the distinct-value count
+   s <- cols[[3L]]
+   expect_equal(s[["col_cat_vals"]], c("y", "x"))
+   expect_equal(s[["col_cat_counts"]], c(3L, 1L))
+   expect_equal(s[["col_n_unique"]], .rs.scalar(2L))
+})
+
+test_that(".rs.describeCols() falls back to a text summary above the bar cutoff", {
+   # 26 distinct values > the 24-bar cutoff (maxCategoryBars), so no
+   # category counts are shipped -- just the cardinality and the dominant
+   # value
+   df <- data.frame(
+      f = factor(rep(letters, times = c(3, rep(1, 25)))),
+      s = rep(LETTERS, times = c(3, rep(1, 25))),
+      stringsAsFactors = FALSE)
+
+   cols <- .rs.describeCols(df)
+
+   f <- cols[[2L]]
+   expect_null(f[["col_cat_counts"]])
+   expect_equal(f$col_vals, letters)
+   expect_equal(f[["col_top_value"]], .rs.scalar("a"))
+   expect_equal(f[["col_top_count"]], .rs.scalar(3L))
+
+   s <- cols[[3L]]
+   expect_null(s[["col_cat_counts"]])
+   expect_equal(s[["col_n_unique"]], .rs.scalar(26L))
+   expect_equal(s[["col_top_value"]], .rs.scalar("A"))
+   expect_equal(s[["col_top_count"]], .rs.scalar(3L))
+})
+
+test_that(".rs.describeCols() skips character categorization above the row limit", {
+   # table() over a long character column is not free, so categorization is
+   # gated on a row-count limit (default 1e6, here lowered for the test)
+   old <- options(rstudio.dataViewer.maxCategorizeRows = 2L)
+   on.exit(options(old), add = TRUE)
+
+   df <- data.frame(s = c("a", "b", "a"), stringsAsFactors = FALSE)
+   cols <- .rs.describeCols(df)
+
+   s <- cols[[2L]]
+   expect_null(s[["col_cat_counts"]])
+   expect_null(s[["col_n_unique"]])
+   expect_null(s[["col_top_value"]])
+})
+
 test_that(".rs.describeCols() reports a nested data.frame column faithfully", {
    df <- data.frame(a = 1:2)
    # a column that is itself a data.frame. describeCols does not flatten (that


### PR DESCRIPTION

<img width="250" height="572" alt="image" src="https://github.com/user-attachments/assets/c939c0d9-503c-408e-987e-49caa45449a6" />

---

A batch of polish for the data viewer's column summary sidebar:

- **Pin and sort from the sidebar.** Each entry carries a pin icon and a sort icon mirroring the grid header's affordances. State syncs both ways (grid header, keyboard, status-bar clear-sort, and the sidebar icons all flow through the same paths), and `handleSortClick` no longer requires a rendered `<th>`, so columns virtualized out of the grid window can still be sorted from the sidebar.

- **Uniform footers.** Numeric columns show their actual data range as `[min, max]` (new `col_min`/`col_max` from `describeCols` -- the histogram breaks are `pretty()`-ed and may extend past the data, and the sparklines have no axis ticks). Factors show "N levels", characters "N unique", and every column shows its NA percentage, dimmed when zero. The interval's bracket/comma adornments are dimmed so the numbers read at full contrast.

- **Categorical mini-plots.** Factor and character columns with at most 24 distinct values (`maxCategoryBars`) draw frequency sparklines in an alternate themeable color (`--grid-spark-categorical`) to cue a discrete x-axis: factors in level order (preserving ordinal structure), characters most frequent first. Above the cutoff the footer names the dominant value instead -- omitted for all-distinct, ID-like columns. Character counting costs a full `table()` hash, so it is gated on `rstudio.dataViewer.maxCategorizeRows` (default 1e6); factor counts are a cheap `tabulate()`.

- **Help dialog.** A "?" in the sidebar header opens a small modal explaining the entry structure, with legend swatches bound to the same CSS variables the sparkline canvases read, so the legend can't drift from the actual colors. Activating it doesn't collapse the panel, and hovering it doesn't light the header's close glyph.

## Testing

- New testthat cases cover the `col_min`/`col_max` range fields, category counts (level order, unused levels, NA exclusion), the exactly-24/25 bar-cutoff boundary, the >24 text fallback for both column types, Inf exclusion from the range, list columns of character/factor vectors, the character row-limit gate (and factor counts surviving it), and malformed `maxCategorizeRows` values (`rstudio-tests --scope r --filter dataviewer`: 182 passing).
- New Playwright tests cover the sidebar pin/sort icons (two-way sync with the grid header, including row-order assertions), sorting a column whose header is virtualized out of the grid window, sidebar icon sync on the status-bar clear-sort and state-restore paths, the uniform footer, category bars vs. text fallback, and the help dialog open/Escape flow without panel collapse (full data-viewer suite: 44 passing).
