### PR TITLE
Describe environment-like S4 objects in the Object Explorer without class modification

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,7 @@
 
 - ([#18139](https://github.com/rstudio/rstudio/issues/18139)): Fixed an issue on Windows where the R session started in the "C" locale instead of the operating system's locale, corrupting non-ASCII console input and breaking `list.files()` and other locale-sensitive operations for users whose locale is not ASCII-compatible (for example Turkish on Windows 11). The session now adopts the operating system locale at startup, restores the session locale rather than pinning it to "C" after rendering an R Markdown document, and logs locale synchronization failures instead of failing silently.
 - ([#18101](https://github.com/rstudio/rstudio/issues/18101)): Fixed "Run Selection as Background Job" (and the related Source/Launcher job commands) appearing to do nothing when invoked from a detached source window on Windows Desktop. The job launcher dialog is shown in the main window, which is now brought forward so the dialog is visible.
+- ([#18143](https://github.com/rstudio/rstudio/issues/18143)): Fixed the Object Explorer emitting `Setting class(x) to "environment"` warnings (and showing no description) for S4 objects wrapping environments, such as reference class instances. The explorer also no longer temporarily modifies the class of an environment being described.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/cpp/session/modules/SessionObjectExplorer.R
+++ b/src/cpp/session/modules/SessionObjectExplorer.R
@@ -102,6 +102,11 @@
    .Call("rs_objectAddress", object, PACKAGE = "(embedding)")
 })
 
+.rs.addFunction("environmentDescription", function(object)
+{
+   .Call("rs_environmentDescription", object, PACKAGE = "(embedding)")
+})
+
 .rs.addFunction("objectClass", function(object)
 {
    .Call("rs_objectClass", object, PACKAGE = "(embedding)")
@@ -1159,9 +1164,10 @@
       }
       else
       {
-         # use 'print.default' to avoid dispatching to custom 'print'
-         # methods, which could evaluate arbitrary user code
-         output <- capture.output(base::print.default(object))[[1]]
+         # generate the default display for the environment directly,
+         # rather than via 'print'; this avoids dispatching to custom
+         # 'print' methods, which could evaluate arbitrary user code
+         output <- .rs.environmentDescription(object)
          more <- FALSE
       }
    }

--- a/src/cpp/session/modules/SessionObjectExplorer.R
+++ b/src/cpp/session/modules/SessionObjectExplorer.R
@@ -1145,19 +1145,24 @@
          )
          more <- FALSE
       }
+      else if (isS4(object))
+      {
+         # S4 objects wrapping environments (e.g. reference class
+         # instances) have type "S4", and so cannot have their class
+         # attribute temporarily re-assigned -- describe them directly
+         fmt <- if (is(object, "envRefClass"))
+            "Reference class object of class %s"
+         else
+            "S4 object of class %s"
+         output <- sprintf(fmt, class(object))
+         more <- FALSE
+      }
       else
       {
-         # NOTE: R prevents us from calling 'unclass' on environment
-         # objects, so we need to do something a bit different here.
-         # We also want to avoid 'print' dispatching to custom methods
-         # to avoid evaluating arbitrary user code here
-         oldClass <- class(object)
-         tryCatch({
-            class(object) <- "environment"
-            output <- capture.output(base::print(object))[[1]]
-            more <- FALSE
-         }, error = identity)
-         class(object) <- oldClass
+         # use 'print.default' to avoid dispatching to custom 'print'
+         # methods, which could evaluate arbitrary user code
+         output <- capture.output(base::print.default(object))[[1]]
+         more <- FALSE
       }
    }
    else if (is.double(object))

--- a/src/cpp/session/modules/SessionObjectExplorer.cpp
+++ b/src/cpp/session/modules/SessionObjectExplorer.cpp
@@ -17,6 +17,8 @@
 
 #include "SessionObjectExplorer.hpp"
 
+#include <cstdint>
+
 #include <boost/bind/bind.hpp>
 
 #include <core/Algorithm.hpp>
@@ -322,6 +324,34 @@ SEXP rs_objectAddress(SEXP objectSEXP)
    return r::sexp::create(ss.str(), &protect);
 }
 
