### PR TITLE
Add Ubuntu 24 Linux Desktop E2E automation (PR, scheduled, cache seed)

### DIFF
--- a/.github/workflows/os-cache-seed-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/os-cache-seed-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -1,0 +1,59 @@
+name: "Cache Seed: E2E Playwright RStudio (Desktop, Ubuntu 24, Open Source)"
+
+# Seeds the build caches (rstudio-tools, build-time R packages, and the GHA
+# sccache object cache) on the default branch so that PR builds start warm.
+# GitHub Actions caches are scoped per-branch: a cache can only be restored
+# from the same branch, the PR's base branch, or the default branch. Sibling
+# branches / PRs cannot see each other's caches. By running the build job on
+# main, the caches it saves land in main's scope, which every PR (based on
+# main) can then restore via the restore-keys prefixes
+# (rstudio-tools-linux-x86_64-, etc.) -- and the GHA-backed sccache backend
+# serves object hits to every branch in the repo. Without this, every new PR
+# branch starts 100% cold on its first Linux Desktop build.
+#
+# The rstudio-tools and build-time R package caches are shared with the Linux
+# Server seed (same keys); the GWT cache key is desktop-specific
+# (rstudio-gwt-linux-desktop-x86_64-v1-), so this seeder warms it on main.
+on:
+  # Re-seed when files under dependencies/ change. This glob is deliberately a
+  # broad superset of the exact hashFiles() patterns that feed the cache keys
+  # (see the build workflow), so the trigger paths don't have to stay in
+  # lockstep with those patterns. Most edits here re-run the seed without
+  # rotating any cache key (refreshing recency only); an edit that touches one
+  # of the hashed files additionally rotates the affected key, saving a fresh
+  # cache on main.
+  push:
+    branches: [main]
+    paths:
+      - "dependencies/**"
+      - ".github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml"
+      - ".github/workflows/os-cache-seed-e2e-rstudio-desktop-os-ubuntu-24.yml"
+  # Nightly re-seed keeps the GHA sccache object cache recent on main so PR
+  # builds get a high compile-cache hit rate. GitHub evicts cache entries that
+  # haven't been accessed in 7 days. Offset from the Linux Server seed (07:00)
+  # so the two don't contend for runners at the same minute.
+  schedule:
+    - cron: '30 7 * * *'
+  workflow_dispatch:
+
+# Don't stack expensive ubuntu builds; the latest seed run wins.
+concurrency:
+  group: cache-seed-desktop-ubuntu24
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # Required so this workflow can pass pull-requests: write to the called
+  # workflow's e2e-merge job (GitHub validates ALL job-level permissions in the
+  # called workflow at call time). The e2e-merge job is skipped when
+  # build_only=true (the only mode the cache seeder uses), so this permission
+  # is never exercised here -- it's declared only to satisfy the validator.
+  pull-requests: write
+
+jobs:
+  seed:
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+    with:
+      build_only: true

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24-scheduled.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24-scheduled.yml
@@ -1,0 +1,23 @@
+name: "Test: E2E Playwright RStudio (Desktop, Ubuntu 24, Open Source, Scheduled)"
+
+on:
+  schedule:
+    # Mon-Fri at 02:30 UTC -- daily run against latest source on main.
+    # Offset from the Linux Server scheduled run (02:00) so the two don't
+    # contend for runners at the same minute.
+    - cron: '30 2 * * 1-5'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  run-desktop-ubuntu24:
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+    with:
+      project: desktop
+      r_version: "release"
+      grep_invert: "@ai"

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -446,8 +446,20 @@ jobs:
             ARGS+=(--grep-invert "$PW_GREP_INVERT")
           fi
           ARGS+=(--shard="${{ matrix.shard }}/${{ strategy.job-total }}")
-          xvfb-run -a --server-args="-screen 0 1920x1080x24" \
-            npx playwright test "${ARGS[@]}"
+          # Run Playwright under our own Xvfb and exec it as the step's main
+          # process, so a job cancellation's SIGTERM reaches Playwright
+          # directly. xvfb-run is a shell wrapper that does not forward signals
+          # to its child, which left cancelled Linux e2e jobs running until
+          # their timeout-minutes instead of stopping. -ac disables X access
+          # control so Chromium connects without an auth cookie; we wait for
+          # the X socket before launching so it doesn't race a cold display.
+          Xvfb :99 -screen 0 1920x1080x24 -ac -nolisten tcp >/tmp/xvfb.log 2>&1 &
+          export DISPLAY=:99
+          for _ in $(seq 1 50); do
+            [ -S /tmp/.X11-unix/X99 ] && break
+            sleep 0.1
+          done
+          exec npx playwright test "${ARGS[@]}"
 
       # Platform-prefixed artifact name. When this Linux Desktop workflow runs
       # from the same parent PR run as the other platforms (via the combined

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -3,8 +3,12 @@ name: "Test: E2E Playwright RStudio (Desktop, Ubuntu 24, Open Source)"
 on:
   workflow_dispatch:
     inputs:
+      build_from_source:
+        description: "Build RStudio Desktop (Electron) from this branch's source. When false, downloads the latest daily .deb installer."
+        type: boolean
+        default: true
       rstudio_installer_url:
-        description: "URL to a Desktop installer (.deb on Ubuntu, .rpm on RHEL/Fedora, .exe on Windows, .dmg on macOS). Leave empty to auto-resolve the latest daily for this workflow's platform. To pin a specific build, paste its full URL from dailies.rstudio.com."
+        description: "Optional .deb URL to test against (e.g. a specific daily from dailies.rstudio.com). Only used when build_from_source is false. Leave empty to auto-resolve the latest daily."
         type: string
         default: ""
       r_version:
@@ -28,15 +32,26 @@ on:
         type: string
         default: ""
       grep_invert:
-        description: "Optional Playwright --grep-invert pattern to skip tests by title."
+        description: "Optional Playwright --grep-invert pattern to skip tests by title. Defaults to '@ai' to skip tests that require credentials not available in unattended runs."
         type: string
-        default: ""
+        default: "@ai"
       rstudio_extra_args:
         description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS."
         type: string
         default: ""
+      build_only:
+        description: "Run only the build job (to seed the rstudio-tools / R-libs / sccache caches) and skip the e2e job."
+        type: boolean
+        default: false
+      post_pr_comment:
+        description: "Post test results as a sticky comment on the PR. Pass true only from PR-triggered callers."
+        type: boolean
+        default: false
   workflow_call:
     inputs:
