### PR TITLE
Preserve pending Posit Assistant update across throttled check

### DIFF
--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -276,6 +276,7 @@ using chat_installation::writeProtocolVersionFileIfMissing;
 using throttle::ManifestCheckRecord;
 using throttle::ResolvedBlock;
 using throttle::SuccessOutcome;
+using throttle::PendingUpdate;
 
 // Static file handler (used once for URI registration)
 using chat_staticfiles::handleAIChatRequest;
@@ -3620,7 +3621,13 @@ void onBackgroundProcessing(bool isIdle)
 // Update Management
 // ============================================================================
 
-// Structure to hold update check state
+// Structure to hold update check state.
+//
+// The pending-update fields (updateAvailable, isDowngrade, newVersion,
+// downloadUrl, expectedSha256) mirror throttle::PendingUpdate, which carries
+// them across a throttled skip in resolveWithoutManifestFetch(). Keep the two
+// field sets in sync: a field added here that isn't carried there would be
+// silently dropped on a skip (the regression #18014 fixed).
 struct UpdateState
 {
    bool updateAvailable;
@@ -4725,6 +4732,28 @@ void resolveWithoutManifestFetch()
 
    {
       boost::mutex::scoped_lock lock(s_updateStateMutex);
+
+      // A throttled skip re-fetches no manifest, so the pending update from the
+      // last completed check is still authoritative -- carry it through instead of
+      // clearing it. Clearing it here would let a later install see no update and
+      // fail with "No update available" even though the pane still offered one. The
+      // carry is gated on the installed version being unchanged from that check
+      // (s_updateState.currentVersion), so an out-of-band install can't leave a
+      // stale target or downgrade classification behind.
+      PendingUpdate prior;
+      prior.updateAvailable = s_updateState.updateAvailable;
+      prior.isDowngrade = s_updateState.isDowngrade;
+      prior.newVersion = s_updateState.newVersion;
+      prior.downloadUrl = s_updateState.downloadUrl;
+      prior.expectedSha256 = s_updateState.expectedSha256;
+      PendingUpdate carried = throttle::carryPendingUpdateThroughSkip(
+         prior, s_updateState.currentVersion, installedVersion);
+
+      if (prior.updateAvailable)
+         DLOG("Throttled skip: pending update {} (installed {}, last checked {})",
+              carried.updateAvailable ? "carried" : "cleared",
+              installedVersion, s_updateState.currentVersion);
+
       s_updateState.currentVersion = installedVersion;
       s_updateState.manifestUnavailable = false;
       s_updateState.errorMessage = "";
@@ -4732,11 +4761,11 @@ void resolveWithoutManifestFetch()
       s_updateState.unsupportedInstalledVersion = unsupportedInstalledVersion;
       s_updateState.noCompatibleVersion = false;
       s_updateState.additionalProvidersAvailable = false;
-      s_updateState.updateAvailable = false;
-      s_updateState.isDowngrade = false;
-      s_updateState.newVersion = "";
-      s_updateState.downloadUrl = "";
-      s_updateState.expectedSha256 = "";
+      s_updateState.updateAvailable = carried.updateAvailable;
+      s_updateState.isDowngrade = carried.isDowngrade;
+      s_updateState.newVersion = carried.newVersion;
+      s_updateState.downloadUrl = carried.downloadUrl;
+      s_updateState.expectedSha256 = carried.expectedSha256;
    }
 
    // Non-blocking, like onUpdateCheckComplete: this resolves the

--- a/src/cpp/session/modules/chat/ChatUpdateThrottle.cpp
+++ b/src/cpp/session/modules/chat/ChatUpdateThrottle.cpp
@@ -220,6 +220,26 @@ SuccessOutcome buildSuccessOutcome(std::time_t now,
    return out;
 }
 
+PendingUpdate carryPendingUpdateThroughSkip(const PendingUpdate& prior,
+                                            const std::string& priorInstalledVersion,
+                                            const std::string& installedVersion)
+{
+   // No pending update from the last completed check -> nothing to carry.
+   if (!prior.updateAvailable)
+      return PendingUpdate();
+
+   // The installed version changed since the check that computed this pending
+   // update (an out-of-band install, or the update itself was applied). Its
+   // target and upgrade/downgrade classification are stale -> clear, and let the
+   // next due fetch recompute against the current install.
+   if (installedVersion != priorInstalledVersion)
+      return PendingUpdate();
+
+   // Installed version unchanged: the last fetch's pending update still applies
+   // exactly. A throttled skip re-fetches nothing, so it must not discard it.
+   return prior;
+}
+
 } // namespace throttle
 } // namespace chat
 } // namespace modules

--- a/src/cpp/session/modules/chat/ChatUpdateThrottle.hpp
+++ b/src/cpp/session/modules/chat/ChatUpdateThrottle.hpp
@@ -60,6 +60,18 @@ struct SuccessOutcome
    ManifestCheckRecord record;
 };
 
+// The pending-update fields of the update state: what the last completed manifest
+// check found, and what an install would act on. These are carried across a
+// throttled skip (a check that does not re-fetch the manifest).
+struct PendingUpdate
+{
+   bool updateAvailable = false;
+   bool isDowngrade = false;
+   std::string newVersion;
+   std::string downloadUrl;
+   std::string expectedSha256;
+};
+
 // Path of the persisted record: <userDataDir>/pai/manifest-check.json.
 core::FilePath manifestCheckStatePath();
 
@@ -121,6 +133,17 @@ SuccessOutcome buildSuccessOutcome(std::time_t now,
                                    bool versionUnsupported,
                                    bool protocolMismatch,
                                    bool unsupportedProtocol);
+
+// Pure: the pending update to keep after a throttled skip (a check that does not
+// re-fetch the manifest). A skip learns nothing new, so the prior fetch's result
+// remains authoritative and must not be discarded -- but only while the installed
+// version is unchanged from the check that produced it (priorInstalledVersion).
+// If it changed out of band (a manual or parallel install, or the update itself
+// was applied), the pending target and its upgrade/downgrade classification are
+// stale, so the pending update is cleared and the next due fetch recomputes it.
+PendingUpdate carryPendingUpdateThroughSkip(const PendingUpdate& prior,
+                                            const std::string& priorInstalledVersion,
+                                            const std::string& installedVersion);
 
 } // namespace throttle
 } // namespace chat

--- a/src/cpp/session/modules/chat/ChatUpdateThrottleTests.cpp
+++ b/src/cpp/session/modules/chat/ChatUpdateThrottleTests.cpp
@@ -202,6 +202,82 @@ TEST(ChatUpdateThrottle, OutcomeCarriesContext)
    EXPECT_TRUE(o.record.unsupportedProtocol);
 }
 
