### PR TITLE
stop e2e cache saves from PR refs and add an eviction sentinel

### DIFF
--- a/.github/actions/os-e2e-deps/action.yml
+++ b/.github/actions/os-e2e-deps/action.yml
@@ -45,16 +45,24 @@ runs:
         echo "Resolved R version (major.minor): $VERSION"
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-    - name: Cache R packages (pak download cache)
-      uses: actions/cache@v4
+    # All three caches below are restore-only, with matching Save steps after
+    # the corresponding install. The saves run only from main-scoped runs (the
+    # scheduled workflows): a cache saved from a PR run lands in that PR's
+    # merge-ref scope, which no other branch can restore -- each copy is pure
+    # pressure on the repo's 10 GB Actions cache quota, and that pressure is
+    # what evicts main's copies and sends every run cold in the first place.
+    - name: Restore R packages (pak download cache)
+      id: pak-cache
+      uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}/.r-pkg-cache
         key: ${{ runner.os }}-pak-${{ steps.r_version.outputs.version }}-${{ hashFiles(format('{0}/DESCRIPTION', inputs.working-directory)) }}
         restore-keys: |
           ${{ runner.os }}-pak-${{ steps.r_version.outputs.version }}-
 
-    - name: Cache R library
-      uses: actions/cache@v4
+    - name: Restore R library
+      id: rlib-cache
+      uses: actions/cache/restore@v4
       with:
         path: ${{ inputs.r-libs-user }}
         key: ${{ runner.os }}-r-${{ steps.r_version.outputs.version }}-${{ hashFiles(format('{0}/DESCRIPTION', inputs.working-directory)) }}
@@ -85,6 +93,20 @@ runs:
         EOF
         Rscript "$SCRIPT"
 
+    - name: Save R packages (pak download cache)
+      if: github.ref == 'refs/heads/main' && steps.pak-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ github.workspace }}/.r-pkg-cache
+        key: ${{ steps.pak-cache.outputs.cache-primary-key }}
+
+    - name: Save R library
+      if: github.ref == 'refs/heads/main' && steps.rlib-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ inputs.r-libs-user }}
+        key: ${{ steps.rlib-cache.outputs.cache-primary-key }}
+
     - name: Install npm dependencies
       shell: bash
       working-directory: ${{ inputs.working-directory }}
@@ -99,8 +121,9 @@ runs:
           sleep 10
         done
 
-    - name: Cache Playwright browsers
-      uses: actions/cache@v4
+    - name: Restore Playwright browsers
+      id: pw-cache
+      uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}/ms-playwright
         key: ${{ runner.os }}-pw-${{ hashFiles(format('{0}/package-lock.json', inputs.working-directory)) }}
@@ -116,3 +139,10 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: npx playwright install --with-deps chromium
+
+    - name: Save Playwright browsers
+      if: github.ref == 'refs/heads/main' && steps.pw-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ github.workspace }}/ms-playwright
+        key: ${{ steps.pw-cache.outputs.cache-primary-key }}

--- a/.github/workflows/os-cache-seed-e2e-macos-26-arm64.yml
+++ b/.github/workflows/os-cache-seed-e2e-macos-26-arm64.yml
@@ -25,6 +25,8 @@ on:
   # by prefix) recent on main so PR builds get a high compile-cache hit rate.
   schedule:
     - cron: '0 7 * * *'
+  # Also dispatched by os-cache-seed-sentinel.yml when this seed's caches
+  # have been evicted from main's scope (10 GB repo quota, LRU eviction).
   workflow_dispatch:
 
 # Don't stack expensive macOS builds; the latest seed run wins.

--- a/.github/workflows/os-cache-seed-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/os-cache-seed-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -34,6 +34,8 @@ on:
   # so the two don't contend for runners at the same minute.
   schedule:
     - cron: '30 7 * * *'
+  # Also dispatched by os-cache-seed-sentinel.yml when this seed's caches
+  # have been evicted from main's scope (10 GB repo quota, LRU eviction).
   workflow_dispatch:
 
 # Don't stack expensive ubuntu builds; the latest seed run wins.

--- a/.github/workflows/os-cache-seed-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-cache-seed-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -17,6 +17,8 @@ on:
       - "src/gwt/conf/**"
       - ".github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml"
       - ".github/workflows/os-cache-seed-e2e-rstudio-desktop-os-windows-server-2025.yml"
