### PR TITLE
Add CODEOWNERS file for path-specific review ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Path-specific review ownership.
+#
+# Entries are added per path as reviewing teams are confirmed. A file with
+# no entries leaves every path unowned, so enabling "Require review from
+# Code Owners" in branch protection has no effect until an entry lands.


### PR DESCRIPTION
Adds `.github/CODEOWNERS`, which the repository has not had until now.

The file intentionally contains no entries yet — only comments explaining the convention. With no entries, every path stays unowned, so enabling "Require review from Code Owners" in branch protection changes the review requirements on nothing. That lets the branch-protection setting be turned on independently, ahead of the first real ownership entry.

Entries will be added per path as reviewing teams are confirmed.