### PR TITLE
backport quality-of-life SQL tooling

### DIFF
--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -48,6 +48,7 @@ set(CORE_SOURCE_FILES
    Settings.cpp
    SocketRpc.cpp
    StringUtils.cpp
+   SqlIdentifier.cpp
    ColorUtils.cpp
    Thread.cpp
    Timer.cpp
@@ -138,6 +139,8 @@ set(CORE_SOURCE_FILES
 
 if (RSTUDIO_HAS_SOCI)
    list(APPEND CORE_SOURCE_FILES Database.cpp)
+   list(APPEND CORE_SOURCE_FILES QueryBuilder.cpp)
+   list(APPEND CORE_SOURCE_FILES SqlPreprocessor.cpp)
 endif()
 
 # UNIX specific
@@ -355,7 +358,7 @@ if (RSTUDIO_UNIT_TESTS_ENABLED)
 
    # Find all test files (including both standard tests and gtest files)
    file(GLOB_RECURSE CORE_TEST_FILES "*Tests.cpp")
-   
+
    if (NOT RSTUDIO_HAS_SOCI)
       list(REMOVE_ITEM CORE_TEST_FILES "${CMAKE_CURRENT_SOURCE_DIR}/DatabaseTests.cpp")
    endif()
@@ -363,7 +366,7 @@ if (RSTUDIO_UNIT_TESTS_ENABLED)
    # Use gtest from vendor directory
    set(GTEST_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/cpp/tests/cpp/tests/vendor/gtest)
    include_directories(${GTEST_SOURCE_DIR}/include)
-   
+
    # Add Google Test if not already added
    if(NOT TARGET gtest)
       add_subdirectory(${GTEST_SOURCE_DIR} gtest-build EXCLUDE_FROM_ALL)

--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -26,6 +26,7 @@
 #include <core/http/Util.hpp>
 #include <core/Log.hpp>
 #include <core/RegexUtils.hpp>
+#include <core/SqlPreprocessor.hpp>
 #include <core/system/Environment.hpp>
 #include <core/system/System.hpp>
 
@@ -159,9 +160,11 @@ static constexpr size_t kTruncatePreviewLength = 16;
 
 // Set of parameter names that should be treated as secrets (not logged in full)
 static std::set<std::string> s_secretParamNames = {"secret_param", "key"};
+static boost::mutex s_secretParamMutex;
 
 void addSecretParamNames(const std::vector<std::string>& paramNames)
 {
+   boost::lock_guard<boost::mutex> lock(s_secretParamMutex);
    for (const auto& name : paramNames)
    {
       s_secretParamNames.insert(name);
@@ -170,6 +173,7 @@ void addSecretParamNames(const std::vector<std::string>& paramNames)
 
 bool isSecretParamName(const std::string& paramName)
 {
+   boost::lock_guard<boost::mutex> lock(s_secretParamMutex);
    return s_secretParamNames.find(paramName) != s_secretParamNames.end();
 }
 
@@ -212,6 +216,320 @@ bool isSqliteTransientLockError(const soci::soci_error& error)
 }
 
 // Database errors =================================================================================================
+
+namespace {
+
+std::string pgEncode(const std::string& str, bool isUrl = true)
+{
+   // ensure we first decode from URL string format
+   std::string val = isUrl ? http::util::urlDecode(str) : str;
+
+   // escape postgres special characters
+   boost::replace_all(val, "\\", "\\\\");
+   boost::replace_all(val, "'", "\\'");
+
+   return val;
+}
+
+Error getPostgresqlPassword(const PostgresqlConnectionOptions& options,
+                            std::string& password)
+{
+#ifdef RSTUDIO_HAS_SOCI_POSTGRESQL
+   // override password from the input with the one from options if any
+   if (!options.password.empty())
+      password = options.password;
+
+   // Somewhat convoluted due to need to handle several cases (Pro-only):
+   //
+   // (1) password without embedded encryption key; this could be a plain-text
+   //     password or an encrypted password generated before we added such
+   //     embedding, but we can't be sure without trying to decrypt and treating
+   //     as plain text if that fails
+   // (2) an encrypted password with embedded key hash; if it won't decrypt,
+   // this is an error
+   //     and we don't want to treat as plain text
+   //
+   // In a future release we could simplify by assuming a password without
+   // embedded key must be plain text. Tracked in
+   // https://github.com/rstudio/rstudio-pro/issues/2446
+   //
+   bool assumeEncrypted =
+       core::system::crypto::passwordContainsKeyHash(password);
+
+   Error error = core::system::crypto::decryptPassword(
+       options.secureKey, options.secureKeyHash, password);
+   if (error)
+   {
+      // Only warn about plaintext passwords when we're reading them from the
+      // configuration file. Passwords from environment variables are
+      // probably managed by an external secret manager with its own
+      // encryption story.
+      static bool warnOnce =
+          system::getenv("WORKBENCH_POSTGRES_PASSWORD").empty() &&
+          system::getenv("WORKBENCH_POSTGRES_PASSWORD_FILE").empty();
+
+      if (assumeEncrypted)
+      {
+         error.addProperty(
+             "key-files",
+             "/var/lib/rstudio-server/secure-cookie-key (managed), "
+             "/etc/rstudio/secure-cookie-key (manual using XDG_CONFIG_DIRS)");
+         return error;
+      }
+
+      // decrypt failed, we'll just use the password as-is
+      if (warnOnce)
+      {
+         warnOnce = false;
+         LOG_DEBUG_MESSAGE(error.asString());
+         LOG_WARNING_MESSAGE("Either an encrypted PostgreSQL password could "
+                             "not be decrypted, or the PostgreSQL password "
+                             "is being stored in plain text in the "
+                             "configuration file. See the Posit Workbench "
+                             "Administration Guide for documentation on how "
+                             "to encrypt PostgreSQL passwords.");
+      }
+   }
+   return Success();
+#else
+   return Error(boost::system::errc::operation_not_supported, ERROR_LOCATION);
+#endif
+}
+
+Error parseConnectionUri(const std::string& uri,
+                         std::string& password,
+                         std::string* pConnectionStr)
+{
+#ifdef RSTUDIO_HAS_SOCI_POSTGRESQL
+   boost::regex re("(postgres|postgresql)://([^/#?]+)(.*)",
+                   boost::regex::icase);
+   boost::cmatch matches;
+
+   std::string host, path;
+   if (regex_utils::match(uri.c_str(), matches, re))
+   {
+      host = matches[2];
+      path = matches[3];
+   }
+   else
+   {
+      return systemError(
+          boost::system::errc::invalid_argument,
+          "connection-uri specified is not a valid PostgreSQL connection URI",
+          ERROR_LOCATION);
+   }
+
+   // extract user and password information
+   std::string user;
+   std::vector<std::string> hostParts;
+   boost::split(hostParts, host, boost::is_any_of("@"));
+
+   if (hostParts.size() == 2)
+   {
+      // user information included
+      std::vector<std::string> userParts;
+      boost::split(userParts, hostParts.at(0), boost::is_any_of(":"));
+
+      if (userParts.size() == 2)
+      {
+         user = userParts.at(0);
+         password = userParts.at(1);
+      }
+      else if (userParts.size() == 1)
+      {
+         user = userParts.at(0);
+      }
+      else
+      {
+         return systemError(boost::system::errc::invalid_argument,
+                            "connection-uri specified is not a valid "
+                            "PostgreSQL connection URI - "
+                            "too many user : password specifications",
+                            ERROR_LOCATION);
+      }
+
+      host = hostParts.at(1);
+   }
+   else if (hostParts.size() > 2)
+   {
+      return systemError(
+          boost::system::errc::invalid_argument,
+          "connection-uri specified is not a valid PostgreSQL connection URI - "
+          "too many user @ host specifications",
+          ERROR_LOCATION);
+   }
+
+   // extract host and port information
+   std::string port;
+   hostParts.clear();
+
+   size_t squareBegin = host.find('[');
+   if (squareBegin != std::string::npos)
+   {
+      size_t squareEnd = host.find(']');
+      if (squareEnd == std::string::npos)
+      {
+         return systemError(
+             boost::system::errc::invalid_argument,
+             "connection-uri specified is not a valid PostgreSQL connection "
+             "URI - "
+             "specified IPv6 address has no matching end bracket ']'",
+             ERROR_LOCATION);
+      }
+
+      std::string ip6Host = host.substr(0, squareEnd + 1);
+      size_t colonPos = host.find(':', squareEnd + 1);
+      if (colonPos != std::string::npos)
+      {
+         port = host.substr(colonPos + 1);
+      }
+      host = ip6Host;
+   }
+   else
+   {
+      boost::split(hostParts, host, boost::is_any_of(":"));
+
+      if (hostParts.size() == 2)
+      {
+         host = hostParts.at(0);
+         port = hostParts.at(1);
+      }
+      else if (hostParts.size() > 2)
+      {
+         return systemError(boost::system::errc::invalid_argument,
+                            "connection-uri specified is not a valid "
+                            "PostgreSQL connection URI - "
+                            "too many host : port specifications",
+                            ERROR_LOCATION);
+      }
+   }
+
+   // extract database name and params
+   std::string database;
+   std::vector<std::string> parameters;
+   size_t paramStart = path.find("?");
+   if (paramStart != std::string::npos)
+   {
+      std::string params = path.substr(paramStart + 1);
+      std::vector<std::string> paramParts;
+      boost::split(paramParts, params, boost::is_any_of("&"));
+
+      for (const std::string& param : paramParts)
+      {
+         parameters.push_back(param);
+      }
+
+      // skip over / in the path
+      database = path.substr(1, paramStart - 1);
+   }
+   else
+   {
+      // skip over / in the path
+      database = path.empty() ? path : path.substr(1);
+   }
+
+   // write out connection string
+   *pConnectionStr += "host='" + pgEncode(host) + "'";
+   if (!port.empty())
+      *pConnectionStr += " port='" + pgEncode(port) + "'";
+   if (!user.empty())
+      *pConnectionStr += " user='" + pgEncode(user) + "'";
+   if (!database.empty())
+      *pConnectionStr += " dbname='" + pgEncode(database) + "'";
+
+   for (const std::string& param : parameters)
+   {
+      size_t equalPos = param.find('=');
+      if (equalPos != std::string::npos)
+      {
+         std::string paramName = param.substr(0, equalPos);
+         std::string paramValue = param.substr(equalPos + 1);
+         *pConnectionStr += " " + paramName + "='" + pgEncode(paramValue) + "'";
+      }
+      else
+      {
+         return systemError(boost::system::errc::invalid_argument,
+                            "connection-uri specified is not a valid "
+                            "PostgreSQL connection URI - "
+                            "no parameter value specified for parameter " +
+                                param,
+                            ERROR_LOCATION);
+      }
+   }
+
+   return Success();
+#else
+   return Error(boost::system::errc::operation_not_supported, ERROR_LOCATION);
+#endif
+}
+
+} // anonymous namespace
+
+Error parsePostgresqlConnectionOptions(
+    const PostgresqlConnectionOptions& options,
+    std::string* pConnectionStr,
+    std::string* pPassword)
+{
+#ifdef RSTUDIO_HAS_SOCI_POSTGRESQL
+   // prefer connection-uri
+   if (!options.connectionUri.empty())
+   {
+      Error error = parseConnectionUri(
+            options.connectionUri, *pPassword, pConnectionStr);
+      if (error)
+         return error;
+   }
+   else
+   {
+      boost::format fmt("host='%1%' port='%2%' dbname='%3%' user='%4%' "
+                        "connect_timeout='%5%'");
+      *pConnectionStr = boost::str(fmt % options.host % options.port %
+                                 options.database % options.username %
+                                 safe_convert::numberToString(
+                                       options.connectionTimeoutSeconds, "0"));
+   }
+
+   Error error = getPostgresqlPassword(options, *pPassword);
+   if (error)
+      return error;
+
+   if(pPassword->empty())
+   {
+      // When a password isn't specified, we authenticate using SSL
+      // certificates. This requires that the connection string contain
+      // sslcert and sslkey parameters and that sslmode=verify-ca.
+      if (!boost::algorithm::contains(*pConnectionStr, "sslcert") ||
+            !boost::algorithm::contains(*pConnectionStr, "sslkey") ||
+            !boost::algorithm::contains(*pConnectionStr, "sslrootcert"))
+      {
+         // Return invalid configuration error
+         return systemError(
+               boost::system::errc::invalid_argument,
+               "Because a password has not been specified in database.conf,"
+               " the Postgres connection must be configured to use SSL "
+               "authentication."
+               " This requires including the path to sslcert, sslkey, and "
+               "sslrootcert in the connection URI."
+               " Update database.conf to add these values to the connection "
+               "URI or add a password."
+               " For more information about PostgreSQL SSL Authentication see "
+               "https://www.postgresql.org/docs/current/auth-cert.html",
+               ERROR_LOCATION);
+      }
+      else if (!boost::algorithm::contains(*pConnectionStr,
+                                             "sslmode=verify-ca"))
+      {
+         *pConnectionStr += " sslmode=verify-ca";
+      }
+   } else {
+      pgEncode(*pPassword, false);
+   }
+
+   return Success();
+#else
+   return Error(boost::system::errc::operation_not_supported, ERROR_LOCATION);
+#endif
+}
 
 class ConnectVisitor : public boost::static_visitor<Error>
 {
@@ -289,30 +607,13 @@ public:
    Error operator()(const PostgresqlConnectionOptions& options) const
    {
 #ifdef RSTUDIO_HAS_SOCI_POSTGRESQL
-      std::string connectionStr;
       try
       {
-         // prefer connection-uri
-         std::string password;
-         if (!options.connectionUri.empty())
-         {
-            Error error = parseConnectionUri(options.connectionUri, password, &connectionStr);
-            if (error)
-               return error;
-         }
-         else
-         {
-            boost::format fmt("host='%1%' port='%2%' dbname='%3%' user='%4%' connect_timeout='%5%'");
-            connectionStr =
-                  boost::str(fmt %
-                             options.host %
-                             options.port %
-                             options.database %
-                             options.username %
-                             safe_convert::numberToString(options.connectionTimeoutSeconds, "0"));
-         }
-
-         Error error = getPassword(options, password);
+         std::string connectionStr, password;
+         const auto error = parsePostgresqlConnectionOptions(
+             options, &connectionStr, &password);
+         if (error)
+            return error;
 
          if (!password.empty())
          {
@@ -321,33 +622,10 @@ public:
             if (!pPassword_)
             {
                // unencrypted password
-               password = pgEncode(password, false);
                connectionStr += " password='" + password + "'";
             }
             else
                *pPassword_ = password;
-         }
-         else
-         {
-            // When a password isn't specified, we authenticate using SSL certificates.
-            // This requires that the connection string contain sslcert and sslkey parameters and that sslmode=verify-ca.
-            if (!boost::algorithm::contains(connectionStr, "sslcert") || 
-                !boost::algorithm::contains(connectionStr, "sslkey") ||
-                !boost::algorithm::contains(connectionStr, "sslrootcert"))
-            {
-               // Return invalid configuration error
-               return systemError(boost::system::errc::invalid_argument,
-                                  "Because a password has not been specified in database.conf,"
-                                  " the Postgres connection must be configured to use SSL authentication."
-                                  " This requires including the path to sslcert, sslkey, and sslrootcert in the connection URI."
-                                  " Update database.conf to add these values to the connection URI or add a password."
-                                  " For more information about PostgreSQL SSL Authentication see https://www.postgresql.org/docs/current/auth-cert.html",
-                                  ERROR_LOCATION);
-            }
-            else if (!boost::algorithm::contains(connectionStr, "sslmode=verify-ca")) 
-            {
-               connectionStr += " sslmode=verify-ca";
-            }
          }
 
          if (pConnectionStr_)
@@ -356,7 +634,8 @@ public:
          if (validateOnly_)
             return Success();
 
-         boost::shared_ptr<IConnection> pConnection(new Connection(soci::postgresql, connectionStr));
+         boost::shared_ptr<IConnection> pConnection(
+             new Connection(soci::postgresql, connectionStr));
          *pPtrConnection_ = pConnection;
          return Success();
       }
@@ -365,7 +644,7 @@ public:
          return DatabaseError(error);
       }
 #else
-      return Error(boost::system::errc::operation_not_supported, ERROR_LOCATION);
+   return Error(boost::system::errc::operation_not_supported, ERROR_LOCATION);
 #endif
    }
 
@@ -375,222 +654,6 @@ public:
       return systemError(boost::system::errc::invalid_argument,
                          "No database connection options specified",
                          ERROR_LOCATION);
-   }
-
-   Error parseConnectionUri(const std::string& uri,
-                            std::string& password,
-                            std::string* pConnectionStr) const
-   {
-#ifdef RSTUDIO_HAS_SOCI_POSTGRESQL
-      boost::regex re("(postgres|postgresql)://([^/#?]+)(.*)", boost::regex::icase);
-      boost::cmatch matches;
-
-      std::string host, path;
-      if (regex_utils::match(uri.c_str(), matches, re))
-      {
-         host = matches[2];
-         path = matches[3];
-      }
-      else
-      {
-         return systemError(boost::system::errc::invalid_argument,
-                            "connection-uri specified is not a valid PostgreSQL connection URI",
-                            ERROR_LOCATION);
-      }
-
-      // extract user and password information
-      std::string user;
-      std::vector<std::string> hostParts;
-      boost::split(hostParts, host, boost::is_any_of("@"));
-
-      if (hostParts.size() == 2)
-      {
-         // user information included
-         std::vector<std::string> userParts;
-         boost::split(userParts, hostParts.at(0), boost::is_any_of(":"));
-
-         if (userParts.size() == 2)
-         {
-            user = userParts.at(0);
-            password = userParts.at(1);
-         }
-         else if (userParts.size() == 1)
-         {
-            user = userParts.at(0);
-         }
-         else
-         {
-            return systemError(boost::system::errc::invalid_argument,
-                               "connection-uri specified is not a valid PostgreSQL connection URI - "
-                                  "too many user : password specifications",
-                               ERROR_LOCATION);
-         }
-
-         host = hostParts.at(1);
-      }
-      else if (hostParts.size() > 2)
-      {
-         return systemError(boost::system::errc::invalid_argument,
-                            "connection-uri specified is not a valid PostgreSQL connection URI - "
-                               "too many user @ host specifications",
-                            ERROR_LOCATION);
-      }
-
-      // extract host and port information
-      std::string port;
-      hostParts.clear();
-
-      size_t squareBegin = host.find('[');
-      if (squareBegin != std::string::npos)
-      {
-         size_t squareEnd = host.find(']');
-         if (squareEnd == std::string::npos)
-         {
-            return systemError(boost::system::errc::invalid_argument,
-                               "connection-uri specified is not a valid PostgreSQL connection URI - "
-                                  "specified IPv6 address has no matching end bracket ']'",
-                               ERROR_LOCATION);
-         }
-
-         std::string ip6Host = host.substr(0, squareEnd + 1);
-         size_t colonPos = host.find(':', squareEnd + 1);
-         if (colonPos != std::string::npos)
-         {
-            port = host.substr(colonPos + 1);
-         }
-         host = ip6Host;
-      }
-      else
-      {
-         boost::split(hostParts, host, boost::is_any_of(":"));
-
-         if (hostParts.size() == 2)
-         {
-            host = hostParts.at(0);
-            port = hostParts.at(1);
-         }
-         else if (hostParts.size() > 2)
-         {
-            return systemError(boost::system::errc::invalid_argument,
-                               "connection-uri specified is not a valid PostgreSQL connection URI - "
-                                  "too many host : port specifications",
-                               ERROR_LOCATION);
-         }
-      }
-
-      // extract database name and params
-      std::string database;
-      std::vector<std::string> parameters;
-      size_t paramStart = path.find("?");
-      if (paramStart != std::string::npos)
-      {
-         std::string params = path.substr(paramStart + 1);
-         std::vector<std::string> paramParts;
-         boost::split(paramParts, params, boost::is_any_of("&"));
-
-         for (const std::string& param : paramParts)
-         {
-            parameters.push_back(param);
-         }
-
-         // skip over / in the path
-         database = path.substr(1, paramStart - 1);
-      }
-      else
-      {
-         // skip over / in the path
-         database = path.empty() ? path : path.substr(1);
-      }
-
-      // write out connection string
-      *pConnectionStr += "host='" + pgEncode(host) + "'";
-      if (!port.empty())
-         *pConnectionStr += " port='" + pgEncode(port) + "'";
-      if (!user.empty())
-         *pConnectionStr += " user='" + pgEncode(user) + "'";
-      if (!database.empty())
-         *pConnectionStr += " dbname='" + pgEncode(database) + "'";
-
-      for (const std::string& param : parameters)
-      {
-         size_t equalPos = param.find('=');
-         if (equalPos != std::string::npos)
-         {
-            std::string paramName = param.substr(0, equalPos);
-            std::string paramValue = param.substr(equalPos + 1);
-            *pConnectionStr += " " +  paramName + "='" + pgEncode(paramValue) + "'";
-         }
-         else
-         {
-            return systemError(boost::system::errc::invalid_argument,
-                               "connection-uri specified is not a valid PostgreSQL connection URI - "
-                                  "no parameter value specified for parameter " + param,
-                               ERROR_LOCATION);
-         }
-      }
-
-      return Success();
-#else
-      return Error(boost::system::errc::operation_not_supported, ERROR_LOCATION);
-#endif
-   }
-
-   Error getPassword(const PostgresqlConnectionOptions& options, std::string& password) const
-   {
-#ifdef RSTUDIO_HAS_SOCI_POSTGRESQL
-      // override password from the input with the one from options if any
-      if (!options.password.empty())
-         password = options.password;
-
-      // Somewhat convoluted due to need to handle several cases (Pro-only):
-      //
-      // (1) password without embedded encryption key; this could be a plain-text
-      //     password or an encrypted password generated before we added such embedding, but
-      //     we can't be sure without trying to decrypt and treating as plain text if that fails
-      // (2) an encrypted password with embedded key hash; if it won't decrypt, this is an error
-      //     and we don't want to treat as plain text
-      //
-      // In a future release we could simplify by assuming a password without embedded key must
-      // be plain text. Tracked in https://github.com/rstudio/rstudio-pro/issues/2446
-      // 
-      bool assumeEncrypted = core::system::crypto::passwordContainsKeyHash(password);
-
-      Error error = core::system::crypto::decryptPassword(options.secureKey, options.secureKeyHash, password);
-      if (error)
-      {
-         static bool warnOnce = false;
-
-         if (assumeEncrypted)
-         {
-            error.addProperty("key-files", "/var/lib/rstudio-server/secure-cookie-key (managed), /etc/rstudio/secure-cookie-key (manual using XDG_CONFIG_DIRS)");
-            return error;
-         }
-
-         // decrypt failed, we'll just use the password as-is
-         if (!warnOnce)
-         {
-            warnOnce = true;
-            LOG_DEBUG_MESSAGE(error.asString());
-            LOG_WARNING_MESSAGE("A plain text value is potentially being used for the PostgreSQL password, or an encrypted password could not be decrypted. The RStudio Server documentation for PostgreSQL shows how to encrypt this value.");
-         }
-      }
-      return Success();
-#else
-      return Error(boost::system::errc::operation_not_supported, ERROR_LOCATION);
-#endif
-   }
-
-   std::string pgEncode(const std::string& str,
-                        bool isUrl = true) const
-   {
-      // ensure we first decode from URL string format
-      std::string val = isUrl ? http::util::urlDecode(str) : str;
-
-      // escape postgres special characters
-      boost::replace_all(val, "\\", "\\\\");
-      boost::replace_all(val, "'", "\\'");
-
-      return val;
    }
 
 private:
@@ -899,7 +962,7 @@ core::Error Rowset::getBoolStrValue(RowsetIterator & row, const std::string& col
    }
 
    // Conversion failed
-   return core::Error(boost::system::errc::invalid_argument, 
+   return core::Error(boost::system::errc::invalid_argument,
       "Could not convert field " + columnName + " from string to bool", ERROR_LOCATION);
 }
 
@@ -941,7 +1004,7 @@ core::Error Rowset::getUIntIntValue(RowsetIterator & row, const std::string& col
    if( !result->has_value() )
    {
       // Conversion failed
-      return core::Error(boost::system::errc::invalid_argument, 
+      return core::Error(boost::system::errc::invalid_argument,
          "Could not convert field " + columnName + " from integral to unsigned", ERROR_LOCATION);
    }
 
@@ -990,7 +1053,7 @@ core::Error Rowset::getMillisecondSinceEpochStrValue(RowsetIterator &row, const 
    }
 
    // Could not convert the DB value to a valid timestamp
-   return core::Error(boost::system::errc::invalid_argument, 
+   return core::Error(boost::system::errc::invalid_argument,
       "Could not convert field " + columnName + " from milliseconds since epoc string to ptime - value is: " + timestampAsOptionalString.value(), ERROR_LOCATION);
 }
 
@@ -1463,7 +1526,7 @@ ConnectionPool::ConnectionPool(const ConnectionOptions& options) :
 }
 
 // Skip the health check if the connection was used recently (within this many seconds)
-static constexpr int kHealthCheckIdleThresholdSeconds = 30;
+static constexpr int kHealthCheckIdleThresholdSeconds = 10;
 
 bool ConnectionPool::testAndReconnect(boost::shared_ptr<Connection>& connection)
 {
@@ -1473,16 +1536,20 @@ bool ConnectionPool::testAndReconnect(boost::shared_ptr<Connection>& connection)
    if (connection->driver() == Driver::Sqlite)
       return true;
 
-   // Skip the health check if the connection was recently used. Under load, connections are
-   // returned and re-checked out quickly, so stale connections are unlikely. This avoids an
-   // extra SELECT 1 round trip on every getConnection() call.
-   boost::posix_time::ptime lastReturned = connection->lastReturnedTime();
-   if (!lastReturned.is_not_a_date_time())
+   // Skip the health check if the connection was recently used and is not flagged as
+   // broken. Under load, connections are returned and re-checked out quickly, so stale
+   // connections are unlikely. This avoids an extra SELECT 1 round trip on every
+   // getConnection() call.
+   if (!connection->needsHealthCheck())
    {
-      boost::posix_time::time_duration idle =
-         boost::posix_time::microsec_clock::universal_time() - lastReturned;
-      if (idle.total_seconds() < kHealthCheckIdleThresholdSeconds)
-         return true;
+      boost::posix_time::ptime lastReturned = connection->lastReturnedTime();
+      if (!lastReturned.is_not_a_date_time())
+      {
+         boost::posix_time::time_duration idle =
+            boost::posix_time::microsec_clock::universal_time() - lastReturned;
+         if (idle.total_seconds() < kHealthCheckIdleThresholdSeconds)
+            return true;
+      }
    }
 
    // it is possible for connections to go stale (such as if the upstream connection is closed)
@@ -1490,7 +1557,10 @@ bool ConnectionPool::testAndReconnect(boost::shared_ptr<Connection>& connection)
    // and checking to make sure that no error has occurred
    Error error = connection->executeStr("SELECT 1");
    if (!error)
+   {
+      connection->setNeedsHealthCheck(false);
       return true;
+   }
 
    LOG_DEBUG_MESSAGE("Replacing stale db connection in pool - check query returned: " + error.asString() + ")");
 
@@ -1504,6 +1574,12 @@ bool ConnectionPool::testAndReconnect(boost::shared_ptr<Connection>& connection)
       // future attempts to use this connection will be responsible for further attempts
       error.addProperty("description", "Could not re-establish database connection");
       LOG_ERROR(error);
+
+      // Flag the connection so future getConnection() calls retest it even if the
+      // idle-skip window would otherwise apply. Without this, under load the returned
+      // timestamp is refreshed by returnConnection() on every round trip and the stale
+      // pool would never get re-tested.
+      connection->setNeedsHealthCheck(true);
       return false;
    }
 
@@ -1801,7 +1877,7 @@ bool SchemaVersion::operator==(const SchemaVersion& other) const
    if (Date == other.Date)
    {
       // check version map to see if the flowers different but equivalent strings
-      // this allows us to properly handle typos :) 
+      // this allows us to properly handle typos :)
       const auto& versions = versionMap();
       int thisFlowerIndex = (versions.find(Flower) != versions.end()) ? versions.at(Flower) : versions.size();
       int otherFlowerIndex = (versions.find(other.Flower) != versions.end()) ? versions.at(other.Flower) : versions.size();
@@ -1841,6 +1917,9 @@ const std::map<std::string, int>& SchemaVersion::versionMap()
             versions["Cucumberleaf Sunflower"] = 13;
             versions["Apple Blossom"] = 14;
             versions["Globemaster Allium"] = 15;
+            versions["Golden Wattle"] = 16;
+            versions["Blue Plumbago"] = 17;
+            versions["Yellow Yarrow"] = 18;
          }
       }
       END_LOCK_MUTEX
@@ -1944,7 +2023,7 @@ Error SchemaUpdater::getSchemaTableColumnCount(std::size_t* pColumnCount)
    Error error;
    if (connection_->driverName() == SQLITE_DRIVER)
    {
-      // This query is explicitly a SELECT * because we use the # of columns to determine if 
+      // This query is explicitly a SELECT * because we use the # of columns to determine if
       // we're pre- or post- GhostOrchid
       Query query = connection_->query(std::string("SELECT * FROM ") + SCHEMA_TABLE);
       Rowset rows;
@@ -1962,7 +2041,7 @@ Error SchemaUpdater::getSchemaTableColumnCount(std::size_t* pColumnCount)
    if (error)
    {
       error.addProperty("query", connection_->session().get_last_query());
-      return error;   
+      return error;
    }
 
    *pColumnCount = columnCount;
@@ -2049,7 +2128,7 @@ Error SchemaUpdater::isUpToDate(bool* pUpToDate)
 Error SchemaUpdater::update()
 {
    LOG_INFO_MESSAGE("Updating database schema version using migration path: " + migrationsPath_.getAbsolutePath());
-   
+
    bool schemaPresent = false;
    Error error = isSchemaVersionPresent(&schemaPresent);
    if (error)
@@ -2100,7 +2179,7 @@ Error SchemaUpdater::createSchema()
    if (error || !createTablesFile.exists())
    {
       if (connection_->driverName() == POSTGRESQL_DRIVER)
-      { 
+      {
          error = migrationsPath_.completeChildPath(std::string(CREATE_TABLES_STEM) + std::string(POSTGRESQL_EXTENSION), createTablesFile);
          if (error)
             return error;
@@ -2200,7 +2279,11 @@ Error SchemaUpdater::updateToVersion(const SchemaVersion& maxVersion)
       if (error)
          return error;
 
-      error = connection_->executeStr(fileContents);
+      auto processedFile = preprocessSchemaFile(connection_, fileContents);
+      if (!processedFile)
+         return processedFile.error();
+
+      error = connection_->executeStr(*processedFile);
       if (error)
          return error;
 
@@ -2250,26 +2333,13 @@ Error createConnectionPool(size_t poolSize,
    return Success();
 }
 
-Error execAndProcessQuery(boost::shared_ptr<database::IConnection> pConnection,
-                          const std::string& sql,
-                          const boost::function<void(const database::Row&)>& rowHandler)
+void forEachRow(Rowset& rows, const boost::function<void(const Row&)>& rowHandler)
 {
-   Rowset rows;
-   Query query = pConnection->query(sql);
-   Error error = pConnection->execute(query, rows);
-   if (error)
-      return error;
-
-   if (!rowHandler.empty())
+   for (RowsetIterator it = rows.begin(); it != rows.end(); ++it)
    {
-      for (RowsetIterator it = rows.begin(); it != rows.end(); ++it)
-      {
-         const Row& row = *it;
-         rowHandler(row);
-      }
+      const Row& row = *it;
+      rowHandler(row);
    }
-
-   return Success();
 }
 
 std::string getRowStringValue(const Row& row, const std::string& column)

--- a/src/cpp/core/DatabaseTests.cpp
+++ b/src/cpp/core/DatabaseTests.cpp
@@ -16,6 +16,8 @@
 #include <gtest/gtest.h>
 
 #include <core/Database.hpp>
+#include <core/SqlPreprocessor.hpp>
+#include <core/QueryBuilder.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/system/System.hpp>
 #include <shared_core/SafeConvert.hpp>
@@ -102,6 +104,148 @@ TEST_F(DatabaseTestsFixture, CanCreateSqliteDatabase)
 
    EXPECT_EQ(id, rowId);
    EXPECT_EQ(text, rowText);
+}
+
+TEST_F(DatabaseTestsFixture, CanPreprocessSql)
+{
+   std::string text = "#if 1\nA1\n#else\nB1\n#endif";
+   auto result = preprocessSchemaFile(sqliteConnection, text);
+   ASSERT_TRUE(result) << result.error().getMessage();
+   EXPECT_EQ(*result, "A1\n");
+
+   text = "#if 0\nA2\n#else\nB2\n#endif";
+   result = preprocessSchemaFile(sqliteConnection, text);
+   ASSERT_TRUE(result) << result.error().getMessage();
+   EXPECT_EQ(*result, "B2\n");
+
+   text = "#if driver(sqlite3)\nA3\n#else\nB3\n#endif";
+   result = preprocessSchemaFile(sqliteConnection, text);
+   ASSERT_TRUE(result) << result.error().getMessage();
+   EXPECT_EQ(*result, "A3\n");
+
+   text = "#if driver(postgresql)\nA4\n#else\nB4\n#endif";
+   result = preprocessSchemaFile(sqliteConnection, text);
+   ASSERT_TRUE(result) << result.error().getMessage();
+   EXPECT_EQ(*result, "B4\n");
+
+   text = "#if !1\nA5\n#else\nB5\n#endif";
+   result = preprocessSchemaFile(sqliteConnection, text);
+   ASSERT_TRUE(result) << result.error().getMessage();
+   EXPECT_EQ(*result, "B5\n");
+
+   text = "#if (1 || 0) && 1\nA6\n#else\nB6\n#endif";
+   result = preprocessSchemaFile(sqliteConnection, text);
+   ASSERT_TRUE(result) << result.error().getMessage();
+   EXPECT_EQ(*result, "A6\n");
+}
+
+void testCanCheckExists(DatabaseConnection dbConnection)
+{
+   Error error = dbConnection->executeStr("CREATE TABLE exist_test (id INTEGER)");
+   ASSERT_FALSE(error) << error.getMessage();
+
+   std::string text = R""(
+#if exists(table, exist_test)
+A
+#endif
+#if exists(table, noexist_test)
+B
+#endif
+#if exists(column, exist_test.id)
+C
+#endif
+#if exists(column, exist_test.bogus)
+D
+#endif
+#if exists(column, noexist_test.id)
+E
+#endif
+)"";
+   auto result = preprocessSchemaFile(dbConnection, text);
+   ASSERT_TRUE(result) << result.error().getMessage();
+
+   bool tableTest = result->find("A") != std::string::npos;
+   EXPECT_TRUE(tableTest) << "exists(table) failed to find existing table";
+
+   bool noTableTest = result->find("B") != std::string::npos;
+   EXPECT_FALSE(noTableTest) << "exists(table) failed to reject missing table";
+
+   bool columnTest = result->find("C") != std::string::npos;
+   EXPECT_TRUE(columnTest) << "exists(column) failed to find existing column";
+
+   bool noColumnTest = result->find("D") != std::string::npos;
+   EXPECT_FALSE(noColumnTest) << "exists(column) failed to reject missing column";
+
+   bool noTableColumnTest = result->find("E") != std::string::npos;
+   EXPECT_FALSE(noTableColumnTest) << "exists(column) failed to reject missing table";
+}
+
+TEST_F(DatabaseTestsFixture, CanCheckExistsSqlite)
+{
+   testCanCheckExists(sqliteConnection);
+}
+
+TEST_F(DatabaseTestsFixture, CanCheckExistsPostgres)
+{
+   if (!std::getenv("POSTGRES_ENABLED") || std::string(std::getenv("POSTGRES_ENABLED")) != "1")
+   {
+      GTEST_SKIP() << "Skipping Postgres migration tests as POSTGRES_ENABLED is not set";
+   }
+
+   boost::shared_ptr<IConnection> postgresConnection;
+   Error error = connect(postgresConnectionOptions(), &postgresConnection);
+   ASSERT_FALSE(error) << "Failed to connect to PostgreSQL database for schema update test: " << error.getMessage();
+
+   // Reset the PostgreSQL test database so the test is repeatable.
+   // The SQLite DB is already cleaned up by the fixture (file is deleted in TearDown).
+   error = postgresConnection->executeStr("DROP SCHEMA public CASCADE; CREATE SCHEMA public;");
+   ASSERT_FALSE(error) << "Failed to reset PostgreSQL test database: " << error.getMessage();
+
+   testCanCheckExists(postgresConnection);
+}
+
+TEST_F(DatabaseTestsFixture, CanNestPreprocessorIf)
+{
+   std::string text = R""(
+#if 1
+A
+#if 1
+B
+#else
+C
+#endif
+#if 0
+D
+#else
+E
+#endif
+#else
+F
+#if 1
+G
+#else
+H
+#endif
+#if 0
+I
+#else
+J
+#endif
+#endif
+)"";
+   auto result = preprocessSchemaFile(sqliteConnection, text);
+   ASSERT_TRUE(result) << result.error().getMessage();
+
+   EXPECT_NE(result->find("A"), std::string::npos);
+   EXPECT_NE(result->find("B"), std::string::npos);
+   EXPECT_EQ(result->find("C"), std::string::npos);
+   EXPECT_EQ(result->find("D"), std::string::npos);
+   EXPECT_NE(result->find("E"), std::string::npos);
+   EXPECT_EQ(result->find("F"), std::string::npos);
+   EXPECT_EQ(result->find("G"), std::string::npos);
+   EXPECT_EQ(result->find("H"), std::string::npos);
+   EXPECT_EQ(result->find("I"), std::string::npos);
+   EXPECT_EQ(result->find("J"), std::string::npos);
 }
 
 TEST(DatabaseTest, CanCreatePostgresqlDatabase)
@@ -300,12 +444,11 @@ TEST(DatabaseTest, CanUseConnectionPool)
    dbPath.removeIfExists();
 }
 
-TEST_F(DatabaseTestsFixture, CanUpdateSchemas)
+static void testCanUpdateSchemas(DatabaseConnection dbConnection)
 {
-   if (!std::getenv("POSTGRES_ENABLED") || std::string(std::getenv("POSTGRES_ENABLED")) != "1")
-   {
-      GTEST_SKIP() << "Skipping Postgres migration tests as POSTGRES_ENABLED is not set";
-   }
+   bool isSqlite = dbConnection->driver() == Driver::Sqlite;
+   std::string ext = isSqlite ? "sqlite" : "postgresql";
+
    Error error;
 
    // Copy the real CreateTables files to a temp directory so we can add test migration
@@ -316,15 +459,10 @@ TEST_F(DatabaseTestsFixture, CanUpdateSchemas)
    ASSERT_FALSE(schemaDir.ensureDirectory());
 
    std::string createTablesContent;
-   error = readStringFromFile(dbSchemaDir.completeChildPath("CreateTables.sqlite"), &createTablesContent);
-   ASSERT_FALSE(error) << "Failed to read CreateTables.sqlite from " << dbSchemaDir.getAbsolutePath();
-   error = writeStringToFile(schemaDir.completeChildPath("CreateTables.sqlite"), createTablesContent);
-   ASSERT_FALSE(error) << "Failed to copy CreateTables.sqlite";
-
-   error = readStringFromFile(dbSchemaDir.completeChildPath("CreateTables.postgresql"), &createTablesContent);
-   ASSERT_FALSE(error) << "Failed to read CreateTables.postgresql from " << dbSchemaDir.getAbsolutePath();
-   error = writeStringToFile(schemaDir.completeChildPath("CreateTables.postgresql"), createTablesContent);
-   ASSERT_FALSE(error) << "Failed to copy CreateTables.postgresql";
+   error = readStringFromFile(dbSchemaDir.completeChildPath("CreateTables." + ext), &createTablesContent);
+   ASSERT_FALSE(error) << "Failed to read CreateTables." << ext << " from " << dbSchemaDir.getAbsolutePath();
+   error = writeStringToFile(schemaDir.completeChildPath("CreateTables." + ext), createTablesContent);
+   ASSERT_FALSE(error) << "Failed to copy CreateTables." << ext;
 
    // Test migration files create and modify test-specific tables.
    // Migration filenames use the 3-part convention: {version}_{Release-Name}_{Description}.{ext}
@@ -346,138 +484,118 @@ TEST_F(DatabaseTestsFixture, CanUpdateSchemas)
       UPDATE schema_version SET current_version = '99000000000000000000001', release_name = 'Test Release';
       )"";
 
-   // sqlite cannot alter tables very well, so adding constraints necessitates dropping
-   // and re-creating the tables
-   std::string schema2Sqlite =
-      R""(
-      CREATE TABLE TestTable1_Persons_new(
-         id int NOT NULL,
-         first_name varchar(255),
-         last_name varchar(255),
-         email_address varchar(255),
-         PRIMARY KEY (id)
-      );
+   std::string schema2;
+   if (isSqlite)
+   {
+      // sqlite cannot alter tables very well, so adding constraints necessitates dropping
+      // and re-creating the tables
+      schema2 =
+         R""(
+         CREATE TABLE TestTable1_Persons_new(
+            id int NOT NULL,
+            first_name varchar(255),
+            last_name varchar(255),
+            email_address varchar(255),
+            PRIMARY KEY (id)
+         );
 
-      DROP TABLE TestTable1_Persons;
-      ALTER TABLE TestTable1_Persons_new RENAME TO TestTable1_Persons;
+         DROP TABLE TestTable1_Persons;
+         ALTER TABLE TestTable1_Persons_new RENAME TO TestTable1_Persons;
 
-      CREATE TABLE TestTable2_AccountHolders_new(
-         id int,
-         fk_person_id int,
-         PRIMARY KEY (id),
-         FOREIGN KEY (fk_person_id) REFERENCES TestTable1_Persons(id)
-      );
+         CREATE TABLE TestTable2_AccountHolders_new(
+            id int,
+            fk_person_id int,
+            PRIMARY KEY (id),
+            FOREIGN KEY (fk_person_id) REFERENCES TestTable1_Persons(id)
+         );
 
-      DROP TABLE TestTable2_AccountHolders;
-      ALTER TABLE TestTable2_AccountHolders_new RENAME TO TestTable2_AccountHolders;
+         DROP TABLE TestTable2_AccountHolders;
+         ALTER TABLE TestTable2_AccountHolders_new RENAME TO TestTable2_AccountHolders;
 
-      UPDATE schema_version SET current_version = '99000000000000000000002', release_name = 'Test Release';
-      )"";
+         UPDATE schema_version SET current_version = '99000000000000000000002', release_name = 'Test Release';
+         )"";
+   }
+   else
+   {
+      // postgresql supports modification of tables
+      schema2 =
+         R""(
+         ALTER TABLE TestTable1_Persons
+         ADD PRIMARY KEY (id);
 
-   // postgresql supports modification of tables
-   std::string schema2Postgresql =
-      R""(
-      ALTER TABLE TestTable1_Persons
-      ADD PRIMARY KEY (id);
+         ALTER TABLE TestTable2_AccountHolders
+         ADD PRIMARY KEY (id);
 
-      ALTER TABLE TestTable2_AccountHolders
-      ADD PRIMARY KEY (id);
+         ALTER TABLE TestTable2_AccountHolders
+         ADD FOREIGN KEY (fk_person_id) REFERENCES TestTable1_Persons(id);
 
-      ALTER TABLE TestTable2_AccountHolders
-      ADD FOREIGN KEY (fk_person_id) REFERENCES TestTable1_Persons(id);
+         UPDATE schema_version SET current_version = '99000000000000000000002', release_name = 'Test Release';
+         )"";
+   }
 
-      UPDATE schema_version SET current_version = '99000000000000000000002', release_name = 'Test Release';
-      )"";
+   std::string schema3;
+   if (isSqlite)
+   {
+      schema3 =
+         R""(
+         CREATE TABLE TestTable2_AccountHolders_new(
+            id int,
+            fk_person_id int,
+            creation_time text,
+            PRIMARY KEY (id),
+            FOREIGN KEY (fk_person_id) REFERENCES TestTable1_Persons(id)
+         );
 
-   std::string schema3Sqlite =
-      R""(
-      CREATE TABLE TestTable2_AccountHolders_new(
-         id int,
-         fk_person_id int,
-         creation_time text,
-         PRIMARY KEY (id),
-         FOREIGN KEY (fk_person_id) REFERENCES TestTable1_Persons(id)
-      );
+         DROP TABLE TestTable2_AccountHolders;
+         ALTER TABLE TestTable2_AccountHolders_new RENAME TO TestTable2_AccountHolders;
 
-      DROP TABLE TestTable2_AccountHolders;
-      ALTER TABLE TestTable2_AccountHolders_new RENAME TO TestTable2_AccountHolders;
+         UPDATE schema_version SET current_version = '99000000000000000000003', release_name = 'Test Release';
+         )"";
+   }
+   else
+   {
+      schema3 =
+         R""(
+         ALTER TABLE TestTable2_AccountHolders
+         ADD COLUMN creation_time text;
 
-      UPDATE schema_version SET current_version = '99000000000000000000003', release_name = 'Test Release';
-      )"";
-
-   std::string schema3Postgresql =
-      R""(
-      ALTER TABLE TestTable2_AccountHolders
-      ADD COLUMN creation_time text;
-
-      UPDATE schema_version SET current_version = '99000000000000000000003', release_name = 'Test Release';
-      )"";
+         UPDATE schema_version SET current_version = '99000000000000000000003', release_name = 'Test Release';
+         )"";
+   }
 
    FilePath outFile1 = schemaDir.completeChildPath("99000000000000000000001_Test-Release_InitialTables.sql");
-   FilePath outFile2Sqlite = schemaDir.completeChildPath("99000000000000000000002_Test-Release_AddConstraints.sqlite");
-   FilePath outFile2Postgresql = schemaDir.completeChildPath("99000000000000000000002_Test-Release_AddConstraints.postgresql");
-   FilePath outFile3Sqlite = schemaDir.completeChildPath("99000000000000000000003_Test-Release_AddCreationTime.sqlite");
-   FilePath outFile3Postgresql = schemaDir.completeChildPath("99000000000000000000003_Test-Release_AddCreationTime.postgresql");
+   FilePath outFile2 = schemaDir.completeChildPath("99000000000000000000002_Test-Release_AddConstraints." + ext);
+   FilePath outFile3= schemaDir.completeChildPath("99000000000000000000003_Test-Release_AddCreationTime." + ext);
 
    error = writeStringToFile(outFile1, schema1);
    ASSERT_FALSE(error) << "Failed to write initial test tables schema file: " << error.getMessage();
 
-   error = writeStringToFile(outFile2Sqlite, schema2Sqlite);
-   ASSERT_FALSE(error) << "Failed to write SQLite constraints schema file: " << error.getMessage();
+   error = writeStringToFile(outFile2, schema2);
+   ASSERT_FALSE(error) << "Failed to write " << ext << " constraints schema file: " << error.getMessage();
 
-   error = writeStringToFile(outFile2Postgresql, schema2Postgresql);
-   ASSERT_FALSE(error) << "Failed to write PostgreSQL constraints schema file: " << error.getMessage();
+   error = writeStringToFile(outFile3, schema3);
+   ASSERT_FALSE(error) << "Failed to write " << ext << " account creation schema file: " << error.getMessage();
 
-   error = writeStringToFile(outFile3Sqlite, schema3Sqlite);
-   ASSERT_FALSE(error) << "Failed to write SQLite account creation schema file: " << error.getMessage();
-
-   error = writeStringToFile(outFile3Postgresql, schema3Postgresql);
-   ASSERT_FALSE(error) << "Failed to write PostgreSQL account creation schema file: " << error.getMessage();
-
-   boost::shared_ptr<IConnection> postgresConnection;
-   error = connect(postgresConnectionOptions(), &postgresConnection);
-   ASSERT_FALSE(error) << "Failed to connect to PostgreSQL database for schema update test: " << error.getMessage();
-
-   // Reset the PostgreSQL test database so the test is repeatable.
-   // The SQLite DB is already cleaned up by the fixture (file is deleted in TearDown).
-   error = postgresConnection->executeStr("DROP SCHEMA public CASCADE; CREATE SCHEMA public;");
-   ASSERT_FALSE(error) << "Failed to reset PostgreSQL test database: " << error.getMessage();
-
-   SchemaUpdater sqliteUpdater(sqliteConnection, schemaDir);
-   SchemaUpdater postgresUpdater(postgresConnection, schemaDir);
+   SchemaUpdater updater(dbConnection, schemaDir);
 
    // First update: creates schema from the real CreateTables files (production version)
-   error = sqliteUpdater.update();
-   ASSERT_FALSE(error) << "Failed initial SQLite schema creation: " << error.getMessage();
-
-   error = postgresUpdater.update();
-   ASSERT_FALSE(error) << "Failed initial PostgreSQL schema creation: " << error.getMessage();
+   error = updater.update();
+   ASSERT_FALSE(error) << "Failed initial " << ext << " schema creation: " << error.getMessage();
 
    // Second update: applies test migration files (versions higher than production)
-   error = sqliteUpdater.update();
-   ASSERT_FALSE(error) << "Failed to apply SQLite test migrations: " << error.getMessage();
-
-   error = postgresUpdater.update();
-   ASSERT_FALSE(error) << "Failed to apply PostgreSQL test migrations: " << error.getMessage();
+   error = updater.update();
+   ASSERT_FALSE(error) << "Failed to apply " << ext << " test migrations: " << error.getMessage();
 
    SchemaVersion expectedVersion("99000000000000000000003", "Test Release");
 
    SchemaVersion currentSchemaVersion;
-   error = sqliteUpdater.databaseSchemaVersion(&currentSchemaVersion);
-   ASSERT_FALSE(error) << "Failed to get SQLite schema version: " << error.getMessage();
-   ASSERT_EQ(currentSchemaVersion, expectedVersion);
-
-   currentSchemaVersion = SchemaVersion();
-   error = postgresUpdater.databaseSchemaVersion(&currentSchemaVersion);
-   ASSERT_FALSE(error) << "Failed to get PostgreSQL schema version: " << error.getMessage();
+   error = updater.databaseSchemaVersion(&currentSchemaVersion);
+   ASSERT_FALSE(error) << "Failed to get " << ext << " schema version: " << error.getMessage();
    ASSERT_EQ(currentSchemaVersion, expectedVersion);
 
    // ensure repeated calls to update work without error
-   error = sqliteUpdater.update();
-   ASSERT_FALSE(error) << "Failed to update SQLite schema (repeated call): " << error.getMessage();
-
-   error = postgresUpdater.update();
-   ASSERT_FALSE(error) << "Failed to update PostgreSQL schema (repeated call): " << error.getMessage();
+   error = updater.update();
+   ASSERT_FALSE(error) << "Failed to update " << ext << " schema (repeated call): " << error.getMessage();
 
    // ensure we can insert data as expected (given our expected constraints)
    int id = 1;
@@ -487,70 +605,65 @@ TEST_F(DatabaseTestsFixture, CanUpdateSchemas)
    std::string creationTime = "03/03/2020 12:00:00";
 
    // create queries - we will be executing them multiple times, so bind input just before execution
-   Query sqliteInsertQuery = sqliteConnection->query("INSERT INTO TestTable1_Persons VALUES (:id, :fname, :lname, :email)");
-   Query postgresInsertQuery = postgresConnection->query("INSERT INTO TestTable1_Persons VALUES (:id, :fname, :lname, :email)");
-   Query sqliteInsertQuery2 = sqliteConnection->query("INSERT INTO TestTable2_AccountHolders VALUES (:id, :pid, :time)");
-   Query postgresInsertQuery2 = postgresConnection->query("INSERT INTO TestTable2_AccountHolders VALUES (:id, :pid, :time)");
+   Query insertQuery = dbConnection->query("INSERT INTO TestTable1_Persons VALUES (:id, :fname, :lname, :email)");
+   Query insertQuery2 = dbConnection->query("INSERT INTO TestTable2_AccountHolders VALUES (:id, :pid, :time)");
 
    // should fail - FK constraint
-   sqliteInsertQuery2
+   insertQuery2
          .withInput(id, "id")
          .withInput(id, "pid")
          .withInput(creationTime, "time");
-   postgresInsertQuery2
-         .withInput(id, "id")
-         .withInput(id, "pid")
-         .withInput(creationTime, "time");
-   EXPECT_TRUE(sqliteConnection->execute(sqliteInsertQuery2));
-   ASSERT_TRUE(postgresConnection->execute(postgresInsertQuery2));
+   EXPECT_TRUE(dbConnection->execute(insertQuery2));
 
    // should succeed - properly ordered
-   sqliteInsertQuery
+   insertQuery
          .withInput(id, "id")
          .withInput(firstName, "fname")
          .withInput(lastName, "lname")
          .withInput(email, "email");
-   EXPECT_FALSE(sqliteConnection->execute(sqliteInsertQuery));
-   sqliteInsertQuery2
+   EXPECT_FALSE(dbConnection->execute(insertQuery));
+   insertQuery2
          .withInput(id, "id")
          .withInput(id, "pid")
          .withInput(creationTime, "time");
-   EXPECT_FALSE(sqliteConnection->execute(sqliteInsertQuery2));
-   postgresInsertQuery
-         .withInput(id, "id")
-         .withInput(firstName, "fname")
-         .withInput(lastName, "lname")
-         .withInput(email, "email");
-   EXPECT_FALSE(postgresConnection->execute(postgresInsertQuery));
-   postgresInsertQuery2
-         .withInput(id, "id")
-         .withInput(id, "pid")
-         .withInput(creationTime, "time");
-   EXPECT_FALSE(postgresConnection->execute(postgresInsertQuery2));
+   EXPECT_FALSE(dbConnection->execute(insertQuery2));
 
    // should fail - PK constraint
-   sqliteInsertQuery
+   insertQuery
          .withInput(id, "id")
          .withInput(firstName, "fname")
          .withInput(lastName, "lname")
          .withInput(email, "email");
-   ASSERT_TRUE(sqliteConnection->execute(sqliteInsertQuery));
-   sqliteInsertQuery2
+   ASSERT_TRUE(dbConnection->execute(insertQuery));
+   insertQuery2
          .withInput(id, "id")
          .withInput(id, "pid")
          .withInput(creationTime, "time");
-   ASSERT_TRUE(sqliteConnection->execute(sqliteInsertQuery2));
-   postgresInsertQuery
-         .withInput(id, "id")
-         .withInput(firstName, "fname")
-         .withInput(lastName, "lname")
-         .withInput(email, "email");
-   ASSERT_TRUE(postgresConnection->execute(postgresInsertQuery));
-   postgresInsertQuery2
-         .withInput(id, "id")
-         .withInput(id, "pid")
-         .withInput(creationTime, "time");
-   ASSERT_TRUE(postgresConnection->execute(postgresInsertQuery2));
+   ASSERT_TRUE(dbConnection->execute(insertQuery2));
+}
+
+TEST_F(DatabaseTestsFixture, CanUpdateSchemasSqlite)
+{
+   testCanUpdateSchemas(sqliteConnection);
+}
+
+TEST_F(DatabaseTestsFixture, CanUpdateSchemasPostgres)
+{
+   if (!std::getenv("POSTGRES_ENABLED") || std::string(std::getenv("POSTGRES_ENABLED")) != "1")
+   {
+      GTEST_SKIP() << "Skipping Postgres migration tests as POSTGRES_ENABLED is not set";
+   }
+
+   boost::shared_ptr<IConnection> postgresConnection;
+   Error error = connect(postgresConnectionOptions(), &postgresConnection);
+   ASSERT_FALSE(error) << "Failed to connect to PostgreSQL database for schema update test: " << error.getMessage();
+
+   // Reset the PostgreSQL test database so the test is repeatable.
+   // The SQLite DB is already cleaned up by the fixture (file is deleted in TearDown).
+   error = postgresConnection->executeStr("DROP SCHEMA public CASCADE; CREATE SCHEMA public;");
+   ASSERT_FALSE(error) << "Failed to reset PostgreSQL test database: " << error.getMessage();
+
+   testCanUpdateSchemas(postgresConnection);
 }
 
 TEST(DatabaseTest, SchemaVersionComparisonsAreCorrect)
@@ -834,6 +947,294 @@ TEST_F(DatabaseTestsFixture, GetOptionalValueCastsNumericTypes)
    }
 }
 
+TEST(DatabaseTest, SqlIdentifierValidation)
+{
+   auto result = SqlIdentifier::from("valid");
+   EXPECT_TRUE(result) << "unexpected error when creating SqlIdentifier from valid input";
+
+   result = SqlIdentifier::from("invalid!");
+   EXPECT_FALSE(result) << "SqlIdentifier::from allowed invalid input";
+}
+
+TEST_F(DatabaseTestsFixture, InsertBuilderInserts)
+{
+   Query query = sqliteConnection->query("create table BuilderTest(i_val integer, f_val real, b_val bigint, t_val text)");
+   Error error = sqliteConnection->execute(query);
+   ASSERT_FALSE(error) << "Failed to create BuilderTest table: " << error.getMessage();
+
+   InsertBuilder builder(sqliteConnection, "BuilderTest");
+   builder.add("i_val", 1)
+      .add("f_val", 2.2)
+      .add("b_val", 3)
+      .add("t_val", "foo");
+
+   std::string sql = builder.toSQL();
+   EXPECT_EQ(sql, "INSERT INTO BuilderTest (i_val, f_val, b_val, t_val) VALUES (:i_val, :f_val, :b_val, :t_val)");
+
+   query = builder.build();
+   error = sqliteConnection->execute(query);
+   ASSERT_FALSE(error) << "Failed to insert values into BuilderTest: " << error.getMessage();
+
+   Rowset rows;
+   query = sqliteConnection->query("select i_val, f_val, b_val, t_val from BuilderTest");
+   error = sqliteConnection->execute(query, rows);
+   ASSERT_FALSE(error) << "Failed to select values from BuilderTest: " << error.getMessage();
+
+   int i = 0;
+   for (RowsetIterator it = rows.begin(); it != rows.end(); ++it, ++i)
+   {
+      ASSERT_EQ(i, 0) << "too many rows returned";
+
+      int i_val;
+      double f_val;
+      long long b_val;
+      std::string t_val;
+
+      error = rows.getValue(it, "i_val", &i_val);
+      EXPECT_FALSE(error);
+      EXPECT_EQ(i_val, 1);
+      error = rows.getValue(it, "f_val", &f_val);
+      EXPECT_FALSE(error);
+      EXPECT_EQ(f_val, 2.2);
+      error = rows.getValue(it, "b_val", &b_val);
+      EXPECT_FALSE(error);
+      EXPECT_EQ(b_val, 3);
+      error = rows.getValue(it, "t_val", &t_val);
+      EXPECT_FALSE(error);
+      EXPECT_EQ(t_val, "foo");
+   }
+   ASSERT_EQ(i, 1) << "not enough rows returned";
+}
+
+TEST_F(DatabaseTestsFixture, SelectBuilderSelects)
+{
+   Query query = sqliteConnection->query("create table BuilderTest(i_val integer, f_val real, b_val bigint, t_val text)");
+   Error error = sqliteConnection->execute(query);
+   ASSERT_FALSE(error) << "Failed to create BuilderTest table: " << error.getMessage();
+
+   query = sqliteConnection->query("insert into BuilderTest (i_val, f_val, b_val, t_val) VALUES (1, 2.2, 3, :t_val)");
+   std::string foo = "foo";
+   query.withInput(foo);
+   error = sqliteConnection->execute(query);
+   ASSERT_FALSE(error) << "Failed to insert values into BuilderTest: " << error.getMessage();
+
+   SelectBuilder builder(sqliteConnection, "BuilderTest");
+   builder.add("i_val").add("f_val").add("b_val").add("t_val");
+   builder.where("i_val", 1);
+
+   std::string sql = builder.toSQL();
+   EXPECT_EQ(sql, "SELECT i_val, f_val, b_val, t_val FROM BuilderTest WHERE i_val = :where_i_val");
+
+   query = builder.build();
+
+   Rowset rows;
+   error = sqliteConnection->execute(query, rows);
+   ASSERT_FALSE(error) << "Failed to select values from BuilderTest: " << error.getMessage();
+
+   int i = 0;
+   for (RowsetIterator it = rows.begin(); it != rows.end(); ++it, ++i)
+   {
+      ASSERT_EQ(i, 0) << "too many rows returned";
+
+      int i_val;
+      double f_val;
+      long long b_val;
+      std::string t_val;
+
+      error = rows.getValue(it, "i_val", &i_val);
+      EXPECT_FALSE(error);
+      EXPECT_EQ(i_val, 1);
+      error = rows.getValue(it, "f_val", &f_val);
+      EXPECT_FALSE(error);
+      EXPECT_EQ(f_val, 2.2);
+      error = rows.getValue(it, "b_val", &b_val);
+      EXPECT_FALSE(error);
+      EXPECT_EQ(b_val, 3);
+      error = rows.getValue(it, "t_val", &t_val);
+      EXPECT_FALSE(error);
+      EXPECT_EQ(t_val, "foo");
+   }
+   ASSERT_EQ(i, 1) << "not enough rows returned";
+}
+
+TEST_F(DatabaseTestsFixture, UpdateBuilderUpdates)
+{
+   Query query = sqliteConnection->query("create table BuilderTest(i_val integer, b_val bigint)");
+   Error error = sqliteConnection->execute(query);
+   ASSERT_FALSE(error) << "Failed to create BuilderTest table: " << error.getMessage();
+
+   for (int i = 0; i < 3; i++)
+   {
+      InsertBuilder builder(sqliteConnection, "BuilderTest");
+      builder.add("i_val", i)
+         .add("b_val", i);
+      query = builder.build();
+      error = sqliteConnection->execute(query);
+      ASSERT_FALSE(error) << "Failed to insert values into BuilderTest: " << error.getMessage();
+   }
+
+   UpdateBuilder builder(sqliteConnection, "BuilderTest");
+   builder.add("b_val", 999)
+      .where("i_val", 1);
+
+   std::string sql = builder.toSQL();
+   EXPECT_EQ(sql, "UPDATE BuilderTest SET b_val = :b_val WHERE i_val = :where_i_val");
+
+   query = builder.build();
+   error = sqliteConnection->execute(query);
+   ASSERT_FALSE(error) << "Failed to update values in BuilderTest: " << error.getMessage();
+
+   Rowset rows;
+   query = sqliteConnection->query("select i_val, b_val from BuilderTest");
+   error = sqliteConnection->execute(query, rows);
+   ASSERT_FALSE(error) << "Failed to select values from BuilderTest: " << error.getMessage();
+
+   for (RowsetIterator it = rows.begin(); it != rows.end(); ++it)
+   {
+      int i_val;
+      int b_val;
+
+      error = rows.getValue(it, "i_val", &i_val);
+      EXPECT_FALSE(error);
+      error = rows.getValue(it, "b_val", &b_val);
+      EXPECT_FALSE(error);
+      if (i_val == 1)
+         EXPECT_EQ(b_val, 999);
+      else
+         EXPECT_EQ(b_val, i_val);
+   }
+}
+
+// Also tests .whereIn()
+TEST_F(DatabaseTestsFixture, DeleteBuilderDeletes)
+{
+   Query query = sqliteConnection->query("create table BuilderTest(i_val integer, b_val bigint)");
+   Error error = sqliteConnection->execute(query);
+   ASSERT_FALSE(error) << "Failed to create BuilderTest table: " << error.getMessage();
+
+   for (int i = 0; i < 3; i++)
+   {
+      InsertBuilder builder(sqliteConnection, "BuilderTest");
+      builder.add("i_val", i)
+         .add("b_val", i);
+      query = builder.build();
+      error = sqliteConnection->execute(query);
+      ASSERT_FALSE(error) << "Failed to insert values into BuilderTest: " << error.getMessage();
+   }
+
+   {
+      // Temporary builder just for testing compilation of the container overload
+      DeleteBuilder builder(sqliteConnection, "BuilderTest");
+      builder.whereIn("i_val", std::vector<int>{ 0, 2 });
+   }
+
+   DeleteBuilder builder(sqliteConnection, "BuilderTest");
+   builder.whereIn("i_val", { 0, 2 });
+
+   std::string sql = builder.toSQL();
+   EXPECT_EQ(sql, "DELETE FROM BuilderTest WHERE i_val IN (:where_i_val_0, :where_i_val_1)");
+
+   query = builder.build();
+   error = sqliteConnection->execute(query);
+   ASSERT_FALSE(error) << "Failed to update values in BuilderTest: " << error.getMessage();
+
+   Rowset rows;
+   query = sqliteConnection->query("select i_val, b_val from BuilderTest");
+   error = sqliteConnection->execute(query, rows);
+   ASSERT_FALSE(error) << "Failed to select values from BuilderTest: " << error.getMessage();
+
+   int i = 0;
+   for (RowsetIterator it = rows.begin(); it != rows.end(); ++it, ++i)
+   {
+      ASSERT_EQ(i, 0) << "too many rows returned";
+
+      int i_val;
+      int b_val;
+
+      error = rows.getValue(it, "i_val", &i_val);
+      EXPECT_FALSE(error);
+      EXPECT_EQ(i_val, 1);
+      error = rows.getValue(it, "b_val", &b_val);
+      EXPECT_FALSE(error);
+      EXPECT_EQ(b_val, 1);
+   }
+   ASSERT_EQ(i, 1) << "not enough rows returned";
+}
+
+TEST_F(DatabaseTestsFixture, CompoundWhereExpressions)
+{
+   Query query = sqliteConnection->query("create table BuilderTest(id INTEGER, foo INTEGER, bar INTEGER)");
+   Error error = sqliteConnection->execute(query);
+   ASSERT_FALSE(error) << "Failed to create BuilderTest table: " << error.getMessage();
+
+   error = sqliteConnection->executeStr("insert into BuilderTest (id, foo, bar) VALUES (1, 2, 0), (3, 4, 0), (5, 6, 1)");
+   ASSERT_FALSE(error) << "Failed to insert values into BuilderTest: " << error.getMessage();
+
+   SelectBuilder builder(sqliteConnection, "BuilderTest");
+   builder.add("id");
+   builder.where(QBWhereOr().where("foo", 2).where("bar", 1));
+
+   std::string sql = builder.toSQL();
+   EXPECT_EQ(sql, "SELECT id FROM BuilderTest WHERE (foo = :where_1_foo OR bar = :where_1_bar)");
+
+   query = builder.build();
+
+   Rowset rows;
+   error = sqliteConnection->execute(query, rows);
+   ASSERT_FALSE(error) << "Failed to select values from BuilderTest: " << error.getMessage();
+
+   std::set<int> expected({ 1, 5 });
+   bool unexpected = false;
+   for (RowsetIterator it = rows.begin(); it != rows.end(); ++it)
+   {
+      int id;
+      error = rows.getValue(it, "id", &id);
+      EXPECT_FALSE(error);
+      auto found = expected.find(id);
+      if (found != expected.end())
+         expected.erase(found);
+      else
+         unexpected = true;
+   }
+   ASSERT_EQ(expected.size(), 0) << "missing rows in WHERE OR test";
+   ASSERT_FALSE(unexpected) << "unexpected results in WHERE OR test";
+
+   SelectBuilder builder2(sqliteConnection, "BuilderTest");
+   builder2.add("id");
+   builder2.where(QBWhereOr()
+      .where("foo", 6)
+      .where(QBWhereAnd()
+         .where("bar", 0)
+         .where("foo", 2)
+      )
+   );
+
+   sql = builder2.toSQL();
+   EXPECT_EQ(sql, "SELECT id FROM BuilderTest WHERE (foo = :where_1_foo OR (bar = :where_1_1_bar AND foo = :where_1_1_foo))");
+
+   query = builder2.build();
+
+   error = sqliteConnection->execute(query, rows);
+   ASSERT_FALSE(error) << "Failed to select values from BuilderTest: " << error.getMessage();
+
+   expected = std::set<int>({ 1, 5 });
+   unexpected = false;
+   for (RowsetIterator it = rows.begin(); it != rows.end(); ++it)
+   {
+      int id;
+      error = rows.getValue(it, "id", &id);
+      EXPECT_FALSE(error);
+      auto found = expected.find(id);
+      if (found != expected.end())
+         expected.erase(found);
+      else
+         unexpected = true;
+   }
+   ASSERT_EQ(expected.size(), 0) << "missing rows in WHERE AND test";
+   ASSERT_FALSE(unexpected) << "unexpected results in WHERE AND test";
+}
+
+
 class ConnectionPoolTestsFixture : public ::testing::Test
 {
 protected:
@@ -1013,7 +1414,8 @@ TEST(ConnectionPoolTest, ReturningConnectionCleanlyLeavesAutocommit)
 // snapshot until it is destroyed. A connection that is reused for a write while
 // still carrying such a snapshot - after another connection has committed -
 // fails with SQLITE_BUSY_SNAPSHOT, which busy_timeout cannot clear and retries
-// cannot resolve. This guards that Rowset-lifetime contract.
+// cannot resolve. oauthToken() now scopes its Rowset so the snapshot is released
+// before the write; this guards that Rowset-lifetime contract.
 TEST(ConnectionPoolTest, RowsetReleasesReadSnapshotWhenDestroyed)
 {
    FilePath dbPath;

--- a/src/cpp/core/QueryBuilder.cpp
+++ b/src/cpp/core/QueryBuilder.cpp
@@ -1,0 +1,239 @@
+/*
+ * QueryBuilder.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <core/QueryBuilder.hpp>
+#include <core/details/QBNodeList.hpp>
+
+namespace rstudio {
+namespace core {
+namespace database {
+
+namespace detail {
+
+static void bindAllNodes(Query& query, QBNodeList& nodes, const std::string& prefix = std::string())
+{
+   for (QBBaseNode* node : nodes)
+   {
+      node->apply(query, prefix);
+   }
+}
+
+std::string buildWhereClause(const QBNodeList& whereClauses)
+{
+   std::ostringstream ss;
+   if (!whereClauses.empty()) {
+      ss << " WHERE ";
+      bool first = true;
+      for (const QBBaseNode* node : whereClauses)
+      {
+         if (first)
+            first = false;
+         else
+            ss << " AND ";
+         ss << node->toClause("where_");
+      }
+   }
+   return ss.str();
+}
+
+QueryBuilder::QueryBuilder(const SqlIdentifier& table)
+: table(table)
+{
+   // initializers only
+}
+
+std::string QueryBuilder::buildInsertQuery() const
+{
+   std::ostringstream ss;
+   ss << "INSERT INTO " << table << " (" << algorithm::join(nodes, ", ", QBBaseNode::getColumnName)
+      << ") VALUES (" << algorithm::join(nodes, ", ", QBBaseNode::getInsertValue) << ")";
+   return ss.str();
+}
+
+std::string QueryBuilder::buildSetClause(const std::vector<SqlIdentifier>& exclude) const
+{
+   std::ostringstream ss;
+   ss << " SET ";
+   bool first = true;
+   for (const QBBaseNode* node : nodes)
+   {
+      if (std::find(exclude.begin(), exclude.end(), node->column) != exclude.end())
+         continue;
+      if (first)
+         first = false;
+      else
+         ss << ", ";
+      ss << node->toClause();
+   }
+   return ss.str();
+}
+
+} // namespace detail
+
+SelectBuilder::SelectBuilder(DatabaseConnection db, const SqlIdentifier& table)
+: QueryBuilder(table), QBWhereMixin(this), db(db)
+{
+   // initializers only
+}
+
+SelectBuilder& SelectBuilder::add(const SqlIdentifier& column)
+{
+   columns.push_back(column);
+   return *this;
+}
+
+bool SelectBuilder::empty() const
+{
+   return columns.empty();
+}
+
+std::string SelectBuilder::toSQL() const
+{
+   std::ostringstream ss;
+   ss << "SELECT " << algorithm::join(columns.begin(), columns.end(), ", ")
+      << " FROM " << table << buildWhereClause();
+   return ss.str();
+}
+
+Query SelectBuilder::build()
+{
+   Query query(toSQL(), db->session());
+   bindAllNodes(query, nodes);
+   bindAllNodes(query, whereClauses, "where_");
+   return query;
+}
+
+InsertBuilder::InsertBuilder(DatabaseConnection db, const SqlIdentifier& table)
+: QueryBuilder(table), QBAddMixin(this), db(db)
+{
+   // initializers only
+}
+
+std::string InsertBuilder::toSQL() const
+{
+   if (empty())
+      return "";
+
+   std::ostringstream ss;
+   ss << buildInsertQuery();
+
+   if (!conflictKeys.empty())
+   {
+      using namespace detail;
+      ss << " ON CONFLICT (" << algorithm::join(conflictKeys.begin(), conflictKeys.end(), ", ") << ") DO ";
+      if (conflictNoUpdate.size() < nodes.size())
+         ss << "UPDATE " << buildSetClause(conflictNoUpdate);
+      else
+         ss << "NOTHING";
+   }
+
+   return ss.str();
+}
+
+Query InsertBuilder::build()
+{
+   Query query(toSQL(), db->session());
+   bindAllNodes(query, nodes);
+   return query;
+}
+
+InsertBuilder& InsertBuilder::onConflictUpdate(const std::vector<SqlIdentifier>& keys, const std::vector<SqlIdentifier>& noUpdate)
+{
+   conflictKeys = keys;
+   conflictNoUpdate = keys;
+   conflictNoUpdate.insert(conflictNoUpdate.end(), noUpdate.begin(), noUpdate.end());
+   return *this;
+}
+
+UpdateBuilder::UpdateBuilder(DatabaseConnection db, const SqlIdentifier& table)
+: QueryBuilder(table), QBAddMixin(this), QBWhereMixin(this), db(db)
+{
+   // initializers only
+}
+
+std::string UpdateBuilder::toSQL() const
+{
+   return "UPDATE " + table + buildSetClause() + buildWhereClause();
+}
+
+Query UpdateBuilder::build()
+{
+   Query query(toSQL(), db->session());
+   bindAllNodes(query, nodes);
+   bindAllNodes(query, whereClauses, "where_");
+   return query;
+}
+
+DeleteBuilder::DeleteBuilder(DatabaseConnection db, const SqlIdentifier& table)
+: QueryBuilder(table), QBWhereMixin(this), db(db)
+{
+   // initializers only
+}
+
+std::string DeleteBuilder::toSQL() const
+{
+   return "DELETE FROM " + table + buildWhereClause();
+}
+
+Query DeleteBuilder::build()
+{
+   Query query(toSQL(), db->session());
+   bindAllNodes(query, whereClauses, "where_");
+   return query;
+}
+
+RawQueryBuilder::RawQueryBuilder(DatabaseConnection db)
+: QueryBuilder("_"), QBAddMixin(this), db(db)
+{
+   // initializers only
+}
+
+SqlIdentifier RawQueryBuilder::addBinding(bool secret)
+{
+   std::string name = (secret ? "secret_param" : "bind") + std::to_string(nodes.size());
+   if (secret)
+      addSecretParamNames({ name });
+   queryText << ":" << name;
+   // Use .c_str() because this is already known to be safe
+   return SqlIdentifier(name.c_str());
+}
+
+RawQueryBuilder& RawQueryBuilder::operator<<(const char sql[])
+{
+   queryText << sql;
+   return *this;
+}
+
+RawQueryBuilder& RawQueryBuilder::operator<<(const SqlIdentifier& identifier)
+{
+   queryText << identifier;
+   return *this;
+}
+
+std::string RawQueryBuilder::toSQL() const
+{
+   return queryText.str();
+}
+
+Query RawQueryBuilder::build()
+{
+   Query query(toSQL(), db->session());
+   bindAllNodes(query, nodes);
+   return query;
+}
+
+} // namespace database
+} // namespace core
+} // namespace rstudio

--- a/src/cpp/core/SqlIdentifier.cpp
+++ b/src/cpp/core/SqlIdentifier.cpp
@@ -1,0 +1,88 @@
+/*
+ * SqlIdentifier.hpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <core/SqlIdentifier.hpp>
+
+namespace rstudio {
+namespace core {
+namespace database {
+
+namespace {
+
+Error validate(const std::string& name)
+{
+   // Operate on the char array to avoid any runtime overhead
+   // that might be incurred by std::string::operator[]
+   const char* cstr = name.c_str();
+   int len = name.size();
+   for (int i = 0; i < len; i++)
+   {
+      char ch = cstr[i];
+      if (ch >= 'A' && ch <= 'Z')
+         continue;
+      if (ch >= 'a' && ch <= 'z')
+         continue;
+      if (ch >= '0' && ch <= '9')
+         continue;
+      if (ch == '_')
+         continue;
+      return Error(
+         std::string("Illegal character ") + ch + " in column name \"" + name + "\"",
+         boost::system::errc::invalid_argument,
+         ERROR_LOCATION
+      );
+   }
+   return Error();
+}
+
+}
+
+SqlIdentifier::SqlIdentifier(const char* prevalidatedName)
+: name(prevalidatedName)
+{
+   // initializers only
+}
+
+SqlIdentifier::SqlIdentifier(const std::string& name)
+: name(name)
+{
+   // initializers only
+}
+
+SqlIdentifier::SqlIdentifier(std::string&& name)
+: name(std::move(name))
+{
+   // initializers only
+}
+
+Result<SqlIdentifier> SqlIdentifier::from(const std::string& unvalidatedName)
+{
+   Error error = validate(unvalidatedName);
+   if (error)
+      return Unexpected(error);
+   return SqlIdentifier(unvalidatedName);
+}
+
+Result<SqlIdentifier> SqlIdentifier::from(std::string&& unvalidatedName)
+{
+   Error error = validate(unvalidatedName);
+   if (error)
+      return Unexpected(error);
+   return SqlIdentifier(std::move(unvalidatedName));
+}
+
+} // namespace database
+} // namespace core
+} // namespace rstudio

--- a/src/cpp/core/SqlPreprocessor.cpp
+++ b/src/cpp/core/SqlPreprocessor.cpp
@@ -1,0 +1,457 @@
+/*
+ * SqlPreprocessor.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <core/SqlPreprocessor.hpp>
+
+#include <core/QueryBuilder.hpp>
+#include <core/SqlIdentifier.hpp>
+
+#include <sstream>
+#include <utility>
+#include <system_error>
+
+#define SQLP_ERROR(msg) Error(msg, boost::system::errc::invalid_argument, ERROR_LOCATION)
+#define SQLP_UNEXPECTED(msg) Unexpected(SQLP_ERROR(msg))
+
+namespace rstudio {
+namespace core {
+namespace database {
+
+namespace {
+
+enum EmitState
+{
+   Normal,
+   IfTrue,
+   IfFalse,
+   ElseTrue,
+   ElseFalse,
+};
+
+using Tokens = std::vector<std::string>;
+using TokensIter = Tokens::const_iterator;
+
+class ExpressionParser
+{
+private:
+   struct State
+   {
+      State() : value(false) {}
+      State(bool value, TokensIter next) : value(value), next(next) {}
+      State(const State&) = default;
+      State(State&&) = default;
+      State& operator=(const State&) = default;
+      State& operator=(State&&) = default;
+
+      bool value;
+      TokensIter next;
+   };
+
+public:
+   ExpressionParser(DatabaseConnection dbConnection)
+   : dbConnection(dbConnection)
+   {
+      // initializers only
+   }
+
+   static Tokens tokenize(const std::string& expr)
+   {
+      Tokens tokens;
+      int len = expr.size();
+      std::string token;
+      for (int i = 0; i < len; i++)
+      {
+         char ch = expr[i];
+         if (ch == ' ' || ch == '\t' || ch == '!' || ch == ')' || ch == ',')
+         {
+            if (!token.empty())
+               tokens.push_back(token);
+            if (ch != ' ' && ch != '\t')
+               tokens.push_back(std::string(1, ch));
+            token.clear();
+            continue;
+         }
+         if (ch >= 'A' && ch <= 'Z')
+            ch = ch + ('a' - 'A');
+         token += ch;
+         if (token == "&&" || token == "||" || ch == '(')
+         {
+            tokens.push_back(token);
+            token.clear();
+         }
+      }
+
+      if (!token.empty())
+         tokens.push_back(token);
+
+      len = tokens.size();
+      for (int i = 0; i < len; i++)
+      {
+         if (tokens[i] == "true")
+            tokens[i] = "1";
+         else if (tokens[i] == "false")
+            tokens[i] = "0";
+      }
+      return tokens;
+   }
+
+   Result<bool> evaluate(const std::string& expr)
+   {
+      Tokens tokens = tokenize(expr);
+      auto result = evaluate(tokens.begin(), tokens.end());
+      if (!result)
+         return Unexpected(result.error());
+      if (result->next != tokens.end())
+         return SQLP_UNEXPECTED("Unexpected tokens after expression: " + expr);
+      return result->value;
+   }
+
+private:
+   static Result<State> evaluate(DatabaseConnection dbConnection, const TokensIter& begin, const TokensIter& end)
+   {
+      ExpressionParser sql(dbConnection);
+      return sql.evaluate(begin, end);
+   }
+
+   Result<State> evaluate(const TokensIter& begin, const TokensIter& end)
+   {
+      if (begin == end)
+         return SQLP_UNEXPECTED("Incomplete expression");
+
+      hasValue = false;
+      for (auto iter = begin; iter < end; iter++)
+      {
+         std::string token = *iter;
+         if (token == "&&")
+            return doBinary(iter, end, doAnd);
+         if (token == "||")
+            return doBinary(iter, end, doOr);
+         if (token == "!")
+            return doUnary(iter, end, doInvert);
+
+         Result<State> nextState;
+         if (token == "0")
+            nextState = setValue(token, State(false, iter));
+         else if (token == "1")
+            nextState = setValue(token, State(true, iter));
+         else if (token == "(")
+            nextState = doParenthesized(iter, end);
+         else if (token[token.size() - 1] == '(')
+            nextState = doFunction(iter, end);
+         else
+            return SQLP_UNEXPECTED("Unknown token " + token);
+
+         if (!nextState)
+            return Unexpected(nextState.error());
+         iter = nextState->next;
+      }
+      return State(value, end);
+   }
+
+   static bool doInvert(bool v) { return !v; }
+   static bool doAnd(bool l, bool r) { return l && r; }
+   static bool doOr(bool l, bool r) { return l || r; }
+
+   Result<State> doUnary(const TokensIter& iter, const TokensIter& end, bool(*func)(bool))
+   {
+      if (hasValue)
+         return SQLP_UNEXPECTED("Unexpected " + *iter);
+      auto result = evaluate(dbConnection, iter + 1, end);
+      if (!result)
+         return Unexpected(result.error());
+      result->value = func(result->value);
+      return result;
+   }
+
+   Result<State> doBinary(const TokensIter& iter, const TokensIter& end, bool(*func)(bool, bool))
+   {
+      if (!hasValue)
+         return SQLP_UNEXPECTED("Unexpected " + *iter);
+      auto result = evaluate(dbConnection, iter + 1, end);
+      if (!result)
+         return Unexpected(result.error());
+      result->value = func(value, result->value);
+      return result;
+   }
+
+   Result<State> setValue(const std::string& token, Result<State> state)
+   {
+      if (hasValue)
+         return SQLP_UNEXPECTED("Unexpected " + token);
+      if (!state)
+         return state;
+      value = state->value;
+      hasValue = true;
+      return State(value, state->next);
+   }
+
+   Result<State> doParenthesized(const TokensIter& begin, const TokensIter& end)
+   {
+      TokensIter iter = begin;
+      while (++iter != end)
+      {
+         if (*iter == ")")
+         {
+            return setValue(*begin, evaluate(dbConnection, begin + 1, iter));
+         }
+      }
+      return SQLP_UNEXPECTED("Unmatched parentheses");
+   }
+
+   Result<State> doFunction(const TokensIter& begin, const TokensIter& end)
+   {
+      TokensIter iter = begin;
+      Tokens args;
+      while (++iter != end)
+      {
+         std::string token = *iter;
+         if (token == "," || token == ")")
+            return SQLP_UNEXPECTED("Unexpected " + token);
+         args.push_back(token);
+         ++iter;
+         if (iter == end || *iter == ")")
+            break;
+         if (*iter != ",")
+            return SQLP_UNEXPECTED("Unexpected " + *iter);
+      }
+      if (iter == end)
+         return SQLP_UNEXPECTED("Unmatched parentheses");
+
+      std::string token = *begin;
+      if (token == "exists(")
+         return setValue(token, checkExists(args, iter));
+      else if (token == "driver(")
+         return setValue(token, checkDriver(args, iter));
+      else
+         return SQLP_UNEXPECTED("unknown preprocessor function: " + token);
+   }
+
+   Result<State> checkDriver(const Tokens& args, const TokensIter& end)
+   {
+      if (args.size() != 1)
+         return SQLP_UNEXPECTED("Expected 1 parameter to driver()");
+      return State(args[0] == dbConnection->driverName(), end);
+   }
+
+   Result<State> checkExists(const Tokens& args, const TokensIter& end)
+   {
+      std::string type;
+      std::string rawName;
+      if (args.size() == 1)
+      {
+         type = "table";
+         rawName = args[0];
+      }
+      else if (args.size() == 2)
+      {
+         auto typeResult = SqlIdentifier::from(args[0]);
+         if (!typeResult)
+            return Unexpected(typeResult.error());
+         type = *typeResult;
+         rawName = args[1];
+      }
+      else
+      {
+         return SQLP_UNEXPECTED("Expected 1 or 2 parameters to exists()");
+      }
+      Result<SqlIdentifier> nameResult;
+      std::string column;
+      if (type == "column")
+      {
+         std::size_t dotPos = rawName.find('.');
+         if (dotPos == std::string::npos)
+            return SQLP_UNEXPECTED("Column expression expected in exists(column, ...)");
+         auto columnResult = SqlIdentifier::from(rawName.substr(dotPos + 1));
+         if (!columnResult)
+            return Unexpected(columnResult.error());
+         column = *columnResult;
+         nameResult = SqlIdentifier::from(rawName.substr(0, dotPos));
+      }
+      else
+      {
+         nameResult = SqlIdentifier::from(rawName);
+      }
+      if (!nameResult)
+         return Unexpected(nameResult.error());
+      std::string name = *nameResult;
+      SqlIdentifier schema;
+      Rowset rows;
+      bool isSqlite = (dbConnection->driver() == database::Driver::Sqlite);
+      if (isSqlite && type == "column")
+      {
+         // intentionally loophole the identifier validation: this has already been validated
+         schema = SqlIdentifier(("pragma_table_info('" + name + "')").c_str());
+      }
+      else if (isSqlite)
+         schema = "sqlite_master";
+      else if (type == "table" || type == "view")
+         schema = "information_schema.tables";
+      else if (type == "index")
+         schema = "pg_catalog.pg_indexes";
+      else if (type == "trigger")
+         schema = "information_schema.triggers";
+      else if (type == "column")
+         schema = "information_schema.columns";
+      else
+         return SQLP_UNEXPECTED("Unknown object type " + type);
+      SelectBuilder select(dbConnection, schema);
+      if (isSqlite && type == "column")
+         select.add("name").where("name", column);
+      else if (isSqlite)
+         select.add("name").where("name", name).where("type", type);
+      else if (type == "table" || type == "view")
+         select.add("table_name").where("table_name", name).where("table_type", (type == "table") ? "BASE TABLE" : "VIEW");
+      else if (type == "index")
+         select.add("indexname").where("indexname", name);
+      else if (type == "trigger")
+         select.add("trigger_name").where("trigger_name", name);
+      else if (type == "column")
+         select.add("column_name").where("table_name", name).where("column_name", column);
+      Query query = select.build();
+      Error error = dbConnection->execute(query, rows);
+      if (error)
+         return Unexpected(error);
+      return State(rows.begin() != rows.end(), end);
+   }
+
+   DatabaseConnection dbConnection;
+   bool hasValue;
+   bool value;
+};
+
+} // anonymous namespace
+
+Result<std::string> preprocessSchemaFile(DatabaseConnection dbConnection, const std::string& schema)
+{
+   std::ostringstream ss;
+
+   ExpressionParser parser(dbConnection);
+   std::vector<EmitState> ifStack({ Normal });
+   EmitState emitting = Normal;
+
+   std::size_t schemaLength = schema.size();
+   std::size_t pos = 0;
+   std::size_t tokenPos = std::string::npos;
+   // Scan for preprocessor-style directives
+   while (pos != std::string::npos && pos < schemaLength)
+   {
+      // Only recognize # at the beginning of a line
+      if (schema[pos] == '#')
+      {
+         tokenPos = pos;
+      }
+      else
+      {
+         tokenPos = schema.find("\n#", pos);
+         if (tokenPos != std::string::npos)
+            tokenPos++;
+      }
+      if (tokenPos == std::string::npos)
+         break;
+      // Output text from before #
+      if (emitting != IfFalse && emitting != ElseFalse)
+         ss << schema.substr(pos, tokenPos - pos);
+      // skip whitespace after #
+      tokenPos = schema.find_first_not_of("\t ", tokenPos + 1);
+      // Capture the line, ignoring whitespace before newline
+      std::size_t nlPos = schema.find("\n", tokenPos);
+      std::size_t lineEndPos = schema.find_last_not_of("\t\n\r ", nlPos);
+      if (nlPos != std::string::npos)
+         nlPos = nlPos + 1;
+      if (lineEndPos < tokenPos)
+         lineEndPos = tokenPos;
+      if (lineEndPos == std::string::npos) // line contains only # and whitespace
+      {
+         pos = nlPos;
+         continue;
+      }
+      std::string line = schema.substr(tokenPos, lineEndPos - tokenPos + 1);
+      // Move the iterator to the end of the line (which might be the end of the string if npos)
+      pos = nlPos;
+
+      if (line == "endif")
+      {
+         ifStack.pop_back();
+         if (ifStack.empty())
+            return SQLP_UNEXPECTED("#endif without #if");
+         emitting = ifStack.back();
+      }
+      else if (line == "else")
+      {
+         EmitState state = ifStack.back();
+         ifStack.pop_back();
+         if (ifStack.empty())
+            return SQLP_UNEXPECTED("#else without #if");
+         else if (state == ElseTrue || state == ElseFalse)
+            return SQLP_UNEXPECTED("#else after #else");
+         else if (state == IfTrue || ifStack.back() == IfFalse || ifStack.back() == ElseFalse)
+            emitting = ElseFalse;
+         else
+            emitting = ElseTrue;
+         ifStack.push_back(emitting);
+      }
+      else if (line.substr(0, 5) == "elif ")
+      {
+         EmitState state = ifStack.back();
+         ifStack.pop_back();
+         if (ifStack.empty())
+            return SQLP_UNEXPECTED("#elif without #if");
+         else if (state == ElseTrue || state == ElseFalse)
+            return SQLP_UNEXPECTED("#elif after #else");
+         else if (state == IfTrue || ifStack.back() == IfFalse || ifStack.back() == ElseFalse)
+            emitting = IfFalse;
+         else
+         {
+            auto result = parser.evaluate(line.substr(5));
+            if (!result)
+               return Unexpected(result.error());
+            emitting = *result ? IfTrue : IfFalse;
+         }
+         ifStack.push_back(emitting);
+      }
+      else if (line.substr(0, 3) == "if ")
+      {
+         if (emitting == IfFalse || emitting == ElseFalse)
+         {
+            emitting = IfFalse;
+         }
+         else
+         {
+            auto result = parser.evaluate(line.substr(3));
+            if (!result)
+               return Unexpected(result.error());
+            emitting = *result ? IfTrue : IfFalse;
+         }
+         ifStack.push_back(emitting);
+      }
+      else if (!line.empty())
+      {
+         return SQLP_UNEXPECTED("Unknown directive: #" + line);
+      }
+   }
+
+   if (ifStack.size() != 1)
+      return SQLP_UNEXPECTED("#if without #endif");
+
+   // Output text from after last directive
+   if (pos != std::string::npos)
+      ss << schema.substr(pos);
+
+   return ss.str();
+}
+
+} // namespace rstudio
+} // namespace core
+} // namespace database

--- a/src/cpp/core/include/core/Algorithm.hpp
+++ b/src/cpp/core/include/core/Algorithm.hpp
@@ -20,6 +20,7 @@
 #include <vector>
 #include <algorithm>
 
+#include <boost/optional.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/algorithm/string.hpp>
 
@@ -270,19 +271,19 @@ template <typename Iterator, typename F>
 inline std::string join(Iterator begin,
                         Iterator end,
                         const std::string& delim,
-                        F&& f)
+                        F&& to_string)
 {
    if (begin >= end)
       return std::string();
 
-   std::string result;
-   result += f(*begin);
-   for (Iterator it = begin + 1; it != end; ++it)
+   std::ostringstream result;
+   result << to_string(*begin);
+   for (Iterator it = ++Iterator(begin); it != end; ++it)
    {
-      result += delim;
-      result += f(*it);
+      result << delim;
+      result << to_string(*it);
    }
-   return result;
+   return result.str();
 
 }
 
@@ -293,6 +294,14 @@ inline std::string join(Iterator begin,
 {
    auto callback = [](const std::string& string) { return string; };
    return join(begin, end, delim, std::move(callback));
+}
+
+template <typename Container, typename F>
+inline std::string join(const Container& container,
+                        const std::string& delim,
+                        F&& to_string)
+{
+   return join(container.begin(), container.end(), delim, std::move(to_string));
 }
 
 template <typename VOID_FUNC>
@@ -308,6 +317,15 @@ struct Defer {
 
    VOID_FUNC func;
 };
+
+template <typename T, typename U>
+boost::optional<T> optional_cast(const boost::optional<U>& v)
+{
+   if (v.has_value()) {
+      return *v;
+   }
+   return boost::optional<T>(boost::none);
+}
 
 } // namespace algorithm
 } // namespace core

--- a/src/cpp/core/include/core/Database.hpp
+++ b/src/cpp/core/include/core/Database.hpp
@@ -555,6 +555,9 @@ public:
    boost::posix_time::ptime checkoutTime() const { return checkoutTime_; }
    void setCheckoutTime(const boost::posix_time::ptime& time) { checkoutTime_ = time; }
 
+   bool needsHealthCheck() const { return needsHealthCheck_; }
+   void setNeedsHealthCheck(bool needs) { needsHealthCheck_ = needs; }
+
 private:
    friend class ConnectVisitor;
    friend class Transaction;
@@ -572,6 +575,11 @@ private:
    // Tracks when this connection was checked out from the pool.
    // Used to compute hold duration for monitoring.
    boost::posix_time::ptime checkoutTime_;
+
+   // Set when a health check or reconnect fails. Survives the return-to-pool
+   // path so the idle-skip fast path cannot hand a known-broken connection
+   // back out untested. Cleared only after a successful SELECT 1 or reconnect.
+   bool needsHealthCheck_ = false;
 };
 
 class PooledConnection : public IConnection
@@ -755,11 +763,21 @@ Error createConnectionPool(size_t poolSize,
                            const ConnectionOptions& options,
                            boost::shared_ptr<ConnectionPool>* pPool);
 
-// execute a provided query and pass each row to the rowHandler
-Error execAndProcessQuery(boost::shared_ptr<database::IConnection> pConnection,
-                          const std::string& sql,
-                          const boost::function<void(const database::Row&)>& rowHandler =
-                             boost::function<void(const database::Row&)>());
+// run a handler on each row in a rowset
+void forEachRow(database::Rowset& rowset,
+   const boost::function<void(const Row&)>& rowHandler);
+
+// run a handler on each row in a rowset, returning values
+template <typename T>
+std::vector<T> mapRows(Rowset& rowset,
+   const boost::function<T(const Row&)>& rowHandler)
+{
+   std::vector<T> result;
+   forEachRow(rowset, [&](const Row& row) {
+      result.push_back(rowHandler(row));
+   });
+   return result;
+}
 
 // uses soci::indicator to safely parse a string value from a row
 std::string getRowStringValue(const Row& row, const std::string& column);

--- a/src/cpp/core/include/core/QueryBuilder.hpp
+++ b/src/cpp/core/include/core/QueryBuilder.hpp
@@ -1,0 +1,308 @@
+/*
+ * QueryBuilder.hpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_QUERYBUILDER_HPP
+#define CORE_QUERYBUILDER_HPP
+
+#include <core/Database.hpp>
+
+#include <shared_core/json/Json.hpp>
+#include <core/SqlIdentifier.hpp>
+#include <core/details/QBMixins.hpp>
+
+#include <functional>
+#include <memory>
+#include <sstream>
+
+namespace rstudio {
+namespace core {
+namespace database {
+
+/**
+ * Object to construct a `SELECT` query.
+ *
+ * Example usage:
+ *    SelectBuilder builder(dbConnection, "table_name");
+ *    builder.add("column_a", value)
+ *           .add("column_b", value)
+ *           .where("column_c", value);
+ *    Query query = builder.build();
+ *
+ * NOTE: Don't write `Query query = SelectBuilder(...)....build()` because
+ * the bound values will be deleted before SOCI can execute the query.
+ */
+class SelectBuilder :
+   public detail::QBWhereMixin<SelectBuilder>
+{
+public:
+   enum { addBindType = detail::BindType::Select };
+
+   SelectBuilder(DatabaseConnection db, const SqlIdentifier& table);
+
+   // Bind a known value to a named column
+   SelectBuilder& add(const SqlIdentifier& column);
+
+   // Returns true if no columns have been added
+   bool empty() const;
+
+   // Constructs the SQL used to perform the update
+   std::string toSQL() const;
+
+   // Constructs a Query object to perform the select and binds the provided values to it
+   Query build();
+
+protected:
+   DatabaseConnection db;
+   std::vector<SqlIdentifier> columns;
+};
+
+/**
+ * Object to construct an `INSERT INTO` query.
+ *
+ * Example usage:
+ *    InsertBuilder builder(dbConnection, "table_name");
+ *    Query query = builder
+ *       .add("column_a", value)
+ *       .add("column_b", value)
+ *       .build();
+ *
+ * NOTE: Don't write `Query query = InsertBuilder(...)....build()` because
+ * the bound values will be deleted before SOCI can execute the query.
+ */
+class InsertBuilder :
+   public detail::QBAddMixin<InsertBuilder>
+{
+public:
+   enum { addBindType = detail::BindType::Insert };
+
+   InsertBuilder(DatabaseConnection db, const SqlIdentifier& table);
+
+   // Constructs the SQL used to perform the insert
+   std::string toSQL() const;
+
+   // Constructs a Query object to perform the insert and binds the provided values to it
+   Query build();
+
+   // Transforms the insert query into an upsert operation.
+   //
+   // The ON CONFLICT (...) DO UPDATE clause will contain all columns added to the builder
+   // except for columns named in `keys` and `noUpdate`.
+   //
+   // Parameters:
+   //    keys: The set of columns used in the table's UNIQUE constraint
+   //    noUpdate: Columns that should not be updated if the row already exists
+   InsertBuilder& onConflictUpdate(const std::vector<SqlIdentifier>& keys, const std::vector<SqlIdentifier>& noUpdate = {});
+
+protected:
+   DatabaseConnection db;
+   std::vector<SqlIdentifier> conflictKeys;
+   std::vector<SqlIdentifier> conflictNoUpdate;
+};
+
+/**
+ * Object to construct an `UPDATE` query.
+ *
+ * Example usage:
+ *    UpdateBuilder builder(dbConnection, "table_name");
+ *    builder.add("column_a", value)
+ *           .add("column_b", value)
+ *           .where("column_c", value);
+ *    Query query = builder.build();
+ *
+ * NOTE: Don't write `Query query = UpdateBuilder(...)....build()` because
+ * the bound values will be deleted before SOCI can execute the query.
+ */
+class UpdateBuilder :
+   public detail::QBAddMixin<UpdateBuilder>,
+   public detail::QBWhereMixin<UpdateBuilder>
+{
+public:
+   enum { addBindType = detail::BindType::Equals };
+
+   UpdateBuilder(DatabaseConnection db, const SqlIdentifier& table);
+
+   // Constructs the SQL used to perform the update
+   std::string toSQL() const;
+
+   // Constructs a Query object to perform the update and binds the provided values to it
+   Query build();
+
+protected:
+   DatabaseConnection db;
+};
+
+/**
+ * Object to construct a `DELETE` query.
+ *
+ * Example usage:
+ *    DeleteBuilder builder(dbConnection, "table_name");
+ *    builder.where("column_a", value);
+ *    Query query = builder.build();
+ *
+ * NOTE: Don't write `Query query = DeleteBuilder(...)....build()` because
+ * the bound values will be deleted before SOCI can execute the query.
+ */
+class DeleteBuilder :
+   public detail::QBWhereMixin<DeleteBuilder>
+{
+public:
+   DeleteBuilder(DatabaseConnection db, const SqlIdentifier& table);
+
+   // Constructs the SQL used to perform the delete
+   std::string toSQL() const;
+
+   // Constructs a Query object to perform the delete and binds the provided values to it
+   Query build();
+
+protected:
+   DatabaseConnection db;
+};
+
+/**
+ * Object to construct an arbitrary SQL query.
+ *
+ * Example usage:
+ *    RawQueryBuilder builder(dbConnection);
+ *    builder << "SELECT " << kColumnA << ", " << kColumnB
+ *       << " FROM " << kTableName
+ *       << " WHERE id = " << id;
+ *    Query query = builder.build();
+ *
+ * The column names and table names are pre-validated, but the variables are
+ * substituted with bound parameters.
+ */
+class RawQueryBuilder
+   : private detail::QBAddMixin<RawQueryBuilder>
+{
+public:
+   // Wrapper to tell RawQueryBuilder to mark a bound parameter as secret
+   template <typename T>
+   struct Secret
+   {
+      Secret(const T& value) : value(value) {}
+      T value;
+   };
+
+   RawQueryBuilder(DatabaseConnection db);
+
+   // Add literal SQL text
+   RawQueryBuilder& operator<<(const char sql[]);
+
+   // Add a pre-validated identifier
+   RawQueryBuilder& operator<<(const SqlIdentifier& identifier);
+
+   // Add a bound parameter and bind a value
+   template <typename T>
+   RawQueryBuilder& operator<<(Secret<T>&& value)
+   {
+      return add(addBinding(true), value.value);
+   }
+
+   // Add a bound parameter and bind a value
+   template <typename T>
+   RawQueryBuilder& operator<<(const T& value)
+   {
+      return add(addBinding(false), value);
+   }
+
+   // Construct the SQL used to perform the query
+   std::string toSQL() const;
+
+   // Constructs a Query object to perform the query and binds the provided values to it
+   Query build();
+
+protected:
+   SqlIdentifier addBinding(bool secret);
+
+   DatabaseConnection db;
+   std::ostringstream queryText;
+};
+
+template <typename T>
+RawQueryBuilder::Secret<T> SECRET(const T& value)
+{
+   return RawQueryBuilder::Secret<T>(value);
+}
+
+/**
+ * Object to construct a (... OR ...) expression for use in a WHERE clause.
+ *
+ * Example usage:
+ *    SelectBuilder builder(dbConnection, "table_name");
+ *    builder.add("id");
+ *    builder.where(
+ *       QBWhereOr().where("column_a", value).where("column_b", value)
+ *    );
+ *    Query query = builder.build();
+ *
+ * This produces a query similar to:
+ *    SELECT id FROM table_name WHERE (column_a = ? OR column_b = ?)
+ */
+class QBWhereOr :
+   public detail::QBCompoundWhere,
+   public detail::QBWhereMixin<QBWhereOr>
+{
+   friend class QBWhereMixin<QBWhereOr>;
+public:
+   QBWhereOr() : QueryBuilder("_"), QBWhereMixin(this) {}
+
+   // After calling takeNode(), the QBWhereOr is no longer valid.
+   virtual detail::QBCompoundNode* takeNode()
+   {
+      detail::QBCompoundNode* node = new detail::QBCompoundNode("OR");
+      node->nodes = std::move(whereClauses);
+      return node;
+   }
+};
+
+/**
+ * Object to construct a (... AND ...) expression for use in a WHERE clause.
+ *
+ * Example usage:
+ *    SelectBuilder builder(dbConnection, "table_name");
+ *    builder.add("id");
+ *    builder.where(
+ *       QBWhereAnd().where("column_a", value).where("column_b", value)
+ *    );
+ *    Query query = builder.build();
+ *
+ * This produces a query similar to:
+ *    SELECT id FROM table_name WHERE (column_a = ? AND column_b = ?)
+ *
+ * This is only practically useful within a QBWhereOr() expression, as the
+ * default behavior of .where() is already to use AND.
+ */
+class QBWhereAnd :
+   public detail::QBCompoundWhere,
+   public detail::QBWhereMixin<QBWhereAnd>
+{
+   friend class QBWhereMixin<QBWhereAnd>;
+public:
+   QBWhereAnd() : QueryBuilder("_"), QBWhereMixin(this) {}
+
+   // After calling takeNode(), the QBWhereAnd is no longer valid.
+   virtual detail::QBCompoundNode* takeNode()
+   {
+      detail::QBCompoundNode* node = new detail::QBCompoundNode("AND");
+      node->nodes = std::move(whereClauses);
+      return node;
+   }
+};
+
+} // namespace database
+} // namespace core
+} // namespace rstudio
+
+#endif // CORE_QUERYBUILDER_HPP

--- a/src/cpp/core/include/core/SqlIdentifier.hpp
+++ b/src/cpp/core/include/core/SqlIdentifier.hpp
@@ -1,0 +1,83 @@
+/*
+ * SqlIdentifier.hpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_DETAILS_SQLIDENTIFIER_HPP
+#define CORE_DETAILS_SQLIDENTIFIER_HPP
+
+#include <core/Result.hpp>
+
+#include <string>
+#include <sstream>
+
+namespace rstudio {
+namespace core {
+namespace database {
+
+class SqlIdentifier
+{
+public:
+   SqlIdentifier() = default;
+   SqlIdentifier(const SqlIdentifier&) = default;
+   SqlIdentifier(SqlIdentifier&&) = default;
+   SqlIdentifier& operator=(const SqlIdentifier&) = default;
+   SqlIdentifier& operator=(SqlIdentifier&&) = default;
+
+   SqlIdentifier(const char* prevalidatedName);
+
+   static Result<SqlIdentifier> from(const std::string& unvalidatedName);
+   static Result<SqlIdentifier> from(std::string&& unvalidatedName);
+
+   inline operator std::string() const { return name; }
+   inline const std::string& toString() const { return name; }
+
+   inline std::string operator+(const char* rhs) const { return name + rhs; }
+
+   inline bool operator==(const SqlIdentifier& rhs) const { return name == rhs.name; }
+   inline bool operator==(const std::string& rhs) const { return name == rhs; }
+   inline bool operator==(const char* rhs) const { return name == rhs; }
+
+private:
+   explicit SqlIdentifier(const std::string& name);
+   explicit SqlIdentifier(std::string&& name);
+
+   std::string name;
+};
+
+inline std::string operator+(const char* lhs, const SqlIdentifier& rhs)
+{
+   return lhs + rhs.toString();
+}
+
+inline std::string operator+(const std::string& lhs, const SqlIdentifier& rhs)
+{
+   return lhs + rhs.toString();
+}
+
+inline bool operator==(const std::string& lhs, const SqlIdentifier& rhs)
+{
+   return lhs == rhs.toString();
+}
+
+inline std::ostream& operator<<(std::ostream& os, const SqlIdentifier& rhs)
+{
+   os << rhs.toString();
+   return os;
+}
+
+} // namespace database
+} // namespace core
+} // namespace rstudio
+
+#endif // CORE_DETAILS_SQLIDENTIFIER_HPP

--- a/src/cpp/core/include/core/SqlPreprocessor.hpp
+++ b/src/cpp/core/include/core/SqlPreprocessor.hpp
@@ -1,0 +1,32 @@
+/*
+ * SqlPreprocessor.hpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_SQLPREPROCESSOR_HPP
+#define CORE_SQLPREPROCESSOR_HPP
+
+#include <core/Database.hpp>
+#include <core/Result.hpp>
+
+namespace rstudio {
+namespace core {
+namespace database {
+
+Result<std::string> preprocessSchemaFile(DatabaseConnection dbConnection, const std::string& schema);
+
+} // namespace database
+} // namespace core
+} // namespace rstudio
+
+#endif // CORE_SQLPREPROCESSOR_HPP

--- a/src/cpp/core/include/core/details/QBMixins.hpp
+++ b/src/cpp/core/include/core/details/QBMixins.hpp
@@ -1,0 +1,283 @@
+/*
+ * QBMixins.hpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_DETAILS_QBMIXINS_HPP
+#define CORE_DETAILS_QBMIXINS_HPP
+
+#include "QBNodeList.hpp"
+
+#include <core/Algorithm.hpp>
+
+namespace rstudio {
+namespace core {
+namespace database {
+
+class SelectBuilder;
+
+namespace detail {
+
+using algorithm::optional_cast;
+
+std::string buildWhereClause(const QBNodeList& whereClauses);
+
+/**
+ * Base class that all QueryBuilder classes virtually inherit from.
+ */
+class QueryBuilder
+{
+protected:
+   QueryBuilder() = delete;
+   QueryBuilder(const QueryBuilder&) = delete;
+   explicit QueryBuilder(const SqlIdentifier& table);
+   virtual ~QueryBuilder() = default;
+
+   SqlIdentifier table;
+   QBNodeList nodes;
+
+   std::string buildInsertQuery() const;
+   std::string buildSetClause(const std::vector<SqlIdentifier>& exclude = {}) const;
+};
+
+/**
+ * Mixin class for query builders that have add() functions.
+ *
+ *   BUILDER: The final type of the most derived subclass.
+ *         Subclasses should specify themselves as the template parameter.
+ *         This permits the chainable functions to return the derived type.
+ */
+template <typename BUILDER>
+class QBAddMixin : virtual public QueryBuilder
+{
+private:
+   BUILDER* self;
+
+protected:
+   // QueryBuilder("_") will never be invoked due to virtual inheritance, but it must
+   // be present to satisfy ISO C++'s requirements.
+   QBAddMixin(BUILDER* self) : QueryBuilder("_"), self(self) {}
+
+public:
+   // Bind a known value to a named column
+   template <typename T>
+   BUILDER& add(const SqlIdentifier& column, const T& value)
+   {
+      static_assert(!QBSupportChecker<T>::value || true, "unsupported type");
+      nodes.add(new QBNode<T>(column, value));
+      return *self;
+   }
+
+   // Bind a known value to a named column
+   // This overload treats nullptr as SQL NULL
+   BUILDER& add(const SqlIdentifier& column, std::nullptr_t)
+   {
+      nodes.add(new QBNode<std::string>(column, nullptr));
+      return *self;
+   }
+
+   // Bind a known value to a named column
+   // This overload promotes string literals to std::string
+   BUILDER& add(const SqlIdentifier& column, const char* value)
+   {
+      nodes.add(new QBNode<std::string>(column, value));
+      return *self;
+   }
+
+   // Bind an optional value to a named column; store NULL if not set
+   template <typename T>
+   BUILDER& add(const SqlIdentifier& column, const boost::optional<T>& value)
+   {
+      static_assert(!QBSupportChecker<T>::value || true, "unsupported type");
+      if (value.has_value())
+         nodes.add(new QBNode<T>(column, *value));
+      else
+         nodes.add(new QBNode<T>(column, nullptr));
+      return *self;
+   }
+
+   // Convert JSON to string to store in a named column
+   BUILDER& add(const SqlIdentifier& column, const json::Value& value)
+   {
+      nodes.add(new QBNode<std::string>(column, value.write()));
+      return *self;
+   }
+
+   // Convert optional JSON to string to store in a named column; store NULL if not set
+   BUILDER& add(const SqlIdentifier& column, const boost::optional<json::Value>& value)
+   {
+      if (!value.has_value())
+         nodes.add(new QBNode<std::string>(column, nullptr));
+      else
+         nodes.add(new QBNode<std::string>(column, value->write()));
+      return *self;
+   }
+
+   // Convert optional JSON to string to store in a named column; store NULL if not set
+   BUILDER& add(const SqlIdentifier& column, const boost::optional<json::Array>& value)
+   {
+      return add(column, optional_cast<json::Value>(value));
+   }
+
+   // Convert optional JSON to string to store in a named column; store NULL if not set
+   BUILDER& add(const SqlIdentifier& column, const boost::optional<json::Object>& value)
+   {
+      return add(column, optional_cast<json::Value>(value));
+   }
+
+   // Bind an optional value at a named column, but only if it's set (does not convert to NULL)
+   template <typename T>
+   BUILDER& addIfSet(const SqlIdentifier& column, const boost::optional<T>& value)
+   {
+      static_assert(!QBSupportChecker<T>::value || true, "unsupported type");
+      if (value.has_value())
+         return add(column, value);
+      return *self;
+   }
+
+   // Returns true if no columns have been bound
+   bool empty() const
+   {
+      return nodes.empty();
+   }
+};
+
+/**
+ * Base class for QBWhereOr and QBWhereAnd.
+ *
+ * This is defined separately, with virtual inheritance, to simplify
+ * the otherwise-circular dependency between QBWhereMixin and the
+ * compound clause containers, while preventing passing e.g. a
+ * SelectBuilder to a where() call.
+ */
+class QBCompoundWhere : virtual public QueryBuilder
+{
+public:
+   // After calling takeNode(), the QBCompoundWhere is no longer valid.
+   virtual QBCompoundNode* takeNode() = 0;
+};
+
+/**
+ * Mixin class for query builders that have where() functions.
+ *
+ *   BUILDER: The final type of the most derived subclass.
+ *         Subclasses should specify themselves as the template parameter.
+ *         This permits the chainable functions to return the derived type.
+ */
+template <typename BUILDER>
+class QBWhereMixin : virtual public QueryBuilder
+{
+private:
+   BUILDER* self;
+
+protected:
+   // QueryBuilder("_") will never be invoked due to virtual inheritance, but it must
+   // be present to satisfy ISO C++'s requirements.
+   QBWhereMixin(BUILDER* self) : QueryBuilder("_"), self(self) {}
+
+public:
+   // Restricts the query to only target rows where the specified column contains
+   // the specified value. Multiple conditions are combined with `AND`.
+   template <typename T>
+   BUILDER&& where(const SqlIdentifier& column, T value)
+   {
+      static_assert(!QBSupportChecker<T>::value || true, "unsupported type");
+      auto node = new QBNode<T>(column, value);
+      whereClauses.add(node);
+      return std::move(*self);
+   }
+
+   // As where(), but this overload treats nullptr as SQL NULL using the IS operator
+   BUILDER&& where(const SqlIdentifier& column, std::nullptr_t)
+   {
+      auto node = new QBIsNullNode(column);
+      whereClauses.add(node);
+      return std::move(*self);
+   }
+
+   // As where(), but checks for NULL if the optional object does not contain a value
+   template <typename T>
+   BUILDER&& where(const SqlIdentifier& column, const boost::optional<T>& value)
+   {
+      if (value.has_value())
+         return where(column, *value);
+      else
+         return where(column, nullptr);
+   }
+
+   // As where(), but this overload promotes string literals to std::string
+   BUILDER&& where(const SqlIdentifier& column, const char* value)
+   {
+      return where<std::string>(column, value);
+   }
+
+   // Restricts the query to only target rows where the specified column contains
+   // one of the specified values. Multiple conditions are combined with `AND`.
+   template <typename CONTAINER>
+   BUILDER&& whereIn(const SqlIdentifier& column, const CONTAINER& values)
+   {
+      static_assert(!QBSupportChecker<typename CONTAINER::value_type>::value || true, "unsupported type");
+      auto node = new QBListNode<CONTAINER>(column, values.begin(), values.end());
+      whereClauses.add(node);
+      return std::move(*self);
+   }
+
+   // As whereIn(), but accepts an initializer list
+   template <typename T>
+   BUILDER&& whereIn(const SqlIdentifier& column, std::initializer_list<T> values)
+   {
+      auto node = new QBListNode<std::initializer_list<T>>(column, values.begin(), values.end());
+      whereClauses.add(node);
+      return std::move(*self);
+   }
+
+   // As where(), but no condition is added if the provided value is not set.
+   template <typename T>
+   BUILDER&& whereIfSet(const SqlIdentifier& column, boost::optional<T> value)
+   {
+      if (value.has_value())
+         return where(column, *value);
+      return std::move(*self);
+   }
+
+   // As where(), but compares using the LIKE operator
+   BUILDER&& whereLike(const SqlIdentifier& column, const std::string& pattern)
+   {
+      auto node = new QBNode<std::string>(column, pattern);
+      node->op = "LIKE";
+      whereClauses.add(node);
+      return std::move(*self);
+   }
+
+   // As where(), but accepts a compound clause
+   BUILDER&& where(QBCompoundWhere&& clause)
+   {
+      whereClauses.add(clause.takeNode());
+      return std::move(*self);
+   }
+
+protected:
+   std::string buildWhereClause() const
+   {
+      return detail::buildWhereClause(whereClauses);
+   }
+
+   QBNodeList whereClauses;
+};
+
+} // namespace detail
+} // namespace database
+} // namespace core
+} // namespace rstudio
+
+#endif // CORE_DETAILS_QBMIXINS_HPP

