### PR TITLE
reduce GitHub Actions cache pressure in e2e workflows

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
@@ -150,23 +150,12 @@ jobs:
           "sha256=$sha"        | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           "filename=$filename" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
-      # Cache the installer keyed on its resolved filename. On the daily
-      # auto-resolve path the filename embeds the version + build number, so
-      # the content is immutable per name: a new daily misses and downloads, a
-      # same-day rerun hits and skips the download (SHA-256 still verified
-      # below). Skip caching on the override path -- a user-supplied URL has no
-      # immutability guarantee and its SHA check is skipped, so a reused
-      # basename could otherwise serve stale, unverified bytes.
-      - name: Cache RStudio installer
-        if: inputs.rstudio_installer_url == ''
-        id: installer-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.resolve.outputs.filename }}
-          key: rstudio-installer-${{ steps.resolve.outputs.filename }}
-
+      # Downloaded fresh every run rather than cached: dailies.rstudio.com is
+      # already S3/CDN-backed, and GH Actions cache scoping means concurrent
+      # runs can't share a cache entry with each other anyway, so caching here
+      # would just duplicate the same bytes into the shared 10 GB cache quota
+      # without saving meaningful time.
       - name: Download RStudio .exe
-        if: steps.installer-cache.outputs.cache-hit != 'true'
         env:
           DOWNLOAD_URL: ${{ steps.resolve.outputs.url }}
           DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -223,11 +223,13 @@ jobs:
             ./make-package --arch=arm64 --build-dmg=0 --use-creds=0
           fi
 
-      # Skip on an exact restore hit: re-saving would just duplicate the entry
-      # into this run's ref scope. PR runs that changed GWT sources still
-      # save, so re-pushes to the same PR skip the recompile.
+      # Save only from main-scoped runs, and only on a key miss. A cache saved
+      # from a PR run lands in that PR's merge-ref scope, which no other
+      # branch can restore -- each copy is pure pressure on the repo's 10 GB
+      # Actions cache quota, and that pressure is what evicts main's copy and
+      # sends every PR build cold in the first place.
       - name: Save GWT output
-        if: steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
+        if: github.ref == 'refs/heads/main' && steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: package/osx/build-arm64/gwt
@@ -361,16 +363,13 @@ jobs:
           echo "sha256=$SHA"   >> "$GITHUB_OUTPUT"
           echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
 
-      - name: Cache RStudio installer
-        if: inputs.build_from_source == false && inputs.rstudio_installer_url == ''
-        id: installer-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.resolve.outputs.filename }}
-          key: rstudio-installer-${{ steps.resolve.outputs.filename }}
-
+      # Downloaded fresh every run rather than cached: dailies.rstudio.com is
+      # already S3/CDN-backed, and GH Actions cache scoping means concurrent
+      # PRs can't share a cache entry with each other anyway (only with their
+      # base branch), so caching here would just duplicate the same bytes
+      # into the shared 10 GB cache quota without saving meaningful time.
       - name: Download RStudio .dmg
-        if: (inputs.build_from_source == false || inputs.rstudio_installer_url != '') && steps.installer-cache.outputs.cache-hit != 'true'
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
         env:
           DOWNLOAD_URL: ${{ steps.resolve.outputs.url }}
           DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-rhel-10-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-rhel-10-x86_64.yml
@@ -279,11 +279,13 @@ jobs:
       # Save GWT output only when the build succeeded. A failed mid-compile run
       # could otherwise write partial GWT output to the cache, and every future
       # restore would silently ship a broken frontend until the hashFiles key
-      # rotates. Skip on an exact restore hit: re-saving would just duplicate
-      # the entry into this run's ref scope. PR runs that changed GWT sources
-      # still save, so re-pushes to the same PR skip the recompile.
+      # rotates. Save only from main-scoped runs, and only on a key miss: a
+      # cache saved from a PR run lands in that PR's merge-ref scope, which no
+      # other branch can restore -- each copy is pure pressure on the repo's
+      # 10 GB Actions cache quota, and that pressure is what evicts main's
+      # copy and sends every PR build cold in the first place.
       - name: Save GWT output
