### PR TITLE
add cross-platform E2E cert workflow + dispatcher script

### DIFF
--- a/.github/workflows/cert-e2e-rstudio.yml
+++ b/.github/workflows/cert-e2e-rstudio.yml
@@ -1,0 +1,191 @@
+name: "Cert: E2E Playwright RStudio (cross-platform release certification)"
+
+# Kicks off an end-to-end certification run across macOS, Windows, and Linux
+# Server against a SPECIFIC pre-built installer for each platform -- the binaries
+# the team has decided to certify, not a fresh source build, not "latest daily".
+#
+# Trigger from gh:
+#   gh workflow run cert-e2e-rstudio.yml --repo rstudio/rstudio \
+#     --ref <release-branch> \
+#     -f mac_installer_url=https://.../RStudio-X.Y.Z.dmg \
+#     -f win_installer_url=https://.../RStudio-X.Y.Z.exe \
+#     -f linux_installer_url=https://.../rstudio-server-X.Y.Z-amd64.deb
+#
+# --ref picks both the workflow file and the e2e/ test version: certify the
+# tests that ship with the release branch against the binaries that ship with
+# the release. There is also a wrapper at scripts/run-cert-e2e.sh.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mac_installer_url:
+        description: "URL to the macOS .dmg installer to certify."
+        type: string
+        required: true
+      win_installer_url:
+        description: "URL to the Windows .exe installer to certify."
+        type: string
+        required: true
+      linux_installer_url:
+        description: "URL to the Linux Server .deb installer to certify (Ubuntu 24)."
+        type: string
+        required: true
+      r_version:
+        description: "R version to install via rig across all three platforms (e.g. 'release', '4.5.3'). Keep consistent across platforms for a meaningful cert."
+        type: string
+        default: "release"
+      grep_invert:
+        description: "Playwright --grep-invert pattern to skip tests by title. Default '@ai' excludes tests requiring credentials not available to unattended cert runs."
+        type: string
+        default: "@ai"
+
+concurrency:
+  # One cert run at a time per branch -- a new dispatch on the same branch
+  # cancels the previous in-flight cert rather than queueing.
+  group: cert-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # Propagated to the per-platform reusables, which declare it for their PR
+  # sticky-comment path. Cert runs themselves set post_pr_comment: false, so
+  # this is unused at the cert level -- kept only so workflow_call doesn't
+  # fail the implicit permission check.
+  pull-requests: write
+
+jobs:
+  # Fail fast before burning ~3 hours of cross-platform runner time on a typo'd
+  # URL or a 404'd build. HEAD-checks each URL and verifies the file extension
+  # matches the target platform (pasting a .dmg URL into the Windows slot is
+  # the most common mistake when copy-pasting from a release tracker).
+  validate-inputs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate URLs reachable and have expected extensions
+        env:
+          MAC_URL: ${{ inputs.mac_installer_url }}
+          WIN_URL: ${{ inputs.win_installer_url }}
+          LINUX_URL: ${{ inputs.linux_installer_url }}
+        run: |
+          set -euo pipefail
+          fail=0
+
+          check() {
+            local label="$1" url="$2" suffix="$3"
+            if [[ "$url" != *"$suffix" ]]; then
+              echo "::error::$label URL does not end in $suffix: $url"
+              fail=1
+              return
+            fi
+            # -L follows redirects (dailies.rstudio.com 302s to S3),
+            # -I issues a HEAD (don't download the installer),
+            # --fail makes 4xx/5xx exit non-zero so the workflow stops here.
+            if ! curl -sSL -I --fail --max-time 30 "$url" -o /dev/null; then
+              echo "::error::$label URL did not respond 2xx to HEAD: $url"
+              fail=1
+              return
+            fi
+            echo "::notice::$label OK: $url"
+          }
+
+          check "macOS"   "$MAC_URL"   ".dmg"
+          check "Windows" "$WIN_URL"   ".exe"
+          check "Linux"   "$LINUX_URL" ".deb"
+
+          if [[ $fail -ne 0 ]]; then
+            echo "::error::One or more cert installer URLs failed validation. Aborting before runner-expensive jobs."
+            exit 1
+          fi
+
+      - name: Record cert context in run summary
+        env:
+          MAC_URL: ${{ inputs.mac_installer_url }}
+          WIN_URL: ${{ inputs.win_installer_url }}
+          LINUX_URL: ${{ inputs.linux_installer_url }}
+        run: |
+          {
+            echo "## Certification run inputs"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Branch (\`--ref\`) | \`${{ github.ref_name }}\` |"
+            echo "| Triggered by | @${{ github.actor }} |"
+            echo "| R version | \`${{ inputs.r_version }}\` |"
+            echo "| \`grep_invert\` | \`${{ inputs.grep_invert }}\` |"
+            echo "| macOS installer | $MAC_URL |"
+            echo "| Windows installer | $WIN_URL |"
+            echo "| Linux installer | $LINUX_URL |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  macos:
+    needs: validate-inputs
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+    secrets:
+      # The reusable declares OP_SERVICE_ACCOUNT_TOKEN, not CONNECT_API_KEY --
+      # it fetches CONNECT_API_KEY (and the @ai-test credentials) from 1Password
+      # using this token. Passing CONNECT_API_KEY directly would be rejected at
+      # workflow_call validation. Empty value is acceptable: the reusable's
+      # 1Password step skips cleanly and dependent features degrade gracefully.
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+    with:
+      build_from_source: false
+      rstudio_installer_url: ${{ inputs.mac_installer_url }}
+      project: desktop
+      r_version: ${{ inputs.r_version }}
+      grep_invert: ${{ inputs.grep_invert }}
+      post_pr_comment: false
+
+  windows:
+    needs: validate-inputs
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+    secrets:
+      # See note on the macos job above re: OP_SERVICE_ACCOUNT_TOKEN vs.
+      # CONNECT_API_KEY.
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+    with:
+      build_from_source: false
+      rstudio_installer_url: ${{ inputs.win_installer_url }}
+      project: desktop
+      r_version: ${{ inputs.r_version }}
+      grep_invert: ${{ inputs.grep_invert }}
+      post_pr_comment: false
+
+  linux-server:
+    needs: validate-inputs
+    # The Linux Server reusable on this branch is the pre-PR-#17939 shape:
+    # no build_from_source / build_only / post_pr_comment inputs, and no
+    # workflow_call.secrets block. By definition cert tests a pinned URL, so
+    # the smaller input set is sufficient. After #17939 merges, this call
+    # can add `build_from_source: false`, `post_pr_comment: false`, and pass
+    # OP_SERVICE_ACCOUNT_TOKEN through for parity with mac/win.
+    uses: ./.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
+    with:
+      rstudio_installer_url: ${{ inputs.linux_installer_url }}
+      project: server
+      r_version: ${{ inputs.r_version }}
+      grep_invert: ${{ inputs.grep_invert }}
+
+  cert-summary:
+    needs: [macos, windows, linux-server]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Per-platform status table
+        run: |
+          {
+            echo "## Certification results"
+            echo
+            echo "| Platform | Result |"
+            echo "|---|---|"
+            echo "| macOS arm64 | ${{ needs.macos.result }} |"
+            echo "| Windows Server 2025 | ${{ needs.windows.result }} |"
+            echo "| Linux Server ubuntu-24 | ${{ needs.linux-server.result }} |"
+            echo
+            echo "Each platform uploads its merged Playwright report as an artifact (\`playwright-report-mac\`, \`playwright-report-win\`, \`playwright-report-linux\` after PR #17939 merges); download from the run's Summary panel to inspect failed tests."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail the overall cert run if any platform did not succeed
+        if: needs.macos.result != 'success' || needs.windows.result != 'success' || needs.linux-server.result != 'success'
+        run: |
+          echo "::error::At least one platform did not pass certification. See per-platform jobs above."
+          exit 1

--- a/scripts/run-cert-e2e.sh
+++ b/scripts/run-cert-e2e.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Kick off a cross-platform RStudio E2E certification run.
+#
+# Dispatches the cert-e2e-rstudio.yml GitHub Actions workflow against
+# rstudio/rstudio, running the full Playwright suite on macOS, Windows, and
+# Linux Server against the three pre-built installers you provide.
+#
+# Requires the gh CLI (https://cli.github.com), authenticated against
+# rstudio/rstudio (gh auth status).
+#
+# Usage:
+#   scripts/run-cert-e2e.sh \
+#     --branch <release-branch> \
+#     --mac   <macOS .dmg URL> \
+#     --win   <Windows .exe URL> \
+#     --linux <Linux .deb URL> \
+#     [--r-version <R version>] \
+#     [--grep-invert <pattern>]
+#
+# Example:
+#   scripts/run-cert-e2e.sh \
+#     --branch rel-blue-plumbago \
+#     --mac   https://dailies.rstudio.com/.../RStudio-2026.06.0.dmg \
+#     --win   https://dailies.rstudio.com/.../RStudio-2026.06.0.exe \
+#     --linux https://dailies.rstudio.com/.../rstudio-server-2026.06.0-amd64.deb
+#
+# The --branch arg becomes the workflow's --ref, which controls BOTH which
+# version of cert-e2e-rstudio.yml runs AND which e2e/ test cut is checked out
+# on each runner. Use the release branch you want to certify.
+#
+# The workflow itself HEAD-checks each URL before launching the per-platform
+# jobs, so a 404'd build fails fast without burning runner minutes.
+
+set -euo pipefail
+
+REPO="rstudio/rstudio"
+WORKFLOW="cert-e2e-rstudio.yml"
+
+usage() {
+  sed -n '3,33p' "$0" | sed 's/^# \{0,1\}//'
+  exit 1
+}
+
+branch=""
+mac=""
+win=""
+linux=""
+r_version=""
+grep_invert=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --branch)      branch="$2";      shift 2 ;;
+    --mac)         mac="$2";         shift 2 ;;
+    --win)         win="$2";         shift 2 ;;
+    --linux)       linux="$2";       shift 2 ;;
+    --r-version)   r_version="$2";   shift 2 ;;
+    --grep-invert) grep_invert="$2"; shift 2 ;;
+    -h|--help)     usage ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+missing=()
+[[ -z "$branch" ]] && missing+=(--branch)
+[[ -z "$mac"    ]] && missing+=(--mac)
+[[ -z "$win"    ]] && missing+=(--win)
+[[ -z "$linux"  ]] && missing+=(--linux)
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "Missing required argument(s): ${missing[*]}" >&2
+  echo
+  usage
+fi
+
+# Local extension sanity check -- catches the most common paste error
+# (wrong URL in the wrong slot) before involving GitHub at all.
+[[ "$mac"   == *.dmg ]] || { echo "macOS URL must end in .dmg: $mac" >&2;   exit 2; }
+[[ "$win"   == *.exe ]] || { echo "Windows URL must end in .exe: $win" >&2; exit 2; }
+[[ "$linux" == *.deb ]] || { echo "Linux URL must end in .deb: $linux" >&2; exit 2; }
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI not found on PATH. Install https://cli.github.com and run 'gh auth login'." >&2
+  exit 3
+fi
+
+echo "Dispatching cert run on $REPO:"
+echo "  Branch:    $branch"
+echo "  macOS:     $mac"
+echo "  Windows:   $win"
+echo "  Linux:     $linux"
+[[ -n "$r_version"   ]] && echo "  R version: $r_version"
+[[ -n "$grep_invert" ]] && echo "  grep_invert: $grep_invert"
+echo
+
+args=(
+  --repo "$REPO"
+  --ref "$branch"
+  -f "mac_installer_url=$mac"
+  -f "win_installer_url=$win"
+  -f "linux_installer_url=$linux"
+)
+[[ -n "$r_version"   ]] && args+=(-f "r_version=$r_version")
+[[ -n "$grep_invert" ]] && args+=(-f "grep_invert=$grep_invert")
+
+gh workflow run "$WORKFLOW" "${args[@]}"
+
+cat <<MSG
+
+Cert run dispatched. View progress at:
+  https://github.com/$REPO/actions/workflows/$WORKFLOW
+
+(Use 'gh run watch' on the latest run for live status in the terminal.)
+MSG


### PR DESCRIPTION
Adds `.github/workflows/cert-e2e-rstudio.yml`, a `workflow_dispatch`-only workflow that fans out to the existing mac/win/linux-server reusables against three pinned installer URLs (a cert candidate's `.dmg`/`.exe`/`.deb`), and `scripts/run-cert-e2e.sh`, a thin `gh` CLI wrapper that drives the dispatch from one command on a release branch.

A `validate-inputs` job HEAD-checks each URL and asserts file extensions before the per-platform jobs start, so a typo'd or 404'd URL fails fast without burning hours of cross-platform runner time. The summary job emits a per-platform pass/fail table and fails the overall run if any platform did not succeed.

Draft until #17939 merges — the Linux Server reusable on the release branch still has the pre-#17939 input shape (no `build_from_source` / `post_pr_comment` / `workflow_call.secrets`); the `linux-server` job comment notes what to add once #17939 lands.

### Intent

Give release engineering a one-command way to drive the full E2E Playwright suite across macOS, Windows, and Linux Server against a *specific* cert candidate — the binaries the team has decided to certify, not a fresh source build and not "latest daily." Previously a cross-platform run against pinned installers meant manually dispatching three separate reusables, copying the same URL/R-version/grep_invert inputs into each, and hand-aggregating results. This collapses that into one dispatch on the release branch, with a single per-platform results table on the run summary.

### Approach

One dispatcher workflow + one shell wrapper, sitting on top of the existing per-platform reusables (no duplication of build/install/run logic):

- `validate-inputs` (Ubuntu, seconds): HEAD-checks each URL with `curl -sSL -I --fail` and asserts the file extension matches the slot (`.dmg`/`.exe`/`.deb`). Catches the most common paste error (wrong URL in the wrong slot) and 404'd builds before any expensive runner spins up. Also writes the run inputs to the step summary so the run page is self-documenting.
- Three platform jobs run in parallel via `workflow_call` into the existing reusables, all passing `build_from_source: false`, the corresponding `*_installer_url`, the shared `r_version` and `grep_invert`, and `post_pr_comment: false` (no PR context on a cert dispatch).
- `cert-summary` runs `if: always()`, prints a per-platform pass/fail table, and fails the overall run if any platform didn't succeed.
- Concurrency group is `cert-e2e-${{ github.ref }}` with `cancel-in-progress: true` — one cert at a time per release branch; re-dispatching the same branch cancels the previous in-flight cert rather than queueing.
- Default `grep_invert: '@ai'` skips credential-gated tests for unattended cert runs.

#### How to kick off a cert run

**Prereqs**

- `gh` CLI installed and authenticated against `rstudio/rstudio` (`gh auth status`).
- The three installer URLs from the cert candidate build (typically `dailies.rstudio.com`).
- This workflow already merged into the release branch you want to certify — `--branch` / `--ref` controls *both* which workflow file runs *and* which `e2e/` test cut is checked out on each runner, by design.

**Recommended: the wrapper script**

```bash
cd rstudio
scripts/run-cert-e2e.sh \
  --branch rel-blue-plumbago \
  --mac   https://dailies.rstudio.com/mac/RStudio-2026.06.0-123.dmg \
  --win   https://dailies.rstudio.com/windows/RStudio-2026.06.0-123.exe \
  --linux https://dailies.rstudio.com/ubuntu-24/rstudio-server-2026.06.0-123-amd64.deb
```

Optional flags:

- `--r-version <ver>` — R version to install via rig (default `release`). Keep consistent across platforms for a meaningful cert.
- `--grep-invert <pattern>` — Playwright `--grep-invert` (default `@ai`).

The script also extension-checks the URLs locally before touching GitHub, so a typo errors out instantly.

**Alternative: direct `gh`**

```bash
gh workflow run cert-e2e-rstudio.yml --repo rstudio/rstudio \
  --ref rel-blue-plumbago \
  -f mac_installer_url=https://... \
  -f win_installer_url=https://... \
  -f linux_installer_url=https://...
```

**Where to read the results**

- Run page → **Summary** panel: the "Certification run inputs" table (what was tested) and the "Certification results" table (which platform passed/failed).
- Per-platform Playwright reports uploaded as artifacts: `playwright-report-mac`, `playwright-report-win`, `playwright-report-linux`. Download, unzip, open `index.html` to triage failures.
- Each platform's job page links to its own merged report under "Upload Playwright report".

### Automated Tests

Workflow-of-workflows; no application code changed. Validated locally:

- `python3 -c 'import yaml; yaml.safe_load(open(...))'` parses the workflow.
- `bash -n scripts/run-cert-e2e.sh` parses.
- `./scripts/run-cert-e2e.sh --help` prints the full usage block.
- Local extension assertions exercised via dummy `.dmg`/`.exe`/`.deb` paths.

End-to-end validation is by definition the cert dispatch itself; once merged into a release branch we'll dispatch a dry run against a known daily and confirm the per-platform table renders and the summary gate fails if a platform fails.

### QA Notes

To smoke-test after merge:

1. From a release branch with this workflow present, dispatch via `scripts/run-cert-e2e.sh` with three valid daily URLs.
2. Confirm `validate-inputs` prints all three "OK" notices and the inputs table appears on the run summary.
3. Confirm the three platform jobs spin up in parallel against the pinned URLs (not a fresh build).
4. After completion, confirm the `cert-summary` results table is on the run summary and the three artifacts (`playwright-report-{mac,win,linux}`) are attached.

Negative path: dispatch with a `.dmg` URL pasted into the Windows slot. The wrapper's local check should reject it before `gh`; if you skip the wrapper, `validate-inputs` should fail-fast in <1 minute.

### Documentation

Inline:

- `cert-e2e-rstudio.yml` header documents the trigger and the `--ref` coupling between workflow file and `e2e/` test cut. Each job's comment block notes the reason for its inputs/secrets (the mac/win secrets block explains why `OP_SERVICE_ACCOUNT_TOKEN` is threaded through rather than `CONNECT_API_KEY`; the linux-server block notes what to add post-#17939).
- `scripts/run-cert-e2e.sh` header is the canonical usage doc — it's what `--help` prints.

No external docs (user/admin guides) are affected; this is internal release-engineering tooling.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
