### PR TITLE
seed .here in sandbox home to prevent reticulate here::here() failure

### DIFF
--- a/e2e/rstudio/fixtures/sandbox-setup.ts
+++ b/e2e/rstudio/fixtures/sandbox-setup.ts
@@ -115,6 +115,18 @@ export default async function globalSetup(config: FullConfig) {
   const userHome = path.join(sandbox, 'user-home');
   fs.mkdirSync(userHome, { recursive: true });
 
+  // Seed an empty `.here` marker in the sandbox home. The home dir has no
+  // project markers (.Rproj/.git/renv.lock/...), so any R code that resolves a
+  // project root via the `here` / `rprojroot` packages -- e.g. reticulate's
+  // pipenv interpreter probe, which calls an unguarded here::here() (see
+  // rstudio/reticulate#1909) -- throws "No root directory found" when run from
+  // here. That error has surfaced as a spurious modal (e.g. "Error Listing
+  // Packages" on session resume) whose glass overlay then wedges unrelated
+  // tests. `.here` is the marker `here` looks for first, so it makes here()
+  // resolve to the home dir instead of erroring. It only affects code that
+  // actually calls here()/rprojroot; RStudio's own project detection ignores it.
+  fs.writeFileSync(path.join(userHome, '.here'), '');
+
   // On Windows, redirecting USERPROFILE to a directory that doesn't contain
   // an AppData/Roaming subdirectory makes Electron's app.getPath('appData')
   // fail at startup ("Failed to get 'appData' path" popup), which blocks

--- a/e2e/rstudio/pages/modals.page.ts
+++ b/e2e/rstudio/pages/modals.page.ts
@@ -35,3 +35,49 @@ export async function clickConfirmIfVisible(page: Page, timeout: number = 15000)
     // No confirmation dialog appeared
   }
 }
+
+/**
+ * Dismiss any modal dialogs currently blocking the UI, returning the labels of
+ * whatever was dismissed (empty array if the stack was already clear).
+ *
+ * A GWT modal renders a `gwt-PopupPanelGlass` overlay that intercepts pointer
+ * events across the whole application. When an *out-of-band* dialog appears --
+ * one the test did not open -- the next click a test makes fails with an opaque
+ * "<div class=\"gwt-PopupPanelGlass\"></div> intercepts pointer events" timeout
+ * that points at the click site, not the real culprit. The canonical example is
+ * a spurious "Error Listing Packages" dialog that surfaces from the packages-
+ * pane refresh right after a session resume: its glass then wedges the next
+ * `executeInConsole`.
+ *
+ * Call this after operations that can surface such a dialog (session
+ * suspend/resume, restart) and before the next pane interaction. It only acts
+ * when a modal is actually up (checked via the automation bridge's
+ * `numShowing()`), and logs what it dismissed so a stray dialog stays visible
+ * in the test output even though clearing it lets the test proceed.
+ */
+export async function dismissBlockingModals(page: Page): Promise<string[]> {
+  const dismissed = await page.evaluate(() => {
+    const r = window.rstudio;
+    if (!r || r.dialogs.numShowing() === 0)
+      return [];
+
+    // Capture labels before dismissing so the caller can report them. Prefer
+    // the accessible name; fall back to a truncated text snippet.
+    const nodes = document.querySelectorAll(
+      '.gwt-DialogBox, [role="alertdialog"], [role="dialog"]',
+    );
+    const labels = Array.from(nodes).map((el) =>
+      el.getAttribute('aria-label') ||
+      (el.textContent ?? '').trim().slice(0, 120) ||
+      '(unlabeled dialog)',
+    );
+
+    r.dialogs.dismissAll();
+    return labels;
+  });
+
+  if (dismissed.length > 0)
+    console.warn(`dismissBlockingModals: dismissed ${dismissed.length} modal(s): ${dismissed.join(' | ')}`);
+
+  return dismissed;
+}

--- a/e2e/rstudio/tests/panes/misc/session_suspend.test.ts
+++ b/e2e/rstudio/tests/panes/misc/session_suspend.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { executeInConsole, CONSOLE_OUTPUT } from '@pages/console_pane.page';
+import { dismissBlockingModals } from '@pages/modals.page';
 import { waitForSessionRestart } from '@utils/project';
 import { rStringLiteral } from '@utils/r';
 import { executeCommand } from '@utils/commands';
@@ -25,6 +26,18 @@ async function captureResult(page: Page, rExpression: string): Promise<string> {
 async function suspendAndResume(page: Page): Promise<void> {
   await executeCommand(page, 'suspendSession');
   await waitForSessionRestart(page);
+
+  // Defensive: a stray modal that pops up during resume renders a
+  // gwt-PopupPanelGlass overlay that then blocks the console tab and wedges the
+  // next executeInConsole with an opaque pointer-intercept timeout. The one
+  // trigger we know of -- reticulate's unguarded here::here() throwing "No root
+  // directory found" from the rootless sandbox HOME (rstudio/reticulate#1909),
+  // surfacing as an "Error Listing Packages" dialog on resume -- is prevented at
+  // the source by the `.here` marker seeded into the sandbox home (see
+  // fixtures/sandbox-setup.ts). This clear stays as a cheap safety net for any
+  // other out-of-band dialog, since these tests exercise search-path
+  // preservation, not whatever pane raised it.
+  await dismissBlockingModals(page);
 }
 
 // Suspend/resume relies on the Server reconnection path. Desktop has no


### PR DESCRIPTION
## Summary

reticulate's pipenv interpreter probe calls an unguarded `here::here()` (rstudio/reticulate#1909). Run from the rootless Playwright sandbox HOME -- which has no project markers (`.Rproj`/`.git`/`renv.lock`/...) -- `here()` throws "No root directory found". That surfaced as a spurious "Error Listing Packages" modal on session resume, whose `gwt-PopupPanelGlass` overlay then wedged unrelated e2e tests with an opaque pointer-intercept timeout.

## Changes

- **`fixtures/sandbox-setup.ts`**: seed an empty `.here` marker into the sandbox `user-home`. `.here` is the first marker `here`/`rprojroot` looks for, so `here()` resolves to HOME instead of erroring. Only affects code that actually calls `here()`/`rprojroot`; RStudio's own project detection ignores it.
- **`pages/modals.page.ts`**: add `dismissBlockingModals()` helper that clears any out-of-band modal (checked via the automation bridge's `numShowing()`) and logs what it dismissed.
- **`tests/panes/misc/session_suspend.test.ts`**: call `dismissBlockingModals()` after suspend/resume as a cheap safety net for any other stray dialog.

This is test-infrastructure only.