+SEXP rs_environmentDescription(SEXP envSEXP)
+{
+   if (TYPEOF(envSEXP) != ENVSXP)
+      return R_NilValue;
+
+   // mirrors the output of R's default print method for environments
+   std::string name;
+   if (envSEXP == R_GlobalEnv)
+      name = "R_GlobalEnv";
+   else if (envSEXP == R_BaseEnv)
+      name = "base";
+   else if (envSEXP == R_EmptyEnv)
+      name = "R_EmptyEnv";
+   else if (R_IsPackageEnv(envSEXP))
+      name = CHAR(STRING_ELT(R_PackageEnvName(envSEXP), 0));
+   else if (R_IsNamespaceEnv(envSEXP))
+      name = std::string("namespace:") + CHAR(STRING_ELT(R_NamespaceEnvSpec(envSEXP), 0));
+
+   std::stringstream ss;
+   if (!name.empty())
+      ss << "<environment: " << name << ">";
+   else
+      ss << "<environment: 0x" << std::hex << reinterpret_cast<std::uintptr_t>(envSEXP) << ">";
+
+   r::sexp::Protect protect;
+   return r::sexp::create(ss.str(), &protect);
+}
+
 SEXP rs_explorerCacheDir()
 {
    r::sexp::Protect protect;
@@ -344,6 +374,7 @@ core::Error initialize()
    
    RS_REGISTER_CALL_METHOD(rs_objectAddress, 1);
    RS_REGISTER_CALL_METHOD(rs_objectClass, 1);
+   RS_REGISTER_CALL_METHOD(rs_environmentDescription, 1);
    RS_REGISTER_CALL_METHOD(rs_explorerCacheDir, 0);
    
    ExecBlock initBlock;

--- a/src/cpp/tests/testthat/test-object-explorer.R
+++ b/src/cpp/tests/testthat/test-object-explorer.R
@@ -76,6 +76,29 @@ test_that("unnamed and empty-named list elements are accessed by index", {
    expect_equal(access, c("#[[1]]", "#[[\"b\"]]", "#[[3]]"))
 })
 
+test_that("environment-like S4 objects are described without warnings", {
+   setClass("TestS4Env", contains = "environment", where = environment())
+   object <- new("TestS4Env")
+   expect_no_warning(desc <- .rs.explorer.objectDesc(object))
+   expect_equal(desc, "S4 object of class TestS4Env")
+
+   generator <- setRefClass("TestRC", fields = list(x = "numeric"), where = environment())
+   object <- generator$new(x = 1)
+   expect_no_warning(desc <- .rs.explorer.objectDesc(object))
+   expect_equal(desc, "Reference class object of class TestRC")
+
+   # describing the object should not strip its S4 bit
+   expect_true(isS4(object))
+})
+
+test_that("environments are described without mutating their class", {
+   object <- new.env()
+   class(object) <- c("foo", "bar")
+   desc <- .rs.explorer.objectDesc(object)
+   expect_match(desc, "^<environment:")
+   expect_equal(class(object), c("foo", "bar"))
+})
+
 test_that("atomic vectors with duplicated names are accessed by index (#17937)", {
    object <- c(a = 1, a = 2, b = 3)
 

--- a/src/cpp/tests/testthat/test-object-explorer.R
+++ b/src/cpp/tests/testthat/test-object-explorer.R
@@ -95,8 +95,16 @@ test_that("environments are described without mutating their class", {
    object <- new.env()
    class(object) <- c("foo", "bar")
    desc <- .rs.explorer.objectDesc(object)
-   expect_match(desc, "^<environment:")
+   expect_match(desc, "^<environment: 0x")
    expect_equal(class(object), c("foo", "bar"))
+})
+
+test_that("named environments are described like R's default print", {
+   expect_equal(.rs.explorer.objectDesc(globalenv()), "<environment: R_GlobalEnv>")
+   expect_equal(.rs.explorer.objectDesc(baseenv()), "<environment: base>")
+   expect_equal(.rs.explorer.objectDesc(emptyenv()), "<environment: R_EmptyEnv>")
+   expect_equal(.rs.explorer.objectDesc(asNamespace("stats")), "<environment: namespace:stats>")
+   expect_equal(.rs.explorer.objectDesc(as.environment("package:stats")), "<environment: package:stats>")
 })
 
 test_that("atomic vectors with duplicated names are accessed by index (#17937)", {


### PR DESCRIPTION
Opening an object containing environment-like S4 objects (e.g. reference class instances, or instances of classes defined with `contains = "environment"`) in the Object Explorer emitted warnings to the console:

```
Warning messages:
1: In class(object) <- "environment" :
  Setting class(x) to "environment" sets attribute to NULL; result will no longer be an S4 object
```

`.rs.explorer.objectDesc()` described environments by temporarily assigning `class(object) <- "environment"`, capturing the default print output, and restoring the previous class. This had two problems:

- For S4 objects wrapping environments, `typeof(x)` is `"S4"` rather than `"environment"`, so the assignment emits the warning above and then errors. The error was swallowed by a surrounding `tryCatch()`, but the warning escaped, and no description was produced.
- Environments have reference semantics, so the temporary class assignment mutated the class of the user's actual object rather than a copy.

This PR:

- describes environment-like S4 objects directly (`Reference class object of class Foo` for reference class instances, `S4 object of class Foo` otherwise), without touching the object's class;
- adds a small `.Call` helper, `rs_environmentDescription()`, that generates the default display for plain environments (`<environment: R_GlobalEnv>`, `<environment: namespace:stats>`, `<environment: 0x...>`, mirroring R's `PrintEnvironment()`), so no class modification, `print` dispatch, or output capture is needed at all.

Includes regression tests covering the S4 cases, the no-mutation guarantee for classed environments, and the descriptions generated for named environments.

Fixes #18143.
