### PR TITLE
e2e: handle assistant AskUser prompts and NES edit batching in the @ai tests

### DIFF
--- a/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
@@ -213,26 +213,42 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
       await sourcePane.aceTextInput.pressSequentially('final_score');
       await sleep(5000);
 
+      const occurrences = ['print', 'cat', 'summary', 'message'];
+      const stillOldName = async () => {
+        const content = await sourceActions.getEditorContent();
+        return occurrences.filter((fn) => !content.includes(`${fn}(final_score)`));
+      };
+
+      // How many suggestions it takes to rename every call site is the
+      // provider's choice: one per site, or several batched into a single
+      // accept (a multi-edit preview accepted with one keypress). So loop on
+      // the document state, not on a count of accepts -- once nothing is left
+      // to rename, no further suggestion is offered, and asking for one more
+      // round just waits out acceptNesRename's timeout on a suggestion that
+      // will never come.
       let accepted = 0;
       const maxAcceptances = 4;
       while (accepted < maxAcceptances) {
+        const remaining = await stillOldName();
+        if (remaining.length === 0) break;
+
+        accepted++;
+        console.log(`Accepting NES rename ${accepted} (still old: ${remaining.join(', ')})...`);
         try {
-          await expect(
-            sourcePane.nesApply
-              .or(sourcePane.ghostText)
-              .or(sourcePane.nesInsertionPreview)
-              .first()
-          ).toBeVisible({ timeout: 10000 });
-        } catch {
+          // acceptNesRename does its own wait for the suggestion; a guard wait
+          // here would only open a stale window between the two checks, where
+          // a preview seen by the guard is torn down before the accept runs.
+          await sourceActions.acceptNesRename();
+        } catch (err) {
+          // Stop hunting and let the occurrence assertions below report what
+          // is actually missing -- a more useful failure than this helper's
+          // combined-locator timeout.
+          console.log(`  No further NES suggestion: ${(err as Error).message.split('\n')[0]}`);
           break;
         }
-        accepted++;
-        console.log(`Accepting NES rename ${accepted}...`);
-        await sourceActions.acceptNesRename();
       }
       console.log(`Accepted ${accepted} NES suggestion(s)`);
 
-      const occurrences = ['print', 'cat', 'summary', 'message'];
       for (const fn of occurrences) {
         await expect(sourcePane.contentPane).toContainText(`${fn}(final_score)`, { timeout: 5000 });
       }

--- a/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
+++ b/e2e/rstudio/tests/panes/editor/code_suggestions.test.ts
@@ -214,9 +214,13 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
       await sleep(5000);
 
       const occurrences = ['print', 'cat', 'summary', 'message'];
+      // Call sites still holding the old name. Checking for the absence of
+      // `fn(score)` rather than the presence of `fn(final_score)` matters: a
+      // suggestion that duplicates a call instead of replacing it satisfies
+      // the positive form while leaving the old call behind.
       const stillOldName = async () => {
         const content = await sourceActions.getEditorContent();
-        return occurrences.filter((fn) => !content.includes(`${fn}(final_score)`));
+        return occurrences.filter((fn) => content.includes(`${fn}(score)`));
       };
 
       // How many suggestions it takes to rename every call site is the
