### PR TITLE
Detect and remove legacy all-users installs when switching install modes

### DIFF
--- a/package/win32/cmake/modules/NSIS.template.in
+++ b/package/win32/cmake/modules/NSIS.template.in
@@ -384,8 +384,26 @@ FunctionEnd
 ; hand a non-admin user an admin-privileged file deletion.
 Function RunCrossModeUninstaller
   StrCpy $0 -1
+  ClearErrors
   ExecWait '$1 /S /uninstall _?=$2' $0
+  ${If} ${Errors}
+    ; Uninstallers from RStudio installers that predate NsisMultiUser have no
+    ; manifest, so Windows installer detection demands elevation and the
+    ; CreateProcess behind ExecWait fails outright when this instance is not
+    ; elevated. ExecShellWait goes through ShellExecute, which shows the UAC
+    ; prompt and waits. Only that legacy all-users uninstaller can end up here
+    ; (NsisMultiUser uninstallers run asInvoker and launch fine), so /allusers
+    ; is the right mode - and legacy uninstallers ignore these switches anyway.
+    ClearErrors
+    ExecShellWait "open" "$2\Uninstall.exe" "/allusers /S /uninstall _?=$2"
+    ${IfNot} ${Errors}
+      StrCpy $0 0
+    ${EndIf}
+  ${EndIf}
   ${If} $0 = 0
+    ; when this instance is not elevated and the removed installation was in
+    ; Program Files, these fail silently and leave only Uninstall.exe and an
+    ; empty folder behind; the registration is gone either way
     Delete "$2\Uninstall.exe"
     RMDir "$2"
   ${EndIf}
@@ -402,8 +420,10 @@ Section "-Remove previous installation"
       DetailPrint "Removing the existing per-user installation..."
       !insertmacro UAC_AsUser_Call Function RunCrossModeUninstaller ${UAC_SYNCREGISTERS}
     ${Else}
-      ; removing a per-machine installation requires elevation; NsisMultiUser
-      ; already elevated this instance for exactly this case (ALLOW_BOTH 0)
+      ; removing a per-machine installation needs admin rights, but selecting
+      ; per-user does not elevate this installer (the install-mode page only
+      ; shows the UAC shield); the spawned uninstaller requests elevation
+      ; itself and shows its own UAC prompt
       DetailPrint "Removing the existing all-users installation..."
       Call RunCrossModeUninstaller
     ${EndIf}
@@ -654,6 +674,50 @@ Function .onInit
   ${endif}
 
   !insertmacro MULTIUSER_INIT
+
+  ;
+  ; RSTUDIO CHANGE - detect all-users installations made by RStudio installers
+  ; that predate NsisMultiUser. Those wrote UninstallString but not
+  ; InstallLocation under the HKLM uninstall key, and InitChecks keys its
+  ; detection on InstallLocation, so a release install is otherwise invisible
+  ; here: the install-mode page would not mention it and the cross-mode
+  ; removal would skip it. Backfill the framework's variables so a legacy
+  ; install behaves like one made by this installer. This runs in both the
+  ; outer and the elevated inner instance, after each has run its own
+  ; InitChecks. The values come from HKLM, so the cross-mode removal still
+  ; acts on admin-controlled paths only.
+  ;
+  ${If} $HasPerMachineInstallation = 0
+    ReadRegStr $R0 HKLM "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}" "UninstallString"
+    ${If} $R0 != ""
+      ; the legacy value is an unquoted uninstaller path with no arguments;
+      ; unquote defensively, then derive the install folder from it
+      StrCpy $R1 $R0 1
+      ${If} $R1 == '"'
+        StrCpy $R0 $R0 "" 1
+        StrCpy $R1 $R0 1 -1
+        ${If} $R1 == '"'
+          StrCpy $R0 $R0 -1
+        ${EndIf}
+      ${EndIf}
+      ${GetParent} $R0 $R1
+      ${If} $R1 != ""
+        StrCpy $PerMachineUninstallString '"$R0"'
+        StrCpy $PerMachineInstallationFolder $R1
+        ReadRegStr $PerMachineInstallationVersion HKLM "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}" "DisplayVersion"
+        StrCpy $HasPerMachineInstallation 1
+        ; in silent runs InstallMode.AllUsers already ran during
+        ; MULTIUSER_INIT with the un-backfilled values (and it returns early
+        ; once the mode is set); replay what it would have derived from them
+        ${If} $MultiUser.InstallMode == "AllUsers"
+          StrCpy $HasCurrentModeInstallation 1
+          ${If} $CmdLineDir == ""
+            StrCpy $INSTDIR $PerMachineInstallationFolder
+          ${EndIf}
+        ${EndIf}
+      ${EndIf}
+    ${EndIf}
+  ${EndIf}
 
   ; Component status (uses SHCTX set by MULTIUSER_INIT)
   !insertmacro SectionList "InitSection"

