### PR TITLE
Let rstudio-tests.bat run more than one scope

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -298,6 +298,10 @@ expression matched against the test file name after its `test-` prefix and
 tests and ignores the testthat files. Rebuild first so the staged R copies
 under `build/src/cpp/session/modules/R/` are current.
 
+On Windows the runner is `rstudio-tests.bat` (from `src/cpp/rstudio-tests.bat.in`),
+where `--scope` takes more than one scope -- `--scope core,rsession` -- and
+`rserver` is a no-op because those tests aren't built there.
+
 
 ### GWT Tests
 

--- a/src/cpp/rstudio-tests.bat.in
+++ b/src/cpp/rstudio-tests.bat.in
@@ -55,6 +55,9 @@ REM gather the values of a --scope flag; unreachable by fallthrough because the
 REM unknown-argument case above always jumps away.
 :scope_values
 if "%~1" == "" goto :parse
+REM the help forms that aren't '-' prefixed would otherwise read as scope names
+if /I "%~1" == "help" goto :parse
+if    "%~1" == "/?"   goto :parse
 set "SCOPE_VALUE=%~1"
 if "!SCOPE_VALUE:~0,1!" == "-" goto :parse
 set "TEST_SCOPE_ARGS=!TEST_SCOPE_ARGS!,%~1"

--- a/src/cpp/rstudio-tests.bat.in
+++ b/src/cpp/rstudio-tests.bat.in
@@ -5,8 +5,7 @@ REM ===========================================================================
 REM RStudio C++/R unit test runner (Windows).
 REM
 REM Mirrors the --scope / --filter interface of the Unix rstudio-tests script
-REM (rstudio-tests.in) so the same test categories can be invoked in CI, and
-REM additionally accepts more than one scope per invocation.
+REM (rstudio-tests.in) so the same test categories can be invoked in CI.
 REM
 REM The Unix-only diagnostics (watchdog timeout, libSegFault, gdb backtraces,
 REM sudo/DropPriv handling) have no Windows equivalent and are not ported.

--- a/src/cpp/rstudio-tests.bat.in
+++ b/src/cpp/rstudio-tests.bat.in
@@ -5,13 +5,18 @@ REM ===========================================================================
 REM RStudio C++/R unit test runner (Windows).
 REM
 REM Mirrors the --scope / --filter interface of the Unix rstudio-tests script
-REM (rstudio-tests.in) so the same test categories can be invoked in CI.
+REM (rstudio-tests.in) so the same test categories can be invoked in CI, and
+REM additionally accepts more than one scope per invocation.
 REM
 REM The Unix-only diagnostics (watchdog timeout, libSegFault, gdb backtraces,
 REM sudo/DropPriv handling) have no Windows equivalent and are not ported.
 REM ===========================================================================
 
-set "TEST_SCOPE="
+REM TEST_SCOPE_ARGS holds the scopes exactly as given on the command line;
+REM TEST_SCOPES holds the validated, canonically-cased, comma-delimited form
+REM that :has_scope matches against.
+set "TEST_SCOPE_ARGS="
+set "TEST_SCOPES="
 set "TEST_FILTER="
 set "TEST_FAILURE=0"
 
@@ -24,12 +29,16 @@ if /I "%~1" == "-h"     goto :usage_ok
 if /I "%~1" == "help"   goto :usage_ok
 if    "%~1" == "/?"     goto :usage_ok
 