+      build_from_source:
+        type: boolean
+        default: true
       rstudio_installer_url:
         type: string
         default: ""
@@ -57,20 +72,200 @@ on:
         default: ""
       grep_invert:
         type: string
-        default: ""
+        default: "@ai"
       rstudio_extra_args:
         type: string
         default: ""
+      build_only:
+        type: boolean
+        default: false
+      post_pr_comment:
+        type: boolean
+        default: false
+    secrets:
+      CONNECT_API_KEY:
+        description: "Posit Connect API key for the E2E Test Insights reporter"
+        required: false
 
 permissions:
   contents: read
+  # Required so the e2e-merge job can post sticky PR comments via
+  # marocchino/sticky-pull-request-comment. GitHub validates ALL job-level
+  # permissions in a reusable workflow at call time, so this must be declared
+  # at the top level even though only e2e-merge uses it.
+  pull-requests: write
 
 jobs:
-  e2e-desktop-ubuntu:
+  # Builds RStudio Desktop (Electron) from this PR's source on the same runner
+  # image as the e2e job below, then uploads the .deb as an artifact for the
+  # e2e job to consume. Skipped when build_from_source is false, in which case
+  # the e2e job downloads the daily .deb (or rstudio_installer_url) instead.
+  build:
+    if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 90
+    env:
+      # Redirect the dependency / package scripts' tool root to a
+      # workspace-local path so it can be cached without sudo.
+      RSTUDIO_TOOLS_ROOT: ${{ github.workspace }}/opt/rstudio-tools/x86_64
+      # Pin R's user library to a workspace-local path so we can cache it.
+      R_LIBS_USER: ${{ github.workspace }}/R-libs/%p/%v
+      SCCACHE_ENABLED: '1'
+      # Route sccache to GitHub's built-in Actions cache API. The
+      # mozilla-actions/sccache-action step below installs sccache and exports
+      # ACTIONS_CACHE_URL + ACTIONS_RUNTIME_TOKEN so the sccache server uses
+      # the GHA backend. Cache hits are object-level (one entry per compiled
+      # .o), so PRs automatically inherit main's warm cache from the seed job
+      # without per-SHA tarball rotation. No AWS / S3 / secrets required.
+      SCCACHE_GHA_ENABLED: 'true'
+      # Quiet npm during install-common's panmirror build, the Electron app
+      # build, and any other transitive npm step.
+      NPM_CONFIG_LOGLEVEL: error
+      NPM_CONFIG_AUDIT: 'false'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pre-built tool deps (Boost, SOCI, pandoc, quarto, GWT, node, panmirror,
+      # copilot-language-server, sccache, etc.) all land under RSTUDIO_TOOLS_ROOT.
+      # Shares the key with the Linux Server build so a single cache (and the
+      # cache-seed job) warms both.
+      - name: Cache rstudio-tools deps
+        id: tools-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.RSTUDIO_TOOLS_ROOT }}
+          key: rstudio-tools-linux-x86_64-${{ hashFiles('dependencies/common/install-*', 'dependencies/linux/install-*', 'dependencies/tools/rstudio-tools.sh') }}
+          restore-keys: |
+            rstudio-tools-linux-x86_64-
+
+      # install-common (called by install-dependencies-noble) installs R
+      # packages (via install-packages) into R_LIBS_USER. Cache the whole
+      # R-libs tree -- R's %p/%v subpaths keep different versions isolated.
+      # Same key as the Linux Server build so the cache is shared.
+      - name: Cache build-time R packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/R-libs
+          key: rstudio-build-rlibs-linux-x86_64-${{ hashFiles('dependencies/common/install-packages', 'dependencies/common/lockfiles/**/renv.lock') }}
+          restore-keys: |
+            rstudio-build-rlibs-linux-x86_64-
+
+      # Cache compiled GWT output (package/linux/build-Electron-DEB/gwt/{bin,www,extras}).
+      # GWT compilation is the single most expensive JS step (~15-30 min). When
+      # GWT Java sources / build scripts haven't changed, make-electron-package
+      # can skip the recompile entirely via the NO_REBUILD env var (sets
+      # GWT_BUILD=no, which becomes -DGWT_BUILD=no to cmake) -- see the
+      # NO_REBUILD/GWT_BUILD handling in package/linux/make-package. The
+      # Electron build dir differs from the Server build dir, so this uses a
+      # desktop-specific key rather than sharing the Server GWT cache.
+      # Restore-only here; the matching Save step runs after the build with a
+      # success gate so a failed mid-compile run can't poison the cache.
+      - name: Restore GWT output
+        id: gwt-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: package/linux/build-Electron-DEB/gwt
+          key: rstudio-gwt-linux-desktop-x86_64-v1-${{ hashFiles('src/gwt/src/**', 'src/gwt/acesupport/**', 'src/gwt/lib/**', 'src/gwt/build.xml', 'src/gwt/conf/**') }}
+          restore-keys: |
+            rstudio-gwt-linux-desktop-x86_64-v1-
+
+      # GHA-backed sccache. Installs sccache on PATH and starts the sccache
+      # server with the GH Actions cache API as the storage backend. Object-level
+      # cache hits, no per-SHA tarball, no AWS credentials. Repo-scoped, so the
+      # object cache is shared with the Linux Server build and inherited by PRs.
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      # install-dependencies-noble: apt-get installs system packages (with sudo
+      # internally), then calls install-common which downloads Boost, SOCI,
+      # pandoc, quarto, node, panmirror, sccache, GWT jar, etc. into
+      # RSTUDIO_TOOLS_ROOT. The scripts are idempotent, so a cache hit on
+      # rstudio-tools-deps makes this a fast pass: the heavy downloads are
+      # skipped and the cached tools are reused.
+      - name: Install build dependencies
+        working-directory: dependencies/linux
+        run: ./install-dependencies-noble
+
+      - name: Zero sccache stats
+        run: sccache --zero-stats || true
+
+      - name: Build RStudio Desktop DEB
+        id: build
+        working-directory: package/linux
+        env:
+          RSTUDIO_VERSION_MAJOR: '99'
+          RSTUDIO_VERSION_MINOR: '9'
+          RSTUDIO_VERSION_PATCH: '9'
+          RSTUDIO_VERSION_SUFFIX: "-pr+${{ github.run_number }}"
+        run: |
+          # NO_REBUILD=1 (see package/linux/make-package) tells the script to
+          # set GWT_BUILD=no, which becomes -DGWT_BUILD=no to cmake, so the
+          # cached GWT bin/www/extras under build-Electron-DEB/gwt are reused
+          # instead of recompiled (~15-30 min saved when sources unchanged).
+          if [ "${{ steps.gwt-cache.outputs.cache-hit }}" = "true" ]; then
+            echo "GWT cache hit -- skipping GWT compile"
+            NO_REBUILD=1 ./make-electron-package DEB
+          else
+            echo "GWT cache miss -- compiling GWT from scratch"
+            ./make-electron-package DEB
+          fi
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
+      # Save GWT output only when the build succeeded. A failed mid-compile run
+      # could otherwise write partial GWT output to the cache, and every future
+      # restore would silently ship a broken frontend until the hashFiles key
+      # rotates.
+      - name: Save GWT output
+        if: steps.build.conclusion == 'success'
+        uses: actions/cache/save@v4
+        with:
+          path: package/linux/build-Electron-DEB/gwt
+          key: ${{ steps.gwt-cache.outputs.cache-primary-key }}
+
+      # Skipped in build_only (seed) runs: no e2e job consumes the artifact,
+      # so packaging and uploading it would be pure waste.
+      - name: Package RStudio Desktop .deb
+        if: inputs.build_only != true
+        run: |
+          DEB=$(find package/linux/build-Electron-DEB -maxdepth 1 -name '*.deb' | head -1)
+          if [ -z "$DEB" ]; then
+            echo "::error::No .deb found in package/linux/build-Electron-DEB"
+            exit 1
+          fi
+          cp "$DEB" "${{ github.workspace }}/rstudio-desktop.deb"
+          echo "Packaged: $DEB"
+
+      - name: Upload RStudio Desktop .deb artifact
+        if: inputs.build_only != true
+        uses: actions/upload-artifact@v4
+        with:
+          name: rstudio-desktop-deb-ubuntu-24
+          path: rstudio-desktop.deb
+          retention-days: 7
+
+  e2e-desktop-ubuntu:
+    needs: build
+    # build is skipped when build_from_source is false; allow this job to run
+    # in that case too (needs.build.result == 'skipped' on the daily-download
+    # path). build_only seeds the build caches without running e2e, so skip.
+    if: |
+      always() &&
+      inputs.build_only != true &&
+      (needs.build.result == 'success' || needs.build.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       R_LIBS_USER: ${{ github.workspace }}/R-libs
+      PW_SANDBOX_ROOT: ${{ github.workspace }}/pw-sandbox
+      PW_SANDBOX_ROOT_CREATE: '1'
 
     steps:
       - uses: actions/checkout@v4
@@ -84,7 +279,22 @@ jobs:
       - name: Install OS dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y xvfb jq
+          # xvfb + jq: virtual display for the Electron app / Playwright, JSON
+          # parsing. The RStudio Desktop .deb pulls its own GUI runtime deps
+          # (libnss3, libgbm1, libgtk-3-0, ...) via apt's dependency resolution
+          # on install. Several R packages used in tests also have system-library
+          # dependencies: libfreetype6 / libfontconfig1 (ragg, systemfonts),
+          # libharfbuzz0b / libfribidi0 (textshaping). Install the runtime libs
+          # (not the -dev variants) so rsession's R can load them without a
+          # source compile.
+          sudo apt-get install -y xvfb jq \
+            libfreetype6 libfontconfig1 libharfbuzz0b libfribidi0
+
+      # Ubuntu 24 restricts unprivileged user namespaces by default, which
+      # blocks the Electron / Chromium sandbox. Enable them before launching
+      # RStudio Desktop.
+      - name: Allow unprivileged user namespaces (required by Electron/Chromium)
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Install rig
         run: |
@@ -100,7 +310,27 @@ jobs:
           rig ls
           mkdir -p "$R_LIBS_USER"
 
-      - name: Resolve RStudio .deb URL
+      # Build-from-source path: extract the .deb artifact produced by the build
+      # job above and install it.
+      - name: Download RStudio Desktop .deb artifact
+        if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
+        uses: actions/download-artifact@v4
+        with:
+          name: rstudio-desktop-deb-ubuntu-24
+          path: ${{ github.workspace }}
+
+      - name: Install RStudio Desktop from artifact
+        if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
+        run: |
+          sudo apt-get install -y "${{ github.workspace }}/rstudio-desktop.deb"
+          ls -la /usr/bin/rstudio
+
+      # Daily-download path: resolve and install the latest (or specified) .deb.
+      # Runs when build_from_source is false (auto-resolve the daily via
+      # dailies.rstudio.com/rstudio/latest/index.json) or when an explicit
+      # rstudio_installer_url is provided (use that URL verbatim).
+      - name: Resolve RStudio Desktop .deb URL
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
         id: resolve
         env:
           INSTALLER_URL: ${{ inputs.rstudio_installer_url }}
@@ -109,39 +339,49 @@ jobs:
           SHA=""
           FILENAME=""
           if [ -z "$URL" ]; then
-            MANIFEST=$(curl -fsSL https://dailies.rstudio.com/rstudio/latest/index.json)
-            URL=$(echo "$MANIFEST" | jq -er '.products.electron.platforms."noble-amd64".link')
-            SHA=$(echo "$MANIFEST" | jq -er '.products.electron.platforms."noble-amd64".sha256')
-            FILENAME=$(echo "$MANIFEST" | jq -er '.products.electron.platforms."noble-amd64".filename')
-            echo "Auto-resolved latest noble-amd64 daily:"
+            MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 'https://dailies.rstudio.com/rstudio/latest/index.json')
+            # The Linux Desktop build ships as an Electron .deb keyed
+            # "noble-amd64" under the electron product in the daily manifest.
+            URL=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["noble-amd64"].link // empty')
+            SHA=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["noble-amd64"].sha256 // empty')
+            FILENAME=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["noble-amd64"].filename // empty')
+            if [ -z "$URL" ] || [ -z "$FILENAME" ] || [ -z "$SHA" ]; then
+              echo "::error::Daily manifest is missing expected fields (url='$URL', filename='$FILENAME', sha256='$SHA'). The schema at https://dailies.rstudio.com/rstudio/latest/index.json may have changed."
+              exit 1
+            fi
+            echo "Auto-resolved latest noble-amd64 desktop daily:"
             echo "  URL:      $URL"
             echo "  SHA-256:  $SHA"
             echo "  Filename: $FILENAME"
           else
-            FILENAME=$(basename "$URL")
+            FILENAME=$(basename "${URL%%\?*}")
+            if [ -z "$FILENAME" ]; then
+              echo "::error::Could not derive filename from rstudio_installer_url='$URL'."
+              exit 1
+            fi
             echo "Using override URL: $URL (SHA-256 verification skipped)"
           fi
-          echo "url=$URL" >> "$GITHUB_OUTPUT"
-          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
+          echo "url=$URL"           >> "$GITHUB_OUTPUT"
+          echo "sha256=$SHA"        >> "$GITHUB_OUTPUT"
           echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
 
-      # Cache the installer keyed on its resolved filename. On the daily
-      # auto-resolve path the filename embeds the version + build number, so
-      # the content is immutable per name: a new daily misses and downloads, a
-      # same-day rerun hits and skips the download (SHA-256 still verified
-      # below). Skip caching on the override path -- a user-supplied URL has no
-      # immutability guarantee and its SHA check is skipped, so a reused
-      # basename could otherwise serve stale, unverified bytes.
-      - name: Cache RStudio installer
-        if: inputs.rstudio_installer_url == ''
+      # Cache the daily installer keyed on its resolved filename. Filenames
+      # embed the version + build number on the auto-resolve path so the content
+      # is immutable per name: new daily misses and downloads, same-day re-run
+      # hits and skips (SHA still verified below). Skip caching on the override
+      # path -- a user-supplied URL has no immutability guarantee and its SHA
+      # check is skipped, so a reused basename could otherwise serve stale,
+      # unverified bytes.
+      - name: Cache RStudio Desktop installer
+        if: inputs.build_from_source == false && inputs.rstudio_installer_url == ''
         id: installer-cache
         uses: actions/cache@v4
         with:
           path: ${{ steps.resolve.outputs.filename }}
-          key: rstudio-installer-${{ steps.resolve.outputs.filename }}
+          key: rstudio-desktop-installer-${{ steps.resolve.outputs.filename }}
 
-      - name: Download RStudio .deb
-        if: steps.installer-cache.outputs.cache-hit != 'true'
+      - name: Download RStudio Desktop .deb
+        if: (inputs.build_from_source == false || inputs.rstudio_installer_url != '') && steps.installer-cache.outputs.cache-hit != 'true'
         env:
           DOWNLOAD_URL: ${{ steps.resolve.outputs.url }}
           DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}
