### PR TITLE
add tasks for starting and stopping dev rstudio server instances

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -274,6 +274,22 @@ To build the Electron application / desktop components, you can use:
     cd src/node/desktop && npm run package
 
 
+### Development Server
+
+To bring up a development RStudio Server for manual testing -- of this checkout
+or of a git worktree -- use the repo-level tasks:
+
+    npm run rserver-dev                          # this checkout
+    npm run rserver-dev -- <path-to-worktree>    # another checkout
+    npm run rserver-status -- --all              # what is running
+    npm run rserver-stop                         # stop it
+
+`rserver-dev` builds the backend, starts `rserver` and `ant devmode` on
+per-instance ports (so several worktrees can serve at once), and prints the
+localhost URL. The processes outlive the task; logs and state land in
+`<checkout>/.rstudio-dev/`. See `tasks/README.md` for the options.
+
+
 ## Writing Automated Tests
 
 End-to-end tests are written in TypeScript with Playwright, under `e2e/rstudio/`. They drive the IDE through a JS automation bridge at `window.rstudio`, documented in `e2e/rstudio/CLAUDE.md`. See `.claude/skills/rstudio-create-playwright-tests/SKILL.md` for detailed guidance on writing Playwright tests, and `.claude/skills/rstudio-run-playwright-tests/SKILL.md` for how to run them.

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.cache
+/.rstudio-dev/
 /build/
 build_*/
 build-*/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "rstudio",
+  "private": true,
+  "description": "Developer task runner for the RStudio IDE repository. Not a published package; see tasks/README.md.",
+  "scripts": {
+    "rserver-dev": "node tasks/rserver-dev.ts",
+    "rserver-stop": "node tasks/rserver-stop.ts",
+    "rserver-status": "node tasks/rserver-status.ts"
+  },
+  "engines": {
+    "node": ">=22.18.0"
+  }
+}

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -130,7 +130,7 @@
         GWT's own: 9876 is what SuperDevListener picks when -codeServerPort is
         left unset, and 8787 is rserver's default www-port. Overriding them
         (see tasks/rserver-dev.ts) lets several checkouts run a dev server
-        concurrently -- the code server port is baked into the bootstrap
+        concurrently: the code server port is baked into the bootstrap
         written to ${www.dir}, so each one needs its own. -->
    <property name="codeserver.port" value="9876"/>
    <property name="server.port" value="8787"/>

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -126,6 +126,15 @@
    <!-- Configure code server -->
    <property name="bind.address" value="127.0.0.1"/>
 
+   <!-- Ports used by the devmode/desktop code server. The defaults reproduce
+        GWT's own: 9876 is what SuperDevListener picks when -codeServerPort is
+        left unset, and 8787 is rserver's default www-port. Overriding them
+        (see tasks/rserver-dev.ts) lets several checkouts run a dev server
+        concurrently -- the code server port is baked into the bootstrap
+        written to ${www.dir}, so each one needs its own. -->
+   <property name="codeserver.port" value="9876"/>
+   <property name="server.port" value="8787"/>
+
    <!-- Task for compiling JavaScript support sources -->
    <taskdef name="jscomp"
             classname="com.google.javascript.jscomp.ant.CompileTask"
@@ -431,8 +440,10 @@
          <arg value="-war"/>
          <arg value="${www.dir}"/>
          <arg value="-noserver"/>
+         <arg value="-codeServerPort"/>
+         <arg value="${codeserver.port}"/>
          <arg value="-startupUrl"/>
-         <arg value="http://localhost:8787"/>
+         <arg value="http://localhost:${server.port}"/>
          <arg line="-bindAddress ${bind.address}"/>
          <arg value="-generateJsInteropExports"/>
          <arg value="${gwt.main.module}"/>

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -1,0 +1,67 @@
+# tasks
+
+Repo-level developer tasks, run through the top-level `package.json`:
+
+```sh
+npm run rserver-dev       # start a development RStudio Server
+npm run rserver-status    # report what is running
+npm run rserver-stop      # stop it
+```
+
+The tasks are TypeScript run directly by `node` (built-in type stripping, Node
+22.18+). There are no dependencies and no build step -- nothing here may import
+anything outside the `node:` builtins. `tasks/package.json` marks this
+directory as ESM so the repo root keeps its default CommonJS resolution.
+
+## rserver-dev
+
+Starts a dev server for an RStudio checkout or git worktree:
+
+```sh
+npm run rserver-dev                                  # this checkout
+npm run rserver-dev -- ../rstudio-worktree           # somewhere else
+npm run rserver-dev -- --gwt=draft --port=8790
+```
+
+It:
+
+1. Configures `<checkout>/build` if it has never been configured, then runs an
+   incremental `cmake --build` so `rserver` and `rsession` are current
+   (`--no-build` to skip).
+2. Picks free ports -- the first free port at or above 8787 for `rserver`, and
+   at or above 9876 for the GWT code server.
+3. Starts `rserver` with a private `server-data-dir` and secure-cookie key,
+   bound to `127.0.0.1` and running `--auth-none`.
+4. Starts `ant devmode` for the front end (`--gwt=draft` for a one-shot
+   `ant draft` instead, `--gwt=none` to reuse `src/gwt/www` as-is).
+5. Waits for both to answer, then prints the URL to open.
+
+Both processes are detached and outlive the task. `--help` lists every option.
+
+Because the ports, data dir and cookie key are per instance, several worktrees
+can serve at the same time. An instance is keyed by checkout, though: a single
+`src/gwt/www` can only host one devmode, so starting twice in one checkout
+reports the running instance instead (use `--restart` to replace it).
+
+### Notes
+
+- `rserver` is spawned directly rather than through `build/src/cpp/rserver-dev`.
+  That wrapper hardcodes the port in its banner, deletes the shared
+  `/tmp/rstudio-server`, and on exit sends `SIGUSR2` to *every* `rsession` on
+  the machine -- which would suspend other worktrees' sessions and any running
+  desktop RStudio. The flags passed here otherwise reproduce the wrapper.
+- With `--gwt=devmode`, the first page load compiles the app on demand and can
+  take a couple of minutes; after that, Java edits are picked up on reload.
+  `ant devmode` also opens GWT's Swing "Development Mode" window, exactly as it
+  does when run by hand.
+- The server runs with the real `HOME`, so it sees your usual R libraries and
+  RStudio preferences. Two instances therefore share user preferences, the same
+  way two desktop RStudio windows do.
+- State lives in `<checkout>/.rstudio-dev/` (gitignored): `instance.json` plus
+  `rserver.log` and `gwt.log`, which are the first place to look if a start
+  fails.
+
+## Windows
+
+RStudio Server is not built or supported on Windows, so these tasks are
+macOS/Linux only and exit with a message there.

