### PR TITLE
Fix mislabeled, non-functional Copilot messages preference

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@
 - ([#18270](https://github.com/rstudio/rstudio/issues/18270)): Fixed an issue on Windows where native dialogs shown by R (e.g. via `utils::askYesNo()`, or when `install.packages()` asks about installing from sources) could open behind the RStudio Desktop window, making the IDE appear frozen while R waited on a dialog the user could not see.
 - ([#8345](https://github.com/rstudio/rstudio/issues/8345)): Help pages opened via the Help pane's "Show in new window" button now follow the IDE's editor theme, instead of always rendering with a light palette.
 - ([#18305](https://github.com/rstudio/rstudio/issues/18305)): The first run of a new RStudio build now always checks for Posit Assistant updates, instead of the check being suppressed for up to the update-check interval (two hours by default) when the previous build had checked recently.
+- ([#18315](https://github.com/rstudio/rstudio/issues/18315)): Fixed the GitHub Copilot section of the Assistant preferences showing a mislabeled "Display account and billing messages from Posit Assistant" checkbox that had no effect. It is now correctly labeled for GitHub Copilot and controls whether Copilot's account and billing messages are shown.
 
 ### Dependencies
 - MathJax 4.1.3 (inline LaTeX / math previews)

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -472,7 +472,6 @@ namespace prefs {
 #define kAssistantIndexingEnabled "assistant_indexing_enabled"
 #define kAssistantNesEnabled "assistant_nes_enabled"
 #define kAssistantNesAutoshow "assistant_nes_autoshow"
-#define kAssistantShowMessages "assistant_show_messages"
 #define kAssistantToolbarButtonVisible "assistant_toolbar_button_visible"
 #define kAssistantUseSystemCa "assistant_use_system_ca"
 #define kPositAssistantTestManifest "posit_assistant_test_manifest"
@@ -2194,12 +2193,6 @@ public:
     */
    bool assistantNesAutoshow();
    core::Error setAssistantNesAutoshow(bool val);
-
-   /**
-    * When enabled, RStudio will show messages from the Posit Assistant in a message box.
-    */
-   bool assistantShowMessages();
-   core::Error setAssistantShowMessages(bool val);
 
    /**
     * When enabled, the Posit Assistant button is displayed in the main toolbar.

--- a/src/cpp/session/modules/SessionAssistant.cpp
+++ b/src/cpp/session/modules/SessionAssistant.cpp
@@ -2086,6 +2086,11 @@ void onBackgroundProcessing(bool isIdle)
                 boost::iequals(type, "Warning") ||
                 boost::iequals(type, "Info"))
             {
+               // This handler is shared by the Copilot and Posit completions
+               // agents (see s_runningAgentType), but always titles the dialog
+               // "Copilot" and gates on the Copilot-specific pref. If the Posit
+               // agent emits window/showMessageRequest, its messages surface
+               // here mislabeled -- revisit with a per-agent title/pref then.
                if (prefs::userPrefs().copilotShowMessages())
                   module_context::showErrorMessage("Copilot", message);
                else

--- a/src/cpp/session/modules/SessionAssistant.cpp
+++ b/src/cpp/session/modules/SessionAssistant.cpp
@@ -2086,7 +2086,6 @@ void onBackgroundProcessing(bool isIdle)
                 boost::iequals(type, "Warning") ||
                 boost::iequals(type, "Info"))
             {
-               // TODO: Copilot vs. Assistant preference here?
                if (prefs::userPrefs().copilotShowMessages())
                   module_context::showErrorMessage("Copilot", message);
                else

--- a/src/cpp/session/modules/SessionUserPrefValues.R
+++ b/src/cpp/session/modules/SessionUserPrefValues.R
@@ -2628,16 +2628,6 @@
    clear = function() { .rs.clearUserPref("assistant_nes_autoshow") }
 )
 
-# Display account and billing messages from Posit Assistant
-#
-# When enabled, RStudio will show messages from the Posit Assistant in a message
-# box.
-.rs.uiPrefs$assistantShowMessages <- list(
-   get = function() { .rs.getUserPref("assistant_show_messages") },
-   set = function(value) { .rs.setUserPref("assistant_show_messages", value) },
-   clear = function() { .rs.clearUserPref("assistant_show_messages") }
-)
-
 # Show Posit Assistant button in toolbar
 #
 # When enabled, the Posit Assistant button is displayed in the main toolbar.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -3664,19 +3664,6 @@ core::Error UserPrefValues::setAssistantNesAutoshow(bool val)
 }
 
 /**
- * When enabled, RStudio will show messages from the Posit Assistant in a message box.
- */
-bool UserPrefValues::assistantShowMessages()
-{
-   return readPref<bool>("assistant_show_messages");
-}
-
-core::Error UserPrefValues::setAssistantShowMessages(bool val)
-{
-   return writePref("assistant_show_messages", val);
-}
-
-/**
  * When enabled, the Posit Assistant button is displayed in the main toolbar.
  */
 bool UserPrefValues::assistantToolbarButtonVisible()
@@ -4258,7 +4245,6 @@ std::vector<std::string> UserPrefValues::allKeys()
       kAssistantIndexingEnabled,
       kAssistantNesEnabled,
       kAssistantNesAutoshow,
-      kAssistantShowMessages,
       kAssistantToolbarButtonVisible,
       kAssistantUseSystemCa,
       kPositAssistantTestManifest,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1925,12 +1925,6 @@
             "description": "When enabled, next edit suggestions will be automatically displayed. When disabled, suggestions will only be shown when hovering over the gutter icon.",
             "fallback": "copilot_nes_autoshow"
         },
-        "assistant_show_messages": {
-            "type": "boolean",
-            "default": true,
-            "title": "Display account and billing messages from Posit Assistant",
-            "description": "When enabled, RStudio will show messages from the Posit Assistant in a message box."
-        },
         "assistant_toolbar_button_visible": {
             "type": "boolean",
             "default": true,

--- a/src/gwt/src/org/rstudio/studio/client/palette/UserPrefPaletteSource.java
+++ b/src/gwt/src/org/rstudio/studio/client/palette/UserPrefPaletteSource.java
@@ -103,11 +103,9 @@ public class UserPrefPaletteSource implements CommandPaletteEntryProvider
          case UserPrefsAccessor.POSIT_ASSISTANT_UPDATE_CHECK_INTERVAL_HOURS:
          case UserPrefsAccessor.CHAT_PROVIDER:
             return !sessionInfo_.getPositAssistantEnabled();
-         // assistant_show_messages is a Posit Assistant setting, but the
-         // preferences pane only surfaces it under the Copilot section, so its
-         // palette availability follows Copilot to stay consistent with where
-         // the pane actually shows it.
-         case UserPrefsAccessor.ASSISTANT_SHOW_MESSAGES:
+         // copilot_show_messages is a GitHub Copilot setting, surfaced in the
+         // preferences pane only under the Copilot section.
+         case UserPrefsAccessor.COPILOT_SHOW_MESSAGES:
             return !sessionInfo_.getCopilotEnabled();
          // The assistant selector and the shared code-suggestion preferences
          // apply to any AI agent (Copilot or Posit Assistant), so hide them

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -324,7 +324,6 @@ public class UserPrefsAccessor extends Prefs
    public static final String ASSISTANT_INDEXING_ENABLED = "assistant_indexing_enabled";
    public static final String ASSISTANT_NES_ENABLED = "assistant_nes_enabled";
    public static final String ASSISTANT_NES_AUTOSHOW = "assistant_nes_autoshow";
-   public static final String ASSISTANT_SHOW_MESSAGES = "assistant_show_messages";
    public static final String ASSISTANT_TOOLBAR_BUTTON_VISIBLE = "assistant_toolbar_button_visible";
    public static final String ASSISTANT_USE_SYSTEM_CA = "assistant_use_system_ca";
    public static final String POSIT_ASSISTANT_TEST_MANIFEST = "posit_assistant_test_manifest";
@@ -4307,18 +4306,6 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * When enabled, RStudio will show messages from the Posit Assistant in a message box.
-    */
-   public PrefValue<Boolean> assistantShowMessages()
-   {
-      return bool(
-         "assistant_show_messages",
-         _constants.assistantShowMessagesTitle(), 
-         _constants.assistantShowMessagesDescription(), 
-         true);
-   }
-
-   /**
     * When enabled, the Posit Assistant button is displayed in the main toolbar.
     */
    public PrefValue<Boolean> assistantToolbarButtonVisible()
@@ -5220,8 +5207,6 @@ public class UserPrefsAccessor extends Prefs
          assistantNesEnabled().setValue(layer, source.getBool("assistant_nes_enabled"));
       if (source.hasKey("assistant_nes_autoshow"))
          assistantNesAutoshow().setValue(layer, source.getBool("assistant_nes_autoshow"));
-      if (source.hasKey("assistant_show_messages"))
-         assistantShowMessages().setValue(layer, source.getBool("assistant_show_messages"));
       if (source.hasKey("assistant_toolbar_button_visible"))
          assistantToolbarButtonVisible().setValue(layer, source.getBool("assistant_toolbar_button_visible"));
       if (source.hasKey("assistant_use_system_ca"))
@@ -5552,7 +5537,6 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(assistantIndexingEnabled());
       prefs.add(assistantNesEnabled());
       prefs.add(assistantNesAutoshow());
-      prefs.add(assistantShowMessages());
       prefs.add(assistantToolbarButtonVisible());
       prefs.add(assistantUseSystemCa());
       prefs.add(positAssistantTestManifest());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -2348,14 +2348,6 @@ public interface UserPrefsAccessorConstants extends Constants {
    String assistantNesAutoshowDescription();
 
    /**
-    * When enabled, RStudio will show messages from the Posit Assistant in a message box.
-    */
-   @DefaultStringValue("Display account and billing messages from Posit Assistant")
-   String assistantShowMessagesTitle();
-   @DefaultStringValue("When enabled, RStudio will show messages from the Posit Assistant in a message box.")
-   String assistantShowMessagesDescription();
-
-   /**
     * When enabled, the Posit Assistant button is displayed in the main toolbar.
     */
    @DefaultStringValue("Show Posit Assistant button in toolbar")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -1179,10 +1179,6 @@ assistantNesEnabledDescription = When enabled, RStudio will display next edit su
 assistantNesAutoshowTitle = Automatically display next edit suggestions in editor
 assistantNesAutoshowDescription = When enabled, next edit suggestions will be automatically displayed. When disabled, suggestions will only be shown when hovering over the gutter icon.
 
-# When enabled, RStudio will show messages from the Posit Assistant in a message box.
-assistantShowMessagesTitle = Display account and billing messages from Posit Assistant
-assistantShowMessagesDescription = When enabled, RStudio will show messages from the Posit Assistant in a message box.
-
 # When enabled, the Posit Assistant button is displayed in the main toolbar.
 assistantToolbarButtonVisibleTitle = Show Posit Assistant button in toolbar
 assistantToolbarButtonVisibleDescription = When enabled, the Posit Assistant button is displayed in the main toolbar.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
@@ -1218,10 +1218,6 @@ assistantNesEnabledDescription=Lorsqu'activé, RStudio affichera les suggestions
 assistantNesAutoshowTitle=Afficher automatiquement les suggestions d'édition suivantes dans l'éditeur
 assistantNesAutoshowDescription=Lorsqu'activé, les suggestions d'édition suivantes seront automatiquement affichées. Lorsque désactivé, les suggestions ne seront affichées qu'au survol de l'icône de gouttière.
 
-# When enabled, RStudio will show messages from the Posit Assistant in a message box.
-assistantShowMessagesTitle=Afficher les messages de compte et de facturation de Posit Assistant
-assistantShowMessagesDescription=Lorsqu'activé, RStudio affichera les messages de Posit Assistant dans une boîte de message.
-
 # When enabled, the Posit Assistant button is displayed in the main toolbar.
 assistantToolbarButtonVisibleTitle=Afficher le bouton Posit Assistant dans la barre d'outils
 assistantToolbarButtonVisibleDescription=Lorsqu'activé, le bouton Posit Assistant est affiché dans la barre d'outils principale.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AssistantPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AssistantPreferencesPane.java
@@ -256,7 +256,7 @@ public class AssistantPreferencesPane extends PreferencesPane
       lblProjectOverride_ = new Label();
       lblProjectOverride_.getElement().getStyle().setFontStyle(FontStyle.ITALIC);
 
-      cbAssistantShowMessages_ = checkboxPref(prefs_.assistantShowMessages(), true);
+      cbCopilotShowMessages_ = checkboxPref(prefs_.copilotShowMessages(), true);
       cbAssistantToolbarButtonVisible_ = checkboxPref(prefs_.assistantToolbarButtonVisible(), true);
       cbAssistantUseSystemCa_ = checkboxPref(prefs_.assistantUseSystemCa(), true);
       nvwAssistantUpdateCheckInterval_ = numericPref(
@@ -650,7 +650,7 @@ public class AssistantPreferencesPane extends PreferencesPane
    {
       VerticalPanel panel = new VerticalPanel();
       panel.add(spacedBefore(headerLabel(constants_.otherCaption())));
-      panel.add(cbAssistantShowMessages_);
+      panel.add(cbCopilotShowMessages_);
       return panel;
    }
 
@@ -1540,7 +1540,7 @@ public class AssistantPreferencesPane extends PreferencesPane
    private final SimplePanel assistantDetailsPanel_;
    private final Label lblAssistantStatus_;
    private final Spinner imgRefreshSpinner_;
-   private final CheckBox cbAssistantShowMessages_;
+   private final CheckBox cbCopilotShowMessages_;
    private final CheckBox cbAssistantToolbarButtonVisible_;
    private final CheckBox cbAssistantUseSystemCa_;
    private final CheckBox cbAssistantNesEnabled_;


### PR DESCRIPTION
In Global Options > Assistant, selecting GitHub Copilot revealed an "Other" section with a checkbox labeled "Display account and billing messages from Posit Assistant." The checkbox was bound to the `assistant_show_messages` preference, which nothing in the backend reads, so toggling it had no effect. The preference that actually controls Copilot's account and billing messages (`copilot_show_messages`, read in `SessionAssistant.cpp`) was never surfaced in the UI.

This change:

- Removes the unused `assistant_show_messages` preference from the user-prefs schema and regenerates the C++/Java/R accessors.
- Binds the "Other" checkbox to `copilot_show_messages`, so it is labeled for GitHub Copilot and controls the setting the backend reads.
- Gates `copilot_show_messages` on Copilot availability in the command palette.
- Replaces a vague TODO in the shared `window/showMessageRequest` handler with a note describing its Copilot-specific labeling, and removes the hand-maintained French translation for the dropped preference.

The `copilot_show_messages` default (`true`) is unchanged, so existing users see no behavior change beyond the checkbox now working. A stale `assistant_show_messages` key left in a user's prefs file is ignored.

Addresses #18315.