### PR TITLE
retry dependency downloads on transient server errors

### DIFF
--- a/dependencies/tools/rstudio-tools.sh
+++ b/dependencies/tools/rstudio-tools.sh
@@ -322,11 +322,12 @@ download () {
 		echo -e "Downloading:\n- '$SRC' -> '$DST'"
 	fi
 
-	# Invoke downloader
+	# Invoke downloader; retry so that transient server errors
+	# (e.g. S3 returning 503) don't fail the build
 	if has-command curl; then
-		curl -L -f -C - "$SRC" > "$DST"
+		curl -L -f -C - --retry 5 "$SRC" > "$DST"
 	elif has-command wget; then
-		wget -c "$SRC" -O "$DST"
+		wget -c --tries=5 --waitretry=5 "$SRC" -O "$DST"
 	else
 		echo "no downloader detected on this system (requires 'curl' or 'wget')"
 		return 1


### PR DESCRIPTION
The Jenkins build for #18210 failed because S3 returned a momentary 503 while downloading the Copilot Language Server archive, and the `download()` helper in `rstudio-tools.sh` performs a single `curl` invocation with no retries, so any transient server error fails the whole dependency install.

This change adds `--retry 5` to the `curl` invocation, which retries (with backoff) on timeouts and on HTTP 408 / 429 / 500 / 502 / 503 / 504 responses. The `wget` fallback similarly gains `--tries=5 --waitretry=5`.

`--retry-all-errors` was deliberately avoided since it requires curl 7.71+, which is newer than what some of our older build platforms ship.

Verified locally against a test HTTP server that returns 503 twice and then 200: the patched `download()` retries twice, succeeds with the correct content, and exits 0; when retries are exhausted it still exits non-zero, so genuine outages continue to fail the build.
