### PR TITLE
Avoid deep-copying request when handing it off to proxy client

### DIFF
--- a/src/cpp/core/http/RequestTests.cpp
+++ b/src/cpp/core/http/RequestTests.cpp
@@ -103,6 +103,77 @@ TEST(RequestTest, ProxiedUriFallsBackToHost)
    EXPECT_EQ("http://localhost:8787/path", req.proxiedUri());
 }
 
+TEST(RequestTest, MoveAssignTransfersFields)
+{
+   Request src;
+   src.setMethod("POST");
+   src.setUri("/some/path");
+   src.setHeader("X-Custom-Header", "custom-value");
+   src.addCookie("session", "abc123");
+   src.setUsername("someuser");
+   src.setBody("request body contents");
+   src.setContentLength(src.body().size());
+
+   Request dest;
+   dest.assign(std::move(src));
+
+   EXPECT_EQ("POST", dest.method());
+   EXPECT_EQ("/some/path", dest.uri());
+   EXPECT_EQ("custom-value", dest.headerValue("X-Custom-Header"));
+   EXPECT_EQ("abc123", dest.cookieValue("session"));
+   EXPECT_EQ("someuser", dest.username());
+   EXPECT_EQ("request body contents", dest.body());
+}
+
+TEST(RequestTest, MoveAssignTransfersFormFields)
+{
+   Request src;
+   src.setContentType("application/x-www-form-urlencoded");
+   src.setBody("field1=value1&field2=value2");
+   src.setContentLength(src.body().size());
+
+   // force form fields to be parsed and cached on src before the move
+   ASSERT_EQ("value1", src.formFieldValue("field1"));
+
+   Request dest;
+   dest.assign(std::move(src));
+
+   EXPECT_EQ("value1", dest.formFieldValue("field1"));
+   EXPECT_EQ("value2", dest.formFieldValue("field2"));
+}
+
+TEST(RequestTest, MoveAssignTransfersFilesAndQueryParams)
+{
+   Request src;
+   src.setUri("/some/path?param1=value1&param2=value2");
+
+   std::string boundary = "TESTBOUNDARY";
+   src.setContentType("multipart/form-data; boundary=" + boundary);
+   src.setBody(
+      "--" + boundary + "\r\n"
+      "Content-Disposition: form-data; name=\"upload\"; filename=\"hello.txt\"\r\n"
+      "Content-Type: text/plain\r\n"
+      "\r\n"
+      "hello file contents"
+      "\r\n--" + boundary + "--\r\n");
+   src.setContentLength(src.body().size());
+
+   // force query params and uploaded files to be parsed and cached on src before the move
+   ASSERT_EQ("value1", src.queryParamValue("param1"));
+   ASSERT_EQ("hello file contents", src.uploadedFile("upload").contents);
+
+   Request dest;
+   dest.assign(std::move(src));
+
+   EXPECT_EQ("value1", dest.queryParamValue("param1"));
+   EXPECT_EQ("value2", dest.queryParamValue("param2"));
+
+   const File& uploaded = dest.uploadedFile("upload");
+   EXPECT_EQ("hello.txt", uploaded.name);
+   EXPECT_EQ("text/plain", uploaded.contentType);
+   EXPECT_EQ("hello file contents", uploaded.contents);
+}
+
 } // namespace tests
 } // namespace http
 } // namespace core

--- a/src/cpp/core/include/core/http/Message.hpp
+++ b/src/cpp/core/include/core/http/Message.hpp
@@ -17,6 +17,7 @@
 #define CORE_HTTP_MESSAGE_HPP
 
 #include <string>
+#include <utility>
 #include <vector>
 #include <algorithm>
 #include <stdint.h>
@@ -126,6 +127,21 @@ protected:
       headers_ = message.headers_;
       overrideHeader_ = message.overrideHeader_;
       httpVersion_ = message.httpVersion_;
