### PR TITLE
make C++ worktree builds practical (ccache BASEDIR + bootstrap --with-build-dir)

### DIFF
--- a/cmake/globals.cmake
+++ b/cmake/globals.cmake
@@ -185,15 +185,49 @@ if(RSTUDIO_USE_CCACHE AND
             RESULT_VARIABLE RSTUDIO_CACHE_RESULT)
          if(RSTUDIO_CACHE_RESULT EQUAL 0 AND RSTUDIO_CACHE_VERSION MATCHES "^${_cache_name}")
             set(RSTUDIO_COMPILER_CACHE "${${_cache_var}_EXECUTABLE}")
+            set(RSTUDIO_COMPILER_CACHE_NAME "${_cache_name}")
             break()
          endif()
       endif()
    endforeach()
 
    if(RSTUDIO_COMPILER_CACHE)
-      set(CMAKE_C_COMPILER_LAUNCHER "${RSTUDIO_COMPILER_CACHE}" CACHE STRING "")
-      set(CMAKE_CXX_COMPILER_LAUNCHER "${RSTUDIO_COMPILER_CACHE}" CACHE STRING "")
+      # By default the launcher is just the cache binary itself.
+      set(RSTUDIO_COMPILER_CACHE_LAUNCHER "${RSTUDIO_COMPILER_CACHE}")
+
+      # For ccache specifically, normalize absolute paths so objects compiled in
+      # one checkout (or git worktree) are reused in another. Without this, each
+      # checkout's absolute source/include paths hash differently and the cache
+      # never hits across checkouts -- defeating the git-worktree reuse this
+      # block exists to provide.
+      #
+      #   CCACHE_BASEDIR   rewrites absolute paths under the source tree to paths
+      #                    relative to the build dir before hashing.
+      #   CCACHE_NOHASHDIR stops ccache from folding the build dir into the hash.
+      #
+      # We thread these through `env` in the launcher list so the normalization
+      # is automatic (no reliance on the developer's shell). ccache-only:
+      # sccache has no BASEDIR equivalent. Non-Windows only: the worktree
+      # workflow this serves is POSIX, and `env` may not be present on Windows.
+      #
+      # Trade-off: a cross-checkout cache hit reuses the object that first
+      # populated the cache, so embedded debug / __FILE__ paths may point at the
+      # checkout that built it. Acceptable for development builds.
+      if(RSTUDIO_COMPILER_CACHE_NAME STREQUAL "ccache" AND NOT WIN32)
+         find_program(RSTUDIO_ENV_EXECUTABLE NAMES env)
+         if(RSTUDIO_ENV_EXECUTABLE)
+            set(RSTUDIO_COMPILER_CACHE_LAUNCHER
+               "${RSTUDIO_ENV_EXECUTABLE}"
+               "CCACHE_BASEDIR=${CMAKE_SOURCE_DIR}"
+               "CCACHE_NOHASHDIR=true"
+               "${RSTUDIO_COMPILER_CACHE}")
+         endif()
+      endif()
+
+      set(CMAKE_C_COMPILER_LAUNCHER   ${RSTUDIO_COMPILER_CACHE_LAUNCHER} CACHE STRING "")
+      set(CMAKE_CXX_COMPILER_LAUNCHER ${RSTUDIO_COMPILER_CACHE_LAUNCHER} CACHE STRING "")
       message(STATUS "Using compiler cache: ${RSTUDIO_COMPILER_CACHE}")
+      message(STATUS "Compiler cache launcher: ${RSTUDIO_COMPILER_CACHE_LAUNCHER}")
    endif()
 endif()
 

--- a/scripts/bootstrap-worktree.sh
+++ b/scripts/bootstrap-worktree.sh
@@ -30,20 +30,36 @@
 # Run under bash (Git Bash or WSL on Windows).
 #
 # Usage:
-#   scripts/bootstrap-worktree.sh [worktree-dir] [--skip-desktop]
+#   scripts/bootstrap-worktree.sh [worktree-dir] [--skip-desktop] \
+#       [--with-build-dir[=<dir>]]
 #
 #   worktree-dir   defaults to the current directory; may be any path inside
 #                  the target worktree (it is normalized to the repo top).
 #   --skip-desktop skip src/node/desktop (its deps are large; skip when you
 #                  only need the e2e/rstudio suite).
+#   --with-build-dir[=<dir>]
+#                  also configure a CMake build directory for the worktree
+#                  (default <worktree>/build; <dir> may be absolute or relative
+#                  to the worktree). This configures FRESH -- it never copies
+#                  the main checkout's build/, which bakes absolute paths (the
+#                  cache's source dir, ninja depfiles, generated dev confs, and
+#                  debug/__FILE__ strings in objects), so a copied tree would
+#                  build and serve the wrong checkout. A fresh configure writes
+#                  correct paths; the cross-checkout CCACHE_BASEDIR setup in
+#                  cmake/globals.cmake then lets the compile reuse objects
+#                  another checkout already built, keeping it cheap.
 
 set -euo pipefail
 
 SKIP_DESKTOP=0
