### PR TITLE
Fix container e2e build-from-source installs and Fedora R build deps

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
@@ -455,7 +455,7 @@ jobs:
       - name: Install RStudio Desktop from artifact
         if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
         run: |
-          apt-get install -y "${{ github.workspace }}/rstudio-desktop.deb"
+          apt-get install -y "$GITHUB_WORKSPACE/rstudio-desktop.deb"
           ls -la /usr/bin/rstudio
 
       # Daily-download path: resolve and install the latest (or specified) .deb.

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-43-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-43-x86_64.yml
@@ -429,7 +429,7 @@ jobs:
       - name: Install RStudio Desktop from artifact
         if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
         run: |
-          dnf -y install "${{ github.workspace }}/rstudio-desktop.rpm"
+          dnf -y install "$GITHUB_WORKSPACE/rstudio-desktop.rpm"
           ls -la /usr/bin/rstudio
 
       # Daily-download path: resolve and install the latest (or specified) .rpm.

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
@@ -428,7 +428,7 @@ jobs:
       - name: Install RStudio Desktop from artifact
         if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
         run: |
-          dnf -y install "${{ github.workspace }}/rstudio-desktop.rpm"
+          dnf -y install "$GITHUB_WORKSPACE/rstudio-desktop.rpm"
           ls -la /usr/bin/rstudio
 
       # Daily-download path: resolve and install the latest (or specified) .rpm.

--- a/dependencies/linux/install-dependencies-yum
+++ b/dependencies/linux/install-dependencies-yum
@@ -31,6 +31,8 @@ PACKAGES=(
 	libffi
 	libuser-devel
 	libuuid-devel
+	libuv-devel
+	libxml2-devel
 	libXScrnSaver-devel
 	libxslt-devel
 	make

--- a/dependencies/linux/install-dependencies-yum
+++ b/dependencies/linux/install-dependencies-yum
@@ -39,6 +39,8 @@ PACKAGES=(
 	pam-devel
 	pango-devel
 	postgresql-devel
+	R-core
+	R-core-devel
 	rpmdevtools
 	sqlite-devel
 	wget


### PR DESCRIPTION
Two fixes that together let the container-based Linux E2E engines run the
build-from-source path end to end. Supersedes #18268.

Container artifact install path. The container engines (Debian 13 arm64,
Fedora 43, Fedora 44) failed at "Install RStudio Desktop from artifact" with:

    E: Unsupported file .../rstudio-desktop.deb given on commandline

In a container job, the `${{ github.workspace }}` expression expands to the
host path, but the downloaded artifact lives at the container's own mounted
path. Switch those install steps to the `$GITHUB_WORKSPACE` environment
variable, which resolves to the container-visible path. The daily-download
path already installs via a relative filename and is unchanged.

Fedora/RHEL build dependencies. The Fedora build job failed at "Install build
dependencies" with `R: command not found`: the yum dependency script never
installed R, which the package-install step needs. Add R-core and R-core-devel
(plus libuv-devel and libxml2-devel for build-time R packages) to the yum
script.
