### PR TITLE
leak statics reachable from background threads at exit

### DIFF
--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -131,6 +131,7 @@
 #include <shared_core/SafeConvert.hpp>
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
+#include <shared_core/Memory.hpp>
 #include <shared_core/system/User.hpp>
 
 #include <core/RegexUtils.hpp>
@@ -332,10 +333,11 @@ Error findProgramOnPath(const std::string& program,
    return fileNotFoundError(program, ERROR_LOCATION);
 }
 
-// statics defined in System.cpp
-extern boost::shared_ptr<log::LogOptions> s_logOptions;
-extern boost::recursive_mutex s_loggingMutex;
-extern std::string s_programIdentity;
+// statics defined in System.cpp (references to intentionally-leaked objects;
+// the declared types here must stay in sync with the definitions)
+extern boost::shared_ptr<log::LogOptions>& s_logOptions;
+extern boost::recursive_mutex& s_loggingMutex;
+extern std::string& s_programIdentity;
 
 Error initializeSystemLog(const std::string& programIdentity,
                           log::LogLevel logLevel,
@@ -360,7 +362,10 @@ Error initializeSystemLog(const std::string& programIdentity,
    return Success();
 }
 
-boost::function<void()> s_sighupHandler;
+// read by the detached SIGHUP config-reload thread below; intentionally
+// leaked so a SIGHUP arriving while the process exits never finds it
+// destroyed during static teardown (#18318)
+boost::function<void()>& s_sighupHandler = make_leaked<boost::function<void()>>();
 
 namespace {
 

--- a/src/cpp/core/system/System.cpp
+++ b/src/cpp/core/system/System.cpp
@@ -114,13 +114,14 @@ std::string generateShortenedUuid()
    return core::hash::crc32HexHash(uuid);
 }
 
-// logger's program identity (this process's binary name)
-std::string s_programIdentity;
+// the program identity, logging options, and mutex are all read by the
+// detached SIGHUP config-reload thread (logConfigReloadThreadFunc in
+// PosixSystem.cpp), which calls reinitLog() and can still be running while
+// the process exits; all three are intentionally leaked so that thread never
+// finds them destroyed during static teardown (#18318)
 
-// the logging options and mutex are on the log-write path (loggerType,
-// lowestLogLevel) for any thread that logs; background threads can still be
-// logging while the process exits, so both are intentionally leaked to avoid
-// running their destructors during static teardown (#18318)
+// logger's program identity (this process's binary name)
+std::string& s_programIdentity = make_leaked<std::string>();
 
 // logging options representing the latest state of the logging configuration file
 boost::shared_ptr<log::LogOptions>& s_logOptions = make_leaked<boost::shared_ptr<log::LogOptions>>();

--- a/src/cpp/core/system/System.cpp
+++ b/src/cpp/core/system/System.cpp
@@ -29,6 +29,7 @@
 #include <shared_core/Hash.hpp>
 #include <shared_core/FileLogDestination.hpp>
 #include <shared_core/FilePath.hpp>
+#include <shared_core/Memory.hpp>
 #include <shared_core/SafeConvert.hpp>
 #include <shared_core/StderrLogDestination.hpp>
 
@@ -116,11 +117,16 @@ std::string generateShortenedUuid()
 // logger's program identity (this process's binary name)
 std::string s_programIdentity;
 
+// the logging options and mutex are on the log-write path (loggerType,
+// lowestLogLevel) for any thread that logs; background threads can still be
+// logging while the process exits, so both are intentionally leaked to avoid
+// running their destructors during static teardown (#18318)
+
 // logging options representing the latest state of the logging configuration file
-boost::shared_ptr<log::LogOptions> s_logOptions;
+boost::shared_ptr<log::LogOptions>& s_logOptions = make_leaked<boost::shared_ptr<log::LogOptions>>();
 
 // mutex for logging synchronization
-boost::recursive_mutex s_loggingMutex;
+boost::recursive_mutex& s_loggingMutex = make_leaked<boost::recursive_mutex>();
 
 namespace {
 

--- a/src/cpp/core/system/file_monitor/FileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/FileMonitor.cpp
@@ -23,6 +23,7 @@
 
 #include <core/Log.hpp>
 #include <shared_core/Error.hpp>
+#include <shared_core/Memory.hpp>
 #include <core/Thread.hpp>
 #include <core/PeriodicCommand.hpp>
 
@@ -472,18 +473,23 @@ private:
    Handle handle_;
 };
 
+// the command and callback queues are used by the file monitor thread, which
+// stop() can abandon (detach) if it fails to join in time -- and some exit
+// paths don't stop it at all. the queues are therefore intentionally leaked
+// so an abandoned thread never finds them destroyed during static teardown
+// (#18318)
 typedef core::thread::ThreadsafeQueue<RegistrationCommand>
                                                       RegistrationCommandQueue;
 RegistrationCommandQueue& registrationCommandQueue()
 {
-   static core::thread::ThreadsafeQueue<RegistrationCommand> instance;
+   static RegistrationCommandQueue& instance = make_leaked<RegistrationCommandQueue>();
    return instance;
 }
 
 typedef core::thread::ThreadsafeQueue<boost::function<void()> > CallbackQueue;
 CallbackQueue& callbackQueue()
 {
-   static core::thread::ThreadsafeQueue<boost::function<void()> > instance;
+   static CallbackQueue& instance = make_leaked<CallbackQueue>();
    return instance;
 }
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -115,6 +115,7 @@
 
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
+#include <shared_core/Memory.hpp>
 #include <shared_core/StderrLogDestination.hpp>
 #include <shared_core/system/encryption/EncryptionConfiguration.hpp>
 
@@ -2029,7 +2030,7 @@ Error ensureLibRSoValid()
 // and the worker is detached, never running ~io_context() avoids destroying it
 // while a detached worker is still inside run() -- the documented Windows-IOCP
 // teardown hang. The OS reclaims it at process exit.
-boost::asio::io_context& s_monitorIoContext = *new boost::asio::io_context();
+boost::asio::io_context& s_monitorIoContext = core::make_leaked<boost::asio::io_context>();
 
 // the monitor worker thread. retained as a joinable handle so that
 // stopMonitorWorkerThread() can wait for run() to return before the process

--- a/src/cpp/session/SessionServerRpc.cpp
+++ b/src/cpp/session/SessionServerRpc.cpp
@@ -17,6 +17,8 @@
 
 #include <string>
 
+#include <shared_core/Memory.hpp>
+
 #include <core/Thread.hpp>
 
 #include <r/RExec.hpp>
@@ -110,7 +112,7 @@ boost::once_flag s_threadOnce = BOOST_ONCE_INIT;
 // exit-time destructor" idiom for a process-lifetime global with a non-trivial,
 // thread-interacting destructor. The only difference from a normal global is at
 // the instant of exit; steady-state behavior is unchanged.
-boost::asio::io_context& s_ioContext = *new boost::asio::io_context();
+boost::asio::io_context& s_ioContext = core::make_leaked<boost::asio::io_context>();
 
 // the RPC worker thread. retained as a joinable handle (rather than launched
 // detached) so that stop() can wait for run() to return before the process

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -330,10 +330,12 @@ SEXP rs_chatNormalizePath(SEXP pathSEXP)
 // R is single-threaded, so only one execution can be active at a time,
 // but we need to track canceled IDs to handle pre-cancellation of queued requests
 //
-// this state (and the other cross-thread chat state below) is intentionally
-// leaked: backend callbacks can fire on background threads that may still be
-// running while the process exits, and they must not find these statics
-// destroyed during static teardown (#18318)
+// this state (and the other mutex-guarded chat state below) is intentionally
+// leaked. current callers stay on the main thread (the backend process sets
+// callbacksRequireMainThread, and the manifest completion marshals through
+// executeOnMainThread), but the mutex-guarded design anticipates cross-thread
+// access; leaking is free and guarantees a late-running background thread can
+// never find these statics destroyed during static teardown (#18318)
 boost::mutex& s_executionTrackingMutex = make_leaked<boost::mutex>();
 std::string& s_currentTrackingId = make_leaked<std::string>();  // Empty string when not executing
 std::set<std::string>& s_canceledTrackingIds = make_leaked<std::set<std::string>>();  // TrackingIds that have been canceled
@@ -3694,9 +3696,9 @@ struct UpdateState
    }
 };
 
