### PR TITLE
surface state folder permission errors at startup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 - ([#18198](https://github.com/rstudio/rstudio/issues/18198)): Fixed tar errors and warnings printed to the console after installing a package from a URL with `install.packages(..., repos = NULL)`.
 - ([#18197](https://github.com/rstudio/rstudio/issues/18197)): Fixed an issue where the Render button failed to render a Quarto document living within a sub-directory of a Quarto project.
 - ([#18208](https://github.com/rstudio/rstudio/issues/18208)): Fixed an issue in RStudio Server where requests could fail with "Unable to connect to service" for 30 seconds or more while a suspended session was relaunching.
+- ([#18179](https://github.com/rstudio/rstudio/issues/18179)): RStudio Desktop now shows an error dialog at startup when folders it needs to write (e.g. `~/.local/share/rstudio`) cannot be created or written, instead of failing silently, and log messages now fall back to stderr when the log directory is not writable.
 - ([#17650](https://github.com/rstudio/rstudio/issues/17650)): Fixed unreadable label text in dark modal dialogs when using third-party themes (e.g. rsthemes) that style dialog labels for light backgrounds.
 - ([#18215](https://github.com/rstudio/rstudio/issues/18215)): Fixed an issue where the Data Viewer could lose its scroll position, or render an empty grid, after switching to another tab and back.
 - ([#18221](https://github.com/rstudio/rstudio/issues/18221)): Fixed an issue on Windows where scrolling the Data Viewer with the mouse wheel could get stuck when the pointer was over the table body.

--- a/src/cpp/core/LoggingTests.cpp
+++ b/src/cpp/core/LoggingTests.cpp
@@ -18,6 +18,8 @@
 #include <core/Log.hpp>
 #include <core/LogOptions.hpp>
 
+#include <shared_core/FileLogDestination.hpp>
+
 #include <core/FileSerializer.hpp>
 #include <core/system/Environment.hpp>
 #include <core/system/System.hpp>
@@ -29,8 +31,13 @@
 
 #include <boost/algorithm/string.hpp>
 
-#include <sstream>
 #include <iomanip>
+#include <iostream>
+#include <sstream>
+
+#ifndef _WIN32
+#include <sys/stat.h>
+#endif
 
 namespace rstudio {
 namespace core {
@@ -981,6 +988,46 @@ TEST(LoggingTest, FileLogsAreCreatedWithCorrectPermissions)
    Error err3 = logFile.getFileMode(mode3);
    ASSERT_FALSE(err3);
    ASSERT_EQ(FileMode::USER_READ_WRITE, mode3);
+}
+
+TEST(LoggingTest, FileLogFallsBackToStderrWhenDirectoryNotWritable)
+{
+   // https://github.com/rstudio/rstudio/issues/18179
+   FilePath tmpPath;
+   ASSERT_FALSE(FilePath::tempFilePath(tmpPath));
+   ASSERT_FALSE(tmpPath.ensureDirectory());
+
+   FilePath logDir = tmpPath.completeChildPath("readonly-logs");
+   ASSERT_FALSE(logDir.ensureDirectory());
+   ASSERT_EQ(0, ::chmod(logDir.getAbsolutePath().c_str(), 0500));
+
+   log::FileLogOptions options(logDir);
+   log::FileLogDestination destination(
+      "stderr-fallback-test",
+      log::LogLevel::WARN,
+      log::LogMessageFormatType::PRETTY,
+      "logging-tests-stderr-fallback",
+      options,
+      false);
+
+   std::ostringstream captured;
+   std::streambuf* previous = std::cerr.rdbuf(captured.rdbuf());
+   destination.writeLog(log::LogLevel::ERR, "first fallback message\n");
+   destination.writeLog(log::LogLevel::ERR, "second fallback message\n");
+   std::cerr.rdbuf(previous);
+
+   // both messages should have been emitted on stderr rather than dropped
+   std::string output = captured.str();
+   EXPECT_NE(std::string::npos, output.find("first fallback message"));
+   EXPECT_NE(std::string::npos, output.find("second fallback message"));
+
+   // the notice explaining the fallback should be emitted exactly once
+   size_t noticePos = output.find("falling back to stderr");
+   ASSERT_NE(std::string::npos, noticePos);
+   EXPECT_EQ(std::string::npos, output.find("falling back to stderr", noticePos + 1));
+
+   ASSERT_EQ(0, ::chmod(logDir.getAbsolutePath().c_str(), 0700));
+   ASSERT_FALSE(tmpPath.remove());
 }
 #endif
 

--- a/src/cpp/core/include/core/system/Xdg.hpp
+++ b/src/cpp/core/include/core/system/Xdg.hpp
@@ -84,8 +84,9 @@ FilePath oldUserCacheDir(
 
 #endif
 
-// This function verifies that the userConfigDir() and userDataDir() exist and are owned by the running user.
-// 
+// This function verifies that the userConfigDir(), userDataDir(), and the user log directory
+// exist and are writable by the running user.
+//
 // It should be invoked once. Any issues with these directories will be emitted to the session log.
 void verifyUserDirs(const boost::optional<std::string>& user = boost::none,
                     const boost::optional<FilePath>& homeDir = boost::none);

--- a/src/cpp/core/system/Xdg.cpp
+++ b/src/cpp/core/system/Xdg.cpp
@@ -393,6 +393,10 @@ void verifyUserDirs(
 
    testDir(userConfigDir(user, homeDir), ERROR_LOCATION);
    testDir(userDataDir(user, homeDir), ERROR_LOCATION);
+
+   // the session always writes its logs beneath the data directory (the log
+   // location is forced in SessionMain); an unwritable log directory made
+   // startup fail with no visible error (https://github.com/rstudio/rstudio/issues/18179)
    testDir(userDataDir(user, homeDir).completePath("log"), ERROR_LOCATION);
 #endif
 }

--- a/src/cpp/core/system/Xdg.cpp
+++ b/src/cpp/core/system/Xdg.cpp
@@ -393,6 +393,7 @@ void verifyUserDirs(
 
    testDir(userConfigDir(user, homeDir), ERROR_LOCATION);
    testDir(userDataDir(user, homeDir), ERROR_LOCATION);
+   testDir(userDataDir(user, homeDir).completePath("log"), ERROR_LOCATION);
 #endif
 }
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -27,6 +27,7 @@
 #include <unistd.h>
 #endif
 
+#include <iostream>
 #include <string>
 #include <vector>
 #include <cstdlib>
@@ -1899,7 +1900,15 @@ int sessionExitFailure(const core::Error& error,
                        const core::ErrorLocation& location)
 {
    if (error)
+   {
       core::log::logError(error, location);
+
+      // also write the error to stderr, so it remains visible even when file
+      // logging is unavailable (e.g. an unwritable log directory); the desktop
+      // frontend surfaces rsession's stderr on its launch-failed error page
+      std::cerr << "rsession startup failed: " << error.asString() << std::endl;
+   }
+
    return EXIT_FAILURE;
 }
 

--- a/src/cpp/shared_core/FileLogDestination.cpp
+++ b/src/cpp/shared_core/FileLogDestination.cpp
@@ -23,6 +23,8 @@
 
 #include <shared_core/FileLogDestination.hpp>
 
+#include <iostream>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/thread.hpp>
 
@@ -276,6 +278,25 @@ struct FileLogDestination::Impl
          LogOutputStream->flush();
          LogOutputStream.reset();
       }
+   }
+
+   // Invoked when the log file cannot be written (e.g. because the log
+   // directory is not writable). Rather than dropping the message, emit it on
+   // stderr so it remains visible to the parent process or system journal.
+   void writeToStderrFallback(const std::string& in_message)
+   {
+      if (!StderrFallbackNotified)
+      {
+         StderrFallbackNotified = true;
+         std::cerr << "Unable to write to log file "
+                   << LogFile.getAbsolutePath()
+                   << "; falling back to stderr. Check this location for missing "
+                   << "or misconfigured directory permissions."
+                   << std::endl;
+      }
+
+      std::cerr << in_message;
+      std::cerr.flush();
    }
 
    // Returns true if the log file was opened, false otherwise.
@@ -538,6 +559,7 @@ struct FileLogDestination::Impl
    FileLogOptions LogOptions;
    FilePath LogFile;
    std::string LogName;
+   bool StderrFallbackNotified = false;
    boost::mutex Mutex;
    std::shared_ptr<std::ostream> LogOutputStream;
    boost::optional<boost::posix_time::ptime> FirstLogLineTime;
@@ -618,18 +640,25 @@ void FileLogDestination::writeLog(LogLevel in_logLevel, const std::string& in_me
             m_impl->SyslogDest->writeLog(in_logLevel, in_message);
 #endif
 
-      // Check to make sure path to file is valid. If not, log nothing.
+      // Check to make sure path to file is valid. If not, fall back to stderr.
       if (!m_impl->verifyLogFilePath())
+      {
+         m_impl->writeToStderrFallback(in_message);
          return;
+      }
 
-      // Rotate the log file if necessary. If it fails to rotate, log nothing.
+      // Rotate the log file if necessary. If it fails to rotate, fall back to stderr.
       if (!m_impl->rotateLogFile())
+      {
+         m_impl->writeToStderrFallback(in_message);
          return;
+      }
 
-      // Open the log file. If it fails to open, log nothing.
+      // Open the log file. If it fails to open, fall back to stderr.
       if (!m_impl->openLogFile())
       {
          m_impl->closeLogFile();
+         m_impl->writeToStderrFallback(in_message);
          return;
       }
 
@@ -643,6 +672,7 @@ void FileLogDestination::writeLog(LogLevel in_logLevel, const std::string& in_me
          if (!m_impl->openLogFile())
          {
             m_impl->closeLogFile();
+            m_impl->writeToStderrFallback(in_message);
             return;
          }
 

--- a/src/node/desktop/src/assets/locales/en.json
+++ b/src/node/desktop/src/assets/locales/en.json
@@ -110,7 +110,10 @@
     "notFoundDotLowercase": "not found.",
     "errorFindingR": "R Not Installed",
     "rstudioFailedToFindRInstalationsOnTheSystem": "R does not appear to be installed. Please install R before using RStudio.\n\nYou can download R from the official R Project website.\nWould you like to go there now?",
-    "newRstudioWindow": "New RStudio Window"
+    "newRstudioWindow": "New RStudio Window",
+    "stateFolderErrorTitle": "RStudio cannot write to required folders",
+    "stateFolderErrorPrefix": "RStudio requires write access to the following folders, but writing to them failed:",
+    "stateFolderErrorSuffix": "RStudio may fail to start or may not work correctly until this is resolved. Please check that these folders have the expected ownership and permissions."
   },
   "detectRTs": {
     "rNotFound": "R not found",

--- a/src/node/desktop/src/assets/locales/fr.json
+++ b/src/node/desktop/src/assets/locales/fr.json
@@ -110,7 +110,10 @@
     "notFoundDotLowercase": "non trouvé.",
     "errorFindingR": "Erreur de recherche de R",
     "rstudioFailedToFindRInstalationsOnTheSystem": "RStudio n'a pas réussi à trouver d'installation R sur le système. Merci d'installer R avant d'utiliser RStudio.\n\nVous pouvez télécharger R sur le site officiel du projet R. \nVoulez-vous y aller maintenant ?",
-    "newRstudioWindow": "Nouvelle fenêtre RStudio"
+    "newRstudioWindow": "Nouvelle fenêtre RStudio",
+    "stateFolderErrorTitle": "RStudio ne peut pas écrire dans les dossiers requis",
+    "stateFolderErrorPrefix": "RStudio nécessite un accès en écriture aux dossiers suivants, mais l'écriture a échoué :",
+    "stateFolderErrorSuffix": "RStudio peut ne pas démarrer ou ne pas fonctionner correctement tant que ce problème n'est pas résolu. Veuillez vérifier que ces dossiers ont les permissions et le propriétaire attendus."
   },
   "detectRTs": {
     "rNotFound": "R non trouvé",

--- a/src/node/desktop/src/core/winston-logger.ts
+++ b/src/node/desktop/src/core/winston-logger.ts
@@ -21,6 +21,7 @@ import LogOptions from '../main/log-options';
 import { getenv } from './environment';
 import { safeError } from './err';
 import { Logger, showDiagnosticsOutput } from './logger';
+import { checkDirectoryWritable } from './xdg';
 
 const { combine, printf, timestamp, json } = winston.format;
 
@@ -52,7 +53,7 @@ export class WinstonLogger implements Logger {
 
     const messageFormat = combine(timestamp({ alias: 'time' }), format);
     const logFile = logOptions.getLogFile();
-    let optionError;
+    const optionErrors: string[] = [];
 
     this.logger = winston.createLogger({
       level: winstonLevel,
@@ -76,26 +77,37 @@ export class WinstonLogger implements Logger {
       this.logger.levels = winston.config.syslog.levels;
       this.usingSyslog = true;
     } else if (loggerType === 'syslog') {
-      optionError = 'syslog not supported';
+      optionErrors.push('syslog not supported');
     }
 
     if (!logTransport) {
-      try {
-        logTransport = new winston.transports.File({
-          filename: logFile.getAbsolutePath(),
-          tailable: true,
-          maxsize: 2000000, // TODO: use max-size from logging.conf (convert from mb to bytes)
-          maxFiles: 100,
-        }); // TODO: use max-rotation from logging.conf
+      // winston only throws when it must create the log directory; when the
+      // directory exists but is not writable, it discards stream write errors
+      // internally and the log output is silently lost. Probe the directory
+      // explicitly so both cases fall back to console logging, keeping
+      // startup errors visible.
+      // https://github.com/rstudio/rstudio/issues/18179
+      const logDirError = checkDirectoryWritable(logFile.getParent());
+      if (logDirError === null) {
+        try {
+          logTransport = new winston.transports.File({
+            filename: logFile.getAbsolutePath(),
+            tailable: true,
+            maxsize: 2000000, // TODO: use max-size from logging.conf (convert from mb to bytes)
+            maxFiles: 100,
+          }); // TODO: use max-rotation from logging.conf
 
-        this.fileTransport = logTransport;
-      } catch (error: unknown) {
-        // winston throws if the log directory cannot be created (e.g. EACCES);
-        // fall back to console logging so startup errors remain visible
-        // https://github.com/rstudio/rstudio/issues/18179
+          this.fileTransport = logTransport;
+        } catch (error: unknown) {
+          optionErrors.push(`Unable to write log file ${logFile.getAbsolutePath()}: ${safeError(error).message}`);
+        }
+      } else {
+        optionErrors.push(`Unable to write log file ${logFile.getAbsolutePath()}: ${logDirError}`);
+      }
+
+      if (!logTransport) {
         logTransport = new Console();
         consoleLogging = true;
-        optionError = `Unable to write log file ${logFile.getAbsolutePath()}: ${safeError(error).message}`;
       }
     }
 
@@ -112,7 +124,7 @@ export class WinstonLogger implements Logger {
       this.logger.add(new Console());
     }
 
-    if (optionError) {
+    for (const optionError of optionErrors) {
       this.logErrorMessage(optionError);
     }
   }

--- a/src/node/desktop/src/core/winston-logger.ts
+++ b/src/node/desktop/src/core/winston-logger.ts
@@ -80,17 +80,32 @@ export class WinstonLogger implements Logger {
     }
 
     if (!logTransport) {
-      logTransport = new winston.transports.File({
-        filename: logFile.getAbsolutePath(),
-        tailable: true,
-        maxsize: 2000000, // TODO: use max-size from logging.conf (convert from mb to bytes)
-        maxFiles: 100,
-      }); // TODO: use max-rotation from logging.conf
+      try {
+        logTransport = new winston.transports.File({
+          filename: logFile.getAbsolutePath(),
+          tailable: true,
+          maxsize: 2000000, // TODO: use max-size from logging.conf (convert from mb to bytes)
+          maxFiles: 100,
+        }); // TODO: use max-rotation from logging.conf
 
-      this.fileTransport = logTransport;
+        this.fileTransport = logTransport;
+      } catch (error: unknown) {
+        // winston throws if the log directory cannot be created (e.g. EACCES);
+        // fall back to console logging so startup errors remain visible
+        // https://github.com/rstudio/rstudio/issues/18179
+        logTransport = new Console();
+        consoleLogging = true;
+        optionError = `Unable to write log file ${logFile.getAbsolutePath()}: ${safeError(error).message}`;
+      }
     }
 
     this.logger.add(logTransport);
+
+    // don't let transport errors (e.g. the log file becoming unwritable after
+    // startup) surface as uncaught exceptions
+    this.logger.on('error', (error) => {
+      console.error(safeError(error));
+    });
 
     // on dev builds, always log to console
     if (!consoleLogging && !app.isPackaged) {

--- a/src/node/desktop/src/core/xdg.ts
+++ b/src/node/desktop/src/core/xdg.ts
@@ -32,9 +32,11 @@
  * the boost::optional arguments.
  */
 
+import fs from 'fs';
 import os from 'os';
 
 import { logger } from './logger';
+import { safeError } from './err';
 import { Environment, expandEnvVars, getenv } from './environment';
 import { username, userHomePath } from './user';
 import { FilePath } from './file-path';
@@ -63,6 +65,47 @@ export function SHGetKnownFolderPath(folderId: WinFolderID): string {
       break;
   }
   return getenv(envVar);
+}
+
+/**
+ * Describes a problem discovered with a directory RStudio needs to write to.
+ */
+export interface UserDirIssue {
+  directory: string;
+  message: string;
+}
+
+/**
+ * Verifies that a directory exists (creating it if necessary) and is writable
+ * by the current user.
+ *
+ * Writability is tested with a probe file rather than `fs.accessSync()`, as
+ * access checks are unreliable for directories on Windows.
+ *
+ * @returns An error message describing the problem, or null if the directory
+ *   is usable.
+ */
+export function checkDirectoryWritable(dir: FilePath): string | null {
+  const error = dir.ensureDirectorySync();
+  if (error) {
+    return error.message;
+  }
+
+  const probeFile = dir.completeChildPath(`.rstudio-write-check-${process.pid}-${Date.now().toString(36)}`);
+  try {
+    fs.writeFileSync(probeFile.getAbsolutePath(), '');
+  } catch (err: unknown) {
+    return safeError(err).message;
+  }
+
+  try {
+    fs.unlinkSync(probeFile.getAbsolutePath());
+  } catch (err: unknown) {
+    // a cleanup failure doesn't imply the directory is unusable
+    logger().logError(err);
+  }
+
+  return null;
 }
 
 // Store the hostname so we don't have to look it up multiple times
@@ -199,19 +242,24 @@ export class Xdg {
   }
 
   /**
-   * This function verifies that the `userConfigDir()` and `userDataDir()` exist and are
-   * owned by the running user.
+   * This function verifies that the `userConfigDir()` and `userDataDir()` exist
+   * (creating them when missing) and are writable by the running user.
    *
-   * It should be invoked once. Any issues with these directories will be emitted to the
-   * session log.
+   * @returns A list of directories that could not be created or written to,
+   *   along with the underlying error messages.
    */
-  static verifyUserDirs(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    user?: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    homeDir?: FilePath,
-  ): void {
-    throw Error('Xdg.verifyUserDirs is NYI');
+  static verifyUserDirs(user?: string, homeDir?: FilePath): UserDirIssue[] {
+    const issues: UserDirIssue[] = [];
+
+    const dirs = [Xdg.userConfigDir(user, homeDir), Xdg.userDataDir(user, homeDir)];
+    for (const dir of dirs) {
+      const message = checkDirectoryWritable(dir);
+      if (message) {
+        issues.push({ directory: dir.getAbsolutePath(), message: message });
+      }
+    }
+
+    return issues;
   }
 
   /**

--- a/src/node/desktop/src/main/app-state.ts
+++ b/src/node/desktop/src/main/app-state.ts
@@ -16,6 +16,7 @@
 import { BrowserWindow, WebContents } from 'electron';
 import { Client, Server } from 'net-ipc';
 import { FilePath } from '../core/file-path';
+import { UserDirIssue } from '../core/xdg';
 
 import { DesktopActivation } from './activation-overlay';
 import { Application } from './application';
@@ -57,6 +58,7 @@ export interface AppState {
   eventBus?: TypedEventEmitter<EventBusTypes>;
   argsManager: ArgsManager;
   projectDirectory?: string;
+  stateDirIssues: UserDirIssue[];
 }
 
 let rstudio: AppState | null = null;

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -47,8 +47,9 @@ import { WindowTracker } from './window-tracker';
 import { configureSatelliteWindow, configureSecondaryWindow } from './window-utils';
 import { Client, Server } from 'net-ipc';
 import { LoggerCallback } from './logger-callback';
-import { Xdg } from '../core/xdg';
+import { checkDirectoryWritable, UserDirIssue, Xdg } from '../core/xdg';
 import { ModalDialogTracker } from './modal-dialog-tracker';
+import LogOptions from './log-options';
 
 /**
  * The RStudio application
@@ -69,6 +70,7 @@ export class Application implements AppState {
   pendingWindows = new Array<PendingWindow>();
   server?: Server;
   client?: Client;
+  stateDirIssues: UserDirIssue[] = [];
 
   appLaunch?: ApplicationLaunch;
   sessionLauncher?: SessionLauncher;
@@ -86,6 +88,11 @@ export class Application implements AppState {
     if (status.exit) {
       return status;
     }
+
+    // verify that the folders RStudio writes at runtime are accessible, and
+    // surface any problems in an error dialog once the app is ready
+    // https://github.com/rstudio/rstudio/issues/18179
+    this.checkStateDirectories();
 
     // attempt to remove stale lockfiles, as they can impede application startup
     try {
@@ -110,6 +117,53 @@ export class Application implements AppState {
 
     logger().logDebug('Ready to run');
     return run();
+  }
+
+  /**
+   * Checks that the state folders RStudio needs to write at runtime exist
+   * (creating them when missing) and are writable, reporting any problems
+   * with an error dialog. Startup continues regardless, so that the R session
+   * error page (which also includes these details) can be shown.
+   */
+  private checkStateDirectories(): void {
+    const issues = Xdg.verifyUserDirs();
+
+    // the log directory may have been relocated via logging.conf, so check
+    // the directory actually in use rather than assuming the default
+    try {
+      const logDir = new LogOptions().getLogFile().getParent();
+      const message = checkDirectoryWritable(logDir);
+      if (message) {
+        issues.push({ directory: logDir.getAbsolutePath(), message: message });
+      }
+    } catch (error: unknown) {
+      logger().logError(error);
+    }
+
+    if (issues.length === 0) {
+      return;
+    }
+
+    for (const issue of issues) {
+      logger().logErrorMessage(`Unable to write to folder ${issue.directory}: ${issue.message}`);
+    }
+
+    this.stateDirIssues = issues;
+
+    // the dialog can only be shown once the app is ready; don't block startup
+    // on it, as Chromium command-line switches must be appended before then
+    const details = issues.map((issue) => `${issue.directory}\n(${issue.message})`).join('\n\n');
+    app
+      .whenReady()
+      .then(async () =>
+        createStandaloneErrorDialog(
+          i18next.t('applicationTs.stateFolderErrorTitle'),
+          `${i18next.t('applicationTs.stateFolderErrorPrefix')}\n\n${details}\n\n${i18next.t(
+            'applicationTs.stateFolderErrorSuffix',
+          )}`,
+        ),
+      )
+      .catch((error: unknown) => logger().logError(error));
   }
 
   private shouldInstanceOpen() {

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -52,6 +52,28 @@ import { ModalDialogTracker } from './modal-dialog-tracker';
 import LogOptions from './log-options';
 
 /**
+ * Collects problems with the state folders RStudio needs to write at runtime:
+ * the user config and data directories, plus the log directory actually in
+ * use (which may have been relocated via logging.conf). Missing folders are
+ * created as a side effect.
+ */
+export function collectStateDirIssues(): UserDirIssue[] {
+  const issues = Xdg.verifyUserDirs();
+
+  try {
+    const logDir = new LogOptions().getLogFile().getParent();
+    const message = checkDirectoryWritable(logDir);
+    if (message) {
+      issues.push({ directory: logDir.getAbsolutePath(), message: message });
+    }
+  } catch (error: unknown) {
+    logger().logError(error);
+  }
+
+  return issues;
+}
+
+/**
  * The RStudio application
  */
 export class Application implements AppState {
@@ -126,20 +148,7 @@ export class Application implements AppState {
    * error page (which also includes these details) can be shown.
    */
   private checkStateDirectories(): void {
-    const issues = Xdg.verifyUserDirs();
-
-    // the log directory may have been relocated via logging.conf, so check
-    // the directory actually in use rather than assuming the default
-    try {
-      const logDir = new LogOptions().getLogFile().getParent();
-      const message = checkDirectoryWritable(logDir);
-      if (message) {
-        issues.push({ directory: logDir.getAbsolutePath(), message: message });
-      }
-    } catch (error: unknown) {
-      logger().logError(error);
-    }
-
+    const issues = collectStateDirIssues();
     if (issues.length === 0) {
       return;
     }

--- a/src/node/desktop/src/main/args-manager.ts
+++ b/src/node/desktop/src/main/args-manager.ts
@@ -205,8 +205,9 @@ export class ArgsManager {
   }
 
   handleLogLevel() {
-    const logOptions = new LogOptions();
+    // constructing LogOptions can throw if logging.conf is unreadable
     try {
+      const logOptions = new LogOptions();
       setLogger(new WinstonLogger(logOptions));
     } catch (error: unknown) {
       console.error(safeError(error));

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -27,6 +27,7 @@ import { generateShortenedUuid, localPeer } from '../core/system';
 
 import i18next from 'i18next';
 import { setTimeoutPromise, sleepPromise } from '../core/wait-utils';
+import { UserDirIssue } from '../core/xdg';
 import { DesktopActivation } from './activation-overlay';
 import { appState } from './app-state';
 import { ApplicationLaunch } from './application-launch';
@@ -138,6 +139,26 @@ function launchProcess(absPath: FilePath, argList: string[]): ChildProcess {
 
 function abendLogPath(): FilePath {
   return userLogPath().completePath('rsession_abort_msg.log');
+}
+
+/**
+ * Selects the 'launch_failed' detail for the launch error page: the abend log
+ * message when the session wrote one, otherwise any state folder issues found
+ * at startup (the session cannot write an abend log when the log folder
+ * itself is not writable), otherwise a placeholder.
+ */
+export function launchFailedDetail(abendMessage: string | null, stateDirIssues: UserDirIssue[]): string {
+  if (abendMessage !== null) {
+    return abendMessage;
+  }
+
+  if (stateDirIssues.length > 0) {
+    return stateDirIssues
+      .map((issue) => `Unable to write to folder ${issue.directory}: ${issue.message}`)
+      .join('\n');
+  }
+
+  return '[No error available]';
 }
 
 export class SessionLauncher {
@@ -367,20 +388,10 @@ export class SessionLauncher {
     const ss = `RStudio ${info.RSTUDIO_VERSION} "${info.RSTUDIO_RELEASE_NAME} " (${gitCommit}, ${info.RSTUDIO_BUILD_DATE}) for ${info.RSTUDIO_PACKAGE_OS}`;
     vars.set('version', ss);
 
-    // Collect message from the abnormal end log path; if the session could
-    // not write one (e.g. because the log folder itself is not writable),
-    // report any state folder issues discovered at startup instead
-    const stateDirIssues = appState().stateDirIssues;
-    if (abendLogPath().existsSync()) {
-      vars.set('launch_failed', this.launchFailedErrorMessage());
-    } else if (stateDirIssues.length > 0) {
-      const details = stateDirIssues
-        .map((issue) => `Unable to write to folder ${issue.directory}: ${issue.message}`)
-        .join('\n');
-      vars.set('launch_failed', details);
-    } else {
-      vars.set('launch_failed', '[No error available]');
-    }
+    // Collect message from the abnormal end log path, falling back to any
+    // state folder issues discovered at startup
+    const abendMessage = abendLogPath().existsSync() ? this.launchFailedErrorMessage() : null;
+    vars.set('launch_failed', launchFailedDetail(abendMessage, appState().stateDirIssues));
 
     // Collect the rsession process exit code
     let exitCode = EXIT_FAILURE;

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -367,9 +367,17 @@ export class SessionLauncher {
     const ss = `RStudio ${info.RSTUDIO_VERSION} "${info.RSTUDIO_RELEASE_NAME} " (${gitCommit}, ${info.RSTUDIO_BUILD_DATE}) for ${info.RSTUDIO_PACKAGE_OS}`;
     vars.set('version', ss);
 
-    // Collect message from the abnormal end log path
+    // Collect message from the abnormal end log path; if the session could
+    // not write one (e.g. because the log folder itself is not writable),
+    // report any state folder issues discovered at startup instead
+    const stateDirIssues = appState().stateDirIssues;
     if (abendLogPath().existsSync()) {
       vars.set('launch_failed', this.launchFailedErrorMessage());
+    } else if (stateDirIssues.length > 0) {
+      const details = stateDirIssues
+        .map((issue) => `Unable to write to folder ${issue.directory}: ${issue.message}`)
+        .join('\n');
+      vars.set('launch_failed', details);
     } else {
       vars.set('launch_failed', '[No error available]');
     }

--- a/src/node/desktop/test/unit/core/xdg.test.ts
+++ b/src/node/desktop/test/unit/core/xdg.test.ts
@@ -201,6 +201,11 @@ describe('Xdg', () => {
     });
   });
   describe('verifyUserDirs', () => {
+    // NOTE: the non-writable scenarios below are skipped on win32; creating a
+    // directory that denies writes requires ACL manipulation that isn't
+    // practical here, so the probe-file behavior (which exists because
+    // fs.accessSync is unreliable for directories on Windows) is only
+    // exercised on POSIX platforms
     let testRoot: string;
 
     beforeEach(() => {

--- a/src/node/desktop/test/unit/core/xdg.test.ts
+++ b/src/node/desktop/test/unit/core/xdg.test.ts
@@ -22,7 +22,7 @@ import os from 'os';
 import path from 'path';
 
 import { FilePath } from '../../../src/core/file-path';
-import { Xdg, SHGetKnownFolderPath, WinFolderID } from '../../../src/core/xdg';
+import { checkDirectoryWritable, Xdg, SHGetKnownFolderPath, WinFolderID } from '../../../src/core/xdg';
 
 function folder() {
   return process.platform === 'win32' ? 'RStudio' : 'rstudio';
@@ -197,8 +197,87 @@ describe('Xdg', () => {
   });
   describe('NYI placeholders', () => {
     it('sync methods should throw exception', () => {
-      assert.throws(() => Xdg.verifyUserDirs());
       assert.throws(() => Xdg.forwardXdgEnvVars({ FOO: 'bar' }));
+    });
+  });
+  describe('verifyUserDirs', () => {
+    let testRoot: string;
+
+    beforeEach(() => {
+      testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'rstudio-xdg-test-'));
+    });
+
+    afterEach(() => {
+      // restore permissions so cleanup can succeed
+      for (const entry of fs.readdirSync(testRoot)) {
+        try {
+          fs.chmodSync(path.join(testRoot, entry), 0o700);
+        } catch {
+          // ignore; removal below is best-effort
+        }
+      }
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    });
+
+    it('checkDirectoryWritable creates missing directories', () => {
+      const dir = new FilePath(path.join(testRoot, 'a', 'b'));
+
+      assert.isNull(checkDirectoryWritable(dir));
+      assert.isTrue(dir.existsSync());
+    });
+
+    it('checkDirectoryWritable reports non-writable directories', function () {
+      if (process.platform === 'win32') {
+        this.skip();
+      }
+
+      const dir = path.join(testRoot, 'readonly');
+      fs.mkdirSync(dir);
+      fs.chmodSync(dir, 0o500);
+
+      const message = checkDirectoryWritable(new FilePath(dir));
+      assert.isString(message);
+      assert.isNotEmpty(message);
+    });
+
+    it('checkDirectoryWritable reports directories that cannot be created', function () {
+      if (process.platform === 'win32') {
+        this.skip();
+      }
+
+      const parent = path.join(testRoot, 'readonly');
+      fs.mkdirSync(parent);
+      fs.chmodSync(parent, 0o500);
+
+      const message = checkDirectoryWritable(new FilePath(path.join(parent, 'child')));
+      assert.isString(message);
+      assert.isNotEmpty(message);
+    });
+
+    it('verifyUserDirs returns no issues when user dirs are writable', () => {
+      process.env.RSTUDIO_CONFIG_HOME = path.join(testRoot, 'config');
+      process.env.RSTUDIO_DATA_HOME = path.join(testRoot, 'data');
+
+      const issues = Xdg.verifyUserDirs();
+      assert.isEmpty(issues);
+    });
+
+    it('verifyUserDirs reports non-writable user dirs', function () {
+      if (process.platform === 'win32') {
+        this.skip();
+      }
+
+      const configDir = path.join(testRoot, 'config');
+      const dataDir = path.join(testRoot, 'data');
+      fs.mkdirSync(dataDir);
+      fs.chmodSync(dataDir, 0o500);
+      process.env.RSTUDIO_CONFIG_HOME = configDir;
+      process.env.RSTUDIO_DATA_HOME = dataDir;
+
+      const issues = Xdg.verifyUserDirs();
+      assert.lengthOf(issues, 1);
+      assert.strictEqual(issues[0].directory, dataDir);
+      assert.isNotEmpty(issues[0].message);
     });
   });
 });

--- a/src/node/desktop/test/unit/main/application.test.ts
+++ b/src/node/desktop/test/unit/main/application.test.ts
@@ -16,10 +16,12 @@
 import { describe } from 'mocha';
 import { assert } from 'chai';
 
+import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
-import { Application } from '../../../src/main/application';
+import { restore, saveAndClear } from '../unit-utils';
+import { Application, collectStateDirIssues } from '../../../src/main/application';
 import { NullLogger, setLogger } from '../../../src/core/logger';
 import { clearCoreSingleton } from '../../../src/core/core-state';
 import { randomString } from '../../../src/main/utils';
@@ -37,6 +39,58 @@ describe('Application', () => {
   function testDir(): FilePath {
     return new FilePath(path.join(os.tmpdir(), 'temp-folder-for-Application-tests-' + randomString()));
   }
+
+  describe('collectStateDirIssues', () => {
+    // NOTE: non-writable scenarios are skipped on win32; creating a directory
+    // that denies writes requires ACL manipulation that isn't practical here,
+    // so the probe-file behavior is only exercised on POSIX platforms
+    const stateEnv: Record<string, string> = {
+      RSTUDIO_CONFIG_HOME: '',
+      RSTUDIO_DATA_HOME: '',
+      RS_LOG_DIR: '',
+      RS_LOG_CONF_FILE: '',
+    };
+    let testRoot: string;
+
+    beforeEach(() => {
+      saveAndClear(stateEnv);
+      testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'rstudio-application-test-'));
+      process.env.RSTUDIO_CONFIG_HOME = path.join(testRoot, 'config');
+      process.env.RSTUDIO_DATA_HOME = path.join(testRoot, 'data');
+      process.env.RS_LOG_DIR = path.join(testRoot, 'logs');
+    });
+
+    afterEach(() => {
+      restore(stateEnv);
+      for (const entry of fs.readdirSync(testRoot)) {
+        try {
+          fs.chmodSync(path.join(testRoot, entry), 0o700);
+        } catch {
+          // ignore; removal below is best-effort
+        }
+      }
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    });
+
+    it('returns no issues when all state dirs are writable', () => {
+      assert.isEmpty(collectStateDirIssues());
+    });
+
+    it('reports a relocated, unwritable log directory', function () {
+      if (process.platform === 'win32') {
+        this.skip();
+      }
+
+      const logDir = path.join(testRoot, 'logs');
+      fs.mkdirSync(logDir);
+      fs.chmodSync(logDir, 0o500);
+
+      const issues = collectStateDirIssues();
+      assert.lengthOf(issues, 1);
+      assert.strictEqual(issues[0].directory, logDir);
+      assert.isNotEmpty(issues[0].message);
+    });
+  });
 
   describe('Command line switches', () => {
     it('run-diagnostics sets diag mode and continues', () => {

--- a/src/node/desktop/test/unit/main/session-launcher.test.ts
+++ b/src/node/desktop/test/unit/main/session-launcher.test.ts
@@ -20,7 +20,7 @@ import { restore, saveAndClear } from '../unit-utils';
 import { FilePath } from '../../../src/core/file-path';
 import { getenv } from '../../../src/core/environment';
 
-import { SessionLauncher } from '../../../src/main/session-launcher';
+import { launchFailedDetail, SessionLauncher } from '../../../src/main/session-launcher';
 import { ApplicationLaunch } from '../../../src/main/application-launch';
 import { Application } from '../../../src/main/application';
 import { appState, clearApplicationSingleton, setApplication } from '../../../src/main/app-state';
@@ -48,6 +48,21 @@ describe('SessionLauncher', () => {
     const token = SessionLauncher.launcherToken;
     assert.isNotEmpty(token);
     assert.strictEqual(SessionLauncher.launcherToken, token);
+  });
+  describe('launchFailedDetail', () => {
+    const issues = [{ directory: '/home/user/.local/share/rstudio/log', message: 'permission denied' }];
+
+    it('prefers the abend log message when present', () => {
+      assert.strictEqual(launchFailedDetail('session aborted', issues), 'session aborted');
+    });
+    it('reports state folder issues when there is no abend message', () => {
+      const detail = launchFailedDetail(null, issues);
+      assert.include(detail, '/home/user/.local/share/rstudio/log');
+      assert.include(detail, 'permission denied');
+    });
+    it('falls back to a placeholder when there is nothing to report', () => {
+      assert.strictEqual(launchFailedDetail(null, []), '[No error available]');
+    });
   });
   it('buildLaunchContext sets RS_LOCAL_PEER on Win32', async () => {
     const launcher = getNewLauncher();

--- a/src/node/desktop/test/unit/main/winston-logger.test.ts
+++ b/src/node/desktop/test/unit/main/winston-logger.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { assert } from 'chai';
-import { openSync, writeFileSync } from 'fs';
+import { chmodSync, mkdirSync, openSync, writeFileSync } from 'fs';
 import { describe } from 'mocha';
 import { coreState } from '../../../src/core/core-state';
 import { FilePath } from '../../../src/core/file-path';
@@ -58,6 +58,27 @@ describe('WinstonLogger', () => {
       assert.equal(logger.logLevel(), logLevel, 'Logger log level should be ' + logLevel);
       logger.closeLogFile();
     });
+  });
+
+  it('Logger falls back to console when log directory is not writable', function () {
+    if (process.platform === 'win32') {
+      this.skip();
+    }
+
+    const roDir = './tmp/readonly';
+    mkdirSync(roDir, { recursive: true });
+    chmodSync(roDir, 0o500);
+
+    const logOptions = new LogOptions(undefined, { config: `[*]\nlog-dir=${roDir}/log` });
+
+    // constructing the logger must not throw even though the log directory
+    // cannot be created; it should fall back to console logging
+    const logger = new WinstonLogger(logOptions);
+    assert.isNull(logger.fileTransport);
+    assert.doesNotThrow(() => logger.logErrorMessage('message after log dir failure'));
+    logger.closeLogFile();
+
+    chmodSync(roDir, 0o700);
   });
 
   it('Logger level is set correctly from environment variable', () => {

--- a/src/node/desktop/test/unit/main/winston-logger.test.ts
+++ b/src/node/desktop/test/unit/main/winston-logger.test.ts
@@ -60,7 +60,12 @@ describe('WinstonLogger', () => {
     });
   });
 
-  it('Logger falls back to console when log directory is not writable', function () {
+  // NOTE: the non-writable scenarios below are skipped on win32; creating a
+  // directory that denies writes requires ACL manipulation that isn't
+  // practical here, so the probe-file behavior (which exists because
+  // fs.accessSync is unreliable for directories on Windows) is only
+  // exercised on POSIX platforms
+  it('Logger falls back to console when log directory cannot be created', function () {
     if (process.platform === 'win32') {
       this.skip();
     }
@@ -73,6 +78,28 @@ describe('WinstonLogger', () => {
 
     // constructing the logger must not throw even though the log directory
     // cannot be created; it should fall back to console logging
+    const logger = new WinstonLogger(logOptions);
+    assert.isNull(logger.fileTransport);
+    assert.doesNotThrow(() => logger.logErrorMessage('message after log dir failure'));
+    logger.closeLogFile();
+
+    chmodSync(roDir, 0o700);
+  });
+
+  it('Logger falls back to console when existing log directory is not writable', function () {
+    if (process.platform === 'win32') {
+      this.skip();
+    }
+
+    // winston does not throw in this case -- it swallows the stream error and
+    // silently drops all log output -- so the fallback relies on the explicit
+    // writability probe rather than the constructor try/catch
+    const roDir = './tmp/readonly-existing';
+    mkdirSync(roDir, { recursive: true });
+    chmodSync(roDir, 0o500);
+
+    const logOptions = new LogOptions(undefined, { config: `[*]\nlog-dir=${roDir}` });
+
     const logger = new WinstonLogger(logOptions);
     assert.isNull(logger.fileTransport);
     assert.doesNotThrow(() => logger.logErrorMessage('message after log dir failure'));


### PR DESCRIPTION
### Intent

Addresses #18179.

When a state folder RStudio needs to write (e.g. `~/.local/share/rstudio` or its `log/` subfolder) is not writable, RStudio Desktop previously failed to launch with the only useful error printed to the terminal, and the launch-failed page showed either "[No error available]" or a misleading "R version newer than maximum supported" message. RStudio Server had the same underlying problem: file logging silently dropped every message, and a fatal rsession startup error was logged only to the (broken) log destination.

### Approach

Desktop (Electron):

- Implement the `Xdg.verifyUserDirs` stub: at startup, verify the user config, data, and log directories exist (creating them when missing) and are writable, using a probe file. Problems are logged, shown in an error dialog once the app is ready, and recorded so the R session launch-failed page can report them instead of "[No error available]". Startup continues (warn-and-continue), since the session error page provides further detail.
- `WinstonLogger` now falls back to a console transport when winston cannot create the log directory, instead of leaving the do-nothing `NullLogger` installed -- previously this made every subsequent startup error invisible (the catch was added in #12990, which kept the window alive but discarded all later logging). Transport errors are also handled so they cannot surface as uncaught exceptions.

Backend (shared by desktop sessions and RStudio Server):

- `FileLogDestination` now falls back to stderr when the log file cannot be written (unwritable directory, failed rotation, failed open), instead of silently dropping messages. A one-time notice names the log file path so the cause is discoverable. For desktop, rsession's stderr is surfaced on the launch-failed page; for server, it lands in the system journal.
- `sessionExitFailure` also echoes the fatal error to stderr, so fatal init failures (e.g. unwritable scratch path) are visible even when file logging is unavailable.
- `core::system::xdg::verifyUserDirs` additionally checks the log directory.

### Automated Tests

- `xdg.test.ts`: new tests for `checkDirectoryWritable` and `Xdg.verifyUserDirs` (creation, non-writable detection, env-var override resolution).
- `winston-logger.test.ts`: new test that the logger falls back to console (and remains usable) when the log directory cannot be created.
- Existing C++ core tests (including logging tests) pass: 434/434.

### QA Notes

To reproduce the original report:

    chmod 500 ~/.local/share/rstudio   # or chmod 500 ~/.local/share/rstudio/log
    open /Applications/RStudio.app

Expected with this change: an error dialog names the unwritable folder(s) with the underlying error, and if the R session fails to boot, the launch-failed page repeats the details rather than showing "[No error available]". On RStudio Server, rsession log messages and fatal startup errors appear on stderr (journal) when the log directory is unwritable. Restore with `chmod 755` afterwards.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] A reviewer is assigned to this PR
- [x] This PR passes all local unit tests