### PR TITLE
harden e2e console focus against async focus steals

### DIFF
--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -3,6 +3,7 @@ import { expect } from '@playwright/test';
 import * as fs from 'fs';
 import {
   ConsolePane,
+  focusConsole,
   getConsolePromptCount,
   waitForConsoleBusy,
   waitForConsoleCommandComplete,
@@ -78,32 +79,16 @@ export class ConsolePaneActions {
    * swallow characters. Prefer this when you just need code to run; use
    * `typeInConsole` only when a test is exercising actual typing behavior.
    */
-  /**
-   * Wait until the console input's Ace editor owns the document focus.
-   * activateConsole schedules the focus shift on the next event loop tick,
-   * so callers that hand the console keystrokes immediately after the
-   * command can race with the focus change. Polling beats a blind sleep
-   * here -- the common case settles in tens of milliseconds.
-   */
-  private async waitForConsoleFocus(): Promise<void> {
-    await this.page.waitForFunction(
-      () => {
-        const el = document.getElementById('rstudio_console_input');
-        return el !== null && el.contains(document.activeElement);
-      },
-      null,
-      { timeout: 5000, polling: 50 },
-    );
-  }
-
   async executeInConsole(command: string, opts: ExecuteInConsoleOptions = {}): Promise<void> {
     // Focus the console via the activateConsole command rather than
     // clicking the console tab. The tab-click path was clicking the
     // same element repeatedly across executeInConsole + clearConsole
     // calls; using the command keeps focus changes deterministic and
-    // avoids any tab-level click side effects.
-    await executeCommand(this.page, 'activateConsole');
-    await this.waitForConsoleFocus();
+    // avoids any tab-level click side effects. focusConsole re-issues
+    // the command until focus sticks, since other UI (e.g. the assistant
+    // pane's trust-prompt iframe load after a project open) can steal
+    // focus after a single dispatch.
+    await focusConsole(this.page);
     await this.page.evaluate((text) => {
       const el = document.getElementById('rstudio_console_input') as AceEditorElement | null;
       const editor = el?.env?.editor;
@@ -139,14 +124,12 @@ export class ConsolePaneActions {
    * fire completers between chars.
    */
   async typeInConsole(text: string, delayMs: number = 50): Promise<void> {
-    await executeCommand(this.page, 'activateConsole');
-    await this.waitForConsoleFocus();
+    await focusConsole(this.page);
     await this.consolePane.consoleInput.pressSequentially(text, { delay: delayMs });
   }
 
   async clearConsole(): Promise<void> {
-    await executeCommand(this.page, 'activateConsole');
-    await this.waitForConsoleFocus();
+    await focusConsole(this.page);
     await this.page.keyboard.press('Control+l');
     await sleep(500);
   }

--- a/e2e/rstudio/pages/console_pane.page.ts
+++ b/e2e/rstudio/pages/console_pane.page.ts
@@ -201,6 +201,46 @@ export async function waitForConsoleFocus(page: Page, timeout: number = 5000): P
   );
 }
 
+/**
+ * Focus the console input, re-issuing `activateConsole` until focus sticks.
+ *
+ * A single activateConsole + waitForConsoleFocus is not enough: other UI can
+ * take focus *after* the command has run and nothing gives it back, so the
+ * wait can never succeed. The known offender is the Posit Assistant pane,
+ * whose iframe reload (e.g. the workspace-trust prompt shown after a project
+ * open) grabs document focus asynchronously. Re-issuing the command inside
+ * the poll loop wins that race deterministically.
+ *
+ * Use this on "just get me a focused console" paths. Tests that assert the
+ * focus behavior of a single activateConsole dispatch should keep using
+ * executeCommand + waitForConsoleFocus so a product regression isn't masked
+ * by the retry.
+ */
+export async function focusConsole(page: Page, timeout: number = 10000): Promise<void> {
+  const deadline = Date.now() + timeout;
+  let attempts = 0;
+
+  for (;;) {
+    attempts++;
+    await executeCommand(page, 'activateConsole');
+
+    const remaining = deadline - Date.now();
+    try {
+      await waitForConsoleFocus(page, Math.min(1000, Math.max(remaining, 100)));
+      return;
+    } catch (err) {
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `focusConsole: console input did not hold focus after ${attempts} ` +
+            `activateConsole dispatches over ${timeout}ms; something is ` +
+            `stealing focus (e.g. an assistant-pane iframe load or a modal)`,
+          { cause: err },
+        );
+      }
+    }
+  }
+}
+
 /** Options accepted by `executeInConsole`. */
 export interface ExecuteInConsoleOptions {
   /**


### PR DESCRIPTION
## Summary

A single `activateConsole` dispatch followed by a 5s focus poll fails permanently when other UI takes focus *after* the command has run, because nothing re-issues the command. The known offender is the Posit Assistant pane: its iframe reload (the workspace-trust prompt shown after a project open) grabs document focus asynchronously. This flaked `tests/projects/shinytest2.test.ts:114` on both the initial attempt and the retry in [this CI run](https://github.com/rstudio/rstudio/actions/runs/29774220955/job/88463748822) -- the failure screenshots show the trust prompt up while `waitForConsoleFocus` times out.

## Changes

- Add a `focusConsole` helper to `pages/console_pane.page.ts` that re-issues `activateConsole` inside the poll loop (1s slices, 10s budget) until the console input holds focus, with a descriptive error naming the likely focus stealers on failure.
- Use it on the `ConsolePaneActions` paths: `executeInConsole`, `typeInConsole`, `clearConsole` (previously a single dispatch + private 5s poll).
- Tests that assert the focus behavior of a single `activateConsole` dispatch (e.g. `console_pane.test.ts`, `console_output.test.ts`) intentionally keep using `executeCommand` + `waitForConsoleFocus`, so a product-side focus regression is not masked by the retry.

## Verification

- `npm run typecheck` passes.
- `tests/panes/console/console_pane.test.ts` (9/9) and `tests/projects/shinytest2.test.ts` (2/2) pass locally on desktop through the new helper.