### PR TITLE
Migrate test_desktop_Create_File_Types.py to Playwright

### DIFF
--- a/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
+++ b/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
@@ -9,9 +9,9 @@ Target: `e2e/rstudio/tests/`
 |--------|-------|
 | Total electron test files | 32 |
 | Total electron test methods | 115 |
-| Files fully converted | 30 |
+| Files fully converted | 31 |
 | Files partially converted | 0 |
-| Files not started | 6 |
+| Files not started | 5 |
 
 ## Conversion Status
 
@@ -37,7 +37,7 @@ Target: `e2e/rstudio/tests/`
 |----------------|---------|-------------------|--------|-------|
 | test_desktop_CodeSuggestions.ts | — | panes/editor/code_suggestions.test.ts (5) | Complete | Already TypeScript in electron-tests |
 | test_desktop_Copilot.py | 12 | panes/editor/copilot_ghost_text.test.ts (22) | Complete | Restructured with loops; test_enabling_copilot not included |
-| test_desktop_Create_File_Types.py | 6 | panes/editor/create_file_types.test.ts (19) | Not started | Data-driven; 15 no-modal + 4 modal tests; includes Sweave creation. TODO: 3 WIP types from Selenium still need conversion (newRDocumentationDoc, newRPlumberDoc, newRPresentationDoc) — each requires extra dialog fields |
+| test_desktop_Create_File_Types.py | 6 | panes/editor/create_file_types.test.ts (22 + 1 fixme) | Complete | One test per type. 13 need no package or dialog (C/C++ x3, CSS, HTML, JavaScript, Markdown, Python, R HTML, Shell, R Script, R Sweave, Text). Each create gates on the source-tab count reaching 2 so it can't race the leftover Untitled placeholder (and the footer reading the placeholder's "R Script"). SQL is its own test: creating it pops an "update RSQLite" modal (from the template's !preview line) which the test declines (the doc is created either way), so the leftover modal can't block the next test -- it was breaking newRNotebook. D3 and R Notebook need packages; R Notebook's footer reads "R Markdown" (it creates an RMARKDOWN doc). Quarto document and presentation, R Markdown, and Shiny drive their creation dialogs; the Selenium presentation method re-ran newQuartoDoc (dead newQuartoPres var), fixed to drive newQuartoPres. Rd and Plumber (Selenium WIP types) pass. Stan (also WIP) skips unless rstan is already installed (no auto-install; heavy source compile). R Presentation is fixme (save-file dialog). |
 | test_desktop_DataViewer.py | 4 | panes/data-viewer/pagination-sorting.test.ts (4) | Complete | |
 | test_desktop_Markdown.py | 2 | panes/editor/markdown.test.ts (2) | Complete | newMarkdownDoc creation, plus previewHTML to the Viewer pane with rendered-text assertions |
 | test_desktop_Quarto.py | 1 | panes/editor/quarto.test.ts (1) | Complete | |
@@ -80,4 +80,4 @@ Target: `e2e/rstudio/tests/`
 
 | Playwright File | Test Name | Blocker | Notes |
 |----------------|-----------|---------|-------|
-| — | — | — | None tracked yet |
+| panes/editor/create_file_types.test.ts | create R Presentation via newRPresentationDoc | Opens a save-file dialog (native OS chooser on Desktop, GWT chooser on Server) to choose the .Rpres path; the harness can't drive that yet. R Presentation was never implemented in Selenium either, only a WIP comment in the source. | — |

--- a/e2e/rstudio/tests/panes/editor/create_file_types.test.ts
+++ b/e2e/rstudio/tests/panes/editor/create_file_types.test.ts
@@ -1,0 +1,266 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { SourcePaneActions } from '@actions/source_pane.actions';
+import { installDepIfPrompted, CONFIRM_BTN, NO_BTN } from '@pages/modals.page';
+import { useSuiteSandbox } from '@utils/sandbox';
+import { executeCommand } from '@utils/commands';
+import type { Page } from 'playwright';
+
+// Original: test_desktop_Create_File_Types.py::TestCreateAllFileTypes
+//
+// Each test creates a new document of a given type via its New-File command and
+// verifies (a) a new Untitled tab opens (or a named tab for Shiny/Plumber), and
+// (b) the editor status-bar footer reports the expected file type.
+//
+// The suite keeps one Untitled placeholder tab open (resetSourcePane never drops
+// to zero tabs, to dodge the #17738 HIDE-animation race), and that placeholder is
+// itself an R Script. Asserting on tab/footer text alone can therefore race a slow
+// create (reading the placeholder's "R Script") or pass falsely for newSourceDoc.
+// So each test waits for the source-tab count to reach 2 -- proof a new doc
+// opened -- before reading the footer. The Selenium version looped all the simple
+// types inside a single test; here they're one test each so one type's failure
+// doesn't mask the rest.
+
+// A successful create opens a new tab next to the placeholder, bringing the
+// source-tab count to 2. Gating on this proves the new doc opened before we read
+// the footer, instead of racing the leftover placeholder.
+function sourceTabs(page: Page) {
+  return page.locator("[class*='rstudio_source_panel'] [role='tab']");
+}
+
+test.describe('Create file types', () => {
+  // Sets cwd to a per-spec sandbox so any on-disk writes land there.
+  useSuiteSandbox();
+  let consoleActions: ConsolePaneActions;
+  let sourceActions: SourcePaneActions;
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+    sourceActions = new SourcePaneActions(page, consoleActions);
+    await consoleActions.resetSourcePane();
+  });
+
+  // ---- Types that need neither an R package nor a creation dialog ----
+  // Original: test_creating_new_file_without_required_packages_nor_modals
+  const simpleTypes: ReadonlyArray<readonly [command: string, fileType: string]> = [
+    ['newCDoc', 'C/C++'],
+    ['newCppDoc', 'C/C++'],
+    ['newHeaderDoc', 'C/C++'],
+    ['newCssDoc', 'CSS'],
+    ['newHtmlDoc', 'HTML'],
+    ['newJavaScriptDoc', 'JavaScript'],
+    ['newMarkdownDoc', 'Markdown'],
+    ['newPythonDoc', 'Python'],
+    ['newRHTMLDoc', 'R HTML'],
+    ['newShellDoc', 'Shell'],
+    // Selenium asserted just "R" here (a loose Selene substring match); the
+    // status bar actually reads "R Script", so assert that.
+    ['newSourceDoc', 'R Script'],
+    // Commented out in the Selenium source (no stated reason); it needs no
+    // package or dialog, so it belongs in this sweep.
+    ['newSweaveDoc', 'R Sweave'],
+    ['newTextDoc', 'Text file'],
+  ];
+
+  for (const [command, fileType] of simpleTypes) {
+    test(`create ${fileType} document via ${command}`, async ({ rstudioPage: page }) => {
+      await executeCommand(page, command);
+      await expect(sourceTabs(page)).toHaveCount(2, { timeout: 20000 });
+      await expect(sourceActions.sourcePane.footerTable).toContainText(fileType);
+      await consoleActions.resetSourcePane();
+    });
+  }
+
+  // SQL is its own test (not in the sweep above) because creating a SQL doc
+  // pops a modal offering to update/install RSQLite -- triggered by the
+  // template's `-- !preview conn=DBI::dbConnect(RSQLite::SQLite())` line. The
+  // doc is created regardless; declining the prompt keeps the leftover modal
+  // from blocking the next test's console focus (it otherwise broke newRNotebook).
+  test('create SQL document via newSqlDoc', async ({ rstudioPage: page }) => {
+    await executeCommand(page, 'newSqlDoc');
+    await expect(sourceTabs(page)).toHaveCount(2, { timeout: 20000 });
+    await expect(sourceActions.sourcePane.footerTable).toContainText('SQL');
+    await page.locator(NO_BTN).click({ timeout: 15000 }); // decline the RSQLite prompt
+    await consoleActions.resetSourcePane();
+  });
+
+  // ---- Types that need an R package and/or a creation dialog ----
+  test.describe('with packages or dialogs', () => {
+    let missingPackages: string[] = [];
+    let rstanAvailable = false;
+
+    test.beforeAll(async ({ rstudioPage: page }) => {
+      // r2d3 -> newD3Doc; rmarkdown -> newRNotebook / Quarto / R Markdown;
+      // shiny -> newRShinyApp; plumber -> newRPlumberDoc. 180s covers a cold
+      // transitive install on a fresh CI runner; warm caches are near-instant.
+      missingPackages = await consoleActions.ensurePackages(
+        ['r2d3', 'rmarkdown', 'shiny', 'plumber'],
+        180_000,
+      );
+      // rstan gates newStanDoc (dependencyManager_.withStan). It's a heavy
+      // source compile where no binary is available, so we don't auto-install
+      // it here -- just check presence. Pre-populate it via REQUIRED_PACKAGES
+      // to enable the Stan test; otherwise it skips cleanly.
+      rstanAvailable = (await consoleActions.evalRLogical('requireNamespace("rstan", quietly = TRUE)')) === true;
+      await consoleActions.clearConsole();
+    });
+
+    // Types that create directly once their package is present (no dialog).
+    // Original: test_creating_new_file_with_required_packages_but_no_modals.
+    // newRNotebook creates a FileTypeRegistry.RMARKDOWN doc (from notebook.Rmd),
+    // so the footer reads "R Markdown" -- not "R Notebook".
+    const packageTypes: ReadonlyArray<readonly [command: string, fileType: string, pkg: string]> = [
+      ['newD3Doc', 'JavaScript', 'r2d3'],
+      ['newRNotebook', 'R Markdown', 'rmarkdown'],
+    ];
+
+    for (const [command, fileType, pkg] of packageTypes) {
+      test(`create ${fileType} document via ${command}`, async ({ rstudioPage: page }) => {
+        test.skip(missingPackages.includes(pkg), `required R package not available: ${pkg}`);
+        await executeCommand(page, command);
+        // Packages are pre-installed in beforeAll, so a dependency prompt
+        // shouldn't appear; keep the check defensive but short.
+        await installDepIfPrompted(page, 2500);
+        await expect(sourceTabs(page)).toHaveCount(2, { timeout: 20000 });
+        await expect(sourceActions.sourcePane.footerTable).toContainText(fileType);
+        await consoleActions.resetSourcePane();
+      });
+    }
+
+    // Stan creates directly (no dialog), but newStanDoc is gated on rstan via
+    // dependencyManager_.withStan. We don't auto-install rstan (heavy source
+    // compile); the test runs only when it's already present, else it skips.
+    test('create Stan document via newStanDoc', async ({ rstudioPage: page }) => {
+      test.skip(!rstanAvailable, 'rstan not installed');
+      await executeCommand(page, 'newStanDoc');
+      await installDepIfPrompted(page, 2500);
+      await expect(sourceTabs(page)).toHaveCount(2, { timeout: 20000 });
+      await expect(sourceActions.sourcePane.footerTable).toContainText('Stan');
+      await consoleActions.resetSourcePane();
+    });
+
+    // Quarto document and presentation both open the New Quarto Document wizard
+    // and create a "Quarto" doc; the only difference is the presentation flag.
+    // Original: test_creating_new_file_quarto / test_creating_new_file_quarto_presentation.
+    // The Selenium presentation test set command="newQuartoPres" but then ran a
+    // helper that re-issued newQuartoDoc, so it never actually exercised the
+    // presentation path -- fixed here by driving each command directly.
+    for (const [command, label] of [
+      ['newQuartoDoc', 'document'],
+      ['newQuartoPres', 'presentation'],
+    ] as const) {
+      test(`create Quarto ${label} via ${command}`, async ({ rstudioPage: page }) => {
+        test.skip(missingPackages.includes('rmarkdown'), 'required R package not available: rmarkdown');
+        await executeCommand(page, command);
+        await installDepIfPrompted(page, 2500);
+
+        // Accept the wizard's defaults. The Create button is briefly disabled
+        // while the dialog initializes, so wait for it to enable before clicking.
+        const okBtn = page.locator(CONFIRM_BTN);
+        await expect(okBtn).toBeEnabled({ timeout: 20000 });
+        await okBtn.click();
+
+        await expect(sourceTabs(page)).toHaveCount(2, { timeout: 20000 });
+        await expect(sourceActions.sourcePane.footerTable).toContainText('Quarto');
+        await expect(sourceActions.sourcePane.publishBtn).toBeVisible({ timeout: 10000 });
+        await consoleActions.resetSourcePane();
+      });
+    }
+
+    test('create R Markdown document via newRMarkdownDoc', async ({ rstudioPage: page }) => {
+      // Original: test_creating_new_file_rmarkdown
+      test.skip(missingPackages.includes('rmarkdown'), 'required R package not available: rmarkdown');
+      await executeCommand(page, 'newRMarkdownDoc');
+      await installDepIfPrompted(page, 2500);
+
+      // Accept the New R Markdown dialog defaults (HTML document).
+      const okBtn = page.locator(CONFIRM_BTN);
+      await expect(okBtn).toBeEnabled({ timeout: 15000 });
+      await okBtn.click();
+
+      await expect(sourceTabs(page)).toHaveCount(2, { timeout: 20000 });
+      await expect(sourceActions.sourcePane.publishBtn).toBeVisible({ timeout: 10000 });
+      await expect(sourceActions.sourcePane.footerTable).toContainText('R Markdown');
+      await consoleActions.resetSourcePane();
+    });
+
+    test('create Shiny app via newRShinyApp', async ({ rstudioPage: page }) => {
+      // Original: test_creating_new_file_r_shiny_app
+      test.skip(missingPackages.includes('shiny'), 'required R package not available: shiny');
+      const appName = `shinyapp_${Date.now()}`;
+
+      await executeCommand(page, 'newRShinyApp');
+      await installDepIfPrompted(page, 2500);
+
+      // Fill the application name; the parent dir defaults to "~", which the
+      // fixture redirects into the sandbox user-home.
+      const nameInput = page.locator('#rstudio_new_shiny_app_name');
+      await expect(nameInput).toBeVisible({ timeout: 15000 });
+      await nameInput.fill(appName);
+      await page.locator(CONFIRM_BTN).click();
+
+      await expect(sourceTabs(page)).toHaveCount(2, { timeout: 20000 });
+      await expect(sourceActions.sourcePane.selectedTab).toContainText('app.R', { timeout: 15000 });
+      await expect(sourceActions.sourcePane.footerTable).toContainText('R Script');
+      await expect(sourceActions.sourcePane.publishBtn).toBeVisible({ timeout: 10000 });
+
+      // Cleanup: close the doc and remove the generated app directory.
+      await consoleActions.resetSourcePane();
+      await consoleActions.executeInConsole(
+        `unlink(file.path("~", "${appName}"), recursive = TRUE)`,
+        { wait: true },
+      );
+    });
+
+    test('create Rd documentation via newRDocumentationDoc', async ({ rstudioPage: page }) => {
+      // WIP type in the Selenium source (never implemented there). No package needed.
+      await executeCommand(page, 'newRDocumentationDoc');
+
+      const dialog = page.locator('div.gwt-DialogBox[aria-label="New R Documentation File"]');
+      await expect(dialog).toBeVisible({ timeout: 15000 });
+      await page.locator('#rstudio_new_rd_name').fill('mytopic');
+      // The template list defaults to "Function" (which would generate a
+      // function shell from the workspace); pick "(Empty Topic)" for a plain,
+      // deterministic Rd document.
+      await page.locator('#rstudio_new_rd_template').selectOption('none');
+      await page.locator(CONFIRM_BTN).click();
+
+      await expect(sourceTabs(page)).toHaveCount(2, { timeout: 20000 });
+      await expect(sourceActions.sourcePane.footerTable).toContainText('Rd File');
+      await consoleActions.resetSourcePane();
+    });
+
+    test('create Plumber API via newRPlumberDoc', async ({ rstudioPage: page }) => {
+      // WIP type in the Selenium source (never implemented there).
+      test.skip(missingPackages.includes('plumber'), 'required R package not available: plumber');
+      const apiName = `plumberapi_${Date.now()}`;
+
+      await executeCommand(page, 'newRPlumberDoc');
+      await installDepIfPrompted(page, 2500);
+
+      const dialog = page.locator('div.gwt-DialogBox[aria-label="New Plumber API"]');
+      await expect(dialog).toBeVisible({ timeout: 15000 });
+      // The API-name box has no stable id; it's the first text input in the
+      // dialog (the second is the directory chooser, which defaults to "~").
+      await dialog.locator('input[type="text"]').first().fill(apiName);
+      await page.locator(CONFIRM_BTN).click(); // OK button caption is "Create"
+
+      await expect(sourceTabs(page)).toHaveCount(2, { timeout: 20000 });
+      await expect(sourceActions.sourcePane.selectedTab).toContainText('plumber.R', { timeout: 15000 });
+      await expect(sourceActions.sourcePane.footerTable).toContainText('R Script');
+
+      // Cleanup: close the doc and remove the generated API directory.
+      await consoleActions.resetSourcePane();
+      await consoleActions.executeInConsole(
+        `unlink(file.path("~", "${apiName}"), recursive = TRUE)`,
+        { wait: true },
+      );
+    });
+
+    // @skip: R Presentation creation opens a save-file dialog (native OS chooser
+    // on Desktop, GWT chooser on Server) to pick the .Rpres path -- driving that
+    // save dialog isn't supported by the harness yet. The Selenium source never
+    // implemented this either (it was left as a WIP comment).
+    test.fixme('create R Presentation via newRPresentationDoc', async () => {});
+  });
+});