@@ -151,15 +391,15 @@ jobs:
             "$DOWNLOAD_URL"
 
       - name: Verify SHA-256
-        if: steps.resolve.outputs.sha256 != ''
+        if: (inputs.build_from_source == false || inputs.rstudio_installer_url != '') && steps.resolve.outputs.sha256 != ''
         env:
           EXPECTED_SHA256: ${{ steps.resolve.outputs.sha256 }}
           DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}
         run: |
-          echo "$EXPECTED_SHA256  $DOWNLOAD_FILENAME" \
-            | sha256sum -c -
+          echo "$EXPECTED_SHA256  $DOWNLOAD_FILENAME" | sha256sum -c -
 
-      - name: Install RStudio
+      - name: Install RStudio Desktop from .deb
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
         env:
           INSTALLER_FILENAME: ${{ steps.resolve.outputs.filename }}
         run: |
@@ -181,6 +421,16 @@ jobs:
           PW_TEST_SELECTOR: ${{ inputs.test_selector }}
           PW_TEST_IGNORE: ${{ inputs.test_ignore }}
           PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
+          # Tells playwright.config.ts to switch to blob reporter for this shard.
+          PW_SHARD: ${{ matrix.shard }}
+          # E2E Test Insights reporter: posts per-shard results to the dashboard.
+          # CONNECT_API_KEY is empty on fork PRs; the reporter still runs but its
+          # uploads fail with warnings (never fails the run).
+          CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+          SHARD_NAME: desktop-linux-${{ matrix.shard }}
+          # Print the GWT launch timeline so the next launch failure shows which
+          # phase exceeded the deadline.
+          PW_DEBUG_LAUNCH: '1'
         run: |
           ARGS=()
           if [ -n "$PW_TEST_SELECTOR" ]; then
