### PR TITLE
e2e: match RStudio PIDs case-insensitively on macOS

### DIFF
--- a/e2e/rstudio/fixtures/desktop.fixture.ts
+++ b/e2e/rstudio/fixtures/desktop.fixture.ts
@@ -770,7 +770,15 @@ export async function relaunchAfterRestart(session: DesktopSession): Promise<Des
   return launchRStudio(configRoot);
 }
 
-/** Get all RStudio PIDs currently running. */
+/**
+ * Get all RStudio PIDs currently running.
+ *
+ * Matched case-insensitively (-i): the executable is `RStudio` on macOS but
+ * `rstudio` on Linux, and a case-sensitive `pgrep -x rstudio` silently matched
+ * nothing on macOS -- the `|| true` turns pgrep's no-match exit 1 into empty
+ * output, so relaunchAfterRestart saw an empty before/after diff and left the
+ * post-restart instance running for the rest of the run.
+ */
 function getRStudioPids(): Set<number> {
   try {
     if (process.platform === 'win32') {
@@ -780,7 +788,7 @@ function getRStudioPids(): Set<number> {
       ).trim();
       return new Set(output ? output.split(',').map(Number) : []);
     } else {
-      const output = execSync('pgrep -x rstudio 2>/dev/null || true', { encoding: 'utf-8' }).trim();
+      const output = execSync('pgrep -ix rstudio 2>/dev/null || true', { encoding: 'utf-8' }).trim();
       return new Set(output ? output.split('\n').map(Number).filter(n => Number.isInteger(n) && n > 0) : []);
     }
   } catch (err) {


### PR DESCRIPTION
## Problem

Running the `@ai` e2e suite on macOS left an orphaned RStudio instance running after the run finished, showing "Posit Assistant not installed" in the chat pane.

`getRStudioPids()` ran `pgrep -x rstudio`, which is case-sensitive. The macOS executable is `/Applications/RStudio.app/Contents/MacOS/RStudio`, so the pattern never matched. The trailing `|| true` turned pgrep's no-match exit 1 into empty output, so the miss was silent — no warning, just an empty set.

`relaunchAfterRestart()` kills the post-restart instance by diffing RStudio PIDs before and after the restart. With both snapshots empty, it killed nothing and logged `New PIDs to kill: none`.

Nothing else caught the orphan. It is spawned by `ApplicationLaunch.launchRStudio` as a detached, `unref`'d process with no `--remote-debugging-port`, so the CDP port cleanup in `launchRStudioOnce`, the `process-reaper` backstop (which only tracks processes the fixture spawned), and `shutdownRStudio` (which only touches `session.rstudioProcess`) all miss it by design.

The orphan inherits the sandbox `RSTUDIO_CONFIG_ROOT` / `RSTUDIO_DATA_HOME` whose `pai` tree `uninstall-posit-ai.test.ts` had just deleted, which is why it renders the "not installed" state. That spec is the last `@ai` file to run under `workers: 1`, so the instance was left over at the end of every run.

Windows was unaffected (`Get-Process` is case-insensitive) and Linux was unaffected (`/usr/bin/rstudio` is already lowercase).

## Change

`pgrep -x rstudio` → `pgrep -ix rstudio`, with a comment recording why the `-i` matters.

## Testing

`npm run test:desktop -- --grep @ai` on macOS: all tests pass and no RStudio instance is left running afterward. `npm run typecheck` passes.

## Note

No NEWS.md entry — this changes e2e test infrastructure only, with no user-facing effect.