### PR TITLE
avoid sqlite C API when probing for open transactions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 - ([#18152](https://github.com/rstudio/rstudio/issues/18152)): Fixed a compilation error when building RStudio Server against SOCI 4.1.4 or newer.
+- ([#18287](https://github.com/rstudio/rstudio/issues/18287)): Fixed another compilation error when building RStudio against system SOCI packages (4.1 or newer), which no longer expose the SQLite C API through their headers.
 - ([#18174](https://github.com/rstudio/rstudio/issues/18174)): Fixed an error when viewing an object from the Object Explorer with the French user interface language enabled.
 - ([#18255](https://github.com/rstudio/rstudio/issues/18255)): Fixed a regression where an unprivileged RStudio Server would fail to start when it could not read a system secure key file (for example, a root-owned key baked into an HPC container image), rather than falling back to its per-user cache.
 - ([#18198](https://github.com/rstudio/rstudio/issues/18198)): Fixed tar errors and warnings printed to the console after installing a package from a URL with `install.packages(..., repos = NULL)`.

--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -1579,41 +1579,47 @@ void rollbackOpenSqliteTransaction(const boost::shared_ptr<Connection>& connecti
    if (connection->driver() != Driver::Sqlite)
       return;
 
-   // Probe for an open transaction with BEGIN rather than calling
-   // sqlite3_get_autocommit(): SOCI 4.1+ no longer exposes the SQLite C API
-   // through soci-sqlite3.h, so builds against a system SOCI cannot use it
-   // (#18287). A deferred BEGIN acquires no locks, so the probe is cheap.
+   // This runs from ~PooledConnection(), an implicitly noexcept destructor, so
+   // no exception may escape; SOCI statements can also throw non-soci_error
+   // types (e.g. std::bad_alloc), hence the catch-all below.
    try
    {
-      connection->session() << "BEGIN";
-   }
-   catch (const soci::soci_error&)
-   {
-      // BEGIN failed, so a transaction is already open; roll it back.
+      // Probe for an open transaction with BEGIN rather than calling
+      // sqlite3_get_autocommit(): SOCI 4.1+ no longer exposes the SQLite C API
+      // through soci-sqlite3.h, so builds against a system SOCI cannot use it
+      // (#18287). A deferred BEGIN acquires no locks, so the probe is cheap.
+      bool hadOpenTransaction = false;
       try
       {
-         connection->session() << "ROLLBACK";
-         LOG_DEBUG_MESSAGE("Rolled back an open transaction before returning a "
-                           "connection to the pool");
+         connection->session() << "BEGIN";
       }
       catch (const soci::soci_error& e)
       {
-         LOG_WARNING_MESSAGE(std::string("Failed to roll back open transaction on a "
-                                         "pooled connection: ") + e.what());
+         // BEGIN normally fails here because a transaction is already open,
+         // but log the original error in case it failed for another reason.
+         DLOGF("BEGIN probe failed on a pooled connection: {}", e.what());
+         hadOpenTransaction = true;
       }
 
-      return;
-   }
-
-   // No transaction was open; close the one the probe just started.
-   try
-   {
+      // Roll back the open transaction (or the one the probe just started).
       connection->session() << "ROLLBACK";
+
+      if (hadOpenTransaction)
+      {
+         LOG_DEBUG_MESSAGE("Rolled back an open transaction before returning a "
+                           "connection to the pool");
+      }
    }
    catch (const soci::soci_error& e)
    {
-      LOG_WARNING_MESSAGE(std::string("Failed to close transaction probe on a "
-                                      "pooled connection: ") + e.what());
+      ELOGF("Failed to roll back transaction on a pooled connection; the "
+            "connection may be returned with a transaction still open: {}",
+            e.what());
+   }
+   catch (...)
+   {
+      ELOGF("Failed to roll back transaction on a pooled connection; the "
+            "connection may be returned with a transaction still open");
    }
 }
 

--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -1579,24 +1579,40 @@ void rollbackOpenSqliteTransaction(const boost::shared_ptr<Connection>& connecti
    if (connection->driver() != Driver::Sqlite)
       return;
 
-   auto* backend = static_cast<soci::sqlite3_session_backend*>(connection->session().get_backend());
-   if (backend == nullptr || backend->conn_ == nullptr)
-      return;
+   // Probe for an open transaction with BEGIN rather than calling
+   // sqlite3_get_autocommit(): SOCI 4.1+ no longer exposes the SQLite C API
+   // through soci-sqlite3.h, so builds against a system SOCI cannot use it
+   // (#18287). A deferred BEGIN acquires no locks, so the probe is cheap.
+   try
+   {
+      connection->session() << "BEGIN";
+   }
+   catch (const soci::soci_error&)
+   {
+      // BEGIN failed, so a transaction is already open; roll it back.
+      try
+      {
+         connection->session() << "ROLLBACK";
+         LOG_DEBUG_MESSAGE("Rolled back an open transaction before returning a "
+                           "connection to the pool");
+      }
+      catch (const soci::soci_error& e)
+      {
+         LOG_WARNING_MESSAGE(std::string("Failed to roll back open transaction on a "
+                                         "pooled connection: ") + e.what());
+      }
 
-   // A nonzero result means the connection is in autocommit (no open
-   // transaction), which is the expected state - nothing to roll back.
-   if (sqlite_api::sqlite3_get_autocommit(backend->conn_) != 0)
       return;
+   }
 
+   // No transaction was open; close the one the probe just started.
    try
    {
       connection->session() << "ROLLBACK";
-      LOG_DEBUG_MESSAGE("Rolled back an open transaction before returning a "
-                        "connection to the pool");
    }
    catch (const soci::soci_error& e)
    {
-      LOG_WARNING_MESSAGE(std::string("Failed to roll back open transaction on a "
+      LOG_WARNING_MESSAGE(std::string("Failed to close transaction probe on a "
                                       "pooled connection: ") + e.what());
    }
 }

--- a/src/cpp/core/DatabaseTests.cpp
+++ b/src/cpp/core/DatabaseTests.cpp
@@ -958,6 +958,57 @@ TEST(ConnectionPoolTest, ReturningConnectionWithOpenTransactionRollsItBack)
    dbPath.removeIfExists();
 }
 
+// The rollback-on-return probe opens its own transaction when none was left
+// open (BEGIN succeeds); that probe transaction must itself be closed before
+// the connection is pooled, or every cleanly-returned connection would come
+// back inside a stale deferred transaction.
+TEST(ConnectionPoolTest, ReturningConnectionCleanlyLeavesAutocommit)
+{
+   FilePath dbPath;
+   ASSERT_FALSE(FilePath::tempFilePath(dbPath));
+   dbPath.removeIfExists();
+
+   SqliteConnectionOptions options;
+   options.file = dbPath.getAbsolutePath();
+
+   {
+      // Pool of one so the re-acquired connection is guaranteed to be the same
+      // underlying connection we just returned.
+      boost::shared_ptr<ConnectionPool> pool;
+      ASSERT_FALSE(createConnectionPool(1, options, &pool)) << "Failed to create connection pool";
+
+      {
+         boost::shared_ptr<IConnection> conn = pool->getConnection();
+         ASSERT_TRUE(conn) << "Failed to get connection from pool";
+         ASSERT_FALSE(conn->executeStr("CREATE TABLE Txn(id int)")) << "Failed to create Txn table";
+
+         // A plain autocommit insert; no transaction is left open.
+         Query insert = conn->query("INSERT INTO Txn(id) VALUES (:id)").withInput(1);
+         ASSERT_FALSE(conn->execute(insert)) << "Failed to insert row";
+         // conn leaves scope here -> returned to pool -> probe runs.
+      }
+
+      boost::shared_ptr<IConnection> conn2 = pool->getConnection();
+      ASSERT_TRUE(conn2) << "Failed to re-acquire connection from pool";
+
+      // The connection must be back in autocommit: if the probe's own BEGIN
+      // had leaked, this BEGIN would fail with "cannot start a transaction
+      // within a transaction".
+      ASSERT_FALSE(conn2->executeStr("BEGIN")) << "Probe transaction leaked into the pooled connection";
+      ASSERT_FALSE(conn2->executeStr("ROLLBACK"));
+
+      // And the committed row must have survived.
+      int count = -1;
+      Query countQuery = conn2->query("SELECT COUNT(*) FROM Txn").withOutput(count);
+      bool dataReturned = false;
+      ASSERT_FALSE(conn2->execute(countQuery, &dataReturned)) << "Failed to count Txn rows";
+      ASSERT_TRUE(dataReturned);
+      EXPECT_EQ(count, 1) << "Committed row should survive the return-to-pool probe";
+   }
+
+   dbPath.removeIfExists();
+}
+
 // Regression for rstudio-pro#10885: a SELECT's Rowset holds a SQLite read
 // snapshot until it is destroyed. A connection that is reused for a write while
 // still carrying such a snapshot - after another connection has committed -


### PR DESCRIPTION
### Intent

Fix a compilation failure when building RStudio against system SOCI packages (4.1 or newer), as Fedora does. #18042 introduced a call to `sqlite_api::sqlite3_get_autocommit()`, but SOCI 4.1+ no longer exposes the SQLite C API through `soci-sqlite3.h` when SOCI is consumed externally (`SOCI_SQLITE3_SOURCE` undefined) -- the `sqlite_api` namespace only forward-declares `sqlite3` and `sqlite3_stmt`, so the symbol does not exist. Our bundled SOCI 4.0.3 includes all of `sqlite3.h` inside the namespace, which is why official builds are unaffected.

Fixes #18287.

### Approach

Replace the C API autocommit check in `rollbackOpenSqliteTransaction()` with a SQL-level probe, as suggested by the reporter: issue `BEGIN`; if it succeeds no transaction was open (the probe transaction is then rolled back), and if it throws a transaction was already open and is rolled back in the catch block. A deferred `BEGIN` acquires no locks, so the probe is cheap, and the common path executes no exceptions. This also removes the reach into SOCI backend internals (`sqlite3_session_backend::conn_`).

Directly including `<sqlite3.h>` instead was not viable: with the bundled SOCI 4.0.3, the header's include guard makes whichever include comes second a no-op, breaking either `::sqlite3` or `sqlite_api::sqlite3` depending on include order.

### Automated Tests

Covered by the existing regression tests from #18042: `ConnectionPoolTest.ReturningConnectionWithOpenTransactionRollsItBack` exercises the leaked-transaction path, and the other pool tests exercise the clean-return path. All database/connection-pool gtests pass locally.

### QA Notes

Building against SOCI 4.1+ (e.g. on Fedora with the system SOCI packages) should be verified by the reporter; the fix removes the only use of the missing symbol.

### Documentation

NEWS.md entry added.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests