### PR TITLE
Fix spawn EINVAL launching Playwright on Windows

### DIFF
--- a/e2e/rstudio/scripts/dev-common.ts
+++ b/e2e/rstudio/scripts/dev-common.ts
@@ -363,10 +363,21 @@ export function runPlaywright(
   const reportEnv = manageReportDir ? { PLAYWRIGHT_HTML_OUTPUT_DIR: reportDir } : {};
 
   const isWindows = process.platform === 'win32';
-  const npx = isWindows ? 'npx.cmd' : 'npx';
-  const args = ['playwright', 'test', ...outputArgs, ...extraArgs];
+  // Run the Playwright CLI with the current node binary rather than the `npx`
+  // shim. On Windows `npx` is `npx.cmd`, and Node (>=22, and >=18.20 / >=20.12)
+  // refuses to spawn .cmd/.bat files without shell:true (CVE-2024-27980), which
+  // throws EINVAL here. shell:true would dodge that but reintroduce a quoting
+  // hazard for args containing spaces (e.g. --grep "open file"); invoking the
+  // resolved cli.js via process.execPath keeps array args intact on every
+  // platform. `playwright/cli` is blocked by the package's exports map, so
+  // resolve it from package.json (cli.js is the package's bin entry).
+  const playwrightCli = path.join(
+    path.dirname(require.resolve('playwright/package.json')),
+    'cli.js',
+  );
+  const args = [playwrightCli, 'test', ...outputArgs, ...extraArgs];
 
-  const child = spawn(npx, args, {
+  const child = spawn(process.execPath, args, {
     stdio: 'inherit',
     env: { ...process.env, PATH: pathWithPinnedNode(), ...reportEnv, ...env },
     // POSIX: give the child its own process group so a terminal Ctrl-C is


### PR DESCRIPTION
## Summary

The local e2e test runners (`npm run test:desktop` and the `*-dev` variants) failed to start on Windows with `Error: spawn EINVAL`.

`runPlaywright()` in `e2e/rstudio/scripts/dev-common.ts` spawned `npx.cmd`. Since the Node fix for CVE-2024-27980 (Node >=18.20.2 / >=20.12.2 / all v22), `child_process.spawn()` refuses to launch `.cmd`/`.bat` files unless `shell: true` is set, so the spawn threw before any test ran. All `test:*` runners funnel through this one spawn.

This invokes the resolved Playwright `cli.js` with the current `node` binary (`process.execPath`) instead of the `npx.cmd` shim -- a real executable, so there is no batch shim to reject. Passing the CLI args as an array (rather than using `shell: true`) keeps arguments containing spaces intact, e.g. `--grep "open file"`. `playwright/cli` is blocked by the package's `exports` map, so the entry is resolved from `playwright/package.json` (its `bin` points at `cli.js`).

## Scope

This only touches the local-dev wrapper. The CI workflows are unaffected: they call `npx playwright test` directly from a shell step rather than through the npm scripts, so they never hit the programmatic-spawn path.

## Testing

- `npm run typecheck` passes.
- `npm run test:desktop -- --grep @ai --list` now launches Playwright and reaches test collection (previously it threw `spawn EINVAL` at startup).