### PR TITLE
data viewer: don't corrupt grid state while the tab is hidden

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 - ([#18198](https://github.com/rstudio/rstudio/issues/18198)): Fixed tar errors and warnings printed to the console after installing a package from a URL with `install.packages(..., repos = NULL)`.
 - ([#18197](https://github.com/rstudio/rstudio/issues/18197)): Fixed an issue where the Render button failed to render a Quarto document living within a sub-directory of a Quarto project.
 - ([#18208](https://github.com/rstudio/rstudio/issues/18208)): Fixed an issue in RStudio Server where requests could fail with "Unable to connect to service" for 30 seconds or more while a suspended session was relaunching.
+- ([#18215](https://github.com/rstudio/rstudio/issues/18215)): Fixed an issue where the Data Viewer could lose its scroll position, or render an empty grid, after switching to another tab and back.
 
 ### Dependencies
 - Ace 1.43.5

--- a/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
@@ -1431,6 +1431,100 @@ test.describe('Data Viewer', () => {
     }
   });
 
+  // https://github.com/rstudio/rstudio/issues/18215
+  //
+  // While the viewer tab is hidden its iframe has no layout: the grid
+  // viewport reads clientWidth/scrollLeft as 0. Grid events that land in that
+  // state (e.g. the scrollend of a gesture interrupted by the tab switch)
+  // used to (a) fold the zeroed scroll position into the lastScrollTop/Left
+  // mirrors, losing the saved position, and (b) collapse the virtualized
+  // column window to a single edge column, which the tab-activation re-render
+  // then used as-is -- leaving the grid mostly spacer. Both reads are now
+  // ignored while the tab has no layout, and onActivate re-derives the
+  // column window from live geometry.
+  test('scroll events on a hidden viewer tab do not corrupt position or column window', async ({ rstudioPage: page }) => {
+    // Wide enough that the rendered column window is a strict subset of the
+    // columns, so a collapsed window is observable.
+    await consoleActions.executeInConsole(
+      '{ .rs.hidden_evt_df <- as.data.frame(matrix(seq_len(4000), nrow = 10, ncol = 400)); View(.rs.hidden_evt_df) }',
+    );
+    try {
+      await waitForViewer(dataViewer);
+
+      // Scroll deep into the columns and capture the settled position.
+      await dataViewer.goToColumn(300);
+      await expect(dataViewer.columnHeader(300)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      const scrollLeftBefore = await dataViewer.viewport.evaluate((el) => el.scrollLeft);
+      expect(scrollLeftBefore).toBeGreaterThan(0);
+
+      // Hide the viewer tab, then replay the tail of a scroll gesture into
+      // the now-hidden grid (both handlers read zeroed geometry here).
+      const sourceTabs = page.locator("[class*='rstudio_source_panel'] .gwt-TabLayoutPanelTab");
+      await sourceTabs.filter({ hasText: 'Untitled' }).first().click();
+      await expect(sourcePane.selectedTab).toContainText('Untitled');
+      await dataViewer.viewport.evaluate((el) => {
+        el.dispatchEvent(new Event('scroll'));
+        el.dispatchEvent(new Event('scrollend'));
+      });
+
+      // Back to the viewer: the grid must still be at column 300, with real
+      // cells rendered there (a collapsed window leaves only spacer here).
+      await sourceTabs.filter({ hasText: '.rs.hidden_evt_df' }).first().click();
+      await expect(dataViewer.columnHeader(300)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      await expect.poll(() => dataViewer.viewport.evaluate((el) => el.scrollLeft))
+        .toBe(scrollLeftBefore);
+    } finally {
+      await consoleActions.executeInConsole(
+        'rm(".rs.hidden_evt_df", envir = .GlobalEnv)',
+      );
+    }
+  });
+
+  // https://github.com/rstudio/rstudio/issues/18215
+  //
+  // Some activation paths (SourceColumn.onActivate) invoke the target's
+  // onActivate before its tab widget is shown. With no layout the scroll
+  // restore is a no-op that used to overwrite the lastScrollTop/Left mirrors
+  // with the hidden viewport's zeros, so the next real activation restored
+  // the top-left corner instead of the user's position. onActivate now
+  // defers itself until the tab has layout.
+  test('onActivate on a hidden viewer tab defers until layout exists', async ({ rstudioPage: page }) => {
+    await consoleActions.executeInConsole(
+      '{ .rs.hidden_act_df <- as.data.frame(matrix(seq_len(4000), nrow = 10, ncol = 400)); View(.rs.hidden_act_df) }',
+    );
+    try {
+      await waitForViewer(dataViewer);
+
+      await dataViewer.goToColumn(300);
+      await expect(dataViewer.columnHeader(300)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      const scrollLeftBefore = await dataViewer.viewport.evaluate((el) => el.scrollLeft);
+      expect(scrollLeftBefore).toBeGreaterThan(0);
+
+      // Hide the viewer tab, then fire the activation hook by hand while the
+      // iframe still has no layout (what the early-activation path does).
+      const sourceTabs = page.locator("[class*='rstudio_source_panel'] .gwt-TabLayoutPanelTab");
+      await sourceTabs.filter({ hasText: 'Untitled' }).first().click();
+      await expect(sourcePane.selectedTab).toContainText('Untitled');
+      await page.evaluate((sel: string) => {
+        const f = document.querySelector(sel) as HTMLIFrameElement | null;
+        const w = f?.contentWindow as unknown as { onActivate?: () => void } | undefined;
+        if (!w?.onActivate) throw new Error('onActivate() not available on data viewer iframe');
+        w.onActivate();
+      }, VIEWER_FRAME);
+
+      // Returning to the tab must land on the saved position, not the
+      // top-left corner the hidden onActivate observed.
+      await sourceTabs.filter({ hasText: '.rs.hidden_act_df' }).first().click();
+      await expect(dataViewer.columnHeader(300)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      await expect.poll(() => dataViewer.viewport.evaluate((el) => el.scrollLeft))
+        .toBe(scrollLeftBefore);
+    } finally {
+      await consoleActions.executeInConsole(
+        'rm(".rs.hidden_act_df", envir = .GlobalEnv)',
+      );
+    }
+  });
+
   // Adding a column flips the server-side column fingerprint, which discards
   // the saved per-object UI state (it can no longer be trusted against the new
   // column structure). The live sidebar choice must NOT be discarded with it:

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -397,6 +397,11 @@ var pendingSparklines_ = [];
 var pendingScrollbarRaf = 0;
 var pendingScrollRaf = 0;
 
+// requestAnimationFrame token for an onActivate that arrived while the tab
+// had no layout (see window.onActivate). Non-zero means a retry is scheduled;
+// cleared on onDeactivate so a pending retry can't outlive the activation.
+var pendingActivateRaf = 0;
+
 // Latched so a localStorage write failure is reported once per session
 // rather than spamming the console on every state-change debounce tick.
 var persistWarned = false;
@@ -1834,8 +1839,16 @@ var getColumnWindow = function(scrollLeft, clientWidth) {
 // position. Returns true if the window changed (so callers can rebuild).
 var computeColumnWindow = function() {
    var viewport = domViewport;
-   var sl = viewport ? viewport.scrollLeft : 0;
-   var cw = viewport ? viewport.clientWidth : 0;
+
+   // No layout (e.g. a background tab): the zero geometry would collapse the
+   // window to a single edge column, and a rebuild against that leaves the
+   // grid mostly spacer when the tab is shown again (#18215). Keep the
+   // current window; onActivate recomputes once real layout exists.
+   if (!viewport || viewport.clientWidth === 0)
+      return false;
+
+   var sl = viewport.scrollLeft;
+   var cw = viewport.clientWidth;
    var win = getColumnWindow(sl, cw);
    var changed = (win.start !== colWinStart || win.end !== colWinEnd);
    colWinStart = win.start;
@@ -4121,7 +4134,9 @@ var onScroll = function() {
    pendingScrollRaf = requestAnimationFrame(function() {
       pendingScrollRaf = 0;
       var viewport = domViewport;
-      if (!viewport) return;
+      // A collapsed viewport reads scroll positions as 0; folding those into
+      // the mirrors would discard the saved position (see onDeactivate).
+      if (!viewport || viewport.offsetHeight === 0) return;
       lastScrollTop = viewport.scrollTop;
       lastScrollLeft = viewport.scrollLeft;
       // Horizontal scroll may slide the column window; when it does, rebuild
@@ -4161,7 +4176,9 @@ var onScrollEnd = function() {
    if (anyScrollbarDragging()) return;
    onScroll.cancel();
    var viewport = domViewport;
-   if (!viewport) return;
+   // A collapsed viewport reads scroll positions as 0; folding those into
+   // the mirrors would discard the saved position (see onDeactivate).
+   if (!viewport || viewport.offsetHeight === 0) return;
    lastScrollTop = viewport.scrollTop;
    lastScrollLeft = viewport.scrollLeft;
    var colsChanged = syncColumnWindow();
@@ -7936,8 +7953,26 @@ window.applySearch = function(text) {
 };
 
 window.onActivate = function() {
-   // Restore scroll position and re-render
    var viewport = domViewport;
+
+   // Some activation paths fire before the tab widget is actually shown
+   // (SourceColumn.onActivate activates the target before selecting its tab).
+   // With no layout every geometry read below is zero -- worse, the scroll
+   // restore would fold that zero back into the lastScrollTop/Left mirrors,
+   // losing the saved position. Defer to the next animation frame: rAF is
+   // paused while the frame is render-throttled (hidden), so the retry runs
+   // once real layout exists.
+   if (viewport && viewport.offsetHeight === 0) {
+      if (!pendingActivateRaf) {
+         pendingActivateRaf = requestAnimationFrame(function() {
+            pendingActivateRaf = 0;
+            window.onActivate();
+         });
+      }
+      return;
+   }
+
+   // Restore scroll position and re-render
    if (viewport) {
       setViewportScrollTop(viewport, lastScrollTop);
       setViewportScrollLeft(viewport, lastScrollLeft);
@@ -7950,6 +7985,14 @@ window.onActivate = function() {
       autoSizeColumns();
       applyPinnedColumns();
    }
+
+   // The column window may have gone stale while the tab was hidden (e.g.
+   // the pane was resized, so it was last computed for a different width --
+   // computeColumnWindow refuses to run against the hidden tab's zero
+   // geometry), and renderVisibleRows renders against it as-is. Re-derive it
+   // from the live geometry, like the scroll handlers and onResize do
+   // (#18215; same class of gap as #18090).
+   syncColumnWindow();
 
    renderVisibleRows(true);
    // The sidebar's visible-entry window is computed from the panel's
@@ -7968,9 +8011,18 @@ window.onActivate = function() {
 };
 
 window.onDeactivate = function() {
-   // Save scroll position
+   // Drop any activation retry still waiting on layout -- the tab is being
+   // switched away from, so the retry's work belongs to the next onActivate.
+   if (pendingActivateRaf) {
+      cancelAnimationFrame(pendingActivateRaf);
+      pendingActivateRaf = 0;
+   }
+
+   // Save scroll position. Skip when the tab already has no layout: a
+   // collapsed viewport reads scrollTop/scrollLeft as 0, and folding that
+   // into the mirrors would discard the real saved position.
    var viewport = domViewport;
-   if (viewport) {
+   if (viewport && viewport.offsetHeight > 0) {
       lastScrollTop = viewport.scrollTop;
       lastScrollLeft = viewport.scrollLeft;
    }


### PR DESCRIPTION
## Summary

Investigating #18215 (data viewer blank after switching tabs and back) turned up a family of defects in how the vanilla-JS grid handles running while its tab is hidden. A hidden tab's iframe has no layout, so the grid viewport reads `clientWidth`/`clientHeight`/`scrollTop`/`scrollLeft` as 0, and grid code running in that state corrupted live state in ways the next activation never healed:

- `computeColumnWindow` collapsed the virtualized column window to a single edge column (the zero-width "never render an empty body" fallback), and `window.onActivate` rebuilt rows against the stale window without recomputing it -- the same class of gap #18090 closed for `onResize`.
- `onScroll`/`onScrollEnd`/`onDeactivate` folded the zeroed scroll reads into the `lastScrollTop`/`lastScrollLeft` mirrors, discarding the saved scroll position.
- `window.onActivate` itself can run before the tab widget is shown (`SourceColumn.onActivate` activates the target before selecting its tab), with the same effects.

## Changes

- `computeColumnWindow` keeps the current window when the viewport has no layout.
- `onScroll`/`onScrollEnd`/`onDeactivate` no longer fold zero-geometry scroll reads into the mirrors.
- `window.onActivate` defers itself to the next animation frame while the tab has no layout (rAF is paused for render-throttled frames, so the retry runs once layout exists), and re-derives the column window from live geometry before re-rendering, like the scroll handlers and `onResize` do.

## Testing

Two new Playwright tests replay the corrupting sequences (a scroll gesture's tail landing after the tab switch; an early `onActivate` on the hidden tab) and assert the grid returns to the saved position with real cells rendered. Both fail without the DataViewer.js changes (scroll position lost, grid rendered at the wrong column window) and pass with them, alongside the neighboring tab-return test.

Whether this is the whole story for the original report is unconfirmed -- the reporter's deterministic mtcars repro (no scrolling) doesn't fit these code paths, and a machine-specific rendering issue is still plausible there -- so this hardens everything found in that investigation without claiming to close it.

Addresses #18215.