### PR TITLE
Pin panmirror to Pacific Dogwood release branch

### DIFF
--- a/dependencies/common/install-panmirror
+++ b/dependencies/common/install-panmirror
@@ -35,8 +35,8 @@ info "QUARTO_DIR: ${QUARTO_DIR}"
 # clone quarto monorepo if not already cloned
 if ! test -e "$QUARTO_DIR"; then
   echo "Cloning quarto repo"
-  git clone https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
-  # git clone --branch release/rstudio-pacific-dogwood https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
+  # git clone https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
+  git clone --branch release/rstudio-pacific-dogwood https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
   pushd $QUARTO_DIR
   git rev-parse HEAD
   popd
@@ -46,8 +46,8 @@ else
   pushd $QUARTO_DIR
   git fetch
   git reset --hard && git clean -dfx
-  git checkout main
-  # git checkout release/rstudio-pacific-dogwood
+  # git checkout main
+  git checkout release/rstudio-pacific-dogwood
   git pull
   git rev-parse HEAD
 

--- a/dependencies/windows/install-panmirror/clone-panmirror-repo.cmd
+++ b/dependencies/windows/install-panmirror/clone-panmirror-repo.cmd
@@ -12,8 +12,8 @@ pushd ..\..\..\src\gwt\lib
 ::            "panmirror check for changes" command to use the equivalent.
 
 if not exist quarto (
-  git clone https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
-  REM git clone --branch release/rstudio-pacific-dogwood https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
+  REM git clone https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
+  git clone --branch release/rstudio-pacific-dogwood https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
   pushd ..\..\..\src\gwt\lib\quarto
   git rev-parse HEAD
   popd
@@ -22,8 +22,8 @@ if not exist quarto (
   git fetch
   git reset --hard
   git clean -dfx
-  git checkout main
-  REM git checkout release/rstudio-pacific-dogwood
+  REM git checkout main
+  git checkout release/rstudio-pacific-dogwood
   git pull
   git rev-parse HEAD
   popd

--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -104,8 +104,8 @@ COPY package/linux/install-dependencies /tmp/
 RUN /bin/bash /tmp/install-dependencies
 
 # panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
 
 # copy common dependency installation scripts
 RUN mkdir -p /opt/rstudio-tools/dependencies/common

--- a/docker/jenkins/Dockerfile.focal
+++ b/docker/jenkins/Dockerfile.focal
@@ -110,8 +110,8 @@ RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common focal

--- a/docker/jenkins/Dockerfile.jammy
+++ b/docker/jenkins/Dockerfile.jammy
@@ -128,8 +128,8 @@ RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common jammy

--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -93,8 +93,8 @@ RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common opensuse15

--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -97,8 +97,8 @@ RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common rhel8

--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -100,8 +100,8 @@ RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common rhel9

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -130,8 +130,8 @@ COPY dependencies/common 'C:\rstudio-tools\dependencies\common'
 COPY dependencies/windows 'C:\rstudio-tools\dependencies\windows'
 
 # panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
 
 ENV DOCKER_IMAGE_BUILD=1
 WORKDIR C:/rstudio-tools/dependencies/windows


### PR DESCRIPTION
Closes #18002.

Near the end of Pacific Dogwood (2026.07) development, re-pin panmirror (Visual Editor) to the `release/rstudio-pacific-dogwood` branch of `quarto-dev/quarto` so that late-cycle changes on `main` don't destabilize the release. This is the inverse of #18001 and mirrors #17852 (which pinned Blue Plumbago).

The `release/rstudio-pacific-dogwood` branch already exists in `quarto-dev/quarto`. In the 9 build files, the `release/rstudio-pacific-dogwood` lines are now uncommented and the `main` lines commented out:

- `dependencies/common/install-panmirror`
- `dependencies/windows/install-panmirror/clone-panmirror-repo.cmd`
- `docker/jenkins/Dockerfile.bionic`
- `docker/jenkins/Dockerfile.focal`
- `docker/jenkins/Dockerfile.jammy`
- `docker/jenkins/Dockerfile.opensuse15`
- `docker/jenkins/Dockerfile.rhel8`
- `docker/jenkins/Dockerfile.rhel9`
- `docker/jenkins/Dockerfile.windows`

When the next release opens `main` for development, this pin will need to be reverted again (mirroring the #17948 -> #18001 cycle). Tracked by #18162.