### PR TITLE
Re-land Windows VS 2026 (msvc145) toolchain migration; target windows2022 Jenkins agents

### DIFF
--- a/.github/actions/setup-msvc-environment/action.yml
+++ b/.github/actions/setup-msvc-environment/action.yml
@@ -1,0 +1,26 @@
+name: "Set up MSVC environment"
+description: >
+  Locate the newest Visual Studio installation providing the VC++ x86/x64
+  toolset (via vswhere) and add its VC\Auxiliary\Build folder to GITHUB_PATH,
+  so later steps can invoke vcvarsall.bat by name. Fails the job when no
+  suitable Visual Studio installation exists on the runner. Windows-only.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Locate Visual Studio and add vcvarsall.bat to PATH
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $vsPath = & 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' `
+          -latest -products * `
+          -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+          -property installationPath
+        if ([string]::IsNullOrEmpty($vsPath)) {
+          Write-Error "vswhere could not find a Visual Studio installation with VC++ tools"
+          exit 1
+        }
+        Write-Host "Visual Studio installation: $vsPath"
+        $vcBuildPath = Join-Path $vsPath 'VC\Auxiliary\Build'
+        Add-Content -Path $env:GITHUB_PATH -Value $vcBuildPath
+        Write-Host "Added to PATH: $vcBuildPath"

--- a/.github/workflows/os-build-dependencies-windows.yml
+++ b/.github/workflows/os-build-dependencies-windows.yml
@@ -20,9 +20,9 @@
 #   exists, run with 'upload' disabled and push the workflow artifacts with
 #   dependencies/tools/upload-windows-dependencies.sh.
 #
-# The MSVC toolset version selects both the compiler toolset and the names
-# of the produced archives: 143 for Visual Studio 2022 (windows-2022
-# runner), 145 for Visual Studio 2026 (windows-2025 runner). See
+# The build targets the MSVC 14.5 toolset (msvc145), which ships with
+# Visual Studio 2026 on the windows-2025 runner; this also names the
+# produced archives (boost-...-msvc145, soci-msvc145-...). See
 # https://github.com/rstudio/rstudio/issues/17986 for background.
 
 name: "Build Dependencies (Windows, Open Source)"
@@ -38,21 +38,6 @@ on:
         description: "SOCI version to build"
         type: string
         default: "4.0.3"
-      msvc_toolset_version:
-        description: "MSVC toolset version to target (143 = VS 2022, 145 = VS 2026)"
-        type: string
-        default: "145"
-      cmake_generator:
-        description: "CMake generator used for the SOCI build"
-        type: string
-        default: "Visual Studio 18 2026"
-      runner:
-        description: "Runner image (windows-2025 ships VS 2026, windows-2022 ships VS 2022)"
-        type: choice
-        options:
-          - windows-2025
-          - windows-2022
-        default: windows-2025
       upload:
         description: "Upload the built archives to s3://rstudio-buildtools"
         type: boolean
@@ -64,14 +49,15 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ inputs.runner }}
+    runs-on: windows-2025
     timeout-minutes: 300
 
     env:
       BOOST_VERSION: ${{ inputs.boost_version }}
       SOCI_VERSION: ${{ inputs.soci_version }}
-      MSVC_TOOLSET_VERSION: ${{ inputs.msvc_toolset_version }}
-      CMAKE_GENERATOR: ${{ inputs.cmake_generator }}
+      # Fixed at the MSVC 14.5 toolset (Visual Studio 2026); used here to name
+      # the packaged/uploaded archives. install-boost/install-soci hardcode it.
+      MSVC_TOOLSET_VERSION: "145"
 
     steps:
       - uses: actions/checkout@v4
@@ -82,12 +68,9 @@ jobs:
         with:
           r-version: release
 
-      # tools.R checks for MSVC at a set of hardcoded VS 2022 paths
-      # (BuildTools / Community). GitHub runners ship VS Enterprise -- and on
-      # windows-2025, VS 2026 -- neither of which is in that list. Locate the
-      # actual installation with vswhere, put vcvarsall.bat on the PATH, and
-      # create a junction at the BuildTools path so tools.R's check passes.
-      # This is the same pattern used by the Windows e2e build workflow.
+      # tools.R locates Visual Studio via vswhere, so no junction is needed.
+      # We still put vcvarsall.bat on the PATH here for later steps (e.g.
+      # make-package.bat) that call it by name.
       - name: Set up MSVC environment
         run: |
           $ErrorActionPreference = 'Stop'
@@ -103,14 +86,6 @@ jobs:
           $vcBuildPath = Join-Path $vsPath 'VC\Auxiliary\Build'
           Add-Content -Path $env:GITHUB_PATH -Value $vcBuildPath
           Write-Host "Added to PATH: $vcBuildPath"
-          $junctionPath = 'C:\Program Files\Microsoft Visual Studio\2022\BuildTools'
-          if (-not (Test-Path $junctionPath)) {
-            New-Item -ItemType Directory -Force -Path (Split-Path $junctionPath) | Out-Null
-            New-Item -ItemType Junction -Path $junctionPath -Target $vsPath | Out-Null
-            Write-Host "Junction created: $junctionPath -> $vsPath"
-          } else {
-            Write-Host "Junction already exists: $junctionPath"
-          }
 
       # tools.R also requires a perl installation; GitHub runner images ship
       # Strawberry Perl, but install it if a future image drops it.
@@ -146,7 +121,7 @@ jobs:
       - name: Upload workflow artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: windows-dependencies-msvc${{ inputs.msvc_toolset_version }}
+          name: windows-dependencies-msvc${{ env.MSVC_TOOLSET_VERSION }}
           path: |
             dependencies/windows/boost-*.zip
             dependencies/windows/soci-*.zip

--- a/.github/workflows/os-build-dependencies-windows.yml
+++ b/.github/workflows/os-build-dependencies-windows.yml
@@ -69,8 +69,8 @@ jobs:
           r-version: release
 
       # tools.R locates Visual Studio via vswhere, so no junction is needed.
-      # We still put vcvarsall.bat on the PATH here for later steps (e.g.
-      # make-package.bat) that call it by name.
+      # We still put vcvarsall.bat on the PATH here because install-boost.R
+      # locates it via Sys.which("vcvarsall.bat").
       - name: Set up MSVC environment
         run: |
           $ErrorActionPreference = 'Stop'

--- a/.github/workflows/os-build-dependencies-windows.yml
+++ b/.github/workflows/os-build-dependencies-windows.yml
@@ -72,20 +72,7 @@ jobs:
       # We still put vcvarsall.bat on the PATH here because install-boost.R
       # locates it via Sys.which("vcvarsall.bat").
       - name: Set up MSVC environment
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $vsPath = & 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' `
-            -latest -products * `
-            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
-            -property installationPath
-          if ([string]::IsNullOrEmpty($vsPath)) {
-            Write-Error "vswhere could not find a Visual Studio installation with VC++ tools"
-            exit 1
-          }
-          Write-Host "Visual Studio installation: $vsPath"
-          $vcBuildPath = Join-Path $vsPath 'VC\Auxiliary\Build'
-          Add-Content -Path $env:GITHUB_PATH -Value $vcBuildPath
-          Write-Host "Added to PATH: $vcBuildPath"
+        uses: ./.github/actions/setup-msvc-environment
 
       # tools.R also requires a perl installation; GitHub runner images ship
       # Strawberry Perl, but install it if a future image drops it.

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -359,14 +359,10 @@ jobs:
             exit 1
           }
 
-      # install-dependencies.cmd (via tools.R) checks for MSVC 2022 at a set of
-      # hardcoded paths: BuildTools, Community, and their x86 variants.  GitHub
-      # runners have Visual Studio 2022 Enterprise, which is not in that list.
-      # Use vswhere.exe to find the actual installation, then:
-      #   1. Add VC\Auxiliary\Build to GITHUB_PATH so vcvarsall.bat is on PATH
-      #      for make-package.bat (which calls it by name).
-      #   2. Create a junction at the BuildTools path so tools.R's file.exists
-      #      check finds MSVC and proceeds to compile SOCI.
+      # install-dependencies.cmd (via tools.R) locates Visual Studio with
+      # vswhere, so no junction is needed. We still add VC\Auxiliary\Build to
+      # GITHUB_PATH so vcvarsall.bat is on PATH for make-package.bat (which
+      # calls it by name).
       - name: Set up MSVC environment
         run: |
           $ErrorActionPreference = 'Stop'
@@ -379,34 +375,17 @@ jobs:
             exit 1
           }
           Write-Host "Visual Studio installation: $vsPath"
-          # 1. PATH for vcvarsall.bat
           $vcBuildPath = Join-Path $vsPath 'VC\Auxiliary\Build'
           Add-Content -Path $env:GITHUB_PATH -Value $vcBuildPath
           Write-Host "Added to PATH: $vcBuildPath"
-          # 2. Junction so tools.R's hardcoded BuildTools check passes
-          $junctionTarget = $vsPath
-          $junctionPath   = 'C:\Program Files\Microsoft Visual Studio\2022\BuildTools'
-          if (-not (Test-Path $junctionPath)) {
-            New-Item -ItemType Junction -Path $junctionPath -Target $junctionTarget | Out-Null
-            Write-Host "Junction created: $junctionPath -> $junctionTarget"
-          } else {
-            Write-Host "Junction already exists: $junctionPath"
-          }
 
-      # install-soci.R defaults its CMake generator to "Visual Studio 17 2022",
-      # which doesn't exist on windows-2025 once the image moves to VS 2026
-      # (CMake reports `could not find any instance of Visual Studio`). Pass the
-      # VS 2026 generator name explicitly so SOCI can configure and build.
-      # MSVC_TOOLSET_VERSION=145 selects the msvc145 Boost prebuilts, matching
-      # the VS 2026 toolset on this runner, so CMakeLists.txt no longer needs
-      # its msvc143 fallback here.
+      # install-dependencies.cmd targets the VS 2026 toolset (msvc145) and the
+      # "Visual Studio 18 2026" CMake generator by default, matching this
+      # runner's Visual Studio 2026.
       - name: Install build dependencies
         id: install-deps
         working-directory: dependencies/windows
         shell: cmd
-        env:
-          CMAKE_GENERATOR: Visual Studio 18 2026
-          MSVC_TOOLSET_VERSION: "145"
         run: install-dependencies.cmd
 
       # GWT's build.xml looks for yarn at ${node.dir}/node_modules/yarn/bin/yarn.cmd

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -364,20 +364,7 @@ jobs:
       # GITHUB_PATH so vcvarsall.bat is on PATH for make-package.bat (which
       # calls it by name).
       - name: Set up MSVC environment
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $vsPath = & 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' `
-            -latest -products * `
-            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
-            -property installationPath
-          if ([string]::IsNullOrEmpty($vsPath)) {
-            Write-Error "vswhere could not find a Visual Studio installation with VC++ tools"
-            exit 1
-          }
-          Write-Host "Visual Studio installation: $vsPath"
-          $vcBuildPath = Join-Path $vsPath 'VC\Auxiliary\Build'
-          Add-Content -Path $env:GITHUB_PATH -Value $vcBuildPath
-          Write-Host "Added to PATH: $vcBuildPath"
+        uses: ./.github/actions/setup-msvc-environment
 
       # install-dependencies.cmd targets the VS 2026 toolset (msvc145) and the
       # "Visual Studio 18 2026" CMake generator by default, matching this

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,9 @@ include(cmake/compiler.cmake)
 # project globals
 include(cmake/globals.cmake)
 
+# validate the Windows build environment (compiler, architecture, generator)
+include(cmake/windows-checks.cmake)
+
 # remove previous installation if requested
 if(RSTUDIO_UNINSTALL_PREVIOUS)
   install(CODE "execute_process(COMMAND rm -rf \${CMAKE_INSTALL_PREFIX})")

--- a/INSTALL
+++ b/INSTALL
@@ -57,14 +57,15 @@ b) Configure the build using cmake as appropriate, e.g.
 
 c) There are additional considerations on Windows. First, RStudio Server
    is not supported on Windows so the configuration always defaults to
-   Electron. Second, you need to add an extra -G parameter to specify the
-   correct build toolchain, for example:
+   Electron. Second, the Windows build uses the Ninja generator (the Visual
+   Studio multi-config generator is not supported), so configure from a
+   Visual Studio developer command prompt with:
 
-   cmake .. -G "Visual Studio 17 2022" -A Win64 -DCMAKE_BUILD_TYPE=Release
+   cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release
 
    To build on Windows:
 
-   cmake --build . --config Release
+   cmake --build .
 
 
 3) Building and Installing

--- a/cmake/windows-checks.cmake
+++ b/cmake/windows-checks.cmake
@@ -40,7 +40,14 @@ endif()
 #    with the real requirement beats the downstream "prebuilts not found"
 #    error, whose advice (re-run install-dependencies.cmd) cannot help a
 #    VS 2022 user: that script only ever installs msvc145 prebuilts.
-#    Keep this pin in sync with dependencies/windows/install-dependencies.cmd.
+#    When bumping the toolset, keep this pin in sync with its other
+#    definition sites:
+#      dependencies/windows/install-dependencies.cmd   (prebuilt archive names)
+#      dependencies/windows/install-boost.cmd
+#      dependencies/windows/install-boost/install-boost.R
+#      dependencies/windows/install-soci/install-soci.R
+#      .github/workflows/os-build-dependencies-windows.yml
+#      jenkins/utils.groovy                            (docker image tag suffix)
 if(NOT MSVC_TOOLSET_VERSION EQUAL 145)
    message(FATAL_ERROR
       "The RStudio Windows build requires the MSVC 14.5 toolset (Visual "

--- a/cmake/windows-checks.cmake
+++ b/cmake/windows-checks.cmake
@@ -1,0 +1,78 @@
+#
+# windows-checks.cmake
+#
+# Copyright (C) 2022 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+# Up-front validation of the Windows build environment. These checks turn the
+# common toolchain misconfigurations into a single, actionable failure during
+# CMake configure -- instead of a cryptic MSVC/linker error deep in the build.
+#
+# Included from the top-level CMakeLists.txt after globals.cmake, so that
+# RSTUDIO_SESSION_WIN32 (and the other RSTUDIO_* variables) are already set.
+#
+
+if(NOT WIN32)
+   return()
+endif()
+
+# 1. Compiler must be MSVC (cl.exe). The boost/SOCI prebuilts are keyed to
+#    MSVC_TOOLSET_VERSION, which only MSVC sets; a stray Clang/GCC on the PATH
+#    otherwise gets picked up and yields a blank msvc<toolset> dependency path.
+if(NOT MSVC)
+   message(FATAL_ERROR
+      "A non-MSVC compiler was detected (${CMAKE_CXX_COMPILER}), but the "
+      "RStudio Windows build requires the MSVC (cl.exe) toolset.\n"
+      "Configure from a Visual Studio developer command prompt, or run "
+      "src/cpp/tools/windows-dev.cmd first, so cl.exe is on the PATH.")
+endif()
+
+# 2. The toolset must match the Boost/SOCI prebuilts, which are pinned to
+#    MSVC 14.5 (Visual Studio 2026) by install-dependencies.cmd. Failing here
+#    with the real requirement beats the downstream "prebuilts not found"
+#    error, whose advice (re-run install-dependencies.cmd) cannot help a
+#    VS 2022 user: that script only ever installs msvc145 prebuilts.
+#    Keep this pin in sync with dependencies/windows/install-dependencies.cmd.
+if(NOT MSVC_TOOLSET_VERSION EQUAL 145)
+   message(FATAL_ERROR
+      "The RStudio Windows build requires the MSVC 14.5 toolset (Visual "
+      "Studio 2026), but toolset ${MSVC_TOOLSET_VERSION} was detected.\n"
+      "Install Visual Studio 2026 (see dependencies/windows/"
+      "Install-RStudio-Prereqs.ps1) and configure from its developer "
+      "command prompt.")
+endif()
+
+# 3. Compiler architecture must match the target. The default target is 64-bit
+#    (we add -D_WIN64 / -D_AMD64_ and link boost64); the SessionWin32 target is
+#    32-bit. A mismatch produces errors like
+#    "'size_t': redefinition; different basic types".
+if(RSTUDIO_SESSION_WIN32 AND NOT CMAKE_SIZEOF_VOID_P EQUAL 4)
+   message(FATAL_ERROR
+      "The SessionWin32 target needs a 32-bit (x86) MSVC compiler, but a "
+      "${CMAKE_SIZEOF_VOID_P}-pointer-byte compiler was detected.\n"
+      "Use the 'x86 Native Tools Command Prompt for VS'.")
+elseif(NOT RSTUDIO_SESSION_WIN32 AND NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+   message(FATAL_ERROR
+      "The Windows build needs a 64-bit (x64) MSVC compiler, but a "
+      "${CMAKE_SIZEOF_VOID_P}-pointer-byte compiler was detected.\n"
+      "Use the 'x64 Native Tools Command Prompt for VS 2026', or run "
+      "src/cpp/tools/windows-dev.cmd (which sets -arch=amd64).")
+endif()
+
+# 4. Ninja is the supported, CI-tested generator. The Visual Studio multi-config
+#    generator can link (see the archive-output pinning in src/cpp/ext), but its
+#    staging/packaging/test layout is not exercised, so warn rather than fail.
+if(NOT CMAKE_GENERATOR MATCHES "Ninja")
+   message(WARNING
+      "Generator '${CMAKE_GENERATOR}' is not the supported Windows generator. "
+      "RStudio's Windows build is tested only with Ninja; reconfigure with "
+      "-G Ninja if you hit staging, packaging, or test-layout issues.")
+endif()

--- a/dependencies/tools/rstudio-tools.cmd
+++ b/dependencies/tools/rstudio-tools.cmd
@@ -511,26 +511,27 @@ exit /b %ERRORLEVEL%
 ::
 :add-vstools-to-path
 
-for %%Q in ("BuildTools" "Community") do (
-  for %%P in ("%ProgramFiles%" "%ProgramFiles(x86)%") do (
-    call :add-vstools-to-path-impl "%%~P\Microsoft Visual Studio\2022\%%~Q"
-    if defined _VCTOOLSDIR (
-      goto :add-vstools-to-path-done
-    )
-  )
+:: Locate Visual Studio via vswhere (ships with the VS installer at a fixed
+:: path). This finds any edition/version carrying the C++ toolset, so we avoid
+:: hardcoding install paths that change across VS releases.
+set "_VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%_VSWHERE%" (
+  echo ^^!^^! ERROR: vswhere.exe not found; cannot locate Visual Studio build tools.
+  exit /b 1
 )
 
-:add-vstools-to-path-impl
-
-if exist "%~f1" (
-  set "_VCTOOLSDIR=%~f1\Common7\Tools"
-  set "_VCBUILDDIR=%~f1\VC\Auxiliary\Build"
+set "_VSINSTALL="
+for /f "usebackq delims=" %%I in (`"%_VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+  set "_VSINSTALL=%%I"
 )
 
