### PR TITLE
fix(macos): pass -f pkcs12 to security import

### DIFF
--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -135,8 +135,18 @@ pipeline {
             security unlock-keychain -p "${KEYCHAIN_PASSPHRASE}" "${KEYCHAIN_PATH}"
             security set-keychain-settings "${KEYCHAIN_PATH}"
 
-            # Import the developer ID from Jenkins secrets
+            # Import the developer ID from Jenkins secrets.
+            #
+            # Pass -f explicitly. Without it, `security import` infers the
+            # input format from the file's extension, and the filename of a
+            # Jenkins "Secret file" credential is not a stable contract:
+            # credentials-binding 728 started writing secrets to a random
+            # `fileNNNNN.tmp` rather than the credential's uploaded filename,
+            # which made this step fail with
+            #   security: SecKeychainItemImport: Unknown format in import.
+            # See jenkinsci/credentials-binding-plugin#534.
             security import "${MACOS_DEVELOPER_CERTIFICATE}" \
+              -f pkcs12                                      \
               -k "${KEYCHAIN_PATH}"                          \
               -P "${MACOS_DEVELOPER_CERTIFICATE_KEY}"        \
               -T /usr/bin/codesign


### PR DESCRIPTION
## Problem

`security import` in the **Build and Sign** stage infers the input format from the file's extension when `-f` is omitted.

The path it is given comes from a Jenkins **Secret file** credential (`MACOS_DEVELOPER_CERTIFICATE`, uploaded as `posit.p12`). That filename turns out not to be a stable contract. `credentials-binding` **728.v902a_273b_8947** ([PR #534](https://github.com/jenkinsci/credentials-binding-plugin/pull/534)) changed `FileBinding` to write secrets to a random temp name:

```diff
-String baseName = new FilePath(new File(credentials.getFileName())).getName();
-FilePath secret = dir.child(baseName);
+FilePath secret = dir.createTempFile("file", null);
```

So the file arrived as `fileNNNNN.tmp`, the `.p12` extension was gone, and signing died:

```
+ security import **** -k .../buildagent.keychain -P **** -T /usr/bin/codesign
security: SecKeychainItemImport: Unknown format in import.
```

Because the `sh` step runs with `-e`, the block aborted there — which is why none of the `security find-identity` verification output appears in the failing logs.

Every macOS hourly and daily build failed from **2026-07-28** (when the plugin was upgraded) until the controller was rolled back to `credentials-binding` 725 today.

## Fix

Pass `-f pkcs12` explicitly. The credential is a PKCS#12 keystore, so this is what the extension was resolving to anyway — it just no longer depends on the filename.

## Why this is worth landing even though the plugin is rolled back

The rollback is a stopgap. #534 is deliberate hardening (it addresses [#532](https://github.com/jenkinsci/credentials-binding-plugin/issues/532)) and is not going to be reverted, so the plugin will move forward again eventually. Until this is in, that upgrade re-breaks macOS signing. This change makes the step version-independent.

## Testing

Not yet exercised on a build — the controller is back on 725, where signing works via extension inference. `-f pkcs12` is correct under both 725 and 728: it states the format the credential already is, rather than changing it.

A macOS build has been requested to confirm the rollback restored signing; I will verify green before merging this.
