### PR TITLE
Fix RStudio launch and R discovery in the Fedora 44 e2e workflow

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
@@ -400,8 +400,17 @@ jobs:
       # ignored on Fedora -- dnf provides whatever R the distro ships.
       - name: Install R (Fedora native)
         run: |
-          dnf -y install R-core R-core-devel
+          # Clear tsflags for this transaction so R's documentation tree is
+          # installed. Fedora container images ship /etc/dnf/dnf.conf with
+          # tsflags=nodocs (a space-saving default), which makes dnf skip
+          # /usr/share/doc/R. RStudio's R discovery (r/session/RDiscovery.cpp)
+          # requires R_DOC_DIR to exist and aborts the session otherwise, so a
+          # docless R install starts but never reaches window.rstudio.ready.
+          dnf -y install --setopt=tsflags='' R-core R-core-devel
           R --version
+          # Diagnostics: the doc dir R reports, and confirm it now exists.
+          Rscript -e 'cat("doc=", R.home("doc"), " R_DOC_DIR=", Sys.getenv("R_DOC_DIR"), "\n", sep="")'
+          ls -ld /usr/share/doc/R || echo "MISSING /usr/share/doc/R"
           mkdir -p "$R_LIBS_USER"
 
       # Build-from-source path: extract the .rpm artifact produced by the build

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
@@ -531,7 +531,15 @@ jobs:
           PW_GREP_INVERT: ${{ inputs.grep_invert }}
           PW_TEST_SELECTOR: ${{ inputs.test_selector }}
           PW_TEST_IGNORE: ${{ inputs.test_ignore }}
-          PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
+          # Always launch with --no-sandbox in this container. Electron's
+          # Chromium sandbox needs an unprivileged user namespace, which the
+          # bare-runner Ubuntu jobs enable via a host sysctl -- unreachable from
+          # inside this fedora:44 container, so the sandbox can't initialize and
+          # RStudio starts but never opens its --remote-debugging-port (CDP
+          # connect gets ECONNREFUSED). The container is already the isolation
+          # boundary here, so disabling the in-process sandbox is safe. Any
+          # caller-supplied rstudio_extra_args are appended.
+          PW_RSTUDIO_EXTRA_ARGS: --no-sandbox ${{ inputs.rstudio_extra_args }}
           # Tells playwright.config.ts to switch to blob reporter for this shard.
           PW_SHARD: ${{ matrix.shard }}
           # E2E Test Insights reporter: posts per-shard results to the dashboard.

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
@@ -325,11 +325,7 @@ jobs:
       # the sandbox still refuses to come up here, pass --no-sandbox via
       # rstudio_extra_args (PW_RSTUDIO_EXTRA_ARGS) rather than changing these.
       options: --cap-add=SYS_ADMIN --security-opt seccomp=unconfined
-    # TEMPORARY: bumped 120 -> 300 to let a COLD-cache run finish the from-source
-    # package compile (Fedora has no binaries) so we can verify the run end to
-    # end. Revert to 120 before merge -- warm-cache runs restore the prebuilt
-    # library and finish well under 120.
-    timeout-minutes: 300
+    timeout-minutes: 120
     env:
       R_LIBS_USER: ${{ github.workspace }}/R-libs
       PW_SANDBOX_ROOT: ${{ github.workspace }}/pw-sandbox


### PR DESCRIPTION
Follow-up to the Fedora 44 desktop e2e workflow. With the earlier PRs the workflow got as far as installing RStudio and the R packages, but the IDE never came up under automation. This fixes the two container-specific reasons and lets the suite actually run: a full warm run is now **443 passed / 3 failed / 17 skipped / 3 flaky (99%)**.

Two root causes, both artifacts of running in a `fedora:44` container rather than on a bare runner:

- **Chromium/Electron sandbox can't initialize.** The bare-runner Linux jobs enable an unprivileged user namespace via a host sysctl, which isn't reachable from inside the container, so RStudio's Electron started but never opened its `--remote-debugging-port` (Playwright got `ECONNREFUSED`). Fixed by always launching with `--no-sandbox` in this workflow (the container is already the isolation boundary). Caller-supplied `rstudio_extra_args` are still appended.

- **R discovery aborts on a missing doc dir.** Fedora container images set `tsflags=nodocs` in `dnf.conf`, so `dnf install R-core` skipped `/usr/share/doc/R`. RStudio's R discovery (`r/session/RDiscovery.cpp`) requires `R_DOC_DIR` to exist and aborts the session otherwise, so the IDE never reached `window.rstudio.ready`. Fixed by installing R with `--setopt=tsflags=''` so the doc tree is present; a short diagnostic in the step prints the resolved doc dir.

Also reverts the e2e job `timeout-minutes` back to 120 (it was temporarily raised to 300 to let a cold-cache from-source compile finish during verification; warm-cache runs complete in ~42 min).

The 3 remaining test failures look like container-timing flakiness (multi-minute timeouts, high flaky count on a resource-constrained runner) rather than product defects, with the terminal "run commands" test worth a closer look; these are being triaged separately and do not affect the workflow itself.