### PR TITLE
e2e: keep s4 unloaded-package spec off the network

### DIFF
--- a/e2e/rstudio/tests/panes/misc/s4_unloaded_package.test.ts
+++ b/e2e/rstudio/tests/panes/misc/s4_unloaded_package.test.ts
@@ -25,7 +25,6 @@ import {
   CONSOLE_INPUT,
   CONSOLE_OUTPUT,
 } from '@pages/console_pane.page';
-import { YES_BTN } from '@pages/modals.page';
 import { executeCommand, setPref } from '@utils/commands';
 import type { Page } from 'playwright';
 
@@ -44,13 +43,15 @@ async function captureResult(page: Page, rExpr: string): Promise<string> {
 }
 
 /**
- * Install DBI, create an S4 object, save workspace, then remove DBI.
- * Also creates plain objects as controls for the Environment pane.
+ * Install DBI, create an S4 object, save workspace, then stash DBI out of
+ * the library. Also creates plain objects as controls for the Environment
+ * pane.
  */
 async function setupWorkspace(page: Page): Promise<void> {
-  // Install DBI if not already present (binary, fast -- only dep is methods,
-  // which is always loaded). ensurePackageInstalled skips the download when
-  // DBI was left behind by a prior run.
+  // A prior run (or a failed earlier attempt) may have left DBI stashed --
+  // restore it first so the ensure-install below is the no-op fast path
+  // rather than a network install.
+  await executeInConsole(page, '.rs.restoreStashedPackage("DBI")', { wait: true });
   await ensurePackageInstalled(page, 'DBI');
 
   // Create an S4 object from DBI
@@ -69,26 +70,21 @@ async function setupWorkspace(page: Page): Promise<void> {
   // Save workspace
   await executeInConsole(page, 'save.image()', { wait: true });
 
-  // Remove DBI so it won't be loadable after restart. This may trigger a
-  // "loaded packages" dialog -- click Yes if it appears. Can't pass
-  // { wait: true } here: if the dialog blocks R, the busy class would never
-  // clear. Fire-and-forget, click the dialog if present, then wait for idle.
-  await executeInConsole(page, 'remove.packages("DBI")');
-  try {
-    await page.locator(YES_BTN).click({ timeout: 3000 });
-    console.log('Clicked Yes on loaded-packages dialog');
-  } catch {
-    // No dialog appeared
-  }
-  await waitForConsoleIdle(page);
+  // Stash DBI so it won't be loadable after restart. Renaming the package
+  // directory aside (instead of remove.packages + a network reinstall in
+  // cleanup) keeps the spec off the network -- CRAN stalls have blown the
+  // 120s afterAll budget here -- and can't trigger the "loaded packages"
+  // dialog that remove.packages shows.
+  await executeInConsole(page, '.rs.stashPackage("DBI")', { wait: true });
 
-  // Verify removal succeeded by checking the disk (not requireNamespace, which
-  // returns TRUE for already-loaded namespaces even after the files are deleted)
+  // Verify the stash succeeded by checking the disk (not requireNamespace,
+  // which returns TRUE for already-loaded namespaces even after the files
+  // are gone)
   const dbiRemoved = await captureResult(page, 'file.exists(file.path(.libPaths()[1], "DBI"))');
-  expect(dbiRemoved, 'DBI should be uninstalled after remove.packages').toBe('FALSE');
+  expect(dbiRemoved, 'DBI should be gone from the library after stashing').toBe('FALSE');
 }
 
-/** Remove test objects, delete .RData, restore preferences, reinstall DBI. */
+/** Remove test objects, delete .RData, restore preferences, un-stash DBI. */
 async function cleanup(page: Page): Promise<void> {
   await executeInConsole(
     page,
@@ -97,9 +93,9 @@ async function cleanup(page: Page): Promise<void> {
   );
   await executeInConsole(page, 'unlink(".RData")', { wait: true });
   await setPref(page, 'save_workspace', 'never');
-  // Reinstall DBI so we leave things as we found them. The test just removed
-  // it, so ensurePackageInstalled will see the gap and do a real install.
-  await ensurePackageInstalled(page, 'DBI');
+  // Put DBI back so we leave things as we found them -- a rename, never a
+  // download.
+  await executeInConsole(page, '.rs.restoreStashedPackage("DBI")', { wait: true });
 }
 
 /** Verify the session survived and the S4 object is handled safely. */

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -413,6 +413,43 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       install.packages(packageName, repos = repos, type = type)
 })
 
