### PR TITLE
stop win32 output capture from logging unboundedly on echo write failure

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,7 @@
 - ([#12572](https://github.com/rstudio/rstudio/issues/12572)): The macOS `diagnostics` and `rpostback` helper binaries are now universal (Apple Silicon + Intel). RStudio no longer prompts to install Rosetta 2 at startup on Apple Silicon.
 - ([#9026](https://github.com/rstudio/rstudio/issues/9026)): The Review Changes window (Git and SVN commit and history) now follows the active theme, instead of always rendering with a light palette. The changelist and diff panes use the editor theme, as they do in the Git pane. The file lists in the Review Changes window and in the Git and SVN panes also show a "No changes" placeholder when there is nothing to review, instead of appearing blank.
 - ([#18378](https://github.com/rstudio/rstudio/issues/18378)): Fixed an issue in the Data Viewer where jumping to the bottom with End or Ctrl+End stopped short, leaving the last row partly hidden below the bottom edge, on platforms whose user-interface font renders taller than expected (Windows, and Linux distributions such as Fedora and RHEL 10 that default to Noto Sans).
+- ([#18414](https://github.com/rstudio/rstudio/issues/18414)): Fixed an issue on Windows where an R session launched with a console attached and stderr logging enabled could flood its logs at full CPU speed if the console later became unwritable; console echo failures and output-capture read errors are now logged once instead of unboundedly.
 
 ### Dependencies
 - MathJax 4.1.3 (inline LaTeX / math previews)

--- a/src/cpp/core/system/Win32OutputCapture.cpp
+++ b/src/cpp/core/system/Win32OutputCapture.cpp
@@ -48,6 +48,9 @@ void standardStreamCaptureThread(
 {
    try
    {
+      bool skipEchoWrite = false;
+      bool loggedReadError = false;
+
       while(true)
       {
          const int kBufferSize = 512;
@@ -59,27 +62,44 @@ void standardStreamCaptureThread(
             {
                outputHandler(std::string(buffer, bytesRead));
 
-               if (hOrigStdHandle)
+               if (hOrigStdHandle && !skipEchoWrite)
                {
-                  bool result = false;
+                  DWORD writeError = ERROR_SUCCESS;
                   LOCK_MUTEX(s_mutex)
                   {
-                     result = ::WriteFile(hOrigStdHandle, buffer, bytesRead, nullptr, nullptr);
+                     if (!::WriteFile(hOrigStdHandle, buffer, bytesRead, nullptr, nullptr))
+                        writeError = ::GetLastError();
                   }
                   END_LOCK_MUTEX
 
-                  if (!result)
+                  if (writeError != ERROR_SUCCESS)
                   {
-                     LOG_ERROR(LAST_SYSTEM_ERROR());
+                     // deliberately give up on the echo after the first failure and
+                     // log only once: with a stderr log destination, a logged error
+                     // is itself captured and read back by this thread, so logging
+                     // every failure spins forever (#18414)
+                     skipEchoWrite = true;
+
+                     LOG_ERROR(systemError(
+                                  writeError,
+                                  "Console is no longer writable. Output will no longer be echoed to the console.",
+                                  ERROR_LOCATION));
                   }
                }
             }
          }
          else
          {
-            // we don't expect errors to ever occur (since the standard
-            // streams are never closed) so log any that do and continue
-            LOG_ERROR(LAST_SYSTEM_ERROR());
+            // we don't expect read errors here (the write end of the pipe is our
+            // own stdout / stderr and is never closed), so log only the first and
+            // back off rather than spinning if one proves persistent (#18414)
+            if (!loggedReadError)
+            {
+               loggedReadError = true;
+               LOG_ERROR(LAST_SYSTEM_ERROR());
+            }
+
+            ::Sleep(100);
          }
       }
    }

--- a/src/cpp/core/system/Win32OutputCapture.cpp
+++ b/src/cpp/core/system/Win32OutputCapture.cpp
@@ -42,6 +42,7 @@ namespace {
 boost::mutex s_mutex;
 
 void standardStreamCaptureThread(
+       const std::string& streamName,
        HANDLE hReadPipe,
        HANDLE hOrigStdHandle,
        const boost::function<void(const std::string&)>& outputHandler)
@@ -67,7 +68,11 @@ void standardStreamCaptureThread(
                   DWORD writeError = ERROR_SUCCESS;
                   LOCK_MUTEX(s_mutex)
                   {
-                     if (!::WriteFile(hOrigStdHandle, buffer, bytesRead, nullptr, nullptr))
+                     // the byte-count out-param is required for synchronous
+                     // handles; a short write is deliberately ignored, as the
+                     // echo is best-effort
+                     DWORD bytesWritten = 0;
+                     if (!::WriteFile(hOrigStdHandle, buffer, bytesRead, &bytesWritten, nullptr))
                         writeError = ::GetLastError();
                   }
                   END_LOCK_MUTEX
@@ -75,14 +80,20 @@ void standardStreamCaptureThread(
                   if (writeError != ERROR_SUCCESS)
                   {
                      // deliberately give up on the echo after the first failure and
-                     // log only once: with a stderr log destination, a logged error
-                     // is itself captured and read back by this thread, so logging
-                     // every failure spins forever (#18414)
+                     // log only once: a stderr log destination writes to the
+                     // redirected stderr, so a logged error is read back by the
+                     // stderr capture thread, and logging every failure spins
+                     // forever. the same option gates both this echo and stderr
+                     // logging, so that feedback loop is guaranteed, not a rare
+                     // configuration (#18414). unlike the Posix twin (#18398),
+                     // no error code is treated as transient here: the console
+                     // handle is opened once at startup and never reopened, so
+                     // the failures targeted here are permanent.
                      skipEchoWrite = true;
 
                      LOG_ERROR(systemError(
                                   writeError,
-                                  "Console is no longer writable. Output will no longer be echoed to the console.",
+                                  streamName + " echo to the attached console failed. Output will no longer be echoed to the console.",
                                   ERROR_LOCATION));
                   }
                }
@@ -90,13 +101,33 @@ void standardStreamCaptureThread(
          }
          else
          {
-            // we don't expect read errors here (the write end of the pipe is our
-            // own stdout / stderr and is never closed), so log only the first and
-            // back off rather than spinning if one proves persistent (#18414)
+            // capture the error code before any other call can clobber it
+            DWORD readError = ::GetLastError();
+
+            // a broken pipe or invalid handle can never recover, and both imply
+            // the pipe no longer accepts writes, so exit instead of polling
+            // forever; logging here is bounded because the thread exits
+            if (readError == ERROR_BROKEN_PIPE || readError == ERROR_INVALID_HANDLE)
+            {
+               LOG_ERROR(systemError(
+                            readError,
+                            streamName + " capture pipe is no longer readable. Output capture stopped.",
+                            ERROR_LOCATION));
+               return;
+            }
+
+            // we don't expect other read errors here (the write end of the pipe
+            // is our own stdout / stderr and is never closed), so log only the
+            // first -- with a stderr log destination, every logged error lands
+            // back in a capture pipe -- and retry at a modest interval rather
+            // than spinning (#18414)
             if (!loggedReadError)
             {
                loggedReadError = true;
-               LOG_ERROR(LAST_SYSTEM_ERROR());
+               LOG_ERROR(systemError(
+                            readError,
+                            streamName + " capture pipe read failed.",
+                            ERROR_LOCATION));
             }
 
             ::Sleep(100);
@@ -247,6 +278,7 @@ Error captureStandardStreams(
 
          // capture stdout
          boost::thread stdoutThread(boost::bind(standardStreamCaptureThread,
+                                                std::string("Stdout"),
                                                 hReadStdoutPipe,
                                                 hOrigStdoutHandle,
                                                 stdoutHandler));
@@ -276,6 +308,7 @@ Error captureStandardStreams(
 
          // capture stderr
          boost::thread stderrThread(boost::bind(standardStreamCaptureThread,
+                                                std::string("Stderr"),
                                                 hReadStderrPipe,
                                                 hOrigStderrHandle,
                                                 stderrHandler));


### PR DESCRIPTION
## Summary

Windows twin of #18398 / PR #18399. `standardStreamCaptureThread` in `Win32OutputCapture.cpp` had the same unbounded-logging shape in two places:

- A failed `WriteFile` to the saved `CONOUT$` console handle was logged on every failure, with no "skip further writes" flag. With a stderr log destination active (`log-stderr=1`, the same option that enables the echo in the first place), each logged error lands on the redirected stderr pipe, is read back by the stderr capture thread, fails to echo again, and logs again -- the same self-sustaining full-CPU loop fixed for Posix in #18399.
- A `ReadFile` failure was logged inside `while (true)` with no bound or backoff, so a persistent read error would also log unboundedly (and spin at full speed).

Reachability is lower than on Posix: in Desktop mode there is no console, so the echo path is disabled at startup. The exposure is a Windows session launched with a console attached and `log-stderr=1`, where the console handle later becomes unwritable.

## Fix

Mirrors #18399:

- On the first echo-write failure, stop echoing to the console for the rest of the session and log the error once. The error code is captured inside the mutex, immediately after the failed `WriteFile`, so an intervening call cannot clobber `GetLastError()`.
- Log only the first `ReadFile` failure, and back off with a short sleep on failed reads so a persistent read error cannot busy-spin.

Client-visible console output is unaffected -- it flows through the capture handlers, not the echo path.

## Verification

This is a Windows-only translation unit, so it cannot be compiled from this macOS checkout; the Windows CI build on this PR is the compile gate. Reproducing the full loop requires a console-attached Windows session with stderr logging whose console becomes unwritable, so this has not been exercised end-to-end.

Addresses #18414.