### PR TITLE
pin rig and sccache installs to skip runtime github api lookups

### DIFF
--- a/.github/actions/os-install-rig-unix/action.yml
+++ b/.github/actions/os-install-rig-unix/action.yml
@@ -1,0 +1,67 @@
+name: "Install rig (Linux / macOS)"
+description: >
+  Install the rig R version manager on a Linux or macOS runner from a pinned
+  GitHub release. Replaces the resolve-latest-via-GitHub-API step: querying
+  api.github.com at runtime is a recurring flake source (intermittent 503s),
+  while a runner-to-GitHub release download needs no API call and is about as
+  reliable as CI networking gets. The "latest" permanent-link release is not
+  an option either -- its binary assets are stale (last updated 2024-04-07 as
+  of writing; see r-lib/rig#343 for a bug this staleness reintroduces).
+
+inputs:
+  rig-version:
+    description: "rig release version to install (without the leading 'v')."
+    required: false
+    default: "0.8.1"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install rig from GitHub releases
+      shell: bash
+      env:
+        RIG_VERSION: ${{ inputs.rig-version }}
+      run: |
+        set -euo pipefail
+
+        # Container jobs run as root and may lack sudo; hosted runners need it.
+        SUDO=""
+        if [ "$(id -u)" != "0" ]; then
+          SUDO="sudo"
+        fi
+
+        # Release assets use "arm64", not uname's "aarch64"; the Linux x86_64
+        # asset carries no arch token.
+        case "$(uname -s)-$(uname -m)" in
+          Linux-x86_64)
+            ASSET="rig-linux-${RIG_VERSION}.tar.gz"
+            ;;
+          Linux-aarch64)
+            ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz"
+            ;;
+          Darwin-arm64)
+            ASSET="rig-${RIG_VERSION}-macOS-arm64.pkg"
+            ;;
+          Darwin-x86_64)
+            ASSET="rig-${RIG_VERSION}-macOS-x86_64.pkg"
+            ;;
+          *)
+            echo "::error::Unsupported platform $(uname -s)-$(uname -m) for rig install"
+            exit 1
+            ;;
+        esac
+
+        URL="https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${ASSET}"
+        echo "Downloading $URL"
+        curl -fsSL --retry 5 --retry-delay 10 -o "${RUNNER_TEMP}/${ASSET}" "$URL"
+
+        case "$ASSET" in
+          *.pkg)
+            $SUDO installer -pkg "${RUNNER_TEMP}/${ASSET}" -target /
+            ;;
+          *)
+            $SUDO tar xzf "${RUNNER_TEMP}/${ASSET}" -C /usr/local
+            ;;
+        esac
+
+        rig --version

--- a/.github/actions/os-install-rig-unix/action.yml
+++ b/.github/actions/os-install-rig-unix/action.yml
@@ -10,7 +10,9 @@ description: >
 
 inputs:
   rig-version:
