### PR TITLE
route rmd chunk execution through the focused editor view

### DIFF
--- a/e2e/rstudio/tests/panes/editor/split_editor_rmd.test.ts
+++ b/e2e/rstudio/tests/panes/editor/split_editor_rmd.test.ts
@@ -11,13 +11,17 @@ import type { ElementHandle, Page } from '@playwright/test';
 //
 // Chunk execution in an R Markdown notebook must follow the focused editor
 // view: Run Line inside a chunk goes through the notebook queue (not the
-// console), and Run Current Chunk resolves the chunk under the focused
-// view's cursor, not the primary view's.
+// console), and Run Current Chunk / Run All Chunks Above resolve chunks
+// from the focused view's cursor, not the primary view's.
 test.describe('Split editor with R Markdown chunks', () => {
   const sandbox = useSuiteSandbox();
   let consoleActions: ConsolePaneActions;
 
-  const FILE = 'split_editor_rmd.Rmd';
+  // One file name per test: reopening a path whose content matches a
+  // previously executed notebook restores its chunk output widgets from the
+  // notebook cache, which would skew the widget-count baselines below.
+  let fileCounter = 0;
+  let file: string;
 
   // The chunk fences are interpolated because heredoc reads template parts
   // raw -- an escaped backtick would land in the file as a literal
@@ -45,8 +49,8 @@ test.describe('Split editor with R Markdown chunks', () => {
   // Element handles (rather than text-filtered locators) because Ace only
   // renders visible rows: a locator filtered on document text stops matching
   // a view as soon as it scrolls the probed line offscreen.
-  async function docViewHandles(page: Page): Promise<ElementHandle[]> {
-    return await page.$$("[class*='rstudio_source_panel'] .ace_editor:visible");
+  async function docViewHandles(page: Page): Promise<ElementHandle<HTMLElement>[]> {
+    return await page.$$("[class*='rstudio_source_panel'] .ace_editor:visible") as ElementHandle<HTMLElement>[];
   }
 
   function viewEditor(handle: ElementHandle) {
@@ -75,7 +79,8 @@ test.describe('Split editor with R Markdown chunks', () => {
   }
 
   async function openAndSplit(page: Page) {
-    await writeAndOpenFile(page, sandbox.dir, FILE, CONTENT);
+    file = `split_editor_rmd_${++fileCounter}.Rmd`;
+    await writeAndOpenFile(page, sandbox.dir, file, CONTENT);
     await expect.poll(async () => (await docViewHandles(page)).length).toBe(1);
 
     await executeCommand(page, 'splitEditorDown');
@@ -89,14 +94,22 @@ test.describe('Split editor with R Markdown chunks', () => {
     const primary = viewEditor(handles[isSplit.indexOf(false)]);
     const split = viewEditor(handles[isSplit.indexOf(true)]);
 
+    // Clear leftover state now: the console helpers put keyboard focus in
+    // the console input, so they must run before the views are focused for
+    // the keyboard-driven Run Line test to exercise real focus routing.
+    await consoleActions.evalRLogical(
+      '{ rm(list = intersect(c("chunk_one", "chunk_two"), ls(globalenv())), envir = globalenv()); TRUE }');
+
+    // Chunk toolbars are line widgets, created asynchronously (one per
+    // chunk) once the notebook's scope tree is ready; wait for them so the
+    // widget-count baselines the tests capture are stable.
+    await expect.poll(() => primary.lineWidgetCount()).toBe(2);
+
     // Primary cursor in chunk-one; split view keeps focus in chunk-two, so
     // a run that reads the wrong view is caught by which chunk executes.
     await primary.focusAndGoto(CHUNK_ONE_LINE);
     await split.focusAndGoto(CHUNK_TWO_LINE);
     await expect.poll(() => split.hasFocus()).toBe(true);
-
-    await consoleActions.evalRLogical(
-      '{ rm(list = intersect(c("chunk_one", "chunk_two"), ls(globalenv())), envir = globalenv()); TRUE }');
 
     return { primary, split };
   }
@@ -120,7 +133,7 @@ test.describe('Split editor with R Markdown chunks', () => {
 
   test.afterEach(async ({ rstudioPage: page }) => {
     await executeCommand(page, 'removeEditorSplit');
-    await closeAndDeleteSandboxFiles(page, sandbox.dir, [FILE]);
+    await closeAndDeleteSandboxFiles(page, sandbox.dir, [file]);
   });
 
   test('Run Line from the split view executes its chunk inline', async ({ rstudioPage: page }) => {
@@ -148,6 +161,19 @@ test.describe('Split editor with R Markdown chunks', () => {
     await executeCommand(page, 'executeCurrentChunk');
 
     expect(await pollWhichRan()).toBe('chunk_one=false chunk_two=true');
+    await expect.poll(() => primary.lineWidgetCount()).toBe(widgetsBefore + 1);
+  });
+
+  test('Run All Chunks Above runs chunks above the focused view cursor', async ({ rstudioPage: page }) => {
+    const { primary } = await openAndSplit(page);
+    const widgetsBefore = await primary.lineWidgetCount();
+
+    // The split view's cursor sits in chunk-two, so the chunk above it --
+    // chunk-one -- must run. Resolving from the primary view's cursor
+    // (inside chunk-one) would find no chunks above it and run nothing.
+    await executeCommand(page, 'executePreviousChunks');
+
+    expect(await pollWhichRan()).toBe('chunk_one=true chunk_two=false');
     await expect.poll(() => primary.lineWidgetCount()).toBe(widgetsBefore + 1);
   });
 });

--- a/e2e/rstudio/tests/panes/editor/split_editor_rmd.test.ts
+++ b/e2e/rstudio/tests/panes/editor/split_editor_rmd.test.ts
@@ -1,0 +1,153 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { useSuiteSandbox } from '@utils/sandbox';
+import { writeAndOpenFile, closeAndDeleteSandboxFiles } from '@utils/files';
+import { executeCommand } from '@utils/commands';
+import { heredoc } from '@utils/heredoc';
+import type { AceEditorElement } from '@utils/ace';
+import type { ElementHandle, Page } from '@playwright/test';
+
+// https://github.com/rstudio/rstudio/issues/2129
+//
+// Chunk execution in an R Markdown notebook must follow the focused editor
+// view: Run Line inside a chunk goes through the notebook queue (not the
+// console), and Run Current Chunk resolves the chunk under the focused
+// view's cursor, not the primary view's.
+test.describe('Split editor with R Markdown chunks', () => {
+  const sandbox = useSuiteSandbox();
+  let consoleActions: ConsolePaneActions;
+
+  const FILE = 'split_editor_rmd.Rmd';
+
+  // The chunk fences are interpolated because heredoc reads template parts
+  // raw -- an escaped backtick would land in the file as a literal
+  // backslash-backtick.
+  const FENCE = '```';
+  const CONTENT = heredoc`
+    ---
+    title: split editor rmd
+    ---
+
+    ${FENCE}{r chunk-one}
+    chunk_one <- 101
+    ${FENCE}
+
+    ${FENCE}{r chunk-two}
+    chunk_two <- 202
+    ${FENCE}
+  `;
+
+  const CHUNK_ONE_LINE = 6;  // 1-based line of 'chunk_one <- 101'
+  const CHUNK_TWO_LINE = 10; // 1-based line of 'chunk_two <- 202'
+
+  // The active tab's editor views. Hidden tabs' editors fail the :visible
+  // filter, and the split view carries the rstudio_editor_split_view class.
+  // Element handles (rather than text-filtered locators) because Ace only
+  // renders visible rows: a locator filtered on document text stops matching
+  // a view as soon as it scrolls the probed line offscreen.
+  async function docViewHandles(page: Page): Promise<ElementHandle[]> {
+    return await page.$$("[class*='rstudio_source_panel'] .ace_editor:visible");
+  }
+
+  function viewEditor(handle: ElementHandle) {
+    return {
+      focusAndGoto: (line: number) =>
+        handle.evaluate((el, ln) => {
+          const editor = (el as AceEditorElement).env?.editor;
+          editor?.focus();
+          editor?.gotoLine(ln, 0, false);
+        }, line),
+      hasFocus: () => handle.evaluate((el) => el.contains(document.activeElement)),
+      // Non-null entries in the session's sparse lineWidgets array. Chunk
+      // toolbars and chunk output widgets are Ace line widgets, so a chunk
+      // executed through the notebook queue adds one to the hosting view,
+      // while console execution adds none.
+      lineWidgetCount: () =>
+        handle.evaluate((el) => {
+          const session = (el as AceEditorElement).env?.editor?.session as unknown as {
+            lineWidgets?: unknown[];
+          };
+          if (!session?.lineWidgets)
+            return 0;
+          return session.lineWidgets.filter((w) => w != null).length;
+        }),
+    };
+  }
+
+  async function openAndSplit(page: Page) {
+    await writeAndOpenFile(page, sandbox.dir, FILE, CONTENT);
+    await expect.poll(async () => (await docViewHandles(page)).length).toBe(1);
+
+    await executeCommand(page, 'splitEditorDown');
+    await expect.poll(async () => (await docViewHandles(page)).length).toBe(2);
+
+    const handles = await docViewHandles(page);
+    const isSplit = await Promise.all(handles.map((handle) =>
+      handle.evaluate((el) => el.classList.contains('rstudio_editor_split_view'))));
+    expect(isSplit.filter(Boolean)).toHaveLength(1);
+
+    const primary = viewEditor(handles[isSplit.indexOf(false)]);
+    const split = viewEditor(handles[isSplit.indexOf(true)]);
+
+    // Primary cursor in chunk-one; split view keeps focus in chunk-two, so
+    // a run that reads the wrong view is caught by which chunk executes.
+    await primary.focusAndGoto(CHUNK_ONE_LINE);
+    await split.focusAndGoto(CHUNK_TWO_LINE);
+    await expect.poll(() => split.hasFocus()).toBe(true);
+
+    await consoleActions.evalRLogical(
+      '{ rm(list = intersect(c("chunk_one", "chunk_two"), ls(globalenv())), envir = globalenv()); TRUE }');
+
+    return { primary, split };
+  }
+
+  // Waits for either chunk variable, then reports which chunk ran, so a
+  // misroute fails with a readable message instead of a poll timeout.
+  async function pollWhichRan(): Promise<string> {
+    await expect
+      .poll(() => consoleActions.evalRLogical('exists("chunk_one") || exists("chunk_two")'),
+            { timeout: 30000 })
+      .toBe(true);
+    const one = await consoleActions.evalRLogical('exists("chunk_one")');
+    const two = await consoleActions.evalRLogical('exists("chunk_two")');
+    return `chunk_one=${one} chunk_two=${two}`;
+  }
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+    await consoleActions.resetSourcePane();
+  });
+
+  test.afterEach(async ({ rstudioPage: page }) => {
+    await executeCommand(page, 'removeEditorSplit');
+    await closeAndDeleteSandboxFiles(page, sandbox.dir, [FILE]);
+  });
+
+  test('Run Line from the split view executes its chunk inline', async ({ rstudioPage: page }) => {
+    const { primary, split } = await openAndSplit(page);
+    const widgetsBefore = await primary.lineWidgetCount();
+
+    // Run Line: must execute the split view's line, through the notebook
+    // queue rather than the console.
+    await page.keyboard.press('Control+Enter');
+
+    expect(await pollWhichRan()).toBe('chunk_one=false chunk_two=true');
+
+    // Inline execution creates a chunk output widget. It renders in the
+    // primary view only for now: chunk output line widgets live on the
+    // primary Ace session. When output fan-out to all views lands, the
+    // split view expectation below should change to match.
+    await expect.poll(() => primary.lineWidgetCount()).toBe(widgetsBefore + 1);
+    expect(await split.lineWidgetCount()).toBe(0);
+  });
+
+  test('Run Current Chunk runs the chunk under the focused view cursor', async ({ rstudioPage: page }) => {
+    const { primary } = await openAndSplit(page);
+    const widgetsBefore = await primary.lineWidgetCount();
+
+    await executeCommand(page, 'executeCurrentChunk');
+
+    expect(await pollWhichRan()).toBe('chunk_one=false chunk_two=true');
+    await expect.poll(() => primary.lineWidgetCount()).toBe(widgetsBefore + 1);
+  });
+});

--- a/e2e/rstudio/utils/ace.ts
+++ b/e2e/rstudio/utils/ace.ts
@@ -71,7 +71,7 @@ export namespace Ace {
     getValue(): string;
     setValue(value: string, cursorPos?: number): void;
     focus(): void;
-    gotoLine(line: number, column?: number): void;
+    gotoLine(line: number, column?: number, animate?: boolean): void;
     getCursorPosition(): Position;
     getSelectedText(): string;
     getFirstVisibleRow(): number;

--- a/src/gwt/src/org/rstudio/core/client/ClassIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ClassIds.java
@@ -67,6 +67,9 @@ public class ClassIds
    public final static String SOURCE_PANEL = "source_panel";
    public final static String DOC_OUTLINE_CONTAINER = "doc_outline_container";
 
+   // The secondary editor view created by splitting a document (Pane > Split)
+   public final static String EDITOR_SPLIT_VIEW = "editor_split_view";
+
    // WindowFrameButton (combined with unique suffix for each panel)
    public final static String PANEL_MIN_BTN = "panel_min_btn";
    public final static String PANEL_MAX_BTN = "panel_max_btn";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -22,6 +22,7 @@ import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.ClassIds;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.HandlerRegistrations;
@@ -169,7 +170,13 @@ public class AceEditorWidget extends Composite
       // handler wiring below, which binds to the session in place
       isDocumentView_ = attachTo != null;
       if (attachTo != null)
+      {
          editor_.attachToDocumentOf(attachTo);
+
+         // tag the view in the DOM so styling and automation can tell the
+         // split view apart from the primary editor
+         ClassIds.assignClassId(getElement(), ClassIds.EDITOR_SPLIT_VIEW);
+      }
 
       editor_.manageDefaultKeybindings();
       editor_.getRenderer().setHScrollBarAlwaysVisible(false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -384,6 +384,7 @@ public class TextEditingTarget implements
       boolean isEditorViewFocused();
       DocDisplay getActiveDisplay();
       void destroyEditorSplit();
+      void syncSplitShowChunkOutputInline();
 
       void setNotebookUIVisible(boolean visible);
 
@@ -4134,6 +4135,17 @@ public class TextEditingTarget implements
          updateCurrentScope();
    }
 
+   // Applies the inline-chunk-output mode to every view of this document.
+   // The flag lives on each editor view, and code execution consults the
+   // view that initiated it, so a stale flag on the split view would send
+   // chunk code to the console instead of the notebook queue.
+   public void setShowChunkOutputInline(boolean show)
+   {
+      docDisplay_.setShowChunkOutputInline(show);
+      if (view_ != null)
+         view_.syncSplitShowChunkOutputInline();
+   }
+
    // Called by the view when the split editor view is destroyed; drop any
    // executor bound to it so re-run-last-code falls back to the primary view.
    void splitEditorRemoved()
@@ -5811,7 +5823,7 @@ public class TextEditingTarget implements
       {
          // turn off inline output in Shiny documents (if it's not already)
          if (docDisplay_.showChunkOutputInline())
-            docDisplay_.setShowChunkOutputInline(false);
+            setShowChunkOutputInline(false);
       }
    }
    
@@ -6850,8 +6862,11 @@ public class TextEditingTarget implements
          // a Scope with an end.
          docDisplay_.getScopeTree();
 
-         executeSweaveChunk(scopeHelper_.getCurrentSweaveChunk(),
-              NotebookQueueUnit.EXEC_MODE_SINGLE, false);
+         // resolve the chunk at the active view's cursor; positions are
+         // document-wide, so the primary view's scope tree can service them
+         executeSweaveChunk(
+               scopeHelper_.getCurrentSweaveChunk(activeDisplay().getCursorPosition()),
+               NotebookQueueUnit.EXEC_MODE_SINGLE, false);
       });
    }
 
@@ -6873,15 +6888,19 @@ public class TextEditingTarget implements
          }
          else
          {
-            // Force scope tree rebuild and get chunk from source mode
+            // Force scope tree rebuild and get chunk from source mode,
+            // looking forward from the active view's selection
             docDisplay_.getScopeTree();
-            nextChunk = scopeHelper_.getNextSweaveChunk();
+            nextChunk = scopeHelper_.getNextSweaveChunk(activeDisplay().getSelectionEnd());
          }
+
+         if (nextChunk == null)
+            return;
 
          executeSweaveChunk(nextChunk, NotebookQueueUnit.EXEC_MODE_SINGLE,
                true);
-         docDisplay_.setCursorPosition(nextChunk.getBodyStart());
-         docDisplay_.ensureCursorVisible();
+         activeDisplay().setCursorPosition(nextChunk.getBodyStart());
+         activeDisplay().ensureCursorVisible();
       });
    }
 
@@ -6940,9 +6959,10 @@ public class TextEditingTarget implements
 
    public void executeChunks(Position position, int which)
    {
-      // null implies we should use current cursor position
+      // null implies we should use the current cursor position, read from
+      // the view that holds it
       if (position == null)
-         position = docDisplay_.getSelectionStart();
+         position = activeDisplay().getSelectionStart();
 
       if (docDisplay_.showChunkOutputInline())
       {
@@ -7193,6 +7213,10 @@ public class TextEditingTarget implements
       if (chunk == null)
          return;
 
+      // cursor and scroll feedback should land in the view that initiated
+      // the execution; capture it now, as execution may be deferred below
+      final DocDisplay display = activeDisplay();
+
       // command used to execute chunk (we may need to defer it if this
       // is an Rmd document as populating params might be necessary)
       final Command executeChunk = new Command() {
@@ -7202,7 +7226,7 @@ public class TextEditingTarget implements
             Range range = scopeHelper_.getSweaveChunkInnerRange(chunk);
             if (scrollNearTop)
             {
-               docDisplay_.navigateToPosition(
+               display.navigateToPosition(
                      SourcePosition.create(range.getStart().getRow(),
                                            range.getStart().getColumn()),
                      true);
@@ -7229,7 +7253,7 @@ public class TextEditingTarget implements
 
                events_.fireEvent(new SendToConsoleEvent(code, language, true));
             }
-            docDisplay_.collapseSelection(true);
+            display.collapseSelection(true);
          }
       };
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -6195,7 +6195,8 @@ public class TextEditingTarget implements
     * Performs a command after synchronizing the document and selection state
     * from visual mode. The command will be passed the current position of the
     * cursor after synchronizing, or null if the cursor in visual mode has no
-    * corresponding location in source mode.
+    * corresponding location in source mode. In source mode, the cursor is
+    * read from the focused editor view, which may be the split view.
     *
     * @param command The command to perform.
     */
@@ -6207,7 +6208,7 @@ public class TextEditingTarget implements
       }
       else
       {
-         command.execute(docDisplay_.getCursorPosition());
+         command.execute(activeDisplay().getCursorPosition());
       }
    }
 
@@ -7214,8 +7215,12 @@ public class TextEditingTarget implements
          return;
 
       // cursor and scroll feedback should land in the view that initiated
-      // the execution; capture it now, as execution may be deferred below
+      // the execution; capture it now, as execution may be deferred below.
+      // record the executed range on that view's executor too, so that
+      // Re-Run Previous re-runs this chunk rather than whatever the
+      // last-used executor ran before it.
       final DocDisplay display = activeDisplay();
+      final EditingTargetCodeExecution codeExecution = codeExecution();
 
       // command used to execute chunk (we may need to defer it if this
       // is an Rmd document as populating params might be necessary)
@@ -7233,7 +7238,7 @@ public class TextEditingTarget implements
             }
             if (!range.isEmpty())
             {
-               codeExecution_.setLastExecuted(range.getStart(), range.getEnd());
+               codeExecution.setLastExecuted(range.getStart(), range.getEnd());
             }
             if (fileType_.isRmd() &&
                 docDisplay_.showChunkOutputInline())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetScopeHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetScopeHelper.java
@@ -34,11 +34,6 @@ public class TextEditingTargetScopeHelper
       docDisplay_ = docDisplay;
    }
 
