### PR TITLE
Add Fedora 44 desktop e2e Playwright workflow

### DIFF
--- a/.github/actions/os-e2e-deps/action.yml
+++ b/.github/actions/os-e2e-deps/action.yml
@@ -97,10 +97,17 @@ runs:
           # there's no cross-release ABI mismatch. Debian/Ubuntu key off the
           # release codename (noble on 24.04, resolute on 26.04); RHEL and its
           # rebuilds have no VERSION_CODENAME, so key off the major version
-          # (rhel9, rhel10) instead.
+          # (rhel9, rhel10) instead. Fedora has no PPM binary repo of its own,
+          # so it borrows the newest RHEL one (rhel10) -- see the fedora branch.
           . /etc/os-release
           if [ "$ID" = "rhel" ] || [ "$ID" = "rocky" ] || [ "$ID" = "almalinux" ] || [ "$ID" = "centos" ] || printf '%s' "$ID_LIKE" | grep -q 'rhel'; then
             export PKG_REPO="https://packagemanager.posit.co/cran/__linux__/rhel${VERSION_ID%%.*}/latest"
+          elif [ "$ID" = "fedora" ]; then
+            # PPM publishes no Fedora binaries, so borrow the newest RHEL binary
+            # repo (rhel10). Fedora is newer than RHEL 10, so forward glibc
+            # compatibility generally lets these binaries load; system-library
+            # soname drift is the residual risk this workflow is validating.
+            export PKG_REPO="https://packagemanager.posit.co/cran/__linux__/rhel10/latest"
           else
             export PKG_REPO="https://packagemanager.posit.co/cran/__linux__/${VERSION_CODENAME}/latest"
           fi
@@ -168,20 +175,21 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       # --with-deps has Playwright shell out to the OS package manager to
       # install the browser's system libraries, but Playwright only supports
-      # that on Debian/Ubuntu. So on RHEL-family hosts we fetch only the browser
-      # binary -- which means the caller MUST have already installed the Chromium
-      # runtime libraries (nss, gtk3, mesa-libgbm, ...) via dnf. This is a real
-      # cross-file contract: a RHEL caller that omits that dnf step gets a
-      # browser that can't launch, surfacing far away as an opaque launch error.
+      # that on Debian/Ubuntu. So on RHEL-family or Fedora hosts we fetch only
+      # the browser binary -- which means the caller MUST have already installed
+      # the Chromium runtime libraries (nss, gtk3, mesa-libgbm, ...) via dnf.
+      # This is a real cross-file contract: a dnf-based caller that omits that
+      # step gets a browser that can't launch, surfacing far away as an opaque
+      # launch error.
       run: |
-        IS_RHEL=false
+        BINARY_ONLY=false
         if [ "$RUNNER_OS" = "Linux" ] && [ -r /etc/os-release ]; then
           . /etc/os-release
-          if [ "$ID" = "rhel" ] || [ "$ID" = "rocky" ] || [ "$ID" = "almalinux" ] || [ "$ID" = "centos" ] || printf '%s' "$ID_LIKE" | grep -q 'rhel'; then
-            IS_RHEL=true
+          if [ "$ID" = "rhel" ] || [ "$ID" = "rocky" ] || [ "$ID" = "almalinux" ] || [ "$ID" = "centos" ] || [ "$ID" = "fedora" ] || printf '%s' "$ID_LIKE" | grep -q 'rhel'; then
+            BINARY_ONLY=true
           fi
         fi
