### PR TITLE
e2e: fix four flakes from the pr-18229 all-platforms report

### DIFF
--- a/e2e/rstudio/tests/panes/misc/build_pane_testthat.test.ts
+++ b/e2e/rstudio/tests/panes/misc/build_pane_testthat.test.ts
@@ -1,36 +1,14 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
-import { TIMEOUTS } from '@utils/constants';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { installDepIfPrompted } from '@pages/modals.page';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { rPathLiteral, rStringLiteral } from '@utils/r';
 import { documentOpen, executeCommand, openProject } from '@utils/commands';
+import { closeProjectIfOpen } from '@utils/project';
 import { seedSandboxFile } from '@utils/files';
 import * as path from 'path';
-import type { Page } from 'playwright';
 
 const PROJECT_MENU = '#rstudio_project_menubutton_toolbar';
-
-async function waitForConsoleIdle(page: Page): Promise<void> {
-  await page.waitForFunction(
-    () => {
-      const el = document.getElementById('rstudio_console_input');
-      return !!el && !el.classList.contains('rstudio-console-busy');
-    },
-    null,
-    { timeout: TIMEOUTS.sessionRestart, polling: 100 },
-  );
-}
-
-async function closeProjectIfOpen(page: Page): Promise<void> {
-  const menu = page.locator(PROJECT_MENU);
-  const label = (await menu.innerText().catch(() => '')).trim();
-  if (label.includes('(None)') || label === '') return;
-  await menu.click();
-  await page.locator('#rstudio_label_close_project_command').click();
-  await expect(menu).toContainText('(None)', { timeout: TIMEOUTS.sessionRestart });
-  await waitForConsoleIdle(page);
-}
 
 test.describe('Build pane', () => {
   const sandbox = useSuiteSandbox();

--- a/e2e/rstudio/tests/panes/terminal/terminal.test.ts
+++ b/e2e/rstudio/tests/panes/terminal/terminal.test.ts
@@ -94,27 +94,32 @@ test.describe.serial('Terminal pane', () => {
     // Send the terminal contents to a new editor tab.
     await executeCommand(page, 'sendTerminalToEditor');
 
-    // Find the new editor by its marker and assert it contains both the
-    // command and the result "2" on its own line. We can't require the
-    // literal substring "expr 1 + 1\n2\n" -- on Server-on-Linux the prompt
-    // ($USER@$HOST:$CWD$ ) is long enough that "expr 1 + 1" wraps in xterm,
-    // and the captured editor content interleaves a wrap marker (·) and the
-    // shell prompt between the command and its output. The semantic check
-    // ("editor has the command and the output 2") is what the test is really
-    // verifying, and that holds regardless of wrap. The rstudioapi::terminalBuffer
-    // ^2$ poll above is the authoritative output check; this assertion only
+    // Find the new editor as the active tab (sendTerminalToEditor activates
+    // it) and assert it contains both the command and the result "2" on its
+    // own line. We can't require any contiguous substring of the command --
+    // on Server-on-Linux the prompt ($USER@$HOST:$CWD$ ) pushes the command
+    // toward the xterm wrap column, and depending on the prompt length the
+    // hard wrap can land anywhere, even mid-word ("...$ exp" / "r 1 + 1" was
+    // observed when the cwd was a long sandbox path). That also rules out
+    // locating the editor by content marker. So compare with all whitespace
+    // and wrap markers (U+00B7 middle dot) stripped, which is invariant
+    // under any wrap position, and check the result "2" (a single character,
+    // so it can't wrap) on a raw line of its own. The rstudioapi::terminalBuffer ^2$
+    // poll above is the authoritative output check; this assertion only
     // confirms the editor tab received both the command and the result.
-    const editor = new AceEditor(page, 'expr 1 + 1');
+    const editor = new AceEditor(page, '');
     await expect.poll(
       async () => {
         try {
-          return (await editor.getValue()).replace(/\r?\n+/g, '\n');
+          const value = (await editor.getValue()).replace(/\r?\n+/g, '\n');
+          const dewrapped = value.replace(/[\s\u00B7]+/g, '');
+          return dewrapped.includes('expr1+1') && /(?:^|\n)2(?:\n|$)/.test(value);
         } catch {
-          return '';
+          return false;
         }
       },
       { timeout: TIMEOUTS.fileOpen },
-    ).toMatch(/expr 1 \+ 1[\s\S]*\n2(?:\n|$)/);
+    ).toBe(true);
   });
 
   test('toolbar shows next and previous terminal buttons', async ({ rstudioPage: page }) => {

--- a/e2e/rstudio/tests/preferences/global_prefs_panels.test.ts
+++ b/e2e/rstudio/tests/preferences/global_prefs_panels.test.ts
@@ -169,18 +169,21 @@ test.describe('Global Options panels', () => {
     await closeGlobalOptions(page);
   });
 
-  // Tracked by #18064 (re-enable on Server).
-  // Server-on-Linux: PYTHON_INTERPRETERS_MODAL doesn't open within 15s
-  // after clicking the interpreter-select button. Native interpreter
-  // selection likely behaves differently on Server; needs investigation.
-  test('Python panel and interpreter selector are accessible', { tag: ['@desktop_only'] }, async ({ rstudioPage: page }) => {
+  // The interpreters modal only opens once python_find_interpreters has
+  // scanned the machine, with a "Finding interpreters..." progress box up in
+  // the meantime. On a cold CI runner that scan can run well past 15s (seen
+  // flaking at 15s on desktop-linux while the progress box was still showing,
+  // with the retry passing in under 4s) -- this, not a Server-specific
+  // behavior, is also what #18064 hit, so the modal wait gets a
+  // discovery-sized timeout and the test runs on Server again.
+  test('Python panel and interpreter selector are accessible', async ({ rstudioPage: page }) => {
     await openGlobalOptions(page);
     await page.locator(PYTHON_TAB).click();
     await expect(page.locator(PYTHON_PANEL)).toBeVisible();
     await expect(page.locator(PYTHON_INTERPRETER_PATH)).toBeVisible();
     await expect(page.locator(PYTHON_INTERPRETER_SELECT_BTN)).toBeVisible();
     await page.locator(PYTHON_INTERPRETER_SELECT_BTN).click();
-    await expect(page.locator(PYTHON_INTERPRETERS_MODAL)).toBeVisible({ timeout: 15000 });
+    await expect(page.locator(PYTHON_INTERPRETERS_MODAL)).toBeVisible({ timeout: 60000 });
     await page.keyboard.press('Escape');
     await page.waitForSelector(PYTHON_INTERPRETERS_MODAL, { state: 'detached', timeout: 10000 });
     await closeGlobalOptions(page);

--- a/e2e/rstudio/tests/projects/shinytest2.test.ts
+++ b/e2e/rstudio/tests/projects/shinytest2.test.ts
@@ -3,15 +3,15 @@ import { TIMEOUTS } from '@utils/constants';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { CONFIRM_BTN } from '@pages/modals.page';
 import { useSuiteSandbox } from '@utils/sandbox';
-import { executeInConsole, CONSOLE_INPUT, CONSOLE_OUTPUT } from '@pages/console_pane.page';
+import { executeInConsole, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { rPathLiteral } from '@utils/r';
 import { documentOpen, executeCommand, openProject } from '@utils/commands';
+import { closeProjectIfOpen } from '@utils/project';
 import { seedSandboxFile } from '@utils/files';
 import * as path from 'path';
 import type { Page } from 'playwright';
 
 const PROJECT_MENU = '#rstudio_project_menubutton_toolbar';
-const CLOSE_PROJECT_MENU_ITEM = '#rstudio_label_close_project_command';
 // The project menu button also has a title containing the project path, so a
 // loose `title*='shinytest2'` selector hits it when the project name contains
 // the word. Match the toolbar button's exact title text instead.
@@ -20,31 +20,6 @@ const CLOSE_PROJECT_MENU_ITEM = '#rstudio_label_close_project_command';
 // the visible instance so strict-mode locator resolution doesn't trip
 // across multiple editors (e.g. an Untitled1 left over from prior tests).
 const SHINYTEST_BUTTON = "button[title='Run test using the shinytest2 package']:visible";
-
-async function waitForConsoleIdle(page: Page): Promise<void> {
-  await page.waitForFunction(
-    () => {
-      const el = document.getElementById('rstudio_console_input');
-      return !!el && !el.classList.contains('rstudio-console-busy');
-    },
-    null,
-    { timeout: TIMEOUTS.sessionRestart, polling: 100 },
-  );
-}
-
-async function closeProjectIfOpen(page: Page): Promise<void> {
-  const menu = page.locator(PROJECT_MENU);
-  const label = (await menu.innerText().catch(() => '')).trim();
-  if (label.includes('(None)') || label === '') return;
-  await menu.click();
-  await page.locator(CLOSE_PROJECT_MENU_ITEM).click();
-  await page.waitForLoadState('load', { timeout: TIMEOUTS.sessionRestart }).catch(() => {});
-  await page.waitForSelector(CONSOLE_INPUT, {
-    state: 'visible',
-    timeout: TIMEOUTS.sessionRestart,
-  });
-  await waitForConsoleIdle(page);
-}
 
 const SHINYTEST2_TEST_CONTENT = `library(shinytest2)
 


### PR DESCRIPTION
Root-causes and fixes the four flaky (pass-on-retry) tests from the pr-18229 all-platforms e2e report. All four are pre-existing harness races, unrelated to that PR.

### Close-project reload race (2 flakes, server-linux)

`shinytest2.test.ts` and `build_pane_testthat.test.ts` carried local copies of `closeProjectIfOpen` whose waits (`waitForLoadState` + console visible + console idle) can all be satisfied against the *old* page before the Server close-project reload actually navigates. The delayed reload then lands during the next test's reset or suite fixture:

- shinytest2 "shinyCompareTest..." failed in `perTestReset` with "Execution context was destroyed, most likely because of a navigation".
- sandbox.test.ts failed in `createSandbox`: the trace shows Enter pressed 13ms after the reload's `GET /`; the reload reset `window.rstudio.console.promptCount`, so the `count > before` wait could never satisfy and timed out at 30s.

Both files now use the shared `utils/project.ts` helper, which blocks on `window.rstudio.project.isActive() === false` -- a signal only the post-reload page can produce.

### Terminal send-to-editor wrap (1 flake, server-linux)

`terminal.test.ts` located the send-to-editor tab by the contiguous substring `expr 1 + 1`, but with a long shell prompt xterm hard-wraps the echoed command at an arbitrary column, even mid-word (the failure snapshot shows `...$ exp` / `r 1 + 1` -- the terminal cwd was a long leftover sandbox path). The test now resolves the editor as the active tab (which `sendTerminalToEditor` activates) and compares with all whitespace and wrap markers stripped, which is invariant under any wrap position.

### Python interpreters modal timeout (1 flake, desktop-linux)

`global_prefs_panels.test.ts` waited a flat 15s for the Python interpreters modal, which only opens once `python_find_interpreters` finishes scanning the machine; the failure snapshot shows the "Finding interpreters..." progress box still up at timeout, and the retry passed in under 4s. The wait now gets a discovery-sized 60s timeout. Since this same slow scan matches the Server failure mode recorded in #18064 (Group 3), the `@desktop_only` tag is removed so this PR's e2e run verifies the test on Server again.

Addresses #18064.

### Verification

All four modified specs pass locally on macOS desktop (27/27, including the previously flaky tests); `npm run typecheck` is clean. The server-linux behavior is exercised by this PR's all-platforms e2e run.