### PR TITLE
build(win): share session code via rsession-shared.dll between launcher stubs

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -595,25 +595,47 @@ endif()
 # define executable
 if(WIN32)
 
-   # define shared object library (avoid re-compiling source files twice)
-   add_library(rsession-objects OBJECT
+   # Build the bulk of the session code into a single shared library so that
+   # rsession.exe and rsession-utf8.exe can share one copy of the code rather
+   # than each statically linking its own. The two executables are identical
+   # apart from their embedded manifest: rsession-utf8 declares a UTF-8 active
+   # code page (for UCRT builds of R 4.2.0 and newer) while rsession uses the
+   # system default. The active code page is fixed at process startup from the
+   # executable's manifest and applies process-wide -- including to code running
+   # in this DLL -- so a thin per-manifest launcher stub is all that differs
+   # between the two. See SessionMain.hpp.
+   add_library(rsession-shared SHARED
        ${SESSION_SOURCE_FILES}
        ${SESSION_HEADER_FILES})
 
-    target_link_libraries(rsession-objects ${SESSION_LIBRARIES})
+   # produce rsession-shared.dll (a distinct name from the rsession.exe stub, so
+   # their import libs and .pdb files do not collide); drop any "lib" prefix
+   set_target_properties(rsession-shared PROPERTIES
+      OUTPUT_NAME "rsession-shared"
+      PREFIX "")
 
-   # main executable
+   # mark rsessionMain() for export from the DLL (vs import in the stubs)
+   target_compile_definitions(rsession-shared PRIVATE RSESSION_BUILDING_SHARED)
+
+   target_link_libraries(rsession-shared ${SESSION_LIBRARIES} "${LIBR_LIBRARIES}")
+   if(RSTUDIO_SERVER)
+      target_link_libraries(rsession-shared rstudio-server-core)
+   endif()
+
+   # thin launcher stub; identical code, manifest embedded via the .rc differs
    add_stripped_executable(
       rsession
       "${CMAKE_CURRENT_BINARY_DIR}/rsession.rc"
-      $<TARGET_OBJECTS:rsession-objects>)
+      SessionMainStub.cpp)
+   target_link_libraries(rsession rsession-shared)
 
    # UTF-8 alternative
    if(RSTUDIO_WIN32_BUILD_UTF8_SESSION)
       add_stripped_executable(
          rsession-utf8
          "${CMAKE_CURRENT_BINARY_DIR}/rsession-utf8.rc"
-         $<TARGET_OBJECTS:rsession-objects>)
+         SessionMainStub.cpp)
+      target_link_libraries(rsession-utf8 rsession-shared)
    endif()
 
 else()
@@ -621,32 +643,33 @@ else()
    add_stripped_executable(
       rsession
       ${SESSION_SOURCE_FILES}
-      ${SESSION_HEADER_FILES})
+      ${SESSION_HEADER_FILES}
+      SessionMainStub.cpp)
 
 endif()
 
-# skip libR RPATH at development time
-if(RSTUDIO_DEVELOPMENT OR RSTUDIO_RUN_IN_PLACE)
-   set_target_properties(rsession PROPERTIES SKIP_BUILD_RPATH TRUE)
-endif()
+# Remaining link configuration for the single-executable (non-Windows) build;
+# the Windows shared-library and launcher-stub targets are fully configured above.
+if(NOT WIN32)
 
-target_link_libraries(rsession ${SESSION_LIBRARIES})
-if(RSTUDIO_WIN32_BUILD_UTF8_SESSION)
-   target_link_libraries(rsession-utf8 ${SESSION_LIBRARIES})
-endif()
-
-if(APPLE)
-   target_link_libraries(rsession "-undefined dynamic_lookup")
-   target_link_libraries(rsession "-Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/rsession.exports")
-else()
-   target_link_libraries(rsession "${LIBR_LIBRARIES}")
-   if(RSTUDIO_WIN32_BUILD_UTF8_SESSION)
-      target_link_libraries(rsession-utf8 "${LIBR_LIBRARIES}")
+   # skip libR RPATH at development time
+   if(RSTUDIO_DEVELOPMENT OR RSTUDIO_RUN_IN_PLACE)
+      set_target_properties(rsession PROPERTIES SKIP_BUILD_RPATH TRUE)
    endif()
-endif()
 
