### PR TITLE
skip empty arguments when scanning for package-library mutations

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -126,6 +126,11 @@
    # recurse into arguments to catch nested calls (e.g. lapply(x, install.packages))
    for (i in seq_along(expr))
    {
+      # skip empty arguments (e.g. the trailing argument in 'mtcars[1, ]');
+      # binding the empty symbol to a variable and evaluating it would error
+      if (identical(expr[[i]], quote(expr = )))
+         next
+
       part <- expr[[i]]
       if (is.call(part) && .rs.exprMutatesPackageLibrary(part))
          return(TRUE)

--- a/src/cpp/tests/testthat/test-packages.R
+++ b/src/cpp/tests/testthat/test-packages.R
@@ -75,6 +75,12 @@ test_that(".rs.isPackageManagementCall handles multi-statement and nested calls"
    expect_false(.rs.isPackageManagementCall("x <- 1; print(remove(y)); z <- 3"))
 })
 
+test_that(".rs.isPackageManagementCall tolerates empty arguments", {
+   expect_false(.rs.isPackageManagementCall("View(mtcars[1, ])"))
+   expect_false(.rs.isPackageManagementCall("mtcars[, 1]"))
+   expect_true(.rs.isPackageManagementCall("f(x[1, ], renv::update())"))
+})
+
 test_that(".rs.isPackageManagementCall tolerates unparseable input", {
    expect_false(.rs.isPackageManagementCall(""))
    expect_false(.rs.isPackageManagementCall("install.packages("))


### PR DESCRIPTION
Typing input containing an empty call argument at the console, e.g.

    View(mtcars[1, ])

produced an error at the console prompt:

    Error in .rs.exprMutatesPackageLibrary(part) :
      argument "part" is missing, with no default

`.rs.exprMutatesPackageLibrary()` (added in #18095) recurses into a call's arguments, but an empty argument is the empty symbol -- binding it to a variable and then evaluating that variable signals a missing-argument error. This PR skips empty arguments during recursion, using the same `identical(x, quote(expr = ))` idiom used elsewhere in the codebase, and adds regression tests.

Since this fixes a bug introduced by the unreleased #18095, no NEWS.md entry is included.