-   public Scope getCurrentSweaveChunk()
-   {
-      return getCurrentSweaveChunk(null);
-   }
-
    public Scope getCurrentSweaveChunk(Position position)
    {
       if (position != null)
@@ -124,12 +119,7 @@ public class TextEditingTargetScopeHelper
       return Range.fromPoints(start, end);
    }
 
-   public Scope[] getPreviousSweaveChunks()
-   {
-      return getSweaveChunks(null, PREVIOUS_CHUNKS);
-   }
-
-   public Scope[] getSweaveChunks(Position startPosition, 
+   public Scope[] getSweaveChunks(Position startPosition,
          final int which)
    {
       // provide default position based on selection if necessary
@@ -158,11 +148,6 @@ public class TextEditingTargetScopeHelper
       return scopeList.getScopes();   
    }
    
-   public Scope getNextSweaveChunk()
-   {
-      return getNextSweaveChunk(docDisplay_.getSelectionEnd());
-   }
-
    public Scope getNextSweaveChunk(final Position position)
    {
       ScopeList scopeList = new ScopeList(docDisplay_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetScopeHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetScopeHelper.java
@@ -160,15 +160,19 @@ public class TextEditingTargetScopeHelper
    
    public Scope getNextSweaveChunk()
    {
+      return getNextSweaveChunk(docDisplay_.getSelectionEnd());
+   }
+
+   public Scope getNextSweaveChunk(final Position position)
+   {
       ScopeList scopeList = new ScopeList(docDisplay_);
       scopeList.selectAll(ScopeList.CHUNK);
-      final Position selectionEnd = docDisplay_.getSelectionEnd();
       return scopeList.findFirst(new ScopePredicate()
       {
          @Override
          public boolean test(Scope scope)
          {
-            return scope.getPreamble().compareTo(selectionEnd) > 0;
+            return scope.getPreamble().compareTo(position) > 0;
          }
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -496,6 +496,7 @@ public class TextEditingTargetWidget
       // document properties
       splitEditor_.setRainbowParentheses(editor_.getRainbowParentheses());
       splitEditor_.setRainbowFencedDivs(editor_.getRainbowFencedDivs());
+      splitEditor_.setShowChunkOutputInline(editor_.showChunkOutputInline());
 
       // forward completion contexts from the editing target so completion
       // behaves the same in either view; contexts must be in place before
@@ -529,6 +530,16 @@ public class TextEditingTargetWidget
       // keep the status bar in sync with the split view's cursor
       splitEditorRegistrations_.add(splitEditor_.addCursorChangedHandler(event ->
             target_.splitEditorCursorChanged(event.getPosition())));
+   }
+
+   // Keep the split view's inline-chunk-output flag matching the primary
+   // editor's, which the notebook maintains (see
+   // TextEditingTarget.setShowChunkOutputInline).
+   @Override
+   public void syncSplitShowChunkOutputInline()
+   {
+      if (splitEditor_ != null)
+         splitEditor_.setShowChunkOutputInline(editor_.showChunkOutputInline());
    }
 
    // Tear down any split editor view when the editing target is dismissed.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -1475,13 +1475,13 @@ public class TextEditingTargetNotebook
       if (!StringUtil.isNullOrEmpty(outputType) && outputType != "undefined")
       {
          // if the document property is set, apply it directly
-         docDisplay_.setShowChunkOutputInline(
+         editingTarget_.setShowChunkOutputInline(
                outputType == CHUNK_OUTPUT_INLINE);
       }
       else
       {
          // otherwise, use the global preference to set the value
-         docDisplay_.setShowChunkOutputInline(
+         editingTarget_.setShowChunkOutputInline(
             docDisplay_.getModeId() == "mode/rmarkdown" &&
             RStudioGinjector.INSTANCE.getUserPrefs()
                                      .rmdChunkOutputInline().getValue());
@@ -1801,7 +1801,7 @@ public class TextEditingTargetNotebook
 
    private void changeOutputMode(String mode)
    {
-      docDisplay_.setShowChunkOutputInline(mode == CHUNK_OUTPUT_INLINE);
+      editingTarget_.setShowChunkOutputInline(mode == CHUNK_OUTPUT_INLINE);
 
       // manage commands
       manageCommands();


### PR DESCRIPTION
When a document's editor is split (#2129, added in #18460), several R Markdown chunk-execution paths ignored which view held the cursor:

- **Run Current Chunk**, **Run Next Chunk**, and **Run Previous/Subsequent Chunks** resolved the target chunk from the *primary* view's cursor, so invoking them with the split view focused ran the wrong chunk.
- **Run Line** inside a chunk bypassed the notebook queue when initiated from the split view and executed at the console instead: the inline-chunk-output flag lives on each editor view, and it was never applied to the split view.

This PR resolves chunk positions from the focused view (positions are document-wide, so the primary view's scope tree can still service them), lands cursor/scroll feedback in the view that initiated the execution, and keeps the split view's inline-output flag in sync -- at split creation, and whenever the notebook changes the output mode.

It also assigns a stable class (`rstudio_editor_split_view`, via `ClassIds`) to the split editor view so automation and styling can tell the two views of a document apart; the new Playwright suite uses it.

Chunk output widgets and chunk toolbars still render only in the primary view's session; fanning those out to every view is tracked as follow-up work.

Includes a Playwright regression suite (`split_editor_rmd.test.ts`) covering both execution paths.

Addresses #2129.