### PR TITLE
fix macOS 15 x86_64 GWT cache path and harden the seed sentinel

### DIFF
--- a/.github/workflows/os-cache-seed-sentinel.yml
+++ b/.github/workflows/os-cache-seed-sentinel.yml
@@ -112,24 +112,55 @@ jobs:
             CONCLUSION="${RUN%% *}"
             RUN_URL="${RUN#* }"
 
+            TITLE="cache seed workflow failing: $SEED"
+            ISSUE=$(gh issue list --state open --search "\"$TITLE\" in:title" --json number --jq '.[0].number // empty')
+
             # No completed runs yet (new seed) counts as healthy.
-            if [ -z "$CONCLUSION" ] || [ "$CONCLUSION" = "success" ] || [ "$CONCLUSION" = "null" ]; then
+            if [ -z "$CONCLUSION" ] || [ "$CONCLUSION" = "null" ]; then
+              continue
+            fi
+
+            # Recovered: retire the alert from the earlier failure, so a
+            # transient flake doesn't leave an issue for someone to close by
+            # hand (and doesn't suppress alerting on the next real breakage).
+            if [ "$CONCLUSION" = "success" ]; then
+              if [ -n "$ISSUE" ]; then
+                echo "Seed $SEED recovered; closing #$ISSUE"
+                COMMENT=$(printf '%s\n\n%s' \
+                  "The latest completed run of \`$SEED\` succeeded: $RUN_URL" \
+                  "(Closed automatically by the cache-seed sentinel.)")
+                gh issue close "$ISSUE" --reason completed --comment "$COMMENT" || FAILED=1
+              fi
               continue
             fi
             echo "Seed $SEED latest completed run: $CONCLUSION"
 
             # One open issue per seed; skip if the previous alert is still open.
-            TITLE="cache seed workflow failing: $SEED"
-            EXISTING=$(gh issue list --state open --search "\"$TITLE\" in:title" --json number --jq 'length')
-            if [ "$EXISTING" -gt 0 ]; then
-              echo "Alert issue already open for $SEED"
+            if [ -n "$ISSUE" ]; then
+              echo "Alert issue already open for $SEED (#$ISSUE)"
+              continue
+            fi
+
+            # A failing conclusion is stale the moment a newer run is queued or
+            # running -- including one this job dispatched above, since that
+            # dispatch happens before this check. Let the retry settle before
+            # calling the seed broken; transient infrastructure faults (DNS,
+            # runner loss) clear on their own and would otherwise file an issue
+            # that is already obsolete when it is opened.
+            PENDING=0
+            for STATUS in queued in_progress; do
+              N=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$SEED/runs?status=$STATUS&per_page=1" --jq .total_count)
+              PENDING=$((PENDING + N))
+            done
+            if [ "$PENDING" -gt 0 ]; then
+              echo "Seed $SEED has a newer run in flight; deferring alert."
               continue
             fi
 
             BODY=$(printf '%s\n\n%s\n\n%s' \
               "The latest completed run of \`$SEED\` finished with conclusion \`$CONCLUSION\`: $RUN_URL" \
               "Until this seed succeeds again, its build caches on main can go stale or evicted, and PR builds for that platform run cold." \
-              "(Opened automatically by the cache-seed sentinel; it skips re-alerting while this issue stays open.)")
+              "(Opened automatically by the cache-seed sentinel; it skips re-alerting while this issue stays open, and closes it once the seed succeeds again.)")
             gh issue create --title "$TITLE" --body "$BODY" || FAILED=1
           done
 

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-15-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-15-x86_64.yml
@@ -169,7 +169,12 @@ jobs:
           restore-keys: |
             rstudio-build-rlibs-x86_64-
 
-      # Cache compiled GWT output (package/osx/build-x86_64/gwt/{bin,www,extras}).
+      # Cache compiled GWT output (package/osx/build/gwt/{bin,www,extras}).
+      # NB: the x86_64 build directory is plain "build", not "build-x86_64" --
+      # make-package only suffixes the arm64 one (BUILD_DIR_X86_64/ARM64 in
+      # package/osx/make-package). Pointing this at build-x86_64 silently
+      # disables the cache: the save step no-ops with a path-validation
+      # warning, so the key never lands and every run recompiles GWT.
       # GWT compilation is the single most expensive JS step (~15-30 min). When
       # GWT Java sources / build scripts haven't changed, cmake skips
       # recompilation via --build-gwt=0 and uses the cached output directly.
