### PR TITLE
e2e: don't race Chromium's Local State write in sibling config dirs

### DIFF
--- a/e2e/rstudio/fixtures/rstudio.fixture.ts
+++ b/e2e/rstudio/fixtures/rstudio.fixture.ts
@@ -32,6 +32,10 @@ interface SessionContext {
   page: Page;
   consoleBuffer: ConsoleLine[];
   logDir?: string;
+  // Config root of this worker's own Desktop launch (desktop only). The
+  // sandbox layout test uses it to scope assertions that only hold while
+  // the launching instance is alive (see #18475).
+  configRoot?: string;
 }
 
 /** Tags whose tests intentionally run with an AI assistant active. */
@@ -251,7 +255,12 @@ export const test = base.extend<
       const session = await launchRStudio();
       attachConsoleCapture(session.page, consoleBuffer);
       await logVersions(session.page);
-      await use({ page: session.page, consoleBuffer, logDir: session.logDir });
+      await use({
+        page: session.page,
+        consoleBuffer,
+        logDir: session.logDir,
+        configRoot: session.configRoot,
+      });
       // Debug-only: keep the session alive after the last test so you can
       // keep inspecting; press Enter in the Console to quit. No-op otherwise.
       await waitForUserConsoleInput(session.page, 'quit RStudio');

--- a/e2e/rstudio/tests/sandbox.test.ts
+++ b/e2e/rstudio/tests/sandbox.test.ts
@@ -19,9 +19,7 @@ const SANDBOX = process.env.PW_SANDBOX;
 test.describe('sandbox layout', { tag: ['@desktop_only'] }, () => {
   test.skip(!SANDBOX, 'PW_SANDBOX is not set; sandbox-setup did not run');
 
-  test('Desktop launch populates electron-userdata and creates data-home/user-home', async ({ rstudioPage }) => {
-    void rstudioPage; // Triggers the worker-scoped launch.
-
+  test('Desktop launch populates electron-userdata and creates data-home/user-home', async ({ rstudioSession }) => {
     // Sandbox-level dirs: user-home is shared; data-home is only the
     // seeded-pai source (Desktop sessions get per-spec data homes below).
     expect(fs.existsSync(path.join(SANDBOX!, 'data-home'))).toBe(true);
@@ -32,7 +30,12 @@ test.describe('sandbox layout', { tag: ['@desktop_only'] }, () => {
     // or relaunch from scratch can add more config dirs over a full-suite
     // run. Validate the layout against *every* config dir so a partial-init
     // sibling (e.g., from a Desktop spawn that died mid-launch) can't pass
-    // silently behind a healthy one chosen by readdir order.
+    // silently behind a healthy one chosen by readdir order. Only markers
+    // written synchronously before/at launch are asserted here: Chromium
+    // writes electron-userdata/Local State through a delayed committer
+    // (~10s after launch), so a healthy sibling instance that exited young
+    // may never have flushed it, and its stale dir would fail this test on
+    // every retry for the rest of the run (#18475).
     const configDirs = fs.readdirSync(SANDBOX!).filter(e => e.startsWith('config_'));
     expect(configDirs.length).toBeGreaterThanOrEqual(1);
 
@@ -43,16 +46,9 @@ test.describe('sandbox layout', { tag: ['@desktop_only'] }, () => {
         `${dir}: expected config-home/rstudio-prefs.json to exist`,
       ).toBe(true);
 
-      const electronData = path.join(configRoot, 'electron-userdata');
       expect(
-        fs.existsSync(electronData),
+        fs.existsSync(path.join(configRoot, 'electron-userdata')),
         `${dir}: expected electron-userdata to exist`,
-      ).toBe(true);
-      // Electron writes Local State asynchronously at startup. Poll for it
-      // rather than asserting readdirSync().length > 0 on a single read.
-      await expect.poll(
-        () => fs.existsSync(path.join(electronData, 'Local State')),
-        { message: `${dir}: expected electron-userdata/Local State to exist` },
       ).toBe(true);
 
       // Each config root carries its own isolated data home; a shared one
@@ -63,6 +59,22 @@ test.describe('sandbox layout', { tag: ['@desktop_only'] }, () => {
         `${dir}: expected per-spec data-home to exist`,
       ).toBe(true);
     }
+
+    // Check Local State -- proof that Electron actually adopted our
+    // --user-data-dir -- only in this worker's own config root, whose
+    // instance is still alive and therefore guaranteed to reach Chromium's
+    // first commit. The poll budget must cover the committer's ~10s delay,
+    // measured from process start; the default 5s expect timeout left too
+    // little headroom when launch readiness came up fast.
+    const ownConfigRoot = rstudioSession.configRoot;
+    expect(ownConfigRoot, 'expected the desktop fixture to expose its config root').toBeTruthy();
+    await expect.poll(
+      () => fs.existsSync(path.join(ownConfigRoot!, 'electron-userdata', 'Local State')),
+      {
+        message: 'expected electron-userdata/Local State to exist in the current spec config root',
+        timeout: 15000,
+      },
+    ).toBe(true);
 
     // The session persists its state under RSTUDIO_DATA_HOME; at least the
     // current worker's launch must have written there. Catches the session


### PR DESCRIPTION
The sandbox layout test polls for `electron-userdata/Local State` in every `config_*` dir of the shared per-run sandbox. Chromium writes that file through a delayed committer (~10s after launch), and `shutdownRStudio` SIGTERMs the process group -- so any Desktop instance that lives less than ~10 seconds (the sandbox-setup warmup probe, the multi-instance specs) can leave a sibling config dir that permanently lacks `Local State`. One such dir makes this test fail on every retry for the rest of the run.

The `Local State` check only proves something for an instance that is still alive, so:

- Sibling `config_*` dirs are now validated against synchronously written markers only (`config-home/rstudio-prefs.json`, `electron-userdata/`, `data-home/`), which is deterministic regardless of how long the sibling instance lived.
- The `Local State` poll is kept for the current worker's own config root (its instance is guaranteed alive), with the poll budget raised to 15s so it covers the committer's ~10s post-launch delay even when launch readiness comes up fast. The worker fixture now exposes its `configRoot` to make that scoping possible.

Verified locally: typecheck clean, and the desktop test passes both in a plain run and with `PW_WARMUP_LAUNCH=1` forcing a short-lived (~5s) sibling launch ahead of the worker's own.

Fixes #18475.
