### PR TITLE
use pre-increment when counting rowset rows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - ([#9924](https://github.com/rstudio/rstudio/issues/9924)): The Files pane now shows a link indicator on symbolic links and macOS Finder aliases, with the link target shown in the icon's tooltip.
 
 ### Fixed
+- ([#18152](https://github.com/rstudio/rstudio/issues/18152)): Fixed a compilation error when building RStudio Server against SOCI 4.1.4 or newer.
 - ([#18174](https://github.com/rstudio/rstudio/issues/18174)): Fixed an error when viewing an object from the Object Explorer with the French user interface language enabled.
 - ([#18198](https://github.com/rstudio/rstudio/issues/18198)): Fixed tar errors and warnings printed to the console after installing a package from a URL with `install.packages(..., repos = NULL)`.
 - ([#18208](https://github.com/rstudio/rstudio/issues/18208)): Fixed an issue in RStudio Server where requests could fail with "Unable to connect to service" for 30 seconds or more while a suspended session was relaunching.

--- a/src/cpp/server/DBActiveSessionStorage.cpp
+++ b/src/cpp/server/DBActiveSessionStorage.cpp
@@ -300,13 +300,12 @@ Error DBActiveSessionStorage::readProperty(const std::string& name, std::string*
       *pValue = std::to_string(iter->get<int>(0));
 
    // Sanity check number of returned rows, by using the pk in the where clause we should only get 1 row
-   if (++iter != rowset.end())
-   {
-      int count = 2;
-      while (++iter != rowset.end())
-         ++count;
+   int count = 1;
+   for (++iter; iter != rowset.end(); ++iter)
+      ++count;
+
+   if (count > 1)
       return Error("Too many sessions returned", errc::TooManySessionsReturned, "Expected only one session returned, found " + std::to_string(count) + "[ session:" + sessionId_ + " ]", ERROR_LOCATION);
-   }
 
 
    return Success();
@@ -343,13 +342,12 @@ Error DBActiveSessionStorage::readProperties(const std::set<std::string>& names,
       populateMapWithRow(iter, pValues, user_);
 
       // Sanity check number of returned rows, by using the pk in the where clause we should only get 1 row
-      if (++iter != rowset.end())
-      {
-         int count = 2;
-         while (++iter != rowset.end())
-            ++count;
+      int count = 1;
+      for (++iter; iter != rowset.end(); ++iter)
+         ++count;
+
+      if (count > 1)
          return Error("Too many sessions returned", errc::TooManySessionsReturned, "Expected only one session returned, found " + std::to_string(count) + "[ session:" + sessionId_ + " ]", ERROR_LOCATION);
-      }
    }
 
    return Success();

--- a/src/cpp/server/DBActiveSessionStorage.cpp
+++ b/src/cpp/server/DBActiveSessionStorage.cpp
@@ -302,8 +302,8 @@ Error DBActiveSessionStorage::readProperty(const std::string& name, std::string*
    // Sanity check number of returned rows, by using the pk in the where clause we should only get 1 row
    if (++iter != rowset.end())
    {
-      int count = 1;
-      while (iter++ != rowset.end())
+      int count = 2;
+      while (++iter != rowset.end())
          ++count;
       return Error("Too many sessions returned", errc::TooManySessionsReturned, "Expected only one session returned, found " + std::to_string(count) + "[ session:" + sessionId_ + " ]", ERROR_LOCATION);
    }
@@ -345,8 +345,8 @@ Error DBActiveSessionStorage::readProperties(const std::set<std::string>& names,
       // Sanity check number of returned rows, by using the pk in the where clause we should only get 1 row
       if (++iter != rowset.end())
       {
-         int count = 1;
-         while (iter++ != rowset.end())
+         int count = 2;
+         while (++iter != rowset.end())
             ++count;
          return Error("Too many sessions returned", errc::TooManySessionsReturned, "Expected only one session returned, found " + std::to_string(count) + "[ session:" + sessionId_ + " ]", ERROR_LOCATION);
       }


### PR DESCRIPTION
SOCI 4.1.4 changed `rowset_iterator`'s post-increment operator to return `void` ([SOCI/soci@rowset.h](https://github.com/SOCI/soci/blob/v4.1.4/include/soci/rowset.h)), so the `iter++ != rowset.end()` loops in `DBActiveSessionStorage.cpp` no longer compile, breaking the Fedora 45 (rawhide) build.

Pre-increment still returns a `rowset_iterator&` in all SOCI versions, so the two row-counting sanity checks are reworked to count the returned rows with a plain for loop and then check the count, keeping increments out of conditional expressions. As a side effect, the loops no longer increment the iterator past `end()`.

Verified the file compiles against the bundled (older) SOCI; the 4.1.4 signature was confirmed against the upstream header.

Addresses #18152.