### PR TITLE
Update Electron to 42.7.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,4 +32,4 @@
 ### Dependencies
 - MathJax 4.1.3 (inline LaTeX / math previews)
 - Copilot Language Server 1.520.0
-- Electron 41.10.2
+- Electron 42.7.0

--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -48,7 +48,7 @@
         "chai": "6.2.2",
         "copy-webpack-plugin": "14.0.0",
         "css-loader": "7.1.4",
-        "electron": "41.10.2",
+        "electron": "42.7.0",
         "electron-mocha": "13.1.0",
         "eslint": "10.7.0",
         "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -5926,11 +5926,10 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "41.10.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.10.2.tgz",
-      "integrity": "sha512-vzSetbn05LPfg0gW0p9txpqmkkFyTXzdSHvKIXbtmsK362hkgUQJu+x19GSSS9v/VXeFi5UJI5TYJ1a+Os3CpA==",
+      "version": "42.7.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.7.0.tgz",
+      "integrity": "sha512-Uu5p03M5o7aqulT8QxFYYg3eJVDfuNEUuasBU1qFl05ghVRRH7UHL7na8S3GhxVScZQ2D7j9DCMsc+qT5FuxtQ==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron-internal/extract-zip": "^1.0.1",
@@ -5938,7 +5937,8 @@
         "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
         "node": ">= 22.12.0"

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -57,7 +57,7 @@
     "chai": "6.2.2",
     "copy-webpack-plugin": "14.0.0",
     "css-loader": "7.1.4",
-    "electron": "41.10.2",
+    "electron": "42.7.0",
     "electron-mocha": "13.1.0",
     "eslint": "10.7.0",
     "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -97,7 +97,7 @@
     "winston-syslog": "2.7.1"
   },
   "allowScripts": {
-    "electron@41.10.2": true,
+    "electron@42.7.0": true,
     "msgpackr-extract@3.0.3": true,
     "unix-dgram@2.0.6": true
   }


### PR DESCRIPTION
Updates the pinned Electron version from 41.10.2 to 42.7.0.

- `NEWS.md`: bump the Electron entry in the Dependencies section.
- `src/node/desktop/package.json`: pin `electron` to exact `42.7.0` and update the `allowScripts` key to `electron@42.7.0`.
- `src/node/desktop/package-lock.json`: regenerated to resolve `electron-42.7.0`.

Desktop unit tests (`npm test`) pass (428 passing).