+
+      std::for_each(extraHeaders.begin(), extraHeaders.end(),
+                    boost::bind(&Message::setExtraHeader, this, _1));
+   }
+
+   // rvalue overload - moves fields instead of copying them; use when the
+   // source message is about to be discarded (e.g. handed off to a client)
+   void assign(Message&& message, const Headers& extraHeaders)
+   {
+      body_ = std::move(message.body_);
+      httpVersionMajor_ = message.httpVersionMajor_;
+      httpVersionMinor_ = message.httpVersionMinor_;
+      headers_ = std::move(message.headers_);
+      overrideHeader_ = std::move(message.overrideHeader_);
+      httpVersion_ = std::move(message.httpVersion_);
 
       std::for_each(extraHeaders.begin(), extraHeaders.end(),
                     boost::bind(&Message::setExtraHeader, this, _1));

--- a/src/cpp/core/include/core/http/Message.hpp
+++ b/src/cpp/core/include/core/http/Message.hpp
@@ -166,7 +166,7 @@ private:
 private:
 
    // IMPORTANT NOTE: when adding data members be sure to update
-   // the implementation of the assign method!!!!!
+   // the implementation of the assign methods!!!!!
 
 
    int httpVersionMajor_;

--- a/src/cpp/core/include/core/http/Request.hpp
+++ b/src/cpp/core/include/core/http/Request.hpp
@@ -260,7 +260,7 @@ private:
    std::string rootPath_;
 
    // IMPORTANT NOTE: when adding data members be sure to update
-   // the implementation of the assign method!!!!!
+   // the implementation of the assign methods!!!!!
 
 
    std::string method_;

--- a/src/cpp/core/include/core/http/Request.hpp
+++ b/src/cpp/core/include/core/http/Request.hpp
@@ -60,6 +60,29 @@ public:
       handlerEndTime_ = request.handlerEndTime_;
    }
 
+   // rvalue overload - moves fields instead of copying them; use when the
+   // source request is about to be discarded (e.g. handed off to a client)
+   void assign(Request&& request, const Headers& extraHeaders = Headers())
+   {
+      Message::assign(std::move(request), extraHeaders);
+      method_ = std::move(request.method_);
+      uri_ = std::move(request.uri_);
+      remoteUid_ = request.remoteUid_;
+      parsedCookies_ = request.parsedCookies_;
+      cookies_ = std::move(request.cookies_);
+      parsedFormFields_ = request.parsedFormFields_;
+      formFields_ = std::move(request.formFields_);
+      files_ = std::move(request.files_);
+      emptyFile_ = std::move(request.emptyFile_);
+      parsedQueryParams_ = request.parsedQueryParams_;
+      queryParams_ = std::move(request.queryParams_);
+      username_ = std::move(request.username_);
+      requestSequence_ = request.requestSequence_;
+      startTime_ = request.startTime_;
+      handlerStartTime_ = request.handlerStartTime_;
+      handlerEndTime_ = request.handlerEndTime_;
+   }
+
 public:
    const std::string& method() const { return method_; }
    void setMethod(const std::string& method) { method_ = method; }

