### PR TITLE
Migrate citation tests from Selenium to Playwright

### DIFF
--- a/.claude/skills/rstudio-create-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-create-playwright-tests/SKILL.md
@@ -72,3 +72,5 @@ When working in these areas, also read the corresponding file:
   `edit_suggestions.test.ts`): see `code-suggestions.md`.
 - **Chat pane / Posit Assistant / RPC interception**
   (`tests/panes/posit-assistant-chat/`): see `chat-pane.md`.
+- **Visual editor / citations** (`tests/panes/editor/citations.test.ts`, and any
+  test that drives the panmirror visual editor): see `visual-editor.md`.

--- a/.claude/skills/rstudio-create-playwright-tests/visual-editor.md
+++ b/.claude/skills/rstudio-create-playwright-tests/visual-editor.md
@@ -1,0 +1,90 @@
+# Visual editor (panmirror) patterns
+
+Read this when driving the visual (WYSIWYG) markdown editor -- the Insert
+Citation dialog, format/insert menus, etc. panmirror is a React app; its source
+lives in the Quarto repo (`packages/editor/src/behaviors/...`), not in this repo.
+
+## Entering visual mode
+
+Citations and the Insert menu exist only in visual mode. Use
+`SourcePaneActions.ensureVisualMode()`; it handles the first-switch
+pandoc-conversion confirmation dialog. Plain `newMarkdownDoc` is the cheapest
+host (no `rmarkdown` package, no Quarto new-doc wizard).
+
+## panmirror renders outside the GWT dialog
+
+panmirror UI (e.g. the Insert Citation panel) renders in a React root that is a
+sibling of the GWT `[role="dialog"]` shell, not inside it. Scope selectors to
+`page` -- a dialog-scoped `locator('button')` or `outerHTML` dump misses the
+real controls.
+
+## Insert Citation dialog
+
+Open it in visual mode:
+
+```typescript
+await page.locator('[aria-label="Insert"]').click();
+await page.locator('#rstudio_label_citation_command').click();
+await page.locator('[role="dialog"][aria-label="Insert Citation"]')
+  .waitFor({ state: 'visible', timeout: 15000 });
+```
+
+**Select a source by clicking the node row, not the icon:**
+`.pm-navigation-tree-node` containing the source's `img[alt='<Source>']`.
+Clicking the img or its wrapper only moves the highlight. The tree is
+react-window virtualized (it scrolls on selection), so don't rapid-fire clicks
+at it.
+
+**Highlight != selected.** `pm-selected-navigation-tree-item` moving to a source
+does not mean its panel is active. Verify true selection by the source's own
+search box (placeholder e.g. `Search DataCite for Citations`) or its Search
+button becoming visible -- never by the highlight class.
+
+**Survive the one-time init reset.** When the dialog's bibliography load
+resolves, panmirror runs a single `setSelectedPanelProvider` that snaps the
+active panel back to the default source (My Sources) while leaving the tree
+highlight where you put it. It fires at most once. So select, and re-select if
+the panel reverts -- the second selection lands after the reset and is
+permanent:
+
+```typescript
+const node = page.locator('.pm-navigation-tree-node', { has: page.locator("[alt='DataCite']") });
+const box = page.getByPlaceholder('Search DataCite for Citations');
+await node.click();
+await expect(box).toBeVisible({ timeout: 15000 });
+const deadline = Date.now() + 6000;
+while (Date.now() < deadline) {
+  if (!(await box.isVisible().catch(() => false))) {
+    await node.click();               // reverted; re-select (now permanent)
+    await expect(box).toBeVisible({ timeout: 15000 });
+    break;
+  }
+  await page.waitForTimeout(200);
+}
+```
+
+## Latent search (external sources: DataCite, Crossref, DOI, PubMed)
+
+Typing does not search -- it only updates the term. The search fires on Enter,
+paste, or the Search button (`button.pm-insert-citation-panel-latent-search-button`),
+which is present whenever the source panel is active and disabled only while a
+search is running. Type, then click the button:
+
+```typescript
+await box.pressSequentially('bobolink');   // real keystrokes, not fill()
+await page.locator('button.pm-insert-citation-panel-latent-search-button').click();
+const results = page.locator("[class*='citation-source-panel-item-detailed']");
+await expect.poll(() => results.count(), { timeout: 30000 }).toBeGreaterThan(0);
+```
+
+Use `pressSequentially`, not `fill()`: `fill()` sets the DOM value but does not
+reliably fire React's controlled-input `onChange`, so the term can stay empty
+and Enter/the button do nothing even though the box visibly shows the text.
+
+## Search RPCs are async
+
+`datacite_search`, `crossref_works`, `pubmed_search`, and `doi_fetch_csl` are
+async RPCs: the POST returns only `{asyncHandle}`, and the results arrive later
+via `/events/get_events` as an `async_completion` event keyed by that handle.
+The service HTTP request is made server-side (rsession), so it is not reachable
+at the API boundary from Playwright -- only the browser<->rsession RPC seam is.

