### PR TITLE
fix grey-screen dead-end when set_user_state fails during bootstrap

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@
 - ([#6147](https://github.com/rstudio/rstudio/issues/6147)): The data viewer's summary sidebar now reflects the active filter and search, rather than always describing the whole frame.
 - ([#17979](https://github.com/rstudio/rstudio/issues/17979)): Add a "Show Filter UI by default" toggle to the data viewer's Settings menu. When enabled, the filter bar is shown automatically each time a data frame is opened, instead of requiring a click to reveal it.
 - ([#17993](https://github.com/rstudio/rstudio/issues/17993)): Add a "Use overlay scrollbars" toggle to the data viewer's Settings menu. When disabled, the data viewer uses native, always-visible scrollbars instead of the auto-hiding overlay scrollbars.
+- ([#18019](https://github.com/rstudio/rstudio/issues/18019)): Fixed an issue where a transient connection failure while writing user state during startup could leave the IDE stuck on an empty grey screen.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -273,6 +273,11 @@ public class Application implements ApplicationEventHandlers
             // in desktop mode, though unsure why). The automation agent must be initialized
             // after this refresh -- registerPrefs() iterates userPrefs_.allPrefs(), and in desktop
             // mode that returns an incomplete set until the pref refresh has run.
+            // The completion booleans report whether the set_user_state /
+            // set_user_prefs RPCs succeeded, but we deliberately proceed to
+            // build the workbench either way: a transient persistence failure
+            // here must not dead-end startup (see #18019). The RPC error has
+            // already been logged by writeState()/writeUserPrefs().
             userState_.get().writeState(boolArg ->
             {
                userPrefs_.get().writeUserPrefs(boolArg1 ->

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -123,14 +123,20 @@ public class SessionInfo extends JavaScriptObject
       return this.user_prefs;
    }-*/;
 
+   // The pref/state layer arrays can momentarily be incomplete during startup
+   // (e.g. if a bootstrap RPC fails before they are fully populated). Clamp the
+   // layer index to the last valid element rather than Math.min(length, LAYER_*),
+   // which would index one past the end when length <= LAYER_* and throw on the
+   // subsequent .getValues(). For a fully-populated array (length > LAYER_*) this
+   // is identical to indexing LAYER_* directly. See #18019.
    public final JsObject getUserPrefs()
    {
-      return getPrefs().get(Math.min(getPrefs().length(), UserPrefs.LAYER_USER)).getValues();
+      return getPrefs().get(Math.min(getPrefs().length() - 1, UserPrefs.LAYER_USER)).getValues();
    }
 
    public final PrefLayer getUserPrefLayer()
    {
-      return getPrefs().get(Math.min(getPrefs().length(), UserPrefs.LAYER_USER));
+      return getPrefs().get(Math.min(getPrefs().length() - 1, UserPrefs.LAYER_USER));
    }
 
    public final native JsArray<PrefLayer> getUserState() /*-{
@@ -141,7 +147,8 @@ public class SessionInfo extends JavaScriptObject
 
    public final PrefLayer getUserStateLayer()
    {
-      return getUserState().get(Math.min(getPrefs().length(), UserState.LAYER_USER));
+      // index and measure the same array (user_state, not user_prefs)
+      return getUserState().get(Math.min(getUserState().length() - 1, UserState.LAYER_USER));
    }
 
    public final static String DESKTOP_MODE = "desktop";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/Prefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/Prefs.java
@@ -23,6 +23,7 @@ import com.google.gwt.event.shared.GwtEvent;
 import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.event.shared.HandlerRegistration;
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.js.JsUtil;
 
@@ -181,7 +182,11 @@ public abstract class Prefs
       {
          JsObject values = layerValues(userLayer());
          if (values == null)
+         {
+            Debug.logWarning("Discarding setGlobalValue for '" + name_ +
+               "': user pref layer (" + userLayer() + ") is not present");
             return;
+         }
          setValue(values, value, fireEvents);
       }
 
@@ -226,7 +231,11 @@ public abstract class Prefs
       {
          JsObject projValues = layerValues(projectLayer());
          if (projValues == null)
+         {
+            Debug.logWarning("Discarding setProjectValue for '" + name_ +
+               "': project pref layer (" + projectLayer() + ") is not present");
             return;
+         }
          setValue(projValues, value, fireEvents);
       }
 
@@ -446,9 +455,15 @@ public abstract class Prefs
 
    // Returns the values for the pref layer at the given index, or null if that
    // layer is not present. The pref layers can momentarily be incomplete during
-   // startup (e.g. if a bootstrap RPC fails before they are fully populated);
-   // callers that index directly into layers_ must tolerate a missing layer
-   // rather than dereferencing undefined. See #18019.
+   // startup (e.g. if a bootstrap RPC fails before they are fully populated).
+   // Accessors that read a fixed layer by position (getGlobalValue,
+   // getProjectValue, setGlobalValue, setProjectValue, removeGlobalValue,
+   // removeProjectValue, hasProjectValue) route through this helper so a missing
+   // layer falls back to the default instead of dereferencing undefined. The
+   // name-iterating accessors (getValue, hasValue, setValue) are already safe by
+   // construction, and getUserLayer() is deliberately left unguarded -- it is
+   // only used by the preferences dialog save path, after the layers are fully
+   // populated. See #18019.
    private JsObject layerValues(int index)
    {
       if (index < 0 || index >= layers_.length())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/Prefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/Prefs.java
@@ -161,9 +161,10 @@ public abstract class Prefs
          // Skip the project layer if it exists by starting at the user layer.
          for (int i = userLayer(); i >= 0; i--)
          {
-            if (layers_.get(i).getValues().hasKey(name_))
+            JsObject values = layerValues(i);
+            if (values != null && values.hasKey(name_))
             {
-               return doGetValue(layers_.get(i).getValues());
+               return doGetValue(values);
             }
          }
          return defaultValue_;
@@ -178,53 +179,61 @@ public abstract class Prefs
 
       public void setGlobalValue(T value, boolean fireEvents)
       {
-         setValue(layers_.get(userLayer()).getValues(), value, fireEvents);
+         JsObject values = layerValues(userLayer());
+         if (values == null)
+            return;
+         setValue(values, value, fireEvents);
       }
-      
+
       public void removeGlobalValue(boolean fireEvents)
       {
          boolean wasUnset = false;
-         
+
          for (int i = userLayer(); i >= 0; i--)
          {
-            JsObject layer = layers_.get(i).getValues();
-            if (layer.hasKey(name_))
+            JsObject layer = layerValues(i);
+            if (layer != null && layer.hasKey(name_))
             {
                layer.unset(name_);
                wasUnset = true;
             }
          }
-         
+
          if (fireEvents && wasUnset)
             ValueChangeEvent.fire(this, getValue());
       }
-      
+
       public T getProjectValue()
       {
-         JsObject projValues = layers_.get(projectLayer()).getValues();
+         JsObject projValues = layerValues(projectLayer());
+         if (projValues == null)
+            return defaultValue_;
          return doGetValue(projValues);
       }
 
       public boolean hasProjectValue()
       {
-         JsObject projValues = layers_.get(projectLayer()).getValues();
-         return projValues.hasKey(name_);
+         JsObject projValues = layerValues(projectLayer());
+         return projValues != null && projValues.hasKey(name_);
       }
-      
+
       public void setProjectValue(T value)
       {
          setProjectValue(value, true);
       }
-      
+
       public void setProjectValue(T value, boolean fireEvents)
       {
-         setValue(layers_.get(projectLayer()).getValues(), value, fireEvents);
+         JsObject projValues = layerValues(projectLayer());
+         if (projValues == null)
+            return;
+         setValue(projValues, value, fireEvents);
       }
-      
+
       public void removeProjectValue(boolean fireEvents)
       {
-         JsObject projValues = layers_.get(projectLayer()).getValues();
-         if (projValues.hasKey(name_))
+         JsObject projValues = layerValues(projectLayer());
+         if (projValues != null && projValues.hasKey(name_))
          {
             projValues.unset(name_);
             if (fireEvents)
@@ -434,6 +443,23 @@ public abstract class Prefs
    
    public abstract int userLayer();
    public abstract int projectLayer();
+
+   // Returns the values for the pref layer at the given index, or null if that
+   // layer is not present. The pref layers can momentarily be incomplete during
+   // startup (e.g. if a bootstrap RPC fails before they are fully populated);
+   // callers that index directly into layers_ must tolerate a missing layer
+   // rather than dereferencing undefined. See #18019.
+   private JsObject layerValues(int index)
+   {
+      if (index < 0 || index >= layers_.length())
+         return null;
+
+      PrefLayer layer = layers_.get(index);
+      if (layer == null)
+         return null;
+
+      return layer.getValues();
+   }
 
    @SuppressWarnings("unchecked")
    protected PrefValue<Boolean> bool(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserState.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserState.java
@@ -87,6 +87,13 @@ public class UserState extends UserStateAccessor implements UserStateChangedEven
             @Override
             public void onError(ServerError error)
             {
+               // still invoke the continuation on failure so that callers
+               // chaining off writeState() (e.g. workbench bootstrap) are not
+               // left dead-ended by a transient RPC failure (see #18019)
+               if (onCompleted != null)
+               {
+                  onCompleted.execute(false);
+               }
                Debug.logError(error);
             }
          });

--- a/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
+++ b/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
@@ -28,6 +28,7 @@ import org.rstudio.studio.client.application.model.SessionScopeTests;
 import org.rstudio.studio.client.common.r.RTokenizerTests;
 import org.rstudio.studio.client.common.sourcemarkers.SourceMarkerItemCodecTests;
 import org.rstudio.studio.client.projects.model.ProjectMRUEntryTests;
+import org.rstudio.studio.client.workbench.prefs.model.PrefsTests;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportPreviewResponseTests;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobManagerTests;
 import org.rstudio.studio.client.workbench.views.jobs.view.JobsListTests;
@@ -73,6 +74,7 @@ public class RStudioUnitTestSuite extends GWTTestSuite
       suite.addTestSuite(ProjectMRUEntryTests.class);
       suite.addTestSuite(YamlTreeTests.class);
       suite.addTestSuite(DataImportPreviewResponseTests.class);
+      suite.addTestSuite(PrefsTests.class);
 
       return suite;
    }

--- a/src/gwt/test/org/rstudio/studio/client/workbench/prefs/model/PrefsTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/workbench/prefs/model/PrefsTests.java
@@ -1,0 +1,93 @@
+/*
+ * PrefsTests.java
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.prefs.model;
+
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.junit.client.GWTTestCase;
+
+public class PrefsTests extends GWTTestCase
+{
+   @Override
+   public String getModuleName()
+   {
+      return "org.rstudio.studio.RStudioTests";
+   }
+
+   // Regression #18019: during startup the pref layers can momentarily be
+   // incomplete (e.g. if a bootstrap RPC fails before they are populated).
+   // The index-based accessors (getGlobalValue, getProjectValue, etc.) index
+   // directly into layers_, and must tolerate a missing layer by falling back
+   // to the default rather than dereferencing an undefined layer and throwing
+   // a TypeError (which previously dead-ended quit/startup code paths).
+
+   // userLayer() == 3 and projectLayer() == 4, matching UserPrefs, but the
+   // layer array here is empty -- so layers_.get(3) / layers_.get(4) are absent.
+   private static class TestPrefs extends Prefs
+   {
+      public TestPrefs(JsArray<PrefLayer> layers)
+      {
+         super(layers);
+      }
+
+      @Override
+      public int userLayer()
+      {
+         return 3;
+      }
+
+      @Override
+      public int projectLayer()
+      {
+         return 4;
+      }
+   }
+
+   private static native JsArray<PrefLayer> emptyLayers() /*-{
+      return [];
+   }-*/;
+
+   public void testGetGlobalValueWithIncompleteLayersReturnsDefault()
+   {
+      TestPrefs prefs = new TestPrefs(emptyLayers());
+      Prefs.PrefValue<Boolean> pref = prefs.bool("test", "Test", "Test pref", true);
+      assertTrue(pref.getGlobalValue());
+   }
+
+   public void testGetProjectValueWithIncompleteLayersReturnsDefault()
+   {
+      TestPrefs prefs = new TestPrefs(emptyLayers());
+      Prefs.PrefValue<Boolean> pref = prefs.bool("test", "Test", "Test pref", true);
+      assertTrue(pref.getProjectValue());
+   }
+
+   public void testHasProjectValueWithIncompleteLayersIsFalse()
+   {
+      TestPrefs prefs = new TestPrefs(emptyLayers());
+      Prefs.PrefValue<Boolean> pref = prefs.bool("test", "Test", "Test pref", true);
+      assertFalse(pref.hasProjectValue());
+   }
+
+   public void testSetGlobalValueWithIncompleteLayersDoesNotThrow()
+   {
+      TestPrefs prefs = new TestPrefs(emptyLayers());
+      Prefs.PrefValue<Boolean> pref = prefs.bool("test", "Test", "Test pref", false);
+
+      // must not throw -- there is no user layer to write to
+      pref.setGlobalValue(true, false);
+
+      // the value still reads as its default since nothing was written
+      assertFalse(pref.getGlobalValue());
+   }
+}

--- a/src/gwt/test/org/rstudio/studio/client/workbench/prefs/model/PrefsTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/workbench/prefs/model/PrefsTests.java
@@ -32,8 +32,7 @@ public class PrefsTests extends GWTTestCase
    // to the default rather than dereferencing an undefined layer and throwing
    // a TypeError (which previously dead-ended quit/startup code paths).
 
-   // userLayer() == 3 and projectLayer() == 4, matching UserPrefs, but the
-   // layer array here is empty -- so layers_.get(3) / layers_.get(4) are absent.
+   // Mirrors the user/project layer positions used by UserPrefs.
    private static class TestPrefs extends Prefs
    {
       public TestPrefs(JsArray<PrefLayer> layers)
@@ -44,18 +43,31 @@ public class PrefsTests extends GWTTestCase
       @Override
       public int userLayer()
       {
-         return 3;
+         return UserPrefsAccessor.LAYER_USER;
       }
 
       @Override
       public int projectLayer()
       {
-         return 4;
+         return UserPrefsAccessor.LAYER_PROJECT;
       }
    }
 
+   // An empty array -- layers_.get(userLayer()/projectLayer()) is out of bounds,
+   // exercising the "index >= layers_.length()" branch of layerValues().
    private static native JsArray<PrefLayer> emptyLayers() /*-{
       return [];
+   }-*/;
+
+   // A long-enough array whose user/project slots are null, exercising the
+   // "layer == null" branch of layerValues() -- this better models the real
+   // bug, where leading layers exist but the user/project layers are not yet
+   // populated.
+   private static native JsArray<PrefLayer> partialLayers() /*-{
+      var layers = [];
+      for (var i = 0; i <= @org.rstudio.studio.client.workbench.prefs.model.UserPrefsAccessor::LAYER_PROJECT; i++)
+         layers.push(null);
+      return layers;
    }-*/;
 
    public void testGetGlobalValueWithIncompleteLayersReturnsDefault()
@@ -89,5 +101,63 @@ public class PrefsTests extends GWTTestCase
 
       // the value still reads as its default since nothing was written
       assertFalse(pref.getGlobalValue());
+   }
+
+   // The following exercise the "layer == null" branch via partialLayers(),
+   // where the array is long enough but the user/project slots are absent.
+
+   public void testGetGlobalValueWithNullLayerReturnsDefault()
+   {
+      TestPrefs prefs = new TestPrefs(partialLayers());
+      Prefs.PrefValue<Boolean> pref = prefs.bool("test", "Test", "Test pref", true);
+      assertTrue(pref.getGlobalValue());
+   }
+
+   public void testGetProjectValueWithNullLayerReturnsDefault()
+   {
+      TestPrefs prefs = new TestPrefs(partialLayers());
+      Prefs.PrefValue<Boolean> pref = prefs.bool("test", "Test", "Test pref", true);
+      assertTrue(pref.getProjectValue());
+   }
+
+   public void testHasProjectValueWithNullLayerIsFalse()
+   {
+      TestPrefs prefs = new TestPrefs(partialLayers());
+      Prefs.PrefValue<Boolean> pref = prefs.bool("test", "Test", "Test pref", true);
+      assertFalse(pref.hasProjectValue());
+   }
+
+   public void testSetProjectValueWithNullLayerDoesNotThrow()
+   {
+      TestPrefs prefs = new TestPrefs(partialLayers());
+      Prefs.PrefValue<Boolean> pref = prefs.bool("test", "Test", "Test pref", false);
+
+      // must not throw -- there is no project layer to write to
+      pref.setProjectValue(true, false);
+
+      // the value still reads as its default since nothing was written
+      assertFalse(pref.getProjectValue());
+   }
+
+   public void testRemoveGlobalValueWithIncompleteLayersDoesNotThrow()
+   {
+      TestPrefs prefs = new TestPrefs(partialLayers());
+      Prefs.PrefValue<Boolean> pref = prefs.bool("test", "Test", "Test pref", true);
+
+      // must not throw -- there is no user layer to remove from
+      pref.removeGlobalValue(false);
+
+      assertTrue(pref.getGlobalValue());
+   }
+
+   public void testRemoveProjectValueWithIncompleteLayersDoesNotThrow()
+   {
+      TestPrefs prefs = new TestPrefs(partialLayers());
+      Prefs.PrefValue<Boolean> pref = prefs.bool("test", "Test", "Test pref", true);
+
+      // must not throw -- there is no project layer to remove from
+      pref.removeProjectValue(false);
+
+      assertTrue(pref.getProjectValue());
    }
 }


### PR DESCRIPTION
## Summary

On RStudio Desktop, a transient `set_user_state` RPC failure during workbench bootstrap could leave the user with an unrecoverable grey screen (title/menu bars present, empty grey content), with no retry or error UI. See #18019 for the full analysis.

The bootstrap in `Application.java` chains `initializeWorkbench()` behind `UserState.writeState()` and then `UserPrefs.writeUserPrefs()`. `UserState.writeState`'s `onError` only logged the error and never invoked the completion continuation, unlike the analogous `UserPrefs.writeUserPrefs`. So when `set_user_state` failed at the TCP level (`ERR_CONNECTION_FAILED`):

- the continuation never ran, so `initializeWorkbench()` never built or painted the IDE (permanent grey screen); and
- `writeUserPrefs()` never ran, so its leading `updatePrefs(getPrefs())` never refreshed the pref layers, leaving them in the incomplete "loaded without sessionInfo" state. That in turn caused a secondary `Cannot read properties of undefined (reading 'values')` TypeError on quit, when index-based pref accessors dereferenced a not-yet-populated layer.

## Changes

- **`UserState.writeState`**: invoke `onCompleted.execute(false)` in `onError`, mirroring `UserPrefs.writeUserPrefs`, so bootstrap continues (and the pref layers get refreshed) even when the RPC fails.
- **`Prefs.java` (defense-in-depth)**: route the index-based accessors (`getGlobalValue`, `getProjectValue`, `setGlobalValue`, `removeGlobalValue`, `hasProjectValue`, `setProjectValue`, `removeProjectValue`) through a new `layerValues()` helper that returns `null` for an absent layer, so reading a pref before the layers are fully populated falls back to the default instead of throwing.
- **Tests**: added `PrefsTests` covering the incomplete-layers accessor behavior.

## Testing

- `ant javac` and `ant unittest` pass (507 tests).
- The primary grey-screen scenario is timing-dependent (a transient connection blip during startup) and requires manual verification; the added unit tests cover the defense-in-depth accessor path.

Addresses #18019