@@ -195,21 +445,179 @@ jobs:
           if [ -n "$PW_GREP_INVERT" ]; then
             ARGS+=(--grep-invert "$PW_GREP_INVERT")
           fi
+          ARGS+=(--shard="${{ matrix.shard }}/${{ strategy.job-total }}")
           xvfb-run -a --server-args="-screen 0 1920x1080x24" \
             npx playwright test "${ARGS[@]}"
 
-      - name: Upload Playwright report
+      # Platform-prefixed artifact name. When this Linux Desktop workflow runs
+      # from the same parent PR run as the other platforms (via the combined
+      # os-test-e2e-rstudio-pr.yml orchestrator), all platforms upload to the
+      # same artifact namespace. macOS uses `-mac-`, Windows uses `-win-`, and
+      # Linux Server uses `-linux-server-`; `-linux-desktop-` keeps this
+      # platform's shard reports separate from all of them so each merge job
+      # downloads only its own.
+      - name: Upload blob report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
-          path: e2e/rstudio/playwright-report/
-          if-no-files-found: ignore
+          name: playwright-blob-report-linux-desktop-${{ matrix.shard }}
+          path: e2e/rstudio/blob-report/
+          if-no-files-found: warn
+          retention-days: 1
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: test-results-linux-desktop-${{ matrix.shard }}
           path: e2e/rstudio/test-results/
           if-no-files-found: ignore