+  # Also dispatched by os-cache-seed-sentinel.yml when this seed's caches
+  # have been evicted from main's scope (10 GB repo quota, LRU eviction).
   workflow_dispatch:
 
 # Don't stack expensive Windows builds; the latest seed run wins.

--- a/.github/workflows/os-cache-seed-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/os-cache-seed-e2e-rstudio-server-os-ubuntu-24.yml
@@ -29,6 +29,8 @@ on:
   # haven't been accessed in 7 days.
   schedule:
     - cron: '0 7 * * *'
+  # Also dispatched by os-cache-seed-sentinel.yml when this seed's caches
+  # have been evicted from main's scope (10 GB repo quota, LRU eviction).
   workflow_dispatch:
 
 # Don't stack expensive ubuntu builds; the latest seed run wins.

--- a/.github/workflows/os-cache-seed-sentinel.yml
+++ b/.github/workflows/os-cache-seed-sentinel.yml
@@ -1,0 +1,100 @@
+name: "Cache Seed: Sentinel (re-seed evicted E2E build caches)"
+
+# The repo's GitHub Actions cache quota is 10 GB; past it, GitHub evicts
+# entries least-recently-used first -- including the build caches the seed
+# workflows maintain on main. PR runs can only restore caches from their own
+# merge ref or from main, so once main's copy is evicted every PR build goes
+# cold (full dependency download + GWT recompile) until the next nightly
+# seed. This sentinel closes that gap: it periodically checks that each
+# expected cache-key prefix still resolves on refs/heads/main and dispatches
+# the owning seed workflow when one has gone missing.
+#
+# Ubuntu 26 AMD64 has no seed workflow yet and is not part of the PR
+# orchestrator, so it is deliberately absent from the checks below.
+on:
+  schedule:
+    # Every 2 hours, offset from the nightly seeds (07:00 / 07:30 UTC).
+    - cron: '45 */2 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: cache-seed-sentinel
+  cancel-in-progress: true
+
+permissions:
+  # Needed both to list caches / workflow runs and to dispatch the seed
+  # workflows via `gh workflow run`.
+  actions: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Re-seed platforms whose main caches were evicted
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # No checkout in this job; gh needs the repo set explicitly.
+          GH_REPO: ${{ github.repository }}
+        run: |
+          # One line per seed workflow: <workflow-file>=<cache-key prefixes>.
+          # The prefixes must track the cache keys in the matching build
+          # workflows (see the "Restore rstudio-tools deps" etc. steps). The
+          # rstudio-tools / rlibs linux keys are shared by the Desktop and
+          # Server Ubuntu 24 builds, so they are listed once, under the
+          # Desktop seed; each seed re-warms every cache its build job
+          # touches, missing or not.
+          CHECKS='
+          os-cache-seed-e2e-rstudio-desktop-os-ubuntu-24.yml=rstudio-tools-linux-x86_64- rstudio-build-rlibs-linux-x86_64- rstudio-gwt-linux-desktop-x86_64-
+          os-cache-seed-e2e-rstudio-server-os-ubuntu-24.yml=rstudio-gwt-linux-x86_64-
+          os-cache-seed-e2e-macos-26-arm64.yml=rstudio-tools-arm64- rstudio-build-rlibs-arm64- rstudio-gwt-arm64-
+          os-cache-seed-e2e-rstudio-desktop-os-windows-server-2025.yml=rstudio-tools-win64- rstudio-gwt-win64-
+          '
+
+          FAILED=0
+          while IFS= read -r LINE; do
+            # Trim leading whitespace; skip blank lines.
+            LINE="${LINE#"${LINE%%[![:space:]]*}"}"
+            if [ -z "$LINE" ]; then
+              continue
+            fi
+
+            SEED="${LINE%%=*}"
+            PREFIXES="${LINE#*=}"
+
+            MISSING=""
+            for PREFIX in $PREFIXES; do
+              # The caches API `key` parameter matches by prefix, so this asks
+              # "does any cache under this prefix still exist in main's scope?"
+              COUNT=$(gh api "repos/$GITHUB_REPOSITORY/actions/caches?ref=refs/heads/main&key=$PREFIX&per_page=1" --jq .total_count)
+              if [ "$COUNT" -eq 0 ]; then
+                MISSING="$MISSING $PREFIX"
+              fi
+            done
+
+            if [ -z "$MISSING" ]; then
+              echo "OK: $SEED -- all prefixes present on main"
+              continue
+            fi
+            echo "Evicted from main:$MISSING"
+
+            # Don't dispatch on top of an active run: the seeds' concurrency
+            # groups cancel in-flight runs, so piling on dispatches could keep
+            # a seed from ever finishing.
+            ACTIVE=0
+            for STATUS in queued in_progress; do
+              N=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$SEED/runs?status=$STATUS&per_page=1" --jq .total_count)
+              ACTIVE=$((ACTIVE + N))
+            done
+            if [ "$ACTIVE" -gt 0 ]; then
+              echo "Seed $SEED is already queued or running; not dispatching."
+              continue
+            fi
+
+            echo "Dispatching $SEED"
+            gh workflow run "$SEED" --ref main || FAILED=1
+          done <<EOF
+          $CHECKS
+          EOF
+
+          exit $FAILED

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -125,10 +125,12 @@ jobs:
       # Pre-built tool deps (Boost, SOCI, pandoc, quarto, GWT, node, panmirror,
       # copilot-language-server, etc.) all land under RSTUDIO_TOOLS_ROOT.
       # Caching this directory turns the install-common step from ~5-10 min
