### PR TITLE
fall back to source build when the e2e daily is stale or unresolvable

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -295,9 +295,11 @@ jobs:
           FILENAME=""
           if [ -z "$URL" ]; then
             MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 'https://dailies.rstudio.com/rstudio/latest/index.json')
-            URL=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["mac-arm64"].link // .products.electron.platforms["mac"].link // empty')
-            SHA=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["mac-arm64"].sha256 // .products.electron.platforms["mac"].sha256 // empty')
-            FILENAME=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["mac-arm64"].filename // .products.electron.platforms["mac"].filename // empty')
+            # macOS ships a single universal .dmg keyed "macos" in the daily
+            # manifest (older schemas used "mac-arm64"/"mac"; kept as fallbacks).
+            URL=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["macos"].link // .products.electron.platforms["mac-arm64"].link // .products.electron.platforms["mac"].link // empty')
+            SHA=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["macos"].sha256 // .products.electron.platforms["mac-arm64"].sha256 // .products.electron.platforms["mac"].sha256 // empty')
+            FILENAME=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["macos"].filename // .products.electron.platforms["mac-arm64"].filename // .products.electron.platforms["mac"].filename // empty')
             if [ -z "$URL" ] || [ -z "$FILENAME" ] || [ -z "$SHA" ]; then
               echo "::error::Daily manifest is missing expected fields (url='$URL', filename='$FILENAME', sha256='$SHA'). The schema at https://dailies.rstudio.com/rstudio/latest/index.json may have changed."
               exit 1

--- a/.github/workflows/os-test-e2e-rstudio-desktop-pr.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-pr.yml
@@ -23,39 +23,111 @@ permissions:
   pull-requests: write
 
 jobs:
-  # Single change-detection job shared by both platforms. Checks if C++,
-  # CMake, build scripts, or dependencies changed. When only e2e tests or
-  # CI workflows changed, both platforms skip the ~60 min source build and
-  # use the latest daily installer instead.
+  # Single change-detection job shared by both platforms. Decides, per
+  # platform, whether to build from source or test against the latest daily
+  # installer. We only use a daily when ALL of the following hold:
+  #   1. No compiled-binary source changed in this PR (else the daily can't
+  #      contain the change under test).
+  #   2. The daily manifest resolves a usable installer for that platform
+  #      (link + filename + sha256 + commit all present).
+  #   3. The daily was built from a commit that already contains this branch's
+  #      merge-base -- otherwise the daily predates the product behavior the
+  #      (possibly main-merged) test-only branch assumes.
+  # Any miss falls back to a source build, so a stale, broken, or unreachable
+  # daily manifest can never silently run the suite against the wrong binary.
+  # The two platforms are decided independently because the manifest can carry
+  # a different commit per platform.
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
-      build_from_source: ${{ steps.check.outputs.build_from_source }}
+      macos_build_from_source: ${{ steps.check.outputs.macos_build_from_source }}
+      windows_build_from_source: ${{ steps.check.outputs.windows_build_from_source }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Check for source changes requiring a build
+      - name: Decide build-from-source vs daily (per platform)
         id: check
         run: |
           BASE=$(git merge-base HEAD origin/${{ github.base_ref }})
           CHANGED=$(git diff --name-only "$BASE" HEAD)
           echo "Changed files vs merge base with ${{ github.base_ref }}:"
           echo "$CHANGED"
+
           # Build from source when C++, GWT, CMake, build scripts, or
-          # dependencies changed — anything that ends up in the compiled binary.
-          # Matches all of package/ (CMakeLists.txt at the root, and every
-          # per-platform subdir) plus the repo-root CMakeLists.txt so a
-          # packaging or top-level cmake change can't silently fall through
-          # to running tests against a daily.
+          # dependencies changed -- anything that ends up in the compiled
+          # binary. Matches all of package/ (CMakeLists.txt at the root, and
+          # every per-platform subdir) plus the repo-root CMakeLists.txt so a
+          # packaging or top-level cmake change can't silently fall through to
+          # running tests against a daily.
+          SOURCE_CHANGED=false
           if echo "$CHANGED" | grep -qE '^(CMakeLists\.txt$|src/|package/|dependencies/|cmake/)'; then
-            echo "Source files changed — building from source"
-            echo "build_from_source=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No source files changed — using daily installer"
-            echo "build_from_source=false" >> "$GITHUB_OUTPUT"
+            SOURCE_CHANGED=true
           fi
+
+          # Fetch the daily manifest once, up front, so both a broken/missing
+          # manifest and a stale daily resolve to the same safe fallback:
+          # build from source. A non-200 response or a body that doesn't parse
+          # as JSON is normalized to empty so decide() treats it as unreachable
+          # rather than letting a later jq error abort this step.
+          MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 'https://dailies.rstudio.com/rstudio/latest/index.json' || echo '')
+          if [ -n "$MANIFEST" ] && ! echo "$MANIFEST" | jq empty 2>/dev/null; then
+            echo "Daily manifest did not parse as JSON -- treating as unreachable"
+            MANIFEST=""
+          fi
+
+          # Echoes "true" (build from source) or "false" (use the daily) for
+          # the electron platform key passed as $1.
+          decide() {
+            local key="$1"
+
+            if [ "$SOURCE_CHANGED" = true ]; then
+              echo "$key: source files changed -- building from source" >&2
+              echo true
+              return
+            fi
+
+            if [ -z "$MANIFEST" ]; then
+              echo "$key: daily manifest unreachable -- building from source" >&2
+              echo true
+              return
+            fi
+
+            local entry link filename sha commit
+            entry=$(echo "$MANIFEST" | jq -c --arg k "$key" '.products.electron.platforms[$k] // empty')
+            link=$(echo "$entry" | jq -r '.link // empty')
+            filename=$(echo "$entry" | jq -r '.filename // empty')
+            sha=$(echo "$entry" | jq -r '.sha256 // empty')
+            commit=$(echo "$entry" | jq -r '.commit // empty')
+            if [ -z "$link" ] || [ -z "$filename" ] || [ -z "$sha" ] || [ -z "$commit" ]; then
+              echo "$key: daily manifest missing fields (link='$link' filename='$filename' sha256='$sha' commit='$commit') -- building from source" >&2
+              echo true
+              return
+            fi
+
+            # The daily's commit must already contain this branch's merge-base,
+            # or it predates the behavior the test-only branch assumes. Fetch
+            # the commit best-effort in case full history isn't local; any
+            # error from --is-ancestor (including an unknown commit) is treated
+            # as "not contained" and falls back to a source build.
+            if ! git cat-file -e "${commit}^{commit}" 2>/dev/null; then
+              git fetch --no-tags --quiet origin "$commit" 2>/dev/null || true
+            fi
+            if git merge-base --is-ancestor "$BASE" "$commit" 2>/dev/null; then
+              echo "$key: daily $commit contains merge-base $BASE -- using daily" >&2
+              echo false
+            else
+              echo "$key: daily $commit does not contain merge-base $BASE -- building from source" >&2
+              echo true
+            fi
+          }
+
+          MACOS=$(decide macos)
+          WINDOWS=$(decide windows)
+          echo "Decision: macos build_from_source=$MACOS, windows build_from_source=$WINDOWS"
+          echo "macos_build_from_source=$MACOS" >> "$GITHUB_OUTPUT"
+          echo "windows_build_from_source=$WINDOWS" >> "$GITHUB_OUTPUT"
 
   windows:
     needs: detect-changes
