### PR TITLE
use project-relative path when previewing quarto documents

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 ### Fixed
 - ([#18174](https://github.com/rstudio/rstudio/issues/18174)): Fixed an error when viewing an object from the Object Explorer with the French user interface language enabled.
 - ([#18198](https://github.com/rstudio/rstudio/issues/18198)): Fixed tar errors and warnings printed to the console after installing a package from a URL with `install.packages(..., repos = NULL)`.
+- ([#18197](https://github.com/rstudio/rstudio/issues/18197)): Fixed an issue where the Render button failed to render a Quarto document living within a sub-directory of a Quarto project.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/cpp/session/modules/quarto/SessionQuartoPreview.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoPreview.cpp
@@ -183,11 +183,13 @@ protected:
             LOG_ERROR(error);
       }
 
-      // preview target file
+      // preview target file, as a path relative to the working directory
+      // the job runs in (see previewDir())
       std::vector<std::string> args = { isShinyDoc ? "serve" : "preview" };
       if (!previewTarget_.isDirectory())
       {
-         args.push_back(string_utils::utf8ToSystem(previewTarget_.getFilename()));
+         std::string targetPath = previewTargetPath(previewTarget_, previewDir());
+         args.push_back(string_utils::utf8ToSystem(targetPath));
 
          if (!isShinyDoc)
          {
@@ -273,7 +275,7 @@ private:
 
    core::FilePath previewDir()
    {
-     return previewTarget_.isDirectory() ? previewTarget_ :  previewTarget_.getParent();
+      return previewWorkingDir(previewTarget_, configFile_);
    }
 
    virtual void onStdErr(const std::string& output)
@@ -713,6 +715,30 @@ void onResume(const Settings&)
 
 } // anonymous namespace
 
+
+core::FilePath previewWorkingDir(const core::FilePath& previewTarget,
+                                 const core::FilePath& projectConfigFile)
+{
+   // whole-project previews target the project directory itself
+   if (previewTarget.isDirectory())
+      return previewTarget;
+
+   // for files within a Quarto project, run from the project root, as
+   // 'quarto preview' can fail to resolve paths relative to a project
+   // sub-directory (https://github.com/rstudio/rstudio/issues/18197)
+   if (!projectConfigFile.isEmpty())
+      return projectConfigFile.getParent();
+
+   return previewTarget.getParent();
+}
+
+std::string previewTargetPath(const core::FilePath& previewTarget,
+                              const core::FilePath& workingDir)
+{
+   return previewTarget.isWithin(workingDir)
+      ? previewTarget.getRelativePath(workingDir)
+      : previewTarget.getAbsolutePath();
+}
 
 bool projectConfigChanged(const FilePath& previewTarget,
                           const FilePath& priorConfigFile,

--- a/src/cpp/session/modules/quarto/SessionQuartoPreview.hpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoPreview.hpp
@@ -49,6 +49,19 @@ bool projectConfigChanged(const core::FilePath& previewTarget,
                           const std::string& priorConfigContents,
                           bool priorConfigCaptured);
 
+// Compute the working directory for a 'quarto preview' / 'quarto serve' job.
+// For files within a Quarto project (identified by the governing project config
+// file) the job runs from the project root, as 'quarto preview' can fail to
+// resolve paths relative to a project sub-directory. See
+// https://github.com/rstudio/rstudio/issues/18197.
+core::FilePath previewWorkingDir(const core::FilePath& previewTarget,
+                                 const core::FilePath& projectConfigFile);
+
+// Compute the preview target path to pass on the 'quarto preview' command line,
+// relative to the working directory the job runs in.
+std::string previewTargetPath(const core::FilePath& previewTarget,
+                              const core::FilePath& workingDir);
+
 } // namespace preview
 } // namespace quarto
 } // namespace modules

--- a/src/cpp/session/modules/quarto/SessionQuartoTests.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoTests.cpp
@@ -244,6 +244,82 @@ TEST_F(PreviewConfigChange, UnreadableConfigIsChanged)
    EXPECT_TRUE(changed(quartoYml, "project:\n  type: default\n"));
 }
 
+// Tests for the working directory and target path used to launch a
+// 'quarto preview' job. Files within a Quarto project are previewed from the
+// project root with a project-relative path, as 'quarto preview' can fail to
+// resolve paths relative to a project sub-directory. See
+// https://github.com/rstudio/rstudio/issues/18197.
+class PreviewWorkingDir : public ::testing::Test
+{
+protected:
+   void SetUp() override
+   {
+      FilePath::tempFilePath(projectDir_);
+      projectDir_.ensureDirectory();
+   }
+
+   void TearDown() override
+   {
+      projectDir_.removeIfExists();
+   }
+
+   FilePath writeFile(const std::string& relativePath)
+   {
+      FilePath file = projectDir_.completeChildPath(relativePath);
+      file.getParent().ensureDirectory();
+      writeStringToFile(file, "---\ntitle: Test\n---\n");
+      return file;
+   }
+
+   FilePath projectDir_;
+};
+
+TEST_F(PreviewWorkingDir, FileInProjectSubdirectoryRunsFromProjectRoot)
+{
+   FilePath quartoYml = writeFile("_quarto.yml");
+   FilePath previewTarget = writeFile("labs/doc.qmd");
+
+   FilePath workingDir = modules::quarto::preview::previewWorkingDir(previewTarget, quartoYml);
+   EXPECT_EQ(workingDir, projectDir_);
+   EXPECT_EQ(modules::quarto::preview::previewTargetPath(previewTarget, workingDir), "labs/doc.qmd");
+}
+
+TEST_F(PreviewWorkingDir, FileAtProjectRootRunsFromProjectRoot)
+{
+   FilePath quartoYml = writeFile("_quarto.yml");
+   FilePath previewTarget = writeFile("doc.qmd");
+
+   FilePath workingDir = modules::quarto::preview::previewWorkingDir(previewTarget, quartoYml);
+   EXPECT_EQ(workingDir, projectDir_);
+   EXPECT_EQ(modules::quarto::preview::previewTargetPath(previewTarget, workingDir), "doc.qmd");
+}
+
+TEST_F(PreviewWorkingDir, FileOutsideProjectRunsFromParentDirectory)
+{
+   FilePath previewTarget = writeFile("labs/doc.qmd");
+
+   FilePath workingDir = modules::quarto::preview::previewWorkingDir(previewTarget, FilePath());
+   EXPECT_EQ(workingDir, previewTarget.getParent());
+   EXPECT_EQ(modules::quarto::preview::previewTargetPath(previewTarget, workingDir), "doc.qmd");
+}
+
+TEST_F(PreviewWorkingDir, DirectoryTargetRunsFromItself)
+{
+   FilePath quartoYml = writeFile("_quarto.yml");
+
+   FilePath workingDir = modules::quarto::preview::previewWorkingDir(projectDir_, quartoYml);
+   EXPECT_EQ(workingDir, projectDir_);
+}
+
+TEST_F(PreviewWorkingDir, TargetOutsideWorkingDirFallsBackToAbsolutePath)
+{
+   FilePath previewTarget = writeFile("doc.qmd");
+   FilePath unrelatedDir = projectDir_.completeChildPath("elsewhere");
+
+   EXPECT_EQ(modules::quarto::preview::previewTargetPath(previewTarget, unrelatedDir),
+             previewTarget.getAbsolutePath());
+}
+
 } // namespace tests
 } // namespace quarto
 } // namespace session


