### PR TITLE
add :z to docker-compile.sh bind mount for SELinux hosts

### DIFF
--- a/docker/docker-compile.sh
+++ b/docker/docker-compile.sh
@@ -186,9 +186,14 @@ echo "Running build command:"
 echo "${CMD}"
 
 # run compile step!
+#
+# The ":z" suffix on the volume mount tells Docker to relabel the bind-mounted
+# content so it's accessible from within the container on hosts with SELinux
+# enabled (otherwise the confined container process is denied access to the
+# source tree and the build fails). The suffix is ignored on non-SELinux hosts.
 docker run                 \
   --name "$CONTAINER_ID"   \
-  --volume "$(pwd):/src"   \
+  --volume "$(pwd):/src:z" \
   "$REPO:$IMAGE_TAG" bash -c "${CMD}"
 
 # extract logs to get filename (should be on the last line)


### PR DESCRIPTION
Addresses #16731.

On hosts with SELinux enabled, `docker-compile.sh` fails because the repo is bind-mounted into the build container without an SELinux relabel. The confined container process is denied access to the unrelabeled source tree under `/src`, so the build aborts.

This appends the `:z` (shared) suffix to the bind mount, which tells Docker to relabel the mounted content so it's accessible from within the container. The suffix is a no-op on non-SELinux hosts (macOS Docker Desktop, plain Ubuntu/Debian), so it's safe to apply unconditionally; `:z` (shared) rather than `:Z` (private) is used because the same source tree is reused across multiple image/flavor builds.

Per the Docker docs referenced in the issue: https://docs.docker.com/engine/storage/bind-mounts/#configure-the-selinux-label

No NEWS.md entry: this is developer build tooling (tech debt), not user-facing.

Note: verified against documented Docker behavior; not reproduced on an SELinux host locally (developed on macOS), hence "Addresses" rather than "Fixes".