### PR TITLE
Add Rocky 9 x86_64 E2E engine and wire into scheduled rotation

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-rocky-9-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-rocky-9-x86_64.yml
@@ -1,0 +1,865 @@
+name: "Test: E2E Playwright RStudio (Desktop, Rocky 9 x86_64, Open Source)"
+
+# Rocky 9 (x86_64) E2E engine. Rocky Linux 9 is a 1:1 rebuild of RHEL 9, so it
+# exercises the RHEL 9 target while staying freely available with no
+# subscription and no registry auth. We use Rocky rather than Red Hat's UBI 9
+# image for the same reason the v10 engine avoids UBI 10: the headless display
+# package (here xorg-x11-server-Xvfb) is absent from UBI 9's curated repo subset
+# (confirmed missing from BaseOS, AppStream, and CRB), whereas Rocky's full repo
+# set carries it in AppStream.
+#
+# Unlike RHEL/Rocky 10, RHEL 9 still ships the X.Org server, so the virtual
+# display comes from Xvfb (as on the Fedora and Ubuntu engines), NOT from
+# Cage/Xwayland -- that dance is only needed on v10, which dropped X.Org.
+#
+# Shape: build the x86_64 Electron .rpm inside a rockylinux/rockylinux:9 container on an
+# ubuntu-latest runner (GitHub has no RHEL/Rocky-hosted runner), then run the
+# e2e job in the same container image and drive Playwright under Xvfb.
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_from_source:
+        description: "Build RStudio Desktop (Electron) from this branch's source. When false, downloads the latest daily .rpm installer."
+        type: boolean
+        default: true
+      rstudio_installer_url:
+        description: "Optional .rpm URL to test against (e.g. a specific daily from dailies.rstudio.com). When set, the source build is skipped and this URL is installed instead, regardless of build_from_source. Leave empty to build from source or auto-resolve the latest daily."
+        type: string
+        default: ""
+      r_version:
+        description: "R version to install via rig (e.g. 'release', 'oldrel', 'devel', '4.4.1')."
+        type: string
+        default: "release"
+      project:
+        description: "Playwright project to run: 'desktop' or 'server'. OS and edition are auto-filtered from the host platform and PW_RSTUDIO_EDITION."
+        type: string
+        default: "desktop"
+      grep:
+        description: "Optional Playwright --grep pattern to run only tests whose title matches."
+        type: string
+        default: ""
+      test_selector:
+        description: "Optional test paths/files/directories to run (space-separated). Matched as substrings against test file paths. Examples: 'autocomplete.test.ts', 'tests/panes/misc/', 'autocomplete tests/panes/posit-assistant-chat/'. Leave empty to run all tests."
+        type: string
+        default: ""
+      test_ignore:
+        description: "Optional test paths/files/directories to exclude (space-separated globs). Examples: '**/code_suggestions.test.ts', '**/posit-assistant-chat/**'. Leave empty to exclude nothing."
+        type: string
+        default: ""
+      grep_invert:
+        description: "Optional Playwright --grep-invert pattern to skip tests by title. Empty by default (runs all tests)."
+        type: string
+        default: ""
+      rstudio_extra_args:
+        description: "Optional extra args passed to RStudio Desktop on launch (space-separated). Maps to PW_RSTUDIO_EXTRA_ARGS. Set to '--no-sandbox' if the in-container Chromium sandbox won't initialize (see the container options below)."
+        type: string
+        default: ""
+      build_only:
+        description: "Run only the build job (to seed the rstudio-tools / R-libs / sccache caches) and skip the e2e job."
+        type: boolean
+        default: false
+      post_pr_comment:
+        description: "Post test results as a sticky comment on the PR. Pass true only from PR-triggered callers."
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      build_from_source:
+        type: boolean
+        default: true
+      rstudio_installer_url:
+        type: string
+        default: ""
+      r_version:
+        type: string
+        default: "release"
+      project:
+        type: string
+        default: "desktop"
+      grep:
+        type: string
+        default: ""
+      test_selector:
+        type: string
+        default: ""
+      test_ignore:
+        type: string
+        default: ""
+      grep_invert:
+        type: string
+        default: ""
+      rstudio_extra_args:
+        type: string
+        default: ""
+      build_only:
+        type: boolean
+        default: false
+      post_pr_comment:
+        type: boolean
+        default: false
+      defer_merge:
+        description: "Skip this workflow's own merge/publish/comment job; the caller merges every platform's blobs into one report instead."
+        type: boolean
+        default: false
+    secrets:
+      CONNECT_API_KEY:
+        description: "Posit Connect API key for the E2E Test Insights reporter"
+        required: false
+      AWS_E2E_REPORTS_ROLE_ARN:
+        description: "IAM role assumed via GitHub OIDC to upload the Playwright report to S3"
+        required: false
+
+permissions:
+  contents: read
+  # Required so the e2e-merge job can post sticky PR comments via
+  # marocchino/sticky-pull-request-comment. GitHub validates ALL job-level
+  # permissions in a reusable workflow at call time, so this must be declared
+  # at the top level even though only e2e-merge uses it.
+  pull-requests: write
+  # Lets the e2e-merge job mint an OIDC token to assume the S3 report-upload
+  # role (see .github/actions/os-publish-e2e-report).
+  id-token: write
+
+jobs:
+  # Builds RStudio Desktop (Electron) from this PR's source inside a rockylinux/rockylinux:9
+  # container on an ubuntu-latest runner (GitHub has no RHEL/Rocky-hosted
+  # runner), then uploads the x86_64 .rpm as an artifact for the e2e job to
+  # consume. Skipped when build_from_source is false or rstudio_installer_url is
+  # set, in which case the e2e job downloads the daily .rpm (or the given URL)
+  # instead.
+  build:
+    if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
+    runs-on: ubuntu-latest
+    # SYS_ADMIN plus an unconfined seccomp profile match the other container
+    # engines. The build itself runs no Chromium, but keeping the options
+    # identical across the build and e2e containers avoids surprises and mirrors
+    # the RHEL/Fedora build jobs.
+    container:
+      image: rockylinux/rockylinux:9
+      # The rockylinux/rockylinux:9 image config defines no default PATH, so
+      # once a tool-cache action (Setup sccache here) prepends its bin dir via
+      # GITHUB_PATH, the runner rebuilds the container-exec PATH as just that dir
+      # and later run steps can't find sh/dnf ("exec: sh: not found", exit 127).
+      # Define an explicit base PATH so the prepend adds to it instead of
+      # replacing it. The fedora/debian sibling images set PATH themselves and
+      # so don't need this.
+      env:
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      options: --cap-add=SYS_ADMIN --security-opt seccomp=unconfined
+    timeout-minutes: 120
+    env:
+      # Redirect the dependency / package scripts' tool root to a
+      # workspace-local path so it can be cached without sudo.
+      RSTUDIO_TOOLS_ROOT: ${{ github.workspace }}/opt/rstudio-tools/x86_64
+      # Pin R's user library to a workspace-local path so we can cache it.
+      R_LIBS_USER: ${{ github.workspace }}/R-libs/%p/%v
+      SCCACHE_ENABLED: '1'
+      # Route sccache to GitHub's built-in Actions cache API. The
+      # mozilla-actions/sccache-action step below installs sccache and exports
+      # ACTIONS_CACHE_URL plus ACTIONS_RUNTIME_TOKEN so the sccache server uses
+      # the GHA backend. Cache hits are object-level (one entry per compiled
+      # .o), so branch runs automatically inherit main's warm cache (seeded by
+      # a build_from_source dispatch on main) without per-SHA tarball rotation.
+      # No AWS / S3 / secrets required.
+      SCCACHE_GHA_ENABLED: 'true'
+      # Compile GWT with readable (PRETTY) symbol names rather than the default
+      # OBFUSCATED output, so the uncaught client exceptions the e2e automation
+      # agent records (window.rstudio.errors) carry decodable Java stack traces.
+      # Consumed by src/gwt/CMakeLists.txt; folded into the GWT cache key below.
+      GWT_STYLE: PRETTY
+      # Quiet npm during install-common's panmirror build, the Electron app
+      # build, and any other transitive npm step.
+      NPM_CONFIG_LOGLEVEL: error
+      NPM_CONFIG_AUDIT: 'false'
+
+    steps:
+      # The rockylinux/rockylinux:9 base image is minimal and the job runs as root. Install
+      # the tools the checkout action, the dependency scripts, and the build need
+      # up front. sudo is required because install-dependencies-yum calls it
+      # internally (root's sudo is a straight passthrough).
+      - name: Prepare Rocky container
+        run: |
+          dnf -y install sudo git tar gzip xz jq which findutils diffutils procps-ng
+
+      # Several build-time -devel packages (boost-devel, pango-devel, ...) live
+      # in EPEL / CodeReady Builder (CRB) rather than the base repos. On Rocky
+      # both are trivially available: epel-release ships in the extras repo, and
+      # the CRB repo is named "crb". Enabling them up front lets
+      # install-dependencies-yum resolve everything.
+      - name: Enable EPEL and CRB repos
+        run: |
+          dnf -y install dnf-plugins-core
+          dnf -y install epel-release
+          dnf config-manager --set-enabled crb
+          dnf repolist --enabled | grep -qiE 'crb|codeready' \
+            || echo "::warning::CRB repo not enabled; build -devel packages may fail to resolve."
+
+      - uses: actions/checkout@v4
+
+      # Pre-built tool deps (Boost, SOCI, pandoc, quarto, GWT, node, panmirror,
+      # copilot-language-server, sccache, etc.) all land under RSTUDIO_TOOLS_ROOT.
+      # rocky9-x86_64-scoped key: these are compiled native artifacts, so they
+      # can't share the arm64 or Fedora build caches. Restore-only here; the Save
+      # steps after "Install build dependencies" run only from main-scoped runs.
+      - name: Restore rstudio-tools deps
+        id: tools-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.RSTUDIO_TOOLS_ROOT }}
+          key: rstudio-tools-linux-rocky9-x86_64-${{ hashFiles('dependencies/common/install-*', 'dependencies/linux/install-*', 'dependencies/tools/rstudio-tools.sh') }}
+          restore-keys: |
+            rstudio-tools-linux-rocky9-x86_64-
+
+      # install-common (called by install-dependencies-yum) installs R packages
+      # (via install-packages) into R_LIBS_USER. Cache the whole R-libs tree.
+      # R's %p/%v subpaths keep different versions isolated. rocky9-x86_64-scoped:
+      # these are compiled against Rocky 9's R, not interchangeable with the
+      # arm64 or Fedora builds.
+      - name: Restore build-time R packages
+        id: rlibs-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/R-libs
+          key: rstudio-build-rlibs-linux-rocky9-x86_64-${{ hashFiles('dependencies/common/install-packages', 'dependencies/common/lockfiles/**/renv.lock') }}
+          restore-keys: |
+            rstudio-build-rlibs-linux-rocky9-x86_64-
+
+      # Cache compiled GWT output (package/linux/build-Electron-RPM/gwt). GWT
+      # compilation is the single most expensive JS step (~15-30 min). When GWT
+      # Java sources / build scripts haven't changed, make-electron-package can
+      # skip the recompile entirely via the NO_REBUILD environment variable (sets
+      # GWT_BUILD=no, which becomes -DGWT_BUILD=no to cmake). See the
+      # NO_REBUILD/GWT_BUILD handling in package/linux/make-package. GWT output
+      # is Java-to-JS and arch-independent, but the key is rocky9-x86_64-scoped
+      # for isolation (matching the tools/rlibs keys); the RPM build dir also
+      # differs from the DEB dir, so the path can't collide either. Restore-only
+      # here; the matching Save step runs after the build with a success gate so
+      # a failed mid-compile run can't poison the cache.
+      - name: Restore GWT output
+        id: gwt-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: package/linux/build-Electron-RPM/gwt
+          key: rstudio-gwt-linux-desktop-rocky9-x86_64-${{ env.GWT_STYLE }}-v1-${{ hashFiles('src/gwt/src/**', 'src/gwt/acesupport/**', 'src/gwt/lib/**', 'src/gwt/build.xml', 'src/gwt/conf/**') }}
+          restore-keys: |
+            rstudio-gwt-linux-desktop-rocky9-x86_64-${{ env.GWT_STYLE }}-v1-
+
+      # GHA-backed sccache. Installs sccache on PATH and starts the sccache
+      # server with the GH Actions cache API as the storage backend. Object-level
+      # cache hits, no per-SHA tarball, no AWS credentials.
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          # Pinned: resolving "latest" queries api.github.com at runtime,
+          # which fails during GitHub API incidents (503s). A pinned version
+          # downloads directly from the release CDN with no API call.
+          version: "v0.16.0"
+
+      # install-dependencies-yum: dnf installs system packages (with sudo
+      # internally), then calls install-common which downloads Boost, SOCI,
+      # pandoc, quarto, node, panmirror, sccache, GWT jar, etc. into
+      # RSTUDIO_TOOLS_ROOT. The scripts are idempotent, so a cache hit on
+      # rstudio-tools-deps makes this a fast pass: the heavy downloads are
+      # skipped and the cached tools are reused.
+      - name: Install build dependencies
+        working-directory: dependencies/linux
+        run: ./install-dependencies-yum
+
+      # Save the tools / R-libs caches only from main-scoped runs (a
+      # build_from_source dispatch on main, or a scheduled caller), and only on
+      # a key miss. A cache saved from a PR run lands in that PR's merge-ref
+      # scope, which no other branch can restore: each copy is pure pressure on
+      # the repo's 10 GB Actions cache quota, and that pressure is what evicts
+      # main's copies and sends every build cold in the first place.
+      - name: Save rstudio-tools deps
+        if: github.ref == 'refs/heads/main' && steps.tools-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.RSTUDIO_TOOLS_ROOT }}
+          key: ${{ steps.tools-cache.outputs.cache-primary-key }}
+
+      - name: Save build-time R packages
+        if: github.ref == 'refs/heads/main' && steps.rlibs-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/R-libs
+          key: ${{ steps.rlibs-cache.outputs.cache-primary-key }}
+
+      - name: Zero sccache stats
+        run: sccache --zero-stats || true
+
+      - name: Build RStudio Desktop RPM
+        id: build
+        working-directory: package/linux
+        env:
+          RSTUDIO_VERSION_MAJOR: '99'
+          RSTUDIO_VERSION_MINOR: '9'
+          RSTUDIO_VERSION_PATCH: '9'
+          RSTUDIO_VERSION_SUFFIX: "-pr+${{ github.run_number }}"
+        run: |
+          # NO_REBUILD=1 (see package/linux/make-package) tells the script to
+          # set GWT_BUILD=no, which becomes -DGWT_BUILD=no to cmake, so the
+          # cached GWT bin/www/extras under build-Electron-RPM/gwt are reused
+          # instead of recompiled (~15-30 min saved when sources unchanged).
+          if [ "${{ steps.gwt-cache.outputs.cache-hit }}" = "true" ]; then
+            echo "GWT cache hit, skipping GWT compile"
+            NO_REBUILD=1 ./make-electron-package RPM
+          else
+            echo "GWT cache miss, compiling GWT from scratch"
+            ./make-electron-package RPM
+          fi
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
+      # Save GWT output only when the build succeeded. A failed mid-compile run
+      # could otherwise write partial GWT output to the cache, and every future
+      # restore would silently ship a broken frontend until the hashFiles key
+      # rotates. Save only from main-scoped runs, and only on a key miss (same
+      # cache-quota reasoning as the tools/rlibs Save steps above).
+      - name: Save GWT output
+        if: github.ref == 'refs/heads/main' && steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: package/linux/build-Electron-RPM/gwt
+          key: ${{ steps.gwt-cache.outputs.cache-primary-key }}
+
+      # Skipped in build_only (seed) runs: no e2e job consumes the artifact,
+      # so packaging and uploading it would be pure waste. CPack writes the
+      # shippable .rpm to the TOP LEVEL of build-Electron-RPM (no
+      # CPACK_PACKAGE_DIRECTORY is set and cpack runs from inside that dir),
+      # so -maxdepth 1 is correct and deterministic. _CPack_Packages/.../RPM
+      # holds only rpmbuild staging copies, which we must not pick up.
+      - name: Package RStudio Desktop .rpm
+        if: inputs.build_only != true
+        run: |
+          RPM=$(find package/linux/build-Electron-RPM -maxdepth 1 -name '*.rpm' | head -1)
+          if [ -z "$RPM" ]; then
+            echo "::error::No .rpm found in package/linux/build-Electron-RPM"
+            exit 1
+          fi
+          cp "$RPM" "$GITHUB_WORKSPACE/rstudio-desktop.rpm"
+          echo "Packaged: $RPM"
+
+      - name: Upload RStudio Desktop .rpm artifact
+        if: inputs.build_only != true
+        uses: actions/upload-artifact@v4
+        with:
+          name: rstudio-desktop-rpm-rocky9-x86_64
+          path: rstudio-desktop.rpm
+          retention-days: 7
+
+  e2e-desktop-rocky9:
+    needs: build
+    # build is skipped when build_from_source is false or rstudio_installer_url
+    # is set; allow this job to run in those cases too (needs.build.result ==
+    # 'skipped' on the download path). build_only seeds the build caches
+    # without running e2e, so skip.
+    if: |
+      always() &&
+      inputs.build_only != true &&
+      (needs.build.result == 'success' || needs.build.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    runs-on: ubuntu-latest
+    container:
+      image: rockylinux/rockylinux:9
+      # SYS_ADMIN plus unconfined seccomp let Chromium/Electron's namespace
+      # sandbox initialize inside the container. The Ubuntu jobs instead flip a
+      # host sysctl (kernel.apparmor_restrict_unprivileged_userns=0), which
+      # isn't reachable from an unprivileged container (/proc/sys is read-only).
+      # Combined with dropping to a non-root user for the run itself (see the
+      # setpriv step below), this keeps the real sandbox ON, matching the
+      # bare-runner siblings. If a future runner kernel forbids unprivileged
+      # user namespaces and the sandbox can't come up, set rstudio_extra_args to
+      # '--no-sandbox' as a fallback rather than changing these.
+      #
+      # --shm-size=2g: container jobs default /dev/shm to 64 MB, which Chromium
+      # uses for cross-process shared memory. Under that cap the Electron
+      # renderer can crash to a blank page mid-suite with no logged cause (seen
+      # on the Debian arm64 sibling). The bare-runner siblings get the host's
+      # full /dev/shm and never hit this. Raising it to 2g is the standard
+      # container fix.
+      # See the build job's container env note: the rockylinux/rockylinux:9
+      # image sets no default PATH, so tool-cache actions (setup-node here) would
+      # otherwise clobber it and break later run steps. Define a base PATH.
+      env:
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      options: --cap-add=SYS_ADMIN --security-opt seccomp=unconfined --shm-size=2g
+    timeout-minutes: 120
+    env:
+      R_LIBS_USER: ${{ github.workspace }}/R-libs
+      PW_SANDBOX_ROOT: ${{ github.workspace }}/pw-sandbox
+      PW_SANDBOX_ROOT_CREATE: '1'
+      # The minimal rockylinux/rockylinux:9 image sets no UTF-8 locale, so R starts with a
+      # non-UTF-8 charset and prints "Character set is not UTF-8; please change
+      # your locale" into the console. Console-content tests (e.g. the ANSI
+      # cursor suite) assert on exact console lines, so that warning breaks them
+      # deterministically. C.UTF-8 is built into glibc (no locale package
+      # needed); setting it job-level carries through the setpriv drop into
+      # Electron and rsession. The bare-runner siblings inherit a UTF-8 locale
+      # from the runner image and never hit this.
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
+
+    steps:
+      # The rockylinux/rockylinux:9 base image is minimal and the job runs as root.
+      # Install what checkout, rig, and the .rpm install need. sudo is kept for
+      # parity with the shared scripts.
+      - name: Prepare Rocky container
+        run: |
+          dnf -y install sudo git tar gzip xz jq which findutils dnf-plugins-core
+
+      # This is a separate container from the build job, so it needs its own repo
+      # enablement. Unlike RHEL 10, RHEL 9 (and thus Rocky 9) still ships the
+      # X.Org server, so the display comes from Xvfb (installed below) out of
+      # AppStream -- no Cage/Xwayland needed. EPEL / CRB are still enabled here
+      # for the R build toolchain's -devel headers (see that step below) and any
+      # runtime lib that lives outside the base repos.
+      - name: Enable EPEL and CRB repos
+        run: |
+          dnf -y install epel-release
+          dnf config-manager --set-enabled crb
+          dnf repolist --enabled | grep -qiE 'crb|codeready' \
+            || echo "::warning::CRB repo not enabled; some -devel headers may fail to resolve."
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
+
+      - name: Install OS dependencies
+        run: |
+          # Xvfb (virtual display for the Electron app / Playwright) plus the
+          # runtime libraries Chromium/Electron and the Playwright-managed
+          # chromium need on Rocky 9. RHEL 9 keeps the X.Org server, so
+          # xorg-x11-server-Xvfb is available in AppStream (RHEL 10 dropped it,
+          # which is why the v10 engine uses Cage/Xwayland instead). This list is
+          # load-bearing, not redundant: the RStudio Electron RPM is built with
+          # CPACK_RPM_PACKAGE_AUTOREQPROV off (see package/linux/CMakeLists.txt)
+          # and declares only libxkbcommon-x11 and sqlite, so dnf does NOT
+          # auto-pull the GUI/Chromium libs on install; they must come from here.
+          # The last row mirrors the font/text libs some test R packages load:
+          # freetype/fontconfig (ragg, systemfonts), harfbuzz/fribidi
+          # (textshaping).
+          # lsof: the desktop fixture uses it to reclaim an orphaned RStudio on
+          # the worker's fixed CDP port; the minimal Rocky image doesn't ship it.
+          dnf -y install \
+            xorg-x11-server-Xvfb lsof \
+            nss nspr atk at-spi2-atk at-spi2-core cups-libs \
+            libdrm mesa-libgbm libxkbcommon \
+            libX11 libXcomposite libXdamage libXext libXfixes libXrandr libXScrnSaver libXtst libxcb \
+            gtk3 pango cairo alsa-lib \
+            freetype fontconfig harfbuzz fribidi
+
+      - name: Install rig
+        uses: ./.github/actions/os-install-rig-unix
+
+      - name: Install R via rig
+        env:
+          R_VERSION: ${{ inputs.r_version }}
+        run: |
+          rig add "$R_VERSION"
+          rig default "$R_VERSION"
+          rig ls
+          mkdir -p "$R_LIBS_USER"
+
+      # Defensive fallback only. On Rocky 9 x86_64, os-e2e-deps points pak at
+      # PPM's rhel9 repo, which DOES serve x86_64 binaries, so the harness's R
+      # packages install as prebuilt binaries (not compiled) -- unlike the
+      # arm64/Fedora engines where source compilation is the norm. This
+      # toolchain is here in case a package has no rhel9 binary and pak has to
+      # source-compile it: a compiler stack (gcc/g++/gfortran + make) plus the
+      # -devel headers the compiled dependencies link against: libcurl/openssl/
+      # libxml2 (curl, openssl, xml2), the font/text stack (systemfonts,
+      # textshaping, ragg), the image libs (ragg), zlib (data.table and others),
+      # and ICU (stringi). NOTE: RHEL 9 still ships classic zlib, so the header
+      # is zlib-devel -- NOT the zlib-ng-compat-devel the v10 engine uses (RHEL
+      # 10 switched to zlib-ng). These -devel packages come from CRB/EPEL,
+      # enabled above.
+      - name: Install R build toolchain and headers
+        run: |
+          dnf -y install \
+            gcc gcc-c++ gcc-gfortran make \
+            libcurl-devel openssl-devel libxml2-devel \
+            fontconfig-devel freetype-devel harfbuzz-devel fribidi-devel \
+            libpng-devel libjpeg-turbo-devel libtiff-devel \
+            zlib-devel libicu-devel cairo-devel
+
+      # Build-from-source path: extract the .rpm artifact produced by the build
+      # job above and install it. The RPM declares only minimal deps (AUTOREQPROV
+      # is off), so the GUI/Chromium runtime libs come from the "Install OS
+      # dependencies" step above, not from the RPM's own resolution.
+      - name: Download RStudio Desktop .rpm artifact
+        if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
+        uses: actions/download-artifact@v4
+        with:
+          name: rstudio-desktop-rpm-rocky9-x86_64
+          path: ${{ github.workspace }}
+
+      - name: Install RStudio Desktop from artifact
+        if: inputs.build_from_source == true && inputs.rstudio_installer_url == ''
+        run: |
+          dnf -y install "$GITHUB_WORKSPACE/rstudio-desktop.rpm"
+          ls -la /usr/bin/rstudio
+
+      # Daily-download path: resolve and install the latest (or specified) .rpm.
+      # Runs when build_from_source is false (auto-resolve the daily via
+      # dailies.rstudio.com/rstudio/latest/index.json) or when an explicit
+      # rstudio_installer_url is provided (use that URL verbatim).
+      - name: Resolve RStudio Desktop .rpm URL
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
+        id: resolve
+        env:
+          INSTALLER_URL: ${{ inputs.rstudio_installer_url }}
+        run: |
+          URL="$INSTALLER_URL"
+          SHA=""
+          FILENAME=""
+          if [ -z "$URL" ]; then
+            MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 'https://dailies.rstudio.com/rstudio/latest/index.json')
+            # The RHEL/Rocky 9 x86_64 Desktop build ships as an Electron .rpm
+            # keyed "rhel9-x86_64" under the electron product.
+            URL=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["rhel9-x86_64"].link // empty')
+            SHA=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["rhel9-x86_64"].sha256 // empty')
+            FILENAME=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["rhel9-x86_64"].filename // empty')
+            if [ -z "$URL" ] || [ -z "$FILENAME" ] || [ -z "$SHA" ]; then
+              echo "::error::Daily manifest is missing expected fields (url='$URL', filename='$FILENAME', sha256='$SHA'). The schema at https://dailies.rstudio.com/rstudio/latest/index.json may have changed."
+              exit 1
+            fi
+            echo "Auto-resolved latest rhel9-x86_64 desktop daily:"
+            echo "  URL:      $URL"
+            echo "  SHA-256:  $SHA"
+            echo "  Filename: $FILENAME"
+          else
+            FILENAME=$(basename "${URL%%\?*}")
+            if [ -z "$FILENAME" ]; then
+              echo "::error::Could not derive filename from rstudio_installer_url='$URL'."
+              exit 1
+            fi
+            echo "Using override URL: $URL (SHA-256 verification skipped)"
+          fi
+          echo "url=$URL"           >> "$GITHUB_OUTPUT"
+          echo "sha256=$SHA"        >> "$GITHUB_OUTPUT"
+          echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
+
+      # Cache the daily installer keyed on its resolved filename. Filenames
+      # embed the version + build number on the auto-resolve path so the content
+      # is immutable per name: new daily misses and downloads, same-day re-run
+      # hits and skips (SHA still verified below). Skip caching on the override
+      # path -- a user-supplied URL has no immutability guarantee and its SHA
+      # check is skipped, so a reused basename could otherwise serve stale,
+      # unverified bytes.
+      - name: Cache RStudio Desktop installer
+        if: inputs.build_from_source == false && inputs.rstudio_installer_url == ''
+        id: installer-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.resolve.outputs.filename }}
+          key: rstudio-desktop-installer-${{ steps.resolve.outputs.filename }}
+
+      - name: Download RStudio Desktop .rpm
+        if: (inputs.build_from_source == false || inputs.rstudio_installer_url != '') && steps.installer-cache.outputs.cache-hit != 'true'
+        env:
+          DOWNLOAD_URL: ${{ steps.resolve.outputs.url }}
+          DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}
+        run: |
+          curl -fsSL --retry 3 --retry-delay 5 \
+            -o "$DOWNLOAD_FILENAME" \
+            "$DOWNLOAD_URL"
+
+      - name: Verify SHA-256
+        if: (inputs.build_from_source == false || inputs.rstudio_installer_url != '') && steps.resolve.outputs.sha256 != ''
+        env:
+          EXPECTED_SHA256: ${{ steps.resolve.outputs.sha256 }}
+          DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}
+        run: |
+          echo "$EXPECTED_SHA256  $DOWNLOAD_FILENAME" | sha256sum -c -
+
+      - name: Install RStudio Desktop from .rpm
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
+        env:
+          INSTALLER_FILENAME: ${{ steps.resolve.outputs.filename }}
+        run: |
+          dnf -y install "./$INSTALLER_FILENAME"
+          ls -la /usr/bin/rstudio
+
+      # os-e2e-deps installs the harness's R packages into R_LIBS_USER. On Rocky
+      # 9 x86_64, os-e2e-deps routes pak at PPM's rhel9 repo, which serves
+      # x86_64 binaries, so this is a fast binary install rather than a source
+      # compile. install-required-packages pulls the full REQUIRED_PACKAGES set
+      # here (not just the e2e DESCRIPTION deps), so the in-test globalSetup,
+      # pointed at this same library via PW_RSTUDIO_R_LIBS_USER below, finds
+      # everything present and installs nothing at test time. (The harness's own
+      # r-libs-setup.ts maps only Ubuntu codenames to PPM and would source-CRAN
+      # on Rocky, so pre-populating here is what keeps test time fast.)
+      - name: Install e2e test dependencies
+        uses: ./.github/actions/os-e2e-deps
+        with:
+          r-libs-user: ${{ env.R_LIBS_USER }}
+          # Isolate the R-library / pak caches from the other Linux workflows:
+          # they all share runner.os == Linux, and this Rocky 9 library is not
+          # interchangeable with the arm64, Fedora, or Debian caches.
+          cache-scope: rocky9-x86_64
+          install-required-packages: 'true'
+
+      # Run the tests as a non-root user, matching the bare-runner siblings
+      # (Ubuntu/macOS/Windows all execute as a non-root user) and the Fedora /
+      # Debian container engines. GHA container jobs default to root, and
+      # RStudio-as-root diverges from real usage: Chromium refuses its sandbox as
+      # root, the terminal gets a root shell, and rsession warns. All the setup
+      # above needs root (dnf, the .rpm install, cache writes, rig), so only the
+      # test step drops down: create the user here and hand it ownership of
+      # everything the run writes under the workspace (R-libs, ms-playwright,
+      # pw-sandbox, the pak cache, and the report dirs under e2e/rstudio).
+      - name: Create non-root test user
+        run: |
+          useradd -m -s /bin/bash rstudio-tester
+          chown -R rstudio-tester:rstudio-tester "$GITHUB_WORKSPACE"
+
+      - name: Run Playwright tests
+        working-directory: e2e/rstudio
+        # Explicit shell: container jobs default run steps to sh, and this script
+        # uses bash arrays (ARGS=(), +=, "${ARGS[@]}"). Red Hat family symlinks
+        # /bin/sh to bash so this would work regardless, but naming bash is
+        # clearer and adds -o pipefail (harmless here, no pipelines).
+        shell: bash
+        env:
+          PW_RSTUDIO_MODE: desktop
+          # Platform-labelled project name; playwright.config.ts uses it both as
+          # the project name in reports (so a cross-platform merged report can
+          # distinguish these results) and to derive the platform+shard-unique
+          # blob report file name. Distinct from the Rocky 10 engine's
+          # "-linux-rocky-arm64" label so the two versions never conflate results.
+          PW_PROJECT_LABEL: ${{ inputs.project }}-linux-rocky9-x86_64
+          PW_GREP: ${{ inputs.grep }}
+          PW_GREP_INVERT: ${{ inputs.grep_invert }}
+          PW_TEST_SELECTOR: ${{ inputs.test_selector }}
+          PW_TEST_IGNORE: ${{ inputs.test_ignore }}
+          # No --no-sandbox: the test step runs as a non-root user (see the
+          # setpriv drop below), so Chromium no longer refuses to start, and the
+          # container's SYS_ADMIN plus unconfined seccomp let its namespace
+          # sandbox initialize, matching how the bare-runner siblings run. If a
+          # future runner kernel forbids unprivileged user namespaces and the
+          # sandbox can't come up, set rstudio_extra_args to '--no-sandbox'.
+          PW_RSTUDIO_EXTRA_ARGS: ${{ inputs.rstudio_extra_args }}
+          # Tells playwright.config.ts to switch to blob reporter for this shard.
+          PW_SHARD: ${{ matrix.shard }}
+          # E2E Test Insights reporter: posts per-shard results to the dashboard.
+          # CONNECT_API_KEY is empty on fork PRs; the reporter still runs but its
+          # uploads fail with warnings (never fails the run).
+          CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+          SHARD_NAME: desktop-linux-rocky9-x86_64-${{ matrix.shard }}
+          # Print the GWT launch timeline so the next launch failure shows which
+          # phase exceeded the deadline.
+          PW_DEBUG_LAUNCH: '1'
+          # Point the harness's R-libs provisioner (fixtures/r-libs-setup.ts, run
+          # in globalSetup) at the same library os-e2e-deps populated, instead of
+          # its default per-host cache. Because os-e2e-deps ran with
+          # install-required-packages, that library already holds the full set,
+          # so globalSetup installs nothing.
+          PW_RSTUDIO_R_LIBS_USER: ${{ github.workspace }}/R-libs
+          # Defensive ceiling. With install-required-packages above, globalSetup
+          # normally compiles nothing. But if a package slips through and has to
+          # source-compile here (the harness source-CRANs on Rocky), that is a
+          # long silent stretch the default 300s heartbeat would kill (exit 124);
+          # the higher ceiling lets it finish.
+          PW_HEARTBEAT_TIMEOUT_SECONDS: '2400'
+        run: |
+          ARGS=()
+          if [ -n "$PW_TEST_SELECTOR" ]; then
+            set -f
+            ARGS+=($PW_TEST_SELECTOR)
+            set +f
+          fi
+          if [ -n "$PW_GREP" ]; then
+            ARGS+=(--grep "$PW_GREP")
+          fi
+          if [ -n "$PW_GREP_INVERT" ]; then
+            ARGS+=(--grep-invert "$PW_GREP_INVERT")
+          fi
+          ARGS+=(--shard="${{ matrix.shard }}/${{ strategy.job-total }}")
+          # Run Playwright under our own Xvfb and exec the watchdog as the step's
+          # main process, so a job cancellation's SIGTERM reaches the watchdog
+          # (which forwards it to Playwright's process group as SIGINT -- its
+          # cancellation signal -- then escalates to SIGKILL if the run doesn't
+          # wind down). xvfb-run is a shell wrapper that does not forward signals
+          # to its child, which left cancelled Linux e2e jobs running until
+          # their timeout-minutes instead of stopping. -ac disables X access
+          # control so Chromium connects without an auth cookie; -nolisten tcp
+          # keeps the display on the local socket only. We wait for the X socket
+          # before launching so it doesn't race a cold display, and fail loudly
+          # (dumping the Xvfb log) if it never comes up, rather than exec-ing
+          # Playwright against a dead display and surfacing an opaque launch error.
+          Xvfb :99 -screen 0 1920x1080x24 -ac -nolisten tcp >/tmp/xvfb.log 2>&1 &
+          export DISPLAY=:99
+          for _ in $(seq 1 50); do
+            [ -S /tmp/.X11-unix/X99 ] && break
+            sleep 0.1
+          done
+          if [ ! -S /tmp/.X11-unix/X99 ]; then
+            echo "::error::Xvfb display :99 never came up after 5s; Xvfb log follows."
+            cat /tmp/xvfb.log || true
+            exit 1
+          fi
+          # Drop to the non-root user for the run itself. setpriv execs in
+          # place (no fork), so a job-cancellation SIGTERM still reaches node
+          # directly and the watchdog's SIGINT->SIGKILL path is preserved --
+          # runuser/su would fork and swallow the signal. --init-groups adopts
+          # the user's groups; the environment is left intact (DISPLAY, PW_*,
+          # PATH, R_LIBS_USER all carry through), and we only override HOME,
+          # since the step's HOME is root-owned and node/Playwright write into
+          # it. Xvfb keeps running as root above; -ac lets the non-root Chromium
+          # attach to :99 without an auth cookie.
+          exec setpriv --reuid=rstudio-tester --regid=rstudio-tester --init-groups \
+            env HOME=/home/rstudio-tester \
+            node scripts/run-with-heartbeat.mjs -- test "${ARGS[@]}"
+
+      # Platform-prefixed artifact name keeps this Rocky 9 x86_64 platform's
+      # shard reports separate from the other platforms' if this workflow is ever
+      # merged into a combined run, so this workflow's own merge job downloads
+      # only its own shards.
+      - name: Upload blob report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-blob-report-linux-desktop-rocky9-x86_64-${{ matrix.shard }}
+          path: e2e/rstudio/blob-report/
+          if-no-files-found: warn
+          retention-days: 1
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-linux-desktop-rocky9-x86_64-${{ matrix.shard }}
+          path: e2e/rstudio/test-results/
+          if-no-files-found: ignore
+
+      # Preserved per-spec sandbox tree on failure: includes rsession logs,
+      # the spec's RStudio config / data home, and per-test working dirs.
+      - name: Upload PW sandbox (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pw-sandbox-linux-desktop-rocky9-x86_64-${{ matrix.shard }}
+          path: ${{ github.workspace }}/pw-sandbox/
+          if-no-files-found: ignore
+
+  # Merge per-shard blob reports into a single HTML report, parse aggregated
+  # counts, and post a sticky PR comment with pass/fail/skip totals
+  # (when post_pr_comment is set). Runs on a plain hosted runner: merging only
+  # needs node plus `playwright merge-reports`, no Rocky container.
+  e2e-merge:
+    needs: [e2e-desktop-rocky9]
+    if: always() && inputs.defer_merge != true && needs.e2e-desktop-rocky9.result != 'skipped' && needs.e2e-desktop-rocky9.result != 'cancelled'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+      # OIDC token for the S3 report upload (os-publish-e2e-report).
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
+
+      - name: Install Playwright
+        working-directory: e2e/rstudio
+        # --ignore-scripts skips the postinstall that downloads browser
+        # binaries; the merge job only invokes `playwright merge-reports`,
+        # which doesn't need Chromium.
+        run: npm ci --ignore-scripts
+
+      - name: Download shard blob reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: playwright-blob-report-linux-desktop-rocky9-x86_64-*
+          path: e2e/rstudio/all-blob-reports
+          merge-multiple: true
+
+      - name: Merge shard reports
+        working-directory: e2e/rstudio
+        run: |
+          if [ -z "$(ls -A all-blob-reports 2>/dev/null)" ]; then
+            echo "::error::No blob reports found, both shards failed to produce artifacts"
+            exit 1
+          fi
+          npx playwright merge-reports --config merge.config.ts ./all-blob-reports
+
+      # Shared summarizer (also used by the PR run's e2e-merge-all job) so every
+      # comment computes pass/fail counts and the rate bar from one definition.
+      - name: Parse aggregated results
+        id: summary
+        if: always()
+        working-directory: e2e/rstudio
+        run: node scripts/summarize-merged-report.mjs playwright-report/test-results.json
+
+      - name: Upload merged Playwright report
+        id: upload-report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-linux-desktop-rocky9-x86_64
+          path: e2e/rstudio/playwright-report/
+          retention-days: 15
+          if-no-files-found: ignore
+
+      # Publish a browsable copy of the report to S3 on failure only, so
+      # reviewers can inspect it without downloading the zip. Best-effort: does
+      # nothing on fork PRs (no secret) and never fails the job.
+      - name: Publish report to S3
+        id: publish-report
+        if: always() && steps.summary.outputs.failed != '0' && steps.summary.outputs.failed != ''
+        uses: ./.github/actions/os-publish-e2e-report
+        with:
+          role-arn: ${{ secrets.AWS_E2E_REPORTS_ROLE_ARN }}
+          label: linux-desktop-rocky9-x86_64
+
+      - name: Post E2E results to PR
+        if: |
+          always() &&
+          inputs.post_pr_comment == true &&
+          github.event.pull_request.head.repo.fork == false &&
+          (steps.summary.outputs.passed != '0' || steps.summary.outputs.failed != '0' || steps.summary.outputs.skipped != '0' || steps.summary.outputs.flaky != '0')
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: e2e-desktop-rocky9-x86_64-results
+          GITHUB_TOKEN: ${{ github.token }}
+          message: |
+            ## ⛰️ Linux Desktop E2E · Rocky 9 (x86_64)
+
+            ${{ needs.e2e-desktop-rocky9.result == 'success' && steps.summary.outputs.failed == '0' && '### ✅ All tests passed!' || format('### ❌ {0} test(s) failed', steps.summary.outputs.failed) }}
+
+            `${{ steps.summary.outputs.bar }}` **${{ steps.summary.outputs.rate }}%** pass rate
+
+            | ✅ Passed | ❌ Failed | ⚠️ Skipped | 🔁 Flaky |
+            | :---: | :---: | :---: | :---: |
+            | **${{ steps.summary.outputs.passed }}** | **${{ steps.summary.outputs.failed }}** | **${{ steps.summary.outputs.skipped }}** | **${{ steps.summary.outputs.flaky }}** |
+
+            <details>
+            <summary>📥 Download Playwright report</summary>
+            ${{ steps.publish-report.outputs.url != '' && format('
+            **[🌐 View report online]({0})**: opens in the browser, no download needed. Available for 14 days.
+            ', steps.publish-report.outputs.url) || '' }}
+            **[⬇️ playwright-report.zip](${{ steps.upload-report.outputs.artifact-url }})**: extract and open `index.html`
+
+            > Includes screenshots, traces, and step-by-step details for every test. Expires in 15 days.
+
+            </details>
+
+            ---
+            <sub>2 shards · rockylinux/rockylinux:9 x86_64 container · commit <code>${{ github.event.pull_request.head.sha }}</code> · <a href="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}">Run #${{ github.run_number }}</a></sub>

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-rocky-9-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-rocky-9-x86_64.yml
@@ -147,7 +147,12 @@ jobs:
       env:
         PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       options: --cap-add=SYS_ADMIN --security-opt seccomp=unconfined
-    timeout-minutes: 120
+    # 150 to match the Rocky 10 engine (near-identical infrastructure and the
+    # same cold-first-build risk): this engine has no seeded main-branch cache
+    # yet, so rstudio-tools / R-libs / GWT all restore-miss and the build
+    # compiles fully cold. Once main has a seeded cache builds are much faster,
+    # but the higher ceiling stays as headroom rather than re-tightening.
+    timeout-minutes: 150
     env:
       # Redirect the dependency / package scripts' tool root to a
       # workspace-local path so it can be cached without sudo.
@@ -550,23 +555,13 @@ jobs:
           echo "sha256=$SHA"        >> "$GITHUB_OUTPUT"
           echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
 
-      # Cache the daily installer keyed on its resolved filename. Filenames
-      # embed the version + build number on the auto-resolve path so the content
-      # is immutable per name: new daily misses and downloads, same-day re-run
-      # hits and skips (SHA still verified below). Skip caching on the override
-      # path -- a user-supplied URL has no immutability guarantee and its SHA
-      # check is skipped, so a reused basename could otherwise serve stale,
-      # unverified bytes.
-      - name: Cache RStudio Desktop installer
-        if: inputs.build_from_source == false && inputs.rstudio_installer_url == ''
-        id: installer-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.resolve.outputs.filename }}
-          key: rstudio-desktop-installer-${{ steps.resolve.outputs.filename }}
-
+      # Downloaded fresh every run rather than cached: dailies.rstudio.com is
+      # already S3/CDN-backed, and GH Actions cache scoping means concurrent
+      # PRs can't share a cache entry with each other anyway (only with their
+      # base branch), so caching here would just duplicate the same bytes
+      # into the shared 10 GB cache quota without saving meaningful time.
       - name: Download RStudio Desktop .rpm
-        if: (inputs.build_from_source == false || inputs.rstudio_installer_url != '') && steps.installer-cache.outputs.cache-hit != 'true'
+        if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
         env:
           DOWNLOAD_URL: ${{ steps.resolve.outputs.url }}
           DOWNLOAD_FILENAME: ${{ steps.resolve.outputs.filename }}

--- a/.github/workflows/os-test-e2e-rstudio-scheduled.yml
+++ b/.github/workflows/os-test-e2e-rstudio-scheduled.yml
@@ -1,10 +1,9 @@
 name: "Test: E2E Playwright RStudio (Scheduled Rotation and Run-All, Open Source)"
 
 # One workflow that drives the reusable per-OS E2E "engines" three ways:
-#   - Weekday cron (Mon-Fri): a fixed slate per weekday (two engines, except
-#     Tuesday's, Wednesday's, and Thursday's three), so every engine runs at
-#     least once a week without running the whole matrix daily.
-#     No weekday pairs two deb-based engines.
+#   - Weekday cron (Mon-Fri): a fixed slate per weekday (two or three engines
+#     per day), so every engine runs at least once a week without running the
+#     whole matrix daily. No weekday pairs two deb-based engines.
 #   - Weekly cron (Sunday): every engine at once, for a full-matrix snapshot.
 #   - Manual dispatch: every engine at once, optionally against a specific daily
 #     build (the "version" input) or built from source (the "build_from_source"
@@ -57,15 +56,15 @@ jobs:
         name: Select engines for this run
         run: |
           # workflow_dispatch and the Sunday cron run every engine; the weekday
-          # cron (Mon-Fri) runs a fixed slate per day (a pair, except Tuesday's,
-          # Wednesday's, and Thursday's three). Each engine runs once a week
-          # except macos26, windows2025, and ubuntu24s, which run twice.
-          ALL='["fedora43","fedora44","ubuntu26","ubuntu24d","ubuntu24s","macos26","windows2025","debian13","rocky10","macos15"]'
+          # cron (Mon-Fri) runs a fixed slate per day (two or three engines).
+          # Each engine runs once a week except macos26, windows2025, and
+          # ubuntu24s, which run twice.
+          ALL='["fedora43","fedora44","ubuntu26","ubuntu24d","ubuntu24s","macos26","windows2025","debian13","rocky10","rocky9","macos15"]'
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event.schedule }}" = "0 8 * * 0" ]; then
             SEL="$ALL"
           else
             case "$(date -u +%u)" in   # %u: 1=Mon .. 7=Sun
