### PR TITLE
Port SQLite snapshot-lock fix.

### DIFF
--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -1568,8 +1568,45 @@ bool ConnectionPool::getConnection(const boost::posix_time::time_duration& maxWa
    return validConnection;
 }
 
+namespace {
+
+// Rolls back any open transaction before returning to the pool; an inherited
+// open transaction can produce SQLITE_BUSY_SNAPSHOT that busy_timeout cannot
+// clear. SQLite WAL-specific: Postgres MVCC (READ COMMITTED) takes a fresh
+// snapshot per statement, so the same failure mode cannot occur there.
+void rollbackOpenSqliteTransaction(const boost::shared_ptr<Connection>& connection)
+{
+   if (connection->driver() != Driver::Sqlite)
+      return;
+
+   auto* backend = static_cast<soci::sqlite3_session_backend*>(connection->session().get_backend());
+   if (backend == nullptr || backend->conn_ == nullptr)
+      return;
+
+   // A nonzero result means the connection is in autocommit (no open
+   // transaction), which is the expected state - nothing to roll back.
+   if (sqlite_api::sqlite3_get_autocommit(backend->conn_) != 0)
+      return;
+
+   try
+   {
+      connection->session() << "ROLLBACK";
+      LOG_DEBUG_MESSAGE("Rolled back an open transaction before returning a "
+                        "connection to the pool");
+   }
+   catch (const soci::soci_error& e)
+   {
+      LOG_DEBUG_MESSAGE(std::string("Failed to roll back open transaction on a "
+                                    "pooled connection: ") + e.what());
+   }
+}
+
+} // anonymous namespace
+
 void ConnectionPool::returnConnection(const boost::shared_ptr<Connection>& connection)
 {
+   rollbackOpenSqliteTransaction(connection);
+
    auto now = boost::posix_time::microsec_clock::universal_time();
    connection->setLastReturnedTime(now);
 

--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -1596,8 +1596,8 @@ void rollbackOpenSqliteTransaction(const boost::shared_ptr<Connection>& connecti
    }
    catch (const soci::soci_error& e)
    {
-      LOG_DEBUG_MESSAGE(std::string("Failed to roll back open transaction on a "
-                                    "pooled connection: ") + e.what());
+      LOG_WARNING_MESSAGE(std::string("Failed to roll back open transaction on a "
+                                      "pooled connection: ") + e.what());
    }
 }
 

--- a/src/cpp/core/DatabaseTests.cpp
+++ b/src/cpp/core/DatabaseTests.cpp
@@ -906,6 +906,122 @@ TEST_F(ConnectionPoolTestsFixture, CanUseConnectionPool)
    ASSERT_TRUE(dataReturned) << "Expected data for id=25";
 }
 
