### PR TITLE
Desktop automation ergonomics: home-aliased paths, focus stealing, worktree dev shim

### DIFF
--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -540,7 +540,10 @@ export async function waitForSourcePaneReset(page: Page, timeout = 10000): Promi
  * On case-insensitive filesystems (macOS HFS+, NTFS) the comparison ignores
  * case. On Windows, backslashes and forward slashes are treated as equivalent
  * so callers can pass Node.js path.join results regardless of whether RStudio
- * normalizes separators.
+ * normalizes separators. RStudio home-aliases doc paths under the rsession's
+ * home directory ("~/sub/file.R"); those match when `expectedPath` ends with
+ * the aliased path minus the "~" -- still a full home-relative comparison, so
+ * same-basename files in different directories can't be confused.
  */
 export async function waitForActiveDocument(
   page: Page,
@@ -550,8 +553,11 @@ export async function waitForActiveDocument(
   await page.waitForFunction(
     (target) => {
       const doc = window.rstudio?.documents.active() ?? null;
-      return doc !== null && doc.path !== null
-        && doc.path.replace(/\\/g, '/').toLowerCase() === target.replace(/\\/g, '/').toLowerCase();
+      if (doc === null || doc.path === null) return false;
+      const dp = doc.path.replace(/\\/g, '/').toLowerCase();
+      const expected = target.replace(/\\/g, '/').toLowerCase();
+      return dp === expected
+        || (dp.startsWith('~/') && expected.endsWith(dp.slice(1)));
     },
     expectedPath,
     { timeout, polling: 100 },

--- a/e2e/rstudio/utils/files.ts
+++ b/e2e/rstudio/utils/files.ts
@@ -113,7 +113,10 @@ export async function seedSandboxFile(
  * `pathOrName` may be a basename, a relative path, or an absolute path.
  * When absolute, the active-doc post-condition compares full paths
  * (case-insensitive, slashes normalized) so two open files that share a
- * basename can't be confused for one another. When relative or a bare
+ * basename can't be confused for one another; a doc.path RStudio reports
+ * home-aliased ("~/sub/file.R" -- anything under the rsession's home,
+ * e.g. a sandbox under C:\Users\<user>\AppData\...\Temp on Windows) is
+ * matched by its home-relative suffix. When relative or a bare
  * basename, falls back to basename match -- R resolves the path against
  * its own cwd, which can differ from Node's, so the absolute form
  * RStudio reports back is not known to the helper.
@@ -142,8 +145,17 @@ export async function openFile(
       const docPath = doc.path.replace(/\\/g, '/');
       if (args.expectedFullPath !== null) {
         // Full-path match: case-insensitive to tolerate macOS HFS+ /
-        // Windows NTFS, where the filesystem itself folds case.
-        if (docPath.toLowerCase() !== args.expectedFullPath.toLowerCase()) return false;
+        // Windows NTFS, where the filesystem itself folds case. RStudio
+        // home-aliases paths under the rsession's home directory
+        // ("~/sub/file.R"), so a home-aliased doc.path matches when the
+        // expected absolute path ends with the aliased path minus the "~".
+        // That is still a full home-relative path comparison, so two open
+        // files sharing a basename can't be confused.
+        const dp = docPath.toLowerCase();
+        const expected = args.expectedFullPath.toLowerCase();
+        const matches = dp === expected
+          || (dp.startsWith('~/') && expected.endsWith(dp.slice(1)));
+        if (!matches) return false;
       } else {
         const docSlash = docPath.lastIndexOf('/');
         const docBase = docSlash >= 0 ? docPath.slice(docSlash + 1) : docPath;

--- a/scripts/bootstrap-worktree.sh
+++ b/scripts/bootstrap-worktree.sh
@@ -29,6 +29,20 @@
 # machine's main checkout, so the compiled native modules match the platform.
 # Run under bash (Git Bash or WSL on Windows).
 #
+# Alongside the desktop deps, this also materializes a "dev shim" build root
+# (<worktree>/build-dev-shim) for running the desktop-dev Playwright suite from
+# the worktree without a C++ build. The Electron dev launcher (findComponents
+# in src/node/desktop/src/main/utils.ts) honors RSTUDIO_CPP_BUILD_OUTPUT and
+# needs <root>/session/rsession.exe plus <root>/conf/rdesktop-dev.conf; the
+# shim links session/ from the main checkout's build and rewrites the conf's
+# www paths to THIS worktree's GWT output. Do NOT point
+# RSTUDIO_CPP_BUILD_OUTPUT at the main checkout's build/src/cpp directly: its
+# conf serves the main checkout's src/gwt/www, which (after `ant desktop` /
+# `ant devmode`) is a Super Dev Mode stub that redirects to a code server on
+# localhost:9876 -- without that code server running, RStudio dies at startup
+# with "code server not available" and automation times out waiting for
+# window.rstudio.ready.
+#
 # Usage:
 #   scripts/bootstrap-worktree.sh [worktree-dir] [--skip-desktop] \
 #       [--with-build-dir[=<dir>]]
@@ -36,7 +50,7 @@
 #   worktree-dir   defaults to the current directory; may be any path inside
 #                  the target worktree (it is normalized to the repo top).
 #   --skip-desktop skip src/node/desktop (its deps are large; skip when you
-#                  only need the e2e/rstudio suite).
+#                  only need the e2e/rstudio suite). Also skips the dev shim.
 #   --with-build-dir[=<dir>]
 #                  also configure a CMake build directory for the worktree
 #                  (default <worktree>/build; <dir> may be absolute or relative
@@ -141,6 +155,62 @@ copy_generated() {
   cp "$MAIN_CHECKOUT/$rel" "$WORKTREE/$rel"
 }
 
+# Materialize the desktop-dev shim build root (see header). Best-effort: when
+# the main checkout has no built rsession/conf yet, warn and move on -- the
+# rest of the bootstrap is still useful. The conf is regenerated on every run
+# (the main checkout's conf may have changed); the session link is only
+# created when missing.
+make_dev_shim() {
+  local dir="$WORKTREE/build-dev-shim"
+  local main_cpp="$MAIN_CHECKOUT/build/src/cpp"
+
+  if [ "$WORKTREE" = "$MAIN_CHECKOUT" ]; then
+    return
+  fi
+  if [ ! -f "$main_cpp/conf/rdesktop-dev.conf" ] || [ ! -d "$main_cpp/session" ]; then
+    echo "[bootstrap] WARNING: no built session/conf under $main_cpp; build the main checkout first -- skipping dev shim"
+    return
+  fi
+
+  mkdir -p "$dir/conf"
+
+  # session/ must hold the main checkout's built rsession. A symlink is fine
+  # everywhere but Windows, where Git Bash's `ln -s` silently degrades to a
+  # copy -- use a real NTFS junction there instead. PowerShell rather than
+  # `cmd /c mklink`: cmd's /c quote-stripping and MSYS path conversion both
+  # mangle the mklink arguments.
+  if [ ! -e "$dir/session" ]; then
+    case "$(uname -s)" in
+      MINGW*|MSYS*|CYGWIN*)
+        powershell.exe -NoProfile -Command \
+          "New-Item -ItemType Junction -Path '$(cygpath -w "$dir/session")' -Target '$(cygpath -w "$main_cpp/session")' | Out-Null"
+        ;;
+      *)
+        ln -s "$main_cpp/session" "$dir/session"
+        ;;
+    esac
+  fi
+
+  # Rewrite the conf's www paths to THIS worktree's GWT output; everything
+  # else (rpostback, staged R modules, dependency paths) stays pointed at the
+  # main checkout's build. The conf wants forward slashes even on Windows.
+  local wt_fwd="$WORKTREE"
+  if command -v cygpath >/dev/null 2>&1; then
+    wt_fwd="$(cygpath -m "$WORKTREE")"
+  fi
+  sed \
+    -e "s|^www-local-path=.*|www-local-path=$wt_fwd/src/gwt/www|" \
+    -e "s|^www-symbol-maps-path=.*|www-symbol-maps-path=$wt_fwd/src/gwt/extras/rstudio/symbolMaps|" \
+    "$main_cpp/conf/rdesktop-dev.conf" > "$dir/conf/rdesktop-dev.conf"
+
+  echo "[bootstrap] dev shim ready: $dir"
+  if [ ! -f "$WORKTREE/src/gwt/www/rstudio/rstudio.nocache.js" ]; then
+    echo "[bootstrap] NOTE: worktree GWT output missing; build it first: (cd src/gwt && ant draft)"
+  fi
+  echo "[bootstrap] run desktop-dev e2e from e2e/rstudio with:"
+  echo "[bootstrap]   PW_RSTUDIO_DEV=1 RSTUDIO_CPP_BUILD_OUTPUT=\"$dir\" npx playwright test <spec> --project=desktop"
+}
+
 # Configure a CMake build directory for the worktree. Always a fresh configure
 # (cmake -S <worktree> -B <dir>), never a copy of the main checkout's build/ --
 # a CMake build tree bakes absolute paths into the cache, ninja depfiles, the
@@ -179,6 +249,7 @@ ensure_deps "e2e/rstudio"
 if [ "$SKIP_DESKTOP" -eq 0 ]; then
   ensure_deps "src/node/desktop"
   copy_generated "src/node/desktop/src/types/user-state-schema.d.ts"
+  make_dev_shim
 else
   echo "[bootstrap] skipping src/node/desktop (--skip-desktop)"
 fi

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -52,6 +52,7 @@ import {
   findRepoRoot,
   getAppPath,
   handleLocaleCookies,
+  isAutomated,
   resolveAliasedPath,
   raiseAndActivateWindow,
 } from './utils';
@@ -577,7 +578,11 @@ export class GwtCallback extends EventEmitter {
         const sender = this.getSender('desktop_open_minimal_window', event.processId, event.frameId);
         const minimalWindow = openMinimalWindow(sender, name, url, width, height);
         minimalWindow.window.once('ready-to-show', () => {
-          minimalWindow.window.show();
+          if (isAutomated()) {
+            minimalWindow.window.showInactive();
+          } else {
+            minimalWindow.window.show();
+          }
         });
       },
     );
@@ -703,7 +708,14 @@ export class GwtCallback extends EventEmitter {
     );
 
     ipcMain.on('desktop_bring_main_frame_to_front', () => {
-      this.mainWindow.window.focus();
+      // GWT requests this on flows like opening a document from a satellite
+      // window. In automation mode, surface the window without stealing OS
+      // focus from whatever the user is doing while the tests run.
+      if (isAutomated()) {
+        this.mainWindow.window.showInactive();
+      } else {
+        this.mainWindow.window.focus();
+      }
     });
 
     ipcMain.on('desktop_bring_main_frame_behind_active', () => {

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -247,8 +247,7 @@ export class SessionLauncher {
         }
         this.showSplash = false;
         // In automation mode, surface the window without pulling focus from
-        // the test driver. See main.ts for the matching macOS activation
-        // policy that suppresses OS-level app activation.
+        // the test driver.
         if (isAutomated()) {
           this.mainWindow?.window.showInactive();
         } else {

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -414,6 +414,12 @@ export function raiseAndActivateWindow(window: BrowserWindow): void {
   if (window.isMinimized()) {
     window.restore();
   }
+  // In automation mode, surface the window without pulling OS focus away
+  // from whatever the user is doing while the tests run.
+  if (isAutomated()) {
+    window.showInactive();
+    return;
+  }
   window.moveTop();
   window.focus();
 }

--- a/src/node/desktop/src/main/whats-new-window.ts
+++ b/src/node/desktop/src/main/whats-new-window.ts
@@ -16,6 +16,7 @@
 import { BrowserWindow, ipcMain, screen, session, shell } from 'electron';
 
 import { logger } from '../core/logger';
+import { isAutomated } from './utils';
 import { createLocalUrlChecker } from './whats-new-utils';
 
 declare const WHATS_NEW_WEBPACK_ENTRY: string;
@@ -43,8 +44,14 @@ export function showWhatsNewWindow(options: WhatsNewWindowOptions): BrowserWindo
       if (activeWindow.isMinimized()) {
         activeWindow.restore();
       }
-      activeWindow.show();
-      activeWindow.focus();
+      // In automation mode, surface the window without stealing OS focus
+      // from whatever the user is doing while the tests run.
+      if (isAutomated()) {
+        activeWindow.showInactive();
+      } else {
+        activeWindow.show();
+        activeWindow.focus();
+      }
     }
     return activeWindow;
   }
@@ -203,7 +210,11 @@ export function showWhatsNewWindow(options: WhatsNewWindowOptions): BrowserWindo
     .then(() => {
       if (activeWindow === win && !win.isDestroyed()) {
         windowReady = true;
-        win.show();
+        if (isAutomated()) {
+          win.showInactive();
+        } else {
+          win.show();
+        }
       }
     })
     .catch((err: unknown) => {


### PR DESCRIPTION
Developer-only improvements to the Playwright automation harness and worktree tooling; no user-facing behavior changes (the desktop changes are gated on `--automation-agent`).

### e2e: match home-aliased document paths in open-file waits

RStudio reports document paths home-aliased (`~/sub/file.R`) whenever the file lives under the home directory the rsession resolved. On Windows desktop runs, the default Playwright sandbox under `os.tmpdir()` lands in `C:/Users/<user>/AppData/...`, so `openFile()` (utils/files.ts) and `waitForActiveDocument()` (utils/commands.ts) never saw their expected absolute path and timed out with an opaque `page.waitForFunction` TimeoutError -- even though the file had opened fine. A home-aliased `doc.path` now matches when the expected absolute path ends with the aliased path minus the `~`. This is still a full home-relative comparison, so two open files sharing a basename cannot be confused.

### desktop: don't steal OS focus in automation mode

The main window and splash already show inactive under `--automation-agent`, but several paths still pulled focus mid-run -- most notably `desktop_bring_main_frame_to_front`, which GWT fires on flows like opening a document. These now use `showInactive()` when automated: `raiseAndActivateWindow`, `desktop_bring_main_frame_to_front`, minimal-window `ready-to-show`, and the What's New window. Tests run without yanking focus from whatever the user is doing.

### scripts: materialize a desktop-dev shim build root in bootstrap-worktree.sh

Running the desktop-dev suite from a worktree needs `RSTUDIO_CPP_BUILD_OUTPUT` pointed at a build root whose `rdesktop-dev.conf` serves the worktree's GWT output. Pointing it at the main checkout's build directly is a footgun: that conf serves the main checkout's `src/gwt/www`, which after `ant desktop` / `ant devmode` is a Super Dev Mode stub redirecting to a code server on localhost:9876 -- without it running, RStudio dies at startup with "code server not available". The bootstrap script now creates `<worktree>/build-dev-shim` (session/ linked from the main checkout's build, conf rewritten to the worktree's www) and prints the exact command to run the suite against it.

### QA notes

- `tests/panes/editor/missing_packages_banner.test.ts` passes on Windows desktop-dev with the sandbox at its default `os.tmpdir()` location (previously timed out in `openFile`), running against the bootstrap-generated shim with the focus changes compiled in.
- `src/node/desktop`: `npm run typecheck`, `npm run lint` clean; `npm test` shows no new failures vs. a main-checkout baseline (one pre-existing `FilePath.createDirectorySync` failure on this machine, plus one worktree-environment-only `findComponents` failure that needs a `build/` dir).
- No NEWS.md entry: developer/test tooling only.
