### PR TITLE
make builds resolve gitignored deps from the primary git worktree

### DIFF
--- a/.claude/skills/rstudio-update-nodejs/SKILL.md
+++ b/.claude/skills/rstudio-update-nodejs/SKILL.md
@@ -108,6 +108,11 @@ NODE_PATH=$(realpath ../../../dependencies/common/node/<VERSION>/bin)
 set(RSTUDIO_NODE_VERSION "<VERSION>")
 ```
 
+**`e2e/rstudio/scripts/dev-common.ts`** (~line 15) — TypeScript constant used by the dev Playwright runners to pin node on PATH:
+```ts
+const PINNED_NODE_VERSION = '<VERSION>';
+```
+
 **`src/node/desktop/.vscode/settings.json`** (~line 81) — JSON string with backslash path separators:
 ```json
 "PATH": "${workspaceFolder}\\..\\..\\..\\dependencies\\common\\node\\<VERSION>;${env:PATH}"

--- a/cmake/git-worktree.cmake
+++ b/cmake/git-worktree.cmake
@@ -1,0 +1,38 @@
+# git-worktree.cmake
+#
+# Resolves the primary git worktree (the main checkout) so that a build run from
+# a secondary `git worktree` can locate downloaded dependencies. Those deps
+# (node, gwtproject, quarto, etc.) are gitignored, so they are only ever
+# populated in the primary checkout -- a freshly added worktree has empty
+# dependency directories. Resolving the primary worktree lets the build borrow
+# them instead of failing or requiring a manual re-install/symlink. This mirrors
+# the ${git.main.worktree} resolution already done in src/gwt/build.xml.
+#
+# Sets RSTUDIO_GIT_MAIN_WORKTREE to the primary worktree root, or leaves it
+# empty when not in a git checkout (or git is unavailable) -- callers must
+# tolerate an empty value and fall back to their existing behavior.
+
+if(DEFINED RSTUDIO_GIT_MAIN_WORKTREE)
+   return()
+endif()
+
+set(RSTUDIO_GIT_MAIN_WORKTREE "" CACHE INTERNAL "Primary git worktree root (source of shared, gitignored dependencies)")
+
+find_program(RSTUDIO_GIT_EXECUTABLE git)
+if(RSTUDIO_GIT_EXECUTABLE)
+   # --git-common-dir resolves to the *primary* checkout's .git directory even
+   # from a linked worktree; its parent is that checkout's working tree.
+   execute_process(
+      COMMAND "${RSTUDIO_GIT_EXECUTABLE}" rev-parse --path-format=absolute --git-common-dir
+      WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
+      OUTPUT_VARIABLE _rstudio_git_common_dir
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+      RESULT_VARIABLE _rstudio_git_result)
+
+   if(_rstudio_git_result EQUAL 0 AND _rstudio_git_common_dir)
+      get_filename_component(_rstudio_main_worktree "${_rstudio_git_common_dir}" DIRECTORY)
+      set(RSTUDIO_GIT_MAIN_WORKTREE "${_rstudio_main_worktree}" CACHE INTERNAL "Primary git worktree root (source of shared, gitignored dependencies)" FORCE)
+      message(STATUS "Primary git worktree: ${RSTUDIO_GIT_MAIN_WORKTREE}")
+   endif()
+endif()

--- a/cmake/globals.cmake
+++ b/cmake/globals.cmake
@@ -139,6 +139,12 @@ endif()
 # recompile from scratch) reuse cached objects. Off for non-development builds
 # (CI/official packaging) and opt-out via -DRSTUDIO_USE_CCACHE=OFF.
 #
+# Note RSTUDIO_DEVELOPMENT is only set when no RSTUDIO_TARGET was given (the
+# inferred-development case above); a build that passes -DRSTUDIO_TARGET=Development
+# explicitly is intentionally excluded here (pass -DRSTUDIO_USE_CCACHE=ON to opt
+# in). RSTUDIO_DEVELOPMENT is a build-wide toggle (see src/cpp/CMakeLists.txt),
+# so we don't widen it just for the cache.
+#
 # CI/package builds opt into sccache explicitly via SCCACHE_ENABLED, which is
 # wired up separately (see cmake/modules/sccache.cmake, included below); defer
 # to it so the two mechanisms never both configure a launcher.