--- a/.claude/skills/rstudio-create-playwright-tests/visual-editor.md
+++ b/.claude/skills/rstudio-create-playwright-tests/visual-editor.md
@@ -41,8 +41,9 @@ search box (placeholder e.g. `Search DataCite for Citations`) or its Search
 button becoming visible -- never by the highlight class.
 
 **Survive the one-time init reset.** When the dialog's bibliography load
-resolves, panmirror runs a single `setSelectedPanelProvider` that snaps the
-active panel back to the default source (My Sources) while leaving the tree
+resolves, the post-load configuration poll fires once and calls
+`setSelectedPanelProvider`, snapping the active panel back to the dialog's
+initially-selected node (My Sources on a fresh open) while leaving the tree
 highlight where you put it. It fires at most once. So select, and re-select if
 the panel reverts -- the second selection lands after the reset and is
 permanent:
@@ -73,7 +74,7 @@ search is running. Type, then click the button:
 ```typescript
 await box.pressSequentially('bobolink');   // real keystrokes, not fill()
 await page.locator('button.pm-insert-citation-panel-latent-search-button').click();
-const results = page.locator("[class*='citation-source-panel-item-detailed']");
+const results = page.locator('.pm-insert-citation-source-panel-item-detailed');
 await expect.poll(() => results.count(), { timeout: 30000 }).toBeGreaterThan(0);
 ```
 

--- a/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
+++ b/e2e/rstudio/docs/MIGRATION_FROM_SELENIUM_PROGRESS.md
@@ -9,7 +9,7 @@ Target: `e2e/rstudio/tests/`
 |--------|-------|
 | Total electron test files | 32 |
 | Total electron test methods | 115 |
-| Files fully converted | 31 |
+| Files fully converted | 32 |
 | Files partially converted | 0 |
 | Files not started | 5 |
 
@@ -19,7 +19,7 @@ Target: `e2e/rstudio/tests/`
 
 | Electron Source | Methods | Playwright Target | Status | Notes |
 |----------------|---------|-------------------|--------|-------|
-| test_desktop_Citations.py | 17 | panes/editor/citations.test.ts (to be scrapped) | Failed miserably (restart from scratch) | First attempt failed miserably: only 6 of 18 tests passing, a mid-session refactor regressed a 9-passing state, and Quarto never reaches visual mode. Scrapping the file and redoing the migration from scratch. |
+| test_desktop_Citations.py | 17 | panes/editor/citations.test.ts (11) | Complete | Restarted from scratch. The 17 Selenium methods are collapsed into 11 representative tests (per-source and per-format delete/blank/dont-escape duplicates folded): DOI insert (markdown + Quarto), R Package insert, delete a staged citation, no-duplicate dedup with a references.bib single-entry check, blank-insert dialog dismissal, non-escaping visual round-trip (.md + .qmd), and keyword search for Crossref/DataCite/PubMed. Insert tests also assert references.bib content (key, entry type, title, DOI, and no author field). All against live services. R Package delete is not ported (delete is source-agnostic, covered by the DOI delete; package staging is covered by the R Package insert). |
 | test_desktop_Command_Palette.py | 2 | panes/misc/command_palette.test.ts (2) | Complete | Open/filter/run (Escape closes; "script" keeps R + SQL script, drops text file; Enter runs the front-loaded New R Script), and the inline native-pipe pref toggle (verified by inserting "\|>"). Both cross-mode. |
 | test_desktop_console.py | 11 | panes/console/console_pane.test.ts (8), panes/console/console_command_effects.test.ts (7), panes/console/execute_from_editor.test.ts (1) | Complete | Split by theme; added Find in Console coverage (3 new tests) and upgraded `help.start()` to verify help-pane contents |
 | test_desktop_EnvironmentPane.py | 5 | panes/environment/environment_pane.test.ts (5) | Complete | Toolbar elements, the import-dataset/object-view/environment-list dropdowns, and memory-pie growth + usage-report modal. No Desktop-only assumptions; the Selenium maximize/restore workaround was dropped. |