-    description: "rig release version to install (without the leading 'v')."
+    description: >-
+      rig release version to install. Keep at 0.8.1 or newer: older releases
+      cannot install R >= 4.6.1 on macOS (r-lib/rig#343).
     required: false
     default: "0.8.1"
 
@@ -23,6 +25,9 @@ runs:
         RIG_VERSION: ${{ inputs.rig-version }}
       run: |
         set -euo pipefail
+
+        # Tolerate a leading 'v' (as in the release tag) in the version input.
+        RIG_VERSION="${RIG_VERSION#v}"
 
         # Container jobs run as root and may lack sudo; hosted runners need it.
         SUDO=""

--- a/.github/actions/os-install-rig-windows/action.yml
+++ b/.github/actions/os-install-rig-windows/action.yml
@@ -10,7 +10,7 @@ description: >
 
 inputs:
   rig-version:
-    description: "rig release version to install (without the leading 'v')."
+    description: "rig release version to install."
     required: false
     default: "0.8.1"
 
@@ -23,6 +23,9 @@ runs:
         RIG_VERSION: ${{ inputs.rig-version }}
       run: |
         $ErrorActionPreference = 'Stop'
+
+        # Tolerate a leading 'v' (as in the release tag) in the version input.
+        $env:RIG_VERSION = $env:RIG_VERSION -replace '^v', ''
 
         $url = "https://github.com/r-lib/rig/releases/download/v$env:RIG_VERSION/rig-windows-$env:RIG_VERSION.exe"
         $installer = Join-Path $env:RUNNER_TEMP "rig-windows-$env:RIG_VERSION.exe"

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
@@ -406,25 +406,8 @@ jobs:
             libxss1 libxtst6 libxcb1 \
             libfreetype6 libfontconfig1 libharfbuzz0b libfribidi0
 
-      # The "latest" release tag is a permanent-link release whose binary
-      # assets are not kept current (last updated 2024-04-07 as of writing --
-      # see r-lib/rig#343 for a bug this staleness reintroduces). Resolve the
-      # actual latest release via the GitHub API instead. $(arch) resolves
-      # aarch64 on arm64, but real releases use "arm64" in the asset name; the
-      # x86_64 asset carries no arch token.
       - name: Install rig
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          RIG_VERSION=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
-          case "$RIG_VERSION" in ''|null) echo "::error::Could not resolve rig's latest version (GitHub API rate limit or outage?)"; exit 1 ;; esac
-          case "$(arch)" in
-            x86_64)  RIG_ASSET="rig-linux-${RIG_VERSION}.tar.gz" ;;
-            aarch64) RIG_ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz" ;;
-            *) echo "::error::Unsupported arch $(arch) for rig install"; exit 1 ;;
-          esac
-          curl -fLs --retry 3 --retry-delay 5 -o rig.tar.gz "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}"
-          tar xzf rig.tar.gz -C /usr/local
+        uses: ./.github/actions/os-install-rig-unix
 
       - name: Install R via rig
         env:

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
@@ -213,6 +213,11 @@ jobs:
       # cache hits, no per-SHA tarball, no AWS credentials.
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          # Pinned: resolving "latest" queries api.github.com at runtime,
+          # which fails during GitHub API incidents (503s). A pinned version
+          # downloads directly from the release CDN with no API call.
+          version: "v0.16.0"
 
       # install-dependencies-noble: apt-get installs system packages (with sudo
       # internally), then calls install-common which downloads Boost, SOCI,

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-43-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-43-x86_64.yml
@@ -205,6 +205,11 @@ jobs:
       # cache hits, no per-SHA tarball, no AWS credentials.
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          # Pinned: resolving "latest" queries api.github.com at runtime,
+          # which fails during GitHub API incidents (503s). A pinned version
+          # downloads directly from the release CDN with no API call.
+          version: "v0.16.0"
 
       # install-dependencies-yum: dnf installs system packages (with sudo
       # internally), then calls install-common which downloads Boost, SOCI,

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
@@ -204,6 +204,11 @@ jobs:
       # cache hits, no per-SHA tarball, no AWS credentials.
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          # Pinned: resolving "latest" queries api.github.com at runtime,
+          # which fails during GitHub API incidents (503s). A pinned version
+          # downloads directly from the release CDN with no API call.
+          version: "v0.16.0"
 
       # install-dependencies-yum: dnf installs system packages (with sudo
       # internally), then calls install-common which downloads Boost, SOCI,

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -289,18 +289,8 @@ jobs:
           cache: 'npm'
           cache-dependency-path: e2e/rstudio/package-lock.json
 
-      # The "latest" release tag is a permanent-link release whose binary
-      # assets are not kept current (last updated 2024-04-07 as of writing --
-      # see r-lib/rig#343 for a bug this staleness reintroduces). Resolve the
-      # actual latest release via the GitHub API instead.
       - name: Install rig
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          RIG_VERSION=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
-          case "$RIG_VERSION" in ''|null) echo "::error::Could not resolve rig's latest version (GitHub API rate limit or outage?)"; exit 1 ;; esac
-          curl -fLs --retry 3 --retry-delay 5 -o rig.pkg "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/rig-${RIG_VERSION}-macOS-arm64.pkg"
-          sudo installer -pkg rig.pkg -target /
+        uses: ./.github/actions/os-install-rig-unix
 
       - name: Install R via rig
         env:

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -207,6 +207,11 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
+        with:
+          # Pinned: resolving "latest" queries api.github.com at runtime,
+          # which fails during GitHub API incidents (503s). A pinned version
+          # downloads directly from the release CDN with no API call.
+          version: "v0.16.0"
 
       - name: Build RStudio Desktop (arm64)
         id: build

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-rhel-10-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-rhel-10-x86_64.yml
@@ -380,25 +380,8 @@ jobs:
             gtk3 pango cairo alsa-lib \
             freetype fontconfig harfbuzz fribidi
 
