### PR TITLE
Stop excluding @ai tests in the E2E workflows

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
@@ -46,9 +46,9 @@ on:
         type: string
         default: ""
       grep_invert:
-        description: "Optional Playwright --grep-invert pattern to skip tests by title. Defaults to '@ai' to skip tests that require credentials not available in unattended runs."
+        description: "Optional Playwright --grep-invert pattern to skip tests by title. Empty by default (runs all tests)."
         type: string
-        default: "@ai"
+        default: ""
       rstudio_extra_args:
         description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS. Set to '--no-sandbox' if the in-container Chromium sandbox won't initialize (see the container options below)."
         type: string
@@ -86,7 +86,7 @@ on:
         default: ""
       grep_invert:
         type: string
-        default: "@ai"
+        default: ""
       rstudio_extra_args:
         type: string
         default: ""

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-43-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-43-x86_64.yml
@@ -32,9 +32,9 @@ on:
         type: string
         default: ""
       grep_invert:
-        description: "Optional Playwright --grep-invert pattern to skip tests by title. Defaults to '@ai' to skip tests that require credentials not available in unattended runs."
+        description: "Optional Playwright --grep-invert pattern to skip tests by title. Empty by default (runs all tests)."
         type: string
-        default: "@ai"
+        default: ""
       rstudio_extra_args:
         description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS. Set to '--no-sandbox' if the in-container Chromium sandbox won't initialize (see the container options below)."
         type: string
@@ -72,7 +72,7 @@ on:
         default: ""
       grep_invert:
         type: string
-        default: "@ai"
+        default: ""
       rstudio_extra_args:
         type: string
         default: ""

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
@@ -32,9 +32,9 @@ on:
         type: string
         default: ""
       grep_invert:
-        description: "Optional Playwright --grep-invert pattern to skip tests by title. Defaults to '@ai' to skip tests that require credentials not available in unattended runs."
+        description: "Optional Playwright --grep-invert pattern to skip tests by title. Empty by default (runs all tests)."
         type: string
-        default: "@ai"
+        default: ""
       rstudio_extra_args:
         description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS. Set to '--no-sandbox' if the in-container Chromium sandbox won't initialize (see the container options below)."
         type: string
@@ -72,7 +72,7 @@ on:
         default: ""
       grep_invert:
         type: string
-        default: "@ai"
+        default: ""
       rstudio_extra_args:
         type: string
         default: ""

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-scheduled.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64-scheduled.yml
@@ -22,4 +22,3 @@ jobs:
     with:
       project: desktop
       r_version: "release"
-      grep_invert: "@ai"

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -32,9 +32,9 @@ on:
         type: string
         default: ""
       grep_invert:
-        description: "Optional Playwright --grep-invert pattern to skip tests by title. Defaults to '@ai' to skip tests that require credentials not available in unattended runs."
+        description: "Optional Playwright --grep-invert pattern to skip tests by title. Empty by default (runs all tests)."
         type: string
-        default: "@ai"
+        default: ""
       rstudio_extra_args:
         description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS."
         type: string
@@ -72,7 +72,7 @@ on:
         default: ""
       grep_invert:
         type: string
-        default: "@ai"
+        default: ""
       rstudio_extra_args:
         type: string
         default: ""

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-rhel-10-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-rhel-10-x86_64.yml
@@ -32,9 +32,9 @@ on:
         type: string
         default: ""
       grep_invert:
-        description: "Optional Playwright --grep-invert pattern to skip tests by title. Defaults to '@ai' to skip tests that require credentials not available in unattended runs."
+        description: "Optional Playwright --grep-invert pattern to skip tests by title. Empty by default (runs all tests)."
         type: string
-        default: "@ai"
+        default: ""
       rstudio_extra_args:
         description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS. Set to '--no-sandbox' if the in-container Chromium sandbox won't initialize (see the container options below)."
         type: string
@@ -72,7 +72,7 @@ on:
         default: ""
       grep_invert:
         type: string
