### PR TITLE
Install R natively on Fedora e2e and compile packages from source

### DIFF
--- a/.github/actions/os-e2e-deps/action.yml
+++ b/.github/actions/os-e2e-deps/action.yml
@@ -23,6 +23,17 @@ inputs:
       Leave empty to keep the legacy runner.os-only key (existing callers).
     required: false
     default: ""
+  install-required-packages:
+    description: >
+      When "true", also install the harness's REQUIRED_PACKAGES set (from
+      <working-directory>/required-packages.txt) into R_LIBS_USER, before the
+      cache save. Set this only on distros with no prebuilt CRAN binaries
+      (Fedora): there the Playwright globalSetup would otherwise source-compile
+      that set at test time, so installing it here lands it in the cached
+      library instead. Platforms that get binaries (Ubuntu/macOS/Windows) leave
+      this empty -- their globalSetup install is a fast download.
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -82,15 +93,19 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: ${{ inputs.r-libs-user }}
-        key: ${{ env.CACHE_OS }}-r-${{ steps.r_version.outputs.version }}-${{ hashFiles(format('{0}/DESCRIPTION', inputs.working-directory)) }}
+        # When install-required-packages is set, fold required-packages.txt into
+        # the key so growing that list invalidates the cached library. Callers
+        # that don't set it get the exact same key as before (no cache churn).
+        key: ${{ env.CACHE_OS }}-r-${{ steps.r_version.outputs.version }}-${{ hashFiles(format('{0}/DESCRIPTION', inputs.working-directory)) }}${{ inputs.install-required-packages == 'true' && format('-req{0}', hashFiles(format('{0}/required-packages.txt', inputs.working-directory))) || '' }}
         restore-keys: |
           ${{ env.CACHE_OS }}-r-${{ steps.r_version.outputs.version }}-
 
-    - name: Install R packages from DESCRIPTION
+    - name: Install R packages (DESCRIPTION, plus required set when requested)
       shell: bash
       env:
         E2E_ROOT: ${{ inputs.working-directory }}
         R_USER_CACHE_DIR: ${{ github.workspace }}/.r-pkg-cache
+        INSTALL_REQUIRED: ${{ inputs.install-required-packages }}
       run: |
         if [ "$RUNNER_OS" = "Linux" ]; then
           # Track the runner's actual distro so PPM serves native binaries and
@@ -125,6 +140,37 @@ runs:
           ask = FALSE,
           upgrade = FALSE
         )
+        # On distros without CRAN binaries (Fedora), also install the harness's
+        # REQUIRED_PACKAGES set now so it lands in the cached library rather than
+        # being source-compiled by the Playwright globalSetup at test time. Reads
+        # the same required-packages.txt that fixtures/r-libs-setup.ts reads, so
+        # the two sets can't drift. Both the presence check and the install are
+        # scoped to R_LIBS_USER (the cached tree), mirroring the harness's own
+        # lib.loc-scoped check -- an unscoped installed.packages() would count a
+        # package sitting only in the system library as "present" and skip it,
+        # so globalSetup would then source-compile it at test time on every run.
+        # Unlike the harness (which warns and lets tests self-heal), a failure
+        # here calls stop(): this is the hard gate that guarantees the cached
+        # library is complete.
+        if (identical(Sys.getenv("INSTALL_REQUIRED"), "true")) {
+          lib <- Sys.getenv("R_LIBS_USER")
+          reqfile <- file.path(Sys.getenv("E2E_ROOT"), "required-packages.txt")
+          lines <- trimws(sub("#.*$", "", readLines(reqfile, warn = FALSE)))
+          pkgs <- lines[nzchar(lines)]
+          if (length(pkgs) == 0L)
+            stop("[os-e2e-deps] required-packages.txt yielded no packages (empty or all-comment): ", reqfile)
+          missing <- setdiff(pkgs, rownames(installed.packages(lib.loc = lib)))
+          if (length(missing)) {
+            cat("[os-e2e-deps] installing required-packages:", paste(missing, collapse = ", "), "\n")
+            installType <- if (identical(.Platform$pkgType, "source")) "source" else "binary"
+            install.packages(missing, lib = lib, type = installType)
+            still <- setdiff(missing, rownames(installed.packages(lib.loc = lib)))
+            if (length(still))
+              stop("[os-e2e-deps] failed to install required-packages: ", paste(still, collapse = ", "))
+          } else {
+            cat("[os-e2e-deps] required-packages already present\n")
+          }
+        }
         EOF
         Rscript "$SCRIPT"
 

