### PR TITLE
backport fix for issue 17743 to Golden Wattle patch 2

### DIFF
--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -325,11 +325,18 @@ int RReadConsole(const char *pmt,
       // s_captureInjected is still true so we skip injection and
       // proceed normally. The next new browse prompt (after stepping)
       // injects again.
+      //
+      // Resolve .rs.captureCurrentEnvironment explicitly through
+      // as.environment("tools:rstudio") rather than relying on the
+      // search path being reachable via lexical scope. Functions
+      // loaded by hermetic module systems (e.g. the 'box' package)
+      // have enclosure chains that bypass the user search path, so
+      // a bare .rs.captureCurrentEnvironment() lookup would fail.
       static bool s_captureInjected = false;
       if (browsing && !s_captureInjected)
       {
          s_captureInjected = true;
-         std::string cmd = ".rs.captureCurrentEnvironment()\n";
+         std::string cmd = "as.environment(\"tools:rstudio\")$.rs.captureCurrentEnvironment()\n";
          cmd.copy((char*)buf, cmd.size());
          buf[cmd.size()] = '\0';
          return 1;

--- a/version/news/os/NEWS-2026.05.2-golden-wattle.md
+++ b/version/news/os/NEWS-2026.05.2-golden-wattle.md
@@ -1,0 +1,8 @@
+## RStudio 2026.05.2 "Golden Wattle" Release Notes
+
+### New
+
+### Fixed
+- ([#17743](https://github.com/rstudio/rstudio/issues/17743)): Fix the debugger failing to capture the browser environment for functions loaded by the `box` package.
+- 
+### Dependencies

--- a/version/news/os/NEWS-2026.05.2-golden-wattle.md
+++ b/version/news/os/NEWS-2026.05.2-golden-wattle.md
@@ -4,5 +4,5 @@
 
 ### Fixed
 - ([#17743](https://github.com/rstudio/rstudio/issues/17743)): Fix the debugger failing to capture the browser environment for functions loaded by the `box` package.
-- 
+ 
 ### Dependencies


### PR DESCRIPTION
Backport of fix for https://github.com/rstudio/rstudio/issues/17743.
Original PR: https://github.com/rstudio/rstudio/pull/17744