### PR TITLE
merge e2e playwright reports across platforms into one report

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -82,6 +82,10 @@ on:
       post_pr_comment:
         type: boolean
         default: false
+      defer_merge:
+        description: "Skip this workflow's own merge/publish/comment job; the caller merges every platform's blobs into one report instead."
+        type: boolean
+        default: false
     secrets:
       CONNECT_API_KEY:
         description: "Posit Connect API key for the E2E Test Insights reporter"
@@ -381,7 +385,9 @@ jobs:
         working-directory: e2e/rstudio
         env:
           PW_RSTUDIO_MODE: desktop
-          PW_PROJECT_NAME: ${{ inputs.project }}
+          # Platform-labelled project name so a cross-platform merged report can
+          # distinguish these results (see PW_PROJECT_LABEL in playwright.config.ts).
+          PW_PROJECT_LABEL: ${{ inputs.project }}-macos
           PW_GREP: ${{ inputs.grep }}
           PW_GREP_INVERT: ${{ inputs.grep_invert }}
           PW_TEST_SELECTOR: ${{ inputs.test_selector }}
@@ -389,6 +395,10 @@ jobs:
           PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
           # Tells playwright.config.ts to switch to blob reporter for this shard.
           PW_SHARD: ${{ matrix.shard }}
+          # Platform+shard-unique blob file name. The default is report-<shard>.zip,
+          # which would collide across platforms (mac shard 1 vs windows shard 1)
+          # when the PR job flattens every platform's blobs into one dir to merge.
+          PLAYWRIGHT_BLOB_OUTPUT_NAME: report-${{ inputs.project }}-macos-${{ matrix.shard }}.zip
           # E2E Test Insights reporter: posts per-shard results to the dashboard
           # API. SHARD_NAME makes each shard's run id unique so shards don't
           # overwrite each other. CONNECT_API_KEY is empty on fork PRs; the
@@ -407,7 +417,7 @@ jobs:
             ARGS+=($PW_TEST_SELECTOR)
             set +f
           fi
-          ARGS+=(--project "$PW_PROJECT_NAME")
+          ARGS+=(--project "$PW_PROJECT_LABEL")
           if [ -n "$PW_GREP" ]; then
             ARGS+=(--grep "$PW_GREP")
           fi
@@ -463,7 +473,7 @@ jobs:
   # (when post_pr_comment is set).
   e2e-merge:
     needs: [e2e-desktop-macos]
-    if: always() && needs.e2e-desktop-macos.result != 'skipped' && needs.e2e-desktop-macos.result != 'cancelled'
+    if: always() && inputs.defer_merge != true && needs.e2e-desktop-macos.result != 'skipped' && needs.e2e-desktop-macos.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -385,8 +385,10 @@ jobs:
         working-directory: e2e/rstudio
         env:
           PW_RSTUDIO_MODE: desktop
-          # Platform-labelled project name so a cross-platform merged report can
-          # distinguish these results (see PW_PROJECT_LABEL in playwright.config.ts).
+          # Platform-labelled project name; playwright.config.ts uses it both as
+          # the project name in reports (so a cross-platform merged report can
+          # distinguish these results) and to derive the platform+shard-unique
+          # blob report file name.
           PW_PROJECT_LABEL: ${{ inputs.project }}-macos
           PW_GREP: ${{ inputs.grep }}
           PW_GREP_INVERT: ${{ inputs.grep_invert }}
@@ -395,10 +397,6 @@ jobs:
           PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
           # Tells playwright.config.ts to switch to blob reporter for this shard.
           PW_SHARD: ${{ matrix.shard }}
-          # Platform+shard-unique blob file name. The default is report-<shard>.zip,
-          # which would collide across platforms (mac shard 1 vs windows shard 1)
-          # when the PR job flattens every platform's blobs into one dir to merge.
-          PLAYWRIGHT_BLOB_OUTPUT_NAME: report-${{ inputs.project }}-macos-${{ matrix.shard }}.zip
           # E2E Test Insights reporter: posts per-shard results to the dashboard
           # API. SHARD_NAME makes each shard's run id unique so shards don't
           # overwrite each other. CONNECT_API_KEY is empty on fork PRs; the
@@ -417,7 +415,6 @@ jobs:
             ARGS+=($PW_TEST_SELECTOR)
             set +f
           fi
-          ARGS+=(--project "$PW_PROJECT_LABEL")
           if [ -n "$PW_GREP" ]; then
             ARGS+=(--grep "$PW_GREP")
           fi
@@ -507,55 +504,15 @@ jobs:
             echo "::error::No blob reports found -- both shards failed to produce artifacts"
             exit 1
           fi
-          cat > merge.config.ts <<'EOF'
-          import { defineConfig } from '@playwright/test';
-          export default defineConfig({
-            reporter: [
-              ['html', { outputFolder: 'playwright-report', open: 'never' }],
-              ['json', { outputFile: 'playwright-report/test-results.json' }],
-            ],
-          });
-          EOF
           npx playwright merge-reports --config merge.config.ts ./all-blob-reports
 
+      # Shared summarizer (also used by the PR run's e2e-merge-all job) so every
+      # comment computes pass/fail counts and the rate bar from one definition.
       - name: Parse aggregated results
         id: summary
         if: always()
-        run: |
-          FILE="e2e/rstudio/playwright-report/test-results.json"
-          if [ -f "$FILE" ]; then
-            if ! PASSED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == true and (.tests[0].status // "expected") != "flaky" and (.tests[0].status // "expected") != "skipped")] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (PASSED)"; exit 1
-            fi
-            if ! FAILED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == false)] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (FAILED)"; exit 1
-            fi
-            if ! SKIPPED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "skipped")] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (SKIPPED)"; exit 1
-            fi
-            if ! FLAKY=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "flaky")] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (FLAKY)"; exit 1
-            fi
-          else
-            PASSED=0; FAILED=0; SKIPPED=0; FLAKY=0
-          fi
-          TOTAL=$((PASSED + FAILED))
-          if [ "$TOTAL" -gt 0 ]; then
-            RATE=$(( (PASSED * 100) / TOTAL ))
-            FILLED=$(( (RATE * 20) / 100 ))
-            EMPTY=$(( 20 - FILLED ))
-            BAR=""
-            [ "$FILLED" -gt 0 ] && BAR=$(printf '█%.0s' $(seq 1 $FILLED))
-            [ "$EMPTY"  -gt 0 ] && BAR="${BAR}$(printf '░%.0s' $(seq 1 $EMPTY))"
-          else
-            RATE=0; BAR="░░░░░░░░░░░░░░░░░░░░"
-          fi
-          echo "passed=$PASSED" >> "$GITHUB_OUTPUT"
-          echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
-          echo "skipped=$SKIPPED" >> "$GITHUB_OUTPUT"
-          echo "flaky=$FLAKY" >> "$GITHUB_OUTPUT"
-          echo "rate=$RATE" >> "$GITHUB_OUTPUT"
-          echo "bar=$BAR" >> "$GITHUB_OUTPUT"
+        working-directory: e2e/rstudio
+        run: node scripts/summarize-merged-report.mjs playwright-report/test-results.json
 
       - name: Upload merged Playwright report
         id: upload-report

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -425,7 +425,7 @@ jobs:
             ARGS+=(--grep-invert "$PW_GREP_INVERT")
           fi
           ARGS+=(--shard="${{ matrix.shard }}/${{ strategy.job-total }}")
-          npx playwright test "${ARGS[@]}"
+          node scripts/run-with-heartbeat.mjs -- test "${ARGS[@]}"
 
       - name: Upload blob report
         if: always()

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -461,9 +461,10 @@ jobs:
             ARGS+=(--grep-invert "$PW_GREP_INVERT")
           fi
           ARGS+=(--shard="${{ matrix.shard }}/${{ strategy.job-total }}")
-          # Run Playwright under our own Xvfb and exec it as the step's main
-          # process, so a job cancellation's SIGTERM reaches Playwright
-          # directly. xvfb-run is a shell wrapper that does not forward signals
+          # Run Playwright under our own Xvfb and exec the watchdog as the step's
+          # main process, so a job cancellation's SIGTERM reaches the watchdog
+          # (which forwards it to Playwright's process tree). xvfb-run is a shell
+          # wrapper that does not forward signals
           # to its child, which left cancelled Linux e2e jobs running until
           # their timeout-minutes instead of stopping. -ac disables X access
           # control so Chromium connects without an auth cookie; -nolisten tcp
@@ -482,7 +483,7 @@ jobs:
             cat /tmp/xvfb.log || true
             exit 1
           fi
-          exec npx playwright test "${ARGS[@]}"
+          exec node scripts/run-with-heartbeat.mjs -- test "${ARGS[@]}"
 
       # Platform-prefixed artifact name. When this Linux Desktop workflow runs
       # from the same parent PR run as the other platforms (via the combined

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -82,6 +82,10 @@ on:
       post_pr_comment:
         type: boolean
         default: false
+      defer_merge:
+        description: "Skip this workflow's own merge/publish/comment job; the caller merges every platform's blobs into one report instead."
+        type: boolean
+        default: false
     secrets:
       CONNECT_API_KEY:
         description: "Posit Connect API key for the E2E Test Insights reporter"
@@ -420,7 +424,9 @@ jobs:
         working-directory: e2e/rstudio
         env:
           PW_RSTUDIO_MODE: desktop
