### PR TITLE
Use bash for the Debian container Playwright step

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
@@ -544,12 +544,17 @@ jobs:
 
       - name: Run Playwright tests
         working-directory: e2e/rstudio
-        # Explicit shell: container jobs default run steps to sh, not bash --
-        # and this script uses bash arrays (ARGS=(), +=, "${ARGS[@]}"). On
-        # Debian /bin/sh is dash, which cannot parse them ("Syntax error: '('
-        # unexpected"). The bare-runner siblings don't need this (their default
-        # really is bash), and the Fedora sibling gets away without it only
-        # because the Red Hat family symlinks /bin/sh to bash.
+        # Explicit shell: container jobs default run steps to sh, not bash
+        # (actions/runner behavior -- the documented bash-with-sh-fallback
+        # default only describes bare runners) -- and this script uses bash
+        # arrays (ARGS=(), +=, "${ARGS[@]}"). On Debian /bin/sh is dash, which
+        # cannot parse them ("Syntax error: '(' unexpected"). The bare-runner
+        # siblings don't need this key (bash is always on PATH on GitHub-hosted
+        # images, so their default resolves to bash), and the Fedora and RHEL
+        # container siblings get away without it only because the Red Hat
+        # family symlinks /bin/sh to bash. Note: an explicit shell adds
+        # -o pipefail, which the siblings' implicit bash default lacks --
+        # harmless today, since this script has no pipelines.
         shell: bash
         env:
           PW_RSTUDIO_MODE: desktop

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
@@ -544,6 +544,13 @@ jobs:
 
       - name: Run Playwright tests
         working-directory: e2e/rstudio
+        # Explicit shell: container jobs default run steps to sh, not bash --
+        # and this script uses bash arrays (ARGS=(), +=, "${ARGS[@]}"). On
+        # Debian /bin/sh is dash, which cannot parse them ("Syntax error: '('
+        # unexpected"). The bare-runner siblings don't need this (their default
+        # really is bash), and the Fedora sibling gets away without it only
+        # because the Red Hat family symlinks /bin/sh to bash.
+        shell: bash
         env:
           PW_RSTUDIO_MODE: desktop
           # Platform-labelled project name; playwright.config.ts uses it both as


### PR DESCRIPTION
The first smoke dispatch of the Debian 13 arm64 engine failed on line 1 of the "Run Playwright tests" script: `Syntax error: "(" unexpected`. Container jobs default `run:` steps to `sh` rather than bash, and Debian's `sh` is dash, which cannot parse the script's bash arrays (`ARGS=()`, `+=`, `"${ARGS[@]}"`). The Fedora 44 engine runs the identical script without an explicit shell and gets away with it only because the Red Hat family symlinks `/bin/sh` to bash.

Fix: declare `shell: bash` on the one step that uses bash syntax. All other `run:` steps in the container job are POSIX-clean under dash (verified by sweeping for arrays, `[[`, `+=`, pushd/popd, and substitution bash-isms), so no other step needs it.