### PR TITLE
Fix detached logger().logError in desktop promise catch handlers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 - ([#18253](https://github.com/rstudio/rstudio/issues/18253)): Added a "Check for Posit Assistant updates" command to the Help menu. It always reports its result in a dialog -- whether Posit Assistant is up to date, an update is available (with the option to install it), or a newer Posit Assistant requires a newer version of RStudio.
 
 ### Fixed
+- ([#18391](https://github.com/rstudio/rstudio/issues/18391)): Fixed RStudio Desktop error logging that reported `TypeError: Cannot read properties of undefined (reading 'logErrorAtLevel')` in place of the actual error when a background operation failed. Closing the main window after its renderer has crashed now also exits RStudio instead of leaving a headless process running.
 - ([#18152](https://github.com/rstudio/rstudio/issues/18152)): Fixed a compilation error when building RStudio Server against SOCI 4.1.4 or newer.
 - ([#18287](https://github.com/rstudio/rstudio/issues/18287)): Fixed another compilation error when building RStudio against system SOCI packages (4.1 or newer), which no longer expose the SQLite C API through their headers.
 - ([#18174](https://github.com/rstudio/rstudio/issues/18174)): Fixed an error when viewing an object from the Object Explorer with the French user interface language enabled.

--- a/src/node/desktop/eslint.config.mjs
+++ b/src/node/desktop/eslint.config.mjs
@@ -80,6 +80,10 @@ export default defineConfig([globalIgnores([
 
         "@/no-throw-literal": ["error"],
         "@typescript-eslint/no-unnecessary-condition": ["error"],
+
+        // detached method references lose their `this` and blow up when
+        // invoked, e.g. `.catch(logger().logError)` (rstudio#18391)
+        "@typescript-eslint/unbound-method": ["error"],
         "@typescript-eslint/promise-function-async": ["warn"],
         "@typescript-eslint/require-array-sort-compare": ["error"],
         "@typescript-eslint/return-await": ["warn"],
@@ -98,5 +102,13 @@ export default defineConfig([globalIgnores([
             allowNullableString: true,
             allowNullableNumber: true,
         }],
+    },
+}, {
+    // sinon assertions take stub method references (e.g.
+    // `sandbox.assert.calledOnce(stub.setSize)`), which trips unbound-method
+    files: ["test/**/*.ts"],
+
+    rules: {
+        "@typescript-eslint/unbound-method": "off",
     },
 }]);

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -349,10 +349,15 @@ export class MainWindow extends GwtWindow {
         } else {
           this.executeJavaScript('window.desktopHooks.quitR()')
             .then(() => (this.quitConfirmed = true))
-            .catch(logger().logError);
+            .catch((error: unknown) => logger().logError(error));
         }
       })
-      .catch(logger().logError);
+      .catch((error: unknown) => {
+        // the desktopHooks probe could not run at all (e.g. the renderer
+        // crashed), so exit rather than leave a headless process behind
+        logger().logError(error);
+        quit();
+      });
   }
 
   collectPendingQuitRequest(): PendingQuit {
@@ -368,7 +373,7 @@ export class MainWindow extends GwtWindow {
       return;
     }
     reloadCount++;
-    this.loadUrl(this.options.baseUrl ?? '').catch(logger().logError);
+    this.loadUrl(this.options.baseUrl ?? '').catch((error: unknown) => logger().logError(error));
   }
 
   onLoadFinished(ok: boolean): void {
@@ -382,7 +387,7 @@ export class MainWindow extends GwtWindow {
         // the load failed, but we haven't yet received word that the
         // session has failed to load. let the user know that the R
         // session is still initializing, and then reload the page.
-        this.loadUrl(LOADING_WINDOW_WEBPACK_ENTRY, false).catch(logger().logError);
+        this.loadUrl(LOADING_WINDOW_WEBPACK_ENTRY, false).catch((error: unknown) => logger().logError(error));
         waitForUrlWithTimeout(this.options.baseUrl ?? '', reloadWaitDuration, reloadWaitDuration, 10)
           .then((error: Err) => {
             if (error) {
@@ -410,7 +415,7 @@ export class MainWindow extends GwtWindow {
     const vars = new Map<string, string>();
     vars.set('retry_url', this.options.baseUrl ?? '');
     appState().gwtCallback?.setErrorPageInfo(vars);
-    this.loadUrl(CONNECT_WINDOW_WEBPACK_ENTRY).catch(logger().logError);
+    this.loadUrl(CONNECT_WINDOW_WEBPACK_ENTRY).catch((error: unknown) => logger().logError(error));
   }
 
   setErrorDisplayed(): void {

--- a/src/node/desktop/src/main/minimal-window.ts
+++ b/src/node/desktop/src/main/minimal-window.ts
@@ -49,7 +49,6 @@ class MinimalWindow extends DesktopBrowserWindow {
     });
 
     // ensure this window closes when the creating window closes
-    this.parentWindowDestroyed = this.parentWindowDestroyed.bind(this);
     this.options.parent?.on(DesktopBrowserWindow.WINDOW_DESTROYED, this.parentWindowDestroyed);
 
     this.window.on('close', () => {
@@ -58,7 +57,9 @@ class MinimalWindow extends DesktopBrowserWindow {
     });
   }
 
-  parentWindowDestroyed(): void {
+  // arrow function so it stays bound to this window when passed to
+  // the parent's event emitter above
+  parentWindowDestroyed = (): void => {
     // The parent listener is removed on this window's 'close' event, but a
     // shutdown-ordering race can fire WINDOW_DESTROYED after this window's
     // BrowserWindow is already destroyed. Guard against closing a dead window
@@ -66,7 +67,7 @@ class MinimalWindow extends DesktopBrowserWindow {
     if (!this.window.isDestroyed()) {
       this.window.close();
     }
-  }
+  };
 }
 
 export function openMinimalWindow(

--- a/src/node/desktop/src/main/satellite-window.ts
+++ b/src/node/desktop/src/main/satellite-window.ts
@@ -64,7 +64,7 @@ export class SatelliteWindow extends GwtWindow {
             `if (window.unregisterDesktopChildWindow)
                window.unregisterDesktopChildWindow(${JSON.stringify(name)});`,
           )
-          .catch(logger().logError);
+          .catch((error: unknown) => logger().logError(error));
       }
     });
 
@@ -74,14 +74,14 @@ export class SatelliteWindow extends GwtWindow {
   onActivated(): void {
     this.executeJavaScript(
       'if (window.notifyRStudioSatelliteReactivated) ' + '  window.notifyRStudioSatelliteReactivated(null);',
-    ).catch(logger().logError);
+    ).catch((error: unknown) => logger().logError(error));
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   closeSatellite(event: Electron.Event): void {
     this.executeJavaScript(
       'if (window.notifyRStudioSatelliteClosing) ' + '  window.notifyRStudioSatelliteClosing();',
-    ).catch(logger().logError);
+    ).catch((error: unknown) => logger().logError(error));
   }
 
   closeEvent(event: Electron.Event): void {
@@ -108,10 +108,10 @@ export class SatelliteWindow extends GwtWindow {
           } else {
             // not ready to close, revert close stage and take care of business
             this.closeStage = 'CloseStageOpen';
-            this.executeJavaScript('window.rstudioCloseSourceWindow()').catch(logger().logError);
+            this.executeJavaScript('window.rstudioCloseSourceWindow()').catch((error: unknown) => logger().logError(error));
           }
         })
-        .catch(logger().logError);
+        .catch((error: unknown) => logger().logError(error));
     } else {
       // not a  source window, just close it
       this.closeSatellite(event);

--- a/src/node/desktop/test/unit/main/main-window.test.ts
+++ b/src/node/desktop/test/unit/main/main-window.test.ts
@@ -19,6 +19,7 @@ import sinon from 'sinon';
 
 import { ChildProcess } from 'child_process';
 
+import { NullLogger, setLogger } from '../../../src/core/logger';
 import { MainWindow } from '../../../src/main/main-window';
 import desktop from '../../../src/native/desktop.node';
 
@@ -75,4 +76,51 @@ describe('MainWindow', () => {
       }
     });
   });
+
+  describe('closeEvent', () => {
+    let nullLogger: NullLogger;
+    let logSpy: sinon.SinonSpy;
+
+    beforeEach(() => {
+      nullLogger = new NullLogger();
+      logSpy = sinon.spy(nullLogger, 'logErrorAtLevel');
+      setLogger(nullLogger);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+      setLogger(new NullLogger());
+    });
+
+    // simulates the close-during-crashed-renderer path from #18391: the
+    // window is closing while a session is still attached, and the renderer
+    // can no longer run the '!!window.desktopHooks' probe
+    function closeEventWithRejectingRenderer(error: Error) {
+      const fake = {
+        geometrySaved: true,
+        quitConfirmed: false,
+        sessionProcess: { exitCode: null },
+        window: {},
+        executeJavaScript: sinon.stub().rejects(error),
+        quit: sinon.stub(),
+      };
+      const event = { preventDefault: sinon.stub() } as unknown as Electron.Event;
+      MainWindow.prototype.closeEvent.call(fake as unknown as MainWindow, event);
+      return fake;
+    }
+
+    it('logs the original error when the desktopHooks probe rejects', async () => {
+      const boom = new Error('render frame was disposed');
+      closeEventWithRejectingRenderer(boom);
+      await new Promise(setImmediate);
+      assert.isTrue(logSpy.calledWith('error', boom));
+    });
+
+    it('quits instead of leaving a headless process when the desktopHooks probe rejects', async () => {
+      const fake = closeEventWithRejectingRenderer(new Error('render frame was disposed'));
+      await new Promise(setImmediate);
+      assert.isTrue(fake.quit.calledOnce);
+    });
+  });
+
 });


### PR DESCRIPTION
Fixes #18391.

## What this changes

Ten call sites in `main-window.ts` and `satellite-window.ts` passed `logger().logError` directly to `.catch()`. The method reads `this.logErrorAtLevel`, so when a promise rejected, the detached call threw `TypeError: Cannot read properties of undefined (reading 'logErrorAtLevel')` inside the catch handler — replacing the original rejection with an unhandled meta-error and hiding the real failure (as seen in the logs on #18323). Each site now invokes the method on its logger instance via an arrow function, which also picks up the current logger at rejection time rather than at registration time.

In `MainWindow.closeEvent`, a rejected `!!window.desktopHooks` probe means the renderer is unreachable (e.g. it crashed). That path now logs the error and quits — matching the existing missing-`desktopHooks` branch — instead of leaving a headless process running after the window closes.

To keep the pattern from coming back, the desktop ESLint config now enables the type-aware `@typescript-eslint/unbound-method` rule, which flags every detached method reference of this kind. Two adaptations for spots that were already safe: `minimal-window.ts`'s `parentWindowDestroyed` is now an arrow property (replacing its manual constructor `.bind`), and test files are exempted because sinon assertions take stub method references by design.

## Tests

- Two new unit tests for `closeEvent` with a rejecting renderer probe: the original error reaches the log sink, and the app quits instead of lingering. Both fail without the fix.
- Full desktop suite passes (447), plus `npm run lint` and `npm run typecheck`.