-        if [ "$IS_RHEL" = true ]; then
+        if [ "$BINARY_ONLY" = true ]; then
           npx playwright install chromium
         else
           npx playwright install --with-deps chromium

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
@@ -1,0 +1,693 @@
+name: "Test: E2E Playwright RStudio (Desktop, Fedora 44 x86_64, Open Source)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_from_source:
+        description: "Build RStudio Desktop (Electron) from this branch's source. When false, downloads the latest daily .rpm installer."
+        type: boolean
+        default: true
+      rstudio_installer_url:
+        description: "Optional .rpm URL to test against (e.g. a specific daily from dailies.rstudio.com). Only used when build_from_source is false. Leave empty to auto-resolve the latest daily."
+        type: string
+        default: ""
+      r_version:
+        description: "R version to install via rig (e.g. 'release', 'oldrel', 'devel', '4.4.1')."
+        type: string
+        default: "release"
+      project:
+        description: "Playwright project to run: 'desktop' or 'server'. OS and edition are auto-filtered from the host platform and PW_RSTUDIO_EDITION."
+        type: string
+        default: "desktop"
+      grep:
+        description: "Optional Playwright --grep pattern to run only tests whose title matches."
+        type: string
+        default: ""
+      test_selector:
+        description: "Optional test paths/files/directories to run (space-separated). Matched as substrings against test file paths. Examples: 'autocomplete.test.ts', 'tests/panes/misc/', 'autocomplete tests/panes/posit-assistant-chat/'. Leave empty to run all tests."
+        type: string
+        default: ""
+      test_ignore:
+        description: "Optional test paths/files/directories to exclude (space-separated globs). Examples: '**/code_suggestions.test.ts', '**/posit-assistant-chat/**'. Leave empty to exclude nothing."
+        type: string
+        default: ""
+      grep_invert:
+        description: "Optional Playwright --grep-invert pattern to skip tests by title. Defaults to '@ai' to skip tests that require credentials not available in unattended runs."
+        type: string
+        default: "@ai"
+      rstudio_extra_args:
+        description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS. Set to '--no-sandbox' if the in-container Chromium sandbox won't initialize (see the container options below)."
+        type: string
+        default: ""
+      build_only:
+        description: "Run only the build job (to seed the rstudio-tools / R-libs / sccache caches) and skip the e2e job."
+        type: boolean
+        default: false
+      post_pr_comment:
+        description: "Post test results as a sticky comment on the PR. Pass true only from PR-triggered callers."
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      build_from_source:
+        type: boolean
+        default: true
+      rstudio_installer_url:
+        type: string
+        default: ""
+      r_version:
+        type: string
+        default: "release"
+      project:
+        type: string
+        default: "desktop"
+      grep:
+        type: string
+        default: ""
+      test_selector:
+        type: string
+        default: ""
+      test_ignore:
+        type: string
+        default: ""
+      grep_invert:
+        type: string
+        default: "@ai"
+      rstudio_extra_args:
+        type: string
+        default: ""
+      build_only:
+        type: boolean
+        default: false
+      post_pr_comment:
+        type: boolean
+        default: false
+      defer_merge:
+        description: "Skip this workflow's own merge/publish/comment job; the caller merges every platform's blobs into one report instead."
+        type: boolean
+        default: false
+    secrets:
+      CONNECT_API_KEY:
+        description: "Posit Connect API key for the E2E Test Insights reporter"
+        required: false
+
+permissions:
+  contents: read
+  # Required so the e2e-merge job can post sticky PR comments via
+  # marocchino/sticky-pull-request-comment. GitHub validates ALL job-level
+  # permissions in a reusable workflow at call time, so this must be declared
+  # at the top level even though only e2e-merge uses it.
+  pull-requests: write
+
+jobs:
+  # Builds RStudio Desktop (Electron) from this PR's source inside a Fedora 44
+  # container (GitHub has no Fedora-hosted runner), then uploads the .rpm as an
+  # artifact for the e2e job to consume. This is the same RPM the RHEL build
+  # produces -- Fedora and RHEL both ship the Electron .rpm. Skipped when
+  # build_from_source is false, in which case the e2e job downloads the daily
+  # .rpm (or rstudio_installer_url) instead.
+  build:
+    if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
+    runs-on: ubuntu-latest
+    # SYS_ADMIN + an unconfined seccomp profile let a later Chromium/Electron
+    # sandbox initialize inside the container (the host sysctl the Ubuntu jobs
+    # flip isn't reachable here -- /proc/sys is read-only in the container).
+    container:
+      image: fedora:44
+      options: --cap-add=SYS_ADMIN --security-opt seccomp=unconfined
+    timeout-minutes: 90
+    env:
+      # Redirect the dependency / package scripts' tool root to a
+      # workspace-local path so it can be cached without sudo.
+      RSTUDIO_TOOLS_ROOT: ${{ github.workspace }}/opt/rstudio-tools/x86_64
+      # Pin R's user library to a workspace-local path so we can cache it.
+      R_LIBS_USER: ${{ github.workspace }}/R-libs/%p/%v
+      SCCACHE_ENABLED: '1'
+      # Route sccache to GitHub's built-in Actions cache API. The
+      # mozilla-actions/sccache-action step below installs sccache and exports
+      # ACTIONS_CACHE_URL + ACTIONS_RUNTIME_TOKEN so the sccache server uses
+      # the GHA backend. Cache hits are object-level (one entry per compiled
+      # .o), so PRs automatically inherit main's warm cache from the seed job
+      # without per-SHA tarball rotation. No AWS / S3 / secrets required.
+      SCCACHE_GHA_ENABLED: 'true'
+      # Compile GWT with readable (PRETTY) symbol names rather than the default
+      # OBFUSCATED output, so the uncaught client exceptions the e2e automation
+      # agent records (window.rstudio.errors) carry decodable Java stack traces.
+      # Consumed by src/gwt/CMakeLists.txt; folded into the GWT cache key below.
+      GWT_STYLE: PRETTY
+      # Quiet npm during install-common's panmirror build, the Electron app
+      # build, and any other transitive npm step.
+      NPM_CONFIG_LOGLEVEL: error
+      NPM_CONFIG_AUDIT: 'false'
+
+    steps:
+      # The Fedora base image is minimal and the job runs as root. Install the
+      # tools the checkout action, the dependency scripts, and the build need up
+      # front. sudo is required because install-dependencies-yum calls it
+      # internally (root's sudo is a straight passthrough). Unlike RHEL's UBI,
+      # Fedora's base repos already carry the build -devel packages, so no EPEL /
+      # CodeReady Builder enablement step is needed.
+      - name: Prepare Fedora container
+        run: |
+          dnf -y install sudo git tar gzip xz jq which findutils diffutils procps-ng
+
+      - uses: actions/checkout@v4
+
+      # Pre-built tool deps (Boost, SOCI, pandoc, quarto, GWT, node, panmirror,
+      # copilot-language-server, sccache, etc.) all land under RSTUDIO_TOOLS_ROOT.
+      # Restore-only; the matching Save steps after "Install build
+      # dependencies" run only from main-scoped runs. Fedora-scoped key so the
+      # fedora44 tools tree never collides with the Ubuntu (noble) or RHEL ones.
+      - name: Restore rstudio-tools deps
+        id: tools-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.RSTUDIO_TOOLS_ROOT }}
+          key: rstudio-tools-linux-fedora44-x86_64-${{ hashFiles('dependencies/common/install-*', 'dependencies/linux/install-*', 'dependencies/tools/rstudio-tools.sh') }}
+          restore-keys: |
+            rstudio-tools-linux-fedora44-x86_64-
+
+      # install-common (called by install-dependencies-yum) installs R packages
+      # (via install-packages) into R_LIBS_USER. Cache the whole R-libs tree --
+      # R's %p/%v subpaths keep different versions isolated.
+      - name: Restore build-time R packages
+        id: rlibs-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/R-libs
+          key: rstudio-build-rlibs-linux-fedora44-x86_64-${{ hashFiles('dependencies/common/install-packages', 'dependencies/common/lockfiles/**/renv.lock') }}
+          restore-keys: |
+            rstudio-build-rlibs-linux-fedora44-x86_64-
+
+      # Cache compiled GWT output (package/linux/build-Electron-RPM/gwt). GWT
+      # compilation is the single most expensive JS step (~15-30 min). When GWT
+      # Java sources / build scripts haven't changed, make-electron-package can
+      # skip the recompile entirely via the NO_REBUILD env var (sets
+      # GWT_BUILD=no, which becomes -DGWT_BUILD=no to cmake) -- see the
+      # NO_REBUILD/GWT_BUILD handling in package/linux/make-package. GWT output
+      # is Java-to-JS and platform-independent, but the key is fedora44-scoped
+      # for per-distro cache isolation (matching the tools/rlibs keys); the RPM
+      # build dir also differs from the DEB dir, so the path can't collide either.
+      # Restore-only here; the matching Save step runs after the build with a
+      # success gate so a failed mid-compile run can't poison the cache.
+      - name: Restore GWT output
+        id: gwt-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: package/linux/build-Electron-RPM/gwt
+          key: rstudio-gwt-linux-desktop-fedora44-x86_64-${{ env.GWT_STYLE }}-v1-${{ hashFiles('src/gwt/src/**', 'src/gwt/acesupport/**', 'src/gwt/lib/**', 'src/gwt/build.xml', 'src/gwt/conf/**') }}
+          restore-keys: |
+            rstudio-gwt-linux-desktop-fedora44-x86_64-${{ env.GWT_STYLE }}-v1-
+
+      # GHA-backed sccache. Installs sccache on PATH and starts the sccache
+      # server with the GH Actions cache API as the storage backend. Object-level
+      # cache hits, no per-SHA tarball, no AWS credentials.
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      # install-dependencies-yum: dnf installs system packages (with sudo
+      # internally), then calls install-common which downloads Boost, SOCI,
+      # pandoc, quarto, node, panmirror, sccache, GWT jar, etc. into
+      # RSTUDIO_TOOLS_ROOT. The scripts are idempotent, so a cache hit on
+      # rstudio-tools-deps makes this a fast pass: the heavy downloads are
+      # skipped and the cached tools are reused.
+      - name: Install build dependencies
+        working-directory: dependencies/linux
+        run: ./install-dependencies-yum
+
+      # Save the tools / R-libs caches only from main-scoped runs (scheduled
+      # or dispatched on main), and only on a key miss. A cache saved from a
+      # PR run lands in that PR's merge-ref scope, which no other branch can
+      # restore -- each copy is pure pressure on the repo's 10 GB Actions
+      # cache quota, and that pressure is what evicts main's copies and sends
+      # every PR build cold in the first place.
+      - name: Save rstudio-tools deps
+        if: github.ref == 'refs/heads/main' && steps.tools-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.RSTUDIO_TOOLS_ROOT }}
+          key: ${{ steps.tools-cache.outputs.cache-primary-key }}
+
+      - name: Save build-time R packages
+        if: github.ref == 'refs/heads/main' && steps.rlibs-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/R-libs
+          key: ${{ steps.rlibs-cache.outputs.cache-primary-key }}
+
+      - name: Zero sccache stats
+        run: sccache --zero-stats || true
+
+      - name: Build RStudio Desktop RPM
+        id: build
+        working-directory: package/linux
+        env:
+          RSTUDIO_VERSION_MAJOR: '99'
+          RSTUDIO_VERSION_MINOR: '9'
+          RSTUDIO_VERSION_PATCH: '9'
+          RSTUDIO_VERSION_SUFFIX: "-pr+${{ github.run_number }}"
+        run: |
+          # NO_REBUILD=1 (see package/linux/make-package) tells the script to
+          # set GWT_BUILD=no, which becomes -DGWT_BUILD=no to cmake, so the
+          # cached GWT bin/www/extras under build-Electron-RPM/gwt are reused
+          # instead of recompiled (~15-30 min saved when sources unchanged).
+          if [ "${{ steps.gwt-cache.outputs.cache-hit }}" = "true" ]; then
+            echo "GWT cache hit -- skipping GWT compile"
+            NO_REBUILD=1 ./make-electron-package RPM
+          else
+            echo "GWT cache miss -- compiling GWT from scratch"
+            ./make-electron-package RPM
+          fi
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
+      # Save GWT output only when the build succeeded. A failed mid-compile run
+      # could otherwise write partial GWT output to the cache, and every future
+      # restore would silently ship a broken frontend until the hashFiles key
+      # rotates. Skip on an exact restore hit: re-saving would just duplicate
+      # the entry into this run's ref scope. PR runs that changed GWT sources
+      # still save, so re-pushes to the same PR skip the recompile.
+      - name: Save GWT output
+        if: steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: package/linux/build-Electron-RPM/gwt
+          key: ${{ steps.gwt-cache.outputs.cache-primary-key }}
+
+      # Skipped in build_only (seed) runs: no e2e job consumes the artifact,
+      # so packaging and uploading it would be pure waste. CPack writes the
+      # shippable .rpm to the TOP LEVEL of build-Electron-RPM (no
+      # CPACK_PACKAGE_DIRECTORY is set and cpack runs from inside that dir),
+      # exactly like the .deb sibling -- so -maxdepth 1 is correct and
+      # deterministic. _CPack_Packages/.../RPM holds only rpmbuild staging
+      # copies and the xcopy tarball, which we must not pick up.
+      - name: Package RStudio Desktop .rpm
+        if: inputs.build_only != true
+        run: |
+          RPM=$(find package/linux/build-Electron-RPM -maxdepth 1 -name '*.rpm' | head -1)
+          if [ -z "$RPM" ]; then
+            echo "::error::No .rpm found in package/linux/build-Electron-RPM"
+            exit 1
+          fi
+          cp "$RPM" "${{ github.workspace }}/rstudio-desktop.rpm"
+          echo "Packaged: $RPM"
+
+      - name: Upload RStudio Desktop .rpm artifact
+        if: inputs.build_only != true
+        uses: actions/upload-artifact@v4
+        with:
+          name: rstudio-desktop-rpm-fedora44-x86_64
+          path: rstudio-desktop.rpm
+          retention-days: 7
+
+  e2e-desktop-fedora:
+    needs: build
+    # build is skipped when build_from_source is false; allow this job to run
+    # in that case too (needs.build.result == 'skipped' on the daily-download
+    # path). build_only seeds the build caches without running e2e, so skip.
+    if: |
+      always() &&
+      inputs.build_only != true &&
+      (needs.build.result == 'success' || needs.build.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:44
+      # SYS_ADMIN + unconfined seccomp let Chromium/Electron's namespace sandbox
+      # initialize inside the container. The Ubuntu jobs instead flip a host
+      # sysctl (kernel.apparmor_restrict_unprivileged_userns=0), which isn't
+      # reachable from an unprivileged container -- /proc/sys is read-only. If
+      # the sandbox still refuses to come up here, pass --no-sandbox via
+      # rstudio_extra_args (PW_RSTUDIO_EXTRA_ARGS) rather than changing these.
+      options: --cap-add=SYS_ADMIN --security-opt seccomp=unconfined
+    timeout-minutes: 120
+    env:
+      R_LIBS_USER: ${{ github.workspace }}/R-libs
+      PW_SANDBOX_ROOT: ${{ github.workspace }}/pw-sandbox
+      PW_SANDBOX_ROOT_CREATE: '1'
+
+    steps:
+      # The Fedora base image is minimal and the job runs as root. Install what
+      # checkout, rig, and the .rpm install need. sudo is kept for parity with
+      # the shared scripts.
+      - name: Prepare Fedora container
+        run: |
+          dnf -y install sudo git tar gzip xz jq which findutils
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
+
+      - name: Install OS dependencies
+        run: |
+          # Xvfb (virtual display for the Electron app / Playwright) plus the
+          # runtime libraries Chromium/Electron and the Playwright-managed
+          # chromium need on Fedora. This list is load-bearing, not redundant:
+          # the RStudio Electron RPM is built with CPACK_RPM_PACKAGE_AUTOREQPROV
+          # off (see package/linux/CMakeLists.txt) and declares only
+          # libxkbcommon-x11 and sqlite, so dnf does NOT auto-pull the
+          # GUI/Chromium libs on install -- they must come from here. The last
+          # row mirrors the font/text libs some test R packages load:
+          # freetype/fontconfig (ragg, systemfonts), harfbuzz/fribidi
+          # (textshaping).
+          dnf -y install \
+            xorg-x11-server-Xvfb \
+            nss nspr atk at-spi2-atk at-spi2-core cups-libs \
+            libdrm mesa-libgbm libxkbcommon \
+            libX11 libXcomposite libXdamage libXext libXfixes libXrandr libXScrnSaver libXtst libxcb \
+            gtk3 pango cairo alsa-lib \
+            freetype fontconfig harfbuzz fribidi
+
+      - name: Install rig
+        run: |
+          curl -fLs https://github.com/r-lib/rig/releases/download/latest/rig-linux-$(arch)-latest.tar.gz \
+            | tar xz -C /usr/local
+
+      - name: Install R via rig
+        env:
+          R_VERSION: ${{ inputs.r_version }}
+        run: |
+          rig add "$R_VERSION"
+          rig default "$R_VERSION"
+          rig ls
+          mkdir -p "$R_LIBS_USER"
+
+      # Build-from-source path: extract the .rpm artifact produced by the build
+      # job above and install it. The RPM declares only minimal deps (AUTOREQPROV
+      # is off), so the GUI/Chromium runtime libs come from the "Install OS
+      # dependencies" step above, not from the RPM's own resolution.
+      - name: Download RStudio Desktop .rpm artifact
+        if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
+        uses: actions/download-artifact@v4
+        with:
+          name: rstudio-desktop-rpm-fedora44-x86_64
+          path: ${{ github.workspace }}
+
+      - name: Install RStudio Desktop from artifact
+        if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
+        run: |
+          dnf -y install "${{ github.workspace }}/rstudio-desktop.rpm"
+          ls -la /usr/bin/rstudio
+
+      # Daily-download path: resolve and install the latest (or specified) .rpm.
+      # Runs when build_from_source is false (auto-resolve the daily via
+      # dailies.rstudio.com/rstudio/latest/index.json) or when an explicit
+      # rstudio_installer_url is provided (use that URL verbatim).
+      - name: Resolve RStudio Desktop .rpm URL
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
+        id: resolve
+        env:
+          INSTALLER_URL: ${{ inputs.rstudio_installer_url }}
+        run: |
+          URL="$INSTALLER_URL"
+          SHA=""
+          FILENAME=""
+          if [ -z "$URL" ]; then
+            MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 'https://dailies.rstudio.com/rstudio/latest/index.json')
+            # There is no separate Fedora daily: the Electron .rpm keyed
+            # "rhel10-x86_64" under the electron product is the RPM the Fedora
+            # tests run against (the same build RHEL uses).
+            URL=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["rhel10-x86_64"].link // empty')
+            SHA=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["rhel10-x86_64"].sha256 // empty')
+            FILENAME=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["rhel10-x86_64"].filename // empty')
+            if [ -z "$URL" ] || [ -z "$FILENAME" ] || [ -z "$SHA" ]; then
+              echo "::error::Daily manifest is missing expected fields (url='$URL', filename='$FILENAME', sha256='$SHA'). The schema at https://dailies.rstudio.com/rstudio/latest/index.json may have changed."
+              exit 1
+            fi
+            echo "Auto-resolved latest rhel10-x86_64 desktop daily:"
+            echo "  URL:      $URL"
+            echo "  SHA-256:  $SHA"
+            echo "  Filename: $FILENAME"
+          else
+            FILENAME=$(basename "${URL%%\?*}")
+            if [ -z "$FILENAME" ]; then
+              echo "::error::Could not derive filename from rstudio_installer_url='$URL'."
+              exit 1
+            fi
+            echo "Using override URL: $URL (SHA-256 verification skipped)"
+          fi
+          echo "url=$URL"           >> "$GITHUB_OUTPUT"
+          echo "sha256=$SHA"        >> "$GITHUB_OUTPUT"
+          echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
+
+      # Cache the daily installer keyed on its resolved filename. Filenames
+      # embed the version + build number on the auto-resolve path so the content
+      # is immutable per name: new daily misses and downloads, same-day re-run
+      # hits and skips (SHA still verified below). Skip caching on the override
+      # path -- a user-supplied URL has no immutability guarantee and its SHA
+      # check is skipped, so a reused basename could otherwise serve stale,
+      # unverified bytes.
+      - name: Cache RStudio Desktop installer
+        if: inputs.build_from_source == false && inputs.rstudio_installer_url == ''
+        id: installer-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.resolve.outputs.filename }}
+          key: rstudio-desktop-installer-${{ steps.resolve.outputs.filename }}
+
+      - name: Download RStudio Desktop .rpm
+        if: (inputs.build_from_source == false || inputs.rstudio_installer_url != '') && steps.installer-cache.outputs.cache-hit != 'true'
+        env:
+          DOWNLOAD_URL: ${{ steps.resolve.outputs.url }}
+          DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}
+        run: |
+          curl -fsSL --retry 3 --retry-delay 5 \
+            -o "$DOWNLOAD_FILENAME" \
+            "$DOWNLOAD_URL"
+
+      - name: Verify SHA-256
+        if: (inputs.build_from_source == false || inputs.rstudio_installer_url != '') && steps.resolve.outputs.sha256 != ''
+        env:
+          EXPECTED_SHA256: ${{ steps.resolve.outputs.sha256 }}
+          DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}
+        run: |
+          echo "$EXPECTED_SHA256  $DOWNLOAD_FILENAME" | sha256sum -c -
+
+      - name: Install RStudio Desktop from .rpm
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
+        env:
+          INSTALLER_FILENAME: ${{ steps.resolve.outputs.filename }}
+        run: |
+          dnf -y install "./$INSTALLER_FILENAME"
+          ls -la /usr/bin/rstudio
+
+      - name: Install e2e test dependencies
+        uses: ./.github/actions/os-e2e-deps
+        with:
+          r-libs-user: ${{ env.R_LIBS_USER }}
+          # Isolate the R-library / pak caches from the Ubuntu workflows: they
+          # all share runner.os == Linux, and an Ubuntu-compiled R library is
+          # ABI-incompatible with Fedora's R. See os-e2e-deps cache-scope.
+          cache-scope: fedora44-x86_64
+
+      - name: Run Playwright tests
+        working-directory: e2e/rstudio
+        env:
+          PW_RSTUDIO_MODE: desktop
+          # Platform-labelled project name; playwright.config.ts uses it both as
+          # the project name in reports (so a cross-platform merged report can
+          # distinguish these results) and to derive the platform+shard-unique
+          # blob report file name.
+          PW_PROJECT_LABEL: ${{ inputs.project }}-linux-fedora
+          PW_GREP: ${{ inputs.grep }}
+          PW_GREP_INVERT: ${{ inputs.grep_invert }}
+          PW_TEST_SELECTOR: ${{ inputs.test_selector }}
+          PW_TEST_IGNORE: ${{ inputs.test_ignore }}
+          PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
+          # Tells playwright.config.ts to switch to blob reporter for this shard.
+          PW_SHARD: ${{ matrix.shard }}
+          # E2E Test Insights reporter: posts per-shard results to the dashboard.
+          # CONNECT_API_KEY is empty on fork PRs; the reporter still runs but its
+          # uploads fail with warnings (never fails the run).
+          CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+          SHARD_NAME: desktop-linux-fedora-${{ matrix.shard }}
+          # Print the GWT launch timeline so the next launch failure shows which
+          # phase exceeded the deadline.
+          PW_DEBUG_LAUNCH: '1'
+        run: |
+          ARGS=()
+          if [ -n "$PW_TEST_SELECTOR" ]; then
+            set -f
+            ARGS+=($PW_TEST_SELECTOR)
+            set +f
+          fi
+          if [ -n "$PW_GREP" ]; then
+            ARGS+=(--grep "$PW_GREP")
+          fi
+          if [ -n "$PW_GREP_INVERT" ]; then
+            ARGS+=(--grep-invert "$PW_GREP_INVERT")
+          fi
+          ARGS+=(--shard="${{ matrix.shard }}/${{ strategy.job-total }}")
+          # Run Playwright under our own Xvfb and exec the watchdog as the step's
+          # main process, so a job cancellation's SIGTERM reaches the watchdog
+          # (which forwards it to Playwright's process group as SIGINT -- its
+          # cancellation signal -- then escalates to SIGKILL if the run doesn't
+          # wind down). xvfb-run is a shell wrapper that does not forward signals
+          # to its child, which left cancelled Linux e2e jobs running until
+          # their timeout-minutes instead of stopping. -ac disables X access
+          # control so Chromium connects without an auth cookie; -nolisten tcp
+          # keeps the display on the local socket only. We wait for the X socket
+          # before launching so it doesn't race a cold display, and fail loudly
+          # (dumping the Xvfb log) if it never comes up, rather than exec-ing
+          # Playwright against a dead display and surfacing an opaque launch error.
+          Xvfb :99 -screen 0 1920x1080x24 -ac -nolisten tcp >/tmp/xvfb.log 2>&1 &
+          export DISPLAY=:99
+          for _ in $(seq 1 50); do
+            [ -S /tmp/.X11-unix/X99 ] && break
+            sleep 0.1
+          done
+          if [ ! -S /tmp/.X11-unix/X99 ]; then
+            echo "::error::Xvfb display :99 never came up after 5s; Xvfb log follows."
+            cat /tmp/xvfb.log || true
+            exit 1
+          fi
+          exec node scripts/run-with-heartbeat.mjs -- test "${ARGS[@]}"
+
+      # Platform-prefixed artifact name keeps this Fedora Desktop platform's
+      # shard reports separate from the other platforms (mac / win /
+      # linux-desktop / linux-server) if this workflow is ever merged into a
+      # combined run, so each merge job downloads only its own.
+      - name: Upload blob report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-blob-report-linux-desktop-fedora-${{ matrix.shard }}
+          path: e2e/rstudio/blob-report/
+          if-no-files-found: warn
+          retention-days: 1
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-linux-desktop-fedora-${{ matrix.shard }}
+          path: e2e/rstudio/test-results/
+          if-no-files-found: ignore
+
+      # Preserved per-spec sandbox tree on failure -- includes rsession logs,
+      # the spec's RStudio config / data home, and per-test working dirs.
+      - name: Upload PW sandbox (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pw-sandbox-linux-desktop-fedora-${{ matrix.shard }}
+          path: ${{ github.workspace }}/pw-sandbox/
+          if-no-files-found: ignore
+
+  # Merge per-shard blob reports into a single HTML report, parse aggregated
+  # counts, and post a sticky PR comment with pass/fail/skip totals
+  # (when post_pr_comment is set). Runs on a plain hosted runner -- merging only
+  # needs node + `playwright merge-reports`, no Fedora container.
+  e2e-merge:
+    needs: [e2e-desktop-fedora]
+    if: always() && inputs.defer_merge != true && needs.e2e-desktop-fedora.result != 'skipped' && needs.e2e-desktop-fedora.result != 'cancelled'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
+
+      - name: Install Playwright
+        working-directory: e2e/rstudio
+        # --ignore-scripts skips the postinstall that downloads browser
+        # binaries; the merge job only invokes `playwright merge-reports`,
+        # which doesn't need Chromium.
+        run: npm ci --ignore-scripts
+
+      - name: Download shard blob reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: playwright-blob-report-linux-desktop-fedora-*
+          path: e2e/rstudio/all-blob-reports
+          merge-multiple: true
+
+      - name: Merge shard reports
+        working-directory: e2e/rstudio
+        run: |
+          if [ -z "$(ls -A all-blob-reports 2>/dev/null)" ]; then
+            echo "::error::No blob reports found -- both shards failed to produce artifacts"
+            exit 1
+          fi
+          npx playwright merge-reports --config merge.config.ts ./all-blob-reports
+
+      # Shared summarizer (also used by the PR run's e2e-merge-all job) so every
+      # comment computes pass/fail counts and the rate bar from one definition.
+      - name: Parse aggregated results
+        id: summary
+        if: always()
+        working-directory: e2e/rstudio
+        run: node scripts/summarize-merged-report.mjs playwright-report/test-results.json
+
+      - name: Upload merged Playwright report
+        id: upload-report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-linux-desktop-fedora
+          path: e2e/rstudio/playwright-report/
+          retention-days: 15
+          if-no-files-found: ignore
+
+      # Publish a browsable copy of the report to Connect on failure only, so
+      # reviewers can inspect it without downloading the zip. Best-effort: a
+      # no-op on fork PRs (empty key) and never fails the job.
+      - name: Publish report to Connect
+        id: publish-report
+        if: always() && steps.summary.outputs.failed != '0' && steps.summary.outputs.failed != ''
+        uses: ./.github/actions/os-publish-e2e-report
+        with:
+          connect-api-key: ${{ secrets.CONNECT_API_KEY }}
+          title: "E2E Fedora 44 Desktop - PR #${{ github.event.pull_request.number }} - run #${{ github.run_number }}"
+
+      - name: Post E2E results to PR
+        if: |
+          always() &&
+          inputs.post_pr_comment == true &&
+          github.event.pull_request.head.repo.fork == false &&
+          (steps.summary.outputs.passed != '0' || steps.summary.outputs.failed != '0' || steps.summary.outputs.skipped != '0' || steps.summary.outputs.flaky != '0')
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: e2e-desktop-fedora44-results
+          GITHUB_TOKEN: ${{ github.token }}
+          message: |
+            ## 🎩 Linux Desktop E2E · Fedora 44
+
+            ${{ needs.e2e-desktop-fedora.result == 'success' && steps.summary.outputs.failed == '0' && '### ✅ All tests passed!' || format('### ❌ {0} test(s) failed', steps.summary.outputs.failed) }}
+
+            `${{ steps.summary.outputs.bar }}` **${{ steps.summary.outputs.rate }}%** pass rate
+
+            | ✅ Passed | ❌ Failed | ⚠️ Skipped | 🔁 Flaky |
+            | :---: | :---: | :---: | :---: |
+            | **${{ steps.summary.outputs.passed }}** | **${{ steps.summary.outputs.failed }}** | **${{ steps.summary.outputs.skipped }}** | **${{ steps.summary.outputs.flaky }}** |
+
+            <details>
+            <summary>📥 Download Playwright report</summary>
+            ${{ steps.publish-report.outputs.url != '' && format('
+            **[🌐 View report online]({0})** — opens in the browser (requires Connect login). Available for up to 1 week.
+            ', steps.publish-report.outputs.url) || '' }}
+            **[⬇️ playwright-report.zip](${{ steps.upload-report.outputs.artifact-url }})** — extract and open `index.html`
+
+            > Includes screenshots, traces, and step-by-step details for every test. Expires in 15 days.
+
+            </details>
+
+            ---
+            <sub>2 shards · fedora:44 container · commit <code>${{ github.event.pull_request.head.sha }}</code> · <a href="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}">Run #${{ github.run_number }}</a></sub>

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
@@ -102,8 +102,8 @@ permissions:
 jobs:
   # Builds RStudio Desktop (Electron) from this PR's source inside a Fedora 44
   # container (GitHub has no Fedora-hosted runner), then uploads the .rpm as an
-  # artifact for the e2e job to consume. This is the same RPM the RHEL build
-  # produces -- Fedora and RHEL both ship the Electron .rpm. Skipped when
+  # artifact for the e2e job to consume. This is the same kind of Electron
+  # .rpm the RHEL build produces -- there is no Fedora-specific SKU. Skipped when
   # build_from_source is false, in which case the e2e job downloads the daily
   # .rpm (or rstudio_installer_url) instead.
   build:
@@ -484,9 +484,10 @@ jobs:
         uses: ./.github/actions/os-e2e-deps
         with:
           r-libs-user: ${{ env.R_LIBS_USER }}
-          # Isolate the R-library / pak caches from the Ubuntu workflows: they
-          # all share runner.os == Linux, and an Ubuntu-compiled R library is
-          # ABI-incompatible with Fedora's R. See os-e2e-deps cache-scope.
+          # Isolate the R-library / pak caches from the Ubuntu and RHEL
+          # workflows: they all share runner.os == Linux, and an Ubuntu- or
+          # RHEL-compiled R library is ABI-incompatible with Fedora's R. See
+          # os-e2e-deps cache-scope.
           cache-scope: fedora44-x86_64
 
       - name: Run Playwright tests


### PR DESCRIPTION
Adds a standalone `workflow_dispatch` / `workflow_call` e2e workflow that runs the Playwright desktop suite against RStudio Desktop on Fedora 44, modeled on the Ubuntu 24 desktop workflow.

Since GitHub has no Fedora-hosted runner, both the build and e2e jobs run inside a `fedora:44` container on `ubuntu-latest` (with `SYS_ADMIN` + unconfined seccomp so the Chromium/Electron sandbox can start). The build produces the Electron `.rpm` via `make-electron-package RPM`; the daily-download path resolves the `rhel10-x86_64` electron key, since there is no separate Fedora daily and the RHEL RPM is what runs on Fedora. Cache keys and the `os-e2e-deps` scope are Fedora-scoped to stay isolated from the Ubuntu and RHEL R libraries.

Not wired into `os-test-e2e-rstudio-pr.yml`: standalone and on-demand for now.