### PR TITLE
Install R in the yum build-dependency script

### DIFF
--- a/dependencies/linux/install-dependencies-yum
+++ b/dependencies/linux/install-dependencies-yum
@@ -31,6 +31,8 @@ PACKAGES=(
 	libffi
 	libuser-devel
 	libuuid-devel
+	libuv-devel
+	libxml2-devel
 	libXScrnSaver-devel
 	libxslt-devel
 	make

--- a/dependencies/linux/install-dependencies-yum
+++ b/dependencies/linux/install-dependencies-yum
@@ -39,6 +39,8 @@ PACKAGES=(
 	pam-devel
 	pango-devel
 	postgresql-devel
+	R-core
+	R-core-devel
 	rpmdevtools
 	sqlite-devel
 	wget


### PR DESCRIPTION
## Summary
`dependencies/linux/install-dependencies-yum` (shared by the Fedora 43, Fedora 44, and RHEL 10 E2E build jobs) never installed an R interpreter before calling `install-common` -> `install-packages`, which assumes `R` is already on `PATH`. This surfaced as `R: command not found` when the Fedora 43/44 build jobs ran with `build_from_source: true` (rstudio/rstudio#18261, #18262). Ubuntu's `install-dependencies-noble` already installs `r-base-dev` for the same reason; this adds the equivalent `R-core`/`R-core-devel` packages here.