-      # The "latest" release tag is a permanent-link release whose binary
-      # assets are not kept current (last updated 2024-04-07 as of writing --
-      # see r-lib/rig#343 for a bug this staleness reintroduces). Resolve the
-      # actual latest release via the GitHub API instead. Real releases use
-      # "arm64" in the asset name, not $(arch)'s "aarch64"; the x86_64 asset
-      # carries no arch token.
       - name: Install rig
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          RIG_VERSION=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
-          case "$RIG_VERSION" in ''|null) echo "::error::Could not resolve rig's latest version (GitHub API rate limit or outage?)"; exit 1 ;; esac
-          case "$(arch)" in
-            x86_64)  RIG_ASSET="rig-linux-${RIG_VERSION}.tar.gz" ;;
-            aarch64) RIG_ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz" ;;
-            *) echo "::error::Unsupported arch $(arch) for rig install"; exit 1 ;;
-          esac
-          curl -fLs --retry 3 --retry-delay 5 -o rig.tar.gz "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}"
-          tar xzf rig.tar.gz -C /usr/local
+        uses: ./.github/actions/os-install-rig-unix
 
       - name: Install R via rig
         env:

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-rhel-10-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-rhel-10-x86_64.yml
@@ -217,6 +217,11 @@ jobs:
       # cache hits, no per-SHA tarball, no AWS credentials.
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          # Pinned: resolving "latest" queries api.github.com at runtime,
+          # which fails during GitHub API incidents (503s). A pinned version
+          # downloads directly from the release CDN with no API call.
+          version: "v0.16.0"
 
       # install-dependencies-yum: dnf installs system packages (with sudo
       # internally), then calls install-common which downloads Boost, SOCI,

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -193,6 +193,11 @@ jobs:
       # object cache is shared with the Linux Server build and inherited by PRs.
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          # Pinned: resolving "latest" queries api.github.com at runtime,
+          # which fails during GitHub API incidents (503s). A pinned version
+          # downloads directly from the release CDN with no API call.
+          version: "v0.16.0"
 
       # install-dependencies-noble: apt-get installs system packages (with sudo
       # internally), then calls install-common which downloads Boost, SOCI,

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -337,25 +337,8 @@ jobs:
       - name: Allow unprivileged user namespaces (required by Electron/Chromium)
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
-      # The "latest" release tag is a permanent-link release whose binary
-      # assets are not kept current (last updated 2024-04-07 as of writing --
-      # see r-lib/rig#343 for a bug this staleness reintroduces). Resolve the
-      # actual latest release via the GitHub API instead. Real releases use
-      # "arm64" in the asset name, not $(arch)'s "aarch64"; the x86_64 asset
-      # carries no arch token.
       - name: Install rig
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          RIG_VERSION=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
-          case "$RIG_VERSION" in ''|null) echo "::error::Could not resolve rig's latest version (GitHub API rate limit or outage?)"; exit 1 ;; esac
-          case "$(arch)" in
-            x86_64)  RIG_ASSET="rig-linux-${RIG_VERSION}.tar.gz" ;;
-            aarch64) RIG_ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz" ;;
-            *) echo "::error::Unsupported arch $(arch) for rig install"; exit 1 ;;
-          esac
-          curl -fLs --retry 3 --retry-delay 5 -o rig.tar.gz "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}"
-          sudo tar xzf rig.tar.gz -C /usr/local
+        uses: ./.github/actions/os-install-rig-unix
 
       - name: Install R via rig
         env:

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
@@ -181,6 +181,11 @@ jobs:
       # object cache is shared with the Linux Server build and inherited by PRs.
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          # Pinned: resolving "latest" queries api.github.com at runtime,
+          # which fails during GitHub API incidents (503s). A pinned version
+          # downloads directly from the release CDN with no API call.
+          version: "v0.16.0"
 
       # install-dependencies-resolute: apt-get installs system packages (with sudo
       # internally), then calls install-common which downloads Boost, SOCI,

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
@@ -325,25 +325,8 @@ jobs:
       - name: Allow unprivileged user namespaces (required by Electron/Chromium)
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
-      # The "latest" release tag is a permanent-link release whose binary
-      # assets are not kept current (last updated 2024-04-07 as of writing --
-      # see r-lib/rig#343 for a bug this staleness reintroduces). Resolve the
-      # actual latest release via the GitHub API instead. Real releases use
-      # "arm64" in the asset name, not $(arch)'s "aarch64"; the x86_64 asset
-      # carries no arch token.
       - name: Install rig
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          RIG_VERSION=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
-          case "$RIG_VERSION" in ''|null) echo "::error::Could not resolve rig's latest version (GitHub API rate limit or outage?)"; exit 1 ;; esac
-          case "$(arch)" in
-            x86_64)  RIG_ASSET="rig-linux-${RIG_VERSION}.tar.gz" ;;
-            aarch64) RIG_ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz" ;;
-            *) echo "::error::Unsupported arch $(arch) for rig install"; exit 1 ;;
-          esac
-          curl -fLs --retry 3 --retry-delay 5 -o rig.tar.gz "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}"
-          sudo tar xzf rig.tar.gz -C /usr/local
+        uses: ./.github/actions/os-install-rig-unix
 
       - name: Install R via rig
         env:

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -319,6 +319,11 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
+        with:
+          # Pinned: resolving "latest" queries api.github.com at runtime,
+          # which fails during GitHub API incidents (503s). A pinned version
+          # downloads directly from the release CDN with no API call.
+          version: "v0.16.0"
 
       # Pre-start the sccache server. Ninja runs parallel cl.exe compiles
       # through `sccache.exe cl.exe ...`; on Windows each sccache.exe