-// Global update state; written on the main thread but read cross-thread, and
-// async process completions can fire on the offline-service background thread,
-// so intentionally leaked to survive static teardown (#18318)
+// Global update state; mutex-guarded for cross-thread reads. Intentionally
+// leaked, defensively -- see the note above the execution-tracking state
+// (#18318)
 UpdateState& s_updateState = make_leaked<UpdateState>();
 boost::mutex& s_updateStateMutex = make_leaked<boost::mutex>();
 

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -46,6 +46,8 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/weak_ptr.hpp>
 
+#include <shared_core/Memory.hpp>
+
 #include <core/AnsiEscapes.hpp>
 #include <core/Exec.hpp>
 #include <core/FileInfo.hpp>
@@ -327,9 +329,14 @@ SEXP rs_chatNormalizePath(SEXP pathSEXP)
 // ============================================================================
 // R is single-threaded, so only one execution can be active at a time,
 // but we need to track canceled IDs to handle pre-cancellation of queued requests
-boost::mutex s_executionTrackingMutex;
-std::string s_currentTrackingId;  // Empty string when not executing
-std::set<std::string> s_canceledTrackingIds;  // TrackingIds that have been canceled
+//
+// this state (and the other cross-thread chat state below) is intentionally
+// leaked: backend callbacks can fire on background threads that may still be
+// running while the process exits, and they must not find these statics
+// destroyed during static teardown (#18318)
+boost::mutex& s_executionTrackingMutex = make_leaked<boost::mutex>();
+std::string& s_currentTrackingId = make_leaked<std::string>();  // Empty string when not executing
+std::set<std::string>& s_canceledTrackingIds = make_leaked<std::set<std::string>>();  // TrackingIds that have been canceled
 
 // ============================================================================
 // Streaming Output Notification Queue with Lifecycle Management
