### PR TITLE
Enqueue test-manifest banner from onClientInit to avoid startup race

### DIFF
--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -4029,13 +4029,24 @@ void showTestManifestWarning()
    module_context::enqueClientEvent(event);
 }
 
-void onDeferredInit(bool)
+// Fire the test-manifest warning bar from onClientInit rather than
+// onDeferredInit. onClientInit runs at the tail of every client_init handler,
+// past the point where a re-join clears pending startup events
+// (SessionClientInit.cpp), so the banner is enqueued after any such clear and
+// reliably reaches the client. Enqueuing it from onDeferredInit instead loses
+// it to an intermittent startup race: if an unlucky request order flips the
+// session-initialized flag before client_init runs, client_init treats itself
+// as a re-join and clears the just-enqueued banner (rstudio/rstudio#18166).
+void onClientInit()
 {
    if (isUsingTestManifest())
    {
       showTestManifestWarning();
    }
+}
 
+void onDeferredInit(bool)
+{
    // Kick off the startup manifest check, deferred off the critical startup
    // path. The fetch is async, but spawning the --vanilla child R process still
    // has a cost (process creation + R DLL load, often AV-scanned on Windows), so
@@ -6303,6 +6314,7 @@ Error initialize()
    events().onBackgroundProcessing.connect(onBackgroundProcessing);
    events().onShutdown.connect(onShutdown);
    events().onProjectOptionsUpdated.connect(onProjectOptionsUpdated);
+   events().onClientInit.connect(onClientInit);
    events().onDeferredInit.connect(onDeferredInit);
 
    // Register handler to detect session close (vs suspend/restart)


### PR DESCRIPTION
## Problem

With the Posit Assistant test manifest enabled (`posit_assistant_test_manifest` user preference or `--posit-assistant-test-manifest` session option), the startup warning bar

> Posit Assistant is using the pre-release (test) manifest. Do not use for production work.

appears only intermittently. Quitting and restarting usually makes it reappear.

The banner was enqueued as a client event from `chat::onDeferredInit`. Deferred init runs lazily off whichever request first calls `ensureSessionInitialized()`, which flips the session-initialized flag. When an unlucky request order flips that flag before `client_init` runs, `handleClientInit` misclassifies itself as a re-join and calls `setClientId(clientId, /*clearEvents=*/true)`, clearing the pending client-event queue and dropping the just-enqueued banner.

## Change

Move the `showTestManifestWarning()` enqueue out of `onDeferredInit` into a handler connected to `events().onClientInit`. `onClientInit` fires at the tail of every `client_init`, after the event-queue clear and after `ensureSessionInitialized()`, so the banner is always enqueued after any clear and reliably reaches the client. The deferred update-check kickoff stays in `onDeferredInit`.

This also means the banner correctly re-shows when a client reconnects, which the previous `onDeferredInit` path did not do.

## Verification

- `rsession` builds and links.
- Manual verification: with the test manifest enabled, the warning bar now shows on every start. The bug is a non-deterministic request-ordering startup race, so it has no deterministic automated reproduction.

Closes #18166