### PR TITLE
fix flaky visual-mode switch race in e2e source pane actions

### DIFF
--- a/e2e/rstudio/actions/source_pane.actions.ts
+++ b/e2e/rstudio/actions/source_pane.actions.ts
@@ -2,7 +2,6 @@ import type { Page } from 'playwright';
 import { expect } from '@playwright/test';
 import { SourcePane } from '../pages/source_pane.page';
 import { ConsolePaneActions } from './console_pane.actions';
-import { clickConfirmIfVisible } from '../pages/modals.page';
 import { TIMEOUTS, sleep } from '../utils/constants';
 import { rStringLiteral } from '../utils/r';
 import { executeCommand } from '../utils/commands';
@@ -254,8 +253,19 @@ export class SourcePaneActions {
     }
 
     await toggle.click();
-    // The first switch to visual mode for a document can raise a confirmation.
-    await clickConfirmIfVisible(this.page, 5000);
+
+    // The first switch to visual mode for a document can raise a confirmation
+    // dialog, but only after the pandoc conversion returns -- a server roundtrip
+    // that on a loaded machine can exceed a fixed dialog-poll window. A separate
+    // short timeout here races that roundtrip and, when it loses, leaves the
+    // modal unconfirmed so the editor never mounts. Instead wait for whichever
+    // appears first -- the dialog or the mounted editor -- then dismiss the
+    // dialog if it showed.
+    const okBtn = this.page.locator('#rstudio_dlg_ok');
+    await expect(proseMirror.first().or(okBtn)).toBeVisible({ timeout: 90000 });
+    if (await okBtn.isVisible().catch(() => false))
+      await okBtn.click();
+
     // Wait for the visual editor to actually mount rather than sleeping a fixed
     // interval: converting a heavier document (a template with chunks/plots)
     // through pandoc takes longer than a blank one, and the old 2s sleep could


### PR DESCRIPTION
## Problem

The Playwright test `panes/editor/quarto.test.ts -> "render quarto document"` is flaky. A failed run shows:

```
TimeoutError: locator.waitFor: Timeout 90000ms exceeded.
  waiting for locator('.ProseMirror').first() to be visible
  at source_pane.actions.ts:264  (ensureVisualMode)
```

The step timeline of the failed attempt:

```
232ms   Click  rstudio_visual_md_on        toggle.click(), switch to visual mode
5105ms  Click  #rstudio_dlg_ok   [ERROR]   clickConfirmIfVisible(5000): polled full 5s, never clicked
90113ms Wait for  .ProseMirror  [ERROR]   editor never mounts -> 90s timeout
```

## Root cause

This is a test race, not a product bug. `ensureVisualMode` clicked the visual-mode toggle and then waited at most a fixed 5s for the first-switch confirmation dialog (`VisualModeConfirmDialog`, `#rstudio_dlg_ok`). That dialog only appears *after* the pandoc conversion returns -- a server roundtrip that on a loaded CI machine can exceed 5s. When the dialog appears after the window closes, the modal sits unconfirmed, the visual editor never mounts, and the subsequent `.ProseMirror` wait burns its full 90s. It passes on retry when the machine is faster (or the confirmation state is already set, so no dialog appears).

## Fix

Stop racing a separate fixed window for the dialog. Wait for whichever appears first within one budget -- the confirmation dialog or the mounted editor -- then dismiss the dialog only if it showed. The dialog can now appear at any point up to the 90s budget and is still handled.

Test-only change; no product code is affected.