### PR TITLE
fix(core): skip FileLogFallsBackToStderrWhenDirectoryNotWritable when…

### DIFF
--- a/src/cpp/core/LoggingTests.cpp
+++ b/src/cpp/core/LoggingTests.cpp
@@ -993,6 +993,12 @@ TEST(LoggingTest, FileLogsAreCreatedWithCorrectPermissions)
 TEST(LoggingTest, FileLogFallsBackToStderrWhenDirectoryNotWritable)
 {
    // https://github.com/rstudio/rstudio/issues/18179
+   // Root bypasses directory write permissions, so the read-only directory below
+   // stays writable and the stderr fallback is never exercised. Some projects run
+   // these unit tests as root; skip there.
+   if (core::system::effectiveUserIsRoot())
+      GTEST_SKIP() << "Root bypasses directory permissions; stderr fallback not exercised";
+
    FilePath tmpPath;
    ASSERT_FALSE(FilePath::tempFilePath(tmpPath));
    ASSERT_FALSE(tmpPath.ensureDirectory());


### PR DESCRIPTION
… run as root

The test makes a log directory read-only (chmod 0500) and asserts that log writes fall back to stderr with a one-time notice. Root bypasses directory permission bits, so the write succeeds, the fallback path is never taken, and the assertions fail. Projects that run these unit tests as root therefore hit a deterministic failure.

Skip the test when the effective user is root, matching the GTEST_SKIP pattern already used for environment-dependent tests in this suite.

<!-- include an entry in NEWS.md if required -->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Ensure you have updated the QA Notes in the original issue.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
