### PR TITLE
Fix publish-build.sh silently skipping hash rewrite on re-publish

### DIFF
--- a/docker/jenkins/publish-build.sh
+++ b/docker/jenkins/publish-build.sh
@@ -216,6 +216,7 @@ payload="{\"message\":\"Add $flower build $version in $build\",\"content\":\"$ba
 echo "Sending to Github: $payload"
 httpCode=$(curl \
    -X PUT \
+   -w %{http_code} \
    -o $curlOutFname \
    -H "Accept: application/vnd.github.v3+json" \
    -H "Authorization: token $pat" \
@@ -243,6 +244,7 @@ if [[ $httpCode -eq 422 ]]; then
    
    httpCode=$(curl \
       -X PUT \
+      -w %{http_code} \
       -o $curlOutFname \
       -H "Accept: application/vnd.github.v3+json" \
       -H "Authorization: token $pat" \
@@ -267,6 +269,7 @@ if [[ $httpCode -eq 409 ]]; then
 
        httpCode=$(curl \
         -X PUT \
+        -w %{http_code} \
         -o $curlOutFname \
         -H "Accept: application/vnd.github.v3+json" \
         -H "Authorization: token $pat" \


### PR DESCRIPTION
## Summary

Backport of the Workbench (rstudio-pro) fix rstudio/rstudio-pro#8034 ("Restore CURL http status output in publish step", commit `a230719dae`, 2025-04-28) to the open-source repo. The pro copy of `docker/jenkins/publish-build.sh` was fixed over a year ago, but the change was never ported back here, so open-source builds kept hitting the bug.

## Problem

The dailies page periodically shows a SHA-256 that doesn't match the downloadable binary (rstudio/rstudio#18000, previously #13709).

`docker/jenkins/publish-build.sh` records the checksum by writing a metadata `.md` file to the `rstudio/latest-builds` repo via the GitHub Contents API. When a build for a version that already exists is re-published, the create `PUT` returns HTTP 422 and the script is supposed to fall back to an update (re-writing `sha256`/`size`).

That fallback never fired. The `curl` PUT calls captured `$(curl ...)` into `httpCode` but omitted `-w %{http_code}`. With `-o` sending the body to a file, `curl` printed nothing to stdout, so `httpCode` was always empty:

- `[[ $httpCode -eq 422 ]]` evaluated as `0 -eq 422` → false, so the existing `.md` was never updated. The stale checksum stayed while the rebuilt binary on S3 changed.
- The final `[[ $((httpCode)) -ge 400 ]]` guard evaluated `0 -ge 400` → false, so failed PUTs exited 0 and masked the failure.

Concrete example (2026.05.1+225): the Linux/macOS binaries were rebuilt and re-uploaded to S3 on 2026-06-07, but the dailies metadata kept the 2026-06-03 checksums. The Windows entries for the same build were correct because Windows publishes via `publish-build.ps1`, which handles the 422 update properly. The Pro/Workbench builds were also correct because they publish via the already-fixed rstudio-pro copy of this script.

## Fix

Add `-w %{http_code}` to all three PUT calls (create, update, retry) so the create/update/retry logic actually sees the HTTP status, matching the rstudio-pro copy.

## Follow-up (data)

The already-published stale entries for 2026.05.1+225 are corrected separately in rstudio/latest-builds#241.