### PR TITLE
Add RHEL 10 desktop e2e Playwright workflow

### DIFF
--- a/.github/actions/os-e2e-deps/action.yml
+++ b/.github/actions/os-e2e-deps/action.yml
@@ -13,6 +13,16 @@ inputs:
     description: "Directory containing the Playwright project (package.json / DESCRIPTION)."
     required: false
     default: "e2e/rstudio"
+  cache-scope:
+    description: >
+      Optional distro/ABI discriminator folded into the R-library and pak cache
+      keys. runner.os is only Linux/macOS/Windows, so every Linux caller would
+      otherwise share one key -- and a compiled R library built on one distro
+      (Ubuntu) is not loadable on another (RHEL). Linux callers on a non-default
+      distro should set this (e.g. 'rhel10-x86_64') to isolate their caches.
+      Leave empty to keep the legacy runner.os-only key (existing callers).
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -28,6 +38,13 @@ runs:
       shell: bash
       run: |
         echo "PLAYWRIGHT_BROWSERS_PATH=${{ github.workspace }}/ms-playwright" >> "$GITHUB_ENV"
+        # Fold the optional distro/ABI scope into a cache-os discriminator used
+        # by the R-library and pak keys below. Empty scope reproduces the legacy
+        # runner.os-only key byte-for-byte, so existing callers are unchanged;
+        # a caller that sets cache-scope (e.g. rhel10-x86_64) gets an isolated
+        # key so its compiled R packages can't collide with another distro's.
+        SCOPE="${{ inputs.cache-scope }}"
+        echo "CACHE_OS=${RUNNER_OS}${SCOPE:+-$SCOPE}" >> "$GITHUB_ENV"
 
     # Resolve the *installed* R version (major.minor) and fold it into the
     # cache keys below. Installed packages and pak's binary downloads are only
@@ -56,18 +73,18 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}/.r-pkg-cache
-        key: ${{ runner.os }}-pak-${{ steps.r_version.outputs.version }}-${{ hashFiles(format('{0}/DESCRIPTION', inputs.working-directory)) }}
+        key: ${{ env.CACHE_OS }}-pak-${{ steps.r_version.outputs.version }}-${{ hashFiles(format('{0}/DESCRIPTION', inputs.working-directory)) }}
         restore-keys: |
-          ${{ runner.os }}-pak-${{ steps.r_version.outputs.version }}-
+          ${{ env.CACHE_OS }}-pak-${{ steps.r_version.outputs.version }}-
 
     - name: Restore R library
       id: rlib-cache
       uses: actions/cache/restore@v4
       with:
         path: ${{ inputs.r-libs-user }}
-        key: ${{ runner.os }}-r-${{ steps.r_version.outputs.version }}-${{ hashFiles(format('{0}/DESCRIPTION', inputs.working-directory)) }}
+        key: ${{ env.CACHE_OS }}-r-${{ steps.r_version.outputs.version }}-${{ hashFiles(format('{0}/DESCRIPTION', inputs.working-directory)) }}
         restore-keys: |
-          ${{ runner.os }}-r-${{ steps.r_version.outputs.version }}-
+          ${{ env.CACHE_OS }}-r-${{ steps.r_version.outputs.version }}-
 
     - name: Install R packages from DESCRIPTION
       shell: bash
@@ -151,8 +168,11 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       # --with-deps has Playwright shell out to the OS package manager to
       # install the browser's system libraries, but Playwright only supports
-      # that on Debian/Ubuntu. On RHEL-family hosts the calling workflow installs
-      # those libraries via dnf, so just fetch the browser binary here.
+      # that on Debian/Ubuntu. So on RHEL-family hosts we fetch only the browser
+      # binary -- which means the caller MUST have already installed the Chromium
+      # runtime libraries (nss, gtk3, mesa-libgbm, ...) via dnf. This is a real
+      # cross-file contract: a RHEL caller that omits that dnf step gets a
+      # browser that can't launch, surfacing far away as an opaque launch error.
       run: |
         IS_RHEL=false
         if [ "$RUNNER_OS" = "Linux" ] && [ -r /etc/os-release ]; then

--- a/.github/actions/os-e2e-deps/action.yml
+++ b/.github/actions/os-e2e-deps/action.yml
@@ -76,11 +76,17 @@ runs:
         R_USER_CACHE_DIR: ${{ github.workspace }}/.r-pkg-cache
       run: |
         if [ "$RUNNER_OS" = "Linux" ]; then
-          # Track the runner's actual Ubuntu release so PPM serves native
-          # binaries (noble on 24.04, resolute on 26.04) and there's no
-          # cross-release ABI mismatch.
+          # Track the runner's actual distro so PPM serves native binaries and
+          # there's no cross-release ABI mismatch. Debian/Ubuntu key off the
+          # release codename (noble on 24.04, resolute on 26.04); RHEL and its
+          # rebuilds have no VERSION_CODENAME, so key off the major version
+          # (rhel9, rhel10) instead.
           . /etc/os-release
-          export PKG_REPO="https://packagemanager.posit.co/cran/__linux__/${VERSION_CODENAME}/latest"
+          if [ "$ID" = "rhel" ] || [ "$ID" = "rocky" ] || [ "$ID" = "almalinux" ] || [ "$ID" = "centos" ] || printf '%s' "$ID_LIKE" | grep -q 'rhel'; then
+            export PKG_REPO="https://packagemanager.posit.co/cran/__linux__/rhel${VERSION_ID%%.*}/latest"
+          else
+            export PKG_REPO="https://packagemanager.posit.co/cran/__linux__/${VERSION_CODENAME}/latest"
+          fi
         else
           export PKG_REPO="https://packagemanager.posit.co/cran/latest"
         fi