-      # of downloads into a no-op on warm runs.
-      - name: Cache rstudio-tools deps
+      # of downloads into a no-op on warm runs. Restore-only; the matching
+      # Save steps after "Install build dependencies" run only from
+      # main-scoped runs.
+      - name: Restore rstudio-tools deps
         id: tools-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.RSTUDIO_TOOLS_ROOT }}
           key: rstudio-tools-arm64-${{ hashFiles('dependencies/common/install-*', 'dependencies/osx/install-*', 'dependencies/tools/rstudio-tools.sh') }}
@@ -139,8 +141,9 @@ jobs:
       # which renv::install()s digest/purrr/rmarkdown/testthat/xml2/yaml into
       # R_LIBS_USER. Cache the whole R-libs tree -- R's %p/%v subpaths keep
       # different versions / platforms isolated automatically.
-      - name: Cache build-time R packages
-        uses: actions/cache@v4
+      - name: Restore build-time R packages
+        id: rlibs-cache
+        uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/R-libs
           key: rstudio-build-rlibs-arm64-${{ hashFiles('dependencies/common/install-packages', 'dependencies/common/lockfiles/**/renv.lock') }}
@@ -172,6 +175,26 @@ jobs:
         working-directory: dependencies/osx
         run: ./install-dependencies-osx-arch
 
+      # Save the tools / R-libs caches only from main-scoped runs (the seed
+      # and scheduled workflows), and only on a key miss. A cache saved from a
+      # PR run lands in that PR's merge-ref scope, which no other branch can
+      # restore -- each copy is pure pressure on the repo's 10 GB Actions
+      # cache quota, and that pressure is what evicts main's copies and sends
+      # every PR build cold in the first place.
+      - name: Save rstudio-tools deps
+        if: github.ref == 'refs/heads/main' && steps.tools-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.RSTUDIO_TOOLS_ROOT }}
+          key: ${{ steps.tools-cache.outputs.cache-primary-key }}
+
+      - name: Save build-time R packages
+        if: github.ref == 'refs/heads/main' && steps.rlibs-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/R-libs
+          key: ${{ steps.rlibs-cache.outputs.cache-primary-key }}
+
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
 
@@ -190,8 +213,11 @@ jobs:
             ./make-package --arch=arm64 --build-dmg=0 --use-creds=0
           fi
 
+      # Skip on an exact restore hit: re-saving would just duplicate the entry
+      # into this run's ref scope. PR runs that changed GWT sources still
+      # save, so re-pushes to the same PR skip the recompile.
       - name: Save GWT output
-        if: steps.build.conclusion == 'success'
+        if: steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: package/osx/build-arm64/gwt

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -134,10 +134,11 @@ jobs:
       # Pre-built tool deps (Boost, SOCI, pandoc, quarto, GWT, node, panmirror,
       # copilot-language-server, sccache, etc.) all land under RSTUDIO_TOOLS_ROOT.
       # Shares the key with the Linux Server build so a single cache (and the
-      # cache-seed job) warms both.
-      - name: Cache rstudio-tools deps
+      # cache-seed job) warms both. Restore-only; the matching Save steps after
+      # "Install build dependencies" run only from main-scoped runs.
+      - name: Restore rstudio-tools deps
         id: tools-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.RSTUDIO_TOOLS_ROOT }}
           key: rstudio-tools-linux-x86_64-${{ hashFiles('dependencies/common/install-*', 'dependencies/linux/install-*', 'dependencies/tools/rstudio-tools.sh') }}