+
+      # Preserved per-spec sandbox tree on failure -- includes rsession logs,
+      # the spec's RStudio config / data home, and per-test working dirs.
+      - name: Upload PW sandbox (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pw-sandbox-linux-desktop-${{ matrix.shard }}
+          path: ${{ github.workspace }}/pw-sandbox/
+          if-no-files-found: ignore
+
+  # Merge per-shard blob reports into a single HTML report, parse aggregated
+  # counts, and post a sticky PR comment with pass/fail/skip totals
+  # (when post_pr_comment is set).
+  e2e-merge:
+    needs: [e2e-desktop-ubuntu]
+    if: always() && needs.e2e-desktop-ubuntu.result != 'skipped' && needs.e2e-desktop-ubuntu.result != 'cancelled'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
+
+      - name: Install Playwright
+        working-directory: e2e/rstudio
+        # --ignore-scripts skips the postinstall that downloads browser
+        # binaries; the merge job only invokes `playwright merge-reports`,
+        # which doesn't need Chromium.
+        run: npm ci --ignore-scripts
+
+      - name: Download shard blob reports
+        uses: actions/download-artifact@v4
+        with:
+          # Linux-Desktop-only glob: in the combined PR orchestrator the other
+          # platforms also publish blob reports (playwright-blob-report-mac-*,
+          # -win-*, -linux-server-*). A bare or `-linux-*` glob would sweep some
+          # of them in.
+          pattern: playwright-blob-report-linux-desktop-*
+          path: e2e/rstudio/all-blob-reports
+          merge-multiple: true
+
+      - name: Merge shard reports
+        working-directory: e2e/rstudio
+        run: |
+          if [ -z "$(ls -A all-blob-reports 2>/dev/null)" ]; then
+            echo "::error::No blob reports found -- both shards failed to produce artifacts"
+            exit 1
+          fi
+          cat > merge.config.ts <<'EOF'
+          import { defineConfig } from '@playwright/test';
+          export default defineConfig({
+            reporter: [
+              ['html', { outputFolder: 'playwright-report', open: 'never' }],
+              ['json', { outputFile: 'playwright-report/test-results.json' }],
+            ],
+          });
+          EOF
+          npx playwright merge-reports --config merge.config.ts ./all-blob-reports
+
+      - name: Parse aggregated results
+        id: summary
+        if: always()
+        run: |
+          FILE="e2e/rstudio/playwright-report/test-results.json"
+          if [ -f "$FILE" ]; then
+            if ! PASSED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == true and (.tests[0].status // "expected") != "flaky" and (.tests[0].status // "expected") != "skipped")] | length' "$FILE"); then
+              echo "::error::Failed to parse test-results.json (PASSED)"; exit 1
+            fi
+            if ! FAILED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == false)] | length' "$FILE"); then
+              echo "::error::Failed to parse test-results.json (FAILED)"; exit 1
+            fi
+            if ! SKIPPED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "skipped")] | length' "$FILE"); then
+              echo "::error::Failed to parse test-results.json (SKIPPED)"; exit 1
+            fi
+            if ! FLAKY=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "flaky")] | length' "$FILE"); then
+              echo "::error::Failed to parse test-results.json (FLAKY)"; exit 1
+            fi
+          else
+            PASSED=0; FAILED=0; SKIPPED=0; FLAKY=0
+          fi
+          TOTAL=$((PASSED + FAILED))
+          if [ "$TOTAL" -gt 0 ]; then
+            RATE=$(( (PASSED * 100) / TOTAL ))
+            FILLED=$(( (RATE * 20) / 100 ))
+            EMPTY=$(( 20 - FILLED ))
+            BAR=""
+            [ "$FILLED" -gt 0 ] && BAR=$(printf '█%.0s' $(seq 1 $FILLED))
+            [ "$EMPTY"  -gt 0 ] && BAR="${BAR}$(printf '░%.0s' $(seq 1 $EMPTY))"
+          else
+            RATE=0; BAR="░░░░░░░░░░░░░░░░░░░░"
+          fi
+          echo "passed=$PASSED" >> "$GITHUB_OUTPUT"
+          echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
+          echo "skipped=$SKIPPED" >> "$GITHUB_OUTPUT"
+          echo "flaky=$FLAKY" >> "$GITHUB_OUTPUT"
+          echo "rate=$RATE" >> "$GITHUB_OUTPUT"
+          echo "bar=$BAR" >> "$GITHUB_OUTPUT"
+
+      - name: Upload merged Playwright report
+        id: upload-report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-linux-desktop
+          path: e2e/rstudio/playwright-report/
+          retention-days: 15
+          if-no-files-found: ignore
+
+      - name: Post E2E results to PR
+        if: |
+          always() &&
+          inputs.post_pr_comment == true &&
+          github.event.pull_request.head.repo.fork == false &&
+          (steps.summary.outputs.passed != '0' || steps.summary.outputs.failed != '0' || steps.summary.outputs.skipped != '0' || steps.summary.outputs.flaky != '0')
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: e2e-desktop-ubuntu24-results
+          GITHUB_TOKEN: ${{ github.token }}
+          message: |
+            ## 🐧 Linux Desktop E2E · Ubuntu 24
+
+            ${{ needs.e2e-desktop-ubuntu.result == 'success' && steps.summary.outputs.failed == '0' && '### ✅ All tests passed!' || format('### ❌ {0} test(s) failed', steps.summary.outputs.failed) }}
+
+            `${{ steps.summary.outputs.bar }}` **${{ steps.summary.outputs.rate }}%** pass rate
+
+            | ✅ Passed | ❌ Failed | ⚠️ Skipped | 🔁 Flaky |
+            | :---: | :---: | :---: | :---: |
+            | **${{ steps.summary.outputs.passed }}** | **${{ steps.summary.outputs.failed }}** | **${{ steps.summary.outputs.skipped }}** | **${{ steps.summary.outputs.flaky }}** |
+
+            <details>
+            <summary>📥 Download Playwright report</summary>
+
+            **[⬇️ playwright-report.zip](${{ steps.upload-report.outputs.artifact-url }})** — extract and open `index.html`
+
+            > Includes screenshots, traces, and step-by-step details for every test. Expires in 15 days.
+
+            </details>
+
+            ---
+            <sub>2 shards · ubuntu-24.04 · commit <code>${{ github.event.pull_request.head.sha }}</code> · <a href="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}">Run #${{ github.run_number }}</a></sub>

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -451,14 +451,22 @@ jobs:
           # directly. xvfb-run is a shell wrapper that does not forward signals
           # to its child, which left cancelled Linux e2e jobs running until
           # their timeout-minutes instead of stopping. -ac disables X access
-          # control so Chromium connects without an auth cookie; we wait for
-          # the X socket before launching so it doesn't race a cold display.
+          # control so Chromium connects without an auth cookie; -nolisten tcp
+          # keeps the display on the local socket only. We wait for the X socket
+          # before launching so it doesn't race a cold display, and fail loudly
+          # (dumping the Xvfb log) if it never comes up, rather than exec-ing
+          # Playwright against a dead display and surfacing an opaque launch error.
           Xvfb :99 -screen 0 1920x1080x24 -ac -nolisten tcp >/tmp/xvfb.log 2>&1 &
           export DISPLAY=:99
           for _ in $(seq 1 50); do
             [ -S /tmp/.X11-unix/X99 ] && break
             sleep 0.1
           done
+          if [ ! -S /tmp/.X11-unix/X99 ]; then
+            echo "::error::Xvfb display :99 never came up after 5s; Xvfb log follows."
+            cat /tmp/xvfb.log || true
+            exit 1
+          fi
           exec npx playwright test "${ARGS[@]}"
 
       # Platform-prefixed artifact name. When this Linux Desktop workflow runs

