### PR TITLE
Add scheduled rotation and run-all workflow for the OS E2E engines

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
@@ -369,11 +369,13 @@ jobs:
           FILENAME=""
           if [ -z "$URL" ]; then
             MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 'https://dailies.rstudio.com/rstudio/latest/index.json')
-            # The Linux Desktop build ships as an Electron .deb keyed
-            # "resolute-amd64" under the electron product in the daily manifest.
-            URL=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["resolute-amd64"].link // empty')
-            SHA=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["resolute-amd64"].sha256 // empty')
-            FILENAME=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["resolute-amd64"].filename // empty')
+            # There is no separate Ubuntu 26 (resolute) daily: the manifest has
+            # no resolute-amd64 key, so we install the Ubuntu 24 build -- the
+            # Electron .deb keyed "noble-amd64" (itself a jammy-built deb Posit
+            # ships across Ubuntu versions).
+            URL=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["noble-amd64"].link // empty')
+            SHA=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["noble-amd64"].sha256 // empty')
+            FILENAME=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["noble-amd64"].filename // empty')
             if [ -z "$URL" ] || [ -z "$FILENAME" ] || [ -z "$SHA" ]; then
               echo "::error::Daily manifest is missing expected fields (url='$URL', filename='$FILENAME', sha256='$SHA'). The schema at https://dailies.rstudio.com/rstudio/latest/index.json may have changed."
               exit 1

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
@@ -380,7 +380,7 @@ jobs:
               echo "::error::Daily manifest is missing expected fields (url='$URL', filename='$FILENAME', sha256='$SHA'). The schema at https://dailies.rstudio.com/rstudio/latest/index.json may have changed."
               exit 1
             fi
-            echo "Auto-resolved latest resolute-amd64 desktop daily:"
+            echo "Auto-resolved latest noble-amd64 (Ubuntu 24) desktop daily:"
             echo "  URL:      $URL"
             echo "  SHA-256:  $SHA"
             echo "  Filename: $FILENAME"