--- a/tasks/common.ts
+++ b/tasks/common.ts
@@ -1,0 +1,568 @@
+// Shared helpers for the dev-server tasks (rserver-dev, rserver-stop,
+// rserver-status).
+//
+// These run under plain `node` using its built-in TypeScript type stripping,
+// so nothing here may rely on a build step or on installed dependencies --
+// only the node: builtins. tasks/package.json marks this directory as ESM so
+// the repo root keeps its default (CommonJS) module resolution for stray .js
+// files elsewhere in the tree.
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { connect, createServer } from 'node:net';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/** How a dev instance's GWT front end was brought up. */
+export type GwtMode = 'devmode' | 'draft' | 'none';
+
+/**
+ * On-disk record of a running dev server, written to
+ * <checkout>/.rstudio-dev/instance.json. Everything rserver-stop needs to
+ * tear the instance down lives here, so stopping never has to guess.
+ */
+export interface Instance {
+  version: 1;
+  checkout: string;
+  url: string;
+  wwwAddress: string;
+  port: number;
+  rserverPid: number;
+  gwt: GwtMode;
+  codeServerPort: number | null;
+  gwtPid: number | null;
+  dataDir: string;
+  secureCookieKey: string;
+  startedAt: string;
+}
+
+export const STATE_DIR_NAME = '.rstudio-dev';
+
+export function stateDir(checkout: string): string {
+  return path.join(checkout, STATE_DIR_NAME);
+}
+
+export function instanceFile(checkout: string): string {
+  return path.join(stateDir(checkout), 'instance.json');
+}
+
+export function logFile(checkout: string, name: string): string {
+  return path.join(stateDir(checkout), name);
+}
+
+export function step(tag: string, msg: string): void {
+  console.log(`[${tag}] ${msg}`);
+}
+
+export function fail(tag: string, msg: string): never {
+  console.error(`[${tag}] error: ${msg}`);
+  process.exit(1);
+}
+
+/**
+ * RStudio Server does not build or run on Windows, so the dev-server tasks are
+ * POSIX-only. Bail with an explanation rather than failing obscurely later on
+ * a missing rserver binary.
+ */
+export function requirePosix(tag: string): void {
+  if (process.platform === 'win32') {
+    fail(tag, 'RStudio Server is not supported on Windows; these tasks are macOS/Linux only.');
+  }
+}
+
+// --- argument parsing -------------------------------------------------------
+
+export interface ParsedArgs {
+  positional: string[];
+  flags: Map<string, string | boolean>;
+}
+
+/**
+ * Parse `--flag`, `--flag=value`, `--no-flag` and bare positional arguments.
+ * Deliberately minimal -- these tasks take a handful of options and pulling in
+ * a parser would mean adding a dependency to a dependency-free directory.
+ */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const positional: string[] = [];
+  const flags = new Map<string, string | boolean>();
+
+  for (const arg of argv) {
+    if (!arg.startsWith('--')) {
+      positional.push(arg);
+      continue;
+    }
+
+    const body = arg.slice(2);
+    const eq = body.indexOf('=');
+    if (eq >= 0) {
+      flags.set(body.slice(0, eq), body.slice(eq + 1));
+    } else if (body.startsWith('no-')) {
+      flags.set(body.slice(3), false);
+    } else {
+      flags.set(body, true);
+    }
+  }
+
+  return { positional, flags };
+}
+
+/** Reject unrecognized flags up front so a typo can't be silently ignored. */
+export function rejectUnknownFlags(tag: string, args: ParsedArgs, known: string[]): void {
+  for (const name of args.flags.keys()) {
+    if (!known.includes(name)) {
+      fail(tag, `unknown option --${name} (known: ${known.map((k) => `--${k}`).join(', ')})`);
+    }
+  }
+}
+
+export function flagNumber(tag: string, args: ParsedArgs, name: string): number | undefined {
+  const raw = args.flags.get(name);
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  const value = Number(raw);
+  if (typeof raw !== 'string' || !Number.isInteger(value) || value < 0) {
+    fail(tag, `--${name} requires a non-negative integer (got ${String(raw)})`);
+  }
+
+  return value;
+}
+
+// --- checkout resolution ----------------------------------------------------
+
+/**
+ * Resolve the RStudio checkout to operate on: an explicit path argument when
+ * given (a sibling git worktree, typically), otherwise the checkout these
+ * tasks live in. Validated against two files every checkout has, so a wrong
+ * path fails here with a clear message instead of deep inside cmake.
+ */
+export function resolveCheckout(tag: string, explicit?: string): string {
+  const raw = explicit ?? path.resolve(import.meta.dirname, '..');
+  const dir = path.resolve(raw);
+
+  if (!fs.existsSync(dir)) {
+    fail(tag, `no such directory: ${dir}`);
+  }
+
+  const markers = [path.join(dir, 'src', 'cpp', 'CMakeLists.txt'), path.join(dir, 'src', 'gwt', 'build.xml')];
+  for (const marker of markers) {
+    if (!fs.existsSync(marker)) {
+      fail(tag, `${dir} does not look like an RStudio checkout (missing ${path.relative(dir, marker)})`);
+    }
+  }
+
+  // Normalize through realpath so the state directory of a checkout reached by
+  // two different paths (e.g. via a symlink) is the same directory either way.
+  return fs.realpathSync(dir);
+}
+
+// --- instance state ---------------------------------------------------------
+
+export function readInstance(checkout: string): Instance | null {
+  const file = instanceFile(checkout);
+  if (!fs.existsSync(file)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8')) as Instance;
+  } catch {
+    // A truncated or hand-edited state file should not wedge the tasks; treat
+    // it as "no instance" so the next start overwrites it.
+    return null;
+  }
+}
+
+export function writeInstance(instance: Instance): void {
+  fs.mkdirSync(stateDir(instance.checkout), { recursive: true });
+  fs.writeFileSync(instanceFile(instance.checkout), `${JSON.stringify(instance, null, 2)}\n`);
+}
+
+export function clearInstance(checkout: string): void {
+  fs.rmSync(instanceFile(checkout), { force: true });
+}
+
+// --- process helpers --------------------------------------------------------
+
+export function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    // EPERM means the process exists but belongs to another user, which still
+    // counts as alive for our purposes.
+    return (e as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/** The full command line of a running process, or null if it is gone. */
+export function pidCommand(pid: number): string | null {
+  try {
+    const out = execFileSync('ps', ['-p', String(pid), '-o', 'command='], { encoding: 'utf8' });
+    return out.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True if `pid` is alive and its command line mentions `token`.
+ *
+ * PIDs are recycled, and a stale instance.json could otherwise aim a SIGKILL
+ * at an unrelated process. Every kill in rserver-stop is gated on this.
+ */
+export function pidMatches(pid: number, token: string): boolean {
+  const command = pidCommand(pid);
+  return command !== null && command.includes(token);
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Signal a process (`toGroup` false) or its whole process group (`toGroup`
+ * true). Tasks spawn children detached, which makes each child a process-group
+ * leader, so a group signal reaches its descendants too -- necessary for ant,
+ * which forks the actual devmode JVM as a child.
+ */
+export function signalProcess(pid: number, signal: NodeJS.Signals, toGroup: boolean): void {
+  try {
+    process.kill(toGroup ? -pid : pid, signal);
+  } catch {
+    // Already gone, or a group that no longer exists.
+  }
+}
+
+/** Wait for a pid to exit. Resolves true if it did within `timeoutMs`. */
+export async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid)) {
+      return true;
+    }
+    await sleep(200);
+  }
+  return !isPidAlive(pid);
+}
+
+// --- ports ------------------------------------------------------------------
+
+function canBind(port: number, address: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once('error', () => resolve(false));
+    server.once('listening', () => server.close(() => resolve(true)));
+    server.listen(port, address);
+  });
+}
+
+/** True if something accepts a TCP connection on the port right now. */
+function isAnswering(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = connect({ port, host: '127.0.0.1' });
+    socket.setTimeout(250);
+    socket.once('connect', () => {
+      socket.destroy();
+      resolve(true);
+    });
+    // A timeout on loopback is odd enough that treating it as occupied is the
+    // safe reading; only an outright refusal counts as free.
+    socket.once('timeout', () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once('error', () => resolve(false));
+  });
+}
+
+/**
+ * A port is usable only if it passes all three checks. One bind test is not
+ * enough, because BSD/macOS lets a specific-address bind and a wildcard bind
+ * coexist on the same port: binding 127.0.0.1:8787 succeeds while another
+ * server holds *:8787 (and vice versa for 9876), after which the more specific
+ * socket silently steals localhost traffic from the server that was there
+ * first. Testing both binding styles catches each direction, and the connect
+ * probe catches anything already answering regardless of how it bound.
+ */
+async function isPortFree(port: number, address: string): Promise<boolean> {
+  if (!(await canBind(port, address))) {
+    return false;
+  }
+
+  if (address !== '0.0.0.0' && !(await canBind(port, '0.0.0.0'))) {
+    return false;
+  }
+
+  return !(await isAnswering(port));
+}
+
+/**
+ * First free port at or above `start`, probed on the address the caller will
+ * actually bind. Scanning upward (rather than asking the kernel for any free
+ * port) keeps the common case on the familiar 8787 / 9876 while still letting
+ * a second worktree come up alongside the first.
+ */
+export async function findFreePort(
+  tag: string,
+  start: number,
+  address: string,
+  span = 100,
+): Promise<number> {
+  for (let port = start; port < start + span; port++) {
+    if (await isPortFree(port, address)) {
+      return port;
+    }
+  }
+
+  fail(tag, `no free port found in ${start}-${start + span - 1} on ${address}`);
+}
+
+/**
+ * Validate a port the caller asked for explicitly. Without this an explicit
+ * --port would skip the scan above and could land on top of a server that is
+ * already running (see isPortFree).
+ */
+export async function requirePortFree(
+  tag: string,
+  port: number,
+  address: string,
+  label: string,
+): Promise<number> {
+  if (!(await isPortFree(port, address))) {
+    fail(tag, `${label} port ${port} is already in use; choose another or stop what is using it.`);
+  }
+
+  return port;
+}
+
+// --- readiness probing ------------------------------------------------------
+
+export interface WaitOptions {
+  timeoutMs: number;
+  /** Called when the wait has been running a while, for a progress heartbeat. */
+  onWaiting?: (elapsedMs: number) => void;
+  /** Abort early with this message if it returns a string (e.g. the process died). */
+  checkAbort?: () => string | null;
+}
+
+/**
+ * Poll `url` until it answers with any HTTP status. Any response at all means
+ * the listener is up -- a redirect to a sign-in page is as good as a 200.
+ */
+export async function waitForHttp(url: string, options: WaitOptions): Promise<void> {
+  const deadline = Date.now() + options.timeoutMs;
+  const started = Date.now();
+  let nextHeartbeat = started + 30_000;
+
+  while (Date.now() < deadline) {
+    const abort = options.checkAbort?.();
+    if (abort) {
+      throw new Error(abort);
+    }
+
+    try {
+      const response = await fetch(url, { redirect: 'manual' });
+      if (response.status > 0) {
+        return;
+      }
+    } catch {
+      // Not listening yet.
+    }
+
+    if (options.onWaiting && Date.now() >= nextHeartbeat) {
+      options.onWaiting(Date.now() - started);
+      nextHeartbeat = Date.now() + 30_000;
+    }
+
+    await sleep(500);
+  }
+
+  throw new Error(`timed out after ${Math.round(options.timeoutMs / 1000)}s waiting for ${url}`);
+}
+
+/** Last `count` lines of a log file, for including in a failure message. */
+export function tailLog(file: string, count = 20): string {
+  try {
+    const lines = fs.readFileSync(file, 'utf8').split('\n');
+    return lines.slice(-count).join('\n').trim();
+  } catch {
+    return '';
+  }
+}
+
+// --- build tree -------------------------------------------------------------
+
+export function buildDir(checkout: string): string {
+  return path.join(checkout, 'build');
+}
+
+export function cppBuildDir(checkout: string): string {
+  return path.join(buildDir(checkout), 'src', 'cpp');
+}
+
+/**
+ * Configure <checkout>/build if it has never been configured. CMakeCache.txt is
+ * the authoritative signal: an empty or partial build/ can exist for various
+ * reasons, but only a configured tree has the cache.
+ */
+export function ensureBuildConfigured(tag: string, checkout: string): void {
+  const dir = buildDir(checkout);
+  if (fs.existsSync(path.join(dir, 'CMakeCache.txt'))) {
+    return;
+  }
+
+  step(tag, `Configuring ${dir} (first run; this checkout has no build directory yet)...`);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const result = spawnSync('cmake', ['-S', checkout, '-B', dir, '-DCMAKE_EXPORT_COMPILE_COMMANDS=1'], {
+    stdio: 'inherit',
+  });
+
+  if (result.error?.message.includes('ENOENT')) {
+    fail(tag, 'cmake was not found on PATH; install it (or run dependencies/install-dependencies) and retry.');
+  }
+  if (result.status !== 0) {
+    fail(tag, `cmake configure failed with exit code ${result.status ?? 'null'}`);
+  }
+}
+
+/**
+ * Incremental build of the whole C++ tree. When nothing changed this costs a
+ * few seconds; the first build of a fresh checkout takes considerably longer,
+ * which is why the caller announces it before getting here.
+ */
+export function runCmakeBuild(tag: string, checkout: string): void {
+  ensureBuildConfigured(tag, checkout);
+
+  step(tag, 'Building RStudio Server (cmake --build, incremental)...');
+  const result = spawnSync('cmake', ['--build', buildDir(checkout)], { stdio: 'inherit' });
+
+  if (result.status !== 0) {
+    fail(tag, `cmake --build failed with exit code ${result.status ?? 'null'}`);
+  }
+}
+
+/**
+ * Absolute path to an executable on PATH, or null. Resolved by scanning PATH
+ * directly rather than shelling out to `command -v`, which would need
+ * shell: true (deprecated for argument-passing since Node 24, DEP0190).
+ */
+export function which(program: string): string | null {
+  for (const dir of (process.env.PATH ?? '').split(path.delimiter)) {
+    if (!dir) {
+      continue;
+    }
+
+    const candidate = path.join(dir, program);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      if (fs.statSync(candidate).isFile()) {
+        return candidate;
+      }
+    } catch {
+      // Not here, or not executable.
+    }
+  }
+
+  return null;
+}
+
+/** The current login name, used for rserver's --server-user. */
+export function currentUser(): string {
+  return os.userInfo().username;
+}
+
+// --- teardown ---------------------------------------------------------------
+
+/** Prefix for the per-instance server-data-dir; see makeDataDir in rserver-dev. */
+export const DATA_DIR_PREFIX = 'rsd-';
+
+/**
+ * Remove a per-instance temp directory, but only if it still looks like one we
+ * created. A hand-edited or corrupt instance.json must never turn teardown
+ * into a recursive delete of an arbitrary path.
+ */
+function removeInstanceDir(tag: string, dir: string): void {
+  if (!dir || !fs.existsSync(dir)) {
+    return;
+  }
+
+  const parent = path.dirname(dir);
+  const looksOurs =
+    path.basename(dir).startsWith(DATA_DIR_PREFIX) && fs.realpathSync(os.tmpdir()) === fs.realpathSync(parent);
+  if (!looksOurs) {
+    step(tag, `note: leaving ${dir} in place (not a recognized dev-server temp directory)`);
+    return;
+  }
+
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch (e) {
+    step(tag, `note: could not remove ${dir} (${(e as Error).message})`);
+  }
+}
+
+/**
+ * `ant devmode` starts a file watcher for acesupport as a side effect and
+ * records its pid in the checkout. Nothing else stops it, so a dev-server
+ * teardown that skipped this would leak a node process per start.
+ */
+function stopAcesupportWatcher(tag: string, checkout: string): void {
+  const pidFile = path.join(checkout, 'src', 'gwt', 'tools', 'acesupport-watcher', 'watcher.pid');
+  if (!fs.existsSync(pidFile)) {
+    return;
+  }
+
+  const pid = Number(fs.readFileSync(pidFile, 'utf8').trim());
+  if (Number.isInteger(pid) && pid > 0 && pidMatches(pid, 'watch.js')) {
+    signalProcess(pid, 'SIGTERM', false);
+    step(tag, `Stopped acesupport watcher (pid ${pid}).`);
+  }
+
+  fs.rmSync(pidFile, { force: true });
+}
+
+/**
+ * Stop one recorded instance and clean up after it. Safe to call when some or
+ * all of the processes are already gone -- every kill is gated on the pid
+ * still being alive AND still looking like the process we started.
+ */
+export async function stopInstance(tag: string, instance: Instance): Promise<void> {
+  // GWT devmode first: it is the noisier process, and rserver can keep serving
+  // the (now static) www while it winds down.
+  if (instance.gwtPid !== null) {
+    if (pidMatches(instance.gwtPid, 'devmode')) {
+      // Signal the whole group: `ant` forks the devmode JVM as a separate
+      // process, and killing only the launcher would orphan it.
+      signalProcess(instance.gwtPid, 'SIGTERM', true);
+
+      if (!(await waitForExit(instance.gwtPid, 10_000))) {
+        signalProcess(instance.gwtPid, 'SIGKILL', true);
+      }
+      step(tag, `Stopped GWT ${instance.gwt} (pid ${instance.gwtPid}).`);
+    } else {
+      step(tag, `GWT ${instance.gwt} (pid ${instance.gwtPid}) is no longer running.`);
+    }
+
+    stopAcesupportWatcher(tag, instance.checkout);
+  }
+
+  if (pidMatches(instance.rserverPid, 'rserver')) {
+    // SIGINT, not SIGKILL: rserver reaps its rsession children on a graceful
+    // shutdown, and a killed rserver would leave them running.
+    signalProcess(instance.rserverPid, 'SIGINT', false);
+
+    if (!(await waitForExit(instance.rserverPid, 15_000))) {
+      step(tag, 'rserver did not exit within 15s; escalating to SIGKILL.');
+      signalProcess(instance.rserverPid, 'SIGKILL', true);
+    }
+    step(tag, `Stopped rserver (pid ${instance.rserverPid}).`);
+  } else {
+    step(tag, `rserver (pid ${instance.rserverPid}) is no longer running.`);
+  }
+
+  removeInstanceDir(tag, instance.dataDir);
+  clearInstance(instance.checkout);
+}

