### PR TITLE
fix(e2e): tear down rstudio when the harness is interrupted

### DIFF
--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -10,6 +10,7 @@ import { TIMEOUTS, RSTUDIO_EXTRA_ARGS, sleep } from '../utils/constants';
 import { CONSOLE_INPUT, executeInConsole } from '../pages/console_pane.page';
 import { dismissAllModals, documentCloseAllNoSave, executeCommand } from '../utils/commands';
 import { rLibsUserTemplate } from './r-libs-setup';
+import { trackForReaping } from './process-reaper';
 import { isDebugMode } from '../utils/debug';
 
 const BASE_PREFS_PATH = path.join(__dirname, 'base-prefs.jsonc');
@@ -439,6 +440,11 @@ async function launchRStudioOnce(existingConfigRoot?: string): Promise<DesktopSe
     console.log(`Starting RStudio with CDP on port ${CDP_PORT}...`);
   }
   const rstudioProcess = spawn(spawnCmd, spawnArgs, spawnOptions);
+  // Backstop: if the worker exits without running shutdownRStudio (e.g. an
+  // interrupted run whose graceful teardown was skipped), force-kill the
+  // RStudio process tree on the way out so it isn't orphaned. The dev-mode
+  // tree is detached into its own group and would otherwise survive the run.
+  trackForReaping(rstudioProcess, () => killProcessTree(rstudioProcess));
   const launchTarget = DEV_MODE ? `npm run start (cwd ${DEV_DESKTOP_DIR})` : RSTUDIO_PATH;
   let launchError: Error | undefined;
   rstudioProcess.on('error', (err) => {

--- a/e2e/rstudio/fixtures/process-reaper.ts
+++ b/e2e/rstudio/fixtures/process-reaper.ts
@@ -1,0 +1,72 @@
+// A worker-process backstop that force-kills spawned RStudio / rserver
+// children if the worker exits without running the normal fixture teardown
+// (shutdownRStudio / shutdownServer).
+//
+// Playwright's graceful interrupt path *does* run worker-fixture teardown:
+// on Ctrl-C the main process sends each worker a __stop__ IPC message, and the
+// worker tears down its worker-scoped fixtures before exiting. But a few paths
+// skip that teardown -- a teardown that wedges past the worker's force-exit
+// timeout, a parent that dies and disconnects, or a crash mid-launch before the
+// fixture's own try/catch is in place. In dev mode the RStudio tree is spawned
+// detached into its own process group (see desktop.fixture.ts), so it never
+// receives the terminal's group SIGINT and would survive indefinitely when
+// teardown is skipped. This reaper is the last line of defense for those cases.
+//
+// Note: a hard SIGKILL of the worker itself bypasses this -- Node runs no
+// 'exit' handler on SIGKILL. The launcher's graceful-first signal handling
+// (scripts/dev-common.ts) is what keeps us out of that case for `npm run
+// test:*-dev`; plain `npx playwright test` relies on Playwright's own graceful
+// stop, which routes through the worker teardown path above.
+
+import type { ChildProcess } from 'child_process';
+
+type Killer = () => void;
+
+const killers = new Set<Killer>();
+let installed = false;
+
+// Synchronously invoke every registered killer. Runs in a Node 'exit' handler,
+// so it must do only synchronous work (no awaits, no async I/O).
+function reapAll(): void {
+  for (const kill of killers) {
+    try {
+      kill();
+    } catch {
+      // Best-effort: the process is already exiting, nothing useful to do.
+    }
+  }
+  killers.clear();
+}
+
+function ensureInstalled(): void {
+  if (installed) {
+    return;
+  }
+  installed = true;
+
+  // 'exit' fires for normal exits and for any process.exit() -- which is how
+  // the Playwright worker terminates, including on its graceful-stop and
+  // disconnect paths. We deliberately do NOT register SIGINT/SIGTERM handlers
+  // here: the Playwright worker installs its own no-op handlers for those so
+  // the main process can coordinate shutdown over IPC, and adding ours would
+  // race that.
+  process.on('exit', reapAll);
+}
+
+/**
+ * Register a child process for last-resort reaping on worker exit.
+ *
+ * `kill` must synchronously terminate the process (and its tree, where
+ * applicable). The reaper skips it automatically if the process has already
+ * exited, so callers don't need to unregister after a clean shutdown.
+ */
+export function trackForReaping(proc: ChildProcess, kill: Killer): void {
+  ensureInstalled();
+
+  killers.add(() => {
+    if (proc.exitCode !== null || proc.signalCode !== null) {
+      return;
+    }
+    kill();
+  });
+}

--- a/e2e/rstudio/fixtures/server.fixture.ts
+++ b/e2e/rstudio/fixtures/server.fixture.ts
@@ -10,6 +10,7 @@ import { CONSOLE_INPUT, executeInConsole } from '../pages/console_pane.page';
 import { sleep } from '../utils/constants';
 import { setPref, documentCloseAllNoSave } from '../utils/commands';
 import { rLibsUserTemplate } from './r-libs-setup';
+import { trackForReaping } from './process-reaper';
 
 // PW_SANDBOX is exported by the globalSetup hook in fixtures/sandbox-setup.ts
 // before any worker spawns. Resolve lazily so importing this module (for
@@ -138,6 +139,13 @@ async function spawnSandboxedRserver(): Promise<SpawnedServer | null> {
     cwd: path.dirname(path.dirname(rserverBin)), // build/src/cpp -- rserver-dev runs here
     stdio: ['ignore', 'pipe', 'pipe'],
   });
+
+  // Backstop: if the worker exits without running shutdownServer (e.g. an
+  // interrupted run whose graceful teardown was skipped), SIGTERM rserver on
+  // the way out so it isn't orphaned. SIGTERM (not SIGKILL) so rserver runs
+  // its own shutdown and reaps its rsession children -- a killed rserver would
+  // leave those behind.
+  trackForReaping(proc, () => proc.kill('SIGTERM'));
 
   // Surface server logs prefixed for triage. Captured but not failing the
   // test directly -- the URL probe below decides whether the server is up.

--- a/e2e/rstudio/scripts/dev-common.ts
+++ b/e2e/rstudio/scripts/dev-common.ts
@@ -119,14 +119,27 @@ export function checkGwtBuildReady(tag: string): void {
   );
 }
 
