### PR TITLE
Resolve e2e daily builds per branch, not via /rstudio/latest

### DIFF
--- a/.github/actions/os-resolve-daily-manifest/action.yml
+++ b/.github/actions/os-resolve-daily-manifest/action.yml
@@ -1,0 +1,62 @@
+name: "Resolve daily build manifest URL"
+description: >
+  Build the URL of the dailies.rstudio.com JSON manifest for the release branch
+  this checkout is on, so the installer CI downloads matches the tests checked
+  out beside it.
+
+  Do not use the /rstudio/latest alias for this. That alias is generated
+  separately from the per-branch manifests, and its index.json can lag a branch
+  rollover by days: after the 2026.08 branch cut, /rstudio/latest/ served
+  Autumn Hawkbit (2026.09) as a web page while /rstudio/latest/index.json still
+  named a Yellow Yarrow (2026.08) build. CI reads the JSON, so the scheduled
+  e2e rotation installed a 2026.08 binary and ran main's tests against it --
+  every test covering behavior added after the cut failed on every platform
+  (#18498). A manifest named after its own branch cannot be mis-pointed that
+  way.
+
+  The path segment is the "flower" name: version/RELEASE, lowercased, with
+  spaces turned into hyphens. docker/jenkins/publish-build.sh derives it the
+  same way when it publishes a build, and writes the manifest under it, so the
+  reader and the writer stay in step.
+
+  Requires the repository to be checked out, because version/RELEASE is read
+  from the workspace. Computes a URL and makes no network request, so it is
+  safe to run in a job that turns out not to need a manifest.
+
+outputs:
+  flower:
+    description: 'Release branch slug taken from version/RELEASE, e.g. "autumn-hawkbit".'
+    value: ${{ steps.resolve.outputs.flower }}
+  manifest-url:
+    description: "URL of the daily build manifest for this branch."
+    value: ${{ steps.resolve.outputs.manifest-url }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: resolve
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if [ ! -e version/RELEASE ]; then
+          echo "::error::version/RELEASE not found. Check out the repository before this action."
+          exit 1
+        fi
+
+        # Same derivation as flower() in docker/jenkins/rstudio-version.sh,
+        # which is the name publish-build.sh writes the manifest under.
+        FLOWER=$(tr ' ' '-' < version/RELEASE | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+
+        # A flower name is one path segment. Rejecting anything else stops a
+        # malformed version/RELEASE from resolving to some other object on the
+        # dailies host instead of failing.
+        if ! printf '%s' "$FLOWER" | grep -qE '^[a-z0-9][a-z0-9-]*$'; then
+          echo "::error::version/RELEASE does not yield a usable manifest path segment (got '$FLOWER')."
+          exit 1
+        fi
+
+        MANIFEST_URL="https://dailies.rstudio.com/rstudio/$FLOWER/index.json"
+        echo "flower=$FLOWER"             >> "$GITHUB_OUTPUT"
+        echo "manifest-url=$MANIFEST_URL" >> "$GITHUB_OUTPUT"
+        echo "Daily manifest for '$FLOWER': $MANIFEST_URL"

--- a/.github/workflows/os-test-e2e-rstudio-desktop-linux.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-linux.yml
@@ -714,21 +714,26 @@ jobs:
           ls -la /usr/bin/rstudio
 
       # Daily-download path: resolve and install the latest (or specified)
-      # installer. Runs when build_from_source is false (auto-resolve the
-      # daily via dailies.rstudio.com/rstudio/latest/index.json) or when an
-      # explicit rstudio_installer_url is provided (use that URL verbatim).
+      # installer. Runs when build_from_source is false (auto-resolve this
+      # branch's daily from its per-branch manifest) or when an explicit
+      # rstudio_installer_url is provided (use that URL verbatim).
+      - name: Resolve daily manifest URL
+        id: manifest
+        uses: ./.github/actions/os-resolve-daily-manifest
+
       - name: Resolve installer URL
         if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
         id: resolve
         env:
           INSTALLER_URL: ${{ inputs.rstudio_installer_url }}
           DAILY_KEY: ${{ needs.setup.outputs.daily_platform_key }}
+          MANIFEST_URL: ${{ steps.manifest.outputs.manifest-url }}
         run: |
           URL="$INSTALLER_URL"
           SHA=""
           FILENAME=""
           if [ -z "$URL" ]; then
-            MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 'https://dailies.rstudio.com/rstudio/latest/index.json')
+            MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 "$MANIFEST_URL")
             # daily_platform_key names this engine's installer under the
             # electron product. Engines with no daily of their own reuse the
             # nearest build of the same arch: Debian -> the Ubuntu 24 daily
@@ -739,10 +744,10 @@ jobs:
             SHA=$(echo "$MANIFEST" | jq -r --arg k "$DAILY_KEY" '.products.electron.platforms[$k].sha256 // empty')
             FILENAME=$(echo "$MANIFEST" | jq -r --arg k "$DAILY_KEY" '.products.electron.platforms[$k].filename // empty')
             if [ -z "$URL" ] || [ -z "$FILENAME" ] || [ -z "$SHA" ]; then
-              echo "::error::Daily manifest is missing expected fields for '$DAILY_KEY' (url='$URL', filename='$FILENAME', sha256='$SHA'). The schema at https://dailies.rstudio.com/rstudio/latest/index.json may have changed."
+              echo "::error::No usable '$DAILY_KEY' entry in $MANIFEST_URL (url='$URL', filename='$FILENAME', sha256='$SHA'). Either this release branch has no daily for that platform yet, or the manifest schema changed. Re-run with build_from_source to test this branch without a daily."
               exit 1
             fi
-            echo "Auto-resolved latest $DAILY_KEY desktop daily:"
+            echo "Auto-resolved $DAILY_KEY desktop daily:"
             echo "  URL:      $URL"
             echo "  SHA-256:  $SHA"
             echo "  Filename: $FILENAME"

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-autocomplete-scheduled-windows-server-2025.yml
@@ -105,26 +105,32 @@ jobs:
           rig ls
           New-Item -ItemType Directory -Force -Path $env:R_LIBS_USER | Out-Null
 
+      - name: Resolve daily manifest URL
+        id: manifest
+        uses: ./.github/actions/os-resolve-daily-manifest
+
       - name: Resolve RStudio .exe URL
         id: resolve
         env:
           INSTALLER_URL: ${{ inputs.rstudio_installer_url }}
+          MANIFEST_URL: ${{ steps.manifest.outputs.manifest-url }}
         run: |
           $ErrorActionPreference = 'Stop'
           $url = $env:INSTALLER_URL
+          $manifestUrl = $env:MANIFEST_URL
           $sha = ''
           $filename = ''
           if ([string]::IsNullOrEmpty($url)) {
-            $manifest = Invoke-RestMethod -Uri 'https://dailies.rstudio.com/rstudio/latest/index.json'
+            $manifest = Invoke-RestMethod -Uri $manifestUrl
             $win = $manifest.products.electron.platforms.windows
             $url = $win.link
             $sha = $win.sha256
             $filename = $win.filename
             if ([string]::IsNullOrEmpty($url) -or [string]::IsNullOrEmpty($filename) -or [string]::IsNullOrEmpty($sha)) {
-              Write-Error "Daily manifest is missing expected fields (url='$url', filename='$filename', sha256='$sha'). The schema at https://dailies.rstudio.com/rstudio/latest/index.json may have changed."
+              Write-Error "No usable windows entry in $manifestUrl (url='$url', filename='$filename', sha256='$sha'). Either this release branch has no Windows daily yet, or the manifest schema changed."
               exit 1
             }
-            Write-Host "Auto-resolved latest windows daily:"
+            Write-Host "Auto-resolved windows daily:"
             Write-Host "  URL:      $url"
             Write-Host "  SHA-256:  $sha"
             Write-Host "  Filename: $filename"

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-14-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-14-arm64.yml
@@ -424,27 +424,32 @@ jobs:
 
       # Daily-download path: resolve and install the latest (or specified) .dmg.
       # Runs when build_from_source is false or an explicit URL was provided.
+      - name: Resolve daily manifest URL
+        id: manifest
+        uses: ./.github/actions/os-resolve-daily-manifest
+
       - name: Resolve RStudio .dmg URL
         if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
         id: resolve
         env:
           INSTALLER_URL: ${{ inputs.rstudio_installer_url }}
+          MANIFEST_URL: ${{ steps.manifest.outputs.manifest-url }}
         run: |
           URL="$INSTALLER_URL"
           SHA=""
           FILENAME=""
           if [ -z "$URL" ]; then
-            MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 'https://dailies.rstudio.com/rstudio/latest/index.json')
+            MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 "$MANIFEST_URL")
             # macOS ships a single universal .dmg keyed "macos" in the daily
             # manifest (older schemas used "mac-arm64"/"mac"; kept as fallbacks).
             URL=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["macos"].link // .products.electron.platforms["mac-arm64"].link // .products.electron.platforms["mac"].link // empty')
             SHA=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["macos"].sha256 // .products.electron.platforms["mac-arm64"].sha256 // .products.electron.platforms["mac"].sha256 // empty')
             FILENAME=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["macos"].filename // .products.electron.platforms["mac-arm64"].filename // .products.electron.platforms["mac"].filename // empty')
             if [ -z "$URL" ] || [ -z "$FILENAME" ] || [ -z "$SHA" ]; then
