### PR TITLE
read child process exit output without a throwaway thread on windows

### DIFF
--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -907,37 +907,34 @@ void AsyncChildProcess::poll()
       }
       else
       {
-         // read all remaining stdout, stderr -- use threads to avoid unexpected
-         // cases where reading from a handle on Windows can block
+         // Drain any remaining stdout/stderr. The process has already exited
+         // (WaitForSingleObject above signaled), so its write ends of the pipes
+         // are closed and whatever it wrote is sitting in the OS pipe buffer.
+         // Read it with the non-blocking, PeekNamedPipe-based helper -- the same
+         // one the steady-state read above uses -- so no read can block.
+         //
+         // This used to spawn a thread per stream running a blocking read and
+         // bound it with timed_join(1s). That had three problems (rstudio#18022):
+         // a join timeout left the boost::thread joinable, so ~thread called
+         // std::terminate; the stdout reader wrote a shadowing local, so trailing
+         // stdout was silently dropped; and on timeout the buffers were read here
+         // while the reader thread might still be writing them. A non-blocking
+         // read on this thread avoids all three.
          std::string stdOut, stdErr;
 
-         auto readStdOutThread = core::thread::run([&]()
+         if (pImpl_->hStdOutRead)
          {
-            if (pImpl_->hStdOutRead)
-            {
-               std::string stdOut;
-               Error error = readPipeUntilDone(pImpl_->hStdOutRead, &stdOut);
-               if (error)
-                  reportError(error);
-            }
-         });
+            Error error = readPipeAvailable(pImpl_->hStdOutRead, &stdOut);
+            if (error)
+               reportError(error);
+         }
 
-         auto readStdErrThread = core::thread::run([&]()
+         if (pImpl_->hStdErrRead)
          {
-            // read all remaining stderr
-            if (pImpl_->hStdErrRead)
-            {
-               Error error = readPipeUntilDone(pImpl_->hStdErrRead, &stdErr);
-               if (error)
-                  reportError(error);
-            }
-         });
-
-         if (readStdOutThread.joinable())
-            readStdOutThread.timed_join(boost::posix_time::seconds(1));
-
-         if (readStdErrThread.joinable())
-            readStdErrThread.timed_join(boost::posix_time::seconds(1));
+            Error error = readPipeAvailable(pImpl_->hStdErrRead, &stdErr);
+            if (error)
+               reportError(error);
+         }
 
          if (!stdOut.empty() && callbacks_.onStdout)
          {

--- a/version/news/os/NEWS-2026.06.0-blue-plumbago.md
+++ b/version/news/os/NEWS-2026.06.0-blue-plumbago.md
@@ -68,6 +68,7 @@
 - ([#17969](https://github.com/rstudio/rstudio/issues/17969)): Fix switching AI assistants while the previous agent was still initializing occasionally double-initializing the new agent and applying the previous assistant's configuration to it; a stale initialization callback is now discarded when cancelled.
 - ([#17994](https://github.com/rstudio/rstudio/pull/17994)): Fix an "Error" dialog ("Cannot read properties of null (reading 'document')") appearing if Global Options was dismissed while the editor theme preview was still finishing its initial Ace JavaScript load; the deferred load callbacks now bail out cleanly when the preview frame has already been detached.
 - ([#17994](https://github.com/rstudio/rstudio/pull/17994)): Fix the macOS desktop GWT output cache occasionally producing installer builds without the visual editor's `panmirror.js` bundle (which manifested as a 404 and a visual editor that never finished mounting); the panmirror build output now lands inside the cached gwt directory rather than the source tree, so cache-hit builds keep it. Affects builds that reuse the cached GWT output via `--build-gwt=0`.
+- ([#18022](https://github.com/rstudio/rstudio/issues/18022)): On Windows, fix the final chunk of a child process's standard output being dropped, and fix a rare session crash when draining a process's output at exit; the remaining output is now read directly instead of on a short-lived helper thread.
 
 ### Dependencies
 - Ace 1.43.5


### PR DESCRIPTION
## Problem

On Windows, `ChildProcess`'s non-PTY exit drain (`Win32ChildProcess.cpp`) read the child's remaining stdout/stderr on a thread per stream running the blocking `readPipeUntilDone`, bounded by `timed_join(1s)`. That had three latent problems (#18022):

1. **Trailing stdout silently dropped.** The stdout lambda declared a shadowing inner `std::string stdOut`, so the outer buffer (the one the delivery check reads) stayed empty and any final stdout was never delivered to `onStdout`. The stderr path wrote the outer buffer correctly, so the two were asymmetric.
2. **`std::terminate` on a join timeout.** If a reader didn't finish within 1s (the case the threads existed to guard against -- e.g. a surviving grandchild holding the pipe's write end open), `timed_join` returned false, the local `boost::thread` stayed joinable, and `~boost::thread` called `std::terminate()` -- crashing the session.
3. **A brief data race** reading the buffers in the timeout window while the reader thread might still be writing them.

(These could not be fixed by the `joinOrAbandonThread` helper from #18021: the stderr reader writes a caller stack buffer by reference, so detaching on timeout would be a use-after-scope. Hence a separate change.)

## Fix

By the time this code runs the process has already exited (`WaitForSingleObject` signaled), so its write ends of the pipes are closed and any remaining output is sitting in the OS pipe buffer. Read it directly on the calling thread with the non-blocking, `PeekNamedPipe`-based `readPipeAvailable` -- the same helper the steady-state read a few lines up already uses. No read can block, so no thread (and no `timed_join`/terminate, no shadowing, no cross-thread buffer access) is needed.

`SyncChildProcess::waitForExit` is intentionally left as-is: it uses caller-owned buffers and a plain `join()` after the process exits, and its blocking semantics are part of that synchronous API.

## Testing

This is Windows-only code and could not be compiled or run in the (macOS) dev environment; verified by inspection that the change only removes the thread machinery and reuses `readPipeAvailable` exactly as the adjacent steady-state path does. Manual verification on Windows is recommended.

Addresses #18022.
