### PR TITLE
e2e: attach browser console + rsession logs to failing playwright tests

### DIFF
--- a/e2e/rstudio/CLAUDE.md
+++ b/e2e/rstudio/CLAUDE.md
@@ -15,6 +15,8 @@ The `window.rstudio` surface includes:
 - `window.rstudio.layout.reset()` -- end any active pane/column zoom or pane maximize.
 - `window.rstudio.errors` -- `list()` / `clear()` the uncaught client exceptions recorded by the agent (message + stack); `simulate(msg)` raises a real one (harness self-test only). The per-test fixture drains this and fails the test that raised an exception (opt out with `PW_IGNORE_CLIENT_EXCEPTIONS=1`).
 
+When a test fails, the per-test fixture (`fixtures/rstudio.fixture.ts`) attaches two diagnostics to the report so symptoms that never reach a failed assertion are still recoverable: `browser-console.log` (buffered `console.error`/`console.warning` plus uncaught `pageerror`s captured during the test body) and, on Desktop, the slice of each rsession log file (`RSTUDIO_DATA_HOME/log/*.log`) written while the test ran. Both are scoped to the single test -- the console buffer is cleared and the log byte-offsets are snapshotted at test start. This is separate from the `window.rstudio.errors` fail-the-test mechanism above: client exceptions still fail the test by themselves, but the attachments add the surrounding browser-console and backend-log context.
+
 Commands and prefs are enumerated up front at agent init, so a missing-by-name lookup is a genuine "doesn't exist" rather than "not yet touched by GWT code".
 
 See `.claude/skills/rstudio-create-playwright-tests/SKILL.md` for detailed guidance on writing Playwright tests, and `.claude/skills/rstudio-run-playwright-tests/SKILL.md` for how to run them.

--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -153,6 +153,10 @@ export interface DesktopSession {
   browser: Browser;
   rstudioProcess: ChildProcess;
   configRoot: string;
+  // Directory rsession writes its log files to for this launch:
+  // RSTUDIO_DATA_HOME/log (see core/system/Xdg.cpp userLogDir). The per-test
+  // fixture reads them from here to attach backend logs on a failure.
+  logDir: string;
 }
 
 // Gated diagnostic: when PW_DEBUG_LAUNCH=1 is set, attach listeners to every
@@ -657,7 +661,9 @@ async function launchRStudioOnce(existingConfigRoot?: string): Promise<DesktopSe
     logLaunchStep('console input not busy');
     console.log('RStudio console is ready');
 
