### PR TITLE
remove per-package install logging from ensurePackage

### DIFF
--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -214,7 +214,6 @@ export class ConsolePaneActions {
     }
 
     // Package not installed -- try to install it
-    console.log(`Installing R package: ${pkg}...`);
     await this.clearConsole();
     const repos = getInstallRepos();
     // Pick the install type at R runtime so source-only R builds (Homebrew
@@ -239,10 +238,8 @@ export class ConsolePaneActions {
     // verify by reading the package's availability back out of the console.
     const installed =
       (await this.evalRLogical(`requireNamespace("${pkg}", quietly = TRUE)`)) === true;
-    if (installed) {
-      console.log(`Package ${pkg} is now available.`);
-    } else {
-      console.log(`WARNING: Failed to install package ${pkg}.`);
+    if (!installed) {
+      console.warn(`WARNING: Failed to install package ${pkg}.`);
     }
     return installed;
   }


### PR DESCRIPTION
Removes the per-package success chatter from `ensurePackage` in the e2e helpers:

```
Installing R package: meditations...
Package meditations is now available.
Installing R package: titanic...
Package titanic is now available.
```

These print for every package a suite installs and carry no diagnostic value on the success path. The failure message (`WARNING: Failed to install package X.`) is kept and promoted to `console.warn`, since a failed install is the case worth surfacing -- the affected tests typically skip or fail right after it.

Companion cleanup to #18118 (per-suite sandbox timeline logs), kept as a separate PR per review preference.

Verified with `npm run typecheck` in `e2e/rstudio`.