### PR TITLE
load vim keybindings from a user vimrc file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - ([#18158](https://github.com/rstudio/rstudio/issues/18158)): On macOS, the Files pane now follows Finder aliases: clicking an alias to a folder navigates to that folder, and clicking an alias to a file opens the file.
 - ([#9924](https://github.com/rstudio/rstudio/issues/9924)): The Files pane now shows a link indicator on symbolic links and macOS Finder aliases, with the link target shown in the icon's tooltip.
 - ([#8715](https://github.com/rstudio/rstudio/issues/8715)): Inline LaTeX / math previews in the source editor and visual editor are now rendered with MathJax 4 (previously MathJax 2.7), adding support for the TeX input extensions introduced in MathJax 3 and later. Rendered R Markdown documents using `mathjax = "local"` continue to use the bundled MathJax 2.7.
+- ([#7350](https://github.com/rstudio/rstudio/issues/7350)): RStudio can now load custom Vim key mappings from `~/.rstudio-vimrc` (or `~/.vimrc`) when Vim editor keybindings are in use. Enable the new preference under Tools > Global Options > Code > Editing; key mapping commands (`map`, `noremap`, `unmap`, and friends) and `set` commands supported by the editor's Vim emulation are applied, and other vimrc content is ignored.
 
 ### Fixed
 - ([#18152](https://github.com/rstudio/rstudio/issues/18152)): Fixed a compilation error when building RStudio Server against SOCI 4.1.4 or newer.

--- a/e2e/rstudio/tests/panes/editor/vimrc_keybindings.test.ts
+++ b/e2e/rstudio/tests/panes/editor/vimrc_keybindings.test.ts
@@ -8,6 +8,7 @@ import type { Page } from 'playwright';
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { AceEditor } from '@pages/ace_editor.page';
+import { SourcePane } from '@pages/source_pane.page';
 import { clearPref, executeCommand, setPref } from '@utils/commands';
 import {
   CODE_TAB,
@@ -21,26 +22,41 @@ import {
 // keeps the test working against both Desktop and Server. ~/.rstudio-vimrc
 // takes priority over ~/.vimrc, so a developer's real ~/.vimrc is never read;
 // any pre-existing ~/.rstudio-vimrc is backed up and restored.
+//
+// Besides the mappings under test, the fixture carries two canaries for the
+// loader's command allowlist (its security boundary): 'call plug#begin()'
+// must be ignored without breaking the load, and 'edit ~/vimrc-canary-e2e.R'
+// -- an ex command RStudio itself registers, with an observable effect --
+// must NOT execute (it would open the canary file in a source tab).
+const CANARY_FILE = 'vimrc-canary-e2e.R';
+
 const SETUP_VIMRC = [
   'if (file.exists("~/.rstudio-vimrc")) file.rename("~/.rstudio-vimrc", "~/.rstudio-vimrc.e2e-backup");',
-  'writeLines(c("\\" comment", "imap jk <Esc>", "nnoremap <silent> Y y$", "call plug#begin()"), "~/.rstudio-vimrc")',
+  `writeLines("# canary", "~/${CANARY_FILE}");`,
+  'writeLines(c("\\" comment", "imap jk <Esc>", "nnoremap <silent> Y y$",',
+  `  "edit ~/${CANARY_FILE}", "call plug#begin()"), "~/.rstudio-vimrc")`,
+].join(' ');
+
+const SETUP_VIMRC_MIDSESSION = [
+  'if (file.exists("~/.rstudio-vimrc")) file.rename("~/.rstudio-vimrc", "~/.rstudio-vimrc.e2e-backup");',
+  'writeLines("imap zz <Esc>", "~/.rstudio-vimrc")',
 ].join(' ');
 
 const RESTORE_VIMRC = [
-  'unlink("~/.rstudio-vimrc");',
+  `unlink(c("~/.rstudio-vimrc", "~/${CANARY_FILE}"));`,
   'if (file.exists("~/.rstudio-vimrc.e2e-backup")) file.rename("~/.rstudio-vimrc.e2e-backup", "~/.rstudio-vimrc")',
 ].join(' ');
 
-// True once the 'imap jk <Esc>' mapping from the vimrc has been registered
-// with the Vim emulation (user mappings land in the shared keymap).
-function vimrcMappingRegistered(page: Page): Promise<boolean> {
-  return page.evaluate(() => {
+// True once a mapping with the given keys has been registered with the Vim
+// emulation (user mappings land in the shared keymap).
+function vimMappingRegistered(page: Page, keys: string): Promise<boolean> {
+  return page.evaluate((mappedKeys) => {
     const w = window as unknown as {
       require(id: string): { handler: { defaultKeymap: Array<{ keys?: string }> } };
     };
     const handler = w.require('ace/keyboard/vim').handler;
-    return handler.defaultKeymap.some((mapping) => mapping.keys === 'jk');
-  });
+    return handler.defaultKeymap.some((mapping) => mapping.keys === mappedKeys);
+  }, keys);
 }
 
 test.describe('Vimrc keybindings', () => {
@@ -48,6 +64,7 @@ test.describe('Vimrc keybindings', () => {
     rstudioPage: page,
   }) => {
     const consoleActions = new ConsolePaneActions(page);
+    const sourcePane = new SourcePane(page);
 
     // run all console commands while keybindings are still the default, so
     // console input behavior isn't affected by Vim mode
@@ -61,24 +78,68 @@ test.describe('Vimrc keybindings', () => {
       // vimrc load
       await executeCommand(page, 'newSourceDoc');
       await expect
-        .poll(() => vimrcMappingRegistered(page), {
+        .poll(() => vimMappingRegistered(page, 'jk'), {
           message: 'expected the vimrc mapping to be registered',
         })
         .toBe(true);
 
-      // exercise the mapping: insert some text, leave insert mode via the
-      // mapped 'jk', then delete a character with normal-mode 'x'. The
-      // unsupported 'call plug#begin()' vimrc line must not break loading.
+      // exercise the mappings: insert some text, leave insert mode via the
+      // mapped 'jk', delete a character with normal-mode 'x', then use the
+      // <silent>-stripped 'Y' (y$, yank to end of line: just 'b') and paste.
+      // Vim's default linewise Y would instead yield 'ab\nab' here.
       const editor = new AceEditor(page, '');
-      await editor.focus();
+      // in Vim normal mode Ace parks its hidden textarea offscreen, so click
+      // the visible editor content to focus the editor
+      await sourcePane.contentPane.click({ force: true });
       await page.keyboard.type('iabc', { delay: 20 });
       await page.keyboard.type('jk', { delay: 20 });
       await page.keyboard.type('x', { delay: 20 });
-
       await expect.poll(() => editor.getValue()).toBe('ab');
+
+      await page.keyboard.type('Yp', { delay: 20 });
+      await expect.poll(() => editor.getValue()).toBe('abb');
+
+      // the blocked 'edit' canary must not have opened a tab
+      await expect(
+        page.locator('.gwt-TabLayoutPanelTab', { hasText: CANARY_FILE }),
+      ).toHaveCount(0);
     } finally {
       // note: mappings already registered with the Vim emulation stay in
       // client memory, but are inert once Vim keybindings are disabled
+      await clearPref(page, 'editor_keybindings');
+      await clearPref(page, 'vim_load_vimrc');
+      await consoleActions.closeAllBuffersWithoutSaving();
+      await consoleActions.executeInConsole(RESTORE_VIMRC);
+    }
+  });
+
+  test('enabling the pref mid-session loads the vimrc immediately', async ({
+    rstudioPage: page,
+  }) => {
+    const consoleActions = new ConsolePaneActions(page);
+    const sourcePane = new SourcePane(page);
+
+    await consoleActions.executeInConsole(SETUP_VIMRC_MIDSESSION);
+
+    try {
+      // Vim keybindings first, with the load pref still disabled
+      await setPref(page, 'editor_keybindings', 'vim');
+      await executeCommand(page, 'newSourceDoc');
+
+      // focus the editor so the mid-session load path has a Vim editor to
+      // apply against, then flip the pref: the mapping should appear without
+      // opening another document
+      // in Vim normal mode Ace parks its hidden textarea offscreen, so click
+      // the visible editor content to focus the editor
+      await sourcePane.contentPane.click({ force: true });
+      await setPref(page, 'vim_load_vimrc', true);
+
+      await expect
+        .poll(() => vimMappingRegistered(page, 'zz'), {
+          message: 'expected the vimrc mapping to be registered after enabling the pref',
+        })
+        .toBe(true);
+    } finally {
       await clearPref(page, 'editor_keybindings');
       await clearPref(page, 'vim_load_vimrc');
       await consoleActions.closeAllBuffersWithoutSaving();

--- a/e2e/rstudio/tests/panes/editor/vimrc_keybindings.test.ts
+++ b/e2e/rstudio/tests/panes/editor/vimrc_keybindings.test.ts
@@ -1,0 +1,110 @@
+// Loading Vim keybindings from a user vimrc file (#7350).
+//
+// When the vim_load_vimrc pref is enabled and Vim editor keybindings are in
+// use, VimrcLoader.java fetches ~/.rstudio-vimrc (or ~/.vimrc) and replays
+// its supported mapping commands through the Ace Vim emulation.
+
+import type { Page } from 'playwright';
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { AceEditor } from '@pages/ace_editor.page';
+import { clearPref, executeCommand, setPref } from '@utils/commands';
+import {
+  CODE_TAB,
+  CODE_EDITING_PANEL,
+  openGlobalOptions,
+  closeGlobalOptions,
+} from '@pages/global_options.page';
+
+// The vimrc is read from the session user's home directory, so create and
+// restore it through the R session rather than the local filesystem -- this
+// keeps the test working against both Desktop and Server. ~/.rstudio-vimrc
+// takes priority over ~/.vimrc, so a developer's real ~/.vimrc is never read;
+// any pre-existing ~/.rstudio-vimrc is backed up and restored.
+const SETUP_VIMRC = [
+  'if (file.exists("~/.rstudio-vimrc")) file.rename("~/.rstudio-vimrc", "~/.rstudio-vimrc.e2e-backup");',
+  'writeLines(c("\\" comment", "imap jk <Esc>", "nnoremap <silent> Y y$", "call plug#begin()"), "~/.rstudio-vimrc")',
+].join(' ');
+
+const RESTORE_VIMRC = [
+  'unlink("~/.rstudio-vimrc");',
+  'if (file.exists("~/.rstudio-vimrc.e2e-backup")) file.rename("~/.rstudio-vimrc.e2e-backup", "~/.rstudio-vimrc")',
+].join(' ');
+
+// True once the 'imap jk <Esc>' mapping from the vimrc has been registered
+// with the Vim emulation (user mappings land in the shared keymap).
+function vimrcMappingRegistered(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const w = window as unknown as {
+      require(id: string): { handler: { defaultKeymap: Array<{ keys?: string }> } };
+    };
+    const handler = w.require('ace/keyboard/vim').handler;
+    return handler.defaultKeymap.some((mapping) => mapping.keys === 'jk');
+  });
+}
+
+test.describe('Vimrc keybindings', () => {
+  test('mappings from ~/.rstudio-vimrc apply when the pref is enabled', async ({
+    rstudioPage: page,
+  }) => {
+    const consoleActions = new ConsolePaneActions(page);
+
+    // run all console commands while keybindings are still the default, so
+    // console input behavior isn't affected by Vim mode
+    await consoleActions.executeInConsole(SETUP_VIMRC);
+
+    try {
+      await setPref(page, 'vim_load_vimrc', true);
+      await setPref(page, 'editor_keybindings', 'vim');
+
+      // open a new document; attaching the Vim keyboard handler triggers the
+      // vimrc load
+      await executeCommand(page, 'newSourceDoc');
+      await expect
+        .poll(() => vimrcMappingRegistered(page), {
+          message: 'expected the vimrc mapping to be registered',
+        })
+        .toBe(true);
+
+      // exercise the mapping: insert some text, leave insert mode via the
+      // mapped 'jk', then delete a character with normal-mode 'x'. The
+      // unsupported 'call plug#begin()' vimrc line must not break loading.
+      const editor = new AceEditor(page, '');
+      await editor.focus();
+      await page.keyboard.type('iabc', { delay: 20 });
+      await page.keyboard.type('jk', { delay: 20 });
+      await page.keyboard.type('x', { delay: 20 });
+
+      await expect.poll(() => editor.getValue()).toBe('ab');
+    } finally {
+      // note: mappings already registered with the Vim emulation stay in
+      // client memory, but are inert once Vim keybindings are disabled
+      await clearPref(page, 'editor_keybindings');
+      await clearPref(page, 'vim_load_vimrc');
+      await consoleActions.closeAllBuffersWithoutSaving();
+      await consoleActions.executeInConsole(RESTORE_VIMRC);
+    }
+  });
+
+  test('the vimrc checkbox follows the keybindings selection', async ({ rstudioPage: page }) => {
+    await openGlobalOptions(page);
+    try {
+      await page.locator(CODE_TAB).click();
+      await expect(page.locator(CODE_EDITING_PANEL)).toBeVisible();
+
+      const checkbox = page.getByLabel('Load Vim keybindings');
+      const keybindings = page.locator(
+        "xpath=//label[contains(text(),'Keybindings:')]/following::select[1]",
+      );
+
+      await keybindings.selectOption({ label: 'Default' });
+      await expect(checkbox).toBeDisabled();
+
+      await keybindings.selectOption({ label: 'Vim' });
+      await expect(checkbox).toBeEnabled();
+    } finally {
+      // cancel so nothing selected here is applied
+      await closeGlobalOptions(page);
+    }
+  });
+});

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -108,6 +108,7 @@ namespace prefs {
 #define kEditorKeybindingsVim "vim"
 #define kEditorKeybindingsEmacs "emacs"
 #define kEditorKeybindingsSublime "sublime"
+#define kVimLoadVimrc "vim_load_vimrc"
 #define kInsertMatching "insert_matching"
 #define kInsertSpacesAroundEquals "insert_spaces_around_equals"
 #define kInsertParensAfterFunctionCompletion "insert_parens_after_function_completion"
@@ -723,6 +724,12 @@ public:
     */
    std::string editorKeybindings();
    core::Error setEditorKeybindings(std::string val);
+
+   /**
+    * Whether to load Vim key mappings from ~/.rstudio-vimrc (or ~/.vimrc) when Vim editor keybindings are enabled.
+    */
+   bool vimLoadVimrc();
+   core::Error setVimLoadVimrc(bool val);
 
    /**
     * Whether to insert matching pairs, such as () and [], when the first is typed.

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -337,6 +337,16 @@
    clear = function() { .rs.clearUserPref("editor_keybindings") }
 )
 
+# Load Vim keybindings from a vimrc file
+#
+# Whether to load Vim key mappings from ~/.rstudio-vimrc (or ~/.vimrc) when Vim
+# editor keybindings are enabled.
+.rs.uiPrefs$vimLoadVimrc <- list(
+   get = function() { .rs.getUserPref("vim_load_vimrc") },
+   set = function(value) { .rs.setUserPref("vim_load_vimrc", value) },
+   clear = function() { .rs.clearUserPref("vim_load_vimrc") }
+)
+
 # Auto-insert matching parentheses and brackets
 #
 # Whether to insert matching pairs, such as () and [], when the first is typed.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -479,6 +479,19 @@ core::Error UserPrefValues::setEditorKeybindings(std::string val)
 }
 
 /**
+ * Whether to load Vim key mappings from ~/.rstudio-vimrc (or ~/.vimrc) when Vim editor keybindings are enabled.
+ */
+bool UserPrefValues::vimLoadVimrc()
+{
+   return readPref<bool>("vim_load_vimrc");
+}
+
+core::Error UserPrefValues::setVimLoadVimrc(bool val)
+{
+   return writePref("vim_load_vimrc", val);
+}
+
+/**
  * Whether to insert matching pairs, such as () and [], when the first is typed.
  */
 bool UserPrefValues::insertMatching()
@@ -4000,6 +4013,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kContinueCommentsOnNewline,
       kHighlightWebLink,
       kEditorKeybindings,
+      kVimLoadVimrc,
       kInsertMatching,
       kInsertSpacesAroundEquals,
       kInsertParensAfterFunctionCompletion,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -326,6 +326,12 @@
             "title": "Keybinding set for editor",
             "description": "The keybindings to use in the RStudio code editor."
         },
+        "vim_load_vimrc": {
+            "type": "boolean",
+            "default": false,
+            "title": "Load Vim keybindings from a vimrc file",
+            "description": "Whether to load Vim key mappings from ~/.rstudio-vimrc (or ~/.vimrc) when Vim editor keybindings are enabled."
+        },
         "insert_matching": {
             "type": "boolean",
             "default": true,

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -174,7 +174,6 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ScopeTreeMa
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetChunks;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetCommentHeaderHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetCompilePdfHelper;
-import org.rstudio.studio.client.workbench.views.source.editors.text.VimrcLoader;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetAssistantHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetCppHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetIdleMonitor;
@@ -185,6 +184,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditing
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetRHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetRMarkdownHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetSqlHelper;
+import org.rstudio.studio.client.workbench.views.source.editors.text.VimrcLoader;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceBackgroundHighlighter;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEditorBackgroundLinkHighlighter;
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionManager;

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -174,6 +174,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ScopeTreeMa
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetChunks;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetCommentHeaderHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetCompilePdfHelper;
+import org.rstudio.studio.client.workbench.views.source.editors.text.VimrcLoader;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetAssistantHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetCppHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetIdleMonitor;
@@ -398,6 +399,7 @@ public interface RStudioGinjector extends Ginjector
    SatelliteManager getSatelliteManager();
    SourceWindowManager getSourceWindowManager();
    SourceWindow getSourceWindow();
+   VimrcLoader getVimrcLoader();
    Server getServer();
    ChunkWindowManager getChunkWindowManager();
    Projects getProjects();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -79,6 +79,7 @@ public class UserPrefsAccessor extends Prefs
    public static final String CONTINUE_COMMENTS_ON_NEWLINE = "continue_comments_on_newline";
    public static final String HIGHLIGHT_WEB_LINK = "highlight_web_link";
    public static final String EDITOR_KEYBINDINGS = "editor_keybindings";
+   public static final String VIM_LOAD_VIMRC = "vim_load_vimrc";
    public static final String INSERT_MATCHING = "insert_matching";
    public static final String INSERT_SPACES_AROUND_EQUALS = "insert_spaces_around_equals";
    public static final String INSERT_PARENS_AFTER_FUNCTION_COMPLETION = "insert_parens_after_function_completion";
@@ -938,6 +939,18 @@ public class UserPrefsAccessor extends Prefs
    public final static String EDITOR_KEYBINDINGS_VIM = "vim";
    public final static String EDITOR_KEYBINDINGS_EMACS = "emacs";
    public final static String EDITOR_KEYBINDINGS_SUBLIME = "sublime";
+
+   /**
+    * Whether to load Vim key mappings from ~/.rstudio-vimrc (or ~/.vimrc) when Vim editor keybindings are enabled.
+    */
+   public PrefValue<Boolean> vimLoadVimrc()
+   {
+      return bool(
+         "vim_load_vimrc",
+         _constants.vimLoadVimrcTitle(), 
+         _constants.vimLoadVimrcDescription(), 
+         false);
+   }
 
    /**
     * Whether to insert matching pairs, such as () and [], when the first is typed.
@@ -4717,6 +4730,8 @@ public class UserPrefsAccessor extends Prefs
          highlightWebLink().setValue(layer, source.getBool("highlight_web_link"));
       if (source.hasKey("editor_keybindings"))
          editorKeybindings().setValue(layer, source.getString("editor_keybindings"));
+      if (source.hasKey("vim_load_vimrc"))
+         vimLoadVimrc().setValue(layer, source.getBool("vim_load_vimrc"));
       if (source.hasKey("insert_matching"))
          insertMatching().setValue(layer, source.getBool("insert_matching"));
       if (source.hasKey("insert_spaces_around_equals"))
@@ -5292,6 +5307,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(continueCommentsOnNewline());
       prefs.add(highlightWebLink());
       prefs.add(editorKeybindings());
+      prefs.add(vimLoadVimrc());
       prefs.add(insertMatching());
       prefs.add(insertSpacesAroundEquals());
       prefs.add(insertParensAfterFunctionCompletion());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -320,6 +320,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String editorKeybindingsEnum_sublime();
 
    /**
+    * Whether to load Vim key mappings from ~/.rstudio-vimrc (or ~/.vimrc) when Vim editor keybindings are enabled.
+    */
+   @DefaultStringValue("Load Vim keybindings from a vimrc file")
+   String vimLoadVimrcTitle();
+   @DefaultStringValue("Whether to load Vim key mappings from ~/.rstudio-vimrc (or ~/.vimrc) when Vim editor keybindings are enabled.")
+   String vimLoadVimrcDescription();
+
+   /**
     * Whether to insert matching pairs, such as () and [], when the first is typed.
     */
    @DefaultStringValue("Auto-insert matching parentheses and brackets")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -165,6 +165,10 @@ editorKeybindingsEnum_vim=Vim
 editorKeybindingsEnum_emacs=Emacs
 editorKeybindingsEnum_sublime=Sublime Text
 
+# Whether to load Vim key mappings from ~/.rstudio-vimrc (or ~/.vimrc) when Vim editor keybindings are enabled.
+vimLoadVimrcTitle = Load Vim keybindings from a vimrc file
+vimLoadVimrcDescription = Whether to load Vim key mappings from ~/.rstudio-vimrc (or ~/.vimrc) when Vim editor keybindings are enabled.
+
 # Whether to insert matching pairs, such as () and [], when the first is typed.
 insertMatchingTitle = Auto-insert matching parentheses and brackets
 insertMatchingDescription = Whether to insert matching pairs, such as () and [], when the first is typed.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CodePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CodePreferencesPane.java
@@ -139,6 +139,11 @@ public class CodePreferencesPane extends PreferencesPane
       lessSpaced(keyboardPanel);
       editingPanel.add(keyboardPanel);
 
+      vimLoadVimrc_ = checkboxPref(prefs_.vimLoadVimrc());
+      vimLoadVimrc_.getElement().getStyle().setMarginTop(6, Unit.PX);
+      editorMode_.addChangeHandler(event -> syncVimLoadVimrcEnabled());
+      editingPanel.add(vimLoadVimrc_);
+
       HorizontalPanel projectPrefsPanel = new HorizontalPanel();
       projectPrefsPanel.getElement().getStyle().setMarginTop(5, Unit.PX);
       Label projectOverride = new Label(constants_.editingProjectOverrideInfoText());
@@ -627,6 +632,7 @@ public class CodePreferencesPane extends PreferencesPane
       showCompletions_.setValue(prefs_.codeCompletion().getValue());
       showCompletionsOther_.setValue(prefs_.codeCompletionOther().getValue());
       editorMode_.setValue(prefs_.editorKeybindings().getValue());
+      syncVimLoadVimrcEnabled();
       foldMode_.setValue(prefs_.foldStyle().getValue());
       indentGuides_.setValue(prefs.indentGuides().getValue());
       delimiterSurroundWidget_.setValue(prefs_.surroundSelection().getValue());
@@ -640,6 +646,11 @@ public class CodePreferencesPane extends PreferencesPane
       {
          autoSaveIdleMs_.setValue("1000");
       }
+   }
+
+   private void syncVimLoadVimrcEnabled()
+   {
+      vimLoadVimrc_.setEnabled(editorMode_.getValue() == UserPrefs.EDITOR_KEYBINDINGS_VIM);
    }
 
    @Override
@@ -731,6 +742,7 @@ public class CodePreferencesPane extends PreferencesPane
    private final SelectWidget showCompletions_;
    private final SelectWidget showCompletionsOther_;
    private final SelectWidget editorMode_;
+   private final CheckBox vimLoadVimrc_;
    private final SelectWidget foldMode_;
    private final SelectWidget indentGuides_;
    private final SelectWidget delimiterSurroundWidget_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1145,11 +1145,18 @@ public class AceEditor implements DocDisplay
 
       // set default key handler
       if (useVimMode_)
+      {
          widget_.getEditor().setKeyboardHandler(KeyboardHandler.vim());
+         RStudioGinjector.INSTANCE.getVimrcLoader().ensureLoaded(widget_.getEditor());
+      }
       else if (useEmacsKeybindings_)
+      {
          widget_.getEditor().setKeyboardHandler(KeyboardHandler.emacs());
+      }
       else
+      {
          widget_.getEditor().setKeyboardHandler(null);
+      }
 
       // add the previewer
       widget_.getEditor().addKeyboardHandler(previewer.getKeyboardHandler());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/VimrcLoader.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/VimrcLoader.java
@@ -1,0 +1,218 @@
+/*
+ * VimrcLoader.java
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.rstudio.core.client.Debug;
+import org.rstudio.studio.client.server.ServerError;
+import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
+import org.rstudio.studio.client.workbench.views.files.model.FilesServerOperations;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEditorNative;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+/**
+ * Loads Vim key mappings from the user's vimrc file (~/.rstudio-vimrc if it
+ * exists, otherwise ~/.vimrc) and applies them to Ace's Vim keybinding
+ * emulation. Mappings are stored in state shared by all editor instances, so
+ * the vimrc only needs to be applied once per client session.
+ */
+@Singleton
+public class VimrcLoader
+{
+   @Inject
+   public VimrcLoader(UserPrefs prefs, FilesServerOperations server)
+   {
+      prefs_ = prefs;
+      server_ = server;
+
+      // load the vimrc when the preference is enabled mid-session
+      prefs_.vimLoadVimrc().addValueChangeHandler(event ->
+      {
+         if (!event.getValue())
+            return;
+
+         AceEditor editor = AceEditor.getLastFocusedEditor();
+         if (editor != null && editor.isVimModeOn())
+            ensureLoaded(editor.getWidget().getEditor());
+      });
+   }
+
+   /**
+    * Load and apply the user's vimrc if the associated preference is enabled.
+    * The supplied editor must have the Vim keyboard handler attached.
+    */
+   public void ensureLoaded(AceEditorNative editor)
+   {
+      if (requested_ || !prefs_.vimLoadVimrc().getValue())
+         return;
+
+      requested_ = true;
+      loadVimrc(editor, 0);
+   }
+
+   private void loadVimrc(AceEditorNative editor, int index)
+   {
+      if (index >= VIMRC_PATHS.length)
+         return;
+
+      String path = VIMRC_PATHS[index];
+      server_.getFileContents(path, "UTF-8", new ServerRequestCallback<String>()
+      {
+         @Override
+         public void onResponseReceived(String contents)
+         {
+            applyVimrc(editor, path, contents);
+         }
+
+         @Override
+         public void onError(ServerError error)
+         {
+            // the file most likely doesn't exist; try the next candidate
+            loadVimrc(editor, index + 1);
+         }
+      });
+   }
+
+   private void applyVimrc(AceEditorNative editor, String path, String contents)
+   {
+      int applied = 0;
+
+      for (String rawLine : contents.split("\n"))
+      {
+         String line = rawLine.trim();
+         if (line.isEmpty() || line.startsWith("\""))
+            continue;
+
+         String prepared = prepareLine(line);
+         if (prepared == null)
+         {
+            Debug.log("VimrcLoader: ignoring unsupported line '" + line + "'");
+            continue;
+         }
+
+         if (applyLine(editor, prepared))
+            applied++;
+         else
+            Debug.log("VimrcLoader: failed to apply line '" + line + "'");
+      }
+
+      if (applied > 0)
+         Debug.log("VimrcLoader: applied " + applied + " command(s) from " + path);
+   }
+
+   /**
+    * Prepare a vimrc line for the Vim emulation, or return null if the line
+    * isn't supported. Only mapping and 'set' commands are allowed through;
+    * this keeps a vimrc from triggering arbitrary ex commands (e.g. ':qall')
+    * as a side effect of being loaded.
+    */
+   private String prepareLine(String line)
+   {
+      String[] tokens = line.split("\\s+");
+
+      String command = tokens[0];
+      if (!SUPPORTED_COMMANDS.contains(command))
+         return null;
+
+      // process any special arguments following the command
+      String rest = line.substring(command.length()).trim();
+      while (rest.startsWith("<"))
+      {
+         int end = rest.indexOf('>');
+         if (end == -1)
+            break;
+
+         String arg = rest.substring(0, end + 1).toLowerCase();
+         if (arg.equals("<expr>") || arg.equals("<buffer>"))
+         {
+            // these change mapping semantics in ways the emulation
+            // doesn't support, so skip the line entirely
+            return null;
+         }
+         else if (SKIPPABLE_ARGUMENTS.contains(arg))
+         {
+            rest = rest.substring(end + 1).trim();
+         }
+         else
+         {
+            // not a special argument; likely the start of the mapping
+            // itself (e.g. '<C-a>')
+            break;
+         }
+      }
+
+      return rest.isEmpty() ? command : command + " " + rest;
+   }
+
+   private static final native boolean applyLine(AceEditorNative editor, String line)
+   /*-{
+      try
+      {
+         var cm = editor.state.cm;
+         if (cm == null)
+            return false;
+
+         var Vim = $wnd.require("ace/keyboard/vim").CodeMirror.Vim;
+         Vim.handleEx(cm, line);
+         return true;
+      }
+      catch (e)
+      {
+         return false;
+      }
+   }-*/;
+
+   private static final String[] VIMRC_PATHS = new String[] {
+      "~/.rstudio-vimrc",
+      "~/.vimrc"
+   };
+
+   private static final Set<String> SUPPORTED_COMMANDS = new HashSet<>(Arrays.asList(
+      "map",
+      "nmap",      "nm",
+      "vmap",      "vm",
+      "imap",      "im",
+      "omap",      "om",
+      "noremap",   "no",
+      "nnoremap",  "nn",
+      "vnoremap",  "vn",
+      "inoremap",  "ino",
+      "onoremap",  "ono",
+      "unmap",
+      "mapclear",  "mapc",
+      "nmapclear", "nmapc",
+      "vmapclear", "vmapc",
+      "imapclear", "imapc",
+      "omapclear", "omapc",
+      "set",       "se",
+      "setlocal",  "setl",
+      "setglobal", "setg"
+   ));
+
+   private static final Set<String> SKIPPABLE_ARGUMENTS = new HashSet<>(Arrays.asList(
+      "<silent>", "<unique>", "<nowait>", "<special>", "<script>"
+   ));
+
+   private final UserPrefs prefs_;
+   private final FilesServerOperations server_;
+
+   private boolean requested_ = false;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/VimrcLoader.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/VimrcLoader.java
@@ -43,11 +43,17 @@ public class VimrcLoader
       prefs_ = prefs;
       server_ = server;
 
-      // load the vimrc when the preference is enabled mid-session
+      // when the preference is enabled mid-session, load the vimrc using the
+      // focused Vim editor; when disabled, reset so that a later re-enable
+      // reloads the file (e.g. after the user has edited it)
       prefs_.vimLoadVimrc().addValueChangeHandler(event ->
       {
          if (!event.getValue())
+         {
+            if (state_ == State.DONE)
+               state_ = State.IDLE;
             return;
+         }
 
          AceEditor editor = AceEditor.getLastFocusedEditor();
          if (editor != null && editor.isVimModeOn())
@@ -57,21 +63,29 @@ public class VimrcLoader
 
    /**
     * Load and apply the user's vimrc if the associated preference is enabled.
-    * The supplied editor must have the Vim keyboard handler attached.
+    * The vimrc is applied at most once per session, no matter how often this
+    * is called; disabling and re-enabling the preference resets that, so the
+    * file can be reloaded without restarting. The supplied editor must have
+    * the Vim keyboard handler attached.
     */
    public void ensureLoaded(AceEditorNative editor)
    {
-      if (requested_ || !prefs_.vimLoadVimrc().getValue())
+      if (state_ != State.IDLE || !prefs_.vimLoadVimrc().getValue())
          return;
 
-      requested_ = true;
+      state_ = State.LOADING;
       loadVimrc(editor, 0);
    }
 
    private void loadVimrc(AceEditorNative editor, int index)
    {
       if (index >= VIMRC_PATHS.length)
+      {
+         // no vimrc could be read; treat as done for this session rather
+         // than re-trying on every editor initialization
+         state_ = State.DONE;
          return;
+      }
 
       String path = VIMRC_PATHS[index];
       server_.getFileContents(path, "UTF-8", new ServerRequestCallback<String>()
@@ -79,13 +93,32 @@ public class VimrcLoader
          @Override
          public void onResponseReceived(String contents)
          {
+            if (!prefs_.vimLoadVimrc().getValue())
+            {
+               // the preference was disabled while the request was in flight
+               state_ = State.IDLE;
+               return;
+            }
+
+            if (!hasVimState(editor))
+            {
+               // the editor that triggered the load was detached while the
+               // request was in flight; let the next Vim editor retry
+               state_ = State.IDLE;
+               return;
+            }
+
+            state_ = State.DONE;
             applyVimrc(editor, path, contents);
          }
 
          @Override
          public void onError(ServerError error)
          {
-            // the file most likely doesn't exist; try the next candidate
+            // typically the file just doesn't exist, but log the failure
+            // since the server doesn't distinguish a missing file from e.g.
+            // a permission or decoding error
+            Debug.log("VimrcLoader: couldn't read " + path + " (" + error.getMessage() + ")");
             loadVimrc(editor, index + 1);
          }
       });
@@ -108,10 +141,11 @@ public class VimrcLoader
             continue;
          }
 
-         if (applyLine(editor, prepared))
+         String error = applyLine(editor, prepared);
+         if (error == null)
             applied++;
          else
-            Debug.log("VimrcLoader: failed to apply line '" + line + "'");
+            Debug.log("VimrcLoader: failed to apply line '" + line + "' (" + error + ")");
       }
 
       if (applied > 0)
@@ -124,11 +158,11 @@ public class VimrcLoader
     * this keeps a vimrc from triggering arbitrary ex commands (e.g. ':qall')
     * as a side effect of being loaded.
     */
-   private String prepareLine(String line)
+   static String prepareLine(String line)
    {
-      String[] tokens = line.split("\\s+");
+      line = line.trim();
 
-      String command = tokens[0];
+      String command = line.split("\\s+")[0];
       if (!SUPPORTED_COMMANDS.contains(command))
          return null;
 
@@ -162,23 +196,27 @@ public class VimrcLoader
       return rest.isEmpty() ? command : command + " " + rest;
    }
 
-   private static final native boolean applyLine(AceEditorNative editor, String line)
+   private static final native boolean hasVimState(AceEditorNative editor)
+   /*-{
+      return editor.state != null && editor.state.cm != null;
+   }-*/;
+
+   // returns null on success, or an error message on failure
+   private static final native String applyLine(AceEditorNative editor, String line)
    /*-{
       try
       {
-         var cm = editor.state.cm;
-         if (cm == null)
-            return false;
-
          var Vim = $wnd.require("ace/keyboard/vim").CodeMirror.Vim;
-         Vim.handleEx(cm, line);
-         return true;
+         Vim.handleEx(editor.state.cm, line);
+         return null;
       }
       catch (e)
       {
-         return false;
+         return "" + e;
       }
    }-*/;
+
+   private enum State { IDLE, LOADING, DONE }
 
    private static final String[] VIMRC_PATHS = new String[] {
       "~/.rstudio-vimrc",
@@ -214,5 +252,5 @@ public class VimrcLoader
    private final UserPrefs prefs_;
    private final FilesServerOperations server_;
 
-   private boolean requested_ = false;
+   private State state_ = State.IDLE;
 }

--- a/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
+++ b/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
@@ -38,6 +38,7 @@ import org.rstudio.studio.client.workbench.views.jobs.model.JobManagerTests;
 import org.rstudio.studio.client.workbench.views.jobs.view.JobsListTests;
 import org.rstudio.studio.client.workbench.views.output.lint.model.LintItemTests;
 import org.rstudio.studio.client.workbench.views.packages.ui.PackageLinkColumnTests;
+import org.rstudio.studio.client.workbench.views.source.editors.text.VimrcLoaderTests;
 import org.rstudio.studio.client.workbench.views.source.editors.text.assist.RChunkHeaderParserTests;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalLocalEchoTests;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalSessionSocketTests;
@@ -85,6 +86,7 @@ public class RStudioUnitTestSuite extends GWTTestSuite
       suite.addTestSuite(YamlTreeTests.class);
       suite.addTestSuite(DataImportPreviewResponseTests.class);
       suite.addTestSuite(PrefsTests.class);
+      suite.addTestSuite(VimrcLoaderTests.class);
 
       return suite;
    }

--- a/src/gwt/test/org/rstudio/studio/client/workbench/views/source/editors/text/VimrcLoaderTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/workbench/views/source/editors/text/VimrcLoaderTests.java
@@ -1,0 +1,103 @@
+/*
+ * VimrcLoaderTests.java
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text;
+
+import com.google.gwt.junit.client.GWTTestCase;
+
+// Tests for VimrcLoader.prepareLine(), which decides which vimrc lines are
+// forwarded to the Vim emulation. The allowlist is a security boundary: it
+// keeps a vimrc from triggering RStudio's own ex commands (:qall, :Rscript,
+// :edit, ...) as a side effect of being loaded.
+public class VimrcLoaderTests extends GWTTestCase
+{
+   @Override
+   public String getModuleName()
+   {
+      return "org.rstudio.studio.RStudioTests";
+   }
+
+   public void testMappingCommandsPassThrough()
+   {
+      assertEquals("imap jk <Esc>", VimrcLoader.prepareLine("imap jk <Esc>"));
+      assertEquals("nnoremap Y y$", VimrcLoader.prepareLine("nnoremap Y y$"));
+      assertEquals("unmap Y", VimrcLoader.prepareLine("unmap Y"));
+      assertEquals("set ignorecase", VimrcLoader.prepareLine("set ignorecase"));
+   }
+
+   public void testShortCommandNamesPassThrough()
+   {
+      assertEquals("nn j gj", VimrcLoader.prepareLine("nn j gj"));
+      assertEquals("se ic", VimrcLoader.prepareLine("se ic"));
+   }
+
+   public void testUnsupportedCommandsRejected()
+   {
+      assertNull(VimrcLoader.prepareLine("call plug#begin()"));
+      assertNull(VimrcLoader.prepareLine("let mapleader = \",\""));
+      assertNull(VimrcLoader.prepareLine("syntax on"));
+
+      // ex commands registered by RStudio itself must not run at load time
+      assertNull(VimrcLoader.prepareLine("qall"));
+      assertNull(VimrcLoader.prepareLine("edit foo.R"));
+      assertNull(VimrcLoader.prepareLine("Rscript"));
+   }
+
+   public void testCommentsAndBlankLinesRejected()
+   {
+      assertNull(VimrcLoader.prepareLine("\" a comment"));
+      assertNull(VimrcLoader.prepareLine(""));
+      assertNull(VimrcLoader.prepareLine("   "));
+   }
+
+   public void testSkippableArgumentsStripped()
+   {
+      assertEquals("nnoremap Y y$", VimrcLoader.prepareLine("nnoremap <silent> Y y$"));
+      assertEquals("nnoremap Y y$", VimrcLoader.prepareLine("nnoremap <silent> <unique> Y y$"));
+
+      // special arguments are case-insensitive
+      assertEquals("nnoremap Y y$", VimrcLoader.prepareLine("nnoremap <Silent> Y y$"));
+   }
+
+   public void testUnsupportedSemanticsRejected()
+   {
+      assertNull(VimrcLoader.prepareLine("nnoremap <expr> j Foo()"));
+      assertNull(VimrcLoader.prepareLine("nnoremap <buffer> j gj"));
+      assertNull(VimrcLoader.prepareLine("nnoremap <silent> <buffer> j gj"));
+   }
+
+   public void testKeyNotationLhsPreserved()
+   {
+      assertEquals("nnoremap <C-a> ggVG", VimrcLoader.prepareLine("nnoremap <C-a> ggVG"));
+      assertEquals("nmap <Leader>w :w<CR>", VimrcLoader.prepareLine("nmap <Leader>w :w<CR>"));
+   }
+
+   public void testArgumentSpacingPreserved()
+   {
+      // spacing within the arguments is significant and must survive
+      assertEquals("imap ,, a  b", VimrcLoader.prepareLine("imap ,, a  b"));
+   }
+
+   public void testEdgeCases()
+   {
+      // bare command
+      assertEquals("map", VimrcLoader.prepareLine("map"));
+
+      // surrounding whitespace is trimmed
+      assertEquals("imap jk <Esc>", VimrcLoader.prepareLine("  imap jk <Esc>  "));
+
+      // unterminated key notation passes through untouched
+      assertEquals("nnoremap <C-a", VimrcLoader.prepareLine("nnoremap <C-a"));
+   }
+}


### PR DESCRIPTION
## Summary

Adds support for loading custom Vim key mappings from a user vimrc file, a long-requested feature (typing `:imap jk <Esc>` every session gets old).

- New user preference `vim_load_vimrc` (Tools > Global Options > Code > Editing; default off). The checkbox is enabled only when Vim editor keybindings are selected.
- When enabled and the Vim keyboard handler attaches to an editor, the new `VimrcLoader` fetches `~/.rstudio-vimrc` (falling back to `~/.vimrc`) via the existing `get_file_contents` RPC and replays its lines through the Ace Vim emulation's ex-command dispatcher (`Vim.handleEx`).
- Only mapping commands (`map`, `noremap`, `unmap`, `mapclear` and their mode variants) and `set`/`setlocal`/`setglobal` are applied. Everything else in the vimrc is ignored, which keeps a vimrc from triggering arbitrary ex commands (e.g. `:qall`, `:Rscript`) as a side effect of being loaded. Benign special arguments (`<silent>`, `<unique>`, `<nowait>`, `<special>`, `<script>`) are stripped; lines using `<expr>` or `<buffer>` semantics are skipped.
- Mappings live in state shared by all Ace instances, so the vimrc is applied once per client session. Enabling the preference mid-session applies it to the current Vim editor immediately.

## Test notes

- New Playwright spec `e2e/rstudio/tests/panes/editor/vimrc_keybindings.test.ts`:
  - writes a temporary `~/.rstudio-vimrc` (backing up any existing one), enables the prefs, and verifies that `imap jk <Esc>` works end-to-end (insert text, leave insert mode via `jk`, delete a character with normal-mode `x`), with an unsupported `call plug#begin()` line present to confirm it is ignored.
  - verifies the new checkbox in Global Options is enabled/disabled as the keybindings selection changes.
- `ant javac` passes; both tests pass locally in desktop-dev mode.

Fixes #7350.