### PR TITLE
Add per-user Windows install option to What's New

### DIFF
--- a/src/node/desktop/src/assets/whats-new/yellow-yarrow/index.html
+++ b/src/node/desktop/src/assets/whats-new/yellow-yarrow/index.html
@@ -11,7 +11,7 @@
   <div class="feature-section">
     <h2>New Features</h2>
     <ul>
-      <li><strong>Add here:</strong> Exciting new feature.</li>
+      <li><strong>Per-user installation on Windows:</strong> The Windows installer now offers the option to install only for the current user, without requiring administrator rights.</li>
     </ul>
   </div>
 

--- a/src/node/desktop/src/assets/whats-new/yellow-yarrow/index.html
+++ b/src/node/desktop/src/assets/whats-new/yellow-yarrow/index.html
@@ -11,7 +11,7 @@
   <div class="feature-section">
     <h2>New Features</h2>
     <ul>
-      <li><strong>Per-user installation on Windows:</strong> The Windows installer now offers the option to install only for the current user, without requiring administrator rights.</li>
+      <li><strong>Per-user installation on Windows:</strong> The RStudio installer for Microsoft Windows now offers the option to install only for the current user, without requiring administrator rights.</li>
     </ul>
   </div>
 


### PR DESCRIPTION
Replaces the placeholder entry in the Yellow Yarrow What's New page with a note about the Windows installer's new per-user installation option (added in #18167).