### PR TITLE
harden linux middle-click primary-selection paste

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@
 - ([#17993](https://github.com/rstudio/rstudio/issues/17993)): Add a "Use overlay scrollbars" toggle to the data viewer's Settings menu. When disabled, the data viewer uses native, always-visible scrollbars instead of the auto-hiding overlay scrollbars.
 - ([#17807](https://github.com/rstudio/rstudio/issues/17807)): Fixed a startup stall and missing package vulnerability badges that could occur when an intermediary (such as a proxy) kept the connection to Posit Package Manager open after responding. RStudio's HTTP client now completes a response as soon as its full Content-Length body has been received, rather than waiting for the connection to close.
 - ([#18019](https://github.com/rstudio/rstudio/issues/18019)): Fixed an issue where a transient connection failure while writing user state during startup could leave the IDE stuck on an empty grey screen.
+- ([#1667](https://github.com/rstudio/rstudio/issues/1667)): On Linux Desktop, hardened middle-click (primary selection) paste in the editor and console: a selection is now flushed to the primary selection on mouse release rather than only after a short delay, and a middle-click paste falls back to the event's clipboard text when the tracked selection is empty, so quickly selecting and middle-click-pasting no longer pastes nothing.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorMixins.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorMixins.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.workbench.views.source.editors.text;
 
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.JavaScriptEventHistory;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.JavaScriptEventHistory.EventData;
@@ -40,6 +41,7 @@ public class AceEditorMixins
          @Override
          public void run()
          {
+            selectionPending_ = false;
             Desktop.getFrame().setGlobalMouseSelection(lastSelection_);
          }
       };
@@ -61,6 +63,7 @@ public class AceEditorMixins
                // save the current selection, and prepare to update pasteboard
                String selection = editor_.getSelectedText();
                lastSelection_ = selection;
+               selectionPending_ = true;
                timer_.schedule(TIMER_DELAY_MS);
             }
          });
@@ -87,6 +90,7 @@ public class AceEditorMixins
 
                String selection = editor_.getSelectedText();
                lastSelection_ = selection;
+               selectionPending_ = true;
                timer_.schedule(TIMER_DELAY_MS);
             }
          });
@@ -103,7 +107,20 @@ public class AceEditorMixins
          selectionChangedReg_ = null;
       }
    }
-   
+
+   // push a pending selection to the global mouse selection immediately,
+   // bypassing the debounce timer (invoked on mouse-up); a no-op when no
+   // selection is pending (e.g. on non-Linux-Desktop platforms)
+   private final void flushPendingSelection()
+   {
+      if (!selectionPending_)
+         return;
+
+      selectionPending_ = false;
+      timer_.cancel();
+      Desktop.getFrame().setGlobalMouseSelection(lastSelection_);
+   }
+
    @Inject
    private void initialize(JavaScriptEventHistory history)
    {
@@ -124,6 +141,13 @@ public class AceEditorMixins
          self.@org.rstudio.studio.client.workbench.views.source.editors.text.AceEditorMixins::onPaste(*)(this, text);
 
       });
+
+      // flush any pending selection to the global mouse selection as soon as
+      // the mouse is released, so a quick select-then-middle-click-paste sees
+      // the selection even before the debounce timer has fired
+      editor.container.addEventListener("mouseup", $entry(function(event) {
+         self.@org.rstudio.studio.client.workbench.views.source.editors.text.AceEditorMixins::flushPendingSelection()();
+      }), true);
 
    }-*/;
    
@@ -153,7 +177,15 @@ public class AceEditorMixins
       if (useGlobalMouseSelection)
       {
          Desktop.getFrame().getGlobalMouseSelection(selection ->
-               onReadyToPaste.execute(selection));
+         {
+            // the tracked selection is pushed on a debounce timer, and only
+            // by Ace editors -- so it can be empty here (e.g. the user selected
+            // and middle-clicked faster than the timer fired, or the selection
+            // came from a non-Ace source). in that case, fall back to the text
+            // the paste event already carried, which holds the primary selection.
+            String pasteText = StringUtil.isNullOrEmpty(selection) ? text : selection;
+            onReadyToPaste.execute(pasteText);
+         });
       }
       else
       {
@@ -197,9 +229,9 @@ public class AceEditorMixins
       // (be permissive as to what mouse even occurred)
       String type = event.getType();
       return
-            type == "mousedown" ||
-            type == "click" ||
-            type == "mouseup";
+            type.contentEquals("mousedown") ||
+            type.contentEquals("click") ||
+            type.contentEquals("mouseup");
    }
    
    private static final native void invokePasteHandler(AceEditorNative editor, String text)
@@ -214,6 +246,7 @@ public class AceEditorMixins
    private final Timer timer_;
 
    private String lastSelection_;
+   private boolean selectionPending_;
    private HandlerRegistration selectionChangedReg_;
    
    // Injected ----


### PR DESCRIPTION
## Summary

Hardens Linux Desktop middle-click (X11 primary selection) paste in the editor and console, addressing long-standing gaps in how the tracked selection is synced and consumed.

Background: on Linux Desktop, RStudio mirrors a focused Ace editor's selection into the X11 primary selection (`clipboard.writeText(sel, 'selection')`) and, on a middle-click paste, reads it back instead of the normal clipboard. The sync was driven solely by a 100ms debounce timer, and the paste path used whatever the tracked selection returned even when empty.

## Changes

- **Flush on mouse-up.** The selection is now pushed to the primary selection immediately on mouse release, rather than waiting up to 100ms for the debounce timer. This closes the race where a quick select-then-middle-click-paste fired before the timer. The timer is retained for keyboard/programmatic selection changes; the new path is a no-op when no selection is pending.
- **Empty-selection fallback.** On a middle-click paste, if the tracked global mouse selection is empty (debounce race, or a selection sourced from a non-Ace widget), we now fall back to the text the paste event already carried -- which holds the primary-selection content -- instead of pasting nothing.
- **Minor:** use `contentEquals` instead of string identity in the middle-click event-type check, for consistency with the surrounding predicate.

## Not addressed here

- The global `MiddleClickAutoscroll` Blink switch (added in #17812 for the data viewer) may compete with middle-click paste in the scrollable editor/console. That needs a Linux X11 repro before changing, since it would risk regressing data-viewer panning. Tracked separately.
- Wayland primary-selection behavior is unchanged (Electron/compositor dependent).

## Testing

- `cd src/gwt && ant javac` succeeds.
- Manual verification on Linux Desktop still required (no automated coverage; see discussion on the difficulty of an E2E test for middle-click paste).

Addresses #1667.