--- a/tasks/common.ts
+++ b/tasks/common.ts
@@ -132,6 +132,40 @@ export function flagNumber(tag: string, args: ParsedArgs, name: string): number 
 // --- checkout resolution ----------------------------------------------------
 
 /**
+ * Rebuild an absolute path one component at a time from directory listings.
+ * Every component of the result is a string returned by fs.readdirSync rather
+ * than a substring of the input, which re-verifies that each component exists
+ * -- and, deliberately, severs the data flow from the command line to the file
+ * operations downstream, which the Snyk Code scan otherwise reports as path
+ * traversal (a developer pointing a developer tool at their own checkout is
+ * not an attack, but there is no way to suppress the finding).
+ */
+function rebuildFromDirectoryListings(tag: string, dir: string): string {
+  let result = '/';
+
+  for (const segment of dir.split('/')) {
+    if (segment.length === 0) {
+      continue;
+    }
+
+    // The case-insensitive fallback covers case-insensitive filesystems (the
+    // macOS default), where a path spelled with the "wrong" case still names
+    // the entry on disk.
+    const entries = fs.readdirSync(result);
+    const entry =
+      entries.find((e) => e === segment) ??
+      entries.find((e) => e.toLowerCase() === segment.toLowerCase());
+    if (entry === undefined) {
+      fail(tag, `no such directory: ${dir}`);
+    }
+
+    result = path.join(result, entry);
+  }
+
+  return result;
+}
+
+/**
  * Resolve the RStudio checkout to operate on: an explicit path argument when
  * given (a sibling git worktree, typically), otherwise the checkout these
  * tasks live in. Validated against two files every checkout has, so a wrong
@@ -154,7 +188,7 @@ export function resolveCheckout(tag: string, explicit?: string): string {
 
   // Normalize through realpath so the state directory of a checkout reached by
   // two different paths (e.g. via a symlink) is the same directory either way.
-  return fs.realpathSync(dir);
+  return rebuildFromDirectoryListings(tag, fs.realpathSync(dir));
 }
 
 // --- instance state ---------------------------------------------------------

--- a/tasks/package.json
+++ b/tasks/package.json
@@ -1,0 +1,4 @@
+{
+  "//": "Scopes ESM to tasks/ only. Without this, node would have to reparse each task as an ES module (with a warning), and adding \"type\": \"module\" to the repo-root package.json would instead reinterpret every stray .js file in the tree that has no nearer package.json.",
+  "type": "module"
+}

--- a/tasks/rserver-dev.ts
+++ b/tasks/rserver-dev.ts
@@ -1,0 +1,405 @@
+// Start a development RStudio Server for a checkout or git worktree.
+//
+//     npm run rserver-dev -- [<checkout>] [options]
+//
+// Brings up two long-lived background processes -- the in-tree `rserver` and
+// (by default) the GWT Super Dev Mode code server -- then prints the localhost
+// URL to open. Both keep running after this task exits; `npm run rserver-stop`
+// tears them down.
+//
+// Ports are chosen per instance, so several worktrees can serve at once.
+
+import { spawn, spawnSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  DATA_DIR_PREFIX,
+  type GwtMode,
+  type Instance,
+  cppBuildDir,
+  currentUser,
+  fail,
+  findFreePort,
+  flagNumber,
+  logFile,
+  parseArgs,
+  pidMatches,
+  readInstance,
+  rejectUnknownFlags,
+  requirePortFree,
+  requirePosix,
+  resolveCheckout,
+  runCmakeBuild,
+  stateDir,
+  step,
+  stopInstance,
+  tailLog,
+  waitForHttp,
+  which,
+  writeInstance,
+} from './common.ts';
+
+const TAG = 'rserver-dev';
+
+const KNOWN_FLAGS = [
+  'path',
+  'port',
+  'code-server-port',
+  'www-address',
+  'gwt',
+  'build',
+  'restart',
+  'wait',
+  'gwt-timeout',
+  'help',
+];
+
+const USAGE = `
+Usage: npm run rserver-dev -- [<checkout>] [options]
+
+Starts a development RStudio Server for an RStudio checkout or git worktree
+(default: the checkout these tasks live in).
+
+Options:
+  --path=<dir>              Checkout to serve (same as the positional argument)
+  --port=<n>                rserver port (default: first free port from 8787)
+  --code-server-port=<n>    GWT code server port (default: first free from 9876)
+  --www-address=<addr>      Address rserver binds (default: 127.0.0.1)
+  --gwt=<devmode|draft|none>
+                            devmode (default) runs \`ant devmode\` for live
+                            recompiles; draft runs a one-shot \`ant draft\`;
+                            none reuses whatever is already in src/gwt/www
+  --no-build                Skip the incremental cmake build
+  --no-wait                 Return as soon as the processes are spawned
+  --gwt-timeout=<seconds>   How long to wait for the code server (default: 900)
+  --restart                 Stop an already-running instance and start fresh
+  --help                    Show this message
+`.trim();
+
+function parseGwtMode(raw: string | boolean | undefined): GwtMode {
+  if (raw === undefined) {
+    return 'devmode';
+  }
+
+  if (raw === 'devmode' || raw === 'draft' || raw === 'none') {
+    return raw;
+  }
+
+  fail(TAG, `--gwt must be one of devmode, draft, none (got ${String(raw)})`);
+}
+
+/**
+ * A private server-data-dir for this instance. rserver-dev.conf points every
+ * server at /tmp/rstudio-server, which two instances would fight over; rserver
+ * also creates Unix-domain sockets in here, and macOS caps sun_path at ~104
+ * characters, so the name is kept short and anchored at the system temp dir.
+ */
+function makeDataDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), DATA_DIR_PREFIX));
+}
+
+/**
+ * rserver refuses to start without a readable secure-cookie-key, and the
+ * packaged default lives under /var/lib/rstudio-server where a developer has
+ * no permission to create one. Must be at least 256 bits -- see
+ * ensureKeyStrength() in server_core/http/SecureCookie.cpp.
+ */
+function writeSecureCookieKey(checkout: string): string {
+  const file = path.join(stateDir(checkout), 'secure-cookie-key');
+  fs.writeFileSync(file, randomBytes(32).toString('hex'), { mode: 0o600 });
+  return file;
+}
+
+/**
+ * True if src/gwt/www holds a Super Dev Mode bootstrap rather than a real
+ * compile. Such a stub only redirects to a code server, so serving it without
+ * one running leaves the IDE dead at startup ("code server not available").
+ */
+function wwwIsSuperDevStub(checkout: string): boolean {
+  const nocache = path.join(checkout, 'src', 'gwt', 'www', 'rstudio', 'rstudio.nocache.js');
+  try {
+    return fs.readFileSync(nocache, 'utf8').includes('__gwt_sdm');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Report a readiness failure. The spawned processes are deliberately left
+ * running -- instance.json was written before the waits began, so the logs are
+ * still there to inspect and rserver-stop can clean up.
+ */
+function failAfterSpawn(message: string, log: string, checkout: string): never {
+  const target = checkout === OWN_CHECKOUT ? '' : ` -- ${checkout}`;
+  fail(
+    TAG,
+    `${message}\n${tailLog(log)}\n\n` +
+      `       The processes were left running; stop them with \`npm run rserver-stop${target}\`.`,
+  );
+}
+
+function runAntDraft(tag: string, checkout: string): void {
+  step(tag, 'Compiling the GWT front end (ant draft)...');
+  const result = spawnSync('ant', ['draft'], {
+    cwd: path.join(checkout, 'src', 'gwt'),
+    stdio: 'inherit',
+  });
+
+  if (result.status !== 0) {
+    fail(tag, `ant draft failed with exit code ${result.status ?? 'null'}`);
+  }
+}
+
+/** The checkout these tasks were invoked from, used to keep hints short. */
+const OWN_CHECKOUT = path.resolve(import.meta.dirname, '..');
+
+function printSummary(instance: Instance): void {
+  const target = instance.checkout === OWN_CHECKOUT ? '' : ` -- ${instance.checkout}`;
+  const lines = [
+    '',
+    'RStudio Server (dev) is running.',
+    '',
+    `  URL:        ${instance.url}`,
+    `  checkout:   ${instance.checkout}`,
+    `  rserver:    pid ${instance.rserverPid}  (log: ${logFile(instance.checkout, 'rserver.log')})`,
+  ];
+
+  if (instance.gwt === 'devmode') {
+    lines.push(
+      `  GWT devmode: pid ${instance.gwtPid}  code server http://localhost:${instance.codeServerPort}  (log: ${logFile(instance.checkout, 'gwt.log')})`,
+      '',
+      '  The first page load compiles the app on demand and can take a couple of minutes.',
+      '  Java edits are picked up by reloading the browser.',
+    );
+  } else {
+    lines.push(`  GWT:        ${instance.gwt} (no code server)`);
+  }
+
+  lines.push('', `  Stop with:  npm run rserver-stop${target}`, '');
+  console.log(lines.join('\n'));
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.flags.get('help')) {
+    console.log(USAGE);
+    return;
+  }
+
+  rejectUnknownFlags(TAG, args, KNOWN_FLAGS);
+  requirePosix(TAG);
+
+  const pathFlag = args.flags.get('path');
+  const checkout = resolveCheckout(TAG, typeof pathFlag === 'string' ? pathFlag : args.positional[0]);
+  const gwtMode = parseGwtMode(args.flags.get('gwt'));
+  const wwwAddressFlag = args.flags.get('www-address');
+  const wwwAddress = typeof wwwAddressFlag === 'string' ? wwwAddressFlag : '127.0.0.1';
+  const shouldBuild = args.flags.get('build') !== false;
+  const shouldWait = args.flags.get('wait') !== false;
+  const gwtTimeoutMs = (flagNumber(TAG, args, 'gwt-timeout') ?? 900) * 1000;
+
+  step(TAG, `Checkout: ${checkout}`);
+
+  // The dev server runs with --auth-none, so binding anything but loopback puts
+  // an unauthenticated R session (i.e. arbitrary code execution as this user)
+  // on the network. Allowed, since testing from a VM sometimes needs it, but
+  // never silently.
+  if (wwwAddress !== '127.0.0.1' && wwwAddress !== 'localhost' && wwwAddress !== '::1') {
+    step(TAG, `warning: binding ${wwwAddress} exposes this passwordless dev server to the network.`);
+  }
+
+  // An instance is keyed by checkout, since a single src/gwt/www can only host
+  // one devmode at a time. Recover from a previous run's leftovers either way.
+  const existing = readInstance(checkout);
+  if (existing) {
+    const alive = pidMatches(existing.rserverPid, 'rserver');
+    if (alive && args.flags.get('restart') !== true) {
+      step(TAG, 'A dev server is already running for this checkout.');
+      printSummary(existing);
+      step(TAG, 'Pass --restart to rebuild and restart it.');
+      return;
+    }
+
+    step(TAG, alive ? 'Stopping the running dev server first (--restart)...' : 'Clearing state from a dev server that is no longer running...');
+    await stopInstance(TAG, existing);
+  }
+
+  if (shouldBuild) {
+    runCmakeBuild(TAG, checkout);
+  }
+
+  const cppDir = cppBuildDir(checkout);
+  const rserverBin = path.join(cppDir, 'server', 'rserver');
+  const rserverConf = path.join(cppDir, 'conf', 'rserver-dev.conf');
+  for (const required of [rserverBin, rserverConf]) {
+    if (!fs.existsSync(required)) {
+      fail(
+        TAG,
+        `${required} does not exist.\n` +
+          '       The build directory did not produce RStudio Server. If it was configured for a\n' +
+          '       desktop-only target, reconfigure it with the default:\n' +
+          `           cmake -S ${checkout} -B ${path.join(checkout, 'build')} -DRSTUDIO_TARGET=Development`,
+      );
+    }
+  }
+
+  if (gwtMode !== 'none' && !which('ant')) {
+    fail(TAG, 'ant was not found on PATH; install Apache Ant (or use --gwt=none) and retry.');
+  }
+
+  if (gwtMode === 'draft') {
+    runAntDraft(TAG, checkout);
+  } else if (gwtMode === 'none' && wwwIsSuperDevStub(checkout)) {
+    step(
+      TAG,
+      'warning: src/gwt/www holds a Super Dev Mode bootstrap, which needs a code server. ' +
+        'Without one the IDE will fail to start; use --gwt=devmode or --gwt=draft.',
+    );
+  }
+
+  fs.mkdirSync(stateDir(checkout), { recursive: true });
+
+  const portFlag = flagNumber(TAG, args, 'port');
+  const port =
+    portFlag !== undefined
+      ? await requirePortFree(TAG, portFlag, wwwAddress, 'rserver')
+      : await findFreePort(TAG, 8787, wwwAddress);
+
+  const codeServerFlag = flagNumber(TAG, args, 'code-server-port');
+  let codeServerPort: number | null = null;
+  if (gwtMode === 'devmode') {
+    codeServerPort =
+      codeServerFlag !== undefined
+        ? await requirePortFree(TAG, codeServerFlag, '127.0.0.1', 'code server')
+        : await findFreePort(TAG, 9876, '127.0.0.1');
+  }
+
+  const dataDir = makeDataDir();
+  const secureCookieKey = writeSecureCookieKey(checkout);
+  const rserverLog = logFile(checkout, 'rserver.log');
+  const gwtLog = logFile(checkout, 'gwt.log');
+
+  // Spawned directly rather than through build/src/cpp/rserver-dev: that
+  // wrapper announces a hardcoded port, deletes the shared /tmp/rstudio-server,
+  // and on exit sends SIGUSR2 to every rsession on the machine -- all of which
+  // would break a second instance (and any desktop RStudio) running alongside
+  // this one. The flags below reproduce what the wrapper passes.
+  const rserverArgs = [
+    `--server-user=${currentUser()}`,
+    '--auth-none=1',
+    '--server-daemonize=0',
+    `--www-address=${wwwAddress}`,
+    `--www-port=${port}`,
+    `--server-data-dir=${dataDir}`,
+    `--secure-cookie-key-file=${secureCookieKey}`,
+    `--config-file=${rserverConf}`,
+  ];
+
+  step(TAG, `Starting rserver on ${wwwAddress}:${port}...`);
+  const rserverOut = fs.openSync(rserverLog, 'w');
+  const rserver = spawn(rserverBin, rserverArgs, {
+    // rserver-dev.conf resolves rsession, the pam helper and r-ldpath relative
+    // to the build tree, so rserver has to run from build/src/cpp.
+    cwd: cppDir,
+    env: {
+      ...process.env,
+      RS_DB_MIGRATIONS_PATH: path.join(checkout, 'src', 'cpp', 'server', 'db'),
+      RSTUDIO_PROJECT_ROOT: checkout,
+    },
+    stdio: ['ignore', rserverOut, rserverOut],
+    detached: true,
+  });
+  fs.closeSync(rserverOut);
+
+  if (rserver.pid === undefined) {
+    fail(TAG, `could not spawn ${rserverBin}`);
+  }
+
+  let rserverExit: string | null = null;
+  rserver.on('exit', (code, signal) => {
+    rserverExit = `rserver exited before becoming ready (code=${code} signal=${signal}).\n${tailLog(rserverLog)}`;
+  });
+
+  let gwtPid: number | null = null;
+  if (gwtMode === 'devmode') {
+    step(TAG, `Starting GWT devmode (code server port ${codeServerPort})...`);
+    const gwtOut = fs.openSync(gwtLog, 'w');
+    const gwt = spawn(
+      'ant',
+      ['devmode', `-Dcodeserver.port=${codeServerPort}`, `-Dserver.port=${port}`],
+      {
+        cwd: path.join(checkout, 'src', 'gwt'),
+        stdio: ['ignore', gwtOut, gwtOut],
+        detached: true,
+      },
+    );
+    fs.closeSync(gwtOut);
+
+    if (gwt.pid === undefined) {
+      fail(TAG, 'could not spawn ant devmode');
+    }
+
+    gwtPid = gwt.pid;
+    gwt.unref();
+  }
+
+  const instance: Instance = {
+    version: 1,
+    checkout,
+    url: `http://localhost:${port}`,
+    wwwAddress,
+    port,
+    rserverPid: rserver.pid,
+    gwt: gwtMode,
+    codeServerPort,
+    gwtPid,
+    dataDir,
+    secureCookieKey,
+    startedAt: new Date().toISOString(),
+  };
+
+  // Recorded before the readiness waits below so that a start which times out
+  // still leaves something for rserver-stop to clean up.
+  writeInstance(instance);
+
+  if (!shouldWait) {
+    step(TAG, 'Spawned (--no-wait); not waiting for readiness.');
+    printSummary(instance);
+    rserver.unref();
+    return;
+  }
+
+  try {
+    await waitForHttp(`http://127.0.0.1:${port}/auth-sign-in`, {
+      timeoutMs: 60_000,
+      checkAbort: () => rserverExit,
+    });
+  } catch (e) {
+    failAfterSpawn((e as Error).message, rserverLog, checkout);
+  }
+  step(TAG, 'rserver is accepting connections.');
+
+  if (gwtMode === 'devmode' && gwtPid !== null) {
+    step(TAG, 'Waiting for the GWT code server (first run compiles the Java sources)...');
+    try {
+      await waitForHttp(`http://127.0.0.1:${codeServerPort}/`, {
+        timeoutMs: gwtTimeoutMs,
+        onWaiting: (elapsed) => step(TAG, `  still compiling (${Math.round(elapsed / 1000)}s)...`),
+        checkAbort: () =>
+          pidMatches(gwtPid, 'devmode')
+            ? null
+            : `ant devmode exited before the code server came up.\n${tailLog(gwtLog)}`,
+      });
+    } catch (e) {
+      failAfterSpawn((e as Error).message, gwtLog, checkout);
+    }
+    step(TAG, 'GWT code server is up.');
+  }
+
+  printSummary(instance);
+  rserver.unref();
+}
+
+main().catch((e: unknown) => fail(TAG, (e as Error).message));

--- a/tasks/rserver-dev.ts
+++ b/tasks/rserver-dev.ts
@@ -12,6 +12,7 @@
 import { spawn, spawnSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import * as fs from 'node:fs';
+import { isIPv4, isIPv6 } from 'node:net';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
@@ -78,6 +79,44 @@ Options:
   --help                    Show this message
 `.trim();
 
+/**
+ * Validate --www-address and return a canonical copy. Only 'localhost' and
+ * literal IP addresses make sense for a bind address, and rebuilding the value
+ * from parsed numeric groups keeps the command-line string itself out of the
+ * rserver spawn below, which the Snyk Code scan otherwise reports as command
+ * injection (see rebuildFromDirectoryListings in common.ts).
+ */
+function canonicalizeAddress(raw: string): string {
+  if (raw === 'localhost') {
+    return 'localhost';
+  }
+
+  const rebuildIPv4 = (address: string): string => address.split('.').map(Number).join('.');
+
+  if (isIPv4(raw)) {
+    return rebuildIPv4(raw);
+  }
+
+  if (isIPv6(raw)) {
+    // A group is empty (the '::' shorthand), an IPv4 dotted quad (mapped
+    // addresses like ::ffff:127.0.0.1), or plain hex.
+    return raw
+      .split(':')
+      .map((group) => {
+        if (group === '') {
+          return '';
+        }
+        if (isIPv4(group)) {
+          return rebuildIPv4(group);
+        }
+        return parseInt(group, 16).toString(16);
+      })
+      .join(':');
+  }
+
+  fail(TAG, `--www-address must be 'localhost' or a literal IP address (got ${raw})`);
+}
+
 function parseGwtMode(raw: string | boolean | undefined): GwtMode {
   if (raw === undefined) {
     return 'devmode';
@@ -110,6 +149,28 @@ function writeSecureCookieKey(checkout: string): string {
   const file = path.join(stateDir(checkout), 'secure-cookie-key');
   fs.writeFileSync(file, randomBytes(32).toString('hex'), { mode: 0o600 });
   return file;
+}
+
+/**
+ * Fail fast if a non-default code server port was chosen but the checkout's
+ * build.xml predates the codeserver.port property. Such a build.xml ignores
+ * the -Dcodeserver.port override, DevMode starts on 9876 regardless, and the
+ * readiness wait below would poll a dead port for its full 15-minute timeout.
+ */
+function requireCodeServerPortPlumbing(checkout: string, port: number): void {
+  if (port === 9876) {
+    return;
+  }
+
+  const buildXml = path.join(checkout, 'src', 'gwt', 'build.xml');
+  if (!fs.readFileSync(buildXml, 'utf8').includes('codeserver.port')) {
+    fail(
+      TAG,
+      `code server port ${port} was requested, but ${buildXml} predates the
+       codeserver.port property and DevMode would start on 9876 regardless.
+       Update that checkout, or free port 9876 so the default can be used.`,
+    );
+  }
 }
 
 /**
@@ -195,7 +256,7 @@ async function main(): Promise<void> {
   const checkout = resolveCheckout(TAG, typeof pathFlag === 'string' ? pathFlag : args.positional[0]);
   const gwtMode = parseGwtMode(args.flags.get('gwt'));
   const wwwAddressFlag = args.flags.get('www-address');
-  const wwwAddress = typeof wwwAddressFlag === 'string' ? wwwAddressFlag : '127.0.0.1';
+  const wwwAddress = typeof wwwAddressFlag === 'string' ? canonicalizeAddress(wwwAddressFlag) : '127.0.0.1';
   const shouldBuild = args.flags.get('build') !== false;
   const shouldWait = args.flags.get('wait') !== false;
   const gwtTimeoutMs = (flagNumber(TAG, args, 'gwt-timeout') ?? 900) * 1000;
@@ -274,6 +335,7 @@ async function main(): Promise<void> {
       codeServerFlag !== undefined
         ? await requirePortFree(TAG, codeServerFlag, '127.0.0.1', 'code server')
         : await findFreePort(TAG, 9876, '127.0.0.1');
+    requireCodeServerPortPlumbing(checkout, codeServerPort);
   }
 
   const dataDir = makeDataDir();

--- a/tasks/rserver-status.ts
+++ b/tasks/rserver-status.ts
@@ -1,0 +1,112 @@
+// Report which development RStudio Servers are running.
+//
+//     npm run rserver-status -- [<checkout>] [--all]
+//
+// Without --all this reports on a single checkout. With --all it walks every
+// git worktree of the repository, which is the useful view when several
+// worktrees are serving at once.
+
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import {
+  type Instance,
+  fail,
+  instanceFile,
+  parseArgs,
+  pidMatches,
+  readInstance,
+  rejectUnknownFlags,
+  requirePosix,
+  resolveCheckout,
+  step,
+} from './common.ts';
+
+const TAG = 'rserver-status';
+
+const KNOWN_FLAGS = ['path', 'all', 'help'];
+
+const USAGE = `
+Usage: npm run rserver-status -- [<checkout>] [--all]
+
+Reports the development RStudio Servers started by rserver-dev.
+
+Options:
+  --path=<dir>   Checkout to report on (same as the positional argument)
+  --all          Report on every git worktree of this repository
+  --help         Show this message
+`.trim();
+
+/** Every worktree path of the repository containing `checkout`, including it. */
+function gitWorktrees(checkout: string): string[] {
+  try {
+    const out = execFileSync('git', ['worktree', 'list', '--porcelain'], {
+      cwd: checkout,
+      encoding: 'utf8',
+    });
+
+    return out
+      .split('\n')
+      .filter((line) => line.startsWith('worktree '))
+      .map((line) => line.slice('worktree '.length).trim())
+      .filter((dir) => fs.existsSync(dir));
+  } catch {
+    // Not a git checkout, or git is unavailable: report on the one we know.
+    return [checkout];
+  }
+}
+
+function reportInstance(instance: Instance): void {
+  const rserverAlive = pidMatches(instance.rserverPid, 'rserver');
+  const gwtAlive = instance.gwtPid !== null && pidMatches(instance.gwtPid, 'devmode');
+
+  console.log(`  ${instance.checkout}`);
+  console.log(`    url:      ${instance.url}  [${rserverAlive ? 'running' : 'DEAD'}]`);
+  console.log(`    rserver:  pid ${instance.rserverPid}`);
+
+  if (instance.gwt === 'devmode') {
+    console.log(
+      `    devmode:  pid ${instance.gwtPid} on port ${instance.codeServerPort}  [${gwtAlive ? 'running' : 'DEAD'}]`,
+    );
+  } else {
+    console.log(`    gwt:      ${instance.gwt} (no code server)`);
+  }
+
+  console.log(`    started:  ${instance.startedAt}`);
+
+  if (!rserverAlive) {
+    console.log(`    note:     stale record; clear it with \`npm run rserver-stop -- ${instance.checkout}\``);
+  }
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.flags.get('help')) {
+    console.log(USAGE);
+    return;
+  }
+
+  rejectUnknownFlags(TAG, args, KNOWN_FLAGS);
+  requirePosix(TAG);
+
+  const pathFlag = args.flags.get('path');
+  const checkout = resolveCheckout(TAG, typeof pathFlag === 'string' ? pathFlag : args.positional[0]);
+  const roots = args.flags.get('all') ? gitWorktrees(checkout) : [checkout];
+
+  const instances = roots
+    .filter((root) => fs.existsSync(instanceFile(root)))
+    .map((root) => readInstance(root))
+    .filter((instance): instance is Instance => instance !== null);
+
+  if (instances.length === 0) {
+    step(TAG, args.flags.get('all') ? 'No dev servers recorded in any worktree.' : `No dev server recorded for ${checkout}.`);
+    return;
+  }
+
+  console.log('');
+  for (const instance of instances) {
+    reportInstance(instance);
+    console.log('');
+  }
+}
+
+main();

