### PR TITLE
fix windows .lnk shortcut tests on ci: short-path home defeats home aliasing

### DIFF
--- a/e2e/rstudio/fixtures/sandbox-setup.ts
+++ b/e2e/rstudio/fixtures/sandbox-setup.ts
@@ -97,7 +97,15 @@ export default async function globalSetup(config: FullConfig) {
   // computes JS-side and paths reported by RStudio would differ otherwise.
   // TextEditingTarget's project-prefix check on save (#16721 / styler reformat
   // on save) is one place that breaks under a path-form mismatch.
-  const sandbox = fs.realpathSync(fs.mkdtempSync(path.join(parent, 'pw_sandbox_')));
+  //
+  // The .native variant is required on Windows: os.tmpdir() commonly contains
+  // 8.3 short-name components (C:\Users\RUNNER~1\... on CI runners), and only
+  // the native realpath expands those to the canonical long form. The JS
+  // implementation leaves them in place, and a short-form HOME defeats
+  // RStudio's home-path aliasing of paths the shell reports in long form --
+  // resolved .lnk targets in the Files pane being the known casualty
+  // (files_shortcuts.test.ts).
+  const sandbox = fs.realpathSync.native(fs.mkdtempSync(path.join(parent, 'pw_sandbox_')));
   fs.mkdirSync(path.join(sandbox, 'data-home'), { recursive: true });
 
   // Seed a locally built Posit Assistant into the sandbox data-home so tests

--- a/e2e/rstudio/fixtures/sandbox-setup.ts
+++ b/e2e/rstudio/fixtures/sandbox-setup.ts
@@ -106,6 +106,17 @@ export default async function globalSetup(config: FullConfig) {
   // resolved .lnk targets in the Files pane being the known casualty
   // (files_shortcuts.test.ts).
   const sandbox = fs.realpathSync.native(fs.mkdtempSync(path.join(parent, 'pw_sandbox_')));
+
+  // Self-guard for the canonicalization above: if the resolved path still
+  // contains an 8.3 short-name component (e.g. RUNNER~1), fail setup with a
+  // labeled error instead of letting the mismatch surface as a confusing
+  // visibility timeout deep in files_shortcuts.test.ts.
+  if (process.platform === 'win32' && sandbox.split(path.sep).some((c) => /~\d+($|\.)/.test(c))) {
+    throw new Error(
+      `[sandbox] resolved sandbox path still contains an 8.3 short-name component: ${sandbox}`,
+    );
+  }
+
   fs.mkdirSync(path.join(sandbox, 'data-home'), { recursive: true });
 
   // Seed a locally built Posit Assistant into the sandbox data-home so tests

--- a/src/cpp/session/SessionModuleContextTests.cpp
+++ b/src/cpp/session/SessionModuleContextTests.cpp
@@ -720,6 +720,55 @@ bool createWindowsShortcut(const core::FilePath& targetPath,
    return SUCCEEDED(hr);
 }
 
+// read the target path exactly as the .lnk stores it (IShellLink::GetPath,
+// no normalization), so a test can verify which form Save actually persisted
+bool readStoredShortcutTarget(const core::FilePath& shortcutPath,
+                              std::wstring* pStoredTarget)
+{
+   IShellLinkW* pShellLink = nullptr;
+   HRESULT hr = ::CoCreateInstance(CLSID_ShellLink,
+                                   nullptr,
+                                   CLSCTX_INPROC_SERVER,
+                                   IID_IShellLinkW,
+                                   (void**) &pShellLink);
+   if (FAILED(hr))
+   {
+      ADD_FAILURE() << "CoCreateInstance(CLSID_ShellLink) failed, hr=0x"
+                    << std::hex << hr;
+      return false;
+   }
+
+   IPersistFile* pPersistFile = nullptr;
+   hr = pShellLink->QueryInterface(IID_IPersistFile, (void**) &pPersistFile);
+   if (FAILED(hr))
+   {
+      ADD_FAILURE() << "QueryInterface(IID_IPersistFile) failed, hr=0x"
+                    << std::hex << hr;
+      pShellLink->Release();
+      return false;
+   }
+
+   std::wstring shortcut = toNativeSeparators(shortcutPath.getAbsolutePathW());
+   hr = pPersistFile->Load(shortcut.c_str(), STGM_READ);
+   if (SUCCEEDED(hr))
+   {
+      wchar_t targetPath[MAX_PATH];
+      hr = pShellLink->GetPath(targetPath, MAX_PATH, nullptr, 0);
+      if (hr == S_OK)
+         pStoredTarget->assign(targetPath);
+      else
+         ADD_FAILURE() << "IShellLinkW::GetPath failed, hr=0x" << std::hex << hr;
+   }
+   else
+   {
+      ADD_FAILURE() << "IPersistFile::Load failed, hr=0x" << std::hex << hr;
+   }
+
+   pPersistFile->Release();
+   pShellLink->Release();
+   return hr == S_OK;
+}
+
 } // anonymous namespace
 
 class WindowsShortcutTest : public ::testing::Test
@@ -925,6 +974,15 @@ TEST_F(WindowsShortcutTest, ResolvesStoredShortPathToLongForm)
 
    core::FilePath shortcut =
          makeShortcut(core::FilePath(shortForm), "short-form-shortcut.lnk");
+
+   // when the shell canonicalized the target at SetPath/Save time, the
+   // stored form is already long and the assertion below would pass even
+   // without the GetLongPathName normalization; skip so a pass always
+   // means the short-to-long seam was actually exercised
+   std::wstring storedTarget;
+   ASSERT_TRUE(readStoredShortcutTarget(shortcut, &storedTarget));
+   if (storedTarget != shortForm)
+      GTEST_SKIP() << "shell canonicalized the stored target at Save time";
 
    core::FilePath resolved;
    bool targetIsDir = true;

--- a/src/cpp/session/SessionModuleContextTests.cpp
+++ b/src/cpp/session/SessionModuleContextTests.cpp
@@ -900,6 +900,40 @@ TEST_F(WindowsShortcutTest, ResolveReturnsStoredPathWhenTargetDeleted)
    EXPECT_FALSE(targetIsDir);
 }
 