@@ -143,7 +149,23 @@ runs:
     - name: Install Playwright browsers
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: npx playwright install --with-deps chromium
+      # --with-deps has Playwright shell out to the OS package manager to
+      # install the browser's system libraries, but Playwright only supports
+      # that on Debian/Ubuntu. On RHEL-family hosts the calling workflow installs
+      # those libraries via dnf, so just fetch the browser binary here.
+      run: |
+        IS_RHEL=false
+        if [ "$RUNNER_OS" = "Linux" ] && [ -r /etc/os-release ]; then
+          . /etc/os-release
+          if [ "$ID" = "rhel" ] || [ "$ID" = "rocky" ] || [ "$ID" = "almalinux" ] || [ "$ID" = "centos" ] || printf '%s' "$ID_LIKE" | grep -q 'rhel'; then
+            IS_RHEL=true
+          fi
+        fi
+        if [ "$IS_RHEL" = true ]; then
+          npx playwright install chromium
+        else
+          npx playwright install --with-deps chromium
+        fi
 
     - name: Save Playwright browsers
       if: github.ref == 'refs/heads/main' && steps.pw-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-rhel-10-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-rhel-10-x86_64.yml
@@ -157,6 +157,12 @@ jobs:
             || dnf config-manager setopt ubi-10-codeready-builder-rpms.enabled=1 2>/dev/null \
             || dnf config-manager --set-enabled crb 2>/dev/null \
             || true
+          # Name the failure here rather than letting an unenabled CRB resurface
+          # two steps later as an opaque "Unable to find a match: boost-devel".
+          # Best-effort still: a warning, not a hard fail, since a given package
+          # set might resolve from the base repos alone.
+          dnf repolist --enabled | grep -qiE 'codeready|crb' \
+            || echo "::warning::CodeReady Builder repo not enabled; build -devel packages may fail to resolve."
 
       - uses: actions/checkout@v4
 
@@ -191,11 +197,12 @@ jobs:
       # Java sources / build scripts haven't changed, make-electron-package can
       # skip the recompile entirely via the NO_REBUILD env var (sets
       # GWT_BUILD=no, which becomes -DGWT_BUILD=no to cmake) -- see the
-      # NO_REBUILD/GWT_BUILD handling in package/linux/make-package. The RPM
-      # build dir differs from the DEB build dir, so this uses an rhel10-specific
-      # key rather than sharing the Ubuntu Electron GWT cache. Restore-only here;
-      # the matching Save step runs after the build with a success gate so a
-      # failed mid-compile run can't poison the cache.
+      # NO_REBUILD/GWT_BUILD handling in package/linux/make-package. GWT output
+      # is Java-to-JS and platform-independent, but the key is rhel10-scoped for
+      # per-distro cache isolation (matching the tools/rlibs keys); the RPM build
+      # dir also differs from the DEB dir, so the path can't collide either.
+      # Restore-only here; the matching Save step runs after the build with a
+      # success gate so a failed mid-compile run can't poison the cache.
       - name: Restore GWT output
         id: gwt-cache
         uses: actions/cache/restore@v4
@@ -283,13 +290,16 @@ jobs:
           key: ${{ steps.gwt-cache.outputs.cache-primary-key }}
 
       # Skipped in build_only (seed) runs: no e2e job consumes the artifact,
-      # so packaging and uploading it would be pure waste. CPack drops the .rpm
-      # under build-Electron-RPM/_CPack_Packages/Linux/RPM, so search the whole
-      # tree rather than just the top level.
+      # so packaging and uploading it would be pure waste. CPack writes the
+      # shippable .rpm to the TOP LEVEL of build-Electron-RPM (no
+      # CPACK_PACKAGE_DIRECTORY is set and cpack runs from inside that dir),
+      # exactly like the .deb sibling -- so -maxdepth 1 is correct and
+      # deterministic. _CPack_Packages/.../RPM holds only rpmbuild staging
+      # copies and the xcopy tarball, which we must not pick up.
       - name: Package RStudio Desktop .rpm
         if: inputs.build_only != true
         run: |
-          RPM=$(find package/linux/build-Electron-RPM -name '*.rpm' | head -1)
+          RPM=$(find package/linux/build-Electron-RPM -maxdepth 1 -name '*.rpm' | head -1)
           if [ -z "$RPM" ]; then
             echo "::error::No .rpm found in package/linux/build-Electron-RPM"
             exit 1
@@ -353,11 +363,13 @@ jobs:
         run: |
           # Xvfb (virtual display for the Electron app / Playwright) plus the
           # runtime libraries Chromium/Electron and the Playwright-managed
-          # chromium need on RHEL. dnf resolves the RStudio .rpm's own GUI deps
-          # on install, but the Playwright browser needs these present too. The
-          # last row mirrors the font/text libs some test R packages load:
-          # freetype/fontconfig (ragg, systemfonts), harfbuzz/fribidi
-          # (textshaping).
+          # chromium need on RHEL. This list is load-bearing, not redundant: the
+          # RStudio Electron RPM is built with CPACK_RPM_PACKAGE_AUTOREQPROV off
+          # (see package/linux/CMakeLists.txt) and declares only libxkbcommon-x11
+          # and sqlite, so dnf does NOT auto-pull the GUI/Chromium libs on
+          # install -- they must come from here. The last row mirrors the
+          # font/text libs some test R packages load: freetype/fontconfig (ragg,
+          # systemfonts), harfbuzz/fribidi (textshaping).
           dnf -y install \
             xorg-x11-server-Xvfb \
             nss nspr atk at-spi2-atk at-spi2-core cups-libs \
