### PR TITLE
Activate Plots pane for interactive Posit Assistant code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - ([#17992](https://github.com/rstudio/rstudio/issues/17992)): The Find in Files replace preview and Replace All results no longer present matches whose proposed replacement is identical to the matched text; lines whose every match would be unchanged are omitted entirely.
 
 ### Fixed
+- ([#18037](https://github.com/rstudio/rstudio/issues/18037)): Fixed the Plots pane not being brought to the front when Posit Assistant runs code that produces a plot. Interactive agent code now activates the Plots pane like a console command does.
 - ([#18033](https://github.com/rstudio/rstudio/issues/18033)): Fix ghost text set via `rstudioapi::setGhostText()` not being dismissed when navigating the cursor away or typing a non-matching character, which left it insertable by Tab even after it appeared to be gone.
 - ([#17970](https://github.com/rstudio/rstudio/issues/17970)): Fix the Packages pane vulnerability dialog listing vulnerabilities that affect a different installed version of the clicked package; the dialog now shows only the vulnerabilities for that row's version. A package with vulnerability records from multiple repositories now shows a single combined warning icon and dialog instead of one per repository.
 - ([#17985](https://github.com/rstudio/rstudio/issues/17985)): Fixed an issue where the Import Dataset preview dialog failed to display error messages when the readr preview subprocess encountered an error, causing the dialog to hang indefinitely waiting for data that would never arrive.

--- a/e2e/rstudio/pages/chat_pane.page.ts
+++ b/e2e/rstudio/pages/chat_pane.page.ts
@@ -13,6 +13,7 @@ export class ChatPane extends FramePageObject {
   public chatRoot: Locator;
   public chatInput: Locator;
   public messageItem: Locator;
+  public assistantMessageItem: Locator;
   public allowBtn: Locator;
   public allowDropdownTrigger: Locator;
   public allowForSessionItem: Locator;
@@ -50,6 +51,11 @@ export class ChatPane extends FramePageObject {
     // <textarea>. editor.setEditable() toggles its contenteditable attribute.
     this.chatInput = this.frame.locator('.tiptap-input-editor');
     this.messageItem = this.frame.locator('[data-message-id]');
+    // Assistant-role bubbles only. The message wrapper carries the role via an
+    // inner .chat-message-assistant / .chat-message-user class (ChatMessage.tsx),
+    // so this excludes the user's own prompt bubble -- letting callers match on
+    // reply content without a fragile "not the prompt text" exclusion.
+    this.assistantMessageItem = this.frame.locator('[data-message-id]:has(.chat-message-assistant)');
     this.allowBtn = this.frame.locator("button:has-text('Allow')");
     this.allowDropdownTrigger = this.frame.locator('button.rounded-l-none:has(svg.lucide-chevron-down)');
     this.allowForSessionItem = this.frame.locator('[role="menuitem"]:has-text("for this session")');

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/plots-pane-activation.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/plots-pane-activation.test.ts
@@ -1,0 +1,98 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { requireAiCredentials } from '@utils/ai-credentials';
+import { executeCommand } from '@utils/commands';
+import { PLOTS_TAB } from '@pages/plots_pane.page';
+import type { ChatPane } from '@pages/chat_pane.page';
+import type { ChatPaneActions } from '@actions/chat_pane.actions';
+import type { ConsolePaneActions } from '@actions/console_pane.actions';
+import type { EnvironmentVersions } from '@pages/console_pane.page';
+import type { Page } from 'playwright';
+import { setupPositAssistantChat, annotateVersions } from './_chat-setup';
+
+// Regression test for https://github.com/rstudio/rstudio/issues/18037.
+//
+// When Posit Assistant runs code that produces a plot, the Plots pane should
+// be brought to the front automatically -- just like plotting from the
+// console. PR #17923 moved the assistant to an interleaved execution path that
+// captures plots itself and calls executeCode with capturePlot disabled; the
+// session then reported ChangeSourceRPC instead of ChangeSourceREPL, so the
+// Plots pane no longer activated even though the plot rendered to the device.
+//
+// This drives the real assistant: it selects Files (which shares the Plots
+// tabset, so Plots is deselected -- the state described in the issue), asks the
+// assistant to draw a base-R plot, then asserts the Plots tab becomes selected.
+
+const PLOT_DONE_MARKER = 'PLOT_DONE_E2E';
+
+// Force base-R plotting (no package dependencies) through the code-execution
+// tool, and end with a deterministic marker so the poll can detect completion.
+const PROMPT =
+  'Use your code execution tool to run exactly this R code and nothing else: ' +
+  'plot(1:10, main = "E2E plot test"). Do not write it to a file and do not ' +
+  `load any packages. After the plot has been drawn, reply with exactly: ${PLOT_DONE_MARKER}`;
+
+async function isPlotsTabSelected(page: Page): Promise<boolean> {
+  return (await page.locator(PLOTS_TAB).getAttribute('aria-selected')) === 'true';
+}
+
+test.describe.serial('Posit Assistant activates the Plots pane', { tag: ['@ai'] }, () => {
+  requireAiCredentials(test, 'positai');
+
+  let chatPane: ChatPane;
+  let chatActions: ChatPaneActions;
+  let consoleActions: ConsolePaneActions;
+  let versions: EnvironmentVersions;
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    // Assistant backend cold-start can outlast the default per-test budget.
+    test.setTimeout(120000);
+    const actions = await setupPositAssistantChat(page);
+    chatPane = actions.chatPane;
+    chatActions = actions.chatActions;
+    consoleActions = actions.consoleActions;
+    versions = actions.versions;
+  });
+
+  test.beforeEach(() => {
+    annotateVersions(versions);
+  });
+
+  test('generating a plot brings the Plots pane to the front', async ({ rstudioPage: page }) => {
+    test.setTimeout(180000);
+
+    await chatActions.startNewConversation();
+
+    // Close any device left open by an earlier test so the activation we assert
+    // on is caused by this turn -- not a stale pending plot that background
+    // rendering could surface on its own and mask the regression.
+    await consoleActions.executeInConsole('graphics.off()', { wait: true });
+
+    // Precondition: the Plots pane is NOT the selected tab. Files shares its
+    // tabset (TabSet2) with Plots, so selecting Files guarantees Plots is
+    // deselected -- the starting state described in the issue.
+    await executeCommand(page, 'activateFiles');
+    await expect.poll(() => isPlotsTabSelected(page)).toBe(false);
+
+    await chatActions.sendChatMessage(PROMPT);
+
+    // Drive the conversation to completion, granting executeCode permission as
+    // its Allow dialog appears. The user's prompt bubble also contains the
+    // marker, so guard against matching it by excluding a prompt-only phrase.
+    await chatActions.pollWithAllowDialogs(async () => {
+      if (await chatPane.isStopButtonVisible()) return false;
+      if ((await chatPane.getMessageCount()) < 2) return false;
+      const lastText = await chatPane.messageItem.last().innerText().catch(() => '');
+      return lastText.includes(PLOT_DONE_MARKER) && !lastText.includes('Use your code execution tool');
+    }, 150000);
+
+    // The regression: the assistant drew a plot, so the Plots pane must be
+    // brought to the front, exactly as a console plot would.
+    await expect
+      .poll(() => isPlotsTabSelected(page), {
+        timeout: 15000,
+        message:
+          'Plots pane was not activated after Posit Assistant generated a plot (issue #18037)',
+      })
+      .toBe(true);
+  });
+});

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/plots-pane-activation.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/plots-pane-activation.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { requireAiCredentials } from '@utils/ai-credentials';
-import { executeCommand } from '@utils/commands';
+import { executeCommand, isCommandEnabled } from '@utils/commands';
 import { PLOTS_TAB } from '@pages/plots_pane.page';
 import type { ChatPane } from '@pages/chat_pane.page';
 import type { ChatPaneActions } from '@actions/chat_pane.actions';
@@ -62,11 +62,17 @@ test.describe.serial('Posit Assistant activates the Plots pane', { tag: ['@ai'] 
     // worker: close the graphics device and clear the Plots pane history.
     if (!consoleActions) return;
     await consoleActions.executeInConsole('graphics.off()', { wait: true });
-    await executeCommand(page, 'clearPlots');
-    const clearYes = page.locator('role=alertdialog >> button:has-text("Yes")');
-    if (await clearYes.isVisible({ timeout: 2000 }).catch(() => false)) {
-      await clearYes.click();
-      await expect(clearYes).not.toBeVisible({ timeout: 5000 });
+    // clearPlots is disabled when there is no plot history (e.g. the test
+    // failed before plotting). Gate on the enabled state so this cleanup never
+    // throws and masks the original failure -- executeCommand otherwise waits
+    // for the command to enable and then times out.
+    if (await isCommandEnabled(page, 'clearPlots')) {
+      await executeCommand(page, 'clearPlots');
+      const clearYes = page.locator('role=alertdialog >> button:has-text("Yes")');
+      if (await clearYes.isVisible({ timeout: 2000 }).catch(() => false)) {
+        await clearYes.click();
+        await expect(clearYes).not.toBeVisible({ timeout: 5000 });
+      }
     }
   });
 

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/plots-pane-activation.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/plots-pane-activation.test.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { requireAiCredentials } from '@utils/ai-credentials';
-import { executeCommand, isCommandEnabled } from '@utils/commands';
+import { executeCommand, isCommandEnabled, numModalsShowing, dismissAllModals } from '@utils/commands';
 import { PLOTS_TAB } from '@pages/plots_pane.page';
+import { YES_BTN } from '@pages/modals.page';
 import type { ChatPane } from '@pages/chat_pane.page';
 import type { ChatPaneActions } from '@actions/chat_pane.actions';
 import type { ConsolePaneActions } from '@actions/console_pane.actions';
@@ -68,11 +69,15 @@ test.describe.serial('Posit Assistant activates the Plots pane', { tag: ['@ai'] 
     // for the command to enable and then times out.
     if (await isCommandEnabled(page, 'clearPlots')) {
       await executeCommand(page, 'clearPlots');
-      const clearYes = page.locator('role=alertdialog >> button:has-text("Yes")');
-      if (await clearYes.isVisible({ timeout: 2000 }).catch(() => false)) {
-        await clearYes.click();
-        await expect(clearYes).not.toBeVisible({ timeout: 5000 });
-      }
+      // Confirm via the stable GWT "Yes" button id, polling for it rather than
+      // racing a fixed timeout. dismissAll only hides dialogs, so it would not
+      // actually clear the history -- the Yes click is what runs clearPlots.
+      await page.locator(YES_BTN).click({ timeout: 10000 }).catch(() => {});
+    }
+    // Safety net: guarantee no modal (confirm or its progress indicator) is
+    // left up to block later specs in this worker, regardless of timing above.
+    if ((await numModalsShowing(page)) > 0) {
+      await dismissAllModals(page);
     }
   });
 
@@ -95,13 +100,14 @@ test.describe.serial('Posit Assistant activates the Plots pane', { tag: ['@ai'] 
     await chatActions.sendChatMessage(PROMPT);
 
     // Drive the conversation to completion, granting executeCode permission as
-    // its Allow dialog appears. The user's prompt bubble also contains the
-    // marker, so guard against matching it by excluding a prompt-only phrase.
+    // its Allow dialog appears. Match the marker only in the assistant's reply
+    // bubble: the user's prompt bubble also contains the marker verbatim, so
+    // scoping to the assistant role avoids depending on a prompt-text exclusion
+    // (which would deadlock until timeout if the reply echoed that phrase).
     await chatActions.pollWithAllowDialogs(async () => {
       if (await chatPane.isStopButtonVisible()) return false;
-      if ((await chatPane.getMessageCount()) < 2) return false;
-      const lastText = await chatPane.messageItem.last().innerText().catch(() => '');
-      return lastText.includes(PLOT_DONE_MARKER) && !lastText.includes('Use your code execution tool');
+      const lastReply = await chatPane.assistantMessageItem.last().innerText().catch(() => '');
+      return lastReply.includes(PLOT_DONE_MARKER);
     }, 150000);
 
     // The regression: the assistant drew a plot, so the Plots pane must be

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/plots-pane-activation.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/plots-pane-activation.test.ts
@@ -67,16 +67,20 @@ test.describe.serial('Posit Assistant activates the Plots pane', { tag: ['@ai'] 
     // failed before plotting). Gate on the enabled state so this cleanup never
     // throws and masks the original failure -- executeCommand otherwise waits
     // for the command to enable and then times out.
-    if (await isCommandEnabled(page, 'clearPlots')) {
-      await executeCommand(page, 'clearPlots');
-      // Confirm via the stable GWT "Yes" button id, polling for it rather than
-      // racing a fixed timeout. dismissAll only hides dialogs, so it would not
-      // actually clear the history -- the Yes click is what runs clearPlots.
-      await page.locator(YES_BTN).click({ timeout: 10000 }).catch(() => {});
-    }
-    // Safety net: guarantee no modal (confirm or its progress indicator) is
-    // left up to block later specs in this worker, regardless of timing above.
-    if ((await numModalsShowing(page)) > 0) {
+    if (!(await isCommandEnabled(page, 'clearPlots'))) return;
+
+    await executeCommand(page, 'clearPlots');
+    // Confirm via the stable GWT "Yes" button id, polling for it rather than
+    // racing a fixed timeout. dismissAll only hides dialogs, so it would not
+    // actually clear the history -- the Yes click is what runs clearPlots.
+    await page.locator(YES_BTN).click({ timeout: 10000 }).catch(() => {});
+
+    // Wait for the confirm dialog and its clearPlots progress indicator to
+    // drain -- i.e. the async clear finished -- so it can't race later specs in
+    // this worker. Only force any still-open modal down if that doesn't happen.
+    try {
+      await expect.poll(() => numModalsShowing(page), { timeout: 10000 }).toBe(0);
+    } catch {
       await dismissAllModals(page);
     }
   });

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/plots-pane-activation.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/plots-pane-activation.test.ts
@@ -57,6 +57,19 @@ test.describe.serial('Posit Assistant activates the Plots pane', { tag: ['@ai'] 
     annotateVersions(versions);
   });
 
+  test.afterAll(async ({ rstudioPage: page }) => {
+    // Don't leak the device/plot this test created into later tests in the
+    // worker: close the graphics device and clear the Plots pane history.
+    if (!consoleActions) return;
+    await consoleActions.executeInConsole('graphics.off()', { wait: true });
+    await executeCommand(page, 'clearPlots');
+    const clearYes = page.locator('role=alertdialog >> button:has-text("Yes")');
+    if (await clearYes.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await clearYes.click();
+      await expect(clearYes).not.toBeVisible({ timeout: 5000 });
+    }
+  });
+
   test('generating a plot brings the Plots pane to the front', async ({ rstudioPage: page }) => {
     test.setTimeout(180000);
 

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -2007,11 +2007,21 @@ void executeCodeImpl(boost::shared_ptr<core::system::ProcessOperations> pOps,
    // Send successful response
    sendJsonRpcResponse(ops, requestId, result);
 
-   // Fire change detection event to trigger environment refresh
-   // Use ChangeSourceREPL if a plot was captured so the Plots pane gets activated
-   module_context::ChangeSource changeSource = !plotsArray.isEmpty()
-      ? module_context::ChangeSourceREPL
-      : module_context::ChangeSourceRPC;
+   // Fire change detection event to trigger environment refresh. Interactive
+   // executions mimic the REPL, which always reports ChangeSourceREPL after a
+   // console turn (see SessionConsoleInput.cpp); that is what lets the Plots
+   // pane activate when R drew a plot. Activation self-gates on actual
+   // graphics-device changes (SessionPlots.cpp), so this is a no-op when
+   // nothing was plotted. We cannot key off plotsArray here: it is only
+   // populated when the caller requests capturePlot, yet an interactive
+   // execution may produce a plot with capturePlot disabled (e.g. the Posit
+   // Assistant's interleaved path, which captures plots through its own R-side
+   // hook). Keying activation off whether this was a console-style turn is
+   // correct regardless of how the caller captures plots. Silent setup/teardown
+   // helpers are not REPL turns and must not activate the pane.
+   module_context::ChangeSource changeSource = silentExecution
+      ? module_context::ChangeSourceRPC
+      : module_context::ChangeSourceREPL;
    module_context::events().onDetectChanges(changeSource);
 }
 


### PR DESCRIPTION
Fixes #18037.

### Problem

When Posit Assistant runs code that produces a plot, the Plots pane is no longer brought to the front automatically. The plot still renders to the device (it appears once the Plots pane is selected manually), but the pane is not activated. This worked in 2026.05.1.

### Root cause

Introduced by #17923, which moved the assistant's code execution to an interleaved path. That path captures plots through its own R-side hook and calls the `executeCode` RPC with `capturePlot` disabled. In `executeCodeImpl`, Plots-pane activation was gated on a non-empty `plotsArray`, which is only populated when the caller requests `capturePlot`. With capture disabled, `plotsArray` is always empty, so the session reported `ChangeSourceRPC` instead of `ChangeSourceREPL` and the pane was never activated.

### Fix

Interactive (non-silent) executions now report `ChangeSourceREPL`, the same source the R console reports after every turn (`SessionConsoleInput.cpp`). That is the mechanism that activates the Plots pane. Activation self-gates on actual graphics-device changes (`SessionPlots.cpp`), so it is a no-op when nothing was plotted. Silent setup/teardown helpers continue to report `ChangeSourceRPC`.

### Tests

Adds an `@ai` end-to-end Playwright test (`e2e/rstudio/tests/panes/posit-assistant-chat/plots-pane-activation.test.ts`): it selects the Files tab (which shares the Plots tabset, so Plots starts deselected), drives the assistant to draw a base-R plot, and asserts the Plots pane tab becomes selected. It runs in the credentialed `@ai` suite.

Also verified by hand:

- Select a non-Plots pane (e.g. Files), ask Posit Assistant to draw a plot -> the Plots pane is brought to the front with the new plot.
- Ask Posit Assistant to run interactive code that does not plot -> the active pane does not change.