-              echo "::error::Daily manifest is missing expected fields (url='$URL', filename='$FILENAME', sha256='$SHA'). The schema at https://dailies.rstudio.com/rstudio/latest/index.json may have changed."
+              echo "::error::No usable macos entry in $MANIFEST_URL (url='$URL', filename='$FILENAME', sha256='$SHA'). Either this release branch has no macOS daily yet, or the manifest schema changed. Re-run with build_from_source to test this branch without a daily."
               exit 1
             fi
-            echo "Auto-resolved latest macOS daily:"
+            echo "Auto-resolved macOS daily:"
             echo "  URL:      $URL"
             echo "  SHA-256:  $SHA"
             echo "  Filename: $FILENAME"

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-15-x86_64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-15-x86_64.yml
@@ -401,27 +401,32 @@ jobs:
 
       # Daily-download path: resolve and install the latest (or specified) .dmg.
       # Runs when build_from_source is false or an explicit URL was provided.
+      - name: Resolve daily manifest URL
+        id: manifest
+        uses: ./.github/actions/os-resolve-daily-manifest
+
       - name: Resolve RStudio .dmg URL
         if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
         id: resolve
         env:
           INSTALLER_URL: ${{ inputs.rstudio_installer_url }}
+          MANIFEST_URL: ${{ steps.manifest.outputs.manifest-url }}
         run: |
           URL="$INSTALLER_URL"
           SHA=""
           FILENAME=""
           if [ -z "$URL" ]; then
