### PR TITLE
surface main window when launching jobs from a detached source window

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,8 @@
 - ([#18065](https://github.com/rstudio/rstudio/issues/18065)): Fixed an uncaught JavaScript exception thrown when an r2d3 widget requested the editor theme, caused by an uninjected user-state provider in the page's message listener. The theme handshake now completes so r2d3 widgets pick up the editor theme.
 - ([#18068](https://github.com/rstudio/rstudio/issues/18068)): Auto-downloaded copies of the Air formatter are now installed under RStudio's per-user data directory (for example `~/.local/share/rstudio/air` on Linux or `%LOCALAPPDATA%\rstudio\air` on Windows) instead of `~/.local/lib/air`. Copies installed by older versions of RStudio in the previous location are still detected and reused.
 
+- ([#18101](https://github.com/rstudio/rstudio/issues/18101)): Fixed "Run Selection as Background Job" (and the related Source/Launcher job commands) appearing to do nothing when invoked from a detached source window on Windows Desktop. The job launcher dialog is shown in the main window, which is now brought forward so the dialog is visible.
+
 ### Dependencies
 - Ace 1.43.5
 - Copilot Language Server 1.509.1

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/events/JobRunScriptEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/events/JobRunScriptEvent.java
@@ -48,6 +48,16 @@ public class JobRunScriptEvent extends CrossWindowEvent<JobRunScriptEvent.Handle
       return TYPE;
    }
 
+   // when fired from a detached source window, this event is forwarded to the
+   // main window, which shows the job launcher dialog. bring the main window
+   // forward so that dialog is visible (otherwise it can appear behind the
+   // source window and the command appears to do nothing; see rstudio#18101)
+   @Override
+   public int focusMode()
+   {
+      return CrossWindowEvent.MODE_FOCUS;
+   }
+
    @Override
    protected void dispatch(Handler handler)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/events/JobRunSelectionEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/events/JobRunSelectionEvent.java
@@ -55,6 +55,16 @@ public class JobRunSelectionEvent extends CrossWindowEvent<JobRunSelectionEvent.
       return TYPE;
    }
 
+   // when fired from a detached source window, this event is forwarded to the
+   // main window, which shows the job launcher dialog. bring the main window
+   // forward so that dialog is visible (otherwise it can appear behind the
+   // source window and the command appears to do nothing; see rstudio#18101)
+   @Override
+   public int focusMode()
+   {
+      return CrossWindowEvent.MODE_FOCUS;
+   }
+
    @Override
    protected void dispatch(Handler handler)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/events/LauncherJobRunScriptEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/events/LauncherJobRunScriptEvent.java
@@ -48,6 +48,16 @@ public class LauncherJobRunScriptEvent extends CrossWindowEvent<LauncherJobRunSc
       return TYPE;
    }
 
+   // when fired from a detached source window, this event is forwarded to the
+   // main window, which shows the job launcher dialog. bring the main window
+   // forward so that dialog is visible (otherwise it can appear behind the
+   // source window and the command appears to do nothing; see rstudio#18101)
+   @Override
+   public int focusMode()
+   {
+      return CrossWindowEvent.MODE_FOCUS;
+   }
+
    @Override
    protected void dispatch(Handler handler)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/events/LauncherJobRunSelectionEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/events/LauncherJobRunSelectionEvent.java
@@ -55,6 +55,16 @@ public class LauncherJobRunSelectionEvent extends CrossWindowEvent<LauncherJobRu
       return TYPE;
    }
 
+   // when fired from a detached source window, this event is forwarded to the
+   // main window, which shows the job launcher dialog. bring the main window
+   // forward so that dialog is visible (otherwise it can appear behind the
+   // source window and the command appears to do nothing; see rstudio#18101)
+   @Override
+   public int focusMode()
+   {
+      return CrossWindowEvent.MODE_FOCUS;
+   }
+
    @Override
    protected void dispatch(Handler handler)
    {


### PR DESCRIPTION
### Summary

"Run Selection as Background Job" (and the related Source/Launcher job commands) appear to do nothing when invoked from a detached (popped-out) source window on Windows Desktop.

### Root cause

These commands are `windowMode="any"`, so their handlers run in the source window and fire a `CrossWindowEvent` (`JobRunSelectionEvent`, `JobRunScriptEvent`, and the `LauncherJob*` variants). The event is forwarded to the main window, whose `JobManager` shows a modal `JobLauncherDialog`. The events used the default `focusMode()` of `MODE_BACKGROUND`, so `EventBus` never brought the main window forward. On Windows Desktop the modal therefore rendered behind the detached source window, so the command looked like it silently did nothing. On macOS/Linux Desktop the OS/Electron surfaced the window anyway, which is why it worked there.

### Fix

Override `focusMode()` to return `MODE_FOCUS` on the four job-launch events, mirroring the existing `SendToConsoleEvent` precedent (commit 28a5788e7a, which did the same for the show-help / send-to-console commands). This brings the main window to the front before the dialog appears, giving Windows the same behavior macOS/Linux already have.

`MODE_AUXILIARY` was considered but rejected: it re-focuses the source window afterward, which would leave a *modal* dialog hidden behind it.

Because the fix lives on the event's `focusMode()`, it only affects the satellite-forwarding path; events fired from the main window are not forwarded and never consult `focusMode()`, so there is no behavior change in the common case.

### Testing

Manual verification required on Windows Desktop (cannot be reproduced on macOS). `cd src/gwt && ant javac` passes.

Addresses #18101.