### PR TITLE
e2e: pre-install required R packages on the windows and macos runners

### DIFF
--- a/.github/actions/os-e2e-deps/action.yml
+++ b/.github/actions/os-e2e-deps/action.yml
@@ -32,7 +32,10 @@ inputs:
       installs nothing at test time. Callers that leave this empty pay
       globalSetup's install into its own (uncached) default library on every
       run: a fast binary download where PPM covers the platform, a full source
-      compile where it doesn't (Fedora). All Linux e2e engines set it.
+      compile where it doesn't (Fedora) -- and any upstream outage during that
+      install surfaces as mid-suite hangs. Every desktop e2e engine sets it;
+      the Linux Server workflow instead seeds a system library of its own
+      (its tests uninstall packages, which a root-owned seed would break).
     required: false
     default: ""
 
@@ -141,9 +144,10 @@ runs:
           ask = FALSE,
           upgrade = FALSE
         )
-        # On distros without CRAN binaries (Fedora), also install the harness's
-        # REQUIRED_PACKAGES set now so it lands in the cached library rather than
-        # being source-compiled by the Playwright globalSetup at test time. Reads
+        # When requested, also install the harness's REQUIRED_PACKAGES set now
+        # so it lands in the cached library rather than being installed by the
+        # Playwright globalSetup at test time (a source compile on distros
+        # without CRAN binaries, a CRAN download everywhere else). Reads
         # the same required-packages.txt that fixtures/r-libs-setup.ts reads, so
         # the two sets can't drift. Both the presence check and the install are
         # scoped to R_LIBS_USER (the cached tree), mirroring the harness's own

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
@@ -80,6 +80,12 @@ jobs:
         shell: pwsh
     env:
       R_LIBS_USER: ${{ github.workspace }}\R-libs
+      # Point globalSetup's R-libs provisioner at the same library the
+      # e2e-deps action installs and caches (see the main windows-server-2025
+      # workflow). Without this the harness default is
+      # %LOCALAPPDATA%\rstudio-playwright\r-libs\... -- a different path, so
+      # packages re-download from CRAN on every run of this ephemeral runner.
+      PW_RSTUDIO_R_LIBS_USER: ${{ github.workspace }}\R-libs
 
     steps:
       - uses: actions/checkout@v4
@@ -181,10 +187,14 @@ jobs:
           }
           Get-Item $exe | Format-List FullName, Length, LastWriteTime
 
+      # install-required-packages: see the main windows-server-2025 workflow --
+      # pre-installs the harness's REQUIRED_PACKAGES set into the cached
+      # library so nothing installs from CRAN at test time.
       - name: Install e2e test dependencies
         uses: ./.github/actions/os-e2e-deps
         with:
           r-libs-user: ${{ env.R_LIBS_USER }}
+          install-required-packages: "true"
 
       - name: Run Playwright tests
         working-directory: e2e/rstudio

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-14-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-14-arm64.yml
@@ -367,6 +367,12 @@ jobs:
       # (PW_SANDBOX_ROOT_CREATE=1).
       PW_SANDBOX_ROOT: ${{ github.workspace }}/pw-sandbox
       PW_SANDBOX_ROOT_CREATE: '1'
+      # Point globalSetup's R-libs provisioner at the same library the
+      # e2e-deps action installs and caches. Without this the harness default
+      # is ~/.cache/rstudio-playwright/r-libs/... -- a different, uncached
+      # path, so packages re-download from CRAN on every run of this
+      # ephemeral runner.
+      PW_RSTUDIO_R_LIBS_USER: ${{ github.workspace }}/R-libs
 
     steps:
       - uses: actions/checkout@v4
@@ -516,6 +522,11 @@ jobs:
           # by both.
           cache-scope: macos14-arm64
           r-libs-user: ${{ env.R_LIBS_USER }}
+          # Pre-install the harness's REQUIRED_PACKAGES set into the cached
+          # library (found via PW_RSTUDIO_R_LIBS_USER in the job env above),
+          # so nothing installs from CRAN at test time; a CRAN outage
+          # otherwise surfaces as mid-suite install hangs.
+          install-required-packages: "true"
 
       - name: Run Playwright tests
         working-directory: e2e/rstudio

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-15-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-15-x86_64.yml
@@ -344,6 +344,12 @@ jobs:
       # (PW_SANDBOX_ROOT_CREATE=1).
       PW_SANDBOX_ROOT: ${{ github.workspace }}/pw-sandbox
       PW_SANDBOX_ROOT_CREATE: '1'
