### PR TITLE
remove persisted super dev mode caches in ant clean

### DIFF
--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -555,6 +555,17 @@
       <delete dir="${panmirror.dir}/node_modules" failonerror="false"/>
       <delete dir="gen" failonerror="false" />
       <delete dir="${extras.dir}" failonerror="false" />
+      <!-- Super Dev Mode persists incremental compile state (unit cache +
+           MinimalRebuildCache) under the system temp directory, outside the
+           repository. Stale entries there can poison later devmode compiles
+           with dangling references to renamed synthetic types (e.g.
+           Foo$lambda$N$Type), so remove them here as well. -->
+      <delete failonerror="false" includeemptydirs="true">
+         <fileset dir="${java.io.tmpdir}" defaultexcludes="false">
+            <include name="gwt-cache-*/**"/>
+            <include name="gwt-cache-*"/>
+         </fileset>
+      </delete>
    </target>
 
    <target name="build-unittests" depends="acesupport,javac" description="Builds JUnit unit tests">


### PR DESCRIPTION
## Problem

GWT Super Dev Mode persists incremental compile state (the unit cache and the MinimalRebuildCache) to `${java.io.tmpdir}/gwt-cache-<md5(cwd + module name)>` -- outside the repository. `ant clean` never touched it, so stale entries survived both `ant clean` and code-server restarts.

When a source file's lambdas get renumbered between devmode sessions (e.g. a lambda added or removed earlier in the file), the code server merges stale per-type JS chunks from that cache with freshly compiled ones, producing internally inconsistent output: call sites like `new AceEditorWidget$lambda$2$Type_2_g$(...)` whose definitions were dropped because the cache retained an older, differently-numbered type under the same name. The browser then fails at startup with:

    ReferenceError: AceEditorWidget$lambda$2$Type_2_g$ is not defined

Full `ant build` / `ant draft` compiles use the monolithic pipeline and are unaffected, which makes the failure look mysterious: static builds work while a freshly `ant clean`-ed devmode stays broken.

## Change

Teach `ant clean` to also delete `gwt-cache-*` directories under the system temp directory. These are pure caches; the cost of removal is one full (rather than incremental) compile on the next devmode startup.

The equivalent live-session fix is the code server's `/clean` endpoint (e.g. `curl http://localhost:9876/clean`), which drops both the in-memory and on-disk caches.

Upstream symptom report: gwtproject/gwt#9565.