### PR TITLE
make block-push-to-main hook worktree-aware

### DIFF
--- a/.claude/hooks/block-push-to-main.sh
+++ b/.claude/hooks/block-push-to-main.sh
@@ -14,17 +14,32 @@ command=$(echo "$input" | jq -r '.tool_input.command // empty') || {
   exit 2
 }
 
+# A git invocation may carry global options between 'git' and its subcommand
+# (e.g. 'git -C <dir> -c x=y commit'), so the subcommand is not necessarily the
+# first token. This fragment matches a run of such options -- '-C <dir>' (whose
+# argument may be single- or double-quoted, e.g. a path with spaces), '-c
+# <name>=<value>', and other single-/double-dash flags -- so we can find the
+# real commit/push subcommand, and the -C target, past them.
+git_opts="([[:space:]]+(-C[[:space:]]+(\"[^\"]*\"|'[^']*'|[^[:space:]]+)|-c[[:space:]]+[^[:space:]]+|--?[^[:space:]]+))*"
+
 # Block git push and git commit on protected branches
-if echo "$command" | grep -qE '\bgit\s+(push|commit)\b'; then
+if echo "$command" | grep -qE "\bgit${git_opts}[[:space:]]+(push|commit)\b"; then
 
   # Resolve the directory the git command actually targets, so that commits
   # and pushes from a worktree are evaluated against the worktree's branch --
   # not whatever branch happens to be checked out in this hook's working
-  # directory (typically the primary checkout). Prefer an explicit
-  # 'git -C <dir> commit|push', then a leading 'cd <dir>', else the cwd.
-  target_dir=$(echo "$command" | grep -oE '\bgit[[:space:]]+-C[[:space:]]+[^ ]+[[:space:]]+(commit|push)\b' | head -1 | sed -E 's/^git[[:space:]]+-C[[:space:]]+//; s/[[:space:]]+(commit|push)$//')
+  # directory (typically the primary checkout). Prefer the argument to an
+  # explicit 'git -C <dir>', then a leading 'cd <dir>', else the cwd. The -C
+  # match is anchored to the leading option region (via "$git_opts") so a -C
+  # appearing only inside a commit message (e.g. -m "see -C") is not mistaken
+  # for a target directory.
+  #
+  # The '|| true' is required: under 'set -e'/'pipefail' a non-matching grep (no
+  # -C / no cd, the common bare 'git commit' case) would otherwise fail the
+  # assignment and abort the hook -- letting the command through unchecked.
+  target_dir=$(echo "$command" | grep -oE "\bgit${git_opts}[[:space:]]+-C[[:space:]]+(\"[^\"]*\"|'[^']*'|[^[:space:]]+)" | head -1 | sed -E "s/.*-C[[:space:]]+//" || true)
   if [ -z "$target_dir" ]; then
-    target_dir=$(echo "$command" | grep -oE '\bcd[[:space:]]+[^ ;&|]+' | head -1 | sed -E 's/^cd[[:space:]]+//')
+    target_dir=$(echo "$command" | grep -oE '\bcd[[:space:]]+[^ ;&|]+' | head -1 | sed -E 's/^cd[[:space:]]+//' || true)
   fi
   target_dir="${target_dir:-.}"
 
@@ -38,7 +53,7 @@ if echo "$command" | grep -qE '\bgit\s+(push|commit)\b'; then
   }
 
   if [ "$branch" = "main" ] || echo "$branch" | grep -qE '^rel-'; then
-    if echo "$command" | grep -qE '\bgit\s+push\b'; then
+    if echo "$command" | grep -qE "\bgit${git_opts}[[:space:]]+push\b"; then
       echo "BLOCKED: git push on '$branch' is not allowed. Create a feature branch first." >&2
     else
       echo "BLOCKED: git commit on '$branch' is not allowed. Create a feature branch first." >&2
@@ -46,3 +61,8 @@ if echo "$command" | grep -qE '\bgit\s+(push|commit)\b'; then
     exit 2
   fi
 fi