### PR DESCRIPTION
## Summary

Clicking the Render button on a Quarto document living within a sub-directory of a Quarto project failed with:

```
Error in rmarkdown:::abs_path(input) :
  The file 'claudetest.qmd' does not exist.
```

RStudio launched the preview job as `quarto preview <filename>` with the file's parent directory as the working directory. Newer versions of Quarto (reproduced with 1.9.38) fail to resolve a bare file name when previewing a file in a project sub-directory: the preview render step resolves the relative input against the project root rather than the process working directory. (Plain `quarto render <filename>` from the sub-directory works fine; the mis-resolution is specific to `quarto preview`.)

The fix runs the preview job from the Quarto project root (already known via the captured project config file) and passes a project-relative path -- i.e. `quarto preview labs/doc.qmd` from the project root, which is the same invocation that works from a terminal. Files not belonging to a Quarto project keep the previous behavior (file's parent directory as cwd), and a defensive fallback passes the absolute path if the target does not live under the computed working directory.

Note that this leaves chunk-evaluation working-directory semantics untouched: Quarto governs the execution directory itself (`execute-dir`), and RStudio's knit-directory preference does not flow into the `quarto preview` code path.

## Testing

- Reproduced the failure with quarto 1.9.38: `quarto preview doc.qmd --to html --no-watch-inputs --no-browse` run from a website project sub-directory fails with the error above; the same preview invoked from the project root with a project-relative path succeeds.
- Added gtest coverage for the new `previewWorkingDir()` / `previewTargetPath()` helpers (project sub-directory, project root, non-project file, whole-project directory target, and the absolute-path fallback).
- `rstudio-tests --scope rsession` passes (365 tests).

Fixes #18197.