@@ -160,38 +166,29 @@ if(RSTUDIO_USE_CCACHE AND
    endif()
 
    # ccache and sccache both work as compiler launchers ("<tool> <compiler>
-   # <args>"); prefer ccache, fall back to sccache. Validate each via --version
-   # with an anchored match: this rejects a 'ccache' that is really a symlink to
+   # <args>"); prefer ccache, fall back to sccache (ccache is listed first in the
+   # loop, and we break on the first match). Validate each via --version with an
+   # anchored "^<name>" match: this rejects a 'ccache' that is really a symlink to
    # sccache (its --version reports "sccache ...", and sccache invoked under the
    # name 'ccache' misparses cmake's -E probes and breaks the build). When that
-   # happens we still find the real sccache by its own name below and use it.
+   # happens we fall through and find the genuine sccache by its own name.
    set(RSTUDIO_COMPILER_CACHE "")
 
-   find_program(CCACHE_EXECUTABLE NAMES ccache HINTS "${RSTUDIO_HOMEBREW_BIN}")
-   if(CCACHE_EXECUTABLE)
-      execute_process(
-         COMMAND "${CCACHE_EXECUTABLE}" --version
-         OUTPUT_VARIABLE RSTUDIO_CACHE_VERSION
-         ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
-         RESULT_VARIABLE RSTUDIO_CACHE_RESULT)
-      if(RSTUDIO_CACHE_RESULT EQUAL 0 AND RSTUDIO_CACHE_VERSION MATCHES "^ccache")
-         set(RSTUDIO_COMPILER_CACHE "${CCACHE_EXECUTABLE}")
-      endif()
-   endif()
-
-   if(NOT RSTUDIO_COMPILER_CACHE)
-      find_program(SCCACHE_EXECUTABLE NAMES sccache HINTS "${RSTUDIO_HOMEBREW_BIN}")
-      if(SCCACHE_EXECUTABLE)
+   foreach(_cache_name ccache sccache)
+      string(TOUPPER "${_cache_name}" _cache_var)
+      find_program(${_cache_var}_EXECUTABLE NAMES ${_cache_name} HINTS "${RSTUDIO_HOMEBREW_BIN}")
+      if(${_cache_var}_EXECUTABLE)
          execute_process(
-            COMMAND "${SCCACHE_EXECUTABLE}" --version
+            COMMAND "${${_cache_var}_EXECUTABLE}" --version
             OUTPUT_VARIABLE RSTUDIO_CACHE_VERSION
             ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
             RESULT_VARIABLE RSTUDIO_CACHE_RESULT)
-         if(RSTUDIO_CACHE_RESULT EQUAL 0 AND RSTUDIO_CACHE_VERSION MATCHES "^sccache")
-            set(RSTUDIO_COMPILER_CACHE "${SCCACHE_EXECUTABLE}")
+         if(RSTUDIO_CACHE_RESULT EQUAL 0 AND RSTUDIO_CACHE_VERSION MATCHES "^${_cache_name}")
+            set(RSTUDIO_COMPILER_CACHE "${${_cache_var}_EXECUTABLE}")
+            break()
          endif()
       endif()
-   endif()
+   endforeach()
 
    if(RSTUDIO_COMPILER_CACHE)
       set(CMAKE_C_COMPILER_LAUNCHER "${RSTUDIO_COMPILER_CACHE}" CACHE STRING "")

--- a/cmake/globals.cmake
+++ b/cmake/globals.cmake
@@ -138,7 +138,12 @@ endif()
 # themselves. This makes repeat and git-worktree builds (which otherwise
 # recompile from scratch) reuse cached objects. Off for non-development builds
 # (CI/official packaging) and opt-out via -DRSTUDIO_USE_CCACHE=OFF.
-if(RSTUDIO_DEVELOPMENT AND NOT DEFINED RSTUDIO_USE_CCACHE)
+#
+# CI/package builds opt into sccache explicitly via SCCACHE_ENABLED, which is
+# wired up separately (see cmake/modules/sccache.cmake, included below); defer
+# to it so the two mechanisms never both configure a launcher.
+if(RSTUDIO_DEVELOPMENT AND NOT DEFINED RSTUDIO_USE_CCACHE AND
+   NOT SCCACHE_ENABLED AND NOT "$ENV{SCCACHE_ENABLED}")
    set(RSTUDIO_USE_CCACHE ON)
 endif()
 if(RSTUDIO_USE_CCACHE AND

--- a/cmake/globals.cmake
+++ b/cmake/globals.cmake
@@ -133,6 +133,41 @@ if(NOT RSTUDIO_TARGET)
 
 endif()
 
+# For development builds, route compilation through ccache when it is available
+# and the user has not configured a launcher themselves. This makes repeat and
+# git-worktree builds (which otherwise recompile from scratch) reuse cached
+# objects. Off for non-development builds (CI/official packaging) and opt-out via
+# -DRSTUDIO_USE_CCACHE=OFF.
+if(RSTUDIO_DEVELOPMENT AND NOT DEFINED RSTUDIO_USE_CCACHE)
+   set(RSTUDIO_USE_CCACHE ON)
+endif()
+if(RSTUDIO_USE_CCACHE AND
+   NOT DEFINED CMAKE_CXX_COMPILER_LAUNCHER AND
+   NOT DEFINED CMAKE_C_COMPILER_LAUNCHER)
+   find_program(CCACHE_EXECUTABLE ccache)
+   if(CCACHE_EXECUTABLE)
+      # Confirm this is genuine ccache before using it as a compiler launcher. A
+      # 'ccache' on PATH is sometimes actually sccache (or another shim) that
+      # rejects the -E compiler-feature probes CMake runs for bundled
+      # dependencies, which breaks the build outright. ccache --version prints
+      # "ccache version ..."; sccache prints "sccache ..." (note: "sccache"
+      # contains "ccache", so anchor the match).
+      execute_process(
+         COMMAND "${CCACHE_EXECUTABLE}" --version
+         OUTPUT_VARIABLE CCACHE_VERSION_OUTPUT
+         ERROR_QUIET
+         OUTPUT_STRIP_TRAILING_WHITESPACE
+         RESULT_VARIABLE CCACHE_VERSION_RESULT)
+      if(CCACHE_VERSION_RESULT EQUAL 0 AND CCACHE_VERSION_OUTPUT MATCHES "^ccache")
+         set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}" CACHE STRING "")
+         set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}" CACHE STRING "")
+         message(STATUS "Using ccache: ${CCACHE_EXECUTABLE}")
+      else()
+         message(STATUS "Skipping compiler cache: '${CCACHE_EXECUTABLE}' is not genuine ccache")
+      endif()
+   endif()
+endif()
+
 # set desktop and server build flags
 if(NOT DEFINED RSTUDIO_SERVER)
    if(NOT WIN32 AND (RSTUDIO_TARGET STREQUAL "Development" OR RSTUDIO_TARGET STREQUAL "Server"))
