### PR TITLE
[DOC] Recommend Ninja for mac/linux too

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -35,8 +35,8 @@ a) From the root of the RStudio tree create a build directory and then
 
 b) Configure the build using cmake as appropriate, e.g.
 
-   cmake .. -DRSTUDIO_TARGET=Server -DCMAKE_BUILD_TYPE=Release
-   cmake .. -DRSTUDIO_TARGET=Electron -DRSTUDIO_PACKAGE_BUILD=1
+   cmake .. -G Ninja -DRSTUDIO_TARGET=Server -DCMAKE_BUILD_TYPE=Release
+   cmake .. -G Ninja -DRSTUDIO_TARGET=Electron -DRSTUDIO_PACKAGE_BUILD=1
 
    Variables that control configuration include:
 


### PR DESCRIPTION
### Intent

Freshen up the `INSTALL` file slightly to include examples that use Ninja as the generator for cmake for all platforms, not just Windows. This leads to auto-detected core counts and also aligns with the `.vscode/` build settings, making vscode + manually run cmake more harmonious.