-        if: steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
+        if: github.ref == 'refs/heads/main' && steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: package/linux/build-Electron-RPM/gwt
@@ -449,23 +451,13 @@ jobs:
           echo "sha256=$SHA"        >> "$GITHUB_OUTPUT"
           echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
 
-      # Cache the daily installer keyed on its resolved filename. Filenames
-      # embed the version + build number on the auto-resolve path so the content
-      # is immutable per name: new daily misses and downloads, same-day re-run
-      # hits and skips (SHA still verified below). Skip caching on the override
-      # path -- a user-supplied URL has no immutability guarantee and its SHA
-      # check is skipped, so a reused basename could otherwise serve stale,
-      # unverified bytes.
-      - name: Cache RStudio Desktop installer
-        if: inputs.build_from_source == false && inputs.rstudio_installer_url == ''
-        id: installer-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.resolve.outputs.filename }}
-          key: rstudio-desktop-installer-${{ steps.resolve.outputs.filename }}
-
+      # Downloaded fresh every run rather than cached: dailies.rstudio.com is
+      # already S3/CDN-backed, and GH Actions cache scoping means concurrent
+      # PRs can't share a cache entry with each other anyway (only with their
+      # base branch), so caching here would just duplicate the same bytes
+      # into the shared 10 GB cache quota without saving meaningful time.
       - name: Download RStudio Desktop .rpm
-        if: (inputs.build_from_source == false || inputs.rstudio_installer_url != '') && steps.installer-cache.outputs.cache-hit != 'true'
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
         env:
           DOWNLOAD_URL: ${{ steps.resolve.outputs.url }}
           DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -255,12 +255,13 @@ jobs:
       # Save GWT output only when the build succeeded. A failed mid-compile run
       # could otherwise write partial GWT output to the cache, and every future
       # restore would silently ship a broken frontend until the hashFiles key
-      # rotates. Skip on an exact restore hit: re-saving would just duplicate
-      # the entry into this run's ref scope (per-PR copies that waste quota).
-      # PR runs that changed GWT sources still save, so re-pushes to the same
-      # PR skip the ~15-30 min recompile.
+      # rotates. Save only from main-scoped runs, and only on a key miss: a
+      # cache saved from a PR run lands in that PR's merge-ref scope, which no
+      # other branch can restore -- each copy is pure pressure on the repo's
+      # 10 GB Actions cache quota, and that pressure is what evicts main's
+      # copy and sends every PR build cold in the first place.
       - name: Save GWT output
-        if: steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
+        if: github.ref == 'refs/heads/main' && steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: package/linux/build-Electron-DEB/gwt
@@ -405,23 +406,13 @@ jobs:
           echo "sha256=$SHA"        >> "$GITHUB_OUTPUT"
           echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
 
-      # Cache the daily installer keyed on its resolved filename. Filenames
-      # embed the version + build number on the auto-resolve path so the content
-      # is immutable per name: new daily misses and downloads, same-day re-run
-      # hits and skips (SHA still verified below). Skip caching on the override
-      # path -- a user-supplied URL has no immutability guarantee and its SHA
-      # check is skipped, so a reused basename could otherwise serve stale,
-      # unverified bytes.
-      - name: Cache RStudio Desktop installer
-        if: inputs.build_from_source == false && inputs.rstudio_installer_url == ''
-        id: installer-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.resolve.outputs.filename }}
-          key: rstudio-desktop-installer-${{ steps.resolve.outputs.filename }}
-
+      # Downloaded fresh every run rather than cached: dailies.rstudio.com is
+      # already S3/CDN-backed, and GH Actions cache scoping means concurrent
+      # PRs can't share a cache entry with each other anyway (only with their
+      # base branch), so caching here would just duplicate the same bytes
+      # into the shared 10 GB cache quota without saving meaningful time.
       - name: Download RStudio Desktop .deb
-        if: (inputs.build_from_source == false || inputs.rstudio_installer_url != '') && steps.installer-cache.outputs.cache-hit != 'true'
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
         env:
           DOWNLOAD_URL: ${{ steps.resolve.outputs.url }}
           DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