@@ -306,6 +341,20 @@ endif()
 # look for dependencies in the source folder if not installed globally
 if(NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}")
    set(RSTUDIO_DEPENDENCIES_DIR "${RSTUDIO_PROJECT_ROOT}/dependencies")
+endif()
+
+# When building from a secondary git worktree, downloaded dependencies are not
+# present in this checkout -- they are gitignored, so they only ever live in the
+# primary checkout. If the resolved dependencies directory has no downloaded
+# content, borrow the primary worktree's instead so worktree builds work without
+# a re-install or manual symlink (mirrors src/gwt/build.xml).
+if(NOT WIN32 AND NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}/common/node")
+   include("${CMAKE_CURRENT_LIST_DIR}/git-worktree.cmake")
+   if(RSTUDIO_GIT_MAIN_WORKTREE AND
+      EXISTS "${RSTUDIO_GIT_MAIN_WORKTREE}/dependencies/common/node")
+      set(RSTUDIO_DEPENDENCIES_DIR "${RSTUDIO_GIT_MAIN_WORKTREE}/dependencies")
+      message(STATUS "Using primary-worktree dependencies: ${RSTUDIO_DEPENDENCIES_DIR}")
+   endif()
 endif()
 
 # tools

--- a/cmake/globals.cmake
+++ b/cmake/globals.cmake
@@ -133,38 +133,65 @@ if(NOT RSTUDIO_TARGET)
 
 endif()
 
