### PR TITLE
Companion for rstudio-pro - 11167

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -44,6 +44,7 @@
 #include <core/IncrementalCommand.hpp>
 #include <core/PeriodicCommand.hpp>
 #include <core/collection/Tree.hpp>
+#include <core/collection/LruCache.hpp>
 
 #include <core/http/Request.hpp>
 #include <core/http/Util.hpp>
@@ -2504,70 +2505,159 @@ void showFile(const FilePath& filePath, const std::string& window)
    }
 }
 
+namespace {
+
+// In-memory record of files the session itself surfaced to the browser via a
+// server-initiated preview/show flow (utils::file.show(), HTML "Show in
+// Browser", source-link clicks, etc.). A subsequent download request whose
+// path is present here -- with the same size and last-write-time it had when
+// registered -- is that preview fetch, not a user-initiated download, so it is
+// not audited.
+//
+// The cache lives only in this (rsession) process's memory: neither the
+// browser nor the in-session R process can insert entries, so membership is an
+// unforgeable grant and needs no signing. This replaces the old ?show=1 query
+// marker, which any authenticated client could append to skip the audit.
+//
+// Bounded to a fixed size. Overflow (eviction) or a content change since
+// registration simply falls through to auditing -- an extra audit row, never
+// a missed one, so both failure modes are fail-safe.
+struct DownloadGrant
+{
+   std::time_t lastWriteTime;
+   uintmax_t size;
+};
+
+core::collection::LruCache<std::string, DownloadGrant>& downloadGrantCache()
+{
+   static core::collection::LruCache<std::string, DownloadGrant> instance(1000);
+   return instance;
+}
+
+bool hasValidDownloadGrant(const core::FilePath& filePath)
+{
+   const std::string key = filePath.getAbsolutePath();
+
+   DownloadGrant grant;
+   if (!downloadGrantCache().get(key, &grant))
+      return false;
+
+   // Confirm the file hasn't been replaced since it was registered; if it has,
+   // drop the stale grant and audit.
+   std::time_t lastWriteTime;
+   Error error = filePath.getLastWriteTime(lastWriteTime);
+   if (error ||
+       grant.lastWriteTime != lastWriteTime ||
+       grant.size != filePath.getSize())
+   {
+      downloadGrantCache().remove(key);
+      return false;
+   }
+
+   return true;
+}
+
+} // anonymous namespace
+
+void registerDownloadGrant(const core::FilePath& filePath)
+{
+   if (!filePath.exists())
+      return;
+
+   std::time_t lastWriteTime;
+   Error error = filePath.getLastWriteTime(lastWriteTime);
+   if (error)
+   {
+      LOG_ERROR(error);
+      return;
+   }
+
+   DownloadGrant grant;
+   grant.lastWriteTime = lastWriteTime;
+   grant.size = filePath.getSize();
+   downloadGrantCache().insert(filePath.getAbsolutePath(), grant);
+}
+
 bool shouldAuditFileDownload(const core::http::Request& request,
                              const core::FilePath& filePath)
 {
-   // Skip when the URL was constructed by an internal preview/show flow
-   // (?show=1 marker, set by createFileUrl above and by Files.java's
-   // companion showFileInBrowser for view-style navigations).
-   if (request.queryParamValue("show") == "1")
+   // Skip files owned by a system account -- an owner uid below the configured
+   // minimum login user id (auth-minimum-user-id), e.g. root-owned fonts or
+   // admin-installed R packages. These are provisioned by the administrator,
+   // not user data, so serving them to the browser isn't a user file download.
+   // The owner uid can't be spoofed by the requesting client, so this is a
+   // safe unconditional skip.
+   uid_t ownerUid;
+   Error ownerError = filePath.getFileOwner(ownerUid);
+   if (!ownerError && ownerUid < session::options().authMinimumUserId())
    {
-      LOG_DEBUG_MESSAGE("Audit skipped (?show=1 marker): " +
+      LOG_DEBUG_MESSAGE("Audit skipped (system-owned, uid=" +
+                        std::to_string(ownerUid) + "): " +
                         filePath.getAbsolutePath());
       return false;
    }
 
-   // Skip HTML sub-resource fetches. Browsers signal these via
-   // Sec-Fetch-Dest. Top-level navigations send "document" (or omit the
-   // header on older browsers); embedded resources send their resource
-   // type. Treat anything in the explicit sub-resource set as not-a-
-   // download so a single HTML preview doesn't generate an audit row
-   // per asset. "iframe" and "frame" are deliberately NOT in this set:
-   // an iframe loading a binary is effectively exfiltration, so let
-   // the Content-Type check below decide.
-   const std::string fetchDest = request.headerValue("Sec-Fetch-Dest");
-   if (fetchDest == "style"        || fetchDest == "script"        ||
-       fetchDest == "image"        || fetchDest == "font"          ||
-       fetchDest == "audio"        || fetchDest == "video"         ||
-       fetchDest == "track"        || fetchDest == "object"        ||
-       fetchDest == "embed"        || fetchDest == "manifest"      ||
-       fetchDest == "xslt"         || fetchDest == "report"        ||
-       fetchDest == "worker"       || fetchDest == "serviceworker" ||
-       fetchDest == "audioworklet" || fetchDest == "paintworklet")
+   // Skip files the session itself surfaced through a server-initiated
+   // preview/show flow. createFileUrl()/showFile() record a grant in the
+   // in-process cache when they build the URL; unlike the old ?show=1 marker,
+   // this grant can only be created by server-side code and so can't be forged
+   // by the requesting client.
+   if (hasValidDownloadGrant(filePath))
    {
-      LOG_DEBUG_MESSAGE("Audit skipped (Sec-Fetch-Dest=" + fetchDest +
-                        " sub-resource): " + filePath.getAbsolutePath());
+      LOG_DEBUG_MESSAGE("Audit skipped (server-initiated preview grant): " +
+                        filePath.getAbsolutePath());
       return false;
    }
 
-   // Skip when the response will be served as a browser-renderable
-   // Content-Type. The bytes are being viewed inline rather than saved
-   // to disk, so it isn't a download from the user's perspective. Note
-   // this means a real "right-click -> Save As" on a rendered PDF will
-   // not produce an audit row; that's an accepted trade-off for not
-   // logging the much more common inline-view case.
-   //
-   // For the audit decision we pass "application/octet-stream" as the
-   // default Content-Type for unknown extensions, even though the
-   // setFile()/setCacheableFile() response path falls back to
-   // "text/plain". The divergence is intentional: it closes a rename-
-   // bypass (renaming secret.zip to "secret" would otherwise resolve
-   // to text/plain and silently skip the audit) at the cost of also
-   // logging legitimate fetches of extensionless text files
-   // (LICENSE, README, Makefile, etc.). Over-logging is the safer
-   // default for an audit record.
-   const std::string mimeType =
-      filePath.getMimeContentType("application/octet-stream");
-   if (mimeType.rfind("text/", 0) == 0  ||
-       mimeType.rfind("image/", 0) == 0 ||
-       mimeType.rfind("audio/", 0) == 0 ||
-       mimeType.rfind("video/", 0) == 0 ||
-       mimeType == "application/pdf"    ||
-       mimeType == "application/json")
+   // The remaining two skips classify a request as a browser sub-resource load
+   // (an HTML preview pulling its styles/scripts/images/fonts, an inline-
+   // rendered document) rather than a download, so a single preview doesn't
+   // generate an audit row per asset. Both signals are supplied by the
+   // requesting client and can be spoofed to evade the audit (e.g. sending
+   // Sec-Fetch-Dest: image, or renaming secret.zip to secret.txt to land a
+   // text/* Content-Type), so they are gated behind an administrator opt-in.
+   // When track-resource-downloads is enabled these skips are disabled and
+   // such requests are audited.
+   if (!session::options().trackResourceDownloads())
    {
-      LOG_DEBUG_MESSAGE("Audit skipped (renderable Content-Type=" +
-                        mimeType + "): " + filePath.getAbsolutePath());
-      return false;
+      // Skip HTML sub-resource fetches. Browsers signal these via
+      // Sec-Fetch-Dest. Top-level navigations send "document" (or omit the
+      // header on older browsers); embedded resources send their resource
+      // type. Treat anything in the explicit sub-resource set as not-a-
+      // download. "iframe" and "frame" are deliberately NOT in this set:
+      // an iframe loading a binary is effectively exfiltration, so let
+      // the Content-Type check below decide.
+      const std::string fetchDest = request.headerValue("Sec-Fetch-Dest");
+      if (fetchDest == "style"        || fetchDest == "script"        ||
+          fetchDest == "image"        || fetchDest == "font"          ||
+          fetchDest == "audio"        || fetchDest == "video"         ||
+          fetchDest == "track"        || fetchDest == "object"        ||
+          fetchDest == "embed"        || fetchDest == "manifest"      ||
+          fetchDest == "xslt"         || fetchDest == "report"        ||
+          fetchDest == "worker"       || fetchDest == "serviceworker" ||
+          fetchDest == "audioworklet" || fetchDest == "paintworklet")
+      {
+         LOG_DEBUG_MESSAGE("Audit skipped (Sec-Fetch-Dest=" + fetchDest +
+                           " sub-resource): " + filePath.getAbsolutePath());
+         return false;
+      }
+
+      // Skip when the response will be served as a browser-renderable
+      // Content-Type. The bytes are being viewed inline rather than saved
+      // to disk, so it isn't a download from the user's perspective.
+      const std::string mimeType =
+         filePath.getMimeContentType("application/octet-stream");
+      if (mimeType.rfind("text/", 0) == 0  ||
+          mimeType.rfind("image/", 0) == 0 ||
+          mimeType.rfind("audio/", 0) == 0 ||
+          mimeType.rfind("video/", 0) == 0 ||
+          mimeType == "application/pdf"    ||
+          mimeType == "application/json")
+      {
+         LOG_DEBUG_MESSAGE("Audit skipped (renderable Content-Type=" +
+                           mimeType + "): " + filePath.getAbsolutePath());
+         return false;
+      }
    }
 
    return true;
@@ -2575,25 +2665,28 @@ bool shouldAuditFileDownload(const core::http::Request& request,
 
 std::string createFileUrl(const core::FilePath& filePath)
 {
-   // determine url based on whether this is in ~ or not. Tag the result
-   // with show=1 so handleFilesRequest / handleFileShow can distinguish
-   // server-initiated preview/show flows from user-initiated downloads
-   // and skip audit logging for the former.
+   // This is a server-initiated preview/show flow, so record a download grant
+   // for the file. handleFilesRequest / handleFileShow / handleShowRequest
+   // consult the grant (via shouldAuditFileDownload) to distinguish this from
+   // a user-initiated download and skip audit logging for the former.
+   registerDownloadGrant(filePath);
+
+   // determine url based on whether this is in ~ or not.
    std::string url;
    if (isVisibleUserFile(filePath))
    {
       auto home = module_context::userHomePath();
       auto path = filePath.getRelativePath(home);
-      url = "files/" + path + "?show=1";
+      url = "files/" + path;
    }
    else if (isPathViewAllowed(filePath))
    {
-      url = "show" + filePath.getAbsolutePath() + "?show=1";
+      url = "show" + filePath.getAbsolutePath();
    }
    else
    {
       auto path = core::http::util::urlEncode(filePath.getAbsolutePath(), true);
-      url = "file_show?path=" + path + "&show=1";
+      url = "file_show?path=" + path;
    }
    return url;
 }

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2581,6 +2581,7 @@ void registerDownloadGrant(const core::FilePath& filePath)
 bool shouldAuditFileDownload(const core::http::Request& request,
                              const core::FilePath& filePath)
 {
+#ifndef _WIN32
    // Skip files owned by a system account -- an owner uid below the configured
    // minimum login user id (auth-minimum-user-id), e.g. root-owned fonts or
    // admin-installed R packages. These are provisioned by the administrator,
@@ -2596,6 +2597,7 @@ bool shouldAuditFileDownload(const core::http::Request& request,
                         filePath.getAbsolutePath());
       return false;
    }
+#endif
 
    // Skip files the session itself surfaced through a server-initiated
    // preview/show flow. createFileUrl()/showFile() record a grant in the

--- a/src/cpp/session/SessionModuleContextTests.cpp
+++ b/src/cpp/session/SessionModuleContextTests.cpp
@@ -20,8 +20,11 @@
 
 #include <gtest/gtest.h>
 
+#include <core/FileSerializer.hpp>
 #include <core/http/Request.hpp>
 #include <shared_core/FilePath.hpp>
+
+#include <session/SessionOptions.hpp>
 
 #ifdef __APPLE__
 # include <climits>
@@ -51,35 +54,10 @@ void initRequest(core::http::Request& request,
 
 } // anonymous namespace
 
-// --- Returns false: ?show=1 marker -----------------------------------------
-
-TEST(ShouldAuditFileDownloadTest, ShowOneSkipsForNonRenderable)
-{
-   // ?show=1 forces a skip even for binary types that the browser would
-   // otherwise download (file.show() of a zip, etc.).
-   core::http::Request request;
-   initRequest(request, "/files/archive.zip?show=1");
-   core::FilePath file("archive.zip");
-   EXPECT_FALSE(shouldAuditFileDownload(request, file));
-}
-
-TEST(ShouldAuditFileDownloadTest, ShowOneSkipsRegardlessOfFetchDest)
-{
-   // The preview marker wins over Sec-Fetch-Dest analysis.
-   core::http::Request request;
-   initRequest(request, "/files/archive.zip?show=1", "document");
-   core::FilePath file("archive.zip");
-   EXPECT_FALSE(shouldAuditFileDownload(request, file));
-}
-
-TEST(ShouldAuditFileDownloadTest, ShowZeroStillAudits)
-{
-   // Only the exact value "1" trips the gate; other values fall through.
-   core::http::Request request;
-   initRequest(request, "/files/archive.zip?show=0");
-   core::FilePath file("archive.zip");
-   EXPECT_TRUE(shouldAuditFileDownload(request, file));
-}
+// The Sec-Fetch-Dest and Content-Type based skips below only apply when the
+// track-resource-downloads option is disabled, which is its default value.
+// The FileDownloadGrantTest fixture further down exercises the opt-in-enabled
+// behavior and the server-initiated preview grant.
 
 // --- Returns false: Sec-Fetch-Dest sub-resource ----------------------------
 
@@ -249,26 +227,135 @@ TEST(ShouldAuditFileDownloadTest, IframeFetchDestForRenderableSkips)
    EXPECT_FALSE(shouldAuditFileDownload(request, file));
 }
 
-// --- Producer-side: createFileUrl round-trip --------------------------------
+// --- Grant + opt-in behavior ------------------------------------------------
+//
+// These need real files (registerDownloadGrant stamps size/mtime) and toggle
+// the process-wide track-resource-downloads option, so they use a fixture that
+// creates temp files and resets the option after each case.
 
-TEST(CreateFileUrlTest, HomeFileRoundTripSkipsAudit)
+class FileDownloadGrantTest : public ::testing::Test
 {
-   // Regression test for the producer-consumer contract between
-   // createFileUrl and shouldAuditFileDownload. If a future edit drops
-   // the ?show=1 marker in the in-home branch of createFileUrl, this
-   // round trip will fail (the URL won't trigger the preview skip and
-   // - because .zip resolves to application/zip - the helper will
-   // return true instead of false).
-   core::FilePath file = userHomePath().completeChildPath("preview.zip");
-   const std::string url = createFileUrl(file);
-   ASSERT_NE(url.find("show=1"), std::string::npos)
-      << "createFileUrl output missing show=1: " << url;
+protected:
+   void TearDown() override
+   {
+      // options() is a process-wide singleton; make sure an opt-in enabled by
+      // one test doesn't leak into the next.
+      session::options().setTrackResourceDownloads(false);
+      for (core::FilePath& file : tempFiles_)
+         file.removeIfExists();
+   }
+
+   core::FilePath makeTempFile(const std::string& extension,
+                               const std::string& contents)
+   {
+      core::FilePath path;
+      core::Error error = core::FilePath::tempFilePath(extension, path);
+      EXPECT_FALSE(error) << error.asString();
+      error = core::writeStringToFile(path, contents);
+      EXPECT_FALSE(error) << error.asString();
+      tempFiles_.push_back(path);
+      return path;
+   }
+
+   void enableResourceTracking()
+   {
+      session::options().setTrackResourceDownloads(true);
+   }
+
+   std::vector<core::FilePath> tempFiles_;
+};
+
+TEST_F(FileDownloadGrantTest, RegisteredPreviewSkipsAudit)
+{
+   // A server-initiated preview registers a grant; the subsequent request for
+   // that exact file (a non-renderable .zip, so nothing else would skip it) is
+   // not audited. This is the unforgeable replacement for the old ?show=1
+   // marker.
+   core::FilePath file = makeTempFile(".zip", "payload");
+   registerDownloadGrant(file);
 
    core::http::Request request;
-   request.setUri("/" + url);
+   EXPECT_FALSE(shouldAuditFileDownload(request, file));
+}
+
+TEST_F(FileDownloadGrantTest, GrantIsPathSpecific)
+{
+   // A grant for one file must not suppress the audit for a different file.
+   core::FilePath granted = makeTempFile(".zip", "payload");
+   core::FilePath other = makeTempFile(".zip", "secret");
+   registerDownloadGrant(granted);
+
+   core::http::Request request;
+   EXPECT_TRUE(shouldAuditFileDownload(request, other));
+}
+
+TEST_F(FileDownloadGrantTest, StaleGrantAudits)
+{
+   // If the file is replaced after the grant is recorded, the size/mtime stamp
+   // no longer matches, so the download is audited -- a grant can't be reused
+   // to smuggle out content swapped in at the same path.
+   core::FilePath file = makeTempFile(".zip", "preview");
+   registerDownloadGrant(file);
+
+   // Rewrite with different-length content to change the stamp.
+   core::Error error = core::writeStringToFile(file, "swapped-in-secret-data");
+   ASSERT_FALSE(error) << error.asString();
+
+   core::http::Request request;
+   EXPECT_TRUE(shouldAuditFileDownload(request, file));
+}
+
+TEST_F(FileDownloadGrantTest, CreateFileUrlRegistersGrantAndDropsShowMarker)
+{
+   // Producer side: createFileUrl registers the grant and no longer appends a
+   // ?show=1 marker. Regression guard for the producer/consumer contract.
+   core::FilePath file = makeTempFile(".zip", "preview");
+   const std::string url = createFileUrl(file);
+
+   EXPECT_EQ(url.find("show=1"), std::string::npos)
+      << "createFileUrl should no longer emit a show=1 marker: " << url;
+
+   core::http::Request request;
    EXPECT_FALSE(shouldAuditFileDownload(request, file))
-      << "round-trip URL " << url
-      << " should skip audit via the ?show=1 marker";
+      << "createFileUrl should have registered a download grant for " << url;
+}
+
+TEST_F(FileDownloadGrantTest, TrackingEnabledAuditsRenamedText)
+{
+   // #3: renaming a binary to a text extension lands a text/* Content-Type,
+   // which is skipped by default. With resource tracking enabled that skip is
+   // off, so the download is audited regardless of the client-influenced type.
+   core::FilePath file = makeTempFile(".txt", "actually-not-text");
+   enableResourceTracking();
+
+   core::http::Request request;
+   EXPECT_TRUE(shouldAuditFileDownload(request, file));
+}
+
+TEST_F(FileDownloadGrantTest, TrackingEnabledAuditsSpoofedFetchDest)
+{
+   // #2: a client can send Sec-Fetch-Dest: image to masquerade as a sub-
+   // resource. With resource tracking enabled that skip is off, so the
+   // download is audited.
+   core::FilePath file = makeTempFile(".zip", "payload");
+   enableResourceTracking();
+
+   core::http::Request request;
+   request.setHeader("Sec-Fetch-Dest", "image");
+   EXPECT_TRUE(shouldAuditFileDownload(request, file));
+}
+
+TEST_F(FileDownloadGrantTest, TrackingEnabledAuditsRenderableType)
+{
+   // A genuinely renderable type (PDF) is skipped by default but audited once
+   // resource tracking is enabled.
+   core::FilePath file = makeTempFile(".pdf", "%PDF-1.4");
+
+   core::http::Request request;
+   EXPECT_FALSE(shouldAuditFileDownload(request, file));
+
+   enableResourceTracking();
+   EXPECT_TRUE(shouldAuditFileDownload(request, file));
 }
 
 // --- shouldIgnoreOutputDir --------------------------------------------------

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -95,14 +95,23 @@ std::string createAliasedPath(const core::FilePath& path);
 std::string createFileUrl(const core::FilePath& path);
 core::FilePath resolveAliasedPath(const std::string& aliasedPath);
 
-// Returns true if a /files/ or /file_show request for filePath should
+// Records that filePath was surfaced to the browser by a server-initiated
+// preview/show flow, so a subsequent request for it is not audited as a
+// download. Called by createFileUrl() and by the Show-in-Browser RPC.
+void registerDownloadGrant(const core::FilePath& filePath);
+
+// Returns true if a /files, /file_show, or /show request for filePath should
 // produce a session_file_download audit event. Returns false when:
-//   (1) the URL carries ?show=1 (server-initiated preview/show flow),
-//   (2) Sec-Fetch-Dest indicates a sub-resource (style/script/image/
-//       font/audio/video/track/object/embed/manifest/xslt/report/
-//       worker/serviceworker/audioworklet/paintworklet), or
-//   (3) the file's Content-Type is browser-renderable: text/*, image/*,
-//       audio/*, video/*, application/pdf, application/json.
+//   (1) the file is owned by a system account (owner uid below
+//       auth-minimum-user-id) -- an admin-provisioned resource, not user data,
+//   (2) filePath has an unexpired server-initiated preview grant recorded via
+//       registerDownloadGrant (replaces the old, forgeable ?show=1 marker), or
+//   (3) track-resource-downloads is disabled (the default) AND the request
+//       looks like a browser sub-resource load -- Sec-Fetch-Dest indicates a
+//       sub-resource, or the file's Content-Type is browser-renderable
+//       (text/*, image/*, audio/*, video/*, application/pdf, application/json).
+//       These signals are client-supplied and spoofable, so administrators who
+//       require such downloads to be audited enable track-resource-downloads.
 bool shouldAuditFileDownload(const core::http::Request& request,
                              const core::FilePath& filePath);
 core::FilePath userScratchPath();

--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -514,7 +514,10 @@ protected:
       value<std::string>(&previewAllowedFunctions_)->default_value(""),
       "A comma- or space-separated list of additional function names (for example, 'mypkg::connect') that may be evaluated without prompting when resolving a file preview connection expression -- the SQL '-- !preview conn=' header or an r2d3 preview. Each listed name is treated as a trusted constructor; its arguments are still validated. Use this to allow connection helpers from internally-built packages.");
 
-   pMisc->add_options();
+   pMisc->add_options()
+      ("track-resource-downloads",
+      value<bool>(&trackResourceDownloads_)->default_value(false),
+      "When enabled, downloads of browser-renderable resources (fonts, images, HTML, and other inline content types served via /files, /file_show, and /show) generate session_file_download audit events instead of being skipped. Defaults to disabled to avoid audit noise from routine resource loads. Administrators who require these downloads to be audited can enable this option.");
 
    FilePath defaultConfigPath = core::system::xdg::findSystemConfigFile("rsession configuration", "rsession.conf");
    std::string configFile = defaultConfigPath.exists() ?
@@ -657,6 +660,7 @@ public:
    int projectTrustDialogs() const { return projectTrustDialogs_; }
    bool projectTrustRequired() const { return projectTrustRequired_; }
    std::string previewAllowedFunctions() const { return previewAllowedFunctions_; }
+   bool trackResourceDownloads() const { return trackResourceDownloads_; }
 
 
 protected:
@@ -796,6 +800,7 @@ protected:
    int projectTrustDialogs_;
    bool projectTrustRequired_;
    std::string previewAllowedFunctions_;
+   bool trackResourceDownloads_;
    virtual bool allowOverlay() const { return false; };
 };
 

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -250,6 +250,14 @@ public:
       return authRequiredUserGroup_;
    }
 
