### PR TITLE
clear pending session launches when the launched process dies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 ### Fixed
 - ([#18174](https://github.com/rstudio/rstudio/issues/18174)): Fixed an error when viewing an object from the Object Explorer with the French user interface language enabled.
 - ([#18198](https://github.com/rstudio/rstudio/issues/18198)): Fixed tar errors and warnings printed to the console after installing a package from a URL with `install.packages(..., repos = NULL)`.
+- ([#18208](https://github.com/rstudio/rstudio/issues/18208)): Fixed an issue in RStudio Server where requests could fail with "Unable to connect to service" for 30 seconds or more while a suspended session was relaunching.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/cpp/server/CMakeLists.txt
+++ b/src/cpp/server/CMakeLists.txt
@@ -301,7 +301,8 @@ if (RSTUDIO_UNIT_TESTS_ENABLED)
      DBActiveSessionStorageTests.cpp
      ServerCheckConfigTests.cpp
      ServerEnvVarsTests.cpp
-     ServerFormatUtilsTests.cpp)
+     ServerFormatUtilsTests.cpp
+     ServerSessionManagerTests.cpp)
 
   list(APPEND SERVER_SOURCE_FILES ${SERVER_TEST_FILES})
 

--- a/src/cpp/server/ServerSessionManagerTests.cpp
+++ b/src/cpp/server/ServerSessionManagerTests.cpp
@@ -1,0 +1,127 @@
+/*
+ * ServerSessionManagerTests.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <server/session/ServerSessionManager.hpp>
+
+#include <boost/asio/io_context.hpp>
+
+#include <core/http/Request.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace server {
+namespace tests {
+
+namespace {
+
+// installs a launch function that only counts invocations, so launchSession
+// exercises the real pending-launch bookkeeping without spawning processes
+int s_launchCount = 0;
+
+Error countingLaunchFunction(boost::asio::io_context&,
+                             const r_util::SessionLaunchProfile&,
+                             const http::Request&,
+                             const http::ResponseHandler&,
+                             const http::ErrorHandler&)
+{
+   s_launchCount++;
+   return Success();
+}
+
+bool attemptLaunch(const r_util::SessionContext& context)
+{
+   boost::asio::io_context ioContext;
+   http::Request request;
+   bool launched = false;
+
+   Error error = sessionManager().launchSession(
+            ioContext, context, request, launched, core::system::Options());
+   EXPECT_FALSE(error);
+
+   return launched;
+}
+
+} // anonymous namespace
+
+TEST(SessionManagerTest, PendingLaunchSuppressesRelaunch)
+{
+   sessionManager().setSessionLaunchFunction(countingLaunchFunction);
+   s_launchCount = 0;
+
+   r_util::SessionContext context("pending-launch-dedupe-user");
+   EXPECT_TRUE(attemptLaunch(context));
+   EXPECT_EQ(1, s_launchCount);
+
+   // a second request while the launch is pending piggybacks on it
+   EXPECT_FALSE(attemptLaunch(context));
+   EXPECT_EQ(1, s_launchCount);
+
+   // once the connection is made the pending launch is removed, so a
+   // later request (e.g. after the session exits) launches again
+   sessionManager().removePendingLaunch(context);
+   EXPECT_TRUE(attemptLaunch(context));
+   EXPECT_EQ(2, s_launchCount);
+
+   sessionManager().removePendingLaunch(context);
+}
+
+TEST(SessionManagerTest, DeadLaunchProcessClearsPendingLaunch)
+{
+   sessionManager().setSessionLaunchFunction(countingLaunchFunction);
+   s_launchCount = 0;
+
+   r_util::SessionContext context("pending-launch-dead-process-user");
+   EXPECT_TRUE(attemptLaunch(context));
+   EXPECT_EQ(1, s_launchCount);
+   sessionManager().notePendingLaunchPid(context, 1234);
+
+   // an exit notification for an unrelated process must not clear the
+   // pending launch
+   sessionManager().removePendingLaunchForPid(context, 9999, 0);
+   EXPECT_FALSE(attemptLaunch(context));
+   EXPECT_EQ(1, s_launchCount);
+
+   // the launched process dying clears the pending launch, so the next
+   // recovery attempt can relaunch instead of stalling behind it
+   sessionManager().removePendingLaunchForPid(context, 1234, 1);
+   EXPECT_TRUE(attemptLaunch(context));
+   EXPECT_EQ(2, s_launchCount);
+
+   sessionManager().removePendingLaunch(context);
+}
+
+TEST(SessionManagerTest, ExitNotificationWithoutRecordedPidIsIgnored)
+{
+   sessionManager().setSessionLaunchFunction(countingLaunchFunction);
+   s_launchCount = 0;
+
+   // a pending launch whose pid was never recorded (custom session
+   // launchers) keeps the previous behavior: only age or an explicit
+   // removal clears it
+   r_util::SessionContext context("pending-launch-no-pid-user");
+   EXPECT_TRUE(attemptLaunch(context));
+   sessionManager().removePendingLaunchForPid(context, 1234, 1);
+   EXPECT_FALSE(attemptLaunch(context));
+   EXPECT_EQ(1, s_launchCount);
+
+   sessionManager().removePendingLaunch(context);
+}
+
+} // namespace tests
+} // namespace server
+} // namespace rstudio

--- a/src/cpp/server/include/server/session/ServerSessionManager.hpp
+++ b/src/cpp/server/include/server/session/ServerSessionManager.hpp
@@ -72,6 +72,16 @@ public:
 
    void removePendingSessionLaunch(const std::string& username, const std::string& sessionId, const bool success = true, const std::string& errorMsg = std::string());
 
+   // associate the launched process with its pending launch so a launch whose
+   // process dies before a client connection can be detected and cleared
+   // (rather than suppressing relaunch attempts until it ages out)
+   void notePendingLaunchPid(const core::r_util::SessionContext& context, PidType pid);
+
+   // remove the pending launch if it still belongs to the given (now exited)
+   // process; a no-op when the context has no pending launch or the pending
+   // launch was recorded for a different process
+   void removePendingLaunchForPid(const core::r_util::SessionContext& context, PidType pid, int exitStatus);
+
    // set a custom session launcher
    typedef boost::function<core::Error(
                            boost::asio::io_context&,
@@ -104,10 +114,16 @@ private:
    int cleanStalePendingLaunches();
 
 private:
-   // pending launches
+   // pending launches; pid is -1 until the launched process is known (custom
+   // session launchers may never report one)
+   struct PendingLaunch
+   {
+      boost::posix_time::ptime launchTime;
+      PidType pid = -1;
+   };
+
    boost::mutex launchesMutex_;
-   typedef std::map<core::r_util::SessionContext,
-                    boost::posix_time::ptime> LaunchMap;
+   typedef std::map<core::r_util::SessionContext, PendingLaunch> LaunchMap;
    LaunchMap pendingLaunches_;
 
    // session launch function

--- a/src/cpp/server/session/ServerSessionManager.cpp
+++ b/src/cpp/server/session/ServerSessionManager.cpp
@@ -19,6 +19,7 @@
 
 #include <shared_core/SafeConvert.hpp>
 
+#include <core/Log.hpp>
 #include <core/SocketRpc.hpp>
 #include <core/system/System.hpp>
 #include <core/system/Process.hpp>
@@ -270,7 +271,7 @@ Error SessionManager::launchSession(boost::asio::io_context& ioContext,
       if (pos != pendingLaunches_.end())
       {
          // if the launch is less than one minute old then return success
-         if ( (pos->second + boost::posix_time::minutes(1))
+         if ( (pos->second.launchTime + boost::posix_time::minutes(1))
                > microsec_clock::universal_time() )
          {
             LOG_DEBUG_MESSAGE("Found existing recent launch < 1 min for: " + context.username + " id: " + context.scope.id());
@@ -290,7 +291,7 @@ Error SessionManager::launchSession(boost::asio::io_context& ioContext,
          }
       }
 
-      pendingLaunches_[context] =  microsec_clock::universal_time();
+      pendingLaunches_[context] = PendingLaunch{ microsec_clock::universal_time() };
 
       numRemoved = cleanStalePendingLaunches();
    }
@@ -414,8 +415,17 @@ Error SessionManager::launchAndTrackSession(
                      " pid: " + safe_convert::numberToString(pid));
    metrics::sessionLaunch(metrics::kEditorRStudio);
 
-   // track it for subsequent reaping
-   processTracker_.addProcess(pid);
+   // record the pid on the pending launch, then track the process for
+   // subsequent reaping. if it dies before a client connection removes the
+   // pending launch (e.g. the launch raced a suspending session's exit), the
+   // exit handler clears the entry so waiting connection retries can relaunch
+   // instead of stalling behind a launch that will never become connectable
+   r_util::SessionContext context = profile.context;
+   notePendingLaunchPid(context, pid);
+   processTracker_.addProcess(pid, [this, context, pid](PidType, int status)
+   {
+      removePendingLaunchForPid(context, pid, status);
+   });
 
    // return success
    return Success();
@@ -443,7 +453,7 @@ void SessionManager::removePendingLaunch(const r_util::SessionContext& context, 
       if (it != pendingLaunches_.cend())
       {
          removed = true;
-         startTime = it->second;
+         startTime = it->second.launchTime;
          pendingLaunches_.erase(context);
       }
    }
@@ -481,7 +491,7 @@ void SessionManager::removePendingSessionLaunch(const std::string& username, con
          if (it->first.username == username && it->first.scope.id() == sessionId)
          {
             removed = true;
-            startTime = it->second;
+            startTime = it->second.launchTime;
             pendingLaunches_.erase(it++);
             break;
          }
@@ -505,6 +515,41 @@ void SessionManager::removePendingSessionLaunch(const std::string& username, con
    }
 }
 
+void SessionManager::notePendingLaunchPid(const r_util::SessionContext& context, PidType pid)
+{
+   LOCK_MUTEX(launchesMutex_)
+   {
+      LaunchMap::iterator it = pendingLaunches_.find(context);
+      if (it != pendingLaunches_.end())
+         it->second.pid = pid;
+   }
+   END_LOCK_MUTEX
+}
+
+void SessionManager::removePendingLaunchForPid(const r_util::SessionContext& context, PidType pid, int exitStatus)
+{
+   bool removed = false;
+   LOCK_MUTEX(launchesMutex_)
+   {
+      // only remove the entry recorded for this pid: a long-lived session's
+      // eventual exit must not clear a newer pending launch for the same
+      // context (its pid differs, or is still unset at -1)
+      LaunchMap::const_iterator it = pendingLaunches_.find(context);
+      if (it != pendingLaunches_.cend() && it->second.pid == pid)
+      {
+         removed = true;
+         pendingLaunches_.erase(it);
+      }
+   }
+   END_LOCK_MUTEX
+
+   if (removed)
+   {
+      WLOGF("Session process {} for user {} (id: {}) exited with status {} before a connection was made; clearing pending launch",
+            pid, context.username, context.scope.id(), exitStatus);
+   }
+}
+
 // Caller should have launchesMutex_. Removes any pendingLaunches that were recorded but where the
 // session never started, or rpcs ended up being handled by another rserver node in the cluster
 int SessionManager::cleanStalePendingLaunches()
@@ -514,7 +559,7 @@ int SessionManager::cleanStalePendingLaunches()
    int numRemoved = 0;
    while (it != pendingLaunches_.cend())
    {
-      if (now > (it->second + boost::posix_time::minutes(3)))
+      if (now > (it->second.launchTime + boost::posix_time::minutes(3)))
       {
          pendingLaunches_.erase(it++);
          numRemoved++;

--- a/src/cpp/server/session/ServerSessionProxy.cpp
+++ b/src/cpp/server/session/ServerSessionProxy.cpp
@@ -23,6 +23,7 @@
 #include <boost/algorithm/string/join.hpp>
 
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/make_shared.hpp>
 
 #include <boost/foreach.hpp>
 #include <boost/thread/mutex.hpp>
@@ -151,7 +152,8 @@ Error launchSessionRecovery(
       boost::shared_ptr<core::http::AsyncConnection> ptrConnection,
       const http::Request& request,
       bool firstAttempt,
-      const r_util::SessionContext& context)
+      const r_util::SessionContext& context,
+      boost::shared_ptr<boost::posix_time::ptime> pNextLaunchAttempt)
 {
    // if this request is marked as requiring an existing
    // session then return session unavailable error
@@ -186,19 +188,28 @@ Error launchSessionRecovery(
       LOG_ERROR(error);
    }
 
-   // attempt to launch the session only if this is the first recovery attempt
+   // attempt to launch the session. this is re-attempted (at most once per
+   // second) on subsequent recovery passes rather than only on the first:
+   // if the launched process dies before a connection is made -- e.g. it
+   // raced a suspending session's exit -- the process tracker clears its
+   // pending launch and a later pass can relaunch, instead of every request
+   // buffered behind the dead launch timing out (#18208). launchSession is
+   // the dedupe point: it no-ops while a recent pending launch is in flight.
+   boost::posix_time::ptime now = boost::posix_time::microsec_clock::universal_time();
+   if (!firstAttempt && now < *pNextLaunchAttempt)
+      return Success();
+   *pNextLaunchAttempt = now + boost::posix_time::seconds(1);
+
    if (firstAttempt)
    {
       LOG_DEBUG_MESSAGE("Launching session for user: " + context.username + (context.scope.isWorkspaces() ? " - workspaces" : " id:" + context.scope.id()) + " for: " + request.debugInfo());
-
-      bool launched;
-
-      core::system::Options environment;
-      return sessionManager().launchSession(ptrConnection->ioContext(), 
-            context, request, launched, environment);
    }
-   else
-      return Success();
+
+   bool launched;
+
+   core::system::Options environment;
+   return sessionManager().launchSession(ptrConnection->ioContext(),
+         context, request, launched, environment);
 }
 
 http::ConnectionRetryProfile sessionRetryProfile(
@@ -209,8 +220,15 @@ http::ConnectionRetryProfile sessionRetryProfile(
    http::ConnectionRetryProfile retryProfile;
    retryProfile.retryInterval = boost::posix_time::milliseconds(25);
    retryProfile.maxWait = boost::posix_time::seconds(options.rsessionProxyMaxWaitSeconds());
+
+   // per-request launch-attempt throttle for launchSessionRecovery (retries
+   // for a connection run sequentially on its strand, so no synchronization
+   // is needed)
+   boost::shared_ptr<boost::posix_time::ptime> pNextLaunchAttempt =
+         boost::make_shared<boost::posix_time::ptime>(boost::posix_time::min_date_time);
+
    retryProfile.recoveryFunction = boost::bind(launchSessionRecovery,
-                                               ptrConnection, _1, _2, context);
+                                               ptrConnection, _1, _2, context, pNextLaunchAttempt);
    return retryProfile;
 }
 


### PR DESCRIPTION
## Summary

rserver already buffers proxied RPCs across a session restart: `sessionRetryProfile` retries the session connection every 25ms for up to `rsession-proxy-max-wait-secs` (default 30s), relaunching the session on the first failed attempt. But that recovery path had a stuck state, diagnosed from the e2e failure on PR #18203:

1. The first post-suspend RPC's relaunch raced the still-exiting suspended session and its process died, leaving a `pendingLaunches_` entry behind.
2. `SessionManager::launchSession` treats any pending launch younger than one minute as in-flight, and `launchSessionRecovery` only attempted a launch on the first recovery pass -- so nothing ever re-attempted the launch. Every request buffered behind the dead launch burned its full 30s wait and failed with `jsonrpc error 1 (Unable to connect to service)`.
3. The stale entry was only cleared when a failing RPC's error handler called `removePendingLaunch`, which is why the next request after the failures relaunched successfully.

Changes:

- `SessionManager` now records the launched pid on the pending-launch entry (`notePendingLaunchPid`), and the default launcher registers a `ChildProcessTracker` exit handler that clears the entry when that process dies before a client connection (`removePendingLaunchForPid`). The removal is pid-matched so a long-lived session's eventual exit cannot clear a newer pending launch for the same context, and pending launches recorded by custom session launchers (no pid) keep the previous age-based behavior.
- `launchSessionRecovery` now re-attempts the launch on subsequent recovery passes (throttled to once per second per request) instead of only the first, so requests already waiting relaunch as soon as the dead launch is cleared. `launchSession`'s pending-entry check remains the dedupe point.

With both pieces, a launch that dies mid-suspend self-heals within about a second instead of stalling every buffered request for 30 seconds.

## Testing

- Added `ServerSessionManagerTests.cpp` covering pending-launch dedupe, pid-matched removal (dead process clears the entry; unrelated pids and unrecorded pids do not).
- Full `rserver-tests` suite passes (39 tests).
- The e2e-side false-pass that let `session_suspend.test.ts` wedge on this window was fixed separately in #18207; the suspend/resume e2e tests exercise this path in CI.

Fixes #18208.