### PR TITLE
Document three e2e completion signals that pass vacuously

### DIFF
--- a/.claude/skills/rstudio-create-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-create-playwright-tests/SKILL.md
@@ -117,7 +117,36 @@ This file covers RStudio-specific gotchas that aren't in the README.
    spuriously idle. Wait for busy first (`waitForConsoleBusy`,
    `pages/console_pane.page.ts`), then for idle.
 
-9. **A stray modal reads as "intercepts pointer events".** Any GWT modal
+9. **A console prompt does not mean R-side change detection has run.** The
+   session enqueues `kConsolePrompt` *before* calling `onDetectChanges`
+   (`SessionConsoleInput.cpp`), so `executeInConsole` -- which resolves on the
+   prompt counter -- returns before any event driven by change detection is even
+   queued: a plot raising the Plots pane, a package-list refresh, files changing.
+   Waiting on the prompt and then measuring makes the assertion pass whether or
+   not the thing under test happened. Wait on the effect itself (e.g. poll the
+   Plots tab's `aria-selected`), and pick a signal that is true on a broken build
+   too, so the gate can't mask the regression it guards.
+
+10. **Client state is pushed on a passive 5s timer.** `persistClientState()`
+   fires `PushClientStateEvent` with `active=false`, so `ClientStateUpdater`
+   reschedules rather than nudging (`PASSIVE_INTERVAL_MILLIS`). A test that
+   changes persisted state and then reloads will usually outrun the save and
+   restore nothing -- passing without exercising the restore at all. Wait for the
+   `set_client_state` RPC carrying your value first:
+   `page.waitForResponse(r => r.url().includes('set_client_state') &&
+   (r.request().postData() ?? '').includes('<YourKey>'))`. All state values ship
+   in one RPC, so this also gates any state written by a different component in
+   the same push.
+
+11. **`window.rstudio.ready`, not a pane selector, gates post-reload state.**
+   Workbench pane elements attach at construction, long before client state is
+   applied, so `waitForSelector('#rstudio_TabSet1_pane')` returns while startup
+   state handling is still pending -- and startup work deferred on a timer (e.g.
+   `PaneManager.ZoomedTabStateValue.onInit`) has not run. Gate on
+   `page.waitForFunction(() => window.rstudio?.ready === true)` and poll the
+   assertion rather than sleeping a fixed margin against a product timer.
+
+12. **A stray modal reads as "intercepts pointer events".** Any GWT modal
    renders a `gwt-PopupPanelGlass` overlay, so an unexpected dialog (e.g.
    "Error Listing Packages" after resume) surfaces as an opaque
    `gwt-PopupPanelGlass intercepts pointer events` timeout at an unrelated

--- a/.claude/skills/rstudio-create-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-create-playwright-tests/SKILL.md
@@ -118,14 +118,16 @@ This file covers RStudio-specific gotchas that aren't in the README.
    `pages/console_pane.page.ts`), then for idle.
 
 9. **A console prompt does not mean R-side change detection has run.** The
-   session queues `kConsolePrompt` before it calls `onDetectChanges`
-   (`SessionConsoleInput.cpp`). `executeInConsole` resolves on the prompt counter,
-   so it returns before change detection has queued anything. A plot that raises
-   the Plots pane, a package-list refresh, and a file change all arrive later. If
-   you wait on the prompt and then measure, the assertion passes whether or not
-   the effect happened. Wait on the effect itself, for example the
-   `aria-selected` value of the Plots tab. Pick a signal that reads differently on
-   a broken build.
+   session queues `kConsolePrompt`, wakes the waiting `get_events` poller
+   (`ClientEventQueue::add` ends in `notify_all`), and calls `onDetectChanges`
+   only after that (`SessionConsoleInput.cpp`). So the prompt is ordered ahead of
+   every change-detection event, and it can reach the client first.
+   `executeInConsole` resolves on the prompt counter. At that moment a plot that
+   raises the Plots pane, a package-list refresh, or a file change can be
+   unqueued, undelivered, or not yet rendered. If you wait on the prompt and then
+   measure, the assertion passes whether or not the effect happened. Wait on the
+   effect itself, for example the `aria-selected` value of the Plots tab. Pick a
+   signal that reads differently on a broken build.
 
 10. **Client state reaches the server on a passive 5s timer.**
    `persistClientState()` fires `PushClientStateEvent` with `active=false`, so

