### PR TITLE
Fix scheduled E2E runs by defaulting build_from_source to false

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-scheduled.yml
+++ b/.github/workflows/os-test-e2e-rstudio-scheduled.yml
@@ -162,7 +162,7 @@ jobs:
       project: desktop
       r_version: "release"
       grep_invert: "@ai"
-      build_from_source: ${{ inputs.build_from_source }}
+      build_from_source: ${{ inputs.build_from_source || false }}
       # Same rhel10-x86_64 .rpm the Fedora 44 engine tests -- there is no
       # separate Fedora 43 daily either.
       rstudio_installer_url: ${{ needs.resolve.outputs.rhel }}
@@ -178,7 +178,7 @@ jobs:
       project: desktop
       r_version: "release"
       grep_invert: "@ai"
-      build_from_source: ${{ inputs.build_from_source }}
+      build_from_source: ${{ inputs.build_from_source || false }}
       rstudio_installer_url: ${{ needs.resolve.outputs.rhel }}
 
   ubuntu26:
@@ -192,7 +192,7 @@ jobs:
       project: desktop
       r_version: "release"
       grep_invert: "@ai"
-      build_from_source: ${{ inputs.build_from_source }}
+      build_from_source: ${{ inputs.build_from_source || false }}
       rstudio_installer_url: ${{ needs.resolve.outputs.noble_amd64 }}
 
   ubuntu24d:
@@ -207,7 +207,7 @@ jobs:
       project: desktop
       r_version: "release"
       grep_invert: "@ai"
-      build_from_source: ${{ inputs.build_from_source }}
+      build_from_source: ${{ inputs.build_from_source || false }}
       rstudio_installer_url: ${{ needs.resolve.outputs.noble_amd64 }}
 
   ubuntu24s:
@@ -222,7 +222,7 @@ jobs:
       project: server
       r_version: "release"
       grep_invert: "@ai"
-      build_from_source: ${{ inputs.build_from_source }}
+      build_from_source: ${{ inputs.build_from_source || false }}
       rstudio_installer_url: ${{ needs.resolve.outputs.server_noble }}
 
   macos26:
@@ -237,7 +237,7 @@ jobs:
       project: desktop
       r_version: "release"
       grep_invert: "@ai"
-      build_from_source: ${{ inputs.build_from_source }}
+      build_from_source: ${{ inputs.build_from_source || false }}
       rstudio_installer_url: ${{ needs.resolve.outputs.macos }}
 
   windows2025:
@@ -252,7 +252,7 @@ jobs:
       project: desktop
       r_version: "release"
       grep_invert: "@ai"
-      build_from_source: ${{ inputs.build_from_source }}
+      build_from_source: ${{ inputs.build_from_source || false }}
       rstudio_installer_url: ${{ needs.resolve.outputs.windows }}
 
   debian13:
@@ -267,5 +267,5 @@ jobs:
       project: desktop
       r_version: "release"
       grep_invert: "@ai"
-      build_from_source: ${{ inputs.build_from_source }}
+      build_from_source: ${{ inputs.build_from_source || false }}
       rstudio_installer_url: ${{ needs.resolve.outputs.noble_arm64 }}


### PR DESCRIPTION
The scheduled OS E2E rotation passed `build_from_source: ${{ inputs.build_from_source }}` to each engine's reusable workflow. The `inputs` context only exists for `workflow_dispatch` and `workflow_call` events, so on a `schedule` trigger the expression rendered to an empty string. The engines declare `build_from_source` as a boolean input, and an empty string fails that type validation, so every selected engine's reusable call failed to start and the run was marked failed before any engine ran. Manual dispatch worked because `inputs.build_from_source` supplied the real boolean default.

This defaults the value to `false` (`${{ inputs.build_from_source || false }}`) across all eight engine blocks, so scheduled runs pass a valid boolean while manual dispatch keeps honoring the checkbox.