### PR TITLE
Resume pulling panmirror from main for 2026.08

### DIFF
--- a/dependencies/common/install-panmirror
+++ b/dependencies/common/install-panmirror
@@ -36,7 +36,7 @@ info "QUARTO_DIR: ${QUARTO_DIR}"
 if ! test -e "$QUARTO_DIR"; then
   echo "Cloning quarto repo"
   git clone https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
-  # git clone --branch release/rstudio-pacific-dogwood https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
+  # git clone --branch release/rstudio-yellow-yarrow https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
   pushd $QUARTO_DIR
   git rev-parse HEAD
   popd
@@ -47,7 +47,7 @@ else
   git fetch
   git reset --hard && git clean -dfx
   git checkout main
-  # git checkout release/rstudio-pacific-dogwood
+  # git checkout release/rstudio-yellow-yarrow
   git pull
   git rev-parse HEAD
 

--- a/dependencies/common/install-panmirror
+++ b/dependencies/common/install-panmirror
@@ -35,8 +35,8 @@ info "QUARTO_DIR: ${QUARTO_DIR}"
 # clone quarto monorepo if not already cloned
 if ! test -e "$QUARTO_DIR"; then
   echo "Cloning quarto repo"
-  # git clone https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
-  git clone --branch release/rstudio-pacific-dogwood https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
+  git clone https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
+  # git clone --branch release/rstudio-pacific-dogwood https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
   pushd $QUARTO_DIR
   git rev-parse HEAD
   popd
@@ -46,8 +46,8 @@ else
   pushd $QUARTO_DIR
   git fetch
   git reset --hard && git clean -dfx
-  # git checkout main
-  git checkout release/rstudio-pacific-dogwood
+  git checkout main
+  # git checkout release/rstudio-pacific-dogwood
   git pull
   git rev-parse HEAD
 

--- a/dependencies/windows/install-panmirror/clone-panmirror-repo.cmd
+++ b/dependencies/windows/install-panmirror/clone-panmirror-repo.cmd
@@ -13,7 +13,7 @@ pushd ..\..\..\src\gwt\lib
 
 if not exist quarto (
   git clone https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
-  REM git clone --branch release/rstudio-pacific-dogwood https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
+  REM git clone --branch release/rstudio-yellow-yarrow https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
   pushd ..\..\..\src\gwt\lib\quarto
   git rev-parse HEAD
   popd
@@ -23,7 +23,7 @@ if not exist quarto (
   git reset --hard
   git clean -dfx
   git checkout main
-  REM git checkout release/rstudio-pacific-dogwood
+  REM git checkout release/rstudio-yellow-yarrow
   git pull
   git rev-parse HEAD
   popd

--- a/dependencies/windows/install-panmirror/clone-panmirror-repo.cmd
+++ b/dependencies/windows/install-panmirror/clone-panmirror-repo.cmd
@@ -12,8 +12,8 @@ pushd ..\..\..\src\gwt\lib
 ::            "panmirror check for changes" command to use the equivalent.
 
 if not exist quarto (
-  REM git clone https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
-  git clone --branch release/rstudio-pacific-dogwood https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
+  git clone https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
+  REM git clone --branch release/rstudio-pacific-dogwood https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
   pushd ..\..\..\src\gwt\lib\quarto
   git rev-parse HEAD
   popd
@@ -22,8 +22,8 @@ if not exist quarto (
   git fetch
   git reset --hard
   git clean -dfx
-  REM git checkout main
-  git checkout release/rstudio-pacific-dogwood
+  git checkout main
+  REM git checkout release/rstudio-pacific-dogwood
   git pull
   git rev-parse HEAD
   popd

--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -104,8 +104,8 @@ COPY package/linux/install-dependencies /tmp/
 RUN /bin/bash /tmp/install-dependencies
 
 # panmirror check for changes
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
 
 # copy common dependency installation scripts
 RUN mkdir -p /opt/rstudio-tools/dependencies/common

--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -105,7 +105,7 @@ RUN /bin/bash /tmp/install-dependencies
 
 # panmirror check for changes
 ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-yellow-yarrow panmirror.version.json
 
 # copy common dependency installation scripts
 RUN mkdir -p /opt/rstudio-tools/dependencies/common

--- a/docker/jenkins/Dockerfile.focal
+++ b/docker/jenkins/Dockerfile.focal
@@ -111,7 +111,7 @@ COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
 ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-yellow-yarrow panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common focal

--- a/docker/jenkins/Dockerfile.focal
+++ b/docker/jenkins/Dockerfile.focal
@@ -110,8 +110,8 @@ RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common focal

--- a/docker/jenkins/Dockerfile.jammy
+++ b/docker/jenkins/Dockerfile.jammy
@@ -128,8 +128,8 @@ RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common jammy

--- a/docker/jenkins/Dockerfile.jammy
+++ b/docker/jenkins/Dockerfile.jammy
@@ -129,7 +129,7 @@ COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
 ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-yellow-yarrow panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common jammy

--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -93,8 +93,8 @@ RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common opensuse15

--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -94,7 +94,7 @@ COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
 ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-yellow-yarrow panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common opensuse15

--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -98,7 +98,7 @@ COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
 ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-yellow-yarrow panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common rhel8

--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -97,8 +97,8 @@ RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common rhel8

--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -100,8 +100,8 @@ RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common rhel9

--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -101,7 +101,7 @@ COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
 ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-yellow-yarrow panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common rhel9

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -130,8 +130,8 @@ COPY dependencies/common 'C:\rstudio-tools\dependencies\common'
 COPY dependencies/windows 'C:\rstudio-tools\dependencies\windows'
 
 # panmirror check for changes
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
 
 ENV DOCKER_IMAGE_BUILD=1
 WORKDIR C:/rstudio-tools/dependencies/windows

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -131,7 +131,7 @@ COPY dependencies/windows 'C:\rstudio-tools\dependencies\windows'
 
 # panmirror check for changes
 ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-pacific-dogwood panmirror.version.json
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-yellow-yarrow panmirror.version.json
 
 ENV DOCKER_IMAGE_BUILD=1
 WORKDIR C:/rstudio-tools/dependencies/windows


### PR DESCRIPTION
Now that `main` is open for development on `2026.08 (Yellow Yarrow)`, undo the panmirror (Visual Editor) pin from #18161 so the build pulls from `quarto-dev/quarto` `main` again.

This reverts #18161 across the nine build files, uncommenting the `main` lines and commenting out the `release/rstudio-pacific-dogwood` lines:

- `dependencies/common/install-panmirror`
- `dependencies/windows/install-panmirror/clone-panmirror-repo.cmd`
- `docker/jenkins/Dockerfile.bionic`
- `docker/jenkins/Dockerfile.focal`
- `docker/jenkins/Dockerfile.jammy`
- `docker/jenkins/Dockerfile.opensuse15`
- `docker/jenkins/Dockerfile.rhel8`
- `docker/jenkins/Dockerfile.rhel9`
- `docker/jenkins/Dockerfile.windows`

Mirrors the #17948 -> #18001 cycle from `2026.07 (Pacific Dogwood)`. When `2026.08` nears the end of development, this pin will need to be re-applied (tracked by #18163).

Closes #18162.