### PR TITLE
auto-resolve conflicts under release-only dirs in merge-release-branch.sh

### DIFF
--- a/scripts/merge-release-branch.sh
+++ b/scripts/merge-release-branch.sh
@@ -13,11 +13,13 @@
 #    archived NEWS path returns git's three-way merged result rather than
 #    the rel branch's actual content, silently corrupting the release notes.
 #
-# 2. Auto-resolve the two conflicts that result:
+# 2. Auto-resolve the expected conflicts:
 #    - NEWS.md (deleted-by-them): keep main's rotated copy.
 #    - version/news/os/NEWS-<ver>-<codename>.md (both-added): take the rel
 #      branch's content, which has any bug-fix entries that landed after
 #      the rotation.
+#    - Any conflict under a release-only directory (e.g. the whats-new
+#      assets): keep main's version, matching the reset policy below.
 #
 # 3. Reset release-only paths (version/BUILDTYPE, the whats-new assets
 #    directory, etc.) to HEAD's value. Git's trivial-merge fast path
@@ -146,6 +148,29 @@ while IFS= read -r path; do
             echo "  resolved $path: took rel branch's content"
             ;;
     esac
+done < <(git diff --name-only --diff-filter=U)
+
+# (3) Conflicts under release-only directories: main's version always
+# wins, same policy the reset pass below applies to paths that merged
+# cleanly. If the path exists in HEAD, restore HEAD's content into the
+# index and working tree; otherwise remove it. Note `git checkout --ours`
+# does not work for all conflict types (e.g. delete/modify, where our
+# stage is absent), so prefer the HEAD-based form.
+while IFS= read -r path; do
+    for d in "${RELEASE_ONLY_DIRS[@]}"; do
+        case "$path" in
+            "$d"/*)
+                if git cat-file -e "HEAD:$path" 2>/dev/null; then
+                    git checkout HEAD -- "$path"
+                    echo "  resolved $path: kept main's version"
+                else
+                    git rm -f -- "$path" >/dev/null
+                    echo "  resolved $path: removed (not present on main)"
+                fi
+                break
+                ;;
+        esac
+    done
 done < <(git diff --name-only --diff-filter=U)
 
 # Report any remaining (unexpected) conflicts.


### PR DESCRIPTION
merge-release-branch.sh exited for manual resolution on any unresolved conflict before its RELEASE_ONLY_DIRS reset pass could run, so a conflict under `src/node/desktop/src/assets/whats-new` (e.g. both-modified or both-added) aborted the merge even though the policy for those paths is unambiguous: main's version always wins.

A new resolution pass now runs before the generic unresolved-conflict check: any unmerged path under a release-only directory is restored to HEAD's content (or removed when not present in HEAD, covering delete/modify conflicts). `git checkout HEAD -- <path>` is used rather than `--ours` since the latter fails for conflict types where our stage is absent.

Verified in a scratch repository simulating UU, AA, and DU conflicts under whats-new (all auto-resolved to main's content, merge left staged) and a genuine conflict elsewhere (still aborts with exit 2).

Developer tooling change; found by code review (roborev job 546).