@@ -381,7 +393,9 @@ jobs:
           mkdir -p "$R_LIBS_USER"
 
       # Build-from-source path: extract the .rpm artifact produced by the build
-      # job above and install it. dnf resolves the runtime GUI deps.
+      # job above and install it. The RPM declares only minimal deps (AUTOREQPROV
+      # is off), so the GUI/Chromium runtime libs come from the "Install OS
+      # dependencies" step above, not from the RPM's own resolution.
       - name: Download RStudio Desktop .rpm artifact
         if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
         uses: actions/download-artifact@v4
@@ -480,6 +494,10 @@ jobs:
         uses: ./.github/actions/os-e2e-deps
         with:
           r-libs-user: ${{ env.R_LIBS_USER }}
+          # Isolate the R-library / pak caches from the Ubuntu workflows: they
+          # all share runner.os == Linux, and an Ubuntu-compiled R library is
+          # ABI-incompatible with RHEL's R. See os-e2e-deps cache-scope.
+          cache-scope: rhel10-x86_64
 
       - name: Run Playwright tests
         working-directory: e2e/rstudio

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-rhel-10-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-rhel-10-x86_64.yml
@@ -1,0 +1,663 @@
+name: "Test: E2E Playwright RStudio (Desktop, RHEL 10 x86_64, Open Source)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_from_source:
+        description: "Build RStudio Desktop (Electron) from this branch's source. When false, downloads the latest daily .rpm installer."
+        type: boolean
+        default: true
+      rstudio_installer_url:
+        description: "Optional .rpm URL to test against (e.g. a specific daily from dailies.rstudio.com). Only used when build_from_source is false. Leave empty to auto-resolve the latest daily."
+        type: string
+        default: ""
+      r_version:
+        description: "R version to install via rig (e.g. 'release', 'oldrel', 'devel', '4.4.1')."
+        type: string
+        default: "release"
+      project:
+        description: "Playwright project to run: 'desktop' or 'server'. OS and edition are auto-filtered from the host platform and PW_RSTUDIO_EDITION."
+        type: string
+        default: "desktop"
+      grep:
+        description: "Optional Playwright --grep pattern to run only tests whose title matches."
+        type: string
+        default: ""
+      test_selector:
+        description: "Optional test paths/files/directories to run (space-separated). Matched as substrings against test file paths. Examples: 'autocomplete.test.ts', 'tests/panes/misc/', 'autocomplete tests/panes/posit-assistant-chat/'. Leave empty to run all tests."
+        type: string
+        default: ""
+      test_ignore:
+        description: "Optional test paths/files/directories to exclude (space-separated globs). Examples: '**/code_suggestions.test.ts', '**/posit-assistant-chat/**'. Leave empty to exclude nothing."
+        type: string
+        default: ""
+      grep_invert:
+        description: "Optional Playwright --grep-invert pattern to skip tests by title. Defaults to '@ai' to skip tests that require credentials not available in unattended runs."
+        type: string
+        default: "@ai"
+      rstudio_extra_args:
+        description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS. Set to '--no-sandbox' if the in-container Chromium sandbox won't initialize (see the container options below)."
+        type: string
+        default: ""
+      build_only:
+        description: "Run only the build job (to seed the rstudio-tools / R-libs / sccache caches) and skip the e2e job."
+        type: boolean
+        default: false
+      post_pr_comment:
+        description: "Post test results as a sticky comment on the PR. Pass true only from PR-triggered callers."
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      build_from_source:
+        type: boolean
+        default: true
+      rstudio_installer_url:
+        type: string
+        default: ""
+      r_version:
+        type: string
+        default: "release"
+      project:
+        type: string
+        default: "desktop"
+      grep:
+        type: string
+        default: ""
+      test_selector:
+        type: string
+        default: ""
+      test_ignore:
+        type: string
+        default: ""
+      grep_invert:
+        type: string
+        default: "@ai"
+      rstudio_extra_args:
+        type: string
+        default: ""
+      build_only:
+        type: boolean
+        default: false
+      post_pr_comment:
+        type: boolean
+        default: false
+    secrets:
+      CONNECT_API_KEY:
+        description: "Posit Connect API key for the E2E Test Insights reporter"
+        required: false
+
+permissions:
+  contents: read
+  # Required so the e2e-merge job can post sticky PR comments via
+  # marocchino/sticky-pull-request-comment. GitHub validates ALL job-level
+  # permissions in a reusable workflow at call time, so this must be declared
+  # at the top level even though only e2e-merge uses it.
+  pull-requests: write
+
+jobs:
+  # Builds RStudio Desktop (Electron) from this PR's source inside a RHEL 10 UBI
+  # container (GitHub has no RHEL-hosted runner), then uploads the .rpm as an
+  # artifact for the e2e job to consume. Skipped when build_from_source is
+  # false, in which case the e2e job downloads the daily .rpm (or
+  # rstudio_installer_url) instead.
+  build:
+    if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
+    runs-on: ubuntu-latest
+    # UBI 10 is the closest freely-redistributable RHEL 10 image; it needs no
+    # subscription and no registry auth. SYS_ADMIN + an unconfined seccomp
+    # profile let a later Chromium/Electron sandbox initialize inside the
+    # container (the host sysctl the Ubuntu jobs flip isn't reachable here).
+    container:
+      image: registry.access.redhat.com/ubi10/ubi:latest
+      options: --cap-add=SYS_ADMIN --security-opt seccomp=unconfined
+    timeout-minutes: 90
+    env:
+      # Redirect the dependency / package scripts' tool root to a
+      # workspace-local path so it can be cached without sudo.
+      RSTUDIO_TOOLS_ROOT: ${{ github.workspace }}/opt/rstudio-tools/x86_64
+      # Pin R's user library to a workspace-local path so we can cache it.
+      R_LIBS_USER: ${{ github.workspace }}/R-libs/%p/%v
+      SCCACHE_ENABLED: '1'
+      # Route sccache to GitHub's built-in Actions cache API. The
+      # mozilla-actions/sccache-action step below installs sccache and exports
+      # ACTIONS_CACHE_URL + ACTIONS_RUNTIME_TOKEN so the sccache server uses
+      # the GHA backend. Cache hits are object-level (one entry per compiled
+      # .o), so PRs automatically inherit main's warm cache from the seed job
+      # without per-SHA tarball rotation. No AWS / S3 / secrets required.
+      SCCACHE_GHA_ENABLED: 'true'
+      # Compile GWT with readable (PRETTY) symbol names rather than the default
+      # OBFUSCATED output, so the uncaught client exceptions the e2e automation
+      # agent records (window.rstudio.errors) carry decodable Java stack traces.
+      # Consumed by src/gwt/CMakeLists.txt; folded into the GWT cache key below.
+      GWT_STYLE: PRETTY
+      # Quiet npm during install-common's panmirror build, the Electron app
+      # build, and any other transitive npm step.
+      NPM_CONFIG_LOGLEVEL: error
+      NPM_CONFIG_AUDIT: 'false'
+
+    steps:
+      # UBI is minimal and the job runs as root. Install the tools the checkout
+      # action, the dependency scripts, and the build need up front. sudo is
+      # required because install-dependencies-yum calls it internally (root's
+      # sudo is a straight passthrough).
+      - name: Prepare UBI container
+        run: |
+          dnf -y install sudo git tar gzip xz jq which findutils diffutils procps-ng
+
+      # Several build-time -devel packages (boost-devel, pango-devel, ...) live
+      # in EPEL / CodeReady Builder rather than the UBI base repos. Enable both
+      # best-effort so install-dependencies-yum can resolve them. dnf5 (UBI 10)
+      # and dnf4 differ on config-manager syntax, so try both.
+      - name: Enable EPEL and CRB repos
+        run: |
+          dnf -y install dnf-plugins-core || true
+          dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm || true
+          dnf config-manager --set-enabled ubi-10-codeready-builder-rpms 2>/dev/null \
+            || dnf config-manager setopt ubi-10-codeready-builder-rpms.enabled=1 2>/dev/null \
+            || dnf config-manager --set-enabled crb 2>/dev/null \
+            || true
+
+      - uses: actions/checkout@v4
+
+      # Pre-built tool deps (Boost, SOCI, pandoc, quarto, GWT, node, panmirror,
+      # copilot-language-server, sccache, etc.) all land under RSTUDIO_TOOLS_ROOT.
+      # Restore-only; the matching Save steps after "Install build
+      # dependencies" run only from main-scoped runs. RHEL-scoped key so the
+      # rhel10 tools tree never collides with the Ubuntu (resolute/noble) ones.
+      - name: Restore rstudio-tools deps
+        id: tools-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.RSTUDIO_TOOLS_ROOT }}
+          key: rstudio-tools-linux-rhel10-x86_64-${{ hashFiles('dependencies/common/install-*', 'dependencies/linux/install-*', 'dependencies/tools/rstudio-tools.sh') }}
+          restore-keys: |
+            rstudio-tools-linux-rhel10-x86_64-
+
+      # install-common (called by install-dependencies-yum) installs R packages
+      # (via install-packages) into R_LIBS_USER. Cache the whole R-libs tree --
+      # R's %p/%v subpaths keep different versions isolated.
+      - name: Restore build-time R packages
+        id: rlibs-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/R-libs
+          key: rstudio-build-rlibs-linux-rhel10-x86_64-${{ hashFiles('dependencies/common/install-packages', 'dependencies/common/lockfiles/**/renv.lock') }}
+          restore-keys: |
+            rstudio-build-rlibs-linux-rhel10-x86_64-
+
+      # Cache compiled GWT output (package/linux/build-Electron-RPM/gwt). GWT
+      # compilation is the single most expensive JS step (~15-30 min). When GWT
+      # Java sources / build scripts haven't changed, make-electron-package can
+      # skip the recompile entirely via the NO_REBUILD env var (sets
+      # GWT_BUILD=no, which becomes -DGWT_BUILD=no to cmake) -- see the
+      # NO_REBUILD/GWT_BUILD handling in package/linux/make-package. The RPM
+      # build dir differs from the DEB build dir, so this uses an rhel10-specific
+      # key rather than sharing the Ubuntu Electron GWT cache. Restore-only here;
+      # the matching Save step runs after the build with a success gate so a
+      # failed mid-compile run can't poison the cache.
+      - name: Restore GWT output
+        id: gwt-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: package/linux/build-Electron-RPM/gwt
+          key: rstudio-gwt-linux-desktop-rhel10-x86_64-${{ env.GWT_STYLE }}-v1-${{ hashFiles('src/gwt/src/**', 'src/gwt/acesupport/**', 'src/gwt/lib/**', 'src/gwt/build.xml', 'src/gwt/conf/**') }}
+          restore-keys: |
+            rstudio-gwt-linux-desktop-rhel10-x86_64-${{ env.GWT_STYLE }}-v1-
+
+      # GHA-backed sccache. Installs sccache on PATH and starts the sccache
+      # server with the GH Actions cache API as the storage backend. Object-level
+      # cache hits, no per-SHA tarball, no AWS credentials.
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      # install-dependencies-yum: dnf installs system packages (with sudo
+      # internally), then calls install-common which downloads Boost, SOCI,
+      # pandoc, quarto, node, panmirror, sccache, GWT jar, etc. into
+      # RSTUDIO_TOOLS_ROOT. The scripts are idempotent, so a cache hit on
+      # rstudio-tools-deps makes this a fast pass: the heavy downloads are
+      # skipped and the cached tools are reused.
+      - name: Install build dependencies
+        working-directory: dependencies/linux
+        run: ./install-dependencies-yum
+
+      # Save the tools / R-libs caches only from main-scoped runs (scheduled
+      # or dispatched on main), and only on a key miss. A cache saved from a
+      # PR run lands in that PR's merge-ref scope, which no other branch can
+      # restore -- each copy is pure pressure on the repo's 10 GB Actions
+      # cache quota, and that pressure is what evicts main's copies and sends
+      # every PR build cold in the first place.
+      - name: Save rstudio-tools deps
+        if: github.ref == 'refs/heads/main' && steps.tools-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.RSTUDIO_TOOLS_ROOT }}
+          key: ${{ steps.tools-cache.outputs.cache-primary-key }}
+
+      - name: Save build-time R packages
+        if: github.ref == 'refs/heads/main' && steps.rlibs-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/R-libs
+          key: ${{ steps.rlibs-cache.outputs.cache-primary-key }}
+
+      - name: Zero sccache stats
+        run: sccache --zero-stats || true
+
+      - name: Build RStudio Desktop RPM
+        id: build
+        working-directory: package/linux
+        env:
+          RSTUDIO_VERSION_MAJOR: '99'
+          RSTUDIO_VERSION_MINOR: '9'
+          RSTUDIO_VERSION_PATCH: '9'
+          RSTUDIO_VERSION_SUFFIX: "-pr+${{ github.run_number }}"
+        run: |
+          # NO_REBUILD=1 (see package/linux/make-package) tells the script to
+          # set GWT_BUILD=no, which becomes -DGWT_BUILD=no to cmake, so the
+          # cached GWT bin/www/extras under build-Electron-RPM/gwt are reused
+          # instead of recompiled (~15-30 min saved when sources unchanged).
+          if [ "${{ steps.gwt-cache.outputs.cache-hit }}" = "true" ]; then
+            echo "GWT cache hit -- skipping GWT compile"
+            NO_REBUILD=1 ./make-electron-package RPM
+          else
+            echo "GWT cache miss -- compiling GWT from scratch"
+            ./make-electron-package RPM
+          fi
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
+      # Save GWT output only when the build succeeded. A failed mid-compile run
+      # could otherwise write partial GWT output to the cache, and every future
+      # restore would silently ship a broken frontend until the hashFiles key
+      # rotates. Skip on an exact restore hit: re-saving would just duplicate
+      # the entry into this run's ref scope. PR runs that changed GWT sources
+      # still save, so re-pushes to the same PR skip the recompile.
+      - name: Save GWT output
+        if: steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: package/linux/build-Electron-RPM/gwt
+          key: ${{ steps.gwt-cache.outputs.cache-primary-key }}
+
+      # Skipped in build_only (seed) runs: no e2e job consumes the artifact,
+      # so packaging and uploading it would be pure waste. CPack drops the .rpm
+      # under build-Electron-RPM/_CPack_Packages/Linux/RPM, so search the whole
+      # tree rather than just the top level.
+      - name: Package RStudio Desktop .rpm
+        if: inputs.build_only != true
+        run: |
+          RPM=$(find package/linux/build-Electron-RPM -name '*.rpm' | head -1)
+          if [ -z "$RPM" ]; then
+            echo "::error::No .rpm found in package/linux/build-Electron-RPM"
+            exit 1
+          fi
+          cp "$RPM" "${{ github.workspace }}/rstudio-desktop.rpm"
+          echo "Packaged: $RPM"
+
+      - name: Upload RStudio Desktop .rpm artifact
+        if: inputs.build_only != true
+        uses: actions/upload-artifact@v4
+        with:
+          name: rstudio-desktop-rpm-rhel10-x86_64
+          path: rstudio-desktop.rpm
+          retention-days: 7
+
+  e2e-desktop-rhel:
+    needs: build
+    # build is skipped when build_from_source is false; allow this job to run
+    # in that case too (needs.build.result == 'skipped' on the daily-download
+    # path). build_only seeds the build caches without running e2e, so skip.
+    if: |
+      always() &&
+      inputs.build_only != true &&
+      (needs.build.result == 'success' || needs.build.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    runs-on: ubuntu-latest
+    container:
+      image: registry.access.redhat.com/ubi10/ubi:latest
+      # SYS_ADMIN + unconfined seccomp let Chromium/Electron's namespace sandbox
+      # initialize inside the container. The Ubuntu jobs instead flip a host
+      # sysctl (kernel.apparmor_restrict_unprivileged_userns=0), which isn't
+      # reachable from an unprivileged container -- /proc/sys is read-only. If
+      # the sandbox still refuses to come up here, pass --no-sandbox via
+      # rstudio_extra_args (PW_RSTUDIO_EXTRA_ARGS) rather than changing these.
+      options: --cap-add=SYS_ADMIN --security-opt seccomp=unconfined
+    timeout-minutes: 120
+    env:
+      R_LIBS_USER: ${{ github.workspace }}/R-libs
+      PW_SANDBOX_ROOT: ${{ github.workspace }}/pw-sandbox
+      PW_SANDBOX_ROOT_CREATE: '1'
+
+    steps:
+      # UBI is minimal and the job runs as root. Install what checkout, rig, and
+      # the .rpm install need. sudo is kept for parity with the shared scripts.
+      - name: Prepare UBI container
+        run: |
+          dnf -y install sudo git tar gzip xz jq which findutils
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
+
+      - name: Install OS dependencies
+        run: |
+          # Xvfb (virtual display for the Electron app / Playwright) plus the
+          # runtime libraries Chromium/Electron and the Playwright-managed
+          # chromium need on RHEL. dnf resolves the RStudio .rpm's own GUI deps
+          # on install, but the Playwright browser needs these present too. The
+          # last row mirrors the font/text libs some test R packages load:
+          # freetype/fontconfig (ragg, systemfonts), harfbuzz/fribidi
+          # (textshaping).
+          dnf -y install \
+            xorg-x11-server-Xvfb \
+            nss nspr atk at-spi2-atk at-spi2-core cups-libs \
+            libdrm mesa-libgbm libxkbcommon \
+            libX11 libXcomposite libXdamage libXext libXfixes libXrandr libXScrnSaver libXtst libxcb \
+            gtk3 pango cairo alsa-lib \
+            freetype fontconfig harfbuzz fribidi
+
+      - name: Install rig
+        run: |
+          curl -fLs https://github.com/r-lib/rig/releases/download/latest/rig-linux-$(arch)-latest.tar.gz \
+            | tar xz -C /usr/local
+
+      - name: Install R via rig
+        env:
+          R_VERSION: ${{ inputs.r_version }}
+        run: |
+          rig add "$R_VERSION"
+          rig default "$R_VERSION"
+          rig ls
+          mkdir -p "$R_LIBS_USER"
+
+      # Build-from-source path: extract the .rpm artifact produced by the build
+      # job above and install it. dnf resolves the runtime GUI deps.
+      - name: Download RStudio Desktop .rpm artifact
+        if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
+        uses: actions/download-artifact@v4
+        with:
+          name: rstudio-desktop-rpm-rhel10-x86_64
+          path: ${{ github.workspace }}
+
+      - name: Install RStudio Desktop from artifact
+        if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
+        run: |
+          dnf -y install "${{ github.workspace }}/rstudio-desktop.rpm"
+          ls -la /usr/bin/rstudio
+
+      # Daily-download path: resolve and install the latest (or specified) .rpm.
+      # Runs when build_from_source is false (auto-resolve the daily via
+      # dailies.rstudio.com/rstudio/latest/index.json) or when an explicit
+      # rstudio_installer_url is provided (use that URL verbatim).
+      - name: Resolve RStudio Desktop .rpm URL
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
+        id: resolve
+        env:
+          INSTALLER_URL: ${{ inputs.rstudio_installer_url }}
+        run: |
+          URL="$INSTALLER_URL"
+          SHA=""
+          FILENAME=""
+          if [ -z "$URL" ]; then
+            MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 'https://dailies.rstudio.com/rstudio/latest/index.json')
+            # The RHEL 10 Desktop build ships as an Electron .rpm keyed
+            # "rhel10-x86_64" under the electron product in the daily manifest.
+            URL=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["rhel10-x86_64"].link // empty')
+            SHA=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["rhel10-x86_64"].sha256 // empty')
+            FILENAME=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["rhel10-x86_64"].filename // empty')
+            if [ -z "$URL" ] || [ -z "$FILENAME" ] || [ -z "$SHA" ]; then
+              echo "::error::Daily manifest is missing expected fields (url='$URL', filename='$FILENAME', sha256='$SHA'). The schema at https://dailies.rstudio.com/rstudio/latest/index.json may have changed."
+              exit 1
+            fi
+            echo "Auto-resolved latest rhel10-x86_64 desktop daily:"
+            echo "  URL:      $URL"
+            echo "  SHA-256:  $SHA"
+            echo "  Filename: $FILENAME"
+          else
+            FILENAME=$(basename "${URL%%\?*}")
+            if [ -z "$FILENAME" ]; then
+              echo "::error::Could not derive filename from rstudio_installer_url='$URL'."
+              exit 1
+            fi
+            echo "Using override URL: $URL (SHA-256 verification skipped)"
+          fi
+          echo "url=$URL"           >> "$GITHUB_OUTPUT"
+          echo "sha256=$SHA"        >> "$GITHUB_OUTPUT"
+          echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
+
+      # Cache the daily installer keyed on its resolved filename. Filenames
+      # embed the version + build number on the auto-resolve path so the content
+      # is immutable per name: new daily misses and downloads, same-day re-run
+      # hits and skips (SHA still verified below). Skip caching on the override
+      # path -- a user-supplied URL has no immutability guarantee and its SHA
+      # check is skipped, so a reused basename could otherwise serve stale,
+      # unverified bytes.
+      - name: Cache RStudio Desktop installer
+        if: inputs.build_from_source == false && inputs.rstudio_installer_url == ''
+        id: installer-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.resolve.outputs.filename }}
+          key: rstudio-desktop-installer-${{ steps.resolve.outputs.filename }}
+
+      - name: Download RStudio Desktop .rpm
+        if: (inputs.build_from_source == false || inputs.rstudio_installer_url != '') && steps.installer-cache.outputs.cache-hit != 'true'
+        env:
+          DOWNLOAD_URL: ${{ steps.resolve.outputs.url }}
+          DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}
+        run: |
+          curl -fsSL --retry 3 --retry-delay 5 \
+            -o "$DOWNLOAD_FILENAME" \
+            "$DOWNLOAD_URL"
+
+      - name: Verify SHA-256
+        if: (inputs.build_from_source == false || inputs.rstudio_installer_url != '') && steps.resolve.outputs.sha256 != ''
+        env:
+          EXPECTED_SHA256: ${{ steps.resolve.outputs.sha256 }}
+          DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}
+        run: |
+          echo "$EXPECTED_SHA256  $DOWNLOAD_FILENAME" | sha256sum -c -
+
+      - name: Install RStudio Desktop from .rpm
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
+        env:
+          INSTALLER_FILENAME: ${{ steps.resolve.outputs.filename }}
+        run: |
+          dnf -y install "./$INSTALLER_FILENAME"
+          ls -la /usr/bin/rstudio
+
+      - name: Install e2e test dependencies
+        uses: ./.github/actions/os-e2e-deps
+        with:
+          r-libs-user: ${{ env.R_LIBS_USER }}
+
+      - name: Run Playwright tests
+        working-directory: e2e/rstudio
+        env:
+          PW_RSTUDIO_MODE: desktop
+          PW_PROJECT_NAME: ${{ inputs.project }}
+          PW_GREP: ${{ inputs.grep }}
+          PW_GREP_INVERT: ${{ inputs.grep_invert }}
+          PW_TEST_SELECTOR: ${{ inputs.test_selector }}
+          PW_TEST_IGNORE: ${{ inputs.test_ignore }}
+          PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
+          # Tells playwright.config.ts to switch to blob reporter for this shard.
+          PW_SHARD: ${{ matrix.shard }}
+          # E2E Test Insights reporter: posts per-shard results to the dashboard.
+          # CONNECT_API_KEY is empty on fork PRs; the reporter still runs but its
+          # uploads fail with warnings (never fails the run).
+          CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+          SHARD_NAME: desktop-linux-rhel10-${{ matrix.shard }}
+          # Print the GWT launch timeline so the next launch failure shows which
+          # phase exceeded the deadline.
+          PW_DEBUG_LAUNCH: '1'
+        run: |
+          ARGS=()
+          if [ -n "$PW_TEST_SELECTOR" ]; then
+            set -f
+            ARGS+=($PW_TEST_SELECTOR)
+            set +f
+          fi
+          ARGS+=(--project "$PW_PROJECT_NAME")
+          if [ -n "$PW_GREP" ]; then
+            ARGS+=(--grep "$PW_GREP")
+          fi
+          if [ -n "$PW_GREP_INVERT" ]; then
+            ARGS+=(--grep-invert "$PW_GREP_INVERT")
+          fi
+          ARGS+=(--shard="${{ matrix.shard }}/${{ strategy.job-total }}")
+          # Run Playwright under our own Xvfb and exec it as the step's main
+          # process, so a job cancellation's SIGTERM reaches Playwright
+          # directly. xvfb-run is a shell wrapper that does not forward signals
+          # to its child, which left cancelled Linux e2e jobs running until
+          # their timeout-minutes instead of stopping. -ac disables X access
+          # control so Chromium connects without an auth cookie; -nolisten tcp
+          # keeps the display on the local socket only. We wait for the X socket
+          # before launching so it doesn't race a cold display, and fail loudly
+          # (dumping the Xvfb log) if it never comes up, rather than exec-ing
+          # Playwright against a dead display and surfacing an opaque launch error.
+          Xvfb :99 -screen 0 1920x1080x24 -ac -nolisten tcp >/tmp/xvfb.log 2>&1 &
+          export DISPLAY=:99
+          for _ in $(seq 1 50); do
+            [ -S /tmp/.X11-unix/X99 ] && break
+            sleep 0.1
+          done
+          if [ ! -S /tmp/.X11-unix/X99 ]; then
+            echo "::error::Xvfb display :99 never came up after 5s; Xvfb log follows."
+            cat /tmp/xvfb.log || true
+            exit 1
+          fi
+          exec npx playwright test "${ARGS[@]}"
+
+      - name: Upload blob report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-blob-report-linux-desktop-rhel10-${{ matrix.shard }}
+          path: e2e/rstudio/blob-report/
+          if-no-files-found: warn
+          retention-days: 1
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-linux-desktop-rhel10-${{ matrix.shard }}
+          path: e2e/rstudio/test-results/
+          if-no-files-found: ignore
+
+      # Preserved per-spec sandbox tree on failure -- includes rsession logs,
+      # the spec's RStudio config / data home, and per-test working dirs.
+      - name: Upload PW sandbox (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pw-sandbox-linux-desktop-rhel10-${{ matrix.shard }}
+          path: ${{ github.workspace }}/pw-sandbox/
+          if-no-files-found: ignore
+
+  # Merge per-shard blob reports into a single HTML report, parse aggregated
+  # counts, and post a sticky PR comment with pass/fail/skip totals
+  # (when post_pr_comment is set). Runs on a plain hosted runner -- merging only
+  # needs node + `playwright merge-reports`, no RHEL container.
+  e2e-merge:
+    needs: [e2e-desktop-rhel]
+    if: always() && needs.e2e-desktop-rhel.result != 'skipped' && needs.e2e-desktop-rhel.result != 'cancelled'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
+
+      - name: Install Playwright
+        working-directory: e2e/rstudio
+        # --ignore-scripts skips the postinstall that downloads browser
+        # binaries; the merge job only invokes `playwright merge-reports`,
+        # which doesn't need Chromium.
+        run: npm ci --ignore-scripts
+
+      - name: Download shard blob reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: playwright-blob-report-linux-desktop-rhel10-*
+          path: e2e/rstudio/all-blob-reports
+          merge-multiple: true
+
+      - name: Merge shard reports
+        working-directory: e2e/rstudio
+        run: |
+          if [ -z "$(ls -A all-blob-reports 2>/dev/null)" ]; then
+            echo "::error::No blob reports found -- both shards failed to produce artifacts"
+            exit 1
+          fi
+          npx playwright merge-reports --config merge.config.ts ./all-blob-reports
+
+      # Shared summarizer (also used by the PR run's e2e-merge-all job) so every
+      # comment computes pass/fail counts and the rate bar from one definition.
+      - name: Parse aggregated results
+        id: summary
+        if: always()
+        working-directory: e2e/rstudio
+        run: node scripts/summarize-merged-report.mjs playwright-report/test-results.json
+
+      - name: Upload merged Playwright report
+        id: upload-report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-linux-desktop-rhel10
+          path: e2e/rstudio/playwright-report/
+          retention-days: 15
+          if-no-files-found: ignore
+
+      - name: Post E2E results to PR
+        if: |
+          always() &&
+          inputs.post_pr_comment == true &&
+          github.event.pull_request.head.repo.fork == false &&
+          (steps.summary.outputs.passed != '0' || steps.summary.outputs.failed != '0' || steps.summary.outputs.skipped != '0' || steps.summary.outputs.flaky != '0')
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: e2e-desktop-rhel10-results
+          GITHUB_TOKEN: ${{ github.token }}
+          message: |
+            ## 🎩 Linux Desktop E2E · RHEL 10
+
+            ${{ needs.e2e-desktop-rhel.result == 'success' && steps.summary.outputs.failed == '0' && '### ✅ All tests passed!' || format('### ❌ {0} test(s) failed', steps.summary.outputs.failed) }}
+
+            `${{ steps.summary.outputs.bar }}` **${{ steps.summary.outputs.rate }}%** pass rate
+
+            | ✅ Passed | ❌ Failed | ⚠️ Skipped | 🔁 Flaky |
+            | :---: | :---: | :---: | :---: |
+            | **${{ steps.summary.outputs.passed }}** | **${{ steps.summary.outputs.failed }}** | **${{ steps.summary.outputs.skipped }}** | **${{ steps.summary.outputs.flaky }}** |
+
+            <details>
+            <summary>📥 Download Playwright report</summary>
+
+            **[⬇️ playwright-report.zip](${{ steps.upload-report.outputs.artifact-url }})** — extract and open `index.html`
+
+            > Includes screenshots, traces, and step-by-step details for every test. Expires in 15 days.
+
+            </details>
+
+            ---
+            <sub>2 shards · ubi10 container · commit <code>${{ github.event.pull_request.head.sha }}</code> · <a href="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}">Run #${{ github.run_number }}</a></sub>


### PR DESCRIPTION
Adds a standalone workflow that runs the RStudio Desktop e2e Playwright suite on RHEL 10, inside a UBI 10 container on a hosted `ubuntu-latest` runner (GitHub has no RHEL-hosted runner). Modeled on the Ubuntu 26 desktop workflow, with RHEL-specific adaptations:

- `dnf`/`yum` dependency install (`install-dependencies-yum`, best-effort EPEL/CRB enablement) and `.rpm` packaging (`make-electron-package RPM`).
- Full `build_from_source` parity: builds the Electron `.rpm` from source, or downloads the `rhel10-x86_64` daily from dailies.rstudio.com.
- RHEL-scoped build caches, plus a new `cache-scope` input on the shared `os-e2e-deps` action so the RHEL e2e R-library/pak caches don't collide with the Ubuntu workflows (all share `runner.os == Linux`, and compiled R packages are ABI-incompatible across distros). Existing callers are unchanged -- an empty scope reproduces the current key.
- Container runs with `--cap-add=SYS_ADMIN --security-opt seccomp=unconfined` so Chromium/Electron's sandbox can initialize; `--no-sandbox` is the documented fallback.

Standalone triggers (`workflow_dispatch` + `workflow_call`); not wired into the PR orchestrator (matching the Ubuntu 26 sibling). Cache-seed/scheduled warming are a deferred, additive follow-up.

Addresses rstudio/rstudio-ide-automation#5191.
