### PR TITLE
Fix VS 2026 Build Tools bootstrapper URL; pin to 18.7.3

### DIFF
--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -79,8 +79,22 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
 # required Windows 10 SDK, as chocolatey doesn't seem to provide the versions we need.
 #
 
+# Install a pinned release of the VS 2026 Build Tools (18.7.3). Fixed-version
+# bootstrapper URLs for other releases are published at:
+#
+#   https://learn.microsoft.com/en-us/visualstudio/releases/2026/release-history
+#
+# Note that VS 2026 replaced the versioned 'vs/<version>/release' aka.ms URLs
+# with channel-based URLs (e.g. 'vs/stable/vs_buildtools.exe') that always
+# track the latest release; use a fixed-version bootstrapper to stay pinned.
+# Beware that unknown aka.ms links silently redirect to a Bing HTML page,
+# which fails later with 'The system cannot execute the specified program.'
+#
+# Keep this pinned version in sync with docker/jenkins/Dockerfile.windows.
+$VsBuildToolsUrl = 'https://download.visualstudio.microsoft.com/download/pr/4037ccca-d103-412b-a678-bc0aa164315e/07b09afd416dc05c781f171c881c23e42907eeb8d812fa1d2993dffb9323c869/vs_BuildTools.exe'
+
 # Download the Build Tools bootstrapper.
-Invoke-DownloadFile https://aka.ms/vs/18/release/vs_buildtools.exe vs_buildtools.exe
+Invoke-DownloadFile $VsBuildToolsUrl vs_buildtools.exe
 
 # Install Build Tools. For whatever reason, this fails when we try to install
 # into C:/Program Files (x86), so just use the "regular" C:/Program Files.

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -30,8 +30,20 @@ WORKDIR "C:/BuildTools"
 # required Windows 10 SDK, as chocolatey doesn't seem to provide the versions we need.
 #
 
+# Install a pinned release of the VS 2026 Build Tools (18.7.3). Fixed-version
+# bootstrapper URLs for other releases are published at:
+#
+#   https://learn.microsoft.com/en-us/visualstudio/releases/2026/release-history
+#
+# Note that VS 2026 replaced the versioned 'vs/<version>/release' aka.ms URLs
+# with channel-based URLs (e.g. 'vs/stable/vs_buildtools.exe') that always
+# track the latest release; use a fixed-version bootstrapper to stay pinned.
+# Beware that unknown aka.ms links silently redirect to a Bing HTML page,
+# which fails later with 'The system cannot execute the specified program.'
+ARG VS_BUILDTOOLS_URL=https://download.visualstudio.microsoft.com/download/pr/4037ccca-d103-412b-a678-bc0aa164315e/07b09afd416dc05c781f171c881c23e42907eeb8d812fa1d2993dffb9323c869/vs_BuildTools.exe
+
 # Download the Build Tools bootstrapper.
-RUN curl -SL --output vs_buildtools.exe https://aka.ms/vs/18/release/vs_buildtools.exe
+RUN curl -SL --output vs_buildtools.exe %VS_BUILDTOOLS_URL%
 
 #
 # Install Build Tools. For whatever reason, this fails when we try to install


### PR DESCRIPTION
## Problem

The Windows docker image build fails at the Visual Studio Build Tools installation step:

```
Step 7/41 : RUN start /w vs_buildtools.exe --quiet --wait --norestart --nocache ...
The system cannot execute the specified program.
```

## Diagnosis

VS 2026 replaced the versioned `aka.ms/vs/<version>/release/...` bootstrapper URLs with channel-based URLs (e.g. `aka.ms/vs/stable/...`), so `https://aka.ms/vs/18/release/vs_buildtools.exe` was never a valid link. Unknown aka.ms short links silently redirect to a Bing search page, so `curl -L` saved a ~65 KB HTML page as `vs_buildtools.exe`, which then failed to execute.

## Fix

Point both `docker/jenkins/Dockerfile.windows` and `dependencies/windows/Install-RStudio-Prereqs.ps1` at the fixed-version VS 2026 Build Tools 18.7.3 bootstrapper, published on the [VS 2026 release history page](https://learn.microsoft.com/en-us/visualstudio/releases/2026/release-history). Using a fixed-version bootstrapper (rather than the evergreen `vs/stable` link) pins installs to a specific release, so a future image rebuild cannot silently pick up a newer VS release or MSVC toolset. In the Dockerfile the URL is an `ARG` so it can be bumped in one place or overridden with `--build-arg`.

Verified the pinned URL downloads a validly Microsoft-signed binary reporting ProductVersion 18.7.3 / FileVersion 18.7.11925.98, matching the build number in the release table.

No NEWS.md entry: build-infrastructure fix for the in-development VS 2026 toolchain migration (#18190).