### PR TITLE
opt the data viewer grid out of browser scroll anchoring

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 - ([#18198](https://github.com/rstudio/rstudio/issues/18198)): Fixed tar errors and warnings printed to the console after installing a package from a URL with `install.packages(..., repos = NULL)`.
 - ([#18197](https://github.com/rstudio/rstudio/issues/18197)): Fixed an issue where the Render button failed to render a Quarto document living within a sub-directory of a Quarto project.
 - ([#18208](https://github.com/rstudio/rstudio/issues/18208)): Fixed an issue in RStudio Server where requests could fail with "Unable to connect to service" for 30 seconds or more while a suspended session was relaunching.
+- ([#18221](https://github.com/rstudio/rstudio/issues/18221)): Fixed an issue on Windows where scrolling the Data Viewer with the mouse wheel could get stuck when the pointer was over the table body.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/cpp/session/resources/grid/DataViewer.css
+++ b/src/cpp/session/resources/grid/DataViewer.css
@@ -147,6 +147,10 @@ body.auto-scrolling {
    overflow-y: auto;
    scrollbar-width: none;                /* Firefox */
    overscroll-behavior: none;
+   /* Rows are virtualized in lockstep with #gridViewport (window replaced,
+      spacer rows resized), so opt out of scroll anchoring here too; see the
+      #gridViewport rule for the full rationale. */
+   overflow-anchor: none;
    position: relative;
    /* Separator between the frozen pane and the scrolling columns. */
    border-right: 1px solid var(--grid-border);
@@ -172,6 +176,13 @@ body.auto-scrolling {
       has known dimensions, so the boundary is already obvious without it.
       Also prevents scroll chaining out of the iframe. */
    overscroll-behavior: none;
+   /* The body rows are virtualized: scrolling replaces the rendered row window
+      and resizes the top spacer row. With scroll anchoring enabled the browser
+      adjusts scrollTop to compensate for that content shift, undoing the
+      user's scroll (wheel scrolling got "stuck" with discrete mouse-wheel
+      ticks on Windows). The virtualizer manages the scroll position itself via
+      the spacers, so opt out of anchoring (same fix as #sidebarContent). */
+   overflow-anchor: none;
 }
 /* Hide native scrollbars only in overlay-scrollbar mode -- the custom
    scrollbars are rendered as sibling divs. The body carries the


### PR DESCRIPTION
Addresses #18221.

### Problem

On Windows, mouse-wheel scrolling over the Data Viewer's table body got "stuck" at arbitrary points, while scrolling over the row names (pinned pane) worked fine.

### Cause

The grid body and pinned pane are virtualized: scrolling replaces the rendered row window and resizes the top spacer row. With browser scroll anchoring enabled, Chromium adjusts `scrollTop` to compensate for that content shift above the anchor node, undoing the user's scroll.

This is most visible on Windows because discrete mouse-wheel ticks are driven through Chromium's smooth-scroll animation, leaving a window between ticks where the spacer resize lands and anchoring snaps the position back, with no follow-up event stream to override it. macOS trackpad scrolling delivers a continuous high-frequency stream that masks the adjustment. Scrolling over the pinned pane works because it mirrors its scroll position onto the viewport programmatically on every scroll event.

### Fix

Opt `#gridViewport` and `#pinnedPane` out of scroll anchoring with `overflow-anchor: none` -- the same fix the virtualized summary sidebar received in #17977. The virtualizer already manages the scroll position itself via the spacer rows.

### QA notes

Requires manual verification on Windows with a discrete-wheel mouse: `View(iris)`, point at the table body, and wheel-scroll vertically; scrolling should be smooth all the way through the dataset. Equivalent to setting `overflowAnchor = "none"` on `#gridViewport` in DevTools, which can be used to confirm the diagnosis on an unpatched build.
