### PR TITLE
Keep Copilot language server token cache out of the OS keychain in e2e runs

### DIFF
--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -491,6 +491,15 @@ async function launchRStudioOnce(existingConfigRoot?: string): Promise<DesktopSe
       // prevents unload; the interactive path shows a native "Leave page?"
       // dialog that automation cannot dismiss (rstudio#17439).
       RSTUDIO_DESKTOP_IGNORE_BEFOREUNLOAD: '1',
+      // The bundled Copilot language server stores the master key for its
+      // encrypted OAuth token cache in the OS keychain (@github/keytar,
+      // service "copilot-language-server", account "oauth-token-key"). Under
+      // the redirected HOME, macOS finds no login keychain and blocks the
+      // run with a "Keychain Not Found" system modal; on Windows the key
+      // would land in the host's real Credential Manager, leaking test state
+      // out of the sandbox. Disable the encryption path so the token cache
+      // stays inside the sandboxed user-home (#18205).
+      GITHUB_COPILOT_AUTH_TOKEN_ENCRYPTION: 'false',
       // Dev mode runs `npm run start` (electron-forge), whose webpack dev-server
       // and logger otherwise bind the fixed defaults 3000 / 9000. Derive both
       // from the per-worker CDP port so concurrent workers -- and a developer's

--- a/e2e/rstudio/fixtures/server.fixture.ts
+++ b/e2e/rstudio/fixtures/server.fixture.ts
@@ -113,6 +113,11 @@ async function spawnSandboxedRserver(): Promise<SpawnedServer | null> {
     RSTUDIO_PROJECT_ROOT: process.env.RSTUDIO_PROJECT_ROOT || REPO_ROOT,
     RSTUDIO_CONFIG_HOME: configHome,
     RSTUDIO_DATA_HOME: dataHome,
+    // Keep the Copilot language server's OAuth token cache out of the OS
+    // keychain -- under the redirected HOME there is no keychain to write to
+    // on macOS. Inherited by every rsession this rserver spawns. Mirrors
+    // desktop.fixture.ts, which documents the full failure mode (#18205).
+    GITHUB_COPILOT_AUTH_TOKEN_ENCRYPTION: 'false',
   };
 
   const args = [

--- a/e2e/rstudio/fixtures/server.fixture.ts
+++ b/e2e/rstudio/fixtures/server.fixture.ts
@@ -113,11 +113,13 @@ async function spawnSandboxedRserver(): Promise<SpawnedServer | null> {
     RSTUDIO_PROJECT_ROOT: process.env.RSTUDIO_PROJECT_ROOT || REPO_ROOT,
     RSTUDIO_CONFIG_HOME: configHome,
     RSTUDIO_DATA_HOME: dataHome,
-    // Keep the Copilot language server's OAuth token cache out of the OS
-    // keychain -- under the redirected HOME there is no keychain to write to
-    // on macOS. Inherited by every rsession this rserver spawns. Mirrors
-    // desktop.fixture.ts, which documents the full failure mode (#18205).
-    GITHUB_COPILOT_AUTH_TOKEN_ENCRYPTION: 'false',
+    // No GITHUB_COPILOT_AUTH_TOKEN_ENCRYPTION here, unlike desktop.fixture.ts
+    // (#18205): rserver builds each rsession's environment from scratch
+    // (runProcess in core/system/PosixSystem.cpp), so arbitrary vars set here
+    // never reach the rsession that hosts the Copilot language server. The
+    // macOS "Keychain Not Found" modal also cannot occur in server mode --
+    // rsession's HOME comes from the passwd db, not this redirect, so the
+    // real login keychain is always found.
   };
 
   const args = [


### PR DESCRIPTION
### Intent

Fixes #18205.

Running the desktop e2e suite on macOS pops a blocking system modal — **Keychain Not Found: A keychain cannot be found to store "oauth-token-key."** — whenever the GitHub Copilot language server signs in. The Copilot LS bundled with RStudio stores the master key for its encrypted OAuth token cache in the OS keychain via `@github/keytar`, and under the e2e sandbox's redirected `HOME` macOS has no login keychain to write to. On Windows the same write would land in the host's real Credential Manager, leaking test state out of the sandbox.

<img width="480" height="245" alt="keychain-not-found" src="https://github.com/user-attachments/assets/5acf4e6c-344a-4796-b259-1fd3888d1459" />


### Approach

`desktop.fixture.ts` now exports `GITHUB_COPILOT_AUTH_TOKEN_ENCRYPTION=false` in the RStudio launch environment. This is the Copilot language server's environment override for its `internal.auth.tokenEncryption` setting; with encryption disabled, the token cache stays inside the sandboxed user-home and nothing touches the OS keychain.

`server.fixture.ts` gets a comment (no env var) documenting why the desktop approach doesn't apply there: rserver builds each rsession's environment from scratch (`runProcess` in `core/system/PosixSystem.cpp`), so the var would never reach the rsession hosting the Copilot LS — and the failure mode cannot occur in server mode anyway, because rsession's `HOME` comes from the passwd db and the real login keychain is always found.

### Automated Tests

This PR changes the e2e harness itself. Verified locally on macOS by running `tests/panes/editor/code_suggestions.test.ts` (desktop project): 26 passed, 2 skipped, no keychain modal. `npm run typecheck` passes in `e2e/rstudio`.

### QA Notes

Test-harness-only change; no product behavior affected. Reproduction of the original problem: on macOS with `~/.config/github-copilot` credentials present on the host, run any desktop `@ai` spec without this change and the keychain modal appears during Copilot sign-in.

### Documentation

None needed — no user-facing change.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` (n/a — test harness only)
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility) (n/a)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
