### PR TITLE
skip citation search tests when the service errors server-side

### DIFF
--- a/e2e/rstudio/pages/insert_citation.page.ts
+++ b/e2e/rstudio/pages/insert_citation.page.ts
@@ -36,6 +36,14 @@ export class InsertCitationDialog extends PageObject {
   /** Result rows in the R Package (typeahead) source's list. */
   public readonly packageResults: Locator;
   public readonly searchButton: Locator;
+  /**
+   * Status line shown in the results area when a latent search fails
+   * service-side (the rsession's download errored or the host was unreachable).
+   * The wording comes from panmirror's errorForStatus() plus the panels'
+   * "unknown error" fallback; the same node also carries "No results..." and
+   * progress text, hence the text filter.
+   */
+  public readonly searchError: Locator;
   public readonly insertButton: Locator;
   public readonly cancelButton: Locator;
   /** Staged citations, shown as tag chips at the bottom of the dialog. */
@@ -47,6 +55,10 @@ export class InsertCitationDialog extends PageObject {
     this.results = page.locator('.pm-insert-citation-source-panel-item-detailed');
     this.packageResults = page.locator('.pm-insert-citation-source-panel-item');
     this.searchButton = page.locator('button.pm-insert-citation-panel-latent-search-button');
+    this.searchError = page
+      .locator('.pm-insert-citation-source-panel-list-noresults-text')
+      .filter({ hasText: /error occurred|Unable to search/ })
+      .first();
     this.insertButton = this.dialog.getByRole('button', { name: 'Insert', exact: true });
     this.cancelButton = this.dialog.getByRole('button', { name: 'Cancel', exact: true });
     this.stagedCitations = page.locator('.pm-tag-input-tag');

--- a/e2e/rstudio/tests/panes/editor/citations.test.ts
+++ b/e2e/rstudio/tests/panes/editor/citations.test.ts
@@ -269,9 +269,31 @@ test.describe('Citations', () => {
       // title matches). Poll to ride out the list still populating.
       await citation.search(searchBox, searchTerm);
       const matcher = new RegExp(searchTerm, 'i');
+      const searchOutcome = async (): Promise<'pending' | 'matched' | 'error'> => {
+        if ((await citation.resultTexts(5)).some((t) => matcher.test(t))) {
+          return 'matched';
+        }
+        if (await citation.searchError.isVisible()) {
+          return 'error';
+        }
+        return 'pending';
+      };
       await expect
-        .poll(async () => (await citation.resultTexts(5)).some((t) => matcher.test(t)), { timeout: 30000 })
-        .toBe(true);
+        .poll(searchOutcome, {
+          timeout: 30000,
+          message: `no ${source.alt} results mentioning "${searchTerm}" and no error status within 30s`,
+        })
+        .not.toBe('pending');
+
+      // The reachability probe above only proves the host answers from Node;
+      // the query itself runs in the rsession and can still fail (e.g. NCBI
+      // rate-limits shared CI egress IPs). That is a service problem, not a
+      // product bug -- skip, as skipUnlessReachable() would have. A timeout
+      // with neither results nor an error line still fails above.
+      if ((await searchOutcome()) === 'error') {
+        await citation.cancel();
+        test.skip(true, `${source.alt} search failed service-side from this runner`);
+      }
 
       await citation.cancel();
     });


### PR DESCRIPTION
## Summary

The citation search e2e tests (`citations.test.ts`, "searches Crossref/DataCite/PubMed and returns matching results") guard against service outages with a Node-side reachability probe, but the search query itself runs in the rsession and can still fail even when the probe passes. That happened in [this run](https://github.com/rstudio/rstudio/actions/runs/29526030071/job/87719284258?pr=18259): the probe saw `eutils.ncbi.nlm.nih.gov` answering, but the rsession's `download.file()` call was rejected (NCBI rate-limits shared CI egress IPs), the dialog showed an error status, and the test failed on a 30s poll timeout on both attempts.

When a search fails service-side, panmirror renders an error status line in the results area (wording from `errorForStatus()`: "An error occurred while searching X." / "Unable to search X. ..." / "An unknown error occurred. ..."). This PR:

- adds a `searchError` locator to `InsertCitationDialog` matching that status line (text-filtered so "No results..." and progress text do not match);
- changes the search tests to poll for either a matching result or the error line, skipping (like `skipUnlessReachable()` would) when the service errored. A timeout with neither results nor an error line still fails, so a product regression that silently renders nothing is not masked.

## Testing

- `npm run typecheck` passes.
- All three "searches ... and returns matching results" tests pass locally on macOS desktop (installed app).
- The skip path is verified against the panmirror source (`insert_citation-source-panel-list.tsx` renders the error `statusMessage` in `.pm-insert-citation-source-panel-list-noresults-text`).

Test-infrastructure-only change; no NEWS.md entry.