### PR TITLE
harden windows e2e toolchain installs against feed outages

### DIFF
--- a/.github/actions/os-install-rig-windows/action.yml
+++ b/.github/actions/os-install-rig-windows/action.yml
@@ -1,0 +1,51 @@
+name: "Install rig (Windows)"
+description: >
+  Install the rig R version manager on a Windows runner from a pinned GitHub
+  release. Replaces `winget install Posit.rig`: the winget community source
+  is a recurring flake source (and its msstore source needs a geographic
+  region GHA does not send, so winget's implicit source update fails with
+  0x8a15000f unless msstore is removed first), while a runner-to-GitHub
+  release download needs no workarounds and is about as reliable as CI
+  networking gets.
+
+inputs:
+  rig-version:
+    description: "rig release version to install (without the leading 'v')."
+    required: false
+    default: "0.8.1"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install rig from GitHub releases
+      shell: pwsh
+      env:
+        RIG_VERSION: ${{ inputs.rig-version }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+
+        $url = "https://github.com/r-lib/rig/releases/download/v$env:RIG_VERSION/rig-windows-$env:RIG_VERSION.exe"
+        $installer = Join-Path $env:RUNNER_TEMP "rig-windows-$env:RIG_VERSION.exe"
+        Write-Host "Downloading $url"
+        Invoke-WebRequest -Uri $url -OutFile $installer -MaximumRetryCount 5 -RetryIntervalSec 10
+
+        # rig's Windows installer is Inno Setup (rig.iss in r-lib/rig);
+        # /VERYSILENT runs it headless. It installs to C:\Program Files\rig.
+        $p = Start-Process -FilePath $installer `
+          -ArgumentList '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART' `
+          -Wait -PassThru
+        if ($p.ExitCode -ne 0) {
+          Write-Error "rig installer exited $($p.ExitCode)"
+          exit 1
+        }
+
+        $rig = 'C:\Program Files\rig\rig.exe'
+        if (-not (Test-Path $rig)) {
+          Write-Error "rig.exe not found at $rig after install"
+          exit 1
+        }
+        & $rig --version
+
+        # The installer adds rig to the machine PATH, but the already-running
+        # runner process won't see that; export it for subsequent steps.
+        Add-Content -Path $env:GITHUB_PATH -Value 'C:\Program Files\rig'

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
@@ -91,21 +91,7 @@ jobs:
           cache-dependency-path: e2e/rstudio/package-lock.json
 
       - name: Install rig
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $maxAttempts = 3
-          for ($i = 1; $i -le $maxAttempts; $i++) {
-            winget install --id Posit.rig --accept-source-agreements --accept-package-agreements --disable-interactivity
-            if ($LASTEXITCODE -eq 0) { break }
-            if ($i -lt $maxAttempts) {
-              Write-Host "winget attempt $i failed (exit $LASTEXITCODE), retrying in 15s..."
-              Start-Sleep -Seconds 15
-            } else {
-              Write-Error "winget install Posit.rig failed after $maxAttempts attempts"
-              exit 1
-            }
-          }
-          Add-Content -Path $env:GITHUB_PATH -Value 'C:\Program Files\rig'
+        uses: ./.github/actions/os-install-rig-windows
 
       - name: Install R via rig
         env:

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -135,6 +135,9 @@ jobs:
       # agent records (window.rstudio.errors) carry decodable Java stack traces.
       # Consumed by src/gwt/CMakeLists.txt; folded into the GWT cache key below.
       GWT_STYLE: PRETTY
+      # NSIS version installed via choco and folded into the NSIS cache key
+      # below. Pinned so the cached tree and a fresh choco install can't drift.
+      NSIS_VERSION: '3.12.0'
 
     steps:
       - uses: actions/checkout@v4
@@ -224,7 +227,21 @@ jobs:
           restore-keys: |
             rstudio-gwt-win64-${{ env.GWT_STYLE }}-
 
+      # NSIS is only needed at packaging time (cpack -G NSIS) but comes from
+      # the chocolatey community feed, whose outages outlast in-step retries
+      # (run 29434172921 got 503/504 on every attempt across ~90s). Cache the
+      # installed NSIS tree: on a warm cache the probe in "Install build
+      # tools" below short-circuits and choco is never contacted. Restore-only;
+      # Save NSIS runs after the install, main-gated like the other caches.
+      - name: Restore NSIS
+        id: nsis-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: C:\Program Files (x86)\NSIS
+          key: nsis-win64-${{ env.NSIS_VERSION }}
+
       - name: Install build tools
+        id: install-tools
         run: |
           $ErrorActionPreference = 'Stop'
 
@@ -232,9 +249,10 @@ jobs:
           # fetch ("installed 0/1 packages"), and can also report a package
           # installed from a prior run's lib record even when the binary is
           # missing/broken. Probing the real tool sidesteps both. ant is
-          # provided by the runner image; nsis is fetched from the community
-          # feed (which intermittently 503s) for the cpack -G NSIS step. Verify
-          # both so a missing tool fails here, not ~1h later at packaging.
+          # provided by the runner image; nsis comes from the NSIS cache above
+          # or, on a cold cache, from the community feed (which intermittently
+          # 503s) for the cpack -G NSIS step. Verify both so a missing tool
+          # fails here, not ~1h later at packaging.
           function Test-AntInstalled {
             [bool](Get-Command ant -ErrorAction SilentlyContinue)
           }
@@ -246,14 +264,21 @@ jobs:
 
           $tools = @(
             @{ Package = 'ant';  Probe = 'Test-AntInstalled'  }
-            @{ Package = 'nsis'; Probe = 'Test-NsisInstalled' }
+            @{ Package = 'nsis'; Probe = 'Test-NsisInstalled'; Version = $env:NSIS_VERSION }
           )
+
+          # Feed outages routinely run several minutes, so back off up to
+          # ~7.5 minutes total (30/60/120/240s) before giving up -- still far
+          # cheaper than failing a ~90 minute build.
+          $delays = @(30, 60, 120, 240)
 
           foreach ($tool in $tools) {
             $ok = $false
-            for ($i = 1; $i -le 3; $i++) {
+            $attempts = $delays.Count + 1
+            for ($i = 1; $i -le $attempts; $i++) {
               if (& $tool.Probe) { $ok = $true; break }     # already usable -> done
               $chocoArgs = @('install', $tool.Package, '--yes', '--no-progress', '--use-enhanced-exit-codes')
+              if ($tool.Version) { $chocoArgs += @('--version', $tool.Version) }
               if ($i -gt 1) { $chocoArgs += '--force' }      # clear a half-installed record on retry
               choco @chocoArgs
 
@@ -274,13 +299,23 @@ jobs:
                 $env:PATH = $savedPath
               }
               if ($ok) { break }
-              Write-Host "::warning::$($tool.Package) not usable after attempt $i; retrying in 15s..."
-              Start-Sleep -Seconds 15
+              if ($i -lt $attempts) {
+                $delay = $delays[$i - 1]
+                Write-Host "::warning::$($tool.Package) not usable after attempt $i; retrying in ${delay}s..."
+                Start-Sleep -Seconds $delay
+              }
             }
             if (-not $ok) {
-              throw "$($tool.Package) not installed/usable after 3 attempts; aborting before the build."
+              throw "$($tool.Package) not installed/usable after $attempts attempts; aborting before the build."
             }
           }
+
+          # A choco install registers NSIS under HKLM\SOFTWARE\NSIS (via the
+          # official installer), which is one of the places cpack's NSIS
+          # generator looks for makensis -- but a cache-restored tree has no
+          # registry entry. Put makensis on PATH (the other place cpack
+          # looks) so packaging works on both paths.
+          Add-Content -Path $env:GITHUB_PATH -Value 'C:\Program Files (x86)\NSIS'
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
@@ -303,32 +338,7 @@ jobs:
         run: sccache --start-server
 
       - name: Install rig
-        run: |
-          $ErrorActionPreference = 'Stop'
-          # Drop the `msstore` winget source before installing. msstore needs
-          # the runner's 2-letter geographic region, which GHA does not send;
-          # winget's implicit `source update` then fails with 0x8a15000f
-          # ("Data required by the source is missing"), and that failure
-          # aborts the whole `winget install` even though Posit.rig lives in
-          # the community `winget` source rather than msstore. Removing
-          # msstore leaves the community source untouched. Best-effort: if
-          # msstore is already absent on this runner image, the remove exits
-          # non-zero, which we swallow.
-          winget source remove --name msstore --disable-interactivity 2>$null
-          $LASTEXITCODE = 0
-          $maxAttempts = 3
-          for ($i = 1; $i -le $maxAttempts; $i++) {
-            winget install --id Posit.rig --source winget --accept-source-agreements --accept-package-agreements --disable-interactivity
-            if ($LASTEXITCODE -eq 0) { break }
-            if ($i -lt $maxAttempts) {
-              Write-Host "winget attempt $i failed (exit $LASTEXITCODE), retrying in 15s..."
-              Start-Sleep -Seconds 15
-            } else {
-              Write-Error "winget install Posit.rig failed after $maxAttempts attempts"
-              exit 1
-            }
-          }
-          Add-Content -Path $env:GITHUB_PATH -Value 'C:\Program Files\rig'
+        uses: ./.github/actions/os-install-rig-windows
 
       - name: Install R via rig
         env:
@@ -504,12 +514,24 @@ jobs:
       # restore -- each copy is pure pressure on the repo's 10 GB Actions
       # cache quota, and that pressure is what evicts main's copies and sends
       # every PR build cold in the first place.
+      # always() is load-bearing: without a status function GitHub implicitly
+      # prepends success(), and a failed build step would skip this save --
+      # defeating the point of saving deps even when compilation fails.
       - name: Save rstudio-tools cache
-        if: steps.install-deps.conclusion == 'success' && github.ref == 'refs/heads/main' && steps.tools-cache.outputs.cache-hit != 'true'
+        if: always() && steps.install-deps.conclusion == 'success' && github.ref == 'refs/heads/main' && steps.tools-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: ${{ env.RSTUDIO_TOOLS_ROOT }}
           key: ${{ steps.tools-cache.outputs.cache-primary-key }}
+
+      # Same shape as rstudio-tools above: the NSIS tree is complete once the
+      # install step succeeds, so save it even when the build itself fails.
+      - name: Save NSIS cache
+        if: always() && steps.install-tools.conclusion == 'success' && github.ref == 'refs/heads/main' && steps.nsis-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: C:\Program Files (x86)\NSIS
+          key: ${{ steps.nsis-cache.outputs.cache-primary-key }}
 
       # Save only from main-scoped runs, and only on a key miss. A cache saved
       # from a PR run lands in that PR's merge-ref scope, which no other
@@ -605,32 +627,7 @@ jobs:
           cache-dependency-path: e2e/rstudio/package-lock.json
 
       - name: Install rig
-        run: |
-          $ErrorActionPreference = 'Stop'
-          # Drop the `msstore` winget source before installing. msstore needs
-          # the runner's 2-letter geographic region, which GHA does not send;
-          # winget's implicit `source update` then fails with 0x8a15000f
-          # ("Data required by the source is missing"), and that failure
-          # aborts the whole `winget install` even though Posit.rig lives in
-          # the community `winget` source rather than msstore. Removing
-          # msstore leaves the community source untouched. Best-effort: if
-          # msstore is already absent on this runner image, the remove exits
-          # non-zero, which we swallow.
-          winget source remove --name msstore --disable-interactivity 2>$null
-          $LASTEXITCODE = 0
-          $maxAttempts = 3
-          for ($i = 1; $i -le $maxAttempts; $i++) {
-            winget install --id Posit.rig --source winget --accept-source-agreements --accept-package-agreements --disable-interactivity
-            if ($LASTEXITCODE -eq 0) { break }
-            if ($i -lt $maxAttempts) {
-              Write-Host "winget attempt $i failed (exit $LASTEXITCODE), retrying in 15s..."
-              Start-Sleep -Seconds 15
-            } else {
-              Write-Error "winget install Posit.rig failed after $maxAttempts attempts"
-              exit 1
-            }
-          }
-          Add-Content -Path $env:GITHUB_PATH -Value 'C:\Program Files\rig'
+        uses: ./.github/actions/os-install-rig-windows
 
       - name: Install R via rig
         env:


### PR DESCRIPTION
The windows build in [run 29434172921](https://github.com/rstudio/rstudio/actions/runs/29434172921/job/87416651190) failed because the chocolatey community feed returned 503/504 for `nsis` on all three retries (~90s window). This PR removes third-party package feeds from the hot path of the Windows e2e workflows:

- **Cache the installed NSIS tree** (`C:\Program Files (x86)\NSIS`, keyed on a pinned `NSIS_VERSION`). On a warm cache the existing `makensis` probe short-circuits and choco is never contacted; choco is only needed to seed the cache from main-scoped runs. On the cold-cache path, the choco backoff is stretched from 3x15s to 30/60/120/240s (~7.5 min tolerance), since feed outages routinely run minutes. `makensis` is also added to `GITHUB_PATH`: a cache-restored tree lacks the `HKLM\SOFTWARE\NSIS` registry entry the official installer writes, which is how cpack's NSIS generator otherwise finds it.

- **Install rig from a pinned GitHub release** via a new shared composite action (`.github/actions/os-install-rig-windows`) instead of `winget install Posit.rig`. The winget community source ran three times per PR run (build + 2 e2e shards), was flaky enough to need retry loops plus the msstore-removal workaround for 0x8a15000f, and a runner-to-GitHub release download needs neither. rig's Windows installer is Inno Setup (`rig.iss`), driven headless with `/VERYSILENT`. Also adopted by the scheduled autocomplete Windows workflow, which duplicated the winget step.

- **Fix the rstudio-tools cache save condition**: its comment says deps are cached "even when compilation fails", but without a status function GitHub implicitly prepends `success()` to the `if:`, so the save was skipped whenever the build step failed. Added `always() &&`. The new NSIS save uses the same shape. (The posix workflows save immediately after the install step, before the build, so they are unaffected.)

Cache saves stay main-gated per the existing quota-pressure convention. R installs via `rig add` are deliberately left uncached: CRAN/r-builds downloads are CDN-backed and "release" is an alias that resolves after the cache key would be needed.

Developer-only CI change; no NEWS entry.