### PR TITLE
raise node heap for panmirror vite build

### DIFF
--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -304,6 +304,12 @@
             <arg value="240000"/>
          </exec>
       </retry>
+      <!-- vite needs more than node's default heap (~2GB on CI runners) to
+           render the panmirror bundle + sourcemap since pinyin 4.x added
+           several MB of dictionary data (quarto-dev/quarto#1057). preserve
+           any caller-provided NODE_OPTIONS; node lets later flags win, so a
+           caller's own heap setting takes precedence over ours. -->
+      <property name="env.NODE_OPTIONS" value=""/>
       <exec executable="${yarn.bin}" dir="${panmirror.dir}" resolveexecutable="true" failonerror="true">
          <arg value="build"/>
          <arg value="--minify"/>
@@ -311,10 +317,7 @@
          <arg value="--sourcemap"/>
          <arg value="true"/>
          <env key="PANMIRROR_OUTDIR" value="dist-rstudio"/>
-         <!-- vite needs more than node's default heap (~2GB on CI runners) to
-              render the panmirror bundle + sourcemap since pinyin 4.x added
-              several MB of dictionary data (quarto-dev/quarto#1057) -->
-         <env key="NODE_OPTIONS" value="--max-old-space-size=4096"/>
+         <env key="NODE_OPTIONS" value="--max-old-space-size=4096 ${env.NODE_OPTIONS}"/>
       </exec>
       <copy todir="${panmirror.build.dir}">
          <fileset dir="${panmirror.dir}/dist-rstudio"/>

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -311,6 +311,10 @@
          <arg value="--sourcemap"/>
          <arg value="true"/>
          <env key="PANMIRROR_OUTDIR" value="dist-rstudio"/>
+         <!-- vite needs more than node's default heap (~2GB on CI runners) to
+              render the panmirror bundle + sourcemap since pinyin 4.x added
+              several MB of dictionary data (quarto-dev/quarto#1057) -->
+         <env key="NODE_OPTIONS" value="--max-old-space-size=4096"/>
       </exec>
       <copy todir="${panmirror.build.dir}">
          <fileset dir="${panmirror.dir}/dist-rstudio"/>


### PR DESCRIPTION
CI builds started failing today on the macOS runners with:

```
[exec] FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
[exec] /bin/sh: line 1: 25640 Abort trap: 6  vite build --minify true --sourcemap true
```

`install-panmirror` clones quarto-dev/quarto at HEAD, and quarto-dev/quarto#1057 (merged today) bumped `pinyin` from 2.x to 4.x, which bundles several MB of pure-JS dictionary data into panmirror.js (4.8 MB -> 13 MB). Rendering the bundle and its sourcemap now exceeds node's default heap limit (~2 GB on the 7 GB macOS runners), so every PR build OOMs during "Building GWT sources".

This sets `NODE_OPTIONS=--max-old-space-size=4096` for the panmirror `yarn build` step.

Verified locally against quarto-dev/quarto@379ffb4 with the bundled node 22.22.2: the build aborts with exit 134 at `--max-old-space-size=2048` and succeeds at `4096`.

The bundle-size regression itself (~8 MB of pinyin dictionaries shipped in panmirror.js) is a separate concern that likely warrants an upstream issue in quarto-dev/quarto.