-        default: "@ai"
+        default: ""
       rstudio_extra_args:
         type: string
         default: ""

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24-scheduled.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24-scheduled.yml
@@ -24,4 +24,3 @@ jobs:
     with:
       project: desktop
       r_version: "release"
-      grep_invert: "@ai"

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
@@ -32,9 +32,9 @@ on:
         type: string
         default: ""
       grep_invert:
-        description: "Optional Playwright --grep-invert pattern to skip tests by title. Defaults to '@ai' to skip tests that require credentials not available in unattended runs."
+        description: "Optional Playwright --grep-invert pattern to skip tests by title. Empty by default (runs all tests)."
         type: string
-        default: "@ai"
+        default: ""
       rstudio_extra_args:
         description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS."
         type: string
@@ -72,7 +72,7 @@ on:
         default: ""
       grep_invert:
         type: string
-        default: "@ai"
+        default: ""
       rstudio_extra_args:
         type: string
         default: ""

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
@@ -32,9 +32,9 @@ on:
         type: string
         default: ""
       grep_invert:
-        description: "Optional Playwright --grep-invert pattern to skip tests by title. Defaults to '@ai' to skip tests that require credentials not available in unattended runs."
+        description: "Optional Playwright --grep-invert pattern to skip tests by title. Empty by default (runs all tests)."
         type: string
-        default: "@ai"
+        default: ""
       rstudio_extra_args:
         description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS."
         type: string
@@ -72,7 +72,7 @@ on:
         default: ""
       grep_invert:
         type: string
-        default: "@ai"
+        default: ""
       rstudio_extra_args:
         type: string
         default: ""

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025-scheduled.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025-scheduled.yml
@@ -26,4 +26,3 @@ jobs:
     with:
       project: desktop
       r_version: "release"
-      grep_invert: "@ai"

--- a/.github/workflows/os-test-e2e-rstudio-pr.yml
+++ b/.github/workflows/os-test-e2e-rstudio-pr.yml
@@ -156,7 +156,6 @@ jobs:
       build_from_source: ${{ fromJSON(needs.detect-changes.outputs.windows_build_from_source) }}
       project: desktop
       r_version: "4.5.3"
-      grep_invert: "@ai"
       # Suppress each platform's own merge/publish/comment; the e2e-merge-all
       # job below combines every platform's blobs into a single report + comment.
       defer_merge: true
@@ -171,7 +170,6 @@ jobs:
       build_from_source: ${{ fromJSON(needs.detect-changes.outputs.macos_build_from_source) }}
       project: desktop
       r_version: "4.5.3"
-      grep_invert: "@ai"
       # Suppress each platform's own merge/publish/comment; the e2e-merge-all
       # job below combines every platform's blobs into a single report + comment.
       defer_merge: true
@@ -186,7 +184,6 @@ jobs:
       build_from_source: ${{ fromJSON(needs.detect-changes.outputs.linux_desktop_build_from_source) }}
       project: desktop
       r_version: "4.5.3"
-      grep_invert: "@ai"
       # Suppress each platform's own merge/publish/comment; the e2e-merge-all
       # job below combines every platform's blobs into a single report + comment.
       defer_merge: true
@@ -201,7 +198,6 @@ jobs:
       build_from_source: ${{ fromJSON(needs.detect-changes.outputs.linux_server_build_from_source) }}
       project: server
       r_version: "4.5.3"
-      grep_invert: "@ai"
       # Suppress each platform's own merge/publish/comment; the e2e-merge-all
       # job below combines every platform's blobs into a single report + comment.
       defer_merge: true

--- a/.github/workflows/os-test-e2e-rstudio-scheduled.yml
+++ b/.github/workflows/os-test-e2e-rstudio-scheduled.yml
@@ -161,7 +161,6 @@ jobs:
     with:
       project: desktop
       r_version: "release"
-      grep_invert: "@ai"
       build_from_source: ${{ inputs.build_from_source || false }}
       # Same rhel10-x86_64 .rpm the Fedora 44 engine tests -- there is no
       # separate Fedora 43 daily either.