-            MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 'https://dailies.rstudio.com/rstudio/latest/index.json')
+            MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 "$MANIFEST_URL")
             # macOS ships a single universal .dmg keyed "macos" in the daily
             # manifest (older schemas used "mac-arm64"/"mac"; kept as fallbacks).
             URL=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["macos"].link // .products.electron.platforms["mac-arm64"].link // .products.electron.platforms["mac"].link // empty')
             SHA=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["macos"].sha256 // .products.electron.platforms["mac-arm64"].sha256 // .products.electron.platforms["mac"].sha256 // empty')
             FILENAME=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["macos"].filename // .products.electron.platforms["mac-arm64"].filename // .products.electron.platforms["mac"].filename // empty')
             if [ -z "$URL" ] || [ -z "$FILENAME" ] || [ -z "$SHA" ]; then
-              echo "::error::Daily manifest is missing expected fields (url='$URL', filename='$FILENAME', sha256='$SHA'). The schema at https://dailies.rstudio.com/rstudio/latest/index.json may have changed."
+              echo "::error::No usable macos entry in $MANIFEST_URL (url='$URL', filename='$FILENAME', sha256='$SHA'). Either this release branch has no macOS daily yet, or the manifest schema changed. Re-run with build_from_source to test this branch without a daily."
               exit 1
             fi
