### PR TITLE
fix readr Import Dataset preview on Windows (escape generated R path) + console-wait reliability

### DIFF
--- a/e2e/rstudio/CLAUDE.md
+++ b/e2e/rstudio/CLAUDE.md
@@ -11,6 +11,7 @@ The `window.rstudio` surface includes:
 - `window.rstudio.project` -- `path()`, `name()`, `isActive()`, `open(path)`.
 - `window.rstudio.version` -- `{ rstudio, r }` version strings.
 - `window.rstudio.dialogs` -- `numShowing()`, `dismissAll()`.
+- `window.rstudio.console.promptCount` -- a monotonic counter that advances by one each time R returns to its top-level prompt (i.e. a submitted console command completed). It is driven by the `ConsolePromptEvent`, so it is a race-free completion signal: `executeInConsole({wait:true})` captures it before submitting and waits for it to increase, rather than sampling the `rstudio-console-busy` class (which can be read stale in the submit->busy gap, or miss a fast command's busy flash). Prefer this for awaiting R-side side effects; the busy-class `waitForConsoleIdle` remains only as a fallback for binaries that predate the counter.
 - `window.rstudio.layout.reset()` -- end any active pane/column zoom or pane maximize.
 - `window.rstudio.errors` -- `list()` / `clear()` the uncaught client exceptions recorded by the agent (message + stack); `simulate(msg)` raises a real one (harness self-test only). The per-test fixture drains this and fails the test that raised an exception (opt out with `PW_IGNORE_CLIENT_EXCEPTIONS=1`).
 

--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -199,6 +199,33 @@ export class ConsolePaneActions {
   }
 
   /**
+   * Evaluate an R expression that yields a single string and return its value
+   * (or null if it couldn't be read). `cat()`s the value between unique
+   * markers and slices it back out of the console, so the value may contain
+   * spaces. Clears the console first so the markers appear at most twice (the
+   * echoed input line and the printed output).
+   *
+   * The leading/trailing `\s+` in the match pattern disambiguates the printed
+   * output from the echoed command: `cat()` separates its arguments with a
+   * space, so in the output each marker is flanked by whitespace, whereas in
+   * the echo the marker is immediately adjacent to a `"` quote. (Same trick as
+   * createSandbox's marker scrape.)
+   *
+   * Intended for diagnostics/state probes where the test wants the R value,
+   * not the console rendering. The expression must evaluate to a single
+   * (length-1) string.
+   */
+  async evalRString(expr: string): Promise<string | null> {
+    await this.clearConsole();
+    const token = `__RVAL_${Date.now()}__`;
+    await this.executeInConsole(`cat(${JSON.stringify(token)}, ${expr}, ${JSON.stringify(token)})`);
+    const output = await this.consolePane.consoleOutput.innerText();
+    const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = output.match(new RegExp(`${escaped}\\s+([\\s\\S]*?)\\s+${escaped}`));
+    return match ? match[1].trim() : null;
+  }
+
+  /**
    * Ensure an R package is available, installing it if necessary.
    * Returns true if the package is available after the check, false if installation failed.
    */

--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -3,7 +3,9 @@ import { expect } from '@playwright/test';
 import * as fs from 'fs';
 import {
   ConsolePane,
+  getConsolePromptCount,
   waitForConsoleBusy,
+  waitForConsoleCommandComplete,
   waitForConsoleIdle,
   type EnvironmentVersions,
   type ExecuteInConsoleOptions,
@@ -109,6 +111,10 @@ export class ConsolePaneActions {
       editor.setValue(text, 1); // 1 = move cursor to end
       editor.focus();
     }, command);
+    // Capture the prompt count before submitting so the wait keys off a new
+    // prompt (command completed), not a sampled busy class -- read it before
+    // pressing Enter, while R is still at the prior prompt.
+    const promptCountBefore = await getConsolePromptCount(this.page);
     if (await this.page.locator('#rstudio_popup_completions').isVisible()) {
       await this.page.keyboard.press('Escape');
     }
@@ -118,7 +124,7 @@ export class ConsolePaneActions {
     // leaving the text in the buffer but never submitted.
     await this.consolePane.consoleInput.press('Enter');
     if (opts.wait ?? true) {
-      await waitForConsoleIdle(this.page, opts.timeout);
+      await waitForConsoleCommandComplete(this.page, promptCountBefore, opts.timeout);
     }
   }
 

--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -205,33 +205,6 @@ export class ConsolePaneActions {
   }
 
   /**
-   * Evaluate an R expression that yields a single string and return its value
-   * (or null if it couldn't be read). `cat()`s the value between unique
-   * markers and slices it back out of the console, so the value may contain
-   * spaces. Clears the console first so the markers appear at most twice (the
-   * echoed input line and the printed output).
-   *
-   * The leading/trailing `\s+` in the match pattern disambiguates the printed
-   * output from the echoed command: `cat()` separates its arguments with a
-   * space, so in the output each marker is flanked by whitespace, whereas in
-   * the echo the marker is immediately adjacent to a `"` quote. (Same trick as
-   * createSandbox's marker scrape.)
-   *
-   * Intended for diagnostics/state probes where the test wants the R value,
-   * not the console rendering. The expression must evaluate to a single
-   * (length-1) string.
-   */
-  async evalRString(expr: string): Promise<string | null> {
-    await this.clearConsole();
-    const token = `__RVAL_${Date.now()}__`;
-    await this.executeInConsole(`cat(${JSON.stringify(token)}, ${expr}, ${JSON.stringify(token)})`);
-    const output = await this.consolePane.consoleOutput.innerText();
-    const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const match = output.match(new RegExp(`${escaped}\\s+([\\s\\S]*?)\\s+${escaped}`));
-    return match ? match[1].trim() : null;
-  }
-
-  /**
    * Ensure an R package is available, installing it if necessary.
    * Returns true if the package is available after the check, false if installation failed.
    */

--- a/e2e/rstudio/pages/console_pane.page.ts
+++ b/e2e/rstudio/pages/console_pane.page.ts
@@ -91,6 +91,51 @@ export async function waitForConsoleIdle(
 }
 
 /**
+ * Read the automation agent's monotonic console prompt counter, or null if the
+ * running binary predates it (`window.rstudio.console.promptCount`, added in
+ * ApplicationAutomation). The counter advances by one each time R returns to
+ * its top-level prompt -- i.e. each time a submitted console command completes
+ * -- so it is a race-free completion signal, unlike the busy CSS class which is
+ * sampled (and can be read stale in the submit->busy gap, or miss a fast
+ * command's busy flash). See waitForConsoleCommandComplete.
+ */
+export async function getConsolePromptCount(page: Page): Promise<number | null> {
+  return page.evaluate(() => {
+    const count = window.rstudio?.console?.promptCount;
+    return typeof count === 'number' ? count : null;
+  });
+}
+
+/**
+ * Wait for a console command to finish, given the prompt count captured *before*
+ * it was submitted (via getConsolePromptCount). Resolves once the count exceeds
+ * `promptCountBefore`, i.e. R emitted a new prompt. This is the reliable
+ * replacement for waitForConsoleIdle when bracketing a submission: it keys off
+ * the prompt *event*, not a sampled class, so it can't return spuriously-idle
+ * before the command starts. Falls back to the busy-class wait when the counter
+ * is unavailable (older binary), preserving prior behavior.
+ */
+export async function waitForConsoleCommandComplete(
+  page: Page,
+  promptCountBefore: number | null,
+  timeout: number = TIMEOUTS.sessionRestart,
+): Promise<void> {
+  if (promptCountBefore === null) {
+    await waitForConsoleIdle(page, timeout);
+    return;
+  }
+
+  await page.waitForFunction(
+    (before) => {
+      const count = window.rstudio?.console?.promptCount;
+      return typeof count === 'number' && count > before;
+    },
+    promptCountBefore,
+    { timeout, polling: 50 },
+  );
+}
+
+/**
  * Wait for the console input to gain its "busy" class -- i.e. for R to start
  * processing submitted code. Pairs with waitForConsoleIdle to bracket an
  * asynchronously-dispatched job (e.g. executeCurrentChunk) whose work doesn't
@@ -162,9 +207,10 @@ export interface ExecuteInConsoleOptions {
  * to run; use `typeInConsole` only when a test is exercising actual typing
  * behavior (e.g. autocomplete triggering).
  *
- * By default this waits for R to finish the command (polling the console-busy
- * class instead of sleeping). Pass `{ wait: false }` for the fire-and-forget
- * pattern (e.g. queuing a marker command behind a long-running install).
+ * By default this waits for R to finish the command -- it waits for a new
+ * console prompt (waitForConsoleCommandComplete) rather than sleeping. Pass
+ * `{ wait: false }` for the fire-and-forget pattern (e.g. queuing a marker
+ * command behind a long-running install).
  */
 export async function executeInConsole(
   page: Page,
@@ -179,6 +225,11 @@ export async function executeInConsole(
     editor.setValue(text, 1); // 1 = move cursor to end
     editor.focus();
   }, command);
+  // Capture the console prompt count before submitting so the wait below can
+  // key off a *new* prompt (command completed) rather than sampling the busy
+  // class. Must be read before any Enter press, while R is still at the prior
+  // prompt.
+  const promptCountBefore = await getConsolePromptCount(page);
   // Try the Enter dispatch a few times. Ace can briefly route the keystroke
   // to an autocomplete / signature-help popup (selecting an entry instead of
   // submitting), and `waitForConsoleIdle` alone can't catch that case
@@ -242,7 +293,7 @@ export async function executeInConsole(
     }
   }
   if (opts.wait ?? true) {
-    await waitForConsoleIdle(page, opts.timeout);
+    await waitForConsoleCommandComplete(page, promptCountBefore, opts.timeout);
   }
 }
 

