### PR TITLE
Add @chat tag for selecting the Posit Assistant e2e tests

### DIFF
--- a/e2e/rstudio/README.md
+++ b/e2e/rstudio/README.md
@@ -491,10 +491,6 @@ npx playwright test --grep-invert @ai
 npx playwright test --grep @chat
 ```
 
-The auth setup project needs no tag of its own: Playwright does not apply
-`--grep` to a project's dependencies, so `--grep @chat` still runs
-`auth.setup.ts` and the Assistant tests start with credentials in place.
-
 You can also exclude tests by file path with `PW_TEST_IGNORE` (whitespace-separated globs):
 
 ```bash

--- a/e2e/rstudio/README.md
+++ b/e2e/rstudio/README.md
@@ -451,6 +451,7 @@ test('specific test', { tag: ['@macos_only'] }, async ({ rstudioPage: page }) =>
 | `@pro_only` | Test requires RStudio Pro |
 | `@os_only` | Test only applies to open-source RStudio |
 | `@ai` | Test exercises an AI feature (Copilot ghost text / NES, Posit Assistant chat). Useful for skipping AI-dependent suites in offline or no-credential runs. |
+| `@chat` | Test covers the Posit Assistant chat pane (everything under `tests/panes/posit-assistant-chat/`). A narrower selector than `@ai`: use it to run the Assistant suite without the Copilot/NES code-suggestion tests. Most `@chat` tests are also `@ai`; the exception is `chat-guardrails-paths.test.ts`, which exercises the guardrails from the R console with no AI provider in the loop. |
 | `@smoke` | Long, low-information liveness check. Excluded by default (redundant alongside the full suite); opt in with `PW_RUN_SMOKE=1`. |
 
 ### Filtering by Tag
@@ -485,7 +486,14 @@ npx playwright test --grep-invert "@pro_only|@server_only"
 
 # Skip AI-dependent tests (Copilot/NES + Posit Assistant chat)
 npx playwright test --grep-invert @ai
+
+# Run only the Posit Assistant chat tests (skips Copilot/NES)
+npx playwright test --grep @chat
 ```
+
+The auth setup project needs no tag of its own: Playwright does not apply
+`--grep` to a project's dependencies, so `--grep @chat` still runs
+`auth.setup.ts` and the Assistant tests start with credentials in place.
 
 You can also exclude tests by file path with `PW_TEST_IGNORE` (whitespace-separated globs):
 

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails-paths.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails-paths.test.ts
@@ -7,6 +7,10 @@
  * read/write path can be covered deterministically. The R-side mechanism
  * is the same; this just removes the assistant from the loop.
  *
+ * That is also why this file is tagged @chat but not @ai: it is part of the
+ * Posit Assistant feature area, but it drives no AI provider and needs no
+ * credentials, so it still runs under --grep-invert @ai.
+ *
  * Tests are grouped by category (read denials, read allows, write
  * denials, write allows, connection denials, error message structure,
  * system file denials, path traversal).
@@ -52,7 +56,7 @@ const GUARDRAILS_MARKER_RE = /__GUARDRAILS_[\d.]+_\d+__/;
 // stop()ed). Sentinel is printed by the error branch.
 const GUARDRAILS_ERR_RE = /__ERR__\s+__GUARDRAILS_[\d.]+_\d+__/;
 
-test.describe.serial('Filesystem Guardrails: paths (#17122)', { tag: ['@serial'] }, () => {
+test.describe.serial('Filesystem Guardrails: paths (#17122)', { tag: ['@chat', '@serial'] }, () => {
   const sandbox = useSuiteSandbox();
   let consoleActions: ConsolePaneActions;
   // Forward-slash sandbox path for safe interpolation into R double-quoted strings.

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails.test.ts
@@ -41,7 +41,7 @@ const OUTSIDE_FILE = `guardrail_outside_${TS}.txt`;
 const RENAME_SRC = `guardrail_rename_${TS}.txt`;
 const READ_FILE = `guardrail_read_${TS}.R`;
 
-test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@serial'] }, () => {
+test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@chat', '@serial'] }, () => {
   requireAiCredentials(test, 'positai');
 
   const sandbox = useSuiteSandbox();

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-messaging.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-messaging.test.ts
@@ -5,7 +5,7 @@ import { ChatPane } from '@pages/chat_pane.page';
 import type { EnvironmentVersions } from '@pages/console_pane.page';
 import { setupPositAssistantChat, annotateVersions } from './_chat-setup';
 
-test.describe.serial('Chat Messaging', { tag: ['@ai'] }, () => {
+test.describe.serial('Chat Messaging', { tag: ['@ai', '@chat'] }, () => {
   requireAiCredentials(test, 'positai');
 
   let chatPane: ChatPane;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-pane-persistence.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-pane-persistence.test.ts
@@ -27,7 +27,7 @@ async function ensureChatPaneVisible(page: Page, chatActions: ChatPaneActions): 
   await sleep(2000);
 }
 
-test.describe.serial('Chat pane persistence', { tag: ['@ai'] }, () => {
+test.describe.serial('Chat pane persistence', { tag: ['@ai', '@chat'] }, () => {
   requireAiCredentials(test, 'positai');
 
   let consoleActions: ConsolePaneActions;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-satellite-commands.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-satellite-commands.test.ts
@@ -12,7 +12,7 @@ const RETURN_TO_MAIN_BTN = '#rstudio_chat_return_to_main_button';
 // Satellite pop-out on Server hits the Chrome window.open() reload path,
 // which is a separate concern from the command wiring this test covers.
 // detachable-sidebar.test.ts is @desktop_only for the same reason.
-test.describe.serial('Chat satellite -- commands', { tag: ['@ai', '@desktop_only'] }, () => {
+test.describe.serial('Chat satellite -- commands', { tag: ['@ai', '@chat', '@desktop_only'] }, () => {
   requireAiCredentials(test, 'positai');
 
   let consoleActions: ConsolePaneActions;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
@@ -84,7 +84,7 @@ async function createSkillFile(
 // Tests
 // ---------------------------------------------------------------------------
 
-test.describe.serial('User-Added Skills', { tag: ['@ai', '@serial'] }, () => {
+test.describe.serial('User-Added Skills', { tag: ['@ai', '@chat', '@serial'] }, () => {
   requireAiCredentials(test, 'positai');
 
   const sandbox = useSuiteSandbox();

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-websocket-url.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-websocket-url.test.ts
@@ -8,7 +8,7 @@ import type { EnvironmentVersions } from '@pages/console_pane.page';
 import type { Response } from 'playwright';
 import { createChatActions, annotateVersions } from './_chat-setup';
 
-test.describe('Chat WebSocket URL', { tag: ['@ai'] }, () => {
+test.describe('Chat WebSocket URL', { tag: ['@ai', '@chat'] }, () => {
   requireAiCredentials(test, 'positai');
 
   let consoleActions: ConsolePaneActions;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/check-for-updates-command.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/check-for-updates-command.test.ts
@@ -54,7 +54,7 @@ const DEFAULT_CHECK_RESPONSE = {
   isInitialInstall: false,
 };
 
-test.describe.serial('Check for Posit Assistant updates -- #18253', { tag: ['@ai', '@serial'] }, () => {
+test.describe.serial('Check for Posit Assistant updates -- #18253', { tag: ['@ai', '@chat', '@serial'] }, () => {
   requireAiCredentials(test, 'positai');
 
   let versions: EnvironmentVersions;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/conversation-history.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/conversation-history.test.ts
@@ -5,7 +5,7 @@ import { ChatPane } from '@pages/chat_pane.page';
 import type { EnvironmentVersions } from '@pages/console_pane.page';
 import { setupPositAssistantChat, annotateVersions } from './_chat-setup';
 
-test.describe.serial('Conversation History', { tag: ['@ai'] }, () => {
+test.describe.serial('Conversation History', { tag: ['@ai', '@chat'] }, () => {
   requireAiCredentials(test, 'positai');
 
   let chatPane: ChatPane;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/deprecate-pai-blocking.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/deprecate-pai-blocking.test.ts
@@ -58,7 +58,7 @@ const DEFAULT_CHECK_RESPONSE = {
 // Tests
 // ---------------------------------------------------------------------------
 
-test.describe.serial('Deprecate old Posit AI builds -- #17145', { tag: ['@ai', '@serial'] }, () => {
+test.describe.serial('Deprecate old Posit AI builds -- #17145', { tag: ['@ai', '@chat', '@serial'] }, () => {
   requireAiCredentials(test, 'positai');
 
   let consoleActions: ConsolePaneActions;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/detachable-sidebar.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/detachable-sidebar.test.ts
@@ -10,7 +10,7 @@ import { setupPositAssistantChat, annotateVersions } from './_chat-setup';
 // Return button in satellite window (has explicit ElementIds assignment)
 const RETURN_TO_MAIN_BTN = '#rstudio_chat_return_to_main_button';
 
-test.describe.serial('Detachable Assistant Sidebar - #16937', { tag: ['@ai', '@desktop_only'] }, () => {
+test.describe.serial('Detachable Assistant Sidebar - #16937', { tag: ['@ai', '@chat', '@desktop_only'] }, () => {
   requireAiCredentials(test, 'positai');
 
   let chatPane: ChatPane;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/enable-assistant.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/enable-assistant.test.ts
@@ -8,7 +8,7 @@ import type { EnvironmentVersions } from '@pages/console_pane.page';
 import { executeCommand } from '@utils/commands';
 import { createChatActions, annotateVersions } from './_chat-setup';
 
-test.describe.serial('Enable Posit Assistant', { tag: ['@ai'] }, () => {
+test.describe.serial('Enable Posit Assistant', { tag: ['@ai', '@chat'] }, () => {
   requireAiCredentials(test, 'positai');
 
   let consoleActions: ConsolePaneActions;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/open-chat-pane.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/open-chat-pane.test.ts
@@ -8,7 +8,7 @@ import type { EnvironmentVersions } from '@pages/console_pane.page';
 import { executeCommand } from '@utils/commands';
 import { createChatActions, annotateVersions } from './_chat-setup';
 
-test.describe('Open Chat Pane', { tag: ['@ai'] }, () => {
+test.describe('Open Chat Pane', { tag: ['@ai', '@chat'] }, () => {
   requireAiCredentials(test, 'positai');
 
   let consoleActions: ConsolePaneActions;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/plots-pane-activation.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/plots-pane-activation.test.ts
@@ -36,7 +36,7 @@ async function isPlotsTabSelected(page: Page): Promise<boolean> {
   return (await page.locator(PLOTS_TAB).getAttribute('aria-selected')) === 'true';
 }
 
-test.describe.serial('Posit Assistant activates the Plots pane', { tag: ['@ai'] }, () => {
+test.describe.serial('Posit Assistant activates the Plots pane', { tag: ['@ai', '@chat'] }, () => {
   requireAiCredentials(test, 'positai');
 
   let chatPane: ChatPane;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/readline-notification.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/readline-notification.test.ts
@@ -10,7 +10,7 @@ import { setupPositAssistantChat, annotateVersions } from './_chat-setup';
 //   https://github.com/rstudio/rstudio/issues/17172
 //   https://github.com/rstudio/rstudio/issues/16957
 
-test.describe.serial('Readline Notification in Chat Pane', { tag: ['@ai', '@serial'] }, () => {
+test.describe.serial('Readline Notification in Chat Pane', { tag: ['@ai', '@chat', '@serial'] }, () => {
   requireAiCredentials(test, 'positai');
 
   let chatPane: ChatPane;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/settings-button.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/settings-button.test.ts
@@ -5,7 +5,7 @@ import { ChatPane } from '@pages/chat_pane.page';
 import type { EnvironmentVersions } from '@pages/console_pane.page';
 import { setupPositAssistantChat, annotateVersions } from './_chat-setup';
 
-test.describe.serial('Settings Button', { tag: ['@ai'] }, () => {
+test.describe.serial('Settings Button', { tag: ['@ai', '@chat'] }, () => {
   requireAiCredentials(test, 'positai');
 
   let chatPane: ChatPane;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
@@ -9,7 +9,7 @@ import type { EnvironmentVersions } from '@pages/console_pane.page';
 import { executeCommand, setPref } from '@utils/commands';
 import { createChatActions, annotateVersions } from './_chat-setup';
 
-test.describe.serial('R Shiny Tip Calculator via Posit Assistant', { tag: ['@ai'] }, () => {
+test.describe.serial('R Shiny Tip Calculator via Posit Assistant', { tag: ['@ai', '@chat'] }, () => {
   requireAiCredentials(test, 'positai');
 
   let chatPane: ChatPane;

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/uninstall-posit-ai.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/uninstall-posit-ai.test.ts
@@ -51,7 +51,7 @@ async function invokeUninstallViaPalette(page: Page): Promise<void> {
   await sleep(500);
 }
 
-base.describe.serial('Uninstall Posit Assistant - #17322', { tag: ['@ai', '@serial', '@desktop_only'] }, () => {
+base.describe.serial('Uninstall Posit Assistant - #17322', { tag: ['@ai', '@chat', '@serial', '@desktop_only'] }, () => {
   requireAiCredentials(base, 'positai');
 
   let session: DesktopSession;


### PR DESCRIPTION
### Intent

The `@ai` tag selects both the Posit Assistant chat suites and the Copilot / Posit AI code-suggestion suites (ghost text, NES). There was no way to run just the Assistant tests. This adds a `@chat` tag for that.

```bash
npx playwright test --grep @chat
```

No associated GitHub issue -- this is test-tooling only.

### Approach

Every suite under `e2e/rstudio/tests/panes/posit-assistant-chat/` is tagged `@chat`:

- The 17 suites that already carried `@ai` keep it and gain `@chat`, so `--grep @ai` selects exactly what it did before.
- `chat-guardrails-paths.test.ts` gets `@chat` only. It drives the guardrails through `.rs.chat.withGuardrails` from the R console with no AI provider in the loop, so it needs no credentials and must keep running under `--grep-invert @ai`. A note in its header docstring records that, so the missing `@ai` doesn't read as an oversight.

No change to `playwright.config.ts`: `@chat` is a selection tag, not an exclusion, so nothing goes into either project's `grepInvert`. No change to `tests/auth.setup.ts` either -- Playwright does not apply `--grep` to a project's dependencies, so the setup project still runs and provisions credentials under `--grep @chat`.

The CI workflows already forward a `grep` `workflow_dispatch` input to `--grep`, so `@chat` works there with no workflow changes.

`shiny-app-python.draft.ts` is left untagged: it is a `.draft.ts` wrapping a `describe.skip`, so it is never collected and a tag on it would be inert.

### Automated Tests

This change is entirely test metadata. Verified by test selection:

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `--grep @chat` | 80 tests / 19 files (78 plus the 2 setup tests) |
| chat files selected by `@chat` | 18 of 18 |
| `code_suggestions` + `edit_suggestions` under `@chat` | 0 |
| `--grep @ai` | 78 tests / 20 files, unchanged |
| `--grep-invert @ai` | still runs `chat-guardrails-paths.test.ts` (31 tests) |
| setup project under `--grep @chat` | both auth tests present |

### QA Notes

None. No product code is touched.

### Documentation

`e2e/rstudio/README.md`: a `@chat` row in the Available Tags table and a `--grep @chat` example in the Filtering by Tag section.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` -- N/A, test tooling only, no user-facing change
- [x] If this PR adds or changes UI, the updated UI meets accessibility standards -- N/A, no UI change
- [ ] A reviewer is assigned to this PR
- [x] This PR passes all local unit tests