@@ -243,11 +243,13 @@ jobs:
       # Save GWT output only when the build succeeded. A failed mid-compile run
       # could otherwise write partial GWT output to the cache, and every future
       # restore would silently ship a broken frontend until the hashFiles key
-      # rotates. Skip on an exact restore hit: re-saving would just duplicate
-      # the entry into this run's ref scope. PR runs that changed GWT sources
-      # still save, so re-pushes to the same PR skip the recompile.
+      # rotates. Save only from main-scoped runs, and only on a key miss: a
+      # cache saved from a PR run lands in that PR's merge-ref scope, which no
+      # other branch can restore -- each copy is pure pressure on the repo's
+      # 10 GB Actions cache quota, and that pressure is what evicts main's
+      # copy and sends every PR build cold in the first place.
       - name: Save GWT output
-        if: steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
+        if: github.ref == 'refs/heads/main' && steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: package/linux/build-Electron-DEB/gwt
@@ -392,23 +394,13 @@ jobs:
           echo "sha256=$SHA"        >> "$GITHUB_OUTPUT"
           echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
 
-      # Cache the daily installer keyed on its resolved filename. Filenames
-      # embed the version + build number on the auto-resolve path so the content
-      # is immutable per name: new daily misses and downloads, same-day re-run
-      # hits and skips (SHA still verified below). Skip caching on the override
-      # path -- a user-supplied URL has no immutability guarantee and its SHA
-      # check is skipped, so a reused basename could otherwise serve stale,
-      # unverified bytes.
-      - name: Cache RStudio Desktop installer
-        if: inputs.build_from_source == false && inputs.rstudio_installer_url == ''
-        id: installer-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.resolve.outputs.filename }}
-          key: rstudio-desktop-installer-${{ steps.resolve.outputs.filename }}
-
+      # Downloaded fresh every run rather than cached: dailies.rstudio.com is
+      # already S3/CDN-backed, and GH Actions cache scoping means concurrent
+      # PRs can't share a cache entry with each other anyway (only with their
+      # base branch), so caching here would just duplicate the same bytes
+      # into the shared 10 GB cache quota without saving meaningful time.
       - name: Download RStudio Desktop .deb
-        if: (inputs.build_from_source == false || inputs.rstudio_installer_url != '') && steps.installer-cache.outputs.cache-hit != 'true'
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
         env:
           DOWNLOAD_URL: ${{ steps.resolve.outputs.url }}
           DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -524,11 +524,13 @@ jobs:
           path: ${{ env.RSTUDIO_TOOLS_ROOT }}
           key: ${{ steps.tools-cache.outputs.cache-primary-key }}
 
-      # Skip on an exact restore hit: re-saving would just duplicate the entry
-      # into this run's ref scope. PR runs that changed GWT sources still
-      # save, so re-pushes to the same PR skip the recompile.
+      # Save only from main-scoped runs, and only on a key miss. A cache saved
+      # from a PR run lands in that PR's merge-ref scope, which no other
+      # branch can restore -- each copy is pure pressure on the repo's 10 GB
+      # Actions cache quota, and that pressure is what evicts main's copy and
+      # sends every PR build cold in the first place.
       - name: Save GWT output
-        if: steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
+        if: github.ref == 'refs/heads/main' && steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: |
@@ -731,16 +733,13 @@ jobs:
           "sha256=$sha"        | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           "filename=$filename" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
-      - name: Cache RStudio installer
-        if: inputs.build_from_source == false && inputs.rstudio_installer_url == ''
-        id: installer-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.resolve.outputs.filename }}
-          key: rstudio-installer-${{ steps.resolve.outputs.filename }}
-
+      # Downloaded fresh every run rather than cached: dailies.rstudio.com is
+      # already S3/CDN-backed, and GH Actions cache scoping means concurrent
+      # PRs can't share a cache entry with each other anyway (only with their
+      # base branch), so caching here would just duplicate the same bytes
+      # into the shared 10 GB cache quota without saving meaningful time.
       - name: Download RStudio .exe
