### PR TITLE
Fix stale rig install in E2E workflows by resolving the actual latest release

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
@@ -406,12 +406,20 @@ jobs:
             libxss1 libxtst6 libxcb1 \
             libfreetype6 libfontconfig1 libharfbuzz0b libfribidi0
 
+      # The "latest" release tag is a permanent-link release whose binary
+      # assets are not kept current (last updated 2024-04-07 as of writing --
+      # see r-lib/rig#343 for a bug this staleness reintroduces). Resolve the
+      # actual latest release via the GitHub API instead. $(arch) resolves
+      # aarch64 on arm64, but real releases use "arm64" in the asset name.
       - name: Install rig
         run: |
-          # $(arch) resolves aarch64 on arm64; rig's rolling "latest" release
-          # publishes rig-linux-aarch64-latest.tar.gz, so this line is unchanged
-          # from the x86_64 siblings.
-          curl -fLs https://github.com/r-lib/rig/releases/download/latest/rig-linux-$(arch)-latest.tar.gz \
+          RIG_VERSION=$(curl -fsSL https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          case "$(arch)" in
+            x86_64)  RIG_ASSET="rig-linux-${RIG_VERSION}.tar.gz" ;;
+            aarch64) RIG_ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz" ;;
+            *) echo "::error::Unsupported arch $(arch) for rig install"; exit 1 ;;
+          esac
+          curl -fLs "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}" \
             | tar xz -C /usr/local
 
       - name: Install R via rig

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
@@ -410,17 +410,21 @@ jobs:
       # assets are not kept current (last updated 2024-04-07 as of writing --
       # see r-lib/rig#343 for a bug this staleness reintroduces). Resolve the
       # actual latest release via the GitHub API instead. $(arch) resolves
-      # aarch64 on arm64, but real releases use "arm64" in the asset name.
+      # aarch64 on arm64, but real releases use "arm64" in the asset name; the
+      # x86_64 asset carries no arch token.
       - name: Install rig
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          RIG_VERSION=$(curl -fsSL https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          RIG_VERSION=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          case "$RIG_VERSION" in ''|null) echo "::error::Could not resolve rig's latest version (GitHub API rate limit or outage?)"; exit 1 ;; esac
           case "$(arch)" in
             x86_64)  RIG_ASSET="rig-linux-${RIG_VERSION}.tar.gz" ;;
             aarch64) RIG_ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz" ;;
             *) echo "::error::Unsupported arch $(arch) for rig install"; exit 1 ;;
           esac
-          curl -fLs "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}" \
-            | tar xz -C /usr/local
+          curl -fLs --retry 3 --retry-delay 5 -o rig.tar.gz "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}"
+          tar xzf rig.tar.gz -C /usr/local
 
       - name: Install R via rig
         env:

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -294,9 +294,12 @@ jobs:
       # see r-lib/rig#343 for a bug this staleness reintroduces). Resolve the
       # actual latest release via the GitHub API instead.
       - name: Install rig
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          RIG_VERSION=$(curl -fsSL https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
-          curl -fLs -o rig.pkg "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/rig-${RIG_VERSION}-macOS-arm64.pkg"
+          RIG_VERSION=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          case "$RIG_VERSION" in ''|null) echo "::error::Could not resolve rig's latest version (GitHub API rate limit or outage?)"; exit 1 ;; esac
+          curl -fLs --retry 3 --retry-delay 5 -o rig.pkg "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/rig-${RIG_VERSION}-macOS-arm64.pkg"
           sudo installer -pkg rig.pkg -target /
 
       - name: Install R via rig

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -289,9 +289,14 @@ jobs:
           cache: 'npm'
           cache-dependency-path: e2e/rstudio/package-lock.json
 
+      # The "latest" release tag is a permanent-link release whose binary
+      # assets are not kept current (last updated 2024-04-07 as of writing --
+      # see r-lib/rig#343 for a bug this staleness reintroduces). Resolve the
+      # actual latest release via the GitHub API instead.
       - name: Install rig
         run: |