-if(RSTUDIO_SERVER)
-   target_link_libraries(rsession rstudio-server-core)
+   target_link_libraries(rsession ${SESSION_LIBRARIES})
+
+   if(APPLE)
+      target_link_libraries(rsession "-undefined dynamic_lookup")
+      target_link_libraries(rsession "-Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/rsession.exports")
+   else()
+      target_link_libraries(rsession "${LIBR_LIBRARIES}")
+   endif()
+
+   if(RSTUDIO_SERVER)
+      target_link_libraries(rsession rstudio-server-core)
+   endif()
+
 endif()
 
 # configure and install r-ldpaths script
@@ -667,6 +690,10 @@ endif()
 
 # install binary
 install(TARGETS rsession DESTINATION "${RSTUDIO_INSTALL_BIN}")
+if(WIN32)
+   # the shared library holding the session code (loaded by the launcher stubs)
+   install(TARGETS rsession-shared RUNTIME DESTINATION "${RSTUDIO_INSTALL_BIN}")
+endif()
 if(RSTUDIO_WIN32_BUILD_UTF8_SESSION)
     install(TARGETS rsession-utf8 DESTINATION "${RSTUDIO_INSTALL_BIN}")
 endif()
@@ -675,6 +702,10 @@ endif()
 if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL Debug)
    install(
       FILES "$<TARGET_PDB_FILE:rsession>"
+      DESTINATION "${RSTUDIO_INSTALL_BIN}")
+   # the shared library carries essentially all of the session debug info
+   install(
+      FILES "$<TARGET_PDB_FILE:rsession-shared>"
       DESTINATION "${RSTUDIO_INSTALL_BIN}")
    if(RSTUDIO_WIN32_BUILD_UTF8_SESSION)
       install(

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -595,23 +595,19 @@ endif()
 # define executable
 if(WIN32)
 
-   # Build the bulk of the session code into a single shared library so that
-   # rsession.exe and rsession-utf8.exe can share one copy of the code rather
-   # than each statically linking its own. The two executables are identical
-   # apart from their embedded manifest: rsession-utf8 declares a UTF-8 active
-   # code page (for UCRT builds of R 4.2.0 and newer) while rsession uses the
-   # system default. The active code page is fixed at process startup from the
-   # executable's manifest and applies process-wide -- including to code running
-   # in this DLL -- so a thin per-manifest launcher stub is all that differs
-   # between the two. See SessionMain.hpp.
+   # Build the bulk of the session code into a single shared library shared by
+   # the thin rsession.exe / rsession-utf8.exe launcher stubs. See SessionMain.hpp.
    add_library(rsession-shared SHARED
        ${SESSION_SOURCE_FILES}
        ${SESSION_HEADER_FILES})
 
-   # produce rsession-shared.dll (a distinct name from the rsession.exe stub, so
-   # their import libs and .pdb files do not collide); drop any "lib" prefix
+   # ship the runtime DLL as rsession.dll, but keep its import lib and .pdb under
+   # the rsession-shared name so they do not collide with the rsession.exe stub's
+   # own .lib/.pdb; drop any "lib" prefix
    set_target_properties(rsession-shared PROPERTIES
-      OUTPUT_NAME "rsession-shared"
+      OUTPUT_NAME "rsession"
+      ARCHIVE_OUTPUT_NAME "rsession-shared"
+      PDB_NAME "rsession-shared"
       PREFIX "")
 
    # mark rsessionMain() for export from the DLL (vs import in the stubs)

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2142,7 +2142,7 @@ void mainThreadWorkaround()
 // run session
 //
 // This is the real entry point for the R session. On Windows it is compiled
-// into a shared library (rsession-shared.dll) and invoked by main() in the thin
+// into a shared library (rsession.dll) and invoked by main() in the thin
 // launcher stubs (rsession.exe / rsession-utf8.exe); see SessionMainStub.cpp
 // and the comments in SessionMain.hpp and CMakeLists.txt.
 RSESSION_MAIN_API int rsessionMain(int argc, char * const argv[])

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2140,7 +2140,12 @@ void mainThreadWorkaround()
 } // anonymous namespace
 
 // run session