--- a/package/win32/cmake/modules/NSIS.template.in
+++ b/package/win32/cmake/modules/NSIS.template.in
@@ -689,6 +689,17 @@ Function .onInit
   ;
   ${If} $HasPerMachineInstallation = 0
     ReadRegStr $R0 HKLM "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}" "UninstallString"
+    ReadRegStr $R2 HKLM "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}" "DisplayVersion"
+    ${If} $R0 == ""
+      ; NsisMultiUser switched this process to the 64-bit registry view
+      ; (MULTIUSER_INSTALLMODE_64_BIT), but the legacy installers were 32-bit
+      ; NSIS without SetRegView, so WOW64 redirected their registration to
+      ; WOW6432Node - visible only in the 32-bit view
+      SetRegView 32
+      ReadRegStr $R0 HKLM "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}" "UninstallString"
+      ReadRegStr $R2 HKLM "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}" "DisplayVersion"
+      SetRegView lastused
+    ${EndIf}
     ${If} $R0 != ""
       ; the legacy value is an unquoted uninstaller path with no arguments;
       ; unquote defensively, then derive the install folder from it
@@ -704,7 +715,7 @@ Function .onInit
       ${If} $R1 != ""
         StrCpy $PerMachineUninstallString '"$R0"'
         StrCpy $PerMachineInstallationFolder $R1
-        ReadRegStr $PerMachineInstallationVersion HKLM "${MULTIUSER_INSTALLMODE_UNINSTALL_REGISTRY_KEY_PATH}" "DisplayVersion"
+        StrCpy $PerMachineInstallationVersion $R2
         StrCpy $HasPerMachineInstallation 1
         ; in silent runs InstallMode.AllUsers already ran during
         ; MULTIUSER_INIT with the un-backfilled values (and it returns early


### PR DESCRIPTION
Installing per-user over an all-users installation from 2026.07 or earlier left both installations on disk. Installers before 2026.08 wrote `UninstallString` but not `InstallLocation` under the HKLM uninstall key, and NsisMultiUser keys its installation detection on `InstallLocation`, so those installations were invisible to the new installer: the install-mode page did not mention them and the cross-mode removal added in #18167 skipped them.

Changes to `NSIS.template.in`:

- `.onInit` now backfills the framework's per-machine variables after `MULTIUSER_INIT` when the HKLM uninstall key has an `UninstallString` but no `InstallLocation`: the uninstall command is quoted, the installation folder is derived from the uninstaller path, and `DisplayVersion` is carried over. The install-mode page then names the existing installation, shows the UAC shield, and the cross-mode removal runs. The backfill reads HKLM only, so the removal still acts on admin-controlled paths exclusively. Because pre-2026.08 installers were 32-bit NSIS without SetRegView while this installer runs under SetRegView 64, their registration lives in the WOW6432Node (32-bit) view; the backfill probes that view when the 64-bit view has no entry.
- `RunCrossModeUninstaller` falls back to `ExecShellWait` when `ExecWait` cannot launch the uninstaller. Pre-2026.08 uninstallers have no manifest, so Windows installer detection requires elevation and the `CreateProcess` behind `ExecWait` fails from an unelevated installer; `ExecShellWait` goes through `ShellExecute`, which shows the UAC prompt and waits for the uninstaller to finish.
- Corrects a comment from #18167: NsisMultiUser does not elevate the installer when per-user is selected over an existing per-machine installation (the install-mode page only shows the shield); the spawned uninstaller elevates itself. When the installer is unelevated, the post-uninstall cleanup of `Uninstall.exe` and the now-empty folder in Program Files fails silently; the Add/Remove registration is removed either way.

Verified with a makensis compile smoke test and an unelevated per-user install/uninstall round trip. The per-user-over-legacy-all-users path (interactive and silent) requires manual verification on a machine with a 2026.07-or-earlier all-users installation: expect the install-mode page to report the existing installation and a UAC prompt from its uninstaller during the install.

Closes #18188.
