### PR TITLE
add 2026.07.1 news entries for backported fixes

### DIFF
--- a/version/news/os/NEWS-2026.07.1-pacific-dogwood.md
+++ b/version/news/os/NEWS-2026.07.1-pacific-dogwood.md
@@ -4,7 +4,9 @@
 -
 
 ### Fixed
--
+- ([#18230](https://github.com/rstudio/rstudio/issues/18230)): Fixed an error printed to the console after evaluating an expression containing a `[` subset with an empty argument (e.g. `mtcars[, 1:3]`).
+- ([#18221](https://github.com/rstudio/rstudio/issues/18221)): Fixed an issue on Windows where scrolling the Data Viewer with the mouse wheel could get stuck when the pointer was over the table body.
+- ([#18215](https://github.com/rstudio/rstudio/issues/18215)): Fixed an issue where the Data Viewer could lose its scroll position, or render an empty grid, after switching to another tab and back.
 
 ### Dependencies
 - Ace 1.43.5


### PR DESCRIPTION
Adds release-notes entries to the 2026.07.1 patch NEWS file for the fixes backported in #18233:

- #18230: console error from `.rs.exprMutatesPackageLibrary` on `[` subsets with empty arguments
- #18221: Data Viewer mouse-wheel scrolling stuck on Windows
- #18215: Data Viewer losing scroll position / rendering blank after tab switches