+      # Point globalSetup's R-libs provisioner at the same library the
+      # e2e-deps action installs and caches. Without this the harness default
+      # is ~/.cache/rstudio-playwright/r-libs/... -- a different, uncached
+      # path, so packages re-download from CRAN on every run of this
+      # ephemeral runner.
+      PW_RSTUDIO_R_LIBS_USER: ${{ github.workspace }}/R-libs
 
     steps:
       - uses: actions/checkout@v4
@@ -490,6 +496,11 @@ jobs:
           # and each restores the other's wrong-arch binaries (pak/cli .so fail
           # to dyn.load). Scope by OS and arch to isolate the two.
           cache-scope: macos15-x86_64
+          # Pre-install the harness's REQUIRED_PACKAGES set into the cached
+          # library (found via PW_RSTUDIO_R_LIBS_USER in the job env above),
+          # so nothing installs from CRAN at test time; a CRAN outage
+          # otherwise surfaces as mid-suite install hangs.
+          install-required-packages: "true"
 
       - name: Run Playwright tests
         working-directory: e2e/rstudio

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -333,6 +333,12 @@ jobs:
       # (PW_SANDBOX_ROOT_CREATE=1).
       PW_SANDBOX_ROOT: ${{ github.workspace }}/pw-sandbox
       PW_SANDBOX_ROOT_CREATE: '1'
+      # Point globalSetup's R-libs provisioner at the same library the
+      # e2e-deps action installs and caches. Without this the harness default
+      # is ~/.cache/rstudio-playwright/r-libs/... -- a different, uncached
+      # path, so packages re-download from CRAN on every run of this
+      # ephemeral runner.
+      PW_RSTUDIO_R_LIBS_USER: ${{ github.workspace }}/R-libs
 
     steps:
       - uses: actions/checkout@v4
@@ -467,6 +473,11 @@ jobs:
           # so scope by OS and arch to keep the arm64 and x86_64 R-library
           # caches from colliding.
           cache-scope: macos26-arm64
+          # Pre-install the harness's REQUIRED_PACKAGES set into the cached
+          # library (found via PW_RSTUDIO_R_LIBS_USER in the job env above),
+          # so nothing installs from CRAN at test time; a CRAN outage
+          # otherwise surfaces as mid-suite install hangs.
+          install-required-packages: "true"
 
       - name: Run Playwright tests
         working-directory: e2e/rstudio

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -878,10 +878,17 @@ jobs:
           }
           Get-Item $exe | Format-List FullName, Length, LastWriteTime
 
+      # install-required-packages pre-installs the harness's REQUIRED_PACKAGES
+      # set into the cached R library that PW_RSTUDIO_R_LIBS_USER (job env
+      # above) points globalSetup at, so tests find every package present and
+      # install nothing at test time. Without it the set is fetched from
+      # cran.r-project.org on every run, and a CRAN outage surfaces as
+      # mid-suite install hangs (s4_unloaded_package, shinytest2).
       - name: Install e2e test dependencies
         uses: ./.github/actions/os-e2e-deps
         with:
           r-libs-user: ${{ env.R_LIBS_USER }}
+          install-required-packages: "true"
 
       - name: Run Playwright tests
         working-directory: e2e/rstudio

--- a/e2e/rstudio/fixtures/r-libs-setup.ts
+++ b/e2e/rstudio/fixtures/r-libs-setup.ts
@@ -43,10 +43,11 @@ const TOTAL_WORKERS_ENV = 'PW_TOTAL_WORKERS';
  *
  * The list lives in ../required-packages.txt as the single source of truth, so
  * the os-e2e-deps action can install the identical set into the cached R