--- a/e2e/rstudio/pages/insert_citation.page.ts
+++ b/e2e/rstudio/pages/insert_citation.page.ts
@@ -33,6 +33,8 @@ export const CITATION_SOURCES = {
 export class InsertCitationDialog extends PageObject {
   public readonly dialog: Locator;
   public readonly results: Locator;
+  /** Result rows in the R Package (typeahead) source's list. */
+  public readonly packageResults: Locator;
   public readonly searchButton: Locator;
   public readonly insertButton: Locator;
   public readonly cancelButton: Locator;
@@ -43,6 +45,7 @@ export class InsertCitationDialog extends PageObject {
     super(page);
     this.dialog = page.locator('[role="dialog"][aria-label="Insert Citation"]');
     this.results = page.locator('.pm-insert-citation-source-panel-item-detailed');
+    this.packageResults = page.locator('.pm-insert-citation-source-panel-item');
     this.searchButton = page.locator('button.pm-insert-citation-panel-latent-search-button');
     this.insertButton = this.dialog.getByRole('button', { name: 'Insert', exact: true });
     this.cancelButton = this.dialog.getByRole('button', { name: 'Cancel', exact: true });
@@ -80,6 +83,39 @@ export class InsertCitationDialog extends PageObject {
       await this.page.waitForTimeout(200);
     }
     return searchBox;
+  }
+
+  /**
+   * Select the R Package source and filter to a package by name, returning its
+   * result row. R Package is a typeahead panel (filters live, no Search button)
+   * and its placeholder is shared with My Sources, so the init reset can't be
+   * detected via the search box the way selectSource() does. Instead we watch
+   * for the package's own result row and re-select if it vanishes -- the reset
+   * reverts the panel to My Sources, which has no such package row.
+   */
+  async selectPackageSource(packageName: string): Promise<Locator> {
+    const node = this.page.locator('.pm-navigation-tree-node', {
+      has: this.page.locator("[alt='R Package']"),
+    });
+    const box = this.page.getByPlaceholder('Search for citation');
+    const match = this.packageResults.filter({ hasText: `@${packageName}` }).first();
+
+    const selectAndFilter = async (): Promise<void> => {
+      await node.click();
+      await box.pressSequentially(packageName); // typeahead filters on each keystroke
+      await expect(match).toBeVisible({ timeout: 15000 });
+    };
+
+    await selectAndFilter();
+    const revertDeadline = Date.now() + 6000;
+    while (Date.now() < revertDeadline) {
+      if (!(await match.isVisible().catch(() => false))) {
+        await selectAndFilter(); // reverted to My Sources; re-select (now permanent)
+        break;
+      }
+      await this.page.waitForTimeout(200);
+    }
+    return match;
   }
 
   /**

--- a/e2e/rstudio/pages/insert_citation.page.ts
+++ b/e2e/rstudio/pages/insert_citation.page.ts
@@ -62,8 +62,9 @@ export class InsertCitationDialog extends PageObject {
   /**
    * Select a network source and return its latent-search box, surviving the
    * dialog's one-time init reset: when the bibliography load resolves, panmirror
-   * snaps the active panel back to My Sources exactly once, leaving the tree
-   * highlight where we put it. Re-select if that happens -- the second selection
+   * snaps the active panel back to the dialog's initially-selected node (My
+   * Sources on a fresh open) exactly once, leaving the tree highlight where we
+   * put it. Re-select if that happens -- the second selection
    * lands after the reset and is permanent.
    */
   async selectSource(source: CitationSource): Promise<Locator> {

--- a/e2e/rstudio/pages/insert_citation.page.ts
+++ b/e2e/rstudio/pages/insert_citation.page.ts
@@ -1,0 +1,129 @@
+import type { Page, Locator } from 'playwright';
+import { expect } from '@playwright/test';
+import { PageObject } from './page_object_base_classes';
+
+/** A network-backed citation source in the Insert Citation dialog. */
+export interface CitationSource {
+  /** Navigation-tree image alt text, e.g. 'DataCite'. */
+  alt: string;
+  /** Latent-search input placeholder, e.g. 'Search DataCite for Citations'. */
+  placeholder: string;
+}
+
+/**
+ * The network-backed sources, in the dialog's tree order (top to bottom). All
+ * four render the same latent-search panel (confirmed in the Quarto editor
+ * source); only the tree label and placeholder differ.
+ */
+export const CITATION_SOURCES = {
+  doi: { alt: 'From DOI', placeholder: 'Paste a DOI to search' },
+  crossref: { alt: 'Crossref', placeholder: 'Search Crossref for Citations' },
+  datacite: { alt: 'DataCite', placeholder: 'Search DataCite for Citations' },
+  pubmed: { alt: 'PubMed', placeholder: 'Search PubMed for Citations' },
+} satisfies Record<string, CitationSource>;
+
+/**
+ * The panmirror Insert Citation dialog (visual editor only).
+ *
+ * The dialog's React UI renders in a root that is a sibling of the GWT dialog
+ * shell, so the tree, search box, and results are page-scoped, not dialog-scoped
+ * (see visual-editor.md). Only the GWT footer buttons (Insert / Cancel) live
+ * inside [role="dialog"].
+ */
+export class InsertCitationDialog extends PageObject {
+  public readonly dialog: Locator;
+  public readonly results: Locator;
+  public readonly searchButton: Locator;
+  public readonly insertButton: Locator;
+  public readonly cancelButton: Locator;
+  /** Staged citations, shown as tag chips at the bottom of the dialog. */
+  public readonly stagedCitations: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.dialog = page.locator('[role="dialog"][aria-label="Insert Citation"]');
+    this.results = page.locator('.pm-insert-citation-source-panel-item-detailed');
+    this.searchButton = page.locator('button.pm-insert-citation-panel-latent-search-button');
+    this.insertButton = this.dialog.getByRole('button', { name: 'Insert', exact: true });
+    this.cancelButton = this.dialog.getByRole('button', { name: 'Cancel', exact: true });
+    this.stagedCitations = page.locator('.pm-tag-input-tag');
+  }
+
+  /** Open Insert > Citation from the visual editor's Insert menu. */
+  async open(): Promise<void> {
+    await this.page.locator('[aria-label="Insert"]').click();
+    await this.page.locator('#rstudio_label_citation_command').click();
+    await this.dialog.waitFor({ state: 'visible', timeout: 15000 });
+  }
+
+  /**
+   * Select a network source and return its latent-search box, surviving the
+   * dialog's one-time init reset: when the bibliography load resolves, panmirror
+   * snaps the active panel back to My Sources exactly once, leaving the tree
+   * highlight where we put it. Re-select if that happens -- the second selection
+   * lands after the reset and is permanent.
+   */
+  async selectSource(source: CitationSource): Promise<Locator> {
+    const node = this.page.locator('.pm-navigation-tree-node', {
+      has: this.page.locator(`[alt='${source.alt}']`),
+    });
+    const searchBox = this.page.getByPlaceholder(source.placeholder);
+    await node.click();
+    await expect(searchBox).toBeVisible({ timeout: 15000 });
+    const revertDeadline = Date.now() + 6000;
+    while (Date.now() < revertDeadline) {
+      if (!(await searchBox.isVisible().catch(() => false))) {
+        await node.click(); // reverted; re-select (now permanent)
+        await expect(searchBox).toBeVisible({ timeout: 15000 });
+        break;
+      }
+      await this.page.waitForTimeout(200);
+    }
+    return searchBox;
+  }
+
+  /**
+   * Type a term with real keystrokes (so React's controlled-input onChange
+   * fires -- fill() doesn't) and run the search via the Search button. Latent
+   * search does not fire on typing alone.
+   */
+  async search(searchBox: Locator, term: string): Promise<void> {
+    await searchBox.pressSequentially(term);
+    await this.searchButton.click();
+  }
+
+  /** Wait for results and stage the first one via its "+" button. */
+  async stageFirstResult(): Promise<void> {
+    const first = this.results.first();
+    await expect(first).toBeVisible({ timeout: 30000 });
+    await first.locator('button').click();
+  }
+
+  /** Remove the first staged citation via its delete icon. */
+  async deleteStagedCitation(): Promise<void> {
+    await this.stagedCitations.first().locator('.pm-tag-input-delete-image').click();
+  }
+
+  /**
+   * Visible text of the first `limit` currently-rendered result rows. The list
+   * is react-window virtualized, so this reflects the rendered window rather
+   * than every hit -- fine for inspecting the leading results.
+   */
+  async resultTexts(limit: number): Promise<string[]> {
+    return this.results.evaluateAll(
+      (els, n) => els.slice(0, n).map((el) => el.textContent ?? ''),
+      limit,
+    );
+  }
+
+  /** Click Insert to add the staged citations to the document. */
+  async insert(): Promise<void> {
+    await this.insertButton.click();
+  }
+
+  /** Close the dialog without inserting. */
+  async cancel(): Promise<void> {
+    await this.cancelButton.click();
+    await expect(this.dialog).toBeHidden({ timeout: 5000 });
+  }
+}

--- a/e2e/rstudio/tests/panes/editor/citations.test.ts
+++ b/e2e/rstudio/tests/panes/editor/citations.test.ts
@@ -1,0 +1,107 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { SourcePaneActions } from '@actions/source_pane.actions';
+import { InsertCitationDialog, CITATION_SOURCES } from '@pages/insert_citation.page';
+import { installDepIfPrompted } from '@pages/modals.page';
+import { useSuiteSandbox } from '@utils/sandbox';
+import { executeCommand } from '@utils/commands';
+import type { Page } from 'playwright';
+
+// Migrated from Selenium test_desktop_Citations.py. Citations live in the
+// panmirror visual editor's Insert menu; see the InsertCitationDialog page
+// object and visual-editor.md for the dialog's selectors and the one-time init
+// reset these tests work around.
+test.describe('Citations', () => {
+  // Inserting a citation writes references.bib to the working directory;
+  // useSuiteSandbox() redirects cwd into the per-run sandbox so nothing lands
+  // in the repo tree or home dir. The globalTeardown removes it.
+  useSuiteSandbox();
+
+  let consoleActions: ConsolePaneActions;
+  let sourceActions: SourcePaneActions;
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+    sourceActions = new SourcePaneActions(page, consoleActions);
+  });
+
+  // Each test starts from a single clean Untitled tab; resetToUntitled reverts
+  // the previous test's dirty doc without a save prompt.
+  test.beforeEach(async () => {
+    await consoleActions.resetSourcePane();
+  });
+
+  // Open a fresh markdown document in visual mode (the only place citations are
+  // reachable). Plain markdown is the cheapest host -- no rmarkdown package, no
+  // Quarto new-doc wizard.
+  async function newMarkdownVisualDoc(page: Page): Promise<void> {
+    await executeCommand(page, 'newMarkdownDoc');
+    await installDepIfPrompted(page);
+    await expect(sourceActions.sourcePane.selectedTab).toContainText('Untitled', { timeout: 20000 });
+    await sourceActions.ensureVisualMode();
+  }
+
+  test('inserts an authorless DOI citation into a markdown visual editor', async ({ rstudioPage: page }) => {
+    await newMarkdownVisualDoc(page);
+
+    const citation = new InsertCitationDialog(page);
+    await citation.open();
+    const searchBox = await citation.selectSource(CITATION_SOURCES.doi);
+
+    // A DOI resolves to exactly one work via a real service call (no intercept).
+    await citation.search(searchBox, '10.3133/93888');
+    await citation.stageFirstResult();
+    await citation.insert();
+
+    // The citation lands in the document. With no author, panmirror derives the
+    // key from the title ("Effects of management practices on grassland birds:
+    // Bobolink", 1999) -> effects1999.
+    await expect(page.locator('.ProseMirror')).toContainText('[@effects1999]', { timeout: 15000 });
+  });
+
+  test('deletes a staged citation', async ({ rstudioPage: page }) => {
+    await newMarkdownVisualDoc(page);
+
+    const citation = new InsertCitationDialog(page);
+    await citation.open();
+    const searchBox = await citation.selectSource(CITATION_SOURCES.doi);
+
+    // Stage the single DOI result, then remove it from the staging area (#9124).
+    await citation.search(searchBox, '10.3133/93888');
+    await citation.stageFirstResult();
+    await expect(citation.stagedCitations).toHaveCount(1);
+
+    await citation.deleteStagedCitation();
+    await expect(citation.stagedCitations).toHaveCount(0);
+
+    await citation.cancel();
+  });
+
+  // Selecting each network-backed source and searching returns matching results.
+  // "bobolink" returns hits on all three services (DataCite, Crossref, PubMed).
+  // Listed in the dialog's tree order (top to bottom): Crossref, DataCite, PubMed.
+  const SEARCH_SOURCES = [CITATION_SOURCES.crossref, CITATION_SOURCES.datacite, CITATION_SOURCES.pubmed];
+  const searchTerm = 'bobolink';
+  for (const source of SEARCH_SOURCES) {
+    test(`searches ${source.alt} and returns matching results`, async ({ rstudioPage: page }) => {
+      await newMarkdownVisualDoc(page);
+
+      const citation = new InsertCitationDialog(page);
+      await citation.open();
+      const searchBox = await citation.selectSource(source);
+
+      // At least one of the first five results should mention the term, not just
+      // that some rows rendered -- otherwise arbitrary or stale hits would pass.
+      // We don't require it of result #1: relevance ranking can put a non-title
+      // match first (e.g. PubMed ranks a "Bobo-link" correspondence hit above the
+      // title matches). Poll to ride out the list still populating.
+      await citation.search(searchBox, searchTerm);
+      const matcher = new RegExp(searchTerm, 'i');
+      await expect
+        .poll(async () => (await citation.resultTexts(5)).some((t) => matcher.test(t)), { timeout: 30000 })
+        .toBe(true);
+
+      await citation.cancel();
+    });
+  }
+});

