### PR TITLE
verify terminal Shift+Backspace via a filesystem side effect

### DIFF
--- a/e2e/rstudio/tests/panes/terminal/terminal.test.ts
+++ b/e2e/rstudio/tests/panes/terminal/terminal.test.ts
@@ -184,19 +184,33 @@ test.describe.serial('Terminal pane', () => {
       await killAllTerminals(page);
       await openTerminal(page);
 
-      await page.keyboard.type('echo hello');
+      // Verify the deletion through a filesystem side effect rather than the
+      // terminal buffer: type a `touch` command with a stray trailing "Q",
+      // delete it with Shift+Backspace, and check which file was created.
+      // The buffer is unsuitable for this assertion: after the deletion,
+      // readline may redraw the whole (wrapped) prompt line instead of
+      // erasing in place, and the server-side buffer capture keeps the stale
+      // pre-erase command image, so a grep for the original text matches even
+      // though the deletion worked. Whether readline erases or redraws
+      // depends on prompt width, which varies per CI runner (hostname and
+      // sandbox path lengths), making buffer greps flaky.
+      const sandboxDir = sandbox.dir.replace(/\\/g, '/');
+      await page.keyboard.type(`cd ${sandboxDir}`);
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('touch term_bs_test.txtQ');
       await page.keyboard.press('Shift+Backspace');
       await page.keyboard.press('Enter');
 
-      // "echo hell" must appear AND "echo hello" must not -- if Shift+Backspace
-      // had no effect the full word would be present and the test would pass
-      // vacuously on the substring match alone.
+      // If Shift+Backspace deleted the trailing "Q", the file without the
+      // "Q" exists and the file with it does not. If the keystroke had no
+      // effect, only "term_bs_test.txtQ" exists and the first condition
+      // stays false; if it deleted more than one character, neither file
+      // matches. The file is cleaned up with the sandbox by globalTeardown.
       await expect.poll(
         () => captureResult(
           page,
-          '{ ids <- rstudioapi::terminalList(); ' +
-          'buf <- paste(rstudioapi::terminalBuffer(ids[[1]]), collapse = "\\n"); ' +
-          'grepl("echo hell", buf) && !grepl("echo hello", buf) }',
+          `{ file.exists(file.path(${rStringLiteral(sandboxDir)}, "term_bs_test.txt")) && ` +
+          `!file.exists(file.path(${rStringLiteral(sandboxDir)}, "term_bs_test.txtQ")) }`,
         ),
         { timeout: TIMEOUTS.consoleReady },
       ).toBe('TRUE');

--- a/e2e/rstudio/tests/panes/terminal/terminal.test.ts
+++ b/e2e/rstudio/tests/panes/terminal/terminal.test.ts
@@ -191,9 +191,11 @@ test.describe.serial('Terminal pane', () => {
       // readline may redraw the whole (wrapped) prompt line instead of
       // erasing in place, and the server-side buffer capture keeps the stale
       // pre-erase command image, so a grep for the original text matches even
-      // though the deletion worked. Whether readline erases or redraws
-      // depends on prompt width, which varies per CI runner (hostname and
-      // sandbox path lengths), making buffer greps flaky.
+      // though the deletion worked. Whether readline erases or redraws is a
+      // shell implementation detail -- the grep started failing with Ubuntu
+      // 26.04 (bash 5.3 / readline 8.3, which reworked redisplay) while
+      // older Ubuntu erased in place -- and also depends on prompt width,
+      // which varies per CI runner (hostname and sandbox path lengths).
       const sandboxDir = sandbox.dir.replace(/\\/g, '/');
       await page.keyboard.type(`cd ${sandboxDir}`);
       await page.keyboard.press('Enter');


### PR DESCRIPTION
The `Shift+Backspace deletes the last character before submission` e2e test fails on Ubuntu 26.04 desktop runs (seen on the [PR #18141 e2e run](https://github.com/rstudio/rstudio/actions/runs/28694406226), where it failed on both the initial attempt and the retry). Ubuntu 26.04 is currently the only platform where it fails; older Ubuntu is fine.

### Diagnosis

The failure artifacts show the deletion actually works: the failing run's terminal buffer contains the output line `hell`, and in the retry the buffer even contains readline's redrawn command line `echo hell`. The shell received `echo hell` in both cases.

The test failed anyway because it asserted `grepl("echo hell", buf) && !grepl("echo hello", buf)` against `rstudioapi::terminalBuffer()`. After the deletion, readline may redraw the whole (wrapped) prompt line rather than erasing in place, and the server-side buffer capture keeps the stale pre-erase `echo hello` image, so the negative grep matches stale echo rather than what was executed.

Whether readline erases in place or redraws is a shell implementation detail. The Ubuntu 26.04-only failure pattern fits: 26.04 ships bash 5.3 / readline 8.3, which reworked the redisplay code, while older Ubuntu (bash 5.2) erased in place and kept the grep accurate. Prompt width (hostname and sandbox workdir lengths vary per runner) also feeds the redisplay decision, which is why the failure can look intermittent within a platform.

### Fix

Assert through a filesystem side effect instead: type `touch term_bs_test.txtQ`, delete the trailing `Q` with Shift+Backspace, submit, and check that `term_bs_test.txt` exists and `term_bs_test.txtQ` does not. This is independent of the shell's echo and redisplay behavior, and still fails if the keystroke has no effect (only the `Q` file exists) or deletes too much (neither file matches). The file lands in the suite sandbox and is cleaned up by globalTeardown.