+TEST_F(WindowsShortcutTest, ResolvesStoredShortPathToLongForm)
+{
+   // home aliasing (createAliasedPath) and the client's duplicate-document
+   // detection are literal string comparisons, so a target reported in 8.3
+   // short form (C:\Users\RUNNER~1\...) fails to alias even when it lives
+   // under the home directory. Resolution must return the canonical long
+   // form regardless of the form the link stores. (The shell itself often
+   // canonicalizes at SetPath/Save time; the GetLongPathName call in
+   // resolveWindowsShortcut covers links where it did not.)
+   core::FilePath target = baseDir_.completeChildPath("long-target-name.txt");
+   core::Error error = target.ensureFile();
+   ASSERT_FALSE(error) << error.asString();
+
+   std::wstring wideTarget = toNativeSeparators(target.getAbsolutePathW());
+   wchar_t shortBuf[MAX_PATH];
+   DWORD length = ::GetShortPathNameW(wideTarget.c_str(), shortBuf, MAX_PATH);
+   ASSERT_GT(length, 0u) << "GetShortPathName failed";
+   ASSERT_LT(length, static_cast<DWORD>(MAX_PATH));
+
+   std::wstring shortForm(shortBuf, length);
+   if (shortForm == wideTarget)
+      GTEST_SKIP() << "8.3 short names are unavailable on this volume";
+
+   core::FilePath shortcut =
+         makeShortcut(core::FilePath(shortForm), "short-form-shortcut.lnk");
+
+   core::FilePath resolved;
+   bool targetIsDir = true;
+   error = resolveWindowsShortcut(shortcut, &resolved, &targetIsDir);
+   EXPECT_FALSE(error) << error.asString();
+   EXPECT_EQ(target.getAbsolutePath(), resolved.getAbsolutePath());
+   EXPECT_FALSE(targetIsDir);
+}
+
 // --- createFileSystemItem shortcut contract -----------------------------------
 //
 // The Files pane decides navigate-vs-open from 'dir' and substitutes

--- a/src/cpp/session/SessionModuleContextWin32.cpp
+++ b/src/cpp/session/SessionModuleContextWin32.cpp
@@ -23,6 +23,8 @@
 #include <cstdio>
 #include <string>
 
+#include <core/system/System.hpp>
+
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
 
