### PR TITLE
Reset Posit Assistant update-check throttle on first run of a new RStudio build

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,7 @@
 - ([#18277](https://github.com/rstudio/rstudio/issues/18277)): Fixed an issue where the GitHub Copilot or Posit Assistant agent could fail to start for the rest of the session after an early startup failure (for example, a misconfigured Node.js path). The agent now retries and starts once the underlying problem is corrected, without restarting the session.
 - ([#18270](https://github.com/rstudio/rstudio/issues/18270)): Fixed an issue on Windows where native dialogs shown by R (e.g. via `utils::askYesNo()`, or when `install.packages()` asks about installing from sources) could open behind the RStudio Desktop window, making the IDE appear frozen while R waited on a dialog the user could not see.
 - ([#8345](https://github.com/rstudio/rstudio/issues/8345)): Help pages opened via the Help pane's "Show in new window" button now follow the IDE's editor theme, instead of always rendering with a light palette.
+- ([#18305](https://github.com/rstudio/rstudio/issues/18305)): The first run of a new RStudio build now always checks for Posit Assistant updates, instead of the check being suppressed for up to two hours when the previous build had checked recently.
 
 ### Dependencies
 - MathJax 4.1.3 (inline LaTeX / math previews)

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,7 +34,7 @@
 - ([#18277](https://github.com/rstudio/rstudio/issues/18277)): Fixed an issue where the GitHub Copilot or Posit Assistant agent could fail to start for the rest of the session after an early startup failure (for example, a misconfigured Node.js path). The agent now retries and starts once the underlying problem is corrected, without restarting the session.
 - ([#18270](https://github.com/rstudio/rstudio/issues/18270)): Fixed an issue on Windows where native dialogs shown by R (e.g. via `utils::askYesNo()`, or when `install.packages()` asks about installing from sources) could open behind the RStudio Desktop window, making the IDE appear frozen while R waited on a dialog the user could not see.
 - ([#8345](https://github.com/rstudio/rstudio/issues/8345)): Help pages opened via the Help pane's "Show in new window" button now follow the IDE's editor theme, instead of always rendering with a light palette.
-- ([#18305](https://github.com/rstudio/rstudio/issues/18305)): The first run of a new RStudio build now always checks for Posit Assistant updates, instead of the check being suppressed for up to two hours when the previous build had checked recently.
+- ([#18305](https://github.com/rstudio/rstudio/issues/18305)): The first run of a new RStudio build now always checks for Posit Assistant updates, instead of the check being suppressed for up to the update-check interval (two hours by default) when the previous build had checked recently.
 
 ### Dependencies
 - MathJax 4.1.3 (inline LaTeX / math previews)

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -4711,7 +4711,8 @@ void onUpdateCheckComplete(const Error& fetchError, const json::Object& manifest
 }
 
 // Decide whether an automatic check must actually fetch the manifest. Always
-// fetches when nothing is installed or the installed protocol mismatches; otherwise
+// fetches when nothing is installed, the installed protocol mismatches, or the
+// persisted record was written by a different RStudio build; otherwise
 // throttles to once per the posit_assistant_update_check_interval_hours preference
 // (0 hours = always check). The test manifest is opt-in for pre-release testing,
 // so throttling is disabled there (every check fetches, as if the interval were 0).
@@ -4732,7 +4733,7 @@ bool shouldFetchManifest(bool force)
    // the rstudioVersion field) must not throttle this build: the first check
    // after installing a different build always fetches (#18305).
    bool rstudioVersionChanged =
-      record && record->rstudioVersion != RSTUDIO_VERSION;
+      throttle::rstudioVersionChanged(record, RSTUDIO_VERSION);
    if (rstudioVersionChanged)
       DLOG("RStudio build changed since last manifest check ('{}' -> '{}'); "
            "update check due", record->rstudioVersion, RSTUDIO_VERSION);

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -4537,8 +4537,8 @@ void onUpdateCheckComplete(const Error& fetchError, const json::Object& manifest
       // timestamp, so a bad manifest cannot bypass the throttle.
       boost::optional<ManifestCheckRecord> prior =
          throttle::readManifestCheckRecord(throttle::manifestCheckStatePath());
-      ManifestCheckRecord record =
-         throttle::recordToPersist(recordToWrite, prior, std::time(nullptr));
+      ManifestCheckRecord record = throttle::recordToPersist(
+         recordToWrite, prior, std::time(nullptr), RSTUDIO_VERSION);
       Error writeError = throttle::writeManifestCheckRecord(
          throttle::manifestCheckStatePath(), record);
       if (writeError)
@@ -4728,13 +4728,22 @@ bool shouldFetchManifest(bool force)
    if (record)
       last = record->lastCheckTime;
 
+   // A record written by a different RStudio build (or by a build that predates
+   // the rstudioVersion field) must not throttle this build: the first check
+   // after installing a different build always fetches (#18305).
+   bool rstudioVersionChanged =
+      record && record->rstudioVersion != RSTUDIO_VERSION;
+   if (rstudioVersionChanged)
+      DLOG("RStudio build changed since last manifest check ('{}' -> '{}'); "
+           "update check due", record->rstudioVersion, RSTUDIO_VERSION);
+
    int throttleSeconds = isUsingTestManifest()
       ? 0
       : throttle::throttleSecondsFromHours(
            prefs::userPrefs().positAssistantUpdateCheckIntervalHours());
 
    return throttle::manifestCheckDue(
-      force, isInstalled, mismatch, last,
+      force, isInstalled, mismatch, rstudioVersionChanged, last,
       std::time(nullptr), throttleSeconds);
 }
 

--- a/src/cpp/session/modules/chat/ChatUpdateThrottle.cpp
+++ b/src/cpp/session/modules/chat/ChatUpdateThrottle.cpp
@@ -96,6 +96,7 @@ boost::optional<ManifestCheckRecord> readManifestCheckRecord(const core::FilePat
    // A present field of the wrong type means the record is corrupt -> malformed.
    boost::optional<std::string> installedVersion;
    boost::optional<std::string> rstudioProtocol;
+   boost::optional<std::string> rstudioVersion;
    boost::optional<bool> unsupportedInstalledVersion;
    boost::optional<bool> unsupportedProtocol;
    auto readOptionalField = [&](const char* fieldName, auto& outValue) -> bool
@@ -111,6 +112,7 @@ boost::optional<ManifestCheckRecord> readManifestCheckRecord(const core::FilePat
    };
    if (readOptionalField("installedVersion", installedVersion) ||
        readOptionalField("rstudioProtocol", rstudioProtocol) ||
+       readOptionalField("rstudioVersion", rstudioVersion) ||
        readOptionalField("unsupportedInstalledVersion", unsupportedInstalledVersion) ||
        readOptionalField("unsupportedProtocol", unsupportedProtocol))
       return boost::none;
@@ -118,6 +120,8 @@ boost::optional<ManifestCheckRecord> readManifestCheckRecord(const core::FilePat
       record.installedVersion = *installedVersion;
    if (rstudioProtocol)
       record.rstudioProtocol = *rstudioProtocol;
+   if (rstudioVersion)
+      record.rstudioVersion = *rstudioVersion;
    if (unsupportedInstalledVersion)
       record.unsupportedInstalledVersion = *unsupportedInstalledVersion;
    if (unsupportedProtocol)
@@ -137,6 +141,7 @@ core::Error writeManifestCheckRecord(const core::FilePath& stateFile,
    obj["lastCheckTime"] = std::to_string(static_cast<long long>(record.lastCheckTime));
    obj["installedVersion"] = record.installedVersion;
    obj["rstudioProtocol"] = record.rstudioProtocol;
+   obj["rstudioVersion"] = record.rstudioVersion;
    obj["unsupportedInstalledVersion"] = record.unsupportedInstalledVersion;
    obj["unsupportedProtocol"] = record.unsupportedProtocol;
    return core::writeStringToFile(stateFile, obj.write());
@@ -152,9 +157,14 @@ ManifestCheckRecord bumpRecord(boost::optional<ManifestCheckRecord> prior,
 
 ManifestCheckRecord recordToPersist(const boost::optional<ManifestCheckRecord>& staged,
                                     const boost::optional<ManifestCheckRecord>& prior,
-                                    std::time_t now)
+                                    std::time_t now,
+                                    const std::string& rstudioVersion)
 {
-   return staged ? *staged : bumpRecord(prior, now);
+   ManifestCheckRecord out = staged ? *staged : bumpRecord(prior, now);
+   // Every attempt stamps the running build, whatever staged or prior carried:
+   // this is the single owner of the field (see header).
+   out.rstudioVersion = rstudioVersion;
+   return out;
 }
 
 int throttleSecondsFromHours(int hours)
@@ -172,11 +182,12 @@ int throttleSecondsFromHours(int hours)
 bool manifestCheckDue(bool force,
                       bool installed,
                       bool protocolMismatch,
+                      bool rstudioVersionChanged,
                       boost::optional<std::time_t> lastCheckTime,
                       std::time_t now,
                       int throttleSeconds)
 {
-   if (force || !installed || protocolMismatch)
+   if (force || !installed || protocolMismatch || rstudioVersionChanged)
       return true;
    if (!lastCheckTime)
       return true;

--- a/src/cpp/session/modules/chat/ChatUpdateThrottle.cpp
+++ b/src/cpp/session/modules/chat/ChatUpdateThrottle.cpp
@@ -167,6 +167,12 @@ ManifestCheckRecord recordToPersist(const boost::optional<ManifestCheckRecord>& 
    return out;
 }
 
+bool rstudioVersionChanged(const boost::optional<ManifestCheckRecord>& record,
+                           const std::string& runningVersion)
+{
+   return record && record->rstudioVersion != runningVersion;
+}
+
 int throttleSecondsFromHours(int hours)
 {
    if (hours <= 0)

--- a/src/cpp/session/modules/chat/ChatUpdateThrottle.hpp
+++ b/src/cpp/session/modules/chat/ChatUpdateThrottle.hpp
@@ -36,11 +36,18 @@ namespace throttle {
 // were computed for, so a stale block is never applied to a different install.
 // Never apply the bool flags directly: resolve them through resolvePersistedBlock(),
 // which drops a flag whose context no longer matches the current install.
+// rstudioVersion records which RStudio build made the last check attempt: a record
+// written by a different build never throttles this one (see manifestCheckDue), so
+// the first check after installing a different RStudio build always fetches.
+// Compatibility: builds that predate the field ignore the extra key when reading
+// and drop it when writing; a missing key reads back as "" here, which compares
+// unequal to any real build and so just costs one extra fetch.
 struct ManifestCheckRecord
 {
    std::time_t lastCheckTime = 0;
    std::string installedVersion;
    std::string rstudioProtocol;
+   std::string rstudioVersion;
    bool unsupportedInstalledVersion = false;
    bool unsupportedProtocol = false;
 };
@@ -93,10 +100,14 @@ ManifestCheckRecord bumpRecord(boost::optional<ManifestCheckRecord> prior,
 // preserve `prior`'s block and bump only the timestamp via bumpRecord(). Only a
 // success may set or clear the persisted block, and every real attempt bumps the
 // timestamp -- so a failed or bad-manifest fetch still records the attempt and
-// cannot bypass the throttle.
+// cannot bypass the throttle. Every attempt (success or failure) also stamps
+// rstudioVersion, the running RStudio build: a new build's first check bypasses
+// the throttle exactly once, then normal throttling resumes even if that first
+// fetch failed.
 ManifestCheckRecord recordToPersist(const boost::optional<ManifestCheckRecord>& staged,
                                     const boost::optional<ManifestCheckRecord>& prior,
-                                    std::time_t now);
+                                    std::time_t now,
+                                    const std::string& rstudioVersion);
 
 // Pure: convert a throttle window expressed in whole hours to seconds, for use as
 // the throttleSeconds argument to manifestCheckDue(). A non-positive value yields 0
@@ -105,14 +116,19 @@ ManifestCheckRecord recordToPersist(const boost::optional<ManifestCheckRecord>& 
 int throttleSecondsFromHours(int hours);
 
 // Pure: is a manifest fetch due now?
-//   force || !installed || protocolMismatch || !lastCheckTime ||
-//   now < *lastCheckTime || (now - *lastCheckTime) >= throttleSeconds
+//   force || !installed || protocolMismatch || rstudioVersionChanged ||
+//   !lastCheckTime || now < *lastCheckTime ||
+//   (now - *lastCheckTime) >= throttleSeconds
+// rstudioVersionChanged means the persisted record was written by a different
+// RStudio build: its timestamp must not throttle this build, so the first check
+// after installing a different build always fetches (#18305).
 // A future lastCheckTime (clock skew or a corrupted/copied state file) is treated
 // as due (the `now < *lastCheckTime` disjunct), so checks resume immediately
 // rather than being suppressed.
 bool manifestCheckDue(bool force,
                       bool installed,
                       bool protocolMismatch,
+                      bool rstudioVersionChanged,
                       boost::optional<std::time_t> lastCheckTime,
                       std::time_t now,
                       int throttleSeconds);

--- a/src/cpp/session/modules/chat/ChatUpdateThrottle.hpp
+++ b/src/cpp/session/modules/chat/ChatUpdateThrottle.hpp
@@ -109,6 +109,15 @@ ManifestCheckRecord recordToPersist(const boost::optional<ManifestCheckRecord>& 
                                     std::time_t now,
                                     const std::string& rstudioVersion);
 
+// Pure: was the persisted record written by a different RStudio build than the
+// one running now? True also for records that predate the rstudioVersion field
+// (the missing key reads back as ""), so the first check after upgrading from
+// any such build fetches. False when there is no record at all: the check is
+// already due via manifestCheckDue's !lastCheckTime disjunct, and "changed"
+// would misattribute the reason.
+bool rstudioVersionChanged(const boost::optional<ManifestCheckRecord>& record,
+                           const std::string& runningVersion);
+
 // Pure: convert a throttle window expressed in whole hours to seconds, for use as
 // the throttleSeconds argument to manifestCheckDue(). A non-positive value yields 0
 // ("always check" -- manifestCheckDue treats a zero window as always due); a value

--- a/src/cpp/session/modules/chat/ChatUpdateThrottleTests.cpp
+++ b/src/cpp/session/modules/chat/ChatUpdateThrottleTests.cpp
@@ -108,6 +108,40 @@ TEST(ChatUpdateThrottle, DueWhenThrottleZero)
    EXPECT_TRUE(manifestCheckDue(false, true, false, false, kNow, kNow, 0));
 }
 
+// ---- rstudioVersionChanged ----
+
+TEST(ChatUpdateThrottle, VersionNotChangedWithoutRecord)
+{
+   // No record: not "changed" -- the check is already due via !lastCheckTime,
+   // and the distinct reason keeps the bypass log honest.
+   EXPECT_FALSE(rstudioVersionChanged(boost::none, "2026.08.0+200"));
+}
+
+TEST(ChatUpdateThrottle, VersionNotChangedWhenStampMatches)
+{
+   ManifestCheckRecord r = makeRecord(kNow, "1.2.3", "10.0", false, false);
+   r.rstudioVersion = "2026.08.0+200";
+   EXPECT_FALSE(rstudioVersionChanged(r, "2026.08.0+200"));
+}
+
+TEST(ChatUpdateThrottle, VersionChangedWhenStampDiffers)
+{
+   ManifestCheckRecord r = makeRecord(kNow, "1.2.3", "10.0", false, false);
+   r.rstudioVersion = "2026.07.0+100";
+   EXPECT_TRUE(rstudioVersionChanged(r, "2026.08.0+200"));
+}
+
+TEST(ChatUpdateThrottle, VersionChangedWhenStampMissing)
+{
+   // A record from a build that predates the field reads back with an empty
+   // stamp; it must count as a different build so the first check after
+   // upgrading from any pre-field build fetches. Guards against a later
+   // "hardening" that skips empty stamps and would silently disable the fix
+   // for exactly the most common upgrade path (#18305).
+   ManifestCheckRecord r = makeRecord(kNow, "1.2.3", "10.0", false, false);
+   EXPECT_TRUE(rstudioVersionChanged(r, "2026.08.0+200"));
+}
+
 // ---- throttleSecondsFromHours ----
 
 TEST(ChatUpdateThrottle, ThrottleZeroHoursMeansAlwaysCheck)
@@ -395,6 +429,20 @@ TEST(ChatUpdateThrottle, ReadMissingFileReturnsNone)
    EXPECT_FALSE(readManifestCheckRecord(tmp));
 }
 
+TEST(ChatUpdateThrottle, ReadUnknownKeysIgnored)
+{
+   // Forward compat: a record written by a future build with extra fields must
+   // still parse -- the same contract that lets builds predating rstudioVersion
+   // read records that carry it. A strict/exhaustive reader would return none
+   // here and silently drop the persisted unsupported-version block on downgrade.
+   FilePath tmp;
+   ASSERT_FALSE(FilePath::tempFilePath(tmp));
+   ASSERT_FALSE(writeStringToFile(tmp,
+      "{\"lastCheckTime\":\"100\",\"someFutureField\":true}"));
+   EXPECT_TRUE(readManifestCheckRecord(tmp));
+   tmp.removeIfExists();
+}
+
 TEST(ChatUpdateThrottle, ReadMalformedReturnsNone)
 {
    FilePath tmp;
@@ -428,9 +476,10 @@ TEST(ChatUpdateThrottle, ReadNonNumericLastCheckTimeReturnsNone)
 
 TEST(ChatUpdateThrottle, ReadMissingOptionalFieldsTolerated)
 {
-   // Also the shape written by builds that predate the rstudioVersion field:
-   // the missing key must read back as empty (-> treated as a different build,
-   // so the first check under this build fetches) rather than as malformed.
+   // Also covers records written by builds that predate the rstudioVersion
+   // field: that key is absent there and must read back as empty (-> treated
+   // as a different build, so the first check under this build fetches)
+   // rather than as malformed.
    FilePath tmp;
    ASSERT_FALSE(FilePath::tempFilePath(tmp));
    ASSERT_FALSE(writeStringToFile(tmp, "{\"lastCheckTime\":\"100\"}"));

--- a/src/cpp/session/modules/chat/ChatUpdateThrottleTests.cpp
+++ b/src/cpp/session/modules/chat/ChatUpdateThrottleTests.cpp
@@ -52,52 +52,60 @@ ManifestCheckRecord makeRecord(std::time_t t,
 
 TEST(ChatUpdateThrottle, DueWhenForced)
 {
-   EXPECT_TRUE(manifestCheckDue(true, true, false, kNow, kNow, kDay));
+   EXPECT_TRUE(manifestCheckDue(true, true, false, false, kNow, kNow, kDay));
 }
 
 TEST(ChatUpdateThrottle, DueWhenNotInstalled)
 {
-   EXPECT_TRUE(manifestCheckDue(false, false, false, kNow, kNow, kDay));
+   EXPECT_TRUE(manifestCheckDue(false, false, false, false, kNow, kNow, kDay));
 }
 
 TEST(ChatUpdateThrottle, DueWhenProtocolMismatch)
 {
-   EXPECT_TRUE(manifestCheckDue(false, true, true, kNow, kNow, kDay));
+   EXPECT_TRUE(manifestCheckDue(false, true, true, false, kNow, kNow, kDay));
+}
+
+TEST(ChatUpdateThrottle, DueWhenRStudioVersionChanged)
+{
+   // The persisted record was written by a different RStudio build, so its
+   // timestamp must not throttle this build even within the window: the first
+   // check after installing a different build always fetches (#18305).
+   EXPECT_TRUE(manifestCheckDue(false, true, false, true, kNow, kNow, kDay));
 }
 
 TEST(ChatUpdateThrottle, DueWhenNoPriorCheck)
 {
-   EXPECT_TRUE(manifestCheckDue(false, true, false, boost::none, kNow, kDay));
+   EXPECT_TRUE(manifestCheckDue(false, true, false, false, boost::none, kNow, kDay));
 }
 
 TEST(ChatUpdateThrottle, NotDueWithinWindow)
 {
    std::time_t last = kNow - (kDay - 1);
-   EXPECT_FALSE(manifestCheckDue(false, true, false, last, kNow, kDay));
+   EXPECT_FALSE(manifestCheckDue(false, true, false, false, last, kNow, kDay));
 }
 
 TEST(ChatUpdateThrottle, DueAtWindowBoundary)
 {
    std::time_t last = kNow - kDay;
-   EXPECT_TRUE(manifestCheckDue(false, true, false, last, kNow, kDay));
+   EXPECT_TRUE(manifestCheckDue(false, true, false, false, last, kNow, kDay));
 }
 
 TEST(ChatUpdateThrottle, DuePastWindow)
 {
    std::time_t last = kNow - (kDay + 100);
-   EXPECT_TRUE(manifestCheckDue(false, true, false, last, kNow, kDay));
+   EXPECT_TRUE(manifestCheckDue(false, true, false, false, last, kNow, kDay));
 }
 
 TEST(ChatUpdateThrottle, DueWhenLastCheckInFuture)
 {
    std::time_t future = kNow + kDay;
-   EXPECT_TRUE(manifestCheckDue(false, true, false, future, kNow, kDay));
+   EXPECT_TRUE(manifestCheckDue(false, true, false, false, future, kNow, kDay));
 }
 
 TEST(ChatUpdateThrottle, DueWhenThrottleZero)
 {
    // A zero window means "always check": even a check made this instant is due.
-   EXPECT_TRUE(manifestCheckDue(false, true, false, kNow, kNow, 0));
+   EXPECT_TRUE(manifestCheckDue(false, true, false, false, kNow, kNow, 0));
 }
 
 // ---- throttleSecondsFromHours ----
@@ -307,7 +315,7 @@ TEST(ChatUpdateThrottle, PersistUsesStagedRecordOnSuccess)
    // how a successful check sets or clears the block.
    ManifestCheckRecord staged = makeRecord(kNow, "1.2.3", "10.0", true, false);
    ManifestCheckRecord prior = makeRecord(kNow - kDay, "1.0.0", "10.0", false, true);
-   ManifestCheckRecord out = recordToPersist(staged, prior, kNow + 5);
+   ManifestCheckRecord out = recordToPersist(staged, prior, kNow + 5, "2026.08.0+200");
    EXPECT_EQ(out.lastCheckTime, kNow);
    EXPECT_EQ(out.installedVersion, "1.2.3");
    EXPECT_TRUE(out.unsupportedInstalledVersion);
@@ -320,7 +328,7 @@ TEST(ChatUpdateThrottle, PersistBumpsAndPreservesPriorWhenNotStaged)
    // attempt is recorded and cannot bypass the throttle) while preserving the prior
    // block (only a success may clear it).
    ManifestCheckRecord prior = makeRecord(kNow - kDay, "1.2.3", "10.0", true, false);
-   ManifestCheckRecord out = recordToPersist(boost::none, prior, kNow);
+   ManifestCheckRecord out = recordToPersist(boost::none, prior, kNow, "2026.08.0+200");
    EXPECT_EQ(out.lastCheckTime, kNow);
    EXPECT_EQ(out.installedVersion, "1.2.3");
    EXPECT_TRUE(out.unsupportedInstalledVersion);
@@ -328,10 +336,34 @@ TEST(ChatUpdateThrottle, PersistBumpsAndPreservesPriorWhenNotStaged)
 
 TEST(ChatUpdateThrottle, PersistBumpsDefaultWhenNoStagedNoPrior)
 {
-   ManifestCheckRecord out = recordToPersist(boost::none, boost::none, kNow);
+   ManifestCheckRecord out =
+      recordToPersist(boost::none, boost::none, kNow, "2026.08.0+200");
    EXPECT_EQ(out.lastCheckTime, kNow);
    EXPECT_TRUE(out.installedVersion.empty());
    EXPECT_FALSE(out.unsupportedInstalledVersion);
+}
+
+TEST(ChatUpdateThrottle, PersistStampsRunningBuildOnSuccess)
+{
+   // recordToPersist owns the rstudioVersion stamp: whatever a staged record
+   // carries is overwritten with the running build.
+   ManifestCheckRecord staged = makeRecord(kNow, "1.2.3", "10.0", false, false);
+   staged.rstudioVersion = "2026.07.0+100";
+   ManifestCheckRecord out =
+      recordToPersist(staged, boost::none, kNow, "2026.08.0+200");
+   EXPECT_EQ(out.rstudioVersion, "2026.08.0+200");
+}
+
+TEST(ChatUpdateThrottle, PersistStampsRunningBuildOnFailedAttempt)
+{
+   // Failure path: the attempt still stamps the running build, so a new build's
+   // first check bypasses the throttle exactly once -- afterward normal
+   // throttling resumes even though the fetch failed.
+   ManifestCheckRecord prior = makeRecord(kNow - kDay, "1.2.3", "10.0", false, false);
+   prior.rstudioVersion = "2026.07.0+100";
+   ManifestCheckRecord out =
+      recordToPersist(boost::none, prior, kNow, "2026.08.0+200");
+   EXPECT_EQ(out.rstudioVersion, "2026.08.0+200");
 }
 
 // ---- read / write round-trip ----
@@ -341,6 +373,7 @@ TEST(ChatUpdateThrottle, RecordRoundTrip)
    FilePath tmp;
    ASSERT_FALSE(FilePath::tempFilePath(tmp));
    ManifestCheckRecord in = makeRecord(kNow, "1.2.3", "10.0", true, false);
+   in.rstudioVersion = "2026.08.0+200";
    ASSERT_FALSE(writeManifestCheckRecord(tmp, in));
 
    boost::optional<ManifestCheckRecord> out = readManifestCheckRecord(tmp);
@@ -348,6 +381,7 @@ TEST(ChatUpdateThrottle, RecordRoundTrip)
    EXPECT_EQ(out->lastCheckTime, kNow);
    EXPECT_EQ(out->installedVersion, "1.2.3");
    EXPECT_EQ(out->rstudioProtocol, "10.0");
+   EXPECT_EQ(out->rstudioVersion, "2026.08.0+200");
    EXPECT_TRUE(out->unsupportedInstalledVersion);
    EXPECT_FALSE(out->unsupportedProtocol);
    tmp.removeIfExists();
@@ -394,6 +428,9 @@ TEST(ChatUpdateThrottle, ReadNonNumericLastCheckTimeReturnsNone)
 
 TEST(ChatUpdateThrottle, ReadMissingOptionalFieldsTolerated)
 {
+   // Also the shape written by builds that predate the rstudioVersion field:
+   // the missing key must read back as empty (-> treated as a different build,
+   // so the first check under this build fetches) rather than as malformed.
    FilePath tmp;
    ASSERT_FALSE(FilePath::tempFilePath(tmp));
    ASSERT_FALSE(writeStringToFile(tmp, "{\"lastCheckTime\":\"100\"}"));
@@ -401,6 +438,7 @@ TEST(ChatUpdateThrottle, ReadMissingOptionalFieldsTolerated)
    ASSERT_TRUE(out);
    EXPECT_EQ(out->lastCheckTime, static_cast<std::time_t>(100));
    EXPECT_TRUE(out->installedVersion.empty());
+   EXPECT_TRUE(out->rstudioVersion.empty());
    EXPECT_FALSE(out->unsupportedInstalledVersion);
    tmp.removeIfExists();
 }


### PR DESCRIPTION
## Problem

The Posit Assistant update check is throttled via a persisted record (`<userDataDir>/pai/manifest-check.json`) holding the last check's timestamp. The record did not track which RStudio build performed the check, so a freshly installed RStudio inherited the previous build's timestamp and skipped the manifest fetch for up to the update-check interval (two hours by default) — suppressing the Assistant update notification right after an RStudio update.

## Change

- The record now stores `rstudioVersion`, the full `RSTUDIO_VERSION` string of the build that made the last check attempt. `recordToPersist()` stamps it on every persisted attempt, success or failure, so a new build bypasses the throttle exactly once and normal throttling then resumes.
- `manifestCheckDue()` gains a `rstudioVersionChanged` disjunct: a record written by a different build never throttles the current one.
- The comparison lives in a pure, unit-tested predicate `throttle::rstudioVersionChanged()`; a missing stamp (record written by a build predating this change) counts as a different build.

## Compatibility

- Builds without this change ignore the extra JSON key when reading and drop it when writing; nothing breaks on downgrade.
- Records written by such builds lack the key, which reads back as empty and triggers an immediate check — the desired behavior on upgrade. The worst case in mixed-build usage is extra manifest fetches, never a wrongly suppressed notification.

## Tests

Adds gtest coverage in `ChatUpdateThrottleTests.cpp`: build-change makes the check due within the window, the stamp is written on both success and failed attempts, the field round-trips through the JSON record, records missing the field parse with an empty stamp, and unknown keys are ignored on read (the contract both compatibility directions rely on).

Fixes #18305.