### PR TITLE
Raise dialogs created by rsession above the RStudio window on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@
 - ([#18260](https://github.com/rstudio/rstudio/issues/18260)): Fixed an issue on macOS where a file change landing just after a bulk change of many files could go undetected by the Files and Git panes until a manual refresh or unrelated later file activity.
 - ([#18273](https://github.com/rstudio/rstudio/issues/18273)): Fixed an issue on Windows where a failure to load the Start Menu Git shortcut while auto-detecting the Git installation went undetected, causing detection to fail later with a less accurate error.
 - ([#18277](https://github.com/rstudio/rstudio/issues/18277)): Fixed an issue where the GitHub Copilot or Posit Assistant agent could fail to start for the rest of the session after an early startup failure (for example, a misconfigured Node.js path). The agent now retries and starts once the underlying problem is corrected, without restarting the session.
+- ([#18270](https://github.com/rstudio/rstudio/issues/18270)): Fixed an issue on Windows where native dialogs shown by R (e.g. via `utils::askYesNo()`, or when `install.packages()` asks about installing from sources) could open behind the RStudio Desktop window, making the IDE appear frozen while R waited on a dialog the user could not see.
 
 ### Dependencies
 - MathJax 4.1.3 (inline LaTeX / math previews)

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -20,6 +20,7 @@ import { Err, safeError } from '../core/err';
 import { logger } from '../core/logger';
 
 import i18next from 'i18next';
+import desktop from '../native/desktop.node';
 import { setDockLabel } from '../native/dock.node';
 import { appState, getEventBus } from './app-state';
 import { ApplicationLaunch, LaunchRStudioOptions } from './application-launch';
@@ -306,6 +307,18 @@ export class MainWindow extends GwtWindow {
 
   setSessionProcess(sessionProcess: ChildProcess | undefined): void {
     this.sessionProcess = sessionProcess;
+
+    // on Windows, dialogs created by the rsession process (e.g. via
+    // utils::askYesNo()) can open behind the RStudio window, leaving the
+    // IDE seemingly frozen while R waits on a dialog the user cannot see
+    // (https://github.com/rstudio/rstudio/issues/18270)
+    if (process.platform === 'win32') {
+      if (sessionProcess?.pid) {
+        desktop.win32WatchSessionDialogs(sessionProcess.pid);
+      } else {
+        desktop.win32StopWatchingSessionDialogs();
+      }
+    }
   }
 
   closeEvent(event: Electron.Event): void {

--- a/src/node/desktop/src/native/desktop.node.d.ts
+++ b/src/node/desktop/src/native/desktop.node.d.ts
@@ -71,6 +71,25 @@ export declare function openExternal(path: string): void;
 export declare function win32ListMonospaceFonts(): string[];
 
 /**
+ * (Windows only)
+ *
+ * Watch for native dialogs created by the given process, raising them
+ * above our windows. Used so that dialogs shown by the rsession process
+ * (e.g. via utils::askYesNo()) don't open behind the RStudio window.
+ * Replaces any watch registered by a previous call.
+ *
+ * @param pid The process to watch (normally the rsession process).
+ */
+export declare function win32WatchSessionDialogs(pid: number): void;
+
+/**
+ * (Windows only)
+ *
+ * Stop watching for session dialogs. Safe to call when no watch is active.
+ */
+export declare function win32StopWatchingSessionDialogs(): void;
+
+/**
  * (macOS only)
  *
  * List all fonts available on the system in a single pass.

--- a/src/node/desktop/src/native/desktop.node.d.ts
+++ b/src/node/desktop/src/native/desktop.node.d.ts
@@ -73,12 +73,14 @@ export declare function win32ListMonospaceFonts(): string[];
 /**
  * (Windows only)
  *
- * Watch for native dialogs created by the given process, raising them
- * above our windows. Used so that dialogs shown by the rsession process
- * (e.g. via utils::askYesNo()) don't open behind the RStudio window.
- * Replaces any watch registered by a previous call.
+ * Watch for native dialogs created by the given process, raising each new
+ * dialog above our windows. Replaces any watch registered by a previous
+ * call. Must be called from the Electron main thread (events are delivered
+ * via its message loop); failure to install the watch is silent (logged
+ * only when RS_LOG_LEVEL=debug).
  *
- * @param pid The process to watch (normally the rsession process).
+ * @param pid The process to watch. A pid of 0 stops any existing watch
+ *   without registering a new one.
  */
 export declare function win32WatchSessionDialogs(pid: number): void;
 

--- a/src/node/desktop/src/native/desktop/desktop.cc
+++ b/src/node/desktop/src/native/desktop/desktop.cc
@@ -903,7 +903,11 @@ HWINEVENTHOOK s_sessionDialogHook = nullptr;
 void CALLBACK onSessionDialogStart(HWINEVENTHOOK, DWORD, HWND hwnd, LONG, LONG, DWORD, DWORD)
 {
    DLOG("Raising dialog created by watched process (hwnd " << hwnd << ")");
-   ::BringWindowToTop(hwnd);
+   if (!::BringWindowToTop(hwnd))
+   {
+      DWORD error = ::GetLastError();
+      DLOG("Error " << error << " raising dialog (hwnd " << hwnd << "): " << getErrorMessage(error));
+   }
 }
 
 void win32StopWatchingSessionDialogsImpl()
@@ -927,6 +931,7 @@ Napi::Value win32WatchSessionDialogs(const Napi::CallbackInfo& info)
    win32StopWatchingSessionDialogsImpl();
 
    // a process id of 0 would tell SetWinEventHook to watch all processes
+   // on the current desktop
    if (processId != 0)
    {
       // WINEVENT_OUTOFCONTEXT delivers events via this thread's message
@@ -938,6 +943,16 @@ Napi::Value win32WatchSessionDialogs(const Napi::CallbackInfo& info)
           processId,
           0,
           WINEVENT_OUTOFCONTEXT);
+
+      if (s_sessionDialogHook == nullptr)
+      {
+         DWORD error = ::GetLastError();
+         DLOG("Error " << error << " watching for dialogs from process " << processId << ": " << getErrorMessage(error));
+      }
+      else
+      {
+         DLOG("Watching for dialogs created by process " << processId);
+      }
    }
 #endif
 

--- a/src/node/desktop/src/native/desktop/desktop.cc
+++ b/src/node/desktop/src/native/desktop/desktop.cc
@@ -896,6 +896,67 @@ namespace {
 
 #ifdef _WIN32
 
+// Hook watching for dialogs created by the rsession process; see
+// win32WatchSessionDialogs().
+HWINEVENTHOOK s_sessionDialogHook = nullptr;
+
+void CALLBACK onSessionDialogStart(HWINEVENTHOOK, DWORD, HWND hwnd, LONG, LONG, DWORD, DWORD)
+{
+   DLOG("Raising dialog created by watched process (hwnd " << hwnd << ")");
+   ::BringWindowToTop(hwnd);
+}
+
+void win32StopWatchingSessionDialogsImpl()
+{
+   if (s_sessionDialogHook != nullptr)
+   {
+      ::UnhookWinEvent(s_sessionDialogHook);
+      s_sessionDialogHook = nullptr;
+   }
+}
+
+#endif
+
+} // end anonymous namespace
+
+Napi::Value win32WatchSessionDialogs(const Napi::CallbackInfo& info)
+{
+#ifdef _WIN32
+   DWORD processId = info[0].As<Napi::Number>().Uint32Value();
+
+   win32StopWatchingSessionDialogsImpl();
+
+   // a process id of 0 would tell SetWinEventHook to watch all processes
+   if (processId != 0)
+   {
+      // WINEVENT_OUTOFCONTEXT delivers events via this thread's message
+      // loop (Electron's main thread), so no DLL injection is involved
+      s_sessionDialogHook = ::SetWinEventHook(
+          EVENT_SYSTEM_DIALOGSTART, EVENT_SYSTEM_DIALOGSTART,
+          nullptr,
+          onSessionDialogStart,
+          processId,
+          0,
+          WINEVENT_OUTOFCONTEXT);
+   }
+#endif
+
+   return Napi::Value();
+}
+
+Napi::Value win32StopWatchingSessionDialogs(const Napi::CallbackInfo& info)
+{
+#ifdef _WIN32
+   win32StopWatchingSessionDialogsImpl();
+#endif
+
+   return Napi::Value();
+}
+
+namespace {
+
+#ifdef _WIN32
+
 int CALLBACK win32ListMonospaceFontsProc(
     ENUMLOGFONTEX* lpelfe,
     NEWTEXTMETRICEX* lpntme,
@@ -1005,6 +1066,8 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
    RS_EXPORT_FUNCTION("searchRegistryForDefaultInstallationOfR", rstudio::desktop::searchRegistryForDefaultInstallationOfR);
    RS_EXPORT_FUNCTION("openExternal", rstudio::desktop::openExternal);
    RS_EXPORT_FUNCTION("win32ListMonospaceFonts", rstudio::desktop::win32ListMonospaceFonts);
+   RS_EXPORT_FUNCTION("win32WatchSessionDialogs", rstudio::desktop::win32WatchSessionDialogs);
+   RS_EXPORT_FUNCTION("win32StopWatchingSessionDialogs", rstudio::desktop::win32StopWatchingSessionDialogs);
    RS_EXPORT_FUNCTION("macOSListFonts", rstudio::desktop::macOSListFonts);
 
    return exports;

--- a/src/node/desktop/test/unit/main/main-window.test.ts
+++ b/src/node/desktop/test/unit/main/main-window.test.ts
@@ -13,11 +13,66 @@
  *
  */
 
+import { assert } from 'chai';
 import { describe } from 'mocha';
-//import { assert } from 'chai';
+import sinon from 'sinon';
 
-//import { MainWindow } from '../../../src/main/main-window';
+import { ChildProcess } from 'child_process';
+
+import { MainWindow } from '../../../src/main/main-window';
+import desktop from '../../../src/native/desktop.node';
 
 describe('MainWindow', () => {
-  // currently can't instantiate a MainWindow during unit tests due to problems with GwtCallback
+  // MainWindow can't be instantiated in unit tests (GwtCallback needs a live
+  // window), so setSessionProcess is invoked against a bare object instead.
+  describe('setSessionProcess', () => {
+    function setSessionProcess(sessionProcess?: { pid?: number }): void {
+      MainWindow.prototype.setSessionProcess.call({} as MainWindow, sessionProcess as ChildProcess | undefined);
+    }
+
+    let watchStub: sinon.SinonStub;
+    let stopStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      watchStub = sinon.stub(desktop, 'win32WatchSessionDialogs');
+      stopStub = sinon.stub(desktop, 'win32StopWatchingSessionDialogs');
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('watches the session pid (win32)', () => {
+      setSessionProcess({ pid: 1234 });
+      if (process.platform === 'win32') {
+        assert.isTrue(watchStub.calledOnceWithExactly(1234));
+      } else {
+        assert.isTrue(watchStub.notCalled);
+      }
+      assert.isTrue(stopStub.notCalled);
+    });
+
+    it('stops watching when the session process is cleared (win32)', () => {
+      setSessionProcess(undefined);
+      assert.isTrue(watchStub.notCalled);
+      if (process.platform === 'win32') {
+        assert.isTrue(stopStub.calledOnce);
+      } else {
+        assert.isTrue(stopStub.notCalled);
+      }
+    });
+
+    it('never watches a falsy pid (win32)', () => {
+      // pid is undefined when spawn fails; a pid of 0 must never reach the
+      // native watch, where it would mean "watch all processes"
+      setSessionProcess({ pid: undefined });
+      setSessionProcess({ pid: 0 });
+      assert.isTrue(watchStub.notCalled);
+      if (process.platform === 'win32') {
+        assert.isTrue(stopStub.calledTwice);
+      } else {
+        assert.isTrue(stopStub.notCalled);
+      }
+    });
+  });
 });

--- a/src/node/desktop/test/unit/native/desktop.test.ts
+++ b/src/node/desktop/test/unit/native/desktop.test.ts
@@ -101,4 +101,25 @@ describe('Desktop Native Code', () => {
     desktop.cleanClipboard(false);
     assert.equal(clipboard.readHTML('clipboard'), expected);
   });
+
+  // The dialog watcher's observable behavior (raising rsession dialogs above
+  // the RStudio window) needs a live rsession showing a Win32 dialog, so these
+  // tests only exercise the exported API surface across its lifecycle.
+  describe('win32 session dialog watcher', () => {
+    it('watch followed by stop does not throw', () => {
+      desktop.win32WatchSessionDialogs(process.pid);
+      desktop.win32StopWatchingSessionDialogs();
+    });
+
+    it('watching again replaces an existing hook without error', () => {
+      desktop.win32WatchSessionDialogs(process.pid);
+      desktop.win32WatchSessionDialogs(process.pid);
+      desktop.win32StopWatchingSessionDialogs();
+    });
+
+    it('stop without a prior watch is a no-op', () => {
+      desktop.win32StopWatchingSessionDialogs();
+      desktop.win32StopWatchingSessionDialogs();
+    });
+  });
 });

--- a/src/node/desktop/test/unit/native/desktop.test.ts
+++ b/src/node/desktop/test/unit/native/desktop.test.ts
@@ -111,7 +111,7 @@ describe('Desktop Native Code', () => {
       desktop.win32StopWatchingSessionDialogs();
     });
 
-    it('watching again replaces an existing hook without error', () => {
+    it('watching again with an active hook does not throw', () => {
       desktop.win32WatchSessionDialogs(process.pid);
       desktop.win32WatchSessionDialogs(process.pid);
       desktop.win32StopWatchingSessionDialogs();


### PR DESCRIPTION
Fixes #18270.

## Summary

On Windows, native modal dialogs shown by R (e.g. `utils::askYesNo()`, including the "Do you want to install from sources...?" prompt from `install.packages()`) belong to the rsession process, so Windows can open them behind the RStudio Desktop window. The IDE then appears frozen while R blocks on a dialog the user cannot see. This was fixed for the Qt desktop in #2916 but was not ported when RStudio Desktop moved to Electron.

This ports that fix to the Electron desktop:

- `desktop.node` (N-API module) gains `win32WatchSessionDialogs(pid)` / `win32StopWatchingSessionDialogs()`. The watcher installs a `SetWinEventHook` for `EVENT_SYSTEM_DIALOGSTART` scoped to the given process id and raises each new dialog with `BringWindowToTop`, exactly as the Qt fix did. The hook uses `WINEVENT_OUTOFCONTEXT`, so events are delivered via the Electron main thread's message loop with no DLL injection.
- `MainWindow.setSessionProcess()` starts watching the rsession pid whenever a session process is set (including session restarts) and stops watching when it is cleared — the direct equivalent of where the Qt fix lived.

On non-Windows platforms the new functions are no-ops.

## Testing

- Unit tests cover the exported API surface (watch/stop lifecycle, re-watch with an active hook, stop without watch) and the `MainWindow.setSessionProcess()` wiring (watch on valid pid, stop on clear, falsy pids never reach the native watch).
- Verified event delivery end-to-end with a standalone Electron harness: a child process showing a `MessageBox` triggers the hook callback on the Electron main thread (confirmed via debug log) and the dialog is raised above the app window.
- Manually verified on a full Windows build: dialogs shown by R (e.g. `utils:::askYesNo()`) now appear in front of the RStudio window.

## QA Notes

With `RS_LOG_LEVEL=debug`, the desktop process logs `Raising dialog created by watched process (hwnd ...)` to stderr whenever the hook fires.
