### PR TITLE
Update Posit Assistant install screen copy and What's New highlights

### DIFF
--- a/docs/user/rstudio/ide/guide/tools/posit-ai.qmd
+++ b/docs/user/rstudio/ide/guide/tools/posit-ai.qmd
@@ -55,3 +55,8 @@ posit-assistant-enabled=0
 ```
 
 See the [Environment Variables](../../reference/environment-variables.qmd) reference for other environment variables that affect RStudio.
+
+## Terms and Conditions
+
+-   [Posit Assistant](posit-assistant-terms.qmd)
+-   [Posit AI](posit-ai-terms.qmd)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants.java
@@ -31,6 +31,7 @@ public interface ChatConstants extends com.google.gwt.i18n.client.Messages {
     String chatNotInstalledTitle();
     String chatNotInstalledWithVersionMessage(String version);
     String chatNotInstalledDescription();
+    String chatNotInstalledDescription2();
     String chatNotInstalledDescriptionWorkbench();
     String chatNotInstalledAdditionalProviders();
     String chatLearnMore();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants_en.properties
@@ -19,12 +19,13 @@ chatIgnore=Ignore
 # Main content area messages (not installed / update available)
 chatNotInstalledTitle=Posit Assistant Not Installed
 chatNotInstalledWithVersionMessage=Posit Assistant ({0}) is available to install.
-chatNotInstalledDescription=Posit Assistant is powered by the Posit AI service and includes collaborative chat and Next Edit Suggestions that predict your next code change.
+chatNotInstalledDescription=Posit Assistant is a data analysis assistant that works across multiple environments — Positron and RStudio. It connects to your live R and Python sessions, sees your data, and helps you explore, visualize, build, and debug.
+chatNotInstalledDescription2=Posit Assistant needs a model provider to power its responses. Try Assistant for free with Posit AI — a managed service from Posit that gives you access to frontier LLMs through a single account. Just sign in and start chatting.
 chatNotInstalledDescriptionWorkbench=Posit Assistant is a collaborative chat agent powered by your organization''s model provider.
 chatNotInstalledAdditionalProviders=Bring your own Key support also adds additional enterprise providers.
 chatLearnMore=Learn More
 chatInstallButton=Install Posit Assistant
-chatInstallTermsOfUse=By installing this software, you agree to the <a href=''https://www.rstudio.org/links/posit-ai-client-terms-of-use'' target=''_blank'' rel=''noopener noreferrer'' style=''white-space: nowrap;''>terms of use</a>.
+chatInstallTermsOfUse=By installing this software, you agree to the <a href=''https://www.rstudio.org/links/posit-assistant-client-terms-of-use'' target=''_blank'' rel=''noopener noreferrer'' style=''white-space: nowrap;''>terms of use</a>.
 chatUpdateAvailableTitle=Posit Assistant Update Available
 chatUpdateAvailableWithVersionsMessage=You have Posit Assistant version {0} installed. Version {1} is available.
 chatUpdateButton=Update Posit Assistant

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants_en.properties
@@ -22,7 +22,7 @@ chatNotInstalledWithVersionMessage=Posit Assistant ({0}) is available to install
 chatNotInstalledDescription=Posit Assistant is a data analysis assistant that works across multiple environments — Positron and RStudio. It connects to your live R and Python sessions, sees your data, and helps you explore, visualize, build, and debug.
 chatNotInstalledDescription2=Posit Assistant needs a model provider to power its responses. Try Assistant for free with Posit AI — a managed service from Posit that gives you access to frontier LLMs through a single account. Just sign in and start chatting.
 chatNotInstalledDescriptionWorkbench=Posit Assistant is a collaborative chat agent powered by your organization''s model provider.
-chatNotInstalledAdditionalProviders=Bring your own Key support also adds additional enterprise providers.
+chatNotInstalledAdditionalProviders=Direct API access to other providers (Anthropic, OpenAI, Amazon Bedrock, and others) is also supported.
 chatLearnMore=Learn More
 chatInstallButton=Install Posit Assistant
 chatInstallTermsOfUse=By installing this software, you agree to the <a href=''https://www.rstudio.org/links/posit-assistant-client-terms-of-use'' target=''_blank'' rel=''noopener noreferrer'' style=''white-space: nowrap;''>terms of use</a>.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants_fr.properties
@@ -22,7 +22,7 @@ chatNotInstalledWithVersionMessage=Posit Assistant ({0}) est disponible pour ins
 chatNotInstalledDescription=Posit Assistant est un assistant d''analyse de données qui fonctionne dans plusieurs environnements — Positron et RStudio. Il se connecte à vos sessions R et Python en cours, voit vos données et vous aide à explorer, visualiser, créer et déboguer.
 chatNotInstalledDescription2=Posit Assistant a besoin d''un fournisseur de modèles pour générer ses réponses. Essayez Assistant gratuitement avec Posit AI — un service géré par Posit qui vous donne accès aux LLM de pointe via un compte unique. Il vous suffit de vous connecter et de commencer à discuter.
 chatNotInstalledDescriptionWorkbench=Posit Assistant est un agent de chat collaboratif alimenté par le fournisseur de modèles de votre organisation.
-chatNotInstalledAdditionalProviders=La prise en charge de votre propre clé ajoute également des fournisseurs d''entreprise supplémentaires.
+chatNotInstalledAdditionalProviders=L''accès direct par API à d''autres fournisseurs (Anthropic, OpenAI, Amazon Bedrock, et autres) est également pris en charge.
 chatLearnMore=En savoir plus
 chatInstallButton=Installer Posit Assistant
 chatInstallTermsOfUse=En installant ce logiciel, vous acceptez les <a href=''https://www.rstudio.org/links/posit-assistant-client-terms-of-use'' target=''_blank'' rel=''noopener noreferrer'' style=''white-space: nowrap;''>conditions d''utilisation</a>.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants_fr.properties
@@ -19,7 +19,8 @@ chatIgnore=Ignorer
 # Messages de la zone de contenu principale (non installé / mise à jour disponible)
 chatNotInstalledTitle=Posit Assistant non installé
 chatNotInstalledWithVersionMessage=Posit Assistant ({0}) est disponible pour installation.
-chatNotInstalledDescription=Posit Assistant est alimenté par le service Posit AI et comprend le chat collaboratif et les suggestions de modification suivante qui prédisent votre prochain changement de code.
+chatNotInstalledDescription=Posit Assistant est un assistant d''analyse de données qui fonctionne dans plusieurs environnements — Positron et RStudio. Il se connecte à vos sessions R et Python en cours, voit vos données et vous aide à explorer, visualiser, créer et déboguer.
+chatNotInstalledDescription2=Posit Assistant a besoin d''un fournisseur de modèles pour générer ses réponses. Essayez Assistant gratuitement avec Posit AI — un service géré par Posit qui vous donne accès aux LLM de pointe via un compte unique. Il vous suffit de vous connecter et de commencer à discuter.
 chatNotInstalledDescriptionWorkbench=Posit Assistant est un agent de chat collaboratif alimenté par le fournisseur de modèles de votre organisation.
 chatNotInstalledAdditionalProviders=La prise en charge de votre propre clé ajoute également des fournisseurs d''entreprise supplémentaires.
 chatLearnMore=En savoir plus

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatConstants_fr.properties
@@ -25,7 +25,7 @@ chatNotInstalledDescriptionWorkbench=Posit Assistant est un agent de chat collab
 chatNotInstalledAdditionalProviders=La prise en charge de votre propre clé ajoute également des fournisseurs d''entreprise supplémentaires.
 chatLearnMore=En savoir plus
 chatInstallButton=Installer Posit Assistant
-chatInstallTermsOfUse=En installant ce logiciel, vous acceptez les <a href=''https://www.rstudio.org/links/posit-ai-client-terms-of-use'' target=''_blank'' rel=''noopener noreferrer'' style=''white-space: nowrap;''>conditions d''utilisation</a>.
+chatInstallTermsOfUse=En installant ce logiciel, vous acceptez les <a href=''https://www.rstudio.org/links/posit-assistant-client-terms-of-use'' target=''_blank'' rel=''noopener noreferrer'' style=''white-space: nowrap;''>conditions d''utilisation</a>.
 chatUpdateAvailableTitle=Mise à jour de Posit Assistant disponible
 chatUpdateAvailableWithVersionsMessage=Vous avez la version {0} de Posit Assistant installée. La version {1} est disponible.
 chatUpdateButton=Mettre à jour Posit Assistant

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPane.java
@@ -737,7 +737,7 @@ public class ChatPane
          "<hr>" +
          descriptionHtml +
          "<p class='detail'>" +
-         "<a href='https://posit.ai' target='_blank' rel='noopener noreferrer'>" +
+         "<a href='https://www.rstudio.org/links/posit-assistant-learn-more' target='_blank' rel='noopener noreferrer'>" +
          constants_.chatLearnMore() + "</a></p>" +
          "<hr>" +
          "<button id='install-btn' class='chatIframeButton'>" +

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPane.java
@@ -708,28 +708,34 @@ public class ChatPane
    private String generateNotInstalledWithInstallHTML(String newVersion,
                                                       boolean additionalProvidersAvailable)
    {
-      String description;
+      String descriptionHtml;
       if (isWorkbench())
       {
-         description = constants_.chatNotInstalledDescriptionWorkbench();
+         descriptionHtml =
+            "<p class='detail'>" + constants_.chatNotInstalledDescriptionWorkbench() + "</p>";
       }
       else
       {
-         description = constants_.chatNotInstalledDescription();
+         String secondParagraph = constants_.chatNotInstalledDescription2();
 
          // The manifest can advertise additional providers for this build; when
-         // it does, extend the description with a sentence about that support.
-         // Only the open-source (Posit AI) description is extended; the Workbench
-         // variant describes the organization's own provider and is left as-is.
+         // it does, extend the provider paragraph with a sentence about that
+         // support. Only the open-source (Posit AI) description is extended; the
+         // Workbench variant describes the organization's own provider and is
+         // left as-is.
          if (additionalProvidersAvailable)
-            description += " " + constants_.chatNotInstalledAdditionalProviders();
+            secondParagraph += " " + constants_.chatNotInstalledAdditionalProviders();
+
+         descriptionHtml =
+            "<p class='detail'>" + constants_.chatNotInstalledDescription() + "</p>" +
+            "<p class='detail'>" + secondParagraph + "</p>";
       }
 
       String body =
          "<h2>" + constants_.chatNotInstalledTitle() + "</h2>" +
          "<p>" + constants_.chatNotInstalledWithVersionMessage(newVersion) + "</p>" +
          "<hr>" +
-         "<p class='detail'>" + description + "</p>" +
+         descriptionHtml +
          "<p class='detail'>" +
          "<a href='https://posit.ai' target='_blank' rel='noopener noreferrer'>" +
          constants_.chatLearnMore() + "</a></p>" +

--- a/src/node/desktop/src/assets/whats-new/pacific-dogwood/index.html
+++ b/src/node/desktop/src/assets/whats-new/pacific-dogwood/index.html
@@ -11,7 +11,12 @@
   <div class="feature-section">
     <h2>New Features</h2>
     <ul>
+      <li><strong>Bring your own provider for Posit Assistant:</strong> Posit Assistant can now be configured to directly use providers other than Posit AI (Anthropic, OpenAI, Amazon Bedrock, and others).</li>
+      <li><strong>Typst output for Quarto documents:</strong> The Quarto Document dialog now offers separate PDF (Typst) and PDF (LaTeX) output options. Typst is bundled with Quarto and requires no additional software.</li>
+      <li><strong>Date and time formatting:</strong> Dates and times (such as the Files pane Modified column) are now formatted according to the system region by default, rather than always using a US-style format. A new settings menu on the Files pane toolbar adds options to use ISO-8601 formatting or the UTC time zone instead.</li>
       <li><strong>Find in Files improvement:</strong> The Find in Files replace preview and Replace All results no longer present matches whose proposed replacement is identical to the matched text; lines whose every match would be unchanged are omitted entirely.</li>
+      <li><strong>rserver --check-config:</strong> Use <code>rserver --check-config</code> (and the <code>rstudio-server check-config</code> admin subcommand) to validate the configuration file without starting the service, reporting all unrecognized options in a single pass. <code>--test-config</code> is now a deprecated alias for <code>--check-config</code> with the same behavior; it previously stopped at the first unrecognized option. Using <code>--test-config</code> prints a deprecation warning, and it will be removed in a future release. <code>--check-config</code> now also validates that configured file paths (secure-cookie-key-file, rsession-config-file, database-config-file) exist on disk, and reports the detected R installation (informational). In Posit Workbench builds, the check also covers database connectivity and license status.</li>
+      <li><strong>Improved performance for projects on network or remote filesystems:</strong> RStudio can now reduce background file operations (recursive file monitoring, code indexing, and external-edit checks) for projects located on network or remote filesystems, improving responsiveness on slow drives. This applies automatically when a remote filesystem is detected, and can be configured globally (Tools > Global Options > General > Advanced) or overridden per-project (Project Options > General).</li>
     </ul>
   </div>
 


### PR DESCRIPTION
Updates copy in the Posit Assistant "not installed" screen, adds release
highlights to the Pacific Dogwood What's New dialog, and links the terms
documents from the Posit Assistant user guide.

## Posit Assistant not-installed screen

- Splits the open-source install description into two paragraphs, each rendered
  as its own `<p class='detail'>` block: what Assistant is, and the model
  provider / Posit AI sign-up path.
- Adds a `chatNotInstalledDescription2` constant (English and French).
- The additional-providers sentence now extends the provider paragraph rather
  than the single description.
- Points the terms-of-use link at the `posit-assistant-client-terms-of-use`
  URL in both the English and French locales.
- Points the Learn More link at the `posit-assistant-learn-more` redirect URL,
  replacing the previous direct `https://posit.ai` link.

<img width="442" height="472" alt="screenshot of posit assistant chat pane when posit assistant is not installed" src="https://github.com/user-attachments/assets/d19914f8-2f1d-4bd9-806f-ff626d8c2ccc" />

## What's New dialog (Pacific Dogwood)

- Adds New Features entries for bring-your-own provider, Typst output for
  Quarto, region-based date/time formatting, `rserver --check-config`, and
  reduced background file operations on remote filesystems.
- Uses `<code>` tags for inline commands, consistent with prior What's New
  dialogs.

<img width="915" height="823" alt="screenshot of proposed what's new dialog for Pacific Dogwood release" src="https://github.com/user-attachments/assets/ebc1936c-441e-4b35-b629-1bece0a26e4d" />

## User guide

- Adds a Terms and Conditions section to the Posit Assistant guide
  (`posit-ai.qmd`) linking to the Posit Assistant and Posit AI terms pages. There's an open question about whether we need both of these, or if the `assistant` one replaces the `ai` one.

<img width="408" height="150" alt="terms" src="https://github.com/user-attachments/assets/41215687-e57d-450b-8993-b248088b1332" />

