### PR TITLE
fix macOS DMG build failure: bump disk image size to 4g

### DIFF
--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -468,9 +468,11 @@ if [ "${build_package}" = "1" ]; then
 
       cd ..
 
-      # allocate oversized dmg, which will be compressed
+      # allocate oversized dmg, which will be compressed (UDZO), so the extra
+      # headroom is reclaimed and does not bloat the final artifact. The app
+      # bundle is ~1.7G+ and outgrew the previous 2g ceiling.
       hdiutil create                       \
-         -size 2g                          \
+         -size 4g                          \
          -fs "APFS"                        \
          -volname "${RSTUDIO_BUNDLE_NAME}" \
          -srcfolder "install"              \


### PR DESCRIPTION
## Problem

Daily macOS builds were failing during DMG creation with `No space left on device`:

```
[I] Creating 'RStudio-2026.07.0-daily-45.dmg ...'
could not access /Volumes/RStudio-2026.07.0-daily-45/RStudio.app/.../libGLESv2.dylib - No space left on device
hdiutil: create failed - No space left on device
```

The failing path is *inside the mounted disk image* (`/Volumes/<dmgname>/...`), not the agent's root volume. The DMG is created by a hand-rolled `hdiutil create` in `package/osx/make-package` with a hardcoded `-size 2g`. The staged app bundle is now ~1.7G+ (the Electron 41.9.0 bump in #18047 grew the frameworks) and outgrew that 2g ceiling, so the copy into the image runs out of space partway through.

## Fix

Bump the image size to `4g` in `package/osx/make-package`. Because the image is `-format UDZO` (compressed), the extra headroom is reclaimed during compression and does **not** bloat the shipped `.dmg`.

This is a stop-gap against the current app size; a follow-up could size the image dynamically from the staged tree to avoid resetting the same ceiling as the app keeps growing.

Developer-only build-tooling change; no associated issue.