### PR TITLE
Disable library validation for bundled node in ad-hoc builds

### DIFF
--- a/package/osx/entitlements/node-adhoc.plist
+++ b/package/osx/entitlements/node-adhoc.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+
+  <!-- Match the default entitlements applied to every bundled binary. -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+
+  <!-- Required for ad-hoc signatures. Node.js dlopens native modules bundled with
+       the Copilot language server, and ad-hoc signatures carry no Team ID for
+       library validation to match against. -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+
+</dict>
+</plist>

--- a/package/osx/entitlements/node-adhoc.plist
+++ b/package/osx/entitlements/node-adhoc.plist
@@ -3,16 +3,19 @@
 <plist version="1.0">
 <dict>
 
-  <!-- Match the default entitlements applied to every bundled binary. -->
+  <!-- Re-signing replaces the entitlement set wholesale, so the two keys node already
+       received from the package-wide default pass have to be restated here. Neither was
+       independently verified as required by node; they are carried over so that
+       re-signing does not narrow what node was previously signed with. -->
   <key>com.apple.security.cs.allow-jit</key>
   <true/>
 
   <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
   <true/>
 
-  <!-- Required for ad-hoc signatures. Node.js dlopens native modules bundled with
-       the Copilot language server, and ad-hoc signatures carry no Team ID for
-       library validation to match against. -->
+  <!-- Required for ad-hoc signatures. Node dlopens native (*.node) modules bundled in
+       the package, currently the Copilot language server's, and an ad-hoc signature
+       carries no Team ID for library validation to match against. -->
   <key>com.apple.security.cs.disable-library-validation</key>
   <true/>
 

--- a/package/osx/entitlements/node-ci.plist
+++ b/package/osx/entitlements/node-ci.plist
@@ -3,9 +3,14 @@
 <plist version="1.0">
 <dict>
 
-  <!-- Match the default entitlements applied to every bundled binary. Signed builds
-       don't need library validation disabled: every binary in the package is signed
-       with the same Team ID, so the native modules Node.js dlopens are accepted. -->
+  <!-- Node is always re-signed with entitlements/node-<type>.plist, so this file has to
+       exist for signed builds. It deliberately omits disable-library-validation: every
+       file in the package is re-signed with Posit's Developer ID, so node and the *.node
+       modules it dlopens from inside the package share a Team ID, and library validation
+       passes without it. -->
+
+  <!-- Re-signing replaces the entitlement set wholesale, so the two keys node already
+       received from the package-wide default pass have to be restated here. -->
   <key>com.apple.security.cs.allow-jit</key>
   <true/>
 

--- a/package/osx/entitlements/node-ci.plist
+++ b/package/osx/entitlements/node-ci.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+
+  <!-- Match the default entitlements applied to every bundled binary. Signed builds
+       don't need library validation disabled: every binary in the package is signed
+       with the same Team ID, so the native modules Node.js dlopens are accepted. -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+
+</dict>
+</plist>

--- a/package/osx/scripts/codesign-package.sh
+++ b/package/osx/scripts/codesign-package.sh
@@ -99,6 +99,11 @@ for executable in rsession rsession-arm64; do
 	fi
 done
 
+for path in "${package}"/Contents/Resources/app/bin/node*/bin/node; do
+	echo "[i] Re-signing ${path} with entitlements -- ${entype}"
+	codesign-binary --entitlements "entitlements/node-${entype}.plist" "${path}"
+done
+
 echo "[i] Re-signing RStudio binary with entitlements -- ${entype}"
 codesign-binary --entitlements "entitlements/rstudio-${entype}.plist" "${package}/Contents/MacOS/RStudio"
 

--- a/package/osx/scripts/codesign-package.sh
+++ b/package/osx/scripts/codesign-package.sh
@@ -99,10 +99,23 @@ for executable in rsession rsession-arm64; do
 	fi
 done
 