-            echo "Auto-resolved latest macOS daily:"
+            echo "Auto-resolved macOS daily:"
             echo "  URL:      $URL"
             echo "  SHA-256:  $SHA"
             echo "  Filename: $FILENAME"

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml
@@ -379,27 +379,32 @@ jobs:
 
       # Daily-download path: resolve and install the latest (or specified) .dmg.
       # Runs when build_from_source is false or an explicit URL was provided.
+      - name: Resolve daily manifest URL
+        id: manifest
+        uses: ./.github/actions/os-resolve-daily-manifest
+
       - name: Resolve RStudio .dmg URL
         if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
         id: resolve
         env:
           INSTALLER_URL: ${{ inputs.rstudio_installer_url }}
+          MANIFEST_URL: ${{ steps.manifest.outputs.manifest-url }}
         run: |
           URL="$INSTALLER_URL"
           SHA=""
           FILENAME=""
           if [ -z "$URL" ]; then
-            MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 'https://dailies.rstudio.com/rstudio/latest/index.json')
+            MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 "$MANIFEST_URL")
             # macOS ships a single universal .dmg keyed "macos" in the daily
             # manifest (older schemas used "mac-arm64"/"mac"; kept as fallbacks).
             URL=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["macos"].link // .products.electron.platforms["mac-arm64"].link // .products.electron.platforms["mac"].link // empty')
             SHA=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["macos"].sha256 // .products.electron.platforms["mac-arm64"].sha256 // .products.electron.platforms["mac"].sha256 // empty')
             FILENAME=$(echo "$MANIFEST" | jq -r '.products.electron.platforms["macos"].filename // .products.electron.platforms["mac-arm64"].filename // .products.electron.platforms["mac"].filename // empty')
             if [ -z "$URL" ] || [ -z "$FILENAME" ] || [ -z "$SHA" ]; then
-              echo "::error::Daily manifest is missing expected fields (url='$URL', filename='$FILENAME', sha256='$SHA'). The schema at https://dailies.rstudio.com/rstudio/latest/index.json may have changed."
+              echo "::error::No usable macos entry in $MANIFEST_URL (url='$URL', filename='$FILENAME', sha256='$SHA'). Either this release branch has no macOS daily yet, or the manifest schema changed. Re-run with build_from_source to test this branch without a daily."
               exit 1
             fi
-            echo "Auto-resolved latest macOS ARM64 daily:"
+            echo "Auto-resolved macOS ARM64 daily:"
             echo "  URL:      $URL"
             echo "  SHA-256:  $SHA"
             echo "  Filename: $FILENAME"

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -794,28 +794,34 @@ jobs:
       # Daily-download path: resolve and install the latest (or specified) .exe.
       # Also runs when build_from_source is true but rstudio_installer_url is set
       # (mirrors macOS: the URL overrides the artifact path).
+      - name: Resolve daily manifest URL
+        id: manifest
+        uses: ./.github/actions/os-resolve-daily-manifest
+
       - name: Resolve RStudio .exe URL
         if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
         id: resolve
         env:
           INSTALLER_URL: ${{ inputs.rstudio_installer_url }}
+          MANIFEST_URL: ${{ steps.manifest.outputs.manifest-url }}
         run: |
           $ErrorActionPreference = 'Stop'
           $url = $env:INSTALLER_URL