+// Defense-in-depth for rstudio-pro#10885: a connection returned to the pool
+// while a transaction is still open must be rolled back before reuse, so a
+// later writer cannot inherit a stale read snapshot.
+TEST(ConnectionPoolTest, ReturningConnectionWithOpenTransactionRollsItBack)
+{
+   FilePath dbPath;
+   ASSERT_FALSE(FilePath::tempFilePath(dbPath));
+   dbPath.removeIfExists();
+
+   SqliteConnectionOptions options;
+   options.file = dbPath.getAbsolutePath();
+
+   {
+      // Pool of one so the re-acquired connection is guaranteed to be the same
+      // underlying connection we just returned.
+      boost::shared_ptr<ConnectionPool> pool;
+      ASSERT_FALSE(createConnectionPool(1, options, &pool)) << "Failed to create connection pool";
+
+      {
+         boost::shared_ptr<IConnection> conn = pool->getConnection();
+         ASSERT_TRUE(conn) << "Failed to get connection from pool";
+         ASSERT_FALSE(conn->executeStr("CREATE TABLE Txn(id int)")) << "Failed to create Txn table";
+
+         // Open a write transaction and leave it open, simulating a path that
+         // returns the connection without committing or rolling back.
+         ASSERT_FALSE(conn->executeStr("BEGIN")) << "Failed to begin transaction";
+         Query insert = conn->query("INSERT INTO Txn(id) VALUES (:id)").withInput(1);
+         ASSERT_FALSE(conn->execute(insert)) << "Failed to insert within transaction";
+         // conn leaves scope here -> returned to pool -> transaction rolled back.
+      }
+
+      boost::shared_ptr<IConnection> conn2 = pool->getConnection();
+      ASSERT_TRUE(conn2) << "Failed to re-acquire connection from pool";
+
+      // The connection must be back in autocommit: without the rollback-on-return
+      // the prior transaction would still be open and this BEGIN would fail with
+      // "cannot start a transaction within a transaction".
+      ASSERT_FALSE(conn2->executeStr("BEGIN")) << "Connection was not returned to autocommit state";
+      ASSERT_FALSE(conn2->executeStr("ROLLBACK"));
+
+      // And the uncommitted row must not have survived.
+      int count = -1;
+      Query countQuery = conn2->query("SELECT COUNT(*) FROM Txn").withOutput(count);
+      bool dataReturned = false;
+      ASSERT_FALSE(conn2->execute(countQuery, &dataReturned)) << "Failed to count Txn rows";
+      ASSERT_TRUE(dataReturned);
+      EXPECT_EQ(count, 0) << "Uncommitted row should have been rolled back on return";
+   }
+
+   dbPath.removeIfExists();
+}
+
+// Regression for rstudio-pro#10885: a SELECT's Rowset holds a SQLite read
+// snapshot until it is destroyed. A connection that is reused for a write while
+// still carrying such a snapshot - after another connection has committed -
+// fails with SQLITE_BUSY_SNAPSHOT, which busy_timeout cannot clear and retries
+// cannot resolve. This guards that Rowset-lifetime contract.
+TEST(ConnectionPoolTest, RowsetReleasesReadSnapshotWhenDestroyed)
+{
+   FilePath dbPath;
+   ASSERT_FALSE(FilePath::tempFilePath(dbPath));
+   dbPath.removeIfExists();
+
+   SqliteConnectionOptions options;
+   options.file = dbPath.getAbsolutePath();
+
+   {
+      boost::shared_ptr<ConnectionPool> pool;
+      ASSERT_FALSE(createConnectionPool(2, options, &pool)) << "Failed to create connection pool";
+
+      boost::shared_ptr<IConnection> reader = pool->getConnection();
+      boost::shared_ptr<IConnection> writer = pool->getConnection();
+      ASSERT_TRUE(reader) << "Failed to get reader connection";
+      ASSERT_TRUE(writer) << "Failed to get writer connection";
+
+      ASSERT_FALSE(reader->executeStr("CREATE TABLE Snap(id int)")) << "Failed to create Snap table";
+      ASSERT_FALSE(reader->executeStr("INSERT INTO Snap(id) VALUES (1)")) << "Failed seed insert";
+
+      // Raw write that bypasses the execute() retry ladder, so a snapshot
+      // conflict surfaces immediately rather than after the retry budget.
+      auto writeOnReader = [&]() -> bool {
+         try
+         {
+            reader->session() << "INSERT INTO Snap(id) VALUES (99)";
+            return true;
+         }
+         catch (const soci::soci_error&)
+         {
+            return false;
+         }
+      };
+
+      {
+         // Hold a read snapshot open on `reader` by starting, but not finishing,
+         // a SELECT.
+         Rowset rows;
+         Query select = reader->query("SELECT id FROM Snap");
+         ASSERT_FALSE(reader->execute(select, rows)) << "Failed to execute SELECT";
+         RowsetIterator it = rows.begin(); // first step opens the read transaction
+         ASSERT_TRUE(it != rows.end());
+
+         // Another connection commits a write, advancing the WAL past the
+         // reader's snapshot.
+         ASSERT_FALSE(writer->executeStr("INSERT INTO Snap(id) VALUES (2)")) << "Writer insert failed";
+
+         // The reader still holds the stale snapshot, so its write conflicts.
+         EXPECT_FALSE(writeOnReader()) << "expected a snapshot conflict while the Rowset is open";
+      } // Rowset/Query destroyed here -> read snapshot released
+
+      // With the snapshot released, the same connection can write.
+      EXPECT_TRUE(writeOnReader()) << "write should succeed once the Rowset is destroyed";
+   }
+
+   dbPath.removeIfExists();
+}
+
 } // namespace tests
 } // namespace core
 } // namespace rstudio


### PR DESCRIPTION
### Intent

For sqlite connections transactions aren't being rolled back when being returned to the connection pool. Which can result in an edge case where the next user of the connection actually has stale state on the new connection.

This gets done automatically on the postgres side automatically.

Related to rstudio-pro#11540

### Approach

Adds rollbackOpenSqliteTransaction() called from ConnectionPool::returnConnection() to roll back any open transaction before a connection re-enters the pool. An inherited open read snapshot causes SQLITE_BUSY_SNAPSHOT on later writers, which busy_timeout cannot clear.

Also adds two regression tests: one verifying the pool rollback and one documenting the Rowset snapshot-lifetime contract.

### Automated Tests

Added tests.

### QA Notes

Added tests.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