--- a/.claude/skills/rstudio-create-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-create-playwright-tests/SKILL.md
@@ -150,11 +150,15 @@ This file covers RStudio-specific gotchas that aren't in the README.
    is still up, so `sessionInfo`'s `deferred_init_completed` is already true and
    `DeferredInitCompletedEvent` never re-fires), `Application.java` sets `ready`
    in `initializeAgent()` and calls `initializeWorkbench()` next -- in the same
-   task, so you cannot observe the gap between them, and seeing `ready` does mean
-   the panes exist. But anything startup defers to a *later* task is still
-   outstanding: `Scheduler.scheduleDeferred` work, and timers such as the 200ms
-   one in `PaneManager.ZoomedTabStateValue.onInit`. Gate on `ready`, then make
-   the assertion itself carry the rest of the wait (see the next entry).
+   task, so you cannot catch it between the two. What is still outstanding when
+   it flips is anything startup defers to a *later* task:
+   `Scheduler.scheduleDeferred` work, and timers such as the 200ms one in
+   `PaneManager.ZoomedTabStateValue.onInit`. Nor does `ready` imply the panes
+   exist at all -- `initializeWorkbench()` bails out early with a `ReloadEvent`
+   when the UI-language cookie or (on Electron) the web-dialogs cookie disagrees
+   with the pref, returning before it builds the workbench and leaving `ready`
+   true across a delayed reload. So gate on `ready`, but let the assertion carry
+   both the element wait and the rest of the timing (see the next entry).
 
 12. **`expect.poll` cannot assert that something never happens.** It returns on
    the first passing sample, so when the pre-condition state *is* the passing

--- a/.claude/skills/rstudio-create-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-create-playwright-tests/SKILL.md
@@ -136,17 +136,36 @@ This file covers RStudio-specific gotchas that aren't in the README.
    `page.waitForResponse(r => r.url().includes('set_client_state') &&
    (r.request().postData() ?? '').includes('<YourKey>'))`. All state values ship
    in one RPC, so this also gates any state written by a different component in
-   the same push.
+   the same push. `waitForResponse` resolves on *any* response, including a
+   rejected one, so assert the response too -- and note that a failed RPC still
+   comes back HTTP 200 with an `error` member (`HttpConnection::sendJsonRpcError`
+   sends through the ordinary `sendJsonRpcResponse` path), so `response.ok()`
+   alone does not prove the state was stored; check the body for `"error"`.
 
-11. **`window.rstudio.ready`, not a pane selector, gates post-reload state.**
-   Workbench pane elements attach at construction, long before client state is
-   applied, so `waitForSelector('#rstudio_TabSet1_pane')` returns while startup
-   state handling is still pending -- and startup work deferred on a timer (e.g.
-   `PaneManager.ZoomedTabStateValue.onInit`) has not run. Gate on
-   `page.waitForFunction(() => window.rstudio?.ready === true)` and poll the
-   assertion rather than sleeping a fixed margin against a product timer.
+11. **`window.rstudio.ready` is the earliest usable post-reload signal, not a
+   state-applied gate.** It beats a pane selector -- workbench panes attach at
+   construction, so `waitForSelector('#rstudio_TabSet1_pane')` returns while
+   startup state handling is still pending. But on the re-join path a
+   `page.reload()` takes (the R session is still up, so `sessionInfo`'s
+   `deferred_init_completed` is already true and `DeferredInitCompletedEvent`
+   never re-fires), `ready` is set in `initializeAgent()` immediately *before*
+   `initializeWorkbench()` -- see `Application.java`. So `ready === true` can be
+   observed before `PaneManager` is even constructed, let alone before state is
+   applied or timer-deferred startup work (e.g.
+   `PaneManager.ZoomedTabStateValue.onInit`) has run. Gate on it, then make the
+   assertion itself carry the wait (see the next entry).
 