-          curl -fLs -o rig.pkg https://github.com/r-lib/rig/releases/download/latest/rig-latest-macOS-arm64.pkg
+          RIG_VERSION=$(curl -fsSL https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          curl -fLs -o rig.pkg "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/rig-${RIG_VERSION}-macOS-arm64.pkg"
           sudo installer -pkg rig.pkg -target /
 
       - name: Install R via rig

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-rhel-10-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-rhel-10-x86_64.yml
@@ -380,9 +380,20 @@ jobs:
             gtk3 pango cairo alsa-lib \
             freetype fontconfig harfbuzz fribidi
 
+      # The "latest" release tag is a permanent-link release whose binary
+      # assets are not kept current (last updated 2024-04-07 as of writing --
+      # see r-lib/rig#343 for a bug this staleness reintroduces). Resolve the
+      # actual latest release via the GitHub API instead. Real releases use
+      # "arm64" in the asset name, not $(arch)'s "aarch64".
       - name: Install rig
         run: |
-          curl -fLs https://github.com/r-lib/rig/releases/download/latest/rig-linux-$(arch)-latest.tar.gz \
+          RIG_VERSION=$(curl -fsSL https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          case "$(arch)" in
+            x86_64)  RIG_ASSET="rig-linux-${RIG_VERSION}.tar.gz" ;;
+            aarch64) RIG_ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz" ;;
+            *) echo "::error::Unsupported arch $(arch) for rig install"; exit 1 ;;
+          esac
+          curl -fLs "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}" \
             | tar xz -C /usr/local
 
       - name: Install R via rig

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-rhel-10-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-rhel-10-x86_64.yml
@@ -384,17 +384,21 @@ jobs:
       # assets are not kept current (last updated 2024-04-07 as of writing --
       # see r-lib/rig#343 for a bug this staleness reintroduces). Resolve the
       # actual latest release via the GitHub API instead. Real releases use
-      # "arm64" in the asset name, not $(arch)'s "aarch64".
+      # "arm64" in the asset name, not $(arch)'s "aarch64"; the x86_64 asset
+      # carries no arch token.
       - name: Install rig
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          RIG_VERSION=$(curl -fsSL https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          RIG_VERSION=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          case "$RIG_VERSION" in ''|null) echo "::error::Could not resolve rig's latest version (GitHub API rate limit or outage?)"; exit 1 ;; esac
           case "$(arch)" in
             x86_64)  RIG_ASSET="rig-linux-${RIG_VERSION}.tar.gz" ;;
             aarch64) RIG_ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz" ;;
             *) echo "::error::Unsupported arch $(arch) for rig install"; exit 1 ;;
           esac
-          curl -fLs "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}" \
-            | tar xz -C /usr/local
+          curl -fLs --retry 3 --retry-delay 5 -o rig.tar.gz "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}"
+          tar xzf rig.tar.gz -C /usr/local
 
       - name: Install R via rig
         env:

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -337,9 +337,20 @@ jobs:
       - name: Allow unprivileged user namespaces (required by Electron/Chromium)
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
+      # The "latest" release tag is a permanent-link release whose binary
+      # assets are not kept current (last updated 2024-04-07 as of writing --
+      # see r-lib/rig#343 for a bug this staleness reintroduces). Resolve the
+      # actual latest release via the GitHub API instead. Real releases use
+      # "arm64" in the asset name, not $(arch)'s "aarch64".
       - name: Install rig
         run: |
-          curl -fLs https://github.com/r-lib/rig/releases/download/latest/rig-linux-$(arch)-latest.tar.gz \
+          RIG_VERSION=$(curl -fsSL https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          case "$(arch)" in
+            x86_64)  RIG_ASSET="rig-linux-${RIG_VERSION}.tar.gz" ;;
+            aarch64) RIG_ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz" ;;
+            *) echo "::error::Unsupported arch $(arch) for rig install"; exit 1 ;;
+          esac
+          curl -fLs "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}" \
             | sudo tar xz -C /usr/local
 
       - name: Install R via rig

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -341,17 +341,21 @@ jobs:
       # assets are not kept current (last updated 2024-04-07 as of writing --
       # see r-lib/rig#343 for a bug this staleness reintroduces). Resolve the
       # actual latest release via the GitHub API instead. Real releases use
-      # "arm64" in the asset name, not $(arch)'s "aarch64".
+      # "arm64" in the asset name, not $(arch)'s "aarch64"; the x86_64 asset
+      # carries no arch token.
       - name: Install rig
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          RIG_VERSION=$(curl -fsSL https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          RIG_VERSION=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          case "$RIG_VERSION" in ''|null) echo "::error::Could not resolve rig's latest version (GitHub API rate limit or outage?)"; exit 1 ;; esac
           case "$(arch)" in
             x86_64)  RIG_ASSET="rig-linux-${RIG_VERSION}.tar.gz" ;;
             aarch64) RIG_ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz" ;;
             *) echo "::error::Unsupported arch $(arch) for rig install"; exit 1 ;;
           esac
-          curl -fLs "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}" \
-            | sudo tar xz -C /usr/local
+          curl -fLs --retry 3 --retry-delay 5 -o rig.tar.gz "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}"
+          sudo tar xzf rig.tar.gz -C /usr/local
 
       - name: Install R via rig
         env:

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
@@ -329,17 +329,21 @@ jobs:
       # assets are not kept current (last updated 2024-04-07 as of writing --
       # see r-lib/rig#343 for a bug this staleness reintroduces). Resolve the
       # actual latest release via the GitHub API instead. Real releases use
