### PR TITLE
fix(core): exclude ManifestTests.cpp when src/cpp/session is absent

### DIFF
--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -363,6 +363,12 @@ if (RSTUDIO_UNIT_TESTS_ENABLED)
       list(REMOVE_ITEM CORE_TEST_FILES "${CMAKE_CURRENT_SOURCE_DIR}/DatabaseTests.cpp")
    endif()
 
+   # ManifestTests.cpp checks manifests under src/cpp/session and src/cpp/diagnostics,
+   # which are not present in other consumers of this library.
+   if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../session")
+      list(REMOVE_ITEM CORE_TEST_FILES "${CMAKE_CURRENT_SOURCE_DIR}/ManifestTests.cpp")
+   endif()
+
    # Use gtest from vendor directory
    set(GTEST_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/cpp/tests/cpp/tests/vendor/gtest)
    include_directories(${GTEST_SOURCE_DIR}/include)


### PR DESCRIPTION
ManifestTests.cpp checks well-formedness of manifest files under src/cpp/session and src/cpp/diagnostics via RSTUDIO_CPP_SOURCE_DIR relative paths. Those directories are part of the full RStudio product tree and are not present in the Launcher's synced subset of src/cpp (only core/server_core/shared_core), so path.exists() fails for every manifest and all three ManifestTest cases fail on every Launcher build, Linux and macOS alike.

Guard the *Tests.cpp glob with an EXISTS check on src/cpp/session, following the same directory-presence idiom already used elsewhere in this tree (see the rstudio-launcher-tests.in check in src/cpp/CMakeLists.txt) to detect the Launcher-only checkout.

<!-- include an entry in NEWS.md if required -->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Ensure you have updated the QA Notes in the original issue.

### Documentation

> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. If documentation was added in a separate PR, link the PR here.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