--- a/.github/actions/os-e2e-deps/action.yml
+++ b/.github/actions/os-e2e-deps/action.yml
@@ -97,17 +97,17 @@ runs:
           # there's no cross-release ABI mismatch. Debian/Ubuntu key off the
           # release codename (noble on 24.04, resolute on 26.04); RHEL and its
           # rebuilds have no VERSION_CODENAME, so key off the major version
-          # (rhel9, rhel10) instead. Fedora has no PPM binary repo of its own,
-          # so it borrows the newest RHEL one (rhel10) -- see the fedora branch.
+          # (rhel9, rhel10) instead. Fedora has no PPM binary repo, so it
+          # compiles from source instead -- see the fedora branch.
           . /etc/os-release
           if [ "$ID" = "rhel" ] || [ "$ID" = "rocky" ] || [ "$ID" = "almalinux" ] || [ "$ID" = "centos" ] || printf '%s' "$ID_LIKE" | grep -q 'rhel'; then
             export PKG_REPO="https://packagemanager.posit.co/cran/__linux__/rhel${VERSION_ID%%.*}/latest"
           elif [ "$ID" = "fedora" ]; then
-            # PPM publishes no Fedora binaries, so borrow the newest RHEL binary
-            # repo (rhel10). Fedora is newer than RHEL 10, so forward glibc
-            # compatibility generally lets these binaries load; system-library
-            # soname drift is the residual risk this workflow is validating.
-            export PKG_REPO="https://packagemanager.posit.co/cran/__linux__/rhel10/latest"
+            # PPM publishes no Fedora binaries and rig/r-builds has no Fedora 44
+            # R, so the Fedora workflow installs R via dnf and compiles CRAN
+            # packages from source. Point pak at PPM's source repo; the Fedora
+            # caller installs the toolchain and -devel headers the builds need.
+            export PKG_REPO="https://packagemanager.posit.co/cran/latest"
           else
             export PKG_REPO="https://packagemanager.posit.co/cran/__linux__/${VERSION_CODENAME}/latest"
           fi

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
@@ -528,6 +528,18 @@ jobs:
           # Print the GWT launch timeline so the next launch failure shows which
           # phase exceeded the deadline.
           PW_DEBUG_LAUNCH: '1'
+          # Point the Playwright harness's own R-libs provisioner
+          # (fixtures/r-libs-setup.ts, run in globalSetup) at the same library
+          # os-e2e-deps already populated, instead of its default per-host cache.
+          # That library holds the e2e DESCRIPTION deps, so globalSetup only has
+          # to add the extra REQUIRED_PACKAGES it doesn't already contain.
+          PW_RSTUDIO_R_LIBS_USER: ${{ github.workspace }}/R-libs
+          # Fedora has no PPM/CRAN binaries, so the harness compiles those extra
+          # packages from source at test time -- a long silent stretch that the
+          # default 300s heartbeat idle-timeout would kill (exit 124). Raise it
+          # so the one-time source build can finish. (Option C: a stopgap until
+          # the harness reuses a fully-built cached library -- see PR #18155.)
+          PW_HEARTBEAT_TIMEOUT_SECONDS: '2400'
         run: |
           ARGS=()
           if [ -n "$PW_TEST_SELECTOR" ]; then

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
@@ -12,7 +12,7 @@ on:
         type: string
         default: ""
       r_version:
-        description: "R version to install via rig (e.g. 'release', 'oldrel', 'devel', '4.4.1')."
+        description: "Ignored on Fedora: R is installed from Fedora's own repos (dnf), so this always uses the distro's R regardless of value. Kept for interface parity with the other platform workflows."
         type: string
         default: "release"
       project:
