### PR TITLE
Bind SM_CLIENT_CERT_FILE_2026 secret file credential directly

### DIFF
--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -101,12 +101,12 @@ pipeline {
     stage('Build Windows') {
       environment {
         // Map the year-suffixed credentials onto the env var names the DigiCert
-        // tools and signing steps read; SM_CLIENT_CERT_FILE is set after decoding
-        // the base64 certificate in the Prepare Client Certificate stage
+        // tools and signing steps read; SM_CLIENT_CERT_FILE_2026 is a secret
+        // file credential, so it binds as the path to the client certificate
         SM_HOST = credentials('SM_HOST_2026')
         SM_API_KEY = credentials('SM_API_KEY_2026')
         SM_CLIENT_CERT_PASSWORD = credentials('SM_CLIENT_CERT_PASSWORD_2026')
-        SM_CLIENT_CERT_B64 = credentials('SM_CLIENT_CERT_FILE_2026')
+        SM_CLIENT_CERT_FILE = credentials('SM_CLIENT_CERT_FILE_2026')
         KEYPAIR_ALIAS = credentials('SM_KEYPAIR_ALIAS_2026')
       }
       agent {
@@ -133,20 +133,12 @@ pipeline {
           }
         }
 
-        stage('Prepare Client Certificate') {
+        stage('Validate Signing Credentials') {
           steps {
             // Signing requires the mTLS host; any other value fails only at the
             // moment of signing, so catch it before the build instead
             bat 'if not "%SM_HOST%"=="https://clientauth.one.digicert.com" (echo SM_HOST must be the clientauth mTLS host; check the SM_HOST_2026 credential & exit /b 1)'
-            powershell '''
-              if (Test-Path -LiteralPath $env:SM_CLIENT_CERT_B64) { throw 'SM_CLIENT_CERT_FILE_2026 is a secret file credential (its value is a file path); bind it directly to SM_CLIENT_CERT_FILE instead of base64-decoding it' }
-              $bytes = [Convert]::FromBase64String($env:SM_CLIENT_CERT_B64)
-              if ($bytes.Length -eq 0) { throw 'SM_CLIENT_CERT_FILE_2026 decoded to zero bytes; the credential value is empty or whitespace' }
-              [IO.File]::WriteAllBytes("$env:WORKSPACE\\sm_client_cert.p12", $bytes)
-            '''
-            script {
-              env.SM_CLIENT_CERT_FILE = "${env.WORKSPACE}\\sm_client_cert.p12"
-            }
+            bat 'if not exist "%SM_CLIENT_CERT_FILE%" (echo SM_CLIENT_CERT_FILE is not a path to the client certificate; check the SM_CLIENT_CERT_FILE_2026 secret file credential & exit /b 1)'
           }
         }
 
@@ -330,15 +322,11 @@ pipeline {
       }
 
       post {
-        // the custom workspace is reused across builds: don't leave the decoded
-        // client auth certificate behind, and remove cert.pem so a failed
-        // download in a later build can never fall back to a stale certificate
+        // the custom workspace is reused across builds: remove cert.pem so a
+        // failed download in a later build can never fall back to a stale
+        // certificate
         always {
-          bat '''
-            if exist "%WORKSPACE%\\sm_client_cert.p12" del /f /q "%WORKSPACE%\\sm_client_cert.p12"
-            if exist "%WORKSPACE%\\cert.pem" del /f /q "%WORKSPACE%\\cert.pem"
-            if exist "%WORKSPACE%\\sm_client_cert.p12" (echo ERROR: could not remove sm_client_cert.p12 from the reused workspace & exit /b 1)
-          '''
+          bat 'if exist "%WORKSPACE%\\cert.pem" del /f /q "%WORKSPACE%\\cert.pem"'
         }
       }
     } // Build Windows Stage


### PR DESCRIPTION
Follow-up to #18401. The hourly build after that merge failed in the Prepare Client Certificate stage with the guard added there: `SM_CLIENT_CERT_FILE_2026` is a Jenkins secret file credential, so `credentials()` binds a path to the certificate file rather than base64 secret text.

- Binds `SM_CLIENT_CERT_FILE` directly to the `SM_CLIENT_CERT_FILE_2026` credential, giving the DigiCert tools the client certificate path with no intermediate step.
- Replaces the Prepare Client Certificate stage with a Validate Signing Credentials stage that keeps the `SM_HOST` check and verifies the certificate file exists before the build starts.
- Removes the base64 decode step and the workspace cleanup for the decoded `sm_client_cert.p12`, which is no longer written. The `cert.pem` cleanup in the post block remains.

The failed build confirms the direct binding resolves inside the build container: the secret file is materialized under the workspace `@tmp` directory, which is mounted into the container, and the previous run located it there.

Verification requires a Jenkins build; running with `PUBLISH=false` exercises executable signing without publishing anything.