-goto :eof
+if not defined _VSINSTALL (
+  echo ^^!^^! ERROR: Could not find a Visual Studio installation with the C++ toolset.
+  exit /b 1
+)
 
-:add-vstools-to-path-done:
-
+set "_VCTOOLSDIR=%_VSINSTALL%\Common7\Tools"
+set "_VCBUILDDIR=%_VSINSTALL%\VC\Auxiliary\Build"
 set "PATH=%_VCTOOLSDIR%;%_VCBUILDDIR%;%PATH%"
 where /Q VsDevCmd.bat
 if %ERRORLEVEL% neq 0 (

--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -80,14 +80,14 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
 #
 
 # Download the Build Tools bootstrapper.
-Invoke-DownloadFile https://aka.ms/vs/17/release/vs_buildtools.exe vs_buildtools.exe
+Invoke-DownloadFile https://aka.ms/vs/18/release/vs_buildtools.exe vs_buildtools.exe
 
 # Install Build Tools. For whatever reason, this fails when we try to install
 # into C:/Program Files (x86), so just use the "regular" C:/Program Files.
 Write-Host "Installing Visual Studio Build Tools..."
 $installArgs = @(
     '--quiet', '--wait', '--norestart', '--nocache',
-    '--installPath', '"C:/Program Files/Microsoft Visual Studio/2022/BuildTools"',
+    '--installPath', '"C:/Program Files/Microsoft Visual Studio/2026/BuildTools"',
     '--add', 'Microsoft.VisualStudio.Workload.VCTools',
     '--add', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
     '--add', 'Microsoft.VisualStudio.Component.VC.Tools.ARM64',
@@ -102,9 +102,9 @@ if ($vsProcess.ExitCode -ne 0) {
 # Try testing the build tools. You might see some telemetry errors here;
 # they can apparently be ignored.
 Write-Host "Testing VsDevCmd.bat..."
-$vsDevCmdPath = "C:\Program Files\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\VsDevCmd.bat"
+$vsDevCmdPath = "C:\Program Files\Microsoft Visual Studio\2026\BuildTools\Common7\Tools\VsDevCmd.bat"
 if (Test-Path $vsDevCmdPath) {
-    Push-Location "C:\Program Files\Microsoft Visual Studio\2022\BuildTools\Common7\Tools"
+    Push-Location "C:\Program Files\Microsoft Visual Studio\2026\BuildTools\Common7\Tools"
     cmd /c "VsDevCmd.bat -clean_env -no_logo && VsDevCmd.bat -arch=x86 -startdir=none -host_arch=x86 -no_logo && echo -- Testing VsDevCmd.bat -- success"
     Pop-Location
     Write-Host "Build tools verification completed"

--- a/dependencies/windows/install-boost.cmd
+++ b/dependencies/windows/install-boost.cmd
@@ -1,10 +1,10 @@
 @echo off
 setlocal
 
-REM Variables defining the build. Update as appropriate, or set in the
-REM environment to override (e.g. when building for a newer MSVC toolset).
+REM Variables defining the build. BOOST_VERSION may be overridden in the
+REM environment; the MSVC toolset is fixed at 145 (Visual Studio 2026).
 if not defined BOOST_VERSION set BOOST_VERSION=1.91.0
-if not defined MSVC_TOOLSET_VERSION set MSVC_TOOLSET_VERSION=143
+set MSVC_TOOLSET_VERSION=145
 
 REM The file name prefix used for Boost build folders.
 set BOOST_PREFIX=boost-%BOOST_VERSION%-win-msvc%MSVC_TOOLSET_VERSION%

--- a/dependencies/windows/install-boost/install-boost.R
+++ b/dependencies/windows/install-boost/install-boost.R
@@ -1,8 +1,8 @@
 
 BOOST_VERSION <- Sys.getenv("BOOST_VERSION", unset = "1.91.0")
-MSVC_TOOLSET_VERSION <- Sys.getenv("MSVC_TOOLSET_VERSION", unset = "143")
+MSVC_TOOLSET_VERSION <- "145"
 
-# derive the b2 toolset from the MSVC toolset version (e.g. 143 => msvc-14.3),
+# derive the b2 toolset from the MSVC toolset version (e.g. 145 => msvc-14.5),
 # unless explicitly overridden in the environment
 BOOST_TOOLSET_DEFAULT <- paste0(
    "msvc-",

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -38,8 +38,8 @@ set GWT_VERSION=2.12.2-apple-blossom
 set LIBCLANG_VERSION=13.0.1
 set MATHJAX_VERSION=2.7.9
 REM The MSVC toolset used for Boost prebuilts. Can be set in the environment
-REM to select a different set of prebuilts (e.g. 145 for Visual Studio 2026).
-if not defined MSVC_TOOLSET_VERSION set MSVC_TOOLSET_VERSION=143
+REM to select a different set of prebuilts (e.g. 143 for Visual Studio 2022).
+if not defined MSVC_TOOLSET_VERSION set MSVC_TOOLSET_VERSION=145
 set NSISMULTIUSER_VERSION=a33d494c62ad
 set NSPROCESS_VERSION=1.6
 set OPENSSL_VERSION=3.1.4

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -37,9 +37,8 @@ set GNUGREP_VERSION=3.0
 set GWT_VERSION=2.12.2-apple-blossom
 set LIBCLANG_VERSION=13.0.1
 set MATHJAX_VERSION=2.7.9
-REM The MSVC toolset used for Boost prebuilts. Can be set in the environment
-REM to select a different set of prebuilts (e.g. 143 for Visual Studio 2022).
-if not defined MSVC_TOOLSET_VERSION set MSVC_TOOLSET_VERSION=145
+REM The MSVC toolset used for Boost prebuilts (145 = Visual Studio 2026).
+set MSVC_TOOLSET_VERSION=145
 set NSISMULTIUSER_VERSION=a33d494c62ad
 set NSPROCESS_VERSION=1.6
 set OPENSSL_VERSION=3.1.4

--- a/dependencies/windows/install-soci/install-soci.R
+++ b/dependencies/windows/install-soci/install-soci.R
@@ -5,8 +5,8 @@ if (file.exists("rstudio.Rproj"))
 
 SOCI_VERSION         <- Sys.getenv("SOCI_VERSION", unset = "4.0.3")
 BOOST_VERSION        <- Sys.getenv("BOOST_VERSION", unset = "1.91.0")
-MSVC_TOOLSET_VERSION <- Sys.getenv("MSVC_TOOLSET_VERSION", unset = "143")
-CMAKE_GENERATOR      <- Sys.getenv("CMAKE_GENERATOR", unset = "Visual Studio 17 2022")
+MSVC_TOOLSET_VERSION <- "145"
+CMAKE_GENERATOR      <- Sys.getenv("CMAKE_GENERATOR", unset = "Visual Studio 18 2026")
 
 # the source-tree folder containing this script and its helpers
 script_dir <- getwd()

--- a/dependencies/windows/tools.R
+++ b/dependencies/windows/tools.R
@@ -233,23 +233,33 @@ interpolate <- function(string) {
 
 initialize <- function() {
 
-   # Make sure MSVC tools are available
-   msvcCandidates <- c(
-      "C:/Program Files/Microsoft Visual Studio/2022/BuildTools/VC/Auxiliary/Build",
-      "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Auxiliary/Build",
-      "C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Auxiliary/Build",
-      "C:/Program Files (x86)/Microsoft Visual Studio/2022/Community/VC/Auxiliary/Build"
-   )
+   # Locate Visual Studio via vswhere, which ships with the VS installer at a
+   # fixed, version-independent path. This finds any edition/version carrying
+   # the C++ toolset, so we avoid hardcoding install paths that change across
+   # VS releases (e.g. the "18" folder used by Visual Studio 2026).
+   vswhere <- "C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+   vsInstall <- if (file.exists(vswhere)) {
+      output <- suppressWarnings(system2(
+         vswhere,
+         c("-latest", "-products", "*",
+           "-requires", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+           "-property", "installationPath"),
+         stdout = TRUE, stderr = FALSE
+      ))
+      if (length(output)) trimws(output[[1L]]) else ""
+   } else {
+      ""
+   }
 
-   msvc <- Filter(file.exists, msvcCandidates)
-   if (length(msvc) == 0L) {
+   msvc <- file.path(vsInstall, "VC/Auxiliary/Build")
+   if (!nzchar(vsInstall) || !dir.exists(msvc)) {
       message <- paste(
-         "No MSVC 2022 installation detected.",
+         "No Visual Studio C++ toolset detected.",
          "Install build tools using 'Install-RStudio-Prereqs.ps1'."
       )
       fatal(message)
    }
-   PATH$prepend(msvc[[1L]])
+   PATH$prepend(msvc)
 
    # Make sure perl is available
    # try to find a perl installation directory

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -1,7 +1,7 @@
 # escape=`
 
 # https://hub.docker.com/r/microsoft/windows-servercore
-FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022
 
 # Use plain cmd shell for initial setup.
 SHELL ["cmd", "/S", "/C"]
@@ -31,7 +31,7 @@ WORKDIR "C:/BuildTools"
 #
 
 # Download the Build Tools bootstrapper.
-RUN curl -SL --output vs_buildtools.exe https://aka.ms/vs/17/release/vs_buildtools.exe
+RUN curl -SL --output vs_buildtools.exe https://aka.ms/vs/18/release/vs_buildtools.exe
 
 #
 # Install Build Tools. For whatever reason, this fails when we try to install
@@ -46,7 +46,7 @@ RUN curl -SL --output vs_buildtools.exe https://aka.ms/vs/17/release/vs_buildtoo
 #
 RUN `
   start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
-    --installPath "C:/Program Files/Microsoft Visual Studio/2022/BuildTools" `
+    --installPath "C:/Program Files/Microsoft Visual Studio/2026/BuildTools" `
     --add Microsoft.VisualStudio.Workload.VCTools `
     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
     --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 `
@@ -54,7 +54,7 @@ RUN `
 
 # Try testing the build tools. You might see some telemetry errors here;
 # they can apparently be ignored.
-WORKDIR "C:/Program Files/Microsoft Visual Studio/2022/BuildTools/Common7/Tools"
+WORKDIR "C:/Program Files/Microsoft Visual Studio/2026/BuildTools/Common7/Tools"
 RUN `
   start /WAIT /B cmd.exe /S /C `
   echo -- Testing VsDevCmd.bat `

--- a/jenkins/Jenkinsfile.build
+++ b/jenkins/Jenkinsfile.build
@@ -5,7 +5,7 @@ def labelForOS = [
   'rhel8':      'linux',
   'rhel9':      'linux',
   'opensuse15': 'linux',
-  'windows':    'windows',
+  'windows':    'windows2022',
   'macos':      'macos'
 ]
 

--- a/jenkins/Jenkinsfile.build
+++ b/jenkins/Jenkinsfile.build
@@ -1,11 +1,13 @@
 def utils
 
-def labelForOS = [
+// Maps each OS axis value to its OS family, for dispatching build stages.
+// Agent node labels are derived separately, via utils.getAgentLabelForOS().
+def familyForOS = [
   'jammy':      'linux',
   'rhel8':      'linux',
   'rhel9':      'linux',
   'opensuse15': 'linux',
-  'windows':    'windows2022',
+  'windows':    'windows',
   'macos':      'macos'
 ]
 
@@ -129,7 +131,7 @@ pipeline {
         stages {
           stage ("Pull Build Push") {
             agent {
-              label "${labelForOS[os]} && ${arch}"
+              label "${utils.getAgentLabelForOS(familyForOS[os], arch)}"
             }
 
             environment {
@@ -172,7 +174,7 @@ pipeline {
         stage ("Build Windows") {
           when {
             anyOf {
-              equals expected: params.OS_FILTER, actual: 'windows';
+              equals expected: familyForOS[params.OS_FILTER], actual: 'windows';
               equals expected: params.OS_FILTER, actual: 'all'
             }
           }
@@ -193,7 +195,7 @@ pipeline {
         stage ("Build Linux") {
           when {
             anyOf {
-              equals expected: labelForOS[params.OS_FILTER], actual: 'linux';
+              equals expected: familyForOS[params.OS_FILTER], actual: 'linux';
               equals expected: params.OS_FILTER, actual: 'all'
             }
           }
@@ -216,7 +218,7 @@ pipeline {
         stage ("Build MacOS") {
           when {
             anyOf {
-              equals expected: labelForOS[params.OS_FILTER], actual: 'macos';
+              equals expected: familyForOS[params.OS_FILTER], actual: 'macos';
               equals expected: params.OS_FILTER, actual: 'all'
             }
           }

--- a/jenkins/Jenkinsfile.build
+++ b/jenkins/Jenkinsfile.build
@@ -172,7 +172,7 @@ pipeline {
         stage ("Build Windows") {
           when {
             anyOf {
-              equals expected: labelForOS[params.OS_FILTER], actual: 'windows';
+              equals expected: params.OS_FILTER, actual: 'windows';
               equals expected: params.OS_FILTER, actual: 'all'
             }
           }

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -159,7 +159,7 @@ pipeline {
           }
           steps {
             bat '''
-              call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\Common7\\Tools\\VsDevCmd.bat"
+              call "C:\\Program Files\\Microsoft Visual Studio\\2026\\BuildTools\\Common7\\Tools\\VsDevCmd.bat"
               curl -O "https://rstudio-buildtools.s3.amazonaws.com/posit-dev/smtools-windows-x64.msi"
               msiexec /i smtools-windows-x64.msi /quiet /qn /L*V smtools-windows-x64.log
               type smtools-windows-x64.log
@@ -209,7 +209,7 @@ pipeline {
 
               steps {
                 bat '''
-                  call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\Common7\\Tools\\VsDevCmd.bat"
+                  call "C:\\Program Files\\Microsoft Visual Studio\\2026\\BuildTools\\Common7\\Tools\\VsDevCmd.bat"
                   C:\\Windows\\System32\\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
                   "C:\\Program Files\\DigiCert\\DigiCert One Signing Manager Tools\\smctl.exe" windows certsync
                   signtool.exe sign /tr http://timestamp.digicert.com /sha1 %DIGICERT_CERTIFICATE_FINGERPRINT% /td SHA256 /fd SHA256 %LONG_PACKAGE_PATH%

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -113,7 +113,7 @@ pipeline {
             registryUrl 'https://263245908434.dkr.ecr.us-east-1.amazonaws.com'
             registryCredentialsId 'ecr:us-east-1:aws-build-role'
             reuseNode true
-          label "windows"
+          label "windows2022 && x86_64"
           // Set a custom workspace relative to the workspace root (C:\Users\jenikns) to ensure file names
           // won't be too long
           customWorkspace "workspace/ide-${IS_PRO ? 'pro' : 'os'}-windows/${env.BRANCH_NAME.replace('/', '-')}"

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -113,7 +113,7 @@ pipeline {
             registryUrl 'https://263245908434.dkr.ecr.us-east-1.amazonaws.com'
             registryCredentialsId 'ecr:us-east-1:aws-build-role'
             reuseNode true
-          label "windows2022 && x86_64"
+          label "${utils.getAgentLabelForOS('windows', 'x86_64')}"
           // Set a custom workspace relative to the workspace root (C:\Users\jenikns) to ensure file names
           // won't be too long
           customWorkspace "workspace/ide-${IS_PRO ? 'pro' : 'os'}-windows/${env.BRANCH_NAME.replace('/', '-')}"

--- a/jenkins/utils.groovy
+++ b/jenkins/utils.groovy
@@ -248,6 +248,17 @@ def getBuildEnv(boolean isHourly) {
 }
 
 /**
+  * Gets the Jenkins node label used to select a build agent for the given
+  * OS family ('linux', 'windows', 'macos') and arch. Windows build agents
+  * are labeled with their Windows Server version; update it here when the
+  * agent fleet is upgraded.
+  */
+def getAgentLabelForOS(String os, String arch) {
+  def label = os == 'windows' ? 'windows2022' : os
+  return "${label} && ${arch}"
+}
+
+/**
   * Gets the Linux agent label based on the arch.
   */
 def getLinuxAgentLabel(String arch) {
@@ -284,9 +295,16 @@ def updateDailyRedirects(String path) {
   * Don't try to change RSTUDIO_VERSION_FLOWER to env.RSTUDIO_VERSION_FLOWER
   * in order for it to match, because for some reason that causes it to
   * resolve to "null". I don't know why.
+  *
+  * The Windows tag carries the MSVC toolset the image provides, so a
+  * toolchain upgrade mints a new tag: builds can never silently pull a stale
+  * image built with the previous toolchain (a not-yet-built tag fails the
+  * docker pull loudly instead). Keep the suffix in sync with the msvc145
+  * pins listed in cmake/windows-checks.cmake.
   */
 def getDockerTag() {
-  return "${IS_PRO ? 'pro-' : ''}${env.OS}-${env.ARCH}-${RSTUDIO_VERSION_FLOWER}"
+  def toolchain = env.OS == 'windows' ? '-msvc145' : ''
+  return "${IS_PRO ? 'pro-' : ''}${env.OS}-${env.ARCH}-${RSTUDIO_VERSION_FLOWER}${toolchain}"
 }
 
 /**

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -251,37 +251,24 @@ else()
       set(BOOST_ARCH "64")
    endif()
 
-   # install-dependencies.cmd downloads Boost prebuilts keyed to a specific
-   # MSVC toolset version. When the CI runner is upgraded to a newer toolset
-   # (e.g. msvc145 on VS 2026) before new prebuilts are available, fall back
-   # to the last-known prebuilt toolset -- MSVC 14.x releases are binary-
-   # compatible, so msvc143 libs link correctly against msvc144/145/etc.
-   set(_RSTUDIO_BOOST_MSVC_TOOLSET ${MSVC_TOOLSET_VERSION})
+   # install-dependencies.cmd downloads Boost prebuilts for the MSVC 14.5
+   # (Visual Studio 2026) toolset; build against the toolset CMake detected.
    if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-      set(_RSTUDIO_BOOST_VARIANT "release")
+      set(BOOST_SUFFIX "vc${MSVC_TOOLSET_VERSION}-mt-x${BOOST_ARCH}-${RSTUDIO_BOOST_VERSION_MAJOR}_${RSTUDIO_BOOST_VERSION_MINOR}.lib")
+      set(BOOST_ROOT "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/boost-${RSTUDIO_BOOST_REQUESTED_VERSION}-win-msvc${MSVC_TOOLSET_VERSION}-release-static/boost${BOOST_ARCH}")
    else()
-      set(_RSTUDIO_BOOST_VARIANT "debug")
-   endif()
-   if(NOT EXISTS "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/boost-${RSTUDIO_BOOST_REQUESTED_VERSION}-win-msvc${_RSTUDIO_BOOST_MSVC_TOOLSET}-${_RSTUDIO_BOOST_VARIANT}-static")
-      set(_RSTUDIO_BOOST_FALLBACK 143)
-      message(STATUS "Boost prebuilts for msvc${_RSTUDIO_BOOST_MSVC_TOOLSET} not found; using msvc${_RSTUDIO_BOOST_FALLBACK} prebuilts (MSVC 14.x binary-compatible)")
-      set(_RSTUDIO_BOOST_MSVC_TOOLSET ${_RSTUDIO_BOOST_FALLBACK})
-   endif()
-
-   if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-      set(BOOST_SUFFIX "vc${_RSTUDIO_BOOST_MSVC_TOOLSET}-mt-x${BOOST_ARCH}-${RSTUDIO_BOOST_VERSION_MAJOR}_${RSTUDIO_BOOST_VERSION_MINOR}.lib")
-      set(BOOST_ROOT "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/boost-${RSTUDIO_BOOST_REQUESTED_VERSION}-win-msvc${_RSTUDIO_BOOST_MSVC_TOOLSET}-release-static/boost${BOOST_ARCH}")
-   else()
-      set(BOOST_SUFFIX "vc${_RSTUDIO_BOOST_MSVC_TOOLSET}-mt-gd-x${BOOST_ARCH}-${RSTUDIO_BOOST_VERSION_MAJOR}_${RSTUDIO_BOOST_VERSION_MINOR}.lib")
-      set(BOOST_ROOT "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/boost-${RSTUDIO_BOOST_REQUESTED_VERSION}-win-msvc${_RSTUDIO_BOOST_MSVC_TOOLSET}-debug-static/boost${BOOST_ARCH}")
+      set(BOOST_SUFFIX "vc${MSVC_TOOLSET_VERSION}-mt-gd-x${BOOST_ARCH}-${RSTUDIO_BOOST_VERSION_MAJOR}_${RSTUDIO_BOOST_VERSION_MINOR}.lib")
+      set(BOOST_ROOT "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/boost-${RSTUDIO_BOOST_REQUESTED_VERSION}-win-msvc${MSVC_TOOLSET_VERSION}-debug-static/boost${BOOST_ARCH}")
    endif()
    set(BOOST_INCLUDEDIR "${BOOST_ROOT}/include/boost-${RSTUDIO_BOOST_VERSION_MAJOR}_${RSTUDIO_BOOST_VERSION_MINOR}")
    # CMake 4.x removed FindBoost.cmake (CMP0167). Since the Windows path
    # hard-codes every Boost path, bypass find_package and wire up
    # Boost_INCLUDE_DIRS directly -- equivalent validation without the module.
    if(NOT EXISTS "${BOOST_INCLUDEDIR}")
-      message(FATAL_ERROR "Boost include directory not found: ${BOOST_INCLUDEDIR}\n"
-                          "Check that install-dependencies.cmd ran successfully.")
+      message(FATAL_ERROR
+         "Boost prebuilts for the MSVC ${MSVC_TOOLSET_VERSION} toolset were not found:\n"
+         "  ${BOOST_INCLUDEDIR}\n"
+         "Run dependencies/windows/install-dependencies.cmd to download them.")
    endif()
    set(Boost_INCLUDE_DIRS "${BOOST_INCLUDEDIR}")
    set(BOOST_LIBRARYDIR "${BOOST_ROOT}/lib")
@@ -299,15 +286,15 @@ include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 # SOCI
 if(WIN32)
-   # Same toolset-fallback logic as Boost above: install-soci.R also defaults
-   # to msvc143, so fall back when the current toolset's directory is absent.
-   set(_RSTUDIO_SOCI_MSVC_TOOLSET ${MSVC_TOOLSET_VERSION})
-   if(NOT EXISTS "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/install-soci/soci-msvc${_RSTUDIO_SOCI_MSVC_TOOLSET}-4.0.3")
-      set(_RSTUDIO_SOCI_FALLBACK 143)
-      message(STATUS "SOCI for msvc${_RSTUDIO_SOCI_MSVC_TOOLSET} not found; using msvc${_RSTUDIO_SOCI_FALLBACK} prebuilts (MSVC 14.x binary-compatible)")
-      set(_RSTUDIO_SOCI_MSVC_TOOLSET ${_RSTUDIO_SOCI_FALLBACK})
+   # install-soci.R builds SOCI for the MSVC 14.5 (Visual Studio 2026) toolset;
+   # locate it using the toolset CMake detected.
+   set(RSTUDIO_TOOLS_SOCI "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/install-soci/soci-msvc${MSVC_TOOLSET_VERSION}-4.0.3")
+   if(NOT EXISTS "${RSTUDIO_TOOLS_SOCI}")
+      message(FATAL_ERROR
+         "SOCI prebuilts for the MSVC ${MSVC_TOOLSET_VERSION} toolset were not found:\n"
+         "  ${RSTUDIO_TOOLS_SOCI}\n"
+         "Run dependencies/windows/install-dependencies.cmd to build them.")
    endif()
-   set(RSTUDIO_TOOLS_SOCI "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/install-soci/soci-msvc${_RSTUDIO_SOCI_MSVC_TOOLSET}-4.0.3")
    if(RSTUDIO_SESSION_WIN32)
       set(SOCI_ARCH "x86")
    else()

--- a/src/cpp/ext/CMakeLists.txt
+++ b/src/cpp/ext/CMakeLists.txt
@@ -533,5 +533,17 @@ if(WIN32 AND ZLIB_ENABLED)
    add_library(rstudio-zlib STATIC ${ZLIB_SOURCE_FILES} ${ZLIB_HEADER_FILES})
    # Source dir for zlib.h et al.; binary dir for the generated zconf.h.
    target_include_directories(rstudio-zlib PUBLIC "${ZLIB_SOURCE_DIR}" "${ZLIB_BINARY_DIR}")
+
+   # Pin the archive output to a flat, config-independent path so the hardcoded
+   # _RSTUDIO_ZLIB_LIBRARY above (fed to libgit2's find_package(ZLIB)) resolves
+   # under both the Ninja (single-config) and Visual Studio (multi-config)
+   # generators; the latter otherwise nests the .lib under a per-config subdir.
+   set_target_properties(rstudio-zlib PROPERTIES
+      ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/src/cpp/ext")
+   foreach(_cfg ${CMAKE_CONFIGURATION_TYPES})
+      string(TOUPPER "${_cfg}" _cfg_upper)
+      set_target_properties(rstudio-zlib PROPERTIES
+         ARCHIVE_OUTPUT_DIRECTORY_${_cfg_upper} "${CMAKE_BINARY_DIR}/src/cpp/ext")
+   endforeach()
 endif()
 

--- a/src/node/desktop/resources/vc_redist/README.md
+++ b/src/node/desktop/resources/vc_redist/README.md
@@ -19,8 +19,8 @@ vs_buildtools.exe --passive --add Microsoft.VisualStudio.Workload.VCTools --add 
 
 Copy all the files from the following to the x64 and x86 folders.
 
-- x64: `C:\Program Files (x86)\Microsoft Visual Studio\2026\BuildTools\VC\Redist\MSVC\14.50.xxxxx\x64\Microsoft.VC145.CRT\*.*`
-- x86: `C:\Program Files (x86)\Microsoft Visual Studio\2026\BuildTools\VC\Redist\MSVC\14.50.xxxxx\x64\Microsoft.VC145.CRT\*.*`
+- x64: `C:\Program Files\Microsoft Visual Studio\2026\BuildTools\VC\Redist\MSVC\14.50.xxxxx\x64\Microsoft.VC145.CRT\*.*`
+- x86: `C:\Program Files\Microsoft Visual Studio\2026\BuildTools\VC\Redist\MSVC\14.50.xxxxx\x86\Microsoft.VC145.CRT\*.*`
 - ARM: future
 
 Note that "2026", "14.50.xxxxx", and "VC145" will need to be updated to match what has actually

--- a/src/node/desktop/resources/vc_redist/README.md
+++ b/src/node/desktop/resources/vc_redist/README.md
@@ -1,7 +1,7 @@
 # Visual C++ Runtime Files
 
 The DLLs in this folder will be installed as part of RStudio, and should be updated to match the
-ones included with most recent major version of the Microsoft Visual C++ toolset (currently 2022).
+ones included with most recent major version of the Microsoft Visual C++ toolset (currently 2026).
 
 ## How To Update These Files
 
@@ -19,11 +19,11 @@ vs_buildtools.exe --passive --add Microsoft.VisualStudio.Workload.VCTools --add 
 
 Copy all the files from the following to the x64 and x86 folders.
 
-- x64: `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.42.34433\x64\Microsoft.VC143.CRT\*.*`
-- x86: `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.42.34433\x64\Microsoft.VC143.CRT\*.*`
+- x64: `C:\Program Files (x86)\Microsoft Visual Studio\2026\BuildTools\VC\Redist\MSVC\14.50.xxxxx\x64\Microsoft.VC145.CRT\*.*`
+- x86: `C:\Program Files (x86)\Microsoft Visual Studio\2026\BuildTools\VC\Redist\MSVC\14.50.xxxxx\x64\Microsoft.VC145.CRT\*.*`
 - ARM: future
 
-Note that "2022", "14.29.30133", and "VC143" will need to be updated to match what has actually
+Note that "2026", "14.50.xxxxx", and "VC145" will need to be updated to match what has actually
 been installed.
 
 ## TLDR; More Background


### PR DESCRIPTION
Re-lands the Windows VS 2026 (MSVC 14.5) toolchain migration, and points the Windows build pipelines at the upgraded Jenkins agents.

The migration was backed out in 724a7ca37af (#18156) because the Jenkins Windows agents were still running Windows Server 2019, which cannot run the `windowsservercore-ltsc2022`-based build image under process isolation. The agents have since been upgraded to Windows Server 2022, so the migration can now re-land.

This PR:

- Reverts 724a7ca37af, restoring the VS 2026 / MSVC 14.5 toolchain configuration (Docker base image `windowsservercore-ltsc2022`, VS 2026 Build Tools, `windows-checks.cmake`, msvc145 Boost/SOCI prebuilts, and the associated GHA workflow changes). The one conflict was in `dependencies/windows/install-dependencies.cmd`, where the `MSVC_TOOLSET_VERSION` default is restored to 145 while keeping the environment-override support and the `NSISMULTIUSER_VERSION` pin that landed after the revert.
- Updates the Windows agent selection in `jenkins/Jenkinsfile.windows` and `jenkins/Jenkinsfile.build` to target the upgraded agents (labeled `windows2022 x86_64 amd64`) via `windows2022 && x86_64`, instead of the old `windows` label.

Addresses #17986.
