### PR TITLE
Enforce per-session memory limits for containerized Workbench

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@
 - ([#18198](https://github.com/rstudio/rstudio/issues/18198)): Fixed tar errors and warnings printed to the console after installing a package from a URL with `install.packages(..., repos = NULL)`.
 - ([#18197](https://github.com/rstudio/rstudio/issues/18197)): Fixed an issue where the Render button failed to render a Quarto document living within a sub-directory of a Quarto project.
 - ([#18208](https://github.com/rstudio/rstudio/issues/18208)): Fixed an issue in RStudio Server where requests could fail with "Unable to connect to service" for 30 seconds or more while a suspended session was relaunching.
-- ([#18213](https://github.com/rstudio/rstudio/issues/18213)): Fixed per-session memory limits not being enforced for Workbench sessions running in a container with a read-only cgroup filesystem, and made the memory gauge, memory-usage report, and abort gate reflect the container rather than the host. Added an `rsession.conf` `memory-usage-mode` option to control how session and total memory usage are computed and reported.
+- ([#17191](https://github.com/rstudio/rstudio/issues/17191)): Fixed per-session memory limits not being enforced for Workbench sessions running in a container with a read-only cgroup filesystem, and made the memory gauge, memory-usage report, and abort gate reflect the container rather than the host. Added an `rsession.conf` `memory-usage-mode` option to control how session and total memory usage are computed and reported.
 
 ### Dependencies
 - Ace 1.43.5

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 - ([#18198](https://github.com/rstudio/rstudio/issues/18198)): Fixed tar errors and warnings printed to the console after installing a package from a URL with `install.packages(..., repos = NULL)`.
 - ([#18197](https://github.com/rstudio/rstudio/issues/18197)): Fixed an issue where the Render button failed to render a Quarto document living within a sub-directory of a Quarto project.
 - ([#18208](https://github.com/rstudio/rstudio/issues/18208)): Fixed an issue in RStudio Server where requests could fail with "Unable to connect to service" for 30 seconds or more while a suspended session was relaunching.
+- ([#18213](https://github.com/rstudio/rstudio/issues/18213)): Fixed per-session memory limits not being enforced for Workbench sessions running in a container with a read-only cgroup filesystem, and made the memory gauge, memory-usage report, and abort gate reflect the container rather than the host. Added an `rsession.conf` `memory-usage-mode` option to control how session and total memory usage are computed and reported.
 
 ### Dependencies
 - Ace 1.43.5

--- a/scripts/generate-options.R
+++ b/scripts/generate-options.R
@@ -339,7 +339,10 @@ generateProgramOptions <- function (optionsJson, overlayOptionsJson) {
             # handle any implicit conversions that we should support
             if (identical(type, "core::FilePath")) {
                accessorCode <- sprintf("return core::FilePath(%s);", memberName)
-            } else if (identical(category, "allow")) {
+            } else if (identical(category, "allow") && identical(type, "bool")) {
+               # Only bool "allow" options OR in the overlay flag. Applying this to
+               # non-bool options (e.g. the int abort-free-mem-percent) collapses the
+               # value to 0/1 (issue #3062), so they fall through to a plain return.
                accessorCode <- sprintf("return %s || allowOverlay();", memberName)
             } else {
                accessorCode <- sprintf("return %s;", memberName)

--- a/src/cpp/core/include/core/system/Resources.hpp
+++ b/src/cpp/core/include/core/system/Resources.hpp
@@ -76,6 +76,33 @@ Error getProcessCpuLimit(double *pNumCpus, MemoryProvider *pProvider);
 
 #ifdef __linux__
 
+// Selects how session and total memory usage are computed and reported. See the
+// rsession.conf "memory-usage-mode" option for the meaning of each mode.
+enum MemoryUsageMode {
+   // Auto-detect: resolves to MemoryUsageModeContainer when running inside a
+   // container and MemoryUsageModeDefault otherwise. This is the default.
+   MemoryUsageModeAuto = 0,
+
+   // Preserve the historical behavior: report the node's physical/cgroup RAM as
+   // the total and rely on node free memory (plus a grace period) for aborts.
+   MemoryUsageModeDefault,
+
+   // Report the session's cgroup memory limit as the total so the session is
+   // aborted when it reaches its own limit rather than when the node runs low.
+   MemoryUsageModeContainer,
+
+   // Force memory usage to be read from the cgroup.
+   MemoryUsageModeCgroup,
+
+   // Force memory usage to be read from the node's /proc/meminfo. Useful when
+   // cgroup memory includes file cache that does not reflect actual session use.
+   MemoryUsageModeMemInfo
+};
+
+// Sets the mode used to compute and report memory usage. Call once at startup,
+// before the memory providers are first used.
+void setMemoryUsageMode(MemoryUsageMode mode);
+
 // Sets the memory limit. Must have privileges and provide the uid of the ultimate process owner
 Error setProcessMemoryLimit(long memHighKb, long memMaxKb, uid_t uid, MemoryProvider *pProvider);
 

--- a/src/cpp/core/system/LinuxResources.cpp
+++ b/src/cpp/core/system/LinuxResources.cpp
@@ -441,10 +441,13 @@ public:
    //
    // In container mode the cgroup is shared by every session in the launcher
    // container, so the cgroup usage is a container-wide aggregate, not this
-   // session's footprint. Return this session's own process-tree RSS (procfs)
-   // instead so the IDE gauge / "Session memory used" figure reflects the
-   // individual session. getTotalMemoryUsed() reports the container-wide cgroup
-   // usage via getCgroupMemoryUsed() so the shared-pressure line stays accurate.
+   // session's footprint. In meminfo mode the cgroup usage is deliberately
+   // avoided because it can include reclaimable file cache that doesn't reflect
+   // actual session use. In both of those modes, return this session's own
+   // process-tree RSS (procfs) so the IDE gauge / "Session memory used" figure
+   // reflects the individual session's real usage. getTotalMemoryUsed() reports
+   // the container-wide cgroup usage via getCgroupMemoryUsed() so the
+   // shared-pressure line stays accurate.
    //
    // In the other cgroup-backed modes the cgroup is scoped to the session (or is
    // being reported deliberately), so keep the cgroup usage. Reading it is also
@@ -454,15 +457,22 @@ public:
    // values in the appropriate category.
    virtual Error getProcessMemoryUsed(long *pUsedKb, MemoryProvider *pProvider)
    {
-      if (effectiveMemoryUsageMode() == MemoryUsageModeContainer)
+      MemoryUsageMode mode = effectiveMemoryUsageMode();
+      if (mode == MemoryUsageModeContainer || mode == MemoryUsageModeMemInfo)
          return LinuxMemoryProvider::getProcessMemoryUsed(pUsedKb, pProvider);
 
-      return getCgroupMemoryUsed(pUsedKb, pProvider);
+      // Other cgroup-backed modes: use the cgroup usage, falling back to
+      // process-tree RSS if the cgroup memory controller isn't available.
+      Error error = getCgroupMemoryUsed(pUsedKb, pProvider);
+      if (error)
+         return LinuxMemoryProvider::getProcessMemoryUsed(pUsedKb, pProvider);
+      return Success();
    }
 
    // Reads the cgroup's memory usage (container-wide in container mode,
-   // session-scoped otherwise). Falls back to process-tree RSS when the cgroup
-   // memory controller isn't available.
+   // session-scoped otherwise). Returns an error if the cgroup memory controller
+   // isn't available; callers choose an appropriate fallback (process-tree RSS
+   // for the per-session figure, node /proc/meminfo for the container-wide one).
    Error getCgroupMemoryUsed(long *pUsedKb, MemoryProvider *pProvider)
    {
       Error error;
@@ -477,12 +487,6 @@ public:
       if (!error)
       {
          *pProvider = MemoryProviderLinuxCgroups;
-      }
-      else
-      {
-         // Even if cgroups is enabled, the memory controller for cgroups may not be installed.
-         // Fall back on looking at process memmory from ps
-         return LinuxMemoryProvider::getProcessMemoryUsed(pUsedKb, pProvider);
       }
 
       return error;
@@ -500,7 +504,15 @@ public:
    {
       MemoryUsageMode mode = effectiveMemoryUsageMode();
       if (mode == MemoryUsageModeContainer || mode == MemoryUsageModeCgroup)
-         return getCgroupMemoryUsed(pUsedKb, pProvider);
+      {
+         // The container-wide "used" must not collapse to a single session's
+         // RSS, so on a cgroup read failure fall back to node /proc/meminfo
+         // rather than to process-tree RSS.
+         Error error = getCgroupMemoryUsed(pUsedKb, pProvider);
+         if (error)
+            return MemInfoMemoryProvider::getTotalMemoryUsed(pUsedKb, pProvider);
+         return Success();
+      }
       return MemInfoMemoryProvider::getTotalMemoryUsed(pUsedKb, pProvider);
    }
 
@@ -616,7 +628,10 @@ public:
 
       if (error)
       {
-         // The cgroup fs is not writable, so fall back to ulimit-based settings.
+         // The cgroup limit could not be written (for example, a read-only
+         // cgroup fs); log the underlying error and fall back to ulimit-based
+         // settings so the limit is still enforced.
+         LOG_ERROR(error);
          return MemInfoMemoryProvider::setProcessMemoryLimit(highMemKb, maxMemKb, pProvider);
       }
       return error;

--- a/src/cpp/core/system/LinuxResources.cpp
+++ b/src/cpp/core/system/LinuxResources.cpp
@@ -23,6 +23,7 @@
 #include <core/StringUtils.hpp>
 #include <core/Thread.hpp>
 #include <core/Truncating.hpp>
+#include <core/system/Container.hpp>
 #include <core/system/Resources.hpp>
 #include <core/system/PosixSystem.hpp>
 
@@ -40,6 +41,20 @@ namespace rstudio {
 namespace core {
 namespace system {
 namespace {
+
+// The mode used to compute and report memory usage. Set from the
+// "memory-usage-mode" option via setMemoryUsageMode().
+MemoryUsageMode s_memoryUsageMode = MemoryUsageModeAuto;
+
+// Returns the effective memory usage mode, resolving the "auto" mode to the
+// container mode when running inside a container and the historical default
+// otherwise.
+MemoryUsageMode effectiveMemoryUsageMode()
+{
+   if (s_memoryUsageMode == MemoryUsageModeAuto)
+      return container::isRunningInContainer() ? MemoryUsageModeContainer : MemoryUsageModeDefault;
+   return s_memoryUsageMode;
+}
 
 // Parses /proc/meminfo to look up specific memory stats.
 Error readProcFileKeys(const std::string& procPath, const std::vector<std::string>& keys, std::vector<long>* pValues)
@@ -422,12 +437,33 @@ public:
       }
    }
 
-   // Overriding the base classes's process memory method that accumulates RSS size of all children since this is way more efficient.
-   // Should be roughly the same, as long as this cgroup is scoped to the session process (as is true in all cases now)
+   // Reports the "process" memory figure for this session.
+   //
+   // In container mode the cgroup is shared by every session in the launcher
+   // container, so the cgroup usage is a container-wide aggregate, not this
+   // session's footprint. Return this session's own process-tree RSS (procfs)
+   // instead so the IDE gauge / "Session memory used" figure reflects the
+   // individual session. getTotalMemoryUsed() reports the container-wide cgroup
+   // usage via getCgroupMemoryUsed() so the shared-pressure line stays accurate.
+   //
+   // In the other cgroup-backed modes the cgroup is scoped to the session (or is
+   // being reported deliberately), so keep the cgroup usage. Reading it is also
+   // more efficient than accumulating RSS across the process tree.
    //
    // If we do add user and group based cgroups, we'll need to identify which mode is used and return the cgroup
    // values in the appropriate category.
    virtual Error getProcessMemoryUsed(long *pUsedKb, MemoryProvider *pProvider)
+   {
+      if (effectiveMemoryUsageMode() == MemoryUsageModeContainer)
+         return LinuxMemoryProvider::getProcessMemoryUsed(pUsedKb, pProvider);
+
+      return getCgroupMemoryUsed(pUsedKb, pProvider);
+   }
+
+   // Reads the cgroup's memory usage (container-wide in container mode,
+   // session-scoped otherwise). Falls back to process-tree RSS when the cgroup
+   // memory controller isn't available.
+   Error getCgroupMemoryUsed(long *pUsedKb, MemoryProvider *pProvider)
    {
       Error error;
       if (!isV2_)
@@ -450,6 +486,22 @@ public:
       }
 
       return error;
+   }
+
+   virtual Error getTotalMemory(long *pTotalKb, MemoryProvider *pProvider)
+   {
+      MemoryUsageMode mode = effectiveMemoryUsageMode();
+      if (mode == MemoryUsageModeContainer || mode == MemoryUsageModeCgroup)
+         return getCgroupsMemoryLimit(pTotalKb, pProvider);
+      return MemInfoMemoryProvider::getTotalMemory(pTotalKb, pProvider);
+   }
+
+   virtual Error getTotalMemoryUsed(long *pUsedKb, MemoryProvider *pProvider)
+   {
+      MemoryUsageMode mode = effectiveMemoryUsageMode();
+      if (mode == MemoryUsageModeContainer || mode == MemoryUsageModeCgroup)
+         return getCgroupMemoryUsed(pUsedKb, pProvider);
+      return MemInfoMemoryProvider::getTotalMemoryUsed(pUsedKb, pProvider);
    }
 
    // Returns a value of 0 if there's no limit
@@ -560,6 +612,12 @@ public:
          error = setCgroupMemoryStat("memory.high", highMemKb * 1024);
          if (!error)
             error = setCgroupMemoryStat("memory.max", maxMemKb * 1024);
+      }
+
+      if (error)
+      {
+         // The cgroup fs is not writable, so fall back to ulimit-based settings.
+         return MemInfoMemoryProvider::setProcessMemoryLimit(highMemKb, maxMemKb, pProvider);
       }
       return error;
    }
@@ -861,10 +919,13 @@ boost::shared_ptr<LinuxMemoryProvider> getMemoryProvider(bool writeLimit, uid_t 
          boost::shared_ptr<CGroupsMemoryProvider> provider = 
             boost::make_shared<CGroupsMemoryProvider>(cgroup);
 
-         // Check memory limit
+         // Check memory limit. Use the raw cgroup limit (not getTotalMemory,
+         // whose reported total varies with the memory-usage mode) so that we
+         // bind the cgroup provider for reads only when a finite cgroup limit
+         // is actually in effect.
          long totalKb;
          MemoryProvider tmpProvider;
-         Error error = provider->getTotalMemory(&totalKb, &tmpProvider);
+         Error error = provider->getCgroupsMemoryLimit(&totalKb, &tmpProvider);
 
          if (error)
          {
@@ -959,6 +1020,11 @@ Error getProcessCpuLimit(double *pNumCpus, MemoryProvider *pProvider)
    *pNumCpus = 0;
    *pProvider = MemoryProviderUnknown;
    return Success();
+}
+
+void setMemoryUsageMode(MemoryUsageMode mode)
+{
+   s_memoryUsageMode = mode;
 }
 
 Error setProcessMemoryLimit(long highMemKb, long maxMemKb, uid_t uid, MemoryProvider *pProvider)

--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -383,7 +383,10 @@ protected:
       "Sets a limit in minutes for the amount of time top level R computations may run before being interrupted.")
       ("limit-xfs-disk-quota",
       value<bool>(&limitXfsDiskQuota_)->default_value(false),
-      "Indicates whether or not XFS quotas should be enforced when performing file operations via the files pane.");
+      "Indicates whether or not XFS quotas should be enforced when performing file operations via the files pane.")
+      ("memory-usage-mode",
+      value<std::string>(&memoryUsageMode_)->default_value("auto"),
+      "Selects how Posit Workbench computes and reports session and total memory usage. 'auto' (the default) uses 'container' when the session runs inside a container and 'default' otherwise. 'default' preserves the historical behavior: total memory is the node's physical or cgroup RAM, and Workbench aborts sessions based on node free memory plus a grace period. 'container' reports the session's cgroup memory limit as the total. 'cgroup' reads memory usage from the cgroup. 'meminfo' reads memory usage from the node's /proc/meminfo (useful when cgroup memory includes file cache that does not reflect actual session use).");
 
    pExternal->add_options()
       ("external-rpostback-path",
@@ -594,7 +597,7 @@ public:
    bool allowFullUI() const { return allowFullUI_ || allowOverlay(); }
    bool allowLauncherJobs() const { return allowLauncherJobs_ || allowOverlay(); }
    bool allowOverLimitSessions() const { return allowOverLimitSessions_ || allowOverlay(); }
-   int abortFreeMemPercent() const { return abortFreeMemPercent_ || allowOverlay(); }
+   int abortFreeMemPercent() const { return abortFreeMemPercent_; }
    bool allowCopilot() const { return allowCopilot_ || allowOverlay(); }
    bool allowPositAssistant() const { return allowPositAssistant_ || allowOverlay(); }
    core::FilePath coreRSourcePath() const { return core::FilePath(coreRSourcePath_); }
@@ -617,6 +620,7 @@ public:
    int limitFileUploadSizeMb() const { return limitFileUploadSizeMb_; }
    int limitCpuTimeMinutes() const { return limitCpuTimeMinutes_; }
    bool limitXfsDiskQuota() const { return limitXfsDiskQuota_; }
+   std::string memoryUsageMode() const { return memoryUsageMode_; }
    core::FilePath rpostbackPath() const { return core::FilePath(rpostbackPath_); }
    core::FilePath consoleIoPath() const { return core::FilePath(consoleIoPath_); }
    core::FilePath gnudiffPath() const { return core::FilePath(gnudiffPath_); }
@@ -753,6 +757,7 @@ protected:
    int limitFileUploadSizeMb_;
    int limitCpuTimeMinutes_;
    bool limitXfsDiskQuota_;
+   std::string memoryUsageMode_;
    std::string rpostbackPath_;
    std::string consoleIoPath_;
    std::string gnudiffPath_;

--- a/src/cpp/session/modules/SessionSystemResources.cpp
+++ b/src/cpp/session/modules/SessionSystemResources.cpp
@@ -25,6 +25,7 @@
 
 #include <core/Exec.hpp>
 #include <core/system/Interrupts.hpp>
+#include <core/system/Resources.hpp>
 
 #include <r/RExec.hpp>
 #include <r/RSexp.hpp>
@@ -51,6 +52,29 @@ bool s_memoryLimitWarningSeen = false;
 // The interval, in seconds, at which we will query for memory statistics
 std::atomic<int> s_queryInterval;
 
+
+#ifdef __linux__
+// Applies the configured memory-usage-mode option to the core memory providers.
+// The core code resolves the "auto" mode to the container mode when running
+// inside a container.
+void applyMemoryUsageMode()
+{
+   std::string mode = options().memoryUsageMode();
+   core::system::MemoryUsageMode usageMode = core::system::MemoryUsageModeAuto;
+   if (mode == "default")
+      usageMode = core::system::MemoryUsageModeDefault;
+   else if (mode == "container")
+      usageMode = core::system::MemoryUsageModeContainer;
+   else if (mode == "cgroup")
+      usageMode = core::system::MemoryUsageModeCgroup;
+   else if (mode == "meminfo")
+      usageMode = core::system::MemoryUsageModeMemInfo;
+   else if (mode != "auto")
+      LOG_WARNING_MESSAGE("Unrecognized memory-usage-mode '" + mode + "'; using auto-detection.");
+
+   core::system::setMemoryUsageMode(usageMode);
+}
+#endif
 
 /**
  * Performs a previously scheduled query for available memory.
@@ -305,6 +329,12 @@ Error initialize()
    using namespace module_context;
 
    s_queryInterval = 0;
+
+#ifdef __linux__
+   // Select how memory usage is computed and reported before the memory
+   // providers are first used.
+   applyMemoryUsageMode();
+#endif
 
    // Listen for user settings changes and change events so we can perform
    // memory statistic refreshes as needed.

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -747,6 +747,13 @@
             "memberName": "limitXfsDiskQuota_",
             "defaultValue": false,
             "description": "Indicates whether or not XFS quotas should be enforced when performing file operations via the files pane."
+         },
+         {
+            "name": "memory-usage-mode",
+            "type": "std::string",
+            "memberName": "memoryUsageMode_",
+            "defaultValue": "auto",
+            "description": "Selects how Posit Workbench computes and reports session and total memory usage. 'auto' (the default) uses 'container' when the session runs inside a container and 'default' otherwise. 'default' preserves the historical behavior: total memory is the node's physical or cgroup RAM, and Workbench aborts sessions based on node free memory plus a grace period. 'container' reports the session's cgroup memory limit as the total. 'cgroup' reads memory usage from the cgroup. 'meminfo' reads memory usage from the node's /proc/meminfo (useful when cgroup memory includes file cache that does not reflect actual session use)."
          }
       ],
       "external": [


### PR DESCRIPTION
## Problem
When Workbench runs in a container with the **Local launcher** and a **read-only cgroup filesystem**, a per-session memory limit (new-session dialog value or launcher profile `max-mem-mb`) **silently did not apply**. A runaway session grew unbounded until the container hit a kernel memory-reclaim **livelock** (not a clean abort): the session wedged and the container reported healthy for several minutes before restarting.

## Root causes & fixes
1. **The per-session limit never reached the session.** `rsandbox` runs as root in this configuration, so it sets the limit through the cgroup-based `CGroupsMemoryProvider::setProcessMemoryLimit()`, whose write hits the read-only cgroup fs and fails. That failure never fell back to a `ulimit`, so `rsession` ran with `RLIMIT_RSS = unlimited` and the in-session poller had no limit to enforce. → `LinuxResources.cpp`: `setProcessMemoryLimit()` now falls back to the base-class ulimit path (soft `RLIMIT_RSS`) when the cgroup write fails.
2. **Memory stats were host-based in a container.** `CGroupsMemoryProvider` inherited host `/proc/meminfo` totals, so the IDE memory gauge, the memory-usage report, and the poller's abort gate measured the node instead of the container. → `getTotalMemory`/`getTotalMemoryUsed` report the cgroup limit/usage; the per-session "process" figure reports this session's own process-tree RSS (the launcher-container cgroup is shared across a user's sessions, so the cgroup usage is a container-wide aggregate, preserved for the shared-pressure line via `getCgroupMemoryUsed()`). `getMemoryProvider()` binds the cgroup provider for reads based on the raw cgroup limit, independent of the reporting mode.
3. **`abortFreeMemPercent` accessor bug.** The options generator emitted `return abortFreeMemPercent_ || allowOverlay();` for this `int` option, collapsing it to 0/1 so the configured percent was ignored. → `generate-options.R`: only OR `allowOverlay()` for **bool** options in the `allow` category; regenerated `SessionOptions.gen.hpp`.

## New option
Adds a configurable `rsession.conf` option **`memory-usage-mode`** selecting how session/total memory usage is computed and reported:

- `auto` — default; resolves to `container` inside a container (via `core::system::container::isRunningInContainer()`), else `default`
- `default` — historical behavior (node total + free-mem grace for aborts)
- `container` — report the session's cgroup memory limit as the total; abort at the limit
- `cgroup` — force cgroup-based memory usage
- `meminfo` — force node `/proc/meminfo` (useful when cgroup memory includes file cache that doesn't reflect actual session use)

## Notes
- `rsandbox`/`SandboxMain.cpp` is **unchanged** — the fix lives entirely in the core memory provider, so it applies to every caller of `setProcessMemoryLimit()` on a read-only cgroup fs.
- Validated end-to-end in a containerized Workbench deployment (over-limit session self-aborts gracefully at its limit; no livelock; IDE gauge/report show container memory).