-12. **A stray modal reads as "intercepts pointer events".** Any GWT modal
+12. **`expect.poll` cannot assert that something never happens.** It returns on
+   the first passing sample, so when the pre-condition state *is* the passing
+   state -- "the pane is not zoomed", "no dialog appeared" -- the poll satisfies
+   immediately and the test is green before the bad state can arrive. Its
+   `timeout` buys nothing in that direction. Pairing it with a fixed `sleep` only
+   races the product timer. For a must-not-happen assertion, sample the predicate
+   *continuously* over a window that outlasts the deferred work and fail on the
+   first violation. Same trap in the other direction as entry 9: pick the signal
+   by asking what a broken build would do, not what a good one does.
+
+13. **A stray modal reads as "intercepts pointer events".** Any GWT modal
    renders a `gwt-PopupPanelGlass` overlay, so an unexpected dialog (e.g.
    "Error Listing Packages" after resume) surfaces as an opaque
    `gwt-PopupPanelGlass intercepts pointer events` timeout at an unrelated

--- a/.claude/skills/rstudio-create-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-create-playwright-tests/SKILL.md
@@ -118,57 +118,63 @@ This file covers RStudio-specific gotchas that aren't in the README.
    `pages/console_pane.page.ts`), then for idle.
 
 9. **A console prompt does not mean R-side change detection has run.** The