@@ -180,7 +185,7 @@ jobs:
         id: gwt-cache
         uses: actions/cache/restore@v4
         with:
-          path: package/osx/build-x86_64/gwt
+          path: package/osx/build/gwt
           key: rstudio-gwt-x86_64-${{ env.GWT_STYLE }}-v2-${{ hashFiles('src/gwt/src/**', 'src/gwt/acesupport/**', 'src/gwt/lib/**', 'src/gwt/build.xml', 'src/gwt/conf/**') }}
           restore-keys: |
             rstudio-gwt-x86_64-${{ env.GWT_STYLE }}-v2-
@@ -292,7 +297,7 @@ jobs:
         if: github.ref == 'refs/heads/main' && steps.build.conclusion == 'success' && steps.gwt-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: package/osx/build-x86_64/gwt
+          path: package/osx/build/gwt
           key: ${{ steps.gwt-cache.outputs.cache-primary-key }}
 
       # tar (not zip) to preserve symlinks and executable permissions in the


### PR DESCRIPTION
### Intent

The cache-seed sentinel has been alerting on `os-cache-seed-e2e-macos-15-x86_64.yml` (#18359, #18373). Investigating #18373 turned up a transient DNS flake on top of a real, long-standing bug: **the macOS 15 x86_64 GWT cache has never once been saved.**

### The bug

`os-test-e2e-rstudio-desktop-os-macos-15-x86_64.yml` caches `package/osx/build-x86_64/gwt` (restore and save). But `package/osx/make-package:162` only suffixes the arm64 directory:

```sh
BUILD_DIR_X86_64="${PKG_DIR}/build"
BUILD_DIR_ARM64="${PKG_DIR}/build-arm64"
```

x86_64 builds into plain `package/osx/build`. The path looks copied from the arm64 workflow, where `build-arm64` is correct, and has been wrong since the workflow landed in #18324 — #18362 didn't touch it.

Every run of the seed shows the full cycle, even when it succeeds ([run 30313084528](https://github.com/rstudio/rstudio/actions/runs/30313084528)):

- `Cache not found for input keys: rstudio-gwt-x86_64-PRETTY-v2-...`
- GWT compiles into `.../package/osx/build/gwt/bin`
- `Path Validation Error: Path(s) specified in the action for caching do(es) not exist` → `Cache save failed.`

### Why it mattered

Because `rstudio-gwt-x86_64-` can never exist on main, the sentinel found it "evicted" on every 2-hourly cycle and dispatched another ~20-minute macOS build that again failed to save it. I confirmed `Evicted from main: rstudio-gwt-x86_64-` → `Dispatching` across four consecutive cycles; there were 12 dispatches on 2026-07-27 alone, on runners that bill at 10x. Repo cache usage sits at 9.79 GiB of the 10 GB quota, so the churn also pressured every other platform's caches. Separately, every macOS 15 x86_64 PR build paid the full GWT compile.

### Changes

1. **Path fix** — point the GWT restore/save at `package/osx/build/gwt`, with a comment recording why x86_64 differs from arm64. No key rotation needed; nothing was ever stored under the `-v2-` key.

2. **Sentinel hardening** (`os-cache-seed-sentinel.yml`) — #18373 was filed for a run that had already been superseded. The dispatch loop runs before the alert check, so the sentinel read a stale conclusion for a seed it had re-dispatched three seconds earlier:
   - Defer the alert while a newer run for that seed is `queued` or `in_progress`.
   - Close the alert issue once the seed's latest completed run succeeds, instead of only suppressing re-alerts while it stays open (both prior alerts needed closing by hand).

### Verification

- Both workflows parse as YAML; the sentinel's `run:` script passes `bash -n`.
- Drove the rewritten alert loop against a mock `gh` across all five branches — recovered-with-open-issue (closes), failure-with-retry-in-flight (defers), failure-with-nothing-in-flight (alerts), failure-with-issue-already-open (skips), and healthy (silent).
- The path fix needs a live seed run on main to confirm the save lands and `rstudio-gwt-x86_64-` appears in main's scope. Worth watching the first post-merge run.

### Note

Auto-closing is a slight behavior change: a genuinely flaky seed will now open and close issues repeatedly rather than holding one open. That seemed better than the current state, where every transient failure leaves manual cleanup, but happy to drop that half if you'd rather the alerts stay sticky.

Addresses #18373