### PR TITLE
skip package source recording for url installs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - ([#18174](https://github.com/rstudio/rstudio/issues/18174)): Fixed an error when viewing an object from the Object Explorer with the French user interface language enabled.
+- ([#18198](https://github.com/rstudio/rstudio/issues/18198)): Fixed tar errors and warnings printed to the console after installing a package from a URL with `install.packages(..., repos = NULL)`.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -2413,6 +2413,11 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 
 .rs.addFunction("readPackageDescription", function(packagePath)
 {
+   # Fail early for non-file inputs (e.g. URLs); the archive readers below
+   # shell out to tar / unzip, which emit noisy errors for such paths.
+   if (!file.exists(packagePath))
+      stop(sprintf("no package file exists at path '%s'", packagePath))
+
    info <- file.info(packagePath, extra_cols = FALSE)
    if (identical(info$isdir, TRUE))
       .rs.readPackageDescriptionFromDirectory(packagePath)

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -2384,7 +2384,15 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
 
          # Record the package source. Note that we need to resolve the path
          # to the newly-installed package post-hoc from the provided path.
-         shouldRecord <- is.character(pkgs) && length(pkgs) == 1L
+         #
+         # Skip URL inputs: install.packages() accepts them when 'repos' is
+         # NULL, but downloads to a private temporary file, so there is no
+         # local archive we can read a DESCRIPTION from after the fact.
+         # https://github.com/rstudio/rstudio/issues/18198
+         shouldRecord <-
+            is.character(pkgs) &&
+            length(pkgs) == 1L &&
+            !grepl("^(?:file|ftp|https?)://", pkgs)
          if (shouldRecord)
          {
             pkgDesc <- tryCatch(

--- a/src/cpp/tests/testthat/test-install-packages.R
+++ b/src/cpp/tests/testthat/test-install-packages.R
@@ -54,6 +54,35 @@ test_that("packages can be installed", {
 
 })
 
+test_that(".rs.readPackageDescription fails cleanly for URL inputs", {
+
+   # Previously a URL was handed straight to the archive reader, which
+   # shelled out to 'tar -tf <URL>' and sprayed tar errors and warnings
+   # into the console. https://github.com/rstudio/rstudio/issues/18198
+   url <- "https://cloud.r-project.org/src/contrib/RECA_1.7.1.tar.gz"
+   expect_no_warning(expect_error(.rs.readPackageDescription(url)))
+
+})
+
+test_that("install hook stays quiet for URL installs with repos = NULL", {
+
+   # https://github.com/rstudio/rstudio/issues/18198
+   skip_on_os("windows")  # source install; no toolchain guarantee in CI
+
+   lib <- tempfile("library-")
+   dir.create(lib)
+   on.exit(unlink(lib, recursive = TRUE), add = TRUE)
+
+   # A small pure-R package with no dependencies; CRAN archive URLs are stable.
+   url <- "https://cloud.r-project.org/src/contrib/Archive/RECA/RECA_1.6.tar.gz"
+   expect_no_warning(
+      install.packages(url, lib = lib, repos = NULL, type = "source", quiet = TRUE)
+   )
+
+   expect_true(file.exists(file.path(lib, "RECA", "DESCRIPTION")))
+
+})
+
 test_that(".rs.installPackagesWhichDeps maps the 'dependencies' argument correctly", {
 
    hard <- c("Depends", "Imports", "LinkingTo")


### PR DESCRIPTION
Fixes #18198.

## Problem

`install.packages()` accepts URLs when `repos = NULL`, downloading them to a private temporary file before installing. The post-install source-recording hook (added in #16112) handed the user's original `pkgs` argument -- the URL -- to `.rs.readPackageDescription()`, which shelled out to `tar -tf '<URL>'`. The install itself succeeded, but tar errors and three warnings were printed to the console afterwards.

## Fix

- Skip post-install source recording when the installed "local" package is a URL. There is no local archive left to read a DESCRIPTION from (and `.rs.recordPackageSourceImpl()` could not record a `local::` remote for a URL anyway, since it calls `normalizePath(pkgSrc, mustWork = TRUE)`).
- Make `.rs.readPackageDescription()` fail early (a plain R error, caught by all existing callers) when the given path does not exist on disk, so no caller can end up invoking `tar` / `unzip` on a non-file input. All existing call sites either check `file.exists()` first or wrap the call in `tryCatch()`.

## Tests

Two new testthat cases in `test-install-packages.R`:

- `.rs.readPackageDescription()` errors cleanly (no warnings) for a URL input.
- An end-to-end `install.packages(<URL>, repos = NULL)` install completes with no warnings and the package is installed.

Both fail against the previous sources (2 failures, 4 warnings from the leaked tar invocations) and pass with this change; the full `install-packages` file passes 42/42.