-    return { page, browser, rstudioProcess, configRoot };
+    // rsession logs land in RSTUDIO_DATA_HOME/log (see core/system/Xdg.cpp).
+    const logDir = path.join(tempConfig.dataHome, 'log');
+    return { page, browser, rstudioProcess, configRoot, logDir };
   } catch (err) {
     await browser?.close().catch(() => {});
     killProcessTree(rstudioProcess);

--- a/e2e/rstudio/fixtures/rstudio.fixture.ts
+++ b/e2e/rstudio/fixtures/rstudio.fixture.ts
@@ -1,4 +1,6 @@
-import { test as base, type Page } from '@playwright/test';
+import { test as base, type Page, type TestInfo } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
 import { launchRStudio, shutdownRStudio } from './desktop.fixture';
 import { launchServer, shutdownServer } from './server.fixture';
 import { getEnvironmentVersions, clearConsole } from '../pages/console_pane.page';
@@ -8,6 +10,29 @@ import { waitForUserConsoleInput } from '../utils/debug';
 
 type Mode = 'desktop' | 'server';
 
+/** One buffered browser-side diagnostic line, captured during a test. */
+interface ConsoleLine {
+  ts: number;
+  kind: 'console' | 'pageerror';
+  type?: string; // console message type ('error' | 'warning'); unset for pageerror
+  text: string;
+}
+
+/**
+ * Worker-scoped session context shared by the page and the per-test reset.
+ *
+ * `consoleBuffer` accumulates browser console errors/warnings and uncaught
+ * page errors for the page; the per-test fixture clears it at the start of
+ * each test and attaches it to the report when that test fails. `logDir` is
+ * the directory rsession writes its log files to (desktop only -- see
+ * DesktopSession.dataHome), read on failure to attach backend logs.
+ */
+interface SessionContext {
+  page: Page;
+  consoleBuffer: ConsoleLine[];
+  logDir?: string;
+}
+
 /** Capture R/RStudio versions once per worker and log them. */
 async function logVersions(page: Page): Promise<void> {
   const versions = await getEnvironmentVersions(page);
@@ -16,31 +41,147 @@ async function logVersions(page: Page): Promise<void> {
 }
 
 /**
+ * Buffer browser console errors/warnings and uncaught page errors into
+ * `buffer`. The page persists across a worker's tests, so the listeners are
+ * attached once here and the per-test fixture scopes capture by clearing the
+ * buffer between tests. Only error/warning console messages are kept -- the
+ * full info/log stream is noisy and rarely diagnostic on failure.
+ */
+function attachConsoleCapture(page: Page, buffer: ConsoleLine[]): void {
+  page.on('console', (msg) => {
+    const type = msg.type();
+    if (type === 'error' || type === 'warning') {
+      buffer.push({ ts: Date.now(), kind: 'console', type, text: msg.text() });
+    }
+  });
+  page.on('pageerror', (err) => {
+    buffer.push({ ts: Date.now(), kind: 'pageerror', text: err.stack || err.message });
+  });
+}
+
+/** Attach the buffered browser console/page errors to a failing test. */
+async function attachBrowserConsole(testInfo: TestInfo, buffer: ConsoleLine[]): Promise<void> {
+  if (buffer.length === 0) return;
+  const t0 = buffer[0].ts;
+  const body = buffer
+    .map((line) => {
+      const rel = `+${(line.ts - t0).toString().padStart(5, ' ')}ms`;
+      const tag = line.kind === 'pageerror' ? 'pageerror' : `console.${line.type}`;
+      return `${rel} [${tag}] ${line.text}`;
+    })
+    .join('\n');
+  await testInfo.attach('browser-console.log', { body, contentType: 'text/plain' });
+}
+
+/**
+ * Record the current byte length of every `.log` file under `logDir`, so a
+ * failing test can later attach only the bytes appended while it ran (the
+ * rsession log is append-only and shared across a worker's tests). Returns an
+ * empty map when no log dir is known (server mode) or it doesn't exist yet.
+ */
+function snapshotLogSizes(logDir?: string): Map<string, number> {
+  const sizes = new Map<string, number>();
+  if (!logDir) return sizes;
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(logDir);
+  } catch {
+    return sizes; // log dir not created yet
+  }
+  for (const name of entries) {
+    if (!name.endsWith('.log')) continue;
+    const filePath = path.join(logDir, name);
+    try {
+      sizes.set(filePath, fs.statSync(filePath).size);
+    } catch {
+      // File vanished between readdir and stat; skip it.
+    }
+  }
+  return sizes;
+}
+
+/**
+ * Attach the slice of each rsession log file written while a failing test
+ * ran. `baseline` is the per-test snapshot from snapshotLogSizes(); we read
+ * from that offset to the current end. If a file shrank (log rotation), read
+ * it from the start instead. Empty slices are skipped.
+ */
+async function attachSessionLogs(
+  testInfo: TestInfo,
+  logDir: string | undefined,
+  baseline: Map<string, number>,
+): Promise<void> {
+  if (!logDir) return;
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(logDir);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    if (!name.endsWith('.log')) continue;
+    const filePath = path.join(logDir, name);
+    let slice: string;
+    try {
+      const size = fs.statSync(filePath).size;
+      const start = baseline.get(filePath) ?? 0;
+      const from = size >= start ? start : 0;
+      const length = size - from;
+      if (length <= 0) continue;
+      const buf = Buffer.alloc(length);
+      const fd = fs.openSync(filePath, 'r');
+      try {
+        fs.readSync(fd, buf, 0, length, from);
+      } finally {
+        fs.closeSync(fd);
+      }
+      slice = buf.toString('utf8');
+    } catch {
+      continue;
+    }
+    if (slice.trim().length === 0) continue;
+    await testInfo.attach(name, { body: slice, contentType: 'text/plain' });
+  }
+}
+
+/**
  * Unified Playwright Test fixture that provides a shared RStudio page.
  *
  * The `mode` option is set per-project in playwright.config.ts; select with
  * `--project=desktop` (default) or `--project=server`.
  */
