### PR TITLE
Match renamed delete-confirmation button in PA history e2e

### DIFF
--- a/e2e/rstudio/pages/chat_pane.page.ts
+++ b/e2e/rstudio/pages/chat_pane.page.ts
@@ -179,7 +179,8 @@ export class ChatPane extends FramePageObject {
    * Get the delete confirmation button
    */
   getDeleteConfirmButton(): Locator {
-    return this.frame.locator('button:has-text("Delete this conversation")');
+    // Exact match: the dialog title is also "Delete conversation"
+    return this.frame.getByRole('button', { name: 'Delete conversation', exact: true });
   }
 }
 

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/conversation-history.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/conversation-history.test.ts
@@ -79,7 +79,7 @@ test.describe.serial('Conversation History', { tag: ['@ai', '@chat'] }, () => {
     // Click Delete from the context menu
     await chatPane.getDeleteMenuItem().click();
 
-    // Confirm deletion by clicking the red "Delete this conversation" button
+    // Confirm deletion by clicking the red "Delete conversation" button
     const deleteButton = chatPane.getDeleteConfirmButton();
     await expect(deleteButton).toBeVisible({ timeout: 5000 });
     await deleteButton.click();


### PR DESCRIPTION
## Summary

Fixes the `@ai` e2e test `panes/posit-assistant-chat/conversation-history.test.ts`, which failed at the delete-confirmation step.

Posit Assistant renamed the delete dialog's confirm button from "Delete this conversation" to "Delete conversation" (posit-dev/assistant#1829, shipped in PA 0.9.x). The page object still matched the old label with a `:has-text()` substring locator, so the button was never found. The stale selector went unnoticed until now because the test previously failed earlier, at the rename step (fixed in posit-dev/assistant#1915).

## Changes

- `chat_pane.page.ts`: `getDeleteConfirmButton()` now uses a role-based locator with an exact accessible name (`getByRole('button', { name: 'Delete conversation', exact: true })`). Exact matching avoids ambiguity with the dialog's identically worded title.
- `conversation-history.test.ts`: update the comment referencing the old button label.

## Testing

- `tsc --noEmit` passes in `e2e/rstudio`.
- Verified against a manual run: the test now reaches the delete dialog with the renamed conversation title displayed; the dialog's confirm button renders as "Delete conversation".