@@ -151,7 +153,26 @@ Error resolveWindowsShortcut(const core::FilePath& shortcutPath,
       return shortcutError(boost::system::errc::no_such_file_or_directory,
                            hr, shortcutPath, ERROR_LOCATION);
 
-   *pTargetPath = FilePath(std::wstring(targetPath));
+   // The stored target may be in a non-canonical form: 8.3 short-name
+   // components (e.g. C:\Users\RUNNER~1\...) or stale character case.
+   // Home aliasing (createAliasedPath) and the client's duplicate-document
+   // detection are literal string comparisons, so a non-canonical form
+   // defeats both even when the target is under the home directory.
+   // Normalize local targets to the canonical long form. UNC and remote
+   // targets are skipped (the lookup would touch the network, violating
+   // the no-target-I/O contract above), and a failed lookup (e.g. a
+   // deleted target) keeps the stored form.
+   std::wstring storedPath(targetPath);
+   if (storedPath.rfind(L"\\\\", 0) != 0 &&
+       !core::system::isRemotePath(FilePath(storedPath)))
+   {
+      wchar_t longPath[MAX_PATH];
+      DWORD length = ::GetLongPathNameW(storedPath.c_str(), longPath, MAX_PATH);
+      if (length > 0 && length < MAX_PATH)
+         storedPath.assign(longPath, length);
+   }
+
+   *pTargetPath = FilePath(storedPath);
    *pTargetIsDirectory = (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
    return Success();
 }

--- a/src/cpp/session/SessionModuleContextWin32.cpp
+++ b/src/cpp/session/SessionModuleContextWin32.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <string>
+#include <vector>
 
 #include <core/system/System.hpp>
 
@@ -158,10 +159,11 @@ Error resolveWindowsShortcut(const core::FilePath& shortcutPath,
    // Home aliasing (createAliasedPath) and the client's duplicate-document
    // detection are literal string comparisons, so a non-canonical form
    // defeats both even when the target is under the home directory.
-   // Normalize local targets to the canonical long form. UNC and remote
-   // targets are skipped (the lookup would touch the network, violating
-   // the no-target-I/O contract above), and a failed lookup (e.g. a
-   // deleted target) keeps the stored form.
+   // Normalize local targets to the canonical long form. This reads the
+   // local filesystem (each path component), which is accepted during
+   // listings; UNC and remote targets are skipped because the same lookup
+   // would incur network I/O. A failed lookup (e.g. a deleted target)
+   // keeps the stored form.
    std::wstring storedPath(targetPath);
    if (storedPath.rfind(L"\\\\", 0) != 0 &&
        !core::system::isRemotePath(FilePath(storedPath)))
@@ -169,7 +171,20 @@ Error resolveWindowsShortcut(const core::FilePath& shortcutPath,
       wchar_t longPath[MAX_PATH];
       DWORD length = ::GetLongPathNameW(storedPath.c_str(), longPath, MAX_PATH);
       if (length > 0 && length < MAX_PATH)
+      {
          storedPath.assign(longPath, length);
+      }
+      else if (length >= MAX_PATH)
+      {
+         // the long form is larger than the stack buffer (the stored form
+         // fit the MAX_PATH GetPath buffer above, but 8.3 components can
+         // hide a long form that does not); the return value is the
+         // required size, so retry on the heap
+         std::vector<wchar_t> buffer(length);
+         length = ::GetLongPathNameW(storedPath.c_str(), &buffer[0], length);
+         if (length > 0 && length < buffer.size())
+            storedPath.assign(&buffer[0], length);
+      }
    }
 
    *pTargetPath = FilePath(storedPath);


### PR DESCRIPTION
## Problem

The scheduled Windows Desktop e2e workflow has failed on every run since #18275 merged (first failure: [run 29611045439](https://github.com/rstudio/rstudio/actions/runs/29611045439), most recent: [run 29955359944](https://github.com/rstudio/rstudio/actions/runs/29955359944)). The three failing tests are the file-shortcut cases in `files_shortcuts.test.ts`.

Root cause: the e2e sandbox derives HOME from `os.tmpdir()`, which on the GitHub Windows runners contains an 8.3 short-name component (`C:\Users\RUNNER~1\...`). `fs.realpathSync` does not expand short names (only `fs.realpathSync.native` does), so rsession runs with a short-form HOME. The shell canonicalizes `.lnk` targets to long form, so `IShellLink::GetPath` reports `C:/Users/runneradmin/...` and `createAliasedPath`'s literal prefix match against home fails. The trace shows the direct consequence: following the shortcut opens the target as a second, path-distinct document (absolute path) alongside the `~/`-aliased one, so `waitForActiveDocument('~/...')` times out and the columns dedupe test sees 3 source panels instead of 2.

## Fixes

- **e2e harness**: canonicalize the sandbox root with `fs.realpathSync.native`, expanding 8.3 short names on Windows (identical behavior on macOS/Linux, verified). This also fixes the spurious `[sandbox] R workdir ... is not under PW_SANDBOX` teardown warnings, which were the same path-form mismatch.
- **rsession**: `resolveWindowsShortcut` now normalizes local targets with `GetLongPathName`, so home aliasing and the client's duplicate-document detection are robust to short-form (or case-mismatched) stored targets regardless of environment. UNC/remote targets are skipped to keep the existing no-network-I/O contract, and a failed lookup (e.g. deleted target) keeps the stored path, preserving the broken-shortcut behavior covered by `ResolveReturnsStoredPathWhenTargetDeleted`.

Includes a new `WindowsShortcutTest.ResolvesStoredShortPathToLongForm` gtest (skips when 8.3 names are disabled on the volume).

## Verification

- `tsc --noEmit` passes for the e2e change; `fs.realpathSync.native` verified equivalent to `fs.realpathSync` on macOS.
- The C++ change is Windows-only and needs the Windows CI build; the new gtest and the next scheduled Windows e2e run are the end-to-end verification.