@@ -367,18 +367,32 @@ jobs:
             gtk3 pango cairo alsa-lib \
             freetype fontconfig harfbuzz fribidi
 
-      - name: Install rig
+      - name: Install R build toolchain and headers
         run: |
-          curl -fLs https://github.com/r-lib/rig/releases/download/latest/rig-linux-$(arch)-latest.tar.gz \
-            | tar xz -C /usr/local
+          # Fedora has no prebuilt CRAN binaries (PPM serves none), so the e2e R
+          # packages (tidyverse, shiny, rmarkdown, roxygen2, ...) are compiled
+          # from source by pak. That needs a compiler stack (gcc/g++/gfortran +
+          # make) plus the -devel headers their compiled dependencies link
+          # against: libcurl/openssl/libxml2 (curl, openssl, xml2), the font/text
+          # stack (systemfonts, textshaping, ragg), the image libs (ragg), zlib
+          # (data.table and others), and ICU (stringi). zlib ships as zlib-ng on
+          # Fedora, so the headers come from zlib-ng-compat-devel.
+          dnf -y install \
+            gcc gcc-c++ gcc-gfortran make \
+            libcurl-devel openssl-devel libxml2-devel \
+            fontconfig-devel freetype-devel harfbuzz-devel fribidi-devel \
+            libpng-devel libjpeg-turbo-devel libtiff-devel \
+            zlib-ng-compat-devel libicu-devel cairo-devel
 
-      - name: Install R via rig
-        env:
-          R_VERSION: ${{ inputs.r_version }}
+      # Fedora is not a supported platform for rig / r-builds (Fedora 44 R
+      # 404s on the rversions service) or for PPM binaries, so install R from
+      # Fedora's own repos and let pak compile CRAN packages from source (see
+      # os-e2e-deps and the toolchain step above). The r_version input is
+      # ignored on Fedora -- dnf provides whatever R the distro ships.
+      - name: Install R (Fedora native)
         run: |
-          rig add "$R_VERSION"
-          rig default "$R_VERSION"
-          rig ls
+          dnf -y install R-core R-core-devel
+          R --version
           mkdir -p "$R_LIBS_USER"
 
       # Build-from-source path: extract the .rpm artifact produced by the build

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
@@ -359,8 +359,13 @@ jobs:
           # row mirrors the font/text libs some test R packages load:
           # freetype/fontconfig (ragg, systemfonts), harfbuzz/fribidi
           # (textshaping).
+          # lsof: the desktop fixture uses it to reclaim an orphaned RStudio on
+          # the worker's fixed CDP port (a leftover from a prior interrupted
+          # run). Ubuntu/macOS ship it; the minimal Fedora image doesn't, so
+          # install it -- otherwise the reclaim and port-free wait silently
+          # degrade (the "lsof: command not found" spam in the logs).
           dnf -y install \
-            xorg-x11-server-Xvfb \
+            xorg-x11-server-Xvfb lsof \
             nss nspr atk at-spi2-atk at-spi2-core cups-libs \
             libdrm mesa-libgbm libxkbcommon \
             libX11 libXcomposite libXdamage libXext libXfixes libXrandr libXScrnSaver libXtst libxcb \

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
@@ -508,6 +508,11 @@ jobs:
           # RHEL-compiled R library is ABI-incompatible with Fedora's R. See
           # os-e2e-deps cache-scope.
           cache-scope: fedora44-x86_64
+          # Fedora has no CRAN binaries, so pre-install the harness's full
+          # REQUIRED_PACKAGES set into the cached R library here. Otherwise the
+          # Playwright globalSetup source-compiles that set at test time, which
+          # is what PW_HEARTBEAT_TIMEOUT_SECONDS below was papering over.
+          install-required-packages: 'true'
 
       - name: Run Playwright tests
         working-directory: e2e/rstudio