@@ -358,10 +365,10 @@ struct PendingNotification
    }
 };
 
-// Global state (all protected by mutex)
-static boost::mutex s_notificationQueueMutex;
-static std::queue<PendingNotification> s_notificationQueue;
-static std::set<std::string> s_activeTrackingIds;  // Active executions
+// Global state (all protected by mutex); intentionally leaked (see above)
+static boost::mutex& s_notificationQueueMutex = make_leaked<boost::mutex>();
+static std::queue<PendingNotification>& s_notificationQueue = make_leaked<std::queue<PendingNotification>>();
+static std::set<std::string>& s_activeTrackingIds = make_leaked<std::set<std::string>>();  // Active executions
 
 // ============================================================================
 // Deferred Code Execution Queue
@@ -385,8 +392,9 @@ struct PendingExecutionRequest
    std::chrono::steady_clock::time_point queuedTime = std::chrono::steady_clock::now();
 };
 
-static boost::mutex s_pendingExecutionMutex;
-static std::queue<PendingExecutionRequest> s_pendingExecutionQueue;
+// intentionally leaked (see above)
+static boost::mutex& s_pendingExecutionMutex = make_leaked<boost::mutex>();
+static std::queue<PendingExecutionRequest>& s_pendingExecutionQueue = make_leaked<std::queue<PendingExecutionRequest>>();
 static bool s_executionScheduled = false;
 
 // Forward declaration
@@ -3686,9 +3694,11 @@ struct UpdateState
    }
 };
 
-// Global update state
-UpdateState s_updateState;
-boost::mutex s_updateStateMutex;
+// Global update state; written on the main thread but read cross-thread, and
+// async process completions can fire on the offline-service background thread,
+// so intentionally leaked to survive static teardown (#18318)
+UpdateState& s_updateState = make_leaked<UpdateState>();
+boost::mutex& s_updateStateMutex = make_leaked<boost::mutex>();
 
 // Posit Assistant manifest endpoints (prod + opt-in test manifest).
 const char* const kManifestUrl     = "https://cdn.posit.co/posit-ai/manifest.json";
