### PR TITLE
initialize COM at rsession startup on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 - ([#18221](https://github.com/rstudio/rstudio/issues/18221)): Fixed an issue on Windows where scrolling the Data Viewer with the mouse wheel could get stuck when the pointer was over the table body.
 - ([#17191](https://github.com/rstudio/rstudio/issues/17191)): Fixed per-session memory limits not being enforced for Workbench sessions running in a container with a read-only cgroup filesystem, and made the memory gauge, memory-usage report, and abort gate reflect the container rather than the host. Added an `rsession.conf` `memory-usage-mode` option to control how session and total memory usage are computed and reported.
 - ([#18225](https://github.com/rstudio/rstudio/issues/18225)): Clicking a console hyperlink to a package source file that no longer exists (for example, srcref paths recording the temporary directory used during package installation) now recovers the source from the package's srcref database when available, instead of showing a "No such file" error.
+- ([#13078](https://github.com/rstudio/rstudio/issues/13078)): Fixed an issue on Windows where `utils::choose.dir()` returned `NA` without showing the folder-selection dialog when running R 4.3.0 or newer.
 
 ### Dependencies
 - Ace 1.43.5

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -69,6 +69,7 @@
 #include <core/system/encryption/Encryption.hpp>
 
 #ifdef _WIN32
+# include <objbase.h>
 # include <core/system/Win32RuntimeLibrary.hpp>
 #else
 # include <core/system/PosixSystem.hpp>
@@ -2245,6 +2246,17 @@ RSESSION_MAIN_API int rsessionMain(int argc, char * const argv[])
                                   core::log::LogLevel::WARN,
                                   core::system::xdg::userLogDir(),
                                   true); // force log dir to be under user's home directory
+
+      // initialize COM eagerly, so the main thread's apartment state is
+      // deterministic rather than depending on which Windows API happens to
+      // initialize COM first. R itself relies on COM being initialized for
+      // utils::choose.dir(), which otherwise fails silently with
+      // CO_E_NOTINITIALIZED outside of Rgui (https://github.com/rstudio/rstudio/issues/13078)
+#ifdef _WIN32
+      HRESULT hr = ::CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+      if (hr != S_OK && hr != S_FALSE)
+         WLOGF("CoInitializeEx() failed (HRESULT {:#010x})", static_cast<unsigned int>(hr));
+#endif
 
       // ignore SIGPIPE
       Error error = core::system::ignoreSignal(core::system::SigPipe);


### PR DESCRIPTION
Since R 4.3.0, `utils::choose.dir()` returns `NA` without showing a dialog whenever R runs outside of Rgui (rsession, Rterm, Rscript). R 4.3 rewrote `askcdstring()` in `src/extra/graphapp/dialogs.c` to use the COM-based `IFileOpenDialog`, but it never initializes COM on the calling thread, so `CoCreateInstance` fails with `CO_E_NOTINITIALIZED` and the failure is silently mapped to `NA` -- unless some other API happened to initialize COM on the thread first. That's why the known workaround (calling `file.choose()` first) works: `GetOpenFileNameW` initializes COM as a side effect. It's also why the bug never reproduced on some machines: `detectGitBinDirFromShortcut()` in SessionGit.cpp calls `CoInitialize()` when git isn't found on the PATH.

This PR initializes COM (STA, the model used by the common dialogs and Rgui) eagerly at rsession startup on Windows, so the main thread's apartment state is deterministic instead of depending on which code path runs first. Per COM semantics this is safe with respect to later initializers: they receive `S_FALSE` (already initialized) and proceed normally. The initialization is intentionally process-lifetime, so there is no matching `CoUninitialize`.

The root cause has also been reported upstream to R (an `askcdstring()` fix would only land in future R versions; this change fixes the behavior for all R >= 4.3.0).

Verification: requires a Windows build; running `utils::choose.dir()` in a fresh session should show the folder picker instead of returning `NA` immediately. I've verified the equivalent state manually via the `file.choose()` workaround (which produces exactly the COM state this change sets up eagerly), but the change itself still needs a Windows smoke test.

Addresses #13078.
