### PR TITLE
backport console error and data viewer fixes to rel-pacific-dogwood

### DIFF
--- a/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
@@ -1431,6 +1431,100 @@ test.describe('Data Viewer', () => {
     }
   });
 
+  // https://github.com/rstudio/rstudio/issues/18215
+  //
+  // While the viewer tab is hidden its iframe has no layout: the grid
+  // viewport reads clientWidth/scrollLeft as 0. Grid events that land in that
+  // state (e.g. the scrollend of a gesture interrupted by the tab switch)
+  // used to (a) fold the zeroed scroll position into the lastScrollTop/Left
+  // mirrors, losing the saved position, and (b) collapse the virtualized
+  // column window to a single edge column, which the tab-activation re-render
+  // then used as-is -- leaving the grid mostly spacer. Both reads are now
+  // ignored while the tab has no layout, and onActivate re-derives the
+  // column window from live geometry.
+  test('scroll events on a hidden viewer tab do not corrupt position or column window', async ({ rstudioPage: page }) => {
+    // Wide enough that the rendered column window is a strict subset of the
+    // columns, so a collapsed window is observable.
+    await consoleActions.executeInConsole(
+      '{ .rs.hidden_evt_df <- as.data.frame(matrix(seq_len(4000), nrow = 10, ncol = 400)); View(.rs.hidden_evt_df) }',
+    );
+    try {
+      await waitForViewer(dataViewer);
+
+      // Scroll deep into the columns and capture the settled position.
+      await dataViewer.goToColumn(300);
+      await expect(dataViewer.columnHeader(300)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      const scrollLeftBefore = await dataViewer.viewport.evaluate((el) => el.scrollLeft);
+      expect(scrollLeftBefore).toBeGreaterThan(0);
+
+      // Hide the viewer tab, then replay the tail of a scroll gesture into
+      // the now-hidden grid (both handlers read zeroed geometry here).
+      const sourceTabs = page.locator("[class*='rstudio_source_panel'] .gwt-TabLayoutPanelTab");
+      await sourceTabs.filter({ hasText: 'Untitled' }).first().click();
+      await expect(sourcePane.selectedTab).toContainText('Untitled');
+      await dataViewer.viewport.evaluate((el) => {
+        el.dispatchEvent(new Event('scroll'));
+        el.dispatchEvent(new Event('scrollend'));
+      });
+
+      // Back to the viewer: the grid must still be at column 300, with real
+      // cells rendered there (a collapsed window leaves only spacer here).
+      await sourceTabs.filter({ hasText: '.rs.hidden_evt_df' }).first().click();
+      await expect(dataViewer.columnHeader(300)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      await expect.poll(() => dataViewer.viewport.evaluate((el) => el.scrollLeft))
+        .toBe(scrollLeftBefore);
+    } finally {
+      await consoleActions.executeInConsole(
+        'rm(".rs.hidden_evt_df", envir = .GlobalEnv)',
+      );
+    }
+  });
+
+  // https://github.com/rstudio/rstudio/issues/18215
+  //
+  // Some activation paths (SourceColumn.onActivate) invoke the target's
+  // onActivate before its tab widget is shown. With no layout the scroll
+  // restore is a no-op that used to overwrite the lastScrollTop/Left mirrors
+  // with the hidden viewport's zeros, so the next real activation restored
+  // the top-left corner instead of the user's position. onActivate now
+  // defers itself until the tab has layout.
+  test('onActivate on a hidden viewer tab defers until layout exists', async ({ rstudioPage: page }) => {
+    await consoleActions.executeInConsole(
+      '{ .rs.hidden_act_df <- as.data.frame(matrix(seq_len(4000), nrow = 10, ncol = 400)); View(.rs.hidden_act_df) }',
+    );
+    try {
+      await waitForViewer(dataViewer);
+
+      await dataViewer.goToColumn(300);
+      await expect(dataViewer.columnHeader(300)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      const scrollLeftBefore = await dataViewer.viewport.evaluate((el) => el.scrollLeft);
+      expect(scrollLeftBefore).toBeGreaterThan(0);
+
+      // Hide the viewer tab, then fire the activation hook by hand while the
+      // iframe still has no layout (what the early-activation path does).
+      const sourceTabs = page.locator("[class*='rstudio_source_panel'] .gwt-TabLayoutPanelTab");
+      await sourceTabs.filter({ hasText: 'Untitled' }).first().click();
+      await expect(sourcePane.selectedTab).toContainText('Untitled');
+      await page.evaluate((sel: string) => {
+        const f = document.querySelector(sel) as HTMLIFrameElement | null;
+        const w = f?.contentWindow as unknown as { onActivate?: () => void } | undefined;
+        if (!w?.onActivate) throw new Error('onActivate() not available on data viewer iframe');
+        w.onActivate();
+      }, VIEWER_FRAME);
+
+      // Returning to the tab must land on the saved position, not the
+      // top-left corner the hidden onActivate observed.
+      await sourceTabs.filter({ hasText: '.rs.hidden_act_df' }).first().click();
+      await expect(dataViewer.columnHeader(300)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      await expect.poll(() => dataViewer.viewport.evaluate((el) => el.scrollLeft))
+        .toBe(scrollLeftBefore);
+    } finally {
+      await consoleActions.executeInConsole(
+        'rm(".rs.hidden_act_df", envir = .GlobalEnv)',
+      );
+    }
+  });
+
   // Adding a column flips the server-side column fingerprint, which discards
   // the saved per-object UI state (it can no longer be trusted against the new
   // column structure). The live sidebar choice must NOT be discarded with it:

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -126,6 +126,11 @@
    # recurse into arguments to catch nested calls (e.g. lapply(x, install.packages))
    for (i in seq_along(expr))
    {
+      # skip empty arguments (e.g. the trailing argument in 'mtcars[1, ]');
+      # binding the empty symbol to a variable and evaluating it would error
+      if (identical(expr[[i]], quote(expr = )))
+         next
+
       part <- expr[[i]]
       if (is.call(part) && .rs.exprMutatesPackageLibrary(part))
          return(TRUE)

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -102,6 +102,14 @@
 # namespace; bare calls resolve their namespace from the global environment.
 .rs.addFunction("exprMutatesPackageLibrary", function(expr)
 {
+   tryCatch(
+      .rs.exprMutatesPackageLibraryImpl(expr),
+      error = function(e) FALSE
+   )
+})
+
+.rs.addFunction("exprMutatesPackageLibraryImpl", function(expr)
+{
    if (!is.call(expr))
       return(FALSE)
 

--- a/src/cpp/session/resources/grid/DataViewer.css
+++ b/src/cpp/session/resources/grid/DataViewer.css
@@ -147,6 +147,10 @@ body.auto-scrolling {
    overflow-y: auto;
    scrollbar-width: none;                /* Firefox */
    overscroll-behavior: none;
+   /* Rows are virtualized in lockstep with #gridViewport (window replaced,
+      spacer rows resized), so opt out of scroll anchoring here too; see the
+      #gridViewport rule for the full rationale. */
+   overflow-anchor: none;
    position: relative;
    /* Separator between the frozen pane and the scrolling columns. */
    border-right: 1px solid var(--grid-border);
@@ -172,6 +176,13 @@ body.auto-scrolling {
       has known dimensions, so the boundary is already obvious without it.
       Also prevents scroll chaining out of the iframe. */
    overscroll-behavior: none;
+   /* The body rows are virtualized: scrolling replaces the rendered row window
+      and resizes the top spacer row. With scroll anchoring enabled the browser
+      adjusts scrollTop to compensate for that content shift, undoing the
+      user's scroll (wheel scrolling got "stuck" with discrete mouse-wheel
+      ticks on Windows). The virtualizer manages the scroll position itself via
+      the spacers, so opt out of anchoring (same fix as #sidebarContent). */
+   overflow-anchor: none;
 }
 /* Hide native scrollbars only in overlay-scrollbar mode -- the custom
    scrollbars are rendered as sibling divs. The body carries the

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -397,6 +397,11 @@ var pendingSparklines_ = [];
 var pendingScrollbarRaf = 0;
 var pendingScrollRaf = 0;
 
+// requestAnimationFrame token for an onActivate that arrived while the tab
+// had no layout (see window.onActivate). Non-zero means a retry is scheduled;
+// cleared on onDeactivate so a pending retry can't outlive the activation.
+var pendingActivateRaf = 0;
+
 // Latched so a localStorage write failure is reported once per session
 // rather than spamming the console on every state-change debounce tick.
 var persistWarned = false;
@@ -1834,8 +1839,16 @@ var getColumnWindow = function(scrollLeft, clientWidth) {
 // position. Returns true if the window changed (so callers can rebuild).
 var computeColumnWindow = function() {
    var viewport = domViewport;
-   var sl = viewport ? viewport.scrollLeft : 0;
-   var cw = viewport ? viewport.clientWidth : 0;
+
+   // No layout (e.g. a background tab): the zero geometry would collapse the
+   // window to a single edge column, and a rebuild against that leaves the
+   // grid mostly spacer when the tab is shown again (#18215). Keep the
+   // current window; onActivate recomputes once real layout exists.
+   if (!viewport || viewport.clientWidth === 0)
+      return false;
+
+   var sl = viewport.scrollLeft;
+   var cw = viewport.clientWidth;
    var win = getColumnWindow(sl, cw);
    var changed = (win.start !== colWinStart || win.end !== colWinEnd);
    colWinStart = win.start;
@@ -4121,7 +4134,9 @@ var onScroll = function() {
    pendingScrollRaf = requestAnimationFrame(function() {
       pendingScrollRaf = 0;
       var viewport = domViewport;
-      if (!viewport) return;
+      // A collapsed viewport reads scroll positions as 0; folding those into
+      // the mirrors would discard the saved position (see onDeactivate).
+      if (!viewport || viewport.offsetHeight === 0) return;
       lastScrollTop = viewport.scrollTop;
       lastScrollLeft = viewport.scrollLeft;
       // Horizontal scroll may slide the column window; when it does, rebuild
@@ -4161,7 +4176,9 @@ var onScrollEnd = function() {
    if (anyScrollbarDragging()) return;
    onScroll.cancel();
    var viewport = domViewport;
-   if (!viewport) return;
+   // A collapsed viewport reads scroll positions as 0; folding those into
+   // the mirrors would discard the saved position (see onDeactivate).
+   if (!viewport || viewport.offsetHeight === 0) return;
    lastScrollTop = viewport.scrollTop;
    lastScrollLeft = viewport.scrollLeft;
    var colsChanged = syncColumnWindow();
@@ -7936,8 +7953,26 @@ window.applySearch = function(text) {
 };
 
 window.onActivate = function() {
-   // Restore scroll position and re-render
    var viewport = domViewport;
+
+   // Some activation paths fire before the tab widget is actually shown
+   // (SourceColumn.onActivate activates the target before selecting its tab).
+   // With no layout every geometry read below is zero -- worse, the scroll
+   // restore would fold that zero back into the lastScrollTop/Left mirrors,
+   // losing the saved position. Defer to the next animation frame: rAF is
+   // paused while the frame is render-throttled (hidden), so the retry runs
+   // once real layout exists.
+   if (viewport && viewport.offsetHeight === 0) {
+      if (!pendingActivateRaf) {
+         pendingActivateRaf = requestAnimationFrame(function() {
+            pendingActivateRaf = 0;
+            window.onActivate();
+         });
+      }
+      return;
+   }
+
+   // Restore scroll position and re-render
    if (viewport) {
       setViewportScrollTop(viewport, lastScrollTop);
       setViewportScrollLeft(viewport, lastScrollLeft);
@@ -7950,6 +7985,14 @@ window.onActivate = function() {
       autoSizeColumns();
       applyPinnedColumns();
    }
+
+   // The column window may have gone stale while the tab was hidden (e.g.
+   // the pane was resized, so it was last computed for a different width --
+   // computeColumnWindow refuses to run against the hidden tab's zero
+   // geometry), and renderVisibleRows renders against it as-is. Re-derive it
+   // from the live geometry, like the scroll handlers and onResize do
+   // (#18215; same class of gap as #18090).
+   syncColumnWindow();
 
    renderVisibleRows(true);
    // The sidebar's visible-entry window is computed from the panel's
@@ -7968,9 +8011,18 @@ window.onActivate = function() {
 };
 
 window.onDeactivate = function() {
-   // Save scroll position
+   // Drop any activation retry still waiting on layout -- the tab is being
+   // switched away from, so the retry's work belongs to the next onActivate.
+   if (pendingActivateRaf) {
+      cancelAnimationFrame(pendingActivateRaf);
+      pendingActivateRaf = 0;
+   }
+
+   // Save scroll position. Skip when the tab already has no layout: a
+   // collapsed viewport reads scrollTop/scrollLeft as 0, and folding that
+   // into the mirrors would discard the real saved position.
    var viewport = domViewport;
-   if (viewport) {
+   if (viewport && viewport.offsetHeight > 0) {
       lastScrollTop = viewport.scrollTop;
       lastScrollLeft = viewport.scrollLeft;
    }

--- a/src/cpp/tests/testthat/test-packages.R
+++ b/src/cpp/tests/testthat/test-packages.R
@@ -75,6 +75,12 @@ test_that(".rs.isPackageManagementCall handles multi-statement and nested calls"
    expect_false(.rs.isPackageManagementCall("x <- 1; print(remove(y)); z <- 3"))
 })
 
+test_that(".rs.isPackageManagementCall tolerates empty arguments", {
+   expect_false(.rs.isPackageManagementCall("View(mtcars[1, ])"))
+   expect_false(.rs.isPackageManagementCall("mtcars[, 1]"))
+   expect_true(.rs.isPackageManagementCall("f(x[1, ], renv::update())"))
+})
+
 test_that(".rs.isPackageManagementCall tolerates unparseable input", {
    expect_false(.rs.isPackageManagementCall(""))
    expect_false(.rs.isPackageManagementCall("install.packages("))


### PR DESCRIPTION
Backports the following fixes from main to `rel-pacific-dogwood` for the next 2026.07.x patch release:

- f211e59bb7 (#18204): skip empty arguments when scanning for package-library mutations. Fixes the spurious `.rs.exprMutatesPackageLibrary(part): argument "part" is missing, with no default` console error in 2026.07.0. Fixes #18230.
- 4ebe4ade7e (#18222): opt the data viewer grid out of browser scroll anchoring. Addresses #18221.
- a7ed3e596f (#18223): data viewer: don't corrupt grid state while the tab is hidden. Addresses #18215.
- 49d3d21831 (#18232): extra defense against failure introspecting expr, so any future introspection failure degrades to "no Packages pane refresh" instead of a console error. Note: #18232 is still open against main.

Notes:

- The NEWS.md hunks from #18222 / #18223 were dropped during cherry-pick, since NEWS.md is deleted on release branches as part of the branch-update rotation.
- Verified locally: the r-scope `packages` testthat suite passes against the backported sources (86 passing, 0 failures), including the new empty-argument regression tests.