--- a/tasks/rserver-stop.ts
+++ b/tasks/rserver-stop.ts
@@ -1,0 +1,58 @@
+// Stop the development RStudio Server started by rserver-dev.
+//
+//     npm run rserver-stop -- [<checkout>]
+//
+// Reads <checkout>/.rstudio-dev/instance.json and shuts down whatever it
+// describes. Safe to run when nothing (or only part of it) is still running.
+
+import {
+  fail,
+  parseArgs,
+  readInstance,
+  rejectUnknownFlags,
+  requirePosix,
+  resolveCheckout,
+  step,
+  stopInstance,
+} from './common.ts';
+
+const TAG = 'rserver-stop';
+
+const KNOWN_FLAGS = ['path', 'help'];
+
+const USAGE = `
+Usage: npm run rserver-stop -- [<checkout>]
+
+Stops the development RStudio Server running for an RStudio checkout or git
+worktree (default: the checkout these tasks live in).
+
+Options:
+  --path=<dir>   Checkout to stop (same as the positional argument)
+  --help         Show this message
+`.trim();
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.flags.get('help')) {
+    console.log(USAGE);
+    return;
+  }
+
+  rejectUnknownFlags(TAG, args, KNOWN_FLAGS);
+  requirePosix(TAG);
+
+  const pathFlag = args.flags.get('path');
+  const checkout = resolveCheckout(TAG, typeof pathFlag === 'string' ? pathFlag : args.positional[0]);
+
+  const instance = readInstance(checkout);
+  if (!instance) {
+    step(TAG, `No dev server recorded for ${checkout}; nothing to stop.`);
+    return;
+  }
+
+  step(TAG, `Stopping the dev server at ${instance.url} (${checkout})...`);
+  await stopInstance(TAG, instance);
+  step(TAG, 'Done.');
+}
+
+main().catch((e: unknown) => fail(TAG, (e as Error).message));


