### PR TITLE
Skip binary builds when only e2e/ files changed

### DIFF
--- a/jenkins/Jenkinsfile.build
+++ b/jenkins/Jenkinsfile.build
@@ -160,7 +160,7 @@ pipeline {
       when {
         anyOf {
           expression { return params.FORCE_BUILD_BINARIES }
-          changeset comparator: 'REGEXP', pattern: '(?:(?!docs/).+|(?!jenkins/Jenkinsfile\\.build))'
+          changeset comparator: 'REGEXP', pattern: '(?:(?!docs/)(?!e2e/).+|(?!jenkins/Jenkinsfile\\.build))'
         }
       }
 


### PR DESCRIPTION
## Problem

The Jenkins build pipeline already skips publishing new binaries when the only changed files are under `docs/`. This avoids the cost of a full binary build cycle when commits only update documentation.

The same condition was not applied to the `e2e/` directory. Commits that only add, modify, or reorganize end-to-end test files (Playwright specs, fixtures, helpers, etc.) have no effect on compiled output, yet they triggered full binary builds across all platforms (Windows, Linux, macOS, SELinux).

## Change

`jenkins/Jenkinsfile.build` — one line changed in the `when` condition for the **"Setup and Trigger Builds"** stage:

```groovy
// Before
changeset comparator: 'REGEXP', pattern: '(?:(?!docs/).+|(?!jenkins/Jenkinsfile\\.build))'

// After
changeset comparator: 'REGEXP', pattern: '(?:(?!docs/)(?!e2e/).+|(?!jenkins/Jenkinsfile\\.build))'
```

The added `(?!e2e/)` is a second negative lookahead chained at position 0. Together, `(?!docs/)(?!e2e/).+` matches any file path that does **not** start with `docs/` **and** does not start with `e2e/`. If every changed file in a push is under `e2e/`, `docs/`, or a mix of both, the `changeset` condition is not satisfied and the binary build pipeline is skipped — unless `FORCE_BUILD_BINARIES` is set.

## Notes

- The `FORCE_BUILD_BINARIES` parameter still overrides this skip, as before.
- The regex uses Jenkins `changeset` with `comparator: 'REGEXP'`, which applies full-string matching semantics. This is consistent with how the existing `docs/` exclusion has worked in production.
- The same change has been applied to `rstudio/rstudio-pro`: https://github.com/rstudio/rstudio-pro/pull/11498

🤖 Generated with [Claude Code](https://claude.com/claude-code)