-      # "arm64" in the asset name, not $(arch)'s "aarch64".
+      # "arm64" in the asset name, not $(arch)'s "aarch64"; the x86_64 asset
+      # carries no arch token.
       - name: Install rig
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          RIG_VERSION=$(curl -fsSL https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          RIG_VERSION=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          case "$RIG_VERSION" in ''|null) echo "::error::Could not resolve rig's latest version (GitHub API rate limit or outage?)"; exit 1 ;; esac
           case "$(arch)" in
             x86_64)  RIG_ASSET="rig-linux-${RIG_VERSION}.tar.gz" ;;
             aarch64) RIG_ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz" ;;
             *) echo "::error::Unsupported arch $(arch) for rig install"; exit 1 ;;
           esac
-          curl -fLs "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}" \
-            | sudo tar xz -C /usr/local
+          curl -fLs --retry 3 --retry-delay 5 -o rig.tar.gz "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}"
+          sudo tar xzf rig.tar.gz -C /usr/local
 
       - name: Install R via rig
         env:

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
@@ -325,9 +325,20 @@ jobs:
       - name: Allow unprivileged user namespaces (required by Electron/Chromium)
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
+      # The "latest" release tag is a permanent-link release whose binary
+      # assets are not kept current (last updated 2024-04-07 as of writing --
+      # see r-lib/rig#343 for a bug this staleness reintroduces). Resolve the
+      # actual latest release via the GitHub API instead. Real releases use
+      # "arm64" in the asset name, not $(arch)'s "aarch64".
       - name: Install rig
         run: |
-          curl -fLs https://github.com/r-lib/rig/releases/download/latest/rig-linux-$(arch)-latest.tar.gz \
+          RIG_VERSION=$(curl -fsSL https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          case "$(arch)" in
+            x86_64)  RIG_ASSET="rig-linux-${RIG_VERSION}.tar.gz" ;;
+            aarch64) RIG_ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz" ;;
+            *) echo "::error::Unsupported arch $(arch) for rig install"; exit 1 ;;
+          esac
+          curl -fLs "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}" \
             | sudo tar xz -C /usr/local
 
       - name: Install R via rig

--- a/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -334,9 +334,20 @@ jobs:
       - name: Allow unprivileged user namespaces (required by Playwright/Chrome)
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
+      # The "latest" release tag is a permanent-link release whose binary
+      # assets are not kept current (last updated 2024-04-07 as of writing --
+      # see r-lib/rig#343 for a bug this staleness reintroduces). Resolve the
+      # actual latest release via the GitHub API instead. Real releases use
+      # "arm64" in the asset name, not $(arch)'s "aarch64".
       - name: Install rig
         run: |
-          curl -fLs https://github.com/r-lib/rig/releases/download/latest/rig-linux-$(arch)-latest.tar.gz \
+          RIG_VERSION=$(curl -fsSL https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          case "$(arch)" in
+            x86_64)  RIG_ASSET="rig-linux-${RIG_VERSION}.tar.gz" ;;
+            aarch64) RIG_ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz" ;;
+            *) echo "::error::Unsupported arch $(arch) for rig install"; exit 1 ;;
+          esac
+          curl -fLs "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}" \
             | sudo tar xz -C /usr/local
 
       - name: Install R via rig

--- a/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -338,17 +338,21 @@ jobs:
       # assets are not kept current (last updated 2024-04-07 as of writing --
       # see r-lib/rig#343 for a bug this staleness reintroduces). Resolve the
       # actual latest release via the GitHub API instead. Real releases use
-      # "arm64" in the asset name, not $(arch)'s "aarch64".
+      # "arm64" in the asset name, not $(arch)'s "aarch64"; the x86_64 asset
+      # carries no arch token.
       - name: Install rig
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          RIG_VERSION=$(curl -fsSL https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          RIG_VERSION=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
+          case "$RIG_VERSION" in ''|null) echo "::error::Could not resolve rig's latest version (GitHub API rate limit or outage?)"; exit 1 ;; esac
           case "$(arch)" in
             x86_64)  RIG_ASSET="rig-linux-${RIG_VERSION}.tar.gz" ;;
             aarch64) RIG_ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz" ;;
             *) echo "::error::Unsupported arch $(arch) for rig install"; exit 1 ;;
           esac
-          curl -fLs "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}" \
-            | sudo tar xz -C /usr/local
+          curl -fLs --retry 3 --retry-delay 5 -o rig.tar.gz "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}"
+          sudo tar xzf rig.tar.gz -C /usr/local
 
       - name: Install R via rig
         env:


### PR DESCRIPTION
rig's "latest" release tag is a permanent link frozen since 2024-04-07, not the real latest release (v0.8.1). That frozen build has the registration bug from r-lib/rig#343, breaking every scheduled macOS run using r_version: "release". Each engine now resolves the real latest release via the GitHub API instead.