@@ -148,8 +149,9 @@ jobs:
       # packages (via install-packages) into R_LIBS_USER. Cache the whole
       # R-libs tree -- R's %p/%v subpaths keep different versions isolated.
       # Same key as the Linux Server build so the cache is shared.
-      - name: Cache build-time R packages
-        uses: actions/cache@v4
+      - name: Restore build-time R packages
+        id: rlibs-cache
+        uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/R-libs
           key: rstudio-build-rlibs-linux-x86_64-${{ hashFiles('dependencies/common/install-packages', 'dependencies/common/lockfiles/**/renv.lock') }}
@@ -192,6 +194,26 @@ jobs:
         working-directory: dependencies/linux
         run: ./install-dependencies-noble
 
+      # Save the tools / R-libs caches only from main-scoped runs (the seed
+      # and scheduled workflows), and only on a key miss. A cache saved from a
+      # PR run lands in that PR's merge-ref scope, which no other branch can
+      # restore -- each copy is pure pressure on the repo's 10 GB Actions
+      # cache quota, and that pressure is what evicts main's copies and sends
+      # every PR build cold in the first place.
+      - name: Save rstudio-tools deps
+        if: github.ref == 'refs/heads/main' && steps.tools-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.RSTUDIO_TOOLS_ROOT }}
+          key: ${{ steps.tools-cache.outputs.cache-primary-key }}
+
+      - name: Save build-time R packages
+        if: github.ref == 'refs/heads/main' && steps.rlibs-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/R-libs
+          key: ${{ steps.rlibs-cache.outputs.cache-primary-key }}
+
       - name: Zero sccache stats
         run: sccache --zero-stats || true
 
@@ -223,9 +245,12 @@ jobs:
       # Save GWT output only when the build succeeded. A failed mid-compile run
       # could otherwise write partial GWT output to the cache, and every future
       # restore would silently ship a broken frontend until the hashFiles key
-      # rotates.
+      # rotates. Skip on an exact restore hit: re-saving would just duplicate
+      # the entry into this run's ref scope (per-PR copies that waste quota).
+      # PR runs that changed GWT sources still save, so re-pushes to the same
+      # PR skip the ~15-30 min recompile.
       - name: Save GWT output
-        if: steps.build.conclusion == 'success'
+        if: steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: package/linux/build-Electron-DEB/gwt

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
@@ -133,9 +133,11 @@ jobs:
 
       # Pre-built tool deps (Boost, SOCI, pandoc, quarto, GWT, node, panmirror,
       # copilot-language-server, sccache, etc.) all land under RSTUDIO_TOOLS_ROOT.
-      - name: Cache rstudio-tools deps
+      # Restore-only; the matching Save steps after "Install build
+      # dependencies" run only from main-scoped runs.
+      - name: Restore rstudio-tools deps
         id: tools-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.RSTUDIO_TOOLS_ROOT }}
           key: rstudio-tools-linux-resolute-x86_64-${{ hashFiles('dependencies/common/install-*', 'dependencies/linux/install-*', 'dependencies/tools/rstudio-tools.sh') }}
@@ -145,8 +147,9 @@ jobs:
       # install-common (called by install-dependencies-resolute) installs R
       # packages (via install-packages) into R_LIBS_USER. Cache the whole
       # R-libs tree -- R's %p/%v subpaths keep different versions isolated.
-      - name: Cache build-time R packages
-        uses: actions/cache@v4
+      - name: Restore build-time R packages
+        id: rlibs-cache
+        uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/R-libs
           key: rstudio-build-rlibs-linux-resolute-x86_64-${{ hashFiles('dependencies/common/install-packages', 'dependencies/common/lockfiles/**/renv.lock') }}
@@ -189,6 +192,26 @@ jobs:
         working-directory: dependencies/linux
         run: ./install-dependencies-resolute
 