--- a/e2e/rstudio/tests/panes/editor/create_file_types.test.ts
+++ b/e2e/rstudio/tests/panes/editor/create_file_types.test.ts
@@ -21,9 +21,7 @@ import type { Page } from 'playwright';
 // types inside a single test; here they're one test each so one type's failure
 // doesn't mask the rest.
 
-// A successful create opens a new tab next to the placeholder, bringing the
-// source-tab count to 2. Gating on this proves the new doc opened before we read
-// the footer, instead of racing the leftover placeholder.
+// Source-document tabs; a successful create brings the count to 2 (see header).
 function sourceTabs(page: Page) {
   return page.locator("[class*='rstudio_source_panel'] [role='tab']");
 }
@@ -71,16 +69,18 @@ test.describe('Create file types', () => {
     });
   }
 
-  // SQL is its own test (not in the sweep above) because creating a SQL doc
-  // pops a modal offering to update/install RSQLite -- triggered by the
-  // template's `-- !preview conn=DBI::dbConnect(RSQLite::SQLite())` line. The
-  // doc is created regardless; declining the prompt keeps the leftover modal
+  // SQL is its own test (not in the sweep above) because the New SQL handler
+  // runs a prerequisites check on the template's preview-connection line, which
+  // can pop a modal offering to install/update RSQLite. The doc is created
+  // regardless; declining the prompt (if it appears) keeps the leftover modal
   // from blocking the next test's console focus (it otherwise broke newRNotebook).
   test('create SQL document via newSqlDoc', async ({ rstudioPage: page }) => {
     await executeCommand(page, 'newSqlDoc');
     await expect(sourceTabs(page)).toHaveCount(2, { timeout: 20000 });
     await expect(sourceActions.sourcePane.footerTable).toContainText('SQL');
-    await page.locator(NO_BTN).click({ timeout: 15000 }); // decline the RSQLite prompt
+    // Decline the RSQLite prompt if it appeared; it may not (e.g. RSQLite
+    // already current), and the doc is created either way.
+    await page.locator(NO_BTN).click({ timeout: 15000 }).catch(() => {});
     await consoleActions.resetSourcePane();
   });
 


### PR DESCRIPTION
Adds create_file_types.test.ts -- one Playwright test per file type, covering
all 6 original Selenium methods plus the 3 WIP types (Rd, Plumber, Stan) that
were never implemented in Selenium.

22 tests pass; Stan skips when rstan is not pre-installed; R Presentation is
fixme (creation opens a native save-file dialog the harness can't drive yet).

Notable findings during migration: creating a SQL document pops an "update
RSQLite" modal triggered by the template's preview line -- the test declines
it so the leftover modal doesn't pollute the next test's console focus. The
Selenium Quarto presentation test had a dead variable bug (newQuartoPres
was set but newQuartoDoc was run); fixed here to drive newQuartoPres correctly.

Updates MIGRATION_FROM_SELENIUM_PROGRESS.md: Create File Types marked
Complete, Fixme table updated, summary counts corrected.