### PR TITLE
use @def / @eval for shared style values instead of literals

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/ThemeColors.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ThemeColors.java
@@ -47,6 +47,9 @@ public class ThemeColors
    public static String lightControlBackground                     = "#FFF";
    public static String lightControlBorder                         = "#d6dadc";
 
+   // A mid-gray used for de-emphasized borders and secondary text.
+   public static String mutedGray                                  = "#a0a0a0";
+
    public static String darkControlBackground                      = "rgb(108,121,131)";
    public static String darkControlBorder                          = "rgb(45,60,75)";
    public static String darkDialogControlBackground                = "rgb(68, 80, 90)";

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/LauncherSessionStatus.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/LauncherSessionStatus.ui.xml
@@ -4,6 +4,8 @@
    ui:generateKeys="com.google.gwt.i18n.server.keygen.MD5KeyGenerator"
    ui:generateLocales="default">
    <ui:style>
+   @eval THEME_MUTED_GRAY org.rstudio.core.client.theme.ThemeColors.mutedGray;
+
    .host
    {
       width: 500px;
@@ -23,7 +25,7 @@
    {
       width: 100%;
       background-color: #e5e5e5;
-      border: 1px solid #a0a0a0;
+      border: 1px solid THEME_MUTED_GRAY;
       border-radius: 3px;
       margin-top: 20px;
       padding: 15px;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RTimeoutOptions.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RTimeoutOptions.ui.xml
@@ -4,9 +4,12 @@
    ui:generateKeys="com.google.gwt.i18n.server.keygen.MD5KeyGenerator"
    ui:generateLocales="default">
    <ui:style>
+   @eval THEME_MUTED_GRAY org.rstudio.core.client.theme.ThemeColors.mutedGray;
+   @def sectionSpacing 20px;
+
    .host
    {
-      margin-top: 20px;
+      margin-top: sectionSpacing;
    }
    
    .warning
@@ -33,9 +36,9 @@
    
    .status
    {
-      margin-top: 20px;
+      margin-top: sectionSpacing;
       font-style: italic;
-      color: #a0a0a0;
+      color: THEME_MUTED_GRAY;
    }
    </ui:style>
    <g:HTMLPanel styleName="{style.host}">

--- a/src/gwt/src/org/rstudio/studio/client/palette/ui/CommandPaletteEntry.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/palette/ui/CommandPaletteEntry.ui.xml
@@ -4,6 +4,7 @@
    <ui:style field="styles_" type="org.rstudio.studio.client.palette.ui.CommandPaletteEntry.Styles">
       @external editor_dark;
       @eval proportionalFont org.rstudio.core.client.theme.ThemeFonts.getProportionalFont();
+      @eval THEME_MUTED_GRAY org.rstudio.core.client.theme.ThemeColors.mutedGray;
 
       div.entry {
          width: 100%;
@@ -32,7 +33,7 @@
       }
 
       .keyboard {
-         border: 1px solid #a0a0a0;
+         border: 1px solid THEME_MUTED_GRAY;
          border-radius: 3px;
          padding: 3px;
          margin-left: 3px;


### PR DESCRIPTION
Addresses #17251.

#17251 asks for named CSS constants in `.ui.xml` templates to centralize repeated literals (e.g. the same color hardcoded across many files). This PR shows that goal does **not** require enabling GSS -- the legacy `CssResource` parser already supports both directives we need, and they work inside an inline `<ui:style>` block.

### Mechanisms (both already supported, no config change)

- **`@def`** -- a file-local named constant, for a value repeated within one template.
- **`@eval`** -- resolves to a Java expression at CSS-generation time, letting many templates share one canonical value. `org.rstudio.core.client.theme.ThemeColors` already exposes ~40 color constants, and ~60 standalone `.css` files already consume them this way. This just extends that established pattern to inline `<ui:style>` blocks, which had not been done before.

### This change (a small pattern-setting slice)

- `ThemeColors.java`: add `mutedGray` (`#a0a0a0`), previously hardcoded in 3 templates.
- `LauncherSessionStatus`, `RTimeoutOptions`, `CommandPaletteEntry`: reference it via `@eval THEME_MUTED_GRAY` instead of hardcoding `#a0a0a0`.
- `RTimeoutOptions`: also demonstrates an in-file `@def sectionSpacing` for its repeated `margin-top`.

### Notes

- **No visual change.** These spots were already a fixed `#a0a0a0`, so the refactor is behavior-preserving (it does not make the value theme-aware -- that would be separate work).
- Verified with `ant draft`: clean build, no warnings, and the resolved values appear in the compiled CSS (the `@def`/`@eval` identifiers do not leak through as literals).
- Intended as the pattern-setter; the broader rollout across other templates can follow incrementally.
- An alternative full-GSS migration exists on `feature/17251-enable-gss` (#18056); this PR is the lighter-weight route that avoids the `.gss` port.
