### PR TITLE
fix(viewer): await setViewerUrl IPC before navigating iframe to prevent cross-origin SecurityError (#17982)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - ([#17992](https://github.com/rstudio/rstudio/issues/17992)): The Find in Files replace preview and Replace All results no longer present matches whose proposed replacement is identical to the matched text; lines whose every match would be unchanged are omitted entirely.
 
 ### Fixed
+- ([#17982](https://github.com/rstudio/rstudio/issues/17982)): Fixed a race condition in RStudio Desktop where the viewer pane iframe could be blocked by Electron's navigation policy, causing cross-origin SecurityErrors when previewing markdown files or R Notebooks as HTML. The `setViewerUrl` IPC call is now awaited before the iframe navigates, ensuring the URL authority is registered in time.
 - ([#18057](https://github.com/rstudio/rstudio/issues/18057)): Reduced the padding on text input fields and drop-down (select) controls, which had grown overly large (most noticeably in dark themes), and made the padding consistent across text inputs, password fields, and selects in both light and dark themes.
 - ([#18037](https://github.com/rstudio/rstudio/issues/18037)): Fixed the Plots pane not being brought to the front when Posit Assistant runs code that produces a plot. Interactive agent code now activates the Plots pane like a console command does.
 - ([#18033](https://github.com/rstudio/rstudio/issues/18033)): Fix ghost text set via `rstudioapi::setGhostText()` not being dismissed when navigating the cursor away or typing a non-matching character, which left it insertable by Tab even after it appeared to be gone.

--- a/e2e/rstudio/tests/panes/editor/markdown.test.ts
+++ b/e2e/rstudio/tests/panes/editor/markdown.test.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
-import * as os from 'os';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePaneActions } from '@actions/source_pane.actions';
 import { installDepIfPrompted } from '@pages/modals.page';
@@ -50,7 +49,6 @@ test.describe('Markdown', () => {
   test('preview markdown file as HTML', async ({ rstudioPage: page }) => {
     // Original: test_desktop_Markdown.py::test_preview_markdown_file_as_html
     test.skip(missingPackages.length > 0, `required R package(s) not available: ${missingPackages.join(', ')}`);
-    test.fixme(['win32', 'darwin'].includes(os.platform()) && !!process.env.CI, 'GWT raises a cross-origin SecurityError accessing the preview iframe on Electron CI (Windows + macOS 26); needs product fix');
 
     const fileName = `markdown_doc_${Date.now()}.md`;
 

--- a/e2e/rstudio/tests/panes/editor/rnotebook.test.ts
+++ b/e2e/rstudio/tests/panes/editor/rnotebook.test.ts
@@ -70,7 +70,6 @@ test.describe('R Notebook', () => {
       `required R package(s) not available: ${missingPackages.join(', ')}`,
     );
   });
-
   test('create new R Notebook and preview', async ({ rstudioPage: page }) => {
     // Original: test_desktop_RNotebook.py::test_creating_new_r_notebook_and_preview
 

--- a/e2e/rstudio/tests/panes/editor/rnotebook.test.ts
+++ b/e2e/rstudio/tests/panes/editor/rnotebook.test.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
-import * as os from 'os';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePaneActions } from '@actions/source_pane.actions';
 import { installDepIfPrompted } from '@pages/modals.page';
@@ -74,7 +73,7 @@ test.describe('R Notebook', () => {
 
   test('create new R Notebook and preview', async ({ rstudioPage: page }) => {
     // Original: test_desktop_RNotebook.py::test_creating_new_r_notebook_and_preview
-    test.fixme(['win32', 'darwin'].includes(os.platform()) && !!process.env.CI, 'Same cross-origin SecurityError as markdown preview; needs product fix');
+
     const fileName = `rnotebook_test_${Date.now()}.Rmd`;
 
     // output: html_notebook is what makes this a Notebook (Preview, not Knit).

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -209,7 +209,7 @@ public interface DesktopFrame extends JavaScriptPassthrough
    
    void reloadZoomWindow();
    
-   void setViewerUrl(String url);
+   void setViewerUrl(String url, Command callback);
    void reloadViewerZoomWindow(String url);
    void setPresentationUrl(String url);
    void setTutorialUrl(String url);

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
@@ -22,13 +22,13 @@ import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.LayoutPanel;
 import com.google.gwt.user.client.ui.ResizeComposite;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
-import org.rstudio.core.client.Command;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.files.FileSystemItem;

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
@@ -28,6 +28,7 @@ import com.google.gwt.user.client.ui.ResizeComposite;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
+import org.rstudio.core.client.Command;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.files.FileSystemItem;
@@ -302,9 +303,23 @@ public class HTMLPreviewPanel extends ResizeComposite
    private void navigate(String url)
    {
       if (Desktop.isDesktop())
-         Desktop.getFrame().setViewerUrl(StringUtil.notNull(url));
-      // use setUrl rather than navigate to deal with same origin policy
-      previewFrame_.setUrl(url);
+      {
+         final String notNullUrl = StringUtil.notNull(url);
+         Desktop.getFrame().setViewerUrl(notNullUrl, new Command()
+         {
+            @Override
+            public void execute()
+            {
+               // use setUrl rather than navigate to deal with same origin policy
+               previewFrame_.setUrl(url);
+            }
+         });
+      }
+      else
+      {
+         // use setUrl rather than navigate to deal with same origin policy
+         previewFrame_.setUrl(url);
+      }
    }
    
    private final LayoutPanel layoutPanel_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPresenter.java
@@ -21,6 +21,7 @@ import com.google.inject.Provider;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import org.rstudio.core.client.Command;
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.HtmlMessageListener;
 import org.rstudio.core.client.SingleShotTimer;
@@ -236,8 +237,18 @@ public class ViewerPresenter extends BasePresenter
          display_.maximize();
       rmdPreviewParams_ = event.getParams();
       if (Desktop.hasDesktopFrame())
-         Desktop.getFrame().setViewerUrl(StringUtil.notNull(event.getParams().getOutputUrl()));
-      display_.previewRmd(event.getParams());
+         Desktop.getFrame().setViewerUrl(
+            StringUtil.notNull(event.getParams().getOutputUrl()),
+            new Command()
+            {
+               @Override
+               public void execute()
+               {
+                  display_.previewRmd(event.getParams());
+               }
+            });
+      else
+         display_.previewRmd(event.getParams());
    }
 
    @Override
@@ -249,8 +260,16 @@ public class ViewerPresenter extends BasePresenter
          manageCommands(true);
          display_.bringToFront();
          if (Desktop.hasDesktopFrame())
-            Desktop.getFrame().setViewerUrl(StringUtil.notNull(event.getParams().getUrl()));
-         display_.previewShiny(event.getParams());
+            Desktop.getFrame().setViewerUrl(StringUtil.notNull(event.getParams().getUrl()), new Command()
+            {
+               @Override
+               public void execute()
+               {
+                  display_.previewShiny(event.getParams());
+               }
+            });
+         else
+            display_.previewShiny(event.getParams());
          runningShinyAppParams_ = event.getParams();
       }
    }
@@ -266,8 +285,16 @@ public class ViewerPresenter extends BasePresenter
             manageCommands(true);
             display_.bringToFront();
             if (Desktop.hasDesktopFrame())
-               Desktop.getFrame().setViewerUrl(StringUtil.notNull(event.getParams().getUrl()));
-            display_.previewPlumber(event.getParams());
+               Desktop.getFrame().setViewerUrl(StringUtil.notNull(event.getParams().getUrl()), new Command()
+               {
+                  @Override
+                  public void execute()
+                  {
+                     display_.previewPlumber(event.getParams());
+                  }
+               });
+            else
+               display_.previewPlumber(event.getParams());
             runningPlumberAPIParams_ = event.getParams();
          });
       }
@@ -527,22 +554,52 @@ public class ViewerPresenter extends BasePresenter
    private void navigate(String url)
    {
       if (Desktop.hasDesktopFrame())
-         Desktop.getFrame().setViewerUrl(StringUtil.notNull(url));
-      display_.navigate(url);
+      {
+         Desktop.getFrame().setViewerUrl(StringUtil.notNull(url), new Command()
+         {
+            @Override
+            public void execute()
+            {
+               display_.navigate(url);
+            }
+         });
+      }
+      else
+      {
+         display_.navigate(url);
+      }
    }
 
    private void navigateQuarto(String url, QuartoNavigate quartoNav)
    { 
       if (Desktop.hasDesktopFrame())
-         Desktop.getFrame().setViewerUrl(StringUtil.notNull(url));
-      display_.previewQuarto(url, quartoNav);
+      {
+         Desktop.getFrame().setViewerUrl(StringUtil.notNull(url), new Command()
+         {
+            @Override
+            public void execute()
+            {
+               display_.previewQuarto(url, quartoNav);
+            }
+         });
+      }
+      else
+      {
+         display_.previewQuarto(url, quartoNav);
+      }
    }
 
    private void updateZoomWindow(String url)
    {
       if (Desktop.hasDesktopFrame()) {
-         Desktop.getFrame().setViewerUrl(StringUtil.notNull(url));
-         Desktop.getFrame().reloadViewerZoomWindow(StringUtil.notNull(url));
+         Desktop.getFrame().setViewerUrl(StringUtil.notNull(url), new Command()
+         {
+            @Override
+            public void execute()
+            {
+               Desktop.getFrame().reloadViewerZoomWindow(StringUtil.notNull(url));
+            }
+         });
       } else if ((zoomWindow_ != null) && !zoomWindow_.isClosed()) {
          zoomWindow_.setLocationHref(url);
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPresenter.java
@@ -21,7 +21,6 @@ import com.google.inject.Provider;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import org.rstudio.core.client.Command;
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.HtmlMessageListener;
 import org.rstudio.core.client.SingleShotTimer;

--- a/src/gwt/www/webkit.nocache.html
+++ b/src/gwt/www/webkit.nocache.html
@@ -75,7 +75,7 @@
           desktop.showKeyboardShortcutHelp();
           desktop.launchSession(true);
           desktop.reloadZoomWindow();
-          desktop.setViewerUrl('foo');
+          desktop.setViewerUrl('foo', function() {});
           
      </script>
   </body>

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -540,6 +540,7 @@ export class DesktopBrowserWindow extends EventEmitter {
   setViewerUrl(viewerUrl: string): void {
     const url = makeAbsoluteUrl(viewerUrl);
     if (!isLocalUrl(url)) {
+      logger().logDebug(`Skipping viewer authority registration for non-local url: ${viewerUrl}`);
       return;
     }
 

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -936,7 +936,7 @@ export class GwtCallback extends EventEmitter {
       this.getSender('desktop_set_tutorial_url', event.processId, event.frameId).setTutorialUrl(url);
     });
 
-    ipcMain.on('desktop_set_viewer_url', (event, url) => {
+    ipcMain.handle('desktop_set_viewer_url', (event, url) => {
       this.getSender('desktop_set_viewer_url', event.processId, event.frameId).setViewerUrl(url);
     });
 

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -595,6 +595,9 @@ export function getDesktopBridge() {
     },
 
     setViewerUrl: (url: string, callback: VoidCallback<void>) => {
+      // Best-effort fallback: even if the IPC call fails, we still attempt
+      // navigation. A blank viewer pane is worse than re-surfacing the
+      // SecurityError from #17982; the logged IpcError can be correlated.
       ipcRenderer
         .invoke('desktop_set_viewer_url', url)
         .then(() => callback())

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -594,8 +594,14 @@ export function getDesktopBridge() {
       ipcRenderer.send('desktop_set_tutorial_url', url);
     },
 
-    setViewerUrl: (url: string) => {
-      ipcRenderer.send('desktop_set_viewer_url', url);
+    setViewerUrl: (url: string, callback: VoidCallback<void>) => {
+      ipcRenderer
+        .invoke('desktop_set_viewer_url', url)
+        .then(() => callback())
+        .catch((error) => {
+          reportIpcError('desktop_set_viewer_url', error);
+          callback();
+        });
     },
 
     setPresentationUrl: (url: string) => {


### PR DESCRIPTION
## Summary

Fixes #17982

The viewer pane iframe could be blocked by Electron's navigation policy, causing cross-origin SecurityErrors when previewing markdown files or R Notebooks as HTML. The `setViewerUrl` IPC call is now awaited before the iframe navigates, ensuring the URL authority is registered in time.

## Changes

- **`src/node/desktop`**: Change `setViewerUrl` IPC from `send` to `handle`/`invoke` for synchronous result, ensuring the URL is registered before navigation
- **`src/gwt`**: Update `DesktopFrame` interface to accept a callback after IPC completes; `HTMLPreviewPanel` and `ViewerPresenter` now await the IPC result before calling `previewFrame_.setUrl()`
- **`e2e/rstudio/tests`**: Remove `test.skip`/`test.fixme` markers from markdown and rnotebook preview tests since the underlying issue is now fixed
- **`NEWS.md`**: Added changelog entry