-   session enqueues `kConsolePrompt` *before* calling `onDetectChanges`
-   (`SessionConsoleInput.cpp`), so `executeInConsole` -- which resolves on the
-   prompt counter -- returns before any event driven by change detection is even
-   queued: a plot raising the Plots pane, a package-list refresh, files changing.
-   Waiting on the prompt and then measuring makes the assertion pass whether or
-   not the thing under test happened. Wait on the effect itself (e.g. poll the
-   Plots tab's `aria-selected`), and pick a signal that is true on a broken build
-   too, so the gate can't mask the regression it guards.
+   session queues `kConsolePrompt` before it calls `onDetectChanges`
+   (`SessionConsoleInput.cpp`). `executeInConsole` resolves on the prompt counter,
+   so it returns before change detection has queued anything. A plot that raises
+   the Plots pane, a package-list refresh, and a file change all arrive later. If
+   you wait on the prompt and then measure, the assertion passes whether or not
+   the effect happened. Wait on the effect itself, for example the
+   `aria-selected` value of the Plots tab. Pick a signal that reads differently on
+   a broken build.
 
-10. **Client state is pushed on a passive 5s timer.** `persistClientState()`
-   fires `PushClientStateEvent` with `active=false`, so `ClientStateUpdater`
-   reschedules rather than nudging (`PASSIVE_INTERVAL_MILLIS`). A test that
-   changes persisted state and then reloads will usually outrun the save and
-   restore nothing -- passing without exercising the restore at all. Wait for the
-   `set_client_state` RPC carrying your value first:
+10. **Client state reaches the server on a passive 5s timer.**
+   `persistClientState()` fires `PushClientStateEvent` with `active=false`, so
+   `ClientStateUpdater` reschedules instead of pushing now
+   (`PASSIVE_INTERVAL_MILLIS`). A test that changes persisted state and then
+   reloads normally outruns the save and restores nothing. It passes without
+   exercising the restore. First wait for the `set_client_state` RPC that carries
+   your value:
    `page.waitForResponse(r => r.url().includes('set_client_state') &&
-   (r.request().postData() ?? '').includes('<YourKey>'))`. All state values ship
-   in one RPC, so this also gates any state written by a different component in
-   the same push. `waitForResponse` resolves on *any* response, including a
-   rejected one, so assert the response too -- and note that a failed RPC still
-   comes back HTTP 200 with an `error` member (`HttpConnection::sendJsonRpcError`
-   sends through the ordinary `sendJsonRpcResponse` path), so `response.ok()`
-   alone does not prove the state was stored; check the body for `"error"`.
+   (r.request().postData() ?? '').includes('<YourKey>'))`. All state values go in
+   one RPC, so this also waits for state from other components. Then make sure
+   the RPC succeeded. `waitForResponse` also resolves for a rejected response,
+   and a rejected RPC returns HTTP 200 with an `error` member, because
+   `HttpConnection::sendJsonRpcError` uses the normal `sendJsonRpcResponse` path.
+   `response.ok()` alone does not prove the write landed. Look for `"error"` in
+   the body.
 
-11. **`window.rstudio.ready` is the earliest usable post-reload signal, not a
-   state-applied gate.** It beats a pane selector -- workbench panes attach at
+11. **`window.rstudio.ready` is the earliest usable post-reload signal. It is
+   not a state-applied gate.** It is better than a pane selector: panes attach at
    construction, so `waitForSelector('#rstudio_TabSet1_pane')` returns while
-   startup state handling is still pending. What it does not tell you is that
-   startup *finished*. On the re-join path a `page.reload()` takes (the R session
-   is still up, so `sessionInfo`'s `deferred_init_completed` is already true and
-   `DeferredInitCompletedEvent` never re-fires), `Application.java` sets `ready`
-   in `initializeAgent()` and calls `initializeWorkbench()` next -- in the same
-   task, so you cannot catch it between the two. What is still outstanding when
-   it flips is anything startup defers to a *later* task:
-   `Scheduler.scheduleDeferred` work, and timers such as the 200ms one in
-   `PaneManager.ZoomedTabStateValue.onInit`. Nor does `ready` imply the panes
-   exist at all -- `initializeWorkbench()` bails out early with a `ReloadEvent`
-   when the UI-language cookie or (on Electron) the web-dialogs cookie disagrees
-   with the pref, returning before it builds the workbench and leaving `ready`
-   true across a delayed reload. So gate on `ready`, but let the assertion carry
-   both the element wait and the rest of the timing (see the next entry).
+   startup state handling is still pending. But `ready` does not mean startup
+   finished, and it does not even mean the panes exist. Two reasons:
+   - `Application.java` sets `ready` in `initializeAgent()`, then calls
+     `initializeWorkbench()` in the same task, so you cannot observe the gap.
+     Work that startup defers to a *later* task is still pending:
+     `Scheduler.scheduleDeferred` work, and timers such as the 200ms timer in
+     `PaneManager.ZoomedTabStateValue.onInit`.
+   - `initializeWorkbench()` returns early with a `ReloadEvent` when the
+     UI-language cookie, or the web-dialogs cookie on Electron, disagrees with
+     its pref. It returns before it builds the workbench, and the reload it
+     fires is delayed.
+
+   On the re-join path of a `page.reload()` the R session stays up, so
+   `sessionInfo.deferred_init_completed` is already true and
+   `DeferredInitCompletedEvent` does not fire again -- which is why `ready` is
+   set in `initializeAgent()` at all. Gate on `ready`, then let the assertion
+   wait for the element and for the timing (see the next entry).
 
 12. **`expect.poll` cannot assert that something never happens.** It returns on
-   the first passing sample, so when the pre-condition state *is* the passing
-   state -- "the pane is not zoomed", "no dialog appeared" -- the poll satisfies
-   immediately and the test is green before the bad state can arrive. Its
-   `timeout` buys nothing in that direction. Pairing it with a fixed `sleep` only
-   races the product timer. For a must-not-happen assertion, sample the predicate
-   *continuously* over a window that outlasts the deferred work and fail on the
-   first violation. Same trap in the other direction as entry 9: pick the signal
-   by asking what a broken build would do, not what a good one does.
+   the first sample that passes. When the starting state is also the passing
+   state -- the pane is not zoomed, no dialog appeared -- the poll succeeds at
+   once, and the test is green before the bad state arrives. Its `timeout` value
+   does not help in that direction, and a fixed `sleep` in front of it only races
+   the product timer. For a must-not-happen assertion, sample the predicate over
+   a window that outlasts the deferred work, and fail on the first violation.
+   Start that window after the first sample passes: a slow first sample can
+   otherwise consume the whole window and check the state once. This is entry 9's
+   trap in the other direction. Pick the signal by asking what a broken build
+   does.
 
 13. **A stray modal reads as "intercepts pointer events".** Any GWT modal
    renders a `gwt-PopupPanelGlass` overlay, so an unexpected dialog (e.g.

--- a/.claude/skills/rstudio-create-playwright-tests/SKILL.md
+++ b/.claude/skills/rstudio-create-playwright-tests/SKILL.md
@@ -145,15 +145,16 @@ This file covers RStudio-specific gotchas that aren't in the README.
 11. **`window.rstudio.ready` is the earliest usable post-reload signal, not a
    state-applied gate.** It beats a pane selector -- workbench panes attach at
    construction, so `waitForSelector('#rstudio_TabSet1_pane')` returns while
-   startup state handling is still pending. But on the re-join path a
-   `page.reload()` takes (the R session is still up, so `sessionInfo`'s
-   `deferred_init_completed` is already true and `DeferredInitCompletedEvent`
-   never re-fires), `ready` is set in `initializeAgent()` immediately *before*
-   `initializeWorkbench()` -- see `Application.java`. So `ready === true` can be
-   observed before `PaneManager` is even constructed, let alone before state is
-   applied or timer-deferred startup work (e.g.
-   `PaneManager.ZoomedTabStateValue.onInit`) has run. Gate on it, then make the
-   assertion itself carry the wait (see the next entry).
+   startup state handling is still pending. What it does not tell you is that
+   startup *finished*. On the re-join path a `page.reload()` takes (the R session
+   is still up, so `sessionInfo`'s `deferred_init_completed` is already true and
+   `DeferredInitCompletedEvent` never re-fires), `Application.java` sets `ready`
+   in `initializeAgent()` and calls `initializeWorkbench()` next -- in the same
+   task, so you cannot observe the gap between them, and seeing `ready` does mean
+   the panes exist. But anything startup defers to a *later* task is still
+   outstanding: `Scheduler.scheduleDeferred` work, and timers such as the 200ms
+   one in `PaneManager.ZoomedTabStateValue.onInit`. Gate on `ready`, then make
+   the assertion itself carry the rest of the wait (see the next entry).
 
 12. **`expect.poll` cannot assert that something never happens.** It returns on
    the first passing sample, so when the pre-condition state *is* the passing


### PR DESCRIPTION
Adds three entries to the "Waits and markers that lie" section of the
`rstudio-create-playwright-tests` skill. No product change; guidance only, so no
NEWS entry and no associated issue.

Each of these was found the hard way while writing the regression tests for
#18444 (#18454): in every case a test passed while never exercising the code it
was written to guard.

1. **A console prompt does not mean R-side change detection has run.** The
   session enqueues `kConsolePrompt` before calling `onDetectChanges`
   (`SessionConsoleInput.cpp`), so `executeInConsole` -- which resolves on the
   prompt counter -- returns before a plot raising the Plots pane, a package-list
   refresh, or a file change has been queued. A test that waits on the prompt and
   then measures asserts against the pre-effect state.

2. **Client state is pushed on a passive 5s timer.** `persistClientState()` fires
   `PushClientStateEvent` with `active=false`, so `ClientStateUpdater` reschedules
   rather than nudging. A test that changes persisted state and reloads outruns
   the save and restores nothing. The entry gives the `set_client_state`
   `waitForResponse` predicate, and notes that all state values ship in one RPC,
   so the wait also gates state written by other components in the same push.

3. **`window.rstudio.ready`, not a pane selector, gates post-reload state.**
   Workbench pane elements attach at construction, well before client state is
   applied, so `waitForSelector('#rstudio_TabSet1_pane')` returns while startup
   state handling is still pending -- including work deferred on a timer, such as
   `PaneManager.ZoomedTabStateValue.onInit`.