-export const test = base.extend<{ perTestReset: void }, { mode: Mode; rstudioPage: Page }>({
+export const test = base.extend<
+  { perTestReset: void },
+  { mode: Mode; rstudioSession: SessionContext; rstudioPage: Page }
+>({
   mode: ['desktop', { option: true, scope: 'worker' }],
-  rstudioPage: [async ({ mode }, use) => {
+  rstudioSession: [async ({ mode }, use) => {
+    const consoleBuffer: ConsoleLine[] = [];
     if (mode === 'server') {
       const session = await launchServer();
+      // Server mode doesn't expose a per-session log dir (the spawned rserver
+      // shares a data home across workers); see the issue's desktop-only note.
+      attachConsoleCapture(session.page, consoleBuffer);
       await logVersions(session.page);
-      await use(session.page);
+      await use({ page: session.page, consoleBuffer });
       // Debug-only: keep the session alive after the last test so you can
       // keep inspecting; press Enter in the Console to quit. No-op otherwise.
       await waitForUserConsoleInput(session.page, 'quit RStudio');
       await shutdownServer(session);
     } else {
       const session = await launchRStudio();
+      attachConsoleCapture(session.page, consoleBuffer);
       await logVersions(session.page);
-      await use(session.page);
+      await use({ page: session.page, consoleBuffer, logDir: session.logDir });
       // Debug-only: keep the session alive after the last test so you can
       // keep inspecting; press Enter in the Console to quit. No-op otherwise.
       await waitForUserConsoleInput(session.page, 'quit RStudio');
       await shutdownRStudio(session);
     }
+  }, { scope: 'worker' }],
+
+  rstudioPage: [async ({ rstudioSession }, use) => {
+    await use(rstudioSession.page);
   }, { scope: 'worker' }],
 
   // Reset the IDE to a clean per-test starting state. See utils/test-reset.ts
@@ -58,7 +199,9 @@ export const test = base.extend<{ perTestReset: void }, { mode: Mode; rstudioPag
   // hid the Environment tab (#17952). Auto fixtures are part of the test type
   // itself, so they run for every test in every file regardless of module
   // caching.
-  perTestReset: [async ({ rstudioPage: page }, use, testInfo) => {
+  perTestReset: [async ({ rstudioSession }, use, testInfo) => {
+    const page = rstudioSession.page;
+
     // Drain exceptions that arrived BEFORE this test (a previous test's
     // teardown, the gap between specs). They can't be attributed to the
     // upcoming test, so log them rather than fail it.
@@ -68,6 +211,12 @@ export const test = base.extend<{ perTestReset: void }, { mode: Mode; rstudioPag
         `[client-exception] recorded between tests (not attributed): ${e.message}\n${e.stack}`,
       );
     }
+
+    // Scope failure diagnostics to this test: start with an empty browser
+    // console buffer and a snapshot of the current rsession log sizes, so on
+    // failure we attach only what this test produced.
+    rstudioSession.consoleBuffer.length = 0;
+    const logBaseline = snapshotLogSizes(rstudioSession.logDir);
 
     await resetForNextTest(page);
 
@@ -87,12 +236,26 @@ export const test = base.extend<{ perTestReset: void }, { mode: Mode; rstudioPag
     // downgrades to a warning if a known benign exception must be tolerated
     // while a fix lands.
     const raised = await drainClientExceptions(page);
+    const ignoreClientExceptions = ['1', 'true'].includes(
+      (process.env.PW_IGNORE_CLIENT_EXCEPTIONS ?? '').toLowerCase(),
+    );
+
+    // Attach browser console + rsession logs whenever the test is failing --
+    // either the body already failed, or a client exception is about to fail
+    // it below. The console output captures symptoms that never reach a
+    // failure assertion (a console error, an uncaught pageerror), and the
+    // rsession log captures backend errors that never reach the browser.
+    const willFail =
+      testInfo.status !== testInfo.expectedStatus ||
+      (raised.length > 0 && !ignoreClientExceptions);
+    if (willFail) {
+      await attachBrowserConsole(testInfo, rstudioSession.consoleBuffer);
+      await attachSessionLogs(testInfo, rstudioSession.logDir, logBaseline);
+    }
+
     if (raised.length > 0) {
       const detail = raised.map((e) => `${e.message}\n${e.stack}`).join('\n---\n');
-      const ignore = ['1', 'true'].includes(
-        (process.env.PW_IGNORE_CLIENT_EXCEPTIONS ?? '').toLowerCase(),
-      );
-      if (ignore) {
+      if (ignoreClientExceptions) {
         console.warn(`[client-exception] during "${testInfo.title}" (ignored by env):\n${detail}`);
       } else {
         throw new Error(

--- a/scripts/bootstrap-worktree.sh
+++ b/scripts/bootstrap-worktree.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Bootstrap a git worktree so the JS/TS test suites "just work".
+#
+# `git worktree add` only materializes tracked files. node_modules is
+# gitignored, and a couple of generated files are gitignored too, so a fresh
+# .worktrees/<name> checkout starts without them -- tsx/ts-node test runs and
+# even `tsc` then fail with "Cannot find module" until deps are installed.
+#
+# When the worktree's package-lock.json matches the main checkout's, the main
+# checkout's node_modules already satisfies it, so we copy-on-write CLONE it
+# (APFS clonefile via `cp -c`, or reflink on Linux) instead of running
+# `npm ci`. A clone is near-instant, needs no network, and -- crucially for
+# src/node/desktop -- skips electron-rebuild and the failing generate.ts
+# postinstall. We clone rather than symlink because tsx/ts-node/electron-mocha
+# resolve files via realpath: a symlinked node_modules resolves back into the
+# main checkout and its loader hook can't intercept the worktree's .ts files. A
+# clone's files have their own worktree realpath, so resolution is correct. We
+# clone rather than hardlink because clones are copy-on-write -- a write in the
+# worktree can't corrupt the parent's node_modules through a shared inode.
+#
+# Falls back to `npm ci` when the lockfiles differ (the branch changed deps) or
+# the main checkout has no node_modules to clone.
+#
+# Platforms: the clone mechanism is gated by OS -- clonefile on macOS (`cp -c`),
+# reflink on Linux (`cp --reflink=auto`). On filesystems without copy-on-write
+# (ext4, NTFS) the clone transparently degrades to a full recursive copy:
+# correct and still offline, just not instant. Cloning is always from THIS
+# machine's main checkout, so the compiled native modules match the platform.
+# Run under bash (Git Bash or WSL on Windows).
+#
+# Usage:
+#   scripts/bootstrap-worktree.sh [worktree-dir] [--skip-desktop]
+#
+#   worktree-dir   defaults to the current directory; may be any path inside
+#                  the target worktree (it is normalized to the repo top).
+#   --skip-desktop skip src/node/desktop (its deps are large; skip when you
+#                  only need the e2e/rstudio suite).
+
+set -euo pipefail
+
+SKIP_DESKTOP=0
+TARGET=""
+for arg in "$@"; do
+  case "$arg" in
+    --skip-desktop) SKIP_DESKTOP=1 ;;
+    *) TARGET="$arg" ;;
+  esac
+done
+
+# Normalize to the repo top of the requested (or current) worktree so the
+# relative package paths below resolve no matter where this is invoked from.
+WORKTREE="$(git -C "${TARGET:-$PWD}" rev-parse --show-toplevel)"
+
+# The primary worktree's .git is a real directory; --git-common-dir points at
+# it, so its parent is the main checkout. We clone node_modules and copy
+# generated-but-gitignored files from there.
+COMMON_DIR="$(git -C "$WORKTREE" rev-parse --path-format=absolute --git-common-dir)"
+MAIN_CHECKOUT="$(dirname "$COMMON_DIR")"
+
+echo "[bootstrap] worktree:      $WORKTREE"
+echo "[bootstrap] main checkout: $MAIN_CHECKOUT"
+
+# Copy-on-write clone a directory tree (clonefile on macOS/APFS, reflink on
+# Linux), falling back to a plain recursive copy where COW is unsupported. The
+# destination must not already exist; we clear a partial tree before falling
+# back so a failed clone can't nest into the retry.
+clone_tree() {
+  local src="$1" dst="$2"
+  rm -rf "$dst"
+  if [ "$(uname -s)" = "Darwin" ]; then
+    cp -Rc "$src" "$dst" 2>/dev/null && return 0
+  else
+    cp -R --reflink=auto "$src" "$dst" 2>/dev/null && return 0
+  fi
+  rm -rf "$dst"
+  cp -R "$src" "$dst"
+}
+
+# Make sure a package dir has node_modules: clone from main when the lockfiles
+# match, otherwise npm ci.
+ensure_deps() {
+  local pkg="$1"
+  local wt="$WORKTREE/$pkg"
+  local main="$MAIN_CHECKOUT/$pkg"
+
+  if [ ! -f "$wt/package-lock.json" ]; then
+    echo "[bootstrap] skip $pkg (no package-lock.json)"
+    return
+  fi
+  if [ -d "$wt/node_modules" ]; then
+    echo "[bootstrap] $pkg already has node_modules; leaving as-is"
+    return
+  fi
+
+  if [ "$WORKTREE" != "$MAIN_CHECKOUT" ] \
+     && [ -d "$main/node_modules" ] \
+     && cmp -s "$wt/package-lock.json" "$main/package-lock.json"; then
+    echo "[bootstrap] cloning $pkg/node_modules from main (lockfiles match)"
+    if clone_tree "$main/node_modules" "$wt/node_modules"; then
+      return
+    fi
+    echo "[bootstrap] clone failed; falling back to npm ci"
+  fi
+
+  echo "[bootstrap] npm ci in $pkg"
+  ( cd "$wt" && npm ci )
+}
+
+# Copy a generated, gitignored file from the main checkout when the worktree is
+# missing it (and we are not already in the main checkout). Cloning
+# node_modules sidesteps the desktop generate.ts postinstall, but this stub
+# lives outside node_modules, so copy it explicitly.
+copy_generated() {
+  local rel="$1"
+  if [ "$WORKTREE" = "$MAIN_CHECKOUT" ] || [ -f "$WORKTREE/$rel" ]; then
+    return
+  fi
+  if [ ! -f "$MAIN_CHECKOUT/$rel" ]; then
+    echo "[bootstrap] WARNING: $rel missing from main checkout too; build it there first"
+    return
+  fi
+  echo "[bootstrap] copying generated $rel"
+  mkdir -p "$(dirname "$WORKTREE/$rel")"
+  cp "$MAIN_CHECKOUT/$rel" "$WORKTREE/$rel"
+}
+
+# The e2e/rstudio Playwright suite -- the common case.
+ensure_deps "e2e/rstudio"
+
+# The Electron desktop suite. Cloning skips its electron-rebuild and the
+# failing generate.ts postinstall; we still copy the type stub that postinstall
+# would have generated (it lives outside node_modules).
+if [ "$SKIP_DESKTOP" -eq 0 ]; then
+  ensure_deps "src/node/desktop"
+  copy_generated "src/node/desktop/src/types/user-state-schema.d.ts"
+else
+  echo "[bootstrap] skipping src/node/desktop (--skip-desktop)"
+fi
+
+echo "[bootstrap] done"


### PR DESCRIPTION
## Summary

Implements the two deferred fixture-level diagnostics from #17805. When a Playwright test fails, the per-test fixture now attaches:

1. **`browser-console.log`** -- buffered `console.error`/`console.warning` plus uncaught `pageerror`s captured during the test body (relative-timestamped). Captures symptoms that never reach a failed assertion (a console error, an uncaught page error).
2. **The rsession log slice** (Desktop) -- the bytes each `RSTUDIO_DATA_HOME/log/*.log` file gained while the test ran. Captures backend errors that never reach the browser (e.g. the `system error 2` from the issue).

Both are scoped to the single failing test: the console buffer is cleared and the log byte-offsets snapshotted at test start. This is separate from, and complementary to, the existing `window.rstudio.errors` fail-the-test mechanism -- client exceptions still fail the test by themselves, but now the surrounding browser-console and backend-log context is attached too.

## Changes

- `fixtures/desktop.fixture.ts`: `DesktopSession` exposes `logDir` (`RSTUDIO_DATA_HOME/log`, per `core/system/Xdg.cpp`).
- `fixtures/rstudio.fixture.ts`: new worker-scoped `rstudioSession` fixture holds `{ page, consoleBuffer, logDir? }`; `rstudioPage` derives from it (tests are unchanged). Console capture + per-test log-slice attachment on failure. Server mode gets console capture but no log dir (the spawned rserver shares a data home across workers -- the issue scoped logs to Desktop).
- `e2e/rstudio/CLAUDE.md`: documents the new attachments.

## Developer tooling (bundled)

- `scripts/bootstrap-worktree.sh`: makes a fresh `git worktree` "just work" for the JS/TS suites. A new worktree has no `node_modules` (gitignored) and lacks a couple of generated files; symlinking `node_modules` breaks tsx/ts-node (realpath resolution). The script copy-on-write CLONES `node_modules` from the main checkout when lockfiles match (clonefile/reflink; ~7s for both `e2e/rstudio` and `src/node/desktop`, vs minutes of `electron-rebuild`), falling back to `npm ci` otherwise, and copies the generated `user-state-schema.d.ts`. Carried here rather than split out, by request.

## Verification

- `npm run typecheck` passes for both `e2e/rstudio` and `src/node/desktop`.
- The bootstrap script was exercised end-to-end (clone path + typecheck on both packages).
- Not yet verified: a deliberately-failing Playwright run confirming the attachments land in the HTML report. Hence "Addresses", not "Fixes".

Addresses #17805.