@@ -177,7 +176,6 @@ jobs:
     with:
       project: desktop
       r_version: "release"
-      grep_invert: "@ai"
       build_from_source: ${{ inputs.build_from_source || false }}
       rstudio_installer_url: ${{ needs.resolve.outputs.rhel }}
 
@@ -191,7 +189,6 @@ jobs:
     with:
       project: desktop
       r_version: "release"
-      grep_invert: "@ai"
       build_from_source: ${{ inputs.build_from_source || false }}
       rstudio_installer_url: ${{ needs.resolve.outputs.noble_amd64 }}
 
@@ -206,7 +203,6 @@ jobs:
     with:
       project: desktop
       r_version: "release"
-      grep_invert: "@ai"
       build_from_source: ${{ inputs.build_from_source || false }}
       rstudio_installer_url: ${{ needs.resolve.outputs.noble_amd64 }}
 
@@ -221,7 +217,6 @@ jobs:
     with:
       project: server
       r_version: "release"
-      grep_invert: "@ai"
       build_from_source: ${{ inputs.build_from_source || false }}
       rstudio_installer_url: ${{ needs.resolve.outputs.server_noble }}
 
@@ -236,7 +231,6 @@ jobs:
     with:
       project: desktop
       r_version: "release"
-      grep_invert: "@ai"
       build_from_source: ${{ inputs.build_from_source || false }}
       rstudio_installer_url: ${{ needs.resolve.outputs.macos }}
 
@@ -251,7 +245,6 @@ jobs:
     with:
       project: desktop
       r_version: "release"
-      grep_invert: "@ai"
       build_from_source: ${{ inputs.build_from_source || false }}
       rstudio_installer_url: ${{ needs.resolve.outputs.windows }}
 
@@ -266,6 +259,5 @@ jobs:
     with:
       project: desktop
       r_version: "release"
-      grep_invert: "@ai"
       build_from_source: ${{ inputs.build_from_source || false }}
       rstudio_installer_url: ${{ needs.resolve.outputs.noble_arm64 }}

--- a/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24-scheduled.yml
+++ b/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24-scheduled.yml
@@ -22,4 +22,3 @@ jobs:
     with:
       project: server
       r_version: "release"
-      grep_invert: "@ai"

--- a/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -32,9 +32,9 @@ on:
         type: string
         default: ""
       grep_invert:
-        description: "Optional Playwright --grep-invert pattern to skip tests by title. Defaults to '@ai' to skip tests that require credentials not available in unattended runs."
+        description: "Optional Playwright --grep-invert pattern to skip tests by title. Empty by default (runs all tests)."
         type: string
-        default: "@ai"
+        default: ""
       build_only:
         description: "Run only the build job (to seed the rstudio-tools / R-libs / sccache caches) and skip the e2e job."
         type: boolean
@@ -68,7 +68,7 @@ on:
         default: ""
       grep_invert:
         type: string
-        default: "@ai"
+        default: ""
       build_only:
         type: boolean
         default: false


### PR DESCRIPTION
## Summary

The E2E callers (PR-triggered and scheduled) and the per-OS engine defaults all passed `grep_invert: "@ai"`, which filtered out the `@ai`-tagged Posit AI and Copilot tests in every automated run. This removes that exclusion end to end:

- Callers no longer pass `grep_invert: "@ai"` (the PR caller, the scheduled orchestrator, and the four old per-OS `-scheduled.yml` callers), so they inherit the engine default.
- The eight per-OS engines that defaulted `grep_invert` to `"@ai"` now default to empty (`windows-server-2025` was already empty). Descriptions updated to match.

With the exclusion gone, the previously-filtered tests are now collected in each run. The tests that require a Posit AI login skip cleanly via `requireAiCredentials()` when no login is present (as in CI today), and will execute once Posit AI credentials are wired into CI. Validated on a manual Ubuntu 24 dispatch: 0 failures, with the Posit-AI-login tests skipping as expected.