-              1) SEL='["ubuntu24d","macos26"]' ;;
+              1) SEL='["ubuntu24d","macos26","rocky9"]' ;;
               2) SEL='["ubuntu24s","windows2025","rocky10"]' ;;
               3) SEL='["ubuntu26","fedora44","macos15"]' ;;
               4) SEL='["fedora43","debian13","windows2025"]' ;;
@@ -84,6 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       rhel:         ${{ steps.resolve.outputs.rhel }}
+      rhel9:        ${{ steps.resolve.outputs.rhel9 }}
       noble_amd64:  ${{ steps.resolve.outputs.noble_amd64 }}
       server_noble: ${{ steps.resolve.outputs.server_noble }}
       macos:        ${{ steps.resolve.outputs.macos }}
@@ -105,6 +105,7 @@ jobs:
           if [ "$BUILD_FROM_SOURCE" = "true" ] || [ -z "$VERSION" ]; then
             {
               echo "rhel="
+              echo "rhel9="
               echo "noble_amd64="
               echo "server_noble="
               echo "macos="
@@ -138,6 +139,7 @@ jobs:
             printf '%s' "$out"
           }
           RHEL=$(emit electron rhel10-x86_64) || exit 1
+          RHEL9=$(emit electron rhel9-x86_64) || exit 1
           NOBLE=$(emit electron noble-amd64) || exit 1
           SERVER=$(emit server noble-amd64) || exit 1
           MAC=$(emit electron macos) || exit 1