+   // Test hook: track-resource-downloads is a regular (non-overlay) option and
+   // is therefore fixed at process start. The unit tests need to flip it at
+   // runtime to exercise both the default (skip) and opt-in (audit) paths.
+   void setTrackResourceDownloads(bool value)
+   {
+      trackResourceDownloads_ = value;
+   }
+
 private:
    bool multiSession_;
    bool showUserHomePage_;
@@ -278,7 +286,7 @@ private:
    // root directory for locating resources
    core::FilePath resourcePath_;
 
-   unsigned int authMinimumUserId_;
+   unsigned int authMinimumUserId_ = 0;
    int64_t limitRpcClientUid_;
 
    // in-session generated RSA keys

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -231,7 +231,7 @@ core::Error getFileContents(const json::JsonRpcRequest& request,
    FilePath targetPath = module_context::resolveAliasedPath(path);
    if (!module_context::isPathViewAllowed(targetPath))
    {
-      return Error(json::errc::ParamInvalid, ERROR_LOCATION);
+      return Error(json::errc::DirectoryViewListingProhibited, ERROR_LOCATION);
    }
 
    std::string contents;
@@ -257,6 +257,10 @@ Error listFiles(const json::JsonRpcRequest& request, json::JsonRpcResponse* pRes
    if (error)
       return error;
    FilePath targetPath = module_context::resolveAliasedPath(path);
+   if (!module_context::isPathViewAllowed(targetPath))
+   {  
+      return Error(json::errc::DirectoryViewListingProhibited, ERROR_LOCATION);
+   }
 
    json::Object result;
    
@@ -693,6 +697,7 @@ void handleFilesRequest(const http::Request& request,
    if (module_context::shouldAuditFileDownload(request, filePath))
    {
       using namespace monitor;
+      LOG_DEBUG_MESSAGE("Sending file session download event for: " + filePath.getAbsolutePath());
       client().logEvent(Event(kSessionScope, kSessionDownloadEvent,
                               module_context::createAliasedPath(filePath)));
    }
@@ -733,7 +738,15 @@ void handleShowRequest(const http::Request& request,
          return;
       }
    }
-   
+
+   if (module_context::shouldAuditFileDownload(request, filePath))
+   {
+      using namespace monitor;
+      LOG_DEBUG_MESSAGE("Sending show session download event for: " + filePath.getAbsolutePath());
+      client().logEvent(Event(kSessionScope, kSessionDownloadEvent,
+                              module_context::createAliasedPath(filePath)));
+   }
+
    pResponse->setNoCacheHeaders();
    pResponse->setFile(filePath, request);
 }
@@ -832,7 +845,7 @@ Error completeUpload(const core::json::JsonRpcRequest& request,
       {
          // calculate target path
          FilePath targetPath = targetDirectoryPath.completeChildPath(filename);
-         
+
          // move the source to the destination, falling back to a copy
          // if the move cannot be completed
          Error copyError = uploadedTempFilePath.move(targetPath, FilePath::MoveCrossDevice, true);
@@ -1470,6 +1483,7 @@ void handleMultipleFileExportRequest(const http::Request& request,
    {
       // let the monitor client know the user has downloaded this file
       using namespace monitor;
+      LOG_DEBUG_MESSAGE("Sending multi session download event for: " + f);
       client().logEvent(Event(kSessionScope, kSessionDownloadEvent, f));
    }
    
@@ -1520,6 +1534,7 @@ void handleFileExportRequest(const http::Request& request,
       
       // let the monitor client know the user has downloaded this file
       using namespace monitor;
+      LOG_DEBUG_MESSAGE("Sending export session download event for: " + file);
       client().logEvent(Event(kSessionScope, kSessionDownloadEvent, file));
 
       // download as attachment

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -1054,7 +1054,13 @@
          }
       ],
       "misc": [
-
+         {
+            "name": "track-resource-downloads",
+            "type": "bool",
+            "defaultValue": false,
+            "memberName": "trackResourceDownloads_",
+            "description": "When enabled, downloads of browser-renderable resources (fonts, images, HTML, and other inline content types served via /files, /file_show, and /show) generate session_file_download audit events instead of being skipped. Defaults to disabled to avoid audit noise from routine resource loads. Administrators who require these downloads to be audited can enable this option."
+         }
       ]
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -987,7 +987,7 @@ public class Files
 
    public void onOpenFileInBrowser(OpenFileInBrowserEvent event)
    {
-      showFileInBrowser(event.getFile(), event.isDownload());
+      showFileInBrowser(event.getFile());
    }
 
    public void onDirectoryNavigate(DirectoryNavigateEvent event)
@@ -1112,26 +1112,10 @@ public class Files
 
    private void showFileInBrowser(FileSystemItem file)
    {
-      showFileInBrowser(file, false);
-   }
-
-   private void showFileInBrowser(FileSystemItem file, boolean asDownload)
-   {
       // show the file in a new window if we can get a file url for it
       String fileURL = server_.getFileUrl(file);
       if (fileURL != null)
-      {
-         // for server URLs that aren't user-initiated downloads (HTML
-         // "Show in Browser", source-code link clicks), tag the URL so
-         // the server skips audit logging - matching the marker that
-         // module_context::createFileUrl applies to server-side preview
-         // flows. Files-pane downloads stay unmarked and are logged like
-         // any other top-level navigation.
-         // Desktop URLs are file:// and don't go through the session.
-         if (!asDownload && !fileURL.startsWith("file:"))
-            fileURL += (fileURL.contains("?") ? "&" : "?") + "show=1";
          globalDisplay_.openWindow(fileURL);
-      }
    }
 
    // generate a filename based on the file type and currentPath_ variable


### PR DESCRIPTION
 ### Intent

Addresses:  https://github.com/rstudio/rstudio-pro/issues/11167
 
 Moves the logic for deciding when to send a file download event
 into a server controlled table instead of query params. Added a new
 option to also track resource downloads that come from user owned
 packages.
