### PR TITLE
Seed What's New content for 2026.09 (Autumn Hawkbit)

### DIFF
--- a/src/node/desktop/src/assets/whats-new/autumn-hawkbit/index.html
+++ b/src/node/desktop/src/assets/whats-new/autumn-hawkbit/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' file:;">
+  <link rel="stylesheet" href="../whats-new-base.css">
+  <title>What's New in RStudio</title>
+</head>
+<body>
+  <div class="feature-section">
+    <h2>New Features</h2>
+    <ul>
+      <li><strong>Coming soon:</strong> TODO replace this placeholder with the first entry.</li>
+    </ul>
+  </div>
+
+  <div class="feature-section">
+    <h2>Fixes</h2>
+    <p>
+      For a full list of bug fixes in this release, see the
+      <a href="https://www.rstudio.org/links/release_notes#rstudio-2026.09.0">release notes</a>.
+    </p>
+  </div>
+
+</body>
+</html>


### PR DESCRIPTION
Adds `src/node/desktop/src/assets/whats-new/autumn-hawkbit/index.html`, the release-content folder for 2026.09. The slug matches `version/RELEASE` ("Autumn Hawkbit"), so **Help** > **What's New** loads this page in a developer build of the current release.

The page follows the template in `whats-new/README.md`: the required `Content-Security-Policy` meta tag, the `whats-new-base.css` link, a "New Features" section holding a single placeholder entry, and a "Fixes" section linking to the `2026.09.0` release notes. The feature list is a `TODO` to be replaced as content is written for the release.

### Verification

The content-validation tests in `test/unit/main/whats-new-utils.test.ts` enumerate the release folders, so the new folder is covered automatically:

```
cd src/node/desktop && npx electron-mocha --no-sandbox --config ./test/unit/mocharc.json --grep "whats-new content validation"

  whats-new content validation
    ✔ autumn-hawkbit/index.html includes CSP meta tag
    ✔ autumn-hawkbit/index.html includes base stylesheet
    ...
  12 passing
```

No NEWS.md entry: this is placeholder content for the in-progress release.