### PR TITLE
strip --| cell-option lines from sql chunks before execution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,7 @@
 - ([#1667](https://github.com/rstudio/rstudio/issues/1667)): On Linux Desktop, hardened middle-click (primary selection) paste in the editor and console: a selection is now flushed to the primary selection on mouse release rather than only after a short delay, and a middle-click paste falls back to the event's clipboard text when the tracked selection is empty, so quickly selecting and middle-click-pasting no longer pastes nothing.
 - ([#18065](https://github.com/rstudio/rstudio/issues/18065)): Fixed an uncaught JavaScript exception thrown when an r2d3 widget requested the editor theme, caused by an uninjected user-state provider in the page's message listener. The theme handshake now completes so r2d3 widgets pick up the editor theme.
 - ([#18068](https://github.com/rstudio/rstudio/issues/18068)): Auto-downloaded copies of the Air formatter are now installed under RStudio's per-user data directory (for example `~/.local/share/rstudio/air` on Linux or `%LOCALAPPDATA%\rstudio\air` on Windows) instead of `~/.local/lib/air`. Copies installed by older versions of RStudio in the previous location are still detected and reused.
+- ([#18093](https://github.com/rstudio/rstudio/issues/18093)): Fixed interactive execution of `sql` chunks that use the `--|` cell-option comment syntax (for example `--| connection: con`). The option line is now stripped from the chunk body before the query is sent to the database, so backends such as MySQL and MariaDB that reject `--|` as invalid SQL syntax no longer error.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -1001,7 +1001,15 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    end   <- min(length(code), grep(.rs.reRmdChunkEnd(), code, perl = TRUE))
 
    code <- code[(start + 1):(end - 1)]
-   code <- gsub("#[|].*$", "", code)
+
+   # strip cell-option lines (e.g. '#| key: value'). these use a
+   # language-specific comment prefix, so handle each of the prefixes
+   # understood by .rs.evaluateChunkOptions(): '#' for most engines,
+   # '--' for sql / haskell, and '//' for c-like engines. this ensures
+   # option lines are never sent to (e.g.) a database server, which some
+   # backends (MySQL / MariaDB) would otherwise reject as invalid syntax.
+   # https://github.com/rstudio/rstudio/issues/18093
+   code <- gsub("(#|--|//)[|].*$", "", code)
 
    paste(code, collapse = "\n")
 })

--- a/src/cpp/tests/testthat/test-notebook.R
+++ b/src/cpp/tests/testthat/test-notebook.R
@@ -19,6 +19,16 @@ test_that("#| comments are removed by .rs.extractChunkInnerCode() (#11606)", {
    expect_true(!any(grepl("#[|]", extract)))
 })
 
+test_that("--| cell options are removed by .rs.extractChunkInnerCode() (#18093)", {
+   # SQL chunks may use the '--|' comment prefix for cell options; these
+   # must be stripped before the body is sent to the database server, as
+   # some backends (MySQL / MariaDB) reject '--|' as invalid SQL syntax.
+   code <- "```{sql}\n--| connection: con\nSELECT 1\n```"
+   extract <- .rs.extractChunkInnerCode(code)
+   expect_false(any(grepl("--[|]", extract)))
+   expect_true(any(grepl("SELECT 1", extract)))
+})
+
 test_that(".rs.rnb.extractInlineRCode() finds inline R code in prose only", {
    contents <- c(
       "---",


### PR DESCRIPTION
## Problem

Running a `{sql}` chunk interactively with the Quarto/knitr cell-option comment syntax fails on MySQL/MariaDB:

`````qmd
```{sql}
--| connection: con
SELECT 1;
```
`````

RStudio sent the option line `--| connection: con` to the database as part of the statement. MySQL/MariaDB require whitespace after `--` for a line comment, so they parse `--|` as SQL and error (1064). SQLite/Postgres tolerate `--|`, which is why the bug was invisible there.

## Root cause

Interactive SQL chunk execution parses the chunk in two independent steps in `SessionRmdNotebook.R`:

- `.rs.evaluateChunkOptions()` extracts the options and already picks the comment prefix per engine (`--` for sql, `//` for C-like, `#` otherwise), so the `connection` option parsed correctly.
- `.rs.extractChunkInnerCode()` extracts the body sent to the DB, but stripped option lines with a hardcoded `#|` pattern only. A `--|` (or `//|`) option line therefore survived into the query.

## Fix

Strip all comment prefixes that `.rs.evaluateChunkOptions()` recognizes:

```r
code <- gsub("(#|--|//)[|].*$", "", code)   # was: "#[|].*$"
```

This function is only used for alternate-engine chunks (sql, stan, Rcpp, js, bash, ...). Verified that `--|`/`//|` option lines are stripped while plain `-- comment` lines and the SQL concat operator `a || b` are left untouched.

## Testing

- Added a `--|` (SQL) test case to `test-notebook.R` alongside the existing `#|` (#11606) case.

Fixes #18093.
