### PR TITLE
use RSTUDIO_TOOLS_ROOT for windows build dependencies

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -113,6 +113,13 @@ jobs:
         shell: pwsh
     env:
       R_LIBS_USER: ${{ github.workspace }}\R-libs
+      # Build dependencies install here (outside any directory holding tracked
+      # files), mirroring the RSTUDIO_TOOLS_ROOT layout the posix workflows
+      # use. Keeping tracked install scripts out of the cached path means a
+      # stale cache restore can never clobber this PR's checked-out scripts
+      # (rstudio/rstudio#18129). Consumed by install-dependencies.cmd,
+      # make-package.bat, and CMake.
+      RSTUDIO_TOOLS_ROOT: ${{ github.workspace }}\rstudio-tools
       SCCACHE_ENABLED: '1'
       SCCACHE_GHA_ENABLED: 'true'
       NPM_CONFIG_LOGLEVEL: error
@@ -166,21 +173,22 @@ jobs:
           Write-Host "Disk space after cleanup:  $freeGB GB free (freed ~$freed GB)"
 
       # Downloaded build deps (Boost, SOCI, GWT, Node, pandoc, quarto, etc.)
-      # land in dependencies/common and dependencies/windows within the
-      # workspace when c:\rstudio-tools\dependencies doesn't exist. Keyed on
-      # the install scripts so a version bump forces a fresh download.
+      # land in RSTUDIO_TOOLS_ROOT\dependencies, outside any directory that
+      # holds tracked files, so restoring a stale cache can never overwrite
+      # this PR's install scripts. Keyed on the install scripts so a version
+      # bump forces a fresh download; the v2 prefix fences off caches saved
+      # under the old in-tree layout, whose archives would extract into
+      # dependencies/ and clobber tracked files (rstudio/rstudio#18129).
       # Restore-only; Save rstudio-tools cache runs after the build (from
       # main-scoped runs only) so deps are cached even when compilation fails.
       - name: Restore rstudio-tools deps
         id: tools-cache
         uses: actions/cache/restore@v4
         with:
-          path: |
-            dependencies/common
-            dependencies/windows
-          key: rstudio-tools-win64-${{ hashFiles('dependencies/common/install-*', 'dependencies/windows/install-dependencies.cmd', 'dependencies/tools/rstudio-tools.cmd') }}
+          path: ${{ env.RSTUDIO_TOOLS_ROOT }}
+          key: rstudio-tools-win64-v2-${{ hashFiles('dependencies/common/install-*', 'dependencies/windows/install-*.cmd', 'dependencies/windows/install-soci/**', 'dependencies/windows/tools.R', 'dependencies/tools/rstudio-tools.cmd') }}
           restore-keys: |
-            rstudio-tools-win64-
+            rstudio-tools-win64-v2-
 
       # Cache compiled GWT output (src/gwt/www, bin, extras). GWT compilation
       # is the single most expensive step in the build (~15-30 min). When the
@@ -395,7 +403,7 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $nodeVersion = (Select-String -Path 'dependencies\tools\rstudio-tools.cmd' `
             -Pattern 'set RSTUDIO_NODE_VERSION=(.+)').Matches[0].Groups[1].Value.Trim()
-          $nodeDir = "$env:GITHUB_WORKSPACE\dependencies\common\node\$nodeVersion"
+          $nodeDir = "$env:RSTUDIO_TOOLS_ROOT\dependencies\common\node\$nodeVersion"
           if (-not (Test-Path $nodeDir)) {
             Write-Error "Bundled node directory not found: $nodeDir"
             exit 1
@@ -432,7 +440,7 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $nodeVersion = (Select-String -Path 'dependencies\tools\rstudio-tools.cmd' `
             -Pattern 'set RSTUDIO_NODE_VERSION=(.+)').Matches[0].Groups[1].Value.Trim()
