### PR TITLE
incorporate review feedback for dependency validation

### DIFF
--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -209,7 +209,9 @@ assign(".rs.loggedMessageCache", new.env(parent = emptyenv()), envir = .rs.tools
 
    # NOTE: here, 'satisfied' means that the package dependency is satisfiable
    # by the version of the package available on CRAN, not that the dependency
-   # is already installed + satisfies the version constraint
+   # is already installed + satisfies the version constraint; when the package
+   # is not available at all, 'satisfied' instead reports whether the package
+   # is installed (see above)
    satisfied <- !nzchar(version) ||
       package_version(availableVersion) >= package_version(version)
 

--- a/src/cpp/session/modules/SessionDependencies.R
+++ b/src/cpp/session/modules/SessionDependencies.R
@@ -201,6 +201,9 @@
 # Parses DESCRIPTION-style dependency fields (e.g. "foo (>= 1.0), bar") into a
 # data frame with 'name', 'op', and 'version' columns. Entries without a version
 # requirement have empty 'op' and 'version'; the R version requirement is dropped.
+# Declared versions that package_version() cannot parse are treated as though no
+# version requirement was declared, so that a single malformed DESCRIPTION in a
+# dependency closure cannot break version comparisons downstream.
 .rs.addFunction("parsePackageDependencyFields", function(contents) {
    contents <- paste(contents[!is.na(contents)], collapse = ", ")
    entries <- trimws(strsplit(contents, ",")[[1]])
@@ -216,9 +219,16 @@
       if (length(match) < 4 || identical(match[[2]], "R"))
          next
 
+      entryOp <- match[[3]]
+      entryVersion <- match[[4]]
+      if (!grepl("^[0-9]+([.-][0-9]+)+$", entryVersion)) {
+         entryOp <- ""
+         entryVersion <- ""
+      }
+
       name <- c(name, match[[2]])
-      op <- c(op, match[[3]])
-      version <- c(version, match[[4]])
+      op <- c(op, entryOp)
+      version <- c(version, entryVersion)
    }
 
    data.frame(name = name, op = op, version = version, stringsAsFactors = FALSE)
@@ -227,19 +237,27 @@
 # Reads the runtime dependencies (Depends and Imports) declared by an installed
 # package, preferring the parsed DESCRIPTION metadata stored with the package.
 # LinkingTo is excluded, as it declares a build-time requirement rather than a
-# runtime one. Base packages are treated as having no dependencies.
+# runtime one. Base packages, and packages whose metadata cannot be read at all
+# (a warning is logged in that case), are treated as having no dependencies.
 .rs.addFunction("installedPackageDependencies", function(pkgPath) {
-   description <- tryCatch(
-      readRDS(file.path(pkgPath, "Meta", "package.rds"))$DESCRIPTION,
-      error = function(e) NULL)
-
-   if (is.null(description)) {
-      description <- tryCatch(
-         drop(read.dcf(file.path(pkgPath, "DESCRIPTION"))),
-         error = function(e) NULL)
+   metaPath <- file.path(pkgPath, "Meta", "package.rds")
+   description <- if (file.exists(metaPath)) {
+      tryCatch(readRDS(metaPath)$DESCRIPTION, error = function(e) NULL)
    }
 
-   if (is.null(description) || identical(unname(description["Priority"]), "base"))
+   descPath <- file.path(pkgPath, "DESCRIPTION")
+   if (is.null(description) && file.exists(descPath)) {
+      description <- tryCatch(drop(read.dcf(descPath)), error = function(e) NULL)
+   }
+
+   if (is.null(description)) {
+      # unreadable package metadata may mask a corrupt installation, so leave
+      # a trace rather than failing silently
+      .rs.logWarningMessage("Unable to read package metadata from '%s'", pkgPath)
+      return(.rs.parsePackageDependencyFields(character()))
+   }
+
+   if (identical(unname(description["Priority"]), "base"))
       return(.rs.parsePackageDependencyFields(character()))
 
    fields <- description[intersect(c("Depends", "Imports"), names(description))]

--- a/src/cpp/session/modules/SessionDependencies.cpp
+++ b/src/cpp/session/modules/SessionDependencies.cpp
@@ -103,62 +103,36 @@ EmbeddedPackage embeddedPackageInfo(const std::string& name)
 namespace modules {
 namespace dependencies {
 
-namespace {
-
-#define kCRANPackageDependency "cran"
-#define kEmbeddedPackageDependency "embedded"
-
-struct Dependency
+Dependency::Dependency(SEXP sexp)
 {
-   Dependency() : 
-      location(kCRANPackageDependency), 
-      source(false), 
-      versionSatisfied(true) {}
+   // Required fields
+   Error error = r::sexp::getNamedListElement(sexp, "name", &name);
+   if (error)
+      LOG_ERROR(error);
+   error = r::sexp::getNamedListElement(sexp, "version", &version);
+   if (error)
+      LOG_ERROR(error);
 
-   // Construct a new Dependency record from an S-expression containing a named list
-   Dependency(SEXP sexp)
-   {
-      // Required fields
-      Error error = r::sexp::getNamedListElement(sexp, "name", &name);
-      if (error)
-         LOG_ERROR(error);
-      error = r::sexp::getNamedListElement(sexp, "version", &version);
-      if (error)
-         LOG_ERROR(error);
+   // Optional fields; members not present in the list keep their defaults
+   r::sexp::getNamedListElement(sexp, "source", &source);
+   r::sexp::getNamedListElement(sexp, "location", &location);
+   r::sexp::getNamedListElement(sexp, "availableVersion", &availableVersion);
+   r::sexp::getNamedListElement(sexp, "versionSatisfied", &versionSatisfied);
+}
 
-      // Establish defaults
-      source = false;
-      location = "cran";
+SEXP Dependency::asSEXP(r::sexp::Protect* protect) const
+{
+   r::sexp::ListBuilder list(protect);
+   list.add("name", name);
+   list.add("location", location);
+   list.add("version", version);
+   list.add("source", source);
+   list.add("availableVersion", availableVersion);
+   list.add("versionSatisfied", versionSatisfied);
+   return r::sexp::create(list, protect);
+}
 
-      // Optional fields
-      r::sexp::getNamedListElement(sexp, "source", &source);
-      r::sexp::getNamedListElement(sexp, "location", &location);
-      r::sexp::getNamedListElement(sexp, "availableVersion", &availableVersion);
-      r::sexp::getNamedListElement(sexp, "versionSatisfied", &versionSatisfied);
-   }
-
-   bool empty() const { return name.empty(); }
-
-   // Return a version of the dependency as an S-expression for processing in R.
-   SEXP asSEXP(r::sexp::Protect *protect) const
-   {
-      r::sexp::ListBuilder list(protect);
-      list.add("name", name);
-      list.add("location", location);
-      list.add("version", version);
-      list.add("source", source);
-      list.add("availableVersion", availableVersion);
-      list.add("versionSatisfied", versionSatisfied);
-      return r::sexp::create(list, protect);
-   }
-
-   std::string location;
-   std::string name;
-   std::string version;
-   bool source;
-   std::string availableVersion;
-   bool versionSatisfied;
-};
+namespace {
 
 std::string nameFromDep(const Dependency& dep)
 {
@@ -250,9 +224,10 @@ void silentUpdateEmbeddedPackage(const EmbeddedPackage& pkg)
 // version satisfies the dependency's version requirement.
 void fillCranVersionInfo(Dependency* pDep)
 {
-   // presume package is available unless we can demonstrate otherwise
-   // (we don't want to block installation attempt unless we're
-   // reasonably confident it will not result in a viable version)
+   // the Dependency defaults presume the package is available and its
+   // version requirement satisfiable; on error we leave those defaults in
+   // place, since we don't want to block an installation attempt unless
+   // we're reasonably confident it will not result in a viable version
    r::sexp::Protect protect;
    SEXP versionInfo = R_NilValue;
 
@@ -391,7 +366,9 @@ Error unsatisfiedDependencies(const json::JsonRpcRequest& request,
    return Success();
 }
 
-// Builds an installation script which will install all the dependencies at once. 
+} // anonymous namespace
+
+// Builds an installation script which will install all the dependencies at once.
 std::string buildCombinedInstallScript(const std::vector<Dependency>& deps)
 {
    bool isRenv = module_context::isRenvActive();
@@ -461,6 +438,8 @@ std::string buildCombinedInstallScript(const std::vector<Dependency>& deps)
 
    return cmd;
 }
+
+namespace {
 
 // Builds an installation script which will install the packages one at a time. This is desirable
 // because it allows us to give much better progress and feedback during the installation process,
@@ -729,7 +708,7 @@ Error installEmbeddedPackage(const std::string& name)
    return module_context::installPackage(pkg.archivePath);
 }
 
-} // anonymous namespace
+} // namespace module_context
 
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/modules/SessionDependencies.hpp
+++ b/src/cpp/session/modules/SessionDependencies.hpp
@@ -17,6 +17,12 @@
 #define SESSION_SESSION_DEPENDENCIES_HPP
 
 #include <string>
+#include <vector>
+
+#include <r/RSexp.hpp>
+
+#define kCRANPackageDependency "cran"
+#define kEmbeddedPackageDependency "embedded"
 
 namespace rstudio {
 namespace core {
@@ -26,8 +32,34 @@ namespace core {
 
 namespace rstudio {
 namespace session {
-namespace modules { 
+namespace modules {
 namespace dependencies {
+
+struct Dependency
+{
+   Dependency() = default;
+
+   // Construct a new Dependency record from an S-expression containing a named
+   // list. Fields not present in the list keep their defaults; in particular,
+   // a dependency is presumed version-satisfied until demonstrated otherwise.
+   Dependency(SEXP sexp);
+
+   bool empty() const { return name.empty(); }
+
+   // Return a version of the dependency as an S-expression for processing in R.
+   SEXP asSEXP(r::sexp::Protect* protect) const;
+
+   std::string location = kCRANPackageDependency;
+   std::string name;
+   std::string version;
+   bool source = false;
+   std::string availableVersion;
+   bool versionSatisfied = true;
+};
+
+// Builds an installation script which will install all the dependencies at
+// once. Exposed for testing.
+std::string buildCombinedInstallScript(const std::vector<Dependency>& deps);
 
 core::Error initialize();
 

--- a/src/cpp/session/modules/SessionDependenciesTests.cpp
+++ b/src/cpp/session/modules/SessionDependenciesTests.cpp
@@ -1,0 +1,138 @@
+/*
+ * SessionDependenciesTests.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <core/system/Environment.hpp>
+
+#include <r/RSexp.hpp>
+
+#include "SessionDependencies.hpp"
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace dependencies {
+namespace {
+
+Dependency cranDependency(const std::string& name, bool source = false)
+{
+   Dependency dep;
+   dep.name = name;
+   dep.source = source;
+   return dep;
+}
+
+// Scoped override of the RENV_PROJECT environment variable, which controls
+// whether install scripts use renv::install() or utils::install.packages().
+class RenvProjectScope
+{
+public:
+   explicit RenvProjectScope(const std::string& value) :
+      saved_(core::system::getenv("RENV_PROJECT"))
+   {
+      core::system::setenv("RENV_PROJECT", value);
+   }
+
+   ~RenvProjectScope()
+   {
+      core::system::setenv("RENV_PROJECT", saved_);
+   }
+
+private:
+   std::string saved_;
+};
+
+TEST(SessionDependenciesTest, SexpConstructorDefaultsOptionalFields)
+{
+   // the runtime dependency walker returns records containing only 'name'
+   // and 'version'; all other fields must fall back to sensible defaults
+   // (in particular, versionSatisfied must not be left uninitialized)
+   r::sexp::Protect protect;
+   r::sexp::ListBuilder builder(&protect);
+   builder.add("name", std::string("foo"));
+   builder.add("version", std::string("1.0"));
+
+   Dependency dep(r::sexp::create(builder, &protect));
+
+   EXPECT_EQ(dep.name, "foo");
+   EXPECT_EQ(dep.version, "1.0");
+   EXPECT_EQ(dep.location, kCRANPackageDependency);
+   EXPECT_FALSE(dep.source);
+   EXPECT_TRUE(dep.availableVersion.empty());
+   EXPECT_TRUE(dep.versionSatisfied);
+}
+
+TEST(SessionDependenciesTest, SexpConstructorReadsOptionalFields)
+{
+   r::sexp::Protect protect;
+   Dependency original = cranDependency("foo", true);
+   original.version = "1.0";
+   original.availableVersion = "0.9";
+   original.versionSatisfied = false;
+
+   Dependency dep(original.asSEXP(&protect));
+
+   EXPECT_EQ(dep.name, "foo");
+   EXPECT_EQ(dep.version, "1.0");
+   EXPECT_EQ(dep.location, kCRANPackageDependency);
+   EXPECT_TRUE(dep.source);
+   EXPECT_EQ(dep.availableVersion, "0.9");
+   EXPECT_FALSE(dep.versionSatisfied);
+}
+
+TEST(SessionDependenciesTest, CombinedInstallScriptIsWellFormed)
+{
+   RenvProjectScope scope("");
+   std::vector<Dependency> deps = {
+      cranDependency("first"),
+      cranDependency("second")
+   };
+
+   EXPECT_EQ(buildCombinedInstallScript(deps),
+             "utils::install.packages(c('first','second'))\n\n");
+}
+
+TEST(SessionDependenciesTest, CombinedInstallScriptInstallsSourcePackagesSeparately)
+{
+   RenvProjectScope scope("");
+   std::vector<Dependency> deps = {
+      cranDependency("binary"),
+      cranDependency("compiled", true)
+   };
+
+   EXPECT_EQ(buildCombinedInstallScript(deps),
+             "utils::install.packages(c('binary'))\n\n"
+             "utils::install.packages(c('compiled'), type = 'source')\n\n");
+}
+
+TEST(SessionDependenciesTest, CombinedInstallScriptUsesRenvWhenActive)
+{
+   RenvProjectScope scope("/tmp/project");
+   std::vector<Dependency> deps = {
+      cranDependency("binary"),
+      cranDependency("compiled", true)
+   };
+
+   EXPECT_EQ(buildCombinedInstallScript(deps),
+             "renv::install(c('binary'))\n\n"
+             "options(pkgType = 'source'); renv::install(c('compiled'))\n\n");
+}
+
+} // anonymous namespace
+} // namespace dependencies
+} // namespace modules
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/tests/testthat/test-dependencies.R
+++ b/src/cpp/tests/testthat/test-dependencies.R
@@ -15,6 +15,24 @@
 
 context("dependencies")
 
+# Fabricates an installed package directory named 'name' in the library at
+# 'lib', with the given DESCRIPTION fields (e.g. Imports, LinkingTo, Priority).
+# Used to exercise the runtime dependency walker against controlled fixtures.
+fabricateInstalledPackage <- function(lib, name, ..., meta = TRUE) {
+   pkgDir <- file.path(lib, name)
+   dir.create(pkgDir, recursive = TRUE)
+
+   description <- c(Package = name, Version = "1.0", c(...))
+   write.dcf(t(as.matrix(description)), file.path(pkgDir, "DESCRIPTION"))
+
+   if (meta) {
+      dir.create(file.path(pkgDir, "Meta"))
+      saveRDS(list(DESCRIPTION = description), file.path(pkgDir, "Meta", "package.rds"))
+   }
+
+   invisible(pkgDir)
+}
+
 test_that("simple topological sort works", {
    # unsorted nodes
    nodes <- c("b", "a", "c")
@@ -207,9 +225,28 @@ test_that("dependency fields are parsed correctly", {
    expect_equal(nrow(deps), 0L)
 })
 
+test_that("malformed declared versions are treated as no version requirement", {
+   deps <- .rs.parsePackageDependencyFields("foo (>= 1.0-), bar (>= 1..0), baz (>= 1)")
+
+   expect_equal(deps$name, c("foo", "bar", "baz"))
+   expect_equal(deps$op, c("", "", ""))
+   expect_equal(deps$version, c("", "", ""))
+})
+
 test_that("packages with intact runtime dependency trees are satisfied", {
+   # base packages are treated as having no runtime dependencies
    expect_equal(.rs.findUnsatisfiedRuntimeDependencies("stats"), list())
-   expect_equal(.rs.findUnsatisfiedRuntimeDependencies("testthat"), list())
+
+   # a controlled fixture: the declared requirement is satisfied exactly
+   lib <- tempfile("library-")
+   fabricateInstalledPackage(lib, "childpkg")
+   fabricateInstalledPackage(lib, "parentpkg", Imports = "childpkg (>= 1.0)")
+
+   libPaths <- .libPaths()
+   on.exit(.libPaths(libPaths), add = TRUE)
+   .libPaths(c(lib, libPaths))
+
+   expect_equal(.rs.findUnsatisfiedRuntimeDependencies("parentpkg"), list())
 })
 
 test_that("packages which are not installed are reported as unsatisfied", {
@@ -222,15 +259,8 @@ test_that("missing and outdated runtime dependencies are reported", {
    # satisfied: one is not installed, and one is installed (utils) but cannot
    # meet the declared version requirement
    lib <- tempfile("library-")
-   pkgDir <- file.path(lib, "fakepkg")
-   dir.create(file.path(pkgDir, "Meta"), recursive = TRUE)
-
-   description <- c(
-      Package = "fakepkg",
-      Version = "1.0",
+   fabricateInstalledPackage(lib, "fakepkg",
       Imports = "missingpkg (>= 2.0), utils (>= 999.999)")
-   write.dcf(t(as.matrix(description)), file.path(pkgDir, "DESCRIPTION"))
-   saveRDS(list(DESCRIPTION = description), file.path(pkgDir, "Meta", "package.rds"))
 
    libPaths <- .libPaths()
    on.exit(.libPaths(libPaths), add = TRUE)
@@ -243,6 +273,137 @@ test_that("missing and outdated runtime dependencies are reported", {
    expect_setequal(names, c("missingpkg", "utils"))
    expect_equal(versions[names == "missingpkg"], "2.0")
    expect_equal(versions[names == "utils"], "999.999")
+})
+
+test_that("the strongest version requirement wins across multiple parents", {
+   lib <- tempfile("library-")
+   fabricateInstalledPackage(lib, "parenta", Imports = "missingpkg (>= 1.0)")
+   fabricateInstalledPackage(lib, "parentb", Imports = "missingpkg (>= 3.0)")
+
+   libPaths <- .libPaths()
+   on.exit(.libPaths(libPaths), add = TRUE)
+   .libPaths(c(lib, libPaths))
+
+   # the strongest requirement is kept regardless of visit order
+   unsatisfied <- .rs.findUnsatisfiedRuntimeDependencies(c("parenta", "parentb"))
+   expect_equal(unsatisfied, list(list(name = "missingpkg", version = "3.0")))
+
+   unsatisfied <- .rs.findUnsatisfiedRuntimeDependencies(c("parentb", "parenta"))
+   expect_equal(unsatisfied, list(list(name = "missingpkg", version = "3.0")))
+})
+
+test_that("strict version requirements are honored at the boundary", {
+   utilsVersion <- as.character(packageVersion("utils"))
+
+   lib <- tempfile("library-")
+   fabricateInstalledPackage(lib, "minpkg",
+      Imports = sprintf("utils (>= %s)", utilsVersion))
+   fabricateInstalledPackage(lib, "strictpkg",
+      Imports = sprintf("utils (> %s)", utilsVersion))
+
+   libPaths <- .libPaths()
+   on.exit(.libPaths(libPaths), add = TRUE)
+   .libPaths(c(lib, libPaths))
+
+   # '>=' is satisfied by an equal version; '>' is not
+   expect_equal(.rs.findUnsatisfiedRuntimeDependencies("minpkg"), list())
+   expect_equal(.rs.findUnsatisfiedRuntimeDependencies("strictpkg"),
+                list(list(name = "utils", version = utilsVersion)))
+})
+
+test_that("LinkingTo dependencies are not treated as runtime dependencies", {
+   lib <- tempfile("library-")
+   fabricateInstalledPackage(lib, "linkpkg", LinkingTo = "missingheaderpkg")
+
+   libPaths <- .libPaths()
+   on.exit(.libPaths(libPaths), add = TRUE)
+   .libPaths(c(lib, libPaths))
+
+   expect_equal(.rs.findUnsatisfiedRuntimeDependencies("linkpkg"), list())
+})
+
+test_that("the DESCRIPTION file is consulted when parsed metadata is missing", {
+   lib <- tempfile("library-")
+   fabricateInstalledPackage(lib, "nometapkg",
+      Imports = "missingpkg (>= 2.0)", meta = FALSE)
+
+   libPaths <- .libPaths()
+   on.exit(.libPaths(libPaths), add = TRUE)
+   .libPaths(c(lib, libPaths))
+
+   unsatisfied <- .rs.findUnsatisfiedRuntimeDependencies("nometapkg")
+   expect_equal(unsatisfied, list(list(name = "missingpkg", version = "2.0")))
+})
+
+test_that("packages with base priority are treated as having no dependencies", {
+   lib <- tempfile("library-")
+   fabricateInstalledPackage(lib, "fakebasepkg",
+      Priority = "base", Imports = "missingpkg")
+
+   libPaths <- .libPaths()
+   on.exit(.libPaths(libPaths), add = TRUE)
+   .libPaths(c(lib, libPaths))
+
+   expect_equal(.rs.findUnsatisfiedRuntimeDependencies("fakebasepkg"), list())
+})
+
+test_that("malformed version requirements do not break the walker", {
+   lib <- tempfile("library-")
+   fabricateInstalledPackage(lib, "badverpkg",
+      Imports = "missingpkg (>= 1.0-), utils (>= 1..0)")
+
+   libPaths <- .libPaths()
+   on.exit(.libPaths(libPaths), add = TRUE)
+   .libPaths(c(lib, libPaths))
+
+   # the missing package is still reported, minus its unparseable version;
+   # the malformed requirement on the installed package is ignored
+   unsatisfied <- .rs.findUnsatisfiedRuntimeDependencies("badverpkg")
+   expect_equal(unsatisfied, list(list(name = "missingpkg", version = "")))
+})
+
+test_that("unreadable package metadata is treated as no dependencies", {
+   deps <- .rs.installedPackageDependencies(tempfile("nonexistent-"))
+   expect_equal(nrow(deps), 0L)
+})
+
+test_that("packageCRANVersionAvailable checks the available version", {
+   # fabricate a package repository advertising a single package
+   repo <- tempfile("repo-")
+   contrib <- file.path(repo, "src", "contrib")
+   dir.create(contrib, recursive = TRUE)
+   writeLines(
+      c("Package: fakecranpkg", "Version: 1.5", ""),
+      file.path(contrib, "PACKAGES"))
+
+   oldRepos <- getOption("repos")
+   on.exit(options(repos = oldRepos), add = TRUE)
+   repoUrl <- paste0("file:///", sub("^/+", "", normalizePath(repo, winslash = "/")))
+   options(repos = c(CRAN = repoUrl))
+
+   # no version requirement: satisfiable
+   result <- .rs.packageCRANVersionAvailable("fakecranpkg", "", source = TRUE)
+   expect_equal(result$version, "1.5")
+   expect_true(result$satisfied)
+
+   # requirement met by the available version
+   result <- .rs.packageCRANVersionAvailable("fakecranpkg", "1.0", source = TRUE)
+   expect_true(result$satisfied)
+
+   # regression check: the required version was previously shadowed by the
+   # available version, so unsatisfiable requirements were reported satisfied
+   result <- .rs.packageCRANVersionAvailable("fakecranpkg", "2.0", source = TRUE)
+   expect_equal(result$version, "1.5")
+   expect_false(result$satisfied)
+
+   # packages missing from the repository fall back to reporting whether the
+   # package is installed
+   result <- .rs.packageCRANVersionAvailable("utils", "1.0", source = TRUE)
+   expect_equal(result$version, "")
+   expect_true(result$satisfied)
+
+   result <- .rs.packageCRANVersionAvailable("nosuchpackage54321", "1.0", source = TRUE)
+   expect_false(result$satisfied)
 })
 
 


### PR DESCRIPTION
Addresses #18199.

Follow-up to #18269, incorporating the [review feedback](https://github.com/rstudio/rstudio/pull/18269#issuecomment-5005749269) that was posted before that PR merged but never applied.

## Fixes

**Uninitialized `versionSatisfied` in `Dependency` records (finding 1).** The `Dependency(SEXP)` constructor set defaults for `source`/`location` but never `versionSatisfied`. Records from the runtime dependency walker contain only `name` and `version`, so the member was left indeterminate; if `.rs.packageCRANVersionAvailable` then errored, `fillCranVersionInfo()` early-returned and an uninitialized bool was serialized as `version_satisfied` -- nondeterministically triggering the blocking "required version not available" dialog in `DependencyManager`. The struct now uses in-class member initializers, so every construction path starts from the documented defaults.

**Malformed version requirements no longer disable the walker (finding 2).** The `[0-9.-]+` capture in `.rs.parsePackageDependencyFields` could produce strings that `package_version()` throws on (`1.0-`, `1..0`, `1`). The error propagated out of `.rs.findUnsatisfiedRuntimeDependencies`, where C++ logged it and silently skipped all recursive validation. Declared versions that don't match R's version grammar are now treated as though no version requirement was declared, at parse time -- which guards every downstream comparison, since all versions flow through the parser.

**Unreadable package metadata is no longer silent (finding 3).** When both `Meta/package.rds` and `DESCRIPTION` are unreadable, `.rs.installedPackageDependencies` now logs a warning instead of quietly treating the package as dependency-free (a corrupt installation previously produced no trace and no prompt). Both reads are also guarded with `file.exists()`, so missing files no longer leak connection warnings.

**Comment accuracy (finding 7).** Updated the `fillCranVersionInfo()` comment (defaults now genuinely exist on all paths), the `satisfied` NOTE in `.rs.packageCRANVersionAvailable` (documents the not-in-repository fallback), the `.rs.installedPackageDependencies` doc (documents the unreadable-metadata fallback), and a mislabeled namespace-closing comment.

## Tests (findings 4-6)

- New `SessionDependenciesTests.cpp` gtests cover `buildCombinedInstallScript()` (regression for the missing-paren fix, including source-package and renv variants, by toggling `RENV_PROJECT`) and the `Dependency(SEXP)` constructor defaults (regression for finding 1). `Dependency` and `buildCombinedInstallScript()` are now declared in `SessionDependencies.hpp` to make them reachable from tests.
- `test-dependencies.R` gains a regression test for the parameter-shadowing fix in `.rs.packageCRANVersionAvailable()`, driven by a fabricated local `file://` repository, plus coverage for the walker branches previously exercised only indirectly: strongest-version-wins across multiple parents, strict `>` at the equality boundary, `LinkingTo` exclusion, the `read.dcf` fallback, base-priority skip, malformed version requirements, and unreadable metadata.
- The fragile `findUnsatisfiedRuntimeDependencies("testthat") == list()` assertion (coupled to the ambient library) is replaced with a controlled two-package fixture.

No NEWS entry: these are fixes and tests for changes merged since the last release.

## Verification

- `rstudio-tests --scope rsession`: 394 tests pass (5 new).
- `rstudio-tests --scope r --filter dependencies`: 37 tests pass (was 17).