--- a/src/cpp/server/include/server/session/ServerSessionProxy.hpp
+++ b/src/cpp/server/include/server/session/ServerSessionProxy.hpp
@@ -93,6 +93,10 @@ void proxyVSCodeRequest(
    
 bool requiresSession(const core::http::Request& request);
 
+// Invariant: If a filter returns false, it should not mutate and must not
+// retain the provided Request. It continues to be used and is later moved
+// to the default proxy forwarder.
+
 typedef boost::function<bool(
     boost::shared_ptr<core::http::AsyncConnection>,
     boost::shared_ptr<core::http::Request>,

--- a/src/cpp/server/session/ServerSessionProxy.cpp
+++ b/src/cpp/server/session/ServerSessionProxy.cpp
@@ -1109,11 +1109,6 @@ void proxyVSCodeRequest(
                                boost::bind(handleContentError, ptrConnection, context, _1));
 }
 
-// scrambled-port URL patterns for localhost proxy requests, precompiled since
-// this function is on the hot path for every proxied localhost request
-const boost::regex kIpv4LocalhostPortRegex("/p/([a-fA-F0-9]{8,9})(/|$)");
-const boost::regex kIpv6LocalhostPortRegex("/p6/([a-fA-F0-9]{8,9})(/|$)");
-
 void proxyLocalhostRequest(
       bool ipv6,
       const std::string& username,
@@ -1138,6 +1133,8 @@ void proxyLocalhostRequest(
 
    // extract the (scrambled) port, which consists of 8 or 9 hex digits
    // (an additional prefix digit may exist for server routing)
+   static const boost::regex kIpv4LocalhostPortRegex("/p/([a-fA-F0-9]{8,9})(/|$)");
+   static const boost::regex kIpv6LocalhostPortRegex("/p6/([a-fA-F0-9]{8,9})(/|$)");
    const boost::regex& re = ipv6 ? kIpv6LocalhostPortRegex : kIpv4LocalhostPortRegex;
    boost::smatch match;
    if (!regex_utils::search(pRequest->uri(), match, re))

--- a/src/cpp/server/session/ServerSessionProxy.cpp
+++ b/src/cpp/server/session/ServerSessionProxy.cpp
@@ -807,8 +807,9 @@ void proxyRequest(
    if (!connectionRetryProfile.empty())
       pClient->setConnectionRetryProfile(connectionRetryProfile);
 
-   // assign request
-   pClient->request().assign(*pRequest);
+   // assign request - pRequest is not used again after this point, so move
+   // its contents into the client's request instead of deep-copying them
+   pClient->request().assign(std::move(*pRequest));
 
    LOG_DEBUG_MESSAGE("- Start server proxy request " + ptrConnection->request().method() + " " + ptrConnection->request().debugInfo() + (context.scope.isWorkspaces() ? " - workspaces" : "") + " for local stream: " + streamPath.getAbsolutePath() + (connectionRetryProfile.empty() ? "" : " with retry"));
 
@@ -1108,6 +1109,11 @@ void proxyVSCodeRequest(
                                boost::bind(handleContentError, ptrConnection, context, _1));
 }
 
+// scrambled-port URL patterns for localhost proxy requests, precompiled since
+// this function is on the hot path for every proxied localhost request
+const boost::regex kIpv4LocalhostPortRegex("/p/([a-fA-F0-9]{8,9})(/|$)");
+const boost::regex kIpv6LocalhostPortRegex("/p6/([a-fA-F0-9]{8,9})(/|$)");
+
 void proxyLocalhostRequest(
       bool ipv6,
       const std::string& username,
@@ -1127,21 +1133,16 @@ void proxyLocalhostRequest(
 
    LOG_DEBUG_MESSAGE("Start localhost proxy request " + ptrConnection->request().method() + " " + ptrConnection->request().debugInfo());
 
-   // make a copy of the request for forwarding
-   http::Request request;
-   request.assign(ptrConnection->request());
-
    // call request filter if we have one
-   invokeRequestFilter(&request);
+   invokeRequestFilter(pRequest.get());
 
-   // extract the (scrambled) port, which consists of 8 or 9 hex digits 
+   // extract the (scrambled) port, which consists of 8 or 9 hex digits
    // (an additional prefix digit may exist for server routing)
-   std::string pMap = ipv6 ? "/p6/" : "/p/";
-   boost::regex re(pMap + "([a-fA-F0-9]{8,9})(/|$)");
+   const boost::regex& re = ipv6 ? kIpv6LocalhostPortRegex : kIpv4LocalhostPortRegex;
    boost::smatch match;
-   if (!regex_utils::search(request.uri(), match, re))
+   if (!regex_utils::search(pRequest->uri(), match, re))
    {
-      ptrConnection->response().setNotFoundError(request);
+      ptrConnection->response().setNotFoundError(*pRequest);
       return;
    }
 
@@ -1159,7 +1160,7 @@ void proxyLocalhostRequest(
    if (portNum < 0)
    {
       // act as though there's no content here if we can't determine the correct port
-      ptrConnection->response().setNotFoundError(request);
+      ptrConnection->response().setNotFoundError(*pRequest);
       return;
    }
 
@@ -1168,29 +1169,29 @@ void proxyLocalhostRequest(
    // strip the port part of the uri
    using namespace boost::algorithm;
    std::string portPath = match[0];
-   std::string uri = replace_first_copy(request.uri(), portPath, "/");
-   request.setUri(uri);
+   std::string uri = replace_first_copy(pRequest->uri(), portPath, "/");
+   pRequest->setUri(uri);
 
    // remove headers to be a correctly behaving proxy
-   request.removeHeader("Keep-Alive");
-   request.removeHeader("Proxy-Authenticate");
-   request.removeHeader("Proxy-Authorization");
-   request.removeHeader("Trailers");
+   pRequest->removeHeader("Keep-Alive");
+   pRequest->removeHeader("Proxy-Authenticate");
+   pRequest->removeHeader("Proxy-Authorization");
+   pRequest->removeHeader("Trailers");
    // spec says we should drop these but we're not sure if that's
    // true for our use case
-   //request.removeHeader("TE");
-   //request.removeHeader("Transfer-Encoding");
+   //pRequest->removeHeader("TE");
+   //pRequest->removeHeader("Transfer-Encoding");
 
    // we had trouble with sending jetty accept-encoding of gzip
    // (it returns content w/o a Content-Length which foilis our
    // decoding code)
-   request.removeHeader("Accept-Encoding");
+   pRequest->removeHeader("Accept-Encoding");
 
    // specify closing of the connection after the request unless this is
    // an attempt to upgrade to websockets
-   if (!http::util::isWSUpgradeRequest(request))
+   if (!http::util::isWSUpgradeRequest(*pRequest))
    {
-      request.setHeader("Connection", "close");
+      pRequest->setHeader("Connection", "close");
    }
 
    LocalhostResponseHandler onResponse =
@@ -1198,7 +1199,7 @@ void proxyLocalhostRequest(
    http::ErrorHandler onError = boost::bind(handleLocalhostError, ptrConnection, _1);
 
    // see if the request should be handled by the overlay (unless it should be handled by the server)
-   if (!server && overlay::proxyLocalhostRequest(request, port, context, ptrConnection, onResponse, onError))
+   if (!server && overlay::proxyLocalhostRequest(*pRequest, port, context, ptrConnection, onResponse, onError))
    {
       // request handled by the overlay
       return;
@@ -1214,14 +1215,16 @@ void proxyLocalhostRequest(
    {
       address = "::1";
    }
-   request.setHost(http::URL::formatHostPort(address, port));
+   pRequest->setHost(http::URL::formatHostPort(address, port));
 
    // create async tcp/ip client and assign request
    boost::shared_ptr<http::IAsyncClient> pClient(
       new server_core::http::LocalhostAsyncClient(ptrConnection->ioContext(), address, port));
-   // Ensure async operations on both the browser->rserver and rserver->backend run on the same thread. 
+   // Ensure async operations on both the browser->rserver and rserver->backend run on the same thread.
    pClient->setStrand(&ptrConnection->getStrand());
-   pClient->request().assign(request);
+   // pRequest is not used again after this point, so move its contents into
+   // the client's request instead of deep-copying them
+   pClient->request().assign(std::move(*pRequest));
 
    // execute request
    pClient->execute(


### PR DESCRIPTION
Companion PR to rstudio-pro#11777 -- as this is my first contribution after joining the workbench team I thought I'd make a fresh PR here and say hi to the open source team :wave: 

proxyLocalhostRequest built a shared pRequest for applyProxyFilter, then threw it away and built a second independent Request copy from the same source for the rest of the function, and copied that into the outbound client. loadBalancerProxyFilter (the only registered ProxyFilter) never mutates the request before returning false, and overlay::proxyLocalhostRequest is agnostic to whether its Request& backs onto a stack or shared_ptr-owned object, so pRequest can be reused throughout instead - matching how proxyRequest() already works. Reduces 3 copies to 1 copy + 1 move.

ServerSessionProxy::proxyRequest() builds a heap-allocated Request, mutates it via filters, then deep-copies every field into the outbound client's Request. Since the source is discarded right after, add rvalue-reference assign() overloads to Message/Request that move fields instead of copying, and use it at the one hot-path call site that doesn't need the source afterward.

Precompile scrambled-port regexes in proxyLocalhostRequest as one more little request proxying optimization.

<!-- include an entry in NEWS.md if required -->

### Intent

Improve request proxying efficiency, primarily by reducing amount of heap data copying that goes on for every request.

### Approach

* Keep one copy of the request to simplify scope and reduce risk. We mutate it before forwarding, so copying/mutating/forwarding seems reasonable
* Avoid additional copying beyond this by: merging two deep copies in proxyLocalhostRequest to just one, and by converting a copy to a move when providing the request to the outbound client. The heaviest properties of the request, like potentially a fully buffered request body in some cases, are now not copied when moved to the client.

### Automated Tests

Includes new unit tests for accuracy of data in the moved request

### QA Notes

> Ensure you have updated the QA Notes in the original issue.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
