### PR TITLE
Update supported operating systems in install links

### DIFF
--- a/docs/_snippets/install-desktop-oss.qmd
+++ b/docs/_snippets/install-desktop-oss.qmd
@@ -1,9 +1,9 @@
 | Platform | Download |
 |----------|----------|
-| Windows | [`RStudio-{{< var osVersion >}}.exe`](https://download1.rstudio.org/electron/windows/RStudio-{{< var osVersion >}}.exe) |
-| Windows (zip archive) | [`RStudio-{{< var osVersion >}}.zip`](https://download1.rstudio.org/electron/windows/RStudio-{{< var osVersion >}}.zip) |
-| macOS 13+ | [`RStudio-{{< var osVersion >}}.dmg`](https://download1.rstudio.org/electron/macos/RStudio-{{< var osVersion >}}.dmg) |
-| Ubuntu 22 / 24, Debian 12 / 13 | [`rstudio-{{< var osVersion >}}-amd64.deb`](https://download1.rstudio.org/electron/jammy/amd64/rstudio-{{< var osVersion >}}-amd64.deb) |
+| Windows 11 | [`RStudio-{{< var osVersion >}}.exe`](https://download1.rstudio.org/electron/windows/RStudio-{{< var osVersion >}}.exe) |
+| Windows 11 (zip archive) | [`RStudio-{{< var osVersion >}}.zip`](https://download1.rstudio.org/electron/windows/RStudio-{{< var osVersion >}}.zip) |
+| macOS 14+ | [`RStudio-{{< var osVersion >}}.dmg`](https://download1.rstudio.org/electron/macos/RStudio-{{< var osVersion >}}.dmg) |
+| Ubuntu 22 / 24, Debian 13 | [`rstudio-{{< var osVersion >}}-amd64.deb`](https://download1.rstudio.org/electron/jammy/amd64/rstudio-{{< var osVersion >}}-amd64.deb) |
 | Ubuntu / Debian (tar.gz) | [`rstudio-{{< var osVersion >}}-amd64-debian.tar.gz`](https://download1.rstudio.org/electron/jammy/amd64/rstudio-{{< var osVersion >}}-amd64-debian.tar.gz) |
 | RHEL 9 / 10, Fedora | [`rstudio-{{< var osVersion >}}-x86_64.rpm`](https://download1.rstudio.org/electron/rhel9/x86_64/rstudio-{{< var osVersion >}}-x86_64.rpm) |
 | RHEL / Fedora (tar.gz) | [`rstudio-{{< var osVersion >}}-x86_64-fedora.tar.gz`](https://download1.rstudio.org/electron/rhel9/x86_64/rstudio-{{< var osVersion >}}-x86_64-fedora.tar.gz) |

--- a/docs/_snippets/install-desktop-pro.qmd
+++ b/docs/_snippets/install-desktop-pro.qmd
@@ -1,7 +1,7 @@
 | Platform | Download |
 |----------|----------|
-| Windows | [`RStudio-pro-{{< var proVersion >}}.exe`](https://download1.rstudio.org/electron/windows/RStudio-pro-{{< var proVersion >}}.exe) |
-| Windows (zip archive) | [`RStudio-pro-{{< var proVersion >}}.zip`](https://download1.rstudio.org/electron/windows/RStudio-pro-{{< var proVersion >}}.zip) |
-| macOS 13+ | [`RStudio-pro-{{< var proVersion >}}.dmg`](https://download1.rstudio.org/electron/macos/RStudio-pro-{{< var proVersion >}}.dmg) |
-| Ubuntu 22 / 24, Debian 12 / 13 | [`rstudio-pro-{{< var proVersion >}}-amd64.deb`](https://download1.rstudio.org/electron/jammy/amd64/rstudio-pro-{{< var proVersion >}}-amd64.deb) |
+| Windows 11 | [`RStudio-pro-{{< var proVersion >}}.exe`](https://download1.rstudio.org/electron/windows/RStudio-pro-{{< var proVersion >}}.exe) |
+| Windows 11 (zip archive) | [`RStudio-pro-{{< var proVersion >}}.zip`](https://download1.rstudio.org/electron/windows/RStudio-pro-{{< var proVersion >}}.zip) |
+| macOS 14+ | [`RStudio-pro-{{< var proVersion >}}.dmg`](https://download1.rstudio.org/electron/macos/RStudio-pro-{{< var proVersion >}}.dmg) |
+| Ubuntu 22 / 24, Debian 13 | [`rstudio-pro-{{< var proVersion >}}-amd64.deb`](https://download1.rstudio.org/electron/jammy/amd64/rstudio-pro-{{< var proVersion >}}-amd64.deb) |
 | RHEL 9 / 10 | [`rstudio-pro-{{< var proVersion >}}-x86_64.rpm`](https://download1.rstudio.org/electron/rhel9/x86_64/rstudio-pro-{{< var proVersion >}}-x86_64.rpm) |

--- a/docs/_snippets/install-server-oss.qmd
+++ b/docs/_snippets/install-server-oss.qmd
@@ -1,6 +1,6 @@
 | Platform | Download |
 |----------|----------|
-| Ubuntu 22 / 24, Debian 12 / 13 | [`rstudio-server-{{< var osVersion >}}-amd64.deb`](https://download2.rstudio.org/server/jammy/amd64/rstudio-server-{{< var osVersion >}}-amd64.deb) |
+| Ubuntu 22 / 24, Debian 13 | [`rstudio-server-{{< var osVersion >}}-amd64.deb`](https://download2.rstudio.org/server/jammy/amd64/rstudio-server-{{< var osVersion >}}-amd64.deb) |
 | RHEL 8 | [`rstudio-server-rhel-{{< var osVersion >}}-x86_64.rpm`](https://download2.rstudio.org/server/rhel8/x86_64/rstudio-server-rhel-{{< var osVersion >}}-x86_64.rpm) |
 | RHEL 9 / 10 | [`rstudio-server-rhel-{{< var osVersion >}}-x86_64.rpm`](https://download2.rstudio.org/server/rhel9/x86_64/rstudio-server-rhel-{{< var osVersion >}}-x86_64.rpm) |
 | SUSE 15 SP7 / openSUSE 15.6 | [`rstudio-server-{{< var osVersion >}}-x86_64.rpm`](https://download2.rstudio.org/server/opensuse15/x86_64/rstudio-server-{{< var osVersion >}}-x86_64.rpm) |


### PR DESCRIPTION
Updates the minimum supported operating system versions shown in the User Guide install tables:

- macOS 13+ -> macOS 14+
- Windows -> Windows 11
- Debian 12 / 13 -> Debian 13

Applies to the open-source desktop, commercial desktop, and RStudio Server install-links snippets.

Closes #18200.