-# For development builds, route compilation through ccache when it is available
-# and the user has not configured a launcher themselves. This makes repeat and
-# git-worktree builds (which otherwise recompile from scratch) reuse cached
-# objects. Off for non-development builds (CI/official packaging) and opt-out via
-# -DRSTUDIO_USE_CCACHE=OFF.
+# For development builds, route compilation through a compiler cache (ccache or
+# sccache) when one is available and the user has not configured a launcher
+# themselves. This makes repeat and git-worktree builds (which otherwise
+# recompile from scratch) reuse cached objects. Off for non-development builds
+# (CI/official packaging) and opt-out via -DRSTUDIO_USE_CCACHE=OFF.
 if(RSTUDIO_DEVELOPMENT AND NOT DEFINED RSTUDIO_USE_CCACHE)
    set(RSTUDIO_USE_CCACHE ON)
 endif()
 if(RSTUDIO_USE_CCACHE AND
    NOT DEFINED CMAKE_CXX_COMPILER_LAUNCHER AND
    NOT DEFINED CMAKE_C_COMPILER_LAUNCHER)
-   find_program(CCACHE_EXECUTABLE ccache)
+
+   # Search the architecture-appropriate Homebrew prefix first so a native tool
+   # is preferred over, e.g., an x86_64 binary in the Intel-Homebrew tree
+   # (/usr/local) on Apple Silicon.
+   if(APPLE AND UNAME_M STREQUAL "arm64")
+      set(RSTUDIO_HOMEBREW_BIN "/opt/homebrew/bin")
+   else()
+      set(RSTUDIO_HOMEBREW_BIN "/usr/local/bin")
+   endif()
+
+   # ccache and sccache both work as compiler launchers ("<tool> <compiler>
+   # <args>"); prefer ccache, fall back to sccache. Validate each via --version
+   # with an anchored match: this rejects a 'ccache' that is really a symlink to
+   # sccache (its --version reports "sccache ...", and sccache invoked under the
+   # name 'ccache' misparses cmake's -E probes and breaks the build). When that
+   # happens we still find the real sccache by its own name below and use it.
+   set(RSTUDIO_COMPILER_CACHE "")
+
+   find_program(CCACHE_EXECUTABLE NAMES ccache HINTS "${RSTUDIO_HOMEBREW_BIN}")
    if(CCACHE_EXECUTABLE)
-      # Confirm this is genuine ccache before using it as a compiler launcher. A
-      # 'ccache' on PATH is sometimes actually sccache (or another shim) that
-      # rejects the -E compiler-feature probes CMake runs for bundled
-      # dependencies, which breaks the build outright. ccache --version prints
-      # "ccache version ..."; sccache prints "sccache ..." (note: "sccache"
-      # contains "ccache", so anchor the match).
       execute_process(
          COMMAND "${CCACHE_EXECUTABLE}" --version
-         OUTPUT_VARIABLE CCACHE_VERSION_OUTPUT
-         ERROR_QUIET
-         OUTPUT_STRIP_TRAILING_WHITESPACE
-         RESULT_VARIABLE CCACHE_VERSION_RESULT)
-      if(CCACHE_VERSION_RESULT EQUAL 0 AND CCACHE_VERSION_OUTPUT MATCHES "^ccache")
-         set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}" CACHE STRING "")
-         set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}" CACHE STRING "")
-         message(STATUS "Using ccache: ${CCACHE_EXECUTABLE}")
-      else()
-         message(STATUS "Skipping compiler cache: '${CCACHE_EXECUTABLE}' is not genuine ccache")
+         OUTPUT_VARIABLE RSTUDIO_CACHE_VERSION
+         ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
+         RESULT_VARIABLE RSTUDIO_CACHE_RESULT)
+      if(RSTUDIO_CACHE_RESULT EQUAL 0 AND RSTUDIO_CACHE_VERSION MATCHES "^ccache")
+         set(RSTUDIO_COMPILER_CACHE "${CCACHE_EXECUTABLE}")
       endif()