+      # Save the tools / R-libs caches only from main-scoped runs (scheduled
+      # or dispatched on main), and only on a key miss. A cache saved from a
+      # PR run lands in that PR's merge-ref scope, which no other branch can
+      # restore -- each copy is pure pressure on the repo's 10 GB Actions
+      # cache quota, and that pressure is what evicts main's copies and sends
+      # every PR build cold in the first place.
+      - name: Save rstudio-tools deps
+        if: github.ref == 'refs/heads/main' && steps.tools-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.RSTUDIO_TOOLS_ROOT }}
+          key: ${{ steps.tools-cache.outputs.cache-primary-key }}
+
+      - name: Save build-time R packages
+        if: github.ref == 'refs/heads/main' && steps.rlibs-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/R-libs
+          key: ${{ steps.rlibs-cache.outputs.cache-primary-key }}
+
       - name: Zero sccache stats
         run: sccache --zero-stats || true
 
@@ -220,9 +243,11 @@ jobs:
       # Save GWT output only when the build succeeded. A failed mid-compile run
       # could otherwise write partial GWT output to the cache, and every future
       # restore would silently ship a broken frontend until the hashFiles key
-      # rotates.
+      # rotates. Skip on an exact restore hit: re-saving would just duplicate
+      # the entry into this run's ref scope. PR runs that changed GWT sources
+      # still save, so re-pushes to the same PR skip the recompile.
       - name: Save GWT output
-        if: steps.build.conclusion == 'success'
+        if: steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: package/linux/build-Electron-DEB/gwt

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -165,8 +165,8 @@ jobs:
       # land in dependencies/common and dependencies/windows within the
       # workspace when c:\rstudio-tools\dependencies doesn't exist. Keyed on
       # the install scripts so a version bump forces a fresh download.
-      # Restore-only; Save rstudio-tools cache runs after the build with
-      # if: always() so deps are cached even when compilation fails.
+      # Restore-only; Save rstudio-tools cache runs after the build (from
+      # main-scoped runs only) so deps are cached even when compilation fails.
       - name: Restore rstudio-tools deps
         id: tools-cache
         uses: actions/cache/restore@v4
@@ -502,8 +502,14 @@ jobs:
             make-package.bat nozip
           )
 
+      # Save the tools cache only from main-scoped runs (the seed and
+      # scheduled workflows), and only on a key miss. A cache saved from a PR
+      # run lands in that PR's merge-ref scope, which no other branch can
+      # restore -- each copy is pure pressure on the repo's 10 GB Actions
+      # cache quota, and that pressure is what evicts main's copies and sends
+      # every PR build cold in the first place.
       - name: Save rstudio-tools cache
-        if: steps.install-deps.conclusion == 'success'
+        if: steps.install-deps.conclusion == 'success' && github.ref == 'refs/heads/main' && steps.tools-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: |
@@ -511,8 +517,11 @@ jobs:
             dependencies/windows
           key: ${{ steps.tools-cache.outputs.cache-primary-key }}
 
+      # Skip on an exact restore hit: re-saving would just duplicate the entry
+      # into this run's ref scope. PR runs that changed GWT sources still
+      # save, so re-pushes to the same PR skip the recompile.
       - name: Save GWT output
-        if: steps.build.conclusion == 'success'
+        if: steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: |

--- a/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -130,9 +130,11 @@ jobs:
 
       # Pre-built tool deps (Boost, SOCI, pandoc, quarto, GWT, node, panmirror,
       # copilot-language-server, sccache, etc.) all land under RSTUDIO_TOOLS_ROOT.
-      - name: Cache rstudio-tools deps
+      # Restore-only; the matching Save steps after "Install build
+      # dependencies" run only from main-scoped runs.
+      - name: Restore rstudio-tools deps
         id: tools-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.RSTUDIO_TOOLS_ROOT }}
           key: rstudio-tools-linux-x86_64-${{ hashFiles('dependencies/common/install-*', 'dependencies/linux/install-*', 'dependencies/tools/rstudio-tools.sh') }}
@@ -142,8 +144,9 @@ jobs:
       # install-common (called by install-dependencies-noble) installs R
       # packages (via install-packages) into R_LIBS_USER. Cache the whole
       # R-libs tree -- R's %p/%v subpaths keep different versions isolated.
-      - name: Cache build-time R packages
-        uses: actions/cache@v4
+      - name: Restore build-time R packages
+        id: rlibs-cache
+        uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/R-libs
           key: rstudio-build-rlibs-linux-x86_64-${{ hashFiles('dependencies/common/install-packages', 'dependencies/common/lockfiles/**/renv.lock') }}
@@ -186,6 +189,26 @@ jobs:
         working-directory: dependencies/linux
         run: ./install-dependencies-noble
 
