### PR TITLE
verify build tools actually installed on windows e2e build

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -223,13 +223,24 @@ jobs:
               $chocoArgs = @('install', $tool.Package, '--yes', '--no-progress', '--use-enhanced-exit-codes')
               if ($i -gt 1) { $chocoArgs += '--force' }      # clear a half-installed record on retry
               choco @chocoArgs
+
               # choco updates the machine PATH and drops shims in
               # C:\ProgramData\chocolatey\bin, but this already-running process
               # won't see them until we re-read the environment -- otherwise a
               # PATH-only probe (e.g. ant) could fail even after a good install.
-              $env:PATH = [Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' +
-                          [Environment]::GetEnvironmentVariable('Path', 'User')
-              if (& $tool.Probe) { $ok = $true; break }
+              # Refresh PATH only for the probe, then restore it, so we don't
+              # disturb the runner-managed PATH ($GITHUB_PATH entries for node,
+              # rig, sccache, MSVC, ...) for the rest of the step.
+              $savedPath = $env:PATH
+              try {
+                $env:PATH = $savedPath + ';' +
+                            [Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' +
+                            [Environment]::GetEnvironmentVariable('Path', 'User')
+                if (& $tool.Probe) { $ok = $true }
+              } finally {
+                $env:PATH = $savedPath
+              }
+              if ($ok) { break }
               Write-Host "::warning::$($tool.Package) not usable after attempt $i; retrying in 15s..."
               Start-Sleep -Seconds 15
             }

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -192,7 +192,45 @@ jobs:
             rstudio-gwt-win64-
 
       - name: Install build tools
-        run: choco install ant nsis --yes --no-progress
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          # Trust the probe, not choco: choco can exit 0 after a failed feed
+          # fetch ("installed 0/1 packages"), and can also report a package
+          # installed from a prior run's lib record even when the binary is
+          # missing/broken. Probing the real tool sidesteps both. ant is
+          # provided by the runner image; nsis is fetched from the community
+          # feed (which intermittently 503s) for the cpack -G NSIS step. Verify
+          # both so a missing tool fails here, not ~1h later at packaging.
+          function Test-AntInstalled {
+            [bool](Get-Command ant -ErrorAction SilentlyContinue)
+          }
+
+          function Test-NsisInstalled {
+            (Get-Command makensis -ErrorAction SilentlyContinue) -or
+            (Test-Path 'C:\Program Files (x86)\NSIS\makensis.exe')
+          }
+
+          $tools = @(
+            @{ Package = 'ant';  Probe = 'Test-AntInstalled'  }
+            @{ Package = 'nsis'; Probe = 'Test-NsisInstalled' }
+          )
+
+          foreach ($tool in $tools) {
+            $ok = $false
+            for ($i = 1; $i -le 3; $i++) {
+              if (& $tool.Probe) { $ok = $true; break }     # already usable -> done
+              $chocoArgs = @('install', $tool.Package, '--yes', '--no-progress', '--use-enhanced-exit-codes')
+              if ($i -gt 1) { $chocoArgs += '--force' }      # clear a half-installed record on retry
+              choco @chocoArgs
+              if (& $tool.Probe) { $ok = $true; break }
+              Write-Host "::warning::$($tool.Package) not usable after attempt $i; retrying in 15s..."
+              Start-Sleep -Seconds 15
+            }
+            if (-not $ok) {
+              throw "$($tool.Package) not installed/usable after 3 attempts; aborting before the build."
+            }
+          }
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -223,6 +223,12 @@ jobs:
               $chocoArgs = @('install', $tool.Package, '--yes', '--no-progress', '--use-enhanced-exit-codes')
               if ($i -gt 1) { $chocoArgs += '--force' }      # clear a half-installed record on retry
               choco @chocoArgs
+              # choco updates the machine PATH and drops shims in
+              # C:\ProgramData\chocolatey\bin, but this already-running process
+              # won't see them until we re-read the environment -- otherwise a
+              # PATH-only probe (e.g. ant) could fail even after a good install.
+              $env:PATH = [Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' +
+                          [Environment]::GetEnvironmentVariable('Path', 'User')
               if (& $tool.Probe) { $ok = $true; break }
               Write-Host "::warning::$($tool.Package) not usable after attempt $i; retrying in 15s..."
               Start-Sleep -Seconds 15


### PR DESCRIPTION
## Problem

The Windows e2e `build` job intermittently runs the full ~1h build and then fails at the very last step, packaging:

```
Creating NSIS setup package...
CPack Error: Cannot find NSIS compiler makensis: likely it is not installed, or not in your PATH
CPack Error: Cannot initialize the generator NSIS
 ERROR: package creation failed
```

NSIS genuinely wasn't installed. The `Install build tools` step had run `choco install ant nsis --yes --no-progress`, and its log shows:

```
Failed to fetch results from V2 feed ... 503 (Service Unavailable).
Need to add specific handling for exception type NuGetResolverInputException
Unable to find package 'nsis'.
Chocolatey installed 0/1 packages.
```

So two problems compounded:

1. **Trigger (transient):** the Chocolatey community feed returned a `503` while resolving `nsis`, so it never installed. `ant` is provided by the runner image, hence "0/1".
2. **Latent bug:** despite installing 0/1 packages, **choco exited 0**, so the step passed and the failure didn't surface until ~1h later at `cpack -G NSIS`.

## Fix

Rework the `Install build tools` step to trust a probe of the real binary rather than choco's exit code or its bookkeeping:

- Table-driven over `ant` + `nsis`, each paired with a named probe function (`Test-AntInstalled` / `Test-NsisInstalled`).
- **Probe-first**: the image-provided `ant` skips the feed entirely; `nsis` is installed only if its probe fails.
- Retry the transient feed failure (3x), escalating to `--force` to clear a half-installed lib record.
- Pass `--use-enhanced-exit-codes` so choco itself is stricter.
- `throw` immediately if a tool still isn't usable, so a missing tool fails here (seconds) instead of ~1h later at packaging.

CI/tooling-only change; no NEWS.md entry or linked issue.

## Testing

Not locally reproducible (the failure is feed-timing-dependent). Validated by the Windows build job running on this PR.