### PR TITLE
theme the popped-out help window like the help pane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@
 - ([#18273](https://github.com/rstudio/rstudio/issues/18273)): Fixed an issue on Windows where a failure to load the Start Menu Git shortcut while auto-detecting the Git installation went undetected, causing detection to fail later with a less accurate error.
 - ([#18277](https://github.com/rstudio/rstudio/issues/18277)): Fixed an issue where the GitHub Copilot or Posit Assistant agent could fail to start for the rest of the session after an early startup failure (for example, a misconfigured Node.js path). The agent now retries and starts once the underlying problem is corrected, without restarting the session.
 - ([#18270](https://github.com/rstudio/rstudio/issues/18270)): Fixed an issue on Windows where native dialogs shown by R (e.g. via `utils::askYesNo()`, or when `install.packages()` asks about installing from sources) could open behind the RStudio Desktop window, making the IDE appear frozen while R waited on a dialog the user could not see.
+- ([#8345](https://github.com/rstudio/rstudio/issues/8345)): Help pages opened via the Help pane's "Show in new window" button now follow the IDE's editor theme, instead of always rendering with a light palette.
 
 ### Dependencies
 - MathJax 4.1.3 (inline LaTeX / math previews)

--- a/e2e/rstudio/tests/panes/help/help_popout_theme.test.ts
+++ b/e2e/rstudio/tests/panes/help/help_popout_theme.test.ts
@@ -1,0 +1,127 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { executeCommand } from '@utils/commands';
+import type { Page } from '@playwright/test';
+
+// Regression test for issue #8345: the Help pane's "Show in new window"
+// button used to open the raw help URL in a plain browser window, so none of
+// the IDE's theming was applied and the page always rendered with R's default
+// light palette. The popout now opens a satellite window hosting the help
+// page in an RStudioThemedFrame, which themes the content like the Help pane
+// and re-themes it live when the editor theme changes.
+
+// 'Cobalt' ships with RStudio and is a dark theme; its stylesheet href always
+// contains "cobalt" when active. 'Textmate (default)' is the light default.
+const DARK_THEME = 'Cobalt';
+const LIGHT_THEME = 'Textmate (default)';
+
+// ID on the <link> element AceThemes.java injects to apply the theme CSS,
+// both in top-level windows and (via RStudioThemedFrame) in themed iframes.
+const ACE_THEME_LINK = '#rstudio-acethemes-linkelement';
+
+// The satellite hosts the help page in an iframe titled "Help"
+// (HelpPopoutPanel.java).
+const POPOUT_HELP_FRAME = 'iframe[title="Help"]';
+
+let consoleActions: ConsolePaneActions;
+
+async function applyEditorTheme(page: Page, theme: string) {
+  await consoleActions.executeInConsole(`.rs.api.applyTheme(${JSON.stringify(theme)})`, {
+    wait: true,
+  });
+}
+
+/** Relative luminance (0 = black, 255 = white) of a CSS rgb()/rgba() color. */
+function luminance(cssColor: string): number {
+  const match = cssColor.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+  if (!match)
+    throw new Error(`unexpected color format: ${cssColor}`);
+  const [r, g, b] = [Number(match[1]), Number(match[2]), Number(match[3])];
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+test.describe.serial('Help popout window theming', () => {
+  let satellitePage: Page | undefined;
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+
+    // remember the active editor theme R-side so afterAll can restore it
+    await consoleActions.executeInConsole(
+      '.rstudio.e2e.popoutThemeOrig <- .rs.api.getThemeInfo()$editor',
+      { wait: true },
+    );
+  });
+
+  test.afterAll(async () => {
+    await satellitePage?.close().catch(() => undefined);
+
+    await consoleActions
+      .executeInConsole(
+        `if (exists(".rstudio.e2e.popoutThemeOrig")) .rs.api.applyTheme(.rstudio.e2e.popoutThemeOrig) else .rs.api.applyTheme(${JSON.stringify(LIGHT_THEME)})`,
+        { wait: true },
+      )
+      .catch((err) => {
+        console.warn(`[help_popout_theme] theme restore failed: ${(err as Error).message}`);
+      });
+  });
+
+  test('popped-out help page follows the editor theme', async ({ rstudioPage: page }) => {
+    await applyEditorTheme(page, DARK_THEME);
+    await expect
+      .poll(async () =>
+        page.evaluate((id) => document.querySelector(id)?.getAttribute('href') ?? '', ACE_THEME_LINK),
+      )
+      .toContain('cobalt');
+
+    // open a help topic in the Help pane
+    await consoleActions.executeInConsole('help("print")', { wait: true });
+    const paneFrame = page.frameLocator('#rstudio_help_frame');
+    await expect(paneFrame.locator('body')).toContainText('print', { timeout: 15000 });
+
+    // pop the help page out into a satellite window
+    const satellitePromise = page.context().waitForEvent('page', { timeout: 30000 });
+    await executeCommand(page, 'helpPopout');
+    satellitePage = await satellitePromise;
+    await satellitePage.waitForLoadState('domcontentloaded');
+    expect(satellitePage.url()).toContain('view=help_popout_');
+
+    // the satellite's help iframe should be themed like the Help pane:
+    // theme stylesheet injected, theming class applied, dark background
+    const helpFrame = satellitePage.frameLocator(POPOUT_HELP_FRAME);
+    await expect(helpFrame.locator('body')).toContainText('print', { timeout: 30000 });
+    await expect
+      .poll(
+        () => helpFrame.locator(ACE_THEME_LINK).getAttribute('href').catch(() => ''),
+        { timeout: 15000 },
+      )
+      .toContain('cobalt');
+    await expect(helpFrame.locator('body.ace_editor_theme')).toBeVisible({ timeout: 15000 });
+    await expect
+      .poll(async () => {
+        const color = await helpFrame
+          .locator('body')
+          .evaluate((el) => getComputedStyle(el).backgroundColor);
+        return luminance(color);
+      }, { timeout: 15000 })
+      .toBeLessThan(128);
+  });
+
+  test('open popout re-themes when the editor theme changes', async ({ rstudioPage: page }) => {
+    test.skip(satellitePage === undefined, 'popout satellite not opened');
+
+    // switch back to a light theme in the main window; the satellite listens
+    // for the change and should re-theme the already-loaded help page
+    await applyEditorTheme(page, LIGHT_THEME);
+
+    const helpFrame = satellitePage!.frameLocator(POPOUT_HELP_FRAME);
+    await expect
+      .poll(async () => {
+        const color = await helpFrame
+          .locator('body')
+          .evaluate((el) => getComputedStyle(el).backgroundColor);
+        return luminance(color);
+      }, { timeout: 15000 })
+      .toBeGreaterThan(128);
+  });
+});

--- a/e2e/rstudio/tests/panes/help/help_popout_theme.test.ts
+++ b/e2e/rstudio/tests/panes/help/help_popout_theme.test.ts
@@ -3,8 +3,8 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { executeCommand } from '@utils/commands';
 import type { Page } from '@playwright/test';
 
-// Regression test for issue #8345: the Help pane's "Show in new window"
-// button used to open the raw help URL in a plain browser window, so none of
+// Regression test for issue #8345: the Help pane's "Show Help in New Window"
+// command used to open the raw help URL in a plain browser window, so none of
 // the IDE's theming was applied and the page always rendered with R's default
 // light palette. The popout now opens a satellite window hosting the help
 // page in an RStudioThemedFrame, which themes the content like the Help pane
@@ -19,13 +19,14 @@ const LIGHT_THEME = 'Textmate (default)';
 // both in top-level windows and (via RStudioThemedFrame) in themed iframes.
 const ACE_THEME_LINK = '#rstudio-acethemes-linkelement';
 
-// The satellite hosts the help page in an iframe titled "Help"
-// (HelpPopoutPanel.java).
-const POPOUT_HELP_FRAME = 'iframe[title="Help"]';
+// The satellite hosts the help page in an RStudioThemedFrame with a stable
+// element id (assigned in HelpPopoutPanel.java); select on that rather than
+// the frame's title, which is localized.
+const POPOUT_HELP_FRAME = '#rstudio_help_popout_frame';
 
 let consoleActions: ConsolePaneActions;
 
-async function applyEditorTheme(page: Page, theme: string) {
+async function applyEditorTheme(theme: string) {
   await consoleActions.executeInConsole(`.rs.api.applyTheme(${JSON.stringify(theme)})`, {
     wait: true,
   });
@@ -33,15 +34,23 @@ async function applyEditorTheme(page: Page, theme: string) {
 
 /** Relative luminance (0 = black, 255 = white) of a CSS rgb()/rgba() color. */
 function luminance(cssColor: string): number {
-  const match = cssColor.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+  const match = cssColor.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/);
   if (!match)
     throw new Error(`unexpected color format: ${cssColor}`);
+
+  // a fully transparent background means no background was actually painted;
+  // return NaN so both light and dark luminance comparisons fail rather than
+  // letting rgba(0, 0, 0, 0) read as black
+  if (match[4] !== undefined && Number(match[4]) === 0)
+    return Number.NaN;
+
   const [r, g, b] = [Number(match[1]), Number(match[2]), Number(match[3])];
   return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 }
 
 test.describe.serial('Help popout window theming', () => {
   let satellitePage: Page | undefined;
+  let vignettePage: Page | undefined;
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     consoleActions = new ConsolePaneActions(page);
@@ -55,6 +64,7 @@ test.describe.serial('Help popout window theming', () => {
 
   test.afterAll(async () => {
     await satellitePage?.close().catch(() => undefined);
+    await vignettePage?.close().catch(() => undefined);
 
     await consoleActions
       .executeInConsole(
@@ -64,10 +74,20 @@ test.describe.serial('Help popout window theming', () => {
       .catch((err) => {
         console.warn(`[help_popout_theme] theme restore failed: ${(err as Error).message}`);
       });
+
+    // drop the fake package library added by the vignette test
+    await consoleActions
+      .executeInConsole(
+        'if (exists(".rstudio.e2e.popoutFakeLib")) { .libPaths(setdiff(.libPaths(), .rstudio.e2e.popoutFakeLib)); rm(.rstudio.e2e.popoutFakeLib) }',
+        { wait: true },
+      )
+      .catch((err) => {
+        console.warn(`[help_popout_theme] fake lib cleanup failed: ${(err as Error).message}`);
+      });
   });
 
   test('popped-out help page follows the editor theme', async ({ rstudioPage: page }) => {
-    await applyEditorTheme(page, DARK_THEME);
+    await applyEditorTheme(DARK_THEME);
     await expect
       .poll(async () =>
         page.evaluate((id) => document.querySelector(id)?.getAttribute('href') ?? '', ACE_THEME_LINK),
@@ -112,7 +132,12 @@ test.describe.serial('Help popout window theming', () => {
 
     // switch back to a light theme in the main window; the satellite listens
     // for the change and should re-theme the already-loaded help page
-    await applyEditorTheme(page, LIGHT_THEME);
+    await applyEditorTheme(LIGHT_THEME);
+    await expect
+      .poll(async () =>
+        page.evaluate((id) => document.querySelector(id)?.getAttribute('href') ?? '', ACE_THEME_LINK),
+      )
+      .toContain('textmate');
 
     const helpFrame = satellitePage!.frameLocator(POPOUT_HELP_FRAME);
     await expect
@@ -123,5 +148,74 @@ test.describe.serial('Help popout window theming', () => {
         return luminance(color);
       }, { timeout: 15000 })
       .toBeGreaterThan(128);
+  });
+
+  test('popped-out vignette-style page is not re-themed', async ({ rstudioPage: page }) => {
+    // RStudioThemedFrame deliberately skips custom styling for documents
+    // that contain an <article> element (typical of HTML vignettes), since
+    // re-theming them can render the content illegible (#11022); the popout
+    // must preserve that opt-out
+    await applyEditorTheme(DARK_THEME);
+    await expect
+      .poll(async () =>
+        page.evaluate((id) => document.querySelector(id)?.getAttribute('href') ?? '', ACE_THEME_LINK),
+      )
+      .toContain('cobalt');
+
+    // fabricate a minimal installed package whose doc directory contains an
+    // <article>-style vignette page, served by R's help server
+    await consoleActions.executeInConsole(
+      [
+        '.rstudio.e2e.popoutFakeLib <- tempfile("popout-fake-lib-")',
+        'dir.create(file.path(.rstudio.e2e.popoutFakeLib, "fakevignette", "doc"), recursive = TRUE)',
+        'writeLines(c("Package: fakevignette", "Version: 0.0.1"), file.path(.rstudio.e2e.popoutFakeLib, "fakevignette", "DESCRIPTION"))',
+        'writeLines("<html><body><article><h1>fake vignette content</h1></article></body></html>", file.path(.rstudio.e2e.popoutFakeLib, "fakevignette", "doc", "vignette.html"))',
+        '.libPaths(c(.rstudio.e2e.popoutFakeLib, .libPaths()))',
+      ].join('; '),
+      { wait: true },
+    );
+
+    // browseURL() on a local help-server URL routes into the Help pane
+    await consoleActions.executeInConsole(
+      'browseURL(paste0("http://127.0.0.1:", .rs.httpdPort(), "/library/fakevignette/doc/vignette.html"))',
+      { wait: true },
+    );
+    const paneFrame = page.frameLocator('#rstudio_help_frame');
+    await expect(paneFrame.locator('body')).toContainText('fake vignette content', {
+      timeout: 15000,
+    });
+
+    // pop the vignette page out into a satellite window
+    const satellitePromise = page.context().waitForEvent('page', { timeout: 30000 });
+    await executeCommand(page, 'helpPopout');
+    vignettePage = await satellitePromise;
+    await vignettePage.waitForLoadState('domcontentloaded');
+    expect(vignettePage.url()).toContain('view=help_popout_');
+
+    // wait until the satellite window itself is themed (proof the theming
+    // machinery ran in that window) and the vignette document has finished
+    // loading, so the frame's load-time theming pass has had its chance
+    await expect
+      .poll(
+        () =>
+          vignettePage!.evaluate(
+            (id) => document.querySelector(id)?.getAttribute('href') ?? '',
+            ACE_THEME_LINK,
+          ),
+        { timeout: 30000 },
+      )
+      .toContain('cobalt');
+    const helpFrame = vignettePage.frameLocator(POPOUT_HELP_FRAME);
+    await expect(helpFrame.locator('body')).toContainText('fake vignette content', {
+      timeout: 30000,
+    });
+    await expect
+      .poll(() => helpFrame.locator('body').evaluate((el) => el.ownerDocument.readyState))
+      .toBe('complete');
+
+    // the vignette document itself must be left unthemed: no injected theme
+    // stylesheet and no theming class on the body
+    await expect(helpFrame.locator(ACE_THEME_LINK)).toHaveCount(0);
+    await expect(helpFrame.locator('body.ace_editor_theme')).toHaveCount(0);
   });
 });

--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -131,6 +131,7 @@ public class ElementIds
    public final static String DEPLOY_CONTENT = "deploy_content";
    public final static String FIND_REPLACE_BAR = "find_replace_bar";
    public final static String HELP_FRAME = "help_frame";
+   public final static String HELP_POPOUT_FRAME = "help_popout_frame";
    public final static String LOADING_SPINNER = "loading_image";
    public final static String PLOT_IMAGE_FRAME = "plot_image_frame";
    public final static String POPUP_COMPLETIONS = "popup_completions";

--- a/src/gwt/src/org/rstudio/core/client/widget/SatelliteFramePanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SatelliteFramePanel.java
@@ -49,7 +49,7 @@ public abstract class SatelliteFramePanel <T extends RStudioFrame>
    
    protected void showUrl(String url, boolean removeToolbar)
    {
-      showUrl(url, false, null);
+      showUrl(url, removeToolbar, null);
    }
 
    protected void showUrl(String url, boolean removeToolbar, LoadHandler onLoad)

--- a/src/gwt/src/org/rstudio/studio/client/RStudio.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudio.java
@@ -85,6 +85,7 @@ import org.rstudio.studio.client.workbench.views.connections.ui.NewConnectionWiz
 import org.rstudio.studio.client.workbench.views.console.ConsoleResources;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.ImportFileSettingsDialog;
 import org.rstudio.studio.client.workbench.views.files.ui.FilesListDataGridResources;
+import org.rstudio.studio.client.workbench.views.help.HelpPopoutSatellite;
 import org.rstudio.studio.client.workbench.views.history.view.HistoryPane;
 import org.rstudio.studio.client.workbench.views.history.view.Shelf;
 import org.rstudio.studio.client.workbench.views.packages.ui.CheckForUpdatesDialog;
@@ -343,6 +344,13 @@ public class RStudio implements EntryPoint
       {
          RStudioGinjector.INSTANCE.getPlumberAPISatellite().go(
                RootLayoutPanel.get(),
+               dismissProgressAnimation_);
+      }
+      else if (view != null &&
+            view.startsWith(HelpPopoutSatellite.NAME_PREFIX))
+      {
+         HelpPopoutSatellite satellite = new HelpPopoutSatellite(view);
+         satellite.go(RootLayoutPanel.get(),
                dismissProgressAnimation_);
       }
       else if (ChatSatellite.NAME.equals(view))

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinModule.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinModule.java
@@ -176,6 +176,8 @@ import org.rstudio.studio.client.workbench.views.files.FilesTab;
 import org.rstudio.studio.client.workbench.views.files.model.FilesServerOperations;
 import org.rstudio.studio.client.workbench.views.help.Help;
 import org.rstudio.studio.client.workbench.views.help.HelpPane;
+import org.rstudio.studio.client.workbench.views.help.HelpPopoutView;
+import org.rstudio.studio.client.workbench.views.help.HelpPopoutWindow;
 import org.rstudio.studio.client.workbench.views.help.HelpTab;
 import org.rstudio.studio.client.workbench.views.help.model.HelpServerOperations;
 import org.rstudio.studio.client.workbench.views.help.search.HelpSearch;
@@ -359,6 +361,7 @@ public class RStudioGinModule extends AbstractGinModule
       bind(ReviewPresenter.class).to(ReviewPresenterImpl.class);
       
       bind(HTMLPreviewApplicationView.class).to(HTMLPreviewApplicationWindow.class);
+      bind(HelpPopoutView.class).to(HelpPopoutWindow.class);
       bind(ShinyApplicationView.class).to(ShinyApplicationWindow.class);
       bind(PlumberAPIView.class).to(PlumberAPIWindow.class);
       bind(ChatSatelliteView.class).to(ChatSatelliteWindow.class);

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -145,6 +145,7 @@ import org.rstudio.studio.client.workbench.views.environment.dataimport.DataImpo
 import org.rstudio.studio.client.workbench.views.environment.dataimport.DataImportFileChooser;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.DataImportOptionsUiCsv;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.DataImportOptionsUiCsvLocale;
+import org.rstudio.studio.client.workbench.views.help.HelpPopoutSatellite;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobsPresenterEventHandlersImpl;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobManager;
 import org.rstudio.studio.client.workbench.views.jobs.view.JobItemFactory;
@@ -273,6 +274,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(SetupChunkOptionsPopupPanel panel);
    void injectMembers(SourceSatellite satellite);
    void injectMembers(ShinyApplicationSatellite satellite);
+   void injectMembers(HelpPopoutSatellite satellite);
    void injectMembers(ModifyKeyboardShortcutsWidget widget);
    void injectMembers(ShortcutManager manager);
    void injectMembers(UserCommandManager manager);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -19,6 +19,7 @@ import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.Point;
 import org.rstudio.core.client.Rectangle;
+import org.rstudio.core.client.Size;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.command.ShortcutManager;
@@ -52,8 +53,8 @@ import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.AutoGlassPanel;
 import org.rstudio.studio.client.common.GlobalDisplay;
-import org.rstudio.studio.client.common.GlobalDisplay.NewWindowOptions;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
+import org.rstudio.studio.client.common.satellite.SatelliteManager;
 import org.rstudio.studio.client.server.Server;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
@@ -109,13 +110,15 @@ public class HelpPane extends WorkbenchPane
                    GlobalDisplay globalDisplay,
                    Commands commands,
                    EventBus events,
-                   UserPrefs prefs)
+                   UserPrefs prefs,
+                   SatelliteManager satelliteManager)
    {
       super(constants_.helpText(), events);
 
       searchProvider_ = searchProvider;
       globalDisplay_ = globalDisplay;
       commands_ = commands;
+      satelliteManager_ = satelliteManager;
       server_ = RStudioGinjector.INSTANCE.getServer();
 
       // init with a no-op timer
@@ -937,10 +940,16 @@ public class HelpPane extends WorkbenchPane
    @Override
    public void popout()
    {
-      String href = getContentWindow().getLocationHref();
-      NewWindowOptions options = new NewWindowOptions();
-      options.setName("helppanepopout_" + popoutCount_++);
-      globalDisplay_.openWebMinimalWindow(href, false, 0, 0, options);
+      // open the current help page in a satellite window; unlike a plain
+      // browser window, the satellite runs GWT code and so can theme the
+      // help content to match the IDE (#8345)
+      WindowEx contentWindow = getContentWindow();
+      String href = contentWindow.getLocationHref();
+      String title = StringUtil.notNull(contentWindow.getDocument().getTitle());
+
+      HelpPopoutParams params = HelpPopoutParams.create(href, title);
+      String name = HelpPopoutSatellite.NAME_PREFIX + popoutCount_++;
+      satelliteManager_.openSatellite(name, params, new Size(800, 900));
    }
 
    @Override
@@ -1033,6 +1042,13 @@ public class HelpPane extends WorkbenchPane
    private static final Resources RES = GWT.create(Resources.class);
    static { RES.styles().ensureInjected(); }
 
+   // used by HelpPopoutPanel so popped-out help windows share the
+   // same content styling as the help pane
+   static String getEditorStyles()
+   {
+      return RES.editorStyles().getText();
+   }
+
    private UserPrefs prefs_;
 
    private final VirtualHistory navStack_;
@@ -1043,6 +1059,7 @@ public class HelpPane extends WorkbenchPane
    private final Provider<HelpSearch> searchProvider_;
    private GlobalDisplay globalDisplay_;
    private final Commands commands_;
+   private final SatelliteManager satelliteManager_;
    private boolean navigated_;
    private boolean initialized_;
    private String targetUrl_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -62,6 +62,7 @@ import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
 import org.rstudio.studio.client.workbench.views.help.Help.LinkMenu;
 import org.rstudio.studio.client.workbench.views.help.events.HelpNavigateEvent;
+import org.rstudio.studio.client.workbench.views.help.model.HelpPopoutParams;
 import org.rstudio.studio.client.workbench.views.help.model.VirtualHistory;
 import org.rstudio.studio.client.workbench.views.help.search.HelpSearch;
 
@@ -943,9 +944,25 @@ public class HelpPane extends WorkbenchPane
       // open the current help page in a satellite window; unlike a plain
       // browser window, the satellite runs GWT code and so can theme the
       // help content to match the IDE (#8345)
-      WindowEx contentWindow = getContentWindow();
-      String href = contentWindow.getLocationHref();
-      String title = StringUtil.notNull(contentWindow.getDocument().getTitle());
+
+      // getUrl() returns null if the frame hasn't loaded yet, or if the
+      // content is cross-origin; nothing sensible to pop out in either case
+      String href = getUrl();
+      if (StringUtil.isNullOrEmpty(href))
+         return;
+
+      String title = "";
+      try
+      {
+         WindowEx contentWindow = getContentWindow();
+         if (contentWindow != null)
+            title = StringUtil.notNull(contentWindow.getDocument().getTitle());
+      }
+      catch (Exception e)
+      {
+         // reading the title can throw a DOM security exception for
+         // cross-origin content; fall back to the default satellite title
+      }
 
       HelpPopoutParams params = HelpPopoutParams.create(href, title);
       String name = HelpPopoutSatellite.NAME_PREFIX + popoutCount_++;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPopoutPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPopoutPanel.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.help;
 import com.google.gwt.core.client.GWT;
 import com.google.inject.Inject;
 
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.widget.RStudioThemedFrame;
 import org.rstudio.core.client.widget.SatelliteFramePanel;
 import org.rstudio.core.client.widget.Toolbar;
@@ -33,7 +34,8 @@ public class HelpPopoutPanel extends SatelliteFramePanel<RStudioThemedFrame>
    @Override
    protected void initToolbar(Toolbar toolbar, Commands commands)
    {
-      // the popped-out help window has no toolbar
+      // no toolbar buttons; the toolbar itself is removed by showHelp()
+      // passing removeToolbar = true to showUrl()
    }
 
    public void showHelp(String url)
@@ -52,6 +54,7 @@ public class HelpPopoutPanel extends SatelliteFramePanel<RStudioThemedFrame>
          false,
          true);
 
+      ElementIds.assignElementId(frame.getElement(), ElementIds.HELP_POPOUT_FRAME);
       frame.addStyleName("ace_editor_theme");
       return frame;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPopoutPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPopoutPanel.java
@@ -1,0 +1,60 @@
+/*
+ * HelpPopoutPanel.java
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.help;
+
+import com.google.gwt.core.client.GWT;
+import com.google.inject.Inject;
+
+import org.rstudio.core.client.widget.RStudioThemedFrame;
+import org.rstudio.core.client.widget.SatelliteFramePanel;
+import org.rstudio.core.client.widget.Toolbar;
+import org.rstudio.studio.client.workbench.commands.Commands;
+
+public class HelpPopoutPanel extends SatelliteFramePanel<RStudioThemedFrame>
+{
+   @Inject
+   public HelpPopoutPanel(Commands commands)
+   {
+      super(commands);
+   }
+
+   @Override
+   protected void initToolbar(Toolbar toolbar, Commands commands)
+   {
+      // the popped-out help window has no toolbar
+   }
+
+   public void showHelp(String url)
+   {
+      showUrl(url, true, null);
+   }
+
+   @Override
+   protected RStudioThemedFrame createFrame(String url)
+   {
+      RStudioThemedFrame frame = new RStudioThemedFrame(
+         constants_.helpText(),
+         url,
+         HelpPane.getEditorStyles(),
+         null,
+         false,
+         true);
+
+      frame.addStyleName("ace_editor_theme");
+      return frame;
+   }
+
+   private static final HelpConstants constants_ = GWT.create(HelpConstants.class);
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPopoutParams.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPopoutParams.java
@@ -1,0 +1,42 @@
+/*
+ * HelpPopoutParams.java
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.help;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+public class HelpPopoutParams extends JavaScriptObject
+{
+   protected HelpPopoutParams()
+   {
+   }
+
+   public static final native HelpPopoutParams create(String url, String title)
+   /*-{
+      return {
+         url: url,
+         title: title
+      };
+   }-*/;
+
+   public final native String getUrl()
+   /*-{
+      return this.url;
+   }-*/;
+
+   public final native String getTitle()
+   /*-{
+      return this.title;
+   }-*/;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPopoutSatellite.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPopoutSatellite.java
@@ -1,0 +1,50 @@
+/*
+ * HelpPopoutSatellite.java
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.help;
+
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.ApplicationUncaughtExceptionHandler;
+import org.rstudio.studio.client.common.satellite.Satellite;
+import org.rstudio.studio.client.common.satellite.SatelliteApplication;
+import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
+import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
+public class HelpPopoutSatellite extends SatelliteApplication
+{
+   public static final String NAME_PREFIX = "help_popout_";
+
+   public HelpPopoutSatellite(String name)
+   {
+      name_ = name;
+      RStudioGinjector.INSTANCE.injectMembers(this);
+   }
+
+   @Inject
+   public void initialize(HelpPopoutView view,
+                          Satellite satellite,
+                          Provider<AceThemes> pAceThemes,
+                          Provider<UserPrefs> pUserPrefs,
+                          ApplicationUncaughtExceptionHandler exHandler,
+                          Commands commands)
+   {
+      initialize(name_, view, satellite, pAceThemes, pUserPrefs, exHandler, commands);
+   }
+
+   private final String name_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPopoutView.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPopoutView.java
@@ -1,0 +1,21 @@
+/*
+ * HelpPopoutView.java
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.help;
+
+import org.rstudio.studio.client.common.satellite.SatelliteApplicationView;
+
+public interface HelpPopoutView extends SatelliteApplicationView
+{
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPopoutWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPopoutWindow.java
@@ -28,6 +28,7 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.satellite.SatelliteWindow;
 import org.rstudio.studio.client.workbench.ui.FontSizeManager;
+import org.rstudio.studio.client.workbench.views.help.model.HelpPopoutParams;
 
 @Singleton
 public class HelpPopoutWindow extends SatelliteWindow

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPopoutWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPopoutWindow.java
@@ -1,0 +1,83 @@
+/*
+ * HelpPopoutWindow.java
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.help;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.LayoutPanel;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
+
+import org.rstudio.core.client.StringUtil;
+import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.common.satellite.SatelliteWindow;
+import org.rstudio.studio.client.workbench.ui.FontSizeManager;
+
+@Singleton
+public class HelpPopoutWindow extends SatelliteWindow
+                              implements HelpPopoutView
+{
+   @Inject
+   public HelpPopoutWindow(Provider<EventBus> pEventBus,
+                           Provider<FontSizeManager> pFSManager,
+                           Provider<HelpPopoutPanel> pPanel)
+   {
+      super(pEventBus, pFSManager);
+      pPanel_ = pPanel;
+   }
+
+   @Override
+   protected void onInitialize(LayoutPanel mainPanel, JavaScriptObject params)
+   {
+      HelpPopoutParams popoutParams = params.cast();
+
+      String title = popoutParams.getTitle();
+      if (StringUtil.isNullOrEmpty(title))
+         title = constants_.helpText();
+      Window.setTitle(title);
+
+      HelpPopoutPanel panel = pPanel_.get();
+      panel.showHelp(popoutParams.getUrl());
+
+      Widget panelWidget = panel.asWidget();
+      mainPanel.add(panelWidget);
+      mainPanel.setWidgetLeftRight(panelWidget, 0, Unit.PX, 0, Unit.PX);
+      mainPanel.setWidgetTopBottom(panelWidget, 0, Unit.PX, 0, Unit.PX);
+   }
+
+   @Override
+   public boolean supportsThemes()
+   {
+      return true;
+   }
+
+   @Override
+   public void reactivate(JavaScriptObject params)
+   {
+   }
+
+   @Override
+   public Widget getWidget()
+   {
+      return this;
+   }
+
+   private final Provider<HelpPopoutPanel> pPanel_;
+   private static final HelpConstants constants_ = GWT.create(HelpConstants.class);
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/HelpPopoutParams.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/HelpPopoutParams.java
@@ -12,7 +12,7 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
-package org.rstudio.studio.client.workbench.views.help;
+package org.rstudio.studio.client.workbench.views.help.model;
 
 import com.google.gwt.core.client.JavaScriptObject;
 


### PR DESCRIPTION
Fixes #8345.

## Problem

The Help pane's "Show in new window" button opened the raw help URL in a plain browser window. Help theming is applied client-side by `RStudioThemedFrame` (theme CSS injection, `AceThemes.applyTheme()`, theme-color CSS variables), so a window running no GWT code always rendered with R's default light palette -- regardless of the IDE theme.

## Fix

The popout now opens a satellite window (`help_popout_*`, modeled on the Shiny app satellite) that hosts the help page in an `RStudioThemedFrame`, so the popped-out page:

- follows the user's actual editor theme (e.g. Cobalt), not a one-size-fits-all dark palette, matching the Help pane exactly (it shares the pane's `HelpPaneEditorStyles.css`);
- re-themes live when the editor theme changes while the window is open (via the `ThemeChangedEvent` re-fire in `SatelliteWindow`);
- keeps the vignette opt-out from `RStudioThemedFrame.isEligibleForCustomStyles()` (#11022), same as the pane.

Works identically on Desktop (Electron satellite window) and Server (same-origin `window.open` satellite).

Also fixes a latent bug in `SatelliteFramePanel.showUrl(url, removeToolbar)`: the two-arg overload ignored its `removeToolbar` argument (no existing caller passed `true`).

## Tests

Adds `e2e/rstudio/tests/panes/help/help_popout_theme.test.ts`:

1. with Cobalt active, popping out a help page yields a satellite whose help iframe has the Cobalt stylesheet, the theming class, and a dark computed background;
2. switching back to a light theme re-themes the open popout.

Both pass locally in desktop-dev mode; verified visually that the popped-out page renders fully themed under Cobalt.