+
+# Allow: nothing matched a protected branch. Exit explicitly so the allow path
+# does not inherit a non-zero status from a preceding test (e.g. the branch
+# comparison above), which Claude Code would surface as a hook error.
+exit 0

--- a/.claude/hooks/block-push-to-main.sh
+++ b/.claude/hooks/block-push-to-main.sh
@@ -16,10 +16,27 @@ command=$(echo "$input" | jq -r '.tool_input.command // empty') || {
 
 # Block git push and git commit on protected branches
 if echo "$command" | grep -qE '\bgit\s+(push|commit)\b'; then
-  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || {
+
+  # Resolve the directory the git command actually targets, so that commits
+  # and pushes from a worktree are evaluated against the worktree's branch --
+  # not whatever branch happens to be checked out in this hook's working
+  # directory (typically the primary checkout). Prefer an explicit
+  # 'git -C <dir> commit|push', then a leading 'cd <dir>', else the cwd.
+  target_dir=$(echo "$command" | grep -oE '\bgit[[:space:]]+-C[[:space:]]+[^ ]+[[:space:]]+(commit|push)\b' | head -1 | sed -E 's/^git[[:space:]]+-C[[:space:]]+//; s/[[:space:]]+(commit|push)$//')
+  if [ -z "$target_dir" ]; then
+    target_dir=$(echo "$command" | grep -oE '\bcd[[:space:]]+[^ ;&|]+' | head -1 | sed -E 's/^cd[[:space:]]+//')
+  fi
+  target_dir="${target_dir:-.}"
+
+  # strip surrounding quotes, if any
+  target_dir="${target_dir%\"}"; target_dir="${target_dir#\"}"
+  target_dir="${target_dir%\'}"; target_dir="${target_dir#\'}"
+
+  branch=$(git -C "$target_dir" rev-parse --abbrev-ref HEAD 2>/dev/null) || {
     echo "WARNING: Could not determine current branch. Blocking as a precaution." >&2
     exit 2
   }
+
   if [ "$branch" = "main" ] || echo "$branch" | grep -qE '^rel-'; then
     if echo "$command" | grep -qE '\bgit\s+push\b'; then
       echo "BLOCKED: git push on '$branch' is not allowed. Create a feature branch first." >&2


### PR DESCRIPTION
Developer-only tooling change (no linked issue).

## worktree-aware push/commit hook (`.claude/hooks/block-push-to-main.sh`)

The Claude Code PreToolUse hook resolved the branch via `git rev-parse` in its
own working directory (the primary checkout), so it blocked *every* commit/push
issued from a worktree -- even when the worktree was on a feature branch.

It now resolves the directory the git command actually targets and checks that
branch:

- prefers the argument to an explicit `git -C <dir>`, then a leading
  `cd <dir>`, else the cwd;
- tolerates global options between `git` and its subcommand
  (e.g. `git -C <dir> -c x=y commit`), so the subcommand and the `-C` target are
  found even when they are not the first token;
- handles single-/double-quoted `-C` arguments (paths containing spaces);
- anchors the `-C` match to the leading option region so a `-C` appearing only
  inside a commit message (e.g. `-m "see -C"`) is not mistaken for a target dir.

It still blocks commits/pushes whose target branch is `main` or `rel-*`,
including from the primary checkout and from a worktree that happens to be on
`main`.

Two robustness fixes to the worktree-aware logic:

- the directory-extraction `$(... grep ...)` substitutions now end in `|| true`;
  under `set -e`/`pipefail` a non-matching grep (the common bare commit case)
  would otherwise fail the assignment and abort the hook, letting the command
  through unchecked;
- the script ends in an explicit `exit 0` so the allow path does not inherit a
  non-zero status from a preceding test, which Claude Code would surface as a
  hook error.

Note: the ccache/sccache compiler-cache change originally in this PR was dropped
-- that feature already exists in a more complete form on `main`
(`cmake/globals.cmake`), and adding a second mechanism in `cmake/compiler.cmake`
(included before `globals.cmake`) actually disabled the existing one.
