### PR TITLE
advance console promptCount on any new prompt, not just top-level

### DIFF
--- a/e2e/rstudio/pages/console_pane.page.ts
+++ b/e2e/rstudio/pages/console_pane.page.ts
@@ -93,11 +93,13 @@ export async function waitForConsoleIdle(
 /**
  * Read the automation agent's monotonic console prompt counter, or null if the
  * running binary predates it (`window.rstudio.console.promptCount`, added in
- * ApplicationAutomation). The counter advances by one each time R returns to
- * its top-level prompt -- i.e. each time a submitted console command completes
- * -- so it is a race-free completion signal, unlike the busy CSS class which is
- * sampled (and can be read stale in the submit->busy gap, or miss a fast
- * command's busy flash). See waitForConsoleCommandComplete.
+ * ApplicationAutomation). The counter advances by one each time R issues a
+ * console prompt awaiting fresh client input -- a submitted command either
+ * completing (top-level prompt) or settling at an interactive sub-prompt
+ * (browser()/readline()/menu()) -- so it is a race-free completion signal,
+ * unlike the busy CSS class which is sampled (and can be read stale in the
+ * submit->busy gap, or miss a fast command's busy flash). See
+ * waitForConsoleCommandComplete.
  */
 export async function getConsolePromptCount(page: Page): Promise<number | null> {
   return page.evaluate(() => {
@@ -112,18 +114,20 @@ let warnedMissingPromptCount = false;
 /**
  * Wait for a console command to finish, given the prompt count captured *before*
  * it was submitted (via getConsolePromptCount). Resolves once the count exceeds
- * `promptCountBefore`, i.e. R returned to its top-level prompt. This is the
- * reliable replacement for waitForConsoleIdle when bracketing a submission: it
- * keys off the prompt *event*, not a sampled class, so it can't return
+ * `promptCountBefore`, i.e. R issued a new prompt awaiting client input. This is
+ * the reliable replacement for waitForConsoleIdle when bracketing a submission:
+ * it keys off the prompt *event*, not a sampled class, so it can't return
  * spuriously-idle before the command starts.
  *
- * The counter advances only on top-level prompts (the bump is gated on the
- * prompt's busy flag in ApplicationAutomation), so nested/intermediate prompts
- * (`browser()`, `readline()`, `menu()`) don't trip it early. It still assumes
- * the submitted command returns to top-level exactly once: a command left
- * sitting at a continuation (`+`) or interactive prompt never advances the
- * counter, so the wait times out rather than resolving. All current callers
- * submit self-contained one-shot expressions, which satisfies this.
+ * Every new prompt event advances the counter, but a single submission only
+ * produces one: the server services a multi-line/multi-statement submission's
+ * intermediate continuation (`+`) and inter-statement prompts from its buffered
+ * input without firing a client event (see ApplicationAutomation.registerConsole
+ * for the full rationale). So this resolves when the command completes (back to
+ * the top-level prompt) OR when it settles at an interactive sub-prompt that
+ * needs the test to act next -- `browser()`/Browse[N]>, readline(), menu(). The
+ * latter is what lets debugger tests submit a breakpoint-triggering call and
+ * proceed once R parks at the Browse prompt, rather than hanging until timeout.
  *
  * Falls back to the busy-class wait when the counter is unavailable (a binary
  * built before the counter, or one where registerConsole failed to install it),

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -229,20 +229,34 @@ public class ApplicationAutomation
    }
 
    // window.rstudio.console.promptCount is a monotonic counter that advances by
-   // one each time R returns to its top-level prompt -- i.e. each time a
-   // submitted console command completes. It is driven by ConsolePromptEvent
-   // (the client-side dispatch of the server's kConsolePrompt event), so it is
-   // a race-free completion signal: automation can capture the value, submit a
-   // command, and wait for the counter to increase, instead of sampling the
-   // rstudio-console-busy CSS class (which can be observed stale in the
-   // submit->busy gap, or miss a fast command's busy flash entirely).
+   // one each time R issues a console prompt that is waiting for fresh client
+   // input -- i.e. each time a submitted command either completes (the top-level
+   // "> " prompt) or settles at an interactive sub-prompt that needs us to act
+   // next (browser()/Browse[N]>, readline(), menu(), scan()). It is driven by
+   // ConsolePromptEvent (the client-side dispatch of the server's kConsolePrompt
+   // event), so it is a race-free completion signal: automation can capture the
+   // value, submit a command, and wait for the counter to increase, instead of
+   // sampling the rstudio-console-busy CSS class (which can be observed stale in
+   // the submit->busy gap, or miss a fast command's busy flash entirely).
    //
-   // The bump is gated on the prompt's busy flag: ConsolePromptEvent also fires
-   // for mid-execution prompts (continuation "+", browser(), readline(),
-   // menu()), which carry busy == true. Counting those would let a waiter
-   // resolve on an intermediate prompt, before the command truly returns to
-   // top-level. Only the top-level prompt (busy == false) advances the counter,
-   // so "promptCount increased" means "command completed".
+   // Every new ConsolePromptEvent advances the counter -- including "busy"
+   // prompts. This is deliberate, and safe: a single submission's intermediate
+   // continuation ("+ ") and inter-statement prompts never reach the client.
+   // The server (SessionConsoleInput.cpp rConsoleRead) services those directly
+   // from its buffered, line-split console input via popConsoleInput() WITHOUT
+   // firing a kConsolePrompt event; a client event fires only once the buffer
+   // drains and R genuinely stops to wait for new input. So a new prompt event
+   // is always a real "R is waiting for us again" point, never a mid-expression
+   // state. Counting only the top-level (busy == false) prompt was too strict:
+   // a command that parks at a browser()/readline() prompt never returns to the
+   // top level on its own, so a waiter would hang until timeout (this broke the
+   // debugger e2e tests, whose commands hit a breakpoint and enter Browse mode).
+   //
+   // The consequence for callers: waitForConsoleCommandComplete now means "R
+   // stopped to ask for input again," not strictly "returned to top level."
+   // That is the desired behavior for the interactive/debugger cases; all
+   // self-contained one-shot expressions still fire exactly one event (at
+   // completion), so their behavior is unchanged.
    //
    // Handlers are registered once per GWT page lifetime (initializeAgent runs
    // again on each session restart), guarded like registerReadinessHandlers.
@@ -256,11 +270,7 @@ public class ApplicationAutomation
       if (consoleHandlersRegistered_)
          return;
 
-      eventBus_.addHandler(ConsolePromptEvent.TYPE, event ->
-      {
-         if (!event.getPrompt().getBusy())
-            bumpConsolePromptCount();
-      });
+      eventBus_.addHandler(ConsolePromptEvent.TYPE, event -> bumpConsolePromptCount());
       consoleHandlersRegistered_ = true;
    }
 


### PR DESCRIPTION
## Summary

`executeInConsole({wait:true})` (e2e helper) waits for `window.rstudio.console.promptCount` to increase. The bump was gated on `!prompt.getBusy()`, so it only advanced at the **top-level** `>` prompt. A command that parks at an interactive sub-prompt -- `browser()`/`Browse[N]>`, `readline()`, `menu()`, `scan()` -- never returns to the top level on its own, so the wait hung until the 30s timeout.

This broke the **debugger e2e tests**: they submit a breakpoint-triggering call (e.g. `brace_fn()`) that enters Browse mode, then assert debug state. The submission never reaches a top-level prompt, so `waitForConsoleCommandComplete` timed out. The failures surfaced in #18059's CI (6 debugger specs, both retries) but were not caused by that PR -- its merge just includes the `promptCount` change from #18048, and it is the first PR exercising the debugger specs against that code.

## Fix

Bump the counter on **every** `ConsolePromptEvent` (drop the busy gate in `ApplicationAutomation.registerConsole()`).

This is safe, and the key reason the original busy gate was unnecessary: a single submission's intermediate continuation (`+`) and inter-statement prompts **never reach the client**. The server splits multi-line/multi-statement console input into per-line entries (`fixupPendingConsoleInput`) and services them directly from its buffer in `rConsoleRead` via `popConsoleInput()` *without* firing a `kConsolePrompt` event -- a client event fires only once the buffer drains and R genuinely stops to wait for new input. So a new prompt event is always a real "R is waiting for us again" point, never a mid-expression state.

Behavior delta:
- One-shot expressions (e.g. the `writeLines(...)` case #18048 fixed): still fire exactly one event at completion -> identical behavior; the race stays fixed because it keys off a prompt *event*, not the sampled busy CSS class.
- Commands that park at an interactive sub-prompt: now resolve at the settle point instead of hanging. `waitForConsoleCommandComplete` now means "R stopped to ask for input again," not strictly "returned to top level" -- which is exactly what the debugger tests want.

## Verification

- Mechanism traced from the #18059 CI artifacts: the failing specs time out in `waitForConsoleCommandComplete`, and the trace shows the debug toolbar visible in `afterEach` (the breakpoint did fire / R entered Browse). Server-side `busy = !isAtTopLevel()`, so a `Browse[N]>` prompt carries `busy == true` and was excluded by the old gate.
- No NEWS.md entry: the `promptCount` bridge is unreleased e2e-test infrastructure, not user-facing.
- Not run locally: `ant javac` (trivial block-lambda -> expression-lambda over an existing method). CI will compile and re-run the debugger specs.

Addresses the debugger e2e failures reported in #18059.