@@ -63,7 +135,7 @@ jobs:
     secrets:
       CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
     with:
-      build_from_source: ${{ fromJSON(needs.detect-changes.outputs.build_from_source) }}
+      build_from_source: ${{ fromJSON(needs.detect-changes.outputs.windows_build_from_source) }}
       project: desktop
       r_version: "4.5.3"
       grep_invert: "@ai"
@@ -75,7 +147,7 @@ jobs:
     secrets:
       CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
     with:
-      build_from_source: ${{ fromJSON(needs.detect-changes.outputs.build_from_source) }}
+      build_from_source: ${{ fromJSON(needs.detect-changes.outputs.macos_build_from_source) }}
       project: desktop
       r_version: "4.5.3"
       grep_invert: "@ai"


### PR DESCRIPTION
## Problem

The PR-triggered Desktop e2e workflow tests a *test-only* PR against the latest daily installer instead of running a ~60 min source build. Two issues surfaced from PR #18039's CI failure:

1. **macOS resolve used a stale manifest key.** It read `.products.electron.platforms["mac-arm64"]` (falling back to `["mac"]`), but the daily now ships a single **universal** `.dmg` keyed `macos`. Both old keys are gone, so every test-only PR failed at resolve with an empty `url`/`filename`/`sha256` ("manifest is missing expected fields"). Windows was unaffected -- it reads `platforms.windows`, which still exists.

2. **A valid daily can still be the wrong binary.** The latest daily may be built from a commit that predates the branch's merge-base (e.g. after merging `main` in), so the suite could run new test code against a binary missing the behavior it assumes.

## Change

Move the daily-vs-source decision into the early `detect-changes` job, decided **per platform** (the manifest can carry a different commit per platform). A daily is used only when all hold:

1. No compiled-binary source changed (existing check).
2. The manifest resolves a usable installer for that platform (`link` + `filename` + `sha256` + `commit` all present).
3. `git merge-base --is-ancestor <merge-base> <daily commit>` -- the daily already contains everything the branch is based on.

Any miss -- source changed, manifest unreachable/malformed/missing-fields, or a stale daily -- falls back to a source build, so a broken or stale daily can never silently run the suite against the wrong binary. Also fixes the macOS resolve key (`macos`, with the old keys kept as fallbacks) so the daily path's own re-resolve succeeds.

## Verification

Tested the `decide` logic against the live manifest under Actions' `bash -eo pipefail`:
- old merge-base contained in daily -> use daily
- merge-base newer than daily -> source build
- source changed -> source build
- empty / malformed / missing-fields manifest -> source build (step does not abort)

## Notes

- CI/tooling only; no user-facing change, so no NEWS.md entry.
- Developer/infra change; no associated issue.