### PR TITLE
data viewer: redraw column window on pane resize

### DIFF
--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -4180,6 +4180,11 @@ var onScrollEnd = function() {
 // internal timer state survives across bootstraps and addEventListener
 // stays idempotent.
 var onResize = debounce(TIMING.resizeDebounce, function() {
+   // A resize changes the viewport's clientWidth, which can widen or narrow the
+   // rendered column window. Recompute it (rebuilding the windowed header) so a
+   // wider pane fills with the now-visible columns instead of leaving the table
+   // cut off at the old window's edge -- the scroll handlers do the same.
+   syncColumnWindow();
    applyPinnedColumns();
    renderVisibleRows(true);
    updateInfoBar();


### PR DESCRIPTION
## Summary

The data viewer grid virtualizes columns: only the columns currently visible in the viewport are rendered, tracked by `colWinStart`/`colWinEnd` and recomputed by `syncColumnWindow()` (which reads the live `viewport.clientWidth`). The scroll handlers (`onScroll`, `onScrollEnd`) call `syncColumnWindow()` whenever the viewport changes, but the `onResize` handler did not.

As a result, resizing the pane re-applied pinned columns and re-rendered rows against the *stale* column window. Widening the pane left the table cut off at the old window's right edge instead of filling the newly available space with the now-visible columns.

The fix adds a `syncColumnWindow()` call at the top of the debounced `onResize` handler in `src/cpp/session/resources/grid/DataViewer.js`, mirroring the scroll handlers.

## Notes

- This is a fix to the still-unreleased continuous-column-scrolling work ([#17977](https://github.com/rstudio/rstudio/pull/17977) / [#6147](https://github.com/rstudio/rstudio/issues/6147)), so no `NEWS.md` entry is added per the repo convention.
- `DataViewer.js` is a plain-JS iframe resource (not GWT-transpiled); validated with `node --check`.

## Testing

- `node --check` passes on the modified file.
- Manual: widen the data viewer pane on a wide data frame and confirm the table now fills the new width instead of staying clipped at the old column window.