### PR TITLE
Update Electron to 42.8.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,5 +11,5 @@
 - ([#18482](https://github.com/rstudio/rstudio/issues/18482)): Fixed an issue on Windows where the R session reported a crash as it exited, if a terminal was still running when the session closed. The session had already shut down and saved its state by that point, so nothing was lost, but the spurious report was recorded in the Windows event log and submitted to Windows Error Reporting.
 
 ### Dependencies
--
+- Electron 42.8.1
 

--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -48,7 +48,7 @@
         "chai": "6.2.2",
         "copy-webpack-plugin": "14.0.0",
         "css-loader": "7.1.4",
-        "electron": "42.7.1",
+        "electron": "42.8.1",
         "electron-mocha": "13.1.0",
         "eslint": "10.7.0",
         "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -5926,9 +5926,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "42.7.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.7.1.tgz",
-      "integrity": "sha512-fmjFv4Ebbs/FNZg6a/IAu25lBb8vo/HBVa2vtE2GvYlgAC7/fu8dx1b2pL2wV1yWlfMI2q3Npe4eVYSFGirnwA==",
+      "version": "42.8.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.8.1.tgz",
+      "integrity": "sha512-zQnW4hKUyxzdsw3gvtBszEfZ0d5SGqkAsfdaVFVdHDmzRsgw3rR5so/gB7LS9TLlewoIC0wg0sTIjtn3ilICuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -57,7 +57,7 @@
     "chai": "6.2.2",
     "copy-webpack-plugin": "14.0.0",
     "css-loader": "7.1.4",
-    "electron": "42.7.1",
+    "electron": "42.8.1",
     "electron-mocha": "13.1.0",
     "eslint": "10.7.0",
     "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -97,7 +97,7 @@
     "winston-syslog": "2.7.1"
   },
   "allowScripts": {
-    "electron@42.7.1": true,
+    "electron@42.8.1": true,
     "msgpackr-extract@3.0.3": true,
     "unix-dgram@2.0.6": true
   }


### PR DESCRIPTION
Bumps the pinned Electron version from 42.7.1 to 42.8.1.

- `src/node/desktop/package.json`: `electron` dependency pinned to the exact version `42.8.1`, and the `allowScripts` key updated from `electron@42.7.1` to `electron@42.8.1` so npm's install-script gating still permits Electron's install script.
- `src/node/desktop/package-lock.json`: regenerated by `npm install --save-exact`.
- `NEWS.md`: Electron entry added under `### Dependencies`.

Verification: `npm test` in `src/node/desktop` passes (451 tests). The unit suite does not launch the packaged app, so `npm run package` is worth a manual check before merge.