### PR TITLE
reduce and unify padding on text inputs and selects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - ([#17992](https://github.com/rstudio/rstudio/issues/17992)): The Find in Files replace preview and Replace All results no longer present matches whose proposed replacement is identical to the matched text; lines whose every match would be unchanged are omitted entirely.
 
 ### Fixed
+- ([#18057](https://github.com/rstudio/rstudio/issues/18057)): Reduced the padding on text input fields and drop-down (select) controls, which had grown overly large (most noticeably in dark themes), and made the padding consistent across text inputs, password fields, and selects in both light and dark themes.
 - ([#18033](https://github.com/rstudio/rstudio/issues/18033)): Fix ghost text set via `rstudioapi::setGhostText()` not being dismissed when navigating the cursor away or typing a non-matching character, which left it insertable by Tab even after it appeared to be gone.
 - ([#17970](https://github.com/rstudio/rstudio/issues/17970)): Fix the Packages pane vulnerability dialog listing vulnerabilities that affect a different installed version of the clicked package; the dialog now shows only the vulnerabilities for that row's version. A package with vulnerability records from multiple repositories now shows a single combined warning icon and dialog instead of one per repository.
 - ([#17985](https://github.com/rstudio/rstudio/issues/17985)): Fixed an issue where the Import Dataset preview dialog failed to display error messages when the readr preview subprocess encountered an error, causing the dialog to hang indefinitely waiting for data that would never arrive.

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1,6 +1,9 @@
 @eval proportionalFont org.rstudio.core.client.theme.ThemeFonts.getProportionalFont();
 @eval fixedWidthFont org.rstudio.core.client.theme.ThemeFonts.getFixedWidthFont();
 
+/* Shared padding for text inputs and selects (.gwt-TextBox, .gwt-ListBox, etc.). */
+@def CONTROL_PADDING 2px 5px;
+
 @external fixedWidthFont;
 @external ace_editor, ace_text-layer, ace_gutter, ace_gutter-layer, ace_gutter-cell, ace_gutter_annotation, ace_info, ace_tooltip, ace_gutter-tooltip, ace_icon, ace_icon_svg, ace_content, ace_line;
 @external ace_info, ace_warning, ace_error;
@@ -239,6 +242,7 @@ body.windows iframe {
 select {
    font-size: 12px;
    background-color: white;
+   padding: CONTROL_PADDING;
 }
 
 input[type="radio"] + label {
@@ -320,7 +324,6 @@ button, input[type="reset"], input[type="button"], input[type="submit"] {
 .gwt-DialogBox input[type=text] {
    border: 1px solid #999;
    height: 25px;
-   padding: 4px 6px;
 }
 .gwt-DialogBox .search input[type=text] {
    border: none;
@@ -3206,13 +3209,13 @@ body .rstudio-themes-alternate {
 	border-color: rgb(133, 133, 133);
 	border-style: solid;
 	font-size: 12px;
-	padding: 4px;
+	padding: CONTROL_PADDING;
 	box-sizing: border-box;
 }
 
 .gwt-ListBox {
 	min-height: 20px;
-	padding: 4px 6px;
+	padding: CONTROL_PADDING;
 }
 
 .gwt-TextBox, .gwt-PasswordTextBox {


### PR DESCRIPTION
### Summary

Text input fields and drop-down (`<select>`) controls had grown overly
padded, which read as cramped/heavy especially in dark themes.

Commit 6904bbccb6 (#17242) added `padding: 4px 6px` to dialog text
inputs, and the shared GWT control rules used `padding: 4px` /
`padding: 4px 6px`. This PR introduces a shared `@def CONTROL_PADDING`
(`2px 5px`) in `themeStyles.css` and applies it uniformly to:

- the bare `select` element rule
- `.gwt-TextBox, .gwt-PasswordTextBox, .gwt-ListBox`
- the `.gwt-ListBox` override

so text inputs and selects share one compact, consistent padding across
light and dark themes.

### Notes

- No functional/behavioral change; CSS only.
- Verify with `cd src/gwt && ant draft` (the GWT compile resolves the
  `@def` constant).