### PR TITLE
Strip WinINet cache dirs before the Windows sandbox artifact upload

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -845,6 +845,24 @@ jobs:
           retention-days: 15
           if-no-files-found: ignore
 
+      # WinINet creates protected cache directories (INetCache\Content.IE5,
+      # WebCache) inside the sandbox user-home when anything on the test path
+      # touches the network. Their deny ACLs make upload-artifact's recursive
+      # directory scan fail with EPERM, so strip them before uploading.
+      - name: Remove protected Windows cache dirs from sandbox (on failure)
+        if: failure()
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $cacheDirs = @('INetCache', 'INetCookies', 'WebCache')
+          Get-ChildItem -Path "${{ github.workspace }}\pw-sandbox" -Directory -Recurse -Force -ErrorAction SilentlyContinue |
+            Where-Object { $cacheDirs -contains $_.Name } |
+            ForEach-Object {
+              takeown /f $_.FullName /r /d y *> $null
+              icacls $_.FullName /reset /t /c /q *> $null
+              Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue
+            }
+          exit 0
+
       - name: Upload PW sandbox (on failure)
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
When a Windows E2E shard fails, the "Upload PW sandbox (on failure)" step zips up `pw-sandbox\` for diagnosis. If anything on the test path touched the network through WinINet (e.g. the citations PubMed test), Windows creates protected cache directories (`INetCache\Content.IE5`, `WebCache`) inside the sandbox user-home. Their deny ACLs make upload-artifact's recursive directory scan die with `EPERM: operation not permitted, scandir ...INetCache\Content.IE5`, so the sandbox diagnostics are lost exactly when a test fails ([example run](https://github.com/rstudio/rstudio/actions/runs/29523924763/job/87707459447)).

This adds an on-failure step before the upload that finds `INetCache`, `INetCookies`, and `WebCache` directories in the sandbox, resets their ACLs with `takeown`/`icacls`, and deletes them. The step swallows its own errors: worst case the upload behaves exactly as it does today. Only the Windows engine needs this; the other engines run on Linux/macOS where these directories never appear.