+# Move an installed package out of the library and into a stash directory
+# inside that same library (so the rename never crosses filesystems). Tests
+# use this to simulate an uninstalled package without discarding the installed
+# copy: .rs.restoreStashedPackage() puts it back with a rename rather than a
+# network reinstall. The stash directory is dot-prefixed, so library scans
+# (which use list.files() defaults) never mistake its contents for packages.
+.rs.addFunction("stashPackage", function(packageName, lib = .libPaths()[1])
+{
+   stash <- file.path(lib, ".rs-package-stash")
+   dir.create(stash, showWarnings = FALSE)
+
+   # drop any stale stash so the rename cannot collide
+   target <- file.path(stash, packageName)
+   unlink(target, recursive = TRUE)
+
+   invisible(file.rename(file.path(lib, packageName), target))
+})
+
+# Restore a package previously moved aside by .rs.stashPackage(). A no-op when
+# nothing is stashed; a stale stash is discarded if the package was already
+# reinstalled in the meantime.
+.rs.addFunction("restoreStashedPackage", function(packageName, lib = .libPaths()[1])
+{
+   source <- file.path(lib, ".rs-package-stash", packageName)
+   if (!file.exists(source))
+      return(invisible(FALSE))
+
+   target <- file.path(lib, packageName)
+   if (file.exists(target))
+   {
+      unlink(source, recursive = TRUE)
+      return(invisible(FALSE))
+   }
+
+   invisible(file.rename(source, target))
+})
+
 .rs.addFunction("getPackageVersion", function(packageName)
 {
    v <- suppressWarnings(utils:::packageDescription(packageName,


### PR DESCRIPTION
Fixes the `s4_unloaded_package.test.ts` failure seen on the linux-desktop e2e job of #18508 ([run](https://github.com/rstudio/rstudio/actions/runs/31462849387/job/93693141740?pr=18508)). The failure is a pre-existing flake in the spec, not caused by that PR (its Linux file-monitor changes are signature plumbing only).

### Diagnosis

The spec simulates an uninstalled package by running `remove.packages("DBI")` and then reinstalling DBI from `https://cran.r-project.org`, both in the `afterAll` cleanup and (via `ensurePackageInstalled`) in any retry's setup. The failing run's screenshots show both hangs sitting on

```
> .rs.ensurePackageInstalled("DBI", repos = "https://cran.r-project.org")
```

with no further output: a stalled CRAN download. That blows the 120s `afterAll` budget (failing the last test of the block), and the retry then hangs the same way in `setupWorkspace`, because the reinstall never landed. Any CRAN slowness reproduces this; on Linux the URL also means a source install.

### Fix

Replace the remove + network-reinstall cycle with a filesystem rename:

- `.rs.stashPackage()` moves the package directory into a dot-prefixed stash directory inside the same library (same filesystem, invisible to library scans);
- `.rs.restoreStashedPackage()` renames it back in cleanup, and also runs at the start of `setupWorkspace` so a retry (or a run killed mid-spec) self-heals without hitting the network.

This also removes the loaded-packages dialog handling: renaming, unlike `remove.packages()`, cannot prompt, so the fire-and-forget + `waitForConsoleIdle` dance becomes a plain `{ wait: true }` call.

### Verification

- Full spec passes locally via `npm run test:desktop-dev -- s4_unloaded_package` (6 passed, both describe blocks including their `afterAll` cleanups); the harness library is left with DBI restored and an empty stash.
- Stash/restore helper semantics exercised standalone in R (stash, restore, no-op restore, stale-stash collision, hidden-dir invisibility to `list.files()`).
- `npm run typecheck` clean in `e2e/rstudio`; `Tools.R` additions are ASCII-only.
