### PR TITLE
fix windows hang on project switch from unstopped io_context workers

### DIFF
--- a/src/cpp/core/Thread.cpp
+++ b/src/cpp/core/Thread.cpp
@@ -95,6 +95,8 @@ bool joinOrAbandonThread(boost::thread& thread,
       }
       catch (...)
       {
+         // Intentionally empty: a throwing detach() here is unrecoverable
+         // mid-teardown, and we must not let an exception escape (see above).
       }
       return false;
    }

--- a/src/cpp/core/Thread.cpp
+++ b/src/cpp/core/Thread.cpp
@@ -17,6 +17,7 @@
 
 #include <shared_core/Error.hpp>
 
+#include <core/Log.hpp>
 #include <core/Macros.hpp>
 #include <core/StringUtils.hpp>
 #include <core/Thread.hpp>
@@ -57,6 +58,45 @@ void safeLaunchThread(boost::function<void()> threadMain,
    {
       LOG_ERROR(Error(boost::thread_error::ec_from_exception(e),
                       ERROR_LOCATION));
+   }
+}
+
+bool joinOrAbandonThread(boost::thread& thread,
+                         const std::string& name,
+                         bool interrupt,
+                         const boost::posix_time::time_duration& timeout)
+{
+   // Never throw: this runs on the process-exit path and some callers invoke it
+   // from a destructor, where an escaping exception would std::terminate during
+   // unwinding. On any failure we still detach so the boost::thread destructor
+   // does not terminate on a still-joinable handle.
+   try
+   {
+      if (!thread.joinable())
+         return true;
+
+      if (interrupt)
+         thread.interrupt();
+
+      if (thread.timed_join(timeout))
+         return true;
+
+      LOG_WARNING_MESSAGE(name + " did not stop on its own; abandoning it");
+      thread.detach();
+      return false;
+   }
+   catch (...)
+   {
+      LOG_WARNING_MESSAGE("error while stopping " + name + "; abandoning it");
+      try
+      {
+         if (thread.joinable())
+            thread.detach();
+      }
+      catch (...)
+      {
+      }
+      return false;
    }
 }
 