### PR DESCRIPTION
Adds a repo-level `package.json` and a `tasks/` directory with three scripts for managing development RStudio Server instances, so bringing one up for manual testing (including for a git worktree) is a single command:

```sh
npm run rserver-dev                          # this checkout
npm run rserver-dev -- ../some-worktree      # another checkout
npm run rserver-status -- --all              # what is running
npm run rserver-stop                         # tear it down
```

`rserver-dev` configures `<checkout>/build` if it has never been configured, runs an incremental `cmake --build`, picks free ports, starts `rserver` with a private data dir and secure-cookie key, starts `ant devmode`, waits for both to answer, and prints the URL. Both processes are detached and outlive the task; state and logs land in `<checkout>/.rstudio-dev/` (gitignored). `--gwt=draft` does a one-shot `ant draft` instead, `--gwt=none` reuses `src/gwt/www` as-is, and `--help` lists the rest.

The tasks are TypeScript run directly by node's built-in type stripping (Node 22.18+) -- no dependencies, no build step, no `node_modules` at the repo root. `tasks/package.json` scopes ESM to that directory so the repo root keeps its default CommonJS resolution for stray `.js` files elsewhere in the tree.

### Concurrent instances

Ports, data dir and cookie key are per instance, so several worktrees can serve at once. The GWT code server port has to vary too, because it is baked into the bootstrap written to `src/gwt/www`, so `build.xml` gains `codeserver.port` and `server.port` properties and passes `-codeServerPort` to DevMode. The defaults (9876 / 8787) reproduce the existing behavior exactly -- 9876 is what `SuperDevListener.chooseCodeServerPort` picks when the flag is unset -- so `ant devmode` run on its own is unchanged.