+   endif()
+
+   if(NOT RSTUDIO_COMPILER_CACHE)
+      find_program(SCCACHE_EXECUTABLE NAMES sccache HINTS "${RSTUDIO_HOMEBREW_BIN}")
+      if(SCCACHE_EXECUTABLE)
+         execute_process(
+            COMMAND "${SCCACHE_EXECUTABLE}" --version
+            OUTPUT_VARIABLE RSTUDIO_CACHE_VERSION
+            ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
+            RESULT_VARIABLE RSTUDIO_CACHE_RESULT)
+         if(RSTUDIO_CACHE_RESULT EQUAL 0 AND RSTUDIO_CACHE_VERSION MATCHES "^sccache")
+            set(RSTUDIO_COMPILER_CACHE "${SCCACHE_EXECUTABLE}")
+         endif()
+      endif()
+   endif()
+
+   if(RSTUDIO_COMPILER_CACHE)
+      set(CMAKE_C_COMPILER_LAUNCHER "${RSTUDIO_COMPILER_CACHE}" CACHE STRING "")
+      set(CMAKE_CXX_COMPILER_LAUNCHER "${RSTUDIO_COMPILER_CACHE}" CACHE STRING "")
+      message(STATUS "Using compiler cache: ${RSTUDIO_COMPILER_CACHE}")
    endif()
 endif()
 

--- a/e2e/rstudio/scripts/dev-common.ts
+++ b/e2e/rstudio/scripts/dev-common.ts
@@ -3,12 +3,58 @@
 // that a `npm run test:*-dev` invocation actually exercises the user's
 // uncommitted changes.
 
-import { spawn, spawnSync } from 'node:child_process';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 export const REPO_ROOT = path.resolve(__dirname, '../../..');
 export const BUILD_DIR = path.join(REPO_ROOT, 'build');