-int main(int argc, char * const argv[])
+//
+// This is the real entry point for the R session. On Windows it is compiled
+// into a shared library (rsession-shared.dll) and invoked by main() in the thin
+// launcher stubs (rsession.exe / rsession-utf8.exe); see SessionMainStub.cpp
+// and the comments in SessionMain.hpp and CMakeLists.txt.
+RSESSION_MAIN_API int rsessionMain(int argc, char * const argv[])
 {
    mainThreadWorkaround();
 

--- a/src/cpp/session/SessionMainStub.cpp
+++ b/src/cpp/session/SessionMainStub.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionMainStub.cpp
  *
- * Copyright (C) 2022 by Posit Software, PBC
+ * Copyright (C) 2026 by Posit Software, PBC
  *
  * Unless you have received this program directly from Posit Software pursuant
  * to the terms of a commercial license agreement with Posit Software, then
@@ -15,17 +15,11 @@
 
 #include <session/SessionMain.hpp>
 
-// Thin launcher stub for the R session.
-//
-// On Windows the session code lives in a shared library (rsession-shared.dll),
-// and this stub is compiled into each launcher executable (rsession.exe and
-// rsession-utf8.exe). Those executables are identical apart from the manifest
-// embedded via their .rc file. The embedded manifest fixes the process active
-// code page at startup, and that setting applies process-wide -- including to
-// the code running in the DLL -- so the two stubs give the shared library
-// the correct (legacy or UTF-8) code page. On other platforms all of the
-// session code is linked into a single executable and this simply forwards to
-// rsessionMain(). See SessionMain.hpp for details.
+// Thin launcher stub for the R session. On Windows the session code lives in a
+// shared library (rsession.dll) loaded by each launcher executable (rsession.exe
+// and rsession-utf8.exe); on other platforms it is linked into a single
+// executable. Either way this simply forwards to rsessionMain(). See
+// SessionMain.hpp for details.
 int main(int argc, char* const argv[])
 {
    return rsessionMain(argc, argv);

--- a/src/cpp/session/SessionMainStub.cpp
+++ b/src/cpp/session/SessionMainStub.cpp
@@ -1,0 +1,32 @@
+/*
+ * SessionMainStub.cpp
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <session/SessionMain.hpp>
+
+// Thin launcher stub for the R session.
+//
+// On Windows the session code lives in a shared library (rsession-shared.dll),
+// and this stub is compiled into each launcher executable (rsession.exe and
+// rsession-utf8.exe). Those executables are identical apart from the manifest
+// embedded via their .rc file. The embedded manifest fixes the process active
+// code page at startup, and that setting applies process-wide -- including to
+// the code running in the DLL -- so the two stubs give the shared library
+// the correct (legacy or UTF-8) code page. On other platforms all of the
+// session code is linked into a single executable and this simply forwards to
+// rsessionMain(). See SessionMain.hpp for details.
+int main(int argc, char* const argv[])
+{
+   return rsessionMain(argc, argv);
+}

--- a/src/cpp/session/include/session/SessionMain.hpp
+++ b/src/cpp/session/include/session/SessionMain.hpp
@@ -17,7 +17,7 @@
 #define SESSION_MAIN_HPP
 
 // On Windows, the bulk of the session code -- including the rsessionMain()
-// entry point below -- is built into a shared library (rsession-shared.dll)
+// entry point below -- is built into a shared library (rsession.dll)
 // shared by two thin launcher executables, rsession.exe and rsession-utf8.exe.
 // Those executables are identical apart from the manifest embedded via their
 // .rc file: rsession-utf8.exe selects a UTF-8 active code page (for UCRT builds

--- a/src/cpp/session/include/session/SessionMain.hpp
+++ b/src/cpp/session/include/session/SessionMain.hpp
@@ -16,6 +16,30 @@
 #ifndef SESSION_MAIN_HPP
 #define SESSION_MAIN_HPP
 
+// On Windows, the bulk of the session code -- including the rsessionMain()
+// entry point below -- is built into a shared library (rsession-shared.dll)
+// shared by two thin launcher executables, rsession.exe and rsession-utf8.exe.
+// Those executables are identical apart from the manifest embedded via their
+// .rc file: rsession-utf8.exe selects a UTF-8 active code page (for UCRT builds
+// of R 4.2.0 and newer) while rsession.exe uses the system default. The active
+// code page is fixed at process startup from the executable's manifest and
+// applies process-wide, including to code running in rsession.dll, so the two
+// stubs are sufficient to give the shared code the correct code page.
+//
+// RSESSION_MAIN_API exports rsessionMain() from that DLL and imports it into
+// the stubs. It expands to nothing on other platforms, where all of the
+// session code is linked into a single rsession executable.
+#if defined(_WIN32) && defined(RSESSION_BUILDING_SHARED)
+# define RSESSION_MAIN_API __declspec(dllexport)
+#elif defined(_WIN32)
+# define RSESSION_MAIN_API __declspec(dllimport)
+#else
+# define RSESSION_MAIN_API
+#endif
+
+// Real entry point for the R session; invoked by main() in SessionMainStub.cpp.
+RSESSION_MAIN_API int rsessionMain(int argc, char* const argv[]);
+
 namespace rstudio {
 namespace session {
 


### PR DESCRIPTION
## Summary

On Windows we ship two R session executables, `rsession.exe` and `rsession-utf8.exe`. They are **identical code** with different embedded manifests (`rsession-utf8.exe` declares a UTF-8 `activeCodePage` for UCRT builds of R 4.2.0+, selected at runtime via `R_RUNTIME=='ucrt'`). Until now each executable statically linked its own full copy of the (large) session code, so we shipped two big binaries.

This builds the session code **once** into `rsession.dll` and turns the two executables into thin launcher stubs that load it. We now ship one copy of the heavy code plus two small stubs.

## Why this is safe

The process active code page is fixed at startup from the **launching executable's** manifest and applies process-wide -- including to code running in a DLL it loads. So a per-manifest stub is all that needs to differ between the two; the shared DLL inherits the correct (legacy or UTF-8) code page from whichever stub launched it.

This was verified empirically on a Windows VM: a single test DLL reported `GetACP() == 1252` when loaded by a stub with no UTF-8 manifest and `65001` when loaded by an otherwise-identical stub carrying the UTF-8 manifest.

## What changed

- `SessionMain.cpp`: the `int main(...)` body becomes `RSESSION_MAIN_API int rsessionMain(...)` (no logic changes).
- `SessionMain.hpp`: adds the `RSESSION_MAIN_API` export/import macro and the `rsessionMain()` declaration.
- `SessionMainStub.cpp` (new): thin `int main()` that forwards to `rsessionMain()`. Compiled into each stub on Windows, and into the single executable on other platforms.
- `CMakeLists.txt` (Windows): the old `rsession-objects` OBJECT library becomes a `SHARED` library shipped as `rsession.dll` (holding `SESSION_LIBRARIES` + `LIBR_LIBRARIES`); `rsession.exe` / `rsession-utf8.exe` become stubs that link it and keep their existing `.rc`/manifest. The CMake target stays named `rsession-shared` and its import lib / `.pdb` are named `rsession-shared.*` so they do not collide with the `rsession.exe` stub's own `.lib`/`.pdb`. The DLL (and its PDB) are installed alongside. Non-Windows link configuration is unchanged (just fenced under `NOT WIN32`).

## Notes

- macOS/Linux are unaffected: still a single `rsession` exporting `_rd_*` via `rsession.exports`. On Windows the two `rd_*` debug helpers (`rd_eval` / `rd_traceback`, declared `RS_EXPORT` == `__declspec(dllexport)`) were previously exported from `rsession.exe`; they are now exported from `rsession.dll` instead. They remain exported and debugger-discoverable in the loaded module, so this is behavior-preserving; the only newly added export is `rsessionMain` (so the stub can call into the DLL).
- `rsession --run-tests` still works (the stub forwards argv to `rsessionMain` in the DLL).
- The runtime DLL ships as `rsession.dll`; its import lib and `.pdb` are kept under the `rsession-shared` name (via `ARCHIVE_OUTPUT_NAME` / `PDB_NAME`) so they don't collide with the `rsession.exe` stub's `.lib`/`.pdb`.
- Executable names are intentionally unchanged. Longer term, when R < 4.2 (MSVCRT) support is dropped, the `rsession-utf8` target and the `R_RUNTIME=='ucrt'` launcher branch can be removed and a single UTF-8 `rsession.exe` shipped.

## Validation

Windows build/packaging is exercised by CI. Worth confirming there: `rsession.dll` is colocated with the stubs for dev/run-in-place launches, the installer picks up the new DLL, and the 32-bit `SessionWin32` build (no UTF-8 variant) packages its DLL + stub.

Developer-only / build change; no user-facing behavior change, so no NEWS.md entry.