### Why not the rserver-dev wrapper

`rserver` is spawned directly rather than through `build/src/cpp/rserver-dev`. That wrapper's SIGINT trap runs `killall -SIGUSR2 rsession`, which would suspend the R sessions of every *other* dev server and any desktop RStudio on the machine; it also deletes the shared `/tmp/rstudio-server` and hardcodes the port in its banner. The flags passed here otherwise reproduce the wrapper, and it is left in place unchanged.

The server binds `127.0.0.1` by default. It runs `--auth-none`, so the wrapper's wildcard bind exposed a passwordless R session to the network; `--www-address` still allows that but warns.

### Port probing

Worth a look during review. A single bind test cannot establish that a port is free on macOS: a specific-address bind and a wildcard bind coexist, and the more specific socket then silently takes `localhost` traffic from whatever was already there. Measured against a running `rserver` on `*:8787` and a devmode on `127.0.0.1:9876`:

| port | bind `127.0.0.1` | bind `0.0.0.0` | connect |
|---|---|---|---|
| 8787 (wildcard held) | **OK** | EADDRINUSE | ANSWERED |
| 9876 (specific held) | EADDRINUSE | **OK** | ANSWERED |
| free | OK | OK | ECONNREFUSED |

Each bind test misses the opposite binding style, so `isPortFree` requires both plus a refused connect. An explicit `--port` is validated the same way instead of bypassing the scan.

