### PR TITLE
Fetch gnupg 1.4.23 from rstudio-buildtools mirror

### DIFF
--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -103,8 +103,9 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common open
 RUN chmod -R 777 /opt/rstudio-tools/src
 
 # install GnuPG 1.4 from source (needed for release signing)
+# mirrored into rstudio-buildtools because gnupg.org returns 403 to the builders
 RUN cd /tmp && \
-    wget https://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.23.tar.bz2 && \
+    wget https://rstudio-buildtools.s3.amazonaws.com/gnupg-1.4.23.tar.bz2 && \
     bzip2 -d gnupg-1.4.23.tar.bz2 && \
     tar xvf gnupg-1.4.23.tar && \
     cd gnupg-1.4.23 && \

--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -114,7 +114,8 @@ RUN cp libuser-libuser-0.62/lib/*.h /usr/include/libuser
 
 # build and install gpg1.4 which we need to sign the builds in headless mode
 # this is unavailable in the official rhel8 repos
-RUN wget https://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.23.tar.bz2
+# mirrored into rstudio-buildtools because gnupg.org returns 403 to the builders
+RUN wget https://rstudio-buildtools.s3.amazonaws.com/gnupg-1.4.23.tar.bz2
 RUN tar xvf gnupg-1.4.23.tar.bz2
 RUN cd gnupg-1.4.23 && ./configure --prefix=/gnupg1 && make && make install
 RUN ln -s /gnupg1/bin/gpg /usr/local/bin/gpg1

--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -111,7 +111,8 @@ RUN chmod -R 777 /opt/rstudio-tools/src
 
 # build and install gpg1.4 which we need to sign the builds in headless mode
 # this is unavailable in the official rhel9 repos
-RUN wget https://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.23.tar.bz2
+# mirrored into rstudio-buildtools because gnupg.org returns 403 to the builders
+RUN wget https://rstudio-buildtools.s3.amazonaws.com/gnupg-1.4.23.tar.bz2
 RUN tar xvf gnupg-1.4.23.tar.bz2
 RUN cd gnupg-1.4.23 && CFLAGS="-fcommon" ./configure --prefix=/gnupg1 && make && make install
 RUN ln -s /gnupg1/bin/gpg /usr/local/bin/gpg1


### PR DESCRIPTION
## Problem

gnupg.org started returning HTTP 403 to the Jenkins builders, failing image builds on four matrix branches:

| Branch | Step |
|---|---|
| `opensuse15` / x86_64 | `Dockerfile.opensuse15:107` |
| `rhel8` / x86_64 | `Dockerfile.rhel8:117` |
| `rhel9` / x86_64 | `Dockerfile.rhel9:114` |
| `rhel9` / arm64 | `Dockerfile.rhel9:114` |

```
wget https://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.23.tar.bz2
  → HTTP request sent, awaiting response... 403 Forbidden
  → exit code: 8
```

These are the three images that build gpg 1.4 from source for headless release signing. The Debian and Ubuntu images were unaffected because they install `gnupg1` from apt.

This was not a regression here. The URL, version and command had been unchanged for months, and years in the rhel8 case (`1e7f6b41ef7`, 2019-11-07). The tarball is still served correctly to other clients, and the response comes from gnupg.org's own Apache with no CDN in front, so the 403 is an IP-level denial against the builders.

## Change

Fetch the tarball from `rstudio-buildtools` instead, removing the third-party host from the build. This matches how Boost, SOCI, GWT, Quarto, pandoc and Node are already sourced.

`s3://rstudio-buildtools/gnupg-1.4.23.tar.bz2` has been uploaded (`public-read`), copied from `https://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.23.tar.bz2`. It sits at the bucket root alongside the other source tarballs (`pcre-8.32.tar.bz2`, `soci-4.0.3.tar.gz`). gnupg 1.4.23 is a frozen 2018 release, so this is a one-time upload.

## Verification

The mirrored bytes were checked against the canonical origin and two independent official mirrors (`mirrors.dotsrc.org`, `www.mirrorservice.org`). All three agree:

```
sha256  c9462f17e651b6507848c08c430c791287cd75491f8b5a8b50c6ed46b12678ba
size    3749353
```

The uploaded object round-trips: an anonymous request with a wget user-agent and no AWS credentials returns 200 with that same sha256, and the archive extracts.

The upstream GPG signature could not be checked. gnupg 1.4.23 was signed by key `D8692123C4065DEA5E0F3AB5249B39D24F25E3B6`, which has been rotated out of gnupg.org's published `signature_key.asc` and is not on keys.openpgp.org. The guarantee is byte-identity with the canonical origin rather than a signature check. The previous code verified nothing at all.

Docker was unavailable locally, so the images were not built end-to-end. S3 reachability from the affected builders is established by the failing log itself: every failing branch downloaded Boost and GWT from `rstudio-buildtools` before failing. The rhel9/arm64 branch installed GWT from that bucket at 03:40:17 and hit the gnupg.org 403 at 03:40:24. The `tar`, `configure` and `make` steps are unchanged and now operate on a byte-identical tarball.

Requires a builder image rebuild to take effect.

## Notes

No NEWS.md entry, as this is build infrastructure and not user-facing. No associated issue; this is a build tooling change.