+WANT_BUILD_DIR=0
+BUILD_DIR_ARG=""
 TARGET=""
 for arg in "$@"; do
   case "$arg" in
     --skip-desktop) SKIP_DESKTOP=1 ;;
+    --with-build-dir) WANT_BUILD_DIR=1 ;;
+    --with-build-dir=*) WANT_BUILD_DIR=1; BUILD_DIR_ARG="${arg#*=}" ;;
     *) TARGET="$arg" ;;
   esac
 done
@@ -125,6 +141,35 @@ copy_generated() {
   cp "$MAIN_CHECKOUT/$rel" "$WORKTREE/$rel"
 }
 
+# Configure a CMake build directory for the worktree. Always a fresh configure
+# (cmake -S <worktree> -B <dir>), never a copy of the main checkout's build/ --
+# a CMake build tree bakes absolute paths into the cache, ninja depfiles, the
+# generated dev confs (www-local-path), and the compiled objects themselves, so
+# a copied tree would build and serve the main checkout rather than this one. A
+# fresh configure writes correct paths; the cross-checkout CCACHE_BASEDIR setup
+# in cmake/globals.cmake makes the subsequent compile reuse cached objects, so
+# this stays cheap despite not copying.
+configure_build() {
+  local dir="$1"
+
+  # Resolve a relative path against the worktree root so the build dir lands
+  # inside the worktree no matter where this script was invoked from.
+  case "$dir" in
+    /*) ;;
+    *) dir="$WORKTREE/$dir" ;;
+  esac
+
+  if ! command -v cmake >/dev/null 2>&1; then
+    echo "[bootstrap] WARNING: cmake not found on PATH; skipping --with-build-dir"
+    return
+  fi
+
+  echo "[bootstrap] configuring CMake build dir: $dir"
+  cmake -S "$WORKTREE" -B "$dir" -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+
+  echo "[bootstrap] build dir configured; compile with: cmake --build \"$dir\""
+}
+
 # The e2e/rstudio Playwright suite -- the common case.
 ensure_deps "e2e/rstudio"
 
@@ -136,6 +181,12 @@ if [ "$SKIP_DESKTOP" -eq 0 ]; then
   copy_generated "src/node/desktop/src/types/user-state-schema.d.ts"
 else
   echo "[bootstrap] skipping src/node/desktop (--skip-desktop)"
+fi
+
+# Optional CMake build-dir configure (default <worktree>/build when no path
+# was given).
+if [ "$WANT_BUILD_DIR" -eq 1 ]; then
+  configure_build "${BUILD_DIR_ARG:-build}"
 fi
 
 echo "[bootstrap] done"


### PR DESCRIPTION
## Summary

Developer-tooling changes that make C++ builds in a git worktree practical, so a worktree's first build doesn't recompile the whole tree from scratch.

## 1. Share ccache across checkouts/worktrees (`cmake/globals.cmake`)

The dev-build compiler-cache block already aimed to let git-worktree builds reuse cached objects, but in practice the cross-checkout hit rate is near zero: ccache hashes absolute source/include paths, which differ between checkouts, so nothing is reused across worktrees.

This threads two env vars through `env` in the compiler-launcher list (ccache-only, non-Windows):

- `CCACHE_BASEDIR` rewrites absolute paths under the source tree to build-dir-relative paths before hashing.
- `CCACHE_NOHASHDIR` stops ccache from folding the build dir into the hash.

With both set, the same source compiled from two different checkout roots produces the same hash, so a fresh worktree's first build reuses objects another checkout already compiled.

**Trade-off:** a cross-checkout cache hit reuses the object that first populated the cache, so embedded debug / `__FILE__` paths may point at the checkout that built it. Acceptable for development builds.

## 2. `bootstrap-worktree.sh --with-build-dir` (`scripts/bootstrap-worktree.sh`)

Adds an opt-in `--with-build-dir[=<dir>]` flag (default `<worktree>/build`; absolute or worktree-relative) that runs a **fresh** `cmake -S <worktree> -B <dir>` configure.

It deliberately configures fresh rather than copying the main checkout's `build/`: a CMake build tree bakes absolute paths into its cache, ninja depfiles, generated dev confs (`www-local-path`), and the compiled objects themselves, so a copied tree would build and serve the wrong checkout. Paired with the `CCACHE_BASEDIR` change above, the subsequent compile reuses cached objects, so a fresh configure stays cheap.

## Testing

- Verified the launcher is wired correctly in `CMakeCache.txt` and that CMake/Ninja compiles cleanly through the `env`-wrapped launcher.
- Confirmed the mechanism empirically: the same source compiled from two different checkout roots is a ccache **hit** with the change and a **miss** without it.
- `bash -n` on the bootstrap script passes; verified `--with-build-dir` resolves the path and configures correctly.

Developer-only tooling change; no associated issue or NEWS entry.
