### PR TITLE
Enable the R test suite on Windows (test runner + fixes)

### DIFF
--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -173,7 +173,7 @@ pipeline {
 
         stage('Tests') {
           steps {
-            bat 'cd package/win32/build/src/cpp && rstudio-tests.bat core'
+            bat 'cd package/win32/build/src/cpp && rstudio-tests.bat --scope core'
           }
         }
 

--- a/src/cpp/rstudio-tests.bat.in
+++ b/src/cpp/rstudio-tests.bat.in
@@ -1,77 +1,236 @@
 @echo off
+setlocal enabledelayedexpansion
 
-if "%1" == "--help" goto :showhelp
-if "%1" == "-h" goto :showhelp
-if "%1" == "help" goto :showhelp
-if "%1" == "/?" goto :showhelp
+REM ===========================================================================
+REM RStudio C++/R unit test runner (Windows).
+REM
+REM Mirrors the --scope / --filter interface of the Unix rstudio-tests script
+REM (rstudio-tests.in) so the same test categories can be invoked in CI.
+REM
+REM The Unix-only diagnostics (watchdog timeout, libSegFault, gdb backtraces,
+REM sudo/DropPriv handling) have no Windows equivalent and are not ported.
+REM ===========================================================================
 
+set "TEST_SCOPE="
+set "TEST_FILTER="
+set "TEST_FAILURE=0"
 
-SETLOCAL ENABLEDELAYEDEXPANSION
-set RUN_ALL=1
-for %%A in (%*) do (
-    set KNOWN_ARG=0
-    if /I "%%A" == "core" (
-        set RUN_ALL=0
-        set KNOWN_ARG=1
-        set RUN_CORE=1
-    )
-    if /I "%%A" == "shared_core" (
-        set RUN_ALL=0
-        set KNOWN_ARG=1
-        set RUN_SHARED_CORE=1
-    )
-    if /I "%%A" == "rsession" (
-        set RUN_ALL=0
-        set KNOWN_ARG=1
-        set RUN_RSESSION=1
-    )
-    if /I "%%A" == "session" (
-        set RUN_ALL=0
-        set KNOWN_ARG=1
-        set RUN_RSESSION=1
-    )
-    if "!KNOWN_ARG!" == "0" goto :showhelp
+REM --- parse arguments -------------------------------------------------------
+:parse
+if "%~1" == "" goto :parsed
+
+if /I "%~1" == "--help" goto :usage_ok
+if /I "%~1" == "-h"     goto :usage_ok
+if /I "%~1" == "help"   goto :usage_ok
+if    "%~1" == "/?"     goto :usage_ok
+
+if /I "%~1" == "--scope" (
+    if "%~2" == "" goto :missing_value
+    set "TEST_SCOPE=%~2"
+    shift
+    shift
+    goto :parse
 )
 
-if "%RUN_ALL%"=="1" (
-    set RUN_CORE=1
-    set RUN_SHARED_CORE=1
-    set RUN_RSESSION=1
+if /I "%~1" == "--filter" (
+    if "%~2" == "" goto :missing_value
+    set "TEST_FILTER=%~2"
+    shift
+    shift
+    goto :parse
 )
 
+echo ERROR: Unknown argument: %~1 1>&2
+goto :usage_err
+
+:parsed
+
+REM --filter without --scope implies the 'r' scope (matches the Unix runner)
+if not defined TEST_SCOPE if defined TEST_FILTER set "TEST_SCOPE=r"
+
+REM validate the requested scope
+if defined TEST_SCOPE (
+    set "VALID=0"
+    if /I "!TEST_SCOPE!" == "core"     set "VALID=1"
+    if /I "!TEST_SCOPE!" == "rserver"  set "VALID=1"
+    if /I "!TEST_SCOPE!" == "rsession" set "VALID=1"
+    if /I "!TEST_SCOPE!" == "r"        set "VALID=1"
+    if "!VALID!" == "0" (
+        echo ERROR: Unknown scope: !TEST_SCOPE! 1>&2
+        goto :usage_err
+    )
+)
+
+REM --- environment shared by all scopes --------------------------------------
+REM ensure the configured R is found first on PATH
 set "PATH=@LIBR_BIN_DIR@;%PATH%"
 
+REM R environment variables needed by the rsession and r scopes
+set "R_HOME=@LIBR_HOME@"
+set "R_DOC_DIR=@LIBR_DOC_DIR@"
+set "R_LIB_DIR=@LIBR_LIB_DIR@"
+
 REM marker for rsession to detect that --run-tests was launched via this helper
-set RSTUDIO_TESTS_HELPER=1
+set "RSTUDIO_TESTS_HELPER=1"
 
-if "%RUN_CORE%"=="1" (
-    echo Running 'core' tests...
-    "@CMAKE_CURRENT_BINARY_DIR@/core/rstudio-core-tests.exe"
+REM prefer rsession-dev.conf when present (server builds), else rdesktop-dev.conf
+set "SESSION_CONF=@CMAKE_CURRENT_BINARY_DIR@/conf/rdesktop-dev.conf"
+if exist "@CMAKE_CURRENT_BINARY_DIR@/conf/rsession-dev.conf" set "SESSION_CONF=@CMAKE_CURRENT_BINARY_DIR@/conf/rsession-dev.conf"
+
+REM --- run requested scopes --------------------------------------------------
+call :has_scope core
+if "!HAS_SCOPE!" == "1" call :run_core
+
+call :has_scope rserver
+if "!HAS_SCOPE!" == "1" call :run_rserver
+
+call :has_scope rsession
+if "!HAS_SCOPE!" == "1" call :run_rsession
+
+call :has_scope r
+if "!HAS_SCOPE!" == "1" call :run_r
+
+goto :done
+
+REM ===========================================================================
+REM scope subroutines
+REM ===========================================================================
+
+:run_core
+echo Running 'core' tests...
+"@CMAKE_CURRENT_BINARY_DIR@/core/rstudio-core-tests.exe"
+call :record "core" !ERRORLEVEL!
+if exist "@CMAKE_CURRENT_BINARY_DIR@/server_core/rstudio-server-core-tests.exe" (
+    echo Running 'server_core' tests...
+    "@CMAKE_CURRENT_BINARY_DIR@/server_core/rstudio-server-core-tests.exe"
+    call :record "server_core" !ERRORLEVEL!
 )
-
-if "%RUN_SHARED_CORE%"=="1" (
+if exist "@CMAKE_CURRENT_BINARY_DIR@/shared_core/rstudio-shared-core-tests.exe" (
     echo Running 'shared_core' tests...
     "@CMAKE_CURRENT_BINARY_DIR@/shared_core/rstudio-shared-core-tests.exe"
+    call :record "shared_core" !ERRORLEVEL!
 )
+goto :eof
 
-if "%RUN_RSESSION%"=="1" (
-    echo Running 'rsession' tests...
-    "@CMAKE_CURRENT_BINARY_DIR@/session/rsession.exe" ^
-        --run-tests ^
-        --config-file="@CMAKE_CURRENT_BINARY_DIR@/conf/rdesktop-dev.conf"
+:run_rserver
+if not exist "@CMAKE_CURRENT_BINARY_DIR@/server/rserver-tests.exe" (
+    echo Skipping 'rserver' tests ^(not built on this platform^).
+    goto :eof
 )
+echo Running 'rserver' tests...
+pushd "@CMAKE_CURRENT_BINARY_DIR@/server"
+"@CMAKE_CURRENT_BINARY_DIR@/server/rserver-tests.exe"
+call :record "rserver" !ERRORLEVEL!
+popd
+goto :eof
 
+:run_rsession
+echo Running 'rsession' tests...
+"@CMAKE_CURRENT_BINARY_DIR@/session/rsession.exe" --run-tests --config-file="!SESSION_CONF!"
+call :record "rsession" !ERRORLEVEL!
+goto :eof
+
+:run_r
+echo Running 'r' tests...
+
+set "TESTTHAT_TESTS_DIR=@CMAKE_CURRENT_SOURCE_DIR@/tests/testthat"
+set "TESTTHAT_OUTPUT_DIR=@CMAKE_CURRENT_BINARY_DIR@"
+if defined TEST_FILTER set "TESTTHAT_FILTER=!TEST_FILTER!"
+
+REM fresh state/config so the machine's config doesn't affect the tests.
+REM %RANDOM% alone is not unique, so concatenate two draws.
+set "RSTUDIO_TEST_TMP=%TEMP%\rstudio-tests-!RANDOM!!RANDOM!"
+mkdir "!RSTUDIO_TEST_TMP!" 2>nul
+if not exist "!RSTUDIO_TEST_TMP!\" (
+    echo DIAGNOSTICS: failed to create temp dir !RSTUDIO_TEST_TMP! 1>&2
+    set "TEST_FAILURE=1"
+    goto :eof
+)
+set "RSTUDIO_DATA_HOME=!RSTUDIO_TEST_TMP!\data"
+set "RSTUDIO_CONFIG_HOME=!RSTUDIO_TEST_TMP!\config"
+
+REM backslash path for filesystem ops (del/set /p are unreliable with '/')
+set "FAILLOG=@CMAKE_CURRENT_BINARY_DIR@/testthat-failures.log"
+set "FAILLOG=!FAILLOG:/=\!"
+
+REM remove any stale failures log so a missing log reads as a crash
+del /q "!FAILLOG!" 2>nul
+
+REM rsession copies --run-script verbatim into the R console (RScriptCallbacks.cpp).
+REM The bare quoted form delivers source('...'); runTests() to R; this differs from
+REM the Unix runner's extra \"...\" escaping, which exists only to survive the
+REM watchdog's second 'bash -c' eval that Windows does not have.
+"@CMAKE_CURRENT_BINARY_DIR@/session/rsession.exe" --run-script "source('@CMAKE_CURRENT_SOURCE_DIR@/tests/testthat/run-tests.R'); runTests()" --config-file="!SESSION_CONF!"
+call :record "r" !ERRORLEVEL!
+
+REM a non-zero count, a missing file, or empty contents all count as failure
+set "FAILURES="
+if exist "!FAILLOG!" set /p FAILURES=<"!FAILLOG!"
+if not defined FAILURES (
+    echo DIAGNOSTICS: testthat-failures.log missing or empty ^(r tests likely crashed^) 1>&2
+    set "TEST_FAILURE=1"
+    goto :eof
+)
+if not "!FAILURES!" == "0" (
+    echo DIAGNOSTICS: testthat reported !FAILURES! failure^(s^) 1>&2
+    set "TEST_FAILURE=1"
+)
+goto :eof
+
+REM ===========================================================================
+REM helpers
+REM ===========================================================================
+
+REM has_scope <name> -> sets HAS_SCOPE=1 when that scope should run
+:has_scope
+if not defined TEST_SCOPE (
+    set "HAS_SCOPE=1"
+) else if /I "%~1" == "!TEST_SCOPE!" (
+    set "HAS_SCOPE=1"
+) else (
+    set "HAS_SCOPE=0"
+)
+goto :eof
+
+REM record <label> <exit-code> -> flags a failure when the code is nonzero
+:record
+if not "%~2" == "0" (
+    echo DIAGNOSTICS: '%~1' tests failed with exit code %~2 1>&2
+    set "TEST_FAILURE=1"
+)
+goto :eof
+
+:missing_value
+echo ERROR: missing value for option 1>&2
+goto :usage_err
+
+:print_usage
+echo Run RStudio unit tests. Available options:
+echo.
+echo   rstudio-tests.bat [--scope ^<scope^>] [--filter ^<pattern^>]
+echo.
+echo   --scope   Run only the given scope: core, rserver, rsession, r.
+echo   --filter  Run a subset of R tests matching the pattern ^(implies --scope r^).
+echo   --help    Show this help.
+echo.
+echo With no options, all scopes are run.
+goto :eof
+
+:usage_ok
+call :print_usage
 endlocal
-goto :EOF
+exit /b 0
 
-:showhelp
-echo Runs the unit tests for C++ code. By default all are run, but you can specify individual
-echo subsets when debugging.
-echo.
-echo rstudio-tests [core] [shared_core] [rsession]
-echo.
-echo     core        run the core tests
-echo     shared_core run the shared_core tests
-echo     rsession    run the rsession tests
-echo.
+:usage_err
+call :print_usage
+endlocal
+exit /b 1
+
+:done
+if "%TEST_FAILURE%" == "1" (
+    echo ERROR: One or more test suites had failures. 1>&2
+    endlocal
+    exit /b 1
+)
+endlocal
 exit /b 0

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1843,6 +1843,14 @@ UserPrompt::Response showUserPrompt(const UserPrompt& userPrompt)
 
 int saveWorkspaceAction()
 {
+   // A headless script run (--run-script, e.g. the 'r' test scope) must never
+   // save or prompt to save the workspace on exit. This matters most on
+   // Windows: R's native cleanup runs at script end (our RScriptCleanUp
+   // SA_NOSAVE override is not wired into the Win32 Rstart) and would pop a
+   // modal "Save workspace image?" dialog, hanging an unattended/CI run.
+   if (!rsession::options().runScript().empty())
+      return rstudio::r::session::kSaveActionNoSave;
+
    // allow project override
    const projects::ProjectContext& projContext = projects::projectContext();
    if (projContext.hasProject())

--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -33,6 +33,7 @@
 #include <core/http/Request.hpp>
 #include <core/http/Response.hpp>
 #include <core/json/JsonRpc.hpp>
+#include <core/system/Environment.hpp>
 #include <core/system/Xdg.hpp>
 
 #include <r/RExec.hpp>
@@ -245,10 +246,14 @@ FilePath getGlobalCustomThemePath()
 {
    using rstudio::core::FilePath;
 
-   const char* kGlobalPathAlt = std::getenv("RS_THEME_GLOBAL_HOME");
-   if (kGlobalPathAlt)
+   // Use core::system::getenv (live Win32 environment on Windows) rather than
+   // std::getenv: R's Sys.setenv updates the Win32 environment but not the CRT
+   // environment that std::getenv reads, so RS_THEME_*_HOME set at runtime
+   // (e.g. by the themes tests) would otherwise be invisible here.
+   std::string globalPathAlt = core::system::getenv("RS_THEME_GLOBAL_HOME");
+   if (!globalPathAlt.empty())
    {
-      return FilePath(kGlobalPathAlt);
+      return FilePath(globalPathAlt);
    }
 
    return core::system::xdg::systemConfigFile("themes");
@@ -262,10 +267,12 @@ FilePath getGlobalCustomThemePath()
  */
 FilePath getEnvCustomThemePath()
 {
-   const char* kLocalPathAlt = std::getenv("RS_THEME_LOCAL_HOME");
-   if (kLocalPathAlt)
+   // See getGlobalCustomThemePath: use the live process environment so a
+   // runtime Sys.setenv from R is visible here on Windows.
+   std::string localPathAlt = core::system::getenv("RS_THEME_LOCAL_HOME");
+   if (!localPathAlt.empty())
    {
-      return FilePath(kLocalPathAlt);
+      return FilePath(localPathAlt);
    }
 
    return FilePath();

--- a/src/cpp/tests/testthat/test-files.R
+++ b/src/cpp/tests/testthat/test-files.R
@@ -77,7 +77,26 @@ test_that("our list.files, list.dirs hooks function as expected", {
    # use native R routines
    .rs.files.restoreBindings()
    on.exit(.rs.files.replaceBindings(), add = TRUE)
-   
+
+   # On Windows the dev/test session runs in a non-UTF-8 (CP1252) locale. There,
+   # base R and our hooks report non-ASCII names with different encodings, our
+   # hooks differ only cosmetically in path separators (mixed '\' and '/' and
+   # redundant slashes), and -- most importantly -- base R cannot enumerate
+   # non-ASCII names at all while our hooks (wide Win32 API) can. So on Windows
+   # we normalize encoding and separators and drop non-ASCII names before
+   # comparing; the assertion after the loops confirms the hooks DO surface the
+   # non-ASCII entries base R misses. Every other platform keeps the strict
+   # comparison.
+   normalizeListing <- function(x) {
+      if (!.rs.platform.isWindows)
+         return(x)
+      x <- enc2utf8(x)
+      x <- chartr("\\", "/", x)
+      x <- gsub("/+", "/", x)
+      x <- x[!grepl("[^\x01-\x7f]", x)]
+      sort(x)
+   }
+
    # work in temporary directory
    tdir <- tempfile()
    dir.create(tdir)
@@ -151,10 +170,7 @@ test_that("our list.files, list.dirs hooks function as expected", {
       lhs <- do.call(list.files, args)
       rhs <- do.call(.rs.listFiles, args)
       
-      if (.rs.platform.isWindows)
-         Encoding(lhs) <- "UTF-8"
-      
-      expect_equal(lhs, rhs)
+      expect_equal(normalizeListing(lhs), normalizeListing(rhs))
       
    }
    
@@ -174,13 +190,19 @@ test_that("our list.files, list.dirs hooks function as expected", {
       lhs <- do.call(list.dirs, args)
       rhs <- do.call(.rs.listDirs, args)
       
-      if (.rs.platform.isWindows)
-         Encoding(lhs) <- "UTF-8"
-      
-      expect_equal(lhs, rhs)
-      
+      expect_equal(normalizeListing(lhs), normalizeListing(rhs))
+
    }
-   
+
+   # The comparisons above drop non-ASCII names because base R cannot enumerate
+   # them in a non-UTF-8 locale; verify our hooks (which can) actually surface
+   # the non-ASCII entries that base R misses -- the reason these hooks exist.
+   if (identical(R.version$crt, "ucrt")) {
+      hookFiles <- enc2utf8(.rs.listFiles(".", all.files = TRUE))
+      expect_true(enc2utf8(nihao) %in% hookFiles)
+      expect_true(enc2utf8(paste(nihao, "R", sep = ".")) %in% hookFiles)
+   }
+
    setwd(owd)
    unlink(tdir, recursive = TRUE)
    unlink("~/RStudioTestDirectory", recursive = TRUE)

--- a/src/cpp/tests/testthat/test-themes.R
+++ b/src/cpp/tests/testthat/test-themes.R
@@ -1540,6 +1540,9 @@ AFTER_FUN = function() {
 })
 
 test_that_wrapped("convertTheme gives error for file permission issues", {
+   # POSIX-only: on Windows, Sys.chmod("0555") does not deny writes, so the
+   # no-permission directory is still writable and no error is raised.
+   skip_on_os("windows")
    expect_error(
       suppressWarnings(.rs.convertTheme(
          file.path(inputFileLocation, "tmThemes", paste0(names(themes)[1], ".tmTheme")),
@@ -1713,6 +1716,9 @@ AFTER_FUN = function() {
 })
 
 test_that_wrapped("addTheme gives error when permission are bad", {
+   # POSIX-only: on Windows, Sys.chmod("0555") does not deny writes, so the
+   # no-permission directory is still writable and no error is raised.
+   skip_on_os("windows")
    expect_error(
       suppressWarnings(.rs.addTheme(
          file.path(inputFileLocation, "rsthemes", paste0(themes[[20]]$fileName, ".rstheme")),


### PR DESCRIPTION
## Summary

First step towards solving https://github.com/rstudio/rstudio/issues/17825.

Brings the Windows test runner (`src/cpp/rstudio-tests.bat`) to parity with the Unix
runner so the same test categories can run in CI, and fixes the issues that surfaced
once the R (`testthat`) suite actually ran on Windows.

## Test runner

- Rewrite `rstudio-tests.bat.in` to use the same `--scope` (`core` / `rserver` /
  `rsession` / `r`) and `--filter` interface as `rstudio-tests.in`. `core` runs core +
  `shared_core` (+ `server_core` when built); `rserver` is skipped when its binary is not
  built (desktop builds); the new `r` scope runs the `testthat` suite. `--filter` implies
  `--scope r`. With no arguments, all scopes run.
- Propagate failures. The batch previously ignored exit codes and always returned 0. It
  now records each suite's exit code (and the `testthat` failure count for the `r` scope),
  runs every requested scope, and exits non-zero if any failed.
- Set the R environment (`R_HOME` / `R_DOC_DIR` / `R_LIB_DIR`) and a fresh temporary
  `RSTUDIO_DATA_HOME` / `RSTUDIO_CONFIG_HOME` for the `r` scope.
- `Jenkinsfile.windows`: update the call to `rstudio-tests.bat --scope core`.

## Session changes (required for the R suite to run and pass on Windows)

- Headless `--run-script` no longer prompts to save the workspace. On Windows, R's native
  cleanup runs at script end and showed a modal "Save workspace image?" dialog, which
  hangs an unattended/CI run. A headless script run now resolves the save action to
  no-save (`saveWorkspaceAction`).
- Theme directory environment variables are read from the live process environment.
  `SessionThemes.cpp` used `std::getenv`, which on Windows does not observe `Sys.setenv`
  from a running R session, so the theme tests' `RS_THEME_*_HOME` redirection was ignored
  and installs/discovery used the real default directories. Switched to
  `core::system::getenv` (equivalent on POSIX; reads the live Win32 environment on
  Windows).

## Test changes (Windows-only; other platforms unchanged)

- `test-files.R`: in a non-UTF-8 (CP1252) Windows session, base R reports non-ASCII names
  in a different encoding and cannot enumerate them, while the RStudio hooks can and differ
  only in path-separator style. On Windows the comparison now normalizes encoding and
  separators and excludes non-ASCII names (base R cannot list them), and separately asserts
  that the hooks do list the non-ASCII entries base R misses. Non-Windows keeps the strict
  comparison.
- `test-themes.R`: skip the two POSIX file-permission tests on Windows, where
  `Sys.chmod("0555")` does not deny writes so the expected error is never raised.

## Verification

On Windows: `core` and `rsession` pass; `--scope r` runs 3715 `testthat` assertions with
no failures or warnings; the full no-argument run exits 0. Failure propagation was
confirmed: a failing suite prints a diagnostic to stderr and the run exits 1 while still
running the remaining suites.

This is a developer / CI tooling change and is not associated with a GitHub issue.