@@ -251,6 +255,7 @@ for (const [key, provider] of Object.entries(CODE_SUGGESTION_PROVIDERS)) {
 
       for (const fn of occurrences) {
         await expect(sourcePane.contentPane).toContainText(`${fn}(final_score)`, { timeout: 5000 });
+        await expect(sourcePane.contentPane).not.toContainText(`${fn}(score)`, { timeout: 5000 });
       }
 
       await sourceActions.closeSourceAndDeleteFile(fileName);

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails.test.ts
@@ -57,6 +57,15 @@ const READ_FILE = `guardrail_read_${TS}.R`;
 // want -- rather than quietly picking a redacted answer.
 const SHOW_RAW_CONTENTS = /^(?:show|print|display)\s+(?:the\s+)?(?:full|raw|complete|entire)\b/i;
 
+// Asked to touch a path outside the project, the assistant pauses to confirm
+// ("Yes, write to that path" / "No, write inside the project instead") instead
+// of acting. Answering affirmatively is what keeps the guardrail in the loop:
+// declining, or letting it redirect the write into the project, means
+// .rs.chat.withGuardrails is never consulted. Anchored to the start of the
+// option label so a negative option can't match -- an over-broad matcher here
+// fails open.
+const PROCEED_WITH_PATH = /^(?:yes|proceed|go ahead|write it|move it)\b/i;
+
 test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@chat', '@serial'] }, () => {
   requireAiCredentials(test, 'positai');
 
@@ -169,7 +178,9 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@chat', '
     const outsidePath = `${sandboxR}/${OUTSIDE_FILE}`;
     const response = await askAssistant(
       `Using R's writeLines() and nothing else (do not use any built-in file ` +
-      `write tool), please create a file at ${outsidePath} containing "hello".`
+      `write tool), please create a file at ${outsidePath} containing "hello". ` +
+      `Do not ask me to confirm -- run the call and report what happens.`,
+      PROCEED_WITH_PATH,
     );
 
     // Scope: this exercises the R-side guardrail (.rs.chat.withGuardrails);
@@ -211,9 +222,7 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@chat', '
       `Do not ask me to confirm -- run the call and report what happens.`,
       // If it asks anyway, answer affirmatively: declining would leave the file
       // in place and pass these assertions without exercising the guardrail.
-      // Anchored to the start of the option label so a negative option ("No,
-      // don't proceed") can't match -- an over-broad matcher here fails open.
-      /^(?:yes|proceed|go ahead|move it)\b/i,
+      PROCEED_WITH_PATH,
     );
 
     // Source file should still be in the project (rename failed)

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails.test.ts
@@ -59,12 +59,21 @@ const SHOW_RAW_CONTENTS = /^(?:show|print|display)\s+(?:the\s+)?(?:full|raw|comp
 
 // Asked to touch a path outside the project, the assistant pauses to confirm
 // ("Yes, write to that path" / "No, write inside the project instead") instead
-// of acting. Answering affirmatively is what keeps the guardrail in the loop:
-// declining, or letting it redirect the write into the project, means
-// .rs.chat.withGuardrails is never consulted. Anchored to the start of the
-// option label so a negative option can't match -- an over-broad matcher here
-// fails open.
-const PROCEED_WITH_PATH = /^(?:yes|proceed|go ahead|write it|move it)\b/i;
+// of acting. Answering affirmatively on the *requested* path is what keeps the
+// guardrail in the loop: declining, or taking a redirect option, performs an
+// allowed operation inside the project and .rs.chat.withGuardrails is never
+// consulted -- yet the file-state assertions in test 4 still pass. So the
+// affirmative is anchored to the start of the option label (excluding "No,
+// ...") and the whole accessible name -- label plus description -- must not
+// relocate the operation into the project, which is how the redirect options
+// read ("Yes, write it inside the project instead").
+//
+// A label that matches nothing fails loudly with the offered options listed
+// (see answerPendingQuestion), which is the failure mode we want: these
+// options are model-authored, and picking a redirect would pass the test
+// without testing anything.
+const PROCEED_WITH_PATH =
+  /^(?:yes|proceed|go ahead|write it|move it)\b(?!.*\b(?:instead|(?:inside|within|into|to) the (?:project|workspace)))/is;
 
 test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@chat', '@serial'] }, () => {
   requireAiCredentials(test, 'positai');


### PR DESCRIPTION
Two failures from a full `--grep @ai` run against 2026.08.0-daily+144 with Posit Assistant 0.7.8.

## Filesystem guardrails, test 3 (write outside the project)

The assistant pauses on an AskUser question ("Write outside project folder") instead of running the `writeLines()` call, and the test passed no answer, so `pollWithAllowDialogs` failed with "paused on a question and no answer was configured".

The prompt now tells the assistant not to ask, and the test answers affirmatively if it asks anyway, so `.rs.chat.withGuardrails` is still what denies the write. The affirmative matcher is shared with test 4 (rename to outside the project) and rejects redirect options: something like "Yes, write it inside the project instead" opens with an affirmative but performs an allowed in-project write, which would satisfy test 4's file assertions without the guardrail being consulted. An option set where nothing matches raises an error listing the options the assistant offered.

## Code suggestions, NES multiple renames

Copilot batched the last three call-site renames into one multi-edit accept, so the document was fully renamed after two accepts. The loop asked for a third: its guard wait saw the outgoing preview, `acceptNesRename` re-checked the same locators after the teardown, and the test failed on a 30s timeout waiting for a suggestion that was no longer needed.

The loop now runs on the call sites still holding the old name rather than a count of accepts, and `acceptNesRename` owns the only wait for a suggestion. A timeout there is logged and falls through to the occurrence assertions, which name the call site that is still wrong. Those assertions also check that each `fn(score)` form is gone, so a suggestion that duplicates a call instead of replacing it fails.

## Verification

Both tests pass on macOS desktop against that daily build. The failures are nondeterministic -- they depend on whether the assistant asks before acting and on how the provider batches NES edits -- so a green run does not by itself exercise the changed paths. The run log shows which path ran: `Answered pending assistant question with ...` for the guardrail test, and `Accepted N NES suggestion(s)` with the per-round remaining-occurrence list for the NES test.

Test-only change, so no NEWS.md entry.