### PR TITLE
Fix Import Dataset preview error display (Addresses #17985)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 - ([#17748](https://github.com/rstudio/rstudio/issues/17748)): When "Use Air for code formatting" is enabled, Air now formats R documents even when no `air.toml` file is present, using the editor's indentation settings (indent style and width). The previous behavior of formatting only in projects containing an `air.toml` can be restored with the new "Only use Air when an air.toml file is found" option (Global Options > Code > Formatting).
 
 ### Fixed
+- ([#17985](https://github.com/rstudio/rstudio/issues/17985)): Fixed an issue where the Import Dataset preview dialog failed to display error messages when the readr preview subprocess encountered an error, causing the dialog to hang indefinitely waiting for data that would never arrive.
 - ([#18003](https://github.com/rstudio/rstudio/issues/18003)): Fixed an issue where reformat-on-save with Air configured as an external formatter ignored the project's air.toml configuration.
 - ([#6147](https://github.com/rstudio/rstudio/issues/6147)): The data viewer now scrolls continuously through the columns of a very wide data frame instead of paging through fixed blocks of columns, so a column's filter, sort, and pin are no longer limited to (or lost when leaving) the currently visible set of columns.
 - ([#6147](https://github.com/rstudio/rstudio/issues/6147)): The data viewer's column-pagination arrows are replaced by a "Go to column" box in the toolbar that jumps to a column by name or number.

--- a/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
+++ b/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
@@ -42,28 +42,31 @@ async function awaitPreviewOrSkip(
 ): Promise<void> {
   const firstColHeader = previewFrame.locator('th[data-col-idx="1"]');
 
-  // Wait for the preview to show its first column header. If it times out,
-  // check for an error indicator to provide a more specific diagnostic.
   const previewReady = await firstColHeader
     .waitFor({ state: 'visible', timeout: 45000 })
     .then(() => true)
-    .catch(async () => {
-      // Header never appeared -- check for an error message in the dialog
-      // to include in the diagnostic. The error indicator uses the progress
-      // indicator's error label (shown when getErrorMessage returns a value).
-      const errorLabels = await dialog.locator('.gwt-Label').allTextContents().catch(() => []);
-      const errorMessage = errorLabels.find((t) => t.includes('valid CSV file') || t.includes('error'));
-      if (errorMessage) {
-        test.fixme(os.platform() === 'win32' && !!process.env.CI, `readr CSV preview failed on Windows CI: ${errorMessage.trim()}`);
-      } else {
-        test.fixme(os.platform() === 'win32' && !!process.env.CI, 'readr CSV preview subprocess did not load on Windows CI');
-      }
-      return false;
-    });
-  if (!previewReady) {
-    await dialog.locator('#rstudio_dlg_cancel').click().catch(() => {});
-    throw new Error('readr CSV preview did not produce column headers within 45 s');
-  }
+    .catch(() => false);
+  if (previewReady)
+    return;
+
+  // The header never appeared. When the preview subprocess fails, the error is
+  // surfaced through the progress indicator's onError, which routes to
+  // GlobalDisplay.showErrorMessage (ModalDialogBase.addProgressIndicator) and
+  // renders a separate top-level "Error" dialog -- not a label inside the
+  // import dialog. Scrape that dialog for a more specific diagnostic. The
+  // message is prefixed with "Is this a valid CSV file? " by
+  // enhancePreviewErrorMessage, so key on that marker.
+  const errorDialog = dialog.page().locator('.gwt-DialogBox[aria-label="Error"]');
+  const errorText = (await errorDialog.textContent().catch(() => null)) ?? '';
+  const detail = errorText.includes('valid CSV file')
+    ? `readr CSV preview failed on Windows CI: ${errorText.trim()}`
+    : 'readr CSV preview subprocess did not load on Windows CI';
+
+  // Cancel out of the import dialog before skipping so teardown stays clean.
+  await dialog.locator('#rstudio_dlg_cancel').click().catch(() => {});
+
+  test.fixme(os.platform() === 'win32' && !!process.env.CI, detail);
+  throw new Error('readr CSV preview did not produce column headers within 45 s');
 }
 
 async function openReadrCsvPreview(

--- a/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
+++ b/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
@@ -41,13 +41,27 @@ async function awaitPreviewOrSkip(
   previewFrame: FrameLocator,
 ): Promise<void> {
   const firstColHeader = previewFrame.locator('th[data-col-idx="1"]');
+
+  // Wait for the preview to show its first column header. If it times out,
+  // check for an error indicator to provide a more specific diagnostic.
   const previewReady = await firstColHeader
     .waitFor({ state: 'visible', timeout: 45000 })
     .then(() => true)
-    .catch(() => false);
+    .catch(async () => {
+      // Header never appeared -- check for an error message in the dialog
+      // to include in the diagnostic. The error indicator uses the progress
+      // indicator's error label (shown when getErrorMessage returns a value).
+      const errorLabels = await dialog.locator('.gwt-Label').allTextContents().catch(() => []);
+      const errorMessage = errorLabels.find((t) => t.includes('valid CSV file') || t.includes('error'));
+      if (errorMessage) {
+        test.fixme(os.platform() === 'win32' && !!process.env.CI, `readr CSV preview failed on Windows CI: ${errorMessage.trim()}`);
+      } else {
+        test.fixme(os.platform() === 'win32' && !!process.env.CI, 'readr CSV preview subprocess did not load on Windows CI');
+      }
+      return false;
+    });
   if (!previewReady) {
     await dialog.locator('#rstudio_dlg_cancel').click().catch(() => {});
-    test.fixme(os.platform() === 'win32' && !!process.env.CI, 'readr CSV preview subprocess did not load on Windows CI');
     throw new Error('readr CSV preview did not produce column headers within 45 s');
   }
 }

--- a/src/cpp/session/modules/data/SessionData.cpp
+++ b/src/cpp/session/modules/data/SessionData.cpp
@@ -129,11 +129,12 @@ private:
    {
       json::Object jsonError;
 
-      jsonError["message"] = message;
-      if (errors_.size() > 0)
-      {
-         jsonError["message"] = json::toJsonArray(errors_);
-      }
+      // Always return message as an array so the frontend can handle it
+      // consistently regardless of whether stderr output was captured.
+      std::vector<std::string> messages;
+      messages.push_back(message);
+      messages.insert(messages.end(), errors_.begin(), errors_.end());
+      jsonError["message"] = json::toJsonArray(messages);
 
       json::Object jsonErrorResponse;
       jsonErrorResponse["error"] = jsonError;

--- a/src/cpp/session/modules/data/SessionData.cpp
+++ b/src/cpp/session/modules/data/SessionData.cpp
@@ -129,11 +129,15 @@ private:
    {
       json::Object jsonError;
 
-      // Always return message as an array so the frontend can handle it
-      // consistently regardless of whether stderr output was captured.
+      // Always return the message as an array so the frontend can handle it
+      // consistently regardless of whether stderr output was captured. Prefer
+      // the captured stderr (errors_) when present; otherwise fall back to the
+      // generic message so the array is never empty.
       std::vector<std::string> messages;
-      messages.push_back(message);
-      messages.insert(messages.end(), errors_.begin(), errors_.end());
+      if (errors_.empty())
+         messages.push_back(message);
+      else
+         messages = errors_;
       jsonError["message"] = json::toJsonArray(messages);
 
       json::Object jsonErrorResponse;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportAssembleResponse.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportAssembleResponse.java
@@ -26,6 +26,9 @@ public class DataImportAssembleResponse extends JavaScriptObject
    public final native String getErrorMessage() /*-{
       if (!this.error || !this.error.message)
          return null;
+      // message is normally an array, but tolerate a bare string defensively
+      // so a malformed or legacy response renders rather than throwing on
+      // Array.prototype.join.
       var msg = this.error.message;
       return (msg instanceof Array) ? msg.join(' ') : String(msg);
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportAssembleResponse.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportAssembleResponse.java
@@ -24,7 +24,10 @@ public class DataImportAssembleResponse extends JavaScriptObject
    }
    
    public final native String getErrorMessage() /*-{
-      return this.error ? this.error.message.join(' ') : null;
+      if (!this.error || !this.error.message)
+         return null;
+      var msg = this.error.message;
+      return (msg instanceof Array) ? msg.join(' ') : String(msg);
    }-*/;
    
    public final native String getPreviewCode() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportPreviewResponse.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportPreviewResponse.java
@@ -26,8 +26,9 @@ public class DataImportPreviewResponse extends JavaScriptObject
    public final native String getErrorMessage() /*-{
       if (!this.error || !this.error.message)
          return null;
-      // The message may be a string (from C++ subprocess errors) or an array
-      // (from R-side errors). Handle both defensively.
+      // message is normally an array, but tolerate a bare string defensively
+      // so a malformed or legacy response renders rather than throwing on
+      // Array.prototype.join.
       var msg = this.error.message;
       return (msg instanceof Array) ? msg.join(' ') : String(msg);
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportPreviewResponse.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportPreviewResponse.java
@@ -24,7 +24,12 @@ public class DataImportPreviewResponse extends JavaScriptObject
    }
    
    public final native String getErrorMessage() /*-{
-      return (this.error && this.error.message) ? this.error.message.join(' ') : null;
+      if (!this.error || !this.error.message)
+         return null;
+      // The message may be a string (from C++ subprocess errors) or an array
+      // (from R-side errors). Handle both defensively.
+      var msg = this.error.message;
+      return (msg instanceof Array) ? msg.join(' ') : String(msg);
    }-*/;
    
    public final native int getParsingErrors() /*-{

--- a/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
+++ b/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
@@ -28,6 +28,7 @@ import org.rstudio.studio.client.application.model.SessionScopeTests;
 import org.rstudio.studio.client.common.r.RTokenizerTests;
 import org.rstudio.studio.client.common.sourcemarkers.SourceMarkerItemCodecTests;
 import org.rstudio.studio.client.projects.model.ProjectMRUEntryTests;
+import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportPreviewResponseTests;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobManagerTests;
 import org.rstudio.studio.client.workbench.views.jobs.view.JobsListTests;
 import org.rstudio.studio.client.workbench.views.output.lint.model.LintItemTests;
@@ -71,6 +72,7 @@ public class RStudioUnitTestSuite extends GWTTestSuite
       suite.addTestSuite(ApplicationUtilsTests.class);
       suite.addTestSuite(ProjectMRUEntryTests.class);
       suite.addTestSuite(YamlTreeTests.class);
+      suite.addTestSuite(DataImportPreviewResponseTests.class);
 
       return suite;
    }

--- a/src/gwt/test/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportPreviewResponseTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportPreviewResponseTests.java
@@ -1,0 +1,71 @@
+/*
+ * DataImportPreviewResponseTests.java
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.environment.dataimport.model;
+
+import com.google.gwt.junit.client.GWTTestCase;
+
+public class DataImportPreviewResponseTests extends GWTTestCase
+{
+   @Override
+   public String getModuleName()
+   {
+      return "org.rstudio.studio.RStudioTests";
+   }
+
+   // Regression #17985: getErrorMessage assumed error.message was always an
+   // array and called .join on it. When the C++ preview subprocess returned a
+   // bare string (e.g. "Operation finished with error code.") this threw a
+   // TypeError and the error was silently swallowed, leaving the preview
+   // hanging. getErrorMessage must tolerate both shapes.
+
+   public void testArrayMessageIsJoined()
+   {
+      DataImportPreviewResponse response = responseWithArrayMessage();
+      assertEquals("Operation failed. details", response.getErrorMessage());
+   }
+
+   public void testStringMessageIsReturnedVerbatim()
+   {
+      DataImportPreviewResponse response =
+            responseWithStringMessage("Operation finished with error code.");
+      assertEquals("Operation finished with error code.", response.getErrorMessage());
+   }
+
+   public void testMissingErrorReturnsNull()
+   {
+      assertNull(responseWithoutError().getErrorMessage());
+   }
+
+   public void testMissingMessageReturnsNull()
+   {
+      assertNull(responseWithoutMessage().getErrorMessage());
+   }
+
+   private static native DataImportPreviewResponse responseWithArrayMessage() /*-{
+      return { error: { message: ["Operation failed.", "details"] } };
+   }-*/;
+
+   private static native DataImportPreviewResponse responseWithStringMessage(String msg) /*-{
+      return { error: { message: msg } };
+   }-*/;
+
+   private static native DataImportPreviewResponse responseWithoutError() /*-{
+      return {};
+   }-*/;
+
+   private static native DataImportPreviewResponse responseWithoutMessage() /*-{
+      return { error: {} };
+   }-*/;
+}


### PR DESCRIPTION
Addresses #17985.

## Problem

The readr CSV preview subprocess occasionally fails to start on Windows CI. While the underlying cause of the subprocess failure is still under investigation, the frontend had a bug that prevented error messages from being displayed when the subprocess failed.

### Root Cause

`DataImportPreviewResponse.getErrorMessage()` assumed the error message was always a JavaScript array and called `join(' ')` on it. When the C++ backend returned a string (the common case for subprocess failures like `"Operation finished with error code."`), this threw a `TypeError: String.prototype.join is not a function` and the error was silently swallowed.

As a result:
1. The error was never displayed to the user
2. The preview grid remained empty
3. The e2e test waited the full 45s timeout before failing

## Changes

### Frontend (GWT/Java)
- **DataImportPreviewResponse.java**: Handle both string and array error messages defensively using `instanceof Array` check
- **DataImportAssembleResponse.java**: Apply the same defensive fix for consistency

### Backend (C++)
- **SessionData.cpp**: Always return error messages as an array so the frontend formats them consistently. Prefer the captured stderr output when present, falling back to the generic message only when no stderr was captured (so the array is never empty and the specific error isn't buried behind the generic one).

### Tests
- **import_dataset.test.ts**: When the preview times out, scrape the top-level "Error" dialog for a specific diagnostic (and soft-skip on Windows CI) instead of failing with only a generic timeout message.

## Note

This fix ensures errors are properly displayed when the preview subprocess fails, but does not address the underlying cause of the subprocess startup failures on Windows CI. That investigation continues separately.