-          PW_PROJECT_NAME: ${{ inputs.project }}
+          # Platform-labelled project name so a cross-platform merged report can
+          # distinguish these results (see PW_PROJECT_LABEL in playwright.config.ts).
+          PW_PROJECT_LABEL: ${{ inputs.project }}-linux
           PW_GREP: ${{ inputs.grep }}
           PW_GREP_INVERT: ${{ inputs.grep_invert }}
           PW_TEST_SELECTOR: ${{ inputs.test_selector }}
@@ -428,6 +434,10 @@ jobs:
           PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
           # Tells playwright.config.ts to switch to blob reporter for this shard.
           PW_SHARD: ${{ matrix.shard }}
+          # Platform+shard-unique blob file name. The default is report-<shard>.zip,
+          # which would collide across platforms (mac shard 1 vs windows shard 1)
+          # when the PR job flattens every platform's blobs into one dir to merge.
+          PLAYWRIGHT_BLOB_OUTPUT_NAME: report-${{ inputs.project }}-linux-${{ matrix.shard }}.zip
           # E2E Test Insights reporter: posts per-shard results to the dashboard.
           # CONNECT_API_KEY is empty on fork PRs; the reporter still runs but its
           # uploads fail with warnings (never fails the run).
@@ -443,7 +453,7 @@ jobs:
             ARGS+=($PW_TEST_SELECTOR)
             set +f
           fi
-          ARGS+=(--project "$PW_PROJECT_NAME")
+          ARGS+=(--project "$PW_PROJECT_LABEL")
           if [ -n "$PW_GREP" ]; then
             ARGS+=(--grep "$PW_GREP")
           fi
@@ -513,7 +523,7 @@ jobs:
   # (when post_pr_comment is set).
   e2e-merge:
     needs: [e2e-desktop-ubuntu]
-    if: always() && needs.e2e-desktop-ubuntu.result != 'skipped' && needs.e2e-desktop-ubuntu.result != 'cancelled'
+    if: always() && inputs.defer_merge != true && needs.e2e-desktop-ubuntu.result != 'skipped' && needs.e2e-desktop-ubuntu.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -424,8 +424,10 @@ jobs:
         working-directory: e2e/rstudio
         env:
           PW_RSTUDIO_MODE: desktop
-          # Platform-labelled project name so a cross-platform merged report can
-          # distinguish these results (see PW_PROJECT_LABEL in playwright.config.ts).
+          # Platform-labelled project name; playwright.config.ts uses it both as
+          # the project name in reports (so a cross-platform merged report can
+          # distinguish these results) and to derive the platform+shard-unique
+          # blob report file name.
           PW_PROJECT_LABEL: ${{ inputs.project }}-linux
           PW_GREP: ${{ inputs.grep }}
           PW_GREP_INVERT: ${{ inputs.grep_invert }}
@@ -434,10 +436,6 @@ jobs:
           PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
           # Tells playwright.config.ts to switch to blob reporter for this shard.
           PW_SHARD: ${{ matrix.shard }}
-          # Platform+shard-unique blob file name. The default is report-<shard>.zip,
-          # which would collide across platforms (mac shard 1 vs windows shard 1)
-          # when the PR job flattens every platform's blobs into one dir to merge.
-          PLAYWRIGHT_BLOB_OUTPUT_NAME: report-${{ inputs.project }}-linux-${{ matrix.shard }}.zip
           # E2E Test Insights reporter: posts per-shard results to the dashboard.
           # CONNECT_API_KEY is empty on fork PRs; the reporter still runs but its
           # uploads fail with warnings (never fails the run).
@@ -453,7 +451,6 @@ jobs:
             ARGS+=($PW_TEST_SELECTOR)
             set +f
           fi
-          ARGS+=(--project "$PW_PROJECT_LABEL")
           if [ -n "$PW_GREP" ]; then
             ARGS+=(--grep "$PW_GREP")
           fi
@@ -463,8 +460,9 @@ jobs:
           ARGS+=(--shard="${{ matrix.shard }}/${{ strategy.job-total }}")
           # Run Playwright under our own Xvfb and exec the watchdog as the step's
           # main process, so a job cancellation's SIGTERM reaches the watchdog
-          # (which forwards it to Playwright's process tree). xvfb-run is a shell
-          # wrapper that does not forward signals
+          # (which forwards it to Playwright's process group as SIGINT -- its
+          # cancellation signal -- then escalates to SIGKILL if the run doesn't
+          # wind down). xvfb-run is a shell wrapper that does not forward signals
           # to its child, which left cancelled Linux e2e jobs running until
           # their timeout-minutes instead of stopping. -ac disables X access
           # control so Chromium connects without an auth cookie; -nolisten tcp
@@ -565,55 +563,15 @@ jobs:
             echo "::error::No blob reports found -- both shards failed to produce artifacts"
             exit 1
           fi
-          cat > merge.config.ts <<'EOF'
-          import { defineConfig } from '@playwright/test';
-          export default defineConfig({
-            reporter: [
-              ['html', { outputFolder: 'playwright-report', open: 'never' }],
-              ['json', { outputFile: 'playwright-report/test-results.json' }],
-            ],
-          });
-          EOF
           npx playwright merge-reports --config merge.config.ts ./all-blob-reports
 
+      # Shared summarizer (also used by the PR run's e2e-merge-all job) so every
+      # comment computes pass/fail counts and the rate bar from one definition.
       - name: Parse aggregated results
         id: summary
         if: always()
-        run: |
-          FILE="e2e/rstudio/playwright-report/test-results.json"
-          if [ -f "$FILE" ]; then
-            if ! PASSED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == true and (.tests[0].status // "expected") != "flaky" and (.tests[0].status // "expected") != "skipped")] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (PASSED)"; exit 1
-            fi
-            if ! FAILED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == false)] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (FAILED)"; exit 1
-            fi
-            if ! SKIPPED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "skipped")] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (SKIPPED)"; exit 1
-            fi
-            if ! FLAKY=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "flaky")] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (FLAKY)"; exit 1
-            fi
-          else
-            PASSED=0; FAILED=0; SKIPPED=0; FLAKY=0
-          fi
-          TOTAL=$((PASSED + FAILED))
-          if [ "$TOTAL" -gt 0 ]; then
-            RATE=$(( (PASSED * 100) / TOTAL ))
-            FILLED=$(( (RATE * 20) / 100 ))
-            EMPTY=$(( 20 - FILLED ))
-            BAR=""
-            [ "$FILLED" -gt 0 ] && BAR=$(printf '█%.0s' $(seq 1 $FILLED))
-            [ "$EMPTY"  -gt 0 ] && BAR="${BAR}$(printf '░%.0s' $(seq 1 $EMPTY))"
-          else
-            RATE=0; BAR="░░░░░░░░░░░░░░░░░░░░"
-          fi
-          echo "passed=$PASSED" >> "$GITHUB_OUTPUT"
-          echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
-          echo "skipped=$SKIPPED" >> "$GITHUB_OUTPUT"
-          echo "flaky=$FLAKY" >> "$GITHUB_OUTPUT"
-          echo "rate=$RATE" >> "$GITHUB_OUTPUT"
-          echo "bar=$BAR" >> "$GITHUB_OUTPUT"
+        working-directory: e2e/rstudio
+        run: node scripts/summarize-merged-report.mjs playwright-report/test-results.json
 
       - name: Upload merged Playwright report
         id: upload-report

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
@@ -540,55 +540,15 @@ jobs:
             echo "::error::No blob reports found -- both shards failed to produce artifacts"
             exit 1
           fi
-          cat > merge.config.ts <<'EOF'
-          import { defineConfig } from '@playwright/test';
-          export default defineConfig({
-            reporter: [
-              ['html', { outputFolder: 'playwright-report', open: 'never' }],
-              ['json', { outputFile: 'playwright-report/test-results.json' }],
-            ],
-          });
-          EOF
           npx playwright merge-reports --config merge.config.ts ./all-blob-reports
 
+      # Shared summarizer (also used by the PR run's e2e-merge-all job) so every
+      # comment computes pass/fail counts and the rate bar from one definition.
       - name: Parse aggregated results
         id: summary
         if: always()
-        run: |
-          FILE="e2e/rstudio/playwright-report/test-results.json"
-          if [ -f "$FILE" ]; then
-            if ! PASSED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == true and (.tests[0].status // "expected") != "flaky" and (.tests[0].status // "expected") != "skipped")] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (PASSED)"; exit 1
-            fi
-            if ! FAILED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == false)] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (FAILED)"; exit 1
-            fi
-            if ! SKIPPED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "skipped")] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (SKIPPED)"; exit 1
-            fi
-            if ! FLAKY=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "flaky")] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (FLAKY)"; exit 1
-            fi
-          else
-            PASSED=0; FAILED=0; SKIPPED=0; FLAKY=0
-          fi
-          TOTAL=$((PASSED + FAILED))
-          if [ "$TOTAL" -gt 0 ]; then
-            RATE=$(( (PASSED * 100) / TOTAL ))
-            FILLED=$(( (RATE * 20) / 100 ))
-            EMPTY=$(( 20 - FILLED ))
-            BAR=""
-            [ "$FILLED" -gt 0 ] && BAR=$(printf '█%.0s' $(seq 1 $FILLED))
-            [ "$EMPTY"  -gt 0 ] && BAR="${BAR}$(printf '░%.0s' $(seq 1 $EMPTY))"
-          else
-            RATE=0; BAR="░░░░░░░░░░░░░░░░░░░░"
-          fi
-          echo "passed=$PASSED" >> "$GITHUB_OUTPUT"
-          echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
-          echo "skipped=$SKIPPED" >> "$GITHUB_OUTPUT"
-          echo "flaky=$FLAKY" >> "$GITHUB_OUTPUT"
-          echo "rate=$RATE" >> "$GITHUB_OUTPUT"
-          echo "bar=$BAR" >> "$GITHUB_OUTPUT"
+        working-directory: e2e/rstudio
+        run: node scripts/summarize-merged-report.mjs playwright-report/test-results.json
 
       - name: Upload merged Playwright report
         id: upload-report

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -816,7 +816,7 @@ jobs:
           }
           $pwArgs += '--shard'
           $pwArgs += "$($env:PW_SHARD)/${{ strategy.job-total }}"
