### PR TITLE
tune .clang-format to match the existing C++ house style

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -345,8 +345,9 @@ When documenting R code, use Roxygen style for formatting. For example:
 C++ code is formatted with clang-format. The configuration is in `src/cpp/.clang-format`. Key settings:
 
 - 3-space indentation
-- Allman brace style
+- Allman brace style, except namespaces keep their opening brace on the same line (`namespace x {`)
 - No tabs
+- No column limit: clang-format does not re-wrap long lines, and include/using order and comment prose are left as written. It acts as a brace/indent/spacing normalizer, so running it over existing code stays low-churn.
 
 
 ### TypeScript (Desktop)

--- a/src/cpp/.clang-format
+++ b/src/cpp/.clang-format
@@ -1,8 +1,46 @@
 ---
+# This configuration is tuned to match the prevailing hand-written style of the
+# existing C++ sources rather than to impose a strict canonical layout. In
+# particular, clang-format is treated as a brace/indent/spacing normalizer, not
+# a line re-wrapper: ColumnLimit is 0 and comment/include/using reordering is
+# disabled so that running it over existing code does not churn deliberate
+# manual wrapping.
 BasedOnStyle: LLVM
+
+# 3-space indentation throughout; the continuation, constructor-initializer, and
+# access-modifier offsets are all kept in step with it (LLVM's defaults assume a
+# 2-space indent and otherwise drift out of alignment with the codebase).
 IndentWidth: 3
+ContinuationIndentWidth: 3
+ConstructorInitializerIndentWidth: 3
+AccessModifierOffset: -3
 UseTab: Never
-BreakBeforeBraces: Allman
+
+# Do not enforce a column limit. The sources contain many intentionally long
+# lines (signatures, string literals, comments) and manage their own wrapping;
+# a limit makes clang-format reflow them and produces large, noisy diffs.
+ColumnLimit: 0
+
+# Allman braces everywhere except namespaces, which keep their opening brace on
+# the same line (the universal convention in this codebase: "namespace x {").
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: false
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+
 AllowShortIfStatementsOnASingleLine: false
 IndentCaseLabels: false
 SpaceAfterCStyleCast: true
@@ -11,4 +49,11 @@ BinPackArguments: false
 BinPackParameters: false
 BreakConstructorInitializers: BeforeColon
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
+
+# Leave include order, using-declaration order, comment prose, and existing
+# blank-line grouping as the author wrote them.
+SortIncludes: false
+SortUsingDeclarations: false
+ReflowComments: false
+MaxEmptyLinesToKeep: 2
 ---


### PR DESCRIPTION
## Summary

The C++ `.clang-format` diverged heavily from how the sources are actually written, so the formatter was rarely run. This retunes the config so clang-format behaves as a brace/indent/spacing normalizer that leaves deliberate manual formatting alone, rather than a line re-wrapper that produces large noisy diffs.

Key changes (on top of the existing settings):

- **`ColumnLimit: 0`** -- stop reflowing the many intentionally long lines (signatures, string literals, comments). This was the single biggest source of churn.
- **Namespaces keep their opening brace on the same line** (`namespace x {`) via `BreakBeforeBraces: Custom` + `BraceWrapping.AfterNamespace: false`. All other braces remain Allman. Plain `Allman` was breaking every namespace brace.
- **`ContinuationIndentWidth`, `ConstructorInitializerIndentWidth`, `AccessModifierOffset`** set to track the 3-space indent (LLVM's defaults assume 2-space and drifted out of alignment).
- **`SortIncludes`, `SortUsingDeclarations`, `ReflowComments` disabled**; `MaxEmptyLinesToKeep: 2`. The repo doesn't sort includes/usings or reflow comment prose, and reordering includes can break compile order.

Also updates the C++ style note in `.claude/CLAUDE.md` to record the namespace-brace exception and the no-column-limit policy.

## How the settings were chosen

Settings were selected by measuring churn (lines clang-format would change) against the real sources, not by guessing:

- Old config: ~7,300 changed lines across a 60-file sample; ~56,800 across 243 recently-touched files.
- New config: roughly **halves** both (e.g. 55% reduction on a fresh sample).

Candidates that measured *worse* were rejected -- e.g. `AlignConsecutiveMacros` (aligned `#define` columns are a local exception, not the norm) and `AlignAfterOpenBracket: DontAlign`.

## Limitations

Residual churn is not zero and can't be: some hand-formatting (RPC key/value args paired two-per-line, fluent `ExecBlock` `()()` chains) is impossible for clang-format to reproduce. The remaining diffs are mostly legitimate normalization (trailing whitespace, `if ( x )` -> `if (x)`, `> >` -> `>>`). So this is a good low-churn normalizer, not a tool for blanket-reformatting the tree.

Validated that the config parses under clang-format 22 and that namespace / constructor-initializer output matches existing style exactly.

Developer-ergonomics / tooling change; no associated issue.