### PR TITLE
re-enable the View() close/open race playwright test

### DIFF
--- a/e2e/rstudio/tests/panes/editor/close_open_race.test.ts
+++ b/e2e/rstudio/tests/panes/editor/close_open_race.test.ts
@@ -50,13 +50,14 @@ test.describe('Source pane open during close race', () => {
     await expect(sourcePane.selectedTab).toContainText(targetFile, { timeout: 10000 });
   });
 
-  // FIXME: the View() / documentCloseAllNoSave race surfaces a real gap that
-  // #17740 doesn't cover -- the data viewer iframe never finishes loading
-  // even with the WindowFrame.onEnsureVisible HIDE-state recovery in place.
-  // Investigate the data-viewer-specific mount path (iframe SRC swap + initial
-  // load events) before un-fixme'ing. The data_viewer.test.ts afterEach uses
-  // resetSourcePaneState() to keep the pane open and side-step the race.
-  test.fixme('View() immediately after documentCloseAllNoSave still renders the data viewer', async ({
+  // The View() / documentCloseAllNoSave variant exercises the same race
+  // through Source.onShowData (data viewer iframe) rather than onFileEdit.
+  // This was left as a fixme when #17740 landed -- at the time the data
+  // viewer iframe still failed to finish loading even with the
+  // WindowFrame.onEnsureVisible HIDE-state recovery in place. The
+  // data-viewer mount path has since been reworked and the race no longer
+  // reproduces; the iframe renders reliably (verified over repeated runs).
+  test('View() immediately after documentCloseAllNoSave still renders the data viewer', async ({
     rstudioPage: page,
   }) => {
     const initialFile = `race_view_initial_${Date.now()}.R`;

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -251,6 +251,7 @@
    <set-if-exists property="panmirror.dir" value="/opt/rstudio-tools/src/gwt/lib/quarto/apps/panmirror"/>
    <set-if-exists property="panmirror.dir" value="c:/rstudio-tools/src/gwt/lib/quarto/apps/panmirror"/>
    <set-if-exists property="panmirror.dir" value="./lib/quarto/apps/panmirror"/>
+   <set-if-exists property="panmirror.dir" value="${git.main.worktree}/src/gwt/lib/quarto/apps/panmirror"/>
    <!-- write panmirror to ${www.dir} so it tracks the same output tree as every
         other ant target. cmake passes -Dwww.dir=<build>/gwt/www to redirect
         ant output into the build tree; with the previous hardcoded ./www path


### PR DESCRIPTION
## Intent

Addresses #17738.

Re-enables the `View()` variant of the source-pane open-during-close race test, and fixes a build-tooling gap that blocked GWT builds in secondary git worktrees.

## Summary

- **Re-enable the test** (`close_open_race.test.ts`): the `View()` / `documentCloseAllNoSave` variant exercises the same race as the `file.edit` test, but through `Source.onShowData` (the data viewer iframe) instead of `onFileEdit`. It was left as `test.fixme` when #17740 landed, because at that time the data viewer iframe still failed to finish loading even with the `WindowFrame.onEnsureVisible` HIDE-state recovery. The data-viewer mount path has since been reworked and the race no longer reproduces -- the test now passes reliably (20/20 in a `--repeat-each=10` stress run on macOS Desktop, alongside the existing `file.edit` test).

- **`src/gwt/build.xml` panmirror fallback**: #18030 gave `lib.dir` and `node.dir` a `${git.main.worktree}` fallback so a fresh worktree can borrow the primary checkout's gitignored dependencies, but `panmirror.dir` was missed. Without it, `ant draft` in a secondary worktree fails with `${panmirror.dir} does not exist`. This adds the same fallback (additive; the local `./lib/...` path still wins when present, so primary/CI builds are unaffected). This was a prerequisite for building and running the test above in a worktree.

## Test plan

- [x] `ant draft` succeeds in a secondary worktree (previously failed on `panmirror.dir`).
- [x] `npm run test:desktop-dev -- tests/panes/editor/close_open_race.test.ts` -- both tests pass.
- [x] `--repeat-each=10` -- 20/20 passed, no flakes.