### PR TITLE
grant id-token: write to cache-seed callers of the e2e workflows

### DIFF
--- a/.github/workflows/os-cache-seed-e2e-macos-26-arm64.yml
+++ b/.github/workflows/os-cache-seed-e2e-macos-26-arm64.yml
@@ -42,6 +42,10 @@ permissions:
   # build_only=true (the only mode the cache seeder uses), so this permission
   # is never exercised here — it's declared only to satisfy the validator.
   pull-requests: write
+  # Likewise required only by the validator: the called workflow's e2e-merge
+  # job declares id-token: write for the OIDC S3 report upload, which never
+  # runs in build_only mode.
+  id-token: write
 
 jobs:
   seed:

--- a/.github/workflows/os-cache-seed-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/os-cache-seed-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -51,6 +51,10 @@ permissions:
   # build_only=true (the only mode the cache seeder uses), so this permission
   # is never exercised here -- it's declared only to satisfy the validator.
   pull-requests: write
+  # Likewise required only by the validator: the called workflow's e2e-merge
+  # job declares id-token: write for the OIDC S3 report upload, which never
+  # runs in build_only mode.
+  id-token: write
 
 jobs:
   seed:

--- a/.github/workflows/os-cache-seed-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-cache-seed-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -32,6 +32,9 @@ permissions:
   # declares pull-requests: write. GitHub validates all declared permissions at
   # call time even for jobs that will be skipped (build_only=true skips e2e-merge).
   pull-requests: write
+  # Likewise required only by the validator: e2e-merge declares id-token: write
+  # for the OIDC S3 report upload, which never runs in build_only mode.
+  id-token: write
 
 jobs:
   seed:

--- a/.github/workflows/os-cache-seed-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/os-cache-seed-e2e-rstudio-server-os-ubuntu-24.yml
@@ -46,6 +46,10 @@ permissions:
   # build_only=true (the only mode the cache seeder uses), so this permission
   # is never exercised here -- it's declared only to satisfy the validator.
   pull-requests: write
+  # Likewise required only by the validator: the called workflow's e2e-merge
+  # job declares id-token: write for the OIDC S3 report upload, which never
+  # runs in build_only mode.
+  id-token: write
 
 jobs:
   seed:

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025-seed.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025-seed.yml
@@ -19,6 +19,9 @@ permissions:
   # declares pull-requests: write. GitHub validates all declared permissions at
   # call time even for jobs that will be skipped (build_only=true skips e2e-merge).
   pull-requests: write
+  # Likewise required only by the validator: e2e-merge declares id-token: write
+  # for the OIDC S3 report upload, which never runs in build_only mode.
+  id-token: write
 
 jobs:
   seed-windows-2025:


### PR DESCRIPTION
## Summary

Every cache-seed workflow has failed with `startup_failure` since #18132 merged. That PR added a top-level `id-token: write` permission to the reusable e2e test workflows (for the OIDC S3 report upload in the e2e-merge job), and GitHub validates at call time that a called reusable workflow's permissions never exceed the caller's grants -- even for jobs that will be skipped. The seeders declare an explicit `permissions` block without `id-token`, so validation fails before any job starts.

Example failing run: https://github.com/rstudio/rstudio/actions/runs/29302093768

This adds `id-token: write` to all five seeder callers:

- `os-cache-seed-e2e-rstudio-desktop-os-ubuntu-24.yml`
- `os-cache-seed-e2e-rstudio-server-os-ubuntu-24.yml`
- `os-cache-seed-e2e-macos-26-arm64.yml`
- `os-cache-seed-e2e-rstudio-desktop-os-windows-server-2025.yml`
- `os-test-e2e-rstudio-desktop-os-windows-server-2025-seed.yml`

The permission is never actually exercised by the seeders (`build_only: true` skips e2e-merge); it is declared only to satisfy the call-time validator, matching the existing `pull-requests: write` pattern.

The scheduled (non-seed) callers were already updated by #18132 and are unaffected.

## Verification

- All five workflows parse as valid YAML and grant `permissions.id-token: write`.
- Call-time validation itself only runs on the default branch's workflow files, so full verification is the next scheduled/push seed run on main after merge.

No NEWS.md entry: internal CI/build-tooling change.