### PR TITLE
Backport the E2E rotation workflow and engines to Pacific Dogwood

### DIFF
--- a/.github/actions/os-e2e-deps/action.yml
+++ b/.github/actions/os-e2e-deps/action.yml
@@ -202,14 +202,20 @@ runs:
           sleep 10
         done
 
+    # Keyed on CACHE_OS (runner.os plus the optional cache-scope) rather than
+    # bare runner.os: browser binaries are architecture-specific, and every
+    # Linux caller would otherwise share one key -- an arm64 caller restoring
+    # x86_64 chromium (or poisoning the shared key in reverse) surfaces later
+    # as an opaque exec-format launch error in a different workflow. Callers
+    # with an empty cache-scope keep the legacy runner.os key byte-for-byte.
     - name: Restore Playwright browsers
       id: pw-cache
       uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}/ms-playwright
-        key: ${{ runner.os }}-pw-${{ hashFiles(format('{0}/package-lock.json', inputs.working-directory)) }}
+        key: ${{ env.CACHE_OS }}-pw-${{ hashFiles(format('{0}/package-lock.json', inputs.working-directory)) }}
         restore-keys: |
-          ${{ runner.os }}-pw-
+          ${{ env.CACHE_OS }}-pw-
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/.github/actions/os-install-rig-unix/action.yml
+++ b/.github/actions/os-install-rig-unix/action.yml
@@ -1,0 +1,72 @@
+name: "Install rig (Linux / macOS)"
+description: >
+  Install the rig R version manager on a Linux or macOS runner from a pinned
+  GitHub release. Replaces the resolve-latest-via-GitHub-API step: querying
+  api.github.com at runtime is a recurring flake source (intermittent 503s),
+  while a runner-to-GitHub release download needs no API call and is about as
+  reliable as CI networking gets. The "latest" permanent-link release is not
+  an option either -- its binary assets are stale (last updated 2024-04-07 as
+  of writing; see r-lib/rig#343 for a bug this staleness reintroduces).
+
+inputs:
+  rig-version:
+    description: >-
+      rig release version to install. Keep at 0.8.1 or newer: older releases
+      cannot install R >= 4.6.1 on macOS (r-lib/rig#343).
+    required: false
+    default: "0.8.1"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install rig from GitHub releases
+      shell: bash
+      env:
+        RIG_VERSION: ${{ inputs.rig-version }}
+      run: |
+        set -euo pipefail
+
+        # Tolerate a leading 'v' (as in the release tag) in the version input.
+        RIG_VERSION="${RIG_VERSION#v}"
+
+        # Container jobs run as root and may lack sudo; hosted runners need it.
+        SUDO=""
+        if [ "$(id -u)" != "0" ]; then
+          SUDO="sudo"
+        fi
+
+        # Release assets use "arm64", not uname's "aarch64"; the Linux x86_64
+        # asset carries no arch token.
+        case "$(uname -s)-$(uname -m)" in
+          Linux-x86_64)
+            ASSET="rig-linux-${RIG_VERSION}.tar.gz"
+            ;;
+          Linux-aarch64)
+            ASSET="rig-linux-arm64-${RIG_VERSION}.tar.gz"
+            ;;
+          Darwin-arm64)
+            ASSET="rig-${RIG_VERSION}-macOS-arm64.pkg"
+            ;;
+          Darwin-x86_64)
+            ASSET="rig-${RIG_VERSION}-macOS-x86_64.pkg"
+            ;;
+          *)
+            echo "::error::Unsupported platform $(uname -s)-$(uname -m) for rig install"
+            exit 1
+            ;;
+        esac
+
+        URL="https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${ASSET}"
+        echo "Downloading $URL"
+        curl -fsSL --retry 5 --retry-delay 10 -o "${RUNNER_TEMP}/${ASSET}" "$URL"
+
+        case "$ASSET" in
+          *.pkg)
+            $SUDO installer -pkg "${RUNNER_TEMP}/${ASSET}" -target /
+            ;;
+          *)
+            $SUDO tar xzf "${RUNNER_TEMP}/${ASSET}" -C /usr/local
+            ;;
+        esac
+
+        rig --version

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
@@ -1,0 +1,795 @@
+name: "Test: E2E Playwright RStudio (Desktop, Debian 13 arm64, Open Source)"
+
+# Debian 13 (arm64) is a hybrid of the two Linux engine shapes: the RStudio
+# Desktop .deb it tests is the SAME package Ubuntu 24 ships (noble build), so
+# the build job is Ubuntu 24's build on an ubuntu-24.04-arm runner -- no Debian
+# dependency script is needed (there is no install-dependencies-trixie, and
+# building on Debian would gain nothing). Only the e2e job runs on Debian: like
+# Fedora (GitHub has no Debian-hosted runner) it runs in a debian:13 container
+# (arm64 image on the arm host), installs that noble .deb, and drives Playwright
+# there. So: build on Ubuntu 24 arm64, test on Debian 13 arm64.
+#
+# R packages come from PPM's NOBLE binary repo, not Trixie: PPM currently serves
+# arm64 binaries for noble but not for trixie, so the e2e job rewrites the
+# container's /etc/os-release codename to noble (see that step). Drop the
+# override once PPM publishes trixie arm64 binaries.
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_from_source:
+        description: "Build RStudio Desktop (Electron) from this branch's source. When false, downloads the latest daily .deb installer."
+        type: boolean
+        default: true
+      rstudio_installer_url:
+        description: "Optional .deb URL to test against (e.g. a specific daily from dailies.rstudio.com). When set, the source build is skipped and this URL is installed instead, regardless of build_from_source. Leave empty to build from source or auto-resolve the latest daily."
+        type: string
+        default: ""
+      r_version:
+        description: "R version to install via rig (e.g. 'release', 'oldrel', 'devel', '4.4.1')."
+        type: string
+        default: "release"
+      project:
+        description: "Playwright project to run: 'desktop' or 'server'. OS and edition are auto-filtered from the host platform and PW_RSTUDIO_EDITION."
+        type: string
+        default: "desktop"
+      grep:
+        description: "Optional Playwright --grep pattern to run only tests whose title matches."
+        type: string
+        default: ""
+      test_selector:
+        description: "Optional test paths/files/directories to run (space-separated). Matched as substrings against test file paths. Examples: 'autocomplete.test.ts', 'tests/panes/misc/', 'autocomplete tests/panes/posit-assistant-chat/'. Leave empty to run all tests."
+        type: string
+        default: ""
+      test_ignore:
+        description: "Optional test paths/files/directories to exclude (space-separated globs). Examples: '**/code_suggestions.test.ts', '**/posit-assistant-chat/**'. Leave empty to exclude nothing."
+        type: string
+        default: ""
+      grep_invert:
+        description: "Optional Playwright --grep-invert pattern to skip tests by title. Empty by default (runs all tests)."
+        type: string
+        default: ""
+      rstudio_extra_args:
+        description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS. Set to '--no-sandbox' if the in-container Chromium sandbox won't initialize (see the container options below)."
+        type: string
+        default: ""
+      build_only:
+        description: "Run only the build job (to seed the rstudio-tools / R-libs / sccache caches) and skip the e2e job."
+        type: boolean
+        default: false
+      post_pr_comment:
+        description: "Post test results as a sticky comment on the PR. Pass true only from PR-triggered callers."
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      build_from_source:
+        type: boolean
+        default: true
+      rstudio_installer_url:
+        type: string
+        default: ""
+      r_version:
+        type: string
+        default: "release"
+      project:
+        type: string
+        default: "desktop"
+      grep:
+        type: string
+        default: ""
+      test_selector:
+        type: string
+        default: ""
+      test_ignore:
+        type: string
+        default: ""
+      grep_invert:
+        type: string
+        default: ""
+      rstudio_extra_args:
+        type: string
+        default: ""
+      build_only:
+        type: boolean
+        default: false
+      post_pr_comment:
+        type: boolean
+        default: false
+      defer_merge:
+        description: "Skip this workflow's own merge/publish/comment job; the caller merges every platform's blobs into one report instead."
+        type: boolean
+        default: false
+    secrets:
+      CONNECT_API_KEY:
+        description: "Posit Connect API key for the E2E Test Insights reporter"
+        required: false
+      AWS_E2E_REPORTS_ROLE_ARN:
+        description: "IAM role assumed via GitHub OIDC to upload the Playwright report to S3"
+        required: false
+
+permissions:
+  contents: read
+  # Required so the e2e-merge job can post sticky PR comments via
+  # marocchino/sticky-pull-request-comment. GitHub validates ALL job-level
+  # permissions in a reusable workflow at call time, so this must be declared
+  # at the top level even though only e2e-merge uses it.
+  pull-requests: write
+  # Lets the e2e-merge job mint an OIDC token to assume the S3 report-upload
+  # role (see .github/actions/os-publish-e2e-report).
+  id-token: write
+
+jobs:
+  # Builds RStudio Desktop (Electron) from this PR's source on an ubuntu-24.04-arm
+  # runner -- NOT on Debian. The arm64 .deb this produces is the same noble build
+  # that installs on Debian 13 arm64, so there is no reason to build in a Debian
+  # container (which would need an install-dependencies-trixie script that doesn't
+  # exist). Skipped when build_from_source is false or rstudio_installer_url is
+  # set, in which case the e2e job downloads the daily .deb (or the given URL)
+  # instead.
+  build:
+    if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 90
+    env:
+      # Redirect the dependency / package scripts' tool root to a
+      # workspace-local path so it can be cached without sudo.
+      RSTUDIO_TOOLS_ROOT: ${{ github.workspace }}/opt/rstudio-tools/arm64
+      # Pin R's user library to a workspace-local path so we can cache it.
+      R_LIBS_USER: ${{ github.workspace }}/R-libs/%p/%v
+      SCCACHE_ENABLED: '1'
+      # Route sccache to GitHub's built-in Actions cache API. The
+      # mozilla-actions/sccache-action step below installs sccache and exports
+      # ACTIONS_CACHE_URL + ACTIONS_RUNTIME_TOKEN so the sccache server uses
+      # the GHA backend. Cache hits are object-level (one entry per compiled
+      # .o), so branch runs automatically inherit main's warm cache (seeded by
+      # a build_only dispatch on main) without per-SHA tarball rotation. No
+      # AWS / S3 / secrets required.
+      SCCACHE_GHA_ENABLED: 'true'
+      # Compile GWT with readable (PRETTY) symbol names rather than the default
+      # OBFUSCATED output, so the uncaught client exceptions the e2e automation
+      # agent records (window.rstudio.errors) carry decodable Java stack traces.
+      # Consumed by src/gwt/CMakeLists.txt; folded into the GWT cache key below.
+      GWT_STYLE: PRETTY
+      # Quiet npm during install-common's panmirror build, the Electron app
+      # build, and any other transitive npm step.
+      NPM_CONFIG_LOGLEVEL: error
+      NPM_CONFIG_AUDIT: 'false'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pre-built tool deps (Boost, SOCI, pandoc, quarto, GWT, node, panmirror,
+      # copilot-language-server, sccache, etc.) all land under RSTUDIO_TOOLS_ROOT.
+      # arm64-scoped key: these are compiled native artifacts, so they can't share
+      # the x86_64 Ubuntu build's cache. No sibling ARM engine seeds this, so a
+      # non-main run builds cold; main-scoped runs populate it via the Save steps.
+      # Restore-only here; the Save steps after "Install build dependencies" run
+      # only from main-scoped runs.
+      - name: Restore rstudio-tools deps
+        id: tools-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.RSTUDIO_TOOLS_ROOT }}
+          key: rstudio-tools-linux-arm64-${{ hashFiles('dependencies/common/install-*', 'dependencies/linux/install-*', 'dependencies/tools/rstudio-tools.sh') }}
+          restore-keys: |
+            rstudio-tools-linux-arm64-
+
+      # install-common (called by install-dependencies-noble) installs R
+      # packages (via install-packages) into R_LIBS_USER. Cache the whole
+      # R-libs tree -- R's %p/%v subpaths keep different versions isolated.
+      # arm64-scoped: these are compiled for arm64, not interchangeable with the
+      # x86_64 build's library.
+      - name: Restore build-time R packages
+        id: rlibs-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/R-libs
+          key: rstudio-build-rlibs-linux-arm64-${{ hashFiles('dependencies/common/install-packages', 'dependencies/common/lockfiles/**/renv.lock') }}
+          restore-keys: |
+            rstudio-build-rlibs-linux-arm64-
+
+      # Cache compiled GWT output (package/linux/build-Electron-DEB/gwt/{bin,www,extras}).
+      # GWT compilation is the single most expensive JS step (~15-30 min). When
+      # GWT Java sources / build scripts haven't changed, make-electron-package
+      # can skip the recompile entirely via the NO_REBUILD env var (sets
+      # GWT_BUILD=no, which becomes -DGWT_BUILD=no to cmake) -- see the
+      # NO_REBUILD/GWT_BUILD handling in package/linux/make-package. GWT output is
+      # Java-to-JS and arch-independent, but the key is arm64-scoped for isolation
+      # (matching the tools/rlibs keys). Restore-only here; the matching Save step
+      # runs after the build with a success gate so a failed mid-compile run can't
+      # poison the cache.
+      - name: Restore GWT output
+        id: gwt-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: package/linux/build-Electron-DEB/gwt
+          key: rstudio-gwt-linux-desktop-arm64-${{ env.GWT_STYLE }}-v1-${{ hashFiles('src/gwt/src/**', 'src/gwt/acesupport/**', 'src/gwt/lib/**', 'src/gwt/build.xml', 'src/gwt/conf/**') }}
+          restore-keys: |
+            rstudio-gwt-linux-desktop-arm64-${{ env.GWT_STYLE }}-v1-
+
+      # GHA-backed sccache. Installs sccache on PATH and starts the sccache
+      # server with the GH Actions cache API as the storage backend. Object-level
+      # cache hits, no per-SHA tarball, no AWS credentials.
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          # Pinned: resolving "latest" queries api.github.com at runtime,
+          # which fails during GitHub API incidents (503s). A pinned version
+          # downloads directly from the release CDN with no API call.
+          version: "v0.16.0"
+
+      # install-dependencies-noble: apt-get installs system packages (with sudo
+      # internally), then calls install-common which downloads Boost, SOCI,
+      # pandoc, quarto, node, panmirror, sccache, GWT jar, etc. into
+      # RSTUDIO_TOOLS_ROOT. The scripts are idempotent, so a cache hit on
+      # rstudio-tools-deps makes this a fast pass: the heavy downloads are
+      # skipped and the cached tools are reused.
+      - name: Install build dependencies
+        working-directory: dependencies/linux
+        run: ./install-dependencies-noble
+
+      # Save the tools / R-libs caches only from main-scoped runs (a build_only
+      # dispatch on main, or any future scheduled caller -- this engine has no
+      # seed workflow of its own), and only on a key miss. A cache saved from a
+      # PR run lands in that PR's merge-ref scope, which no other branch can
+      # restore -- each copy is pure pressure on the repo's 10 GB Actions
+      # cache quota, and that pressure is what evicts main's copies and sends
+      # every build cold in the first place.
+      - name: Save rstudio-tools deps
+        if: github.ref == 'refs/heads/main' && steps.tools-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.RSTUDIO_TOOLS_ROOT }}
+          key: ${{ steps.tools-cache.outputs.cache-primary-key }}
+
+      - name: Save build-time R packages
+        if: github.ref == 'refs/heads/main' && steps.rlibs-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/R-libs
+          key: ${{ steps.rlibs-cache.outputs.cache-primary-key }}
+
+      - name: Zero sccache stats
+        run: sccache --zero-stats || true
+
+      - name: Build RStudio Desktop DEB
+        id: build
+        working-directory: package/linux
+        env:
+          RSTUDIO_VERSION_MAJOR: '99'
+          RSTUDIO_VERSION_MINOR: '9'
+          RSTUDIO_VERSION_PATCH: '9'
+          RSTUDIO_VERSION_SUFFIX: "-pr+${{ github.run_number }}"
+        run: |
+          # NO_REBUILD=1 (see package/linux/make-package) tells the script to
+          # set GWT_BUILD=no, which becomes -DGWT_BUILD=no to cmake, so the
+          # cached GWT bin/www/extras under build-Electron-DEB/gwt are reused
+          # instead of recompiled (~15-30 min saved when sources unchanged).
+          if [ "${{ steps.gwt-cache.outputs.cache-hit }}" = "true" ]; then
+            echo "GWT cache hit -- skipping GWT compile"
+            NO_REBUILD=1 ./make-electron-package DEB
+          else
+            echo "GWT cache miss -- compiling GWT from scratch"
+            ./make-electron-package DEB
+          fi
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
+      # Save GWT output only when the build succeeded. A failed mid-compile run
+      # could otherwise write partial GWT output to the cache, and every future
+      # restore would silently ship a broken frontend until the hashFiles key
+      # rotates. Save only from main-scoped runs, and only on a key miss: a
+      # cache saved from a PR run lands in that PR's merge-ref scope, which no
+      # other branch can restore -- each copy is pure pressure on the repo's
+      # 10 GB Actions cache quota, and that pressure is what evicts main's
+      # copy and sends every build cold in the first place.
+      - name: Save GWT output
+        if: github.ref == 'refs/heads/main' && steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: package/linux/build-Electron-DEB/gwt
+          key: ${{ steps.gwt-cache.outputs.cache-primary-key }}
+
+      # Skipped in build_only (seed) runs: no e2e job consumes the artifact,
+      # so packaging and uploading it would be pure waste.
+      - name: Package RStudio Desktop .deb
+        if: inputs.build_only != true
+        run: |
+          DEB=$(find package/linux/build-Electron-DEB -maxdepth 1 -name '*.deb' | head -1)
+          if [ -z "$DEB" ]; then
+            echo "::error::No .deb found in package/linux/build-Electron-DEB"
+            exit 1
+          fi
+          cp "$DEB" "${{ github.workspace }}/rstudio-desktop.deb"
+          echo "Packaged: $DEB"
+
+      - name: Upload RStudio Desktop .deb artifact
+        if: inputs.build_only != true
+        uses: actions/upload-artifact@v4
+        with:
+          name: rstudio-desktop-deb-debian-13-arm64
+          path: rstudio-desktop.deb
+          retention-days: 7
+
+  e2e-desktop-debian:
+    needs: build
+    # build is skipped when build_from_source is false or rstudio_installer_url
+    # is set; allow this job to run in those cases too (needs.build.result ==
+    # 'skipped' on the download path). build_only seeds the build caches
+    # without running e2e, so skip.
+    if: |
+      always() &&
+      inputs.build_only != true &&
+      (needs.build.result == 'success' || needs.build.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    runs-on: ubuntu-24.04-arm
+    container:
+      image: debian:13
+      # SYS_ADMIN + unconfined seccomp let Chromium/Electron's namespace sandbox
+      # initialize inside the container. The bare-runner Ubuntu jobs instead flip
+      # a host sysctl (kernel.apparmor_restrict_unprivileged_userns=0), which
+      # isn't reachable from an unprivileged container -- /proc/sys is read-only.
+      # Combined with dropping to a non-root user for the run itself (see the
+      # setpriv step below), this keeps the real sandbox ON, matching the
+      # bare-runner siblings. If a future runner kernel forbids unprivileged user
+      # namespaces and the sandbox can't come up, set rstudio_extra_args to
+      # '--no-sandbox' as a fallback rather than changing these.
+      #
+      # --shm-size=2g: container jobs default /dev/shm to 64 MB, which Chromium
+      # uses for cross-process shared memory. Under that cap the Electron
+      # renderer crashes to a blank page with no logged cause after a while
+      # (observed in the first arm64 run: the app worked for dozens of tests,
+      # then "Target crashed" mid-suite with nothing in rdesktop.log or the
+      # trace). The bare-runner siblings get the host's full /dev/shm and never
+      # hit this. Raising it to 2g is the standard container fix.
+      options: --cap-add=SYS_ADMIN --security-opt seccomp=unconfined --shm-size=2g
+    timeout-minutes: 120
+    env:
+      R_LIBS_USER: ${{ github.workspace }}/R-libs
+      PW_SANDBOX_ROOT: ${{ github.workspace }}/pw-sandbox
+      PW_SANDBOX_ROOT_CREATE: '1'
+      # The minimal debian:13 image sets no locale, so R starts with a non-UTF-8
+      # charset and prints "Character set is not UTF-8; please change your
+      # locale" into the console. Console-content tests (e.g. the ANSI cursor
+      # suite) assert on exact console lines, so that warning breaks them
+      # deterministically. C.UTF-8 is built into glibc on Debian 13 (no
+      # locale-gen needed); setting it job-level carries through the setpriv
+      # drop into Electron and rsession. The bare-runner siblings inherit a
+      # UTF-8 locale from the runner image and never hit this.
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
+
+    steps:
+      # The debian:13 base image is minimal and the job runs as root. Install
+      # what checkout, rig, apt's .deb install, and the run need up front.
+      # (tar and gzip are Debian essentials, so unlike the Fedora sibling they
+      # need no explicit install.)
+      - name: Prepare Debian container
+        run: |
+          apt-get update
+          apt-get install -y \
+            ca-certificates curl git sudo jq xz-utils procps findutils
+          update-ca-certificates
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
+
+      - name: Install OS dependencies
+        run: |
+          # Xvfb (virtual display for the Electron app / Playwright) plus the
+          # runtime libraries Electron/Chromium needs on Debian. This list is
+          # load-bearing, not redundant: the RStudio Desktop .deb declares only
+          # libssl-dev, libclang-dev, libsqlite3-0, libxkbcommon-x11-0, and
+          # libc6 (see RSTUDIO_DEBIAN_DEPENDS in package/linux/CMakeLists.txt),
+          # so apt does NOT pull the GUI/Chromium libs when it installs the
+          # .deb -- they must come from here. The bare-runner Ubuntu siblings
+          # get them for free from the runner image; a minimal container does
+          # not. Playwright's later `install --with-deps` overlaps much of this
+          # set but omits GTK3 / libxss1 / libxtst6, which the Electron app
+          # itself needs. Package names are trixie's (t64 suffixes from the
+          # time64 transition). The last row mirrors the font/text libs some
+          # test R packages load: freetype/fontconfig (ragg, systemfonts),
+          # harfbuzz/fribidi (textshaping).
+          # lsof: the desktop fixture uses it to reclaim an orphaned RStudio on
+          # the worker's fixed CDP port; the minimal Debian image doesn't ship it.
+          apt-get install -y xvfb jq lsof \
+            libnss3 libnspr4 libatk1.0-0t64 libatk-bridge2.0-0t64 libatspi2.0-0t64 \
+            libcups2t64 libdbus-1-3 libdrm2 libgbm1 libxkbcommon0 \
+            libgtk-3-0t64 libpango-1.0-0 libcairo2 libasound2t64 \
+            libx11-6 libxcomposite1 libxdamage1 libxext6 libxfixes3 libxrandr2 \
+            libxss1 libxtst6 libxcb1 \
+            libfreetype6 libfontconfig1 libharfbuzz0b libfribidi0
+
+      - name: Install rig
+        uses: ./.github/actions/os-install-rig-unix
+
+      - name: Install R via rig
+        env:
+          R_VERSION: ${{ inputs.r_version }}
+        run: |
+          rig add "$R_VERSION"
+          rig default "$R_VERSION"
+          rig ls
+          mkdir -p "$R_LIBS_USER"
+
+      # Point R package installs at the Ubuntu 24 (noble) PPM, the only codename
+      # with arm64 binaries. Both os-e2e-deps and the in-test Playwright harness
+      # (fixtures/r-libs-setup.ts) derive the PPM binary repo from
+      # /etc/os-release's VERSION_CODENAME, which is "trixie" in this container --
+      # but PPM serves NO arm64 binaries for trixie yet (x86_64 only), while noble
+      # has both. Rewriting the codename to noble steers BOTH shared consumers to
+      # https://packagemanager.posit.co/cran/__linux__/noble/latest so R packages
+      # arrive as noble arm64 binaries instead of source-compiling every one.
+      # Done after rig (which needed the real distro) and before any R package
+      # install. apt is unaffected -- it keys off /etc/apt/sources.list.
+      # TEMPORARY: remove this step once PPM publishes trixie arm64 binaries, so
+      # the tests use native Debian 13 packages (PPM already serves trixie
+      # x86_64 binaries; arm64 is the only gap).
+      - name: Use the Ubuntu 24 (noble) PPM for R packages (arm64 binaries)
+        run: |
+          sed -i 's/^VERSION_CODENAME=.*/VERSION_CODENAME=noble/' /etc/os-release
+          grep '^VERSION_CODENAME=' /etc/os-release
+
+      # Build-from-source path: extract the .deb artifact produced by the build
+      # job above and install it. Its GUI/Chromium runtime libs come from the
+      # "Install OS dependencies" step above, not from the .deb's own Depends
+      # (which are minimal -- see that step's comment).
+      - name: Download RStudio Desktop .deb artifact
+        if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
+        uses: actions/download-artifact@v4
+        with:
+          name: rstudio-desktop-deb-debian-13-arm64
+          path: ${{ github.workspace }}
+
+      - name: Install RStudio Desktop from artifact
+        if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
+        run: |
+          apt-get install -y "$GITHUB_WORKSPACE/rstudio-desktop.deb"
+          ls -la /usr/bin/rstudio
+
+      # Daily-download path: resolve and install the latest (or specified) .deb.
+      # Runs when build_from_source is false (auto-resolve the daily via
+      # dailies.rstudio.com/rstudio/latest/index.json) or when an explicit
+      # rstudio_installer_url is provided (use that URL verbatim).
+      - name: Resolve RStudio Desktop .deb URL
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
+        id: resolve
+        env:
+          INSTALLER_URL: ${{ inputs.rstudio_installer_url }}
+        run: |
+          URL="$INSTALLER_URL"
+          SHA=""
+          FILENAME=""
+          if [ -z "$URL" ]; then
+            MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 'https://dailies.rstudio.com/rstudio/latest/index.json')
+            # Debian 13 arm64 runs the same Electron .deb as Ubuntu 24 arm64: the
+            # daily keyed "noble-arm64" under the electron product. There is no
+            # Debian-specific desktop SKU. (jammy-arm64 also exists but is Ubuntu
+            # 22, and its PPM has no arm64 binaries, so noble is the right analog.)
+            URL=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["noble-arm64"].link // empty')
+            SHA=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["noble-arm64"].sha256 // empty')
+            FILENAME=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["noble-arm64"].filename // empty')
+            if [ -z "$URL" ] || [ -z "$FILENAME" ] || [ -z "$SHA" ]; then
+              echo "::error::Daily manifest is missing expected fields (url='$URL', filename='$FILENAME', sha256='$SHA'). The schema at https://dailies.rstudio.com/rstudio/latest/index.json may have changed."
+              exit 1
+            fi
+            echo "Auto-resolved latest noble-arm64 desktop daily:"
+            echo "  URL:      $URL"
+            echo "  SHA-256:  $SHA"
+            echo "  Filename: $FILENAME"
+          else
+            FILENAME=$(basename "${URL%%\?*}")
+            if [ -z "$FILENAME" ]; then
+              echo "::error::Could not derive filename from rstudio_installer_url='$URL'."
+              exit 1
+            fi
+            echo "Using override URL: $URL (SHA-256 verification skipped)"
+          fi
+          echo "url=$URL"           >> "$GITHUB_OUTPUT"
+          echo "sha256=$SHA"        >> "$GITHUB_OUTPUT"
+          echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
+
+      # Downloaded fresh every run rather than cached: dailies.rstudio.com is
+      # already S3/CDN-backed, and GH Actions cache scoping means concurrent
+      # PRs can't share a cache entry with each other anyway (only with their
+      # base branch), so caching here would just duplicate the same bytes
+      # into the shared 10 GB cache quota without saving meaningful time.
+      - name: Download RStudio Desktop .deb
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
+        env:
+          DOWNLOAD_URL: ${{ steps.resolve.outputs.url }}
+          DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}
+        run: |
+          curl -fsSL --retry 3 --retry-delay 5 \
+            -o "$DOWNLOAD_FILENAME" \
+            "$DOWNLOAD_URL"
+
+      - name: Verify SHA-256
+        if: (inputs.build_from_source == false || inputs.rstudio_installer_url != '') && steps.resolve.outputs.sha256 != ''
+        env:
+          EXPECTED_SHA256: ${{ steps.resolve.outputs.sha256 }}
+          DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}
+        run: |
+          echo "$EXPECTED_SHA256  $DOWNLOAD_FILENAME" | sha256sum -c -
+
+      - name: Install RStudio Desktop from .deb
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
+        env:
+          INSTALLER_FILENAME: ${{ steps.resolve.outputs.filename }}
+        run: |
+          apt-get install -y "./$INSTALLER_FILENAME"
+          ls -la /usr/bin/rstudio
+
+      # R packages install from PPM's noble arm64 binary repo (see the codename
+      # override step above). os-e2e-deps derives the repo from the (rewritten)
+      # /etc/os-release codename, so it resolves
+      # https://packagemanager.posit.co/cran/__linux__/noble/latest -- native
+      # noble arm64 binaries, no source compile.
+      - name: Install e2e test dependencies
+        uses: ./.github/actions/os-e2e-deps
+        with:
+          r-libs-user: ${{ env.R_LIBS_USER }}
+          # Isolate the R-library / pak caches from the other Linux workflows:
+          # they all share runner.os == Linux, and this arm64 library (noble
+          # binaries in a Debian container) is not interchangeable with the
+          # x86_64 bare-runner Ubuntu caches.
+          cache-scope: debian13-arm64
+
+      # Run the tests as a non-root user, matching the bare-runner siblings
+      # (Ubuntu/macOS/Windows all execute as a non-root user) and the Fedora
+      # container engine. GHA container jobs default to root, and RStudio-as-root
+      # diverges from real usage: Chromium refuses its sandbox as root, the
+      # terminal gets a root shell, and rsession warns. All the setup above needs
+      # root (apt, the .deb install, cache writes, rig), so only the test step
+      # drops down -- create the user here and hand it ownership of everything the
+      # run writes under the workspace (R-libs, ms-playwright, pw-sandbox, the pak
+      # cache, and the report dirs under e2e/rstudio).
+      - name: Create non-root test user
+        run: |
+          useradd -m -s /bin/bash rstudio-tester
+          chown -R rstudio-tester:rstudio-tester "$GITHUB_WORKSPACE"
+
+      - name: Run Playwright tests
+        working-directory: e2e/rstudio
+        # Explicit shell: container jobs default run steps to sh, not bash
+        # (actions/runner behavior -- the documented bash-with-sh-fallback
+        # default only describes bare runners) -- and this script uses bash
+        # arrays (ARGS=(), +=, "${ARGS[@]}"). On Debian /bin/sh is dash, which
+        # cannot parse them ("Syntax error: '(' unexpected"). The bare-runner
+        # siblings don't need this key (bash is always on PATH on GitHub-hosted
+        # images, so their default resolves to bash), and the Fedora and RHEL
+        # container siblings get away without it only because the Red Hat
+        # family symlinks /bin/sh to bash. Note: an explicit shell adds
+        # -o pipefail, which the siblings' implicit bash default lacks --
+        # harmless today, since this script has no pipelines.
+        shell: bash
+        env:
+          PW_RSTUDIO_MODE: desktop
+          # Platform-labelled project name; playwright.config.ts uses it both as
+          # the project name in reports (so a cross-platform merged report can
+          # distinguish these results) and to derive the platform+shard-unique
+          # blob report file name.
+          PW_PROJECT_LABEL: ${{ inputs.project }}-linux-debian-arm64
+          PW_GREP: ${{ inputs.grep }}
+          PW_GREP_INVERT: ${{ inputs.grep_invert }}
+          PW_TEST_SELECTOR: ${{ inputs.test_selector }}
+          PW_TEST_IGNORE: ${{ inputs.test_ignore }}
+          # No --no-sandbox: the test step runs as a non-root user (see the
+          # setpriv drop below), so Chromium no longer refuses to start, and the
+          # container's SYS_ADMIN + unconfined seccomp let its namespace sandbox
+          # initialize -- matching how the bare-runner siblings run (sandbox on).
+          # If a future runner kernel forbids unprivileged user namespaces and
+          # the sandbox can't come up, set rstudio_extra_args to '--no-sandbox'.
+          PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
+          # Tells playwright.config.ts to switch to blob reporter for this shard.
+          PW_SHARD: ${{ matrix.shard }}
+          # E2E Test Insights reporter: posts per-shard results to the dashboard.
+          # CONNECT_API_KEY is empty on fork PRs; the reporter still runs but its
+          # uploads fail with warnings (never fails the run).
+          CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+          SHARD_NAME: desktop-linux-debian-arm64-${{ matrix.shard }}
+          # Print the GWT launch timeline so the next launch failure shows which
+          # phase exceeded the deadline.
+          PW_DEBUG_LAUNCH: '1'
+        run: |
+          ARGS=()
+          if [ -n "$PW_TEST_SELECTOR" ]; then
+            set -f
+            ARGS+=($PW_TEST_SELECTOR)
+            set +f
+          fi
+          if [ -n "$PW_GREP" ]; then
+            ARGS+=(--grep "$PW_GREP")
+          fi
+          if [ -n "$PW_GREP_INVERT" ]; then
+            ARGS+=(--grep-invert "$PW_GREP_INVERT")
+          fi
+          ARGS+=(--shard="${{ matrix.shard }}/${{ strategy.job-total }}")
+          # Run Playwright under our own Xvfb and exec the watchdog as the step's
+          # main process, so a job cancellation's SIGTERM reaches the watchdog
+          # (which forwards it to Playwright's process group as SIGINT -- its
+          # cancellation signal -- then escalates to SIGKILL if the run doesn't
+          # wind down). xvfb-run is a shell wrapper that does not forward signals
+          # to its child, which left cancelled Linux e2e jobs running until
+          # their timeout-minutes instead of stopping. -ac disables X access
+          # control so Chromium connects without an auth cookie; -nolisten tcp
+          # keeps the display on the local socket only. We wait for the X socket
+          # before launching so it doesn't race a cold display, and fail loudly
+          # (dumping the Xvfb log) if it never comes up, rather than exec-ing
+          # Playwright against a dead display and surfacing an opaque launch error.
+          Xvfb :99 -screen 0 1920x1080x24 -ac -nolisten tcp >/tmp/xvfb.log 2>&1 &
+          export DISPLAY=:99
+          for _ in $(seq 1 50); do
+            [ -S /tmp/.X11-unix/X99 ] && break
+            sleep 0.1
+          done
+          if [ ! -S /tmp/.X11-unix/X99 ]; then
+            echo "::error::Xvfb display :99 never came up after 5s; Xvfb log follows."
+            cat /tmp/xvfb.log || true
+            exit 1
+          fi
+          # Drop to the non-root user for the run itself. setpriv execs in
+          # place (no fork), so a job-cancellation SIGTERM still reaches node
+          # directly and the watchdog's SIGINT->SIGKILL path is preserved --
+          # runuser/su would fork and swallow the signal. --init-groups adopts
+          # the user's groups; the environment is left intact (DISPLAY, PW_*,
+          # PATH, R_LIBS_USER all carry through), and we only override HOME,
+          # since the step's HOME is root-owned and node/Playwright write into
+          # it. Xvfb keeps running as root above; -ac lets the non-root Chromium
+          # attach to :99 without an auth cookie.
+          exec setpriv --reuid=rstudio-tester --regid=rstudio-tester --init-groups \
+            env HOME=/home/rstudio-tester \
+            node scripts/run-with-heartbeat.mjs -- test "${ARGS[@]}"
+
+      # Platform-prefixed artifact name keeps this Debian arm64 platform's shard
+      # reports separate from the other platforms' if this workflow is ever
+      # merged into a combined run, so this workflow's own merge job downloads
+      # only its own shards.
+      - name: Upload blob report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-blob-report-linux-desktop-debian-arm64-${{ matrix.shard }}
+          path: e2e/rstudio/blob-report/
+          if-no-files-found: warn
+          retention-days: 1
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-linux-desktop-debian-arm64-${{ matrix.shard }}
+          path: e2e/rstudio/test-results/
+          if-no-files-found: ignore
+
+      # Preserved per-spec sandbox tree on failure -- includes rsession logs,
+      # the spec's RStudio config / data home, and per-test working dirs.
+      - name: Upload PW sandbox (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pw-sandbox-linux-desktop-debian-arm64-${{ matrix.shard }}
+          path: ${{ github.workspace }}/pw-sandbox/
+          if-no-files-found: ignore
+
+  # Merge per-shard blob reports into a single HTML report, parse aggregated
+  # counts, and post a sticky PR comment with pass/fail/skip totals
+  # (when post_pr_comment is set). Runs on a plain hosted runner -- merging only
+  # needs node + `playwright merge-reports`, no Debian container.
+  e2e-merge:
+    needs: [e2e-desktop-debian]
+    if: always() && inputs.defer_merge != true && needs.e2e-desktop-debian.result != 'skipped' && needs.e2e-desktop-debian.result != 'cancelled'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+      # OIDC token for the S3 report upload (os-publish-e2e-report).
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
+
+      - name: Install Playwright
+        working-directory: e2e/rstudio
+        # --ignore-scripts skips the postinstall that downloads browser
+        # binaries; the merge job only invokes `playwright merge-reports`,
+        # which doesn't need Chromium.
+        run: npm ci --ignore-scripts
+
+      - name: Download shard blob reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: playwright-blob-report-linux-desktop-debian-arm64-*
+          path: e2e/rstudio/all-blob-reports
+          merge-multiple: true
+
+      - name: Merge shard reports
+        working-directory: e2e/rstudio
+        run: |
+          if [ -z "$(ls -A all-blob-reports 2>/dev/null)" ]; then
+            echo "::error::No blob reports found -- both shards failed to produce artifacts"
+            exit 1
+          fi
+          npx playwright merge-reports --config merge.config.ts ./all-blob-reports
+
+      # Shared summarizer (also used by the PR run's e2e-merge-all job) so every
+      # comment computes pass/fail counts and the rate bar from one definition.
+      - name: Parse aggregated results
+        id: summary
+        if: always()
+        working-directory: e2e/rstudio
+        run: node scripts/summarize-merged-report.mjs playwright-report/test-results.json
+
+      - name: Upload merged Playwright report
+        id: upload-report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-linux-desktop-debian-arm64
+          path: e2e/rstudio/playwright-report/
+          retention-days: 15
+          if-no-files-found: ignore
+
+      # Publish a browsable copy of the report to S3 on failure only, so
+      # reviewers can inspect it without downloading the zip. Best-effort: a
+      # no-op on fork PRs (no secret) and never fails the job.
+      - name: Publish report to S3
+        id: publish-report
+        if: always() && steps.summary.outputs.failed != '0' && steps.summary.outputs.failed != ''
+        uses: ./.github/actions/os-publish-e2e-report
+        with:
+          role-arn: ${{ secrets.AWS_E2E_REPORTS_ROLE_ARN }}
+          label: linux-desktop-debian-arm64
+
+      - name: Post E2E results to PR
+        if: |
+          always() &&
+          inputs.post_pr_comment == true &&
+          github.event.pull_request.head.repo.fork == false &&
+          (steps.summary.outputs.passed != '0' || steps.summary.outputs.failed != '0' || steps.summary.outputs.skipped != '0' || steps.summary.outputs.flaky != '0')
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: e2e-desktop-debian13-arm64-results
+          GITHUB_TOKEN: ${{ github.token }}
+          message: |
+            ## 🌀 Linux Desktop E2E · Debian 13 (arm64)
+
+            ${{ needs.e2e-desktop-debian.result == 'success' && steps.summary.outputs.failed == '0' && '### ✅ All tests passed!' || format('### ❌ {0} test(s) failed', steps.summary.outputs.failed) }}
+
+            `${{ steps.summary.outputs.bar }}` **${{ steps.summary.outputs.rate }}%** pass rate
+
+            | ✅ Passed | ❌ Failed | ⚠️ Skipped | 🔁 Flaky |
+            | :---: | :---: | :---: | :---: |
+            | **${{ steps.summary.outputs.passed }}** | **${{ steps.summary.outputs.failed }}** | **${{ steps.summary.outputs.skipped }}** | **${{ steps.summary.outputs.flaky }}** |
+
+            <details>
+            <summary>📥 Download Playwright report</summary>
+            ${{ steps.publish-report.outputs.url != '' && format('
+            **[🌐 View report online]({0})** — opens in the browser, no download needed. Available for 14 days.
+            ', steps.publish-report.outputs.url) || '' }}
+            **[⬇️ playwright-report.zip](${{ steps.upload-report.outputs.artifact-url }})** — extract and open `index.html`
+
+            > Includes screenshots, traces, and step-by-step details for every test. Expires in 15 days.
+
+            </details>
+
+            ---
+            <sub>2 shards · debian:13 arm64 container · commit <code>${{ github.event.pull_request.head.sha }}</code> · <a href="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}">Run #${{ github.run_number }}</a></sub>

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-43-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-43-x86_64.yml
@@ -1,0 +1,782 @@
+name: "Test: E2E Playwright RStudio (Desktop, Fedora 43 x86_64, Open Source)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_from_source:
+        description: "Build RStudio Desktop (Electron) from this branch's source. When false, downloads the latest daily .rpm installer."
+        type: boolean
+        default: true
+      rstudio_installer_url:
+        description: "Optional .rpm URL to test against (e.g. a specific daily from dailies.rstudio.com). Only used when build_from_source is false. Leave empty to auto-resolve the latest daily."
+        type: string
+        default: ""
+      r_version:
+        description: "Ignored on Fedora: R is installed from Fedora's own repos (dnf), so this always uses the distro's R regardless of value. Kept for interface parity with the other platform workflows."
+        type: string
+        default: "release"
+      project:
+        description: "Playwright project to run: 'desktop' or 'server'. OS and edition are auto-filtered from the host platform and PW_RSTUDIO_EDITION."
+        type: string
+        default: "desktop"
+      grep:
+        description: "Optional Playwright --grep pattern to run only tests whose title matches."
+        type: string
+        default: ""
+      test_selector:
+        description: "Optional test paths/files/directories to run (space-separated). Matched as substrings against test file paths. Examples: 'autocomplete.test.ts', 'tests/panes/misc/', 'autocomplete tests/panes/posit-assistant-chat/'. Leave empty to run all tests."
+        type: string
+        default: ""
+      test_ignore:
+        description: "Optional test paths/files/directories to exclude (space-separated globs). Examples: '**/code_suggestions.test.ts', '**/posit-assistant-chat/**'. Leave empty to exclude nothing."
+        type: string
+        default: ""
+      grep_invert:
+        description: "Optional Playwright --grep-invert pattern to skip tests by title. Empty by default (runs all tests)."
+        type: string
+        default: ""
+      rstudio_extra_args:
+        description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS. Set to '--no-sandbox' if the in-container Chromium sandbox won't initialize (see the container options below)."
+        type: string
+        default: ""
+      build_only:
+        description: "Run only the build job (to seed the rstudio-tools / R-libs / sccache caches) and skip the e2e job."
+        type: boolean
+        default: false
+      post_pr_comment:
+        description: "Post test results as a sticky comment on the PR. Pass true only from PR-triggered callers."
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      build_from_source:
+        type: boolean
+        default: true
+      rstudio_installer_url:
+        type: string
+        default: ""
+      r_version:
+        type: string
+        default: "release"
+      project:
+        type: string
+        default: "desktop"
+      grep:
+        type: string
+        default: ""
+      test_selector:
+        type: string
+        default: ""
+      test_ignore:
+        type: string
+        default: ""
+      grep_invert:
+        type: string
+        default: ""
+      rstudio_extra_args:
+        type: string
+        default: ""
+      build_only:
+        type: boolean
+        default: false
+      post_pr_comment:
+        type: boolean
+        default: false
+      defer_merge:
+        description: "Skip this workflow's own merge/publish/comment job; the caller merges every platform's blobs into one report instead."
+        type: boolean
+        default: false
+    secrets:
+      CONNECT_API_KEY:
+        description: "Posit Connect API key for the E2E Test Insights reporter"
+        required: false
+
+permissions:
+  contents: read
+  # Required so the e2e-merge job can post sticky PR comments via
+  # marocchino/sticky-pull-request-comment. GitHub validates ALL job-level
+  # permissions in a reusable workflow at call time, so this must be declared
+  # at the top level even though only e2e-merge uses it.
+  pull-requests: write
+
+jobs:
+  # Builds RStudio Desktop (Electron) from this PR's source inside a Fedora 43
+  # container (GitHub has no Fedora-hosted runner), then uploads the .rpm as an
+  # artifact for the e2e job to consume. This is the same kind of Electron
+  # .rpm the RHEL build produces -- there is no Fedora-specific SKU. Skipped when
+  # build_from_source is false, in which case the e2e job downloads the daily
+  # .rpm (or rstudio_installer_url) instead.
+  build:
+    if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
+    runs-on: ubuntu-latest
+    # SYS_ADMIN + an unconfined seccomp profile let a later Chromium/Electron
+    # sandbox initialize inside the container (the host sysctl the Ubuntu jobs
+    # flip isn't reachable here -- /proc/sys is read-only in the container).
+    container:
+      image: fedora:43
+      options: --cap-add=SYS_ADMIN --security-opt seccomp=unconfined
+    timeout-minutes: 90
+    env:
+      # Redirect the dependency / package scripts' tool root to a
+      # workspace-local path so it can be cached without sudo.
+      RSTUDIO_TOOLS_ROOT: ${{ github.workspace }}/opt/rstudio-tools/x86_64
+      # Pin R's user library to a workspace-local path so we can cache it.
+      R_LIBS_USER: ${{ github.workspace }}/R-libs/%p/%v
+      SCCACHE_ENABLED: '1'
+      # Route sccache to GitHub's built-in Actions cache API. The
+      # mozilla-actions/sccache-action step below installs sccache and exports
+      # ACTIONS_CACHE_URL + ACTIONS_RUNTIME_TOKEN so the sccache server uses
+      # the GHA backend. Cache hits are object-level (one entry per compiled
+      # .o), so PRs automatically inherit main's warm cache from the seed job
+      # without per-SHA tarball rotation. No AWS / S3 / secrets required.
+      SCCACHE_GHA_ENABLED: 'true'
+      # Compile GWT with readable (PRETTY) symbol names rather than the default
+      # OBFUSCATED output, so the uncaught client exceptions the e2e automation
+      # agent records (window.rstudio.errors) carry decodable Java stack traces.
+      # Consumed by src/gwt/CMakeLists.txt; folded into the GWT cache key below.
+      GWT_STYLE: PRETTY
+      # Quiet npm during install-common's panmirror build, the Electron app
+      # build, and any other transitive npm step.
+      NPM_CONFIG_LOGLEVEL: error
+      NPM_CONFIG_AUDIT: 'false'
+
+    steps:
+      # The Fedora base image is minimal and the job runs as root. Install the
+      # tools the checkout action, the dependency scripts, and the build need up
+      # front. sudo is required because install-dependencies-yum calls it
+      # internally (root's sudo is a straight passthrough). Unlike RHEL's UBI,
+      # Fedora's base repos already carry the build -devel packages, so no EPEL /
+      # CodeReady Builder enablement step is needed.
+      - name: Prepare Fedora container
+        run: |
+          dnf -y install sudo git tar gzip xz jq which findutils diffutils procps-ng
+
+      - uses: actions/checkout@v4
+
+      # Pre-built tool deps (Boost, SOCI, pandoc, quarto, GWT, node, panmirror,
+      # copilot-language-server, sccache, etc.) all land under RSTUDIO_TOOLS_ROOT.
+      # Restore-only; the matching Save steps after "Install build
+      # dependencies" run only from main-scoped runs. Fedora-scoped key so the
+      # fedora43 tools tree never collides with the Ubuntu (noble), RHEL, or
+      # Fedora 44 ones.
+      - name: Restore rstudio-tools deps
+        id: tools-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.RSTUDIO_TOOLS_ROOT }}
+          key: rstudio-tools-linux-fedora43-x86_64-${{ hashFiles('dependencies/common/install-*', 'dependencies/linux/install-*', 'dependencies/tools/rstudio-tools.sh') }}
+          restore-keys: |
+            rstudio-tools-linux-fedora43-x86_64-
+
+      # install-common (called by install-dependencies-yum) installs R packages
+      # (via install-packages) into R_LIBS_USER. Cache the whole R-libs tree --
+      # R's %p/%v subpaths keep different versions isolated.
+      - name: Restore build-time R packages
+        id: rlibs-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/R-libs
+          key: rstudio-build-rlibs-linux-fedora43-x86_64-${{ hashFiles('dependencies/common/install-packages', 'dependencies/common/lockfiles/**/renv.lock') }}
+          restore-keys: |
+            rstudio-build-rlibs-linux-fedora43-x86_64-
+
+      # Cache compiled GWT output (package/linux/build-Electron-RPM/gwt). GWT
+      # compilation is the single most expensive JS step (~15-30 min). When
+      # GWT Java sources / build scripts haven't changed, make-electron-package
+      # can skip the recompile entirely via the NO_REBUILD env var (sets
+      # GWT_BUILD=no, which becomes -DGWT_BUILD=no to cmake) -- see the
+      # NO_REBUILD/GWT_BUILD handling in package/linux/make-package. GWT output
+      # is Java-to-JS and platform-independent, but the key is fedora43-scoped
+      # for per-distro cache isolation (matching the tools/rlibs keys); the RPM
+      # build dir also differs from the DEB dir, so the path can't collide either.
+      # Restore-only here; the matching Save step runs after the build with a
+      # success gate so a failed mid-compile run can't poison the cache.
+      - name: Restore GWT output
+        id: gwt-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: package/linux/build-Electron-RPM/gwt
+          key: rstudio-gwt-linux-desktop-fedora43-x86_64-${{ env.GWT_STYLE }}-v1-${{ hashFiles('src/gwt/src/**', 'src/gwt/acesupport/**', 'src/gwt/lib/**', 'src/gwt/build.xml', 'src/gwt/conf/**') }}
+          restore-keys: |
+            rstudio-gwt-linux-desktop-fedora43-x86_64-${{ env.GWT_STYLE }}-v1-
+
+      # GHA-backed sccache. Installs sccache on PATH and starts the sccache
+      # server with the GH Actions cache API as the storage backend. Object-level
+      # cache hits, no per-SHA tarball, no AWS credentials.
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          # Pinned: resolving "latest" queries api.github.com at runtime,
+          # which fails during GitHub API incidents (503s). A pinned version
+          # downloads directly from the release CDN with no API call.
+          version: "v0.16.0"
+
+      # install-dependencies-yum: dnf installs system packages (with sudo
+      # internally), then calls install-common which downloads Boost, SOCI,
+      # pandoc, quarto, node, panmirror, sccache, GWT jar, etc. into
+      # RSTUDIO_TOOLS_ROOT. The scripts are idempotent, so a cache hit on
+      # rstudio-tools-deps makes this a fast pass: the heavy downloads are
+      # skipped and the cached tools are reused.
+      - name: Install build dependencies
+        working-directory: dependencies/linux
+        run: ./install-dependencies-yum
+
+      # Save the tools / R-libs caches only from main-scoped runs (scheduled
+      # or dispatched on main), and only on a key miss. A cache saved from a
+      # PR run lands in that PR's merge-ref scope, which no other branch can
+      # restore -- each copy is pure pressure on the repo's 10 GB Actions
+      # cache quota, and that pressure is what evicts main's copies and sends
+      # every PR build cold in the first place.
+      - name: Save rstudio-tools deps
+        if: github.ref == 'refs/heads/main' && steps.tools-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.RSTUDIO_TOOLS_ROOT }}
+          key: ${{ steps.tools-cache.outputs.cache-primary-key }}
+
+      - name: Save build-time R packages
+        if: github.ref == 'refs/heads/main' && steps.rlibs-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/R-libs
+          key: ${{ steps.rlibs-cache.outputs.cache-primary-key }}
+
+      - name: Zero sccache stats
+        run: sccache --zero-stats || true
+
+      - name: Build RStudio Desktop RPM
+        id: build
+        working-directory: package/linux
+        env:
+          RSTUDIO_VERSION_MAJOR: '99'
+          RSTUDIO_VERSION_MINOR: '9'
+          RSTUDIO_VERSION_PATCH: '9'
+          RSTUDIO_VERSION_SUFFIX: "-pr+${{ github.run_number }}"
+        run: |
+          # NO_REBUILD=1 (see package/linux/make-package) tells the script to
+          # set GWT_BUILD=no, which becomes -DGWT_BUILD=no to cmake, so the
+          # cached GWT bin/www/extras under build-Electron-RPM/gwt are reused
+          # instead of recompiled (~15-30 min saved when sources unchanged).
+          if [ "${{ steps.gwt-cache.outputs.cache-hit }}" = "true" ]; then
+            echo "GWT cache hit -- skipping GWT compile"
+            NO_REBUILD=1 ./make-electron-package RPM
+          else
+            echo "GWT cache miss -- compiling GWT from scratch"
+            ./make-electron-package RPM
+          fi
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
+      # Save GWT output only when the build succeeded. A failed mid-compile run
+      # could otherwise write partial GWT output to the cache, and every future
+      # restore would silently ship a broken frontend until the hashFiles key
+      # rotates. Skip on an exact restore hit: re-saving would just duplicate
+      # the entry into this run's ref scope. PR runs that changed GWT sources
+      # still save, so re-pushes to the same PR skip the recompile.
+      - name: Save GWT output
+        if: steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: package/linux/build-Electron-RPM/gwt
+          key: ${{ steps.gwt-cache.outputs.cache-primary-key }}
+
+      # Skipped in build_only (seed) runs: no e2e job consumes the artifact,
+      # so packaging and uploading it would be pure waste. CPack writes the
+      # shippable .rpm to the TOP LEVEL of build-Electron-RPM (no
+      # CPACK_PACKAGE_DIRECTORY is set and cpack runs from inside that dir),
+      # exactly like the .deb sibling -- so -maxdepth 1 is correct and
+      # deterministic. _CPack_Packages/.../RPM holds only rpmbuild staging
+      # copies and the xcopy tarball, which we must not pick up.
+      - name: Package RStudio Desktop .rpm
+        if: inputs.build_only != true
+        run: |
+          RPM=$(find package/linux/build-Electron-RPM -maxdepth 1 -name '*.rpm' | head -1)
+          if [ -z "$RPM" ]; then
+            echo "::error::No .rpm found in package/linux/build-Electron-RPM"
+            exit 1
+          fi
+          cp "$RPM" "${{ github.workspace }}/rstudio-desktop.rpm"
+          echo "Packaged: $RPM"
+
+      - name: Upload RStudio Desktop .rpm artifact
+        if: inputs.build_only != true
+        uses: actions/upload-artifact@v4
+        with:
+          name: rstudio-desktop-rpm-fedora43-x86_64
+          path: rstudio-desktop.rpm
+          retention-days: 7
+
+  e2e-desktop-fedora43:
+    needs: build
+    # build is skipped when build_from_source is false; allow this job to run
+    # in that case too (needs.build.result == 'skipped' on the daily-download
+    # path). build_only seeds the build caches without running e2e, so skip.
+    if: |
+      always() &&
+      inputs.build_only != true &&
+      (needs.build.result == 'success' || needs.build.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:43
+      # SYS_ADMIN + unconfined seccomp let Chromium/Electron's namespace sandbox
+      # initialize inside the container. The Ubuntu jobs instead flip a host
+      # sysctl (kernel.apparmor_restrict_unprivileged_userns=0), which isn't
+      # reachable from an unprivileged container -- /proc/sys is read-only. If
+      # the sandbox still refuses to come up here, pass --no-sandbox via
+      # rstudio_extra_args (PW_RSTUDIO_EXTRA_ARGS) rather than changing these.
+      options: --cap-add=SYS_ADMIN --security-opt seccomp=unconfined
+    timeout-minutes: 120
+    env:
+      R_LIBS_USER: ${{ github.workspace }}/R-libs
+      PW_SANDBOX_ROOT: ${{ github.workspace }}/pw-sandbox
+      PW_SANDBOX_ROOT_CREATE: '1'
+
+    steps:
+      # The Fedora base image is minimal and the job runs as root. Install what
+      # checkout, node, and the .rpm install need. sudo is kept for parity with
+      # the shared scripts.
+      - name: Prepare Fedora container
+        run: |
+          dnf -y install sudo git tar gzip xz jq which findutils
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
+
+      - name: Install OS dependencies
+        run: |
+          # Xvfb (virtual display for the Electron app / Playwright) plus the
+          # runtime libraries Chromium/Electron and the Playwright-managed
+          # chromium need on Fedora. This list is load-bearing, not redundant:
+          # the RStudio Electron RPM is built with CPACK_RPM_PACKAGE_AUTOREQPROV
+          # off (see package/linux/CMakeLists.txt) and declares only
+          # libxkbcommon-x11 and sqlite, so dnf does NOT auto-pull the
+          # GUI/Chromium libs on install -- they must come from here. The last
+          # row mirrors the font/text libs some test R packages load:
+          # freetype/fontconfig (ragg, systemfonts), harfbuzz/fribidi
+          # (textshaping).
+          # lsof: the desktop fixture uses it to reclaim an orphaned RStudio on
+          # the worker's fixed CDP port (a leftover from a prior interrupted
+          # run). Ubuntu/macOS ship it; the minimal Fedora image doesn't, so
+          # install it -- otherwise the reclaim and port-free wait silently
+          # degrade (the "lsof: command not found" spam in the logs).
+          dnf -y install \
+            xorg-x11-server-Xvfb lsof \
+            nss nspr atk at-spi2-atk at-spi2-core cups-libs \
+            libdrm mesa-libgbm libxkbcommon \
+            libX11 libXcomposite libXdamage libXext libXfixes libXrandr libXScrnSaver libXtst libxcb \
+            gtk3 pango cairo alsa-lib \
+            freetype fontconfig harfbuzz fribidi
+
+      - name: Install R build toolchain and headers
+        run: |
+          # Fedora has no prebuilt CRAN binaries (PPM serves none), so the e2e R
+          # packages (tidyverse, shiny, rmarkdown, roxygen2, ...) are compiled
+          # from source by pak. That needs a compiler stack (gcc/g++/gfortran +
+          # make) plus the -devel headers their compiled dependencies link
+          # against: libcurl/openssl/libxml2 (curl, openssl, xml2), the font/text
+          # stack (systemfonts, textshaping, ragg), the image libs (ragg), zlib
+          # (data.table and others), and ICU (stringi). zlib ships as zlib-ng on
+          # Fedora, so the headers come from zlib-ng-compat-devel.
+          dnf -y install \
+            gcc gcc-c++ gcc-gfortran make \
+            libcurl-devel openssl-devel libxml2-devel \
+            fontconfig-devel freetype-devel harfbuzz-devel fribidi-devel \
+            libpng-devel libjpeg-turbo-devel libtiff-devel \
+            zlib-ng-compat-devel libicu-devel cairo-devel
+
+      # Fedora is not a supported platform for rig / r-builds (Fedora R 404s on
+      # the rversions service) or for PPM binaries, so install R from Fedora's
+      # own repos and let pak compile CRAN packages from source (see
+      # os-e2e-deps and the toolchain step above). The r_version input is
+      # ignored on Fedora -- dnf provides whatever R the distro ships.
+      - name: Install R (Fedora native)
+        run: |
+          # Clear tsflags for this transaction so R's documentation tree is
+          # installed. Fedora container images ship /etc/dnf/dnf.conf with
+          # tsflags=nodocs (a space-saving default), which makes dnf skip
+          # /usr/share/doc/R. RStudio's R discovery (r/session/RDiscovery.cpp)
+          # requires R_DOC_DIR to exist and aborts the session otherwise, so a
+          # docless R install starts but never reaches window.rstudio.ready.
+          dnf -y install --setopt=tsflags='' R-core R-core-devel
+          R --version
+          # Diagnostics: the doc dir R reports, and confirm it now exists.
+          Rscript -e 'cat("doc=", R.home("doc"), " R_DOC_DIR=", Sys.getenv("R_DOC_DIR"), "\n", sep="")'
+          ls -ld /usr/share/doc/R || echo "MISSING /usr/share/doc/R"
+          mkdir -p "$R_LIBS_USER"
+
+      # Build-from-source path: extract the .rpm artifact produced by the build
+      # job above and install it. The RPM declares only minimal deps (AUTOREQPROV
+      # is off), so the GUI/Chromium runtime libs come from the "Install OS
+      # dependencies" step above, not from the RPM's own resolution.
+      - name: Download RStudio Desktop .rpm artifact
+        if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
+        uses: actions/download-artifact@v4
+        with:
+          name: rstudio-desktop-rpm-fedora43-x86_64
+          path: ${{ github.workspace }}
+
+      - name: Install RStudio Desktop from artifact
+        if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
+        run: |
+          dnf -y install "$GITHUB_WORKSPACE/rstudio-desktop.rpm"
+          ls -la /usr/bin/rstudio
+
+      # Daily-download path: resolve and install the latest (or specified) .rpm.
+      # Runs when build_from_source is false (auto-resolve the daily via
+      # dailies.rstudio.com/rstudio/latest/index.json) or when an explicit
+      # rstudio_installer_url is provided (use that URL verbatim).
+      - name: Resolve RStudio Desktop .rpm URL
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
+        id: resolve
+        env:
+          INSTALLER_URL: ${{ inputs.rstudio_installer_url }}
+        run: |
+          URL="$INSTALLER_URL"
+          SHA=""
+          FILENAME=""
+          if [ -z "$URL" ]; then
+            MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 'https://dailies.rstudio.com/rstudio/latest/index.json')
+            # There is no separate Fedora daily: the Electron .rpm keyed
+            # "rhel10-x86_64" under the electron product is the RPM the Fedora
+            # tests run against (the same build RHEL uses).
+            URL=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["rhel10-x86_64"].link // empty')
+            SHA=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["rhel10-x86_64"].sha256 // empty')
+            FILENAME=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["rhel10-x86_64"].filename // empty')
+            if [ -z "$URL" ] || [ -z "$FILENAME" ] || [ -z "$SHA" ]; then
+              echo "::error::Daily manifest is missing expected fields (url='$URL', filename='$FILENAME', sha256='$SHA'). The schema at https://dailies.rstudio.com/rstudio/latest/index.json may have changed."
+              exit 1
+            fi
+            echo "Auto-resolved latest rhel10-x86_64 desktop daily:"
+            echo "  URL:      $URL"
+            echo "  SHA-256:  $SHA"
+            echo "  Filename: $FILENAME"
+          else
+            FILENAME=$(basename "${URL%%\?*}")
+            if [ -z "$FILENAME" ]; then
+              echo "::error::Could not derive filename from rstudio_installer_url='$URL'."
+              exit 1
+            fi
+            echo "Using override URL: $URL (SHA-256 verification skipped)"
+          fi
+          echo "url=$URL"           >> "$GITHUB_OUTPUT"
+          echo "sha256=$SHA"        >> "$GITHUB_OUTPUT"
+          echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
+
+      # Cache the daily installer keyed on its resolved filename. Filenames
+      # embed the version + build number on the auto-resolve path so the content
+      # is immutable per name: new daily misses and downloads, same-day re-run
+      # hits and skips (SHA still verified below). Skip caching on the override
+      # path -- a user-supplied URL has no immutability guarantee and its SHA
+      # check is skipped, so a reused basename could otherwise serve stale,
+      # unverified bytes. This is the same rhel10-x86_64 .rpm the Fedora 44
+      # engine downloads, so a cache hit here is shared with that workflow too.
+      - name: Cache RStudio Desktop installer
+        if: inputs.build_from_source == false && inputs.rstudio_installer_url == ''
+        id: installer-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.resolve.outputs.filename }}
+          key: rstudio-desktop-installer-${{ steps.resolve.outputs.filename }}
+
+      - name: Download RStudio Desktop .rpm
+        if: (inputs.build_from_source == false || inputs.rstudio_installer_url != '') && steps.installer-cache.outputs.cache-hit != 'true'
+        env:
+          DOWNLOAD_URL: ${{ steps.resolve.outputs.url }}
+          DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}
+        run: |
+          curl -fsSL --retry 3 --retry-delay 5 \
+            -o "$DOWNLOAD_FILENAME" \
+            "$DOWNLOAD_URL"
+
+      - name: Verify SHA-256
+        if: (inputs.build_from_source == false || inputs.rstudio_installer_url != '') && steps.resolve.outputs.sha256 != ''
+        env:
+          EXPECTED_SHA256: ${{ steps.resolve.outputs.sha256 }}
+          DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}
+        run: |
+          echo "$EXPECTED_SHA256  $DOWNLOAD_FILENAME" | sha256sum -c -
+
+      - name: Install RStudio Desktop from .rpm
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
+        env:
+          INSTALLER_FILENAME: ${{ steps.resolve.outputs.filename }}
+        run: |
+          dnf -y install "./$INSTALLER_FILENAME"
+          ls -la /usr/bin/rstudio
+
+      - name: Install e2e test dependencies
+        uses: ./.github/actions/os-e2e-deps
+        with:
+          r-libs-user: ${{ env.R_LIBS_USER }}
+          # Isolate the R-library / pak caches from the Ubuntu, RHEL, and
+          # Fedora 44 workflows: they all share runner.os == Linux, and an
+          # R library compiled under a different distro/version is ABI-
+          # incompatible with Fedora 43's R. See os-e2e-deps cache-scope.
+          cache-scope: fedora43-x86_64
+          # Fedora has no CRAN binaries, so pre-install the harness's full
+          # REQUIRED_PACKAGES set into the cached R library here. Otherwise the
+          # Playwright globalSetup source-compiles that set at test time, which
+          # is what PW_HEARTBEAT_TIMEOUT_SECONDS below was papering over.
+          install-required-packages: 'true'
+
+      # Run the tests as a non-root user, matching the bare-runner siblings
+      # (Ubuntu/macOS/Windows all execute as a non-root user). GHA container
+      # jobs default to root, and RStudio-as-root diverges from real usage:
+      # Chromium refuses its sandbox as root, the terminal gets a root shell,
+      # and rsession warns. All the setup above needs root (dnf, the .rpm
+      # install, cache writes), so only the test step drops down -- create the
+      # user here and hand it ownership of everything the run writes under the
+      # workspace (R-libs and its per-worker clones, ms-playwright, pw-sandbox,
+      # the pak cache, and the report dirs under e2e/rstudio).
+      - name: Create non-root test user
+        run: |
+          useradd -m -s /bin/bash rstudio-tester
+          chown -R rstudio-tester:rstudio-tester "$GITHUB_WORKSPACE"
+
+      - name: Run Playwright tests
+        working-directory: e2e/rstudio
+        env:
+          PW_RSTUDIO_MODE: desktop
+          # Platform-labelled project name; playwright.config.ts uses it both as
+          # the project name in reports (so a cross-platform merged report can
+          # distinguish these results) and to derive the platform+shard-unique
+          # blob report file name. Distinct from the Fedora 44 engine's
+          # "-linux-fedora" label so the two versions never conflate results.
+          PW_PROJECT_LABEL: ${{ inputs.project }}-linux-fedora43
+          PW_GREP: ${{ inputs.grep }}
+          PW_GREP_INVERT: ${{ inputs.grep_invert }}
+          PW_TEST_SELECTOR: ${{ inputs.test_selector }}
+          PW_TEST_IGNORE: ${{ inputs.test_ignore }}
+          # No --no-sandbox: the test step runs as a non-root user (see the
+          # "Create non-root test user" step and the setpriv drop below), so
+          # Chromium no longer refuses to start, and the container's SYS_ADMIN +
+          # unconfined seccomp let its namespace sandbox initialize -- matching
+          # how the bare-runner siblings run (sandbox on). If a future runner
+          # kernel forbids unprivileged user namespaces and the sandbox can't
+          # come up, set rstudio_extra_args to '--no-sandbox' as a fallback.
+          PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
+          # Tells playwright.config.ts to switch to blob reporter for this shard.
+          PW_SHARD: ${{ matrix.shard }}
+          # E2E Test Insights reporter: posts per-shard results to the dashboard.
+          # CONNECT_API_KEY is empty on fork PRs; the reporter still runs but its
+          # uploads fail with warnings (never fails the run).
+          CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+          SHARD_NAME: desktop-linux-fedora43-${{ matrix.shard }}
+          # Print the GWT launch timeline so the next launch failure shows which
+          # phase exceeded the deadline.
+          PW_DEBUG_LAUNCH: '1'
+          # Point the Playwright harness's own R-libs provisioner
+          # (fixtures/r-libs-setup.ts, run in globalSetup) at the same library
+          # os-e2e-deps populated, instead of its default per-host cache. Because
+          # os-e2e-deps ran with install-required-packages, that library holds
+          # both the e2e DESCRIPTION deps and the full REQUIRED_PACKAGES set, so
+          # globalSetup finds everything present and installs nothing.
+          PW_RSTUDIO_R_LIBS_USER: ${{ github.workspace }}/R-libs
+          # Defensive fallback. With install-required-packages above, globalSetup
+          # normally compiles nothing at test time. But if a package slipped
+          # through and had to be source-compiled here (Fedora has no PPM/CRAN
+          # binaries), that is a long silent stretch the default 300s heartbeat
+          # idle-timeout would kill (exit 124); the higher ceiling lets it finish
+          # rather than failing the run outright.
+          PW_HEARTBEAT_TIMEOUT_SECONDS: '2400'
+        run: |
+          ARGS=()
+          if [ -n "$PW_TEST_SELECTOR" ]; then
+            set -f
+            ARGS+=($PW_TEST_SELECTOR)
+            set +f
+          fi
+          if [ -n "$PW_GREP" ]; then
+            ARGS+=(--grep "$PW_GREP")
+          fi
+          if [ -n "$PW_GREP_INVERT" ]; then
+            ARGS+=(--grep-invert "$PW_GREP_INVERT")
+          fi
+          ARGS+=(--shard="${{ matrix.shard }}/${{ strategy.job-total }}")
+          # Run Playwright under our own Xvfb and exec the watchdog as the step's
+          # main process, so a job cancellation's SIGTERM reaches the watchdog
+          # (which forwards it to Playwright's process group as SIGINT -- its
+          # cancellation signal -- then escalates to SIGKILL if the run doesn't
+          # wind down). xvfb-run is a shell wrapper that does not forward signals
+          # to its child, which left cancelled Linux e2e jobs running until
+          # their timeout-minutes instead of stopping. -ac disables X access
+          # control so Chromium connects without an auth cookie; -nolisten tcp
+          # keeps the display on the local socket only. We wait for the X socket
+          # before launching so it doesn't race a cold display, and fail loudly
+          # (dumping the Xvfb log) if it never comes up, rather than exec-ing
+          # Playwright against a dead display and surfacing an opaque launch error.
+          Xvfb :99 -screen 0 1920x1080x24 -ac -nolisten tcp >/tmp/xvfb.log 2>&1 &
+          export DISPLAY=:99
+          for _ in $(seq 1 50); do
+            [ -S /tmp/.X11-unix/X99 ] && break
+            sleep 0.1
+          done
+          if [ ! -S /tmp/.X11-unix/X99 ]; then
+            echo "::error::Xvfb display :99 never came up after 5s; Xvfb log follows."
+            cat /tmp/xvfb.log || true
+            exit 1
+          fi
+          # Drop to the non-root user for the run itself. setpriv execs in
+          # place (no fork), so a job-cancellation SIGTERM still reaches node
+          # directly and the watchdog's SIGINT->SIGKILL path is preserved --
+          # runuser/su would fork and swallow the signal. --init-groups adopts
+          # the user's groups; the environment is left intact (DISPLAY, PW_*,
+          # PATH, R_LIBS_USER all carry through), and we only override HOME,
+          # since the step's HOME is root-owned and node/Playwright write into
+          # it. Xvfb keeps running as root above; -ac lets the non-root Chromium
+          # attach to :99 without an auth cookie.
+          exec setpriv --reuid=rstudio-tester --regid=rstudio-tester --init-groups \
+            env HOME=/home/rstudio-tester \
+            node scripts/run-with-heartbeat.mjs -- test "${ARGS[@]}"
+
+      # Platform-prefixed artifact name keeps this Fedora 43 platform's shard
+      # reports separate from the other platforms (mac / win / linux-desktop /
+      # linux-server / Fedora 44) if this workflow is ever run alongside them
+      # in the same overall run (e.g. the scheduled rotation's all-engines
+      # dispatch), so each merge job downloads only its own.
+      - name: Upload blob report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-blob-report-linux-desktop-fedora43-${{ matrix.shard }}
+          path: e2e/rstudio/blob-report/
+          if-no-files-found: warn
+          retention-days: 1
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-linux-desktop-fedora43-${{ matrix.shard }}
+          path: e2e/rstudio/test-results/
+          if-no-files-found: ignore
+
+      # Preserved per-spec sandbox tree on failure -- includes rsession logs,
+      # the spec's RStudio config / data home, and per-test working dirs.
+      - name: Upload PW sandbox (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pw-sandbox-linux-desktop-fedora43-${{ matrix.shard }}
+          path: ${{ github.workspace }}/pw-sandbox/
+          if-no-files-found: ignore
+
+  # Merge per-shard blob reports into a single HTML report, parse aggregated
+  # counts, and post a sticky PR comment with pass/fail/skip totals
+  # (when post_pr_comment is set). Runs on a plain hosted runner -- merging only
+  # needs node + `playwright merge-reports`, no Fedora container.
+  e2e-merge:
+    needs: [e2e-desktop-fedora43]
+    if: always() && inputs.defer_merge != true && needs.e2e-desktop-fedora43.result != 'skipped' && needs.e2e-desktop-fedora43.result != 'cancelled'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
+
+      - name: Install Playwright
+        working-directory: e2e/rstudio
+        # --ignore-scripts skips the postinstall that downloads browser
+        # binaries; the merge job only invokes `playwright merge-reports`,
+        # which doesn't need Chromium.
+        run: npm ci --ignore-scripts
+
+      - name: Download shard blob reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: playwright-blob-report-linux-desktop-fedora43-*
+          path: e2e/rstudio/all-blob-reports
+          merge-multiple: true
+
+      - name: Merge shard reports
+        working-directory: e2e/rstudio
+        run: |
+          if [ -z "$(ls -A all-blob-reports 2>/dev/null)" ]; then
+            echo "::error::No blob reports found -- both shards failed to produce artifacts"
+            exit 1
+          fi
+          npx playwright merge-reports --config merge.config.ts ./all-blob-reports
+
+      # Shared summarizer (also used by the PR run's e2e-merge-all job) so every
+      # comment computes pass/fail counts and the rate bar from one definition.
+      - name: Parse aggregated results
+        id: summary
+        if: always()
+        working-directory: e2e/rstudio
+        run: node scripts/summarize-merged-report.mjs playwright-report/test-results.json
+
+      - name: Upload merged Playwright report
+        id: upload-report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-linux-desktop-fedora43
+          path: e2e/rstudio/playwright-report/
+          retention-days: 15
+          if-no-files-found: ignore
+
+      # Publish a browsable copy of the report to Connect on failure only, so
+      # reviewers can inspect it without downloading the zip. Best-effort:
+      # does nothing on fork PRs (empty key) and never fails the job.
+      - name: Publish report to Connect
+        id: publish-report
+        if: always() && steps.summary.outputs.failed != '0' && steps.summary.outputs.failed != ''
+        uses: ./.github/actions/os-publish-e2e-report
+        with:
+          connect-api-key: ${{ secrets.CONNECT_API_KEY }}
+          title: "E2E Fedora 43 Desktop - PR #${{ github.event.pull_request.number }} - run #${{ github.run_number }}"
+
+      - name: Post E2E results to PR
+        if: |
+          always() &&
+          inputs.post_pr_comment == true &&
+          github.event.pull_request.head.repo.fork == false &&
+          (steps.summary.outputs.passed != '0' || steps.summary.outputs.failed != '0' || steps.summary.outputs.skipped != '0' || steps.summary.outputs.flaky != '0')
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: e2e-desktop-fedora43-results
+          GITHUB_TOKEN: ${{ github.token }}
+          message: |
+            ## 🎩 Linux Desktop E2E · Fedora 43
+
+            ${{ needs.e2e-desktop-fedora43.result == 'success' && steps.summary.outputs.failed == '0' && '### ✅ All tests passed!' || format('### ❌ {0} test(s) failed', steps.summary.outputs.failed) }}
+
+            `${{ steps.summary.outputs.bar }}` **${{ steps.summary.outputs.rate }}%** pass rate
+
+            | ✅ Passed | ❌ Failed | ⚠️ Skipped | 🔁 Flaky |
+            | :---: | :---: | :---: | :---: |
+            | **${{ steps.summary.outputs.passed }}** | **${{ steps.summary.outputs.failed }}** | **${{ steps.summary.outputs.skipped }}** | **${{ steps.summary.outputs.flaky }}** |
+
+            <details>
+            <summary>📥 Download Playwright report</summary>
+            ${{ steps.publish-report.outputs.url != '' && format('
+            **[🌐 View report online]({0})** — opens in the browser (requires Connect login). Available for up to 1 week.
+            ', steps.publish-report.outputs.url) || '' }}
+            **[⬇️ playwright-report.zip](${{ steps.upload-report.outputs.artifact-url }})** — extract and open `index.html`
+
+            > Includes screenshots, traces, and step-by-step details for every test. Expires in 15 days.
+
+            </details>
+
+            ---
+            <sub>2 shards · fedora:43 container · commit <code>${{ github.event.pull_request.head.sha }}</code> · <a href="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}">Run #${{ github.run_number }}</a></sub>

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
@@ -32,9 +32,9 @@ on:
         type: string
         default: ""
       grep_invert:
-        description: "Optional Playwright --grep-invert pattern to skip tests by title. Defaults to '@ai' to skip tests that require credentials not available in unattended runs."
+        description: "Optional Playwright --grep-invert pattern to skip tests by title. Empty by default (runs all tests)."
         type: string
-        default: "@ai"
+        default: ""
       rstudio_extra_args:
         description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS. Set to '--no-sandbox' if the in-container Chromium sandbox won't initialize (see the container options below)."
         type: string
@@ -72,7 +72,7 @@ on:
         default: ""
       grep_invert:
         type: string
-        default: "@ai"
+        default: ""
       rstudio_extra_args:
         type: string
         default: ""
@@ -204,6 +204,11 @@ jobs:
       # cache hits, no per-SHA tarball, no AWS credentials.
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          # Pinned: resolving "latest" queries api.github.com at runtime,
+          # which fails during GitHub API incidents (503s). A pinned version
+          # downloads directly from the release CDN with no API call.
+          version: "v0.16.0"
 
       # install-dependencies-yum: dnf installs system packages (with sudo
       # internally), then calls install-common which downloads Boost, SOCI,
@@ -325,11 +330,7 @@ jobs:
       # the sandbox still refuses to come up here, pass --no-sandbox via
       # rstudio_extra_args (PW_RSTUDIO_EXTRA_ARGS) rather than changing these.
       options: --cap-add=SYS_ADMIN --security-opt seccomp=unconfined
-    # TEMPORARY: bumped 120 -> 300 to let a COLD-cache run finish the from-source
-    # package compile (Fedora has no binaries) so we can verify the run end to
-    # end. Revert to 120 before merge -- warm-cache runs restore the prebuilt
-    # library and finish well under 120.
-    timeout-minutes: 300
+    timeout-minutes: 120
     env:
       R_LIBS_USER: ${{ github.workspace }}/R-libs
       PW_SANDBOX_ROOT: ${{ github.workspace }}/pw-sandbox
@@ -400,8 +401,17 @@ jobs:
       # ignored on Fedora -- dnf provides whatever R the distro ships.
       - name: Install R (Fedora native)
         run: |
-          dnf -y install R-core R-core-devel
+          # Clear tsflags for this transaction so R's documentation tree is
+          # installed. Fedora container images ship /etc/dnf/dnf.conf with
+          # tsflags=nodocs (a space-saving default), which makes dnf skip
+          # /usr/share/doc/R. RStudio's R discovery (r/session/RDiscovery.cpp)
+          # requires R_DOC_DIR to exist and aborts the session otherwise, so a
+          # docless R install starts but never reaches window.rstudio.ready.
+          dnf -y install --setopt=tsflags='' R-core R-core-devel
           R --version
+          # Diagnostics: the doc dir R reports, and confirm it now exists.
+          Rscript -e 'cat("doc=", R.home("doc"), " R_DOC_DIR=", Sys.getenv("R_DOC_DIR"), "\n", sep="")'
+          ls -ld /usr/share/doc/R || echo "MISSING /usr/share/doc/R"
           mkdir -p "$R_LIBS_USER"
 
       # Build-from-source path: extract the .rpm artifact produced by the build
@@ -418,7 +428,7 @@ jobs:
       - name: Install RStudio Desktop from artifact
         if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
         run: |
-          dnf -y install "${{ github.workspace }}/rstudio-desktop.rpm"
+          dnf -y install "$GITHUB_WORKSPACE/rstudio-desktop.rpm"
           ls -la /usr/bin/rstudio
 
       # Daily-download path: resolve and install the latest (or specified) .rpm.
@@ -518,6 +528,20 @@ jobs:
           # is what PW_HEARTBEAT_TIMEOUT_SECONDS below was papering over.
           install-required-packages: 'true'
 
+      # Run the tests as a non-root user, matching the bare-runner siblings
+      # (Ubuntu/macOS/Windows all execute as a non-root user). GHA container
+      # jobs default to root, and RStudio-as-root diverges from real usage:
+      # Chromium refuses its sandbox as root, the terminal gets a root shell,
+      # and rsession warns. All the setup above needs root (dnf, the .rpm
+      # install, cache writes), so only the test step drops down -- create the
+      # user here and hand it ownership of everything the run writes under the
+      # workspace (R-libs and its per-worker clones, ms-playwright, pw-sandbox,
+      # the pak cache, and the report dirs under e2e/rstudio).
+      - name: Create non-root test user
+        run: |
+          useradd -m -s /bin/bash rstudio-tester
+          chown -R rstudio-tester:rstudio-tester "$GITHUB_WORKSPACE"
+
       - name: Run Playwright tests
         working-directory: e2e/rstudio
         env:
@@ -531,6 +555,13 @@ jobs:
           PW_GREP_INVERT: ${{ inputs.grep_invert }}
           PW_TEST_SELECTOR: ${{ inputs.test_selector }}
           PW_TEST_IGNORE: ${{ inputs.test_ignore }}
+          # No --no-sandbox: the test step runs as a non-root user (see the
+          # "Create non-root test user" step and the setpriv drop below), so
+          # Chromium no longer refuses to start, and the container's SYS_ADMIN +
+          # unconfined seccomp let its namespace sandbox initialize -- matching
+          # how the bare-runner siblings run (sandbox on). If a future runner
+          # kernel forbids unprivileged user namespaces and the sandbox can't
+          # come up, set rstudio_extra_args to '--no-sandbox' as a fallback.
           PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
           # Tells playwright.config.ts to switch to blob reporter for this shard.
           PW_SHARD: ${{ matrix.shard }}
@@ -593,7 +624,18 @@ jobs:
             cat /tmp/xvfb.log || true
             exit 1
           fi
-          exec node scripts/run-with-heartbeat.mjs -- test "${ARGS[@]}"
+          # Drop to the non-root user for the run itself. setpriv execs in
+          # place (no fork), so a job-cancellation SIGTERM still reaches node
+          # directly and the watchdog's SIGINT->SIGKILL path is preserved --
+          # runuser/su would fork and swallow the signal. --init-groups adopts
+          # the user's groups; the environment is left intact (DISPLAY, PW_*,
+          # PATH, R_LIBS_USER all carry through), and we only override HOME,
+          # since the step's HOME is root-owned and node/Playwright write into
+          # it. Xvfb keeps running as root above; -ac lets the non-root Chromium
+          # attach to :99 without an auth cookie.
+          exec setpriv --reuid=rstudio-tester --regid=rstudio-tester --init-groups \
+            env HOME=/home/rstudio-tester \
+            node scripts/run-with-heartbeat.mjs -- test "${ARGS[@]}"
 
       # Platform-prefixed artifact name keeps this Fedora Desktop platform's
       # shard reports separate from the other platforms (mac / win /

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -290,9 +290,7 @@ jobs:
           cache-dependency-path: e2e/rstudio/package-lock.json
 
       - name: Install rig
-        run: |
-          curl -fLs -o rig.pkg https://github.com/r-lib/rig/releases/download/latest/rig-latest-macOS-arm64.pkg
-          sudo installer -pkg rig.pkg -target /
+        uses: ./.github/actions/os-install-rig-unix
 
       - name: Install R via rig
         env:

--- a/.github/workflows/os-test-e2e-rstudio-scheduled.yml
+++ b/.github/workflows/os-test-e2e-rstudio-scheduled.yml
@@ -1,0 +1,263 @@
+name: "Test: E2E Playwright RStudio (Scheduled Rotation and Run-All, Open Source)"
+
+# One workflow that drives the reusable per-OS E2E "engines" three ways:
+#   - Weekday cron (Mon-Fri): a fixed slate per weekday (two engines, except
+#     Thursday's three), so every engine runs at least once a week without
+#     running the whole matrix daily.
+#     No weekday pairs two deb-based engines.
+#   - Weekly cron (Sunday): every engine at once, for a full-matrix snapshot.
+#   - Manual dispatch: every engine at once, optionally against a specific daily
+#     build (the "version" input) or built from source (the "build_from_source"
+#     input).
+#
+# Binary selection: scheduled runs test the daily build (build_from_source
+# false). With no version, each engine self-resolves the latest daily (keeping
+# its SHA-256 check); a specific version builds each platform's download URL by
+# token-swap, and since there is no per-build manifest that path skips SHA-256
+# (see rstudio/latest-builds#251). Manual dispatch can instead build every
+# engine from source via build_from_source.
+#
+# Cron times are UTC: 08:00 UTC is 4 AM EDT in summer, 3 AM EST in winter.
+
+on:
+  schedule:
+    - cron: '0 8 * * 1-5'   # Mon-Fri 08:00 UTC (4 AM EDT) -- fixed pair per weekday
+    - cron: '0 8 * * 0'     # Sunday 08:00 UTC (4 AM EDT) -- all engines (this string must match the check in the pick job)
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Daily build to test, given as the version string exactly as shown on dailies.rstudio.com (e.g. 2026.08.0-daily+44). Leave empty to test the latest daily. Ignored when build_from_source is checked. Applies to every engine."
+        type: string
+        default: ""
+      build_from_source:
+        description: "Build every engine from source instead of installing a daily build. Overrides the version input."
+        type: boolean
+        default: false
+
+concurrency:
+  group: pw-scheduled-e2e
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: write  # the engines' e2e-merge job declares this
+  # Most engines' e2e-merge jobs assume the S3 report-upload role via OIDC
+  # (fedora43, fedora44, and ubuntu26 don't upload); a reusable workflow's id-token grant
+  # is capped by its caller's.
+  id-token: write
+
+jobs:
+  pick:
+    name: Pick engines
+    runs-on: ubuntu-latest
+    outputs:
+      selected: ${{ steps.pick.outputs.selected }}
+    steps:
+      - id: pick
+        name: Select engines for this run
+        run: |
+          # workflow_dispatch and the Sunday cron run every engine; the weekday
+          # cron (Mon-Fri) runs a fixed slate per day (a pair, except Thursday's
+          # three). Each engine runs once a week except macos26, windows2025,
+          # and ubuntu24s, which run twice.
+          ALL='["fedora43","fedora44","ubuntu26","ubuntu24d","ubuntu24s","macos26","windows2025","debian13"]'
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event.schedule }}" = "0 8 * * 0" ]; then
+            SEL="$ALL"
+          else
+            case "$(date -u +%u)" in   # %u: 1=Mon .. 7=Sun
+              1) SEL='["ubuntu24d","macos26"]' ;;
+              2) SEL='["ubuntu24s","windows2025"]' ;;
+              3) SEL='["ubuntu26","fedora44"]' ;;
+              4) SEL='["fedora43","debian13","macos26"]' ;;
+              5) SEL='["ubuntu24s","windows2025"]' ;;
+              # Only reachable by re-running a weekday run on Sat/Sun, or if the
+              # Sunday cron above changed without updating the check above.
+              # Fail loudly rather than silently selecting nothing.
+              *) echo "::error::No engine slate for weekday $(date -u +%u). If the Sunday cron changed, update the '0 8 * * 0' check in this job."; exit 1 ;;
+            esac
+          fi
+          echo "selected=$SEL" >> "$GITHUB_OUTPUT"
+          echo "::notice::Selected engines: $SEL"
+
+  resolve:
+    name: Resolve installer URLs
+    runs-on: ubuntu-latest
+    outputs:
+      rhel:         ${{ steps.resolve.outputs.rhel }}
+      noble_amd64:  ${{ steps.resolve.outputs.noble_amd64 }}
+      server_noble: ${{ steps.resolve.outputs.server_noble }}
+      macos:        ${{ steps.resolve.outputs.macos }}
+      windows:      ${{ steps.resolve.outputs.windows }}
+      noble_arm64:  ${{ steps.resolve.outputs.noble_arm64 }}
+    steps:
+      - id: resolve
+        name: Build per-platform installer URLs for a specific version
+        env:
+          VERSION: ${{ inputs.version }}
+          BUILD_FROM_SOURCE: ${{ inputs.build_from_source }}
+        run: |
+          # Emit empty URLs when building from source (engines build, ignoring
+          # any URL) or when no version is given (engines self-resolve the
+          # latest daily, keeping their SHA-256 check). Only a specific version
+          # needs URLs built here: swap the version token (+ -> -) into each
+          # platform's latest download URL.
+          if [ "$BUILD_FROM_SOURCE" = "true" ] || [ -z "$VERSION" ]; then
+            {
+              echo "rhel="
+              echo "noble_amd64="
+              echo "server_noble="
+              echo "macos="
+              echo "windows="
+              echo "noble_arm64="
+            } >> "$GITHUB_OUTPUT"
+            echo "No installer URLs to resolve (building from source or using the latest daily)."
+            exit 0
+          fi
+          M=$(curl -fsSL --retry 3 --retry-delay 5 'https://dailies.rstudio.com/rstudio/latest/index.json')
+          REQ=${VERSION//+/-}
+          emit() {
+            local product="$1" key="$2" link ver cur
+            link=$(printf '%s' "$M" | jq -r ".products.${product}.platforms[\"${key}\"].link // empty")
+            ver=$(printf '%s' "$M" | jq -r ".products.${product}.platforms[\"${key}\"].version // empty")
+            cur=${ver//+/-}
+            if [ -z "$link" ] || [ -z "$cur" ]; then
+              echo "::error::Could not build a URL for ${product}/${key} from the latest manifest." >&2
+              return 1
+            fi
+            local out=${link//$cur/$REQ}
+            if [ "$REQ" != "$cur" ] && [ "$out" = "$link" ]; then
+              echo "::error::Version '$REQ' did not substitute into the ${product}/${key} URL ($link); the manifest link format may have changed." >&2
+              return 1
+            fi
+            if ! curl -fsI "$out" >/dev/null 2>&1; then
+              echo "::error::Resolved URL for ${product}/${key} does not exist: $out (version '$VERSION' may be unavailable or mistyped)." >&2
+              return 1
+            fi
+            printf '%s' "$out"
+          }
+          RHEL=$(emit electron rhel10-x86_64) || exit 1
+          NOBLE=$(emit electron noble-amd64) || exit 1
+          SERVER=$(emit server noble-amd64) || exit 1
+          MAC=$(emit electron macos) || exit 1
+          WIN=$(emit electron windows) || exit 1
+          NARM=$(emit electron noble-arm64) || exit 1
+          {
+            echo "rhel=$RHEL"
+            echo "noble_amd64=$NOBLE"
+            echo "server_noble=$SERVER"
+            echo "macos=$MAC"
+            echo "windows=$WIN"
+            echo "noble_arm64=$NARM"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved URLs for version $VERSION."
+
+  fedora43:
+    name: Fedora 43 x86_64
+    needs: [pick, resolve]
+    if: ${{ contains(fromJSON(needs.pick.outputs.selected), 'fedora43') }}
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-43-x86_64.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+    with:
+      project: desktop
+      r_version: "release"
+      build_from_source: ${{ inputs.build_from_source || false }}
+      # Same rhel10-x86_64 .rpm the Fedora 44 engine tests -- there is no
+      # separate Fedora 43 daily either.
+      rstudio_installer_url: ${{ needs.resolve.outputs.rhel }}
+
+  fedora44:
+    name: Fedora 44 x86_64
+    needs: [pick, resolve]
+    if: ${{ contains(fromJSON(needs.pick.outputs.selected), 'fedora44') }}
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-fedora-44-x86_64.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+    with:
+      project: desktop
+      r_version: "release"
+      build_from_source: ${{ inputs.build_from_source || false }}
+      rstudio_installer_url: ${{ needs.resolve.outputs.rhel }}
+
+  ubuntu26:
+    name: Ubuntu 26 amd64
+    needs: [pick, resolve]
+    if: ${{ contains(fromJSON(needs.pick.outputs.selected), 'ubuntu26') }}
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-26-amd64.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+    with:
+      project: desktop
+      r_version: "release"
+      build_from_source: ${{ inputs.build_from_source || false }}
+      rstudio_installer_url: ${{ needs.resolve.outputs.noble_amd64 }}
+
+  ubuntu24d:
+    name: Ubuntu 24 Desktop
+    needs: [pick, resolve]
+    if: ${{ contains(fromJSON(needs.pick.outputs.selected), 'ubuntu24d') }}
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-ubuntu-24.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+      AWS_E2E_REPORTS_ROLE_ARN: ${{ secrets.AWS_E2E_REPORTS_ROLE_ARN }}
+    with:
+      project: desktop
+      r_version: "release"
+      build_from_source: ${{ inputs.build_from_source || false }}
+      rstudio_installer_url: ${{ needs.resolve.outputs.noble_amd64 }}
+
+  ubuntu24s:
+    name: Ubuntu 24 Server
+    needs: [pick, resolve]
+    if: ${{ contains(fromJSON(needs.pick.outputs.selected), 'ubuntu24s') }}
+    uses: ./.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+      AWS_E2E_REPORTS_ROLE_ARN: ${{ secrets.AWS_E2E_REPORTS_ROLE_ARN }}
+    with:
+      project: server
+      r_version: "release"
+      build_from_source: ${{ inputs.build_from_source || false }}
+      rstudio_installer_url: ${{ needs.resolve.outputs.server_noble }}
+
+  macos26:
+    name: macOS 26 arm64
+    needs: [pick, resolve]
+    if: ${{ contains(fromJSON(needs.pick.outputs.selected), 'macos26') }}
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+      AWS_E2E_REPORTS_ROLE_ARN: ${{ secrets.AWS_E2E_REPORTS_ROLE_ARN }}
+    with:
+      project: desktop
+      r_version: "release"
+      build_from_source: ${{ inputs.build_from_source || false }}
+      rstudio_installer_url: ${{ needs.resolve.outputs.macos }}
+
+  windows2025:
+    name: Windows Server 2025
+    needs: [pick, resolve]
+    if: ${{ contains(fromJSON(needs.pick.outputs.selected), 'windows2025') }}
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+      AWS_E2E_REPORTS_ROLE_ARN: ${{ secrets.AWS_E2E_REPORTS_ROLE_ARN }}
+    with:
+      project: desktop
+      r_version: "release"
+      build_from_source: ${{ inputs.build_from_source || false }}
+      rstudio_installer_url: ${{ needs.resolve.outputs.windows }}
+
+  debian13:
+    name: Debian 13 arm64
+    needs: [pick, resolve]
+    if: ${{ contains(fromJSON(needs.pick.outputs.selected), 'debian13') }}
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-debian-13-arm64.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+      AWS_E2E_REPORTS_ROLE_ARN: ${{ secrets.AWS_E2E_REPORTS_ROLE_ARN }}
+    with:
+      project: desktop
+      r_version: "release"
+      build_from_source: ${{ inputs.build_from_source || false }}
+      rstudio_installer_url: ${{ needs.resolve.outputs.noble_arm64 }}


### PR DESCRIPTION
Backports the unified E2E rotation workflow (`os-test-e2e-rstudio-scheduled.yml`) from `main` so the full engine slate can be dispatched manually against Pacific Dogwood daily builds with the branch's own test code.

All five files are verbatim copies from `main`:

- `os-test-e2e-rstudio-scheduled.yml`—the rotation workflow (manual dispatch only on this branch; cron fires solely from the default branch)
- The Fedora 43 and Debian 13 arm64 engines, which landed on `main` after the branch cut
- `.github/actions/os-install-rig-unix`—rig installer the Debian 13 engine uses
- `.github/actions/os-e2e-deps`—keys the Playwright browser cache on architecture so the arm64 engine can't poison the x86_64 cache (engines without a `cache-scope` keep their existing key)

The six engines already on this branch are untouched. When dispatching here, always fill in the `version` input with a Pacific Dogwood daily (e.g. `2026.07.1+147`); left empty, the engines self-resolve the latest dev daily instead.