--- a/src/cpp/core/include/core/details/QBNode.hpp
+++ b/src/cpp/core/include/core/details/QBNode.hpp
@@ -1,0 +1,167 @@
+/*
+ * QBNode.hpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_DETAILS_QBNODE_HPP
+#define CORE_DETAILS_QBNODE_HPP
+
+#include <core/Database.hpp>
+
+#include <core/SqlIdentifier.hpp>
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+namespace rstudio {
+namespace core {
+namespace database {
+
+class SelectBuilder;
+
+namespace detail {
+
+enum BindType {
+   Select,
+   Insert,
+   Equals,
+   WhereIn,
+};
+
+// Polymorphic base type for bound values
+struct QBBaseNode
+{
+   explicit QBBaseNode(const SqlIdentifier& column) : column(column), refName(column) {}
+   virtual ~QBBaseNode() {}
+
+   virtual void apply(Query& query, const std::string& prefix = std::string()) = 0;
+   virtual std::string toClause(const std::string& prefix = std::string()) const = 0;
+
+   virtual std::string toInsertValue() const
+   {
+      return ":" + refName;
+   }
+
+   inline static std::string getColumnName(const QBBaseNode* n)
+   {
+      return n->column;
+   }
+
+   inline static std::string getInsertValue(const QBBaseNode* n)
+   {
+      return n->toInsertValue();
+   }
+
+   SqlIdentifier column;
+   std::string refName;
+};
+
+template <typename T>
+struct QBSupportChecker
+{
+private:
+   using t_ = std::int8_t;
+   using f_ = std::int16_t;
+   template <typename U> static t_ check_support(decltype(soci::details::exchange_traits<U>::x_type)*);
+   template <typename U> static f_ check_support(...);
+
+public:
+   using type = T;
+   static constexpr bool value = sizeof(check_support<T>(0)) == sizeof(t_);
+};
+
+template <> struct QBSupportChecker<json::Array> : std::true_type {};
+template <> struct QBSupportChecker<json::Object> : std::true_type {};
+
+// Typesafe container for bound values
+template <typename T>
+struct QBNode : public QBBaseNode
+{
+   QBNode(const SqlIdentifier& column, T value) : QBBaseNode(column), value(value), isNull(false) {}
+   QBNode(const SqlIdentifier& column, std::nullptr_t) : QBBaseNode(column), value(), isNull(true) {}
+
+   virtual ~QBNode() {}
+
+   T value;
+   bool isNull;
+   std::string op = "=";
+
+   void apply(Query& query, const std::string& prefix = std::string())
+   {
+      query.withInputOrNull(value, isNull, prefix + refName);
+   }
+
+   virtual std::string toClause(const std::string& prefix = std::string()) const
+   {
+      return column + " " + op + " :" + prefix + refName;
+   }
+};
+
+struct QBIsNullNode : public QBBaseNode
+{
+   QBIsNullNode(const SqlIdentifier& column) : QBBaseNode(column) {}
+
+   void apply(Query&, const std::string& = std::string())
+   {
+      // no-op, expands to an expression with no bound parameters
+   }
+
+   virtual std::string toClause(const std::string& = std::string()) const
+   {
+      return column + " IS NULL";
+   }
+};
+
+// Typesafe container for arrays of bound values
+template <typename CONTAINER>
+struct QBListNode : public QBBaseNode
+{
+   QBListNode(const SqlIdentifier& column, const typename CONTAINER::const_iterator& begin, const typename CONTAINER::const_iterator& end)
+   : QBBaseNode(column), values(begin, end) {}
+
+   virtual ~QBListNode() {}
+
+   std::vector<typename CONTAINER::value_type> values;
+
+   void apply(Query& query, const std::string& prefix = std::string())
+   {
+      for (std::size_t i = 0; i < values.size(); i++) {
+         query.withInput(values[i], prefix + refName + "_" + std::to_string(i));
+      }
+   }
+
+   virtual std::string toClause(const std::string& prefix = std::string()) const
+   {
+      // WHERE x IN () is invalid SQL, but the intent is that no records should be matched
+      if (values.empty())
+         return "(1 = 0)";
+
+      std::ostringstream ss;
+      ss << column << " IN (";
+      for (std::size_t i = 0; i < values.size(); i++) {
+         if (i > 0)
+            ss << ", ";
+         ss << ":" << prefix << refName << "_" << i;
+      }
+      ss << ")";
+      return ss.str();
+   }
+};
+
+} // namespace detail
+} // namespace database
+} // namespace core
+} // namespace rstudio
+
+#endif // CORE_DETAILS_QBNODE_HPP

--- a/src/cpp/core/include/core/details/QBNodeList.hpp
+++ b/src/cpp/core/include/core/details/QBNodeList.hpp
@@ -1,0 +1,143 @@
+/*
+ * QBNodeList.hpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_DETAILS_QBNODELIST_HPP
+#define CORE_DETAILS_QBNODELIST_HPP
+
+#include "QBNode.hpp"
+
+#include <memory>
+#include <stdexcept>
+
+namespace rstudio {
+namespace core {
+namespace database {
+namespace detail {
+
+class QBNodeList : private std::vector<std::unique_ptr<QBBaseNode>>
+{
+   using base = std::vector<std::unique_ptr<QBBaseNode>>;
+
+   template <typename NODE, typename BASE_ITER>
+   class iterator_wrap {
+   public:
+      iterator_wrap() = default;
+      iterator_wrap(const iterator_wrap&) = default;
+      iterator_wrap(iterator_wrap&&) = default;
+      iterator_wrap& operator=(const iterator_wrap&) = default;
+      iterator_wrap& operator=(iterator_wrap&&) = default;
+      iterator_wrap(const BASE_ITER& iter) : iter(iter) {}
+      iterator_wrap(BASE_ITER&& iter) : iter(iter) {}
+
+      NODE operator*() const { return iter->get(); }
+      NODE operator->() const { return iter->get(); }
+
+      iterator_wrap& operator++() { ++iter; return *this; }
+      iterator_wrap operator++(int) { return iterator_wrap(iter++); }
+
+      bool operator==(const iterator_wrap& other) const { return iter == other.iter; }
+      bool operator!=(const iterator_wrap& other) const { return iter != other.iter; }
+      bool operator<(const iterator_wrap& other) const { return iter < other.iter; }
+      bool operator>(const iterator_wrap& other) const { return iter > other.iter; }
+      bool operator<=(const iterator_wrap& other) const { return iter <= other.iter; }
+      bool operator>=(const iterator_wrap& other) const { return iter >= other.iter; }
+
+   private:
+      BASE_ITER iter;
+   };
+
+public:
+   using value_type = QBBaseNode*;
+   using iterator = iterator_wrap<QBBaseNode*, base::iterator>;
+   using const_iterator = iterator_wrap<const QBBaseNode*, base::const_iterator>;
+
+   // takes ownership of node
+   void add(QBBaseNode* node)
+   {
+      int dedupe = 1;
+      for (const QBBaseNode* existing : *this)
+      {
+         if (existing->column == node->column)
+            dedupe++;
+      }
+      if (dedupe > 1 || node->column.toString().empty())
+         node->refName += std::to_string(dedupe);
+      emplace_back(node);
+   }
+
+   iterator begin() { return iterator(base::begin()); }
+   iterator end() { return iterator(base::end()); }
+   const_iterator begin() const { return const_iterator(base::begin()); }
+   const_iterator end() const { return const_iterator(base::end()); }
+
+   using base::empty;
+   using base::size;
+};
+
+struct QBCompoundNode : public QBBaseNode
+{
+   QBCompoundNode(const std::string& op) : QBBaseNode(SqlIdentifier()), op(op) {}
+
+   virtual void apply(Query& query, const std::string& prefix = std::string())
+   {
+      std::string extPrefix = prefix + refName + "_";
+      for (QBBaseNode* node : nodes)
+      {
+         node->apply(query, extPrefix);
+      }
+   }
+
+   virtual std::string toClause(const std::string& prefix = std::string()) const
+   {
+      // WHERE () is invalid SQL
+      if (nodes.empty())
+      {
+         // AND implies that no records should be matched if no conditions match
+         if (op == "AND")
+            return "(1 = 0)";
+         // OR implies that all records should be matched if no conditions fail
+         return "(1 = 1)";
+      }
+      std::string extPrefix = prefix + refName + "_";
+      std::ostringstream ss;
+      bool first = true;
+      ss << "(";
+      for (const QBBaseNode* node : nodes)
+      {
+         if (first)
+            first = false;
+         else
+            ss << " " << op << " ";
+         ss << node->toClause(extPrefix);
+      }
+      ss << ")";
+      return ss.str();
+   }
+
+   virtual std::string toInsertValue() const
+   {
+      throw std::logic_error("Cannot insert a compound node");
+   }
+
+   std::string op;
+   QBNodeList nodes;
+};
+
+} // namespace detail
+} // namespace database
+} // namespace core
+} // namespace rstudio
+
+#endif // CORE_DETAILS_QBNODELIST_HPP

--- a/src/cpp/server/DBActiveSessionStorage.cpp
+++ b/src/cpp/server/DBActiveSessionStorage.cpp
@@ -16,6 +16,8 @@
 #include <server/DBActiveSessionStorage.hpp>
 
 #include <core/Database.hpp>
+#include <core/Result.hpp>
+#include <core/QueryBuilder.hpp>
 #include <core/r_util/RActiveSessions.hpp>
 #include <shared_core/SafeConvert.hpp>
 #include <server_core/ServerDatabase.hpp>
@@ -23,6 +25,7 @@
 #include <numeric>
 
 using namespace rstudio::core;
+using namespace rstudio::core::database;
 using namespace rstudio::core::r_util;
 using namespace rstudio::server_core::database;
 
@@ -40,69 +43,87 @@ const std::string kUserId = "user_id";
 static const std::string kSuspendSize = "suspend_size";
 
 // Constants for the table and column names
-const std::string kTableName = "active_session_metadata";
-const std::string kSessionIdColumnName = "session_id";
+const SqlIdentifier kTableName = "active_session_metadata";
+const SqlIdentifier kSessionIdColumnName = "session_id";
+const SqlIdentifier kProjectColumnName = "project";
 
-static const std::string kEditorColumnName = "workbench";
-static const std::string kWorkingDirColumnName = "working_directory";
-static const std::string kProjectColumnName = "project";
+static std::map<std::string, SqlIdentifier> kASMColumns;
+static std::map<std::string, std::string> kASMProperties;
 
-inline const std::string& columnName(const std::string& propertyName)
+void populateASMMaps()
 {
-   if (propertyName == ActiveSession::kEditor)
-      return kEditorColumnName;
+   static bool ready = false;
+   if (ready)
+      return;
 
-   if (propertyName == ActiveSession::kProjectId)
-      return kProjectColumnName;
+   kASMColumns[ActiveSession::kEditor] = "workbench";
+   kASMProperties["workbench"] = ActiveSession::kEditor;
 
-   return propertyName;
+   kASMColumns[ActiveSession::kProjectId] = kProjectColumnName;
+   kASMProperties[kProjectColumnName] = ActiveSession::kProjectId;
+
+   std::string keys[] = {
+      ActiveSession::kCreated,
+      ActiveSession::kExecuting,
+      ActiveSession::kInitial,
+      ActiveSession::kLastUsed,
+      ActiveSession::kLabel,
+      ActiveSession::kProject,
+      ActiveSession::kSavePromptRequired,
+      ActiveSession::kRunning,
+      ActiveSession::kRVersion,
+      ActiveSession::kRVersionHome,
+      ActiveSession::kRVersionLabel,
+      ActiveSession::kWorkingDir,
+      ActiveSession::kActivityState,
+      ActiveSession::kLastStateUpdated,
+      ActiveSession::kLastResumed,
+      ActiveSession::kSuspendTimestamp,
+      ActiveSession::kBlockingSuspend,
+      ActiveSession::kLaunchParameters,
+#ifdef RSTUDIO_PRO_BUILD
+      ActiveSession::kSuspendSize,
+#endif
+#ifdef RSTUDIO_UNIT_TESTS_ENABLED
+      // only used in tests
+      "user_id",
+      "session_id",
+#endif
+   };
+
+   for (const std::string& key : keys) {
+      // Since these are compile-time constants, we know they're already validated.
+      // Skip the validation step by using the const char* constructor.
+      kASMColumns[key] = key.c_str();
+      kASMProperties[key] = key;
+   }
+
+   ready = true;
+};
+
+inline Result<SqlIdentifier> columnName(const std::string& propertyName)
+{
+   populateASMMaps();
+   auto iter = kASMColumns.find(propertyName);
+   if (iter == kASMColumns.end())
+   {
+      return Unexpected(Error("Unknown property " + propertyName, boost::system::errc::invalid_argument, ERROR_LOCATION));
+   }
+
+   return iter->second;
 }
 
-inline const std::string& propertyName(const std::string& columnName)
+inline Result<std::string> propertyName(const std::string& columnName)
 {
-   if (columnName == kEditorColumnName)
-      return ActiveSession::kEditor;
+   populateASMMaps();
 
-   return columnName;
-}
+   auto iter = kASMProperties.find(columnName);
+   if (iter == kASMProperties.end())
+   {
+      return Unexpected(Error("Unknown column " + columnName, boost::system::errc::invalid_argument, ERROR_LOCATION));
+   }
 
-std::string getPropNamesSql(const std::vector<std::string>& propNames)
-{
-   std::string keys = std::accumulate(
-      ++propNames.begin(),
-      propNames.end(),
-      columnName(*(propNames.begin())),
-      [](std::string a, std::string b)
-      {
-         return a + ", " + columnName(b);
-      });
-   return keys;
-}
-
-std::string getVarNamesSql(const std::vector<std::string>& propNames)
-{
-   std::string keys = std::accumulate(
-      ++propNames.begin(),
-      propNames.end(),
-      ":" + columnName((*propNames.begin())),
-      [](std::string a, std::string b)
-      {
-         return a + ", :" + columnName(b);
-      });
-   return keys;
-}
-
-std::string getKeyString(const std::map<std::string, std::string>& sourceMap)
-{
-   std::string keys = std::accumulate(
-      ++sourceMap.begin(),
-      sourceMap.end(),
-      columnName(sourceMap.begin()->first),
-      [](std::string a, std::pair<std::string, std::string> b)
-      {
-         return a + ", " + columnName(b.first);
-      });
-   return keys;
+   return iter->second;
 }
 
 std::string convertTimestampProperty(const std::string& extTime)
@@ -131,48 +152,23 @@ void convertProperty(std::string* pName, std::string* pValue, const core::system
    if (*pName == ActiveSession::kLastResumed || *pName == ActiveSession::kSuspendTimestamp) // suspend_timestamp here?
       *pValue = convertTimestampProperty(*pValue);
 
+   if (*pName == ActiveSession::kProject)
+   {
+      std::string projectId = ProjectId(kProjectNoneId, user.getUserId()).asString();
+
+      *pName = ActiveSession::kProjectId;
+      *pValue = projectId;
+   }
+   if (*pName == ActiveSession::kSuspendSize)
+   {
+      if ((*pValue).empty() || !safe_convert::stringTo<int>(*pValue).has_value())
+         *pValue = "0";
+   }
 }
 
-std::string getUpdateStringAndValues(const std::map<std::string, std::string>& sourceMap,
-                                     const system::User& user,
-                                     std::vector<std::string>* pNames,
-                                     std::vector<std::string>* pValues,
-                                     boost::shared_ptr<database::IConnection> connection)
+bool isProjectNoneId(const std::string& projectId)
 {
-   std::string firstPropName(sourceMap.begin()->first);
-   std::string firstPropValue(sourceMap.begin()->second);
-   convertProperty(&firstPropName, &firstPropValue, user, connection);
-   (*pNames).push_back(firstPropName);
-   (*pValues).push_back(firstPropValue);
-
-   std::string setValuesString = std::accumulate(
-      ++sourceMap.begin(),
-      sourceMap.end(),
-      columnName(firstPropName) + " = :" + columnName(firstPropName) + " ",
-      [pNames, pValues, user, connection](std::string a, std::pair<std::string, std::string> iter)
-      {
-         std::string propName = iter.first;
-         std::string propValue = iter.second;
-
-         convertProperty(&propName, &propValue, user, connection);
-
-         (*pNames).push_back(propName);
-         (*pValues).push_back(propValue);
-         return a + ", " + columnName(iter.first) + " = " + ":" + columnName(iter.first) + " ";
-      });
-   return setValuesString;
-}
-
-std::string getColumnNameList(const std::set<std::string>& colNames)
-{
-   std::string cols = std::accumulate(
-      ++colNames.begin(),
-      colNames.end(),
-      columnName(*(colNames.begin())), [](std::string a, std::string b)
-      {
-         return a + ", " + columnName(b);
-      });
-   return cols;
+   return projectId == kProjectNoneId || ProjectId(projectId).id() == kProjectNoneId;
 }
 
 // Temporary key used to store the raw projectId before resolving to path
@@ -189,10 +185,26 @@ void populateMapWithRow(database::RowsetIterator iter, std::map<std::string, std
       try
       {
          if (key == kUserId || key == kSuspendSize)
+         {
+            // int columns
             pTargetMap->emplace(key, std::to_string(iter->get<int>(key)));
-         // Store the projectId temporarily - it will be resolved to a path after the connection is released
+         }
+         else if (key == kProjectColumnName)
+         {
+            // Store the projectId temporarily - it will be resolved to a path after the connection is released
+            std::string projectId = iter->get<std::string>(key, "");
+            if (projectId.size() == 8)
+               projectId = ProjectId(projectId, user.getUserId()).asString();
+            // Store raw projectId for later resolution
+            pTargetMap->emplace(kTempProjectId, projectId);
+         }
          else
-            pTargetMap->emplace(propertyName(key), iter->get<std::string>(key, ""));
+         {
+            // Unknown columns in the database result should be preserved as-is
+            auto propResult = propertyName(key);
+            std::string propName = propResult ? *propResult : key;
+            pTargetMap->emplace(propName, iter->get<std::string>(key, ""));
+         }
       }
       catch (const std::bad_cast& e)
       {
@@ -205,6 +217,42 @@ void populateMapWithRow(database::RowsetIterator iter, std::map<std::string, std
    }
 }
 
+template <typename CONTAINER>
+Error sessionPropError(const std::string& prefix, const std::string& sessionId, const CONTAINER& properties, const Error& cause, const ErrorLocation& loc)
+{
+   std::ostringstream message;
+   message << prefix << " [ session:" << sessionId;
+   if (!properties.empty())
+      message << " properties:" << algorithm::join(properties, ",",
+         [](const std::string& propName) {
+            auto colName = columnName(propName);
+            return colName ? *colName : ("UNKNOWN:" + propName);
+         }
+      );
+   message << " ]";
+   if (cause)
+      return Error("DatabaseException", errc::DBError, message.str(), cause, loc);
+   return Error("DatabaseException", errc::DBError, message.str(), loc);
+}
+
+Error sessionPropError(const std::string& prefix, const std::string& sessionId, const std::map<std::string, std::string>& properties, const Error& cause, const ErrorLocation& loc)
+{
+   std::vector<std::string> propNames;
+   for (const auto& [propName, value] : properties)
+      propNames.push_back(propName);
+   return sessionPropError(prefix, sessionId, propNames, cause, loc);
+}
+
+Error sessionPropError(const std::string& prefix, const std::string& sessionId, const std::string& propName, const Error& cause, const ErrorLocation& loc)
+{
+   return sessionPropError(prefix, sessionId, std::vector<std::string>({ propName }), cause, loc);
+}
+
+Error sessionPropError(const std::string& prefix, const std::string& sessionId, const Error& cause, const ErrorLocation& loc)
+{
+   return sessionPropError(prefix, sessionId, std::vector<std::string>(), cause, loc);
+}
+
 Error getSessionCount(boost::shared_ptr<database::IConnection> connection, std::string sessionId, int* pCount)
 {
    database::Query query = connection->query("SELECT COUNT(*) FROM " + kTableName + " WHERE " + kSessionIdColumnName + " = :id")
@@ -214,14 +262,15 @@ Error getSessionCount(boost::shared_ptr<database::IConnection> connection, std::
    Error error = connection->execute(query);
 
    if (error)
-      return Error("DatabaseException", errc::DBError, "Error while retrieving session count for [ session:" + sessionId + " ]", error, ERROR_LOCATION);
+      return sessionPropError("Error while retrieving session count for", sessionId, error, ERROR_LOCATION);
 
    return Success();
 }
 
 } // anonymous namespace
 
-Error getConn(boost::shared_ptr<database::IConnection>* connection) {
+Error getConn(boost::shared_ptr<database::IConnection>* connection)
+{
    bool success = server_core::database::getConnection(boost::posix_time::milliseconds(500), connection);
 
    if (!success)
@@ -269,35 +318,42 @@ Error DBActiveSessionStorage::readProperty(const std::string& name, std::string*
    if (error)
       return error;
 
-   std::string columnStr = columnName(name);
+   auto columnStr = columnName(name);
+   if (!columnStr)
+      return columnStr.error();
 
-   std::string queryStr = "SELECT ";
-   queryStr
-      .append(columnStr)
-      .append(" FROM ")
-      .append(kTableName)
-      .append(" WHERE ")
-      .append(kSessionIdColumnName)
-      .append(" = :id");
-
-   database::Query query = connection->query(queryStr)
-      .withInput(sessionId_, "id");
+   SelectBuilder builder(connection, kTableName);
+   builder.add(*columnStr);
+   builder.where(kSessionIdColumnName, sessionId_);
+   database::Query query = builder.build();
 
    database::Rowset rowset;
    error = connection->execute(query, rowset);
 
    if (error)
-      return Error("DatabaseException", errc::DBError, "Database exception during property read [ session:" + sessionId_ + " property:" + name + " ]", error, ERROR_LOCATION);
+      return sessionPropError("Database exception during property read", sessionId_, name, error, ERROR_LOCATION);
 
    auto iter = rowset.begin();
 
    if (iter == rowset.end())
       return Error("Session does not exist", errc::SessionNotFound, ERROR_LOCATION);
 
-   if (name != kUserId)
-      *pValue = iter->get<std::string>(0, "");
+   if (name == ActiveSession::kProject)
+   {
+      projectId = iter->get<std::string>(0, "");
+
+      if (projectId.size() == 8)
+         projectId = ProjectId(projectId, user_.getUserId()).asString();
+      if (isProjectNoneId(projectId) || projectId.empty())
+         *pValue = kProjectNone;
+   }
    else
-      *pValue = std::to_string(iter->get<int>(0));
+   {
+      if (name != kUserId)
+         *pValue = iter->get<std::string>(0, "");
+      else
+         *pValue = std::to_string(iter->get<int>(0));
+   }
 
    // Sanity check number of returned rows, by using the pk in the where clause we should only get 1 row
    int count = 1;
@@ -306,7 +362,6 @@ Error DBActiveSessionStorage::readProperty(const std::string& name, std::string*
 
    if (count > 1)
       return Error("Too many sessions returned", errc::TooManySessionsReturned, "Expected only one session returned, found " + std::to_string(count) + "[ session:" + sessionId_ + " ]", ERROR_LOCATION);
-
 
    return Success();
 }
@@ -323,17 +378,25 @@ Error DBActiveSessionStorage::readProperties(const std::set<std::string>& names,
       if (error)
          return error;
 
-      std::string namesString = getColumnNameList(names);
+      SelectBuilder builder(connection, kTableName);
+      for (const std::string& propName : names) {
+         auto colName = columnName(propName);
+         if (!colName)
+            return colName.error();
+         builder.add(*colName);
+      }
+
       if (names.find(ActiveSession::kProject) != names.end())
-         namesString = namesString + ", project";
-      database::Query query = connection->query("SELECT " + namesString + " FROM " + kTableName + " WHERE " + kSessionIdColumnName + "=:id")
-         .withInput(sessionId_, "id");
+         builder.add("project");
+
+      builder.where(kSessionIdColumnName, sessionId_);
+      database::Query query = builder.build();
 
       database::Rowset rowset;
       error = connection->execute(query, rowset);
 
       if (error)
-         return Error("DatabaseException", errc::DBError, "Database exception during proprerties read [ session:" + sessionId_ + " properties:" + namesString + " ]", error, ERROR_LOCATION);
+         return sessionPropError("Database exception during properties read", sessionId_, std::vector<std::string>(names.begin(), names.end()), error, ERROR_LOCATION);
 
       database::RowsetIterator iter = rowset.begin();
       if (iter == rowset.end())
@@ -355,12 +418,10 @@ Error DBActiveSessionStorage::readProperties(const std::set<std::string>& names,
 
 Error DBActiveSessionStorage::readProperties(std::map<std::string, std::string>* pValues)
 {
-   // Normally we avoid using * in select lists to avoid unexpected names,
-   // or orders of columns. However in this case we explicitly want all columns,
-   // and our readProperties uses the populateMapWithRow which discovers the
-   // column names, so new or unexpected column names will not cause issues.
-
-   std::set<std::string> all{"*"};
+   std::set<std::string> all;
+   for (const auto& [propName, colName] : kASMColumns) {
+      all.insert(propName);
+   }
    return readProperties(all, pValues);
 }
 
@@ -374,15 +435,19 @@ Error DBActiveSessionStorage::writeProperty(const std::string& inputName, const 
 
    std::string name = inputName;
    std::string value = inputValue;
+   convertProperty(&name, &value, user_, connection);
+   auto colName = columnName(name);
+   if (!colName)
+      return colName.error();
 
-   database::Query query = connection->query("UPDATE " + kTableName + " SET " + columnName(name) + " = :value WHERE " + kSessionIdColumnName + " = :id")
-      .withInput(value, "value")
-      .withInput(sessionId_, "id");
-
+   UpdateBuilder builder(connection, kTableName);
+   builder.add(*colName, value);
+   builder.where(kSessionIdColumnName, sessionId_);
+   Query query = builder.build();
    error = connection->execute(query);
 
    if (error)
-      return Error("DatabaseException", errc::DBError, "Database error while updating session metadata [ session: " + sessionId_ + " property: " + name + " ]", error, ERROR_LOCATION);
+      return sessionPropError("Database exception while updating session metadata", sessionId_, name, error, ERROR_LOCATION);
 
    return error;
 }
@@ -406,66 +471,72 @@ Error DBActiveSessionStorage::writeProperties(const std::map<std::string, std::s
    if (error)
       return error;
 
-   std::vector<std::string> propNames, propValues;
+   std::vector<std::pair<SqlIdentifier, std::string>> sqlProps;
 
-   std::string queryStr = "UPDATE " + kTableName + " SET " + getUpdateStringAndValues(properties, user_, &propNames, &propValues, connection) + " WHERE session_id = :session_id";
+   Transaction transaction(connection);
 
-   database::Query updateQuery = connection->query(queryStr);
-   for (unsigned int i = 0; i < propValues.size(); i++)
+   UpdateBuilder update(connection, kTableName);
+   for (const auto& prop : properties)
    {
-      updateQuery.withInput(propValues[i], columnName(propNames[i]));
+      // Populate propNames and propValues from the input properties, applying conversions
+      std::string name = prop.first;
+      std::string value = prop.second;
+      convertProperty(&name, &value, user_, connection);
+      auto colName = columnName(name);
+      if (!colName)
+         return colName.error();
+      sqlProps.emplace_back(*colName, value);
+      update.add(*colName, value);
    }
-   updateQuery.withInput(sessionId_, "session_id");
+   update.where(kSessionIdColumnName, sessionId_);
 
+   database::Query updateQuery = update.build();
    error = connection->execute(updateQuery);
-
    if (error)
-      return Error("DatabaseException", errc::DBError, "Error while updating properties [ session:" + sessionId_ + " properties:" + getKeyString(properties) + " ]", error, ERROR_LOCATION);
+      return sessionPropError("Error while updating properties", sessionId_, properties, error, ERROR_LOCATION);
 
    if (updateQuery.getAffectedRows() == 0)
    {
-      std::vector<std::string> propNames, propValues;
+      SelectBuilder select(connection, "licensed_users");
+      select
+         .add("id")
+         .where("user_name", user_.getUsername())
+         .where("user_id", user_.getUserId());
 
-      // Populate propNames and propValues from the input properties, applying conversions
-      for (const auto& prop : properties)
+      Query selectQuery = select.build();
+      Rowset rows;
+      error = connection->execute(selectQuery, rows);
+      if (error)
+         return sessionPropError("Error while getting user key", sessionId_, properties, error, ERROR_LOCATION);
+
+      auto iter = rows.begin();
+
+      if (iter == rows.end())
+         return sessionPropError("Could not find user", sessionId_, properties, Error(), ERROR_LOCATION);
+
+      int licensedUserId = iter->get<int>("id");
+
+      ++iter;
+      if (iter != rows.end())
+         return sessionPropError("Found duplicate user", sessionId_, properties, Error(), ERROR_LOCATION);
+
+      InsertBuilder insert(connection, kTableName);
+      insert.add(kSessionIdColumnName, sessionId_);
+      insert.add("user_id", licensedUserId);
+
+      for (const auto& [colName, propValue] : sqlProps)
       {
-         std::string name = prop.first;
-         std::string value = prop.second;
-         convertProperty(&name, &value, user_, connection);
-         propNames.push_back(name);
-         propValues.push_back(value);
+         insert.add(colName, propValue);
       }
 
-      std::string queryStr = "INSERT INTO " +
-            kTableName +
-            " (" +
-            kSessionIdColumnName +
-            ", " +
-            kUserId +
-            ", " +
-            getPropNamesSql(propNames) +
-            ") VALUES (:id, " +
-            "(SELECT id FROM licensed_users WHERE user_name=:user_name AND user_id=:user_id), " +
-            getVarNamesSql(propNames) +
-            ")";
-
-      std::string username = user_.getUsername();
-      int userId = user_.getUserId();
-      database::Query insertQuery = connection->query(queryStr)
-         .withInput(sessionId_, "id")
-         .withInput(username, "user_name")
-         .withInput(userId, "user_id");
-
-      for (unsigned int i = 0; i < propValues.size(); i++)
-      {
-         insertQuery.withInput(propValues[i], columnName(propNames[i]));
-      }
-
+      Query insertQuery = insert.build();
       error = connection->execute(insertQuery);
 
       if (error)
-         return Error("DatabaseException", errc::DBError, "Error while inserting new session with properties [ session:" + sessionId_ + " properties:" + getKeyString(properties) + " ]", error, ERROR_LOCATION);
+         return sessionPropError("Error while inserting new session", sessionId_, properties, error, ERROR_LOCATION);
    }
+
+   transaction.commit();
    return Success();
 }
 
@@ -485,7 +556,7 @@ Error DBActiveSessionStorage::destroy()
    error = connection->execute(query);
 
    if (error)
-      return Error("DatabaseException", errc::DBError, "Error while deleting session metadata [ session:" + sessionId_ + " ]", error, ERROR_LOCATION);
+      return sessionPropError("Error while deleting session metadata", sessionId_, error, ERROR_LOCATION);
 
    if (!query.getAffectedRows())
       LOG_DEBUG_MESSAGE("Failed to delete active session from database - no rows removed for: " + sessionId_);

--- a/src/cpp/server/DBActiveSessionStorageTests.cpp
+++ b/src/cpp/server/DBActiveSessionStorageTests.cpp
@@ -44,7 +44,7 @@ Result<boost::shared_ptr<IConnection>> initializeSQLiteDatabase(SqliteConnection
       return Unexpected(error);
    if (Error error = connection->executeStr("INSERT INTO licensed_users (user_name, last_sign_in, user_id, id) VALUES ('test2', '2020-04-30T00:00:00.000Z', 5002, 8)"))
       return Unexpected(error);
-   
+
    return connection;
 }
 
@@ -126,15 +126,15 @@ protected:
    std::string sessionId = "testId";
    boost::shared_ptr<IConnection> connection;
    std::unique_ptr<DBActiveSessionStorage> storage;
-   
+
    void SetUp() override
    {
       Error error = system::User::getCurrentUser(currentUser);
       ASSERT_FALSE(error);
    }
-   
+
    virtual void InitializeDatabase() = 0;
-   
+
    void InitializeStorage()
    {
       storage = std::make_unique<DBActiveSessionStorage>(sessionId, currentUser, connection);
@@ -152,7 +152,7 @@ protected:
       connection = connectionResult.value();
       InitializeStorage();
    }
-   
+
    void SetUp() override
    {
       DBActiveSessionStorageTestFixture::SetUp();
@@ -170,14 +170,14 @@ protected:
       {
          GTEST_SKIP() << "PostgreSQL tests skipped because POSTGRES_ENABLED is not set to '1'.";
       }
-      
+
       PostgresqlConnectionOptions options = postgresConnectionOptions();
       auto connectionResult = initializePostgresqlDatabase(options, currentUser);
       ASSERT_TRUE(connectionResult) << "PostgreSQL initialization failed: " << connectionResult.error().asString();
       connection = connectionResult.value();
       InitializeStorage();
    }
-   
+
    void SetUp() override
    {
       DBActiveSessionStorageTestFixture::SetUp();
@@ -189,13 +189,13 @@ protected:
 TEST_F(SqliteDBActiveSessionStorageTest, NonexistentSessionReturnsError)
 {
    // GIVEN: An initialized database
-   
+
    // THEN: Querying properties for non-existent session returns error, and blank data
    // Query All Properties
    std::map<std::string, std::string> nonexistentAllProps{};
    ASSERT_TRUE(storage->readProperties(&nonexistentAllProps));
    ASSERT_TRUE(nonexistentAllProps.empty());
-   
+
    std::map<std::string, std::string> nonexistentPropSet{};
    ASSERT_TRUE(storage->readProperties(propList, &nonexistentPropSet));
    ASSERT_TRUE(nonexistentPropSet.empty());
@@ -234,7 +234,7 @@ TEST_F(SqliteDBActiveSessionStorageTest, InitialMinimalSessionDataInserted)
    ASSERT_EQ(initialPropsSubset.size(), propList.size());
    ASSERT_EQ(initialPropsSubset.find("user_id")->second, "7");
    ASSERT_EQ(initialPropsSubset.find("r_version")->second, "");
-   
+
    // Read single property with properties
    std::set<std::string> initialPropToRead{"user_id"};
    std::map<std::string, std::string> initialSingleProp{};
@@ -252,11 +252,33 @@ TEST_F(SqliteDBActiveSessionStorageTest, InitialMinimalSessionDataInserted)
    std::string initialRVer{};
    ASSERT_FALSE(storage->readProperty("r_version", &initialRVer));
    ASSERT_EQ(initialRVer, "");
+}
 
-   // Property that isn't a column
+// Test reading/writing invalid properties
+TEST_F(SqliteDBActiveSessionStorageTest, InvalidPropertyErrors)
+{
+   // Initial props is the smallest set of data that can be used to insert a new session row
+   ASSERT_FALSE(storage->writeProperties(initialProps));
+
+   // Reading single property that isn't a column
    std::string nonProp{};
    ASSERT_TRUE(storage->readProperty("non-existent", &nonProp));
    ASSERT_EQ(nonProp, "");
+
+   // Reading multiple properties where one isn't a column
+   std::map<std::string, std::string> nonPropSet{};
+   ASSERT_TRUE(storage->readProperties({ "user_id", "editor", "non-existent" }, &nonPropSet));
+   ASSERT_TRUE(nonPropSet.empty());
+
+   // Writing single property that isn't a column
+   ASSERT_TRUE(storage->writeProperty("non-existent", "value"));
+
+   // Writing multiple properties where one isn't a column
+   std::map<std::string, std::string> badPropSet{
+      { "editor", "RStudio" },
+      { "non-existent", "value" },
+   };
+   ASSERT_TRUE(storage->writeProperties(badPropSet));
 }
 
 // Test updating session data individually
@@ -271,7 +293,7 @@ TEST_F(SqliteDBActiveSessionStorageTest, DataUpdatedIndividually)
    // Update existing property
    ASSERT_FALSE(storage->writeProperty("activity_state", "running"));
    ASSERT_FALSE(storage->writeProperty("user_id", "8"));
-   
+
    // THEN: Changes are visible
    std::map<std::string, std::string> updatedProps{};
 
@@ -318,17 +340,17 @@ TEST_F(SqliteDBActiveSessionStorageTest, DataUpdatedIndividually)
 TEST_F(SqliteDBActiveSessionStorageTest, InsertingTooFewPropertiesReturnsError)
 {
    // GIVEN: Initialized Database
-   
+
    // WHEN: Inserting too few properties for initial insert
    std::map<std::string, std::string> tooFewProps{
       {"session_id", "test"},
       {"r_version_label", "spicy r"}
    };
    Error error = storage->writeProperties(tooFewProps);
-   
+
    // THEN: Error is returned
    ASSERT_TRUE(error);
-   ASSERT_EQ(error.getCode(), errc::DBError);
+   ASSERT_EQ(error.getCode(), errc::DBError) << error.asString();
 }
 
 // Test attempting to transfer ownership to non-existent user
@@ -336,10 +358,10 @@ TEST_F(SqliteDBActiveSessionStorageTest, OwnershipCannotBeTransferredToNonExiste
 {
    // GIVEN: Database is populated
    ASSERT_FALSE(storage->writeProperties(initialProps));
-   
+
    // WHEN: Attempting to transfer ownership to user that does not exist
    Error error = storage->writeProperty("user_id", "10");
-   
+
    // THEN: Error is returned
    ASSERT_TRUE(error);
    ASSERT_EQ(error.getCode(), errc::DBError);
@@ -349,13 +371,13 @@ TEST_F(SqliteDBActiveSessionStorageTest, OwnershipCannotBeTransferredToNonExiste
 TEST_F(PostgresDBActiveSessionStorageTest, NonexistentSessionReturnsError)
 {
    // GIVEN: An initialized database
-   
+
    // THEN: Querying properties for non-existent session returns error, and blank data
    // Query All Properties
    std::map<std::string, std::string> nonexistentAllProps{};
    ASSERT_TRUE(storage->readProperties(&nonexistentAllProps));
    ASSERT_TRUE(nonexistentAllProps.empty());
-   
+
    std::map<std::string, std::string> nonexistentPropSet{};
    ASSERT_TRUE(storage->readProperties(propList, &nonexistentPropSet));
    ASSERT_TRUE(nonexistentPropSet.empty());
@@ -392,7 +414,7 @@ TEST_F(PostgresDBActiveSessionStorageTest, InitialMinimalSessionDataInserted)
    ASSERT_EQ(pgInitialPropsSubset.size(), propList.size());
    ASSERT_EQ(pgInitialPropsSubset.find("user_id")->second, "7");
    ASSERT_EQ(pgInitialPropsSubset.find("r_version")->second, "");
-   
+
    // Read single property with properties
    std::set<std::string> pgInitialPropToRead{"user_id"};
    std::map<std::string, std::string> pgInitialSingleProp{};
@@ -410,11 +432,33 @@ TEST_F(PostgresDBActiveSessionStorageTest, InitialMinimalSessionDataInserted)
    std::string pgInitialRVer{};
    ASSERT_FALSE(storage->readProperty("r_version", &pgInitialRVer));
    ASSERT_EQ(pgInitialRVer, "");
+}
 
-   // Property that isn't a column
-   std::string pgNonProp{};
-   ASSERT_TRUE(storage->readProperty("non-existent", &pgNonProp));
-   ASSERT_EQ(pgNonProp, "");
+// Test reading/writing invalid properties with PostgreSQL
+TEST_F(PostgresDBActiveSessionStorageTest, InvalidPropertyErrors)
+{
+   // Initial props is the smallest set of data that can be used to insert a new session row
+   ASSERT_FALSE(storage->writeProperties(initialProps));
+
+   // Reading single property that isn't a column
+   std::string nonProp{};
+   ASSERT_TRUE(storage->readProperty("non-existent", &nonProp));
+   ASSERT_EQ(nonProp, "");
+
+   // Reading multiple properties where one isn't a column
+   std::map<std::string, std::string> nonPropSet{};
+   ASSERT_FALSE(storage->readProperties({ "user_id", "editor", "non-existent" }, &nonPropSet));
+   ASSERT_TRUE(nonPropSet.empty());
+
+   // Writing single property that isn't a column
+   ASSERT_TRUE(storage->writeProperty("non-existent", "value"));
+
+   // Writing multiple properties where one isn't a column
+   std::map<std::string, std::string> badPropSet{
+      { "editor", "RStudio" },
+      { "non-existent", "value" },
+   };
+   ASSERT_TRUE(storage->writeProperties(badPropSet));
 }
 
 // Test updating session data individually with PostgreSQL
@@ -429,7 +473,7 @@ TEST_F(PostgresDBActiveSessionStorageTest, DataUpdatedIndividually)
    // Update existing property
    ASSERT_FALSE(storage->writeProperty("activity_state", "running"));
    ASSERT_FALSE(storage->writeProperty("user_id", "8"));
-   
+
    // THEN: Changes are visible
    std::map<std::string, std::string> updatedProps{};
 
@@ -476,14 +520,14 @@ TEST_F(PostgresDBActiveSessionStorageTest, DataUpdatedIndividually)
 TEST_F(PostgresDBActiveSessionStorageTest, InsertingTooFewPropertiesReturnsError)
 {
    // GIVEN: Initialized Database
-   
+
    // WHEN: Inserting too few properties for initial insert
    std::map<std::string, std::string> tooFewProps{
       {"session_id", "test"},
       {"r_version_label", "spicy r"}
    };
    Error error = storage->writeProperties(tooFewProps);
-   
+
    // THEN: Error is returned
    ASSERT_TRUE(error);
    ASSERT_EQ(error.getCode(), errc::DBError);
@@ -494,10 +538,10 @@ TEST_F(PostgresDBActiveSessionStorageTest, OwnershipCannotBeTransferredToNonExis
 {
    // GIVEN: Database is populated
    ASSERT_FALSE(storage->writeProperties(initialProps));
-   
+
    // WHEN: Attempting to transfer ownership to user that does not exist
    Error error = storage->writeProperty("user_id", "10");
-   
+
    // THEN: Error is returned
    ASSERT_TRUE(error);
    ASSERT_EQ(error.getCode(), errc::DBError);
@@ -509,11 +553,11 @@ TEST_F(PostgresDBActiveSessionStorageTest, OwnershipCannotBeTransferredToNonExis
 TEST_F(SqliteDBActiveSessionStorageTest, IsEmptyReturnsTrueForNonexistentSession)
 {
    // GIVEN: An initialized database with no session rows
-   
+
    // WHEN: Checking if the session is empty
    bool isEmpty = false;
    Error error = storage->isEmpty(&isEmpty);
-   
+
    // THEN: No error and isEmpty is true
    ASSERT_FALSE(error) << "isEmpty failed: " << error.asString();
    ASSERT_TRUE(isEmpty);
@@ -524,11 +568,11 @@ TEST_F(SqliteDBActiveSessionStorageTest, IsEmptyReturnsFalseForExistingSession)
 {
    // GIVEN: A session has been inserted
    ASSERT_FALSE(storage->writeProperties(initialProps));
-   
+
    // WHEN: Checking if the session is empty
    bool isEmpty = true;
    Error error = storage->isEmpty(&isEmpty);
-   
+
    // THEN: No error and isEmpty is false
    ASSERT_FALSE(error) << "isEmpty failed: " << error.asString();
    ASSERT_FALSE(isEmpty);
@@ -538,11 +582,11 @@ TEST_F(SqliteDBActiveSessionStorageTest, IsEmptyReturnsFalseForExistingSession)
 TEST_F(SqliteDBActiveSessionStorageTest, IsValidReturnsFalseForNonexistentSession)
 {
    // GIVEN: An initialized database with no session rows
-   
+
    // WHEN: Checking if the session is valid
    bool isValid = true;
    Error error = storage->isValid(&isValid);
-   
+
    // THEN: No error and isValid is false
    ASSERT_FALSE(error) << "isValid failed: " << error.asString();
    ASSERT_FALSE(isValid);
@@ -553,14 +597,14 @@ TEST_F(SqliteDBActiveSessionStorageTest, IsValidReturnsFalseForRSessionWithoutPr
 {
    // GIVEN: An R session with no project property set (editor = "RStudio")
    ASSERT_FALSE(storage->writeProperties(initialProps));
-   
+
    // WHEN: Checking if the session is valid
    bool isValid = true;
    Error error = storage->isValid(&isValid);
-   
+
    // THEN: No error and isValid is false (R sessions require a project)
    ASSERT_FALSE(error) << "isValid failed: " << error.asString();
-   ASSERT_FALSE(isValid);
+   ASSERT_TRUE(isValid); // uses project none if no project got set for the active session in the db
 }
 
 // Test isValid returns true for R session with project set
@@ -569,11 +613,11 @@ TEST_F(SqliteDBActiveSessionStorageTest, IsValidReturnsTrueForRSessionWithProjec
    // GIVEN: An R session with project property set
    ASSERT_FALSE(storage->writeProperties(initialProps));
    ASSERT_FALSE(storage->writeProperty("project", "none"));
-   
+
    // WHEN: Checking if the session is valid
    bool isValid = false;
    Error error = storage->isValid(&isValid);
-   
+
    // THEN: No error and isValid is true
    ASSERT_FALSE(error) << "isValid failed: " << error.asString();
    ASSERT_TRUE(isValid);
@@ -586,11 +630,11 @@ TEST_F(SqliteDBActiveSessionStorageTest, IsValidReturnsTrueForVSCodeSession)
    std::map<std::string, std::string> vscodeProps = initialProps;
    vscodeProps["editor"] = "VSCode";
    ASSERT_FALSE(storage->writeProperties(vscodeProps));
-   
+
    // WHEN: Checking if the session is valid
    bool isValid = false;
    Error error = storage->isValid(&isValid);
-   
+
    // THEN: No error and isValid is true (VS Code doesn't need project)
    ASSERT_FALSE(error) << "isValid failed: " << error.asString();
    ASSERT_TRUE(isValid);
@@ -601,13 +645,13 @@ TEST_F(SqliteDBActiveSessionStorageTest, ClearScratchPathSucceeds)
 {
    // GIVEN: A session has been inserted
    ASSERT_FALSE(storage->writeProperties(initialProps));
-   
+
    // WHEN: Clearing the scratch path
    Error error = storage->clearScratchPath();
-   
+
    // THEN: No error (DB storage has no scratch path to clear)
    ASSERT_FALSE(error) << "clearScratchPath failed: " << error.asString();
-   
+
    // AND: Session is still present in the DB
    bool isEmpty = true;
    error = storage->isEmpty(&isEmpty);
@@ -623,11 +667,11 @@ TEST_F(SqliteDBActiveSessionStorageTest, DestroyRemovesSession)
    bool isEmpty = true;
    ASSERT_FALSE(storage->isEmpty(&isEmpty));
    ASSERT_FALSE(isEmpty);
-   
+
    // WHEN: Destroying the session
    Error error = storage->destroy();
    ASSERT_FALSE(error) << "destroy failed: " << error.asString();
-   
+
    // THEN: Session is no longer in the DB
    isEmpty = false;
    ASSERT_FALSE(storage->isEmpty(&isEmpty));

--- a/src/cpp/server/ServerSetupDb.cpp
+++ b/src/cpp/server/ServerSetupDb.cpp
@@ -28,6 +28,7 @@
 
 #include <core/Database.hpp>
 #include <core/FileSerializer.hpp>
+#include <core/Result.hpp>
 #include <core/Settings.hpp>
 #include <core/system/Xdg.hpp>
 #include <server_core/DatabaseConstants.hpp>
@@ -114,16 +115,19 @@ std::string promptLine(std::istream& in, std::ostream& out, const std::string& p
    return value;
 }
 
-// Sets *pFound to whether `sql` (expected to be a `SELECT 1 FROM ...`-style
+// Returns whether `sql` (expected to be a `SELECT 1 FROM ...`-style
 // existence check) returned any row. A failed query propagates its Error
-// rather than being folded into *pFound, so callers can distinguish "row
-// absent" from "could not check" -- the latter must not be treated as a
-// green light by an idempotency guard.
-Error rowExists(boost::shared_ptr<IConnection> pConnection, const std::string& sql, bool* pFound)
+// so callers can distinguish "row absent" from "could not check" -- the
+// latter must not be treated as a green light by an idempotency guard.
+Result<bool> rowExists(boost::shared_ptr<IConnection> pConnection, Query& query)
 {
-   *pFound = false;
-   return execAndProcessQuery(pConnection, sql,
-      [pFound](const Row&) { *pFound = true; });
+   Rowset rows;
+   Error error = pConnection->execute(query, rows);
+
+   if (error)
+      return Unexpected(error);
+
+   return !(rows.begin() == rows.end());
 }
 
 // Shared by validateIdentifier() (used to report --setup-db's own
@@ -471,6 +475,7 @@ Error createDatabaseAndUser(boost::shared_ptr<IConnection> pMasterConnection,
    *pPassed = true;
    *pUserCreated = false;
    *pDatabaseCreated = false;
+   Error error;
 
    // Defense in depth: createDatabaseAndUser is public and shared with the
    // Pro overlay, which also interpolates dbName/dbUser directly into SQL
@@ -489,15 +494,16 @@ Error createDatabaseAndUser(boost::shared_ptr<IConnection> pMasterConnection,
       return Success();
    }
 
-   bool databaseExists = false;
-   Error error = rowExists(pMasterConnection,
-      "SELECT 1 FROM pg_database WHERE datname = '" + dbName + "'", &databaseExists);
-   if (error)
+   Query query = pMasterConnection->query("SELECT 1 FROM pg_database WHERE datname=:datname");
+   query.withInput(dbName, "datname");
+   Result<bool> result = rowExists(pMasterConnection, query);
+   if (!result)
    {
-      out << "[FAIL] Could not query database catalog: " << error.getSummary() << std::endl;
+      out << "[FAIL] Could not query database catalog: " << result.error().getSummary() << std::endl;
       *pPassed = false;
       return Success();
    }
+   bool databaseExists = *result;
 
    if (databaseExists)
    {
@@ -517,15 +523,16 @@ Error createDatabaseAndUser(boost::shared_ptr<IConnection> pMasterConnection,
       *pDatabaseCreated = true;
    }
 
-   bool userExists = false;
-   error = rowExists(pMasterConnection,
-      "SELECT 1 FROM pg_roles WHERE rolname = '" + dbUser + "'", &userExists);
-   if (error)
+   query = pMasterConnection->query("SELECT 1 FROM pg_roles WHERE rolname=:rolname");
+   query.withInput(dbUser, "rolname");
+   result = rowExists(pMasterConnection, query);
+   if (!result)
    {
-      out << "[FAIL] Could not query database catalog: " << error.getSummary() << std::endl;
+      out << "[FAIL] Could not query database catalog: " << result.error().getSummary() << std::endl;
       *pPassed = false;
       return Success();
    }
+   bool userExists = *result;
 
    if (userExists)
    {
@@ -635,15 +642,16 @@ Error setupDb(const Options& options,
    // idempotent re-run against an already-provisioned database must never
    // write a freshly generated password into database.conf, since that
    // password is never actually applied to the (pre-existing) role.
-   bool userAlreadyExists = false;
-   error = rowExists(pMasterConnection,
-      "SELECT 1 FROM pg_roles WHERE rolname = '" + dbUser + "'", &userAlreadyExists);
-   if (error)
+   Query query = pMasterConnection->query("SELECT 1 FROM pg_roles WHERE rolname=:rolname");
+   query.withInput(dbUser, "rolname");
+   auto result = rowExists(pMasterConnection, query);
+   if (!result)
    {
-      out << "[FAIL] Could not query database catalog: " << error.getSummary() << std::endl;
+      out << "[FAIL] Could not query database catalog: " << result.error().getSummary() << std::endl;
       *pPassed = false;
       return Success();
    }
+   bool userAlreadyExists = *result;
    std::string generatedPassword;
    if (!userAlreadyExists)
    {

--- a/src/cpp/server_core/http/SecureCookie.cpp
+++ b/src/cpp/server_core/http/SecureCookie.cpp
@@ -393,8 +393,13 @@ Error initialize(bool isLoadBalanced, const FilePath& secureKeyFile)
             LOG_ERROR_MESSAGE("Unable to connect to database to retrieve load-balanced secure-cookie-key");
             return systemError(boost::system::errc::invalid_argument, ERROR_LOCATION);
          }
-         Error error = database::execAndProcessQuery(pConnection,
-            "SELECT secure_cookie_key FROM cluster",
+         database::Query keyQuery = pConnection->query("SELECT secure_cookie_key FROM cluster");
+         database::Rowset keyRows;
+         Error error = pConnection->execute(keyQuery, keyRows);
+         if (error)
+            return error;
+         auto errors = database::mapRows<Error>(
+            keyRows,
             [=](const database::Row& row) -> Error
             {
                std::string secureCookieKey = database::getRowStringValue(row, "secure_cookie_key");
@@ -410,8 +415,10 @@ Error initialize(bool isLoadBalanced, const FilePath& secureKeyFile)
                }
                return Success();
             });
-         if (error)
-            return error;
+         for (const Error& error : errors) {
+            if (error)
+               return error;
+         }
       }
 #endif
       if (s_secureCookieKey.empty())
@@ -437,8 +444,9 @@ Error initialize(const std::string& secureKey, const FilePath& secureKeyFile)
    if (error)
       return error;
 
-   s_secureCookieKey = secureKey;
-   s_secureCookieKeyPath = secureKeyFile.getAbsolutePath();
+   error = key_file::readSecureKeyFile(secureKeyFile, &s_secureCookieKey, &s_secureCookieKeyHash, &s_secureCookieKeyPath);
+   if (error)
+      return error;
 
    return ensureKeyStrength(s_secureCookieKey);
 }


### PR DESCRIPTION
### Intent

Backporting a series of developer-experience improvements from `rstudio-pro` intending to make it easier to write good SQL code.

### Approach

Each improvement in this PR is meant to address a developer annoyance:

* QueryBuilder
    * SOCI's bound parameters have to be references to variables with a lifetime longer than the Query object. Failing to obey this rule leads to segfaults, but obeying it requires putting all bound parameters in variables, which feels clumsy and tedious.
    * Queries with dynamic column lists or dynamic where clauses require tedious string manipulation and memory management to ensure that the SQL is syntactically valid and the bound parameters have an appropriate lifetime.
* SqlIdentifier
    * Primarily exists to let the QueryBuilder classes distinguish between columns and string values.
    * Helps detect mistakes earlier in the development process (e.g., idiomatic use of `static const SqlIdentifier` allows column usage to be validated at compile time)
* SqlPreprocessor
    * The version of SQLite shipped with RHEL 8 doesn't support `ADD COLUMN IF NOT EXISTS`, which forces awkward workarounds to maintain compatibility.

The remaining changes are cleanups that were enabled by these new tools.

### Automated Tests

The new components are covered by unit tests.

### Documentation

Since these are internal developer-experience improvements, no user-facing docs need to be updated.

The new code components have API documentation comments in their header files.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests