### PR TITLE
trim hard-coded feature dependency lists to direct dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,7 @@
 - ([#17191](https://github.com/rstudio/rstudio/issues/17191)): Fixed per-session memory limits not being enforced for Workbench sessions running in a container with a read-only cgroup filesystem, and made the memory gauge, memory-usage report, and abort gate reflect the container rather than the host. Added an `rsession.conf` `memory-usage-mode` option to control how session and total memory usage are computed and reported.
 - ([#18225](https://github.com/rstudio/rstudio/issues/18225)): Clicking a console hyperlink to a package source file that no longer exists (for example, srcref paths recording the temporary directory used during package installation) now recovers the source from the package's srcref database when available, instead of showing a "No such file" error.
 - ([#13078](https://github.com/rstudio/rstudio/issues/13078)): Fixed an issue on Windows where `utils::choose.dir()` returned `NA` without showing the folder-selection dialog when running R 4.3.0 or newer.
-- ([#18199](https://github.com/rstudio/rstudio/issues/18199)): RStudio no longer prompts to install packages that are no longer dependencies of rmarkdown (e.g. stringr, glue) when rendering R Markdown or Quarto documents, most visibly in renv projects with minimal project libraries.
+- ([#18199](https://github.com/rstudio/rstudio/issues/18199)): RStudio no longer prompts to install packages that are no longer dependencies of rmarkdown (e.g. stringr, glue) when rendering R Markdown or Quarto documents, most visibly in renv projects with minimal project libraries. Required packages are now validated against the dependencies declared by the installed packages themselves, rather than a hard-coded dependency tree.
 
 ### Dependencies
 - MathJax 4.1.3 (inline LaTeX / math previews)

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 - ([#17191](https://github.com/rstudio/rstudio/issues/17191)): Fixed per-session memory limits not being enforced for Workbench sessions running in a container with a read-only cgroup filesystem, and made the memory gauge, memory-usage report, and abort gate reflect the container rather than the host. Added an `rsession.conf` `memory-usage-mode` option to control how session and total memory usage are computed and reported.
 - ([#18225](https://github.com/rstudio/rstudio/issues/18225)): Clicking a console hyperlink to a package source file that no longer exists (for example, srcref paths recording the temporary directory used during package installation) now recovers the source from the package's srcref database when available, instead of showing a "No such file" error.
 - ([#13078](https://github.com/rstudio/rstudio/issues/13078)): Fixed an issue on Windows where `utils::choose.dir()` returned `NA` without showing the folder-selection dialog when running R 4.3.0 or newer.
+- ([#18199](https://github.com/rstudio/rstudio/issues/18199)): RStudio no longer prompts to install packages that are no longer dependencies of rmarkdown (e.g. stringr, glue) when rendering R Markdown or Quarto documents, most visibly in renv projects with minimal project libraries.
 
 ### Dependencies
 - MathJax 4.1.3 (inline LaTeX / math previews)

--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -205,14 +205,17 @@ assign(".rs.loggedMessageCache", new.env(parent = emptyenv()), envir = .rs.tools
    
    # take the first row in case we had duplicates
    dbEntry <- dbEntries[1, ]
-   version <- dbEntry$Version
-   
+   availableVersion <- dbEntry$Version
+
    # NOTE: here, 'satisfied' means that the package dependency is satisfiable
    # by the version of the package available on CRAN, not that the dependency
    # is already installed + satisfies the version constraint
+   satisfied <- !nzchar(version) ||
+      package_version(availableVersion) >= package_version(version)
+
    list(
-      version   = version,
-      satisfied = package_version(version) >= package_version(version)
+      version   = availableVersion,
+      satisfied = satisfied
    )
 })
 

--- a/src/cpp/session/modules/SessionDependencies.R
+++ b/src/cpp/session/modules/SessionDependencies.R
@@ -198,6 +198,137 @@
    result
 })
 
+# Parses DESCRIPTION-style dependency fields (e.g. "foo (>= 1.0), bar") into a
+# data frame with 'name', 'op', and 'version' columns. Entries without a version
+# requirement have empty 'op' and 'version'; the R version requirement is dropped.
+.rs.addFunction("parsePackageDependencyFields", function(contents) {
+   contents <- paste(contents[!is.na(contents)], collapse = ", ")
+   entries <- trimws(strsplit(contents, ",")[[1]])
+   entries <- entries[nzchar(entries)]
+
+   pattern <- "^([a-zA-Z0-9._]+)(?:\\s*\\(\\s*([><=]+)\\s*([0-9.-]+)\\s*\\))?"
+   matches <- regmatches(entries, regexec(pattern, entries))
+
+   name <- character()
+   op <- character()
+   version <- character()
+   for (match in matches) {
+      if (length(match) < 4 || identical(match[[2]], "R"))
+         next
+
+      name <- c(name, match[[2]])
+      op <- c(op, match[[3]])
+      version <- c(version, match[[4]])
+   }
+
+   data.frame(name = name, op = op, version = version, stringsAsFactors = FALSE)
+})
+
+# Reads the runtime dependencies (Depends and Imports) declared by an installed
+# package, preferring the parsed DESCRIPTION metadata stored with the package.
+# LinkingTo is excluded, as it declares a build-time requirement rather than a
+# runtime one. Base packages are treated as having no dependencies.
+.rs.addFunction("installedPackageDependencies", function(pkgPath) {
+   description <- tryCatch(
+      readRDS(file.path(pkgPath, "Meta", "package.rds"))$DESCRIPTION,
+      error = function(e) NULL)
+
+   if (is.null(description)) {
+      description <- tryCatch(
+         drop(read.dcf(file.path(pkgPath, "DESCRIPTION"))),
+         error = function(e) NULL)
+   }
+
+   if (is.null(description) || identical(unname(description["Priority"]), "base"))
+      return(.rs.parsePackageDependencyFields(character()))
+
+   fields <- description[intersect(c("Depends", "Imports"), names(description))]
+   .rs.parsePackageDependencyFields(fields)
+})
+
+# Records an unsatisfied dependency, keeping the strongest version requirement
+# seen when a dependency is required by multiple packages.
+.rs.addFunction("markUnsatisfiedDependency", function(unsatisfied, name, version) {
+   record <- unsatisfied[[name]]
+   supersedes <- is.null(record) ||
+      (nzchar(version) &&
+       (!nzchar(record$version) ||
+        package_version(version) > package_version(record$version)))
+
+   if (supersedes)
+      unsatisfied[[name]] <- list(name = name, version = version)
+
+   unsatisfied
+})
+
+# Verifies that the given packages, along with their recursive runtime
+# dependencies (the Depends and Imports declared by the installed packages
+# themselves), are installed with the required versions. Returns a list of
+# records with 'name' and 'version' entries for each missing or outdated
+# dependency; 'version' is the strongest declared requirement, or an empty
+# string when no version was required.
+#
+# Note that this intentionally visits only the packages reachable from the
+# requested packages, rather than scanning the entire library with
+# installed.packages() -- full library scans can be very slow with large
+# libraries on networked filesystems.
+.rs.addFunction("findUnsatisfiedRuntimeDependencies", function(packages) {
+   queue <- as.character(packages)
+   visited <- character()
+   unsatisfied <- list()
+
+   while (length(queue) > 0) {
+      pkg <- queue[[1]]
+      queue <- queue[-1]
+
+      if (pkg %in% visited)
+         next
+      visited <- c(visited, pkg)
+
+      pkgPath <- find.package(pkg, quiet = TRUE)
+      if (length(pkgPath) == 0) {
+         # only packages supplied by the caller can be missing here; missing
+         # recursive dependencies are recorded when their edge is examined
+         if (is.null(unsatisfied[[pkg]]))
+            unsatisfied[[pkg]] <- list(name = pkg, version = "")
+         next
+      }
+
+      deps <- .rs.installedPackageDependencies(pkgPath[[1]])
+      for (i in seq_len(nrow(deps))) {
+         depName <- deps$name[[i]]
+         depOp <- deps$op[[i]]
+         depVersion <- deps$version[[i]]
+
+         depPath <- find.package(depName, quiet = TRUE)
+         if (length(depPath) == 0) {
+            unsatisfied <- .rs.markUnsatisfiedDependency(unsatisfied, depName, depVersion)
+            next
+         }
+
+         # the dependency is installed; check any declared version requirement.
+         # as in .rs.expandDependencies, operators other than '>' are treated
+         # as a simple minimum version
+         if (nzchar(depVersion)) {
+            installedVersion <- tryCatch(packageVersion(depName), error = function(e) NULL)
+            satisfied <- if (is.null(installedVersion))
+               FALSE
+            else if (identical(depOp, ">"))
+               installedVersion > package_version(depVersion)
+            else
+               installedVersion >= package_version(depVersion)
+
+            if (!satisfied)
+               unsatisfied <- .rs.markUnsatisfiedDependency(unsatisfied, depName, depVersion)
+         }
+
+         queue <- c(queue, depName)
+      }
+   }
+
+   unname(unsatisfied)
+})
+
 .rs.addFunction("onInstallScriptJobStarted", function()
 {
    .rs.setVar("jobPackageInfo", .rs.installedPackagesFileInfo())

--- a/src/cpp/session/modules/SessionDependencies.cpp
+++ b/src/cpp/session/modules/SessionDependencies.cpp
@@ -375,8 +375,8 @@ std::string buildCombinedInstallScript(const std::vector<Dependency>& deps)
       }
       else
       {
-         cmd += "utils::install.packages(c(" + pkgList + ")\n\n";
-     }
+         cmd += "utils::install.packages(c(" + pkgList + "))\n\n";
+      }
    }
 
    // Install the CRAN source packages with a single call

--- a/src/cpp/session/modules/SessionDependencies.cpp
+++ b/src/cpp/session/modules/SessionDependencies.cpp
@@ -246,6 +246,30 @@ void silentUpdateEmbeddedPackage(const EmbeddedPackage& pkg)
       LOG_ERROR(error);
 }
 
+// Fills in the version of the package available on CRAN, and whether that
+// version satisfies the dependency's version requirement.
+void fillCranVersionInfo(Dependency* pDep)
+{
+   // presume package is available unless we can demonstrate otherwise
+   // (we don't want to block installation attempt unless we're
+   // reasonably confident it will not result in a viable version)
+   r::sexp::Protect protect;
+   SEXP versionInfo = R_NilValue;
+
+   // find the version that will be installed from CRAN
+   Error error = r::exec::RFunction(".rs.packageCRANVersionAvailable",
+         pDep->name, pDep->version, pDep->source).call(&versionInfo, &protect);
+   if (error)
+   {
+      LOG_ERROR(error);
+      return;
+   }
+
+   // if these fail, we'll fall back on defaults
+   r::sexp::getNamedListElement(versionInfo, "version", &pDep->availableVersion);
+   r::sexp::getNamedListElement(versionInfo, "satisfied", &pDep->versionSatisfied);
+}
+
 
 Error unsatisfiedDependencies(const json::JsonRpcRequest& request,
                               json::JsonRpcResponse* pResponse)
@@ -265,34 +289,23 @@ Error unsatisfiedDependencies(const json::JsonRpcRequest& request,
       return Success();
    }
 
-   // build the list of unsatisfied dependencies
+   // build the list of unsatisfied dependencies, keeping track of the
+   // dependencies which are installed so their own runtime dependencies can
+   // be validated below
    using namespace module_context;
    std::vector<Dependency> unsatisfiedDeps;
+   std::vector<std::string> installedPackages;
    for (Dependency& dep : deps)
    {
       if (dep.location == kCRANPackageDependency)
       {
-         if (!isPackageVersionInstalled(dep.name, dep.version))
+         if (isPackageVersionInstalled(dep.name, dep.version))
          {
-            // presume package is available unless we can demonstrate otherwise
-            // (we don't want to block installation attempt unless we're
-            // reasonably confident it will not result in a viable version)
-            r::sexp::Protect protect;
-            SEXP versionInfo = R_NilValue;
-
-            // find the version that will be installed from CRAN
-            error = r::exec::RFunction(".rs.packageCRANVersionAvailable", 
-                  dep.name, dep.version, dep.source).call(&versionInfo, &protect);
-            if (error) {
-               LOG_ERROR(error);
-            } else {
-               // if these fail, we'll fall back on defaults set above
-               r::sexp::getNamedListElement(versionInfo, "version", 
-                     &dep.availableVersion);
-               r::sexp::getNamedListElement(versionInfo, "satisfied", 
-                     &dep.versionSatisfied);
-            }
-
+            installedPackages.push_back(dep.name);
+         }
+         else
+         {
+            fillCranVersionInfo(&dep);
             unsatisfiedDeps.push_back(dep);
          }
       }
@@ -304,9 +317,13 @@ Error unsatisfiedDependencies(const json::JsonRpcRequest& request,
          if (!isPackageInstalled(dep.name))
          {
             unsatisfiedDeps.push_back(dep);
+            continue;
          }
+
+         installedPackages.push_back(dep.name);
+
          // silent update if necessary (as long as we aren't packified)
-         else if (silentUpdate && !packratContext().packified)
+         if (silentUpdate && !packratContext().packified)
          {
             // package installed was from IDE but is out of date
             if (embeddedPackageRequiresUpdate(pkg))
@@ -325,6 +342,46 @@ Error unsatisfiedDependencies(const json::JsonRpcRequest& request,
                // already installed (e.g. directly from github). in this case
                // we do nothing
             }
+         }
+      }
+   }
+
+   // the checks above only consider the dependencies declared by RStudio;
+   // verify that the recursive runtime dependencies declared by the installed
+   // packages themselves are also installed (a package's dependencies can
+   // change between releases, so this cannot be known statically)
+   if (!installedPackages.empty())
+   {
+      r::sexp::Protect protect;
+      SEXP unsatisfiedSEXP = R_NilValue;
+      error = r::exec::RFunction(".rs.findUnsatisfiedRuntimeDependencies", installedPackages)
+            .call(&unsatisfiedSEXP, &protect);
+      if (error)
+      {
+         LOG_ERROR(error);
+      }
+      else
+      {
+         int numRecords = r::sexp::length(unsatisfiedSEXP);
+         for (int i = 0; i < numRecords; i++)
+         {
+            Dependency dep(VECTOR_ELT(unsatisfiedSEXP, i));
+            if (dep.empty())
+               continue;
+
+            // skip dependencies already reported above
+            auto matchesName = [&dep](const Dependency& unsatisfied)
+            {
+               return unsatisfied.name == dep.name;
+            };
+            if (std::find_if(unsatisfiedDeps.begin(), unsatisfiedDeps.end(), matchesName) !=
+                unsatisfiedDeps.end())
+            {
+               continue;
+            }
+
+            fillCranVersionInfo(&dep);
+            unsatisfiedDeps.push_back(dep);
          }
       }
    }

--- a/src/cpp/session/resources/dependencies/r-packages.json
+++ b/src/cpp/session/resources/dependencies/r-packages.json
@@ -347,9 +347,6 @@
         "r2d3": {
             "description": "R2D3",
             "packages": [
-                "htmltools",
-                "htmlwidgets",
-                "jsonlite",
                 "r2d3"
             ]
         },
@@ -362,11 +359,6 @@
         "plumber": {
             "description": "Plumber R APIs",
             "packages": [
-                "R6",
-                "stringi",
-                "jsonlite",
-                "httpuv",
-                "crayon",
                 "plumber"
             ]
         },
@@ -379,32 +371,17 @@
         "rsconnect": {
             "description": "Publishing",
             "packages": [
-                "curl",
-                "jsonlite",
-                "openssl",
-                "rstudioapi",
-                "yaml",
-                "packrat",
                 "rsconnect"
             ]
         },
         "rmarkdown": {
             "description": "R Markdown",
             "packages": [
-                "base64enc",
                 "digest",
-                "evaluate",
-                "glue",
-                "highr",
                 "htmltools",
                 "jsonlite",
                 "knitr",
-                "magrittr",
-                "mime",
                 "rmarkdown",
-                "stringi",
-                "stringr",
-                "xfun",
                 "yaml"
             ]
         },
@@ -418,27 +395,12 @@
         "shiny": {
             "description": "Shiny",
             "packages": [
-                "crayon",
-                "digest",
-                "htmltools",
-                "httpuv",
-                "jsonlite",
-                "later",
-                "mime",
-                "promises",
-                "rlang",
-                "R6",
-                "Rcpp",
-                "shiny",
-                "sourcetools",
-                "xtable"
+                "shiny"
             ]
         },
         "reticulate": {
             "description": "Python/Reticulate",
             "packages": [
-                "jsonlite",
-                "png",
                 "reticulate"
             ]
         },
@@ -464,22 +426,19 @@
         "import_csv": {
             "description": "CSV Import",
             "packages": [
-                "readr",
-                "Rcpp"
+                "readr"
             ]
         },
         "import_sav": {
             "description": "SPSS/SAS/Stata Import",
             "packages": [
-                "haven",
-                "Rcpp"
+                "haven"
             ]
         },
         "import_xls": {
             "description": "Excel Import",
             "packages": [
-                "readxl",
-                "Rcpp"
+                "readxl"
             ]
         },
         "import_xml": {
@@ -497,8 +456,7 @@
         "import_jdbc": {
             "description": "JDBC Import",
             "packages": [
-                "RJDBC",
-                "rJava"
+                "RJDBC"
             ]
         },
         "import_odbc": {
@@ -510,17 +468,12 @@
         "import_mongo": {
             "description": "Mongo DB Import",
             "packages": [
-                "mongolite",
-                "jsonlite"
+                "mongolite"
             ]
         },
         "profvis": {
             "description": "Visual Profiling",
             "packages": [
-                "stringr",
-                "jsonlite",
-                "htmltools",
-                "yaml",
                 "htmlwidgets",
                 "profvis"
             ]
@@ -573,22 +526,8 @@
         "tutorial": {
             "description": "RStudio Tutorials",
             "packages": [
-                "checkmate",
-                "ellipsis",
-                "evaluate",
-                "fastmap",
-                "htmltools",
-                "htmlwidgets",
-                "jsonlite",
-                "knitr",
                 "learnr",
-                "rmarkdown",
-                "rappdirs",
-                "renv",
-                "rprojroot",
-                "rstudioapi",
-                "shiny",
-                "withr"
+                "rstudioapi"
             ]
         }
     }

--- a/src/cpp/tests/testthat/test-dependencies.R
+++ b/src/cpp/tests/testthat/test-dependencies.R
@@ -191,4 +191,58 @@ test_that("dependencies are installed only once", {
               source   = FALSE)))
 })
 
+test_that("dependency fields are parsed correctly", {
+   contents <- "R (>= 3.5), foo (>= 1.0), bar,\n  baz.qux (> 2.0-1)"
+   deps <- .rs.parsePackageDependencyFields(contents)
+
+   expect_equal(deps$name, c("foo", "bar", "baz.qux"))
+   expect_equal(deps$op, c(">=", "", ">"))
+   expect_equal(deps$version, c("1.0", "", "2.0-1"))
+
+   # multiple fields are combined; NA fields are ignored
+   deps <- .rs.parsePackageDependencyFields(c(Depends = "foo", Imports = NA))
+   expect_equal(deps$name, "foo")
+
+   deps <- .rs.parsePackageDependencyFields(character())
+   expect_equal(nrow(deps), 0L)
+})
+
+test_that("packages with intact runtime dependency trees are satisfied", {
+   expect_equal(.rs.findUnsatisfiedRuntimeDependencies("stats"), list())
+   expect_equal(.rs.findUnsatisfiedRuntimeDependencies("testthat"), list())
+})
+
+test_that("packages which are not installed are reported as unsatisfied", {
+   unsatisfied <- .rs.findUnsatisfiedRuntimeDependencies("nosuchpackage54321")
+   expect_equal(unsatisfied, list(list(name = "nosuchpackage54321", version = "")))
+})
+
+test_that("missing and outdated runtime dependencies are reported", {
+   # fabricate an installed package whose declared dependencies cannot be
+   # satisfied: one is not installed, and one is installed (utils) but cannot
+   # meet the declared version requirement
+   lib <- tempfile("library-")
+   pkgDir <- file.path(lib, "fakepkg")
+   dir.create(file.path(pkgDir, "Meta"), recursive = TRUE)
+
+   description <- c(
+      Package = "fakepkg",
+      Version = "1.0",
+      Imports = "missingpkg (>= 2.0), utils (>= 999.999)")
+   write.dcf(t(as.matrix(description)), file.path(pkgDir, "DESCRIPTION"))
+   saveRDS(list(DESCRIPTION = description), file.path(pkgDir, "Meta", "package.rds"))
+
+   libPaths <- .libPaths()
+   on.exit(.libPaths(libPaths), add = TRUE)
+   .libPaths(c(lib, libPaths))
+
+   unsatisfied <- .rs.findUnsatisfiedRuntimeDependencies("fakepkg")
+   names <- vapply(unsatisfied, `[[`, "", "name")
+   versions <- vapply(unsatisfied, `[[`, "", "version")
+
+   expect_setequal(names, c("missingpkg", "utils"))
+   expect_equal(versions[names == "missingpkg"], "2.0")
+   expect_equal(versions[names == "utils"], "999.999")
+})
+
 


### PR DESCRIPTION
Addresses #18199.

## Problem

The feature package lists in `src/cpp/session/resources/dependencies/r-packages.json` were frozen *transitive* dependency closures, mostly dating from ~2021. As packages evolve, these lists drift out of sync: rmarkdown dropped its stringr dependency in December 2023, so rendering an R Markdown or Quarto document in an renv project (whose minimal project library reflects the *real* dependency tree) made RStudio insist on installing stringr, stringi, glue, and magrittr for no reason.

The drift was systemic, not rmarkdown-specific. Comparing every hard-coded list against current CRAN metadata:

| Feature | Hard-coded packages no longer in the real dependency tree |
|---|---|
| rmarkdown | glue, magrittr, stringi, stringr |
| shiny | crayon |
| profvis | stringr |
| tutorial | ellipsis, rstudioapi |
| import_csv / import_sav / import_xls | Rcpp (readr/haven/readxl moved to cpp11) |

## Fix

Two complementary changes:

**1. Trim each feature list to the packages RStudio itself calls directly.** Each surviving entry was audited for direct usage in `src/cpp` / `src/gwt` (e.g. knitr/yaml/htmltools/jsonlite for the notebook rendering paths, rstudioapi in `SessionTutorial.R`, htmlwidgets in `SessionProfiler.R`), and every dropped entry was verified to be either still transitively guaranteed by the feature's top-level package on today's CRAN, or genuinely stale with zero direct references.

**2. Validate recursive runtime dependencies against the installed packages themselves.** The `unsatisfied_dependencies` RPC now walks the recursive Depends/Imports declared by each installed dependency (`.rs.findUnsatisfiedRuntimeDependencies`) and reports anything missing or version-unsatisfied. Validation therefore always reflects the dependency tree of the versions actually installed and can never drift again -- and genuinely broken libraries (e.g. a package deleted out from under rmarkdown) are still caught up front, which the old hard-coded snapshot could not reliably do.

Implementation notes:

- The walk visits only packages reachable from the checked dependencies (same design as renv's `renv_package_dependencies()`), reading each package's cached DESCRIPTION metadata (`Meta/package.rds`), rather than scanning the entire library with `installed.packages()` -- full-library scans can be very slow on networked filesystems (see #18060).
- LinkingTo is excluded: it declares a build-time requirement, and following it would wrongly prompt for e.g. cpp11 under binary installs of readr.
- Version requirements declared in DESCRIPTION fields are honored (strongest requirement wins when multiple parents require the same package); renv's walker doesn't check versions, but here an outdated dependency should trigger the install prompt.
- The top-level `packages` version map in r-packages.json is left intact (including now-unreferenced entries) because it backs the public `rstudioapi::getPackageDependencies()` API used for pre-provisioning; `markdown` already had this status.

## Also fixed

- A latent R syntax error in `buildCombinedInstallScript()`, which generated `utils::install.packages(c('a','b')` with a missing closing paren. Only reachable with the non-default `install_pkg_deps_individually` pref disabled and renv inactive.
- A parameter-shadowing bug in `.rs.packageCRANVersionAvailable()`: the required version was overwritten by the available CRAN version, so `satisfied` compared the available version to itself and was always true. **Behavior note**: fixing this revives the previously unreachable "required package versions are not available" error path in `DependencyManager` for users whose configured repos cannot supply the minimum required version (previously they'd get a doomed install prompt loop instead).

## Tests

`test-dependencies.R` gains coverage for the DESCRIPTION dependency-field parser and the runtime walker (intact trees pass; missing packages, uninstalled inputs, and unsatisfiable version requirements are reported). Run with `rstudio-tests --scope r --filter dependencies`; all 17 pass.

## QA Notes

To reproduce the original issue: create a project, add a Quarto document with an R chunk, `renv::init()`, then render. Before this change, RStudio prompts to install glue/magrittr/stringi/stringr; after, no prompt appears (rmarkdown and knitr are already in the renv library and their installed trees are intact). Deleting a real dependency out of the renv library (e.g. `utils::remove.packages("evaluate")`) should still produce a prompt -- now for the genuinely missing package.