### PR TITLE
fix find-in-files Replace All results cleared by a stale preview

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/DebouncedCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/DebouncedCommand.java
@@ -45,6 +45,15 @@ public abstract class DebouncedCommand
       suspended_ = true;
    }
 
+   // Cancel a pending (scheduled-but-not-yet-fired) execution without latching
+   // the command off the way suspend() does -- subsequent nudges are still
+   // honored. Used to drop a debounced action that a newer action has made
+   // obsolete (e.g. cancelling a queued replace preview when Replace All runs).
+   public void cancelPending()
+   {
+      timer_.cancel();
+   }
+
    public void resume()
    {
       suspended_ = false;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPane.java
@@ -560,6 +560,16 @@ public class FindOutputPane extends WorkbenchPane
          replaceProgress_.setVisible(false);
    }
 
+   @Override
+   public void cancelReplacePreview()
+   {
+      // drop any queued replace preview so it cannot fire after a Replace All
+      // has begun -- a stale preview would stopAndClear the running replace and
+      // re-grep the just-modified files, dropping the real results
+      if (displayPreview_ != null)
+         displayPreview_.cancelPending();
+   }
+
    private void createDisplayPreview()
    {
       displayPreview_ = new DebouncedCommand(500)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
@@ -109,6 +109,7 @@ public class FindOutputPresenter extends BasePresenter
       void setReplaceAllButtonEnabled(boolean enabled);
       void turnOnReplaceMode();
       void turnOffReplaceMode();
+      void cancelReplacePreview();
 
       void showProgress();
       void hideProgress();
@@ -219,6 +220,14 @@ public class FindOutputPresenter extends BasePresenter
          @Override
          public void onPreviewReplace(PreviewReplaceEvent event)
          {
+            // ignore a preview that arrives while a find or replace is already
+            // running: it would stopAndClear the in-flight operation and (after
+            // a Replace All) re-grep the just-modified files, dropping the real
+            // results. The debounced preview is also cancelled when Replace All
+            // starts (cancelReplacePreview); this guards an already-queued event.
+            if (findInProgress_)
+               return;
+
             view_.setRegexPreviewMode(true);
             stopAndClear();
             dialogState_.clearResultsCount();
@@ -315,6 +324,11 @@ public class FindOutputPresenter extends BasePresenter
                      @Override
                      public void execute()
                      {
+                        // drop any queued replace preview before starting: a
+                        // preview firing mid-replace would stopAndClear this
+                        // operation and re-grep the just-modified files (see
+                        // onPreviewReplace), dropping the replace results
+                        view_.cancelReplacePreview();
                         stopAndClear();
                         // the replace runs its own grep; keep Replace All
                         // disabled until it completes (re-enabled when the

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
@@ -220,11 +220,12 @@ public class FindOutputPresenter extends BasePresenter
          @Override
          public void onPreviewReplace(PreviewReplaceEvent event)
          {
-            // ignore a preview that arrives while a find or replace is already
-            // running: it would stopAndClear the in-flight operation and (after
-            // a Replace All) re-grep the just-modified files, dropping the real
-            // results. The debounced preview is also cancelled when Replace All
-            // starts (cancelReplacePreview); this guards an already-queued event.
+            // ignore a preview that arrives while a find or Replace All is
+            // already running: it would stopAndClear the in-flight operation and
+            // (after a Replace All) re-grep the just-modified files, dropping the
+            // real results. The debounced preview is also cancelled when Replace
+            // All starts (cancelReplacePreview); this guards an already-queued
+            // event.
             if (findInProgress_)
                return;
 
@@ -369,6 +370,22 @@ public class FindOutputPresenter extends BasePresenter
                                                                         dialogState_.isWholeWord(),
                                                                         dialogState_.isRegex(),
                                                                         view_.getReplaceText());
+                                                   }
+
+                                                   @Override
+                                                   public void onError(ServerError error)
+                                                   {
+                                                      // a failed replace fires no
+                                                      // FindOperationEndedEvent, so reset the
+                                                      // in-progress state here; otherwise Replace
+                                                      // All and the regex preview stay disabled
+                                                      // for the rest of the session
+                                                      Debug.logError(error);
+                                                      findInProgress_ = false;
+                                                      stopAndClear();
+                                                      view_.setStopReplaceButtonVisible(false);
+                                                      view_.hideProgress();
+                                                      view_.enableReplace();
                                                    }
                                                 });
                      }
