### PR TITLE
fix waitForSessionRestart marker false-pass during session resume

### DIFF
--- a/e2e/rstudio/utils/project.ts
+++ b/e2e/rstudio/utils/project.ts
@@ -93,8 +93,8 @@ export async function restartSessionWithSentinel(page: Page): Promise<void> {
  * unavailable; this best-effort sequence waits for the page to load, the
  * console input to reappear, and R to confirm idle by echoing a unique marker.
  *
- * Logs a warning and returns if R does not confirm idle within three attempts;
- * the caller decides how to proceed.
+ * Logs a warning and returns if R does not confirm idle within the retry
+ * budget; the caller decides how to proceed.
  *
  * Prefer restartSessionWithSentinel when the test is the one invoking
  * .rs.api.restartSession -- the sentinel-based confirmation avoids the
@@ -103,13 +103,30 @@ export async function restartSessionWithSentinel(page: Page): Promise<void> {
 export async function waitForSessionRestart(page: Page): Promise<void> {
   await waitForPostRestartReady(page);
 
-  for (let attempt = 0; attempt < 3; attempt++) {
+  // The marker is typed in two halves so the joined string can only appear in
+  // the console as cat() output: the submitted command is echoed into the
+  // console output too, and a whole-marker cat() false-passes off its own echo
+  // when the input never reaches R (e.g. "jsonrpc error 1 (Unable to connect
+  // to service)" while a suspended session is still relaunching).
+  //
+  // One timestamp for the whole call: rserver holds an undeliverable console
+  // input for up to rsession-proxy-max-wait-secs (default 30s) before failing
+  // it, so an early attempt's cat() may only run -- and print -- while a later
+  // attempt is checking. Any attempt's output confirms readiness.
+  const stamp = Date.now();
+  const marker = `[pw:session-restart-ready ${stamp}]`;
+  const command = `cat("[pw:session-restart-", "ready ${stamp}]", sep = "")`;
+
+  // The retry budget must cover a suspended session's full relaunch, which can
+  // exceed 30s when the first reconnect RPC races the still-exiting session
+  // (its failed relaunch poisons rserver's pending-launch entry until an RPC
+  // error clears it).
+  for (let attempt = 0; attempt < 12; attempt++) {
     try {
-      const marker = `[pw:session-restart-ready ${Date.now()}]`;
       await page.locator(CONSOLE_TAB).click();
       await page.locator(CONSOLE_INPUT).click({ force: true });
       await sleep(200);
-      await page.locator(CONSOLE_INPUT).pressSequentially(`cat("${marker}")`);
+      await page.locator(CONSOLE_INPUT).pressSequentially(command);
       await page.locator(CONSOLE_INPUT).press('Enter');
       await sleep(1500);
       const output = await page.locator(CONSOLE_OUTPUT).innerText();
@@ -119,7 +136,7 @@ export async function waitForSessionRestart(page: Page): Promise<void> {
     }
     await sleep(2000);
   }
-  console.warn('waitForSessionRestart: R session did not confirm idle after 3 attempts');
+  console.warn('waitForSessionRestart: R session did not confirm idle after 12 attempts');
 }
 
 /**


### PR DESCRIPTION
## Summary

The server-linux `session_suspend.test.ts` failure on PR #18203 (run 29273786621) traced back to a false-pass in `waitForSessionRestart`: the helper typed `cat("<marker>")` and checked `output.includes(marker)`, but the submitted command is echoed into the console output, so the check passed off the echo even when the console input never reached R. In the failing run, the input came back as `jsonrpc error 1 (Unable to connect to service)` -- rserver's ConnectionError envelope while the suspended session was still relaunching -- yet the helper declared the session ready on its first attempt. The test's next `executeInConsole({ wait: true })` input was swallowed the same way, so `promptCount` never advanced and the 30s wait timed out.

Changes:

- Split the marker across two `cat()` arguments (`cat("[pw:session-restart-", "ready <ts>]", sep = "")`) so the joined marker can only appear as real R output, never in the command echo. A failed delivery now correctly falls through to the retry loop.
- Use one timestamp for the whole call: rserver holds an undeliverable console input for up to `rsession-proxy-max-wait-secs` (default 30s) before failing it, so an early attempt's `cat()` may only execute during a later attempt's check -- any attempt's output confirms readiness.
- Widen the retry budget from 3 attempts (~11s) to 12 (~45s): in the failing trace the session was unreachable for ~38s because the first reconnect RPC's relaunch raced the still-exiting session and its pending-launch entry suppressed relaunch attempts by subsequent RPCs until an RPC error cleared it (`SessionManager::launchSession` returns early for pending launches < 1 minute old).

Test-infra only; no NEWS entry.

## Testing

- `npx tsc --noEmit` in `e2e/rstudio` passes.
- Verified against the failing run's Playwright trace: both failed inputs returned rserver's JSON-RPC error envelope over HTTP 200, and the console screenshot shows the echoed commands that satisfied the old `includes()` check.