### PR TITLE
harden help-popup data-preview test against single-result auto-accept

### DIFF
--- a/e2e/rstudio/tests/panes/data-viewer/help_popup_data_preview.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/help_popup_data_preview.test.ts
@@ -19,6 +19,7 @@
 // the fix -- pre-fix this host defaulted show_summary to true and the sidebar
 // was expanded.
 
+import type { Page } from 'playwright';
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { COMPLETION_POPUP } from '@actions/autocomplete.actions';
@@ -28,6 +29,18 @@ import { TIMEOUTS } from '@utils/constants';
 // is unambiguously the help-popup preview.
 const GRID_FRAME = 'iframe[src*="grid_resource/gridviewer.html"]';
 const LIST_NAME = 'list_17735_preview';
+
+// Automation-only override: force the completion popup to render even when a
+// request returns a single result. The list under test has one member (`df`),
+// so completing `<list>$` yields exactly one completion; RCompletionManager
+// auto-accepts a lone result without ever showing the popup, which the
+// Ctrl+Space fallback below would otherwise trigger. Mirrors the convention in
+// autocomplete.actions.ts; no-op on builds that predate the knob.
+async function setAlwaysShowCompletionPopup(page: Page, force: boolean): Promise<void> {
+  await page.evaluate((f) => {
+    window.rstudio?.completions?.setAlwaysShowPopup(f);
+  }, force);
+}
 
 test.describe('Help popup data preview - #17735', () => {
   let consoleActions: ConsolePaneActions;
@@ -50,29 +63,37 @@ test.describe('Help popup data preview - #17735', () => {
     // to the DATAFRAME help path (getHelpDataFrame) that embeds the preview.
     await consoleActions.executeInConsole(`${LIST_NAME} <- list(df = head(mtcars))`, { wait: true });
 
-    // Type up to the `$` and trigger member completion. The selected member's
-    // help (the data preview) renders alongside the completion popup.
-    await consoleActions.typeInConsole(`${LIST_NAME}$`);
-    if (!(await page.locator(COMPLETION_POPUP).isVisible())) {
-      await page.keyboard.press('Control+Space');
+    // Force the popup so the lone `df` completion is listed instead of being
+    // auto-accepted by the Ctrl+Space fallback below (see the helper comment).
+    // Set before typing so the `$` auto-trigger is covered too.
+    await setAlwaysShowCompletionPopup(page, true);
+    try {
+      // Type up to the `$` and trigger member completion. The selected member's
+      // help (the data preview) renders alongside the completion popup.
+      await consoleActions.typeInConsole(`${LIST_NAME}$`);
+      if (!(await page.locator(COMPLETION_POPUP).isVisible())) {
+        await page.keyboard.press('Control+Space');
+      }
+      await expect(page.locator(COMPLETION_POPUP)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+
+      // The preview iframe is the shared grid viewer in server mode (env/obj).
+      const previewFrame = page.frameLocator(GRID_FRAME);
+
+      // Wait for the grid to bootstrap (first data column header). initSidebar
+      // runs during bootstrap, so the sidebar's collapsed/expanded state is
+      // settled once the header is visible.
+      await expect(previewFrame.locator('th[data-col-idx="1"]'))
+        .toBeVisible({ timeout: TIMEOUTS.fileOpen });
+
+      // The fix: the summary sidebar is collapsed in this host.
+      await expect(previewFrame.locator('#sidebarPanel')).not.toHaveClass(/\bexpanded\b/);
+      await expect(previewFrame.locator('#sidebarToggle')).toHaveAttribute('aria-expanded', 'false');
+
+      // Dismiss the completion + help popups.
+      await page.keyboard.press('Escape');
+      await page.keyboard.press('Escape');
+    } finally {
+      await setAlwaysShowCompletionPopup(page, false);
     }
-    await expect(page.locator(COMPLETION_POPUP)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
-
-    // The preview iframe is the shared grid viewer in server mode (env/obj).
-    const previewFrame = page.frameLocator(GRID_FRAME);
-
-    // Wait for the grid to bootstrap (first data column header). initSidebar
-    // runs during bootstrap, so the sidebar's collapsed/expanded state is
-    // settled once the header is visible.
-    await expect(previewFrame.locator('th[data-col-idx="1"]'))
-      .toBeVisible({ timeout: TIMEOUTS.fileOpen });
-
-    // The fix: the summary sidebar is collapsed in this host.
-    await expect(previewFrame.locator('#sidebarPanel')).not.toHaveClass(/\bexpanded\b/);
-    await expect(previewFrame.locator('#sidebarToggle')).toHaveAttribute('aria-expanded', 'false');
-
-    // Dismiss the completion + help popups.
-    await page.keyboard.press('Escape');
-    await page.keyboard.press('Escape');
   });
 });


### PR DESCRIPTION
## Problem

The `help_popup_data_preview.test.ts` e2e test is intermittently failing on loaded CI runners (observed on `macos / e2e-desktop-macos`), timing out at:

```
Error: expect(locator).toBeVisible() failed
  Locator: locator('#rstudio_popup_completions')
  Timeout: 20000ms
```

## Root cause

The test creates a **single-member** list, `list(df = head(mtcars))`, then completes `<list>$` and asserts the completion popup appears. Its trigger races:

```js
await consoleActions.typeInConsole(`${LIST_NAME}$`);
if (!(await page.locator(COMPLETION_POPUP).isVisible())) {  // point-in-time sample
  await page.keyboard.press('Control+Space');               // explicit request
}
```

`Control+Space` routes to `RCompletionManager.codeCompletion()` -> `beginSuggest(..., canAutoInsert=true)`. In `RCompletionManager` a request that returns **exactly one** result with `canAutoAccept_` is **auto-accepted without ever showing the popup** (unless `isCompletionPopupForced()`). Because the list has a single member, the completion is unique:

- **Idle machine:** the `$` auto-trigger popup is already visible when `isVisible()` is sampled, the fallback is skipped, and the popup stays up -> passes.
- **Loaded runner:** the `$` popup has not rendered yet at sample time, the fallback `Control+Space` fires, the lone `df` is auto-accepted, and the popup never appears -> 20s timeout on both the attempt and the retry.

The sibling helpers in `autocomplete.actions.ts` already guard against this with `setAlwaysShowPopup(true)`; this test never adopted the convention.

## Fix

Force the completion popup via the automation-only `window.rstudio.completions.setAlwaysShowPopup` override **before** triggering completion (wrapped in `try/finally` to restore it). This defeats the single-result auto-accept, so the popup renders deterministically regardless of runner load, timing, or member count. Mirrors the existing `autocomplete.actions.ts` pattern; no-op on builds predating the knob.

`npm run typecheck` passes.