--- a/.github/workflows/os-test-e2e-rstudio-pr.yml
+++ b/.github/workflows/os-test-e2e-rstudio-pr.yml
@@ -34,11 +34,10 @@ jobs:
   #      (link + filename + sha256 + commit all present).
   #   3. The daily's commit already contains this branch's merge-base, else it
   #      predates the behavior the (possibly main-merged) test-only branch assumes.
-  # Any miss falls back to a source build. macOS, Windows, and Linux Desktop are
-  # decided independently via decide() -- each has an electron-product entry in
-  # the manifest, possibly carrying a different commit per platform. Linux Server
-  # ships as a .deb the electron manifest doesn't cover, so it uses the simpler
-  # source-changed signal instead.
+  # Any miss falls back to a source build. All four platforms are decided
+  # independently via decide(): macOS/Windows/Linux Desktop look up the electron
+  # product, Linux Server the server product. Each manifest entry carries its own
+  # commit, so every platform is checked against its own daily build.
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
@@ -81,31 +80,33 @@ jobs:
             MANIFEST=""
           fi
 
-          # Echoes "true" (build from source) or "false" (use the daily) for
-          # the electron platform key passed as $1.
+          # Echoes "true" (build from source) or "false" (use the daily) for the
+          # manifest product ($1, e.g. "electron" or "server") and platform key
+          # ($2). product/key appears in every log line because some keys
+          # (e.g. "noble-amd64") exist under more than one product.
           decide() {
-            local key="$1"
+            local product="$1" key="$2"
 
             if [ "$SOURCE_CHANGED" = true ]; then
-              echo "$key: source files changed -- building from source" >&2
+              echo "$product/$key: source files changed -- building from source" >&2
               echo true
               return
             fi
 
             if [ -z "$MANIFEST" ]; then
-              echo "$key: daily manifest unreachable -- building from source" >&2
+              echo "$product/$key: daily manifest unreachable -- building from source" >&2
               echo true
               return
             fi
 
             local entry link filename sha commit
-            entry=$(echo "$MANIFEST" | jq -c --arg k "$key" '.products.electron.platforms[$k] // empty')
+            entry=$(echo "$MANIFEST" | jq -c --arg p "$product" --arg k "$key" '.products[$p].platforms[$k] // empty')
             link=$(echo "$entry" | jq -r '.link // empty')
             filename=$(echo "$entry" | jq -r '.filename // empty')
             sha=$(echo "$entry" | jq -r '.sha256 // empty')
             commit=$(echo "$entry" | jq -r '.commit // empty')
             if [ -z "$link" ] || [ -z "$filename" ] || [ -z "$sha" ] || [ -z "$commit" ]; then
-              echo "$key: daily manifest missing fields (link='$link' filename='$filename' sha256='$sha' commit='$commit') -- building from source" >&2
+              echo "$product/$key: daily manifest missing fields (link='$link' filename='$filename' sha256='$sha' commit='$commit') -- building from source" >&2
               echo true
               return
             fi
@@ -119,30 +120,27 @@ jobs:
               git fetch --no-tags --quiet origin "$commit" 2>/dev/null || true
             fi
             if git merge-base --is-ancestor "$BASE" "$commit" 2>/dev/null; then
-              echo "$key: daily $commit contains merge-base $BASE -- using daily" >&2
+              echo "$product/$key: daily $commit contains merge-base $BASE -- using daily" >&2
               echo false
             else
-              echo "$key: daily $commit does not contain merge-base $BASE -- building from source" >&2
+              echo "$product/$key: daily $commit does not contain merge-base $BASE -- building from source" >&2
               echo true
             fi
           }
 
-          MACOS=$(decide macos)
-          WINDOWS=$(decide windows)
-          # Linux Desktop ships as an Electron .deb keyed "noble-amd64" under
-          # the electron product in the manifest, so it rides decide() with that
-          # key just like macOS/Windows.
-          LINUXDESKTOP=$(decide noble-amd64)
-          # Linux Server ships as a .deb the electron daily manifest doesn't
-          # carry, so it can't use decide()'s per-platform daily lookup. Use the
-          # source-changed signal: build from source on a source change;
-          # otherwise the linux server reusable resolves the latest daily .deb
-          # itself.
-          echo "Decision: macos build_from_source=$MACOS, windows build_from_source=$WINDOWS, linux-desktop build_from_source=$LINUXDESKTOP, linux-server build_from_source=$SOURCE_CHANGED"
+          # macOS/Windows/Linux Desktop are electron-product builds; Linux Server
+          # is the server-product .deb. Both products carry the same per-platform
+          # fields (link/filename/sha256/commit), so all four ride decide() and
+          # get the same staleness check against the daily's commit.
+          MACOS=$(decide electron macos)
+          WINDOWS=$(decide electron windows)
+          LINUXDESKTOP=$(decide electron noble-amd64)
+          LINUXSERVER=$(decide server noble-amd64)
+          echo "Decision: macos build_from_source=$MACOS, windows build_from_source=$WINDOWS, linux-desktop build_from_source=$LINUXDESKTOP, linux-server build_from_source=$LINUXSERVER"
           echo "macos_build_from_source=$MACOS" >> "$GITHUB_OUTPUT"
           echo "windows_build_from_source=$WINDOWS" >> "$GITHUB_OUTPUT"
           echo "linux_desktop_build_from_source=$LINUXDESKTOP" >> "$GITHUB_OUTPUT"
-          echo "linux_server_build_from_source=$SOURCE_CHANGED" >> "$GITHUB_OUTPUT"
+          echo "linux_server_build_from_source=$LINUXSERVER" >> "$GITHUB_OUTPUT"
 
   windows:
     needs: detect-changes

--- a/.github/workflows/os-test-e2e-rstudio-pr.yml
+++ b/.github/workflows/os-test-e2e-rstudio-pr.yml
@@ -13,6 +13,7 @@ on:
       - ".github/workflows/os-test-e2e-rstudio-pr.yml"
       - ".github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml"
       - ".github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml"
+      - ".github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml"
       - ".github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml"
 
 concurrency:
@@ -25,22 +26,25 @@ permissions:
 
 jobs:
   # Single change-detection job shared by all e2e platforms (Windows Desktop,
