### PR TITLE
upgrade inline math previews to mathjax 4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - ([#18153](https://github.com/rstudio/rstudio/issues/18153)): Added a preference (General > Basic) to disable the "What's New" window that RStudio Desktop shows after updating to a new version.
 - ([#18158](https://github.com/rstudio/rstudio/issues/18158)): On macOS, the Files pane now follows Finder aliases: clicking an alias to a folder navigates to that folder, and clicking an alias to a file opens the file.
 - ([#9924](https://github.com/rstudio/rstudio/issues/9924)): The Files pane now shows a link indicator on symbolic links and macOS Finder aliases, with the link target shown in the icon's tooltip.
+- ([#8715](https://github.com/rstudio/rstudio/issues/8715)): Inline LaTeX / math previews in the source editor and visual editor are now rendered with MathJax 4 (previously MathJax 2.7), adding support for the TeX input extensions introduced in MathJax 3 and later. Rendered R Markdown documents using `mathjax = "local"` continue to use the bundled MathJax 2.7.
 
 ### Fixed
 - ([#18174](https://github.com/rstudio/rstudio/issues/18174)): Fixed an error when viewing an object from the Object Explorer with the French user interface language enabled.
@@ -12,6 +13,7 @@
 
 ### Dependencies
 - Ace 1.43.5
+- MathJax 4.1.3 (inline LaTeX / math previews)
 - Copilot Language Server 1.520.0
 - Electron 41.9.0
 - Node.js 22.22.2 (copilot, Posit Assistant)

--- a/dependencies/.gitignore
+++ b/dependencies/.gitignore
@@ -1,0 +1,2 @@
+mathjax-27/
+mathjax-4/

--- a/dependencies/common/install-mathjax
+++ b/dependencies/common/install-mathjax
@@ -22,20 +22,48 @@ section "Installing Mathjax"
 
 URL="${RSTUDIO_BUILDTOOLS}"
 
-# download and extract mathjax if necessary
-MATHJAX_DIR="${RSTUDIO_TOOLS_ROOT}/mathjax-27"
-if [ -d "$MATHJAX_DIR" ]; then
-   echo "Mathjax already installed at '${MATHJAX_DIR}'"
+MATHJAX4_VERSION="4.1.3"
+
+# MathJax 2.7 is bundled for rendered R Markdown documents (rmarkdown's
+# 'mathjax = "local"' mode); MathJax 4 is bundled for the IDE's inline
+# LaTeX / math previews
+MATHJAX2_DIR="${RSTUDIO_TOOLS_ROOT}/mathjax-27"
+MATHJAX4_DIR="${RSTUDIO_TOOLS_ROOT}/mathjax-4"
+if [ -d "$MATHJAX2_DIR" ] && [ -d "$MATHJAX4_DIR" ]; then
+   echo "Mathjax already installed at '${MATHJAX2_DIR}' and '${MATHJAX4_DIR}'"
    exit 0
 fi
 
 sudo-if-necessary-for "${RSTUDIO_TOOLS_ROOT}" "$@"
 cd "${RSTUDIO_TOOLS_ROOT}"
 
-# NOTE: Unpacks to 'mathjax-27' directory
-MATHJAX=mathjax-2.7.9.zip
-download "${URL}/${MATHJAX}"
-rm -rf "${MATHJAX_DIR}"
-unzip -q "$MATHJAX"
-rm "$MATHJAX"
+# download and extract mathjax 2.7 if necessary
+if [ ! -d "$MATHJAX2_DIR" ]; then
 
+   # NOTE: Unpacks to 'mathjax-27' directory
+   MATHJAX=mathjax-2.7.9.zip
+   download "${URL}/${MATHJAX}"
+   rm -rf "${MATHJAX2_DIR}"
+   unzip -q "$MATHJAX"
+   rm "$MATHJAX"
+
+fi
+
+# download and extract mathjax 4 if necessary
+if [ ! -d "$MATHJAX4_DIR" ]; then
+
+   # NOTE: Unpacks to 'mathjax-4' directory
+   MATHJAX4="mathjax-${MATHJAX4_VERSION}.zip"
+   if download "${URL}/${MATHJAX4}"; then
+      rm -rf "${MATHJAX4_DIR}"
+      unzip -q "$MATHJAX4"
+      rm "$MATHJAX4"
+   else
+      # fall back to assembling the bundle from npm registry tarballs
+      echo "Assembling MathJax 4 bundle from npm registry tarballs..."
+      "$(dirname "${BASH_SOURCE[0]}")/../tools/build-mathjax4" \
+         "${RSTUDIO_TOOLS_ROOT}" \
+         "${MATHJAX4_VERSION}"
+   fi
+
+fi

--- a/dependencies/common/install-mathjax
+++ b/dependencies/common/install-mathjax
@@ -17,7 +17,9 @@
 
 set -e
 
-source "$(dirname "${BASH_SOURCE[0]}")/../tools/rstudio-tools.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "${SCRIPT_DIR}/../tools/rstudio-tools.sh"
 section "Installing Mathjax"
 
 URL="${RSTUDIO_BUILDTOOLS}"
@@ -60,8 +62,10 @@ if [ ! -d "$MATHJAX4_DIR" ]; then
       rm "$MATHJAX4"
    else
       # fall back to assembling the bundle from npm registry tarballs
+      # (a failed download can leave an empty file behind; remove it)
+      rm -f "$MATHJAX4"
       echo "Assembling MathJax 4 bundle from npm registry tarballs..."
-      "$(dirname "${BASH_SOURCE[0]}")/../tools/build-mathjax4" \
+      "${SCRIPT_DIR}/../tools/build-mathjax4" \
          "${RSTUDIO_TOOLS_ROOT}" \
          "${MATHJAX4_VERSION}"
    fi

--- a/dependencies/metadata/general-js.txt
+++ b/dependencies/metadata/general-js.txt
@@ -32,6 +32,22 @@ dependency(MATHJAX
    ATTRIBUTION  "Copyright (c) 2009-2020 The MathJax Consortium"
 )
 
+dependency(MATHJAX4
+   DEPNAME      "MathJax"
+   REPOSITORY   "https://github.com/mathjax/MathJax"
+   VERSION      "4.1.3"
+   LICENSE      "Apache-2.0"
+   ATTRIBUTION  "Copyright (c) 2009-2026 The MathJax Consortium"
+)
+
+dependency(MATHJAX_NEWCM_FONT
+   DEPNAME      "MathJax NewCM Font"
+   REPOSITORY   "https://github.com/mathjax/mathjax-newcm-font"
+   VERSION      "4.1.3"
+   LICENSE      "Apache-2.0"
+   ATTRIBUTION  "Copyright (c) 2009-2026 The MathJax Consortium"
+)
+
 dependency(BOOTSTRAP
    DEPNAME      "Bootstrap"
    REPOSITORY   "https://github.com/twbs/bootstrap"

--- a/dependencies/tools/build-mathjax4
+++ b/dependencies/tools/build-mathjax4
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+#
+# build-mathjax4
+#
+# Copyright (C) 2026 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+#
+# This script assembles a MathJax 4 bundle suitable for serving locally
+# from RStudio, using the 'mathjax' and '@mathjax/mathjax-newcm-font'
+# npm packages. The bundle is pruned down to what the IDE needs for
+# inline LaTeX / math previews:
+#
+# - the 'tex-mml-chtml.js' combined component (TeX + MathML inputs,
+#   CHTML output, with the static mathjax-newcm font data inlined),
+# - the component directories used for dynamic loading (input, output,
+#   ui, a11y, sre),
+# - the mathjax-newcm font's CHTML resources (woff2 web fonts and
+#   dynamically-loaded glyph range data), placed under
+#   'fonts/mathjax-newcm-font' to match the '%%FONT%%-font' template
+#   used by the MathJax 'fontPath' output option.
+#
+# usage: build-mathjax4 <parent-dir> [version]
+#
+# The bundle is created at '<parent-dir>/mathjax-4'.
+#
+
+set -e
+
+if [ -z "$1" ]; then
+   echo "usage: build-mathjax4 <parent-dir> [version]"
+   exit 1
+fi
+
+PARENT_DIR="$1"
+VERSION="${2:-4.1.3}"
+
+REGISTRY="${NPM_REGISTRY:-https://registry.npmjs.org}"
+MATHJAX_TGZ="${REGISTRY}/mathjax/-/mathjax-${VERSION}.tgz"
+FONT_TGZ="${REGISTRY}/@mathjax/mathjax-newcm-font/-/mathjax-newcm-font-${VERSION}.tgz"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+# download and extract the npm tarballs (each unpacks to 'package')
+mkdir -p "${WORK_DIR}/mathjax" "${WORK_DIR}/font"
+curl -L -f -s "${MATHJAX_TGZ}" | tar -xzf - -C "${WORK_DIR}/mathjax"
+curl -L -f -s "${FONT_TGZ}" | tar -xzf - -C "${WORK_DIR}/font"
+
+BUNDLE_DIR="${WORK_DIR}/mathjax-4"
+mv "${WORK_DIR}/mathjax/package" "${BUNDLE_DIR}"
+
+# prune development / node-only files
+rm -f "${BUNDLE_DIR}/README.md"
+rm -f "${BUNDLE_DIR}/CONTRIBUTING.md"
+rm -f "${BUNDLE_DIR}/node-main-setup.cjs"
+rm -f "${BUNDLE_DIR}/node-main.cjs"
+rm -f "${BUNDLE_DIR}/node-main.js"
+rm -f "${BUNDLE_DIR}/node-main.mjs"
+rm -f "${BUNDLE_DIR}/require.mjs"
+rm -rf "${BUNDLE_DIR}/adaptors"
+
+# prune combined components other than tex-mml-chtml.js, along with
+# the SVG output component (the IDE only uses CHTML output)
+rm -f "${BUNDLE_DIR}"/mml-chtml*.js
+rm -f "${BUNDLE_DIR}"/mml-svg*.js
+rm -f "${BUNDLE_DIR}"/tex-chtml*.js
+rm -f "${BUNDLE_DIR}"/tex-svg*.js
+rm -f "${BUNDLE_DIR}"/tex-mml-svg*.js
+rm -f "${BUNDLE_DIR}/tex-mml-chtml-nofont.js"
+rm -f "${BUNDLE_DIR}/output/svg.js"
+
+# install the mathjax-newcm font's CHTML resources
+FONT_SRC="${WORK_DIR}/font/package"
+FONT_DIR="${BUNDLE_DIR}/fonts/mathjax-newcm-font"
+mkdir -p "${FONT_DIR}"
+cp "${FONT_SRC}/package.json" "${FONT_DIR}/package.json"
+cp "${FONT_SRC}/chtml.js" "${FONT_DIR}/chtml.js"
+cp -R "${FONT_SRC}/def" "${FONT_DIR}/def"
+cp -R "${FONT_SRC}/chtml" "${FONT_DIR}/chtml"
+
+# move the assembled bundle into place
+rm -rf "${PARENT_DIR}/mathjax-4"
+mkdir -p "${PARENT_DIR}"
+mv "${BUNDLE_DIR}" "${PARENT_DIR}/mathjax-4"
+
+echo "MathJax ${VERSION} bundle assembled at '${PARENT_DIR}/mathjax-4'"

--- a/dependencies/tools/upload-mathjax4.sh
+++ b/dependencies/tools/upload-mathjax4.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# This script assembles the MathJax 4 bundle used by RStudio (see
+# build-mathjax4) and uploads it as a zip to the RStudio Build Tools
+# (rstudio-buildtools) S3 bucket. Presumes you've already got AWS command
+# line tools (awscli) installed, and configured with a valid AWS account.
+
+set -e
+
+# Modify to set the MathJax version to upload
+MATHJAX4_VERSION=4.1.3
+
+AWS_BUCKET="s3://rstudio-buildtools"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+# Assemble the pruned bundle (creates ${WORK_DIR}/mathjax-4)
+"$(dirname "${BASH_SOURCE[0]}")/build-mathjax4" "${WORK_DIR}" "${MATHJAX4_VERSION}"
+
+# Zip it up; the archive should unpack to a 'mathjax-4' directory
+FILENAME="mathjax-${MATHJAX4_VERSION}.zip"
+(cd "${WORK_DIR}" && zip -r -9 -q "${FILENAME}" "mathjax-4")
+
+# Upload to S3 bucket
+aws s3 cp "${WORK_DIR}/${FILENAME}" "${AWS_BUCKET}/" --acl public-read

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -37,6 +37,7 @@ set GNUGREP_VERSION=3.0
 set GWT_VERSION=2.12.2-apple-blossom
 set LIBCLANG_VERSION=13.0.1
 set MATHJAX_VERSION=2.7.9
+set MATHJAX4_VERSION=4.1.3
 REM The MSVC toolset used for Boost prebuilts (145 = Visual Studio 2026).
 set MSVC_TOOLSET_VERSION=145
 set NSISMULTIUSER_VERSION=a33d494c62ad
@@ -141,6 +142,11 @@ set MATHJAX_FOLDER=mathjax-27
 set MATHJAX_OUTPUT=
 
 
+set MATHJAX4_URL=mathjax-%MATHJAX4_VERSION%.zip
+set MATHJAX4_FOLDER=mathjax-4
+set MATHJAX4_OUTPUT=
+
+
 set PANDOC_URL=pandoc/%PANDOC_VERSION%/pandoc-%PANDOC_VERSION%-windows-x86_64.zip
 set PANDOC_FOLDER=pandoc
 set PANDOC_OUTPUT=pandoc
@@ -171,6 +177,7 @@ cd /d "%COMMON_INSTALL_DIR%"
 %RUN% install GWT
 %RUN% install DICTIONARIES
 %RUN% install MATHJAX
+%RUN% install MATHJAX4
 %RUN% install LIBCLANG
 
 REM Determine if we have the correct version of quarto.exe already installed

--- a/e2e/rstudio/tests/panes/editor/math_preview.test.ts
+++ b/e2e/rstudio/tests/panes/editor/math_preview.test.ts
@@ -111,6 +111,46 @@ test.describe('Inline LaTeX math previews', () => {
     const popupMath = page.locator('mjx-container:not(.rstudio-mathjax-root mjx-container)');
     await expect(popupMath).toBeVisible({ timeout: 60000 });
 
+    // watch the popup's math element: rendered TeX errors must never enter
+    // the visible DOM (typesets happen in a hidden scratch element, and a
+    // failed render keeps the previous output). track scratch-element
+    // removals on the parent as the "a re-render completed" signal.
+    await page.evaluate(() => {
+      const container = Array.from(document.querySelectorAll('mjx-container')).find(
+        (c) => (c as HTMLElement).offsetParent != null
+      );
+      const el = container!.parentElement!;
+      (window as any).__merrorSeen = false;
+      (window as any).__renderAttempts = 0;
+      new MutationObserver(() => {
+        if (el.querySelector('mjx-merror, [data-mjx-error]'))
+          (window as any).__merrorSeen = true;
+      }).observe(el, { childList: true, subtree: true });
+      new MutationObserver((mutations) => {
+        for (const m of mutations) {
+          if (m.removedNodes.length > 0)
+            (window as any).__renderAttempts += 1;
+        }
+      }).observe(el.parentElement!, { childList: true });
+    });
+
+    // type a trailing subscript, making the expression incomplete
+    // ("Missing superscript or subscript argument")
+    await moveCursorTo(page, 5, 24);
+    await page.keyboard.type('_');
+
+    // wait for the resulting background re-render to complete, then verify
+    // the previous render was kept and no error output was ever shown
+    await expect
+      .poll(async () => await page.evaluate(() => (window as any).__renderAttempts), {
+        timeout: 30000,
+      })
+      .toBeGreaterThan(0);
+
+    expect(await page.evaluate(() => (window as any).__merrorSeen)).toBe(false);
+    await expect(popupMath).toBeVisible();
+    await expect(popupMath).not.toContainText('Missing');
+
     await sourceActions.closeSourceAndDeleteFile(fileName);
   });
 });

--- a/e2e/rstudio/tests/panes/editor/math_preview.test.ts
+++ b/e2e/rstudio/tests/panes/editor/math_preview.test.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { SourcePaneActions } from '@actions/source_pane.actions';
+import { useSuiteSandbox } from '@utils/sandbox';
+import { setPref, clearPref } from '@utils/commands';
+import { heredoc } from '@utils/heredoc';
+import type { Page } from '@playwright/test';
+
+// Inline LaTeX / math previews in the source editor (line widgets for $$
+// display math, a popup for inline math), rendered client-side by the
+// MathJax 4 bundle served from the session's /mathjax4/ URI.
+test.describe('Inline LaTeX math previews', () => {
+  useSuiteSandbox();
+  let consoleActions: ConsolePaneActions;
+  let sourceActions: SourcePaneActions;
+
+  // Move the cursor into the editor via the automation bridge; the resulting
+  // cursor-changed event arms the idle monitor, which fires the LaTeX
+  // preview after its 700ms idle delay. Line numbers are 1-based.
+  const moveCursorTo = async (page: Page, line: number, column: number) => {
+    await page.evaluate(
+      ([lineNumber, columnNumber]) => {
+        const editor = window.rstudio?.documents.activeEditor();
+        if (!editor)
+          throw new Error('no active editor');
+        editor.focus();
+        editor.gotoLine(lineNumber, columnNumber);
+      },
+      [line, column]
+    );
+  };
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+    sourceActions = new SourcePaneActions(page, consoleActions);
+
+    await consoleActions.resetSourcePane();
+    await setPref(page, 'latexPreviewOnCursorIdle', 'always');
+  });
+
+  test.afterAll(async ({ rstudioPage: page }) => {
+    await clearPref(page, 'latexPreviewOnCursorIdle');
+  });
+
+  test('MathJax 4 is loaded from the local bundle', async ({ rstudioPage: page }) => {
+    // the loader is invoked at session init; the bundle comes from the
+    // /mathjax4/ URI handler rather than a CDN
+    const script = page.locator('script[src*="mathjax4/tex-mml-chtml.js"]');
+    await expect(script).toBeAttached({ timeout: 30000 });
+
+    await expect
+      .poll(async () => await page.evaluate(() => (window as any).MathJax?.version ?? ''), {
+        timeout: 60000,
+      })
+      .toMatch(/^4\./);
+
+    // our configuration survived the load: inline $-math is enabled, and
+    // dynamically-loaded font resources resolve locally rather than via CDN
+    const config = await page.evaluate(() => ({
+      inlineMath: JSON.stringify((window as any).MathJax?.config?.tex?.inlineMath ?? null),
+      fontPath: (window as any).MathJax?.config?.output?.fontPath ?? null,
+    }));
+    expect(config.inlineMath).toContain('"$"');
+    expect(config.fontPath).toContain('mathjax4/fonts');
+  });
+
+  test('display math renders as a line-widget preview', async ({ rstudioPage: page }) => {
+    const fileName = `math_preview_widget_${Date.now()}.Rmd`;
+    const content = heredoc`
+      ---
+      title: "Math"
+      ---
+
+      Some prose, then math:
+
+      $$
+      e = mc^2
+      $$
+    `;
+
+    await sourceActions.createAndOpenFile(fileName, content);
+    await expect(sourceActions.sourcePane.selectedTab).toContainText(fileName, { timeout: 20000 });
+
+    // place the cursor inside the display math chunk (line of 'e = mc^2')
+    await moveCursorTo(page, 8, 2);
+
+    // the preview line widget renders typeset CHTML output
+    const widget = page.locator('.rstudio-mathjax-root mjx-container');
+    await expect(widget).toBeVisible({ timeout: 60000 });
+
+    await sourceActions.closeSourceAndDeleteFile(fileName);
+  });
+
+  test('inline math renders a popup preview', async ({ rstudioPage: page }) => {
+    const fileName = `math_preview_popup_${Date.now()}.Rmd`;
+    const content = heredoc`
+      ---
+      title: "Math"
+      ---
+
+      Einstein wrote $e = mc^2$ and moved on.
+    `;
+
+    await sourceActions.createAndOpenFile(fileName, content);
+    await expect(sourceActions.sourcePane.selectedTab).toContainText(fileName, { timeout: 20000 });
+
+    // place the cursor inside the inline math region
+    await moveCursorTo(page, 5, 20);
+
+    // the popup preview typesets outside of any line widget
+    const popupMath = page.locator('mjx-container:not(.rstudio-mathjax-root mjx-container)');
+    await expect(popupMath).toBeVisible({ timeout: 60000 });
+
+    await sourceActions.closeSourceAndDeleteFile(fileName);
+  });
+});

--- a/src/cpp/conf/rdesktop-dev.conf
+++ b/src/cpp/conf/rdesktop-dev.conf
@@ -40,6 +40,7 @@ external-sumatra-path=${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/sumatra/3.1.2
 external-winutils-path=${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/winutils/1.0
 external-hunspell-dictionaries-path=${RSTUDIO_DEPENDENCIES_DICTIONARIES_DIR}
 external-mathjax-path=${RSTUDIO_DEPENDENCIES_MATHJAX_DIR}
+external-mathjax4-path=${RSTUDIO_DEPENDENCIES_MATHJAX4_DIR}
 external-pandoc-path=${RSTUDIO_DEPENDENCIES_PANDOC_DIR}
 external-quarto-path=${RSTUDIO_DEPENDENCIES_QUARTO_DIR}
 external-copilot-path=${RSTUDIO_DEPENDENCIES_COPILOT_DIR}

--- a/src/cpp/conf/rsession-dev.conf
+++ b/src/cpp/conf/rsession-dev.conf
@@ -36,6 +36,7 @@ external-rpostback-path=session/postback/rpostback
 # common dependencies
 external-hunspell-dictionaries-path=${RSTUDIO_DEPENDENCIES_DICTIONARIES_DIR}
 external-mathjax-path=${RSTUDIO_DEPENDENCIES_MATHJAX_DIR}
+external-mathjax4-path=${RSTUDIO_DEPENDENCIES_MATHJAX4_DIR}
 external-pandoc-path=${RSTUDIO_DEPENDENCIES_PANDOC_DIR}
 external-quarto-path=${RSTUDIO_DEPENDENCIES_QUARTO_DIR}
 external-copilot-path=${RSTUDIO_DEPENDENCIES_COPILOT_DIR}

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -33,6 +33,7 @@ endif()
 if(WIN32)
    set(RSTUDIO_DEPENDENCIES_DICTIONARIES_DIR "${RSTUDIO_DEPENDENCIES_DIR}/common/dictionaries")
    set(RSTUDIO_DEPENDENCIES_MATHJAX_DIR      "${RSTUDIO_DEPENDENCIES_DIR}/common/mathjax-27")
+   set(RSTUDIO_DEPENDENCIES_MATHJAX4_DIR     "${RSTUDIO_DEPENDENCIES_DIR}/common/mathjax-4")
    set(RSTUDIO_DEPENDENCIES_QUARTO_DIR       "${RSTUDIO_DEPENDENCIES_DIR}/common/quarto")
    set(RSTUDIO_DEPENDENCIES_COPILOT_DIR      "${RSTUDIO_DEPENDENCIES_DIR}/common/copilot-language-server-js")
 else()
@@ -48,6 +49,12 @@ else()
       set(RSTUDIO_DEPENDENCIES_MATHJAX_DIR "${RSTUDIO_TOOLS_ROOT}/mathjax-27")
    else()
       set(RSTUDIO_DEPENDENCIES_MATHJAX_DIR "${RSTUDIO_DEPENDENCIES_DIR}/mathjax-27")
+   endif()
+
+   if(EXISTS "${RSTUDIO_TOOLS_ROOT}/mathjax-4")
+      set(RSTUDIO_DEPENDENCIES_MATHJAX4_DIR "${RSTUDIO_TOOLS_ROOT}/mathjax-4")
+   else()
+      set(RSTUDIO_DEPENDENCIES_MATHJAX4_DIR "${RSTUDIO_DEPENDENCIES_DIR}/mathjax-4")
    endif()
 
    if(EXISTS "${RSTUDIO_TOOLS_ROOT}/quarto")
@@ -79,6 +86,7 @@ endif()
 # validate our dependencies exist
 foreach(VAR RSTUDIO_DEPENDENCIES_DICTIONARIES_DIR
             RSTUDIO_DEPENDENCIES_MATHJAX_DIR
+            RSTUDIO_DEPENDENCIES_MATHJAX4_DIR
             RSTUDIO_DEPENDENCIES_PANDOC_DIR
             RSTUDIO_DEPENDENCIES_QUARTO_DIR
             RSTUDIO_DEPENDENCIES_COPILOT_DIR)
@@ -797,6 +805,10 @@ if(NOT RSTUDIO_SESSION_WIN32 AND NOT RSESSION_ALTERNATE_BUILD)
 
    # install mathjax for local html preview
    install(DIRECTORY "${RSTUDIO_DEPENDENCIES_MATHJAX_DIR}"
+           DESTINATION "${RSTUDIO_INSTALL_SUPPORTING}/resources")
+
+   # install mathjax 4 for inline latex / math previews
+   install(DIRECTORY "${RSTUDIO_DEPENDENCIES_MATHJAX4_DIR}"
            DESTINATION "${RSTUDIO_INSTALL_SUPPORTING}/resources")
 
    # install node -- on Apple arm64-only builds, install-npm-dependencies

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -323,6 +323,7 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
 #endif // _WIN32
    resolvePath(resourcePath_, &hunspellDictionariesPath_);
    resolvePath(resourcePath_, &mathjaxPath_);
+   resolvePath(resourcePath_, &mathjax4Path_);
    resolvePandocPath(resourcePath_, &pandocPath_);
    resolveQuartoPath(resourcePath_, &quartoPath_);
    resolveCopilotPath(resourcePath_, &copilotPath_);

--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -413,6 +413,9 @@ protected:
       ("external-mathjax-path",
       value<std::string>(&mathjaxPath_)->default_value("resources/mathjax-27"),
       "Specifies the path to the mathjax library.")
+      ("external-mathjax4-path",
+      value<std::string>(&mathjax4Path_)->default_value("resources/mathjax-4"),
+      "Specifies the path to the mathjax 4 library.")
       ("external-pandoc-path",
       value<std::string>(&pandocPath_)->default_value(kDefaultPandocPath),
       "Specifies the path to pandoc binaries.")
@@ -623,6 +626,7 @@ public:
    core::FilePath winutilsPath() const { return core::FilePath(winutilsPath_); }
    core::FilePath hunspellDictionariesPath() const { return core::FilePath(hunspellDictionariesPath_); }
    core::FilePath mathjaxPath() const { return core::FilePath(mathjaxPath_); }
+   core::FilePath mathjax4Path() const { return core::FilePath(mathjax4Path_); }
    core::FilePath pandocPath() const { return core::FilePath(pandocPath_); }
    core::FilePath quartoPath() const { return core::FilePath(quartoPath_); }
    core::FilePath copilotPath() const { return core::FilePath(copilotPath_); }
@@ -758,6 +762,7 @@ protected:
    std::string winutilsPath_;
    std::string hunspellDictionariesPath_;
    std::string mathjaxPath_;
+   std::string mathjax4Path_;
    std::string pandocPath_;
    std::string quartoPath_;
    std::string copilotPath_;

--- a/src/cpp/session/modules/mathjax/SessionMathJax.cpp
+++ b/src/cpp/session/modules/mathjax/SessionMathJax.cpp
@@ -24,6 +24,7 @@
 #include <session/SessionModuleContext.hpp>
 
 #define kMathJaxURIPrefix "/mathjax/"
+#define kMathJax4URIPrefix "/mathjax4/"
 
 using namespace rstudio::core;
 
@@ -38,9 +39,20 @@ void handleMathJax(const http::Request& request, http::Response* pResponse)
 {
    // extract path from URI
    std::string path = request.path().substr(strlen(kMathJaxURIPrefix));
-   
+
    // construct path to resource
    FilePath mathjaxPath = options().mathjaxPath();
+   FilePath resourcePath = mathjaxPath.completePath(path);
+   pResponse->setCacheableFile(resourcePath, request);
+}
+
+void handleMathJax4(const http::Request& request, http::Response* pResponse)
+{
+   // extract path from URI
+   std::string path = request.path().substr(strlen(kMathJax4URIPrefix));
+
+   // construct path to resource
+   FilePath mathjaxPath = options().mathjax4Path();
    FilePath resourcePath = mathjaxPath.completePath(path);
    pResponse->setCacheableFile(resourcePath, request);
 }
@@ -53,7 +65,10 @@ Error initialize()
    using boost::bind;
    using namespace module_context;
    ExecBlock initBlock;
+   // NOTE: URI handlers match by prefix, in registration order, so
+   // "/mathjax4" must be registered before "/mathjax"
    initBlock.addFunctions()
+      (bind(registerUriHandler, "/mathjax4", handleMathJax4))
       (bind(registerUriHandler, "/mathjax", handleMathJax))
    ;
    return initBlock.execute();

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -817,6 +817,13 @@
             "description": "Specifies the path to the mathjax library."
          },
          {
+            "name": "external-mathjax4-path",
+            "type": "core::FilePath",
+            "memberName": "mathjax4Path_",
+            "defaultValue": "resources/mathjax-4",
+            "description": "Specifies the path to the mathjax 4 library."
+         },
+         {
             "name": "external-pandoc-path",
             "type": "core::FilePath",
             "memberName": "pandocPath_",

--- a/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxLoader.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxLoader.java
@@ -31,21 +31,21 @@ public class MathJaxLoader
    {
       public void onLoaded(boolean alreadyLoaded);
    }
-   
+
    public MathJaxLoader()
    {
    }
-   
+
    public static boolean isMathJaxLoaded()
    {
       return MATHJAX_LOADED;
    }
-   
+
    public static void ensureMathJaxLoaded()
    {
       if (MATHJAX_LOADED)
          return;
-      
+
       initializeMathJaxConfig();
       ScriptElement mathJaxEl = createMathJaxScriptElement();
       HeadElement headEl = Document.get().getHead();
@@ -60,85 +60,88 @@ public class MathJaxLoader
                MATHJAX_LOADED = true;
                for (Callback callback : MATHJAX_CALLBACKS)
                   callback.onLoaded(false);
-               onMathJaxLoaded();
                return false;
             }
-            
+
             RETRY_COUNT++;
             return RETRY_COUNT < 50;
          }
       }, 500);
    }
-   
+
    public static final void withMathJaxLoaded(Callback callback)
    {
       if (callback == null)
          return;
-         
+
       if (MATHJAX_LOADED)
       {
          callback.onLoaded(true);
          return;
       }
-      
+
       MATHJAX_CALLBACKS.add(callback);
    }
-   
+
    // Private Methods ----
-   
-   private static final native void onMathJaxLoaded() /*-{
-      var MathJax = $wnd.MathJax;
-      
-      // avoid jittering
-      MathJax.Hub.processSectionDelay = 0;
-   }-*/;
-   
+
    private static final native void initializeMathJaxConfig() /*-{
 
       if (typeof $wnd.MathJax !== "undefined")
          return;
 
-      $wnd.MathJax = {
-         extensions: ['tex2jax.js', 'Safe.js'],
-         jax: ['input/TeX', 'output/HTML-CSS'],
-         tex2jax: {
-            inlineMath:  [['$', '$'], ['\\(', '\\)']],
-            displayMath: [['$$', '$$'], ['\\[', '\\]']],
+      var config = {
+         startup: {
+            typeset: false
+         },
+         loader: {
+            load: ["ui/safe"]
+         },
+         tex: {
+            inlineMath:  [["$", "$"], ["\\(", "\\)"]],
+            displayMath: [["$$", "$$"], ["\\[", "\\]"]],
             processEscapes: true
          },
-         "HTML-CSS": {
-            minScaleAdjust: 125,
-            availableFonts: []
+         options: {
+            enableMenu: false,
+            enableSpeech: false,
+            enableBraille: false,
+            enableEnrichment: false
          },
-         showProcessingMessages: false,
-         showMathMenu: false,
-         messageStyle: "none",
-         skipStartupTypeset: true,
-         menuSettings: {
-            zoom: "None",
-            context: "Browser",
-            inTabOrder: false,
+         output: {
+            // resolve dynamically-loaded font resources (woff2 web fonts and
+            // rare glyph range data) against our locally served copy, rather
+            // than the CDN default
+            fontPath: "mathjax4/fonts/%%FONT%%-font"
          }
       };
 
+      // MathJax's option merging only accepts plain objects whose constructor
+      // is the host window's Object; this literal is created in the GWT
+      // frame's realm, so round-trip it through the host window's JSON to
+      // re-create it there (otherwise the config is silently ignored)
+      $wnd.MathJax = $wnd.JSON.parse(JSON.stringify(config));
+
    }-*/;
-   
+
    private static final native boolean isMathJaxReady() /*-{
+      // MathJax.typesetPromise is created once startup has finished
+      // (including dynamic loading of any requested components)
       var mathjax = $wnd.MathJax || {};
-      return mathjax.isReady;
+      return typeof mathjax.typesetPromise === "function";
    }-*/;
-   
+
    private static ScriptElement createMathJaxScriptElement()
    {
       ScriptElement el = Document.get().createScriptElement();
       el.setAttribute("type", "text/javascript");
-      el.setSrc("mathjax/MathJax.js?config=TeX-MML-AM_CHTML");
+      el.setSrc("mathjax4/tex-mml-chtml.js");
       el.setAttribute("async", "true");
       return el;
    }
-   
+
    private static List<Callback> MATHJAX_CALLBACKS = new ArrayList<>();
    private static boolean MATHJAX_LOADED = false;
    private static int RETRY_COUNT = 0;
-   
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxTypeset.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxTypeset.java
@@ -56,51 +56,62 @@ public class MathJaxTypeset
    /*-{
       var MathJax = $wnd.MathJax;
 
-      // save last successfully rendered text, so we can restore the previous
-      // rendering if the new text fails to typeset
-      var lastRenderedText = el.getAttribute("data-mathjax-last-text") || "";
-
       var onCompleted = $entry(function(error) {
          @org.rstudio.studio.client.common.mathjax.MathJaxTypeset::onMathJaxTypesetCompleted(ZLjava/lang/Object;)(error, callback);
       });
 
-      var typeset = function(text) {
-         MathJax.typesetClear([el]);
-         el.innerText = text;
-         return MathJax.typesetPromise([el]).then(function() {
-            // failed typesets surface in two ways, neither of which rejects
-            // the typeset promise: recoverable TeX errors render as 'merror'
-            // nodes, while malformed inputs (e.g. unbalanced braces) are
-            // skipped by the math finder entirely, leaving raw text behind
-            var container = el.querySelector("mjx-container");
-            var merror = el.querySelector("mjx-merror, [data-mjx-error]");
-            return container == null || merror != null;
-         });
+      // bail (keeping the typeset queue alive) if the target has been
+      // detached in the interim
+      if (el.parentNode == null)
+      {
+         onCompleted(true);
+         return;
+      }
+
+      // typeset into a hidden scratch sibling, so that in-progress (or
+      // failed) renders are never visible -- while typing, incomplete
+      // expressions would otherwise flash a rendered TeX error before the
+      // previous render could be restored. the scratch element shares the
+      // target's parent and class so it typesets with the same font metrics
+      var scratch = el.ownerDocument.createElement(el.tagName);
+      scratch.className = el.className;
+      scratch.style.position = "absolute";
+      scratch.style.visibility = "hidden";
+      if (el.offsetWidth > 0)
+         scratch.style.width = el.offsetWidth + "px";
+      scratch.innerText = currentText;
+      el.parentNode.appendChild(scratch);
+
+      var cleanup = function() {
+         MathJax.typesetClear([scratch]);
+         scratch.parentNode.removeChild(scratch);
       };
 
-      typeset(currentText).then(function(error) {
+      MathJax.typesetPromise([scratch]).then(function() {
 
-         if (!error)
+         // failed typesets surface in two ways, neither of which rejects
+         // the typeset promise: recoverable TeX errors render as 'merror'
+         // nodes, while malformed inputs (e.g. unbalanced braces) are
+         // skipped by the math finder entirely, leaving raw text behind
+         var container = scratch.querySelector("mjx-container");
+         var merror = scratch.querySelector("mjx-merror, [data-mjx-error]");
+         var error = container == null || merror != null;
+
+         // swap the new output into place on success; on failure, keep any
+         // previous (successful) render, but surface the error output when
+         // there is no previous render to preserve
+         if (!error || el.querySelector("mjx-container") == null)
          {
-            el.setAttribute("data-mathjax-last-text", currentText);
-            onCompleted(false);
-            return;
+            el.innerHTML = "";
+            while (scratch.firstChild)
+               el.appendChild(scratch.firstChild);
          }
 
-         // restore the previous (successful) render on failure
-         if (lastRenderedText.length)
-         {
-            typeset(lastRenderedText).then(function() {
-               onCompleted(true);
-            }, function() {
-               onCompleted(true);
-            });
-            return;
-         }
-
-         onCompleted(true);
+         cleanup();
+         onCompleted(error);
 
       }, function(err) {
+         cleanup();
          onCompleted(true);
       });
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxTypeset.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxTypeset.java
@@ -16,24 +16,21 @@ package org.rstudio.studio.client.common.mathjax;
 
 import org.rstudio.core.client.SerializedCommand;
 import org.rstudio.core.client.SerializedCommandQueue;
-import org.rstudio.core.client.dom.DomUtils;
 
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.Style.Visibility;
-import com.google.gwt.user.client.Timer;
 
 public class MathJaxTypeset
-{ 
+{
    public static interface Callback
    {
       void onMathJaxTypesetComplete(boolean error);
    }
-   
+
    public static void typeset(Element el, String currentText, Callback callback)
    {
       typeset(el, currentText, false, callback);
    }
-   
+
    public static void typeset(Element el, String currentText, boolean priority, Callback callback)
    {
       SerializedCommand cmd = (cont) -> {
@@ -44,96 +41,83 @@ public class MathJaxTypeset
                callback.onMathJaxTypesetComplete(error);
                cont.execute();
             }
-         }, 0);
+         });
       };
-         
+
       if (priority)
          TYPESET_QUEUE.addPriorityCommand(cmd);
       else
          TYPESET_QUEUE.addCommand(cmd);
    }
 
-   public static final native void typesetNative(Element el, 
-                                                 String currentText,
-                                                 Object callback,
-                                                 int attempt)
+   private static final native void typesetNative(Element el,
+                                                  String currentText,
+                                                  Object callback)
    /*-{
       var MathJax = $wnd.MathJax;
-      
-      // save last rendered text
-      var jax = MathJax.Hub.getAllJax(el)[0];
-      var lastRenderedText = jax && jax.originalText || "";
-      
-      // update text in element
-      el.innerText = currentText;
-      
-      // typeset element
-      var self = this;
-      MathJax.Hub.Queue($entry(function() {
-         MathJax.Hub.Typeset(el, $entry(function() {
-            // restore original typesetting on failure
-            jax = MathJax.Hub.getAllJax(el)[0];
-            var error = !!(jax && jax.texError);
-            if (error && lastRenderedText.length)
-               jax.Text(lastRenderedText);
 
-            // callback to GWT
-            @org.rstudio.studio.client.common.mathjax.MathJaxTypeset::onMathJaxTypesetCompleted(Ljava/lang/Object;Ljava/lang/String;ZLjava/lang/Object;I)(el, currentText, error, callback, attempt);
-         }));
-      }));
-   }-*/;
-   
-   
-   private static void onMathJaxTypesetCompleted(final Object mathjaxElObject,
-                                                 final String text,
-                                                 final boolean error,
-                                                 final Object commandObject,
-                                                 final int attempt)
-   {
-      final Element mathjaxEl = (Element) mathjaxElObject;
+      // save last successfully rendered text, so we can restore the previous
+      // rendering if the new text fails to typeset
+      var lastRenderedText = el.getAttribute("data-mathjax-last-text") || "";
 
-      if (attempt < MAX_RENDER_ATTEMPTS)
-      {
-         // if mathjax displayed an error, try re-rendering once more
-         Element[] errorEls = DomUtils.getElementsByClassName(mathjaxEl, 
-               "MathJax_Error");
-         if (errorEls != null && errorEls.length > 0 &&
-             attempt < MAX_RENDER_ATTEMPTS)
+      var onCompleted = $entry(function(error) {
+         @org.rstudio.studio.client.common.mathjax.MathJaxTypeset::onMathJaxTypesetCompleted(ZLjava/lang/Object;)(error, callback);
+      });
+
+      var typeset = function(text) {
+         MathJax.typesetClear([el]);
+         el.innerText = text;
+         return MathJax.typesetPromise([el]).then(function() {
+            // failed typesets surface in two ways, neither of which rejects
+            // the typeset promise: recoverable TeX errors render as 'merror'
+            // nodes, while malformed inputs (e.g. unbalanced braces) are
+            // skipped by the math finder entirely, leaving raw text behind
+            var container = el.querySelector("mjx-container");
+            var merror = el.querySelector("mjx-merror, [data-mjx-error]");
+            return container == null || merror != null;
+         });
+      };
+
+      typeset(currentText).then(function(error) {
+
+         if (!error)
          {
-            // hide the error and retry in 25ms (experimentally this seems to
-            // produce a better shot at rendering successfully than an immediate
-            // or deferred retry)
-            mathjaxEl.getStyle().setVisibility(Visibility.HIDDEN);
-            new Timer()
-            {
-               @Override
-               public void run()
-               {
-                  typesetNative(mathjaxEl, text, commandObject, attempt + 1);
-               }
-            }.schedule(25);
+            el.setAttribute("data-mathjax-last-text", currentText);
+            onCompleted(false);
             return;
          }
-      }
-      
-      // show whatever we've got (could be an error if we ran out of retries)
-      mathjaxEl.getStyle().setVisibility(Visibility.VISIBLE);
-      
-      // execute callback
+
+         // restore the previous (successful) render on failure
+         if (lastRenderedText.length)
+         {
+            typeset(lastRenderedText).then(function() {
+               onCompleted(true);
+            }, function() {
+               onCompleted(true);
+            });
+            return;
+         }
+
+         onCompleted(true);
+
+      }, function(err) {
+         onCompleted(true);
+      });
+   }-*/;
+
+
+   private static void onMathJaxTypesetCompleted(final boolean error,
+                                                 final Object commandObject)
+   {
       if (commandObject != null && commandObject instanceof MathJaxTypeset.Callback)
       {
          MathJaxTypeset.Callback callback = (MathJaxTypeset.Callback) commandObject;
          callback.onMathJaxTypesetComplete(error);
       }
    }
-   
-   
-   // sometimes MathJax fails to render initially but succeeds if asked to do so
-   // again; this is the maximum number of times we'll try to re-render the same
-   // text automatically before giving up
-   private static final int MAX_RENDER_ATTEMPTS = 2;
-   
+
+
    // can't call mathjax for typesetting concurrently so we serialize the calls with this queue
    private static final SerializedCommandQueue TYPESET_QUEUE = new SerializedCommandQueue();
-   
+
 }


### PR DESCRIPTION
Addresses #8715.

This is phase 1 of the MathJax upgrade discussed in #8715: the IDE's inline LaTeX / math previews (source editor line widgets and popup, and the visual editor's live math preview via `PanmirrorUIMath`) now render with MathJax 4.1.3, while rendered R Markdown documents are untouched -- rmarkdown's `mathjax = "local"` mode still uses the bundled MathJax 2.7.9 via `RMARKDOWN_MATHJAX_PATH` (rmarkdown hardcodes the v2 `MathJax.js?config=` entry point, so swapping that bundle requires coordinated rmarkdown changes; that's phase 2).

### What's included

- **Dependency**: `install-mathjax` now also installs a `mathjax-4` bundle. It first tries `mathjax-4.1.3.zip` from rstudio-buildtools, and falls back to assembling the bundle from npm registry tarballs (`dependencies/tools/build-mathjax4`, which prunes the `mathjax@4` package and adds the `@mathjax/mathjax-newcm-font` CHTML resources under `fonts/mathjax-newcm-font`). `dependencies/tools/upload-mathjax4.sh` builds and uploads the zip.
- **Serving**: new `external-mathjax4-path` session option (default `resources/mathjax-4`), installed by CMake next to `mathjax-27`, and served at the `/mathjax4/` URI (registered before `/mathjax`, since URI handlers match by prefix in registration order). The server-side `/mathjax` proxy forwards `/mathjax4/` by prefix, so no server changes are needed.
- **GWT port**: `MathJaxLoader` now sets a v4-style config (inline `$`/display `$$` TeX delimiters, `ui/safe`, menu/speech/enrichment disabled, `output.fontPath` pointed at the locally served font so woff2 fonts and dynamic glyph-range data never hit the CDN) and loads `mathjax4/tex-mml-chtml.js`. `MathJaxTypeset` is ported from `MathJax.Hub.Queue/Typeset/getAllJax` to `MathJax.typesetPromise`, keeping the restore-previous-render-on-error behavior via a `data-mathjax-last-text` attribute. The v2-era hidden-retry hack is gone.

### Notable findings

- **MathJax 4 silently ignores cross-realm configs.** Its option merger only accepts objects whose `constructor` is identity-equal to the host window's `Object`; a config literal created inside the GWT frame fails that check and the whole config is dropped (symptom: `$$` math worked, `$...$` didn't, fonts fell back to jsdelivr). The loader now re-creates the config in the host realm via `$wnd.JSON.parse(JSON.stringify(config))`.
- **v4 failure modes differ from v2**: malformed TeX (e.g. unbalanced braces) is skipped by the math finder entirely (no output, no error node), while recoverable TeX errors render `mjx-merror` nodes; undefined macros render as red text via the bundled `noundefined` package. Error detection accounts for both.

### Action needed before Windows CI can build this

`dependencies/windows/install-dependencies.cmd` expects `mathjax-4.1.3.zip` on the rstudio-buildtools S3 bucket; someone with AWS credentials needs to run `dependencies/tools/upload-mathjax4.sh` once. macOS/Linux builds work without it via the npm-registry fallback.

Developers will need to re-run `install-mathjax` (or `install-dependencies`) after pulling, since CMake now validates the `mathjax-4` directory.

### Testing

- New Playwright coverage in `e2e/rstudio/tests/panes/editor/math_preview.test.ts`: MathJax 4 loads from the local bundle with the RStudio config applied, display math renders as a line-widget preview, and inline math renders a popup preview. All pass against the dev desktop build.
- Standalone browser verification of the bundle: local font/dynamic glyph loading (no CDN requests), TeX error rendering, and the restore-on-error flow.
- `ant javac` / `ant draft`, backend build, and e2e typecheck all clean.