### PR TITLE
pin data viewer cell line-height so rows render at row-height everywhere

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,7 @@
 - ([#18340](https://github.com/rstudio/rstudio/issues/18340)): Fixed an issue in RStudio Server where the IDE could stop receiving updates from the session after an R session restart until the user's next interaction -- most visibly, "Restart R and Run All Chunks" restarting R but appearing to hang before running the chunks, and console output after a suspended session resumed not appearing until the user did something else.
 - ([#12572](https://github.com/rstudio/rstudio/issues/12572)): The macOS `diagnostics` and `rpostback` helper binaries are now universal (Apple Silicon + Intel). RStudio no longer prompts to install Rosetta 2 at startup on Apple Silicon.
 - ([#9026](https://github.com/rstudio/rstudio/issues/9026)): The Review Changes window (Git and SVN commit and history) now follows the active theme, instead of always rendering with a light palette. The changelist and diff panes use the editor theme, as they do in the Git pane. The file lists in the Review Changes window and in the Git and SVN panes also show a "No changes" placeholder when there is nothing to review, instead of appearing blank.
+- ([#18378](https://github.com/rstudio/rstudio/issues/18378)): Fixed an issue in the Data Viewer where jumping to the bottom with End or Ctrl+End stopped short, leaving the last row partly hidden below the bottom edge, on platforms whose user-interface font renders taller than expected (Windows, and Linux distributions such as Fedora and RHEL 10 that default to Noto Sans).
 
 ### Dependencies
 - MathJax 4.1.3 (inline LaTeX / math previews)

--- a/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
@@ -8,7 +8,6 @@
 // values and column names.
 
 import { test, expect } from '@fixtures/rstudio.fixture';
-import * as os from 'os';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePane } from '@pages/source_pane.page';
 import { DataViewerPane } from '@pages/data_viewer.page';
@@ -1310,28 +1309,21 @@ test.describe('Data Viewer', () => {
   });
 
   // https://github.com/rstudio/rstudio/issues/17958
+  // https://github.com/rstudio/rstudio/issues/18378
   //
-  // Two regressions from the vanilla-JS grid rewrite: (1) End/Ctrl+End jumped
-  // to the last *column* (Excel semantics) instead of scrolling to the bottom
-  // of the current column like the pre-rewrite viewer; (2) the bottom-edge
-  // math in ensureActiveCellVisible used the raw viewport clientHeight,
-  // ignoring the sticky header inside it, so the jump landed a header-height
-  // short and the target row stayed hidden below the fold.
+  // Three regressions from the vanilla-JS grid rewrite: (1) End/Ctrl+End
+  // jumped to the last *column* (Excel semantics) instead of scrolling to the
+  // bottom of the current column like the pre-rewrite viewer; (2) the
+  // bottom-edge math in ensureActiveCellVisible used the raw viewport
+  // clientHeight, ignoring the sticky header inside it, so the jump landed a
+  // header-height short and the target row stayed hidden below the fold;
+  // (3) on platforms whose UI font has an 11px line box taller than 14px
+  // (Segoe UI on Windows, Noto Sans on Fedora / RHEL 10+), rendered rows grew
+  // past the 23px ROW_HEIGHT the scroll math assumes -- td height is only a
+  // minimum -- so the jump stopped a pixel short per rendered row, ~24px in
+  // this layout. Fixed by pinning the td line-height (#18378); this test was
+  // previously test.fixme'd on Windows CI because of that shortfall.
   test('End scrolls to the last row of the current column, fully visible (#17958)', async ({ rstudioPage: page }) => {
-    // Windows CI: the bottom-edge assertion below reliably fails on
-    // windows-2025 -- cellBox.y + cellBox.height lands ~24px below the
-    // viewport's bottom (observed 332.25 vs 308.5) even though
-    // visibleBodyHeight subtracts the 10px custom horizontal scrollbar
-    // overlay. The 24px overshoot matches neither headerH nor the 10px
-    // scrollbar height, so the gap is most likely a row-height or
-    // viewport-clientHeight delta on Windows Chromium/Electron that the
-    // ensureActiveCellVisible math (DataViewer.js: rowBottom - bodyHeight)
-    // doesn't account for. The product fix in #17961 was developed on
-    // macOS with overlay scrollbars; Windows needs a follow-up to
-    // visibleBodyHeight (or the test's tolerance) once someone with a
-    // Windows box can repro and tune the subtraction.
-    test.fixme(os.platform() === 'win32' && !!process.env.CI, 'visibleBodyHeight undersubtracts on Windows -- see #17958 / #17961');
-
     // 500 rows forces vertical virtual scrolling; 30 columns force horizontal
     // overflow so a wrong jump-to-last-column would visibly move scrollLeft.
     await consoleActions.executeInConsole(

--- a/src/cpp/session/resources/grid/DataViewer.css
+++ b/src/cpp/session/resources/grid/DataViewer.css
@@ -239,6 +239,14 @@ td {
    font-size: 11px;
    background-color: var(--grid-bg);
    height: var(--row-height);
+   /* height on a table cell is only a minimum, so the line box must be pinned
+      for rows to actually measure --row-height: 14px line + 8px padding + 1px
+      border = 23px. With line-height left normal, fonts whose 11px line box is
+      15px (Segoe UI on Windows, Noto Sans on Fedora / RHEL 10+) grew every
+      rendered row to 24px, breaking the uniform-ROW_HEIGHT assumption the
+      virtual-scroll math depends on -- Ctrl+End then stopped a pixel short of
+      the bottom for each rendered row (#18378). */
+   line-height: 14px;
    overflow: hidden;
 }
 


### PR DESCRIPTION
The data viewer's virtual-scroll math assumes every data row is exactly `ROW_HEIGHT` (23px), but `height` on a table cell is only a *minimum*. The grid's font stack starts with DejaVu Sans, whose 11px line box (13px) fits inside the 14px available (23px minus 8px vertical padding and 1px border). On platforms where DejaVu Sans is not installed, the resolved font's normal line box is 15px -- Segoe UI on Windows, Noto Sans on Fedora and RHEL 10+ (which dropped DejaVu from the default font set) -- so every *rendered* row grew to 24px while the spacer rows standing in for off-window rows stayed at 23px per row. Ctrl+End computes its scroll target from the 23px constant, so the jump landed one pixel short per rendered row (~24px in the e2e layout), leaving the last row cut off below the bottom edge.

This explains the platform matrix in the issue exactly: Ubuntu, Debian, and Rocky 9 ship DejaVu Sans (13px line box, 23px rows, pass); macOS resolves Lucida Grande (13px, pass); Windows, Fedora 43/44, and Rocky 10 resolve a 15px-line-box font (24px rows, fail). Architecture is irrelevant, matching the observed results.

The fix pins `line-height: 14px` on the grid `td` so 14px line + 8px padding + 1px border = `--row-height` exactly, independent of platform font metrics. Since `line-height` applies uniformly to all font-fallback runs, this also keeps rows at 23px for cell text drawn with fallback fonts (e.g. CJK). Verified in headless Chromium with the real Noto Sans TTF: with normal line-height the row measures 24px (line box 15px); with the pin it measures exactly 23px, even under fonts with far taller metrics (Zapfino's 38px line box).

Also removes the `test.fixme` Windows CI guard from the "End scrolls to the last row of the current column, fully visible" e2e test -- it was skipping exactly this failure (the observed ~24px shortfall in its comment is the per-rendered-row pixel deficit) -- so Windows CI now verifies the fix.

The full data viewer e2e spec passes on macOS desktop-dev (40/40) with the fix in place; dispatched e2e runs on Fedora 43 and Windows Server 2025 validate it on platforms that reproduce the bug.

Fixes #18378.