### PR TITLE
Add What's New page for yellow-yarrow

### DIFF
--- a/src/node/desktop/src/assets/whats-new/yellow-yarrow/index.html
+++ b/src/node/desktop/src/assets/whats-new/yellow-yarrow/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' file:;">
+  <link rel="stylesheet" href="../whats-new-base.css">
+  <title>What's New in RStudio</title>
+</head>
+<body>
+  <div class="feature-section">
+    <h2>New Features</h2>
+    <ul>
+      <li><strong>Add here:</strong> Exciting new feature.</li>
+    </ul>
+  </div>
+
+  <div class="feature-section">
+    <h2>Fixes</h2>
+    <p>
+      For a full list of bug fixes in this release, see the
+      <a href="https://www.rstudio.org/links/release_notes#rstudio-2026.08.0">release notes</a>.
+    </p>
+  </div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add the What's New placeholder page for the yellow-yarrow (2026.08) milestone, to be filled in during development.