@@ -758,10 +775,13 @@ public class FindOutputPresenter extends BasePresenter
    private String currentFindHandle_;
    // true while a find or replace grep operation is in flight; used to keep the
    // Replace All action disabled until it has finished or been stopped, so a new
-   // replace cannot overlap a still-running one. (A transient replace preview is
-   // intentionally not gated here -- the user keeps editing while it runs, and a
-   // Replace All that supersedes it is made safe by GrepOperation::onStdout in
-   // SessionFind.cpp dropping the stale operation's buffered output.)
+   // replace cannot overlap a still-running one. A transient replace preview does
+   // not itself set this flag -- the user keeps editing while it runs -- but a
+   // preview that arrives while a find or Replace All is in flight is now dropped
+   // in onPreviewReplace, so it cannot stopAndClear the in-flight operation and
+   // re-grep the just-modified files. (A preview superseding an earlier preview
+   // is still handled server-side by GrepOperation::onStdout in SessionFind.cpp
+   // dropping the stale operation's buffered output.)
    private boolean findInProgress_;
    private FindInFilesDialog.State dialogState_;
 

--- a/src/gwt/test/org/rstudio/core/client/DebouncedCommandTests.java
+++ b/src/gwt/test/org/rstudio/core/client/DebouncedCommandTests.java
@@ -1,0 +1,150 @@
+/*
+ * DebouncedCommandTests.java
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client;
+
+import com.google.gwt.junit.client.GWTTestCase;
+import com.google.gwt.user.client.Timer;
+
+public class DebouncedCommandTests extends GWTTestCase
+{
+   @Override
+   public String getModuleName()
+   {
+      return "org.rstudio.studio.RStudioTests";
+   }
+
+   // a DebouncedCommand that counts how many times it has executed
+   private static class CountingCommand extends DebouncedCommand
+   {
+      CountingCommand(int delayMs)
+      {
+         super(delayMs);
+      }
+
+      @Override
+      protected void execute()
+      {
+         executeCount++;
+      }
+
+      int executeCount = 0;
+   }
+
+   // baseline: a nudge() executes once the delay elapses
+   public void testNudgeFiresAfterDelay()
+   {
+      final CountingCommand cmd = new CountingCommand(DELAY_MS);
+
+      delayTestFinish(TEST_TIMEOUT_MS);
+      cmd.nudge();
+
+      new Timer()
+      {
+         @Override
+         public void run()
+         {
+            assertEquals(1, cmd.executeCount);
+            finishTest();
+         }
+      }.schedule(CHECK_MS);
+   }
+
+   // cancelPending() drops a queued execution: the nudged command never fires
+   public void testCancelPendingDropsQueuedExecution()
+   {
+      final CountingCommand cmd = new CountingCommand(DELAY_MS);
+
+      delayTestFinish(TEST_TIMEOUT_MS);
+      cmd.nudge();
+      cmd.cancelPending();
+
+      new Timer()
+      {
+         @Override
+         public void run()
+         {
+            assertEquals(0, cmd.executeCount);
+            finishTest();
+         }
+      }.schedule(CHECK_MS);
+   }
+
+   // the contract that distinguishes cancelPending() from suspend(): a nudge()
+   // after cancelPending() is still honored and fires
+   public void testNudgeAfterCancelPendingStillFires()
+   {
+      final CountingCommand cmd = new CountingCommand(DELAY_MS);
+
+      delayTestFinish(TEST_TIMEOUT_MS);
+      cmd.nudge();
+      cmd.cancelPending();
+      cmd.nudge();
+
+      new Timer()
+      {
+         @Override
+         public void run()
+         {
+            assertEquals(1, cmd.executeCount);
+            finishTest();
+         }
+      }.schedule(CHECK_MS);
+   }
+
+   // by contrast, suspend() latches the command off: a later nudge() does not fire
+   public void testNudgeAfterSuspendDoesNotFire()
+   {
+      final CountingCommand cmd = new CountingCommand(DELAY_MS);
+
+      delayTestFinish(TEST_TIMEOUT_MS);
+      cmd.suspend();
+      cmd.nudge();
+
+      new Timer()
+      {
+         @Override
+         public void run()
+         {
+            assertEquals(0, cmd.executeCount);
+            finishTest();
+         }
+      }.schedule(CHECK_MS);
+   }
+
+   // resume() re-enables a suspended command so that nudge() fires again
+   public void testNudgeAfterResumeFires()
+   {
+      final CountingCommand cmd = new CountingCommand(DELAY_MS);
+
+      delayTestFinish(TEST_TIMEOUT_MS);
+      cmd.suspend();
+      cmd.resume();
+      cmd.nudge();
+
+      new Timer()
+      {
+         @Override
+         public void run()
+         {
+            assertEquals(1, cmd.executeCount);
+            finishTest();
+         }
+      }.schedule(CHECK_MS);
+   }
+
+   private static final int DELAY_MS = 50;
+   private static final int CHECK_MS = 300;
+   private static final int TEST_TIMEOUT_MS = 2000;
+}

--- a/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
+++ b/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client;
 
 import org.rstudio.core.client.AnsiCodeTests;
 import org.rstudio.core.client.ConsoleOutputWriterTests;
+import org.rstudio.core.client.DebouncedCommandTests;
 import org.rstudio.core.client.ElementIdsTests;
 import org.rstudio.core.client.SafeHtmlUtilTests;
 import org.rstudio.core.client.StringUtilTests;
@@ -52,6 +53,7 @@ public class RStudioUnitTestSuite extends GWTTestSuite
       suite.addTestSuite(VirtualConsoleTests.class); // SLOW
       suite.addTestSuite(ConsoleOutputWriterTests.class); // SLOW
       suite.addTestSuite(StringUtilTests.class);
+      suite.addTestSuite(DebouncedCommandTests.class);
       suite.addTestSuite(DomUtilsTests.class);
       suite.addTestSuite(AnsiCodeTests.class);
       suite.addTestSuite(TerminalLocalEchoTests.class);


### PR DESCRIPTION
## Summary

Find in Files "Replace All" would intermittently end on "(No results found)" even though the replacement was correctly written to disk. This was the flaky failure of the `find_in_files_replace.test.ts` > "omits all-no-op lines..." e2e test.

## Root cause

`FindOutputPane.displayPreview_` is a 500ms `DebouncedCommand`, nudged as the user types in the replace box. For a **regex** replace it dispatches `PreviewReplaceEvent`; its handler (`onPreviewReplace`) calls `stopAndClear()` and starts a fresh preview grep.

When the replacement is typed and Replace All is clicked within that 500ms window, the debounced preview fires **after** Replace All has started. It then:

1. `stopAndClear()`s the in-flight replace grep and wipes the results table, and
2. re-greps the **already-replaced** files.

Since #17995 omits no-op matches, the re-grep over post-replace content (where the match now equals the replacement, e.g. `cat` matched by `/c.t/` -> `cat`) drops every line, leaving the pane on "(No results found)". The on-disk replacement is correct and atomic (`writeStringToFileAtomic`); only the displayed results are lost.

It's timing-dependent (hence flaky): if the debounce fires before the click, the preview runs on pre-replace content and Replace All then repaints cleanly.

The underlying race -- a stale preview superseding Replace All -- predates #17995; #17995 (unreleased) is what turned the outcome into a visible empty result.

## Fix

- **Cancel** any queued replace preview when Replace All starts (`DebouncedCommand.cancelPending()` + `view_.cancelReplacePreview()`), so the stale preview never fires.
- **Guard** `onPreviewReplace` to ignore a `PreviewReplaceEvent` that arrives while a find/replace is already in progress (`findInProgress_`), covering an event already queued when the cancel runs.

## Testing

`cd src/gwt && ant javac` passes. The existing "omits all-no-op lines" e2e test (reverted to its committed form) exercises this path; with the fix the stale preview no longer clobbers the results. CI's desktop e2e shards run it directly.

No NEWS.md entry: the visible empty-results behavior is a regression from the unreleased #17995, which the project's NEWS convention excludes.

Discovered while investigating an unrelated CI flake; no separate tracking issue.