### PR TITLE
Publish Ubuntu 26 (resolute) daily builds via Jammy republish

### DIFF
--- a/jenkins/utils.groovy
+++ b/jenkins/utils.groovy
@@ -170,13 +170,15 @@ def publishToDailiesSite(String packageFile, String destinationPath, String urlP
 def optionalPublishToDailies(String packageFile, String destinationPath, String urlPath = '', String product = '') {
   // Define OS mappings for republishing compatible binaries
   def osRepublishMappings = [
-    'jammy': 'noble',  // Noble and Jammy use the same binaries
-    'rhel9': 'rhel10'  // RHEL 10 and RHEL 9 use the same binaries
+    'jammy': ['noble', 'resolute'],  // Noble and Resolute use the same binaries as Jammy
+    'rhel9': ['rhel10']              // RHEL 10 uses the same binaries as RHEL 9
   ]
-  
+
   def currentOs = env.OS
   if (osRepublishMappings.containsKey(currentOs)) {
-    republishForCompatibleOs(packageFile, destinationPath, urlPath, product, osRepublishMappings[currentOs])
+    osRepublishMappings[currentOs].each { targetOs ->
+      republishForCompatibleOs(packageFile, destinationPath, urlPath, product, targetOs)
+    }
   }
 }
 
@@ -212,7 +214,7 @@ def urlExists(String url) {
  * noarch -> all    on Debian
  */
 def getArchForOs(String os, String arch) {
-  def debianLikeOS = ["focal", "jammy", "noble"]
+  def debianLikeOS = ["focal", "jammy", "noble", "resolute"]
   def isDebianLike = debianLikeOS.contains(os)
 
   if ((arch == "noarch") && isDebianLike) {


### PR DESCRIPTION
## Intent

Start producing and publishing Ubuntu 26.04 (`resolute`) daily builds, following the existing Noble republish pattern.

Ubuntu 26 uses the same binaries as Jammy (same as Noble does today), so no new build target is needed. This republishes the existing Jammy dailies under a `resolute-*` platform path, the same way Jammy is already republished as Noble.

Port of rstudio/rstudio-pro#11937 to OS.

## Approach

`jenkins/utils.groovy`:

- **`optionalPublishToDailies`** — the republish mapping was a 1:1 map (`'jammy': 'noble'`), which can't express a second target for the same source OS. Changed the values to lists (`'jammy': ['noble', 'resolute']`) and loop over them, so Jammy now republishes as both Noble and Resolute. RHEL 9 → RHEL 10 is unchanged in behavior.
- **`getArchForOs`** — added `resolute` to the Debian-like OS list so the arch translation (`x86_64` → `amd64`, `noarch` → `all`) applies to the republished Ubuntu 26 packages.

## Note

The Ubuntu 26.04 short name is assumed to be `resolute`. If Canonical's final short name differs, the mapping value and downstream platform keys need updating.