### PR TITLE
Fix rstudio-server test-config swallowing its verdict and exit code

### DIFF
--- a/src/cpp/server/extras/admin/rstudio-server.in
+++ b/src/cpp/server/extras/admin/rstudio-server.in
@@ -15,7 +15,7 @@ daemonCmd() {
 }
 
 testConfig() {
-  `${CMAKE_INSTALL_PREFIX}/bin/rserver --test-config`
+  ${CMAKE_INSTALL_PREFIX}/bin/rserver --test-config
 }
 
 checkConfig() {

--- a/src/cpp/server/extras/admin/rstudio-server.mac.in
+++ b/src/cpp/server/extras/admin/rstudio-server.mac.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 testConfig() {
- `${CMAKE_INSTALL_PREFIX}/bin/rserver --test-config`
+ ${CMAKE_INSTALL_PREFIX}/bin/rserver --test-config
 }
 
 checkConfig() {


### PR DESCRIPTION
Follow-up to #18020.

`rstudio-server test-config` is broken on `main` since #18020. The `testConfig()` helper in the rstudio-server admin script wraps `rserver --test-config` in backtick command substitution. That was harmless while `--test-config` reported only to stderr, but #18020 turned `--test-config` into a deprecated alias for `--check-config`, which writes its `[PASS]`/`[FAIL]` verdict to stdout. The backticks capture that stdout and then attempt to execute the verdict text as a shell command, so `rstudio-server test-config` prints `[FAIL]: command not found`, hides the real verdict, and exits 127 instead of propagating the validator's exit code.

The fix runs the binary directly, matching the `checkConfig()` helper added in #18020, in both the Linux (`rstudio-server.in`) and macOS (`rstudio-server.mac.in`) templates.

### Verification

Reproduced the failure mode with a stand-in that mimics the new stdout verdict plus a non-zero exit:

```
# with backticks (current main):
environment: line 1: [FAIL]: command not found
exit=127
# without backticks (this PR):
[FAIL] Config file ...: unrecognized option(s):
  - fake-config
exit=1
```

These are configured shell templates (CMake substitutes `CMAKE_INSTALL_PREFIX` only), so no build is required to exercise the change.

No `NEWS.md` entry: #18020 is unreleased (2026.07 / Pacific Dogwood), so this corrects an unreleased change.