+// ---- carryPendingUpdateThroughSkip ----
+
+TEST(ChatUpdateThrottle, ThrottledSkipPreservesPendingUpdateWhenInstalledUnchanged)
+{
+   // A prior fetch found an available upgrade (0.5.0 installed -> 0.5.1 offered).
+   // A later throttled check does not re-fetch and the install is unchanged, so it
+   // learns nothing new and must not discard that pending update -- otherwise a
+   // click on "Update" afterwards hits "No update available".
+   PendingUpdate prior;
+   prior.updateAvailable = true;
+   prior.isDowngrade = false;
+   prior.newVersion = "0.5.1";
+   prior.downloadUrl = "https://cdn.posit.co/posit-ai/assistant-rstudio-0.5.1.zip";
+   prior.expectedSha256 = "695adb72723a3bb6d69c3e1cafd439f953e68f9ae3e5c0a10265a4314013cbcc";
+
+   PendingUpdate out = carryPendingUpdateThroughSkip(prior, "0.5.0", "0.5.0");
+
+   EXPECT_TRUE(out.updateAvailable);
+   EXPECT_FALSE(out.isDowngrade);
+   EXPECT_EQ(out.newVersion, "0.5.1");
+   EXPECT_EQ(out.downloadUrl, "https://cdn.posit.co/posit-ai/assistant-rstudio-0.5.1.zip");
+   EXPECT_EQ(out.expectedSha256, "695adb72723a3bb6d69c3e1cafd439f953e68f9ae3e5c0a10265a4314013cbcc");
+}
+
+TEST(ChatUpdateThrottle, ThrottledSkipPreservesDowngradeClassificationWhenInstalledUnchanged)
+{
+   // A pending downgrade offer must survive a skip with its isDowngrade flag
+   // intact, not just an upgrade -- guards against a future edit that hardcodes
+   // isDowngrade in the carry path instead of returning the prior verbatim.
+   PendingUpdate prior;
+   prior.updateAvailable = true;
+   prior.isDowngrade = true;
+   prior.newVersion = "0.4.8";
+   prior.downloadUrl = "https://cdn.posit.co/posit-ai/assistant-rstudio-0.4.8.zip";
+
+   PendingUpdate out = carryPendingUpdateThroughSkip(prior, "0.5.0", "0.5.0");
+
+   EXPECT_TRUE(out.updateAvailable);
+   EXPECT_TRUE(out.isDowngrade);
+   EXPECT_EQ(out.newVersion, "0.4.8");
+}
+
+TEST(ChatUpdateThrottle, ThrottledSkipClearsWhenNoPriorUpdate)
+{
+   // No pending update from the last check: a skip must not resurrect one from
+   // stale leftover fields.
+   PendingUpdate prior;
+   prior.updateAvailable = false;
+   prior.newVersion = "0.5.1";
+
+   PendingUpdate out = carryPendingUpdateThroughSkip(prior, "0.5.0", "0.5.0");
+
+   EXPECT_FALSE(out.updateAvailable);
+   EXPECT_TRUE(out.newVersion.empty());
+}
+
+TEST(ChatUpdateThrottle, ThrottledSkipClearsWhenInstalledChanged)
+{
+   // The installed version changed out of band since the check that produced the
+   // pending update (a manual or parallel install, or the update was applied).
+   // The skip must clear rather than carry a stale target and downgrade
+   // classification; the next due fetch recomputes against the current install.
+   PendingUpdate prior;
+   prior.updateAvailable = true;
+   prior.isDowngrade = true;
+   prior.newVersion = "0.5.0";
+   prior.downloadUrl = "https://cdn.posit.co/posit-ai/assistant-rstudio-0.5.0.zip";
+
+   PendingUpdate out = carryPendingUpdateThroughSkip(prior, "0.5.1", "0.4.0");
+
+   EXPECT_FALSE(out.updateAvailable);
+   EXPECT_FALSE(out.isDowngrade);
+   EXPECT_TRUE(out.newVersion.empty());
+   EXPECT_TRUE(out.downloadUrl.empty());
+}
+
 // ---- bumpRecord ----
 
 TEST(ChatUpdateThrottle, BumpPreservesPriorAndBumpsTime)


### PR DESCRIPTION
Fixes #18014.

## Problem

In the Posit Assistant pane, clicking Install/Update intermittently failed with the banner "Update failed: Error occurred while executing method" (Retry did not help; a restart was needed). It affected the update path for an already-installed copy — both upgrades and downgrades.

## Root cause

`resolveWithoutManifestFetch()` is the throttled-skip path: an update check that does not re-fetch the manifest. It unconditionally cleared the pending-update fields (`updateAvailable`/`isDowngrade`/`newVersion`/`downloadUrl`/`expectedSha256`) in the global `s_updateState`.

When a prior fetch had found a pending update and the pane offered it, a later non-forced check (e.g. the deferred startup check) would throttle-skip and wipe that state. A subsequent install then saw `updateAvailable == false` and returned "No update available", which the JSON-RPC layer surfaces as the generic top-level `ExecutionError` message — shown to the user as "Update failed: Error occurred while executing method". The behavior was intermittent because it depended on which of the two startup checks ran first.

This was introduced by the recent manifest-check throttling (#17917, #17926, #17988); before throttling, every check re-fetched and recomputed the state.

## Fix

- New pure helper `throttle::carryPendingUpdateThroughSkip(prior, priorInstalledVersion, installedVersion)`: a throttled skip learns nothing new, so it carries the pending update from the last completed check — but only while the installed version is unchanged from the check that produced it. It clears otherwise (no pending update, or the install changed out of band), so a stale target or upgrade/downgrade classification cannot ride along.
- `resolveWithoutManifestFetch()` snapshots the pending-update fields, runs them through the helper, and writes the carried result instead of zeroing them. This also covers the install-time path that joins an in-flight throttled check.

## Tests

- Unit tests in `ChatUpdateThrottleTests.cpp`: carry-when-installed-unchanged (the regression gate), preserve-downgrade-classification, clear-when-no-prior-update, clear-when-installed-changed.
- Manually verified the original reproduction is resolved across multiple runs.

## Notes

- No `NEWS.md` entry: this regression was introduced during development and has not shipped in an official release.