-  # macOS Desktop, Linux Server). Decides, per platform, whether to build from
-  # source or test against the latest daily. A daily is used only when ALL hold:
+  # macOS Desktop, Linux Desktop, Linux Server). Decides, per platform, whether
+  # to build from source or test against the latest daily. A daily is used only
+  # when ALL hold:
   #   1. No compiled-binary source changed in this PR.
   #   2. The daily manifest resolves a usable installer for that platform
   #      (link + filename + sha256 + commit all present).
   #   3. The daily's commit already contains this branch's merge-base, else it
   #      predates the behavior the (possibly main-merged) test-only branch assumes.
-  # Any miss falls back to a source build. macOS and Windows are decided
-  # independently because the manifest can carry a different commit per platform.
-  # Linux Server ships as a .deb the electron manifest doesn't cover, so it uses
-  # the simpler source-changed signal instead.
+  # Any miss falls back to a source build. macOS, Windows, and Linux Desktop are
+  # decided independently via decide() -- each has an electron-product entry in
+  # the manifest, possibly carrying a different commit per platform. Linux Server
+  # ships as a .deb the electron manifest doesn't cover, so it uses the simpler
+  # source-changed signal instead.
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
       macos_build_from_source: ${{ steps.check.outputs.macos_build_from_source }}
       windows_build_from_source: ${{ steps.check.outputs.windows_build_from_source }}
+      linux_desktop_build_from_source: ${{ steps.check.outputs.linux_desktop_build_from_source }}
       linux_server_build_from_source: ${{ steps.check.outputs.linux_server_build_from_source }}
     steps:
       - uses: actions/checkout@v4
@@ -125,15 +129,19 @@ jobs:
 
           MACOS=$(decide macos)
           WINDOWS=$(decide windows)
-          # Linux Server ships as a .deb, which the electron daily manifest
-          # (macOS/Windows desktop builds) doesn't carry, so it can't use
-          # decide()'s per-platform daily lookup. Use the source-changed signal:
-          # build from source on a source change; otherwise the linux server
-          # reusable resolves the latest daily .deb itself. A future Linux
-          # Desktop callee would be electron and would ride decide() instead.
-          echo "Decision: macos build_from_source=$MACOS, windows build_from_source=$WINDOWS, linux-server build_from_source=$SOURCE_CHANGED"
+          # Linux Desktop ships as an Electron .deb keyed "noble-amd64" under
+          # the electron product in the manifest, so it rides decide() with that
+          # key just like macOS/Windows.
+          LINUXDESKTOP=$(decide noble-amd64)
+          # Linux Server ships as a .deb the electron daily manifest doesn't
+          # carry, so it can't use decide()'s per-platform daily lookup. Use the
+          # source-changed signal: build from source on a source change;
+          # otherwise the linux server reusable resolves the latest daily .deb
+          # itself.
+          echo "Decision: macos build_from_source=$MACOS, windows build_from_source=$WINDOWS, linux-desktop build_from_source=$LINUXDESKTOP, linux-server build_from_source=$SOURCE_CHANGED"
           echo "macos_build_from_source=$MACOS" >> "$GITHUB_OUTPUT"
           echo "windows_build_from_source=$WINDOWS" >> "$GITHUB_OUTPUT"
+          echo "linux_desktop_build_from_source=$LINUXDESKTOP" >> "$GITHUB_OUTPUT"
           echo "linux_server_build_from_source=$SOURCE_CHANGED" >> "$GITHUB_OUTPUT"
 
   windows:
@@ -155,6 +163,18 @@ jobs:
       CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
     with:
       build_from_source: ${{ fromJSON(needs.detect-changes.outputs.macos_build_from_source) }}
+      project: desktop
+      r_version: "4.5.3"
+      grep_invert: "@ai"
+      post_pr_comment: true
+
+  linux-desktop:
+    needs: detect-changes
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+    with:
+      build_from_source: ${{ fromJSON(needs.detect-changes.outputs.linux_desktop_build_from_source) }}
       project: desktop
       r_version: "4.5.3"
       grep_invert: "@ai"

--- a/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -537,14 +537,22 @@ jobs:
           # directly. xvfb-run is a shell wrapper that does not forward signals
           # to its child, which left cancelled Linux e2e jobs running until
           # their timeout-minutes instead of stopping. -ac disables X access
-          # control so Chromium connects without an auth cookie; we wait for
-          # the X socket before launching so it doesn't race a cold display.
+          # control so Chromium connects without an auth cookie; -nolisten tcp
+          # keeps the display on the local socket only. We wait for the X socket
+          # before launching so it doesn't race a cold display, and fail loudly
+          # (dumping the Xvfb log) if it never comes up, rather than exec-ing
+          # Playwright against a dead display and surfacing an opaque launch error.
           Xvfb :99 -screen 0 1920x1080x24 -ac -nolisten tcp >/tmp/xvfb.log 2>&1 &
           export DISPLAY=:99
           for _ in $(seq 1 50); do
             [ -S /tmp/.X11-unix/X99 ] && break
             sleep 0.1
           done
+          if [ ! -S /tmp/.X11-unix/X99 ]; then
+            echo "::error::Xvfb display :99 never came up after 5s; Xvfb log follows."
+            cat /tmp/xvfb.log || true
+            exit 1
+          fi
           exec npx playwright test "${ARGS[@]}"
 
       # Platform-prefixed artifact name. When this Linux Server workflow runs

--- a/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -532,8 +532,20 @@ jobs:
             ARGS+=(--grep-invert "$PW_GREP_INVERT")
           fi
           ARGS+=(--shard="${{ matrix.shard }}/${{ strategy.job-total }}")
-          xvfb-run -a --server-args="-screen 0 1920x1080x24" \
-            npx playwright test "${ARGS[@]}"
+          # Run Playwright under our own Xvfb and exec it as the step's main
+          # process, so a job cancellation's SIGTERM reaches Playwright
+          # directly. xvfb-run is a shell wrapper that does not forward signals
+          # to its child, which left cancelled Linux e2e jobs running until
+          # their timeout-minutes instead of stopping. -ac disables X access
+          # control so Chromium connects without an auth cookie; we wait for
+          # the X socket before launching so it doesn't race a cold display.
+          Xvfb :99 -screen 0 1920x1080x24 -ac -nolisten tcp >/tmp/xvfb.log 2>&1 &
+          export DISPLAY=:99
+          for _ in $(seq 1 50); do
+            [ -S /tmp/.X11-unix/X99 ] && break
+            sleep 0.1
+          done
+          exec npx playwright test "${ARGS[@]}"
 
       # Platform-prefixed artifact name. When this Linux Server workflow runs
       # from the same parent PR run as the other platforms (via the combined