--- a/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -334,25 +334,8 @@ jobs:
       - name: Allow unprivileged user namespaces (required by Playwright/Chrome)
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
-      # The "latest" release tag is a permanent-link release whose binary
-      # assets are not kept current (last updated 2024-04-07 as of writing --
-      # see r-lib/rig#343 for a bug this staleness reintroduces). Resolve the
-      # actual latest release via the GitHub API instead. Real releases use
-      # "arm64" in the asset name, not $(arch)'s "aarch64"; the x86_64 asset
-      # carries no arch token.
       - name: Install rig
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          RIG_VERSION=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/r-lib/rig/releases/latest | jq -r '.tag_name | ltrimstr("v")')
-          case "$RIG_VERSION" in ''|null) echo "::error::Could not resolve rig's latest version (GitHub API rate limit or outage?)"; exit 1 ;; esac
-          case "$(arch)" in
-            x86_64)  RIG_ASSET="rig-linux-${RIG_VERSION}.tar.gz" ;;
-            aarch64) RIG_ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz" ;;
-            *) echo "::error::Unsupported arch $(arch) for rig install"; exit 1 ;;
-          esac
-          curl -fLs --retry 3 --retry-delay 5 -o rig.tar.gz "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_ASSET}"
-          sudo tar xzf rig.tar.gz -C /usr/local
+        uses: ./.github/actions/os-install-rig-unix
 
       - name: Install R via rig
         env:

--- a/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -188,6 +188,11 @@ jobs:
       # no AWS credentials. Repo-scoped so PRs inherit main's warm cache.
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          # Pinned: resolving "latest" queries api.github.com at runtime,
+          # which fails during GitHub API incidents (503s). A pinned version
+          # downloads directly from the release CDN with no API call.
+          version: "v0.16.0"
 
       # install-dependencies-noble: apt-get installs system packages (with sudo
       # internally), then calls install-common which downloads Boost, SOCI,


### PR DESCRIPTION
## Summary

The e2e workflows resolved two tool versions at runtime via `api.github.com`: rig (an explicit `releases/latest` curl in six workflows) and sccache (`mozilla-actions/sccache-action` calls `getLatestRelease` when no `version` input is given). Both fail whenever GitHub's REST API has an incident -- rig 503'd in [this run](https://github.com/rstudio/rstudio/actions/runs/29538676901/job/87759895442) on #18269, and the 2026-07-16 'Degraded REST API Availability' incident then failed every Setup sccache step.

Two changes, same principle -- pin the version and download directly from the release CDN, with no API call:

- **rig**: a new shared composite action `.github/actions/os-install-rig-unix` replaces the six duplicated resolve-latest steps (Linux x86_64/arm64 tar.gz, macOS pkg; sudo only when not already root). Same approach `os-install-rig-windows` adopted in #18241. Pinned to 0.8.1, which also carries the fix for installing R >= 4.6.1 on macOS (r-lib/rig#343) that the stale `latest` permalink release lacks; the action docs note that floor. Both rig actions now tolerate a leading 'v' in the version input.
- **sccache**: pass `version: v0.16.0` (what latest resolves to today, so cache behavior is unchanged) to all nine `sccache-action` uses; the action then downloads the release asset directly with a sha256 check.

## Trade-off

Tool updates no longer arrive automatically; bumping is a one-line change per pin (the maintenance model the Windows rig action already uses).

## Testing

- YAML validated on all touched files; `actionlint` reports only pre-existing findings in untouched steps; `shellcheck` passes on the rig action's embedded script.
- The PR-triggered e2e workflows exercise the Ubuntu rig + sccache paths directly (results pending GitHub's API incident recovery).