+      # Save the tools / R-libs caches only from main-scoped runs (the seed
+      # and scheduled workflows), and only on a key miss. A cache saved from a
+      # PR run lands in that PR's merge-ref scope, which no other branch can
+      # restore -- each copy is pure pressure on the repo's 10 GB Actions
+      # cache quota, and that pressure is what evicts main's copies and sends
+      # every PR build cold in the first place.
+      - name: Save rstudio-tools deps
+        if: github.ref == 'refs/heads/main' && steps.tools-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.RSTUDIO_TOOLS_ROOT }}
+          key: ${{ steps.tools-cache.outputs.cache-primary-key }}
+
+      - name: Save build-time R packages
+        if: github.ref == 'refs/heads/main' && steps.rlibs-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/R-libs
+          key: ${{ steps.rlibs-cache.outputs.cache-primary-key }}
+
       - name: Zero sccache stats
         run: sccache --zero-stats || true
 
@@ -218,8 +241,11 @@ jobs:
       # run could otherwise write partial GWT output to the cache, and every
       # future restore would silently ship a broken frontend until the
       # hashFiles key rotates. Same poison-resistance pattern macOS uses.
+      # Skip on an exact restore hit: re-saving would just duplicate the entry
+      # into this run's ref scope. PR runs that changed GWT sources still
+      # save, so re-pushes to the same PR skip the recompile.
       - name: Save GWT output
-        if: steps.build.conclusion == 'success'
+        if: steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: package/linux/build-Server-DEB/gwt


### PR DESCRIPTION
## Problem

The repo is pinned at the 10 GB Actions cache quota (9.4 GB / 5,300 entries at time of writing), so GitHub's LRU eviction regularly drops main's seeded build caches. Today the `rstudio-tools-linux-x86_64-*` and `rstudio-build-rlibs-linux-*` caches were gone from main's scope even though the Ubuntu 24 seed workflows had run successfully the same morning -- so every Linux PR build went cold (full dependency download) until the next nightly seed.

Worse, each cold PR run then saved its rebuilt caches into its own `refs/pull/N/merge` scope, which no other branch can restore. The split `actions/cache/save` steps (Windows tools, all GWT outputs) even re-saved on exact restore hits, duplicating a ~70-500 MB entry into every PR's scope on every run. Those per-PR copies are pure quota pressure, which evicts more of main's entries -- a vicious cycle.

## Changes

**Stop cache saves from PR refs.** The `rstudio-tools` / build-time R-libs caches in all five e2e build workflows (Ubuntu 24 Desktop/Server, Ubuntu 26, macOS, Windows), and the pak / R-library / Playwright-browser caches in the `os-e2e-deps` composite action, are now restore-only with explicit save steps gated to `refs/heads/main` (the seed and scheduled workflows). GWT saves keep running from PRs that changed GWT sources -- so re-pushes to the same PR still skip the ~15-30 min recompile -- but no save re-saves an exact restore hit anymore.

**Add `os-cache-seed-sentinel.yml`.** Every 2 hours it checks that each seed workflow's cache-key prefixes still resolve on `refs/heads/main` (the caches API matches keys by prefix) and dispatches the owning seed when one has been evicted, so an eviction hole lasts at most ~2 hours instead of until the next nightly seed. It skips dispatching when that seed already has a queued/running run, since the seeds' concurrency groups would otherwise cancel-loop.

A sentinel was chosen over dispatch-on-miss from PR builds because the reusable e2e workflows would all need `actions: write` plumbed through every caller, and fork PRs (read-only token) couldn't dispatch anyway.

## Notes

- Trade-off: a PR that rotates a dependency cache key (edits `dependencies/`) now rebuilds tools on every push to that PR rather than reusing a PR-scoped copy. Dependency bumps are rare, and the seed re-warms main with the new key right after merge (push-path trigger on `dependencies/**`).
- Ubuntu 26 AMD64 gets the same save gating but has no seed workflow yet (it is not in the PR orchestrator), so the sentinel deliberately does not cover it.
- The sccache GHA backend remains the biggest source of entry churn (one Actions cache entry per object file); this PR doesn't change that, the sentinel compensates for the eviction pressure it creates.

## Verification

- All changed workflow files parse as valid YAML.
- The sentinel's shell script was dry-run with a stubbed `gh` (correctly detects an evicted prefix, dispatches only the owning seed, honors the queued/running guard) and its cache-prefix and workflow-runs API queries were verified against the live repo.