### PR TITLE
Raise container /dev/shm to 2g for the Debian 13 arm64 E2E engine

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
@@ -335,7 +335,15 @@ jobs:
       # bare-runner siblings. If a future runner kernel forbids unprivileged user
       # namespaces and the sandbox can't come up, set rstudio_extra_args to
       # '--no-sandbox' as a fallback rather than changing these.
-      options: --cap-add=SYS_ADMIN --security-opt seccomp=unconfined
+      #
+      # --shm-size=2g: container jobs default /dev/shm to 64 MB, which Chromium
+      # uses for cross-process shared memory. Under that cap the Electron
+      # renderer crashes to a blank page with no logged cause after a while
+      # (observed in the first arm64 run: the app worked for dozens of tests,
+      # then "Target crashed" mid-suite with nothing in rdesktop.log or the
+      # trace). The bare-runner siblings get the host's full /dev/shm and never
+      # hit this. Raising it to 2g is the standard container fix.
+      options: --cap-add=SYS_ADMIN --security-opt seccomp=unconfined --shm-size=2g
     timeout-minutes: 120
     env:
       R_LIBS_USER: ${{ github.workspace }}/R-libs


### PR DESCRIPTION
The first arm64 smoke run of the Debian 13 engine (after the shell fix in PR 18243) got the tests actually executing, then hit renderer instability: the app ran fine for dozens of tests, then the Electron/Chromium renderer crashed to a blank page (`Target crashed`), cascading into timeouts across the remaining tests.

Investigation of the preserved pw-sandbox and Playwright trace ruled out the usual suspects: no OOM (the "oom" trace hits were base64 blobs and `zoom:1` CSS), the R backend was healthy (rsession logged only a benign LANG warning), the app clearly worked (41 tests passed first), and the tests' own assertions passed with real values. The renderer crash left no cause in any log -- Electron's `rdesktop.log` was empty on both shards, and the trace had no console errors or page errors.

The signature -- a container renderer crashing to a blank page with no logged cause after working for a while -- is the textbook symptom of `/dev/shm` exhaustion: GitHub container jobs default `/dev/shm` to 64 MB, and Chromium uses it for cross-process shared memory. The bare-runner siblings get the host's full `/dev/shm` and never hit this. This raises the container's `/dev/shm` to 2 GB via `--shm-size=2g`.

Single-variable change, so a re-dispatch cleanly confirms or refutes the hypothesis; if renderer crashes persist we will escalate to an instrumented run (verbose Chromium logging / core dumps).