### PR TITLE
add regression tests for help arguments header rewrite

### DIFF
--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -367,12 +367,8 @@ public:
       boost::algorithm::replace_all(dest, "src=\"/", "src=\"" + baseUrl + "/");
       boost::algorithm::replace_all(dest, "src='/", "src='" + baseUrl + "/");
       
-      // add classes to headers; the h3 may carry an id attribute when R's
-      // dynamic help server emits a table of contents (R >= 4.6.0), so
-      // preserve any existing attributes via the capture group
-      boost::regex reHeader("<h3([^>]*)>Arguments</h3>");
-      std::string reFormat("<h3$1 class=\"r-arguments-title\">Arguments</h3>");
-      boost::algorithm::replace_all_regex(dest, reHeader, reFormat);
+      // add classes to headers
+      detail::addArgumentsHeaderClass(&dest);
       
       // append javascript callbacks
       std::string js(kJsCallbacks);
@@ -1225,7 +1221,21 @@ SEXP rs_showPythonHelp(SEXP codeSEXP)
 }
 
 } // anonymous namespace
-   
+
+namespace detail {
+
+void addArgumentsHeaderClass(std::vector<char>* pContents)
+{
+   // the h3 may carry an id attribute when R's dynamic help server emits
+   // a table of contents (R >= 4.6.0), so preserve any existing attributes
+   // via the capture group
+   boost::regex reHeader("<h3([^>]*)>Arguments</h3>");
+   std::string reFormat("<h3$1 class=\"r-arguments-title\">Arguments</h3>");
+   boost::algorithm::replace_all_regex(*pContents, reHeader, reFormat);
+}
+
+} // namespace detail
+
 Error initialize()
 {
    RS_REGISTER_CALL_METHOD(rs_previewRd, 1);

--- a/src/cpp/session/modules/SessionHelp.hpp
+++ b/src/cpp/session/modules/SessionHelp.hpp
@@ -16,19 +16,34 @@
 #ifndef SESSION_HELP_HPP
 #define SESSION_HELP_HPP
 
+#include <vector>
+
 namespace rstudio {
 namespace core {
    class Error;
 }
 }
- 
+
 namespace rstudio {
 namespace session {
-namespace modules { 
+namespace modules {
 namespace help {
-   
+
 core::Error initialize();
-                       
+
+// Helpers for help page post-processing. Exposed via the header only so
+// they can be exercised by SessionHelpTests; production code applies them
+// from the help contents filter when serving help pages.
+namespace detail {
+
+// Add the "r-arguments-title" class to the "<h3>Arguments</h3>" section
+// header of a rendered help page. The h3 may carry attributes (e.g. an id
+// when R's dynamic help server emits a table of contents, R >= 4.6.0), so
+// any existing attributes are preserved.
+void addArgumentsHeaderClass(std::vector<char>* pContents);
+
+} // namespace detail
+
 } // namespace help
 } // namespace modules
 } // namespace session

--- a/src/cpp/session/modules/SessionHelpTests.cpp
+++ b/src/cpp/session/modules/SessionHelpTests.cpp
@@ -1,0 +1,93 @@
+/*
+ * SessionHelpTests.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "SessionHelp.hpp"
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace help {
+namespace {
+
+// apply the production rewrite to a help page fragment; the filter operates
+// on a character buffer, so round-trip through one here
+std::string addArgumentsHeaderClass(const std::string& html)
+{
+   std::vector<char> contents(html.begin(), html.end());
+   detail::addArgumentsHeaderClass(&contents);
+   return std::string(contents.begin(), contents.end());
+}
+
+TEST(SessionHelpTest, ArgumentsHeaderGetsClass)
+{
+   EXPECT_EQ(
+      "<h3 class=\"r-arguments-title\">Arguments</h3>",
+      addArgumentsHeaderClass("<h3>Arguments</h3>"));
+}
+
+TEST(SessionHelpTest, ArgumentsHeaderWithAttributesPreservesThem)
+{
+   // R's dynamic help server may emit attributes on the header, e.g. an id
+   // when generating a table of contents (R >= 4.6.0); regression test for
+   // the match broadening in commit 852f68f
+   EXPECT_EQ(
+      "<h3 id='arguments' class=\"r-arguments-title\">Arguments</h3>",
+      addArgumentsHeaderClass("<h3 id='arguments'>Arguments</h3>"));
+
+   EXPECT_EQ(
+      "<h3 id=\"_sec_arguments\" class=\"r-arguments-title\">Arguments</h3>",
+      addArgumentsHeaderClass("<h3 id=\"_sec_arguments\">Arguments</h3>"));
+}
+
+TEST(SessionHelpTest, ArgumentsHeaderRewrittenWithinSurroundingContent)
+{
+   std::string input =
+      "<h2>rnorm</h2>\n"
+      "<h3 id=\"_sec_usage\">Usage</h3>\n"
+      "<h3 id=\"_sec_arguments\">Arguments</h3>\n"
+      "<table></table>\n";
+
+   std::string expected =
+      "<h2>rnorm</h2>\n"
+      "<h3 id=\"_sec_usage\">Usage</h3>\n"
+      "<h3 id=\"_sec_arguments\" class=\"r-arguments-title\">Arguments</h3>\n"
+      "<table></table>\n";
+
+   EXPECT_EQ(expected, addArgumentsHeaderClass(input));
+}
+
+TEST(SessionHelpTest, OtherHeadersUntouched)
+{
+   const std::string others[] = {
+      "<h3>Usage</h3>",
+      "<h3>Value</h3>",
+      "<h2>Arguments</h2>",
+      "<h3>Arguments and More</h3>",
+   };
+
+   for (const std::string& html : others)
+      EXPECT_EQ(html, addArgumentsHeaderClass(html));
+}
+
+} // anonymous namespace
+} // namespace help
+} // namespace modules
+} // namespace session
+} // namespace rstudio


### PR DESCRIPTION
The Help pane's `<h3>Arguments</h3>` rewrite (which attaches the `r-arguments-title` class used by R.css for argument-table alignment) has broken once before when newer R versions started emitting attributes on the header (fixed in 852f68f for #17622), and had no test coverage.

The rewrite is moved verbatim from the help contents filter into `help::detail::addArgumentsHeaderClass()` -- following the existing `SessionLists` detail-namespace precedent for exposing file-local helpers to tests -- and exercised by four new gtests in `SessionHelpTests.cpp`: the bare header, attributed variants (including R 4.6's `id="_sec_arguments"`), the header embedded in surrounding page content, and negative cases that must pass through untouched. Behavior-preserving refactor; the regex is unchanged.

All 337 rsession-scope tests pass, including the 4 new ones (`rstudio-tests --scope rsession`).

Addresses #17622.