+          $manifestUrl = $env:MANIFEST_URL
           $sha = ''
           $filename = ''
           if ([string]::IsNullOrEmpty($url)) {
-            $manifest = Invoke-RestMethod -Uri 'https://dailies.rstudio.com/rstudio/latest/index.json' `
+            $manifest = Invoke-RestMethod -Uri $manifestUrl `
               -MaximumRetryCount 3 -RetryIntervalSec 5
             $win = $manifest.products.electron.platforms.windows
             $url = $win.link
             $sha = $win.sha256
             $filename = $win.filename
             if ([string]::IsNullOrEmpty($url) -or [string]::IsNullOrEmpty($filename) -or [string]::IsNullOrEmpty($sha)) {
-              Write-Error "Daily manifest is missing expected fields (url='$url', filename='$filename', sha256='$sha'). The schema at https://dailies.rstudio.com/rstudio/latest/index.json may have changed."
+              Write-Error "No usable windows entry in $manifestUrl (url='$url', filename='$filename', sha256='$sha'). Either this release branch has no Windows daily yet, or the manifest schema changed. Re-run with build_from_source to test this branch without a daily."
               exit 1
             }
-            Write-Host "Auto-resolved latest windows daily:"
+            Write-Host "Auto-resolved windows daily:"
             Write-Host "  URL:      $url"
             Write-Host "  SHA-256:  $sha"
             Write-Host "  Filename: $filename"

--- a/.github/workflows/os-test-e2e-rstudio-pr.yml
+++ b/.github/workflows/os-test-e2e-rstudio-pr.yml
@@ -11,6 +11,13 @@ on:
       - "e2e/rstudio/**"
       - ".github/actions/os-e2e-deps/**"
       - ".github/actions/os-publish-e2e-report/**"
+      - ".github/actions/os-resolve-daily-manifest/**"
+      # version/RELEASE picks which branch's daily every platform resolves, so
+      # a change to it changes the binary under test. A flower with no daily
+      # yet resolves to a source build via decide(), which is the answer we
+      # want to see proven on the PR that renames it rather than in the next
+      # cron rotation.
+      - "version/RELEASE"
       - ".github/workflows/os-test-e2e-rstudio-pr.yml"
       - ".github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml"
       - ".github/workflows/os-test-e2e-rstudio-desktop-os-macos-26-arm64.yml"

--- a/.github/workflows/os-test-e2e-rstudio-pr.yml
+++ b/.github/workflows/os-test-e2e-rstudio-pr.yml
@@ -55,8 +55,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Resolve daily manifest URL
+        id: manifest
+        uses: ./.github/actions/os-resolve-daily-manifest
+
       - name: Decide build-from-source vs daily (per platform)
         id: check
+        env:
+          MANIFEST_URL: ${{ steps.manifest.outputs.manifest-url }}
         run: |
           BASE=$(git merge-base HEAD origin/${{ github.base_ref }})
           CHANGED=$(git diff --name-only "$BASE" HEAD)
@@ -79,7 +85,7 @@ jobs:
           # build from source. A non-200 response or a body that doesn't parse
           # as JSON is normalized to empty so decide() treats it as unreachable
           # rather than letting a later jq error abort this step.
-          MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 'https://dailies.rstudio.com/rstudio/latest/index.json' || echo '')
+          MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 "$MANIFEST_URL" || echo '')
           if [ -n "$MANIFEST" ] && ! echo "$MANIFEST" | jq empty 2>/dev/null; then
             echo "Daily manifest did not parse as JSON -- treating as unreachable"
             MANIFEST=""

--- a/.github/workflows/os-test-e2e-rstudio-scheduled.yml
+++ b/.github/workflows/os-test-e2e-rstudio-scheduled.yml
@@ -22,6 +22,10 @@ name: "Test: E2E Playwright RStudio (Scheduled Rotation and Run-All, Open Source
 # (see rstudio/latest-builds#251). Manual dispatch can instead build every
 # engine from source via build_from_source.
 #
+# Either way the daily comes from the manifest for the branch this workflow is
+# checked out on, never the /rstudio/latest alias -- see
+# .github/actions/os-resolve-daily-manifest for why (#18498).
+#
 # Cron times are UTC: 08:00 UTC is 4 AM EDT in summer, 3 AM EST in winter.
 
 on:
@@ -161,17 +165,28 @@ jobs:
       jammy_amd64:  ${{ steps.resolve.outputs.jammy_amd64 }}
       resolute_amd64: ${{ steps.resolve.outputs.resolute_amd64 }}
     steps:
+      # version/RELEASE names the branch whose daily manifest the URLs below
+      # come from, so this job needs the repository.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Resolve daily manifest URL
+        id: manifest
+        uses: ./.github/actions/os-resolve-daily-manifest
+
       - id: resolve
         name: Build per-platform installer URLs for a specific version
         env:
           VERSION: ${{ inputs.version }}
           BUILD_FROM_SOURCE: ${{ inputs.build_from_source }}
+          MANIFEST_URL: ${{ steps.manifest.outputs.manifest-url }}
         run: |
           # Emit empty URLs when building from source (engines build, ignoring
-          # any URL) or when no version is given (engines self-resolve the
-          # latest daily, keeping their SHA-256 check). Only a specific version
-          # needs URLs built here: swap the version token (+ -> -) into each
-          # platform's latest download URL.
+          # any URL) or when no version is given (engines self-resolve their
+          # branch's latest daily, keeping their SHA-256 check). Only a specific
+          # version needs URLs built here: swap the version token (+ -> -) into
+          # each platform's latest download URL.
           if [ "$BUILD_FROM_SOURCE" = "true" ] || [ -z "$VERSION" ]; then
             {
               echo "rhel="
@@ -188,7 +203,7 @@ jobs:
             echo "No installer URLs to resolve (building from source or using the latest daily)."
             exit 0
           fi
-          M=$(curl -fsSL --retry 3 --retry-delay 5 'https://dailies.rstudio.com/rstudio/latest/index.json')
+          M=$(curl -fsSL --retry 3 --retry-delay 5 "$MANIFEST_URL")
           REQ=${VERSION//+/-}
           emit() {
             local product="$1" key="$2" link ver cur
@@ -196,7 +211,7 @@ jobs:
             ver=$(printf '%s' "$M" | jq -r ".products.${product}.platforms[\"${key}\"].version // empty")
             cur=${ver//+/-}
             if [ -z "$link" ] || [ -z "$cur" ]; then
-              echo "::error::Could not build a URL for ${product}/${key} from the latest manifest." >&2
+              echo "::error::Could not build a URL for ${product}/${key} from $MANIFEST_URL." >&2
               return 1
             fi
             local out=${link//$cur/$REQ}

--- a/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
+++ b/.github/workflows/os-test-e2e-rstudio-server-os-ubuntu-24.yml
@@ -414,28 +414,33 @@ jobs:
           sudo rstudio-server verify-installation
 
       # Daily-download path: resolve and install the latest (or specified)
-      # .deb. Runs when build_from_source is false (auto-resolve the daily
-      # via dailies.rstudio.com/rstudio/latest/index.json) or when an
-      # explicit rstudio_installer_url is provided (use that URL verbatim).
+      # .deb. Runs when build_from_source is false (auto-resolve this branch's
+      # daily from its per-branch manifest) or when an explicit
+      # rstudio_installer_url is provided (use that URL verbatim).
+      - name: Resolve daily manifest URL
+        id: manifest
+        uses: ./.github/actions/os-resolve-daily-manifest
+
       - name: Resolve RStudio Server .deb URL
         if: inputs.build_from_source == false || inputs.rstudio_installer_url != ''
         id: resolve
         env:
           INSTALLER_URL: ${{ inputs.rstudio_installer_url }}
+          MANIFEST_URL: ${{ steps.manifest.outputs.manifest-url }}
         run: |
           URL="$INSTALLER_URL"
           SHA=""
           FILENAME=""
           if [ -z "$URL" ]; then
-            MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 'https://dailies.rstudio.com/rstudio/latest/index.json')
+            MANIFEST=$(curl -fsSL --retry 3 --retry-delay 5 "$MANIFEST_URL")
             URL=$(echo "$MANIFEST" | jq -r '.products.server.platforms["noble-amd64"].link // empty')
             SHA=$(echo "$MANIFEST" | jq -r '.products.server.platforms["noble-amd64"].sha256 // empty')
             FILENAME=$(echo "$MANIFEST" | jq -r '.products.server.platforms["noble-amd64"].filename // empty')
             if [ -z "$URL" ] || [ -z "$FILENAME" ] || [ -z "$SHA" ]; then
-              echo "::error::Daily manifest is missing expected fields (url='$URL', filename='$FILENAME', sha256='$SHA'). The schema at https://dailies.rstudio.com/rstudio/latest/index.json may have changed."
+              echo "::error::No usable server noble-amd64 entry in $MANIFEST_URL (url='$URL', filename='$FILENAME', sha256='$SHA'). Either this release branch has no Server daily yet, or the manifest schema changed. Re-run with build_from_source to test this branch without a daily."
               exit 1
             fi
-            echo "Auto-resolved latest noble-amd64 server daily:"
+            echo "Auto-resolved noble-amd64 server daily:"
             echo "  URL:      $URL"
             echo "  SHA-256:  $SHA"
             echo "  Filename: $FILENAME"


### PR DESCRIPTION
## Problem

The e2e workflows installed the build named by
`dailies.rstudio.com/rstudio/latest/index.json` while running the tests from the
checked-out branch. Those are two different branches whenever the alias lags a
rollover, and its `index.json` does lag: after the 2026.08 branch cut, the
`/rstudio/latest/` page served Autumn Hawkbit (2026.09) while
`/rstudio/latest/index.json` still named a Yellow Yarrow (2026.08) build.

CI reads the JSON. So the scheduled rotation installed a 2026.08 binary and ran
`main`'s tests against it, and every test covering behavior added after the cut
failed on every platform with nothing wrong in either the test or the product.
Both #18454 and #18470 landed that way: 8 of the 9 tests #18454 added failed,
and the only one that passed was the one asserting behavior that predates it.

## Change

- New `.github/actions/os-resolve-daily-manifest` derives the manifest URL from
  `version/RELEASE`, turning it into the "flower" path segment the same way
  `docker/jenkins/publish-build.sh` does when it writes the manifest. Reader and
  writer stay in step, and a manifest named after its own branch cannot be
  mis-pointed by an alias.
- The nine workflows that read `/rstudio/latest/index.json` now consume that
  output.
- The action validates the derived segment, so a malformed `version/RELEASE`
  fails instead of resolving to some other object on the dailies host.
- The scheduled workflow's `resolve` job gains a checkout, since it cannot read
  `version/RELEASE` otherwise.
- A missing platform key now fails with the branch and key named, and says that
  a source build is how to test a branch without a daily.
- The PR workflow's `paths` filter picks up the new action and `version/RELEASE`,
  so a change to the resolver, or to the input that selects which branch's daily
  it resolves, triggers the workflow that exercises it.

The action computes a URL and makes no network request, so it is safe in the
jobs that end up using an override installer URL instead of a manifest.

## Verification

- `actionlint` over all nine workflows reports the same 17 pre-existing
  shellcheck items as `main`, and no new ones. `shellcheck` is clean on the
  action's script.
- The slug derivation resolves `Autumn Hawkbit` and `Yellow Yarrow` correctly,
  with and without a trailing newline, and rejects `../../evil`, `foo/bar`, an
  empty file, `-leading-dash`, and `Autumn Hawkbit?x=1`.
- Both resolved manifest URLs return HTTP 200 with the expected branch.
- Every `daily_platform_key` in `.github/e2e-linux/*.json`, plus `macos` and
  server `noble-amd64`, resolves in the per-branch manifest.

No NEWS.md entry: this is CI wiring with no user-facing change.

Addresses #18498.
