### PR TITLE
automate building windows boost/soci prebuilts via github actions

### DIFF
--- a/.github/workflows/os-build-dependencies-windows.yml
+++ b/.github/workflows/os-build-dependencies-windows.yml
@@ -15,7 +15,10 @@
 #   the rstudio-buildtools bucket (install-boost.R downloads it from there),
 #   as must the SOCI source archive soci-<version>.tar.gz.
 # - S3 upload requires the AWS_BUILDTOOLS_UPLOAD_ROLE_ARN secret to be
-#   configured with an OIDC role that can write to rstudio-buildtools.
+#   configured with an OIDC role that can write to rstudio-buildtools
+#   (tracked in https://github.com/rstudio/rstudio/issues/18124). Until it
+#   exists, run with 'upload' disabled and push the workflow artifacts with
+#   dependencies/tools/upload-windows-dependencies.sh.
 #
 # The MSVC toolset version selects both the compiler toolset and the names
 # of the produced archives: 143 for Visual Studio 2022 (windows-2022

--- a/.github/workflows/os-build-dependencies-windows.yml
+++ b/.github/workflows/os-build-dependencies-windows.yml
@@ -1,0 +1,169 @@
+# Builds the Windows Boost and SOCI prebuilts consumed by
+# dependencies/windows/install-dependencies.cmd, replacing the manual
+# build-on-a-developer-machine + hand-upload process.
+#
+# The workflow always publishes the built archives as workflow artifacts.
+# When 'upload' is enabled, it also pushes them to the rstudio-buildtools
+# S3 bucket, where install-dependencies.cmd downloads them from:
+#
+#   s3://rstudio-buildtools/Boost/boost-<version>-win-msvc<toolset>.zip
+#   s3://rstudio-buildtools/soci-msvc<toolset>-<soci-version>.zip
+#
+# Prerequisites:
+#
+# - The Boost source archive Boost/boost_<X_Y_Z>.7z must already exist in
+#   the rstudio-buildtools bucket (install-boost.R downloads it from there),
+#   as must the SOCI source archive soci-<version>.tar.gz.
+# - S3 upload requires the AWS_BUILDTOOLS_UPLOAD_ROLE_ARN secret to be
+#   configured with an OIDC role that can write to rstudio-buildtools.
+#
+# The MSVC toolset version selects both the compiler toolset and the names
+# of the produced archives: 143 for Visual Studio 2022 (windows-2022
+# runner), 145 for Visual Studio 2026 (windows-2025 runner). See
+# https://github.com/rstudio/rstudio/issues/17986 for background.
+
+name: "Build Dependencies (Windows, Open Source)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      boost_version:
+        description: "Boost version to build"
+        type: string
+        default: "1.90.0"
+      soci_version:
+        description: "SOCI version to build"
+        type: string
+        default: "4.0.3"
+      msvc_toolset_version:
+        description: "MSVC toolset version to target (143 = VS 2022, 145 = VS 2026)"
+        type: string
+        default: "145"
+      cmake_generator:
+        description: "CMake generator used for the SOCI build"
+        type: string
+        default: "Visual Studio 18 2026"
+      runner:
+        description: "Runner image (windows-2025 ships VS 2026, windows-2022 ships VS 2022)"
+        type: choice
+        options:
+          - windows-2025
+          - windows-2022
+        default: windows-2025
+      upload:
+        description: "Upload the built archives to s3://rstudio-buildtools"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 300
+
+    env:
+      BOOST_VERSION: ${{ inputs.boost_version }}
+      SOCI_VERSION: ${{ inputs.soci_version }}
+      MSVC_TOOLSET_VERSION: ${{ inputs.msvc_toolset_version }}
+      CMAKE_GENERATOR: ${{ inputs.cmake_generator }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # install-boost.R and install-soci.R are driven by R.
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+
+      # tools.R checks for MSVC at a set of hardcoded VS 2022 paths
+      # (BuildTools / Community). GitHub runners ship VS Enterprise -- and on
+      # windows-2025, VS 2026 -- neither of which is in that list. Locate the
+      # actual installation with vswhere, put vcvarsall.bat on the PATH, and
+      # create a junction at the BuildTools path so tools.R's check passes.
+      # This is the same pattern used by the Windows e2e build workflow.
+      - name: Set up MSVC environment
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $vsPath = & 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' `
+            -latest -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -property installationPath
+          if ([string]::IsNullOrEmpty($vsPath)) {
+            Write-Error "vswhere could not find a Visual Studio installation with VC++ tools"
+            exit 1
+          }
+          Write-Host "Visual Studio installation: $vsPath"
+          $vcBuildPath = Join-Path $vsPath 'VC\Auxiliary\Build'
+          Add-Content -Path $env:GITHUB_PATH -Value $vcBuildPath
+          Write-Host "Added to PATH: $vcBuildPath"
+          $junctionPath = 'C:\Program Files\Microsoft Visual Studio\2022\BuildTools'
+          if (-not (Test-Path $junctionPath)) {
+            New-Item -ItemType Directory -Force -Path (Split-Path $junctionPath) | Out-Null
+            New-Item -ItemType Junction -Path $junctionPath -Target $vsPath | Out-Null
+            Write-Host "Junction created: $junctionPath -> $vsPath"
+          } else {
+            Write-Host "Junction already exists: $junctionPath"
+          }
+
+      # tools.R also requires a perl installation; GitHub runner images ship
+      # Strawberry Perl, but install it if a future image drops it.
+      - name: Ensure Strawberry Perl is available
+        run: |
+          if (-not (Test-Path 'C:\Strawberry\perl\bin')) {
+            choco install -y strawberryperl
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
+
+      # Builds debug + release static variants (32- and 64-bit) and packages
+      # them as boost-<version>-win-msvc<toolset>.zip.
+      - name: Build Boost
+        working-directory: dependencies/windows
+        shell: cmd
+        run: install-boost.cmd
+
+      # Builds SOCI against the Boost prebuilts produced above; the output
+      # lands in install-soci/soci-msvc<toolset>-<version>.
+      - name: Build SOCI
+        working-directory: dependencies/windows
+        shell: cmd
+        run: install-soci.cmd
+
+      - name: Package SOCI
+        working-directory: dependencies/windows
+        shell: cmd
+        run: |
+          7z a -mmt8 -mx9 -xr!*.obj -xr!*.tlog ^
+            soci-msvc%MSVC_TOOLSET_VERSION%-%SOCI_VERSION%.zip ^
+            .\install-soci\soci-msvc%MSVC_TOOLSET_VERSION%-%SOCI_VERSION%
+
+      - name: Upload workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-dependencies-msvc${{ inputs.msvc_toolset_version }}
+          path: |
+            dependencies/windows/boost-*.zip
+            dependencies/windows/soci-*.zip
+          if-no-files-found: error
+
+      - name: Configure AWS credentials
+        if: ${{ inputs.upload }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BUILDTOOLS_UPLOAD_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Upload to rstudio-buildtools
+        if: ${{ inputs.upload }}
+        working-directory: dependencies/windows
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $boostZip = "boost-$env:BOOST_VERSION-win-msvc$env:MSVC_TOOLSET_VERSION.zip"
+          aws s3 cp $boostZip "s3://rstudio-buildtools/Boost/$boostZip" --acl public-read
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $sociZip = "soci-msvc$env:MSVC_TOOLSET_VERSION-$env:SOCI_VERSION.zip"
+          aws s3 cp $sociZip "s3://rstudio-buildtools/$sociZip" --acl public-read
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/dependencies/tools/upload-windows-dependencies.sh
+++ b/dependencies/tools/upload-windows-dependencies.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# This script downloads the Boost + SOCI prebuilt archives produced by the
+# "Build Dependencies (Windows, Open Source)" GitHub Actions workflow, and
+# copies them into the RStudio Build Tools (rstudio-buildtools) S3 bucket.
+# Use it until the workflow can upload to S3 directly; see
+# https://github.com/rstudio/rstudio/issues/18124 for details.
+#
+# Presumes you've got the GitHub CLI (gh) and AWS command line tools (awscli)
+# installed, and configured with a valid AWS account.
+#
+# Usage: upload-windows-dependencies.sh <workflow-run-id>
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Usage: $(basename "$0") <workflow-run-id>"
+    echo "Find run ids with: gh run list --workflow os-build-dependencies-windows.yml"
+    exit 1
+fi
+
+RUN_ID="$1"
+AWS_BUCKET="s3://rstudio-buildtools"
+
+# Check that we're logged in with AWS
+aws sts get-caller-identity || aws sso login
+
+# Download the prebuilt archives from the workflow run
+STAGING=$(mktemp -d)
+gh run download "${RUN_ID}" --repo rstudio/rstudio --pattern 'windows-dependencies-*' --dir "${STAGING}"
+
+# Upload Boost archives under Boost/, and SOCI archives at the bucket root,
+# matching the paths install-dependencies.cmd downloads from.
+find "${STAGING}" -name 'boost-*.zip' | while read -r FILE; do
+    aws s3 cp "${FILE}" "${AWS_BUCKET}/Boost/$(basename "${FILE}")" --acl public-read
+done
+
+find "${STAGING}" -name 'soci-*.zip' | while read -r FILE; do
+    aws s3 cp "${FILE}" "${AWS_BUCKET}/$(basename "${FILE}")" --acl public-read
+done
+
+rm -rf "${STAGING}"

--- a/dependencies/windows/install-boost.cmd
+++ b/dependencies/windows/install-boost.cmd
@@ -1,9 +1,10 @@
 @echo off
 setlocal
 
-REM Variables defining the build. Update as appropriate.
-set BOOST_VERSION=1.90.0
-set MSVC_TOOLSET_VERSION=143
+REM Variables defining the build. Update as appropriate, or set in the
+REM environment to override (e.g. when building for a newer MSVC toolset).
+if not defined BOOST_VERSION set BOOST_VERSION=1.90.0
+if not defined MSVC_TOOLSET_VERSION set MSVC_TOOLSET_VERSION=143
 
 REM The file name prefix used for Boost build folders.
 set BOOST_PREFIX=boost-%BOOST_VERSION%-win-msvc%MSVC_TOOLSET_VERSION%
@@ -13,8 +14,19 @@ set PATH=%CD%\tools;%PATH%
 
 REM Build Boost.
 cd install-boost
+
 cmd.exe /C R --vanilla -s -f install-boost.R --args debug static
+if ERRORLEVEL 1 (
+  echo ^^!^^! ERROR: Boost debug build failed.
+  exit /b 1
+)
+
 cmd.exe /C R --vanilla -s -f install-boost.R --args release static
+if ERRORLEVEL 1 (
+  echo ^^!^^! ERROR: Boost release build failed.
+  exit /b 1
+)
+
 cd ..
 
 REM Build the Boost archive for upload to S3.
@@ -23,4 +35,8 @@ echo -- Packaging Boost %BOOST_VERSION% ...
    %BOOST_PREFIX%.zip ^
    %BOOST_PREFIX%-debug-static ^
    %BOOST_PREFIX%-release-static
+if ERRORLEVEL 1 (
+  echo ^^!^^! ERROR: Failed to package Boost archive.
+  exit /b 1
+)
 echo -- Done!

--- a/dependencies/windows/install-boost.cmd
+++ b/dependencies/windows/install-boost.cmd
@@ -17,13 +17,13 @@ cd install-boost
 
 cmd.exe /C R --vanilla -s -f install-boost.R --args debug static
 if ERRORLEVEL 1 (
-  echo ^^!^^! ERROR: Boost debug build failed.
+  echo !! ERROR: Boost debug build failed.
   exit /b 1
 )
 
 cmd.exe /C R --vanilla -s -f install-boost.R --args release static
 if ERRORLEVEL 1 (
-  echo ^^!^^! ERROR: Boost release build failed.
+  echo !! ERROR: Boost release build failed.
   exit /b 1
 )
 
@@ -36,7 +36,7 @@ echo -- Packaging Boost %BOOST_VERSION% ...
    %BOOST_PREFIX%-debug-static ^
    %BOOST_PREFIX%-release-static
 if ERRORLEVEL 1 (
-  echo ^^!^^! ERROR: Failed to package Boost archive.
+  echo !! ERROR: Failed to package Boost archive.
   exit /b 1
 )
 echo -- Done!

--- a/dependencies/windows/install-boost/install-boost.R
+++ b/dependencies/windows/install-boost/install-boost.R
@@ -1,7 +1,16 @@
 
 BOOST_VERSION <- Sys.getenv("BOOST_VERSION", unset = "1.90.0")
-BOOST_TOOLSET <- Sys.getenv("BOOST_TOOLSET", unset = "msvc-14.3")
 MSVC_TOOLSET_VERSION <- Sys.getenv("MSVC_TOOLSET_VERSION", unset = "143")
+
+# derive the b2 toolset from the MSVC toolset version (e.g. 143 => msvc-14.3),
+# unless explicitly overridden in the environment
+BOOST_TOOLSET_DEFAULT <- paste0(
+   "msvc-",
+   substring(MSVC_TOOLSET_VERSION, 1L, 2L),
+   ".",
+   substring(MSVC_TOOLSET_VERSION, 3L)
+)
+BOOST_TOOLSET <- Sys.getenv("BOOST_TOOLSET", unset = BOOST_TOOLSET_DEFAULT)
 
 argument <- function(index, default) {
    args <- commandArgs(TRUE)

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -16,7 +16,9 @@ set GNUGREP_VERSION=3.0
 set GWT_VERSION=2.12.2-apple-blossom
 set LIBCLANG_VERSION=13.0.1
 set MATHJAX_VERSION=2.7.9
-set MSVC_TOOLSET_VERSION=143
+REM The MSVC toolset used for Boost prebuilts. Can be set in the environment
+REM to select a different set of prebuilts (e.g. 145 for Visual Studio 2026).
+if not defined MSVC_TOOLSET_VERSION set MSVC_TOOLSET_VERSION=143
 set NSPROCESS_VERSION=1.6
 set OPENSSL_VERSION=3.1.4
 set PANDOC_VERSION=3.2

--- a/dependencies/windows/install-soci.cmd
+++ b/dependencies/windows/install-soci.cmd
@@ -1,4 +1,9 @@
 @echo off
 cd install-soci
 R --vanilla -s -f install-soci.R
+if ERRORLEVEL 1 (
+  echo ^^!^^! ERROR: SOCI build failed.
+  cd ..
+  exit /b 1
+)
 cd ..

--- a/dependencies/windows/install-soci.cmd
+++ b/dependencies/windows/install-soci.cmd
@@ -2,7 +2,7 @@
 cd install-soci
 R --vanilla -s -f install-soci.R
 if ERRORLEVEL 1 (
-  echo ^^!^^! ERROR: SOCI build failed.
+  echo !! ERROR: SOCI build failed.
   cd ..
   exit /b 1
 )


### PR DESCRIPTION
### Intent

Addresses #17986.

Boost (and SOCI) prebuilts for Windows are currently built manually on a developer's machine via `install-boost.cmd` / `install-soci.cmd` and hand-uploaded to the `rstudio-buildtools` S3 bucket. #17986 needs new `msvc145` prebuilts published for the VS 2026 toolset so the CI fallback-to-`msvc143` stopgaps from #17850 can eventually be dropped. This PR automates that build-and-publish step.

### What changed

- **New `workflow_dispatch` workflow** (`.github/workflows/os-build-dependencies-windows.yml`):
  - Inputs: Boost version, SOCI version, MSVC toolset version (default `145`), CMake generator (default `Visual Studio 18 2026`), runner image (`windows-2025` = VS 2026, `windows-2022` = VS 2022), and an `upload` toggle.
  - Builds Boost (debug + release, 32/64-bit static) via `install-boost.cmd`, then builds SOCI against those prebuilts via `install-soci.cmd`, and packages both as zips.
  - Always publishes the archives as workflow artifacts; when `upload` is enabled, pushes them to `s3://rstudio-buildtools` under the same keys `install-dependencies.cmd` downloads from (`Boost/boost-<ver>-win-msvc<toolset>.zip`, `soci-msvc<toolset>-<ver>.zip`).
  - Reuses the vswhere-junction pattern from the Windows e2e workflow so `tools.R`'s hardcoded VS 2022 path check passes on runner images with VS Enterprise / VS 2026.
- **`install-boost.cmd` / `install-dependencies.cmd`**: `BOOST_VERSION` / `MSVC_TOOLSET_VERSION` now honor values preset in the environment (defaults unchanged: `1.90.0` / `143`), so CI can request a different toolset without editing the scripts. Jenkins and local dev flows are unaffected.
- **`install-boost.R`**: the b2 toolset default is now derived from `MSVC_TOOLSET_VERSION` (`143` => `msvc-14.3`, `145` => `msvc-14.5`) instead of being hardcoded to `msvc-14.3`; `BOOST_TOOLSET` still overrides.
- **`install-boost.cmd` / `install-soci.cmd`**: propagate failures via `exit /b 1` instead of always exiting 0 (previously a failed build could be silently packaged/ignored, which would let a broken automated run "succeed").

### S3 upload credentials

The S3 upload step authenticates via GitHub OIDC and expects an `AWS_BUILDTOOLS_UPLOAD_ROLE_ARN` repository secret pointing at a role with write access to `rstudio-buildtools`. No such secret exists yet -- that's tracked in #18124. Until it's configured, run the workflow with `upload: false` and push the artifacts with the new `dependencies/tools/upload-windows-dependencies.sh`, which downloads a run's artifacts via `gh run download` and uploads them with developer SSO credentials (same flow as the other `upload-*.sh` scripts).

### QA Notes

This can only be exercised end-to-end by dispatching the workflow after merge (workflow_dispatch requires the workflow to exist on the default branch). Suggested first run: defaults (`msvc145` on `windows-2025`), `upload: false`, then inspect the artifacts. Note the first run also validates that Boost 1.90's bundled b2 accepts the `msvc-14.5` toolset / `vc145` bootstrap argument on VS 2026 -- if b2 predates VS 2026 support, the `boost_toolset` derivation may need adjusting.

Not adding a NEWS.md entry per the developer-only/build-tooling exception.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests
