### PR TITLE
immortalize scheduled-command statics to avoid teardown races

### DIFF
--- a/src/cpp/core/include/core/Memory.hpp
+++ b/src/cpp/core/include/core/Memory.hpp
@@ -1,0 +1,68 @@
+/*
+ * Memory.hpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_MEMORY_HPP
+#define CORE_MEMORY_HPP
+
+#include <utility>
+
+#if defined(__has_feature)
+# if __has_feature(address_sanitizer)
+#  define RSTUDIO_HAS_LSAN 1
+# endif
+#elif defined(__SANITIZE_ADDRESS__)
+# define RSTUDIO_HAS_LSAN 1
+#endif
+
+#ifdef RSTUDIO_HAS_LSAN
+# include <sanitizer/lsan_interface.h>
+#endif
+
+namespace rstudio {
+namespace core {
+
+// construct an object on the heap that is intentionally never destroyed.
+//
+// use this for objects with static storage duration that background threads
+// might touch while the process is exiting: exit() runs static destructors,
+// so an ordinary file-scope static can be destroyed while a detached thread
+// still holds a reference to it. a leaked object has no destructor to run,
+// and the process is exiting anyway, so the leak is unobservable.
+//
+// typical usage binds the result to a file-scope reference:
+//
+//    boost::mutex& s_mutex = core::make_leaked<boost::mutex>();
+//
+// leak checkers do not flag objects created this way: the reference above
+// keeps the object reachable, so Valgrind classifies it as "still reachable"
+// (not reported by default) and LeakSanitizer does not report it at all. in
+// sanitizer builds we additionally mark the allocation as intentionally
+// leaked via __lsan_ignore_object.
+template <typename T, typename... Args>
+T& make_leaked(Args&&... args)
+{
+   T* pObject = new T(std::forward<Args>(args)...);
+
+#ifdef RSTUDIO_HAS_LSAN
+   __lsan_ignore_object(pObject);
+#endif
+
+   return *pObject;
+}
+
+} // namespace core
+} // namespace rstudio
+
+#endif // CORE_MEMORY_HPP

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -131,6 +131,7 @@
 #include <shared_core/SafeConvert.hpp>
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
+#include <shared_core/Memory.hpp>
 #include <shared_core/system/User.hpp>
 
 #include <core/RegexUtils.hpp>
@@ -332,10 +333,11 @@ Error findProgramOnPath(const std::string& program,
    return fileNotFoundError(program, ERROR_LOCATION);
 }
 
-// statics defined in System.cpp
-extern boost::shared_ptr<log::LogOptions> s_logOptions;
-extern boost::recursive_mutex s_loggingMutex;
-extern std::string s_programIdentity;
+// statics defined in System.cpp (references to intentionally-leaked objects;
+// the declared types here must stay in sync with the definitions)
+extern boost::shared_ptr<log::LogOptions>& s_logOptions;
+extern boost::recursive_mutex& s_loggingMutex;
+extern std::string& s_programIdentity;
 
 Error initializeSystemLog(const std::string& programIdentity,
                           log::LogLevel logLevel,
@@ -360,7 +362,10 @@ Error initializeSystemLog(const std::string& programIdentity,
    return Success();
 }
 
-boost::function<void()> s_sighupHandler;
+// read by the detached SIGHUP config-reload thread below; intentionally
+// leaked so a SIGHUP arriving while the process exits never finds it
+// destroyed during static teardown (#18318)
+boost::function<void()>& s_sighupHandler = make_leaked<boost::function<void()>>();
 
 namespace {
 

--- a/src/cpp/core/system/System.cpp
+++ b/src/cpp/core/system/System.cpp
@@ -29,6 +29,7 @@
 #include <shared_core/Hash.hpp>
 #include <shared_core/FileLogDestination.hpp>
 #include <shared_core/FilePath.hpp>
+#include <shared_core/Memory.hpp>
 #include <shared_core/SafeConvert.hpp>
 #include <shared_core/StderrLogDestination.hpp>
 
@@ -113,14 +114,20 @@ std::string generateShortenedUuid()
    return core::hash::crc32HexHash(uuid);
 }
 
+// the program identity, logging options, and mutex are all read by the
+// detached SIGHUP config-reload thread (logConfigReloadThreadFunc in
+// PosixSystem.cpp), which calls reinitLog() and can still be running while
+// the process exits; all three are intentionally leaked so that thread never
+// finds them destroyed during static teardown (#18318)
+
 // logger's program identity (this process's binary name)
-std::string s_programIdentity;
+std::string& s_programIdentity = make_leaked<std::string>();
 
 // logging options representing the latest state of the logging configuration file
-boost::shared_ptr<log::LogOptions> s_logOptions;
+boost::shared_ptr<log::LogOptions>& s_logOptions = make_leaked<boost::shared_ptr<log::LogOptions>>();
 
 // mutex for logging synchronization
-boost::recursive_mutex s_loggingMutex;
+boost::recursive_mutex& s_loggingMutex = make_leaked<boost::recursive_mutex>();
 
 namespace {
 

--- a/src/cpp/core/system/file_monitor/FileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/FileMonitor.cpp
@@ -23,6 +23,7 @@
 
 #include <core/Log.hpp>
 #include <shared_core/Error.hpp>
+#include <shared_core/Memory.hpp>
 #include <core/Thread.hpp>
 #include <core/PeriodicCommand.hpp>
 
@@ -472,18 +473,23 @@ private:
    Handle handle_;
 };
 
+// the command and callback queues are used by the file monitor thread, which
+// stop() can abandon (detach) if it fails to join in time -- and some exit
+// paths don't stop it at all. the queues are therefore intentionally leaked
+// so an abandoned thread never finds them destroyed during static teardown
+// (#18318)
 typedef core::thread::ThreadsafeQueue<RegistrationCommand>
                                                       RegistrationCommandQueue;
 RegistrationCommandQueue& registrationCommandQueue()
 {
-   static core::thread::ThreadsafeQueue<RegistrationCommand> instance;
+   static RegistrationCommandQueue& instance = make_leaked<RegistrationCommandQueue>();
    return instance;
 }
 
 typedef core::thread::ThreadsafeQueue<boost::function<void()> > CallbackQueue;
 CallbackQueue& callbackQueue()
 {
-   static core::thread::ThreadsafeQueue<boost::function<void()> > instance;
+   static CallbackQueue& instance = make_leaked<CallbackQueue>();
    return instance;
 }
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -115,6 +115,7 @@
 
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
+#include <shared_core/Memory.hpp>
 #include <shared_core/StderrLogDestination.hpp>
 #include <shared_core/system/encryption/EncryptionConfiguration.hpp>
 
@@ -2029,7 +2030,7 @@ Error ensureLibRSoValid()
 // and the worker is detached, never running ~io_context() avoids destroying it
 // while a detached worker is still inside run() -- the documented Windows-IOCP
 // teardown hang. The OS reclaims it at process exit.
-boost::asio::io_context& s_monitorIoContext = *new boost::asio::io_context();
+boost::asio::io_context& s_monitorIoContext = core::make_leaked<boost::asio::io_context>();
 
 // the monitor worker thread. retained as a joinable handle so that
 // stopMonitorWorkerThread() can wait for run() to return before the process

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -872,24 +872,42 @@ namespace {
 
 typedef std::vector<boost::shared_ptr<ScheduledCommand> >
                                                       ScheduledCommands;
-ScheduledCommands s_scheduledCommands;
-ScheduledCommands s_idleScheduledCommands;
+
+// the scheduled-command lists and their mutex are reached from background
+// threads (via executeOnMainThread and friends), so they are intentionally
+// leaked via construct-on-first-use: rsession exits through ::exit() (or
+// exit() within libR), which runs static destructors, and a background
+// thread that unblocks during teardown must not find them destroyed (#18318)
+ScheduledCommands& scheduledCommands()
+{
+   static ScheduledCommands* pCommands = new ScheduledCommands();
+   return *pCommands;
+}
+
+ScheduledCommands& idleScheduledCommands()
+{
+   static ScheduledCommands* pCommands = new ScheduledCommands();
+   return *pCommands;
+}
 
 // guards the scheduled command lists: commands are scheduled from background
-// threads (via executeOnMainThread and friends) while the main thread
-// executes them. command execution itself always happens on the main thread,
-// outside the mutex.
-boost::mutex s_scheduledCommandsMutex;
+// threads while the main thread executes them. command execution itself
+// always happens on the main thread, outside the mutex.
+boost::mutex& scheduledCommandsMutex()
+{
+   static boost::mutex* pMutex = new boost::mutex();
+   return *pMutex;
+}
 
 void addScheduledCommand(boost::shared_ptr<ScheduledCommand> pCommand,
                          bool idleOnly)
 {
-   LOCK_MUTEX(s_scheduledCommandsMutex)
+   LOCK_MUTEX(scheduledCommandsMutex())
    {
       if (idleOnly)
-         s_idleScheduledCommands.push_back(pCommand);
+         idleScheduledCommands().push_back(pCommand);
       else
-         s_scheduledCommands.push_back(pCommand);
+         scheduledCommands().push_back(pCommand);
    }
    END_LOCK_MUTEX
 }
@@ -902,7 +920,7 @@ void executeScheduledCommands(ScheduledCommands* pCommands)
    // scheduled commands to be mutated and these iterators
    // invalidated)
    ScheduledCommands commands;
-   LOCK_MUTEX(s_scheduledCommandsMutex)
+   LOCK_MUTEX(scheduledCommandsMutex())
    {
       commands = *pCommands;
    }
@@ -916,7 +934,7 @@ void executeScheduledCommands(ScheduledCommands* pCommands)
                  boost::bind(&ScheduledCommand::execute, _1));
 
    // remove any commands which are finished
-   LOCK_MUTEX(s_scheduledCommandsMutex)
+   LOCK_MUTEX(scheduledCommandsMutex())
    {
       pCommands->erase(
                     std::remove_if(
@@ -1062,9 +1080,9 @@ void onBackgroundProcessing(bool isIdle)
    events().onBackgroundProcessing(isIdle);
 
    // execute incremental commands
-   executeScheduledCommands(&s_scheduledCommands);
+   executeScheduledCommands(&scheduledCommands());
    if (isIdle)
-      executeScheduledCommands(&s_idleScheduledCommands);
+      executeScheduledCommands(&idleScheduledCommands());
 }
 
 #ifdef _WIN32

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -42,6 +42,7 @@
 #include <core/markdown/Markdown.hpp>
 #include <core/system/FileScanner.hpp>
 #include <core/IncrementalCommand.hpp>
+#include <core/Memory.hpp>
 #include <core/PeriodicCommand.hpp>
 #include <core/collection/Tree.hpp>
 #include <core/collection/LruCache.hpp>
@@ -875,39 +876,26 @@ typedef std::vector<boost::shared_ptr<ScheduledCommand> >
 
 // the scheduled-command lists and their mutex are reached from background
 // threads (via executeOnMainThread and friends), so they are intentionally
-// leaked via construct-on-first-use: rsession exits through ::exit() (or
-// exit() within libR), which runs static destructors, and a background
-// thread that unblocks during teardown must not find them destroyed (#18318)
-ScheduledCommands& scheduledCommands()
-{
-   static ScheduledCommands* pCommands = new ScheduledCommands();
-   return *pCommands;
-}
-
-ScheduledCommands& idleScheduledCommands()
-{
-   static ScheduledCommands* pCommands = new ScheduledCommands();
-   return *pCommands;
-}
+// leaked: rsession exits through ::exit() (or exit() within libR), which
+// runs static destructors, and a background thread that unblocks during
+// teardown must not find them destroyed (#18318)
+ScheduledCommands& s_scheduledCommands = make_leaked<ScheduledCommands>();
+ScheduledCommands& s_idleScheduledCommands = make_leaked<ScheduledCommands>();
 
 // guards the scheduled command lists: commands are scheduled from background
 // threads while the main thread executes them. command execution itself
 // always happens on the main thread, outside the mutex.
-boost::mutex& scheduledCommandsMutex()
-{
-   static boost::mutex* pMutex = new boost::mutex();
-   return *pMutex;
-}
+boost::mutex& s_scheduledCommandsMutex = make_leaked<boost::mutex>();
 
 void addScheduledCommand(boost::shared_ptr<ScheduledCommand> pCommand,
                          bool idleOnly)
 {
-   LOCK_MUTEX(scheduledCommandsMutex())
+   LOCK_MUTEX(s_scheduledCommandsMutex)
    {
       if (idleOnly)
-         idleScheduledCommands().push_back(pCommand);
+         s_idleScheduledCommands.push_back(pCommand);
       else
-         scheduledCommands().push_back(pCommand);
+         s_scheduledCommands.push_back(pCommand);
    }
    END_LOCK_MUTEX
 }
@@ -920,7 +908,7 @@ void executeScheduledCommands(ScheduledCommands* pCommands)
    // scheduled commands to be mutated and these iterators
    // invalidated)
    ScheduledCommands commands;
-   LOCK_MUTEX(scheduledCommandsMutex())
+   LOCK_MUTEX(s_scheduledCommandsMutex)
    {
       commands = *pCommands;
    }
@@ -934,7 +922,7 @@ void executeScheduledCommands(ScheduledCommands* pCommands)
                  boost::bind(&ScheduledCommand::execute, _1));
 
    // remove any commands which are finished
-   LOCK_MUTEX(scheduledCommandsMutex())
+   LOCK_MUTEX(s_scheduledCommandsMutex)
    {
       pCommands->erase(
                     std::remove_if(
@@ -1080,9 +1068,9 @@ void onBackgroundProcessing(bool isIdle)
    events().onBackgroundProcessing(isIdle);
 
    // execute incremental commands
-   executeScheduledCommands(&scheduledCommands());
+   executeScheduledCommands(&s_scheduledCommands);
    if (isIdle)
-      executeScheduledCommands(&idleScheduledCommands());
+      executeScheduledCommands(&s_idleScheduledCommands);
 }
 
 #ifdef _WIN32

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -28,6 +28,7 @@
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
 #include <shared_core/Hash.hpp>
+#include <shared_core/Memory.hpp>
 
 #include <core/BoostSignals.hpp>
 #include <core/BoostThread.hpp>
@@ -42,7 +43,6 @@
 #include <core/markdown/Markdown.hpp>
 #include <core/system/FileScanner.hpp>
 #include <core/IncrementalCommand.hpp>
-#include <core/Memory.hpp>
 #include <core/PeriodicCommand.hpp>
 #include <core/collection/Tree.hpp>
 #include <core/collection/LruCache.hpp>

--- a/src/cpp/session/SessionServerRpc.cpp
+++ b/src/cpp/session/SessionServerRpc.cpp
@@ -17,6 +17,8 @@
 
 #include <string>
 
+#include <shared_core/Memory.hpp>
+
 #include <core/Thread.hpp>
 
 #include <r/RExec.hpp>
@@ -110,7 +112,7 @@ boost::once_flag s_threadOnce = BOOST_ONCE_INIT;
 // exit-time destructor" idiom for a process-lifetime global with a non-trivial,
 // thread-interacting destructor. The only difference from a normal global is at
 // the instant of exit; steady-state behavior is unchanged.
-boost::asio::io_context& s_ioContext = *new boost::asio::io_context();
+boost::asio::io_context& s_ioContext = core::make_leaked<boost::asio::io_context>();
 
 // the RPC worker thread. retained as a joinable handle (rather than launched
 // detached) so that stop() can wait for run() to return before the process

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -46,6 +46,8 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/weak_ptr.hpp>
 
+#include <shared_core/Memory.hpp>
+
 #include <core/AnsiEscapes.hpp>
 #include <core/Exec.hpp>
 #include <core/FileInfo.hpp>
@@ -327,9 +329,16 @@ SEXP rs_chatNormalizePath(SEXP pathSEXP)
 // ============================================================================
 // R is single-threaded, so only one execution can be active at a time,
 // but we need to track canceled IDs to handle pre-cancellation of queued requests
-boost::mutex s_executionTrackingMutex;
-std::string s_currentTrackingId;  // Empty string when not executing
-std::set<std::string> s_canceledTrackingIds;  // TrackingIds that have been canceled
+//
+// this state (and the other mutex-guarded chat state below) is intentionally
+// leaked. current callers stay on the main thread (the backend process sets
+// callbacksRequireMainThread, and the manifest completion marshals through
+// executeOnMainThread), but the mutex-guarded design anticipates cross-thread
+// access; leaking is free and guarantees a late-running background thread can
+// never find these statics destroyed during static teardown (#18318)
+boost::mutex& s_executionTrackingMutex = make_leaked<boost::mutex>();
+std::string& s_currentTrackingId = make_leaked<std::string>();  // Empty string when not executing
+std::set<std::string>& s_canceledTrackingIds = make_leaked<std::set<std::string>>();  // TrackingIds that have been canceled
 
 // ============================================================================
 // Streaming Output Notification Queue with Lifecycle Management
@@ -358,10 +367,10 @@ struct PendingNotification
    }
 };
 
-// Global state (all protected by mutex)
-static boost::mutex s_notificationQueueMutex;
-static std::queue<PendingNotification> s_notificationQueue;
-static std::set<std::string> s_activeTrackingIds;  // Active executions
+// Global state (all protected by mutex); intentionally leaked (see above)
+static boost::mutex& s_notificationQueueMutex = make_leaked<boost::mutex>();
+static std::queue<PendingNotification>& s_notificationQueue = make_leaked<std::queue<PendingNotification>>();
+static std::set<std::string>& s_activeTrackingIds = make_leaked<std::set<std::string>>();  // Active executions
 
 // ============================================================================
 // Deferred Code Execution Queue
@@ -385,8 +394,9 @@ struct PendingExecutionRequest
    std::chrono::steady_clock::time_point queuedTime = std::chrono::steady_clock::now();
 };
 
-static boost::mutex s_pendingExecutionMutex;
-static std::queue<PendingExecutionRequest> s_pendingExecutionQueue;
+// intentionally leaked (see above)
+static boost::mutex& s_pendingExecutionMutex = make_leaked<boost::mutex>();
+static std::queue<PendingExecutionRequest>& s_pendingExecutionQueue = make_leaked<std::queue<PendingExecutionRequest>>();
 static bool s_executionScheduled = false;
 
 // Forward declaration
@@ -3686,9 +3696,11 @@ struct UpdateState
    }
 };
 
-// Global update state
-UpdateState s_updateState;
-boost::mutex s_updateStateMutex;
+// Global update state; mutex-guarded for cross-thread reads. Intentionally
+// leaked, defensively -- see the note above the execution-tracking state
+// (#18318)
+UpdateState& s_updateState = make_leaked<UpdateState>();
+boost::mutex& s_updateStateMutex = make_leaked<boost::mutex>();
 
 // Posit Assistant manifest endpoints (prod + opt-in test manifest).
 const char* const kManifestUrl     = "https://cdn.posit.co/posit-ai/manifest.json";
@@ -3749,8 +3761,9 @@ void onUpdateCheckComplete(const Error& fetchError, const json::Object& manifest
 // responses as status 0 in dev-mode Electron, so an in-rsession override
 // is the only path that actually reaches ChatPresenter's blocking-state
 // callbacks.
-boost::optional<json::Object> s_updateCheckOverride;
-boost::mutex s_updateCheckOverrideMutex;
+// intentionally leaked (see s_updateState above)
+boost::optional<json::Object>& s_updateCheckOverride = make_leaked<boost::optional<json::Object>>();
+boost::mutex& s_updateCheckOverrideMutex = make_leaked<boost::mutex>();
 
 // Validate that a URL uses HTTPS protocol
 bool isHttpsUrl(const std::string& url)

--- a/src/cpp/shared_core/Logger.cpp
+++ b/src/cpp/shared_core/Logger.cpp
@@ -36,6 +36,7 @@
 #include <shared_core/Error.hpp>
 #include <shared_core/FileLogDestination.hpp>
 #include <shared_core/json/Json.hpp>
+#include <shared_core/Memory.hpp>
 #include <shared_core/ReaderWriterMutex.hpp>
 #include <shared_core/SafeConvert.hpp>
 #include <shared_core/StderrLogDestination.hpp>
@@ -187,7 +188,12 @@ json::Object errorToJson(const Error& in_error)
    return error;
 }
 
-std::unordered_map<std::type_index, boost::function<void(json::Object&, const std::pair<std::string, boost::any>&)>> s_logMessagePropertiesToJsonMap =
+// the property-formatter maps are on the log-write path for any thread that
+// logs with message properties; background threads can still be logging while
+// the process exits, so the maps are intentionally leaked to avoid running
+// their destructors during static teardown (#18318)
+typedef std::unordered_map<std::type_index, boost::function<void(json::Object&, const std::pair<std::string, boost::any>&)>> LogMessagePropertiesToJsonMap;
+LogMessagePropertiesToJsonMap& s_logMessagePropertiesToJsonMap = make_leaked<LogMessagePropertiesToJsonMap>(LogMessagePropertiesToJsonMap
 {
    {typeid(int), [](json::Object& obj, const std::pair<std::string, boost::any>& prop){obj[prop.first] = boost::any_cast<int>(prop.second);}},
    {typeid(uint64_t), [](json::Object& obj, const std::pair<std::string, boost::any>& prop){obj[prop.first] = boost::any_cast<uint64_t>(prop.second);}},
@@ -201,7 +207,7 @@ std::unordered_map<std::type_index, boost::function<void(json::Object&, const st
    {typeid(json::Object), [](json::Object& obj, const std::pair<std::string, boost::any>& prop){obj[prop.first] = boost::any_cast<json::Object>(prop.second);}},
    {typeid(json::Array), [](json::Object& obj, const std::pair<std::string, boost::any>& prop){obj[prop.first] = boost::any_cast<json::Array>(prop.second);}},
    {typeid(Error), [](json::Object& obj, const std::pair<std::string, boost::any>& prop){obj[prop.first] = errorToJson(boost::any_cast<Error>(prop.second));}}
-};
+});
 
 json::Object logMessagePropertiesToJson(const LogMessageProperties& in_properties)
 {
@@ -233,7 +239,8 @@ json::Object logMessagePropertiesToJson(const LogMessageProperties& in_propertie
    return obj;
 }
 
-std::unordered_map<std::type_index, boost::function<std::string(const std::pair<std::string, boost::any>&)>> s_logMessagePropertiesToStringMap =
+typedef std::unordered_map<std::type_index, boost::function<std::string(const std::pair<std::string, boost::any>&)>> LogMessagePropertiesToStringMap;
+LogMessagePropertiesToStringMap& s_logMessagePropertiesToStringMap = make_leaked<LogMessagePropertiesToStringMap>(LogMessagePropertiesToStringMap
 {
    {typeid(int), [](const std::pair<std::string, boost::any>& prop){return safe_convert::numberToString(boost::any_cast<int>(prop.second));}},
    {typeid(uint64_t), [](const std::pair<std::string, boost::any>& prop){return safe_convert::numberToString(boost::any_cast<uint64_t>(prop.second));}},
@@ -247,7 +254,7 @@ std::unordered_map<std::type_index, boost::function<std::string(const std::pair<
    {typeid(json::Object), [](const std::pair<std::string, boost::any>& prop){return boost::any_cast<json::Object>(prop.second).write();}},
    {typeid(json::Array), [](const std::pair<std::string, boost::any>& prop){return boost::any_cast<json::Array>(prop.second).write();}},
    {typeid(Error), [](const std::pair<std::string, boost::any>& prop){return errorToJson(boost::any_cast<Error>(prop.second)).write();}}
-};
+});
 
 std::string logMessagePropertiesToString(const LogMessageProperties& in_properties)
 {
@@ -440,8 +447,8 @@ Logger& logger()
 {
    // Intentionally leak the logger object to avoid some crashes because we don't (can't currently) always wait for all
    // the background threads of a process, and destruction isn't necessary.
-   static Logger* logger = new Logger();
-   return *logger;
+   static Logger& logger = make_leaked<Logger>();
+   return logger;
 }
 
 void Logger::writeMessageToDestinations(

--- a/src/cpp/shared_core/include/shared_core/Memory.hpp
+++ b/src/cpp/shared_core/include/shared_core/Memory.hpp
@@ -3,18 +3,26 @@
  *
  * Copyright (C) 2026 by Posit Software, PBC
  *
- * Unless you have received this program directly from Posit Software pursuant
- * to the terms of a commercial license agreement with Posit Software, then
- * this program is licensed to you under the terms of version 3 of the
- * GNU Affero General Public License. This program is distributed WITHOUT
- * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
- * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
- * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ * Unless you have received this program directly from Posit Software pursuant to the terms of a commercial license agreement
+ * with Posit, then this program is licensed to you under the following terms:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  */
 
-#ifndef CORE_MEMORY_HPP
-#define CORE_MEMORY_HPP
+#ifndef SHARED_CORE_MEMORY_HPP
+#define SHARED_CORE_MEMORY_HPP
 
 #include <utility>
 
@@ -65,4 +73,4 @@ T& make_leaked(Args&&... args)
 } // namespace core
 } // namespace rstudio
 
-#endif // CORE_MEMORY_HPP
+#endif // SHARED_CORE_MEMORY_HPP


### PR DESCRIPTION
## Summary

The scheduled-command lists in `SessionModuleContext.cpp` (and the mutex guarding them, added in #18302) are file-scope statics that background threads reach via `module_context::executeOnMainThread()` (SessionPPM, SessionChat, the installed-package event-hook scan). Both process-lifetime exit paths run C++ static destructors -- `exitEarly()` calls `::exit()`, and the everyday quit path ends with `exit()` inside libR via `Rstd_CleanUp` -- so a detached background thread that unblocks during teardown (e.g. an abandoned package scan on a hung network mount finally returning) could touch destroyed statics.

This PR immortalizes the two command lists and their mutex by binding file-scope references to intentionally-leaked heap objects, via a new `core::make_leaked<T>()` helper (`shared_core/Memory.hpp`):

```cpp
ScheduledCommands& s_scheduledCommands = make_leaked<ScheduledCommands>();
ScheduledCommands& s_idleScheduledCommands = make_leaked<ScheduledCommands>();
boost::mutex& s_scheduledCommandsMutex = make_leaked<boost::mutex>();
```

References are not destroyed at exit and the pointee is never deleted, so there is no destructor for a late-running thread to race; call sites keep their original spelling. The leak is unobservable (the objects live for the life of the process either way), and leak checkers do not flag it: the file-scope reference keeps the object reachable, so Valgrind classifies it as "still reachable" (not reported by default) and LeakSanitizer treats it as rooted; in sanitizer builds `make_leaked` additionally calls `__lsan_ignore_object()` to mark the allocation as intentional.

Switching `exitEarly()` to `::_exit()` was considered and rejected -- see #18318 for the full analysis (it doesn't cover the libR exit path, and it would skip the `PosixParentProcessMonitor` atexit handshake, stdio/log flushes, and coverage/profiling flushes).

No NEWS entry: internal hardening with no observed user-facing failure.

## Testing

- Full `core` (457) and `rsession` (405) C++ suites pass.
- `r` scope `packages` tests pass (116; these pump the scheduled-command queue heavily, including from a background scan thread).

Addresses #18318.