--- a/e2e/rstudio/pages/console_pane.page.ts
+++ b/e2e/rstudio/pages/console_pane.page.ts
@@ -106,14 +106,29 @@ export async function getConsolePromptCount(page: Page): Promise<number | null> 
   });
 }
 
+/** Set once we've warned about a missing prompt counter, to avoid log spam. */
+let warnedMissingPromptCount = false;
+
 /**
  * Wait for a console command to finish, given the prompt count captured *before*
  * it was submitted (via getConsolePromptCount). Resolves once the count exceeds
- * `promptCountBefore`, i.e. R emitted a new prompt. This is the reliable
- * replacement for waitForConsoleIdle when bracketing a submission: it keys off
- * the prompt *event*, not a sampled class, so it can't return spuriously-idle
- * before the command starts. Falls back to the busy-class wait when the counter
- * is unavailable (older binary), preserving prior behavior.
+ * `promptCountBefore`, i.e. R returned to its top-level prompt. This is the
+ * reliable replacement for waitForConsoleIdle when bracketing a submission: it
+ * keys off the prompt *event*, not a sampled class, so it can't return
+ * spuriously-idle before the command starts.
+ *
+ * The counter advances only on top-level prompts (the bump is gated on the
+ * prompt's busy flag in ApplicationAutomation), so nested/intermediate prompts
+ * (`browser()`, `readline()`, `menu()`) don't trip it early. It still assumes
+ * the submitted command returns to top-level exactly once: a command left
+ * sitting at a continuation (`+`) or interactive prompt never advances the
+ * counter, so the wait times out rather than resolving. All current callers
+ * submit self-contained one-shot expressions, which satisfies this.
+ *
+ * Falls back to the busy-class wait when the counter is unavailable (a binary
+ * built before the counter, or one where registerConsole failed to install it),
+ * preserving prior behavior; warns once so a silent revert to the flaky path is
+ * visible in the log.
  */
 export async function waitForConsoleCommandComplete(
   page: Page,
@@ -121,6 +136,14 @@ export async function waitForConsoleCommandComplete(
   timeout: number = TIMEOUTS.sessionRestart,
 ): Promise<void> {
   if (promptCountBefore === null) {
+    if (!warnedMissingPromptCount) {
+      warnedMissingPromptCount = true;
+      console.warn(
+        '[console] window.rstudio.console.promptCount unavailable; falling back ' +
+        'to the busy-class wait (waitForConsoleIdle). This is the known-flaky ' +
+        'path -- expected only against a binary that predates the counter.',
+      );
+    }
     await waitForConsoleIdle(page, timeout);
     return;
   }
@@ -178,13 +201,12 @@ export async function waitForConsoleFocus(page: Page, timeout: number = 5000): P
 export interface ExecuteInConsoleOptions {
   /**
    * Whether to wait for R to finish processing the command before returning
-   * (via `waitForConsoleIdle`). Defaults to `true`: most callers expect the
-   * command to have fully executed before the next step runs, and waiting on
-   * the console-busy class is faster and more reliable than a blind sleep.
-   * It also matters for correctness -- a command is only added to recall
-   * history when R *executes* it, so firing several commands without waiting
-   * leaves the later ones queued (not yet in history) and makes history
-   * navigation nondeterministic.
+   * (via `waitForConsoleCommandComplete`, which keys off a new top-level
+   * prompt). Defaults to `true`: most callers expect the command to have fully
+   * executed before the next step runs. It also matters for correctness -- a
+   * command is only added to recall history when R *executes* it, so firing
+   * several commands without waiting leaves the later ones queued (not yet in
+   * history) and makes history navigation nondeterministic.
    *
    * Pass `wait: false` for the fire-and-forget pattern: submitting a
    * long-running command (e.g. `install.packages`) and then queuing a marker
@@ -232,11 +254,12 @@ export async function executeInConsole(
   const promptCountBefore = await getConsolePromptCount(page);
   // Try the Enter dispatch a few times. Ace can briefly route the keystroke
   // to an autocomplete / signature-help popup (selecting an entry instead of
-  // submitting), and `waitForConsoleIdle` alone can't catch that case
-  // because R was already idle -- so it returns immediately while the
-  // command sits unsubmitted in the editor. After each press we verify the
-  // editor is now empty (Ace clears the input on submit); if not, dismiss
-  // any popup and try again.
+  // submitting). The completion wait below can't catch that case on its own:
+  // if nothing was submitted, no new prompt arrives, so the wait would just
+  // time out (and the busy-class fallback returns immediately, R already being
+  // idle) while the command sits unsubmitted in the editor. After each press
+  // we verify the editor is now empty (Ace clears the input on submit); if
+  // not, dismiss any popup and try again.
   const MAX_ATTEMPTS = 3;
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     if (attempt === 1) {

--- a/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
+++ b/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
@@ -21,6 +21,7 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { executeCommand } from '@utils/commands';
 import { installDepIfPrompted } from '@pages/modals.page';
 import { useSuiteSandbox } from '@utils/sandbox';
+import { rPathLiteral } from '@utils/r';
 import { TIMEOUTS } from '@utils/constants';
 
 // The dialog's aria-label comes from the caption passed to the
@@ -30,23 +31,16 @@ const IMPORT_DIALOG = '.gwt-DialogBox[aria-label="Import Text Data"]';
 // The preview iframe is a GridViewerFrame titled with constants_.dataPreview().
 const PREVIEW_FRAME = 'iframe[title="Data Preview"]';
 
-// Open Import Dataset > From Text (readr) for the given CSV path and drive the
-// dialog until the preview iframe is up. Returns the dialog + preview frame so
-// each test can assert on the rendered preview. The caller cancels the dialog.
-// Waits for the readr preview iframe to show its first column header.
-// On Windows CI the preview subprocess occasionally fails to start; soft-skip
-// rather than hard-fail so an environment issue doesn't mask other results.
-//
-// `consoleActions` and `csvPath` are used only on the failure path, to probe
-// the R session for the CSV's on-disk state. #17985 manifests as the preview
-// subprocess reporting the CSV "does not exist"; the probe records whether the
-// file is actually missing (write failed / wrong path) or present-but-invisible
-// to the separate preview process, so the skip reason is actionable.
-async function awaitPreviewOrSkip(
+// Wait for the readr preview iframe to render its first column header. On
+// failure, scrape the top-level "Error" dialog into the thrown message: when
+// the preview subprocess errors, the message surfaces through the progress
+// indicator's onError -> GlobalDisplay.showErrorMessage
+// (ModalDialogBase.addProgressIndicator), which renders a separate top-level
+// "Error" dialog rather than a label inside the import dialog. The message is
+// prefixed with "Is this a valid CSV file? " by enhancePreviewErrorMessage.
+async function awaitPreview(
   dialog: Locator,
   previewFrame: FrameLocator,
-  consoleActions: ConsolePaneActions,
-  csvPath: string,
 ): Promise<void> {
   const firstColHeader = previewFrame.locator('th[data-col-idx="1"]');
 
@@ -57,41 +51,11 @@ async function awaitPreviewOrSkip(
   if (previewReady)
     return;
 
-  // The header never appeared. When the preview subprocess fails, the error is
-  // surfaced through the progress indicator's onError, which routes to
-  // GlobalDisplay.showErrorMessage (ModalDialogBase.addProgressIndicator) and
-  // renders a separate top-level "Error" dialog -- not a label inside the
-  // import dialog. Scrape that dialog for a more specific diagnostic. The
-  // message is prefixed with "Is this a valid CSV file? " by
-  // enhancePreviewErrorMessage, so key on that marker.
   const errorDialog = dialog.page().locator('.gwt-DialogBox[aria-label="Error"]');
   const errorText = (await errorDialog.textContent().catch(() => null)) ?? '';
-  let detail = errorText.includes('valid CSV file')
-    ? `readr CSV preview failed on Windows CI: ${errorText.trim()}`
-    : 'readr CSV preview subprocess did not load on Windows CI';
-
-  // Cancel out of the import dialog and dismiss the top-level Error dialog (if
-  // any) before probing/skipping, so the console is reachable for the probe
-  // below and teardown stays clean.
-  await dialog.locator('#rstudio_dlg_cancel').click().catch(() => {});
-  await errorDialog.getByRole('button', { name: 'OK' }).click().catch(() => {});
-
-  // Best-effort: capture the R session's view of the CSV so the skip/throw
-  // reason says whether the file is on disk (write failed / wrong path) or
-  // present-but-invisible to the separate preview process (the suspected
-  // Windows-CI filesystem-visibility flake in #17985).
-  const fsState = await consoleActions
-    .evalRString(
-      `paste0("wd=[", getwd(), "] exists=", file.exists("${csvPath}"), ` +
-      `" dirfiles=[", paste(list.files(dirname("${csvPath}")), collapse=", "), "]")`,
-    )
-    .catch(() => null);
-  if (fsState)
-    detail += ` [R fs: ${fsState}]`;
-
-  test.fixme(os.platform() === 'win32' && !!process.env.CI, detail);
   throw new Error(
-    `readr CSV preview did not produce column headers within 45 s [R fs: ${fsState ?? 'unavailable'}]`,
+    'readr CSV preview did not render its column headers within 45s' +
+    (errorText ? ` (Error dialog: ${errorText.trim()})` : ''),
   );
 }
 
@@ -99,16 +63,20 @@ async function openReadrCsvPreview(
   page: Page,
   consoleActions: ConsolePaneActions,
   csvPath: string,
-): Promise<{ dialog: Locator; previewFrame: FrameLocator; csvPath: string }> {
+): Promise<{ dialog: Locator; previewFrame: FrameLocator }> {
   // Write the CSV via the R session so the path is valid on the rsession host
   // (matters for Server mode where runner and session can differ). The preview
   // runs in a separate --vanilla R subprocess, so the file must be on disk
-  // before the dialog opens or vroom reports "<csv> does not exist" and the
-  // preview times out after 45s (#17985). executeInConsole({wait:true}) now
-  // waits for a new console prompt (waitForConsoleCommandComplete), so the
-  // write is guaranteed complete on return.
+  // before the dialog opens, or vroom reports "<csv> does not exist" and the
+  // preview never renders (#17985).
+  //
+  // Use rPathLiteral, NOT a raw "${csvPath}": on Windows sandbox.dir comes back
+  // from R's tempfile() with backslashes, and embedding that into R source
+  // turns it into escape sequences (\r, \a become control chars; \p, \w are a
+  // hard parse error), so the writeLines never runs. rPathLiteral normalizes to
+  // forward slashes (which R accepts on Windows) and quotes safely.
   await consoleActions.executeInConsole(
-    `writeLines(c("a,b,c","1,2,3","4,5,6"), "${csvPath}")`,
+    `writeLines(c("a,b,c","1,2,3","4,5,6"), ${rPathLiteral(csvPath)})`,
     { wait: true },
   );
 
@@ -132,10 +100,12 @@ async function openReadrCsvPreview(
   // the label-association in DataImport.ui.xml.
   const fileInput = dialog.getByRole('textbox', { name: 'File/URL:' });
   await expect(fileInput).toBeVisible({ timeout: 5000 });
-  // On Windows the readr dialog's file chooser passes the path to a subprocess
-  // via Java's File API, which expects backslash separators. Forward-slash
-  // paths (produced by R's tempfile()) cause the preview to silently fail.
-  const fillPath = os.platform() === 'win32' ? csvPath.replace(/\//g, '\\') : csvPath;
+  // The file chooser passes the typed path to Java's File API; on Windows use
+  // native backslash separators. Normalize to forward slashes first, since
+  // sandbox.dir may already be backslashes (R tempfile()) joined with a forward
+  // slash, then convert -- so the result is uniformly separated on each OS.
+  const forwardPath = csvPath.replace(/\\/g, '/');
+  const fillPath = os.platform() === 'win32' ? forwardPath.replace(/\//g, '\\') : forwardPath;
   await fileInput.fill(fillPath);
 
   // Click "Update" to commit the path and kick off preview_data_import_async.
@@ -148,7 +118,7 @@ async function openReadrCsvPreview(
   await expect(updateBtn).toBeVisible({ timeout: 5000 });
   await updateBtn.click();
 
-  return { dialog, previewFrame: dialog.frameLocator(PREVIEW_FRAME), csvPath };
+  return { dialog, previewFrame: dialog.frameLocator(PREVIEW_FRAME) };
 }
 
 test.describe('Import Dataset (readr)', () => {
@@ -161,7 +131,7 @@ test.describe('Import Dataset (readr)', () => {
 
   // https://github.com/rstudio/rstudio/issues/17777
   test('CSV preview renders without an .rs.digest lookup error', async ({ rstudioPage: page }) => {
-    const { dialog, previewFrame, csvPath } = await openReadrCsvPreview(
+    const { dialog, previewFrame } = await openReadrCsvPreview(
       page, consoleActions, `${sandbox.dir}/sample.csv`,
     );
 
@@ -171,7 +141,7 @@ test.describe('Import Dataset (readr)', () => {
     // CSV file?" error prefix instead. The grid renders each header as
     // "<name>(<type>)" once column inference completes; anchor on the name
     // prefix so the assertion doesn't depend on the inferred type string.
-    await awaitPreviewOrSkip(dialog, previewFrame, consoleActions, csvPath);
+    await awaitPreview(dialog, previewFrame);
 
     const firstColHeader = previewFrame.locator('th[data-col-idx="1"]');
     await expect(firstColHeader).toHaveText(/^a/);
@@ -190,12 +160,12 @@ test.describe('Import Dataset (readr)', () => {
 
   // https://github.com/rstudio/rstudio/issues/17735
   test('preview hides the column-summary sidebar', async ({ rstudioPage: page }) => {
-    const { dialog, previewFrame, csvPath } = await openReadrCsvPreview(
+    const { dialog, previewFrame } = await openReadrCsvPreview(
       page, consoleActions, `${sandbox.dir}/summary.csv`,
     );
 
     // Gate on the preview being up before asserting sidebar state.
-    await awaitPreviewOrSkip(dialog, previewFrame, consoleActions, csvPath);
+    await awaitPreview(dialog, previewFrame);
 
     // The fix: GridViewerFrame requests show_summary=0, so the panel never
     // gains the "expanded" class and the toggle reports collapsed. Pre-fix the

--- a/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
+++ b/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
@@ -101,9 +101,11 @@ async function openReadrCsvPreview(
   const fileInput = dialog.getByRole('textbox', { name: 'File/URL:' });
   await expect(fileInput).toBeVisible({ timeout: 5000 });
   // The file chooser passes the typed path to Java's File API; on Windows use
-  // native backslash separators. Normalize to forward slashes first, since
-  // sandbox.dir may already be backslashes (R tempfile()) joined with a forward
-  // slash, then convert -- so the result is uniformly separated on each OS.
+  // native backslash separators. createSandbox now normalizes its workdir to
+  // forward slashes, so csvPath has no backslashes and the first replace is a
+  // belt-and-suspenders no-op on every platform; it stays only to guard a
+  // future caller that builds csvPath from a raw backslash path. The Windows
+  // branch then converts to backslashes for the File API.
   const forwardPath = csvPath.replace(/\\/g, '/');
   const fillPath = os.platform() === 'win32' ? forwardPath.replace(/\//g, '\\') : forwardPath;
   await fileInput.fill(fillPath);

--- a/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
+++ b/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
@@ -100,22 +100,14 @@ async function openReadrCsvPreview(
   consoleActions: ConsolePaneActions,
   csvPath: string,
 ): Promise<{ dialog: Locator; previewFrame: FrameLocator; csvPath: string }> {
-  // Write the CSV via the R session so the path is valid on the rsession host
-  // (matters for Server mode where runner and session can be on different
-  // machines).
-  const writeCmd = `writeLines(c("a,b,c","1,2,3","4,5,6"), "${csvPath}")`;
-  await consoleActions.executeInConsole(writeCmd, { wait: true });
-
-  // Verify the CSV actually landed before opening the dialog. The preview runs
-  // in a separate --vanilla R subprocess; if the write silently failed (a
-  // transient open/lock failure on Windows CI is swallowed by wait:true) the
-  // subprocess reports the file "does not exist" and the preview times out
-  // after 45s (#17985). Poll file.exists() from the session, retry the write
-  // once, and surface a setup error here rather than misattributing it to the
-  // preview. file.exists() is the session's own view -- a cross-process
-  // visibility lag still slips through, but awaitPreviewOrSkip's probe records
-  // that case.
-  await ensureCsvWritten(consoleActions, csvPath, writeCmd);
+  // Write the CSV via the R session (so the path is valid on the rsession host
+  // -- matters for Server mode where runner and session can differ) and confirm
+  // it actually landed before opening the dialog. The preview runs in a
+  // separate --vanilla R subprocess; if the write hasn't completed when the
+  // subprocess opens the file, vroom reports "<csv> does not exist" and the
+  // preview times out after 45s (#17985). See writeCsvConfirmed for why a plain
+  // executeInConsole({wait:true}) isn't a sufficient gate here.
+  await writeCsvConfirmed(consoleActions, csvPath);
 
   // The presenter wraps the dialog in a dependency check; accept the install
   // prompt if readr (or a transitive dep) isn't already on the library path.
@@ -156,27 +148,31 @@ async function openReadrCsvPreview(
   return { dialog, previewFrame: dialog.frameLocator(PREVIEW_FRAME), csvPath };
 }
 
-// Confirm the CSV is on disk from the R session's point of view, retrying the
-// write once. Throws a setup-level error (not a preview timeout) if the file
-// never appears -- see openReadrCsvPreview for why this guards #17985.
-async function ensureCsvWritten(
+// Write the CSV and confirm it landed, in a single R round-trip per attempt.
+// The block returns file.exists(), which evalRLogical reads from the printed
+// `[1] TRUE/FALSE`. That printed result only appears after R has actually run
+// the expression, so it is a true completion signal -- unlike
+// executeInConsole({wait:true}), whose wait-for-idle (waitForConsoleIdle) can
+// return in the submit->busy gap before the write has even run. That premature
+// return is the suspected source of the intermittent "<csv> does not exist"
+// preview failure in #17985: the preview subprocess opens the CSV before the
+// writeLines completes. Retries once, then throws a setup-level error (not a
+// preview timeout) so a genuine write failure is attributed here.
+async function writeCsvConfirmed(
   consoleActions: ConsolePaneActions,
   csvPath: string,
-  writeCmd: string,
 ): Promise<void> {
-  const exists = async (): Promise<boolean> =>
-    (await consoleActions.evalRLogical(`file.exists("${csvPath}")`)) === true;
+  const writeAndCheck =
+    `{ writeLines(c("a,b,c","1,2,3","4,5,6"), "${csvPath}"); file.exists("${csvPath}") }`;
 
-  if (await exists())
-    return;
-
-  await consoleActions.executeInConsole(writeCmd, { wait: true });
-  if (await exists())
-    return;
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    if ((await consoleActions.evalRLogical(writeAndCheck)) === true)
+      return;
+  }
 
   throw new Error(
     `Import Dataset test setup: CSV not written to ${csvPath} ` +
-    `(file.exists() is FALSE after two writeLines attempts).`,
+    `(file.exists() is FALSE after two confirmed-write attempts).`,
   );
 }
 

--- a/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
+++ b/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
@@ -100,14 +100,17 @@ async function openReadrCsvPreview(
   consoleActions: ConsolePaneActions,
   csvPath: string,
 ): Promise<{ dialog: Locator; previewFrame: FrameLocator; csvPath: string }> {
-  // Write the CSV via the R session (so the path is valid on the rsession host
-  // -- matters for Server mode where runner and session can differ) and confirm
-  // it actually landed before opening the dialog. The preview runs in a
-  // separate --vanilla R subprocess; if the write hasn't completed when the
-  // subprocess opens the file, vroom reports "<csv> does not exist" and the
-  // preview times out after 45s (#17985). See writeCsvConfirmed for why a plain
-  // executeInConsole({wait:true}) isn't a sufficient gate here.
-  await writeCsvConfirmed(consoleActions, csvPath);
+  // Write the CSV via the R session so the path is valid on the rsession host
+  // (matters for Server mode where runner and session can differ). The preview
+  // runs in a separate --vanilla R subprocess, so the file must be on disk
+  // before the dialog opens or vroom reports "<csv> does not exist" and the
+  // preview times out after 45s (#17985). executeInConsole({wait:true}) now
+  // waits for a new console prompt (waitForConsoleCommandComplete), so the
+  // write is guaranteed complete on return.
+  await consoleActions.executeInConsole(
+    `writeLines(c("a,b,c","1,2,3","4,5,6"), "${csvPath}")`,
+    { wait: true },
+  );
 
   // The presenter wraps the dialog in a dependency check; accept the install
   // prompt if readr (or a transitive dep) isn't already on the library path.
@@ -146,34 +149,6 @@ async function openReadrCsvPreview(
   await updateBtn.click();
 
   return { dialog, previewFrame: dialog.frameLocator(PREVIEW_FRAME), csvPath };
-}
-
-// Write the CSV and confirm it landed, in a single R round-trip per attempt.
-// The block returns file.exists(), which evalRLogical reads from the printed
-// `[1] TRUE/FALSE`. That printed result only appears after R has actually run
-// the expression, so it is a true completion signal -- unlike
-// executeInConsole({wait:true}), whose wait-for-idle (waitForConsoleIdle) can
-// return in the submit->busy gap before the write has even run. That premature
-// return is the suspected source of the intermittent "<csv> does not exist"
-// preview failure in #17985: the preview subprocess opens the CSV before the
-// writeLines completes. Retries once, then throws a setup-level error (not a
-// preview timeout) so a genuine write failure is attributed here.
-async function writeCsvConfirmed(
-  consoleActions: ConsolePaneActions,
-  csvPath: string,
-): Promise<void> {
-  const writeAndCheck =
-    `{ writeLines(c("a,b,c","1,2,3","4,5,6"), "${csvPath}"); file.exists("${csvPath}") }`;
-
-  for (let attempt = 1; attempt <= 2; attempt++) {
-    if ((await consoleActions.evalRLogical(writeAndCheck)) === true)
-      return;
-  }
-
-  throw new Error(
-    `Import Dataset test setup: CSV not written to ${csvPath} ` +
-    `(file.exists() is FALSE after two confirmed-write attempts).`,
-  );
 }
 
 test.describe('Import Dataset (readr)', () => {

--- a/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
+++ b/e2e/rstudio/tests/panes/environment/import_dataset.test.ts
@@ -36,9 +36,17 @@ const PREVIEW_FRAME = 'iframe[title="Data Preview"]';
 // Waits for the readr preview iframe to show its first column header.
 // On Windows CI the preview subprocess occasionally fails to start; soft-skip
 // rather than hard-fail so an environment issue doesn't mask other results.
+//
+// `consoleActions` and `csvPath` are used only on the failure path, to probe
+// the R session for the CSV's on-disk state. #17985 manifests as the preview
+// subprocess reporting the CSV "does not exist"; the probe records whether the
+// file is actually missing (write failed / wrong path) or present-but-invisible
+// to the separate preview process, so the skip reason is actionable.
 async function awaitPreviewOrSkip(
   dialog: Locator,
   previewFrame: FrameLocator,
+  consoleActions: ConsolePaneActions,
+  csvPath: string,
 ): Promise<void> {
   const firstColHeader = previewFrame.locator('th[data-col-idx="1"]');
 
@@ -58,29 +66,56 @@ async function awaitPreviewOrSkip(
   // enhancePreviewErrorMessage, so key on that marker.
   const errorDialog = dialog.page().locator('.gwt-DialogBox[aria-label="Error"]');
   const errorText = (await errorDialog.textContent().catch(() => null)) ?? '';
-  const detail = errorText.includes('valid CSV file')
+  let detail = errorText.includes('valid CSV file')
     ? `readr CSV preview failed on Windows CI: ${errorText.trim()}`
     : 'readr CSV preview subprocess did not load on Windows CI';
 
-  // Cancel out of the import dialog before skipping so teardown stays clean.
+  // Cancel out of the import dialog and dismiss the top-level Error dialog (if
+  // any) before probing/skipping, so the console is reachable for the probe
+  // below and teardown stays clean.
   await dialog.locator('#rstudio_dlg_cancel').click().catch(() => {});
+  await errorDialog.getByRole('button', { name: 'OK' }).click().catch(() => {});
+
+  // Best-effort: capture the R session's view of the CSV so the skip/throw
+  // reason says whether the file is on disk (write failed / wrong path) or
+  // present-but-invisible to the separate preview process (the suspected
+  // Windows-CI filesystem-visibility flake in #17985).
+  const fsState = await consoleActions
+    .evalRString(
+      `paste0("wd=[", getwd(), "] exists=", file.exists("${csvPath}"), ` +
+      `" dirfiles=[", paste(list.files(dirname("${csvPath}")), collapse=", "), "]")`,
+    )
+    .catch(() => null);
+  if (fsState)
+    detail += ` [R fs: ${fsState}]`;
 
   test.fixme(os.platform() === 'win32' && !!process.env.CI, detail);
-  throw new Error('readr CSV preview did not produce column headers within 45 s');
+  throw new Error(
+    `readr CSV preview did not produce column headers within 45 s [R fs: ${fsState ?? 'unavailable'}]`,
+  );
 }
 
 async function openReadrCsvPreview(
   page: Page,
   consoleActions: ConsolePaneActions,
   csvPath: string,
-): Promise<{ dialog: Locator; previewFrame: FrameLocator }> {
+): Promise<{ dialog: Locator; previewFrame: FrameLocator; csvPath: string }> {
   // Write the CSV via the R session so the path is valid on the rsession host
   // (matters for Server mode where runner and session can be on different
   // machines).
-  await consoleActions.executeInConsole(
-    `writeLines(c("a,b,c","1,2,3","4,5,6"), "${csvPath}")`,
-    { wait: true },
-  );
+  const writeCmd = `writeLines(c("a,b,c","1,2,3","4,5,6"), "${csvPath}")`;
+  await consoleActions.executeInConsole(writeCmd, { wait: true });
+
+  // Verify the CSV actually landed before opening the dialog. The preview runs
+  // in a separate --vanilla R subprocess; if the write silently failed (a
+  // transient open/lock failure on Windows CI is swallowed by wait:true) the
+  // subprocess reports the file "does not exist" and the preview times out
+  // after 45s (#17985). Poll file.exists() from the session, retry the write
+  // once, and surface a setup error here rather than misattributing it to the
+  // preview. file.exists() is the session's own view -- a cross-process
+  // visibility lag still slips through, but awaitPreviewOrSkip's probe records
+  // that case.
+  await ensureCsvWritten(consoleActions, csvPath, writeCmd);
 
   // The presenter wraps the dialog in a dependency check; accept the install
   // prompt if readr (or a transitive dep) isn't already on the library path.
@@ -118,7 +153,31 @@ async function openReadrCsvPreview(
   await expect(updateBtn).toBeVisible({ timeout: 5000 });
   await updateBtn.click();
 
-  return { dialog, previewFrame: dialog.frameLocator(PREVIEW_FRAME) };
+  return { dialog, previewFrame: dialog.frameLocator(PREVIEW_FRAME), csvPath };
+}
+
+// Confirm the CSV is on disk from the R session's point of view, retrying the
+// write once. Throws a setup-level error (not a preview timeout) if the file
+// never appears -- see openReadrCsvPreview for why this guards #17985.
+async function ensureCsvWritten(
+  consoleActions: ConsolePaneActions,
+  csvPath: string,
+  writeCmd: string,
+): Promise<void> {
+  const exists = async (): Promise<boolean> =>
+    (await consoleActions.evalRLogical(`file.exists("${csvPath}")`)) === true;
+
+  if (await exists())
+    return;
+
+  await consoleActions.executeInConsole(writeCmd, { wait: true });
+  if (await exists())
+    return;
+
+  throw new Error(
+    `Import Dataset test setup: CSV not written to ${csvPath} ` +
+    `(file.exists() is FALSE after two writeLines attempts).`,
+  );
 }
 
 test.describe('Import Dataset (readr)', () => {
@@ -131,7 +190,7 @@ test.describe('Import Dataset (readr)', () => {
 
   // https://github.com/rstudio/rstudio/issues/17777
   test('CSV preview renders without an .rs.digest lookup error', async ({ rstudioPage: page }) => {
-    const { dialog, previewFrame } = await openReadrCsvPreview(
+    const { dialog, previewFrame, csvPath } = await openReadrCsvPreview(
       page, consoleActions, `${sandbox.dir}/sample.csv`,
     );
 
@@ -141,7 +200,7 @@ test.describe('Import Dataset (readr)', () => {
     // CSV file?" error prefix instead. The grid renders each header as
     // "<name>(<type>)" once column inference completes; anchor on the name
     // prefix so the assertion doesn't depend on the inferred type string.
-    await awaitPreviewOrSkip(dialog, previewFrame);
+    await awaitPreviewOrSkip(dialog, previewFrame, consoleActions, csvPath);
 
     const firstColHeader = previewFrame.locator('th[data-col-idx="1"]');
     await expect(firstColHeader).toHaveText(/^a/);
@@ -160,12 +219,12 @@ test.describe('Import Dataset (readr)', () => {
 
   // https://github.com/rstudio/rstudio/issues/17735
   test('preview hides the column-summary sidebar', async ({ rstudioPage: page }) => {
-    const { dialog, previewFrame } = await openReadrCsvPreview(
+    const { dialog, previewFrame, csvPath } = await openReadrCsvPreview(
       page, consoleActions, `${sandbox.dir}/summary.csv`,
     );
 
     // Gate on the preview being up before asserting sidebar state.
-    await awaitPreviewOrSkip(dialog, previewFrame);
+    await awaitPreviewOrSkip(dialog, previewFrame, consoleActions, csvPath);
 
     // The fix: GridViewerFrame requests show_summary=0, so the panel never
     // gains the "expanded" class and the toggle reports collapsed. Pre-fix the

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -19,6 +19,7 @@ type CommandEntry = {
   (): void;
   isChecked(): boolean;
   isEnabled(): boolean;
+  isVisible(): boolean;
 };
 
 type PrefEntry = {
@@ -183,6 +184,18 @@ type ErrorsBridge = {
   simulate(message: string): void;
 };
 
+type ConsoleBridge = {
+  /**
+   * Monotonic count of console prompts: advances by one each time R returns to
+   * its top-level prompt (i.e. a submitted console command completed). Driven
+   * by ConsolePromptEvent, so it is a race-free completion signal --
+   * executeInConsole captures it before submitting and waits for it to
+   * increase, rather than sampling the busy class. Absent on binaries built
+   * before the counter was added (ApplicationAutomation.registerConsole).
+   */
+  promptCount: number;
+};
+
 type ShinyBridge = {
   /**
    * Stop the running foreground shiny app via shiny::stopApp() on rsession.
@@ -203,6 +216,8 @@ type RStudioBridge = {
   dialogs: DialogsBridge;
   layout: LayoutBridge;
   errors: ErrorsBridge;
+  /** Console completion-signal surface (promptCount). */
+  console?: ConsoleBridge;
   /** Shiny-app automation surface. */
   shiny?: ShinyBridge;
   /** Chat-pane state surface (populated lazily by ChatPresenter). */
@@ -257,7 +272,7 @@ export async function executeCommand(page: Page, commandId: string): Promise<voi
   try {
     await page.waitForFunction(
       (id) => {
-        const cmd = (window.rstudio?.commands as Record<string, ((() => void) & { isEnabled(): boolean; isVisible(): boolean }) | undefined> | undefined)?.[id];
+        const cmd = window.rstudio?.commands?.[id];
         return typeof cmd === 'function' && (cmd.isEnabled() || !cmd.isVisible());
       },
       commandId,
@@ -268,7 +283,7 @@ export async function executeCommand(page: Page, commandId: string): Promise<voi
     // failure names the command and its actual blocking condition, rather
     // than a generic waitForFunction timeout.
     const exists = await page.evaluate(
-      (id) => typeof (window.rstudio?.commands as Record<string, unknown> | undefined)?.[id] === 'function',
+      (id) => typeof window.rstudio?.commands?.[id] === 'function',
       commandId,
     );
     throw new Error(

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -186,12 +186,10 @@ type ErrorsBridge = {
 
 type ConsoleBridge = {
   /**
-   * Monotonic count of console prompts: advances by one each time R returns to
-   * its top-level prompt (i.e. a submitted console command completed). Driven
-   * by ConsolePromptEvent, so it is a race-free completion signal --
-   * executeInConsole captures it before submitting and waits for it to
-   * increase, rather than sampling the busy class. Absent on binaries built
-   * before the counter was added (ApplicationAutomation.registerConsole).
+   * Monotonic count of completed console commands (advances on each top-level
+   * prompt). Absent on binaries built before the counter was added. See
+   * ApplicationAutomation.registerConsole for the authoritative rationale, and
+   * waitForConsoleCommandComplete for how callers consume it.
    */
   promptCount: number;
 };

--- a/e2e/rstudio/utils/sandbox.ts
+++ b/e2e/rstudio/utils/sandbox.ts
@@ -48,10 +48,20 @@ export async function createSandbox(page: Page): Promise<string> {
 
   // Build the R expression on a single line so executeInConsole's single
   // press('Enter') executes it atomically.
+  //
+  // normalizePath(winslash = "/") forces forward slashes: on Windows tempfile()
+  // yields a backslash path (the tmpdir root comes from PW_SANDBOX, a Node
+  // path), and backslashes are escape sequences in an R string literal -- so
+  // embedding the returned dir into generated R code (e.g.
+  // writeLines(..., "<dir>/foo")) mangles it or hard-errors (\p, \w are
+  // unrecognized escapes; see #17985). R accepts forward slashes on every
+  // platform, so this is the safe canonical form for callers to interpolate.
+  // (Defense in depth: callers should still pass paths through rPathLiteral.)
   const rCode = [
     `{ root <- ${rootExpr()}`,
     `d <- tempfile("${SANDBOX_DIR_PREFIX}", tmpdir = root)`,
     `dir.create(d, recursive = TRUE)`,
+    `d <- normalizePath(d, winslash = "/", mustWork = FALSE)`,
     `setwd(d)`,
     `cat("${marker}", d, "${marker}") }`,
   ].join('; ');

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -237,6 +237,13 @@ public class ApplicationAutomation
    // rstudio-console-busy CSS class (which can be observed stale in the
    // submit->busy gap, or miss a fast command's busy flash entirely).
    //
+   // The bump is gated on the prompt's busy flag: ConsolePromptEvent also fires
+   // for mid-execution prompts (continuation "+", browser(), readline(),
+   // menu()), which carry busy == true. Counting those would let a waiter
+   // resolve on an intermediate prompt, before the command truly returns to
+   // top-level. Only the top-level prompt (busy == false) advances the counter,
+   // so "promptCount increased" means "command completed".
+   //
    // Handlers are registered once per GWT page lifetime (initializeAgent runs
    // again on each session restart), guarded like registerReadinessHandlers.
    // The counter is intentionally not reset across restarts -- it only needs to
@@ -249,7 +256,11 @@ public class ApplicationAutomation
       if (consoleHandlersRegistered_)
          return;
 
-      eventBus_.addHandler(ConsolePromptEvent.TYPE, event -> bumpConsolePromptCount());
+      eventBus_.addHandler(ConsolePromptEvent.TYPE, event ->
+      {
+         if (!event.getPrompt().getBusy())
+            bumpConsolePromptCount();
+      });
       consoleHandlersRegistered_ = true;
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -42,6 +42,7 @@ import org.rstudio.studio.client.workbench.prefs.model.Prefs;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.ui.PaneManager;
 import org.rstudio.studio.client.workbench.views.chat.server.ChatServerOperations;
+import org.rstudio.studio.client.workbench.views.console.events.ConsolePromptEvent;
 import org.rstudio.studio.client.workbench.views.source.SourceColumnManager;
 
 import com.google.gwt.core.client.GWT;
@@ -101,6 +102,11 @@ import com.google.inject.Singleton;
  *   window.rstudio.shiny.stopForegroundApp() // stop the running foreground
  *                                            // shiny app via shiny::stopApp();
  *                                            // resolves once R exits runApp
+ *
+ *   window.rstudio.console.promptCount   // monotonic count of console prompts
+ *                                        // (advances when a submitted command
+ *                                        // completes); a race-free completion
+ *                                        // signal, vs sampling the busy class
  * </pre>
  *
  * <h2>Why enumerate everything up front</h2>
@@ -157,6 +163,7 @@ public class ApplicationAutomation
       registerDialogs();
       registerLayout();
       registerErrors();
+      registerConsole();
       registerReadinessHandlers();
    }
 
@@ -219,6 +226,31 @@ public class ApplicationAutomation
          setReadyFlag(true);
 
       readinessHandlersRegistered_ = true;
+   }
+
+   // window.rstudio.console.promptCount is a monotonic counter that advances by
+   // one each time R returns to its top-level prompt -- i.e. each time a
+   // submitted console command completes. It is driven by ConsolePromptEvent
+   // (the client-side dispatch of the server's kConsolePrompt event), so it is
+   // a race-free completion signal: automation can capture the value, submit a
+   // command, and wait for the counter to increase, instead of sampling the
+   // rstudio-console-busy CSS class (which can be observed stale in the
+   // submit->busy gap, or miss a fast command's busy flash entirely).
+   //
+   // Handlers are registered once per GWT page lifetime (initializeAgent runs
+   // again on each session restart), guarded like registerReadinessHandlers.
+   // The counter is intentionally not reset across restarts -- it only needs to
+   // be monotonic so a captured "before" value stays comparable; a full page
+   // reload wipes it back to 0 with the rest of the JS state.
+   private void registerConsole()
+   {
+      registerConsoleObject();
+
+      if (consoleHandlersRegistered_)
+         return;
+
+      eventBus_.addHandler(ConsolePromptEvent.TYPE, event -> bumpConsolePromptCount());
+      consoleHandlersRegistered_ = true;
    }
 
    private void registerCommands()
@@ -748,6 +780,20 @@ public class ApplicationAutomation
       });
    }-*/;
 
+   // Install (idempotently) window.rstudio.console.promptCount. Not reset on
+   // re-init so the counter stays monotonic across session restarts; see
+   // registerConsole for the rationale and how callers use it.
+   private native final void registerConsoleObject() /*-{
+      $wnd.rstudio.console = $wnd.rstudio.console || {};
+      if (typeof $wnd.rstudio.console.promptCount !== 'number')
+         $wnd.rstudio.console.promptCount = 0;
+   }-*/;
+
+   private native final void bumpConsolePromptCount() /*-{
+      if ($wnd.rstudio && $wnd.rstudio.console)
+         $wnd.rstudio.console.promptCount = ($wnd.rstudio.console.promptCount || 0) + 1;
+   }-*/;
+
    // Versions are stable for the life of the session, so install a plain
    // object rather than getter functions. Read via window.rstudio.version.
    private native final void registerVersionObject(String rstudio, String r) /*-{
@@ -868,4 +914,5 @@ public class ApplicationAutomation
    private final Provider<PaneManager> pPaneManager_;
    private boolean isAutomationAgent_ = false;
    private boolean readinessHandlersRegistered_ = false;
+   private boolean consoleHandlersRegistered_ = false;
 }


### PR DESCRIPTION
Addresses #17985.

## Root cause (corrected)

The readr Import Dataset preview e2e test failed on Windows CI. The real cause is **not** a subprocess-start failure (as the issue title implies) or a console wait race (an earlier hypothesis in this PR) -- it's an **unescaped path in generated R code**:

The test wrote the CSV via `writeLines(..., "${csvPath}")`, where `csvPath` embeds `sandbox.dir`. On Windows that path comes back from R's `tempfile()` with **backslashes** (`D:\a\rstudio\rstudio\pw-sandbox\pw_sandbox_*\workdir_*`). Embedded raw into R source, the backslashes are escape sequences -- `\r`/`\a` become control chars and `\p` (pw-sandbox) / `\w` (workdir) are a **hard parse error**:

```
'\p' is an unrecognized escape in character string
```

So `writeLines` never runs, the CSV is never written, and vroom's `check_path` reports the file "does not exist." macOS uses forward-slash sandbox paths, so it never reproduced (nor did local desktop-dev validation).

## Fix

Use the existing `rPathLiteral` helper (`utils/r.ts` -- normalizes `\` -> `/`, which R accepts on Windows, then quotes), the same idiom other tests already use (`project_id`, `project_editor_theme`, ...). Dropped the `test.fixme` guard and the diagnostic scaffolding built around the earlier wait-race hypothesis.

## Also in this PR: console-wait reliability (independent improvement)

While investigating, I found a genuine latent race: `executeInConsole({wait:true})` uses `waitForConsoleIdle`, which only samples the `rstudio-console-busy` class and can return in the submit->busy gap before R runs the command. This is **not** what broke #17985, but it's a real footgun for ~456 callers. Fixed by exposing `window.rstudio.console.promptCount` on the automation bridge (a monotonic counter bumped on `ConsolePromptEvent`); `executeInConsole` now waits for the count to advance, with a busy-class fallback for older binaries. Plus a small typing cleanup (`CommandEntry.isVisible()`).

> If reviewers would prefer, the console-wait change can be split into its own PR -- happy to do that.

## Verification

- `import_dataset` 2/2 on the macOS dev build; `rs_value_contents` 4/4 (console-heavy, exercises the new wait path); `tsc --noEmit` and `ant javac`/`ant draft` clean.
- The Windows-specific fix is verified by this PR's Windows CI run (the failure was Windows-only).