-        if: (inputs.build_from_source == false || inputs.rstudio_installer_url != '') && steps.installer-cache.outputs.cache-hit != 'true'
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
         env:
           DOWNLOAD_URL: ${{ steps.resolve.outputs.url }}
           DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}

--- a/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -251,11 +251,13 @@ jobs:
       # run could otherwise write partial GWT output to the cache, and every
       # future restore would silently ship a broken frontend until the
       # hashFiles key rotates. Same poison-resistance pattern macOS uses.
-      # Skip on an exact restore hit: re-saving would just duplicate the entry
-      # into this run's ref scope. PR runs that changed GWT sources still
-      # save, so re-pushes to the same PR skip the recompile.
+      # Save only from main-scoped runs, and only on a key miss: a cache saved
+      # from a PR run lands in that PR's merge-ref scope, which no other
+      # branch can restore -- each copy is pure pressure on the repo's 10 GB
+      # Actions cache quota, and that pressure is what evicts main's copy and
+      # sends every PR build cold in the first place.
       - name: Save GWT output
-        if: steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
+        if: github.ref == 'refs/heads/main' && steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: package/linux/build-Server-DEB/gwt
@@ -400,23 +402,13 @@ jobs:
           echo "sha256=$SHA"        >> "$GITHUB_OUTPUT"
           echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
 
-      # Cache the daily installer keyed on its resolved filename. Filenames
-      # embed the version + build number on the auto-resolve path so the
-      # content is immutable per name: new daily misses and downloads, same
-      # day re-run hits and skips (SHA still verified below). Skip caching
-      # on the override path -- a user-supplied URL has no immutability
-      # guarantee and its SHA check is skipped, so a reused basename could
-      # otherwise serve stale, unverified bytes.
-      - name: Cache RStudio Server installer
-        if: inputs.build_from_source == false && inputs.rstudio_installer_url == ''
-        id: installer-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.resolve.outputs.filename }}
-          key: rstudio-server-installer-${{ steps.resolve.outputs.filename }}
-
+      # Downloaded fresh every run rather than cached: dailies.rstudio.com is
+      # already S3/CDN-backed, and GH Actions cache scoping means concurrent
+      # PRs can't share a cache entry with each other anyway (only with their
+      # base branch), so caching here would just duplicate the same bytes
+      # into the shared 10 GB cache quota without saving meaningful time.
       - name: Download RStudio Server .deb
-        if: (inputs.build_from_source == false || inputs.rstudio_installer_url != '') && steps.installer-cache.outputs.cache-hit != 'true'
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
         env:
           DOWNLOAD_URL: ${{ steps.resolve.outputs.url }}
           DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}


### PR DESCRIPTION
## Summary

The repo's e2e Actions cache was pinned at the 10 GB quota (3,576 active cache entries), which was causing eviction of the caches PR builds most depend on (`rstudio-tools`, R-libs, GWT output). This trims two sources of pure waste:

- **Drop the RStudio installer caches** (`actions/cache@v4`, no branch gate). These steps don't build anything — when `build_from_source == false` they just re-download an already-published daily build from `dailies.rstudio.com` (itself S3/CDN-backed). Because GitHub's cache scoping doesn't let concurrent PRs share a cache entry with each other (only with their base branch), every PR that hit this path was independently downloading and caching its own duplicate multi-hundred-MB copy of identical bytes, with no real time savings over just downloading fresh.
- **Gate the "Save GWT output" step to main-scoped runs only**, matching the main-only-save pattern already used for the `rstudio-tools` and R-libs caches elsewhere in these same workflows. A cache saved from a PR run is only ever visible to that same PR (never to main or other PRs), so PR-side saves were pure one-way quota pressure on main's copy — the one every other PR actually depends on for a fast, warm GWT build.

## Test plan

- [x] All 7 edited workflow YAML files parse successfully (validated with PyYAML)
- [ ] Confirm a PR-triggered e2e run still downloads/installs the daily build correctly with caching removed
- [ ] Confirm a main-branch run still saves the GWT cache, and a subsequent PR run restores it (cache-hit skips recompilation)