### PR TITLE
Handle in-place bin/<platform>/ session binary layout

### DIFF
--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -128,6 +128,11 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
    }
 #endif
 
+   // Rootless sessions run rsession from bin/<platform>/, which leaves the
+   // computed resource path one level shallow (on bin/); step up to the root.
+   if (resourcePath_.getFilename() == "bin")
+      resourcePath_ = resourcePath_.getParent();
+
    // build options
    options_description automation("automation");
    options_description tests("tests");

--- a/src/cpp/session/SessionPostback.cpp
+++ b/src/cpp/session/SessionPostback.cpp
@@ -95,9 +95,13 @@ FilePath rPostbackPath()
 
 FilePath rPostbackScriptsDir()
 {
-   // postback scripts should lie in a 'postback' directory,
-   // located in the same folder as the 'rpostback' binary
-   return rPostbackPath().getParent().completeChildPath("postback");
+   // postback scripts normally sit next to the rpostback binary; in the
+   // in-place bin/<platform>/ layout the binary moves but the shared scripts
+   // stay at the top-level bin/postback
+   FilePath dir = rPostbackPath().getParent().completeChildPath("postback");
+   if (!dir.exists())
+      dir = session::options().resourcePath().completeChildPath("bin/postback");
+   return dir;
 }
 
 FilePath rPostbackScriptPath(const std::string& scriptName)

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -235,6 +235,11 @@ public:
          return core::FilePath();
    }
 
+   core::FilePath resourcePath() const
+   {
+      return resourcePath_;
+   }
+
    std::string defaultRVersion() const
    {
       return defaultRVersion_;


### PR DESCRIPTION
### Intent

Open-source companion to rstudio-pro#11895. That PR changes rootless Workbench launcher sessions to run their per-OS session binaries in place from `bin/<platform>/` instead of promoting them into a shared `bin/` tree. It touches three files that are shared between the open-source and pro trees; this PR mirrors those changes here to keep the two in sync.

### Approach

- `SessionOptions.cpp`: when `rsession` runs from `bin/<platform>/`, the computed resource path lands one level shallow (on `bin/`); step it up to the install root.
- `SessionPostback.cpp`: postback scripts stay at the top-level `bin/postback` in the in-place layout, so fall back there when the sibling `postback/` directory is absent.
- `SessionOptions.hpp`: add a `resourcePath()` accessor used by the postback fallback.

Both guards are no-ops under the open-source layout: `resourcePath_` never resolves to `bin`, and `bin/postback` always sits next to `rpostback`. The change is behavior-neutral here and exists purely to prevent the shared files from diverging across the two repositories.

### Automated Tests

None added. The changed code paths only activate under the pro `bin/<platform>/` layout, which the open-source build does not produce; coverage lives with the pro change.

### QA Notes

No functional change in open-source RStudio. Verification of the actual in-place behavior is covered by rstudio-pro#11895.