### Testing

Verified locally on macOS: start/probe/stop; two concurrent instances (8787 + 8788) across two worktrees; idempotent double start; `--restart`; recovery from stale state; per-instance temp dir cleanup; that the probe skips a port held by an already-running server and rejects an explicit one; and that `-D` overrides survive ant's `<antcall>` chain with the defaults reproducing today's values.

The `--gwt=devmode` path has since been exercised end to end as well: `rserver-dev` brought up `rserver` and `ant devmode` for a separate checkout, and a headless-browser load booted the full workbench (live R session at the console) through the Super Dev Mode on-demand compile. That run also surfaced a trap worth guarding: a checkout whose `build.xml` predates the `codeserver.port` property silently ignores `-Dcodeserver.port`, so the code server starts on 9876 while the task polls the requested port until its timeout. `rserver-dev` now fails fast in that case.

### Snyk

The diff-scoped Snyk Code scan reported every argv-derived path handed to `fs` as path traversal, and the `rserver` spawn as command injection -- for a local developer tool whose purpose is operating on the checkout you point it at. Snyk Code has no per-finding suppression (`.snyk` supports only whole-file excludes), and its taint tracking survives `path.resolve` and `fs.realpathSync`. Instead, `resolveCheckout` now rebuilds the canonicalized path one component at a time from `readdirSync` listings (which also re-verifies each component exists), and `--www-address` is validated and rebuilt numerically -- so the values reaching the sinks are no longer derived from command-line strings.

No NEWS.md entry: developer tooling, not user-facing.

