### PR TITLE
run all unit tests on Windows bulids

### DIFF
--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -173,7 +173,7 @@ pipeline {
 
         stage('Tests') {
           steps {
-            bat 'cd package/win32/build/src/cpp && rstudio-tests.bat --scope core'
+            bat 'cd package/win32/build/src/cpp && rstudio-tests.bat'
           }
         }
 


### PR DESCRIPTION
Fixes #17825

With #18069 the full suite of unit tests are now passing locally on Windows, but we're only running `core` on builds.

This PR removes that filter and (tries) running all of them in CI. We'll see how that goes...