--- a/.github/workflows/os-test-e2e-rstudio-scheduled.yml
+++ b/.github/workflows/os-test-e2e-rstudio-scheduled.yml
@@ -1,0 +1,232 @@
+name: "Test: E2E Playwright RStudio (Scheduled Rotation and Run-All, Open Source)"
+
+# One workflow that drives the reusable per-OS E2E "engines" three ways:
+#   - Weekday cron (Mon-Fri): a fixed two-engine slate per weekday, so every
+#     engine runs at least once a week without running the whole matrix daily.
+#     No weekday pairs two deb-based engines.
+#   - Weekly cron (Saturday): every engine at once, for a full-matrix snapshot.
+#   - Manual dispatch: every engine at once, optionally against a specific daily
+#     build (see the "version" input).
+#
+# Binary selection: engines test the daily build (build_from_source: false).
+# With no version given, each engine resolves the latest daily itself, which
+# keeps its SHA-256 check. Given a specific version, the resolve job builds each
+# platform's download URL from that version string and passes it in; there is no
+# per-build manifest, so that path skips SHA-256 (see rstudio/rstudio#18238).
+#
+# Note: the Debian 13 engine it calls is not yet on main; that job will fail
+# until it lands via its own PR.
+
+on:
+  schedule:
+    - cron: '0 2 * * 1-5'   # Mon-Fri 02:00 UTC -- rolling pair (rotation)
+    - cron: '0 4 * * 6'     # Saturday 04:00 UTC -- all engines
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Daily build to test as a full version string (e.g. 2026.07.0+139). Leave empty to test the latest daily. Applies to every engine."
+        type: string
+        default: ""
+
+concurrency:
+  group: pw-scheduled-e2e
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: write  # the engines' e2e-merge job declares this
+  # The engines' e2e-merge job assumes the S3 report-upload role via OIDC; a
+  # reusable workflow's id-token grant is capped by its caller's.
+  id-token: write
+
+jobs:
+  pick:
+    name: Pick engines
+    runs-on: ubuntu-latest
+    outputs:
+      selected: ${{ steps.pick.outputs.selected }}
+    steps:
+      - id: pick
+        name: Select engines for this run
+        run: |
+          # workflow_dispatch and the Saturday cron run every engine; the
+          # weekday cron (Mon-Fri) runs a fixed pair per day. Each engine runs
+          # once a week except macos, windows, and ubuntu24s, which run twice.
+          ALL='["fedora","ubuntu26","ubuntu24d","ubuntu24s","macos","windows","debian13"]'
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event.schedule }}" = "0 4 * * 6" ]; then
+            SEL="$ALL"
+          else
+            case "$(date -u +%u)" in   # %u: 1=Mon .. 7=Sun
+              1) SEL='["ubuntu24d","macos"]' ;;
+              2) SEL='["ubuntu24s","windows"]' ;;
+              3) SEL='["ubuntu26","fedora"]' ;;
+              4) SEL='["debian13","macos"]' ;;
+              5) SEL='["ubuntu24s","windows"]' ;;
+              *) SEL='[]' ;;   # weekend: the weekday cron never fires here
+            esac
+          fi
+          echo "selected=$SEL" >> "$GITHUB_OUTPUT"
+          echo "Selected engines: $SEL"
+
+  resolve:
+    name: Resolve installer URLs
+    runs-on: ubuntu-latest
+    outputs:
+      rhel:         ${{ steps.resolve.outputs.rhel }}
+      noble_amd64:  ${{ steps.resolve.outputs.noble_amd64 }}
+      server_noble: ${{ steps.resolve.outputs.server_noble }}
+      macos:        ${{ steps.resolve.outputs.macos }}
+      windows:      ${{ steps.resolve.outputs.windows }}
+      noble_arm64:  ${{ steps.resolve.outputs.noble_arm64 }}
+    steps:
+      - id: resolve
+        name: Build per-platform installer URLs for a specific version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          # With no version, emit empty URLs so each engine self-resolves the
+          # latest daily (keeping its SHA-256 check). With a version, swap the
+          # version token (+ -> -) into each platform's latest download URL.
+          if [ -z "$VERSION" ]; then
+            {
+              echo "rhel="
+              echo "noble_amd64="
+              echo "server_noble="
+              echo "macos="
+              echo "windows="
+              echo "noble_arm64="
+            } >> "$GITHUB_OUTPUT"
+            echo "No version given; engines will resolve the latest daily."
+            exit 0
+          fi
+          M=$(curl -fsSL --retry 3 --retry-delay 5 'https://dailies.rstudio.com/rstudio/latest/index.json')
+          REQ=${VERSION//+/-}
+          emit() {
+            local product="$1" key="$2" link ver cur
+            link=$(printf '%s' "$M" | jq -r ".products.${product}.platforms[\"${key}\"].link // empty")
+            ver=$(printf '%s' "$M" | jq -r ".products.${product}.platforms[\"${key}\"].version // empty")
+            cur=${ver//+/-}
+            if [ -z "$link" ] || [ -z "$cur" ]; then
+              echo "::error::Could not build a URL for ${product}/${key} from the latest manifest." >&2
+              return 1
+            fi
+            printf '%s' "${link/$cur/$REQ}"
+          }
+          RHEL=$(emit electron rhel10-x86_64) || exit 1
+          NOBLE=$(emit electron noble-amd64) || exit 1
+          SERVER=$(emit server noble-amd64) || exit 1
+          MAC=$(emit electron macos) || exit 1
+          WIN=$(emit electron windows) || exit 1
+          NARM=$(emit electron noble-arm64) || exit 1
+          {
+            echo "rhel=$RHEL"
+            echo "noble_amd64=$NOBLE"
+            echo "server_noble=$SERVER"
+            echo "macos=$MAC"
+            echo "windows=$WIN"
+            echo "noble_arm64=$NARM"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved URLs for version $VERSION."
+
+  fedora:
+    name: Fedora 44 x86_64
+    needs: [pick, resolve]
+    if: ${{ contains(fromJSON(needs.pick.outputs.selected), 'fedora') }}
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+    with:
+      project: desktop
+      r_version: "release"
+      grep_invert: "@ai"
+      build_from_source: false
+      rstudio_installer_url: ${{ needs.resolve.outputs.rhel }}
+
+  ubuntu26:
+    name: Ubuntu 26 amd64
+    needs: [pick, resolve]
+    if: ${{ contains(fromJSON(needs.pick.outputs.selected), 'ubuntu26') }}
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+    with:
+      project: desktop
+      r_version: "release"
+      grep_invert: "@ai"
+      build_from_source: false
+      rstudio_installer_url: ${{ needs.resolve.outputs.noble_amd64 }}
+
+  ubuntu24d:
+    name: Ubuntu 24 Desktop
+    needs: [pick, resolve]
+    if: ${{ contains(fromJSON(needs.pick.outputs.selected), 'ubuntu24d') }}
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+      AWS_E2E_REPORTS_ROLE_ARN: ${{ secrets.AWS_E2E_REPORTS_ROLE_ARN }}
+    with:
+      project: desktop
+      r_version: "release"
+      grep_invert: "@ai"
+      build_from_source: false
+      rstudio_installer_url: ${{ needs.resolve.outputs.noble_amd64 }}
+
+  ubuntu24s:
+    name: Ubuntu 24 Server
+    needs: [pick, resolve]
+    if: ${{ contains(fromJSON(needs.pick.outputs.selected), 'ubuntu24s') }}
+    uses: ./.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+      AWS_E2E_REPORTS_ROLE_ARN: ${{ secrets.AWS_E2E_REPORTS_ROLE_ARN }}
+    with:
+      project: server
+      r_version: "release"
+      grep_invert: "@ai"
+      build_from_source: false
+      rstudio_installer_url: ${{ needs.resolve.outputs.server_noble }}
+
+  macos:
+    name: macOS 26 arm64
+    needs: [pick, resolve]
+    if: ${{ contains(fromJSON(needs.pick.outputs.selected), 'macos') }}
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+      AWS_E2E_REPORTS_ROLE_ARN: ${{ secrets.AWS_E2E_REPORTS_ROLE_ARN }}
+    with:
+      project: desktop
+      r_version: "release"
+      grep_invert: "@ai"
+      build_from_source: false
+      rstudio_installer_url: ${{ needs.resolve.outputs.macos }}
+
+  windows:
+    name: Windows Server 2025
+    needs: [pick, resolve]
+    if: ${{ contains(fromJSON(needs.pick.outputs.selected), 'windows') }}
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+      AWS_E2E_REPORTS_ROLE_ARN: ${{ secrets.AWS_E2E_REPORTS_ROLE_ARN }}
+    with:
+      project: desktop
+      r_version: "release"
+      grep_invert: "@ai"
+      build_from_source: false
+      rstudio_installer_url: ${{ needs.resolve.outputs.windows }}
+
+  debian13:
+    name: Debian 13 arm64
+    needs: [pick, resolve]
+    if: ${{ contains(fromJSON(needs.pick.outputs.selected), 'debian13') }}
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+      AWS_E2E_REPORTS_ROLE_ARN: ${{ secrets.AWS_E2E_REPORTS_ROLE_ARN }}
+    with:
+      project: desktop
+      r_version: "release"
+      grep_invert: "@ai"
+      build_from_source: false
+      rstudio_installer_url: ${{ needs.resolve.outputs.noble_arm64 }}

--- a/.github/workflows/os-test-e2e-rstudio-scheduled.yml
+++ b/.github/workflows/os-test-e2e-rstudio-scheduled.yml
@@ -12,19 +12,19 @@ name: "Test: E2E Playwright RStudio (Scheduled Rotation and Run-All, Open Source
 # With no version given, each engine resolves the latest daily itself, which
 # keeps its SHA-256 check. Given a specific version, the resolve job builds each
 # platform's download URL from that version string and passes it in; there is no
-# per-build manifest, so that path skips SHA-256 (see rstudio/rstudio#18238).
+# per-build manifest, so that path skips SHA-256 (see rstudio/latest-builds#251).
 #
 # Note: the Debian 13 engine it calls is not yet on main; that job will fail
 # until it lands via its own PR.
 
 on:
   schedule:
-    - cron: '0 2 * * 1-5'   # Mon-Fri 02:00 UTC -- rolling pair (rotation)
-    - cron: '0 4 * * 6'     # Saturday 04:00 UTC -- all engines
+    - cron: '0 2 * * 1-5'   # Mon-Fri 02:00 UTC -- fixed pair per weekday
+    - cron: '0 4 * * 6'     # Saturday 04:00 UTC -- all engines (this string must match the check in the pick job)
   workflow_dispatch:
     inputs:
       version:
-        description: "Daily build to test as a full version string (e.g. 2026.07.0+139). Leave empty to test the latest daily. Applies to every engine."
+        description: "Daily build to test, given as the version string exactly as shown on dailies.rstudio.com (e.g. 2026.08.0-daily+44). Leave empty to test the latest daily. Applies to every engine."
         type: string
         default: ""
 
@@ -35,8 +35,9 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write  # the engines' e2e-merge job declares this
-  # The engines' e2e-merge job assumes the S3 report-upload role via OIDC; a
-  # reusable workflow's id-token grant is capped by its caller's.
+  # Most engines' e2e-merge jobs assume the S3 report-upload role via OIDC
+  # (fedora and ubuntu26 don't upload); a reusable workflow's id-token grant is
+  # capped by its caller's.
   id-token: write
 
 jobs:
@@ -62,11 +63,14 @@ jobs:
               3) SEL='["ubuntu26","fedora"]' ;;
               4) SEL='["debian13","macos"]' ;;
               5) SEL='["ubuntu24s","windows"]' ;;