--- a/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -535,20 +535,18 @@ jobs:
           xvfb-run -a --server-args="-screen 0 1920x1080x24" \
             npx playwright test "${ARGS[@]}"
 
-      # Platform-prefixed artifact name. When this Linux workflow runs from
-      # the same parent PR run as the Desktop platforms (via the combined
-      # os-test-e2e-rstudio-pr.yml orchestrator), all three platforms upload
-      # to the same artifact namespace. macOS uses `-mac-`, Windows uses
-      # `-win-`; matching them with `-linux-` keeps each platform's merge
-      # job downloading ONLY its own shard reports. Without the prefix, the
-      # Linux merge job globs `playwright-blob-report-*` and silently
-      # ingests every platform's blobs, reporting combined totals under the
-      # Linux Server sticky comment header.
+      # Platform-prefixed artifact name. When this Linux Server workflow runs
+      # from the same parent PR run as the other platforms (via the combined
+      # os-test-e2e-rstudio-pr.yml orchestrator), all platforms upload to the
+      # same artifact namespace. macOS uses `-mac-`, Windows uses `-win-`, and
+      # Linux Desktop uses `-linux-desktop-`; `-linux-server-` keeps this
+      # platform's shard reports separate so its merge job downloads ONLY its
+      # own. A bare `-linux-` prefix would also match the Linux Desktop blobs.
       - name: Upload blob report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-blob-report-linux-${{ matrix.shard }}
+          name: playwright-blob-report-linux-server-${{ matrix.shard }}
           path: e2e/rstudio/blob-report/
           if-no-files-found: warn
           retention-days: 1
@@ -560,22 +558,23 @@ jobs:
           # Platform-prefixed for the same reason as the blob report above:
           # macOS uploads test-results-${{ matrix.shard }} too, so under the
           # combined PR orchestrator the two would collide and upload-artifact
-          # would reject the second one. -linux- matches the -mac- / -win-
-          # convention the Desktop workflows already use.
-          name: test-results-linux-${{ matrix.shard }}
+          # would reject the second one. -linux-server- distinguishes this from
+          # the Linux Desktop workflow's test-results-linux-desktop-*.
+          name: test-results-linux-server-${{ matrix.shard }}
           path: e2e/rstudio/test-results/
           if-no-files-found: ignore
 
       # Preserved per-spec sandbox tree on failure -- includes rsession logs,
       # the spec's RStudio config / data home, and per-test working dirs.
-      # Platform-prefixed name to avoid colliding with the macOS Desktop
-      # workflow's identically-named pw-sandbox-${{ matrix.shard }} when both
-      # platforms run under the combined PR orchestrator.
+      # Platform-prefixed name to avoid colliding with the other platforms'
+      # sandbox artifacts (macOS pw-sandbox-${{ matrix.shard }}, Linux Desktop
+      # pw-sandbox-linux-desktop-*) when they run under the combined PR
+      # orchestrator.
       - name: Upload PW sandbox (on failure)
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: pw-sandbox-linux-${{ matrix.shard }}
+          name: pw-sandbox-linux-server-${{ matrix.shard }}
           path: ${{ github.workspace }}/pw-sandbox/
           if-no-files-found: ignore
 
@@ -636,11 +635,12 @@ jobs:
       - name: Download shard blob reports
         uses: actions/download-artifact@v4
         with:
-          # Linux-only glob: in the combined PR orchestrator, macOS and
-          # Windows shards also publish under the same artifact namespace
-          # (playwright-blob-report-mac-* and playwright-blob-report-win-*).
-          # A bare `playwright-blob-report-*` would sweep all three.
-          pattern: playwright-blob-report-linux-*
+          # Linux-Server-only glob: in the combined PR orchestrator the other
+          # platforms also publish blob reports (playwright-blob-report-mac-*,
+          # -win-*, and -linux-desktop-*). A bare `playwright-blob-report-*` --
+          # or even `-linux-*`, which would match the Linux Desktop blobs --
+          # would sweep in other platforms' reports.
+          pattern: playwright-blob-report-linux-server-*
           path: e2e/rstudio/all-blob-reports
           merge-multiple: true
 
@@ -706,10 +706,10 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          # Match the -mac / -win suffix the Desktop workflows already use
-          # for their merged reports. Avoids a future collision if the bare
+          # Match the -mac / -win / -linux-desktop suffixes the other workflows
+          # use for their merged reports. Avoids a future collision if the bare
           # `playwright-report` name is ever introduced by another callee.
-          name: playwright-report-linux
+          name: playwright-report-linux-server
           path: e2e/rstudio/playwright-report/
           retention-days: 15
           if-no-files-found: ignore


### PR DESCRIPTION
Adds Linux Desktop (Electron, Ubuntu 24) to the E2E Playwright suite, bringing it to parity with the existing macOS Desktop, Windows Desktop, and Linux Server platforms.

**New engine** `os-test-e2e-rstudio-desktop-os-ubuntu-24.yml` (rewritten from the previous daily-only stub, which had no callers and had never run):
- Builds RStudio Desktop from this PR's source via `make-electron-package DEB`, with shared rstudio-tools / R-libs caches, a desktop-specific GWT cache, and GHA-backed sccache.
- Falls back to the latest daily `.deb` (electron `noble-amd64`) when no compiled-binary source changed.
- Runs across 2 shards under `xvfb`, merges blob reports, and posts a sticky PR comment.

**PR orchestrator** `os-test-e2e-rstudio-pr.yml`: adds a `linux-desktop` caller and a `linux_desktop_build_from_source` decision via `decide noble-amd64` (the path the existing `detect-changes` comment anticipated). Manifest gaps fall back to a source build.

**Companions:** `...-ubuntu-24-scheduled.yml` (nightly) and `os-cache-seed-...-ubuntu-24.yml` (warms `main`'s caches), mirroring the other platforms.

**Linux Server artifact rename:** its blob / test-results / sandbox / merged-report names move from `-linux-*` to `-linux-server-*` (and its merge glob with them), so the Server merge job no longer sweeps in the new Desktop blobs when both run in the same PR.

Note: the Linux Desktop build-from-source path has no prior CI analog; it mirrors the proven Linux Server build plus the documented packaging script, and is exercised for the first time by this PR's own run.

**Linux Server and dailies:** Switch Linux Server to use `decide()` to avoid using stale dailies, similar to desktop checks.

**Cancellation:** Make cancellation reach Playwright on Linux end-to-end jobs. Cancellation requests were sent, but Playwright jobs had to fully complete. Switched to use `exec` which cancels the Playwright jobs.