### PR TITLE
make citation source selection resilient to the dialog's one-time init reset

### DIFF
--- a/e2e/rstudio/pages/insert_citation.page.ts
+++ b/e2e/rstudio/pages/insert_citation.page.ts
@@ -64,20 +64,31 @@ export class InsertCitationDialog extends PageObject {
    * dialog's one-time init reset: when the bibliography load resolves, panmirror
    * snaps the active panel back to the dialog's initially-selected node (My
    * Sources on a fresh open) exactly once, leaving the tree highlight where we
-   * put it. Re-select if that happens -- the second selection
-   * lands after the reset and is permanent.
+   * put it. The reset can land on either side of our first sighting of the
+   * panel, so both the initial selection and the post-sighting watch must be
+   * able to re-click.
    */
   async selectSource(source: CitationSource): Promise<Locator> {
     const node = this.page.locator('.pm-navigation-tree-node', {
       has: this.page.locator(`[alt='${source.alt}']`),
     });
     const searchBox = this.page.getByPlaceholder(source.placeholder);
-    await node.click();
-    await expect(searchBox).toBeVisible({ timeout: 15000 });
+
+    // Click and verify as one retryable unit: if the reset fires before the
+    // panel is ever seen (slow bibliography load on a loaded CI machine), the
+    // panel snaps back to My Sources with our node still highlighted, and only
+    // another click can bring it back -- a plain visibility wait just times out.
+    await expect(async () => {
+      await node.click();
+      await expect(searchBox).toBeVisible({ timeout: 3000 });
+    }).toPass({ timeout: 30000 });
+
+    // The reset may instead land after the panel was seen; watch briefly and
+    // re-select if the panel reverts (the re-selection is permanent).
     const revertDeadline = Date.now() + 6000;
     while (Date.now() < revertDeadline) {
       if (!(await searchBox.isVisible().catch(() => false))) {
-        await node.click(); // reverted; re-select (now permanent)
+        await node.click();
         await expect(searchBox).toBeVisible({ timeout: 15000 });
         break;
       }
@@ -103,11 +114,21 @@ export class InsertCitationDialog extends PageObject {
 
     const selectAndFilter = async (): Promise<void> => {
       await node.click();
+      // Clear leftover filter text from a prior attempt with real key events
+      // (React's controlled input ignores fill()), then retype. The reset can
+      // remount the panel mid-typing, wiping or orphaning what was typed.
+      await box.click();
+      await this.page.keyboard.press('ControlOrMeta+a');
+      await this.page.keyboard.press('Backspace');
       await box.pressSequentially(packageName); // typeahead filters on each keystroke
-      await expect(match).toBeVisible({ timeout: 15000 });
+      await expect(match).toBeVisible({ timeout: 5000 });
     };
 
-    await selectAndFilter();
+    // Retryable for the same reason as selectSource(): the one-time init reset
+    // can land before the package row is ever seen, and only re-selecting the
+    // node recovers from that.
+    await expect(selectAndFilter).toPass({ timeout: 30000 });
+
     const revertDeadline = Date.now() + 6000;
     while (Date.now() < revertDeadline) {
       if (!(await match.isVisible().catch(() => false))) {

--- a/e2e/rstudio/tests/panes/editor/citations.test.ts
+++ b/e2e/rstudio/tests/panes/editor/citations.test.ts
@@ -7,7 +7,17 @@ import { useSuiteSandbox } from '@utils/sandbox';
 import { executeCommand } from '@utils/commands';
 import { executeInConsole, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { rStringLiteral } from '@utils/r';
+import { isServiceReachable, CITATION_SERVICE_HOSTS } from '@utils/network';
 import type { Page } from 'playwright';
+
+// Skip (rather than fail) a test whose citation source depends on an external
+// service that is unreachable from this runner -- an outage or blocked egress
+// is not a product bug. Probes are Node-side and cached; see utils/network.ts.
+async function skipUnlessReachable(...urls: string[]): Promise<void> {
+  for (const url of urls) {
+    test.skip(!(await isServiceReachable(url)), `${url} is unreachable from this runner`);
+  }
+}
 
 // Read the value of an R expression via marker-wrapped console output. Runs on
 // the rsession host, so it reads files the IDE wrote (e.g. references.bib in the
@@ -76,6 +86,7 @@ test.describe('Citations', () => {
   }
 
   test('inserts an authorless DOI citation into a markdown visual editor', async ({ rstudioPage: page }) => {
+    await skipUnlessReachable(CITATION_SERVICE_HOSTS.doi);
     await newMarkdownVisualDoc(page);
 
     const citation = new InsertCitationDialog(page);
@@ -110,6 +121,7 @@ test.describe('Citations', () => {
   // where the previous migration attempt stalled ("never reaches visual mode").
   // Opening a file-based .qmd and using ensureVisualMode() gets there reliably.
   test('inserts a DOI citation into a Quarto visual editor', async ({ rstudioPage: page }) => {
+    await skipUnlessReachable(CITATION_SERVICE_HOSTS.doi);
     const fileName = `citations_${Date.now()}.qmd`;
     await sourceActions.createAndOpenFile(fileName, '---\ntitle: Citations\n---\n\nGrassland bird research.\n');
     await expect(sourceActions.sourcePane.selectedTab).toContainText(fileName, { timeout: 20000 });
@@ -147,6 +159,7 @@ test.describe('Citations', () => {
   });
 
   test('deletes a staged citation', async ({ rstudioPage: page }) => {
+    await skipUnlessReachable(CITATION_SERVICE_HOSTS.doi);
     await newMarkdownVisualDoc(page);
 
     const citation = new InsertCitationDialog(page);
@@ -169,6 +182,8 @@ test.describe('Citations', () => {
   // key twice; a regression would produce a de-duplicated variant like
   // "bermúdez2020a" (and a second bib entry) instead.
   test('does not duplicate a citation inserted from two sources', async ({ rstudioPage: page }) => {
+    // The same work is inserted first via From DOI, then via DataCite.
+    await skipUnlessReachable(CITATION_SERVICE_HOSTS.doi, CITATION_SERVICE_HOSTS.datacite);
     await newMarkdownVisualDoc(page);
     const citation = new InsertCitationDialog(page);
     const doi = '10.5281/ZENODO.4266706';
@@ -232,10 +247,15 @@ test.describe('Citations', () => {
   // Selecting each network-backed source and searching returns matching results.
   // "bobolink" returns hits on all three services (DataCite, Crossref, PubMed).
   // Listed in the dialog's tree order (top to bottom): Crossref, DataCite, PubMed.
-  const SEARCH_SOURCES = [CITATION_SOURCES.crossref, CITATION_SOURCES.datacite, CITATION_SOURCES.pubmed];
+  const SEARCH_SOURCES = [
+    { source: CITATION_SOURCES.crossref, host: CITATION_SERVICE_HOSTS.crossref },
+    { source: CITATION_SOURCES.datacite, host: CITATION_SERVICE_HOSTS.datacite },
+    { source: CITATION_SOURCES.pubmed, host: CITATION_SERVICE_HOSTS.pubmed },
+  ];
   const searchTerm = 'bobolink';
-  for (const source of SEARCH_SOURCES) {
+  for (const { source, host } of SEARCH_SOURCES) {
     test(`searches ${source.alt} and returns matching results`, async ({ rstudioPage: page }) => {
+      await skipUnlessReachable(host);
       await newMarkdownVisualDoc(page);
 
       const citation = new InsertCitationDialog(page);

--- a/e2e/rstudio/utils/network.ts
+++ b/e2e/rstudio/utils/network.ts
@@ -1,0 +1,42 @@
+/**
+ * Reachability probes for tests that depend on external services.
+ *
+ * Some tests exercise features whose lookups hit live third-party APIs (e.g.
+ * the Insert Citation dialog's DOI/Crossref/DataCite/PubMed sources). An
+ * outage or blocked egress on a CI runner is not a product bug, so such tests
+ * should skip -- not fail -- when the service cannot be reached at all.
+ */
+
+/**
+ * External hosts the rsession's citation lookups hit. The requests originate
+ * in the C++ session process, not the browser (see the modules under
+ * src/cpp/session/modules/panmirror/), so they cannot be intercepted or
+ * mocked via Playwright routing.
+ */
+export const CITATION_SERVICE_HOSTS = {
+  doi: 'https://doi.org',
+  crossref: 'https://api.crossref.org',
+  datacite: 'https://api.datacite.org',
+  pubmed: 'https://eutils.ncbi.nlm.nih.gov',
+} as const;
+
+const probeCache = new Map<string, Promise<boolean>>();
+
+/**
+ * Whether an external service is reachable from this runner. Probes from Node
+ * (not through the product) so that tests skip on genuine egress/outage
+ * problems while a regression in RStudio's own request layer still fails
+ * them. Any HTTP response -- including an error status or redirect -- counts
+ * as reachable; only network-level failures (DNS, connect, TLS, timeout) do
+ * not. Results are cached per URL for the lifetime of the worker.
+ */
+export function isServiceReachable(url: string, timeoutMs = 10000): Promise<boolean> {
+  let probe = probeCache.get(url);
+  if (!probe) {
+    probe = fetch(url, { redirect: 'manual', signal: AbortSignal.timeout(timeoutMs) })
+      .then(() => true)
+      .catch(() => false);
+    probeCache.set(url, probe);
+  }
+  return probe;
+}


### PR DESCRIPTION
## Summary

The citation e2e tests added in #18116 flaked on linux CI (both desktop and server projects, across several unrelated PRs, e.g. runs [28614679201](https://github.com/rstudio/rstudio/actions/runs/28614679201) and [28608398057](https://github.com/rstudio/rstudio/actions/runs/28608398057)).

The Insert Citation dialog's one-time init reset (when the bibliography load resolves, panmirror snaps the active panel back to My Sources exactly once, leaving the tree highlight in place) can fire *before* `selectSource()` / `selectPackageSource()` first sees the requested panel. The existing workaround only re-clicked after the panel had been seen once, so when the reset won that race the initial visibility wait just timed out:

- From DOI: failure screenshots show the "From DOI" node highlighted with the panel still on My Sources ("Paste a DOI to search" never appears).
- R Package: the panel remount wipes the filter text typed mid-reset, so the `@knitr` row never shows.

## Fixes

1. **Init-reset race**: treat click-and-verify as one retryable unit (`expect(...).toPass()`) so a reset landing before the first sighting replays the selection; keep the existing post-sighting revert watch. For the R Package typeahead, clear any leftover filter text with real key events before retyping on each attempt.

2. **External-service outages should skip, not fail**: seven of these tests exercise live third-party services (doi.org, Crossref, DataCite, PubMed) via the rsession's C++ request layer, which Playwright cannot intercept or mock. A new `utils/network.ts` probes each service from Node (cached per worker) and the tests `test.skip()` with a clear reason when the service is unreachable from the runner. Probing Node-side is deliberate: an egress/outage problem skips, while a regression in RStudio's own HTTP layer still fails.

Test-only change; no NEWS entry.

## Verification

All 11 citation tests pass locally on macOS desktop (installed build), including the two that failed on CI. Probe semantics verified directly: a dead host reports unreachable (would skip); all four live services report reachable.