### PR TITLE
Prefix rserver --setup-db flags and harden non-interactive runs

### DIFF
--- a/src/cpp/core/ProgramOptions.cpp
+++ b/src/cpp/core/ProgramOptions.cpp
@@ -83,42 +83,42 @@ bool detectSetupDbMode(int argc, const char* const argv[])
 
 bool detectShowPassword(int argc, const char* const argv[])
 {
-   return argHasFlag(argc, argv, "show-password");
+   return argHasFlag(argc, argv, "setup-db-show-password");
 }
 
 bool detectPrintOnly(int argc, const char* const argv[])
 {
-   return argHasFlag(argc, argv, "print-only");
+   return argHasFlag(argc, argv, "setup-db-print-only");
 }
 
 std::string extractMasterPasswordFile(int argc, const char* const argv[])
 {
-   return extractFlagValue(argc, argv, "master-password-file");
+   return extractFlagValue(argc, argv, "setup-db-master-password-file");
 }
 
 std::string extractHost(int argc, const char* const argv[])
 {
-   return extractFlagValue(argc, argv, "host");
+   return extractFlagValue(argc, argv, "setup-db-host");
 }
 
 std::string extractPort(int argc, const char* const argv[])
 {
-   return extractFlagValue(argc, argv, "port");
+   return extractFlagValue(argc, argv, "setup-db-port");
 }
 
 std::string extractMasterUsername(int argc, const char* const argv[])
 {
-   return extractFlagValue(argc, argv, "master-username");
+   return extractFlagValue(argc, argv, "setup-db-master-username");
 }
 
 std::string extractDatabaseName(int argc, const char* const argv[])
 {
-   return extractFlagValue(argc, argv, "database-name");
+   return extractFlagValue(argc, argv, "setup-db-database-name");
 }
 
 std::string extractDatabaseUser(int argc, const char* const argv[])
 {
-   return extractFlagValue(argc, argv, "database-user");
+   return extractFlagValue(argc, argv, "setup-db-database-user");
 }
 
 namespace {
@@ -344,14 +344,14 @@ ProgramStatus read(const OptionsDescription& optionsDescription,
          ("test-config", "deprecated alias for --check-config")
          ("check-config", "validate the configuration file and report all unrecognized options in a single pass")
          ("setup-db", "create the product database, service user, and grants on a PostgreSQL server")
-         ("master-password-file", value<std::string>(), "path to a file whose first line is the --setup-db master database password")
-         ("show-password", "print the generated service-user password to stdout when running --setup-db")
-         ("print-only", "write --setup-db credentials to a standalone file instead of the product config file")
-         ("host", value<std::string>(), "PostgreSQL host for --setup-db (skips the interactive prompt when set)")
-         ("port", value<std::string>(), "PostgreSQL port for --setup-db (skips the interactive prompt when set)")
-         ("master-username", value<std::string>(), "PostgreSQL master username for --setup-db (skips the interactive prompt when set)")
-         ("database-name", value<std::string>(), "database name for --setup-db (skips the interactive prompt when set)")
-         ("database-user", value<std::string>(), "database user for --setup-db (skips the interactive prompt when set)")
+         ("setup-db-master-password-file", value<std::string>(), "path to a file whose first line is the --setup-db master database password")
+         ("setup-db-show-password", "print the generated service-user password to stdout when running --setup-db")
+         ("setup-db-print-only", "write --setup-db credentials to a standalone file instead of the product config file")
+         ("setup-db-host", value<std::string>(), "PostgreSQL host for --setup-db (skips the interactive prompt when set)")
+         ("setup-db-port", value<std::string>(), "PostgreSQL port for --setup-db (skips the interactive prompt when set)")
+         ("setup-db-master-username", value<std::string>(), "PostgreSQL master username for --setup-db (skips the interactive prompt when set)")
+         ("setup-db-database-name", value<std::string>(), "database name for --setup-db (skips the interactive prompt when set)")
+         ("setup-db-database-user", value<std::string>(), "database user for --setup-db (skips the interactive prompt when set)")
          ("config-file",
            value<std::string>(&configFile)->default_value(
                                     optionsDescription.defaultConfigFilePath),

--- a/src/cpp/core/ProgramOptionsTests.cpp
+++ b/src/cpp/core/ProgramOptionsTests.cpp
@@ -191,7 +191,7 @@ TEST(ProgramOptionsTests, DetectSetupDbModeAbsentByDefault)
 
 TEST(ProgramOptionsTests, DetectShowPasswordFindsFlag)
 {
-   const char* argv[] = { "rserver", "--setup-db", "--show-password" };
+   const char* argv[] = { "rserver", "--setup-db", "--setup-db-show-password" };
    EXPECT_TRUE(detectShowPassword(3, argv));
 }
 
@@ -203,7 +203,7 @@ TEST(ProgramOptionsTests, DetectShowPasswordAbsentByDefault)
 
 TEST(ProgramOptionsTests, DetectPrintOnlyFindsFlag)
 {
-   const char* argv[] = { "rserver", "--setup-db", "--print-only" };
+   const char* argv[] = { "rserver", "--setup-db", "--setup-db-print-only" };
    EXPECT_TRUE(detectPrintOnly(3, argv));
 }
 
@@ -215,13 +215,13 @@ TEST(ProgramOptionsTests, DetectPrintOnlyAbsentByDefault)
 
 TEST(ProgramOptionsTests, ExtractMasterPasswordFileFindsSeparateArgForm)
 {
-   const char* argv[] = { "rserver", "--setup-db", "--master-password-file", "/etc/rstudio/master-pw" };
+   const char* argv[] = { "rserver", "--setup-db", "--setup-db-master-password-file", "/etc/rstudio/master-pw" };
    EXPECT_EQ("/etc/rstudio/master-pw", extractMasterPasswordFile(4, argv));
 }
 
 TEST(ProgramOptionsTests, ExtractMasterPasswordFileFindsEqualsForm)
 {
-   const char* argv[] = { "rserver", "--setup-db", "--master-password-file=/etc/rstudio/master-pw" };
+   const char* argv[] = { "rserver", "--setup-db", "--setup-db-master-password-file=/etc/rstudio/master-pw" };
    EXPECT_EQ("/etc/rstudio/master-pw", extractMasterPasswordFile(3, argv));
 }
 
@@ -233,13 +233,13 @@ TEST(ProgramOptionsTests, ExtractMasterPasswordFileEmptyByDefault)
 
 TEST(ProgramOptionsTests, ExtractHostFindsSeparateArgForm)
 {
-   const char* argv[] = { "rserver", "--setup-db", "--host", "db.internal" };
+   const char* argv[] = { "rserver", "--setup-db", "--setup-db-host", "db.internal" };
    EXPECT_EQ("db.internal", extractHost(4, argv));
 }
 
 TEST(ProgramOptionsTests, ExtractHostFindsEqualsForm)
 {
-   const char* argv[] = { "rserver", "--setup-db", "--host=db.internal" };
+   const char* argv[] = { "rserver", "--setup-db", "--setup-db-host=db.internal" };
    EXPECT_EQ("db.internal", extractHost(3, argv));
 }
 
@@ -251,25 +251,25 @@ TEST(ProgramOptionsTests, ExtractHostEmptyByDefault)
 
 TEST(ProgramOptionsTests, ExtractHostEmptyWhenFlagIsFinalToken)
 {
-   const char* argv[] = { "rserver", "--host" };
+   const char* argv[] = { "rserver", "--setup-db-host" };
    EXPECT_EQ("", extractHost(2, argv));
 }
 
 TEST(ProgramOptionsTests, ExtractHostEmptyWithEmptyEqualsForm)
 {
-   const char* argv[] = { "rserver", "--host=" };
+   const char* argv[] = { "rserver", "--setup-db-host=" };
    EXPECT_EQ("", extractHost(2, argv));
 }
 
 TEST(ProgramOptionsTests, ExtractPortFindsSeparateArgForm)
 {
-   const char* argv[] = { "rserver", "--setup-db", "--port", "5433" };
+   const char* argv[] = { "rserver", "--setup-db", "--setup-db-port", "5433" };
    EXPECT_EQ("5433", extractPort(4, argv));
 }
 
 TEST(ProgramOptionsTests, ExtractPortFindsEqualsForm)
 {
-   const char* argv[] = { "rserver", "--setup-db", "--port=5433" };
+   const char* argv[] = { "rserver", "--setup-db", "--setup-db-port=5433" };
    EXPECT_EQ("5433", extractPort(3, argv));
 }
 
@@ -281,13 +281,13 @@ TEST(ProgramOptionsTests, ExtractPortEmptyByDefault)
 
 TEST(ProgramOptionsTests, ExtractMasterUsernameFindsSeparateArgForm)
 {
-   const char* argv[] = { "rserver", "--setup-db", "--master-username", "postgres" };
+   const char* argv[] = { "rserver", "--setup-db", "--setup-db-master-username", "postgres" };
    EXPECT_EQ("postgres", extractMasterUsername(4, argv));
 }
 
 TEST(ProgramOptionsTests, ExtractMasterUsernameFindsEqualsForm)
 {
-   const char* argv[] = { "rserver", "--setup-db", "--master-username=postgres" };
+   const char* argv[] = { "rserver", "--setup-db", "--setup-db-master-username=postgres" };
    EXPECT_EQ("postgres", extractMasterUsername(3, argv));
 }
 
@@ -299,13 +299,13 @@ TEST(ProgramOptionsTests, ExtractMasterUsernameEmptyByDefault)
 
 TEST(ProgramOptionsTests, ExtractDatabaseNameFindsSeparateArgForm)
 {
-   const char* argv[] = { "rserver", "--setup-db", "--database-name", "rstudio" };
+   const char* argv[] = { "rserver", "--setup-db", "--setup-db-database-name", "rstudio" };
    EXPECT_EQ("rstudio", extractDatabaseName(4, argv));
 }
 
 TEST(ProgramOptionsTests, ExtractDatabaseNameFindsEqualsForm)
 {
-   const char* argv[] = { "rserver", "--setup-db", "--database-name=rstudio" };
+   const char* argv[] = { "rserver", "--setup-db", "--setup-db-database-name=rstudio" };
    EXPECT_EQ("rstudio", extractDatabaseName(3, argv));
 }
 
@@ -317,13 +317,13 @@ TEST(ProgramOptionsTests, ExtractDatabaseNameEmptyByDefault)
 
 TEST(ProgramOptionsTests, ExtractDatabaseUserFindsSeparateArgForm)
 {
-   const char* argv[] = { "rserver", "--setup-db", "--database-user", "rstudio" };
+   const char* argv[] = { "rserver", "--setup-db", "--setup-db-database-user", "rstudio" };
    EXPECT_EQ("rstudio", extractDatabaseUser(4, argv));
 }
 
 TEST(ProgramOptionsTests, ExtractDatabaseUserFindsEqualsForm)
 {
-   const char* argv[] = { "rserver", "--setup-db", "--database-user=rstudio" };
+   const char* argv[] = { "rserver", "--setup-db", "--setup-db-database-user=rstudio" };
    EXPECT_EQ("rstudio", extractDatabaseUser(3, argv));
 }
 

--- a/src/cpp/core/include/core/ProgramOptions.hpp
+++ b/src/cpp/core/include/core/ProgramOptions.hpp
@@ -116,37 +116,37 @@ bool detectCheckConfigMode(int argc, const char* const argv[]);
 // Returns true if --setup-db is present in argv.
 bool detectSetupDbMode(int argc, const char* const argv[]);
 
-// Returns true if --show-password is present in argv. Used by --setup-db.
+// Returns true if --setup-db-show-password is present in argv. Used by --setup-db.
 bool detectShowPassword(int argc, const char* const argv[]);
 
-// Returns true if --print-only is present in argv. Used by --setup-db.
+// Returns true if --setup-db-print-only is present in argv. Used by --setup-db.
 bool detectPrintOnly(int argc, const char* const argv[]);
 
-// Returns the value of --master-password-file <path> (or --master-password-file=<path>)
+// Returns the value of --setup-db-master-password-file <path> (or --setup-db-master-password-file=<path>)
 // if present in argv, or an empty string otherwise. Used by --setup-db.
 std::string extractMasterPasswordFile(int argc, const char* const argv[]);
 
-// Returns the value of --host <host> (or --host=<host>) if present in argv,
+// Returns the value of --setup-db-host <host> (or --setup-db-host=<host>) if present in argv,
 // or an empty string otherwise. Used by --setup-db to skip the interactive
 // PostgreSQL host prompt when supplied.
 std::string extractHost(int argc, const char* const argv[]);
 
-// Returns the value of --port <port> (or --port=<port>) if present in argv,
+// Returns the value of --setup-db-port <port> (or --setup-db-port=<port>) if present in argv,
 // or an empty string otherwise. Used by --setup-db to skip the interactive
 // PostgreSQL port prompt when supplied.
 std::string extractPort(int argc, const char* const argv[]);
 
-// Returns the value of --master-username <user> (or --master-username=<user>)
+// Returns the value of --setup-db-master-username <user> (or --setup-db-master-username=<user>)
 // if present in argv, or an empty string otherwise. Used by --setup-db to
 // skip the interactive master username prompt when supplied.
 std::string extractMasterUsername(int argc, const char* const argv[]);
 
-// Returns the value of --database-name <name> (or --database-name=<name>) if
+// Returns the value of --setup-db-database-name <name> (or --setup-db-database-name=<name>) if
 // present in argv, or an empty string otherwise. Used by --setup-db to skip
 // the interactive database name prompt when supplied.
 std::string extractDatabaseName(int argc, const char* const argv[]);
 
-// Returns the value of --database-user <user> (or --database-user=<user>) if
+// Returns the value of --setup-db-database-user <user> (or --setup-db-database-user=<user>) if
 // present in argv, or an empty string otherwise. Used by --setup-db to skip
 // the interactive database user prompt when supplied.
 std::string extractDatabaseUser(int argc, const char* const argv[]);

--- a/src/cpp/server/ServerSetupDb.cpp
+++ b/src/cpp/server/ServerSetupDb.cpp
@@ -88,11 +88,21 @@ std::string readMaskedLine(std::istream& in, std::ostream& out)
    return value;
 }
 
-std::string promptLine(std::istream& in, std::ostream& out, const std::string& prompt)
+// Reads a line from `in`, writing `prompt` to `out` first. If `pEof` is
+// non-null, *pEof is set to true only when the stream hit end-of-input with
+// nothing typed -- interactively pressing enter also yields an empty value,
+// but without eof(), so that case leaves *pEof false and existing
+// empty-value defaults still apply. Callers use *pEof to distinguish a
+// deliberate blank answer from a non-interactive run that piped in less
+// input than --setup-db needed.
+std::string promptLine(std::istream& in, std::ostream& out, const std::string& prompt,
+                        bool* pEof = nullptr)
 {
    out << prompt;
    std::string value;
    std::getline(in, value);
+   if (pEof != nullptr)
+      *pEof = in.eof() && value.empty();
    return value;
 }
 
@@ -360,17 +370,47 @@ Error connectAsMaster(const SetupDbFlags& flags,
 
    std::string host = flags.host;
    if (host.empty())
-      host = promptLine(in, out, "PostgreSQL host: ");
+   {
+      bool eof = false;
+      host = promptLine(in, out, "PostgreSQL host: ", &eof);
+      if (eof)
+      {
+         out << "[FAIL] No PostgreSQL host provided. Pass --setup-db-host to run --setup-db "
+                "without interactive input." << std::endl;
+         *pPassed = false;
+         return Success();
+      }
+   }
 
    std::string port = flags.port;
    if (port.empty())
-      port = promptLine(in, out, "PostgreSQL port [5432]: ");
+   {
+      bool eof = false;
+      port = promptLine(in, out, "PostgreSQL port [5432]: ", &eof);
+      if (eof)
+      {
+         out << "[FAIL] No PostgreSQL port provided. Pass --setup-db-port to run --setup-db "
+                "without interactive input." << std::endl;
+         *pPassed = false;
+         return Success();
+      }
+   }
    if (port.empty())
       port = "5432";
 
    std::string masterUser = flags.masterUsername;
    if (masterUser.empty())
-      masterUser = promptLine(in, out, "Master username: ");
+   {
+      bool eof = false;
+      masterUser = promptLine(in, out, "Master username: ", &eof);
+      if (eof)
+      {
+         out << "[FAIL] No PostgreSQL master username provided. Pass --setup-db-master-username "
+                "to run --setup-db without interactive input." << std::endl;
+         *pPassed = false;
+         return Success();
+      }
+   }
 
    std::string masterPassword;
    Error error = resolveMasterPassword(flags.masterPasswordFile, in, out, &masterPassword);
@@ -533,13 +573,33 @@ Error setupDb(const Options& options,
 
    std::string dbName = flags.databaseName;
    if (dbName.empty())
-      dbName = promptLine(in, out, "Database name [" + defaultName + "]: ");
+   {
+      bool eof = false;
+      dbName = promptLine(in, out, "Database name [" + defaultName + "]: ", &eof);
+      if (eof)
+      {
+         out << "[FAIL] No database name provided. Pass --setup-db-database-name to run "
+                "--setup-db without interactive input." << std::endl;
+         *pPassed = false;
+         return Success();
+      }
+   }
    if (dbName.empty())
       dbName = defaultName;
 
    std::string dbUser = flags.databaseUser;
    if (dbUser.empty())
-      dbUser = promptLine(in, out, "Database user [" + defaultName + "]: ");
+   {
+      bool eof = false;
+      dbUser = promptLine(in, out, "Database user [" + defaultName + "]: ", &eof);
+      if (eof)
+      {
+         out << "[FAIL] No database user provided. Pass --setup-db-database-user to run "
+                "--setup-db without interactive input." << std::endl;
+         *pPassed = false;
+         return Success();
+      }
+   }
    if (dbUser.empty())
       dbUser = defaultName;
 

--- a/src/cpp/server/ServerSetupDb.cpp
+++ b/src/cpp/server/ServerSetupDb.cpp
@@ -52,8 +52,13 @@ const std::string kPasswordCharset =
 // password prompt. Restores echo before returning, even on error. Only
 // disables echo when `in` is actually the controlling terminal (stdin is
 // both connected to a real tty and the stream in use); under test, `in` is
-// a plain istringstream and this is a no-op.
-std::string readMaskedLine(std::istream& in, std::ostream& out)
+// a plain istringstream and this is a no-op. The `pEof` out-parameter mirrors
+// promptLine(): if non-null, *pEof is set to true only when the read failed
+// with nothing typed (!in.good() && value.empty()), so callers can fail a
+// non-interactive run that never supplied a password while still allowing an
+// interactively empty password (e.g. peer/trust auth, where the stream stays
+// good()).
+std::string readMaskedLine(std::istream& in, std::ostream& out, bool* pEof = nullptr)
 {
    bool isRealTty = (&in == &std::cin) && (isatty(STDIN_FILENO) != 0);
    bool settingsSaved = false;
@@ -76,6 +81,8 @@ std::string readMaskedLine(std::istream& in, std::ostream& out)
 
    std::string value;
    std::getline(in, value);
+   if (pEof != nullptr)
+      *pEof = !in.good() && value.empty();
 
    // Only restore if we actually saved the prior settings above; if
    // tcgetattr failed, oldSettings was never populated and there is nothing
@@ -89,9 +96,10 @@ std::string readMaskedLine(std::istream& in, std::ostream& out)
 }
 
 // Reads a line from `in`, writing `prompt` to `out` first. If `pEof` is
-// non-null, *pEof is set to true only when the stream hit end-of-input with
-// nothing typed -- interactively pressing enter also yields an empty value,
-// but without eof(), so that case leaves *pEof false and existing
+// non-null, *pEof is set to true only when the read failed with nothing typed
+// -- i.e. end-of-input (eofbit) or a stream error (failbit/badbit), detected
+// as !in.good(). Interactively pressing enter also yields an empty value, but
+// the stream stays good(), so that case leaves *pEof false and existing
 // empty-value defaults still apply. Callers use *pEof to distinguish a
 // deliberate blank answer from a non-interactive run that piped in less
 // input than --setup-db needed.
@@ -102,7 +110,7 @@ std::string promptLine(std::istream& in, std::ostream& out, const std::string& p
    std::string value;
    std::getline(in, value);
    if (pEof != nullptr)
-      *pEof = in.eof() && value.empty();
+      *pEof = !in.good() && value.empty();
    return value;
 }
 
@@ -164,7 +172,7 @@ Error ensureFileExistsWithUserOnlyMode(const FilePath& path)
 
 // Writes the given key/value pairs as a fresh, 0600 config file at `path`,
 // overwriting anything already there. Used only for the standalone
-// --print-only credentials file: it has no other keys worth preserving, and
+// --setup-db-print-only credentials file: it has no other keys worth preserving, and
 // may be stale from a previous run, so a fresh write is the right behavior
 // there (unlike database.conf -- see mergeWriteDatabaseConfigFile below).
 Error writeCredentialsFileFresh(const FilePath& path,
@@ -324,8 +332,12 @@ const std::string& serviceUserPasswordCharset()
 Error resolveMasterPassword(const std::string& masterPasswordFile,
                              std::istream& in,
                              std::ostream& out,
-                             std::string* pPassword)
+                             std::string* pPassword,
+                             bool* pEof)
 {
+   if (pEof != nullptr)
+      *pEof = false;
+
    if (!masterPasswordFile.empty())
    {
       std::ifstream file(masterPasswordFile);
@@ -355,7 +367,7 @@ Error resolveMasterPassword(const std::string& masterPasswordFile,
    }
 
    out << "Master password: ";
-   *pPassword = readMaskedLine(in, out);
+   *pPassword = readMaskedLine(in, out, pEof);
    return Success();
 }
 
@@ -413,9 +425,18 @@ Error connectAsMaster(const SetupDbFlags& flags,
    }
 
    std::string masterPassword;
-   Error error = resolveMasterPassword(flags.masterPasswordFile, in, out, &masterPassword);
+   bool passwordEof = false;
+   Error error = resolveMasterPassword(flags.masterPasswordFile, in, out, &masterPassword, &passwordEof);
    if (error)
       return error;
+   if (passwordEof)
+   {
+      out << "[FAIL] No master password provided. Pass --setup-db-master-password-file or set "
+             "RSERVER_SETUP_DB_MASTER_PASSWORD to run --setup-db without interactive input."
+          << std::endl;
+      *pPassed = false;
+      return Success();
+   }
 
    pMasterOptions->host = host;
    pMasterOptions->port = port;
@@ -687,7 +708,7 @@ Error setupDb(const Options& options,
          *pPassed = false;
          return Success();
       }
-      out << "[INFO] --print-only set: no config file was modified. Credentials written to "
+      out << "[INFO] --setup-db-print-only set: no config file was modified. Credentials written to "
           << credentialsPath.getAbsolutePath() << "." << std::endl;
       out << "       host=" << masterConnectionOptions.host << " port=" << masterConnectionOptions.port
           << " database=" << dbName << " username=" << dbUser << std::endl;

--- a/src/cpp/server/ServerSetupDb.hpp
+++ b/src/cpp/server/ServerSetupDb.hpp
@@ -50,11 +50,17 @@ const std::string& serviceUserPasswordCharset();
 // Resolves the master password in order of precedence: masterPasswordFile (its
 // first line), then the RSERVER_SETUP_DB_MASTER_PASSWORD environment variable,
 // then a masked interactive prompt on `in`/`out`. Returns a non-Success Error
-// only if masterPasswordFile was specified but could not be read.
+// only if masterPasswordFile was specified but could not be read. If pEof is
+// non-null, *pEof is set to true when the interactive prompt was reached but
+// `in` was already exhausted (a non-interactive run that supplied neither the
+// file nor the env var); the caller should then fail loudly rather than
+// proceed with an empty password. An interactively empty password (stream
+// still good()) leaves *pEof false, preserving peer/trust-auth logins.
 core::Error resolveMasterPassword(const std::string& masterPasswordFile,
                                    std::istream& in,
                                    std::ostream& out,
-                                   std::string* pPassword);
+                                   std::string* pPassword,
+                                   bool* pEof = nullptr);
 
 // Options controlling --setup-db behavior, parsed from argv by the caller
 // (see program_options::detectShowPassword/detectPrintOnly/extractMasterPasswordFile/
@@ -121,7 +127,7 @@ core::Error ensureFileExistsWithUserOnlyMode(const core::FilePath& path);
 
 // Writes the given key/value pairs as a fresh, 0600 config file at `path`,
 // overwriting anything already there. Used only for the standalone
-// --print-only credentials file: it has no other keys worth preserving, and
+// --setup-db-print-only credentials file: it has no other keys worth preserving, and
 // may be stale from a previous run, so a fresh write is the right behavior
 // there (unlike database.conf -- see mergeWriteDatabaseConfigFile below).
 // Exposed here (rather than kept file-local) so it can be unit tested

--- a/src/cpp/server/ServerSetupDbTests.cpp
+++ b/src/cpp/server/ServerSetupDbTests.cpp
@@ -257,6 +257,162 @@ TEST(ServerSetupDbTests, ConnectAsMasterReportsConnectFailure)
    EXPECT_NE(std::string::npos, out.str().find("[FAIL]"));
 }
 
+TEST(ServerSetupDbTests, ConnectAsMasterFailsOnEofForMissingHost)
+{
+   // The host prompt is the first one connectAsMaster issues, so hitting EOF
+   // there is reachable without ever attempting a connection -- no live
+   // PostgreSQL server needed for this case.
+   std::istringstream in(""); // at EOF from the start; host flag left empty
+   std::ostringstream out;
+
+   SetupDbFlags flags;
+   boost::shared_ptr<database::IConnection> pConnection;
+   database::PostgresqlConnectionOptions masterOptions;
+   bool passed = true;
+   Error error = connectAsMaster(flags, in, out, &pConnection, &masterOptions, &passed);
+
+   EXPECT_FALSE(error);
+   EXPECT_FALSE(passed);
+   EXPECT_NE(std::string::npos, out.str().find("[FAIL]"));
+   EXPECT_NE(std::string::npos, out.str().find("--setup-db-host"));
+}
+
+TEST(ServerSetupDbTests, ConnectAsMasterFailsOnEofForMissingPort)
+{
+   // Supply host via flag so the port prompt is the one reached at EOF.
+   std::istringstream in("");
+   std::ostringstream out;
+
+   SetupDbFlags flags;
+   flags.host = "127.0.0.1";
+   boost::shared_ptr<database::IConnection> pConnection;
+   database::PostgresqlConnectionOptions masterOptions;
+   bool passed = true;
+   Error error = connectAsMaster(flags, in, out, &pConnection, &masterOptions, &passed);
+
+   EXPECT_FALSE(error);
+   EXPECT_FALSE(passed);
+   EXPECT_NE(std::string::npos, out.str().find("--setup-db-port"));
+}
+
+TEST(ServerSetupDbTests, ConnectAsMasterFailsOnEofForMissingMasterUsername)
+{
+   // Supply host and port via flags so the master username prompt is the one
+   // reached at EOF.
+   std::istringstream in("");
+   std::ostringstream out;
+
+   SetupDbFlags flags;
+   flags.host = "127.0.0.1";
+   flags.port = "5432";
+   boost::shared_ptr<database::IConnection> pConnection;
+   database::PostgresqlConnectionOptions masterOptions;
+   bool passed = true;
+   Error error = connectAsMaster(flags, in, out, &pConnection, &masterOptions, &passed);
+
+   EXPECT_FALSE(error);
+   EXPECT_FALSE(passed);
+   EXPECT_NE(std::string::npos, out.str().find("--setup-db-master-username"));
+}
+
+TEST(ServerSetupDbTests, ConnectAsMasterHonorsHostPortAndMasterUsernameFlags)
+{
+   // host/port/masterUsername are all supplied via flags against a fully
+   // empty (already-at-EOF) input stream. If any of the three flags were not
+   // honored, the corresponding prompt would consume from the empty stream,
+   // hit EOF, and fail with a "no ... provided" message before ever
+   // attempting to connect. Getting past all three to a real (failing, since
+   // nothing is listening) connect attempt proves the flags were honored and
+   // their prompts skipped.
+   std::istringstream in("");
+   std::ostringstream out;
+   setenv("RSERVER_SETUP_DB_MASTER_PASSWORD", "unused", 1 /* overwrite */);
+
+   SetupDbFlags flags;
+   flags.host = "127.0.0.1";
+   flags.port = "1";
+   flags.masterUsername = "no-such-user";
+   boost::shared_ptr<database::IConnection> pConnection;
+   database::PostgresqlConnectionOptions masterOptions;
+   bool passed = true;
+   Error error = connectAsMaster(flags, in, out, &pConnection, &masterOptions, &passed);
+
+   unsetenv("RSERVER_SETUP_DB_MASTER_PASSWORD");
+
+   EXPECT_FALSE(error);
+   EXPECT_FALSE(passed);
+   EXPECT_EQ(std::string::npos, out.str().find("No PostgreSQL host provided"));
+   EXPECT_EQ(std::string::npos, out.str().find("No PostgreSQL port provided"));
+   EXPECT_EQ(std::string::npos, out.str().find("No PostgreSQL master username provided"));
+   EXPECT_NE(std::string::npos, out.str().find("[FAIL] Could not connect"));
+}
+
+TEST(ServerSetupDbTests, SetupDbFailsOnEofForMissingDatabaseName)
+{
+   // The database-name prompt is the first setupDb() issues, and this EOF
+   // path returns before pMasterConnection is ever dereferenced, so a null
+   // connection is safe here -- no live PostgreSQL server needed.
+   Options& options = server::options();
+   SetupDbFlags flags;
+   std::istringstream in("");
+   std::ostringstream out;
+   boost::shared_ptr<database::IConnection> pMasterConnection;
+   database::PostgresqlConnectionOptions masterOptions;
+   bool passed = true;
+   Error error = setupDb(options, flags, pMasterConnection, masterOptions, in, out, &passed);
+
+   EXPECT_FALSE(error);
+   EXPECT_FALSE(passed);
+   EXPECT_NE(std::string::npos, out.str().find("[FAIL]"));
+   EXPECT_NE(std::string::npos, out.str().find("--setup-db-database-name"));
+}
+
+TEST(ServerSetupDbTests, SetupDbFailsOnEofForMissingDatabaseUser)
+{
+   // Supply the database name via flag so the database-user prompt is the
+   // one reached at EOF; still returns before pMasterConnection is
+   // dereferenced.
+   Options& options = server::options();
+   SetupDbFlags flags;
+   flags.databaseName = "rstudio-os";
+   std::istringstream in("");
+   std::ostringstream out;
+   boost::shared_ptr<database::IConnection> pMasterConnection;
+   database::PostgresqlConnectionOptions masterOptions;
+   bool passed = true;
+   Error error = setupDb(options, flags, pMasterConnection, masterOptions, in, out, &passed);
+
+   EXPECT_FALSE(error);
+   EXPECT_FALSE(passed);
+   EXPECT_NE(std::string::npos, out.str().find("--setup-db-database-user"));
+}
+
+TEST(ServerSetupDbTests, SetupDbHonorsDatabaseNameAndUserFlagsAndSkipsPrompts)
+{
+   // Supplying invalid identifiers (rather than valid ones) via flags keeps
+   // this test DB-free: an invalid identifier fails validateIdentifier() and
+   // returns before setupDb() ever touches pMasterConnection, while still
+   // proving the flags were honored -- if they were NOT honored, the empty
+   // (already-at-EOF) `in` stream below would instead trip the "no ...
+   // provided" EOF guard first.
+   Options& options = server::options();
+   SetupDbFlags flags;
+   flags.databaseName = "not valid!";
+   flags.databaseUser = "not valid!";
+   std::istringstream in("");
+   std::ostringstream out;
+   boost::shared_ptr<database::IConnection> pMasterConnection;
+   database::PostgresqlConnectionOptions masterOptions;
+   bool passed = true;
+   Error error = setupDb(options, flags, pMasterConnection, masterOptions, in, out, &passed);
+
+   EXPECT_FALSE(error);
+   EXPECT_FALSE(passed);
+   EXPECT_EQ(std::string::npos, out.str().find("No database name provided"));
+   EXPECT_EQ(std::string::npos, out.str().find("No database user provided"));
+   EXPECT_NE(std::string::npos, out.str().find("not a valid database/user name"));
+}
+
 TEST(ServerSetupDbTests, MergeWriteDatabaseConfigFilePreservesUnrelatedKeys)
 {
    FilePath dir = makeTempDir();

--- a/src/cpp/server/ServerSetupDbTests.cpp
+++ b/src/cpp/server/ServerSetupDbTests.cpp
@@ -315,6 +315,35 @@ TEST(ServerSetupDbTests, ConnectAsMasterFailsOnEofForMissingMasterUsername)
    EXPECT_NE(std::string::npos, out.str().find("--setup-db-master-username"));
 }
 
+TEST(ServerSetupDbTests, ConnectAsMasterFailsOnEofForMissingMasterPassword)
+{
+   // Supply host/port/master-username via flags and provide neither a
+   // password file nor RSERVER_SETUP_DB_MASTER_PASSWORD, so the masked
+   // password prompt is the one reached at EOF. Before this hardening the
+   // prompt returned "" on exhausted stdin and setup proceeded with an empty
+   // password; it must now fail loudly like the sibling prompts.
+   unsetenv("RSERVER_SETUP_DB_MASTER_PASSWORD");
+   std::istringstream in("");
+   std::ostringstream out;
+
+   SetupDbFlags flags;
+   flags.host = "127.0.0.1";
+   flags.port = "5432";
+   flags.masterUsername = "postgres";
+   boost::shared_ptr<database::IConnection> pConnection;
+   database::PostgresqlConnectionOptions masterOptions;
+   bool passed = true;
+   Error error = connectAsMaster(flags, in, out, &pConnection, &masterOptions, &passed);
+
+   EXPECT_FALSE(error);
+   EXPECT_FALSE(passed);
+   EXPECT_NE(std::string::npos, out.str().find("[FAIL]"));
+   EXPECT_NE(std::string::npos, out.str().find("--setup-db-master-password-file"));
+   EXPECT_NE(std::string::npos, out.str().find("RSERVER_SETUP_DB_MASTER_PASSWORD"));
+   // Must not have reached the connect attempt with an empty password.
+   EXPECT_EQ(std::string::npos, out.str().find("[FAIL] Could not connect"));
+}
+
 TEST(ServerSetupDbTests, ConnectAsMasterHonorsHostPortAndMasterUsernameFlags)
 {
    // host/port/masterUsername are all supplied via flags against a fully
@@ -345,6 +374,48 @@ TEST(ServerSetupDbTests, ConnectAsMasterHonorsHostPortAndMasterUsernameFlags)
    EXPECT_EQ(std::string::npos, out.str().find("No PostgreSQL port provided"));
    EXPECT_EQ(std::string::npos, out.str().find("No PostgreSQL master username provided"));
    EXPECT_NE(std::string::npos, out.str().find("[FAIL] Could not connect"));
+
+   // Prove the flag values flowed into the master connection options (which
+   // are populated before connect() and survive its failure), not merely that
+   // the prompts were skipped -- a bug that skipped the prompt but assigned a
+   // wrong/fixed value would still get past the EOF guards above.
+   EXPECT_EQ("127.0.0.1", masterOptions.host);
+   EXPECT_EQ("1", masterOptions.port);
+   EXPECT_EQ("no-such-user", masterOptions.username);
+}
+
+TEST(ServerSetupDbTests, ConnectAsMasterBlankPortLineKeepsDefaultWhenNotEof)
+{
+   // The port prompt receives a blank line, but more input follows on the
+   // stream, so this is an interactive "press enter to accept the default"
+   // rather than an exhausted-stdin EOF. The blank must fall through to the
+   // documented 5432 default instead of tripping the EOF guard. This is the
+   // only test that exercises the not-eof side of promptLine's
+   // (!in.good() && value.empty()) predicate: with every other guarded-prompt
+   // test feeding either "" (immediate EOF) or a flag value, weakening the
+   // predicate to just value.empty() would otherwise leave the suite green.
+   std::istringstream in("\nno-such-user\n"); // blank port, then master username
+   std::ostringstream out;
+   setenv("RSERVER_SETUP_DB_MASTER_PASSWORD", "unused", 1 /* overwrite */);
+
+   SetupDbFlags flags;
+   flags.host = "127.0.0.1"; // supplied so the port prompt is the blank one
+   boost::shared_ptr<database::IConnection> pConnection;
+   database::PostgresqlConnectionOptions masterOptions;
+   bool passed = true;
+   Error error = connectAsMaster(flags, in, out, &pConnection, &masterOptions, &passed);
+
+   unsetenv("RSERVER_SETUP_DB_MASTER_PASSWORD");
+
+   EXPECT_FALSE(error);
+   // The blank port must not be mistaken for exhausted stdin...
+   EXPECT_EQ(std::string::npos, out.str().find("No PostgreSQL port provided"));
+   // ...and must default to 5432. masterOptions.port is assigned immediately
+   // before connect(), so this holds whether or not anything is actually
+   // listening on 5432 -- keeping the test independent of the local
+   // environment while still proving both the port and username prompts were
+   // reached and cleared without tripping the EOF guard.
+   EXPECT_EQ("5432", masterOptions.port);
 }
 
 TEST(ServerSetupDbTests, SetupDbFailsOnEofForMissingDatabaseName)
@@ -411,6 +482,10 @@ TEST(ServerSetupDbTests, SetupDbHonorsDatabaseNameAndUserFlagsAndSkipsPrompts)
    EXPECT_EQ(std::string::npos, out.str().find("No database name provided"));
    EXPECT_EQ(std::string::npos, out.str().find("No database user provided"));
    EXPECT_NE(std::string::npos, out.str().find("not a valid database/user name"));
+   // The invalid-identifier message quotes the offending name, so asserting the
+   // supplied flag value appears proves the flag value itself reached
+   // validateIdentifier() -- not just that the prompt was skipped.
+   EXPECT_NE(std::string::npos, out.str().find("\"not valid!\""));
 }
 
 TEST(ServerSetupDbTests, MergeWriteDatabaseConfigFilePreservesUnrelatedKeys)


### PR DESCRIPTION
## Summary
Follow-up refinement to `rserver --setup-db` (added in #18172, unreleased).

- Prefixes the eight `--setup-db` value flags with `setup-db-` (e.g. `--setup-db-host`, `--setup-db-port`). They were registered in the general option group parsed on every `rserver` start, so a normal start like `rserver --port 8788` silently parsed them as no-ops. The prefix makes them unambiguously setup-db-only.
- Makes the value prompts fail on end of input rather than silently defaulting. A non-interactive run (empty stdin) that omitted a flag previously fell back to a default — port `5432`, database name/user to the default, host/master-username to empty (which libpq can resolve to the local socket) — so a partially-flagged run could quietly target the wrong database. Each prompt now errors, naming the flag to pass; interactively pressing enter still accepts the documented default.

## Testing
- `rstudio-core-tests --gtest_filter='ProgramOptions*'`: 33/33
- `rserver-tests --gtest_filter='ServerSetupDbTests.*'`: 29/29 (8 new, covering EOF failures per field and flags-honored paths)
- Verified the new EOF tests fail with the fix reverted and pass with it restored.
- OSS build (`RSTUDIO_PRO_BUILD=0`): `rserver` links clean.