+
+// The pinned node toolchain version (keep in sync with RSTUDIO_NODE_VERSION in
+// dependencies/tools/rstudio-tools.sh and the cmake/ant builds).
+const PINNED_NODE_VERSION = '22.22.2';
+
+// Resolve the primary git worktree (main checkout). Downloaded deps are
+// gitignored, so a secondary worktree must borrow them from the primary --
+// matching the resolution in cmake/git-worktree.cmake and src/gwt/build.xml.
+function gitMainWorktree(): string | null {
+  try {
+    const out = execFileSync('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    }).trim();
+    return out ? path.dirname(out) : null;
+  } catch {
+    return null;
+  }
+}
+
+// Locate the pinned node's bin directory: this checkout, then the primary
+// worktree, then the global tools location. Returns null if none has it.
+export function pinnedNodeBinDir(): string | null {
+  const arch = process.arch === 'arm64' ? '-arm64' : '';
+  const rel = path.join('dependencies', 'common', 'node', `${PINNED_NODE_VERSION}${arch}`, 'bin');
+  const roots = [REPO_ROOT, gitMainWorktree(), '/opt/rstudio-tools'].filter(
+    (r): r is string => !!r,
+  );
+  const exe = process.platform === 'win32' ? 'node.exe' : 'node';
+  for (const root of roots) {
+    const bin = path.join(root, rel);
+    if (fs.existsSync(path.join(bin, exe)))
+      return bin;
+  }
+  return null;
+}
+
+// process.env.PATH with the pinned node bin prepended, so spawned npm /
+// electron-forge / npx use the project's node rather than whatever is on the
+// developer's system PATH (a mismatched system node breaks npm postinstall).
+export function pathWithPinnedNode(): string {
+  const sep = path.delimiter;
+  const current = process.env.PATH ?? '';
+  const bin = pinnedNodeBinDir();
+  return bin ? `${bin}${sep}${current}` : current;
+}
 
 // The e2e/rstudio directory (where the npm scripts run and where Playwright
 // writes its reports). Resolved from this script's location so it's correct
@@ -308,7 +354,7 @@ export function runPlaywright(
 
   const child = spawn(npx, args, {
     stdio: 'inherit',
-    env: { ...process.env, ...reportEnv, ...env },
+    env: { ...process.env, PATH: pathWithPinnedNode(), ...reportEnv, ...env },
     // POSIX: give the child its own process group so a terminal Ctrl-C is
     // delivered only to this launcher, not also straight to the child group.
     // The launcher then forwards a single, well-timed signal (see below)

--- a/e2e/rstudio/scripts/dev-common.ts
+++ b/e2e/rstudio/scripts/dev-common.ts
@@ -32,7 +32,10 @@ function gitMainWorktree(): string | null {
 // Locate the pinned node's bin directory: this checkout, then the primary
 // worktree, then the global tools location. Returns null if none has it.
 export function pinnedNodeBinDir(): string | null {
-  const arch = process.arch === 'arm64' ? '-arm64' : '';
+  // The '-arm64' dir suffix is a macOS-only convention in this repo (see
+  // rstudio-tools.sh and CMakeNodeTools.txt); on Linux aarch64 node lives in an
+  // unsuffixed dir, so only apply the suffix on Darwin arm64.
+  const arch = process.platform === 'darwin' && process.arch === 'arm64' ? '-arm64' : '';
   const rel = path.join('dependencies', 'common', 'node', `${PINNED_NODE_VERSION}${arch}`, 'bin');
   const roots = [REPO_ROOT, gitMainWorktree(), '/opt/rstudio-tools'].filter(
     (r): r is string => !!r,
@@ -53,7 +56,18 @@ export function pathWithPinnedNode(): string {
   const sep = path.delimiter;
   const current = process.env.PATH ?? '';
   const bin = pinnedNodeBinDir();
-  return bin ? `${bin}${sep}${current}` : current;
+  if (!bin) {
+    // The whole point of this helper is to avoid a mismatched system node, so
+    // leave a breadcrumb when we couldn't find the pinned one and fall back to
+    // whatever PATH already has.
+    console.warn(
+      `warning: pinned node ${PINNED_NODE_VERSION} not found in this checkout, the primary ` +
+        'worktree, or /opt/rstudio-tools; spawned npm/npx will use the system node on PATH ' +
+        '(a mismatched version may break npm postinstall).',
+    );
+    return current;
+  }
+  return `${bin}${sep}${current}`;
 }
 
 // The e2e/rstudio directory (where the npm scripts run and where Playwright

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -501,6 +501,14 @@ set(RSTUDIO_PANMIRROR_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/../../gwt/lib/quarto/pa
 if(NOT EXISTS "${RSTUDIO_PANMIRROR_SCRIPT}")
    set(RSTUDIO_PANMIRROR_SCRIPT ${RSTUDIO_TOOLS_ROOT}/../src/gwt/lib/quarto/packages/editor-server/src/resources/md-writer.lua)
 endif()
+# quarto is gitignored, so a secondary git worktree won't have it in its source
+# tree -- fall back to the primary checkout's copy (see cmake/git-worktree.cmake)
+if(NOT EXISTS "${RSTUDIO_PANMIRROR_SCRIPT}")
+   include("${CMAKE_SOURCE_DIR}/cmake/git-worktree.cmake")
+   if(RSTUDIO_GIT_MAIN_WORKTREE)
+      set(RSTUDIO_PANMIRROR_SCRIPT ${RSTUDIO_GIT_MAIN_WORKTREE}/src/gwt/lib/quarto/packages/editor-server/src/resources/md-writer.lua)
+   endif()
+endif()
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/resources/panmirror-scripts)
 configure_file(${RSTUDIO_PANMIRROR_SCRIPT}
                ${CMAKE_CURRENT_SOURCE_DIR}/resources/panmirror-scripts/ COPYONLY)

--- a/src/node/CMakeNodeTools.txt
+++ b/src/node/CMakeNodeTools.txt
@@ -37,14 +37,19 @@ endif()
 
 if(APPLE AND UNAME_M STREQUAL arm64)
 
-   # make sure we're using arm64 binaries of node / npm for arm64 builds
-   set(NODE_BIN_DIR "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}-arm64/bin")
-   if(NOT EXISTS "${NODE_BIN_DIR}" AND RSTUDIO_WORKTREE_NODE_DIR)
-      set(NODE_BIN_DIR "${RSTUDIO_WORKTREE_NODE_DIR}-arm64/bin")
+   # make sure we're using arm64 binaries of node / npm for arm64 builds; search
+   # this checkout first, then the primary worktree. Use find_program (like the
+   # else branch) so a missing path leaves the var empty and trips the clear
+   # "not found" error below rather than passing a bogus path on to first use.
+   set(RSTUDIO_NODE_ARM64_PATHS
+      "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}-arm64")
+   if(RSTUDIO_WORKTREE_NODE_DIR)
+      list(APPEND RSTUDIO_NODE_ARM64_PATHS "${RSTUDIO_WORKTREE_NODE_DIR}-arm64")
    endif()
-   set(NODEJS "${NODE_BIN_DIR}/node")
-   set(NPM    "${NODE_BIN_DIR}/npm")
-   set(NPX    "${NODE_BIN_DIR}/npx")
+
+   find_program(NODEJS NAMES node NO_DEFAULT_PATH PATH_SUFFIXES "bin" PATHS ${RSTUDIO_NODE_ARM64_PATHS})
+   find_program(NPM    NAMES npm  NO_DEFAULT_PATH PATH_SUFFIXES "bin" PATHS ${RSTUDIO_NODE_ARM64_PATHS})
+   find_program(NPX    NAMES npx  NO_DEFAULT_PATH PATH_SUFFIXES "bin" PATHS ${RSTUDIO_NODE_ARM64_PATHS})
 
 else()
 

--- a/src/node/CMakeNodeTools.txt
+++ b/src/node/CMakeNodeTools.txt
@@ -27,15 +27,24 @@ endif()
 
 # set cmake env vars for node (NODEJS) and node tools, like YARN, and NPM
 
+# resolve the primary git worktree so a secondary worktree (whose downloaded
+# deps are gitignored and hence empty) can borrow the primary checkout's node
+include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/git-worktree.cmake")
+set(RSTUDIO_WORKTREE_NODE_DIR "")
+if(RSTUDIO_GIT_MAIN_WORKTREE)
+   set(RSTUDIO_WORKTREE_NODE_DIR "${RSTUDIO_GIT_MAIN_WORKTREE}/dependencies/common/node/${RSTUDIO_NODE_VERSION}")
+endif()
+
 if(APPLE AND UNAME_M STREQUAL arm64)
 
    # make sure we're using arm64 binaries of node / npm for arm64 builds
-   set(NODEJS 
-      "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}-arm64/bin/node")
-   set(NPM 
-      "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}-arm64/bin/npm")
-   set(NPX 
-      "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}-arm64/bin/npx")
+   set(NODE_BIN_DIR "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}-arm64/bin")
+   if(NOT EXISTS "${NODE_BIN_DIR}" AND RSTUDIO_WORKTREE_NODE_DIR)
+      set(NODE_BIN_DIR "${RSTUDIO_WORKTREE_NODE_DIR}-arm64/bin")
+   endif()
+   set(NODEJS "${NODE_BIN_DIR}/node")
+   set(NPM    "${NODE_BIN_DIR}/npm")
+   set(NPX    "${NODE_BIN_DIR}/npx")
 
 else()
 
@@ -46,7 +55,8 @@ else()
       PATHS "${RSTUDIO_TOOLS_ROOT}/dependencies/common/node/${RSTUDIO_NODE_VERSION}"
       "/opt/rstudio-tools/dependencies/common/node/${RSTUDIO_NODE_VERSION}"
       "c:/rstudio-tools/dependencies/common/node/${RSTUDIO_NODE_VERSION}"
-      "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}")
+      "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}"
+      "${RSTUDIO_WORKTREE_NODE_DIR}")
 
    find_program(NPM
       NAMES npm
@@ -55,7 +65,8 @@ else()
       PATHS "${RSTUDIO_TOOLS_ROOT}/dependencies/common/node/${RSTUDIO_NODE_VERSION}"
       "/opt/rstudio-tools/dependencies/common/node/${RSTUDIO_NODE_VERSION}"
       "c:/rstudio-tools/dependencies/common/node/${RSTUDIO_NODE_VERSION}"
-      "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}")
+      "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}"
+      "${RSTUDIO_WORKTREE_NODE_DIR}")
 
    find_program(NPX
       NAMES npx
@@ -64,7 +75,8 @@ else()
       PATHS "${RSTUDIO_TOOLS_ROOT}/dependencies/common/node/${RSTUDIO_NODE_VERSION}"
       "/opt/rstudio-tools/dependencies/common/node/${RSTUDIO_NODE_VERSION}"
       "c:/rstudio-tools/dependencies/common/node/${RSTUDIO_NODE_VERSION}"
-      "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}")
+      "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}"
+      "${RSTUDIO_WORKTREE_NODE_DIR}")
 
 endif()
    


### PR DESCRIPTION
## Summary

Building from a secondary `git worktree` did not work out of the box: a freshly added worktree has empty dependency directories (node, gwtproject, quarto, etc. are gitignored and only populated in the primary checkout). This caused:

- `cmake` configure to **fail** on the panmirror/quarto script (`session/CMakeLists.txt`), requiring a manual symlink;
- node-based steps to use whatever `node` was on the developer's PATH — a mismatched system node (e.g. v26 vs the pinned 22.22.2) breaks `npm` postinstall.

`src/gwt/build.xml` already solved this for ant via `${git.main.worktree}`. This PR extends the same idea to the other build entry points so worktree builds "just work" with no symlinks or manual node management.

## Changes (all additive and gated)

- **`cmake/git-worktree.cmake`** (new): resolves the primary checkout via `git rev-parse --path-format=absolute --git-common-dir` into `RSTUDIO_GIT_MAIN_WORKTREE` (empty when not in a git checkout; callers tolerate that).
- **`cmake/globals.cmake`**: when this checkout's `dependencies/` has no downloaded content, borrow the primary worktree's. Also auto-enable a **compiler cache** for development builds (see below).
- **`src/cpp/session/CMakeLists.txt`**: fall back to the primary worktree for the gitignored panmirror/quarto `md-writer.lua` (the hard configure failure).
- **`src/node/CMakeNodeTools.txt`**: fall back to the primary worktree's node toolchain (the Apple arm64 branch had no fallback at all).
- **`e2e/rstudio/scripts/dev-common.ts`**: prepend the pinned node (resolved local → primary worktree → tools) to `PATH` for spawned `npx`/`npm run start`, so the dev e2e flow uses the project node, not a stray system node.

CI/official builders resolve their existing paths first (global tools dir / source tree), so they are unaffected.

### Compiler cache (ccache / sccache)

For **development** builds only, auto-enable a compiler cache when available (opt out with `-DRSTUDIO_USE_CCACHE=OFF`):

- Searches the **architecture-appropriate Homebrew prefix first** (`/opt/homebrew/bin` on Apple Silicon, `/usr/local/bin` otherwise) so a native tool wins over an x86_64 one in the Intel-Homebrew tree.
- Accepts **either ccache or sccache** (both work as `CMAKE_<LANG>_COMPILER_LAUNCHER`); prefers ccache.
- Each candidate is validated by an anchored `--version` match. This rejects a `ccache` that is actually a symlink to **sccache** — sccache invoked under the name `ccache` misparses cmake's `-E` feature probes and breaks the build; the real `sccache` is then found by its own name and used safely.

**Coexistence with the existing `SCCACHE_ENABLED` mechanism:** package/CI builds (`package/osx`, `package/linux`) already opt into sccache via the `SCCACHE_ENABLED` env/cmake var, wired through `cmake/modules/sccache.cmake`. Those builds also pass `-DRSTUDIO_TARGET`, so `RSTUDIO_DEVELOPMENT` is unset and this dev block never runs there. As belt-and-suspenders, the dev block also explicitly **defers when `SCCACHE_ENABLED` is set**, so the two mechanisms can never both configure a launcher (verified: with `SCCACHE_ENABLED=1`, `sccache.cmake` wins; without it, dev builds auto-select ccache).

## Verification

In a clean secondary worktree (no manual setup):
- `cmake` configure succeeds with **no quarto symlink** (resolves the primary worktree + its deps).
- Full C++ build (`rsession`): 878/879 steps, 0 errors.
- Compiler cache selects the genuine arm64 `/opt/homebrew/bin/ccache`; a `rstudio-core` build engages it (196/196 cacheable calls) with no breakage; the broken x86 `ccache→sccache` symlink is correctly rejected; `SCCACHE_ENABLED=1` correctly defers to `sccache.cmake`.
- `CMakeNodeTools` node resolution and the `dev-common` node resolution each verified to resolve to the primary checkout's node (the full packaged-desktop build was not run; the dev e2e flow uses `npm run start`, where the `dev-common` PATH pinning applies).
- Reviewed `package/osx` (dual-arch x86_64 + arm64): unaffected — `RSTUDIO_TARGET=Electron` disables the dev cache block, and the deps/quarto/node fallbacks are inert when packaging from the main checkout.

Developer-ergonomics change; no associated issue.