### PR TITLE
Fix dismissSetupPrompts race when Posit Assistant is not installed

### DIFF
--- a/e2e/rstudio/actions/chat_pane.actions.ts
+++ b/e2e/rstudio/actions/chat_pane.actions.ts
@@ -67,11 +67,18 @@ export class ChatPaneActions {
    * waitForChatReady) may remain. Install is checked before update because the
    * downgrade variant of the update view also carries an "Install ..." button.
    *
-   * On timeout, returns 'ready' so the caller defers to waitForChatReady, whose
-   * sign-in vs. stalled error is more actionable than anything we'd raise here.
+   * The timeout must exceed the backend manifest-fetch bound that gates which
+   * view renders: chat_check_for_updates can run a manifest download for up to
+   * kManifestDeadlineSeconds (30s, SessionChat.cpp) before any prompt appears,
+   * so a shorter window could give up just before a slow-manifest Install
+   * prompt renders. We poll past that bound with margin.
+   *
+   * On timeout (a genuine stall past the manifest bound), returns 'ready' so
+   * the caller defers to waitForChatReady, whose sign-in vs. stalled error is
+   * more actionable than anything we'd raise here.
    */
   private async waitForSetupState(
-    timeout: number = 15000
+    timeout: number = 40000
   ): Promise<'install' | 'update' | 'ready'> {
     const deadline = Date.now() + timeout;
     while (Date.now() < deadline) {

--- a/e2e/rstudio/actions/chat_pane.actions.ts
+++ b/e2e/rstudio/actions/chat_pane.actions.ts
@@ -69,9 +69,9 @@ export class ChatPaneActions {
    *
    * The timeout must exceed the backend manifest-fetch bound that gates which
    * view renders: chat_check_for_updates can run a manifest download for up to
-   * kManifestDeadlineSeconds (30s, SessionChat.cpp) before any prompt appears,
-   * so a shorter window could give up just before a slow-manifest Install
-   * prompt renders. We poll past that bound with margin.
+   * kManifestDeadlineSeconds (currently 30s, SessionChat.cpp) before any prompt
+   * appears, so a shorter window could give up just before a slow-manifest
+   * Install prompt renders. We poll past that bound with margin.
    *
    * On timeout (a genuine stall past the manifest bound), returns 'ready' so
    * the caller defers to waitForChatReady, whose sign-in vs. stalled error is
@@ -93,6 +93,9 @@ export class ChatPaneActions {
       }
       await sleep(500);
     }
+    // Not a positive signal: waitForChatReady() (which dismissSetupPrompts always
+    // calls next) is the real readiness gate and throws on a genuine stall. Keep
+    // that call if this code is ever refactored, or this becomes a silent failure.
     return 'ready';
   }
 

--- a/e2e/rstudio/actions/chat_pane.actions.ts
+++ b/e2e/rstudio/actions/chat_pane.actions.ts
@@ -28,25 +28,65 @@ export class ChatPaneActions {
   }
 
   async dismissSetupPrompts(): Promise<void> {
-    // These prompts are visible immediately when present; absence is the common
-    // case. Gate each click on isVisible() (snapshot) so we don't burn the full
-    // click({ timeout }) auto-wait when the button is missing.
-    if (await this.chatPane.installBtn.isVisible()) {
+    // openChatPane() only waits for the iframe element, not its contents. The
+    // setup prompts (Install / Update) and the real chat app all render
+    // asynchronously after a backend install-status round-trip, so a single
+    // isVisible() snapshot here races that render: when Posit Assistant is not
+    // installed, the "Not Installed" view (with its Install button) has not
+    // appeared yet, the snapshot reads false, and we fall through to
+    // waitForChatReady() -- which then waits 30s for a composer that will never
+    // exist. Poll until one terminal setup state is reached instead.
+    const state = await this.waitForSetupState();
+
+    if (state === 'install') {
       await this.chatPane.installBtn.click();
       console.log('Clicked Install button -- waiting for installation...');
       await expect(this.chatPane.chatRoot).toBeVisible({ timeout: 60000 });
       await expect(this.chatPane.chatInput).toBeVisible({ timeout: 30000 });
-    } else if (await this.chatPane.updateBtn.isVisible()) {
+    } else if (state === 'update') {
       await this.chatPane.updateBtn.click();
       console.log('Clicked Update on update prompt -- updating Posit Assistant');
       await expect(this.chatPane.chatRoot).toBeVisible({ timeout: 30000 });
     }
 
     // The TrustOverlay and the chat input both render asynchronously after
-    // the iframe loads; waitForChatReady polls for either path through the
+    // the chat app loads; waitForChatReady polls for either path through the
     // workspace-trust dialog or a clean editable composer, so callers don't
     // need to handle it themselves.
     await this.waitForChatReady();
+  }
+
+  /**
+   * Poll the chat iframe until it settles into a terminal setup state:
+   * an Install prompt ('install'), an Update prompt ('update'), or the real
+   * chat app having loaded ('ready').
+   *
+   * The chat app mounts at #root, which the plain-HTML "Not Installed" /
+   * "Update Available" views never contain, so its presence reliably means
+   * installation is complete and only trust/sign-in (handled by
+   * waitForChatReady) may remain. Install is checked before update because the
+   * downgrade variant of the update view also carries an "Install ..." button.
+   *
+   * On timeout, returns 'ready' so the caller defers to waitForChatReady, whose
+   * sign-in vs. stalled error is more actionable than anything we'd raise here.
+   */
+  private async waitForSetupState(
+    timeout: number = 15000
+  ): Promise<'install' | 'update' | 'ready'> {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      if (await this.chatPane.installBtn.isVisible().catch(() => false)) {
+        return 'install';
+      }
+      if (await this.chatPane.updateBtn.isVisible().catch(() => false)) {
+        return 'update';
+      }
+      if (await this.chatPane.chatRoot.isVisible().catch(() => false)) {
+        return 'ready';
+      }
+      await sleep(500);
+    }
+    return 'ready';
   }
 
   /**


### PR DESCRIPTION
## Problem

The `@ai` e2e test `uninstall-posit-ai.test.ts` could fail in its `beforeAll` with:

```
waitForChatReady: chat input still not editable after 30000ms
(no Sign-In button, no Trust dialog). Chat pane initialization may have stalled.
```

while the chat pane visibly showed the "Posit Assistant Not Installed" view.

`dismissSetupPrompts()` detected the Install/Update setup prompts with a single non-waiting `isVisible()` snapshot taken right after `openChatPane()`. But `openChatPane()` only waits for the chat iframe element to appear, not its contents. When Posit Assistant is not installed, the "Not Installed" view (with its Install button) renders asynchronously inside the iframe after a backend `chat_check_for_updates` round-trip. The snapshot ran before the button existed, read false, and fell through to `waitForChatReady()`, which then waited 30s for a composer that never appears in the not-installed state.

## Change

Replace the snapshot with `waitForSetupState()`, which polls every 500ms until one terminal setup state is reached:

- `install` — the Not Installed view's Install button is present
- `update` — the Update Available view's Update button is present
- `ready` — the chat app's `#root` is present (the plain-HTML setup views never contain it)

The poll window is 40s so it exceeds the backend manifest-fetch bound (`kManifestDeadlineSeconds = 30`, `src/cpp/session/modules/SessionChat.cpp`) that gates when the prompt renders; a shorter window could give up just before a slow-manifest Install prompt appears. On timeout it returns `ready` so the caller defers to `waitForChatReady()`, whose sign-in-vs-stalled error is more actionable.

Install is checked before update because the downgrade variant of the update view also carries an "Install Version ..." button.

This helper is shared by the chat test suite, so the not-installed path is handled wherever `dismissSetupPrompts()` is called. The common installed path returns `ready` as soon as `#root` appears.

## Verification

- `cd e2e/rstudio && npm run typecheck` passes.
- Re-run the suite against a machine with Posit Assistant uninstalled:
  `PW_RSTUDIO_PREFS_OVERRIDE=.prefs.local.json npm run test:desktop -- --grep @ai`
  The `uninstall-posit-ai` `beforeAll` now detects the Install button and installs Posit Assistant instead of stalling.