+REM --scope takes one or more scopes and may be repeated. cmd.exe treats a comma
+REM as an argument separator, so '--scope core,rsession' arrives as two separate
+REM arguments; collect every argument up to the next option to accept the comma,
+REM space, and repeated-flag forms alike.
 if /I "%~1" == "--scope" (
     if "%~2" == "" goto :missing_value
-    set "TEST_SCOPE=%~2"
+    set "SCOPE_VALUE=%~2"
+    if "!SCOPE_VALUE:~0,1!" == "-" goto :missing_value
     shift
-    shift
-    goto :parse
+    goto :scope_values
 )
 
 if /I "%~1" == "--filter" (
@@ -43,20 +52,28 @@ if /I "%~1" == "--filter" (
 echo ERROR: Unknown argument: %~1 1>&2
 goto :usage_err
 
+REM gather the values of a --scope flag; unreachable by fallthrough because the
+REM unknown-argument case above always jumps away.
+:scope_values
+if "%~1" == "" goto :parse
+set "SCOPE_VALUE=%~1"
+if "!SCOPE_VALUE:~0,1!" == "-" goto :parse
+set "TEST_SCOPE_ARGS=!TEST_SCOPE_ARGS!,%~1"
+shift
+goto :scope_values
+
 :parsed
 
 REM --filter without --scope implies the 'r' scope (matches the Unix runner)
-if not defined TEST_SCOPE if defined TEST_FILTER set "TEST_SCOPE=r"
+if not defined TEST_SCOPE_ARGS if defined TEST_FILTER set "TEST_SCOPE_ARGS=r"
 
-REM validate the requested scope
-if defined TEST_SCOPE (
-    set "VALID=0"
-    if /I "!TEST_SCOPE!" == "core"     set "VALID=1"
-    if /I "!TEST_SCOPE!" == "rserver"  set "VALID=1"
-    if /I "!TEST_SCOPE!" == "rsession" set "VALID=1"
-    if /I "!TEST_SCOPE!" == "r"        set "VALID=1"
-    if "!VALID!" == "0" (
-        echo ERROR: Unknown scope: !TEST_SCOPE! 1>&2
+REM validate the requested scopes and build the delimited list to match against
+if defined TEST_SCOPE_ARGS (
+    set "TEST_SCOPES=,"
+    for %%S in (!TEST_SCOPE_ARGS!) do call :add_scope "%%~S"
+    if defined SCOPE_ERROR goto :usage_err
+    if "!TEST_SCOPES!" == "," (
+        echo ERROR: no scopes given 1>&2
         goto :usage_err
     )
 )
@@ -181,11 +198,29 @@ REM ===========================================================================
 REM helpers
 REM ===========================================================================
 
+REM add_scope <name> -> appends the canonical form of a requested scope to
+REM TEST_SCOPES, or sets SCOPE_ERROR when the name isn't a known scope
+:add_scope
+set "SCOPE_NAME="
+if /I "%~1" == "core"     set "SCOPE_NAME=core"
+if /I "%~1" == "rserver"  set "SCOPE_NAME=rserver"
+if /I "%~1" == "rsession" set "SCOPE_NAME=rsession"
+if /I "%~1" == "r"        set "SCOPE_NAME=r"
+if not defined SCOPE_NAME (
+    echo ERROR: Unknown scope: %~1 1>&2
+    set "SCOPE_ERROR=1"
+    goto :eof
+)
+REM keep the list free of duplicates so a scope can't be run twice
+call :has_scope "!SCOPE_NAME!"
+if "!HAS_SCOPE!" == "0" set "TEST_SCOPES=!TEST_SCOPES!!SCOPE_NAME!,"
+goto :eof
+
 REM has_scope <name> -> sets HAS_SCOPE=1 when that scope should run
 :has_scope
-if not defined TEST_SCOPE (
+if not defined TEST_SCOPES (
     set "HAS_SCOPE=1"
-) else if /I "%~1" == "!TEST_SCOPE!" (
+) else if not "!TEST_SCOPES:,%~1,=!" == "!TEST_SCOPES!" (
     set "HAS_SCOPE=1"
 ) else (
     set "HAS_SCOPE=0"
@@ -207,9 +242,13 @@ goto :usage_err
 :print_usage
 echo Run RStudio unit tests. Available options:
 echo.
-echo   rstudio-tests.bat [--scope ^<scope^>] [--filter ^<pattern^>]
+echo   rstudio-tests.bat [--scope ^<scopes^>] [--filter ^<pattern^>]
 echo.
-echo   --scope   Run only the given scope: core, rserver, rsession, r.
+echo   --scope   Run only the given scopes: core, rserver, rsession, r.
+echo             Takes more than one scope and may be repeated, so
+echo             '--scope core,rsession', '--scope core rsession', and
+echo             '--scope core --scope rsession' are all equivalent.
+echo             Scopes always run in the order listed above.
 echo   --filter  Run a subset of R tests matching the pattern ^(implies --scope r^).
 echo   --help    Show this help.
 echo.


### PR DESCRIPTION
`--scope` in the Windows test runner accepted exactly one scope, so running two of
the four suites meant two invocations. It now takes several.

`cmd.exe` treats a comma as an argument separator, so `--scope core,rsession` arrives
as two separate arguments. `--scope` therefore collects every argument up to the next
option, which makes three forms equivalent:

    rstudio-tests.bat --scope core,rsession
    rstudio-tests.bat --scope core rsession
    rstudio-tests.bat --scope core --scope rsession

Scope names are validated, case-normalized, and de-duplicated into a delimited list
before any suite runs, so a typo anywhere in the list fails up front rather than after
the first suite finishes. Scopes run in the fixed `core`, `rserver`, `rsession`, `r`
order regardless of the order requested, which keeps the slow `r` scope last.

The `help` and `/?` arguments are not `-` prefixed, so scope collection stops at them
as well; `rstudio-tests.bat --scope core help` prints usage and exits 0.

The Unix `rstudio-tests` script still takes a single scope. Existing single-scope
callers, including `--scope core` in `jenkins/Jenkinsfile.windows`, are unaffected.

## Testing

Argument handling was exercised against a copy of the script whose scope subroutines
were replaced with stubs that echo instead of running the suites: single scope, all
three multi-scope forms, mixed case, duplicates, `--filter` on either side of
`--scope`, `--filter` alone still implying `r`, each help form both alone and trailing
a `--scope`, and the error paths (unknown scope alone and inside a list, `--scope`
with no value, and whitespace-only).

`rstudio-tests.bat --scope core,rserver` was then run against a real build: the
`core` and `shared_core` suites ran, `rserver` reported that it is not built on this
platform, and the exit code still reflected the one failing test
(`Win32ConPtyTest.CtrlCByteTerminatesBusyChild`, a pre-existing failure under a nested
pseudo-console).