### PR TITLE
collapse duplicated browser-active cache in SessionEnvironment

### DIFF
--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -67,11 +67,6 @@ EnvironmentMonitor* s_pEnvironmentMonitor = nullptr;
 // which Python module is currently being monitored, if any?
 std::string s_monitoredPythonModule;
 
-// is the browser currently active? we store this state
-// so that we can query this from R, without 'hiding' the
-// browser state by pushing new contexts / frames on the stack
-bool s_browserActive = false;
-
 // the environment being browsed (set by onConsolePrompt when entering debug).
 // this is needed because during promise forcing, the browser's environment
 // may differ from any sys.frame() visible from R.
@@ -915,7 +910,7 @@ Error setContextDepth(boost::shared_ptr<int> pContextDepth,
    // set state for the new depth
    *pContextDepth = requestedDepth;
    SEXP env = R_GlobalEnv;
-   r::session::getFunctionContext(requestedDepth, s_browserActive, nullptr, &env);
+   r::session::getFunctionContext(requestedDepth, r::session::isBrowseActive(), nullptr, &env);
    s_pEnvironmentMonitor->setMonitoredEnvironment(env);
 
    // populate the new state on the client
@@ -1065,15 +1060,15 @@ void onConsolePrompt(boost::shared_ptr<int> pContextDepth,
    // If we were debugging but there's no longer a browser on the context stack,
    // switch back to the top level; otherwise, examine the stack and find the
    // first function there running user code.
-   s_browserActive = r::session::isBrowseActive();
-   if (*pContextDepth > 0 && !s_browserActive)
+   bool browserActive = r::session::isBrowseActive();
+   if (*pContextDepth > 0 && !browserActive)
    {
       s_browserEnv.set(R_NilValue);
    }
    else
    {
       // Find the function context associated with the browser
-      r::session::getFunctionContext(0, s_browserActive, &depth, &environmentTop);
+      r::session::getFunctionContext(0, browserActive, &depth, &environmentTop);
       s_browserEnv.set(environmentTop);
    }
    
@@ -1085,7 +1080,7 @@ void onConsolePrompt(boost::shared_ptr<int> pContextDepth,
       // browser call somewhere on the stack. if there isn't, then we're
       // probably just waiting for user input inside a function (e.g. scan());
       // assume the user isn't interested in seeing the function's internals.
-      if (*pContextDepth == 0 && !s_browserActive)
+      if (*pContextDepth == 0 && !browserActive)
       {
          return;
       }
@@ -1133,8 +1128,7 @@ void onBeforeExecute()
    // however if R continues running then the client will properly restore
    // the state of the interruptR command
 
-   s_browserActive = r::session::isBrowseActive();
-   if (s_browserActive)
+   if (r::session::isBrowseActive())
    {
       ClientEvent event(client_events::kBusy, true);
       module_context::enqueClientEvent(event);
@@ -1456,7 +1450,7 @@ json::Value environmentStateAsJson()
 SEXP rs_isBrowserActive()
 {
    r::sexp::Protect protect;
-   return r::sexp::create(s_browserActive, &protect);
+   return r::sexp::create(r::session::isBrowseActive(), &protect);
 }
 
 SEXP rs_getBrowserEnv()


### PR DESCRIPTION
## Intent

Fixes #17492. Removes the file-local `s_browserActive` cache in `SessionEnvironment.cpp`, which duplicated the authoritative copy in `RSession.cpp` and was a latent desync class.

## Summary

`RSession.cpp` owns the authoritative browser state -- it is set/cleared synchronously from `RReadConsole` based on the prompt, and `r::session::isBrowseActive()` reads it directly. `SessionEnvironment.cpp` kept a derived `s_browserActive` that was only ever refreshed by assigning `r::session::isBrowseActive()` right before each use, so it could only ever go stale relative to the source of truth.

This removes that cache entirely and has every reader consult `r::session::isBrowseActive()` directly:

- `s_browserActive` declaration deleted.
- `rs_isBrowserActive()` returns `r::session::isBrowseActive()`.
- `setContextDepth`, `onConsolePrompt`, and `onBeforeExecute` consult `r::session::isBrowseActive()` instead of the cache. In `onConsolePrompt` the value is read once into a function-local `browserActive` and reused within the call (it cannot change mid-handler), which is a convenience local, not a persisted cache.

`isBrowseActive()` is a side-effect-free read of two statics, so reading it on demand is no more expensive than the old assign-then-read pattern.

## Testing

No behavior change: the cache was always assigned `isBrowseActive()` immediately before use, so a direct read is identical. The existing Playwright test `multi-line input at Browse[N]> preserves browser state` (debugger_extras.test.ts) already exercises the changed `rs_isBrowserActive()` path -- it submits a multi-line block at the `Browse[N]>` prompt, steps through a nested debug invocation, and asserts `.rs.isBrowserActive()` returns `TRUE` mid-block. That is the stepping-through-multi-line-paste case called out in the issue's acceptance criteria.

Note: the issue's acceptance mentions "BRAT tests" -- BRAT has since been migrated to Playwright (#17713), so the relevant coverage now lives under `e2e/rstudio/tests/panes/debugger/`.