-          $bundledNodeDir = "$env:GITHUB_WORKSPACE\dependencies\common\node\$nodeVersion"
+          $bundledNodeDir = "$env:RSTUDIO_TOOLS_ROOT\dependencies\common\node\$nodeVersion"
           $bundledGypDir  = "$bundledNodeDir\node_modules\npm\node_modules\node-gyp"
           if (-not (Test-Path $bundledGypDir)) {
             Write-Error "Bundled node-gyp directory not found: $bundledGypDir"
@@ -516,9 +524,7 @@ jobs:
         if: steps.install-deps.conclusion == 'success' && github.ref == 'refs/heads/main' && steps.tools-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: |
-            dependencies/common
-            dependencies/windows
+          path: ${{ env.RSTUDIO_TOOLS_ROOT }}
           key: ${{ steps.tools-cache.outputs.cache-primary-key }}
 
       # Skip on an exact restore hit: re-saving would just duplicate the entry

--- a/cmake/globals.cmake
+++ b/cmake/globals.cmake
@@ -386,12 +386,30 @@ endif()
 
 # dependencies
 if(WIN32)
-   if(EXISTS "C:/rstudio-tools/dependencies")
-      set(RSTUDIO_DEPENDENCIES_DIR "C:/rstudio-tools/dependencies")
-      set(RSTUDIO_WINDOWS_DEPENDENCIES_DIR "${RSTUDIO_DEPENDENCIES_DIR}/windows")
-   else()
-      set(RSTUDIO_WINDOWS_DEPENDENCIES_DIR "${RSTUDIO_PROJECT_ROOT}/dependencies/windows")
+
+   # Resolve the tools root first; Windows dependencies are installed within
+   # it by dependencies/windows/install-dependencies.cmd. Honor an explicit
+   # override (CMake or environment variable); otherwise, use the default
+   # install location on the system drive.
+   if(NOT DEFINED RSTUDIO_TOOLS_ROOT)
+      if(DEFINED ENV{RSTUDIO_TOOLS_ROOT})
+         file(TO_CMAKE_PATH "$ENV{RSTUDIO_TOOLS_ROOT}" RSTUDIO_TOOLS_ROOT)
+      elseif(DEFINED ENV{SYSTEMDRIVE})
+         file(TO_CMAKE_PATH "$ENV{SYSTEMDRIVE}/rstudio-tools" RSTUDIO_TOOLS_ROOT)
+      else()
+         set(RSTUDIO_TOOLS_ROOT "C:/rstudio-tools")
+      endif()
    endif()
+
+   # Prefer dependencies installed within the tools root; fall back to
+   # dependencies installed within the source tree (the legacy layout).
+   if(EXISTS "${RSTUDIO_TOOLS_ROOT}/dependencies/windows")
+      set(RSTUDIO_DEPENDENCIES_DIR "${RSTUDIO_TOOLS_ROOT}/dependencies")
+   else()
+      set(RSTUDIO_DEPENDENCIES_DIR "${RSTUDIO_PROJECT_ROOT}/dependencies")
+   endif()
+
+   set(RSTUDIO_WINDOWS_DEPENDENCIES_DIR "${RSTUDIO_DEPENDENCIES_DIR}/windows")
    set(CPACK_DEPENDENCIES_DIR "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}")
    set(CPACK_NSPROCESS_VERSION "1.6")
 else()
@@ -420,12 +438,10 @@ if(NOT WIN32 AND NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}/common/node")
    endif()
 endif()
 
-# tools
+# tools (the Windows tools root is resolved above, before dependencies)
 if(NOT DEFINED RSTUDIO_TOOLS_ROOT)
    if(DEFINED ENV{RSTUDIO_TOOLS_ROOT})
       set(RSTUDIO_TOOLS_ROOT $ENV{RSTUDIO_TOOLS_ROOT})
-   elseif(WIN32)
-      set(RSTUDIO_TOOLS_ROOT "${RSTUDIO_DEPENDENCIES_DIR}")
    elseif(APPLE)
       find_path(RSTUDIO_TOOLS_ROOT
          NAMES boost

--- a/dependencies/tools/rstudio-tools.cmd
+++ b/dependencies/tools/rstudio-tools.cmd
@@ -44,6 +44,19 @@ exit /b %ERRORLEVEL%
 :: Set the project root directory
 call :find-project-root
 
+:: Pick a default RSTUDIO_TOOLS_ROOT location. Build dependencies are
+:: downloaded and installed here, outside of the source tree. This is the
+:: Windows analog of the default chosen in rstudio-tools.sh.
+if not defined RSTUDIO_TOOLS_ROOT (
+  if defined SYSTEMDRIVE (
+    set "RSTUDIO_TOOLS_ROOT=%SYSTEMDRIVE%\rstudio-tools"
+  ) else (
+    set "RSTUDIO_TOOLS_ROOT=C:\rstudio-tools"
+  )
+)
+
+echo -- Using RStudio tools root: %RSTUDIO_TOOLS_ROOT%
+
 :: Put Visual Studio tools on the PATH
 call :add-vstools-to-path
 

--- a/dependencies/windows/README.md
+++ b/dependencies/windows/README.md
@@ -23,6 +23,21 @@ a successful build environment if different versions of any dependencies are alr
 - `install-dependencies.cmd`
 - Wait for the script to complete
 
+### Dependency install location
+
+`install-dependencies.cmd` downloads and installs build dependencies into
+`RSTUDIO_TOOLS_ROOT` (default: `%SYSTEMDRIVE%\rstudio-tools`, so normally
+`C:\rstudio-tools`), outside the source tree. This mirrors how the other
+platforms use `/opt/rstudio-tools`. Set the `RSTUDIO_TOOLS_ROOT` environment
+variable before running the script to install elsewhere.
+
+Older checkouts installed dependencies into the source tree itself (in
+`dependencies\common` and `dependencies\windows`). The build still discovers
+dependencies there as a fallback when `RSTUDIO_TOOLS_ROOT` has not been
+populated, so existing setups keep working; when both locations are present,
+the tools root wins. To avoid confusion after migrating, delete the
+downloaded (gitignored) artifacts from the source tree.
+
 ## Build Java/Gwt
 
 - `cd rstudio\src\gwt`

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -2,14 +2,35 @@
 @echo off
 setlocal EnableDelayedExpansion
 
-for %%F in ("%CD%\..\tools\rstudio-tools.cmd") do (
+:: Resolve paths relative to this script (not the current directory), so the
+:: tracked install scripts can be run from anywhere.
+for %%F in ("%~dp0..\tools\rstudio-tools.cmd") do (
   set "RSTUDIO_TOOLS=%%~fF"
 )
 
 echo -- Using RStudio tools: %RSTUDIO_TOOLS%
 call %RSTUDIO_TOOLS%
 
-set PATH=%CD%\tools;%PATH%
+:: The source-tree directories holding the (tracked) install scripts. The
+:: dependencies themselves are downloaded and installed into
+:: RSTUDIO_TOOLS_ROOT (set by rstudio-tools.cmd if not already defined in
+:: the environment), so that downloaded artifacts live outside the source
+:: tree. Set RSTUDIO_TOOLS_ROOT to the root of an RStudio checkout to
+:: reproduce the legacy in-tree layout.
+set "WINDOWS_SCRIPTS_DIR=%~dp0"
+for %%F in ("%~dp0..\common") do (
+  set "COMMON_SCRIPTS_DIR=%%~fF"
+)
+
+set "COMMON_INSTALL_DIR=%RSTUDIO_TOOLS_ROOT%\dependencies\common"
+set "WINDOWS_INSTALL_DIR=%RSTUDIO_TOOLS_ROOT%\dependencies\windows"
+
+if not exist "%COMMON_INSTALL_DIR%" mkdir "%COMMON_INSTALL_DIR%"
+if not exist "%WINDOWS_INSTALL_DIR%" mkdir "%WINDOWS_INSTALL_DIR%"
+
+echo -- Installing dependencies to: %RSTUDIO_TOOLS_ROOT%\dependencies
+
+set PATH=%WINDOWS_SCRIPTS_DIR%tools;%PATH%
 
 set BOOST_VERSION=1.90.0
 set GNUGREP_VERSION=3.0
@@ -139,8 +160,8 @@ set NODEBUNDLE_URL=%RSTUDIO_BUILDTOOLS%/node/v%NODEBUNDLE_VERSION%/%NODEBUNDLE_F
 set NODEBUNDLE_FOLDER=node\%NODEBUNDLE_VERSION%-installed
 set NODEBUNDLE_OUTPUT=node
 
-:: Install dependencies within 'common' first.
-cd ..\common
+:: Install 'common' dependencies first.
+cd /d "%COMMON_INSTALL_DIR%"
 
 %RUN% install GWT
 %RUN% install DICTIONARIES
@@ -230,10 +251,10 @@ if not exist yarn.cmd (
 popd
 
 echo -- Installing packages
-call install-packages.cmd
+call "%COMMON_SCRIPTS_DIR%\install-packages.cmd"
 
-:: Install the rest of our dependencies in the 'windows' folder.
-cd ..\windows
+:: Install the rest of our dependencies into the 'windows' folder.
+cd /d "%WINDOWS_INSTALL_DIR%"
 
 %RUN% install GNUDIFF
 %RUN% install GNUGREP
@@ -246,11 +267,13 @@ cd ..\windows
 
 
 echo -- Installing panmirror (Visual Editor)
-pushd install-panmirror
+pushd "%WINDOWS_SCRIPTS_DIR%install-panmirror"
 call clone-panmirror-repo.cmd
 popd
 
 echo -- Installing SOCI
-call install-soci.cmd
+call "%WINDOWS_SCRIPTS_DIR%install-soci.cmd"
 
+:: The i18n helper scripts live relative to the source tree; run from there.
+cd /d "%WINDOWS_SCRIPTS_DIR%"
 %RUN% install-i18n-dependencies

--- a/dependencies/windows/install-soci.cmd
+++ b/dependencies/windows/install-soci.cmd
@@ -1,9 +1,13 @@
 @echo off
-cd install-soci
+setlocal
+
+REM Run from the script directory; install-soci.R places its build artifacts
+REM under RSTUDIO_TOOLS_ROOT when that is set in the environment.
+pushd "%~dp0install-soci"
 R --vanilla -s -f install-soci.R
 if ERRORLEVEL 1 (
   echo !! ERROR: SOCI build failed.
-  cd ..
+  popd
   exit /b 1
 )
-cd ..
+popd

--- a/dependencies/windows/install-soci/install-soci.R
+++ b/dependencies/windows/install-soci/install-soci.R
@@ -8,17 +8,30 @@ BOOST_VERSION        <- Sys.getenv("BOOST_VERSION", unset = "1.90.0")
 MSVC_TOOLSET_VERSION <- Sys.getenv("MSVC_TOOLSET_VERSION", unset = "143")
 CMAKE_GENERATOR      <- Sys.getenv("CMAKE_GENERATOR", unset = "Visual Studio 17 2022")
 
-owd <- getwd()
+# the source-tree folder containing this script and its helpers
+script_dir <- getwd()
 source("../tools.R")
 section("Building SOCI %s", SOCI_VERSION)
+
+# put RStudio tools on PATH (resolve now; the working directory may change)
+PATH$prepend(normalizePath("../tools"))
+
+# build into RSTUDIO_TOOLS_ROOT when set (see install-dependencies.cmd), so
+# that build artifacts land outside the source tree; otherwise, build within
+# the source tree as before
+tools_root <- Sys.getenv("RSTUDIO_TOOLS_ROOT", unset = "")
+if (nzchar(tools_root)) {
+   install_dir <- file.path(tools_root, "dependencies/windows/install-soci")
+   dir.create(install_dir, recursive = TRUE, showWarnings = FALSE)
+   setwd(install_dir)
+}
+
+owd <- getwd()
 
 # initialize log directory (for when things go wrong)
 unlink("logs", recursive = TRUE)
 dir.create("logs")
 options(log.dir = normalizePath("logs"))
-
-# put RStudio tools on PATH
-PATH$prepend("../tools")
 
 # initialize variables
 output_dir <- normalizePath("..", winslash = "/")
@@ -69,8 +82,9 @@ Sys.setenv(PATH = paste(path, collapse = ";"))
 dir.create(sqlite_dir, recursive = TRUE, showWarnings = FALSE)
 downloadAndUnzip(sqlite_header_zip, sqlite_dir, sqlite_header_zip_url)
 
-# build SQLite static library
-run("build-sqlite.cmd")
+# build SQLite static library (the script lives in the source tree; its
+# artifacts are placed relative to the current working directory)
+run(shQuote(normalizePath(file.path(script_dir, "build-sqlite.cmd"))))
 
 # clone repository if we dont already have it
 if (!file.exists(soci_base_name)) {

--- a/package/win32/make-package.bat
+++ b/package/win32/make-package.bat
@@ -16,13 +16,17 @@
 setlocal EnableDelayedExpansion
 set "PACKAGE_DIR=%CD%"
 
-if not exist c:\rstudio-tools\dependencies (
-    set RSTUDIO_DEPENDENCIES=%PACKAGE_DIR%\..\..\dependencies
-) else (
-    set RSTUDIO_DEPENDENCIES=c:\rstudio-tools\dependencies
-)
+REM This defines RSTUDIO_TOOLS_ROOT if it isn't already set in the environment.
+call %PACKAGE_DIR%\..\..\dependencies\tools\rstudio-tools.cmd
 
-call %RSTUDIO_DEPENDENCIES%\tools\rstudio-tools.cmd
+REM Prefer dependencies installed within the tools root (see
+REM dependencies/windows/install-dependencies.cmd); fall back to
+REM dependencies installed within the source tree (the legacy layout).
+if exist "%RSTUDIO_TOOLS_ROOT%\dependencies\windows" (
+    set "RSTUDIO_DEPENDENCIES=%RSTUDIO_TOOLS_ROOT%\dependencies"
+) else (
+    set RSTUDIO_DEPENDENCIES=%PACKAGE_DIR%\..\..\dependencies
+)
 
 %RUN% normalize-path "%PACKAGE_DIR%\..\..\src\node\desktop" ELECTRON_SOURCE_DIR
 %RUN% normalize-path "%ELECTRON_SOURCE_DIR%\..\desktop-build-AMD64" ELECTRON_BINARY_DIR

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -499,6 +499,12 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../../../NOTICE
 # environments found in the source tree.
 set(RSTUDIO_PANMIRROR_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/../../gwt/lib/quarto/packages/editor-server/src/resources/md-writer.lua)
 if(NOT EXISTS "${RSTUDIO_PANMIRROR_SCRIPT}")
+   # Windows tools root layout (e.g. C:/rstudio-tools/src/gwt/lib/quarto)
+   set(RSTUDIO_PANMIRROR_SCRIPT ${RSTUDIO_TOOLS_ROOT}/src/gwt/lib/quarto/packages/editor-server/src/resources/md-writer.lua)
+endif()
+if(NOT EXISTS "${RSTUDIO_PANMIRROR_SCRIPT}")
+   # posix tools root layout (e.g. /opt/rstudio-tools/src/gwt/lib/quarto,
+   # a sibling of the arch-specific tools root)
    set(RSTUDIO_PANMIRROR_SCRIPT ${RSTUDIO_TOOLS_ROOT}/../src/gwt/lib/quarto/packages/editor-server/src/resources/md-writer.lua)
 endif()
 # quarto is gitignored, so a secondary git worktree won't have it in its source

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -96,10 +96,15 @@
    </exec>
    <dirname property="git.main.worktree" file="${git.common.dir}"/>
 
+   <!-- Environment variables (e.g. env.RSTUDIO_TOOLS_ROOT) -->
+   <property environment="env"/>
+
    <!-- Path to GWT libraries -->
+   <set-if-exists property="lib.dir" value="${env.RSTUDIO_TOOLS_ROOT}/dependencies/common/gwtproject"/>
    <set-if-exists property="lib.dir" value="../../dependencies/common/gwtproject"/>
    <set-if-exists property="lib.dir" value="${git.main.worktree}/dependencies/common/gwtproject"/>
    <set-if-exists property="lib.dir" value="/opt/rstudio-tools/dependencies/common/gwtproject"/>
+   <set-if-exists property="lib.dir" value="${env.SYSTEMDRIVE}/rstudio-tools/dependencies/common/gwtproject"/>
    <set-if-exists property="lib.dir" value="C:/rstudio-tools/dependencies/common/gwtproject"/>
 
    <!-- Configure path to GWT SDK -->
@@ -245,15 +250,20 @@
    <!-- panmirror typescript library -->
    <!-- ensure version matches RSTUDIO_NODE_VERSION -->
    <property name="node.version" value="22.22.2"/>
+   <set-if-exists property="node.dir" value="${env.RSTUDIO_TOOLS_ROOT}/dependencies/common/node/${node.version}"/>
    <set-if-exists property="node.dir" value="../../dependencies/common/node/${node.version}"/>
    <set-if-exists property="node.dir" value="${git.main.worktree}/dependencies/common/node/${node.version}"/>
    <set-if-exists property="node.dir" value="/opt/rstudio-tools/dependencies/common/node/${node.version}"/>
+   <set-if-exists property="node.dir" value="${env.SYSTEMDRIVE}/rstudio-tools/dependencies/common/node/${node.version}"/>
+   <set-if-exists property="node.dir" value="C:/rstudio-tools/dependencies/common/node/${node.version}"/>
    <set-if-unset  property="node.dir" value="../../dependencies/common/node/${node.version}"/>
 
 
    <!-- use yarn from system but will prefer yarn from dependencies if available -->
    <set-if-exists property="yarn.bin" value="${node.dir}/bin/yarn"/>
    <set-if-exists property="yarn.bin" value="/opt/rstudio-tools/dependencies/common/node/${node.version}/bin/yarn"/>
+   <set-if-exists property="yarn.bin" value="${env.RSTUDIO_TOOLS_ROOT}/dependencies/common/node/${node.version}/node_modules/yarn/bin/yarn.cmd"/>
+   <set-if-exists property="yarn.bin" value="${env.SYSTEMDRIVE}/rstudio-tools/dependencies/common/node/${node.version}/node_modules/yarn/bin/yarn.cmd"/>
    <set-if-exists property="yarn.bin" value="c:/rstudio-tools/dependencies/common/node/${node.version}/node_modules/yarn/bin/yarn.cmd"/>
    <set-if-exists property="yarn.bin" value="${node.dir}/node_modules/yarn/bin/yarn.cmd"/>
    <set-if-unset  property="yarn.bin" value="yarn"/>

--- a/src/tools/envvars.bat
+++ b/src/tools/envvars.bat
@@ -9,7 +9,7 @@ call %RSTUDIO_TOOLS%
 
 %RUN% add-first-to-path ^
 	%RSTUDIO_PROJECT_ROOT%\dependencies\common\node\%RSTUDIO_NODE_VERSION% ^
-	c:\rstudio-tools\dependencies\common\node\%RSTUDIO_NODE_VERSION%
+	%RSTUDIO_TOOLS_ROOT%\dependencies\common\node\%RSTUDIO_NODE_VERSION%
 
 %RUN% subprocess "node --version" NODE_VERSION
 echo node: %NODE_VERSION%


### PR DESCRIPTION
Addresses #18129.

## Problem

Windows build dependencies installed into the source tree (`dependencies/common`, `dependencies/windows`), mixing multi-GB downloaded artifacts with the tracked install scripts. The Windows e2e workflow cached those directories wholesale, so when a PR changed an install script, the `restore-keys` prefix restored a stale cache from main whose extraction overwrote the PR's checked-out scripts (this is what broke the Boost 1.91 upgrade in #18128).

## Change

Windows now uses `RSTUDIO_TOOLS_ROOT` the same way the posix platforms use `/opt/rstudio-tools`:

- `dependencies/tools/rstudio-tools.cmd` defaults `RSTUDIO_TOOLS_ROOT` to `%SYSTEMDRIVE%\rstudio-tools` (normally `C:\rstudio-tools`) when unset, mirroring `rstudio-tools.sh`. An environment override is honored everywhere.
- `install-dependencies.cmd` still runs the tracked scripts from the source tree, but downloads/extracts everything into `%RSTUDIO_TOOLS_ROOT%\dependencies\{common,windows}`. Setting `RSTUDIO_TOOLS_ROOT` to a checkout root reproduces the legacy in-tree layout exactly.
- `install-soci.R` places its sqlite/SOCI build artifacts under the tools root when `RSTUDIO_TOOLS_ROOT` is set; when unset (as in `os-build-dependencies-windows.yml`, which packages the in-tree outputs) it builds in-tree as before.
- `cmake/globals.cmake` resolves the Windows tools root first (env override, else system drive) and prefers `${RSTUDIO_TOOLS_ROOT}/dependencies` when populated, **falling back to in-tree dependencies for older setups**. On Windows `RSTUDIO_TOOLS_ROOT` now means the root (e.g. `C:/rstudio-tools`) rather than aliasing the dependencies dir; the only Windows consumers of the old alias were `CMakeNodeTools.txt` (whose `${RSTUDIO_TOOLS_ROOT}/dependencies/common/node` probe now resolves correctly) and the panmirror `md-writer.lua` lookup in `src/cpp/session/CMakeLists.txt` (given an explicit `${RSTUDIO_TOOLS_ROOT}/src/gwt/...` probe for the docker layout).
- `make-package.bat` and `src/gwt/build.xml` gain the same prefer-tools-root / fall-back-to-in-tree discovery.
- The Windows e2e workflow sets `RSTUDIO_TOOLS_ROOT` to `${{ github.workspace }}\rstudio-tools` (no tracked files inside, matching the posix workflows), caches that path, and bumps the cache key prefix to `rstudio-tools-win64-v2-` so cache archives saved under the old in-tree layout can never restore over tracked scripts.

## Compatibility

- **Jenkins docker image**: unchanged behavior. `Dockerfile.windows` copies the dependency tree to `C:\rstudio-tools\dependencies` and runs the installer from there; with the default tools root the installer writes to the same location, and CMake/`make-package.bat` discover it the same way they discovered the hardcoded `C:\rstudio-tools\dependencies` before.
- **Existing developer setups** with in-tree artifacts keep building via the fallback discovery paths; re-running `install-dependencies.cmd` migrates to the tools root (documented in `dependencies/windows/README.md`).
- **`os-build-dependencies-windows.yml`** (Boost/SOCI prebuilt builder) is unaffected: it invokes `install-boost.cmd` / `install-soci.cmd` without `RSTUDIO_TOOLS_ROOT` in the environment, so outputs stay in-tree where its packaging steps expect them.

## On C: vs SYSTEMDRIVE

The default uses `%SYSTEMDRIVE%\rstudio-tools` with a literal `C:\rstudio-tools` fallback only when `SYSTEMDRIVE` is somehow undefined. `SYSTEMDRIVE` is `C:` on GitHub-hosted runners, the Jenkins Windows containers, and virtually all developer machines, so this is equivalent to hardcoding `C:` in practice while remaining correct on nonstandard images. CI environments where the system drive is space-constrained should (and the e2e workflow does) set `RSTUDIO_TOOLS_ROOT` explicitly rather than rely on the default.

## Validation

- YAML/XML/R syntax checks pass locally; CMake if/endif structure verified.
- Windows e2e build workflow dispatched from this branch (build_only) to exercise the full install + build with the new layout.