### PR TITLE
install auto-downloaded air under the rstudio data directory

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
 - ([#17807](https://github.com/rstudio/rstudio/issues/17807)): Fixed a startup stall and missing package vulnerability badges that could occur when an intermediary (such as a proxy) kept the connection to Posit Package Manager open after responding. RStudio's HTTP client now completes a response as soon as its full Content-Length body has been received, rather than waiting for the connection to close.
 - ([#18019](https://github.com/rstudio/rstudio/issues/18019)): Fixed an issue where a transient connection failure while writing user state during startup could leave the IDE stuck on an empty grey screen.
 - ([#1667](https://github.com/rstudio/rstudio/issues/1667)): On Linux Desktop, hardened middle-click (primary selection) paste in the editor and console: a selection is now flushed to the primary selection on mouse release rather than only after a short delay, and a middle-click paste falls back to the event's clipboard text when the tracked selection is empty, so quickly selecting and middle-click-pasting no longer pastes nothing.
+- ([#18068](https://github.com/rstudio/rstudio/issues/18068)): Auto-downloaded copies of the Air formatter are now installed under RStudio's per-user data directory (for example `~/.local/share/rstudio/air` on Linux or `%LOCALAPPDATA%\rstudio\air` on Windows) instead of `~/.local/lib/air`. Copies installed by older versions of RStudio in the previous location are still detected and reused.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/cpp/session/modules/SessionAir.R
+++ b/src/cpp/session/modules/SessionAir.R
@@ -82,8 +82,18 @@
 
 .rs.addFunction("air.installedVersions", function()
 {
-   versions <- list.files(.rs.air.rootDir())
-   versions <- versions[file.exists(.rs.air.exePath(versions))]
+   # Search every known root (the current data directory plus any legacy
+   # locations) so that copies of air installed by older versions of
+   # RStudio are still discovered. https://github.com/rstudio/rstudio/issues/18068
+   versions <- character()
+   for (root in .rs.air.rootDirs())
+   {
+      candidates <- list.files(root)
+      candidates <- candidates[file.exists(.rs.air.exePath(candidates, root))]
+      versions <- c(versions, candidates)
+   }
+
+   versions <- unique(versions)
    if (length(versions) == 0L)
       return(character())
 
@@ -119,22 +129,39 @@
    if (is.null(version))
       version <- .rs.air.defaultVersion()
 
-   exe <- .rs.air.exePath(version)
-   if (!file.exists(exe))
+   # Use an existing copy if we can find one (searching legacy roots too);
+   # otherwise install into the current data directory.
+   exe <- .rs.air.findExe(version)
+   if (is.null(exe))
    {
       autoinstall <- getOption("rstudio.air.autoinstall", default = TRUE)
       if (autoinstall)
          .rs.air.installVersion(version)
+
+      exe <- .rs.air.findExe(version)
    }
 
-   if (!file.exists(exe))
-      stop(sprintf("Air binary not found at '%s'.", exe))
+   if (is.null(exe))
+      stop(sprintf("Air binary not found at '%s'.", .rs.air.exePath(version)))
 
    normalizePath(exe)
 })
 
 .rs.addFunction("air.rootDir", function()
 {
+   # Install air underneath RStudio's per-user data directory, e.g.
+   # '~/.local/share/rstudio/air' on Linux, '~/Library/.../rstudio/air' on
+   # macOS, or '%LOCALAPPDATA%\rstudio\air' on Windows. The C++ helper handles
+   # the platform-specific resolution (and any environment overrides).
+   # https://github.com/rstudio/rstudio/issues/18068
+   dataDir <- .Call("rs_userDataDir", PACKAGE = "(embedding)")
+   chartr("\\", "/", file.path(dataDir, "air"))
+})
+
+.rs.addFunction("air.oldRootDir", function()
+{
+   # The location used by older versions of RStudio. We still look here when
+   # discovering already-installed copies of air, but never install here.
    homeDir <- if (.rs.platform.isWindows)
    {
       Sys.getenv("USERPROFILE", unset = path.expand("~"))
@@ -147,15 +174,37 @@
    chartr("\\", "/", file.path(homeDir, ".local", "lib", "air"))
 })
 
-.rs.addFunction("air.binDir", function(version)
+.rs.addFunction("air.rootDirs", function()
 {
-   file.path(.rs.air.rootDir(), version, "bin")
+   # The current root is searched first, so installations there take
+   # precedence over copies left behind in a legacy location.
+   unique(c(.rs.air.rootDir(), .rs.air.oldRootDir()))
 })
 
-.rs.addFunction("air.exePath", function(version)
+.rs.addFunction("air.binDir", function(version, root = .rs.air.rootDir())
+{
+   file.path(root, version, "bin")
+})
+
+.rs.addFunction("air.exePath", function(version, root = .rs.air.rootDir())
 {
    exe <- if (.rs.platform.isWindows) "air.exe" else "air"
-   file.path(.rs.air.binDir(version), exe)
+   file.path(.rs.air.binDir(version, root), exe)
+})
+
+.rs.addFunction("air.findExe", function(version)
+{
+   # Return the path to an installed copy of air for the requested version,
+   # preferring the current root but falling back to legacy locations.
+   # Returns NULL when no installed copy exists.
+   for (root in .rs.air.rootDirs())
+   {
+      exe <- .rs.air.exePath(version, root)
+      if (file.exists(exe))
+         return(exe)
+   }
+
+   NULL
 })
 
 .rs.addFunction("air.installVersion", function(version)

--- a/src/cpp/tests/testthat/test-air.R
+++ b/src/cpp/tests/testthat/test-air.R
@@ -15,27 +15,32 @@
 
 context("air")
 
-# Point the air installation root at a sandbox by overriding the home
-# directory used by .rs.air.rootDir(). Returns the sandbox root.
+# Point the air installation roots at sandboxes by overriding the data
+# directory used by .rs.air.rootDir() and the home directory used by
+# .rs.air.oldRootDir(). RSTUDIO_DATA_HOME is honored on every platform and is
+# used verbatim (no 'rstudio' suffix), so .rs.air.rootDir() resolves to
+# '<data>/air'. Returns the (current) sandbox root.
 local_air_root <- function(envir = parent.frame()) {
 
+   data <- tempfile("air-data-")
    home <- tempfile("air-home-")
+   dir.create(data, recursive = TRUE)
    dir.create(home, recursive = TRUE)
 
    withr::local_envvar(
-      c(HOME = home, USERPROFILE = home),
+      c(RSTUDIO_DATA_HOME = data, HOME = home, USERPROFILE = home),
       .local_envir = envir
    )
 
-   withr::defer(unlink(home, recursive = TRUE), envir = envir)
+   withr::defer(unlink(c(data, home), recursive = TRUE), envir = envir)
 
    .rs.air.rootDir()
 }
 
-# Create a fake air installation for the given version.
-install_fake_air <- function(version, withExe = TRUE) {
+# Create a fake air installation for the given version, in the given root.
+install_fake_air <- function(version, withExe = TRUE, root = .rs.air.rootDir()) {
 
-   binDir <- .rs.air.binDir(version)
+   binDir <- .rs.air.binDir(version, root)
    dir.create(binDir, recursive = TRUE, showWarnings = FALSE)
 
    if (withExe) {
@@ -62,6 +67,45 @@ test_that(".rs.air.installedVersions() finds and sorts installed versions", {
    expect_identical(
       .rs.air.installedVersions(),
       c("v0.11.0", "0.10.1", "0.9.0", "0.4.0")
+   )
+
+})
+
+test_that(".rs.air.installedVersions() also discovers copies in the legacy root", {
+
+   local_air_root()
+
+   # one copy in the current root, one only in the legacy root
+   install_fake_air("0.9.0")
+   install_fake_air("0.4.0", root = .rs.air.oldRootDir())
+
+   expect_identical(
+      .rs.air.installedVersions(),
+      c("0.9.0", "0.4.0")
+   )
+
+})
+
+test_that(".rs.air.ensureAvailable() reuses a copy from the legacy root", {
+
+   local_air_root()
+
+   # only available in the legacy location
+   install_fake_air("0.7.1", root = .rs.air.oldRootDir())
+
+   # make sure any 'air' on the PATH is not used
+   oldPath <- Sys.getenv("PATH")
+   Sys.setenv(PATH = tempdir())
+   on.exit(Sys.setenv(PATH = oldPath), add = TRUE)
+
+   # never query GitHub or install; the legacy copy must be reused as-is
+   options(rstudio.air.version = "0.7.1", rstudio.air.autoinstall = FALSE)
+   on.exit(options(rstudio.air.version = NULL, rstudio.air.autoinstall = NULL), add = TRUE)
+
+   exe <- .rs.air.ensureAvailable()
+   expect_identical(
+      normalizePath(exe),
+      normalizePath(.rs.air.exePath("0.7.1", .rs.air.oldRootDir()))
    )
 
 })


### PR DESCRIPTION
## Summary

Auto-downloaded copies of the Air formatter were installed under `~/.local/lib/air`, which is a non-standard location: the XDG Base Directory Specification has no `lib` concept, nothing else RStudio writes goes there, and on Windows it produced an alien `%USERPROFILE%\.local\lib\air`.

This moves auto-downloaded Air installations into RStudio's per-user data directory (via `xdg::userDataDir()`, exposed to R as `rs_userDataDir`):

- Linux: `~/.local/share/rstudio/air`
- macOS: the equivalent under the user data dir
- Windows: `%LOCALAPPDATA%\rstudio\air`

Platform-specific resolution (and environment overrides) stays in the existing C++ helper.

## Backwards compatibility

Copies of Air installed by older versions of RStudio in the previous `~/.local/lib/air` location are still **discovered and reused** -- `installedVersions()` and `ensureAvailable()` search both the new root and the legacy root (new root first). Only *new* downloads are written to the new location; nothing is ever installed into the legacy location.

A user-managed `air` on the `PATH` continues to take precedence over either location, as before.

## Testing

Added testthat coverage for legacy-root discovery and legacy-root reuse (no re-download), and updated the sandbox helper to use `RSTUDIO_DATA_HOME` so it works across platforms.

    ./build/src/cpp/rstudio-tests --scope r --filter air
    [ FAIL 0 | WARN 0 | SKIP 0 | PASS 8 ]

Fixes #18068.