@@ -146,6 +148,7 @@ jobs:
           ROCKY=$(emit electron rhel10-arm64) || exit 1
           {
             echo "rhel=$RHEL"
+            echo "rhel9=$RHEL9"
             echo "noble_amd64=$NOBLE"
             echo "server_noble=$SERVER"
             echo "macos=$MAC"
@@ -297,3 +300,19 @@ jobs:
       # RHEL/Rocky 10 arm64 daily .rpm (served from rhel9/arm64 as an
       # aarch64.rpm); the Rocky engine installs the same package.
       rstudio_installer_url: ${{ needs.resolve.outputs.rocky }}
+
+  rocky9:
+    name: Rocky 9 x86_64
+    needs: [pick, resolve]
+    if: ${{ contains(fromJSON(needs.pick.outputs.selected), 'rocky9') }}
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-rocky-9-x86_64.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+      AWS_E2E_REPORTS_ROLE_ARN: ${{ secrets.AWS_E2E_REPORTS_ROLE_ARN }}
+    with:
+      project: desktop
+      r_version: "release"
+      build_from_source: ${{ inputs.build_from_source || false }}
+      # RHEL/Rocky 9 x86_64 daily .rpm; the Rocky 9 engine installs the same
+      # package.
+      rstudio_installer_url: ${{ needs.resolve.outputs.rhel9 }}

--- a/.github/workflows/zz-temp-rocky9-trigger.yml
+++ b/.github/workflows/zz-temp-rocky9-trigger.yml
@@ -1,0 +1,29 @@
+name: "zz-temp Rocky 9 trigger (DELETE before merge)"
+
+# TEMPORARY pre-merge validation trigger for the Rocky 9 x86_64 E2E engine.
+# A brand-new engine that isn't on the default branch yet can't be reached by
+# workflow_dispatch/schedule, but a push trigger runs from the branch's own
+# files. This fires the engine on push to the feature branch so it can be
+# validated pre-merge. DELETE THIS FILE before the PR merges.
+
+on:
+  push:
+    branches:
+      - test/ron/rocky-9-e2e-engine-workflow
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  rocky9:
+    uses: ./.github/workflows/os-test-e2e-rstudio-desktop-os-rocky-9-x86_64.yml
+    secrets:
+      CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+      AWS_E2E_REPORTS_ROLE_ARN: ${{ secrets.AWS_E2E_REPORTS_ROLE_ARN }}
+    with:
+      build_from_source: false
+      project: desktop
+      r_version: "release"
+      test_selector: "smoke/startup.test.ts"

--- a/.github/workflows/zz-temp-rocky9-trigger.yml
+++ b/.github/workflows/zz-temp-rocky9-trigger.yml
@@ -23,7 +23,6 @@ jobs:
       CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
       AWS_E2E_REPORTS_ROLE_ARN: ${{ secrets.AWS_E2E_REPORTS_ROLE_ARN }}
     with:
-      build_from_source: false
+      build_from_source: true
       project: desktop
       r_version: "release"
-      test_selector: "smoke/startup.test.ts"


### PR DESCRIPTION
Adds a Rocky 9 x86_64 desktop E2E Playwright engine and wires it into the scheduled rotation, extending RHEL-family coverage to RHEL/Rocky 9 (the Rocky 10 arm64 engine already covers v10).

The engine is modeled on the Rocky 10 arm64 engine, with these platform differences:
- Runs in a `rockylinux/rockylinux:9` container on `ubuntu-latest` (x86_64).
- Uses Xvfb for the headless display. Unlike RHEL 10, RHEL 9 still ships the X.Org server, so it does not need the Cage/Xwayland setup the v10 engine uses.
- Installs R via rig and pulls R packages as PPM `rhel9` x86_64 binaries.
- Toolchain fallback uses `zlib-devel` (RHEL 9 keeps classic zlib), not the `zlib-ng-compat-devel` the v10 engine needs.
- Installs the `rhel9-x86_64` daily `.rpm` on the download path.

Rocky (a 1:1 RHEL rebuild) is used rather than Red Hat UBI 9 because UBI 9 omits `xorg-x11-server-Xvfb` from all its public repos, the same blocker that keeps the v10 engine off UBI 10 (missing Xwayland).

Rotation wiring: `rocky9` added to the all-engines list and to Monday weekday slate, with a `rhel9` installer-URL resolver output for specific-version dispatches.