### PR TITLE
install libsecret headers on linux builders for keytar source builds

### DIFF
--- a/dependencies/linux/install-dependencies-bionic
+++ b/dependencies/linux/install-dependencies-bionic
@@ -53,6 +53,7 @@ sudo apt-get -y install \
   libpam-dev \
   libpango1.0-dev \
   libpq-dev \
+  libsecret-1-dev \
   libsqlite3-dev \
   libssl-dev \
   libuser1-dev \

--- a/dependencies/linux/install-dependencies-focal
+++ b/dependencies/linux/install-dependencies-focal
@@ -53,6 +53,7 @@ sudo apt-get -y install \
   libpam-dev \
   libpango1.0-dev \
   libpq-dev \
+  libsecret-1-dev \
   libsqlite3-dev \
   libssl-dev \
   libuser1-dev \

--- a/dependencies/linux/install-dependencies-jammy
+++ b/dependencies/linux/install-dependencies-jammy
@@ -52,6 +52,7 @@ sudo apt-get -y install \
   libpam-dev \
   libpango1.0-dev \
   libpq-dev \
+  libsecret-1-dev \
   libsqlite3-dev \
   libssl-dev \
   libuser1-dev \

--- a/dependencies/linux/install-dependencies-noble
+++ b/dependencies/linux/install-dependencies-noble
@@ -51,6 +51,7 @@ sudo apt-get -y install \
   libpam-dev \
   libpango1.0-dev \
   libpq-dev \
+  libsecret-1-dev \
   libsqlite3-dev \
   libssl-dev \
   libuser1-dev \

--- a/dependencies/linux/install-dependencies-resolute
+++ b/dependencies/linux/install-dependencies-resolute
@@ -51,6 +51,7 @@ sudo apt-get -y install \
   libpam-dev \
   libpango1.0-dev \
   libpq-dev \
+  libsecret-1-dev \
   libsqlite3-dev \
   libssl-dev \
   libuser1-dev \

--- a/dependencies/linux/install-dependencies-yum
+++ b/dependencies/linux/install-dependencies-yum
@@ -29,6 +29,7 @@ PACKAGES=(
 	java-devel
 	jq
 	libffi
+	libsecret-devel
 	libuser-devel
 	libuuid-devel
 	libuv-devel

--- a/dependencies/linux/install-dependencies-zypper
+++ b/dependencies/linux/install-dependencies-zypper
@@ -32,6 +32,7 @@ sudo zypper --non-interactive in libuuid-devel
 sudo zypper --non-interactive in libopenssl-devel
 sudo zypper --non-interactive in libpq-devel
 sudo zypper --non-interactive in libsqlite-devel
+sudo zypper --non-interactive in libsecret-devel
 sudo zypper --non-interactive in pam-devel
 
 # boost

--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -44,6 +44,7 @@ RUN apt-get update && \
     libpango1.0-dev \
     libpng-dev\
     libpq-dev \
+    libsecret-1-dev \
     libsqlite3-dev \
     libssl-dev \
     libssh2-1-dev \

--- a/docker/jenkins/Dockerfile.focal
+++ b/docker/jenkins/Dockerfile.focal
@@ -44,6 +44,7 @@ RUN apt-get update && \
     libpango1.0-dev \
     libpng-dev \
     libpq-dev \
+    libsecret-1-dev \
     libsqlite3-dev \
     libssl-dev \
     libtiff5-dev \

--- a/docker/jenkins/Dockerfile.jammy
+++ b/docker/jenkins/Dockerfile.jammy
@@ -48,6 +48,7 @@ RUN apt-get update && \
     libpango1.0-dev \
     libpng-dev\
     libpq-dev \
+    libsecret-1-dev \
     libsqlite3-dev \
     libssl-dev \
     libtiff5-dev\

--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -35,6 +35,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     libjpeg-devel \
     libopenssl-devel \
     libpng-devel  \
+    libsecret-devel \
     libtiff-devel  \
     libtool \
     libwebp-devel \

--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -37,6 +37,7 @@ RUN yum install -y \
     libcap-devel \
     libcurl-devel \
     libpq-devel \
+    libsecret-devel \
     libtool \
     libuuid-devel \
     libxml2-devel \

--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -47,6 +47,7 @@ RUN dnf install -y \
     libffi \
     libjpeg-turbo-devel \
     libpng-devel \
+    libsecret-devel \
     libtiff-devel \
     libtool \
     libwebp-devel \


### PR DESCRIPTION
Fixes #18539

## Summary

The GWT `panmirror` target runs `yarn install` in the quarto monorepo checkout under `src/gwt/lib/quarto`. Because it is a yarn workspace, that installs dependencies for every workspace package -- including `apps/vscode`, whose `vsce@2.x` dependency hard-depends on `keytar`.

`keytar` normally installs a prebuilt binary via `prebuild-install`, but when that download fails (transiently, as it did on the `linux-desktop / Build (ubuntu-24-x86_64)` job in run [31640451121](https://github.com/rstudio/rstudio/actions/runs/31640451121)), the fallback is a node-gyp source build that requires libsecret headers:

```
Package libsecret-1 was not found in the pkg-config search path.
gyp: Call to 'pkg-config --cflags libsecret-1' returned exit status 1 while in binding.gyp.
```

Without the headers, all three ant retries of `yarn install` fail the same way and the whole build dies. Only builds with a GWT cache miss run this path, which is why the failure appears sporadic.

## Changes

Install the libsecret development package everywhere we build panmirror on Linux:

- `dependencies/linux/install-dependencies-{bionic,focal,jammy,noble,resolute}`: `libsecret-1-dev` (used by the GitHub Actions ubuntu builders and dev machines)
- `dependencies/linux/install-dependencies-{yum,zypper}`: `libsecret-devel`
- `docker/jenkins/Dockerfile.{bionic,focal,jammy,rhel8,rhel9,opensuse15}`: same packages for the Jenkins build images (rhel8/rhel9 already enable PowerTools/CRB, where `libsecret-devel` lives)

Developer/build-infrastructure change only; no NEWS entry.