@@ -3749,8 +3759,9 @@ void onUpdateCheckComplete(const Error& fetchError, const json::Object& manifest
 // responses as status 0 in dev-mode Electron, so an in-rsession override
 // is the only path that actually reaches ChatPresenter's blocking-state
 // callbacks.
-boost::optional<json::Object> s_updateCheckOverride;
-boost::mutex s_updateCheckOverrideMutex;
+// intentionally leaked (see s_updateState above)
+boost::optional<json::Object>& s_updateCheckOverride = make_leaked<boost::optional<json::Object>>();
+boost::mutex& s_updateCheckOverrideMutex = make_leaked<boost::mutex>();
 
 // Validate that a URL uses HTTPS protocol
 bool isHttpsUrl(const std::string& url)

--- a/src/cpp/shared_core/Logger.cpp
+++ b/src/cpp/shared_core/Logger.cpp
@@ -36,6 +36,7 @@
 #include <shared_core/Error.hpp>
 #include <shared_core/FileLogDestination.hpp>
 #include <shared_core/json/Json.hpp>
+#include <shared_core/Memory.hpp>
 #include <shared_core/ReaderWriterMutex.hpp>
 #include <shared_core/SafeConvert.hpp>
 #include <shared_core/StderrLogDestination.hpp>
@@ -187,7 +188,12 @@ json::Object errorToJson(const Error& in_error)
    return error;
 }
 
