### PR TITLE
Reset assistant agent status on early startAgent failures

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@
 - ([#18199](https://github.com/rstudio/rstudio/issues/18199)): RStudio no longer prompts to install packages that are no longer dependencies of rmarkdown (e.g. stringr, glue) when rendering R Markdown or Quarto documents, most visibly in renv projects with minimal project libraries. Required packages are now validated against the dependencies declared by the installed packages themselves, rather than a hard-coded dependency tree.
 - ([#18257](https://github.com/rstudio/rstudio/issues/18257)): Fixed the IDE becoming unresponsive for an extended period after a large number of git-tracked files changed at once (e.g. moving or committing thousands of files); Git pane updates are now batched instead of rebuilding the changelist once per changed file.
 - ([#18260](https://github.com/rstudio/rstudio/issues/18260)): Fixed an issue on macOS where a file change landing just after a bulk change of many files could go undetected by the Files and Git panes until a manual refresh or unrelated later file activity.
+- ([#18277](https://github.com/rstudio/rstudio/issues/18277)): Fixed an issue where the GitHub Copilot or Posit Assistant agent could fail to start for the rest of the session after an early startup failure (for example, a misconfigured Node.js path). The agent now retries and starts once the underlying problem is corrected, without restarting the session.
 
 ### Dependencies
 - MathJax 4.1.3 (inline LaTeX / math previews)

--- a/src/cpp/session/modules/SessionAssistant.cpp
+++ b/src/cpp/session/modules/SessionAssistant.cpp
@@ -1258,9 +1258,9 @@ Error startAgent(const std::string& assistantType = "")
    // error return that leaves the status at 'Preparing' would wedge every
    // later start attempt for the rest of the session (issue #18277). Reset to
    // 'Stopped' on any exit that leaves the status stuck at 'Preparing'; exits
-   // that reach a terminal status deliberately are left untouched (the success
-   // path reaches 'Starting'/'Running', the runProgram and startup-timeout
-   // failures set 'Unknown', and the install-lock refusal sets 'Stopped').
+   // that set a status deliberately are left untouched (the success path
+   // reaches 'Starting'/'Running', the runProgram and startup-timeout failures
+   // set 'Unknown', and the install-lock refusal sets 'Stopped').
    BOOST_SCOPE_EXIT(void)
    {
       if (s_agentRuntimeStatus == AgentRuntimeStatus::Preparing)

--- a/src/cpp/session/modules/SessionAssistant.cpp
+++ b/src/cpp/session/modules/SessionAssistant.cpp
@@ -2125,7 +2125,13 @@ void synchronize()
    // Start or stop the agent as appropriate.
    if (s_assistantEnabled)
    {
-      startAgent();
+      // Log a start failure the way ensureAgentRunning() does; otherwise a
+      // synchronize triggered by a preference or project-option change would
+      // drop the error silently (several startAgent failure paths report
+      // nothing on their own and rely on the caller to log).
+      Error error = startAgent();
+      if (error)
+         LOG_ERROR(error);
    }
    else
    {

--- a/src/cpp/session/modules/SessionAssistant.cpp
+++ b/src/cpp/session/modules/SessionAssistant.cpp
@@ -22,6 +22,7 @@
 #include <boost/current_function.hpp>
 #include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm/copy.hpp>
+#include <boost/scope_exit.hpp>
 
 #include <shared_core/Error.hpp>
 #include <shared_core/json/Json.hpp>
@@ -1252,6 +1253,20 @@ Error startAgent(const std::string& assistantType = "")
    }
 
    setAgentRuntimeStatus(AgentRuntimeStatus::Preparing);
+
+   // The guard above only advances from 'Unknown' or 'Stopped', so any early
+   // error return that leaves the status at 'Preparing' would wedge every
+   // later start attempt for the rest of the session (issue #18277). Reset to
+   // 'Stopped' on any exit that leaves the status stuck at 'Preparing'; exits
+   // that reach a terminal status deliberately are left untouched (the success
+   // path reaches 'Starting'/'Running', the runProgram and startup-timeout
+   // failures set 'Unknown', and the install-lock refusal sets 'Stopped').
+   BOOST_SCOPE_EXIT(void)
+   {
+      if (s_agentRuntimeStatus == AgentRuntimeStatus::Preparing)
+         setAgentRuntimeStatus(AgentRuntimeStatus::Stopped);
+   }
+   BOOST_SCOPE_EXIT_END
 
    Error error;
 

--- a/src/cpp/session/modules/SessionAssistant.cpp
+++ b/src/cpp/session/modules/SessionAssistant.cpp
@@ -1532,7 +1532,7 @@ Error startAgent(const std::string& assistantType = "")
    {
       ELOG("Agent startup timed out [node='{}', stderr='{}'].",
            nodePath.getAbsolutePath(), s_agentStartupError);
-      s_agentRuntimeStatus = AgentRuntimeStatus::Unknown;
+      setAgentRuntimeStatus(AgentRuntimeStatus::Unknown);
       s_runningAgentType.clear();  // Clear since agent failed to start
       return Error(boost::system::errc::no_such_process, ERROR_LOCATION);
    }
@@ -1574,7 +1574,7 @@ Error startAgent(const std::string& assistantType = "")
    {
       if (error)
       {
-         s_agentRuntimeStatus = AgentRuntimeStatus::Unknown;
+         setAgentRuntimeStatus(AgentRuntimeStatus::Unknown);
          LOG_ERROR(error);
          return;
       }
@@ -2757,7 +2757,7 @@ Error assistantNotifyInstalled(const json::JsonRpcRequest& request,
    stopAgentSync();
 
    // Reset the runtime status to allow the agent to start fresh
-   s_agentRuntimeStatus = AgentRuntimeStatus::Unknown;
+   setAgentRuntimeStatus(AgentRuntimeStatus::Unknown);
 
    synchronize();
    return Success();


### PR DESCRIPTION
`startAgent()` in `SessionAssistant.cpp` sets the runtime status to `Preparing` before validating its preconditions, but several early error returns (node not found, node path missing, missing Copilot/Posit helper or agent scripts) returned without resetting it. Since the guard at the top of `startAgent()` only proceeds from `Unknown` or `Stopped`, a failure that left the status at `Preparing` caused every later start attempt to short-circuit with `Success()` -- wedging the agent for the rest of the session even after the underlying problem was corrected.

A scope guard armed right after the `Preparing` assignment resets the status to `Stopped` on any exit that leaves it stuck at `Preparing`. Deliberate outcomes are untouched: the success path reaches `Starting`/`Running`, the `runProgram` and startup-timeout failures set `Unknown`, and the install-lock refusal sets `Stopped`.

### Also included (found during review of this change)

- `synchronize()` discarded `startAgent()`'s returned error, so a start failure triggered by a preference change, project-option update, or install notification was dropped silently. It now logs the error like `ensureAgentRunning()` does.
- Three status resets (startup-timeout, initialize-failure continuation, install-notification reset) assigned `s_agentRuntimeStatus` directly instead of via `setAgentRuntimeStatus()`, so no `kAssistantStatusChanged` event reached the frontend. All three now route through the setter.

Closes #18277.

### Verification

No unit harness exists for these module statics. Verified by the repro in the issue: after correcting a misconfigured node path mid-session, the agent starts on the next completion without restarting the session.