### PR TITLE
use default light label color in dark modal dialogs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 - ([#18198](https://github.com/rstudio/rstudio/issues/18198)): Fixed tar errors and warnings printed to the console after installing a package from a URL with `install.packages(..., repos = NULL)`.
 - ([#18197](https://github.com/rstudio/rstudio/issues/18197)): Fixed an issue where the Render button failed to render a Quarto document living within a sub-directory of a Quarto project.
 - ([#18208](https://github.com/rstudio/rstudio/issues/18208)): Fixed an issue in RStudio Server where requests could fail with "Unable to connect to service" for 30 seconds or more while a suspended session was relaunching.
+- ([#17650](https://github.com/rstudio/rstudio/issues/17650)): Fixed unreadable label text in dark modal dialogs when using third-party themes (e.g. rsthemes) that style dialog labels for light backgrounds.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2610,6 +2610,15 @@ input[type="checkbox"]:checked:before {
    color: #eee;
 }
 
+/* Default label color for dark dialogs. The extra .dialogContent class is
+   needed to outrank third-party full-IDE themes (e.g. rsthemes) that hardcode
+   a dark .gwt-DialogBox-ModalDialog .dialogContent .gwt-Label color intended
+   for light dialog backgrounds (#17650). Rules that dim specific labels must
+   match this specificity and appear later in the cascade. */
+.rstudio-themes-dark.rstudio-theme-aware-dialog .dialogContent .gwt-Label {
+   color: #eee;
+}
+
 .rstudio-themes-dark.rstudio-theme-aware-dialog input[type="text"],
 .rstudio-themes-dark.rstudio-theme-aware-dialog input[type="password"],
 .rstudio-themes-dark.rstudio-theme-aware-dialog input[type="number"],
@@ -2677,7 +2686,8 @@ input[type="checkbox"]:checked:before {
    color: #888;
 }
 
-.rstudio-themes-dark.rstudio-theme-aware-dialog .rstudio-trust-detail {
+.rstudio-themes-dark.rstudio-theme-aware-dialog .rstudio-trust-detail,
+.rstudio-themes-dark.rstudio-theme-aware-dialog .dialogContent .rstudio-trust-detail {
    color: #aaa;
 }
 
@@ -2696,7 +2706,8 @@ input[type="checkbox"]:checked:before {
    border-color: THEME_DARKGREY_BORDER;
 }
 
-.rstudio-themes-dark.rstudio-theme-aware-dialog .rstudio-HyperlinkLabel {
+.rstudio-themes-dark.rstudio-theme-aware-dialog .rstudio-HyperlinkLabel,
+.rstudio-themes-dark.rstudio-theme-aware-dialog .dialogContent .rstudio-HyperlinkLabel {
    color: #abc;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/widget/Wizard.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/Wizard.css
@@ -109,11 +109,15 @@
 /* Dark theme overrides (only active for wizards that opt in via setThemeAware) */
 @external rstudio-themes-dark;
 @external rstudio-theme-aware-dialog;
+@external dialogContent;
 @eval THEME_DARKGREY_INACTIVE org.rstudio.core.client.theme.ThemeColors.darkGreyInactiveBackground;
 @eval THEME_DARKGREY_MOST_INACTIVE org.rstudio.core.client.theme.ThemeColors.darkGreyMostInactiveBackground;
 @eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.darkGreyBorder;
 
-.rstudio-themes-dark.rstudio-theme-aware-dialog .subcaptionLabel {
+/* The .dialogContent variant outranks the default dark-dialog .gwt-Label color
+   from themeStyles.css */
+.rstudio-themes-dark.rstudio-theme-aware-dialog .subcaptionLabel,
+.rstudio-themes-dark.rstudio-theme-aware-dialog .dialogContent .subcaptionLabel {
    color: #aaa;
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorDialogsStyles.css
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorDialogsStyles.css
@@ -1,4 +1,4 @@
-@external gwt-Label, gwt-TextBox, gwt-RadioButton, suggestPopupMiddleCenter, rstudio-themes-dark, rstudio-theme-aware-dialog, rstudio-ImageButton;
+@external gwt-Label, gwt-TextBox, gwt-RadioButton, suggestPopupMiddleCenter, rstudio-themes-dark, rstudio-theme-aware-dialog, rstudio-ImageButton, dialogContent;
 
 @eval THEME_DARKGREY_MENU_BORDER org.rstudio.core.client.theme.ThemeColors.darkGreyMenuBorder;
 
@@ -199,9 +199,14 @@
    color: rgba(0, 0, 0, 0.6);
 }
 
+/* The .dialogContent variants outrank the default dark-dialog .gwt-Label color
+   from themeStyles.css */
 .rstudio-themes-dark.rstudio-theme-aware-dialog .dialog .infoLabel,
+.rstudio-themes-dark.rstudio-theme-aware-dialog .dialogContent .dialog .infoLabel,
 .rstudio-themes-dark.rstudio-theme-aware-dialog .dialog .inlineInfoLabel,
-.rstudio-themes-dark.rstudio-theme-aware-dialog .dialog .heightAuto {
+.rstudio-themes-dark.rstudio-theme-aware-dialog .dialogContent .dialog .inlineInfoLabel,
+.rstudio-themes-dark.rstudio-theme-aware-dialog .dialog .heightAuto,
+.rstudio-themes-dark.rstudio-theme-aware-dialog .dialogContent .dialog .heightAuto {
    color: #aaa;
 }
 


### PR DESCRIPTION
Third-party full-IDE themes generated by packages like [rsthemes](https://github.com/gadenbuie/rsthemes) inject a hardcoded rule:

```css
.gwt-DialogBox-ModalDialog .dialogContent .gwt-Label {
  color: #333333;
}
```

This was written when modal dialogs always had light backgrounds. With dark theme-aware modal dialogs (`use_dark_theme_modal_dialogs`, on by default), that rule outranks RStudio's dark-dialog text color at specificity (0,3,0) vs (0,2,0), leaving dark-grey label text on a dark-grey background (see https://github.com/rstudio/rstudio/issues/17650#issuecomment-4744348606 for the full analysis).

This PR hardens the dark-dialog styling:

- Adds a default label color for dark theme-aware dialogs at specificity (0,4,0), mirroring the theme selector shape (`.dialogContent .gwt-Label`) so it only affects elements those theme rules were already targeting, and only when RStudio itself has painted the dialog dark.
- Bumps the specificity of our own dimmed-label rules (trust detail, hyperlink labels, wizard subcaptions, panmirror info labels) so they continue to apply over the new default. Other dark-dialog color rules were audited and either don't target `gwt-Label` widgets, already use `#eee`, or are unused.

Themes that intentionally restyle dark dialogs can still override with higher specificity, and users can disable dark modal dialogs via the existing preference.

Verified with a GWT draft build; needs manual verification with an rsthemes/base16 dark theme applied.

Addresses #17650.