--- a/src/cpp/core/ThreadTests.cpp
+++ b/src/cpp/core/ThreadTests.cpp
@@ -1,0 +1,93 @@
+/*
+ * ThreadTests.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include <boost/thread.hpp>
+
+#include <core/Thread.hpp>
+
+namespace rstudio {
+namespace core {
+namespace thread {
+
+TEST(ThreadTests, JoinOrAbandonNonJoinableIsNoOp)
+{
+   // A default-constructed thread was never started, so there is nothing to
+   // join: the contract is a no-op that reports success.
+   boost::thread thread;
+   EXPECT_FALSE(thread.joinable());
+   EXPECT_TRUE(joinOrAbandonThread(thread, "never-started", false));
+}
+
+TEST(ThreadTests, JoinOrAbandonJoinsAFinishingThread)
+{
+   // A thread that returns promptly should be joined within the timeout, leave
+   // the handle non-joinable, and report success.
+   boost::thread thread([] {});
+   EXPECT_TRUE(joinOrAbandonThread(
+      thread, "quick", false, boost::posix_time::seconds(5)));
+   EXPECT_FALSE(thread.joinable());
+}
+
+TEST(ThreadTests, JoinOrAbandonDetachesOnTimeout)
+{
+   // A worker that ignores interruption (no interruption points) and runs past
+   // the timeout must be detached: the call returns false and the handle is left
+   // non-joinable so ~boost::thread does not terminate.
+   std::atomic<bool> release(false);
+   boost::thread thread([&release] {
+      while (!release.load())
+         boost::this_thread::yield();
+   });
+
+   EXPECT_FALSE(joinOrAbandonThread(
+      thread, "stuck", false, boost::posix_time::milliseconds(100)));
+   EXPECT_FALSE(thread.joinable());
+
+   // let the abandoned worker exit before the test (and the atomic) goes away
+   release.store(true);
+}
+
+TEST(ThreadTests, JoinOrAbandonInterruptsAndJoins)
+{
+   // A worker that polls an interruption point should be woken by interrupt=true
+   // and then join well within the timeout, reporting success.
+   boost::thread thread([] {
+      try
+      {
+         while (true)
+         {
+            boost::this_thread::interruption_point();
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+         }
+      }
+      catch (const boost::thread_interrupted&)
+      {
+      }
+   });
+
+   EXPECT_TRUE(joinOrAbandonThread(
+      thread, "interruptible", true, boost::posix_time::seconds(5)));
+   EXPECT_FALSE(thread.joinable());
+}
+
+} // end namespace thread
+} // end namespace core
+} // end namespace rstudio

--- a/src/cpp/core/include/core/Thread.hpp
+++ b/src/cpp/core/include/core/Thread.hpp
@@ -439,6 +439,26 @@ boost::thread run(F&& f)
 void safeLaunchThread(boost::function<void()> threadMain,
                       boost::thread* pThread = nullptr);
 
+// Best-effort join for a background worker on the process-exit path. Waits up
+// to `timeout` for `thread` to finish; if it doesn't, logs a warning naming the
+// thread and detaches it (so ~boost::thread does not std::terminate() on a
+// still-joinable handle) and returns so shutdown can proceed instead of hanging
+// indefinitely. A non-joinable thread (never started or already joined) is a
+// no-op. Returns true if the thread was joined, false if it timed out and was
+// detached. Never throws, so it is safe to call from a destructor.
+//
+// `interrupt` is deliberately required so every caller decides how its thread
+// is woken: pass true for a thread whose run loop polls boost interruption
+// points (this calls boost::thread::interrupt() before joining); pass false for
+// a thread woken another way (for example an io_context worker, which is not an
+// interruption point and must be released via io_context::stop() by the caller
+// before calling this).
+bool joinOrAbandonThread(
+   boost::thread& thread,
+   const std::string& name,
+   bool interrupt,
+   const boost::posix_time::time_duration& timeout = boost::posix_time::seconds(3));
+
 void initializeMainThreadId(boost::thread::id id);
 
 bool isMainThread();

--- a/src/cpp/core/system/file_monitor/FileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/FileMonitor.cpp
@@ -631,18 +631,10 @@ void initialize()
 
 void stop()
 {
-   if (s_fileMonitorThread.joinable())
-   {
-      s_fileMonitorThread.interrupt();
-
-      // wait for for the thread to stop
-      if (!s_fileMonitorThread.timed_join(boost::posix_time::seconds(3)))
-      {
-         LOG_WARNING_MESSAGE("file monitor thread didn't stop on its own");
-      }
-
-      s_fileMonitorThread.detach();
-   }
+   core::thread::joinOrAbandonThread(
+      s_fileMonitorThread,
+      "file monitor thread",
+      true);
 }
 
 void registerMonitor(const FilePath& filePath,

--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -26,6 +26,7 @@
 #include <core/ProgramStatus.hpp>
 #include <core/ProgramOptions.hpp>
 #include <core/SocketRpc.hpp>
+#include <core/Thread.hpp>
 #include <core/json/JsonRpc.hpp>
 
 #include <core/text/TemplateFilter.hpp>
@@ -505,7 +506,15 @@ Error waitForSignals()
             }
          });
 
-         waitThread.timed_join(boost::chrono::seconds(60));
+         // the reaper blocks in waitpid(), which is not an interruption point;
+         // it ends on its own once every child is reaped. bound the wait so a
+         // child that refuses to die can't hang shutdown, and abandon it
+         // otherwise (the stuck-process check below then reports what remains).
+         core::thread::joinOrAbandonThread(
+               waitThread,
+               "child reaper thread",
+               false,
+               boost::posix_time::seconds(60));
 
          // notify user if there seem to still be some processes around
          int status = 0;

--- a/src/cpp/session/SessionClientEventService.cpp
+++ b/src/cpp/session/SessionClientEventService.cpp
@@ -88,28 +88,11 @@ Error ClientEventService::start(const std::string& clientId)
    
 void ClientEventService::stop()
 {
-   try
-   {
-      if (serviceThread_.joinable())
-      {
-         serviceThread_.interrupt();
-
-         // wait for for the service thread to stop
-         if (!serviceThread_.timed_join(
-               boost::posix_time::seconds(kLastChanceWaitSeconds + 1)))
-         {
-            LOG_WARNING_MESSAGE("ClientEventService didn't stop on its own");
-         }
-
-         serviceThread_.detach();
-      }
-   }
-   catch(const boost::thread_interrupted&)
-   {
-      // the main thread is the one who calls stop() and it should 
-      // NEVER be interrupted for any reason
-      LOG_WARNING_MESSAGE("thread interrupted during stop");
-   }
+   core::thread::joinOrAbandonThread(
+         serviceThread_,
+         "ClientEventService thread",
+         true,
+         boost::posix_time::seconds(kLastChanceWaitSeconds + 1));
 }
    
 void ClientEventService::setClientId(const std::string& clientId, bool clearEvents)

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2001,8 +2001,15 @@ Error ensureLibRSoValid()
    return Success();
 }
 
-// io_context for performing monitor work on the thread
-boost::asio::io_context s_monitorIoContext;
+// io_context for performing monitor work on the thread.
+//
+// Intentionally heap-allocated and never freed, for the same reason as
+// server_rpc's s_ioContext (see the comment there): stopMonitorWorkerThread()
+// stops it and joins the worker on the clean path, but if the join times out
+// and the worker is detached, never running ~io_context() avoids destroying it
+// while a detached worker is still inside run() -- the documented Windows-IOCP
+// teardown hang. The OS reclaims it at process exit.
+boost::asio::io_context& s_monitorIoContext = *new boost::asio::io_context();
 
 // the monitor worker thread. retained as a joinable handle so that
 // stopMonitorWorkerThread() can wait for run() to return before the process
@@ -2018,11 +2025,12 @@ void monitorWorkerThreadFunc()
 void stopMonitorWorkerThread()
 {
    // stop() makes run() return; we then wait for the thread to actually leave
-   // run() before s_monitorIoContext is destroyed. Without this, ::exit()
-   // destroys this file-scope io_context while the worker is still inside
-   // run() -- undefined behavior that can hang on Windows (see the matching
+   // run() so this is a clean, prompt shutdown of the worker (see the matching
    // server_rpc::stop()). joinOrAbandonThread bounds the wait so we never trade
-   // that teardown hang for an indefinite join hang on the process-exit path.
+   // a teardown hang for an indefinite join hang on the process-exit path; if it
+   // times out and detaches the worker, s_monitorIoContext is never destroyed
+   // (it is the intentionally-leaked global above), so ~io_context() cannot run
+   // while the detached worker is still inside run() -- the Windows-IOCP hang.
    s_monitorIoContext.stop();
    core::thread::joinOrAbandonThread(
       s_monitorWorkerThread,
@@ -2052,7 +2060,7 @@ void initMonitorClient()
    // connect to, so every async log/event would fail-fast and race the worker
    // thread against the initiating thread on the same socket. The worker thread
    // also never gets stopped on the test path (R exits via exit()), so it would
-   // race static destruction of s_monitorIoContext at process exit. Both produce
+   // race static destruction of other process state at exit. Both produce
    // intermittent SIGSEGVs. The client object is still initialized above so that
   // monitor::client() stays valid; queued async ops are simply never processed.
    if (!options().runTests())

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1762,6 +1762,7 @@ namespace session {
 void exitEarly(int status)
 {
    stopMonitorWorkerThread();
+   server_rpc::stop();
    offlineService().stop();
    FileLock::cleanUp();
    FilePath(s_fallbackLibraryPath).removeIfExists();
@@ -2003,6 +2004,11 @@ Error ensureLibRSoValid()
 // io_context for performing monitor work on the thread
 boost::asio::io_context s_monitorIoContext;
 
+// the monitor worker thread. retained as a joinable handle so that
+// stopMonitorWorkerThread() can wait for run() to return before the process
+// tears s_monitorIoContext down at exit (see stopMonitorWorkerThread).
+boost::thread s_monitorWorkerThread;
+
 void monitorWorkerThreadFunc()
 {
    auto guard = boost::asio::make_work_guard(s_monitorIoContext);
@@ -2011,7 +2017,17 @@ void monitorWorkerThreadFunc()
 
 void stopMonitorWorkerThread()
 {
+   // stop() makes run() return; we then wait for the thread to actually leave
+   // run() before s_monitorIoContext is destroyed. Without this, ::exit()
+   // destroys this file-scope io_context while the worker is still inside
+   // run() -- undefined behavior that can hang on Windows (see the matching
+   // server_rpc::stop()). joinOrAbandonThread bounds the wait so we never trade
+   // that teardown hang for an indefinite join hang on the process-exit path.
    s_monitorIoContext.stop();
+   core::thread::joinOrAbandonThread(
+      s_monitorWorkerThread,
+      "monitor worker thread",
+      false); // released via s_monitorIoContext.stop() above, not interruptible
 }
 
 void initMonitorClient()
@@ -2040,7 +2056,7 @@ void initMonitorClient()
    // intermittent SIGSEGVs. The client object is still initialized above so that
   // monitor::client() stays valid; queued async ops are simply never processed.
    if (!options().runTests())
-      core::thread::safeLaunchThread(monitorWorkerThreadFunc);
+      core::thread::safeLaunchThread(monitorWorkerThreadFunc, &s_monitorWorkerThread);
 }
 
 void beforeResume()

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -135,6 +135,10 @@ public:
    
    ~ConsoleInputService()
    {
+      // seconds(1) is a real 1-second bound. This replaced a prior bare
+      // timed_join(1), which boost interprets as 1 nanosecond -- effectively no
+      // wait, which left the thread joinable and could std::terminate from this
+      // destructor. The worker polls boost interruption points, so interrupt.
       core::thread::joinOrAbandonThread(
             thread_,
             "console input service thread",

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -31,6 +31,7 @@
 
 #include <core/BoostSignals.hpp>
 #include <core/BoostThread.hpp>
+#include <core/Thread.hpp>
 #include <core/Debug.hpp>
 #include <core/FileInfo.hpp>
 #include <core/Log.hpp>
@@ -134,8 +135,11 @@ public:
    
    ~ConsoleInputService()
    {
-      thread_.interrupt();
-      thread_.timed_join(1);
+      core::thread::joinOrAbandonThread(
+            thread_,
+            "console input service thread",
+            true,
+            boost::posix_time::seconds(1));
    }
    
    void enqueue(const std::string& input)

--- a/src/cpp/session/SessionOfflineService.cpp
+++ b/src/cpp/session/SessionOfflineService.cpp
@@ -108,28 +108,11 @@ Error OfflineService::start()
    
 void OfflineService::stop()
 {
-   try
-   {
-      if (offlineThread_.joinable())
-      {
-         offlineThread_.interrupt();
-
-         // wait for for the service thread to stop
-         if (!offlineThread_.timed_join(
-               boost::posix_time::seconds(2)))
-         {
-            LOG_WARNING_MESSAGE("OfflineService didn't stop on its own");
-         }
-
-         offlineThread_.detach();
-      }
-   }
-   catch(const boost::thread_interrupted&)
-   {
-      // the main thread is the one who calls stop() and it should 
-      // NEVER be interrupted for any reason
-      LOG_WARNING_MESSAGE("OfflineService thread interrupted during stop");
-   }
+   core::thread::joinOrAbandonThread(
+         offlineThread_,
+         "OfflineService thread",
+         true,
+         boost::posix_time::seconds(2));
 }
 
 // Called for each connection in mainConnectionQueue until an offlineable request is found.

--- a/src/cpp/session/SessionServerRpc.cpp
+++ b/src/cpp/session/SessionServerRpc.cpp
@@ -99,6 +99,11 @@ boost::once_flag s_threadOnce = BOOST_ONCE_INIT;
 // io_context for performing RPC work on the thread
 boost::asio::io_context s_ioContext;
 
+// the RPC worker thread. retained as a joinable handle (rather than launched
+// detached) so that stop() can wait for run() to return before the process
+// tears s_ioContext down at exit -- see stop().
+boost::thread s_rpcWorkerThread;
+
 void rpcWorkerThreadFunc()
 {
    auto work = boost::asio::make_work_guard(s_ioContext);
@@ -111,7 +116,7 @@ void ensureRpcWorkerThreadRunning()
    boost::call_once(s_threadOnce,
                     boost::bind(core::thread::safeLaunchThread,
                                 rpcWorkerThreadFunc,
-                                nullptr));
+                                &s_rpcWorkerThread));
 }
 
 } // anonymous namespace
@@ -120,6 +125,25 @@ boost::asio::io_context& ioContext()
 {
    ensureRpcWorkerThreadRunning();
    return s_ioContext;
+}
+
+void stop()
+{
+   // The worker thread runs s_ioContext.run() behind a work guard, so it never
+   // returns on its own. stop() forces run() to return; we then wait for the
+   // thread to actually leave run() before s_ioContext is destroyed. Without
+   // this, ::exit() (called on the main thread from exitEarly()) destroys this
+   // file-scope io_context while the worker is still inside run() -- undefined
+   // behavior that hangs on Windows (rstudio#18018). stop() abandons any
+   // in-flight request rather than draining it, so a clean shutdown joins almost
+   // immediately; joinOrAbandonThread bounds the wait so we never trade the
+   // teardown hang for an indefinite join hang, and is a no-op if the thread was
+   // never started (no async RPC was ever issued).
+   s_ioContext.stop();
+   core::thread::joinOrAbandonThread(
+      s_rpcWorkerThread,
+      "server RPC worker thread",
+      false); // released via s_ioContext.stop() above, not interruptible
 }
 
 Error invokeServerRpc(const json::JsonRpcRequest& request, json::JsonRpcResponse* pResponse)

--- a/src/cpp/session/SessionServerRpc.cpp
+++ b/src/cpp/session/SessionServerRpc.cpp
@@ -96,8 +96,21 @@ SEXP rs_invokeServerRpc(SEXP name, SEXP args)
 // once flag for lazy initializing async RPC thread
 boost::once_flag s_threadOnce = BOOST_ONCE_INIT;
 
-// io_context for performing RPC work on the thread
-boost::asio::io_context s_ioContext;
+// io_context for performing RPC work on the thread.
+//
+// Intentionally heap-allocated and never freed. stop() below stops the context
+// and joins the worker on the clean exit path, but if a request is wedged in a
+// blocking operation that io_context::stop() cannot unblock, joinOrAbandonThread
+// detaches the worker after a timeout and lets shutdown proceed. Were this a
+// normal global, ~io_context() would then run during static destruction while
+// the detached worker is still inside run() -- a documented Windows-IOCP hang
+// (asio issue #869, rstudio#18018). Never destroying it removes that teardown
+// entirely: the OS reclaims the io_context (and force-terminates the detached
+// worker) at process exit, which is well-defined. This is the standard "no
+// exit-time destructor" idiom for a process-lifetime global with a non-trivial,
+// thread-interacting destructor. The only difference from a normal global is at
+// the instant of exit; steady-state behavior is unchanged.
+boost::asio::io_context& s_ioContext = *new boost::asio::io_context();
 
 // the RPC worker thread. retained as a joinable handle (rather than launched
 // detached) so that stop() can wait for run() to return before the process
@@ -131,14 +144,17 @@ void stop()
 {
    // The worker thread runs s_ioContext.run() behind a work guard, so it never
    // returns on its own. stop() forces run() to return; we then wait for the
-   // thread to actually leave run() before s_ioContext is destroyed. Without
-   // this, ::exit() (called on the main thread from exitEarly()) destroys this
-   // file-scope io_context while the worker is still inside run() -- undefined
-   // behavior that hangs on Windows (rstudio#18018). stop() abandons any
-   // in-flight request rather than draining it, so a clean shutdown joins almost
-   // immediately; joinOrAbandonThread bounds the wait so we never trade the
-   // teardown hang for an indefinite join hang, and is a no-op if the thread was
-   // never started (no async RPC was ever issued).
+   // thread to actually leave run(). stop() declines to start any further queued
+   // work, so when nothing is mid-flight (the common exit case) the worker leaves
+   // run() and joins almost immediately. joinOrAbandonThread bounds the wait so
+   // we never trade a clean shutdown for an indefinite join hang, and is a no-op
+   // if the thread was never started (no async RPC was ever issued).
+   //
+   // If a request is wedged in a blocking operation that stop() cannot unblock,
+   // the join times out and the worker is detached. s_ioContext is never
+   // destroyed (see its declaration), so ~io_context() cannot run while that
+   // detached worker is still inside run() -- the Windows-IOCP teardown hang
+   // this whole dance exists to avoid (rstudio#18018, asio issue #869).
    s_ioContext.stop();
    core::thread::joinOrAbandonThread(
       s_rpcWorkerThread,

--- a/src/cpp/session/http/SessionHttpConnectionListenerImpl.hpp
+++ b/src/cpp/session/http/SessionHttpConnectionListenerImpl.hpp
@@ -26,6 +26,7 @@
 
 #include <core/Macros.hpp>
 #include <core/BoostThread.hpp>
+#include <core/Thread.hpp>
 #include <shared_core/FilePath.hpp>
 #include <core/FileLock.hpp>
 #include <shared_core/Error.hpp>
@@ -153,20 +154,12 @@ public:
       if (ec)
          LOG_ERROR(core::Error(ec, ERROR_LOCATION));
 
-      // stop the server
+      // stop the server, then wait for the listener thread to finish
       ioContext().stop();
-
-      // join the thread and wait for it complete
-      if (listenerThread_.joinable())
-      {
-         if (!listenerThread_.timed_join(boost::posix_time::seconds(3)))
-         {
-            LOG_WARNING_MESSAGE(
-                  "HttpConnectionListener didn't stop within 3 sec");
-         }
-
-         listenerThread_.detach();
-      }
+      core::thread::joinOrAbandonThread(
+            listenerThread_,
+            "HttpConnectionListener thread",
+            false); // released via ioContext().stop() above, not interruptible
 
       // allow subclass specific cleanup
       core::Error error = cleanup();

--- a/src/cpp/session/include/session/SessionServerRpc.hpp
+++ b/src/cpp/session/include/session/SessionServerRpc.hpp
@@ -32,6 +32,11 @@ namespace server_rpc {
 // useful if building clients "by hand" that conceptually perform server RPCs
 boost::asio::io_context& ioContext();
 
+// stop the io_context worker thread (if running) and wait for it to exit.
+// must be called before process teardown destroys the io_context -- see the
+// implementation for details.
+void stop();
+
 core::Error invokeServerRpc(const core::json::JsonRpcRequest& request,
                             core::json::JsonRpcResponse* pResponse);
 

--- a/src/cpp/session/modules/SessionPPM.R
+++ b/src/cpp/session/modules/SessionPPM.R
@@ -409,6 +409,7 @@
          "(?<platform>[^/]+)/",             # platform for binaries
       ")?",                                 # end optional binary parts
       "(?<snapshot>[^/]+)",                 # snapshot
+      "/?",                                 # tolerate a trailing slash
       "$"
    )
    

--- a/src/cpp/tests/testthat/test-ppm.R
+++ b/src/cpp/tests/testthat/test-ppm.R
@@ -502,7 +502,8 @@ test_that("fromRepositoryUrl tolerates a trailing slash", {
    # RStudio's own CRAN-mirror UI normalizes the repo URL with a trailing slash,
    # so a UI-configured PPM repo lands in options(repos) as ".../latest/". Both
    # forms must be detected as the same repo, or such users silently get no
-   # vulnerability badges (rstudio#18018).
+   # vulnerability badges. (Trailing-slash defect found while investigating
+   # rstudio#18018.)
    bare <- .rs.ppm.fromRepositoryUrl("https://packagemanager.posit.co/cran/latest")
    slash <- .rs.ppm.fromRepositoryUrl("https://packagemanager.posit.co/cran/latest/")
    expect_false(is.null(slash))
@@ -516,6 +517,18 @@ test_that("fromRepositoryUrl tolerates a trailing slash", {
 test_that("fromRepositoryUrl extracts the optional binary / platform parts", {
    parts <- .rs.ppm.fromRepositoryUrl(
       "https://packagemanager.posit.co/cran/__linux__/jammy/2024-01-01"
+   )
+   expect_equal(parts[["repos"]], "cran")
+   expect_equal(parts[["binary"]], "__linux__")
+   expect_equal(parts[["platform"]], "jammy")
+   expect_equal(parts[["snapshot"]], "2024-01-01")
+})
+
+test_that("fromRepositoryUrl tolerates a trailing slash on a binary URL", {
+   # the optional trailing slash must apply to the binary / platform shape too,
+   # and must not bleed into the snapshot.
+   parts <- .rs.ppm.fromRepositoryUrl(
+      "https://packagemanager.posit.co/cran/__linux__/jammy/2024-01-01/"
    )
    expect_equal(parts[["repos"]], "cran")
    expect_equal(parts[["binary"]], "__linux__")

--- a/src/cpp/tests/testthat/test-ppm.R
+++ b/src/cpp/tests/testthat/test-ppm.R
@@ -498,6 +498,21 @@ test_that("fromRepositoryUrl classifies a plain PPM repo URL", {
    expect_false(nzchar(parts[["binary"]]))
 })
 
+test_that("fromRepositoryUrl tolerates a trailing slash", {
+   # RStudio's own CRAN-mirror UI normalizes the repo URL with a trailing slash,
+   # so a UI-configured PPM repo lands in options(repos) as ".../latest/". Both
+   # forms must be detected as the same repo, or such users silently get no
+   # vulnerability badges (rstudio#18018).
+   bare <- .rs.ppm.fromRepositoryUrl("https://packagemanager.posit.co/cran/latest")
+   slash <- .rs.ppm.fromRepositoryUrl("https://packagemanager.posit.co/cran/latest/")
+   expect_false(is.null(slash))
+   expect_equal(slash[["root"]], "https://packagemanager.posit.co")
+   expect_equal(slash[["repos"]], "cran")
+   expect_equal(slash[["snapshot"]], "latest")
+   # the snapshot must not absorb the trailing slash
+   expect_equal(slash[["snapshot"]], bare[["snapshot"]])
+})
+
 test_that("fromRepositoryUrl extracts the optional binary / platform parts", {
    parts <- .rs.ppm.fromRepositoryUrl(
       "https://packagemanager.posit.co/cran/__linux__/jammy/2024-01-01"


### PR DESCRIPTION
## Problem

RStudio Desktop on Windows hangs indefinitely when switching projects, closing a project, or opening a project from "no project". Reproduces on `2026.05.1+225` ("Golden Wattle"), not on `2026.05.0+218`.

## Root cause

`server_rpc`'s vulnerability/RPC `io_context` worker thread (`SessionServerRpc.cpp`) is a **file-scope global**, launched **detached** behind a perpetual `make_work_guard`, and was never stopped. On project switch/close the desktop session quits via `exitEarly()` -> `::exit()`, which runs static/global destructors. So `~io_context()` runs on the main thread while the detached worker is still inside `run()` -- undefined behavior that characteristically hangs on the Windows IOCP backend.

This started hitting ordinary desktop users because of two commits between `+218` and `+225`:

- #17808 moved the PPM vulnerability download off the R main thread, onto `server_rpc::ioContext()`.
- #17823 removed the `isPpmIntegrationEnabled()` env-var gate, so the fetch now fires for **any** session whose `getOption("repos")` is a Posit Package Manager URL (e.g. `packagemanager.posit.co`) -- exactly the affected population. `SessionPPM` is the only caller of `server_rpc::ioContext()`, so before these commits the worker thread never started on desktop and `::exit` tore down an idle, never-`run()` context harmlessly.

## Fix

**The hang:**
- Retain a joinable handle for the `server_rpc` worker and `stop()` + join it from `exitEarly()`.
- Add a `core::thread::joinOrAbandonThread()` helper that performs the bounded shutdown join: optional interrupt, `timed_join`, and `detach()` on timeout so the exit path never trades the teardown hang for an indefinite join hang. It never throws (safe from a destructor), and requires callers to state whether the thread needs interrupting (io_context workers are not interruption points and must be released via `io_context::stop()`).
- Fix the same latent race in the monitor `io_context` worker (it was `stop()`'d but never joined).
- Migrate the other duplicated bounded-join shutdown tails onto the helper: `OfflineService`, `ClientEventService`, file monitor, `ConsoleInputService`, `HttpConnectionListener`, and the `rserver` child-reaper in `ServerMain`. This also fixes latent `std::terminate`s where a join timeout left a thread joinable (`ConsoleInputService`'s destructor; the `rserver` reaper). `Win32ChildProcess`'s pipe-reader `timed_join`s are intentionally left as-is -- one reader writes an outer stack buffer by reference, so detaching on timeout would be a use-after-scope and needs a different fix.

**Related defect found during investigation (trailing-slash detection):**
- `.rs.ppm.fromRepositoryUrl` matched with a fully-anchored regex ending in `(?<snapshot>[^/]+)$`, so a PPM repo URL with a trailing slash (e.g. `.../cran/latest/`) did not match. RStudio's own CRAN-mirror UI normalizes repo URLs with a trailing slash, so users who configured a PPM repo that way silently received **no vulnerability badges** -- the feature #17823 was meant to deliver to desktop. The detection regex now tolerates an optional trailing slash.

## Testing

- Verified all affected C++ translation units compile.
- `rstudio-tests --scope r --filter ppm` passes, including a new `fromRepositoryUrl` case covering the trailing-slash form.
- The hang itself is a Windows-only shutdown race that requires a PPM repo (without a trailing slash) active at session start; manual verification on Windows is recommended.

Addresses #18018.