--- a/e2e/rstudio/tests/panes/editor/citations.test.ts
+++ b/e2e/rstudio/tests/panes/editor/citations.test.ts
@@ -95,6 +95,10 @@ test.describe('Citations', () => {
     expect(bib).toContain('effects1999');
     expect(bib).toContain('Bobolink');
     expect(bib).toContain('10.3133/93888');
+    // No author: the key is title-derived. If this DOI ever gains an author
+    // field upstream, the key would change and this test's premise breaks --
+    // fail here rather than silently testing the wrong thing.
+    expect(bib).not.toMatch(/author\s*=/i);
   });
 
   // The same DOI insert flow works in a Quarto (.qmd) document -- the format

--- a/e2e/rstudio/tests/panes/editor/citations.test.ts
+++ b/e2e/rstudio/tests/panes/editor/citations.test.ts
@@ -5,7 +5,34 @@ import { InsertCitationDialog, CITATION_SOURCES } from '@pages/insert_citation.p
 import { installDepIfPrompted } from '@pages/modals.page';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { executeCommand } from '@utils/commands';
+import { executeInConsole, CONSOLE_OUTPUT } from '@pages/console_pane.page';
+import { rStringLiteral } from '@utils/r';
 import type { Page } from 'playwright';
+
+// Read the value of an R expression via marker-wrapped console output. Runs on
+// the rsession host, so it reads files the IDE wrote (e.g. references.bib in the
+// working directory) regardless of where the sandbox lives.
+async function captureResult(page: Page, rExpression: string): Promise<string> {
+  const marker = `__CIT_${Date.now()}__`;
+  await executeInConsole(
+    page,
+    `cat(${rStringLiteral(marker)}, ${rExpression}, ${rStringLiteral(marker)})`,
+    { wait: true },
+  );
+  const pattern = new RegExp(`${marker}\\s+(.*?)\\s+${marker}`, 's');
+  let match: RegExpMatchArray | null = null;
+  await expect
+    .poll(
+      async () => {
+        const output = await page.locator(CONSOLE_OUTPUT).innerText();
+        match = output.match(pattern);
+        return match !== null;
+      },
+      { timeout: 15000 },
+    )
+    .toBe(true);
+  return match![1].trim();
+}
 
 // Migrated from Selenium test_desktop_Citations.py. Citations live in the
 // panmirror visual editor's Insert menu; see the InsertCitationDialog page