-              *) SEL='[]' ;;   # weekend: the weekday cron never fires here
+              # Only reachable by re-running a weekday run on Sat/Sun, or if the
+              # Saturday cron above changed without updating the check above.
+              # Fail loudly rather than silently selecting nothing.
+              *) echo "::error::No engine slate for weekday $(date -u +%u). If the Saturday cron changed, update the '0 4 * * 6' check in this job."; exit 1 ;;
             esac
           fi
           echo "selected=$SEL" >> "$GITHUB_OUTPUT"
-          echo "Selected engines: $SEL"
+          echo "::notice::Selected engines: $SEL"
 
   resolve:
     name: Resolve installer URLs
@@ -110,7 +114,16 @@ jobs:
               echo "::error::Could not build a URL for ${product}/${key} from the latest manifest." >&2
               return 1
             fi
-            printf '%s' "${link/$cur/$REQ}"
+            local out=${link//$cur/$REQ}
+            if [ "$REQ" != "$cur" ] && [ "$out" = "$link" ]; then
+              echo "::error::Version '$REQ' did not substitute into the ${product}/${key} URL ($link); the manifest link format may have changed." >&2
+              return 1
+            fi
+            if ! curl -fsI "$out" >/dev/null 2>&1; then
+              echo "::error::Resolved URL for ${product}/${key} does not exist: $out (version '$VERSION' may be unavailable or mistyped)." >&2
+              return 1
+            fi
+            printf '%s' "$out"
           }
           RHEL=$(emit electron rhel10-x86_64) || exit 1
           NOBLE=$(emit electron noble-amd64) || exit 1


### PR DESCRIPTION
Adds one scheduled workflow that drives the reusable per-OS E2E engines three ways:

- Weekday cron (Mon-Fri): a fixed two-engine slate per day, so every engine runs
  at least once a week without running the whole matrix daily. No weekday pairs
  two deb-based engines:

      Mon: ubuntu24d, macos
      Tue: ubuntu24s, windows
      Wed: ubuntu26,  fedora
      Thu: debian13,  macos
      Fri: ubuntu24s, windows

- Weekly cron (Saturday): all engines at once.
- Manual dispatch: all engines, with an optional `version` field to target a
  specific daily build.

Engines test the daily build (build_from_source: false). With no version, each
engine self-resolves the latest daily, keeping its SHA-256 check. With a version,
a resolve job builds each platform's download URL from the version string; there
is no per-build manifest, so that path skips SHA-256 (see #18238).

Also fixes the Ubuntu 26 engine's daily resolution, which looked up a
non-existent `resolute-amd64` key; it now installs the `noble-amd64` (Ubuntu 24)
deb.