-          npx playwright test $pwArgs
+          node scripts/run-with-heartbeat.mjs -- test $pwArgs
 
       - name: Upload blob report
         if: always()

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -86,6 +86,10 @@ on:
       post_pr_comment:
         type: boolean
         default: false
+      defer_merge:
+        description: "Skip this workflow's own merge/publish/comment job; the caller merges every platform's blobs into one report instead."
+        type: boolean
+        default: false
     secrets:
       CONNECT_API_KEY:
         description: "Posit Connect API key for the E2E Test Insights reporter"
@@ -774,7 +778,9 @@ jobs:
         working-directory: e2e/rstudio
         env:
           PW_RSTUDIO_MODE: desktop
-          PW_PROJECT_NAME: ${{ inputs.project }}
+          # Platform-labelled project name so a cross-platform merged report can
+          # distinguish these results (see PW_PROJECT_LABEL in playwright.config.ts).
+          PW_PROJECT_LABEL: ${{ inputs.project }}-windows
           PW_GREP: ${{ inputs.grep }}
           PW_GREP_INVERT: ${{ inputs.grep_invert }}
           PW_TEST_SELECTOR: ${{ inputs.test_selector }}
@@ -783,6 +789,10 @@ jobs:
           PW_DEBUG_LAUNCH: '1'
           # Tells playwright.config.ts to switch to blob reporter for this shard.
           PW_SHARD: ${{ matrix.shard }}
+          # Platform+shard-unique blob file name. The default is report-<shard>.zip,
+          # which would collide across platforms (mac shard 1 vs windows shard 1)
+          # when the PR job flattens every platform's blobs into one dir to merge.
+          PLAYWRIGHT_BLOB_OUTPUT_NAME: report-${{ inputs.project }}-windows-${{ matrix.shard }}.zip
           # E2E Test Insights reporter: posts per-shard results to the dashboard.
           # CONNECT_API_KEY is empty on fork PRs; reporter runs but uploads fail
           # with warnings (never fails the run).
@@ -795,7 +805,7 @@ jobs:
             $pwArgs += ($env:PW_TEST_SELECTOR -split '\s+' | Where-Object { $_ -ne '' })
           }
           $pwArgs += '--project'
-          $pwArgs += $env:PW_PROJECT_NAME
+          $pwArgs += $env:PW_PROJECT_LABEL
           if (-not [string]::IsNullOrEmpty($env:PW_GREP)) {
             $pwArgs += '--grep'
             $pwArgs += $env:PW_GREP
@@ -869,7 +879,7 @@ jobs:
   # (when post_pr_comment is set).
   e2e-merge:
     needs: [e2e-desktop-windows]
-    if: always() && needs.e2e-desktop-windows.result != 'skipped' && needs.e2e-desktop-windows.result != 'cancelled'
+    if: always() && inputs.defer_merge != true && needs.e2e-desktop-windows.result != 'skipped' && needs.e2e-desktop-windows.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -778,8 +778,10 @@ jobs:
         working-directory: e2e/rstudio
         env:
           PW_RSTUDIO_MODE: desktop
-          # Platform-labelled project name so a cross-platform merged report can
-          # distinguish these results (see PW_PROJECT_LABEL in playwright.config.ts).
+          # Platform-labelled project name; playwright.config.ts uses it both as
+          # the project name in reports (so a cross-platform merged report can
+          # distinguish these results) and to derive the platform+shard-unique
+          # blob report file name.
           PW_PROJECT_LABEL: ${{ inputs.project }}-windows
           PW_GREP: ${{ inputs.grep }}
           PW_GREP_INVERT: ${{ inputs.grep_invert }}
@@ -789,10 +791,6 @@ jobs:
           PW_DEBUG_LAUNCH: '1'
           # Tells playwright.config.ts to switch to blob reporter for this shard.
           PW_SHARD: ${{ matrix.shard }}
-          # Platform+shard-unique blob file name. The default is report-<shard>.zip,
-          # which would collide across platforms (mac shard 1 vs windows shard 1)
-          # when the PR job flattens every platform's blobs into one dir to merge.
-          PLAYWRIGHT_BLOB_OUTPUT_NAME: report-${{ inputs.project }}-windows-${{ matrix.shard }}.zip
           # E2E Test Insights reporter: posts per-shard results to the dashboard.
           # CONNECT_API_KEY is empty on fork PRs; reporter runs but uploads fail
           # with warnings (never fails the run).
@@ -804,8 +802,6 @@ jobs:
           if (-not [string]::IsNullOrEmpty($env:PW_TEST_SELECTOR)) {
             $pwArgs += ($env:PW_TEST_SELECTOR -split '\s+' | Where-Object { $_ -ne '' })
           }
-          $pwArgs += '--project'
-          $pwArgs += $env:PW_PROJECT_LABEL
           if (-not [string]::IsNullOrEmpty($env:PW_GREP)) {
             $pwArgs += '--grep'
             $pwArgs += $env:PW_GREP
@@ -913,55 +909,15 @@ jobs:
             echo "::error::No blob reports found -- both shards failed to produce artifacts"
             exit 1
           fi
-          cat > merge.config.ts <<'EOF'
-          import { defineConfig } from '@playwright/test';
-          export default defineConfig({
-            reporter: [
-              ['html', { outputFolder: 'playwright-report', open: 'never' }],
-              ['json', { outputFile: 'playwright-report/test-results.json' }],
-            ],
-          });
-          EOF
           npx playwright merge-reports --config merge.config.ts ./all-blob-reports
 
+      # Shared summarizer (also used by the PR run's e2e-merge-all job) so every
+      # comment computes pass/fail counts and the rate bar from one definition.
       - name: Parse aggregated results
         id: summary
         if: always()
-        run: |
-          FILE="e2e/rstudio/playwright-report/test-results.json"
-          if [ -f "$FILE" ]; then
-            if ! PASSED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == true and (.tests[0].status // "expected") != "flaky" and (.tests[0].status // "expected") != "skipped")] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (PASSED)"; exit 1
-            fi
-            if ! FAILED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == false)] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (FAILED)"; exit 1
-            fi
-            if ! SKIPPED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "skipped")] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (SKIPPED)"; exit 1
-            fi
-            if ! FLAKY=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "flaky")] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (FLAKY)"; exit 1
-            fi
-          else
-            PASSED=0; FAILED=0; SKIPPED=0; FLAKY=0
-          fi
-          TOTAL=$((PASSED + FAILED))
-          if [ "$TOTAL" -gt 0 ]; then
-            RATE=$(( (PASSED * 100) / TOTAL ))
-            FILLED=$(( (RATE * 20) / 100 ))
-            EMPTY=$(( 20 - FILLED ))
-            BAR=""
-            [ "$FILLED" -gt 0 ] && BAR=$(printf '█%.0s' $(seq 1 $FILLED))
-            [ "$EMPTY"  -gt 0 ] && BAR="${BAR}$(printf '░%.0s' $(seq 1 $EMPTY))"
-          else
-            RATE=0; BAR="░░░░░░░░░░░░░░░░░░░░"
-          fi
-          echo "passed=$PASSED" >> "$GITHUB_OUTPUT"
-          echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
-          echo "skipped=$SKIPPED" >> "$GITHUB_OUTPUT"
-          echo "flaky=$FLAKY" >> "$GITHUB_OUTPUT"
-          echo "rate=$RATE" >> "$GITHUB_OUTPUT"
-          echo "bar=$BAR" >> "$GITHUB_OUTPUT"
+        working-directory: e2e/rstudio
+        run: node scripts/summarize-merged-report.mjs playwright-report/test-results.json
 
       - name: Upload merged Playwright report
         id: upload-report

--- a/.github/workflows/os-test-e2e-rstudio-pr.yml
+++ b/.github/workflows/os-test-e2e-rstudio-pr.yml
@@ -153,7 +153,9 @@ jobs:
       project: desktop
       r_version: "4.5.3"
       grep_invert: "@ai"
-      post_pr_comment: true
+      # Suppress each platform's own merge/publish/comment; the e2e-merge-all
+      # job below combines every platform's blobs into a single report + comment.
+      defer_merge: true
 
   macos:
     needs: detect-changes
@@ -165,7 +167,9 @@ jobs:
       project: desktop
       r_version: "4.5.3"
       grep_invert: "@ai"
