### PR TITLE
Add version floors to i18n-helpers Python requirements

### DIFF
--- a/src/gwt/tools/i18n-helpers/commands.cmd.xml/requirements.txt
+++ b/src/gwt/tools/i18n-helpers/commands.cmd.xml/requirements.txt
@@ -1,2 +1,2 @@
-pytest
-lxml
+pytest>=8.4.1
+lxml>=6.0.1


### PR DESCRIPTION
## Summary

Snyk flags `src/gwt/tools/i18n-helpers/commands.cmd.xml/requirements.txt` for [CVE-2024-5569](https://nvd.nist.gov/vuln/detail/CVE-2024-5569) / [SNYK-PYTHON-ZIPP-7430899](https://security.snyk.io/vuln/SNYK-PYTHON-ZIPP-7430899) (infinite loop in `zipp`, CVSS 6.9 medium), introduced through `pytest@7.4.4 → importlib-metadata@6.7.0 → zipp@3.15.0`.

That resolution path only exists when the unpinned manifest is resolved for Python 3.7 — those are the last 3.7-compatible releases. On modern Python, pytest ≥ 8 has no `importlib-metadata`/`zipp` dependency at all, so no actual developer or build machine installs the vulnerable package. This change adds version floors (`pytest>=8.4.1`, `lxml>=6.0.1`) so a vulnerable dependency graph can no longer resolve, closing the Snyk finding without pinning a package the tool never uses.

This is a developer-only tooling change (the i18n helper runs at build time and nothing here ships in the product), so there is no NEWS.md entry.

## Verification

- Fresh venv install from the updated requirements resolves pytest 9.1.1 / lxml 6.1.1 with no `zipp` or `importlib-metadata` present
- `python -m pytest test_commands_xml_to_i18n.py` passes on the new versions
- Regenerating `CmdConstants_en.properties` from `Commands.cmd.xml` with the new versions produces byte-identical output to the committed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)