-std::unordered_map<std::type_index, boost::function<void(json::Object&, const std::pair<std::string, boost::any>&)>> s_logMessagePropertiesToJsonMap =
+// the property-formatter maps are on the log-write path for any thread that
+// logs with message properties; background threads can still be logging while
+// the process exits, so the maps are intentionally leaked to avoid running
+// their destructors during static teardown (#18318)
+typedef std::unordered_map<std::type_index, boost::function<void(json::Object&, const std::pair<std::string, boost::any>&)>> LogMessagePropertiesToJsonMap;
+LogMessagePropertiesToJsonMap& s_logMessagePropertiesToJsonMap = make_leaked<LogMessagePropertiesToJsonMap>(LogMessagePropertiesToJsonMap
 {
    {typeid(int), [](json::Object& obj, const std::pair<std::string, boost::any>& prop){obj[prop.first] = boost::any_cast<int>(prop.second);}},
    {typeid(uint64_t), [](json::Object& obj, const std::pair<std::string, boost::any>& prop){obj[prop.first] = boost::any_cast<uint64_t>(prop.second);}},
@@ -201,7 +207,7 @@ std::unordered_map<std::type_index, boost::function<void(json::Object&, const st
    {typeid(json::Object), [](json::Object& obj, const std::pair<std::string, boost::any>& prop){obj[prop.first] = boost::any_cast<json::Object>(prop.second);}},
    {typeid(json::Array), [](json::Object& obj, const std::pair<std::string, boost::any>& prop){obj[prop.first] = boost::any_cast<json::Array>(prop.second);}},
    {typeid(Error), [](json::Object& obj, const std::pair<std::string, boost::any>& prop){obj[prop.first] = errorToJson(boost::any_cast<Error>(prop.second));}}
-};
+});
 
 json::Object logMessagePropertiesToJson(const LogMessageProperties& in_properties)
 {
@@ -233,7 +239,8 @@ json::Object logMessagePropertiesToJson(const LogMessageProperties& in_propertie
    return obj;
 }
 
-std::unordered_map<std::type_index, boost::function<std::string(const std::pair<std::string, boost::any>&)>> s_logMessagePropertiesToStringMap =
+typedef std::unordered_map<std::type_index, boost::function<std::string(const std::pair<std::string, boost::any>&)>> LogMessagePropertiesToStringMap;
+LogMessagePropertiesToStringMap& s_logMessagePropertiesToStringMap = make_leaked<LogMessagePropertiesToStringMap>(LogMessagePropertiesToStringMap
 {
    {typeid(int), [](const std::pair<std::string, boost::any>& prop){return safe_convert::numberToString(boost::any_cast<int>(prop.second));}},
    {typeid(uint64_t), [](const std::pair<std::string, boost::any>& prop){return safe_convert::numberToString(boost::any_cast<uint64_t>(prop.second));}},
@@ -247,7 +254,7 @@ std::unordered_map<std::type_index, boost::function<std::string(const std::pair<
    {typeid(json::Object), [](const std::pair<std::string, boost::any>& prop){return boost::any_cast<json::Object>(prop.second).write();}},
    {typeid(json::Array), [](const std::pair<std::string, boost::any>& prop){return boost::any_cast<json::Array>(prop.second).write();}},
    {typeid(Error), [](const std::pair<std::string, boost::any>& prop){return errorToJson(boost::any_cast<Error>(prop.second)).write();}}
-};
+});
 
 std::string logMessagePropertiesToString(const LogMessageProperties& in_properties)
 {
@@ -440,8 +447,8 @@ Logger& logger()
 {
    // Intentionally leak the logger object to avoid some crashes because we don't (can't currently) always wait for all
    // the background threads of a process, and destruction isn't necessary.
-   static Logger* logger = new Logger();
-   return *logger;
+   static Logger& logger = make_leaked<Logger>();
+   return logger;
 }
 
 void Logger::writeMessageToDestinations(


### PR DESCRIPTION
## Summary

Follow-up to #18320, which added `core::make_leaked<T>()` (`shared_core/Memory.hpp`) and immortalized the scheduled-command statics. A survey of `src/cpp` found the remaining file-scope statics with non-trivial destructors that detached background threads can plausibly touch while `exit()` runs static destructors. This PR converts them to intentionally-leaked objects:

- **Logging / SIGHUP config reload** (the detached, never-joined `logConfigReloadThreadFunc` thread loops in `sigwait` forever and calls `reinitLog()` on SIGHUP, so it can run during teardown):
  - `shared_core/Logger.cpp`: the two property-formatter maps on the log-write path (any thread that logs with message properties)
  - `core/system/System.cpp`: `s_logOptions`, `s_loggingMutex`, and `s_programIdentity`, all read by the SIGHUP reload thread via `reinitLog()` -> `initializeLogWriters()`
  - `core/system/PosixSystem.cpp`: `s_sighupHandler` (a `boost::function`, invoked by the same thread), plus its `extern` declarations of the System.cpp statics updated to reference types to match the new definitions
- **File monitor** (`core/system/file_monitor/FileMonitor.cpp`): the registration-command and callback queues were Meyers function-local statics -- exactly the destructor-at-exit problem -- used by the monitor thread, which `stop()` can abandon (detach) on join timeout and which `exitEarly()` never stops.
- **Chat** (`session/modules/SessionChat.cpp`): the mutex-guarded cross-thread state groups (execution tracking, streaming-notification queue, pending-execution queue, manifest update state, update-check override). Current callers marshal onto the main thread (`callbacksRequireMainThread`, `executeOnMainThread`), so these are defensive: the design anticipates cross-thread access and the leak removes any teardown-order risk at zero cost.

Also migrates the existing hand-rolled leaks to `make_leaked` for consistency and greppability: the `Logger` singleton (`static Logger* = new Logger()`) and the two asio `io_context`s (`SessionServerRpc.cpp`, `SessionMain.cpp`, both already `*new ...` with teardown comments from #18018).

Intentionally left alone:

- `SessionClientEventQueue.cpp`'s `s_pClientEventQueue` -- already teardown-safe (raw pointer assigned in an explicit init, never deleted; its mutex/condition members are heap pointers on the leaked object). Converting it would be restructuring churn with no safety gain.
- `ClientEventService` / `OfflineService` Meyers singletons own joinable `boost::thread` members at exit -- a related but different bug class (destructor of a joinable thread), tracked separately if it proves problematic in practice.
- rserver's `ServerAuthHandler.cpp` statics (touched from the HTTP thread pool) -- different process with a different exit discipline; can be done as a follow-up if desired.

No NEWS entry: internal hardening with no observed user-facing failure.

## Testing

- Full `core` (457, including the `LoggingTests` that exercise `reinitLog()`) and `rsession` (405) C++ suites pass.
- `r` scope `packages` + `chat` tests pass (248).

Stacked on #18320 (the base branch); will retarget to `main` once that merges.

Addresses #18318.
