### PR TITLE
run installed-package event-hook scan on a background thread

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 - ([#18274](https://github.com/rstudio/rstudio/issues/18274)): On Windows, the Files pane now follows .lnk shortcuts: clicking a shortcut to a folder navigates to that folder, and clicking a shortcut to a file opens the file. Shortcuts are marked with a link indicator, like symbolic links and macOS Finder aliases.
 - ([#8715](https://github.com/rstudio/rstudio/issues/8715)): Inline LaTeX / math previews in the source editor and visual editor are now rendered with MathJax 4 (previously MathJax 2.7), adding support for the TeX input extensions introduced in MathJax 3 and later. Rendered R Markdown documents using `mathjax = "local"` continue to use the bundled MathJax 2.7.
 - ([#7350](https://github.com/rstudio/rstudio/issues/7350)): RStudio can now load custom Vim key mappings from `~/.rstudio-vimrc` (or `~/.vimrc`) when Vim editor keybindings are in use. Enable the new preference under Tools > Global Options > Code > Editing; key mapping commands (`map`, `noremap`, `unmap`, and friends) and `set` commands supported by the editor's Vim emulation are applied, and other vimrc content is ignored.
+- ([#18060](https://github.com/rstudio/rstudio/issues/18060)): The installed-package scan used to track package load and attach events now runs on a background thread, so session startup (and package installation) no longer blocks while enumerating library paths on slow or remote filesystems.
 
 ### Fixed
 - ([#18152](https://github.com/rstudio/rstudio/issues/18152)): Fixed a compilation error when building RStudio Server against SOCI 4.1.4 or newer.

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -874,13 +874,23 @@ typedef std::vector<boost::shared_ptr<ScheduledCommand> >
 ScheduledCommands s_scheduledCommands;
 ScheduledCommands s_idleScheduledCommands;
 
+// guards the scheduled command lists: commands are scheduled from background
+// threads (via executeOnMainThread and friends) while the main thread
+// executes them. command execution itself always happens on the main thread,
+// outside the mutex.
+boost::mutex s_scheduledCommandsMutex;
+
 void addScheduledCommand(boost::shared_ptr<ScheduledCommand> pCommand,
                          bool idleOnly)
 {
-   if (idleOnly)
-      s_idleScheduledCommands.push_back(pCommand);
-   else
-      s_scheduledCommands.push_back(pCommand);
+   LOCK_MUTEX(s_scheduledCommandsMutex)
+   {
+      if (idleOnly)
+         s_idleScheduledCommands.push_back(pCommand);
+      else
+         s_scheduledCommands.push_back(pCommand);
+   }
+   END_LOCK_MUTEX
 }
 
 void executeScheduledCommands(ScheduledCommands* pCommands)
@@ -890,20 +900,31 @@ void executeScheduledCommands(ScheduledCommands* pCommands)
    // R code executing which in turn could cause the list of
    // scheduled commands to be mutated and these iterators
    // invalidated)
-   ScheduledCommands commands = *pCommands;
+   ScheduledCommands commands;
+   LOCK_MUTEX(s_scheduledCommandsMutex)
+   {
+      commands = *pCommands;
+   }
+   END_LOCK_MUTEX
 
-   // execute all commands
+   // execute all commands (outside the mutex: commands can themselves
+   // schedule more commands, and can run R code which pumps background
+   // processing re-entrantly)
    std::for_each(commands.begin(),
                  commands.end(),
                  boost::bind(&ScheduledCommand::execute, _1));
 
    // remove any commands which are finished
-   pCommands->erase(
-                 std::remove_if(
-                    pCommands->begin(),
-                    pCommands->end(),
-                    boost::bind(&ScheduledCommand::finished, _1)),
-                 pCommands->end());
+   LOCK_MUTEX(s_scheduledCommandsMutex)
+   {
+      pCommands->erase(
+                    std::remove_if(
+                       pCommands->begin(),
+                       pCommands->end(),
+                       boost::bind(&ScheduledCommand::finished, _1)),
+                    pCommands->end());
+   }
+   END_LOCK_MUTEX
 }
 
 

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -494,6 +494,11 @@ void scheduleDelayedWork(const boost::posix_time::time_duration& period,
                          const boost::function<void()> &execute,
                          bool idleOnly = true);
 
+// execute work on the main thread: immediately when already on the main
+// thread, otherwise as delayed work the next time the main thread performs
+// background processing. this function (like the schedule*Work functions
+// above) may be called from background threads; the work itself always runs
+// on the main thread, so it may safely call into R.
 void executeOnMainThread(const boost::function<void()> &execute);
 
 core::string_utils::LineEnding lineEndings(const core::FilePath& filePath);

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1167,92 +1167,112 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    }
 })
 
+.rs.addFunction("reportPackageStatus", function(pkgname, attached)
+{
+   packagePath <- .rs.pathPackage(pkgname, quiet = TRUE)
+   libraryPath <- dirname(packagePath)
+
+   # For renv with shared cache, the loaded package path might be in the cache,
+   # but we want to report the library path that contains a symlink to it.
+   # This ensures the status update matches the listed package.
+   normalizedPackagePath <- normalizePath(packagePath, winslash = "/", mustWork = FALSE)
+   for (libPath in .libPaths())
+   {
+      pkgInLib <- file.path(libPath, pkgname)
+      if (file.exists(pkgInLib))
+      {
+         normalizedPkgInLib <- normalizePath(pkgInLib, winslash = "/", mustWork = FALSE)
+         if (identical(normalizedPkgInLib, normalizedPackagePath))
+         {
+            libraryPath <- libPath
+            break
+         }
+      }
+   }
+
+   packageStatus <- list(
+      name     = I(pkgname),
+      library  = I(.rs.createAliasedPath(libraryPath)),
+      path     = I(.rs.createAliasedPath(packagePath)),
+      attached = I(attached)
+   )
+   .rs.enqueClientEvent("package_status_changed", packageStatus)
+})
+
+.rs.addFunction("notifyPackageAttached", function(pkgname, ...)
+{
+   .rs.reportPackageStatus(pkgname, attached = TRUE)
+})
+
+.rs.addFunction("notifyPackageDetached", function(pkgname, ...)
+{
+   .rs.reportPackageStatus(pkgname, attached = FALSE)
+})
+
+.rs.addFunction("notifyPackageLoaded", function(pkgname, ...)
+{
+   .Call("rs_packageLoaded", pkgname, PACKAGE = "(embedding)")
+
+   # when a package is loaded, it can register S3 methods which replace overrides we've
+   # attached manually; take this opportunity to reattach them.
+   .rs.reattachS3Overrides()
+})
+
+.rs.addFunction("notifyPackageUnloaded", function(pkgname, ...)
+{
+   .rs.beforePackageUnloaded(pkgname)
+   .Call("rs_packageUnloaded", pkgname, PACKAGE = "(embedding)")
+})
+
+.rs.addFunction("registerPackageEventHooks", function(pkgNames)
+{
+   pkgNames <- setdiff(pkgNames, .rs.hookedPackages)
+
+   for (packageName in pkgNames)
+   {
+      attachEventName <- packageEvent(packageName, "attach")
+      setHook(attachEventName, .rs.notifyPackageAttached, action = "append")
+
+      loadEventName <- packageEvent(packageName, "onLoad")
+      setHook(loadEventName, .rs.notifyPackageLoaded, action = "append")
+
+      unloadEventName <- packageEvent(packageName, "onUnload")
+      setHook(unloadEventName, .rs.notifyPackageUnloaded, action = "append")
+
+      detachEventName <- packageEvent(packageName, "detach")
+      setHook(detachEventName, .rs.notifyPackageDetached, action = "append")
+   }
+
+   .rs.setVar("hookedPackages", union(.rs.hookedPackages, pkgNames))
+
+   # a package loaded between the scan being scheduled and these hooks being
+   # registered may have clobbered our S3 overrides without the onLoad hook
+   # firing, so reattach them now
+   .rs.reattachS3Overrides()
+
+   invisible(pkgNames)
+})
+
 .rs.addFunction("updatePackageEvents", function()
 {
-   reportPackageStatus <- function(attached)
-   {
-      function(pkgname, ...)
-      {
-         packagePath <- .rs.pathPackage(pkgname, quiet = TRUE)
-         libraryPath <- dirname(packagePath)
-
-         # For renv with shared cache, the loaded package path might be in the cache,
-         # but we want to report the library path that contains a symlink to it.
-         # This ensures the status update matches the listed package.
-         normalizedPackagePath <- normalizePath(packagePath, winslash = "/", mustWork = FALSE)
-         for (libPath in .libPaths())
-         {
-            pkgInLib <- file.path(libPath, pkgname)
-            if (file.exists(pkgInLib))
-            {
-               normalizedPkgInLib <- normalizePath(pkgInLib, winslash = "/", mustWork = FALSE)
-               if (identical(normalizedPkgInLib, normalizedPackagePath))
-               {
-                  libraryPath <- libPath
-                  break
-               }
-            }
-         }
-
-         packageStatus = list(
-            name     = I(pkgname),
-            library  = I(.rs.createAliasedPath(libraryPath)),
-            path     = I(.rs.createAliasedPath(packagePath)),
-            attached = I(attached)
-         )
-         .rs.enqueClientEvent("package_status_changed", packageStatus)
-      }
-   }
-   
-   notifyPackageLoaded <- function(pkgname, ...)
-   {
-      .Call("rs_packageLoaded", pkgname, PACKAGE = "(embedding)")
-
-      # when a package is loaded, it can register S3 methods which replace overrides we've
-      # attached manually; take this opportunity to reattach them.
-      .rs.reattachS3Overrides()
-   }
-
-   notifyPackageUnloaded <- function(pkgname, ...)
-   {
-      .rs.beforePackageUnloaded(pkgname)
-      .Call("rs_packageUnloaded", pkgname, PACKAGE = "(embedding)")
-   }
-   
-   pkgNames <-
-      base::list.dirs(.libPaths(), full.names = FALSE, recursive = FALSE)
-   
-   sapply(pkgNames, function(packageName)
-   {
-      if ( !(packageName %in% .rs.hookedPackages) )
-      {
-         attachEventName = packageEvent(packageName, "attach")
-         setHook(attachEventName, reportPackageStatus(TRUE), action = "append")
-         
-         loadEventName = packageEvent(packageName, "onLoad")
-         setHook(loadEventName, notifyPackageLoaded, action = "append")
-
-         unloadEventName = packageEvent(packageName, "onUnload")
-         setHook(unloadEventName, notifyPackageUnloaded, action = "append")
-             
-         detachEventName = packageEvent(packageName, "detach")
-         setHook(detachEventName, reportPackageStatus(FALSE), action = "append")
-          
-         .rs.setVar("hookedPackages", append(.rs.hookedPackages, packageName))
-      }
-   })
+   # enumerating every package in .libPaths() can be slow (or block outright)
+   # when a library lives on a remote filesystem, so the scan runs on a
+   # background thread; hooks are registered via .rs.registerPackageEventHooks
+   # on the main R thread once it completes
+   invisible(.Call("rs_updatePackageEvents", PACKAGE = "(embedding)"))
 })
 
 .rs.addFunction("packages.initialize", function()
-{  
+{
    # list of packages we have hooked attach/detach for
    .rs.setVar("hookedPackages", character())
 
    # set flag indicating we should not ignore loadedPackageUpdates checks
    .rs.setVar("ignoreNextLoadedPackageCheck", FALSE)
-    
-   # ensure we are subscribed to package attach/detach events
-   .rs.updatePackageEvents()
+
+   # NOTE: the initial subscription to package attach/detach events happens
+   # at deferred init (see onDeferredInit in SessionPackages.cpp), as the
+   # rs_updatePackageEvents routine is not yet available for .Call here
 })
 
 .rs.addFunction( "addRToolsToPath", function()

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1241,9 +1241,13 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
 
       detachEventName <- packageEvent(packageName, "detach")
       setHook(detachEventName, .rs.notifyPackageDetached, action = "append")
-   }
 
-   .rs.setVar("hookedPackages", union(.rs.hookedPackages, pkgNames))
+      # record each package as its hooks land, rather than all at once after
+      # the loop: if we error out partway through, packages already hooked
+      # must be on record, or a later scan would register their hooks again
+      # and produce duplicate package_status_changed events
+      .rs.setVar("hookedPackages", c(.rs.hookedPackages, packageName))
+   }
 
    # a package loaded between the scan being scheduled and these hooks being
    # registered may have clobbered our S3 overrides without the onLoad hook
@@ -1258,7 +1262,9 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    # enumerating every package in .libPaths() can be slow (or block outright)
    # when a library lives on a remote filesystem, so the scan runs on a
    # background thread; hooks are registered via .rs.registerPackageEventHooks
-   # on the main R thread once it completes
+   # on the main R thread once it completes. returns TRUE if a new scan was
+   # started, or FALSE if a scan was already in flight (in which case a
+   # follow-up pass has been queued behind it)
    invisible(.Call("rs_updatePackageEvents", PACKAGE = "(embedding)"))
 })
 

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -377,8 +377,9 @@ void onPackageEventScanTimeout(boost::shared_ptr<PackageEventScan> pScan)
 
 // Runs on a background thread: filesystem access only, no R. No exception may
 // escape (safeLaunchThread doesn't guard the thread body, so one would
-// terminate the process), and the completion callback must be posted on every
-// exit path, as the main thread relies on it to allow future scans.
+// terminate the process). The completion callback is posted on every exit
+// path; if the post itself fails, the watchdog reclaims the scan state after
+// the timeout.
 void scanForInstalledPackages(std::vector<FilePath> libPaths,
                               boost::shared_ptr<PackageEventScan> pScan)
 {
@@ -408,9 +409,16 @@ void scanForInstalledPackages(std::vector<FilePath> libPaths,
    }
    CATCH_UNEXPECTED_EXCEPTION
 
-   pScan->pkgNames = std::move(pkgNames);
-   module_context::executeOnMainThread(
-            boost::bind(onPackageEventScanCompleted, pScan));
+   // guard the post separately: its allocations (binding the callback,
+   // scheduling the delayed work) can throw under memory pressure, and an
+   // exception here would escape the thread body
+   try
+   {
+      pScan->pkgNames = std::move(pkgNames);
+      module_context::executeOnMainThread(
+               boost::bind(onPackageEventScanCompleted, pScan));
+   }
+   CATCH_UNEXPECTED_EXCEPTION
 }
 
 void startPackageEventScan()

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -20,8 +20,6 @@
 
 #include "SessionPackages.hpp"
 
-#include <atomic>
-
 #include <boost/format.hpp>
 #include <boost/bind/bind.hpp>
 #include <boost/make_shared.hpp>
@@ -311,18 +309,15 @@ SEXP rs_packageLibraryMutated()
 }
 
 // Result of a background package-event scan. The background thread fills in
-// 'pkgNames' under the mutex and then sets 'done'; the main thread polls it
-// via schedulePeriodicWork. We deliberately avoid executeOnMainThread() here,
-// as scheduling work from a background thread mutates the scheduled-command
-// list without synchronization.
+// 'pkgNames' and then posts onPackageEventScanCompleted() to the main thread
+// via executeOnMainThread(); the scheduled-command queue provides the
+// happens-before edge for 'pkgNames', and the other fields are only ever
+// touched on the main thread.
 struct PackageEventScan
 {
-   boost::mutex mutex;
-   std::atomic<bool> done = { false };
-   bool consumed = false; // main thread only
-   boost::posix_time::ptime startTime =
-         boost::posix_time::microsec_clock::universal_time();
-   std::vector<std::string> pkgNames;
+   std::vector<std::string> pkgNames; // written by the background thread
+   bool completed = false;            // main thread only
+   bool abandoned = false;            // main thread only
 };
 
 // Coalescing state for package-event scans; main thread only.
@@ -330,16 +325,60 @@ bool s_packageEventScanRunning = false;
 bool s_packageEventScanPending = false;
 
 // If a scan hasn't completed after this long (e.g. a library path on a hung
-// network mount), stop polling it so package-event tracking isn't wedged for
-// the rest of the session.
+// network mount), abandon it so package-event tracking isn't wedged for the
+// rest of the session.
 constexpr int kPackageEventScanTimeoutSeconds = 300;
 
 void startPackageEventScan();
 
+// Runs on the main thread once the background scan has finished.
+void onPackageEventScanCompleted(boost::shared_ptr<PackageEventScan> pScan)
+{
+   // if the watchdog abandoned this scan, drop its (very late) result: the
+   // coalescing state no longer tracks it, and a fresh scan may be in flight
+   if (pScan->abandoned)
+      return;
+
+   pScan->completed = true;
+
+   Error error = r::exec::RFunction(".rs.registerPackageEventHooks", pScan->pkgNames).call();
+   if (error)
+      LOG_ERROR(error);
+
+   s_packageEventScanRunning = false;
+
+   // if another scan was requested while this one was in flight (e.g. an
+   // install completed), run it now so newly-installed packages get hooked
+   if (s_packageEventScanPending)
+   {
+      s_packageEventScanPending = false;
+      startPackageEventScan();
+   }
+}
+
+// Watchdog, on the main thread: if the scan hasn't completed (e.g. blocked on
+// a hung network mount), abandon it rather than wedge package-event tracking
+// for the rest of the session; later library mutations can start fresh scans.
+// We don't run a pending pass here -- it would most likely hang the same way
+// and pile up abandoned threads.
+void onPackageEventScanTimeout(boost::shared_ptr<PackageEventScan> pScan)
+{
+   if (pScan->completed)
+      return;
+
+   LOG_WARNING_MESSAGE("Abandoning package event scan; it did not complete within " +
+                       safe_convert::numberToString(kPackageEventScanTimeoutSeconds) +
+                       " seconds");
+
+   pScan->abandoned = true;
+   s_packageEventScanRunning = false;
+   s_packageEventScanPending = false;
+}
+
 // Runs on a background thread: filesystem access only, no R. No exception may
 // escape (safeLaunchThread doesn't guard the thread body, so one would
-// terminate the process), and 'done' must be set on every exit path, as the
-// main-thread poller relies on it to stop polling and allow future scans.
+// terminate the process), and the completion callback must be posted on every
+// exit path, as the main thread relies on it to allow future scans.
 void scanForInstalledPackages(std::vector<FilePath> libPaths,
                               boost::shared_ptr<PackageEventScan> pScan)
 {
@@ -369,72 +408,9 @@ void scanForInstalledPackages(std::vector<FilePath> libPaths,
    }
    CATCH_UNEXPECTED_EXCEPTION
 
-   LOCK_MUTEX(pScan->mutex)
-   {
-      pScan->pkgNames = std::move(pkgNames);
-   }
-   END_LOCK_MUTEX
-
-   // set 'done' last, outside the mutex block: a throwing lock is swallowed
-   // by END_LOCK_MUTEX, and 'done' must still be set in that case
-   pScan->done = true;
-}
-
-// Main-thread poll for scan completion; returns true to keep polling.
-bool checkPackageEventScan(boost::shared_ptr<PackageEventScan> pScan)
-{
-   // if this scan's result was already consumed, this is a re-entrant poll
-   // (background processing can run while the R call below executes); treat
-   // the scan as still pending rather than register twice -- the outermost
-   // poll returns false and stops the polling
-   if (pScan->consumed)
-      return true;
-
-   if (!pScan->done)
-   {
-      // watchdog: if the scan has overrun (e.g. blocked on a hung network
-      // mount), abandon it rather than wedge package-event tracking for the
-      // rest of the session; later library mutations can start fresh scans.
-      // don't run a pending pass here -- it would most likely hang the same
-      // way and pile up abandoned threads
-      auto elapsed = boost::posix_time::microsec_clock::universal_time() - pScan->startTime;
-      if (elapsed > boost::posix_time::seconds(kPackageEventScanTimeoutSeconds))
-      {
-         LOG_WARNING_MESSAGE("Abandoning package event scan; it did not complete within " +
-                             safe_convert::numberToString(kPackageEventScanTimeoutSeconds) +
-                             " seconds");
-         s_packageEventScanRunning = false;
-         s_packageEventScanPending = false;
-         return false;
-      }
-
-      return true;
-   }
-
-   pScan->consumed = true;
-
-   std::vector<std::string> pkgNames;
-   LOCK_MUTEX(pScan->mutex)
-   {
-      pkgNames = std::move(pScan->pkgNames);
-   }
-   END_LOCK_MUTEX
-
-   Error error = r::exec::RFunction(".rs.registerPackageEventHooks", pkgNames).call();
-   if (error)
-      LOG_ERROR(error);
-
-   s_packageEventScanRunning = false;
-
-   // if another scan was requested while this one was in flight (e.g. an
-   // install completed), run it now so newly-installed packages get hooked
-   if (s_packageEventScanPending)
-   {
-      s_packageEventScanPending = false;
-      startPackageEventScan();
-   }
-
-   return false;
+   pScan->pkgNames = std::move(pkgNames);
+   module_context::executeOnMainThread(
+            boost::bind(onPackageEventScanCompleted, pScan));
 }
 
 void startPackageEventScan()
@@ -448,9 +424,9 @@ void startPackageEventScan()
    core::thread::safeLaunchThread(
             boost::bind(scanForInstalledPackages, libPaths, pScan));
 
-   module_context::schedulePeriodicWork(
-            boost::posix_time::milliseconds(100),
-            boost::bind(checkPackageEventScan, pScan),
+   module_context::scheduleDelayedWork(
+            boost::posix_time::seconds(kPackageEventScanTimeoutSeconds),
+            boost::bind(onPackageEventScanTimeout, pScan),
             false);
 }
 

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -20,6 +20,8 @@
 
 #include "SessionPackages.hpp"
 
+#include <atomic>
+
 #include <boost/format.hpp>
 #include <boost/bind/bind.hpp>
 #include <boost/make_shared.hpp>
@@ -27,6 +29,7 @@
 
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
+#include <shared_core/SafeConvert.hpp>
 
 #include <core/Algorithm.hpp>
 #include <core/Exec.hpp>
@@ -308,14 +311,17 @@ SEXP rs_packageLibraryMutated()
 }
 
 // Result of a background package-event scan. The background thread fills in
-// 'pkgNames' and sets 'done' under the mutex; the main thread polls it via
-// schedulePeriodicWork. We deliberately avoid executeOnMainThread() here, as
-// scheduling work from a background thread mutates the scheduled-command list
-// without synchronization.
+// 'pkgNames' under the mutex and then sets 'done'; the main thread polls it
+// via schedulePeriodicWork. We deliberately avoid executeOnMainThread() here,
+// as scheduling work from a background thread mutates the scheduled-command
+// list without synchronization.
 struct PackageEventScan
 {
    boost::mutex mutex;
-   bool done = false;
+   std::atomic<bool> done = { false };
+   bool consumed = false; // main thread only
+   boost::posix_time::ptime startTime =
+         boost::posix_time::microsec_clock::universal_time();
    std::vector<std::string> pkgNames;
 };
 
@@ -323,55 +329,93 @@ struct PackageEventScan
 bool s_packageEventScanRunning = false;
 bool s_packageEventScanPending = false;
 
+// If a scan hasn't completed after this long (e.g. a library path on a hung
+// network mount), stop polling it so package-event tracking isn't wedged for
+// the rest of the session.
+constexpr int kPackageEventScanTimeoutSeconds = 300;
+
 void startPackageEventScan();
 
-// Runs on a background thread: filesystem access only, no R.
+// Runs on a background thread: filesystem access only, no R. No exception may
+// escape (safeLaunchThread doesn't guard the thread body, so one would
+// terminate the process), and 'done' must be set on every exit path, as the
+// main-thread poller relies on it to stop polling and allow future scans.
 void scanForInstalledPackages(std::vector<FilePath> libPaths,
                               boost::shared_ptr<PackageEventScan> pScan)
 {
    std::vector<std::string> pkgNames;
-   for (const FilePath& libPath : libPaths)
+
+   try
    {
-      if (!libPath.exists())
-         continue;
-
-      std::vector<FilePath> children;
-      Error error = libPath.getChildren(children);
-      if (error)
+      for (const FilePath& libPath : libPaths)
       {
-         LOG_ERROR(error);
-         continue;
-      }
+         if (!libPath.exists())
+            continue;
 
-      for (const FilePath& child : children)
-      {
-         if (child.isDirectory())
-            pkgNames.push_back(child.getFilename());
+         std::vector<FilePath> children;
+         Error error = libPath.getChildren(children);
+         if (error)
+         {
+            LOG_ERROR(error);
+            continue;
+         }
+
+         for (const FilePath& child : children)
+         {
+            if (child.isDirectory())
+               pkgNames.push_back(child.getFilename());
+         }
       }
    }
+   CATCH_UNEXPECTED_EXCEPTION
 
    LOCK_MUTEX(pScan->mutex)
    {
       pScan->pkgNames = std::move(pkgNames);
-      pScan->done = true;
    }
    END_LOCK_MUTEX
+
+   // set 'done' last, outside the mutex block: a throwing lock is swallowed
+   // by END_LOCK_MUTEX, and 'done' must still be set in that case
+   pScan->done = true;
 }
 
 // Main-thread poll for scan completion; returns true to keep polling.
 bool checkPackageEventScan(boost::shared_ptr<PackageEventScan> pScan)
 {
-   std::vector<std::string> pkgNames;
+   // if this scan's result was already consumed, this is a re-entrant poll
+   // (background processing can run while the R call below executes); treat
+   // the scan as still pending rather than register twice -- the outermost
+   // poll returns false and stops the polling
+   if (pScan->consumed)
+      return true;
 
+   if (!pScan->done)
+   {
+      // watchdog: if the scan has overrun (e.g. blocked on a hung network
+      // mount), abandon it rather than wedge package-event tracking for the
+      // rest of the session; later library mutations can start fresh scans.
+      // don't run a pending pass here -- it would most likely hang the same
+      // way and pile up abandoned threads
+      auto elapsed = boost::posix_time::microsec_clock::universal_time() - pScan->startTime;
+      if (elapsed > boost::posix_time::seconds(kPackageEventScanTimeoutSeconds))
+      {
+         LOG_WARNING_MESSAGE("Abandoning package event scan; it did not complete within " +
+                             safe_convert::numberToString(kPackageEventScanTimeoutSeconds) +
+                             " seconds");
+         s_packageEventScanRunning = false;
+         s_packageEventScanPending = false;
+         return false;
+      }
+
+      return true;
+   }
+
+   pScan->consumed = true;
+
+   std::vector<std::string> pkgNames;
    LOCK_MUTEX(pScan->mutex)
    {
-      if (!pScan->done)
-         return true;
-
-      // consume the result: background processing can run re-entrantly while
-      // the R call below executes, and a second poll of this same scan should
-      // treat it as still pending rather than register twice
-      pScan->done = false;
       pkgNames = std::move(pScan->pkgNames);
    }
    END_LOCK_MUTEX
@@ -413,19 +457,25 @@ void startPackageEventScan()
 // Enumerating the library paths can be slow on remote filesystems, so it runs
 // on a background thread; if a scan is already in flight, just request another
 // pass once it completes (the running scan may have raced with the library
-// mutation that triggered this call).
-void updatePackageEventsAsync()
+// mutation that triggered this call). Returns true if a new scan was started,
+// false if one was already in flight and a follow-up pass was queued.
+bool updatePackageEventsAsync()
 {
    if (s_packageEventScanRunning)
+   {
       s_packageEventScanPending = true;
-   else
-      startPackageEventScan();
+      return false;
+   }
+
+   startPackageEventScan();
+   return true;
 }
 
 SEXP rs_updatePackageEvents()
 {
-   updatePackageEventsAsync();
-   return R_NilValue;
+   bool started = updatePackageEventsAsync();
+   r::sexp::Protect protect;
+   return r::sexp::create(started, &protect);
 }
 
 void detectLibPathsChanges()

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -22,12 +22,15 @@
 
 #include <boost/format.hpp>
 #include <boost/bind/bind.hpp>
+#include <boost/make_shared.hpp>
 #include <boost/regex.hpp>
 
 #include <shared_core/Error.hpp>
+#include <shared_core/FilePath.hpp>
 
 #include <core/Algorithm.hpp>
 #include <core/Exec.hpp>
+#include <core/Thread.hpp>
 
 #include <r/RExec.hpp>
 #include <r/RFunctionHook.hpp>
@@ -304,6 +307,127 @@ SEXP rs_packageLibraryMutated()
    return R_NilValue;
 }
 
+// Result of a background package-event scan. The background thread fills in
+// 'pkgNames' and sets 'done' under the mutex; the main thread polls it via
+// schedulePeriodicWork. We deliberately avoid executeOnMainThread() here, as
+// scheduling work from a background thread mutates the scheduled-command list
+// without synchronization.
+struct PackageEventScan
+{
+   boost::mutex mutex;
+   bool done = false;
+   std::vector<std::string> pkgNames;
+};
+
+// Coalescing state for package-event scans; main thread only.
+bool s_packageEventScanRunning = false;
+bool s_packageEventScanPending = false;
+
+void startPackageEventScan();
+
+// Runs on a background thread: filesystem access only, no R.
+void scanForInstalledPackages(std::vector<FilePath> libPaths,
+                              boost::shared_ptr<PackageEventScan> pScan)
+{
+   std::vector<std::string> pkgNames;
+   for (const FilePath& libPath : libPaths)
+   {
+      if (!libPath.exists())
+         continue;
+
+      std::vector<FilePath> children;
+      Error error = libPath.getChildren(children);
+      if (error)
+      {
+         LOG_ERROR(error);
+         continue;
+      }
+
+      for (const FilePath& child : children)
+      {
+         if (child.isDirectory())
+            pkgNames.push_back(child.getFilename());
+      }
+   }
+
+   LOCK_MUTEX(pScan->mutex)
+   {
+      pScan->pkgNames = std::move(pkgNames);
+      pScan->done = true;
+   }
+   END_LOCK_MUTEX
+}
+
+// Main-thread poll for scan completion; returns true to keep polling.
+bool checkPackageEventScan(boost::shared_ptr<PackageEventScan> pScan)
+{
+   std::vector<std::string> pkgNames;
+
+   LOCK_MUTEX(pScan->mutex)
+   {
+      if (!pScan->done)
+         return true;
+
+      // consume the result: background processing can run re-entrantly while
+      // the R call below executes, and a second poll of this same scan should
+      // treat it as still pending rather than register twice
+      pScan->done = false;
+      pkgNames = std::move(pScan->pkgNames);
+   }
+   END_LOCK_MUTEX
+
+   Error error = r::exec::RFunction(".rs.registerPackageEventHooks", pkgNames).call();
+   if (error)
+      LOG_ERROR(error);
+
+   s_packageEventScanRunning = false;
+
+   // if another scan was requested while this one was in flight (e.g. an
+   // install completed), run it now so newly-installed packages get hooked
+   if (s_packageEventScanPending)
+   {
+      s_packageEventScanPending = false;
+      startPackageEventScan();
+   }
+
+   return false;
+}
+
+void startPackageEventScan()
+{
+   s_packageEventScanRunning = true;
+
+   // resolve library paths on the main thread; this calls into R
+   std::vector<FilePath> libPaths = module_context::getLibPaths();
+
+   auto pScan = boost::make_shared<PackageEventScan>();
+   core::thread::safeLaunchThread(
+            boost::bind(scanForInstalledPackages, libPaths, pScan));
+
+   module_context::schedulePeriodicWork(
+            boost::posix_time::milliseconds(100),
+            boost::bind(checkPackageEventScan, pScan),
+            false);
+}
+
+// Enumerating the library paths can be slow on remote filesystems, so it runs
+// on a background thread; if a scan is already in flight, just request another
+// pass once it completes (the running scan may have raced with the library
+// mutation that triggered this call).
+void updatePackageEventsAsync()
+{
+   if (s_packageEventScanRunning)
+      s_packageEventScanPending = true;
+   else
+      startPackageEventScan();
+}
+
+SEXP rs_updatePackageEvents()
+{
+   updatePackageEventsAsync();
+   return R_NilValue;
+}
+
 void detectLibPathsChanges()
 {
    static std::vector<std::string> s_lastLibPaths;
@@ -425,6 +549,12 @@ void onDeferredInit(bool /* newSession */)
    if (error)
       LOG_ERROR(error);
 
+   // subscribe to package attach / detach events. this happens here (rather
+   // than at module init) both to keep the scan off the startup critical path
+   // and because the rs_* routines it relies upon are only registered with R
+   // once the init sequence has completed
+   updatePackageEventsAsync();
+
    // monitor libPaths for changes
    detectLibPathsChanges();
    module_context::events().onDetectChanges.connect(onDetectChanges);
@@ -494,6 +624,7 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_packageLibraryMutated);
    RS_REGISTER_CALL_METHOD(rs_getCachedAvailablePackages);
    RS_REGISTER_CALL_METHOD(rs_downloadAvailablePackages);
+   RS_REGISTER_CALL_METHOD(rs_updatePackageEvents);
 
    using boost::bind;
    using namespace module_context;

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -326,8 +326,17 @@ bool s_packageEventScanPending = false;
 
 // If a scan hasn't completed after this long (e.g. a library path on a hung
 // network mount), abandon it so package-event tracking isn't wedged for the
-// rest of the session.
+// rest of the session. The R option exists so tests can exercise the
+// watchdog path without waiting out the default.
 constexpr int kPackageEventScanTimeoutSeconds = 300;
+
+int packageEventScanTimeoutSeconds()
+{
+   return r::options::getOption<int>(
+            "rstudio.packageEventScanTimeout",
+            kPackageEventScanTimeoutSeconds,
+            false);
+}
 
 void startPackageEventScan();
 
@@ -360,14 +369,19 @@ void onPackageEventScanCompleted(boost::shared_ptr<PackageEventScan> pScan)
 // a hung network mount), abandon it rather than wedge package-event tracking
 // for the rest of the session; later library mutations can start fresh scans.
 // We don't run a pending pass here -- it would most likely hang the same way
-// and pile up abandoned threads.
-void onPackageEventScanTimeout(boost::shared_ptr<PackageEventScan> pScan)
+// and pile up abandoned threads. Note that a scan completing right at the
+// timeout boundary loses the race with this watchdog (it is queued ahead of
+// the scan's completion command): the completion then sees 'abandoned' and
+// drops the result, and hooks wait for the next library mutation to trigger
+// a fresh scan.
+void onPackageEventScanTimeout(boost::shared_ptr<PackageEventScan> pScan,
+                               int timeoutSeconds)
 {
    if (pScan->completed)
       return;
 
    LOG_WARNING_MESSAGE("Abandoning package event scan; it did not complete within " +
-                       safe_convert::numberToString(kPackageEventScanTimeoutSeconds) +
+                       safe_convert::numberToString(timeoutSeconds) +
                        " seconds");
 
    pScan->abandoned = true;
@@ -425,17 +439,23 @@ void startPackageEventScan()
 {
    s_packageEventScanRunning = true;
 
-   // resolve library paths on the main thread; this calls into R
+   // resolve library paths and the watchdog timeout on the main thread;
+   // both call into R
    std::vector<FilePath> libPaths = module_context::getLibPaths();
+   int timeoutSeconds = packageEventScanTimeoutSeconds();
 
    auto pScan = boost::make_shared<PackageEventScan>();
+
+   // queue the watchdog before launching the thread, so that it is always
+   // ordered ahead of the scan's completion command in the scheduled-command
+   // queue (and still reclaims the scan state if the launch itself fails)
+   module_context::scheduleDelayedWork(
+            boost::posix_time::seconds(timeoutSeconds),
+            boost::bind(onPackageEventScanTimeout, pScan, timeoutSeconds),
+            false);
+
    core::thread::safeLaunchThread(
             boost::bind(scanForInstalledPackages, libPaths, pScan));
-
-   module_context::scheduleDelayedWork(
-            boost::posix_time::seconds(kPackageEventScanTimeoutSeconds),
-            boost::bind(onPackageEventScanTimeout, pScan),
-            false);
 }
 
 // Enumerating the library paths can be slow on remote filesystems, so it runs

--- a/src/cpp/tests/testthat/test-packages.R
+++ b/src/cpp/tests/testthat/test-packages.R
@@ -116,6 +116,36 @@ test_that(".rs.isPackageManagementCall does not force promises", {
    expect_identical(forced, 0L)
 })
 
+# Pump background processing until 'pkg' appears in .rs.hookedPackages, or
+# the timeout elapses; returns TRUE if the package was hooked. The library
+# scan runs on a background thread and hooks are registered from a scheduled
+# command on the main thread, so tests must pump background processing
+# manually (the headless test harness has no scheduled-command pump). Note
+# that scan state is process-global: a scan kicked off outside the test (e.g.
+# at deferred init) may still be in flight when a test starts; polling until
+# the package of interest is hooked tolerates that.
+waitUntilHooked <- function(pkg, timeout = 30)
+{
+   deadline <- Sys.time() + timeout
+   while (!pkg %in% .rs.hookedPackages && Sys.time() < deadline)
+   {
+      .Call("rs_performBackgroundProcessing", FALSE, PACKAGE = "(embedding)")
+      Sys.sleep(0.1)
+   }
+   pkg %in% .rs.hookedPackages
+}
+
+# testthat::local_mocked_bindings cannot mock functions in the locked
+# "tools:rstudio" environment, so save, replace, and restore via assign().
+withRsMock <- function(targetName, newValue, expr)
+{
+   rsEnv <- as.environment("tools:rstudio")
+   original <- get(targetName, envir = rsEnv)
+   on.exit(assign(targetName, original, envir = rsEnv), add = TRUE)
+   assign(targetName, newValue, envir = rsEnv)
+   force(expr)
+}
+
 test_that(".rs.registerPackageEventHooks registers hooks once per package", {
    fakePkg <- basename(tempfile("rstudioFakePkg"))
    expect_false(fakePkg %in% .rs.hookedPackages)
@@ -125,10 +155,13 @@ test_that(".rs.registerPackageEventHooks registers hooks once per package", {
    expect_identical(result$value, fakePkg)
 
    expect_true(fakePkg %in% .rs.hookedPackages)
-   expect_length(getHook(packageEvent(fakePkg, "attach")), 1L)
-   expect_length(getHook(packageEvent(fakePkg, "onLoad")), 1L)
-   expect_length(getHook(packageEvent(fakePkg, "onUnload")), 1L)
-   expect_length(getHook(packageEvent(fakePkg, "detach")), 1L)
+
+   # each event must be bound to its matching handler; a transposition here
+   # would invert the attached flag reported to the client
+   expect_identical(getHook(packageEvent(fakePkg, "attach")), list(.rs.notifyPackageAttached))
+   expect_identical(getHook(packageEvent(fakePkg, "onLoad")), list(.rs.notifyPackageLoaded))
+   expect_identical(getHook(packageEvent(fakePkg, "onUnload")), list(.rs.notifyPackageUnloaded))
+   expect_identical(getHook(packageEvent(fakePkg, "detach")), list(.rs.notifyPackageDetached))
 
    # re-registering an already-hooked package is a no-op
    result <- .rs.registerPackageEventHooks(fakePkg)
@@ -136,28 +169,80 @@ test_that(".rs.registerPackageEventHooks registers hooks once per package", {
    expect_length(getHook(packageEvent(fakePkg, "attach")), 1L)
 })
 
+test_that(".rs.registerPackageEventHooks dedupes duplicate package names", {
+   # the same package name can appear under multiple library paths, so a
+   # single scan can hand us duplicates; each package must be hooked once
+   fakePkg <- basename(tempfile("rstudioFakePkg"))
+   .rs.registerPackageEventHooks(c(fakePkg, fakePkg))
+   expect_length(getHook(packageEvent(fakePkg, "attach")), 1L)
+})
+
+test_that("package attach and detach hooks report the matching attached flag", {
+   events <- list()
+   recorder <- function(type, data = NULL)
+      events[[length(events) + 1L]] <<- list(type = type, data = data)
+
+   withRsMock(".rs.enqueClientEvent", recorder, {
+      .rs.notifyPackageAttached("stats")
+      .rs.notifyPackageDetached("stats")
+   })
+
+   expect_length(events, 2L)
+   expect_identical(events[[1L]]$type, "package_status_changed")
+   expect_identical(as.character(events[[1L]]$data$name), "stats")
+   expect_true(as.logical(events[[1L]]$data$attached))
+   expect_identical(events[[2L]]$type, "package_status_changed")
+   expect_identical(as.character(events[[2L]]$data$name), "stats")
+   expect_false(as.logical(events[[2L]]$data$attached))
+})
+
 test_that(".rs.updatePackageEvents hooks packages found on the library paths", {
    libDir <- tempfile("rstudioFakeLib")
    fakePkg <- basename(tempfile("rstudioFakePkg"))
    dir.create(file.path(libDir, fakePkg), recursive = TRUE)
-   on.exit(unlink(libDir, recursive = TRUE), add = TRUE)
 
    oldPaths <- .libPaths()
-   .libPaths(c(libDir, oldPaths))
    on.exit(.libPaths(oldPaths), add = TRUE)
+   on.exit(unlink(libDir, recursive = TRUE), add = TRUE)
+   .libPaths(c(libDir, oldPaths))
 
    .rs.updatePackageEvents()
 
-   # the library scan runs on a background thread, and hooks are registered
-   # from a scheduled command on the main thread, so wait for the round trip;
-   # background processing must be pumped manually during headless tests
-   deadline <- Sys.time() + 30
-   while (!fakePkg %in% .rs.hookedPackages && Sys.time() < deadline)
-   {
-      .Call("rs_performBackgroundProcessing", FALSE, PACKAGE = "(embedding)")
-      Sys.sleep(0.1)
-   }
-
-   expect_true(fakePkg %in% .rs.hookedPackages)
+   expect_true(
+      waitUntilHooked(fakePkg),
+      info = "timed out waiting for the package event scan to hook the fake package"
+   )
    expect_length(getHook(packageEvent(fakePkg, "onLoad")), 1L)
+})
+
+test_that(".rs.updatePackageEvents coalesces overlapping scans into a follow-up pass", {
+   libDir1 <- tempfile("rstudioFakeLib")
+   libDir2 <- tempfile("rstudioFakeLib")
+   pkgA <- basename(tempfile("rstudioFakePkg"))
+   pkgB <- basename(tempfile("rstudioFakePkg"))
+   dir.create(file.path(libDir1, pkgA), recursive = TRUE)
+   dir.create(file.path(libDir2, pkgB), recursive = TRUE)
+
+   oldPaths <- .libPaths()
+   on.exit(.libPaths(oldPaths), add = TRUE)
+   on.exit(unlink(c(libDir1, libDir2), recursive = TRUE), add = TRUE)
+   .libPaths(c(libDir1, oldPaths))
+
+   # after this call a scan is in flight: either this call started one, or it
+   # queued a follow-up pass behind a scan that was already running
+   .rs.updatePackageEvents()
+
+   # make libDir2 visible only now, after any in-flight scan has already
+   # snapshotted the library paths: pkgB can only be hooked by a follow-up
+   # pass started after the in-flight scan completes
+   .libPaths(c(libDir2, libDir1, oldPaths))
+
+   # no background processing has been pumped since the call above, so the
+   # scan is still in flight and this call must take the coalescing branch
+   expect_false(.rs.updatePackageEvents())
+
+   expect_true(
+      waitUntilHooked(pkgB),
+      info = "timed out waiting for the follow-up package event scan to hook the fake package"
+   )
 })

--- a/src/cpp/tests/testthat/test-packages.R
+++ b/src/cpp/tests/testthat/test-packages.R
@@ -115,3 +115,49 @@ test_that(".rs.isPackageManagementCall does not force promises", {
    expect_false(.rs.isPackageManagementCall("install.packages(x)"))
    expect_identical(forced, 0L)
 })
+
+test_that(".rs.registerPackageEventHooks registers hooks once per package", {
+   fakePkg <- basename(tempfile("rstudioFakePkg"))
+   expect_false(fakePkg %in% .rs.hookedPackages)
+
+   result <- withVisible(.rs.registerPackageEventHooks(fakePkg))
+   expect_false(result$visible)
+   expect_identical(result$value, fakePkg)
+
+   expect_true(fakePkg %in% .rs.hookedPackages)
+   expect_length(getHook(packageEvent(fakePkg, "attach")), 1L)
+   expect_length(getHook(packageEvent(fakePkg, "onLoad")), 1L)
+   expect_length(getHook(packageEvent(fakePkg, "onUnload")), 1L)
+   expect_length(getHook(packageEvent(fakePkg, "detach")), 1L)
+
+   # re-registering an already-hooked package is a no-op
+   result <- .rs.registerPackageEventHooks(fakePkg)
+   expect_length(result, 0L)
+   expect_length(getHook(packageEvent(fakePkg, "attach")), 1L)
+})
+
+test_that(".rs.updatePackageEvents hooks packages found on the library paths", {
+   libDir <- tempfile("rstudioFakeLib")
+   fakePkg <- basename(tempfile("rstudioFakePkg"))
+   dir.create(file.path(libDir, fakePkg), recursive = TRUE)
+   on.exit(unlink(libDir, recursive = TRUE), add = TRUE)
+
+   oldPaths <- .libPaths()
+   .libPaths(c(libDir, oldPaths))
+   on.exit(.libPaths(oldPaths), add = TRUE)
+
+   .rs.updatePackageEvents()
+
+   # the library scan runs on a background thread, and hooks are registered
+   # from a scheduled command on the main thread, so wait for the round trip;
+   # background processing must be pumped manually during headless tests
+   deadline <- Sys.time() + 30
+   while (!fakePkg %in% .rs.hookedPackages && Sys.time() < deadline)
+   {
+      .Call("rs_performBackgroundProcessing", FALSE, PACKAGE = "(embedding)")
+      Sys.sleep(0.1)
+   }
+
+   expect_true(fakePkg %in% .rs.hookedPackages)
+   expect_length(getHook(packageEvent(fakePkg, "onLoad")), 1L)
+})

--- a/src/cpp/tests/testthat/test-packages.R
+++ b/src/cpp/tests/testthat/test-packages.R
@@ -246,3 +246,49 @@ test_that(".rs.updatePackageEvents coalesces overlapping scans into a follow-up 
       info = "timed out waiting for the follow-up package event scan to hook the fake package"
    )
 })
+
+test_that("the watchdog abandons a scan that does not complete in time", {
+   libDir <- tempfile("rstudioFakeLib")
+   fakePkg <- basename(tempfile("rstudioFakePkg"))
+   dir.create(file.path(libDir, fakePkg), recursive = TRUE)
+
+   oldPaths <- .libPaths()
+   on.exit(.libPaths(oldPaths), add = TRUE)
+   on.exit(unlink(libDir, recursive = TRUE), add = TRUE)
+   .libPaths(c(libDir, oldPaths))
+
+   # a zero-second timeout makes the watchdog due at the first pump; it is
+   # queued when the scan starts, ahead of the scan's completion command, so
+   # the scan is deterministically abandoned no matter how quickly the
+   # background thread finishes
+   options(rstudio.packageEventScanTimeout = 0L)
+   on.exit(options(rstudio.packageEventScanTimeout = NULL), add = TRUE)
+
+   # a scan started outside this test (e.g. at deferred init, or coalesced
+   # behind one from an earlier test) uses the default timeout; pump until we
+   # can start a scan of our own, which picks up the zero-second timeout
+   deadline <- Sys.time() + 30
+   started <- .rs.updatePackageEvents()
+   while (!started && Sys.time() < deadline)
+   {
+      .Call("rs_performBackgroundProcessing", FALSE, PACKAGE = "(embedding)")
+      Sys.sleep(0.1)
+      started <- .rs.updatePackageEvents()
+   }
+   expect_true(started, info = "timed out waiting to start a zero-timeout scan")
+
+   # pump: the watchdog abandons the scan, and its completion (arriving
+   # whenever the background thread finishes) is dropped, so the package
+   # must not be hooked
+   expect_false(waitUntilHooked(fakePkg, timeout = 1))
+
+   # the watchdog must also have reset the coalescing state: with the
+   # timeout restored, a fresh scan can start immediately and hooks the
+   # package the abandoned scan never delivered
+   options(rstudio.packageEventScanTimeout = NULL)
+   expect_true(.rs.updatePackageEvents())
+   expect_true(
+      waitUntilHooked(fakePkg),
+      info = "timed out waiting for the post-abandonment scan to hook the fake package"
+   )
+})


### PR DESCRIPTION
## Summary

The installed-package scan used by `.rs.updatePackageEvents()` to register package load/attach/detach hooks previously ran `list.dirs(.libPaths())` on the main R thread. R's internal `list_dirs` performs one `stat()` per directory entry, so on a remote/network library path this is O(#packages) network round trips -- and it ran synchronously at module init (blocking session startup), after every `install.packages()` / `remove.packages()`, and from the renv monitor.

This PR moves the library enumeration to a background thread:

- The filesystem scan (`FilePath::getChildren` over each lib path) runs via `core::thread::safeLaunchThread`; no R calls are made off the main thread.
- The scheduled-command queue in `SessionModuleContext` is now guarded by a mutex, making `executeOnMainThread()` (and the `schedule*Work` functions) safe to call from background threads; commands still execute only on the main thread, outside the lock. The background scan posts its result back to the main thread via `executeOnMainThread()`, which registers hooks via the new `.rs.registerPackageEventHooks()`. This also retroactively fixes existing background-thread callers of `executeOnMainThread()` (e.g. SessionPPM, SessionChat), which previously mutated the scheduled-command list without synchronization.
- A one-shot watchdog abandons a scan that hasn't completed within 5 minutes (e.g. a library path on a hung network mount), so package-event tracking isn't wedged for the rest of the session; a late result arriving from an abandoned scan is dropped. The timeout is overridable via the `rstudio.packageEventScanTimeout` R option, which the tests use to exercise the abandonment path. An abandoned thread is leaked (detached), matching the existing pattern for background callers of `executeOnMainThread()`; rsession exits via `::exit()`, so a leaked thread that unblocks during teardown could in principle touch destroyed statics, but that window pre-exists this PR and lasts milliseconds.
- Concurrent scan requests coalesce: if a scan is already in flight, a follow-up pass is queued so packages installed mid-scan still get hooked.
- The hook closures formerly local to `updatePackageEvents` are hoisted to top-level functions (`.rs.notifyPackageAttached` / `Detached` / `Loaded` / `Unloaded`, `.rs.reportPackageStatus`).
- The initial subscription now happens at deferred init (from `onDeferredInit` in `SessionPackages.cpp`) rather than during synchronous module init, both to keep the scan off the startup critical path and because the `rs_*` routines it relies upon are only registered with R once the init sequence has completed.

Hook registration arriving slightly after startup is safe: the Packages pane's initial loaded/attached state comes from `get_package_state` / `.rs.listInstalledPackages`, not from hook events, and `.rs.registerPackageEventHooks()` reattaches S3 overrides to cover a package loaded before the hooks landed. Non-pane consumers of `onPackageLoaded` (e.g. SessionShiny's stale-shiny-version warning) can likewise miss a load that happens inside the scan window; this is an accepted trade-off of going async.

## Testing

- New testthat coverage for `.rs.registerPackageEventHooks()` (idempotent registration) and the async round trip through `.rs.updatePackageEvents()` (background scan -> main-thread hook registration), pumping background processing manually since the headless test harness has no scheduled-command pump.
- The watchdog path is covered deterministically: with a zero-second `rstudio.packageEventScanTimeout`, the watchdog (queued ahead of the scan's completion command) always abandons the scan on the first pump, the late result is dropped, and a subsequent scan with the default timeout recovers and hooks the package.
- Full rsession C++ suite passes with the mutex-guarded scheduled-command queue.
- Verified interactively (against the earlier polling-based iteration of this PR; the automated tests above cover the reworked completion path): deferred-init scan hooks packages at startup; `library(DBI)` in the console checks the Packages pane checkbox via the attach hook; libraries added to `.libPaths()` at runtime are picked up after a package command.

Addresses #18060.

