### PR TITLE
remove per-suite sandbox timeline logging from e2e tests

### DIFF
--- a/e2e/rstudio/utils/sandbox.ts
+++ b/e2e/rstudio/utils/sandbox.ts
@@ -111,7 +111,6 @@ export async function createSandbox(page: Page): Promise<string> {
           `[sandbox] R workdir ${dir} is not under PW_SANDBOX (${sandbox}); rsession appears to be on a different host. Workdir will not be auto-cleaned.`,
         );
       }
-      console.log(`[sandbox] createSandbox: workdir ${dir}`);
       return dir;
     }
   }
@@ -169,18 +168,7 @@ export function useSuiteSandbox(): { dir: string } {
     },
   };
   test.beforeAll(async ({ rstudioPage }) => {
-    // Timeline instrumentation: bracket the sandbox creation with the suite
-    // name so a later "Error Opening Project" / empty-dir failure can be
-    // correlated against whether (and when) this suite's workdir was created.
-    let suite = '';
-    try {
-      suite = test.info().titlePath.join(' > ');
-    } catch {
-      // test.info() unavailable outside a running hook/test; name is optional.
-    }
-    console.log(`[sandbox] useSuiteSandbox beforeAll start${suite ? ` (${suite})` : ''}`);
     ref.dir = await createSandbox(rstudioPage);
-    console.log(`[sandbox] useSuiteSandbox beforeAll done: dir=${ref.dir}`);
   });
   return ref;
 }


### PR DESCRIPTION
Removes the `[sandbox]` per-suite timeline logs from the Playwright test output:

```
[sandbox] useSuiteSandbox beforeAll start (panes\environment\import_dataset.test.ts > ...)
[sandbox] createSandbox: workdir D:/a/rstudio/rstudio/pw-sandbox/pw_sandbox_du07zi/workdir_...
[sandbox] useSuiteSandbox beforeAll done: dir=...
```

These were timeline instrumentation added in #17795 to correlate "Error Opening Project" / empty-dir failures against when each suite's sandbox workdir was created. That failure mode was since root-caused (module-scope hooks not applying past the first spec file per worker; fixed by the auto-fixture migration, #17955/#17956), so the bracket lines are now just noise repeated for every suite.

The genuinely diagnostic `[sandbox]` messages are untouched: the `sandbox.dir` read-while-empty warning (with stack), the workdir-not-under-PW_SANDBOX warning, and the once-per-run seeding/teardown/preserve logs.

Verified with `npm run typecheck` in `e2e/rstudio`.