### PR TITLE
ensure bundled fmt headers win over a system-installed fmt

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -451,7 +451,17 @@ endif()
 
 # external libraries
 add_subdirectory(ext)
-include_directories(SYSTEM "${FMT_SOURCE_DIR}/include")
+
+# Make the bundled {fmt} headers available to all targets. We deliberately add
+# this as a normal (non-SYSTEM) include placed BEFORE the other directories,
+# rather than via include_directories(SYSTEM ...). On macOS, clang searches the
+# driver-added /usr/local/include ahead of every -isystem directory, so a stray
+# fmt installed there (e.g. a Homebrew fmt under the /usr/local prefix) would
+# shadow our bundled headers and pull in a different fmt ABI version -- yielding
+# undefined fmt::v<N> symbols at link time against the bundled libfmt. A -I entry
+# is searched before /usr/local/include, so this guarantees the bundled headers
+# win regardless of what is installed on the system.
+include_directories(BEFORE "${FMT_SOURCE_DIR}/include")
 
 # shared library
 add_subdirectory(shared_core)


### PR DESCRIPTION
## Summary

`src/cpp/CMakeLists.txt` added the bundled `{fmt}` headers to the global include path via `include_directories(SYSTEM ...)`, which emits them as `-isystem`. On macOS, clang's driver searches `/usr/local/include` *ahead of* every `-isystem` directory, so an fmt installed under the `/usr/local` prefix (e.g. a Homebrew fmt) shadows the bundled headers. Objects then compile against the wrong fmt ABI version and fail to link against the bundled `libfmt`:

```
Undefined symbols for architecture arm64:
  "fmt::v12::vformat(...)", referenced from:
      ...resolveXdgPath(...) in librstudio-core.a[102](Xdg.cpp.o)
```

## Fix

Add the bundled fmt include as a non-SYSTEM `-I` entry placed `BEFORE` the other directories. The regular `-I` group is searched ahead of `/usr/local/include`, so the bundled headers win regardless of what fmt is installed on the system.

The only tradeoff is that fmt header warnings are no longer suppressed; the build uses `-Werror=return-type` (no blanket `-Werror`) and the bundled fmt is warning-clean, so this is safe.

## Testing

With a stray fmt 12 still present at `/usr/local/include/fmt`, verified that:
- the bundled `fmt-src/include` now precedes `/usr/local/include` in clang's `#include <...>` search order;
- `#include <fmt/format.h>` resolves to the bundled header; and
- a freshly-built `Xdg.cpp.o` references `fmt::v11` (matching the bundled `libfmt`).