### PR TITLE
fix build break in find-in-files replace preview

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1956,7 +1956,7 @@ Error Replacer::replacePreview(const size_t dMatchOn, const size_t dMatchOff,
                                          pDecodedLine->end(),
                                          &originalDecodedSize);
       if (error)
-         logError(error, "Failed to compute UTF-8 distance in replace preview");
+         LOG_ERROR(error);
 
       *pDecodedLine = decode(*pEncodedLine);
 
@@ -1965,7 +1965,7 @@ Error Replacer::replacePreview(const size_t dMatchOn, const size_t dMatchOff,
                                          pDecodedLine->end(),
                                          &newDecodedSize);
       if (error)
-         logError(error, "Failed to compute UTF-8 distance in replace preview");
+         LOG_ERROR(error);
 
       *pReplaceMatchOff = dMatchOff + (newDecodedSize - originalDecodedSize);
    }
@@ -2082,7 +2082,6 @@ std::string Replacer::decode(const std::string& encoded, const std::string& enco
    return decoded;
 }
 
-#ifdef SESSION_FIND_TESTS
 // Test-only: configure the global FindInFilesState so that
 // Replacer::replacePreview can be exercised in unit tests.
 void setFindResultsForTest(const std::string& searchPattern,
@@ -2095,7 +2094,6 @@ void setFindResultsForTest(const std::string& searchPattern,
                               regex, ignoreCase, false);
    findResults().onReplaceBegin("test-handle", true, replacePattern, nullptr);
 }
-#endif
 
 } // namespace find
 } // namespace modules

--- a/src/cpp/session/modules/SessionFind.hpp
+++ b/src/cpp/session/modules/SessionFind.hpp
@@ -110,14 +110,12 @@ private:
 // Test-only helper: configure the global FindInFilesState so that
 // Replacer::replacePreview can be exercised in unit tests without
 // driving the full session-layer handlers.
-#ifdef SESSION_FIND_TESTS
 namespace find {
 void setFindResultsForTest(const std::string& searchPattern,
                            const std::string& replacePattern,
                            bool regex,
                            bool ignoreCase);
 } // namespace find
-#endif
 
 } // namespace modules
 } // namespace session


### PR DESCRIPTION
The C++ backend build was broken on `main` by #17995 ("omit no-op matches from find-in-files replace candidates"). Two compile errors in the find-in-files replace-preview code:

1. `SessionFind.cpp` called `logError(error, "...")`, but no such 2-argument function exists (`core::log::logError` takes a single argument). Replaced both call sites with `LOG_ERROR(error)`, matching the convention used elsewhere in the file.

2. `SessionFindTests.cpp` referenced `setFindResultsForTest`, which was declared in `SessionFind.hpp` and defined in `SessionFind.cpp` but guarded behind `#ifdef SESSION_FIND_TESTS`. That macro is never defined anywhere, so the helper was compiled out entirely and the tests could not see it. Removed the guard so the helper is always compiled in.

## Verification

- `cmake --build . --target all` succeeds (previously failed).
- The `SessionFindTest` suite passes, including the new `ReplacePreviewNoOp` and `ReplacePreviewRealChange` cases.