### PR TITLE
Match both Configure menu labels in chat pane test

### DIFF
--- a/e2e/rstudio/pages/chat_pane.page.ts
+++ b/e2e/rstudio/pages/chat_pane.page.ts
@@ -68,7 +68,12 @@ export class ChatPane extends FramePageObject {
     this.trustWorkspaceBtn = this.frame.locator("button:has-text('Trust this workspace')");
     this.moreBtn = this.frame.getByRole('button', { name: 'More' });
     this.settingsMenu = this.frame.locator("[data-slot='dropdown-menu-content']");
-    this.configurePositAiItem = this.frame.locator("xpath=//span[contains(text(), 'Configure Posit AI')] | //div[contains(text(), 'Configure Posit AI')] | //*[@role='menuitem'][contains(., 'Configure Posit AI')]");
+    // The provider-settings menu item was relabeled "Configure LLM providers"
+    // (was "Configure Posit AI"). Match either so the test passes against both
+    // the current and older assistant builds we exercise during rollout.
+    this.configurePositAiItem = this.frame.getByRole('menuitem', {
+      name: /Configure (LLM providers|Posit AI)/i,
+    });
     this.aboutItem = this.frame.locator("xpath=//span[contains(text(), 'About')] | //div[contains(text(), 'About')] | //*[@role='menuitem'][contains(., 'About')]");
     this.newConversationBtn = this.frame.getByRole('button', { name: 'New conversation' });
     this.historyBtn = this.frame.getByRole('button', { name: 'Conversation history' });


### PR DESCRIPTION
## Summary

The Posit Assistant chat pane's provider-settings menu item was relabeled from "Configure Posit AI" to "Configure LLM providers". The `settings-button` Playwright test located the item by its old text only, so the assertion timed out and the test failed.

This updates the `configurePositAiItem` locator in the chat pane page object to a role-based selector whose name matches either label:

```ts
this.configurePositAiItem = this.frame.getByRole('menuitem', {
  name: /Configure (LLM providers|Posit AI)/i,
});
```

Matching both labels keeps the test green across the different assistant builds exercised during rollout. The role-based locator also replaces a hand-built XPath OR-chain, consistent with the other locators in this page object.

## Testing

- `npm run typecheck` (clean)