- * library on distros without CRAN binaries (Fedora) -- if the two lists ever
- * drifted, globalSetup would source-compile the difference at test time. One
- * package per line; blank lines and #-comments are ignored. Adding a package
- * is cheap; trim only when it's genuinely unused by any test in the suite.
+ * library in CI -- if the two lists ever drifted, globalSetup would install
+ * the difference at test time (a source compile on distros without CRAN
+ * binaries). One package per line; blank lines and #-comments are ignored.
+ * Adding a package is cheap; trim only when it's genuinely unused by any test
+ * in the suite.
  */
 const requiredPackagesFile = path.join(__dirname, '..', 'required-packages.txt');
 export const REQUIRED_PACKAGES: readonly string[] = fs

--- a/e2e/rstudio/required-packages.txt
+++ b/e2e/rstudio/required-packages.txt
@@ -1,7 +1,7 @@
 # R packages pre-installed into the shared R library by globalSetup
-# (fixtures/r-libs-setup.ts) and, on distros without CRAN binaries (Fedora),
-# by the os-e2e-deps action so they land in the cached library instead of
-# compiling at test time. Single source of truth -- both the TypeScript
+# (fixtures/r-libs-setup.ts) and, in CI, by the os-e2e-deps action
+# (install-required-packages) so they land in the cached library instead of
+# being installed at test time. Single source of truth -- both the TypeScript
 # harness and the bash action read this file. One package per line; blank
 # lines and #-comments are ignored.
 DBI


### PR DESCRIPTION
## Problem

In the [pr-18449 all-platforms e2e run](https://rstudio-playwright-reports.s3.amazonaws.com/pr-18449/31218669330-1/all-platforms/index.html), all three unexpected failures were desktop-windows tests hung in mid-suite package installs: `s4_unloaded_package.test.ts` stuck on `.rs.ensurePackageInstalled("DBI", repos = "https://cran.r-project.org")` with

```
warning: unable to access index for repository https://cran.r-project.org/src/contrib:
  cannot open URL 'https://cran.r-project.org/src/contrib/PACKAGES'
```

and `shinytest2.test.ts` stuck on `install.packages("shinytest2", ...)` with no output, both until the test timeout.

The root cause is that the Windows and macOS e2e workflows never pass `install-required-packages` to the `os-e2e-deps` action, so the cached R library contains only the harness's DESCRIPTION dependencies. The `required-packages.txt` set (which already includes DBI and shinytest2) is instead installed from **cran.r-project.org at test time on every run** -- by globalSetup when CRAN is reachable, and by per-test `ensurePackages` self-healing when it is not. A CRAN outage therefore surfaces as mid-suite hangs rather than a fast, clearly-attributed setup failure.

Linux already works the way we want: PR #18390 flipped `preinstall_r_packages` on for every Linux engine, installing the set from PPM into the cached library before tests run.

## Change

- Pass `install-required-packages: "true"` to `os-e2e-deps` in the Windows main workflow, the scheduled Windows autocomplete workflow, and all three macOS workflows, matching the Linux engines. The set installs from PPM (not cran.r-project.org) in the deps step, lands in the cached `R-libs` tree, and a warm cache installs nothing at all. A cold-cache install failure now fails the "Install e2e test dependencies" step instead of hanging tests.
- Add the `PW_RSTUDIO_R_LIBS_USER` wiring (pointing globalSetup at that same library) to the macOS and autocomplete workflows; the main Windows workflow already had it. Without it, globalSetup provisions the harness-default per-host path, which is a different, uncached directory on these ephemeral runners.
- Refresh the comments in `os-e2e-deps/action.yml`, `required-packages.txt`, and `r-libs-setup.ts` that described the required-set install as Fedora-only.

The Linux Server workflow is deliberately unchanged: it seeds a root-owned system library with its own curated list, because its sessions run as a per-run user and tests that exercise uninstall flows (fortunes, DBI) cannot remove packages from a root-owned library.

## Notes

- The R-library cache key gains a `-req<hash>` suffix when the flag is set; `restore-keys` still prefix-matches the old caches, so the first runs restore the existing library and top up the missing packages. The scheduled main-branch runs then save the complete library under the new key.
- Test-time `ensurePackages`/`ensurePackageInstalled` calls still exist as a self-heal path, and they still point at cran.r-project.org; with the library pre-populated they reduce to presence checks. Repointing them at PPM would be a possible follow-up but is not needed for this fix.

## Verification

- YAML parses; `actionlint` reports only pre-existing shellcheck style notes (identical count on `main`).
- `e2e/rstudio` source changes are comment-only.