+// Grace period between asking Playwright to stop and force-killing it, so a
+// single Ctrl-C reliably ends even a wedged run. Generous because a graceful
+// stop has to quit RStudio (shutdownRStudio waits up to ~8s) before the child
+// exits on its own -- which usually happens well inside this window, tripping
+// child.on('exit') long before the timer fires. Overridable for tuning/tests.
+const STOP_GRACE_MS = Number(process.env.PW_STOP_GRACE_MS) || 30000;
+
 // Spawn `npx playwright test ...` with the supplied args appended and the
 // supplied env merged on top of process.env. Inherits stdio so the user
 // sees the live test output, and propagates the playwright exit code.
 //
-// Logs the Playwright launcher PID up front so a stuck run is easy to
-// abort -- `kill <pid>` on this PID tears down the launcher, the per-test
-// worker, the dev-build Electron process, and the in-tree rsession in
-// one shot.
+// Signal handling: a terminal Ctrl-C, or `kill <pid>` on the launcher PID we
+// log below, must tear down the whole run -- the worker, the dev-build
+// Electron process / in-tree rserver, and their rsession children -- not just
+// this launcher. On POSIX the child is spawned in its own process group so the
+// launcher is the sole signal coordinator: it forwards a graceful SIGINT to
+// the child's group (the only signal Playwright treats as a cancellation),
+// then escalates to SIGKILL if the run doesn't wind down within STOP_GRACE_MS.
+// We never signal RStudio directly -- SIGINT to an rsession merely interrupts
+// R; the actual shutdown is Playwright's worker-fixture teardown, which quits
+// RStudio cleanly (q(save="no") then a SIGTERM-based process-tree kill).
 export function runPlaywright(
   tag: string,
   extraArgs: string[],
@@ -151,17 +164,63 @@ export function runPlaywright(
     console.log(`[${tag}] artifacts -> test-results/${runId} (prior runs preserved)`);
   }
 
-  const npx = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+  const isWindows = process.platform === 'win32';
+  const npx = isWindows ? 'npx.cmd' : 'npx';
   const args = ['playwright', 'test', ...outputArgs, ...extraArgs];
 
   const child = spawn(npx, args, {
     stdio: 'inherit',
     env: { ...process.env, ...env },
+    // POSIX: give the child its own process group so a terminal Ctrl-C is
+    // delivered only to this launcher, not also straight to the child group.
+    // The launcher then forwards a single, well-timed signal (see below)
+    // instead of racing the kernel's group delivery. Windows lacks POSIX
+    // process groups, so the child stays in ours there and we signal it
+    // directly.
+    detached: !isWindows,
   });
 
   if (child.pid !== undefined) {
     console.log(`[${tag}] Playwright launcher PID: ${child.pid} (kill this to abort the run)`);
   }
+
+  // Deliver a signal to the child -- to its whole process group on POSIX (so
+  // npx, Playwright, and the test workers all receive it), or directly on
+  // Windows.
+  const signalChild = (signal: NodeJS.Signals): void => {
+    if (child.pid === undefined)
+      return;
+    try {
+      if (!isWindows)
+        process.kill(-child.pid, signal);
+      else
+        child.kill(signal);
+    } catch {
+      // Child / group already gone.
+    }
+  };
+
+  // On the first interrupt, forward a graceful SIGINT and arm a hard-kill
+  // fallback; on a repeat (impatient second Ctrl-C, or the run wedging), kill
+  // immediately. The launcher stays alive throughout so the inherited stdio
+  // and foreground pipeline survive until Playwright finishes tearing down --
+  // child.on('exit') below is what actually ends the launcher.
+  let stopRequested = false;
+  const requestStop = (): void => {
+    if (!stopRequested) {
+      stopRequested = true;
+      signalChild('SIGINT');
+
+      const timer = setTimeout(() => signalChild('SIGKILL'), STOP_GRACE_MS);
+      timer.unref();
+    } else {
+      signalChild('SIGKILL');
+    }
+  };
+
+  process.on('SIGINT', requestStop);
+  process.on('SIGTERM', requestStop);
+  process.on('SIGHUP', requestStop);
 
   // stdio:'inherit' keeps Node's event loop alive until the child exits, so
   // we don't need to await here. Propagate the exit status when the child


### PR DESCRIPTION
## Problem

Interrupting an e2e run with Ctrl-C (SIGINT) didn't actually stop it. For the dev-mode runners (`npm run test:desktop-dev` / `test:server-dev`) the launcher exited immediately on SIGINT without propagating the signal, so the orphaned Playwright run -- and the RStudio / rserver processes its workers had spawned -- kept running in the background while the shell returned to a prompt.

## Root cause

- Playwright **workers** install no-op `SIGINT`/`SIGTERM` handlers (they shut down only when the main process tells them to over IPC), so a group-delivered Ctrl-C is ignored by the worker that owns the RStudio process.
- The dev launcher (`scripts/dev-common.ts`) registered **no** signal handlers, so it died on Node's default SIGINT action and never waited for Playwright to tear down.
- The dev-mode RStudio is spawned `detached` into its own process group, so it never receives the terminal's group SIGINT anyway -- it relies entirely on the fixture teardown running.

Signal semantics matter here: per `SessionMain.cpp`, **SIGINT to an rsession only sets the R interrupt flag** (it does not quit), `SIGUSR1`/`SIGUSR2` are *ignored* in desktop mode (and mean *suspend* in server mode), and **SIGTERM** is the signal that actually shuts a session down. So the fix forwards cancellation to *Playwright*, not to RStudio, and lets the existing SIGTERM-based teardown do the killing.

## Changes

**Launcher as signal coordinator** (`scripts/dev-common.ts`)
- Spawns the Playwright child in its own process group on POSIX (`detached`) so the launcher is the sole signal coordinator.
- Forwards a graceful `SIGINT` to the child's group (Playwright-main acts on it; workers no-op it), stays alive until the child exits so inherited stdio / the foreground pipeline survive teardown, and escalates to `SIGKILL` after a grace period (`PW_STOP_GRACE_MS`, default 30s) or on a second Ctrl-C.

**Worker-side backstop reaper** (new `fixtures/process-reaper.ts`, wired into both fixtures)
- Force-kills the tracked RStudio / rserver tree from a `process.on('exit')` handler if a teardown is ever skipped (wedged teardown, parent disconnect, mid-launch crash). Desktop reuses the SIGTERM-based `killProcessTree`; server sends `SIGTERM` to rserver so it reaps its own rsession children. Registers only `exit` (not the signals Playwright's workers no-op) to avoid racing Playwright's own shutdown.

## Verification

- `npm run typecheck` passes (no ESLint config/`lint` script exists in the e2e dir).
- Verified the underlying OS behavior live: a `detached` child gets its own process group and `kill(-pid, SIGINT)` reaches the child *and* its non-detached descendants on macOS.
- Manual: `npm run test:desktop-dev -- <filter>`, Ctrl-C mid-run, then confirm no orphans via `pgrep -fl 'RStudio|rsession|electron-forge'`.

## Notes

- Plain `npx playwright test` (`test:desktop`/`test:server`) was already mostly fine on a single Ctrl-C via Playwright's graceful stop; the reaper hardens it too.
- Residual: a hard `SIGKILL` of a worker (e.g. the second-Ctrl-C escalation) skips the `exit` reaper, so a detached dev-mode RStudio could orphan -- the next launch self-heals via the existing `lsof -ti :CDP_PORT | kill` cleanup.
- No `NEWS.md` entry: this is test-harness / developer tooling, not user-facing product behavior.

Requires manual verification (interactive Ctrl-C).
