### PR TITLE
Set a UTF-8 locale in the Debian 13 arm64 E2E container

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
@@ -349,6 +349,16 @@ jobs:
       R_LIBS_USER: ${{ github.workspace }}/R-libs
       PW_SANDBOX_ROOT: ${{ github.workspace }}/pw-sandbox
       PW_SANDBOX_ROOT_CREATE: '1'
+      # The minimal debian:13 image sets no locale, so R starts with a non-UTF-8
+      # charset and prints "Character set is not UTF-8; please change your
+      # locale" into the console. Console-content tests (e.g. the ANSI cursor
+      # suite) assert on exact console lines, so that warning breaks them
+      # deterministically. C.UTF-8 is built into glibc on Debian 13 (no
+      # locale-gen needed); setting it job-level carries through the setpriv
+      # drop into Electron and rsession. The bare-runner siblings inherit a
+      # UTF-8 locale from the runner image and never hit this.
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
 
     steps:
       # The debian:13 base image is minimal and the job runs as root. Install


### PR DESCRIPTION
The Debian 13 arm64 E2E engine's first full runs failed a cluster of console-content and Unicode tests (ANSI cursor movement, console output/command, code-folding em-dashes/box-drawing, Unicode-column autocomplete). Root cause: the minimal `debian:13` image sets no locale, so R starts with a non-UTF-8 charset and prints `Warning message: Character set is not UTF-8; please change your locale` into the console -- which the content assertions then see as unexpected output. The bare-runner siblings inherit a UTF-8 locale from the runner image and never hit this.

Fix: set `LANG`/`LC_ALL` to `C.UTF-8` (built into glibc on Debian 13, no `locale-gen` needed) as job-level env, carried through the `setpriv` drop into Electron and rsession.

Verified: a full-suite branch dispatch after this change passes with 0 failures on both shards (234/0 and 220/0), versus ~14 locale-rooted failures before. This is independent of and complementary to the `--shm-size=2g` renderer-crash fix (PR 18251); together they get the engine to a clean run.