@@ -535,15 +540,17 @@ jobs:
           PW_DEBUG_LAUNCH: '1'
           # Point the Playwright harness's own R-libs provisioner
           # (fixtures/r-libs-setup.ts, run in globalSetup) at the same library
-          # os-e2e-deps already populated, instead of its default per-host cache.
-          # That library holds the e2e DESCRIPTION deps, so globalSetup only has
-          # to add the extra REQUIRED_PACKAGES it doesn't already contain.
+          # os-e2e-deps populated, instead of its default per-host cache. Because
+          # os-e2e-deps ran with install-required-packages, that library holds
+          # both the e2e DESCRIPTION deps and the full REQUIRED_PACKAGES set, so
+          # globalSetup finds everything present and installs nothing.
           PW_RSTUDIO_R_LIBS_USER: ${{ github.workspace }}/R-libs
-          # Fedora has no PPM/CRAN binaries, so the harness compiles those extra
-          # packages from source at test time -- a long silent stretch that the
-          # default 300s heartbeat idle-timeout would kill (exit 124). Raise it
-          # so the one-time source build can finish. (Option C: a stopgap until
-          # the harness reuses a fully-built cached library -- see PR #18155.)
+          # Defensive fallback. With install-required-packages above, globalSetup
+          # normally compiles nothing at test time. But if a package slipped
+          # through and had to be source-compiled here (Fedora has no PPM/CRAN
+          # binaries), that is a long silent stretch the default 300s heartbeat
+          # idle-timeout would kill (exit 124); the higher ceiling lets it finish
+          # rather than failing the run outright.
           PW_HEARTBEAT_TIMEOUT_SECONDS: '2400'
         run: |
           ARGS=()

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
@@ -325,7 +325,11 @@ jobs:
       # the sandbox still refuses to come up here, pass --no-sandbox via
       # rstudio_extra_args (PW_RSTUDIO_EXTRA_ARGS) rather than changing these.
       options: --cap-add=SYS_ADMIN --security-opt seccomp=unconfined
-    timeout-minutes: 120
+    # TEMPORARY: bumped 120 -> 300 to let a COLD-cache run finish the from-source
+    # package compile (Fedora has no binaries) so we can verify the run end to
+    # end. Revert to 120 before merge -- warm-cache runs restore the prebuilt
+    # library and finish well under 120.
+    timeout-minutes: 300
     env:
       R_LIBS_USER: ${{ github.workspace }}/R-libs
       PW_SANDBOX_ROOT: ${{ github.workspace }}/pw-sandbox

--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -119,7 +119,12 @@ function defaultCdpPort(): number {
   return CDP_PORT_BASE + checkoutPortOffset() + idx;
 }
 export const CDP_PORT = Number(process.env.PW_CDP_PORT) || defaultCdpPort();
-export const CDP_URL = `http://localhost:${CDP_PORT}`;
+// Connect over IPv4 explicitly. Electron's --remote-debugging-port listens on
+// 127.0.0.1 only, but "localhost" resolves to IPv6 ::1 first on some Linux
+// distros (e.g. Fedora), so connectOverCDP dials ::1 and gets ECONNREFUSED even
+// though RStudio is up on 127.0.0.1. Using the literal 127.0.0.1 removes the
+// resolution ambiguity and is correct on every platform.
+export const CDP_URL = `http://127.0.0.1:${CDP_PORT}`;
 
 // PW_RSTUDIO_DEV=1 launches the in-tree dev build via `npm run start`
 // (electron-forge) in src/node/desktop, instead of the installed RStudio