-for path in "${package}"/Contents/Resources/app/bin/node*/bin/node; do
-	echo "[i] Re-signing ${path} with entitlements -- ${entype}"
+# Must precede the Contents/MacOS/RStudio re-sign below: that re-seals the bundle,
+# repairing the resource seal which re-signing a nested binary invalidates.
+#
+# bin/node is installed unconditionally (src/cpp/session/CMakeLists.txt), so sign it
+# with no existence test -- a layout change should fail the build. A skipped re-sign
+# would leave node validly signed with the wrong entitlements, and codesign --strict
+# checks seals, not entitlement content, so nothing downstream would notice.
+echo "[i] Re-signing node with entitlements -- ${entype}"
+codesign-binary --entitlements "entitlements/node-${entype}.plist" \
+	"${package}/Contents/Resources/app/bin/node/bin/node"
+
+# bin/node-arm64 is copied only for universal builds (package/osx/cmake/prepare-package.cmake).
+path="${package}/Contents/Resources/app/bin/node-arm64/bin/node"
+if [ -e "${path}" ]; then
+	echo "[i] Re-signing node-arm64 with entitlements -- ${entype}"
 	codesign-binary --entitlements "entitlements/node-${entype}.plist" "${path}"
-done
+fi
 
 echo "[i] Re-signing RStudio binary with entitlements -- ${entype}"
 codesign-binary --entitlements "entitlements/rstudio-${entype}.plist" "${package}/Contents/MacOS/RStudio"


### PR DESCRIPTION
Closes #18450.

Ad-hoc signed macOS packages sign every file in the bundle with `--options runtime` and `entitlements/default.plist`, which grants only `allow-jit` and `allow-unsigned-executable-memory`. The hardened runtime enforces library validation, and ad-hoc signatures carry no Team ID, so the bundled `node` was refused every `*.node` module in the package. The Copilot language server exited with `ERR_DLOPEN_FAILED` on `watcher.node`, and the assistant pane reported that the assistant was not running.

`rsession` and `Contents/MacOS/RStudio` are already re-signed with `disable-library-validation` from their `*-adhoc.plist` files. This adds the same treatment for the bundled Node.js.

## Changes

- `entitlements/node-adhoc.plist` — the two keys from `default.plist` plus `com.apple.security.cs.disable-library-validation`.
- `entitlements/node-ci.plist` — the two default keys only. Signed builds re-sign every file in the package with Posit's Developer ID, so `node` and the modules it loads share a Team ID and library validation passes without the entitlement.
- `codesign-package.sh` — re-signs `bin/node/bin/node` with `entitlements/node-${entype}.plist`, and `bin/node-arm64/bin/node` when present.

`bin/node` is installed unconditionally (`src/cpp/session/CMakeLists.txt`), so it is signed with no existence test: a layout change fails the build. `bin/node-arm64` is copied only for universal builds (`package/osx/cmake/prepare-package.cmake`) and keeps an existence test. The distinction matters because a skipped re-sign leaves `node` validly signed with the wrong entitlements, and `codesign --strict` checks seals rather than entitlement content, so nothing downstream would report it.

The node re-sign is placed before the `Contents/MacOS/RStudio` re-sign, which re-seals the bundle and repairs the resource seal that re-signing a nested binary invalidates. Moving it after that step fails packaging with `a sealed resource is missing or invalid`.

Signed and notarized builds get the same entitlement set they had before.

## Verification

Ran `codesign-package.sh` against synthetic bundles:

| case | result |
| --- | --- |
| ad-hoc | `allow-jit`, `allow-unsigned-executable-memory`, `disable-library-validation` on both node binaries |
| ci | the two default keys only |
| `node-arm64` absent | skipped, exit 0 |
| `bin/node` relocated | exit 1, naming the missing path |

Confirmed the original failure and the fix directly:

```
$ .../bin/node-arm64/bin/node -e "require('.../darwin/arm64/watcher.node')"
Error: dlopen(...) ... ERR_DLOPEN_FAILED

# after re-signing with node-adhoc.plist
OK: watcher.node loaded
```

A from-scratch ad-hoc package build installed to `/Applications/RStudio.app` now signs in to Copilot and the assistant pane works.

No NEWS.md entry: ad-hoc signing is the local developer path (`make-package` uses credentials on Jenkins), so no released build is affected.