@@ -29,6 +56,9 @@ test.describe('Citations', () => {
   // the previous test's dirty doc without a save prompt.
   test.beforeEach(async () => {
     await consoleActions.resetSourcePane();
+    // Citation inserts append to references.bib in the shared workdir; remove
+    // any leftover so each test's bib assertions start from a clean file.
+    await consoleActions.executeInConsole('unlink("references.bib")', { wait: true });
   });
 
   // Open a fresh markdown document in visual mode (the only place citations are
@@ -57,6 +87,14 @@ test.describe('Citations', () => {
     // key from the title ("Effects of management practices on grassland birds:
     // Bobolink", 1999) -> effects1999.
     await expect(page.locator('.ProseMirror')).toContainText('[@effects1999]', { timeout: 15000 });
+
+    // The citation metadata is persisted to references.bib (in the session's
+    // working directory), not just the key placed in the document.
+    expect(await captureResult(page, 'file.exists("references.bib")')).toBe('TRUE');
+    const bib = await captureResult(page, 'readLines("references.bib")');
+    expect(bib).toContain('effects1999');
+    expect(bib).toContain('Bobolink');
+    expect(bib).toContain('10.3133/93888');
   });
 
   // The same DOI insert flow works in a Quarto (.qmd) document -- the format
@@ -80,6 +118,23 @@ test.describe('Citations', () => {
     await citation.insert();
 
     await expect(page.locator('.ProseMirror')).toContainText('[@effects1999]', { timeout: 15000 });
+  });
+
+  // The R Package source is a typeahead list of installed packages, not a latent
+  // search. Insert one and verify it lands in the document -- the only insert
+  // test that exercises a non-network source.
+  test('inserts an R Package citation into the document', async ({ rstudioPage: page }) => {
+    await newMarkdownVisualDoc(page);
+
+    const citation = new InsertCitationDialog(page);
+    await citation.open();
+
+    // knitr is pre-installed (REQUIRED_PACKAGES); its cite key is the package name.
+    const match = await citation.selectPackageSource('knitr');
+    await match.locator('button').click(); // stage via "+"
+    await citation.insert();
+
+    await expect(page.locator('.ProseMirror')).toContainText('[@knitr]', { timeout: 15000 });
   });
 
   test('deletes a staged citation', async ({ rstudioPage: page }) => {
@@ -125,6 +180,10 @@ test.describe('Citations', () => {
     await citation.stageFirstResult();
     await citation.insert();
     await expect(page.locator('.ProseMirror')).toContainText('[@bermúdez2020][@bermúdez2020]', { timeout: 15000 });
+
+    // references.bib holds a single entry despite two citations in the document
+    // -- the direct #8335 check (one "@" entry header, not two).
+    expect(await captureResult(page, 'sum(grepl("^@", readLines("references.bib")))')).toBe('1');
   });
 
   // Clicking Insert with nothing staged should dismiss the dialog rather than

--- a/e2e/rstudio/tests/panes/editor/citations.test.ts
+++ b/e2e/rstudio/tests/panes/editor/citations.test.ts
@@ -28,7 +28,10 @@ async function captureResult(page: Page, rExpression: string): Promise<string> {
         match = output.match(pattern);
         return match !== null;
       },
-      { timeout: 15000 },
+      {
+        timeout: 15000,
+        message: `captureResult: no marker-wrapped output for \`${rExpression}\` within 15s -- the R expression likely errored (e.g. references.bib missing)`,
+      },
     )
     .toBe(true);
   return match![1].trim();
@@ -52,8 +55,9 @@ test.describe('Citations', () => {
     sourceActions = new SourcePaneActions(page, consoleActions);
   });
 
-  // Each test starts from a single clean Untitled tab; resetToUntitled reverts
-  // the previous test's dirty doc without a save prompt.
+  // Each test starts from a single clean Untitled tab. resetSourcePane()
+  // dispatches resetToUntitled under the hood, reverting the previous test's
+  // dirty doc without a save prompt.
   test.beforeEach(async () => {
     await consoleActions.resetSourcePane();
     // Citation inserts append to references.bib in the shared workdir; remove
@@ -93,6 +97,7 @@ test.describe('Citations', () => {
     expect(await captureResult(page, 'file.exists("references.bib")')).toBe('TRUE');
     const bib = await captureResult(page, 'readLines("references.bib")');
     expect(bib).toContain('effects1999');
+    expect(bib).toContain('@techreport'); // entry type, not just fields
     expect(bib).toContain('Bobolink');
     expect(bib).toContain('10.3133/93888');
     // No author: the key is title-derived. If this DOI ever gains an author
@@ -202,22 +207,27 @@ test.describe('Citations', () => {
   });
 
   // A citation already in the text must survive a visual<->source round-trip
-  // without its brackets being backslash-escaped (#10075).
-  test('does not escape citation brackets across a visual round-trip', async ({ rstudioPage: page }) => {
-    const fileName = `citation_escape_${Date.now()}.md`;
-    const line = 'This is some text [@abelsen1993, 93].';
-    await sourceActions.createAndOpenFile(fileName, line);
-    await expect(sourceActions.sourcePane.selectedTab).toContainText(fileName, { timeout: 20000 });
+  // without its brackets being backslash-escaped (#10075). Checked in both
+  // markdown and Quarto: pandoc's markdown and quarto writers escape
+  // differently, so the .qmd round-trip is distinct coverage.
+  for (const ext of ['md', 'qmd']) {
+    test(`does not escape citation brackets across a visual round-trip (.${ext})`, async ({ rstudioPage: page }) => {
+      const fileName = `citation_escape_${Date.now()}.${ext}`;
+      const line = 'This is some text [@abelsen1993, 93].';
+      await sourceActions.createAndOpenFile(fileName, line);
+      await expect(sourceActions.sourcePane.selectedTab).toContainText(fileName, { timeout: 20000 });
 
-    // Visual mode renders the citation as-is.
-    await sourceActions.ensureVisualMode();
-    await expect(page.locator('.ProseMirror')).toContainText(line, { timeout: 15000 });
+      // Visual mode renders the citation as-is.
+      await sourceActions.ensureVisualMode();
+      await expect(page.locator('.ProseMirror')).toContainText(line, { timeout: 15000 });
 
-    // Back in source mode the brackets must remain unescaped (no backslashes).
-    await sourceActions.ensureSourceMode();
-    await expect(sourceActions.sourcePane.contentPane).toContainText(line, { timeout: 10000 });
-    await expect(sourceActions.sourcePane.contentPane).not.toContainText('\\[@abelsen1993');
-  });
+      // Back in source mode the brackets must remain unescaped (no backslashes).
+      await sourceActions.ensureSourceMode();
+      await expect(sourceActions.sourcePane.contentPane).toContainText(line, { timeout: 10000 });
+      await expect(sourceActions.sourcePane.contentPane).not.toContainText('\\[@abelsen1993');
+      await expect(sourceActions.sourcePane.contentPane).not.toContainText('93\\]');
+    });
+  }
 
   // Selecting each network-backed source and searching returns matching results.
   // "bobolink" returns hits on all three services (DataCite, Crossref, PubMed).

--- a/e2e/rstudio/tests/panes/editor/citations.test.ts
+++ b/e2e/rstudio/tests/panes/editor/citations.test.ts
@@ -59,6 +59,29 @@ test.describe('Citations', () => {
     await expect(page.locator('.ProseMirror')).toContainText('[@effects1999]', { timeout: 15000 });
   });
 
+  // The same DOI insert flow works in a Quarto (.qmd) document -- the format
+  // where the previous migration attempt stalled ("never reaches visual mode").
+  // Opening a file-based .qmd and using ensureVisualMode() gets there reliably.
+  test('inserts a DOI citation into a Quarto visual editor', async ({ rstudioPage: page }) => {
+    const fileName = `citations_${Date.now()}.qmd`;
+    await sourceActions.createAndOpenFile(fileName, '---\ntitle: Citations\n---\n\nGrassland bird research.\n');
+    await expect(sourceActions.sourcePane.selectedTab).toContainText(fileName, { timeout: 20000 });
+    await sourceActions.ensureVisualMode();
+
+    // Citations are disabled while the cursor sits in the YAML; click into the
+    // body paragraph first (the analogue of the Selenium navigate_out_of_quarto_yaml).
+    await page.locator('.ProseMirror').getByText('Grassland bird research.').click();
+
+    const citation = new InsertCitationDialog(page);
+    await citation.open();
+    const searchBox = await citation.selectSource(CITATION_SOURCES.doi);
+    await citation.search(searchBox, '10.3133/93888');
+    await citation.stageFirstResult();
+    await citation.insert();
+
+    await expect(page.locator('.ProseMirror')).toContainText('[@effects1999]', { timeout: 15000 });
+  });
+
   test('deletes a staged citation', async ({ rstudioPage: page }) => {
     await newMarkdownVisualDoc(page);
 
@@ -75,6 +98,62 @@ test.describe('Citations', () => {
     await expect(citation.stagedCitations).toHaveCount(0);
 
     await citation.cancel();
+  });
+
+  // Inserting the same work via two different sources reuses its citation key
+  // rather than creating a duplicate (#8335). The document ends up showing the
+  // key twice; a regression would produce a de-duplicated variant like
+  // "bermúdez2020a" (and a second bib entry) instead.
+  test('does not duplicate a citation inserted from two sources', async ({ rstudioPage: page }) => {
+    await newMarkdownVisualDoc(page);
+    const citation = new InsertCitationDialog(page);
+    const doi = '10.5281/ZENODO.4266706';
+
+    // First insert via From DOI -> [@bermúdez2020].
+    await citation.open();
+    let searchBox = await citation.selectSource(CITATION_SOURCES.doi);
+    await citation.search(searchBox, doi);
+    await citation.stageFirstResult();
+    await citation.insert();
+    await expect(page.locator('.ProseMirror')).toContainText('[@bermúdez2020]', { timeout: 15000 });
+
+    // Insert the same work again via DataCite. It is already in the bibliography,
+    // so panmirror reuses the same key -> the document shows it twice.
+    await citation.open();
+    searchBox = await citation.selectSource(CITATION_SOURCES.datacite);
+    await citation.search(searchBox, doi);
+    await citation.stageFirstResult();
+    await citation.insert();
+    await expect(page.locator('.ProseMirror')).toContainText('[@bermúdez2020][@bermúdez2020]', { timeout: 15000 });
+  });
+
+  // Clicking Insert with nothing staged should dismiss the dialog rather than
+  // leaving it stuck open (#12833).
+  test('dismisses the dialog when inserting with nothing staged', async ({ rstudioPage: page }) => {
+    await newMarkdownVisualDoc(page);
+
+    const citation = new InsertCitationDialog(page);
+    await citation.open();
+    await citation.insert();
+    await expect(citation.dialog).toBeHidden({ timeout: 5000 });
+  });
+
+  // A citation already in the text must survive a visual<->source round-trip
+  // without its brackets being backslash-escaped (#10075).
+  test('does not escape citation brackets across a visual round-trip', async ({ rstudioPage: page }) => {
+    const fileName = `citation_escape_${Date.now()}.md`;
+    const line = 'This is some text [@abelsen1993, 93].';
+    await sourceActions.createAndOpenFile(fileName, line);
+    await expect(sourceActions.sourcePane.selectedTab).toContainText(fileName, { timeout: 20000 });
+
+    // Visual mode renders the citation as-is.
+    await sourceActions.ensureVisualMode();
+    await expect(page.locator('.ProseMirror')).toContainText(line, { timeout: 15000 });
+
+    // Back in source mode the brackets must remain unescaped (no backslashes).
+    await sourceActions.ensureSourceMode();
+    await expect(sourceActions.sourcePane.contentPane).toContainText(line, { timeout: 10000 });
+    await expect(sourceActions.sourcePane.contentPane).not.toContainText('\\[@abelsen1993');
   });
 
   // Selecting each network-backed source and searching returns matching results.


### PR DESCRIPTION
Migrates `test_desktop_Citations.py` from the Selenium/Selene suite to a Playwright/TypeScript spec at `e2e/rstudio/tests/panes/editor/citations.test.ts`, backed by a new `InsertCitationDialog` page object and a `visual-editor.md` skill doc describing the panmirror Insert Citation dialog.

Coverage (11 tests, all against live citation services, no mocks):
- Insert a citation into a markdown and a Quarto visual editor (authorless DOI, title-derived key), and from the R Package source.
- Delete a staged citation.
- No-duplicate dedup ([#8335](https://github.com/rstudio/rstudio/issues/8335)): the same work inserted via two sources reuses one key and writes a single `references.bib` entry.
- Blank-insert dialog dismissal ([#12833](https://github.com/rstudio/rstudio/issues/12833)).
- Non-escaping visual↔source round-trip ([#10075](https://github.com/rstudio/rstudio/issues/10075)) in both `.md` and `.qmd`.
- Keyword search returns matching results for Crossref, DataCite, and PubMed.

Insert tests also assert `references.bib` persistence (key, entry type, title, DOI, and absence of an author field).