--- a/e2e/rstudio/fixtures/r-libs-setup.ts
+++ b/e2e/rstudio/fixtures/r-libs-setup.ts
@@ -36,38 +36,29 @@ const TOTAL_WORKERS_ENV = 'PW_TOTAL_WORKERS';
 
 /**
  * Packages every Playwright run should be able to find without paying the
- * lazy-install tax inside an individual test. The list intentionally mirrors
- * what the suite already references via `ensurePackages` -- pre-populating it
- * once in globalSetup means tests start with the dependencies they expect.
+ * lazy-install tax inside an individual test. Pre-populating them once in
+ * globalSetup means tests start with the dependencies they expect.
  *
- * Adding a new package here is cheap; trim only when a package is genuinely
- * unused by any test in the suite.
+ * The list lives in ../required-packages.txt as the single source of truth, so
+ * the os-e2e-deps action (bash) can install the identical set into the cached
+ * R library on distros without CRAN binaries (Fedora) -- if the two lists ever
+ * drifted, globalSetup would source-compile the difference at test time. One
+ * package per line; blank lines and #-comments are ignored. Adding a package
+ * is cheap; trim only when it's genuinely unused by any test in the suite.
  */
-export const REQUIRED_PACKAGES = [
-  'DBI',
-  'MASS',
-  'S7',
-  'bslib',
-  'data.table',
-  'devtools',
-  'dplyr',
-  'evaluate',
-  'ggplot2',
-  'knitr',
-  'nycflights13',
-  'pillar',
-  'praise',
-  'remotes',
-  'reticulate',
-  'rmarkdown',
-  'rstudioapi',
-  'shiny',
-  'shinytest2',
-  'stringr',
-  'styler',
-  'testthat',
-  'tibble',
-] as const;
+const requiredPackagesFile = path.join(__dirname, '..', 'required-packages.txt');
+export const REQUIRED_PACKAGES: readonly string[] = fs
+  .readFileSync(requiredPackagesFile, 'utf8')
+  .split('\n')
+  .map((line) => line.replace(/#.*$/, '').trim()) // strip comments + whitespace
+  .filter((line) => line.length > 0);
+// Guard against an empty/all-comment manifest: without this the list would be
+// [] and globalSetup would install nothing while logging "all packages
+// present" -- silently reverting to slow per-test installs, worst on the
+// no-binaries platforms this manifest exists to speed up.
+if (REQUIRED_PACKAGES.length === 0) {
+  throw new Error(`No packages parsed from ${requiredPackagesFile} (empty or all-comment).`);
+}
 
 /**
  * Build the default R_LIBS_USER template. Resolved *before* HOME is redirected,

--- a/e2e/rstudio/required-packages.txt
+++ b/e2e/rstudio/required-packages.txt
@@ -1,0 +1,29 @@
+# R packages pre-installed into the shared R library by globalSetup
+# (fixtures/r-libs-setup.ts) and, on distros without CRAN binaries (Fedora),
+# by the os-e2e-deps action so they land in the cached library instead of
+# compiling at test time. Single source of truth -- both the TypeScript
+# harness and the bash action read this file. One package per line; blank
+# lines and #-comments are ignored.
+DBI
+MASS
+S7
+bslib
+data.table
+devtools
+dplyr
+evaluate
+ggplot2
+knitr
+nycflights13
+pillar
+praise
+remotes
+reticulate
+rmarkdown
+rstudioapi
+shiny
+shinytest2
+stringr
+styler
+testthat
+tibble


### PR DESCRIPTION
Follow-up to the Fedora 44 desktop e2e workflow (#18154). A dispatch run revealed Fedora 44 isn't supported by Posit's R distribution stack: `rig`/r-builds has no Fedora 44 R (the rversions service 404s on `linux-fedora-44`, though 38/40/41/42 resolve), and Posit Package Manager publishes no Fedora binaries for any version. The initial "borrow rhel10 binaries" approach can't work: it fails at R install, and RHEL-built packages wouldn't load on a Fedora-native R anyway.

This switches Fedora to a fully native setup:

- `os-e2e-deps` points Fedora's `pak` repo at PPM's source repo instead of a binary one.
- The Fedora workflow installs R via `dnf` (`R-core`, `R-core-devel`) instead of `rig`, and installs a compiler toolchain plus the `-devel` headers needed to source-compile the e2e R packages (tidyverse, shiny, rmarkdown, roxygen2, ...).
- The `r_version` input is now documented as ignored on Fedora (the distro provides R).

The `os-e2e-deps` change adds a Fedora-only case and does not alter behavior for Ubuntu/RHEL/macOS/Windows callers.