-      post_pr_comment: true
+      # Suppress each platform's own merge/publish/comment; the e2e-merge-all
+      # job below combines every platform's blobs into a single report + comment.
+      defer_merge: true
 
   linux-desktop:
     needs: detect-changes
@@ -177,7 +181,9 @@ jobs:
       project: desktop
       r_version: "4.5.3"
       grep_invert: "@ai"
-      post_pr_comment: true
+      # Suppress each platform's own merge/publish/comment; the e2e-merge-all
+      # job below combines every platform's blobs into a single report + comment.
+      defer_merge: true
 
   linux-server:
     needs: detect-changes
@@ -189,4 +195,125 @@ jobs:
       project: server
       r_version: "4.5.3"
       grep_invert: "@ai"
-      post_pr_comment: true
+      # Suppress each platform's own merge/publish/comment; the e2e-merge-all
+      # job below combines every platform's blobs into a single report + comment.
+      defer_merge: true
+
+  # Combine every platform's per-shard blob reports into ONE HTML report, publish
+  # it to Connect, and post a single PR comment with a per-platform breakdown.
+  # Artifacts are shared across the whole run, so this job can read the blobs
+  # uploaded by the reusable platform workflows above. Runs even when some
+  # platforms failed (if: always) so a partial report is still produced.
+  e2e-merge-all:
+    needs: [windows, macos, linux-desktop, linux-server]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
+
+      - name: Install Playwright
+        working-directory: e2e/rstudio
+        run: npm ci --ignore-scripts
+
+      # Every platform's shards uploaded blobs named
+      # playwright-blob-report-<platform>-<shard>; pull them all into one dir.
+      # Blob file names are platform+shard unique (PLAYWRIGHT_BLOB_OUTPUT_NAME),
+      # so flattening with merge-multiple cannot clobber one platform with another.
+      - name: Download all platform blob reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: playwright-blob-report-*
+          path: e2e/rstudio/all-blob-reports
+          merge-multiple: true
+
+      - name: Merge all reports
+        working-directory: e2e/rstudio
+        run: |
+          if [ -z "$(ls -A all-blob-reports 2>/dev/null)" ]; then
+            echo "::error::No blob reports found -- every platform failed to produce artifacts"
+            exit 1
+          fi
+          cat > merge.config.ts <<'EOF'
+          import { defineConfig } from '@playwright/test';
+          export default defineConfig({
+            reporter: [
+              ['html', { outputFolder: 'playwright-report', open: 'never' }],
+              ['json', { outputFile: 'playwright-report/test-results.json' }],
+            ],
+          });
+          EOF
+          npx playwright merge-reports --config merge.config.ts ./all-blob-reports
+
+      - name: Summarize results
+        id: summary
+        if: always()
+        working-directory: e2e/rstudio
+        run: node scripts/summarize-merged-report.mjs playwright-report/test-results.json
+
+      - name: Upload merged Playwright report
+        id: upload-report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: e2e/rstudio/playwright-report/
+          retention-days: 15
+          if-no-files-found: ignore
+
+      # Publish the merged report to Connect on every PR run (pass or fail) so a
+      # browsable link is always available. Best-effort: a no-op on fork PRs
+      # (empty key) and never fails the job. The daily cleanup cron reaps it.
+      - name: Publish report to Connect
+        id: publish-report
+        if: always() && github.event.pull_request.head.repo.fork == false
+        uses: ./.github/actions/os-publish-e2e-report
+        with:
+          connect-api-key: ${{ secrets.CONNECT_API_KEY }}
+          title: "E2E RStudio (all platforms) - PR #${{ github.event.pull_request.number }} - run #${{ github.run_number }}"
+
+      - name: Post E2E results to PR
+        if: |
+          always() &&
+          github.event.pull_request.head.repo.fork == false &&
+          (steps.summary.outputs.passed != '0' || steps.summary.outputs.failed != '0' || steps.summary.outputs.skipped != '0' || steps.summary.outputs.flaky != '0')
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          header: e2e-results
+          message: |
+            ## RStudio E2E - all platforms
+
+            ${{ steps.summary.outputs.failed == '0' && '### All tests passed!' || format('### {0} test(s) failed', steps.summary.outputs.failed) }}
+
+            `${{ steps.summary.outputs.bar }}` **${{ steps.summary.outputs.rate }}%** pass rate
+
+            | Passed | Failed | Skipped | Flaky |
+            | :---: | :---: | :---: | :---: |
+            | **${{ steps.summary.outputs.passed }}** | **${{ steps.summary.outputs.failed }}** | **${{ steps.summary.outputs.skipped }}** | **${{ steps.summary.outputs.flaky }}** |
+
+            ${{ steps.summary.outputs.platform_table }}
+
+            <details>
+            <summary>View / download the full report</summary>
+            ${{ steps.publish-report.outputs.url != '' && format('
+            **[View report online]({0})** -- opens in the browser (requires Connect login). Available for up to 1 week.
+            ', steps.publish-report.outputs.url) || '' }}
+            **[Download playwright-report.zip](${{ steps.upload-report.outputs.artifact-url }})** -- extract and open `index.html`
+
+            > Includes screenshots, traces, and step-by-step details for every test. Expires in 15 days.
+
+            </details>
+
+            ---
+            <sub>All platforms - commit <code>${{ github.event.pull_request.head.sha }}</code> - <a href="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}">Run #${{ github.run_number }}</a></sub>

--- a/.github/workflows/os-test-e2e-rstudio-pr.yml
+++ b/.github/workflows/os-test-e2e-rstudio-pr.yml
@@ -203,10 +203,15 @@ jobs:
   # it to Connect, and post a single PR comment with a per-platform breakdown.
   # Artifacts are shared across the whole run, so this job can read the blobs
   # uploaded by the reusable platform workflows above. Runs even when some
-  # platforms failed (if: always) so a partial report is still produced.
+  # platforms failed, so a partial report is still produced -- but not when the
+  # run was cancelled or every platform was skipped (e.g. detect-changes
+  # failed), where there is provably nothing to merge and a red "No blob
+  # reports found" would only obscure the real upstream failure.
   e2e-merge-all:
     needs: [windows, macos, linux-desktop, linux-server]
-    if: always()
+    if: >-
+      !cancelled() &&
+      (contains(needs.*.result, 'success') || contains(needs.*.result, 'failure'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -228,8 +233,9 @@ jobs:
 
       # Every platform's shards uploaded blobs named
       # playwright-blob-report-<platform>-<shard>; pull them all into one dir.
-      # Blob file names are platform+shard unique (PLAYWRIGHT_BLOB_OUTPUT_NAME),
-      # so flattening with merge-multiple cannot clobber one platform with another.
+      # Blob file names are platform+shard unique (see the blob reporter's
+      # fileName in playwright.config.ts), so flattening with merge-multiple
+      # cannot clobber one platform with another.
       - name: Download all platform blob reports
         uses: actions/download-artifact@v4
         with:
@@ -238,21 +244,13 @@ jobs:
           merge-multiple: true
 
       - name: Merge all reports
+        id: merge
         working-directory: e2e/rstudio
         run: |
           if [ -z "$(ls -A all-blob-reports 2>/dev/null)" ]; then
             echo "::error::No blob reports found -- every platform failed to produce artifacts"
             exit 1
           fi
-          cat > merge.config.ts <<'EOF'
-          import { defineConfig } from '@playwright/test';
-          export default defineConfig({
-            reporter: [
-              ['html', { outputFolder: 'playwright-report', open: 'never' }],
-              ['json', { outputFile: 'playwright-report/test-results.json' }],
-            ],
-          });
-          EOF
           npx playwright merge-reports --config merge.config.ts ./all-blob-reports
 
       - name: Summarize results
@@ -282,11 +280,17 @@ jobs:
           connect-api-key: ${{ secrets.CONNECT_API_KEY }}
           title: "E2E RStudio (all platforms) - PR #${{ github.event.pull_request.number }} - run #${{ github.run_number }}"
 
+      # Post when there are results to report OR the merge itself did not
+      # succeed (failed, or skipped because an earlier step failed) -- otherwise
+      # a broken merge would zero out every count and silently suppress the only
+      # e2e feedback this PR run produces (the per-platform comments are
+      # suppressed via defer_merge). The all-zero-with-successful-merge case
+      # (every platform skipped) still posts nothing.
       - name: Post E2E results to PR
         if: |
           always() &&
           github.event.pull_request.head.repo.fork == false &&
-          (steps.summary.outputs.passed != '0' || steps.summary.outputs.failed != '0' || steps.summary.outputs.skipped != '0' || steps.summary.outputs.flaky != '0')
+          (steps.merge.outcome != 'success' || steps.summary.outputs.passed != '0' || steps.summary.outputs.failed != '0' || steps.summary.outputs.skipped != '0' || steps.summary.outputs.flaky != '0')
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           GITHUB_TOKEN: ${{ github.token }}
@@ -294,7 +298,7 @@ jobs:
           message: |
             ## RStudio E2E - all platforms
 
-            ${{ steps.summary.outputs.failed == '0' && '### All tests passed!' || format('### {0} test(s) failed', steps.summary.outputs.failed) }}
+            ${{ steps.merge.outcome != 'success' && ':warning: **The merged report could not be produced** -- results below are incomplete or missing; see the run log.' || steps.summary.outputs.failed == '0' && '### All tests passed!' || format('### {0} test(s) failed', steps.summary.outputs.failed) }}
 
             `${{ steps.summary.outputs.bar }}` **${{ steps.summary.outputs.rate }}%** pass rate
 
@@ -309,7 +313,7 @@ jobs:
             ${{ steps.publish-report.outputs.url != '' && format('
             **[View report online]({0})** -- opens in the browser (requires Connect login). Available for up to 1 week.
             ', steps.publish-report.outputs.url) || '' }}
-            **[Download playwright-report.zip](${{ steps.upload-report.outputs.artifact-url }})** -- extract and open `index.html`
+            ${{ steps.upload-report.outputs.artifact-url != '' && format('**[Download playwright-report.zip]({0})** -- extract and open `index.html`', steps.upload-report.outputs.artifact-url) || '_No report artifact was produced._' }}
 
             > Includes screenshots, traces, and step-by-step details for every test. Expires in 15 days.
 

--- a/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -516,8 +516,10 @@ jobs:
           PW_RSTUDIO_MODE: server
           PW_RSTUDIO_EDITION: os
           PW_RSTUDIO_SERVER_URL: http://localhost:8787
-          # Platform-labelled project name so a cross-platform merged report can
-          # distinguish these results (see PW_PROJECT_LABEL in playwright.config.ts).
+          # Platform-labelled project name; playwright.config.ts uses it both as
+          # the project name in reports (so a cross-platform merged report can
+          # distinguish these results) and to derive the platform+shard-unique
+          # blob report file name.
           PW_PROJECT_LABEL: ${{ inputs.project }}-linux
           PW_GREP: ${{ inputs.grep }}
           PW_GREP_INVERT: ${{ inputs.grep_invert }}
@@ -525,10 +527,6 @@ jobs:
           PW_TEST_IGNORE: ${{ inputs.test_ignore }}
           # Tells playwright.config.ts to switch to blob reporter for this shard.
           PW_SHARD: ${{ matrix.shard }}
-          # Platform+shard-unique blob file name. The default is report-<shard>.zip,
-          # which would collide across platforms (server shard 1 vs desktop shard 1)
-          # when the PR job flattens every platform's blobs into one dir to merge.
-          PLAYWRIGHT_BLOB_OUTPUT_NAME: report-${{ inputs.project }}-linux-${{ matrix.shard }}.zip
           # E2E Test Insights reporter: posts per-shard results to the dashboard.
           CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
           SHARD_NAME: server-ubuntu24-${{ matrix.shard }}
@@ -539,7 +537,6 @@ jobs:
             ARGS+=($PW_TEST_SELECTOR)
             set +f
           fi
-          ARGS+=(--project "$PW_PROJECT_LABEL")
           if [ -n "$PW_GREP" ]; then
             ARGS+=(--grep "$PW_GREP")
           fi
@@ -549,8 +546,9 @@ jobs:
           ARGS+=(--shard="${{ matrix.shard }}/${{ strategy.job-total }}")
           # Run Playwright under our own Xvfb and exec the watchdog as the step's
           # main process, so a job cancellation's SIGTERM reaches the watchdog
-          # (which forwards it to Playwright's process tree). xvfb-run is a shell
-          # wrapper that does not forward signals
+          # (which forwards it to Playwright's process group as SIGINT -- its
+          # cancellation signal -- then escalates to SIGKILL if the run doesn't
+          # wind down). xvfb-run is a shell wrapper that does not forward signals
           # to its child, which left cancelled Linux e2e jobs running until
           # their timeout-minutes instead of stopping. -ac disables X access
           # control so Chromium connects without an auth cookie; -nolisten tcp
@@ -687,55 +685,15 @@ jobs:
             echo "::error::No blob reports found -- both shards failed to produce artifacts"
             exit 1
           fi
-          cat > merge.config.ts <<'EOF'
-          import { defineConfig } from '@playwright/test';
-          export default defineConfig({
-            reporter: [
-              ['html', { outputFolder: 'playwright-report', open: 'never' }],
-              ['json', { outputFile: 'playwright-report/test-results.json' }],
-            ],
-          });
-          EOF
           npx playwright merge-reports --config merge.config.ts ./all-blob-reports
 
+      # Shared summarizer (also used by the PR run's e2e-merge-all job) so every
+      # comment computes pass/fail counts and the rate bar from one definition.
       - name: Parse aggregated results
         id: summary
         if: always()
-        run: |
-          FILE="e2e/rstudio/playwright-report/test-results.json"
-          if [ -f "$FILE" ]; then
-            if ! PASSED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == true and (.tests[0].status // "expected") != "flaky" and (.tests[0].status // "expected") != "skipped")] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (PASSED)"; exit 1
-            fi
-            if ! FAILED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]? | select(.ok == false)] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (FAILED)"; exit 1
-            fi
-            if ! SKIPPED=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "skipped")] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (SKIPPED)"; exit 1
-            fi
-            if ! FLAKY=$(jq '[.suites[] | recurse(.suites[]?) | .specs[]?.tests[]? | select(.status == "flaky")] | length' "$FILE"); then
-              echo "::error::Failed to parse test-results.json (FLAKY)"; exit 1
-            fi
-          else
-            PASSED=0; FAILED=0; SKIPPED=0; FLAKY=0
-          fi
-          TOTAL=$((PASSED + FAILED))
-          if [ "$TOTAL" -gt 0 ]; then
-            RATE=$(( (PASSED * 100) / TOTAL ))
-            FILLED=$(( (RATE * 20) / 100 ))
-            EMPTY=$(( 20 - FILLED ))
-            BAR=""
-            [ "$FILLED" -gt 0 ] && BAR=$(printf '█%.0s' $(seq 1 $FILLED))
-            [ "$EMPTY"  -gt 0 ] && BAR="${BAR}$(printf '░%.0s' $(seq 1 $EMPTY))"
-          else
-            RATE=0; BAR="░░░░░░░░░░░░░░░░░░░░"
-          fi
-          echo "passed=$PASSED" >> "$GITHUB_OUTPUT"
-          echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
-          echo "skipped=$SKIPPED" >> "$GITHUB_OUTPUT"
-          echo "flaky=$FLAKY" >> "$GITHUB_OUTPUT"
-          echo "rate=$RATE" >> "$GITHUB_OUTPUT"
-          echo "bar=$BAR" >> "$GITHUB_OUTPUT"
+        working-directory: e2e/rstudio
+        run: node scripts/summarize-merged-report.mjs playwright-report/test-results.json
 
       - name: Upload merged Playwright report
         id: upload-report

--- a/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -75,6 +75,10 @@ on:
       post_pr_comment:
         type: boolean
         default: false
+      defer_merge:
+        description: "Skip this workflow's own merge/publish/comment job; the caller merges every platform's blobs into one report instead."
+        type: boolean
+        default: false
     secrets:
       CONNECT_API_KEY:
         description: "Posit Connect API key for the E2E Test Insights reporter"
@@ -512,13 +516,19 @@ jobs:
           PW_RSTUDIO_MODE: server
           PW_RSTUDIO_EDITION: os
           PW_RSTUDIO_SERVER_URL: http://localhost:8787
-          PW_PROJECT_NAME: ${{ inputs.project }}
+          # Platform-labelled project name so a cross-platform merged report can
+          # distinguish these results (see PW_PROJECT_LABEL in playwright.config.ts).
+          PW_PROJECT_LABEL: ${{ inputs.project }}-linux
           PW_GREP: ${{ inputs.grep }}
           PW_GREP_INVERT: ${{ inputs.grep_invert }}
           PW_TEST_SELECTOR: ${{ inputs.test_selector }}
           PW_TEST_IGNORE: ${{ inputs.test_ignore }}
           # Tells playwright.config.ts to switch to blob reporter for this shard.
           PW_SHARD: ${{ matrix.shard }}
+          # Platform+shard-unique blob file name. The default is report-<shard>.zip,
+          # which would collide across platforms (server shard 1 vs desktop shard 1)
+          # when the PR job flattens every platform's blobs into one dir to merge.
+          PLAYWRIGHT_BLOB_OUTPUT_NAME: report-${{ inputs.project }}-linux-${{ matrix.shard }}.zip
           # E2E Test Insights reporter: posts per-shard results to the dashboard.
           CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
           SHARD_NAME: server-ubuntu24-${{ matrix.shard }}
@@ -529,7 +539,7 @@ jobs:
             ARGS+=($PW_TEST_SELECTOR)
             set +f
           fi
-          ARGS+=(--project "$PW_PROJECT_NAME")
+          ARGS+=(--project "$PW_PROJECT_LABEL")
           if [ -n "$PW_GREP" ]; then
             ARGS+=(--grep "$PW_GREP")
           fi
@@ -633,7 +643,7 @@ jobs:
   # (when post_pr_comment is set).
   e2e-merge:
     needs: [e2e-server-ubuntu]
-    if: always() && needs.e2e-server-ubuntu.result != 'skipped' && needs.e2e-server-ubuntu.result != 'cancelled'
+    if: always() && inputs.defer_merge != true && needs.e2e-server-ubuntu.result != 'skipped' && needs.e2e-server-ubuntu.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -547,9 +547,10 @@ jobs:
             ARGS+=(--grep-invert "$PW_GREP_INVERT")
           fi
           ARGS+=(--shard="${{ matrix.shard }}/${{ strategy.job-total }}")
-          # Run Playwright under our own Xvfb and exec it as the step's main
-          # process, so a job cancellation's SIGTERM reaches Playwright
-          # directly. xvfb-run is a shell wrapper that does not forward signals
+          # Run Playwright under our own Xvfb and exec the watchdog as the step's
+          # main process, so a job cancellation's SIGTERM reaches the watchdog
+          # (which forwards it to Playwright's process tree). xvfb-run is a shell
+          # wrapper that does not forward signals
           # to its child, which left cancelled Linux e2e jobs running until
           # their timeout-minutes instead of stopping. -ac disables X access
           # control so Chromium connects without an auth cookie; -nolisten tcp
@@ -568,7 +569,7 @@ jobs:
             cat /tmp/xvfb.log || true
             exit 1
           fi
-          exec npx playwright test "${ARGS[@]}"
+          exec node scripts/run-with-heartbeat.mjs -- test "${ARGS[@]}"
 
       # Platform-prefixed artifact name. When this Linux Server workflow runs
       # from the same parent PR run as the other platforms (via the combined

--- a/e2e/rstudio/merge.config.ts
+++ b/e2e/rstudio/merge.config.ts
@@ -1,0 +1,12 @@
+// Reporter configuration for `npx playwright merge-reports`, shared by the CI
+// merge jobs (each platform's e2e-merge and the PR run's e2e-merge-all) so the
+// merged-report reporter set is defined once. Not auto-discovered by
+// `playwright test` (only playwright.config.* is); always passed via --config.
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: [
+    ['html', { outputFolder: 'playwright-report', open: 'never' }],
+    ['json', { outputFile: 'playwright-report/test-results.json' }],
+  ],
+});

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -89,8 +89,11 @@ function parseProjectFromArgv(): string | undefined {
 }
 
 const argvProject = parseProjectFromArgv()?.toLowerCase();
-if (argvProject) {
+if (argvProject === 'desktop' || argvProject === 'server') {
   // --project wins over a pre-existing PW_RSTUDIO_MODE (README documents this).
+  // Only the bare mode names drive mode selection; a platform-labelled project
+  // (e.g. --project desktop-macos, see PW_PROJECT_LABEL below) must NOT clobber
+  // PW_RSTUDIO_MODE, or the modeEnv guard would reject it.
   process.env.PW_RSTUDIO_MODE = argvProject;
 }
 
@@ -98,7 +101,17 @@ const modeEnv = process.env.PW_RSTUDIO_MODE?.toLowerCase() ?? 'desktop';
 if (modeEnv !== 'desktop' && modeEnv !== 'server') {
   throw new Error(`PW_RSTUDIO_MODE="${modeEnv}" -- expected "desktop" or "server"`);
 }
-const projects = allProjects.filter(p => p.name === modeEnv);
+
+// Display label for the active project, surfaced as the project "name" in
+// reports (and matched by --project). CI passes a distinct label per platform
+// (e.g. desktop-macos, desktop-windows, server-linux) so a cross-platform
+// merged report can tell results apart -- without it every desktop platform
+// collapses under a single indistinguishable "desktop" group. Defaults to the
+// mode for local runs, so `--project desktop|server` keeps working unchanged.
+const projectLabel = process.env.PW_PROJECT_LABEL || modeEnv;
+const projects = allProjects
+  .filter(p => p.name === modeEnv)
+  .map(p => ({ ...p, name: projectLabel }));
 
 const testIgnore = (process.env.PW_TEST_IGNORE ?? '')
   .split(/\s+/)

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -89,11 +89,8 @@ function parseProjectFromArgv(): string | undefined {
 }
 
 const argvProject = parseProjectFromArgv()?.toLowerCase();
-if (argvProject === 'desktop' || argvProject === 'server') {
+if (argvProject) {
   // --project wins over a pre-existing PW_RSTUDIO_MODE (README documents this).
-  // Only the bare mode names drive mode selection; a platform-labelled project
-  // (e.g. --project desktop-macos, see PW_PROJECT_LABEL below) must NOT clobber
-  // PW_RSTUDIO_MODE, or the modeEnv guard would reject it.
   process.env.PW_RSTUDIO_MODE = argvProject;
 }
 
@@ -103,11 +100,15 @@ if (modeEnv !== 'desktop' && modeEnv !== 'server') {
 }
 
 // Display label for the active project, surfaced as the project "name" in
-// reports (and matched by --project). CI passes a distinct label per platform
-// (e.g. desktop-macos, desktop-windows, server-linux) so a cross-platform
-// merged report can tell results apart -- without it every desktop platform
-// collapses under a single indistinguishable "desktop" group. Defaults to the
-// mode for local runs, so `--project desktop|server` keeps working unchanged.
+// reports. CI sets a distinct label per platform (e.g. desktop-macos,
+// desktop-windows, server-linux) so a cross-platform merged report can tell
+// results apart -- without it every desktop platform collapses under a single
+// indistinguishable "desktop" group. The label is env-only: CI does not pass
+// --project (the config already narrows to one project), so mode selection
+// never sees the label. Defaults to the mode for local runs, so
+// `--project desktop|server` keeps working unchanged. NOTE: the E2E Test
+// Insights reporter also records this as its dashboard "project" field, so
+// per-platform labels show up there as distinct series.
 const projectLabel = process.env.PW_PROJECT_LABEL || modeEnv;
 const projects = allProjects
   .filter(p => p.name === modeEnv)
@@ -144,17 +145,24 @@ if (process.env.GITHUB_ACTIONS)
   }]);
 
 // Sharded CI runs use blob reporter so the merge job can reassemble a single
-// HTML report and accurate counts from all shards. Other human-facing reporters
-// are suppressed per-shard. 'list' is kept so the CI log shows per-test progress
-// (blob is silent during the run); this also gives the run-with-heartbeat
-// watchdog a reliable heartbeat -- a line per test -- so a hung run is detected
-// by its silence. sandbox-reporter is kept so teardown can still detect failures
-// and preserve sandbox state for artifact upload. The E2E Test Insights reporter
-// rides alongside blob so per-shard results also reach the dashboard. Without
-// CONNECT_API_KEY (e.g. fork PRs) it still runs but its uploads fail with
-// warnings (never fails the run).
+// HTML report and accurate counts from all shards. The blob file name embeds
+// the platform label and shard: the default report-<shard>.zip would collide
+// across platforms (mac shard 1 vs windows shard 1) when the PR run flattens
+// every platform's blobs into one directory to merge. Other human-facing
+// reporters are suppressed per-shard. 'list' is kept so the CI log shows
+// per-test progress (blob is silent during the run); this also gives the
+// run-with-heartbeat watchdog a reliable heartbeat -- a line per test -- so a
+// hung run is detected by its silence. sandbox-reporter is kept so teardown can
+// still detect failures and preserve sandbox state for artifact upload. The E2E
+// Test Insights reporter rides alongside blob so per-shard results also reach
+// the dashboard. Without CONNECT_API_KEY (e.g. fork PRs) it still runs but its
+// uploads fail with warnings (never fails the run).
 if (process.env.GITHUB_ACTIONS && process.env.PW_SHARD)
-  reporters.splice(0, reporters.length, ['blob'], ['list'], ['./fixtures/sandbox-reporter.ts'], ['@midleman/playwright-reporter', { mode: 'prod' }]);
+  reporters.splice(0, reporters.length,
+    ['blob', { fileName: `report-${projectLabel}-${process.env.PW_SHARD}.zip` }],
+    ['list'],
+    ['./fixtures/sandbox-reporter.ts'],
+    ['@midleman/playwright-reporter', { mode: 'prod' }]);
 
 export default defineConfig<{}, ProjectOptions>({
   testDir: './tests',

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -145,13 +145,16 @@ if (process.env.GITHUB_ACTIONS)
 
 // Sharded CI runs use blob reporter so the merge job can reassemble a single
 // HTML report and accurate counts from all shards. Other human-facing reporters
-// are suppressed per-shard. sandbox-reporter is kept so teardown can still
-// detect failures and preserve sandbox state for artifact upload. The E2E Test
-// Insights reporter rides alongside blob so per-shard results also reach the
-// dashboard. Without CONNECT_API_KEY (e.g. fork PRs) it still runs but
-// its uploads fail with warnings (never fails the run).
+// are suppressed per-shard. 'list' is kept so the CI log shows per-test progress
+// (blob is silent during the run); this also gives the run-with-heartbeat
+// watchdog a reliable heartbeat -- a line per test -- so a hung run is detected
+// by its silence. sandbox-reporter is kept so teardown can still detect failures
+// and preserve sandbox state for artifact upload. The E2E Test Insights reporter
+// rides alongside blob so per-shard results also reach the dashboard. Without
+// CONNECT_API_KEY (e.g. fork PRs) it still runs but its uploads fail with
+// warnings (never fails the run).
 if (process.env.GITHUB_ACTIONS && process.env.PW_SHARD)
-  reporters.splice(0, reporters.length, ['blob'], ['./fixtures/sandbox-reporter.ts'], ['@midleman/playwright-reporter', { mode: 'prod' }]);
+  reporters.splice(0, reporters.length, ['blob'], ['list'], ['./fixtures/sandbox-reporter.ts'], ['@midleman/playwright-reporter', { mode: 'prod' }]);
 
 export default defineConfig<{}, ProjectOptions>({
   testDir: './tests',

--- a/e2e/rstudio/scripts/run-with-heartbeat.mjs
+++ b/e2e/rstudio/scripts/run-with-heartbeat.mjs
@@ -4,15 +4,24 @@
 // further output) would otherwise idle until the job's timeout-minutes -- ~2
 // hours of a wedged runner. This wrapper streams the child's output through and
 // resets a timer on every chunk; if nothing is written for the idle window it
-// treats the run as hung, kills the whole process tree, and exits non-zero so
+// treats the run as hung, stops the whole process tree, and exits non-zero so
 // the shard fails fast. The `list` reporter (added for sharded CI in
 // playwright.config.ts) emits a line per test, which is the heartbeat this
 // relies on.
 //
+// Stops are graceful-first, mirroring runPlaywright() in dev-common.ts: forward
+// SIGINT (the only signal Playwright treats as a cancellation) so reporters and
+// globalTeardown can flush the blob report and preserve sandbox state, then
+// escalate to SIGKILL if the run doesn't wind down within the grace window.
+// A repeated signal (e.g. the runner's SIGTERM after its cancellation SIGINT)
+// escalates immediately. Windows has no SIGINT delivery to a detached tree, so
+// there we fall back to a forceful taskkill.
+//
 // Everything after `--` is forwarded to the Playwright CLI, e.g.
-//   node run-with-heartbeat.mjs -- test --project desktop-macos --shard 1/2
+//   node run-with-heartbeat.mjs -- test --shard 1/2
 //
 // Idle window: PW_HEARTBEAT_TIMEOUT_SECONDS (default 300).
+// Grace window: PW_STOP_GRACE_MS (default 30000).
 
 import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
@@ -20,6 +29,7 @@ import path from 'node:path';
 
 const IDLE_SECONDS = Number(process.env.PW_HEARTBEAT_TIMEOUT_SECONDS || '300');
 const IDLE_MS = IDLE_SECONDS * 1000;
+const STOP_GRACE_MS = Number(process.env.PW_STOP_GRACE_MS) || 30000;
 
 const separator = process.argv.indexOf('--');
 const cliArgs = separator === -1 ? [] : process.argv.slice(separator + 1);
@@ -46,22 +56,41 @@ const child = spawn(process.execPath, [cli, ...cliArgs], {
 
 let timer;
 let killedForIdle = false;
+let stopRequested = false;
 
-function killTree() {
+function signalTree(signal) {
+  if (child.pid === undefined)
+    return;
   try {
     if (isWindows)
+      // No graceful option here: taskkill without /F posts WM_CLOSE, which
+      // console processes ignore, so forceful is the only reliable tree kill.
       spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore' });
     else
-      process.kill(-child.pid, 'SIGKILL');
+      process.kill(-child.pid, signal);
   } catch {
-    // Child already exited; nothing to kill.
+    // Child / group already gone; nothing to signal.
   }
+}
+
+function stopTree() {
+  if (stopRequested) {
+    signalTree('SIGKILL');
+    return;
+  }
+  stopRequested = true;
+  signalTree('SIGINT');
+
+  // unref so this timer alone doesn't keep the watchdog alive once the child
+  // has exited gracefully.
+  const killTimer = setTimeout(() => signalTree('SIGKILL'), STOP_GRACE_MS);
+  killTimer.unref();
 }
 
 function onIdle() {
   killedForIdle = true;
   process.stderr.write(`\n::error::run-with-heartbeat: no output for ${IDLE_SECONDS}s -- treating the run as hung and terminating it.\n`);
-  killTree();
+  stopTree();
 }
 
 function resetTimer() {
@@ -75,7 +104,7 @@ child.stderr.on('data', (chunk) => { process.stderr.write(chunk); resetTimer(); 
 
 // Forward cancellation (job cancelled / timed out) to the child tree too.
 for (const signal of ['SIGINT', 'SIGTERM'])
-  process.on(signal, killTree);
+  process.on(signal, stopTree);
 
 console.log(`run-with-heartbeat: watchdog armed (idle timeout ${IDLE_SECONDS}s)`);
 resetTimer();

--- a/e2e/rstudio/scripts/run-with-heartbeat.mjs
+++ b/e2e/rstudio/scripts/run-with-heartbeat.mjs
@@ -1,0 +1,98 @@
+// Run the Playwright CLI under a no-output watchdog.
+//
+// A hung e2e run (e.g. the GWT app never reaches ready, so a test blocks with no
+// further output) would otherwise idle until the job's timeout-minutes -- ~2
+// hours of a wedged runner. This wrapper streams the child's output through and
+// resets a timer on every chunk; if nothing is written for the idle window it
+// treats the run as hung, kills the whole process tree, and exits non-zero so
+// the shard fails fast. The `list` reporter (added for sharded CI in
+// playwright.config.ts) emits a line per test, which is the heartbeat this
+// relies on.
+//
+// Everything after `--` is forwarded to the Playwright CLI, e.g.
+//   node run-with-heartbeat.mjs -- test --project desktop-macos --shard 1/2
+//
+// Idle window: PW_HEARTBEAT_TIMEOUT_SECONDS (default 300).
+
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const IDLE_SECONDS = Number(process.env.PW_HEARTBEAT_TIMEOUT_SECONDS || '300');
+const IDLE_MS = IDLE_SECONDS * 1000;
+
+const separator = process.argv.indexOf('--');
+const cliArgs = separator === -1 ? [] : process.argv.slice(separator + 1);
+if (cliArgs.length === 0) {
+  console.error('run-with-heartbeat: no Playwright CLI args given after --');
+  process.exit(2);
+}
+
+// Resolve the Playwright CLI (the same entry `npx playwright` runs) and invoke it
+// with the current node binary. Spawning node directly with an argv array -- no
+// shell -- keeps argument quoting identical across bash and PowerShell callers.
+const require = createRequire(import.meta.url);
+const cli = path.join(path.dirname(require.resolve('playwright/package.json')), 'cli.js');
+
+const isWindows = process.platform === 'win32';
+
+// On POSIX, put the child in its own process group so we can signal the entire
+// tree (Playwright's workers plus the RStudio/Electron process it launches). On
+// Windows we tear the tree down with `taskkill /T` instead.
+const child = spawn(process.execPath, [cli, ...cliArgs], {
+  stdio: ['ignore', 'pipe', 'pipe'],
+  detached: !isWindows,
+});
+
+let timer;
+let killedForIdle = false;
+
+function killTree() {
+  try {
+    if (isWindows)
+      spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore' });
+    else
+      process.kill(-child.pid, 'SIGKILL');
+  } catch {
+    // Child already exited; nothing to kill.
+  }
+}
+
+function onIdle() {
+  killedForIdle = true;
+  process.stderr.write(`\n::error::run-with-heartbeat: no output for ${IDLE_SECONDS}s -- treating the run as hung and terminating it.\n`);
+  killTree();
+}
+
+function resetTimer() {
+  if (timer)
+    clearTimeout(timer);
+  timer = setTimeout(onIdle, IDLE_MS);
+}
+
+child.stdout.on('data', (chunk) => { process.stdout.write(chunk); resetTimer(); });
+child.stderr.on('data', (chunk) => { process.stderr.write(chunk); resetTimer(); });
+
+// Forward cancellation (job cancelled / timed out) to the child tree too.
+for (const signal of ['SIGINT', 'SIGTERM'])
+  process.on(signal, killTree);
+
+console.log(`run-with-heartbeat: watchdog armed (idle timeout ${IDLE_SECONDS}s)`);
+resetTimer();
+
+child.on('error', (err) => {
+  if (timer)
+    clearTimeout(timer);
+  console.error(`run-with-heartbeat: failed to start Playwright: ${err.message}`);
+  process.exit(1);
+});
+
+child.on('exit', (code, signal) => {
+  if (timer)
+    clearTimeout(timer);
+  if (killedForIdle)
+    process.exit(124); // conventional timeout exit code
+  if (signal)
+    process.exit(1);
+  process.exit(code ?? 1);
+});

--- a/e2e/rstudio/scripts/summarize-merged-report.mjs
+++ b/e2e/rstudio/scripts/summarize-merged-report.mjs
@@ -1,8 +1,9 @@
-// Summarize a merged Playwright JSON report for the unified PR comment.
+// Summarize a merged Playwright JSON report for the CI PR comments.
 //
-// The PR e2e run merges every platform's blob reports into one HTML report
-// (see os-test-e2e-rstudio-pr.yml). This script reads the companion
-// test-results.json and emits, to $GITHUB_OUTPUT:
+// Used by both the per-platform e2e-merge jobs (scheduled/standalone runs) and
+// the PR run's unified e2e-merge-all job (see os-test-e2e-rstudio-pr.yml), so
+// every comment computes its counts from one definition. This script reads the
+// merged report's companion test-results.json and emits, to $GITHUB_OUTPUT:
 //
 //   passed / failed / skipped / flaky  -- overall test counts
 //   rate / bar                         -- overall pass-rate percent and a bar
@@ -46,10 +47,14 @@ for (const suite of data.suites ?? [])
 function tally(list) {
   const counts = { passed: 0, failed: 0, flaky: 0, skipped: 0 };
   for (const test of list) {
-    if (test.status === 'expected')        counts.passed++;
-    else if (test.status === 'unexpected') counts.failed++;
-    else if (test.status === 'flaky')      counts.flaky++;
-    else if (test.status === 'skipped')    counts.skipped++;
+    if (test.status === 'expected')
+      counts.passed++;
+    else if (test.status === 'unexpected')
+      counts.failed++;
+    else if (test.status === 'flaky')
+      counts.flaky++;
+    else if (test.status === 'skipped')
+      counts.skipped++;
   }
   return counts;
 }
@@ -77,12 +82,11 @@ const table = [
   ...(rows.length > 0 ? rows : ['| _no results_ | 0 | 0 | 0 | 0 |']),
 ].join('\n');
 
-// Pass rate over decided tests only (passed + failed), matching the per-platform
-// jobs' definition, rendered as a 20-cell bar.
+// Pass rate over decided tests only (passed + failed), rendered as a 20-cell bar.
 const decided = overall.passed + overall.failed;
 const rate = decided > 0 ? Math.floor((overall.passed * 100) / decided) : 0;
 const filled = Math.floor((rate * 20) / 100);
-const bar = '█'.repeat(filled) + '░'.repeat(20 - filled);
+const bar = '#'.repeat(filled) + '-'.repeat(20 - filled);
 
 function setOutput(name, value) {
   const delimiter = `__EOF_${name}__`;

--- a/e2e/rstudio/scripts/summarize-merged-report.mjs
+++ b/e2e/rstudio/scripts/summarize-merged-report.mjs
@@ -1,0 +1,104 @@
+// Summarize a merged Playwright JSON report for the unified PR comment.
+//
+// The PR e2e run merges every platform's blob reports into one HTML report
+// (see os-test-e2e-rstudio-pr.yml). This script reads the companion
+// test-results.json and emits, to $GITHUB_OUTPUT:
+//
+//   passed / failed / skipped / flaky  -- overall test counts
+//   rate / bar                         -- overall pass-rate percent and a bar
+//   platform_table                     -- a markdown table with one row per
+//                                         platform (Playwright "project"), so a
+//                                         single comment shows which OS failed
+//
+// Platforms are distinguished by the per-platform project label set via
+// PW_PROJECT_LABEL in each platform workflow (e.g. desktop-macos, server-linux).
+//
+// Usage: node summarize-merged-report.mjs <path-to-test-results.json>
+
+import fs from 'node:fs';
+
+const file = process.argv[2];
+const outFile = process.env.GITHUB_OUTPUT;
+
+let data;
+try {
+  data = JSON.parse(fs.readFileSync(file, 'utf8'));
+} catch {
+  // No parseable report (e.g. every platform failed to produce a blob). Fall
+  // back to an empty result so the caller still renders a comment noting it.
+  data = { suites: [] };
+}
+
+// Collect every test result across all (possibly nested) suites and specs.
+const tests = [];
+function walk(suite) {
+  for (const spec of suite.specs ?? []) {
+    for (const test of spec.tests ?? [])
+      tests.push(test);
+  }
+  for (const child of suite.suites ?? [])
+    walk(child);
+}
+for (const suite of data.suites ?? [])
+  walk(suite);
+
+// Map Playwright's per-test outcome to the four buckets the comment reports.
+function tally(list) {
+  const counts = { passed: 0, failed: 0, flaky: 0, skipped: 0 };
+  for (const test of list) {
+    if (test.status === 'expected')        counts.passed++;
+    else if (test.status === 'unexpected') counts.failed++;
+    else if (test.status === 'flaky')      counts.flaky++;
+    else if (test.status === 'skipped')    counts.skipped++;
+  }
+  return counts;
+}
+
+const overall = tally(tests);
+
+// Per-project (= per-platform) breakdown, one row per distinct project label.
+const byProject = new Map();
+for (const test of tests) {
+  const key = test.projectName || 'unknown';
+  if (!byProject.has(key))
+    byProject.set(key, []);
+  byProject.get(key).push(test);
+}
+
+const rows = [...byProject.keys()].sort().map((name) => {
+  const c = tally(byProject.get(name));
+  const status = c.failed > 0 ? ':x:' : ':white_check_mark:';
+  return `| ${status} \`${name}\` | ${c.passed} | ${c.failed} | ${c.skipped} | ${c.flaky} |`;
+});
+
+const table = [
+  '| Platform | :white_check_mark: Passed | :x: Failed | :warning: Skipped | :repeat: Flaky |',
+  '| :--- | :---: | :---: | :---: | :---: |',
+  ...(rows.length > 0 ? rows : ['| _no results_ | 0 | 0 | 0 | 0 |']),
+].join('\n');
+
+// Pass rate over decided tests only (passed + failed), matching the per-platform
+// jobs' definition, rendered as a 20-cell bar.
+const decided = overall.passed + overall.failed;
+const rate = decided > 0 ? Math.floor((overall.passed * 100) / decided) : 0;
+const filled = Math.floor((rate * 20) / 100);
+const bar = '█'.repeat(filled) + '░'.repeat(20 - filled);
+
+function setOutput(name, value) {
+  const delimiter = `__EOF_${name}__`;
+  const line = `${name}<<${delimiter}\n${value}\n${delimiter}\n`;
+  if (outFile)
+    fs.appendFileSync(outFile, line);
+}
+
+setOutput('passed', String(overall.passed));
+setOutput('failed', String(overall.failed));
+setOutput('skipped', String(overall.skipped));
+setOutput('flaky', String(overall.flaky));
+setOutput('rate', String(rate));
+setOutput('bar', bar);
+setOutput('platform_table', table);
+
+// Echo to the step log for debugging when the comment looks wrong.
+console.log(`Overall: passed=${overall.passed} failed=${overall.failed} skipped=${overall.skipped} flaky=${overall.flaky} rate=${rate}%`);
+console.log(table);


### PR DESCRIPTION
## Summary

Follow-up to #18112. On PR-triggered e2e runs, this replaces the four separate
per-platform Playwright reports/comments with a **single unified report** that
covers every platform (Windows Desktop, macOS Desktop, Linux Desktop, Linux
Server), and publishes that one report to Posit Connect so reviewers can browse
it online.

## What this does

- **Per-platform project labels**: each platform records its results under a
  distinct Playwright project name (`desktop-macos`, `desktop-windows`,
  `desktop-linux`, `server-linux`) via a new `PW_PROJECT_LABEL` env, so the
  merged report can tell which OS a result came from instead of collapsing every
  desktop platform under one indistinguishable `desktop` group.
  `playwright.config.ts` defaults the label to the mode, so local
  `--project=desktop|server` is unchanged.
- **Collision-safe blob names**: shards write `report-<platform>-<shard>.zip`
  (via `PLAYWRIGHT_BLOB_OUTPUT_NAME`) instead of the default `report-<shard>.zip`,
  which would otherwise clash across platforms when flattened into one directory
  (Playwright's `merge-reports` scans only the top level of the given dir).
- **`defer_merge` input**: each reusable platform workflow gains a `defer_merge`
  input (default `false`). The PR orchestrator sets it `true`, suppressing each
  platform's own merge/publish/comment job.
- **New `e2e-merge-all` job** in `os-test-e2e-rstudio-pr.yml`: downloads every
  platform's blob artifacts (shared across the run), merges them into one HTML
  report, **always** publishes it to Connect via the `os-publish-e2e-report`
  action, and posts a single sticky PR comment with an overall pass-rate plus a
  per-platform breakdown table. A small committed Node script
  (`e2e/rstudio/scripts/summarize-merged-report.mjs`) parses the merged JSON.

Scheduled/standalone platform runs are unchanged -- they don't set `defer_merge`,
so each still produces its own report (they can't cross-merge anyway, being
separate runs).

## Needs live validation

Like #18112, the cross-workflow artifact sharing and the Connect publish path
can only be fully exercised by a real CI run. A run should confirm that the
`e2e-merge-all` job can read blobs uploaded by the reusable platform workflows,
and that the single comment/report render as intended.

Developer/CI tooling change -- no user-facing NEWS entry.

## Review follow-up (second commit)

- **Graceful stop in the watchdog**: `run-with-heartbeat.mjs` now forwards
  SIGINT (Playwright's cancellation signal) and escalates to SIGKILL after a
  grace window (`PW_STOP_GRACE_MS`, default 30s), mirroring `dev-common.ts`,
  instead of SIGKILLing the process tree -- so a cancelled or hung shard can
  still flush its blob report and run teardown.
- **`e2e-merge-all` guards**: the job now skips when the run is cancelled or
  every platform job was skipped (nothing to merge), and the unified comment is
  posted with a warning header when the merge itself fails, instead of being
  silently suppressed by all-zero counts.
- **Blob names derived in config**: `playwright.config.ts` computes the
  platform+shard-unique blob file name from `PW_PROJECT_LABEL` + `PW_SHARD`;
  the `PLAYWRIGHT_BLOB_OUTPUT_NAME` env and the redundant `--project` label
  args are gone (which also restores the loud unknown-mode validation for
  `--project` typos).
- **One summarizer + one merge config**: all merge jobs (per-platform and
  unified) now call `scripts/summarize-merged-report.mjs` and use a committed
  `e2e/rstudio/merge.config.ts`, replacing the inline jq blocks and the
  per-workflow heredocs.

**Heads-up, E2E Test Insights dashboard**: the per-platform project labels also
flow into the dashboard's `project` field (the reporter records the live
Playwright project name), so results now arrive as `desktop-macos`,
`desktop-windows`, `desktop-linux`, and `server-linux` instead of a single
`desktop`/`server`. Dashboard views keyed on the old names will need updating.
