### PR TITLE
Preserve package-provided protocol.json on Posit Assistant install

### DIFF
--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -245,7 +245,6 @@ namespace chat_staticfiles = rstudio::session::modules::chat::staticfiles;
 
 // Constants used throughout
 using chat_constants::kProtocolVersion;
-using chat_constants::kProtocolVersionFileName;
 using chat_constants::kMaxQueueSize;
 using chat_constants::kMaxBufferSize;
 using chat_constants::kMaxDelay;
@@ -271,6 +270,7 @@ using chat_installation::locatePositAssistantInstallation;
 using chat_installation::verifyPositAiInstallation;
 using chat_installation::getInstalledVersion;
 using chat_installation::getInstalledProtocolVersion;
+using chat_installation::writeProtocolVersionFileIfMissing;
 
 // Update throttle types used throughout
 using throttle::ManifestCheckRecord;
@@ -4410,13 +4410,9 @@ Error installPackage(const FilePath& packagePath)
       }
    }
 
-   // Write protocol.json so future update checks can detect mismatches
-   core::FilePath protoFile =
-      aiDir.completeChildPath(kProtocolVersionFileName);
-   json::Object protoJson;
-   protoJson["protocol"] = kProtocolVersion;
-   Error protoError = core::writeStringToFile(
-      protoFile, protoJson.write());
+   // Write protocol.json so future update checks can detect mismatches, unless
+   // the package already shipped one (newer packages bundle protocol.json).
+   Error protoError = writeProtocolVersionFileIfMissing(aiDir);
    if (protoError)
    {
       return protoError;

--- a/src/cpp/session/modules/chat/ChatInstallation.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallation.cpp
@@ -188,6 +188,24 @@ std::string getInstalledProtocolVersion()
    return version;
 }
 
+core::Error writeProtocolVersionFileIfMissing(const core::FilePath& positAiPath)
+{
+   core::FilePath protoFile =
+      positAiPath.completeChildPath(kProtocolVersionFileName);
+
+   // Newer packages bundle their own protocol.json; preserve it so we record
+   // the protocol the package actually declares rather than RStudio's default.
+   if (protoFile.exists())
+   {
+      DLOG("protocol.json already present; leaving package-provided file intact");
+      return core::Success();
+   }
+
+   core::json::Object protoJson;
+   protoJson["protocol"] = kProtocolVersion;
+   return core::writeStringToFile(protoFile, protoJson.write());
+}
+
 } // namespace installation
 } // namespace chat
 } // namespace modules

--- a/src/cpp/session/modules/chat/ChatInstallation.hpp
+++ b/src/cpp/session/modules/chat/ChatInstallation.hpp
@@ -17,6 +17,7 @@
 #define SESSION_CHAT_INSTALLATION_HPP
 
 #include <string>
+#include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
 
 namespace rstudio {
@@ -75,6 +76,19 @@ std::string getInstalledVersion();
  * @return Protocol version string (e.g., "10.0"), or empty string if missing or unreadable
  */
 std::string getInstalledProtocolVersion();
+
+/**
+ * Ensure a protocol.json file exists in the given installation directory.
+ *
+ * Newer Posit Assistant packages bundle their own protocol.json. To avoid
+ * clobbering the version the package declares, RStudio's compiled-in protocol
+ * version is written only when the file is absent (e.g. older packages that
+ * predate protocol.json).
+ *
+ * @param positAiPath Path to the AI installation directory
+ * @return Success, or an error if the file was missing and could not be written
+ */
+core::Error writeProtocolVersionFileIfMissing(const core::FilePath& positAiPath);
 
 } // namespace installation
 } // namespace chat

--- a/src/cpp/session/modules/chat/ChatInstallationTests.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallationTests.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 #include <core/FileSerializer.hpp>
 #include <core/system/Environment.hpp>
+#include <shared_core/json/Json.hpp>
 
 using namespace rstudio::core;
 using namespace rstudio::session::modules::chat::installation;
@@ -263,6 +264,56 @@ TEST(ChatInstallation, GetInstalledProtocolVersionReturnsCorrectVersion)
       system::setenv("RSTUDIO_POSIT_AI_PATH", originalPath);
    else
       system::unsetenv("RSTUDIO_POSIT_AI_PATH");
+
+   tempDir.removeIfExists();
+}
+
+TEST(ChatInstallation, WriteProtocolVersionFileWritesWhenMissing)
+{
+   FilePath tempDir;
+   FilePath::tempFilePath(tempDir);
+   tempDir.ensureDirectory();
+
+   FilePath protoFile = tempDir.completeChildPath(kProtocolVersionFileName);
+   EXPECT_FALSE(protoFile.exists());
+
+   Error error = writeProtocolVersionFileIfMissing(tempDir);
+   EXPECT_FALSE(error);
+   EXPECT_TRUE(protoFile.exists());
+
+   // The written file records RStudio's compiled-in protocol version.
+   std::string content;
+   error = readStringFromFile(protoFile, &content);
+   EXPECT_FALSE(error);
+
+   json::Value value;
+   Error parseError = value.parse(content);
+   EXPECT_FALSE(parseError);
+   ASSERT_TRUE(value.isObject());
+   EXPECT_EQ(value.getObject()["protocol"].getString(), std::string(kProtocolVersion));
+
+   tempDir.removeIfExists();
+}
+
+TEST(ChatInstallation, WriteProtocolVersionFilePreservesPackageProvidedFile)
+{
+   FilePath tempDir;
+   FilePath::tempFilePath(tempDir);
+   tempDir.ensureDirectory();
+
+   // Simulate a package that bundled its own protocol.json.
+   FilePath protoFile = tempDir.completeChildPath(kProtocolVersionFileName);
+   std::string packageContent = "{\"protocol\": \"99.0\"}";
+   writeStringToFile(protoFile, packageContent);
+
+   Error error = writeProtocolVersionFileIfMissing(tempDir);
+   EXPECT_FALSE(error);
+
+   // The package-provided file is left untouched.
+   std::string content;
+   error = readStringFromFile(protoFile, &content);
+   EXPECT_FALSE(error);
+   EXPECT_EQ(content, packageContent);
 
    tempDir.removeIfExists();
 }


### PR DESCRIPTION
When RStudio downloads and extracts the Posit Assistant package, it writes a `protocol.json` recording the protocol version the install was built for. Newer Posit Assistant packages now ship their own `protocol.json` as part of the package.

RStudio now writes `protocol.json` only when the extracted package does not already contain one, so a package-provided file is preserved instead of being overwritten with RStudio's compiled-in protocol version. The write is extracted into `installation::writeProtocolVersionFileIfMissing()`, alongside the existing `getInstalledProtocolVersion()` reader, with unit tests covering both the missing-file and package-provided-file cases.