### PR TITLE
Remove quarto.org cachebust from Jenkins build images

### DIFF
--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -118,8 +118,6 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common bion
 # panmirror needs to be able to build in this location
 RUN chmod -R 777 /opt/rstudio-tools/src
 
-# cachebust for Quarto release
-ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 
 # set github login from build argument if defined

--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -118,8 +118,6 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common bion
 # panmirror needs to be able to build in this location
 RUN chmod -R 777 /opt/rstudio-tools/src
 
-RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
-
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN

--- a/docker/jenkins/Dockerfile.focal
+++ b/docker/jenkins/Dockerfile.focal
@@ -119,8 +119,6 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common foca
 # panmirror needs to be able to build in this location
 RUN chmod -R 777 /opt/rstudio-tools/src
 
-# cachebust for Quarto release
-ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 
 # set github login from build argument if defined

--- a/docker/jenkins/Dockerfile.focal
+++ b/docker/jenkins/Dockerfile.focal
@@ -119,8 +119,6 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common foca
 # panmirror needs to be able to build in this location
 RUN chmod -R 777 /opt/rstudio-tools/src
 
-RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
-
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN

--- a/docker/jenkins/Dockerfile.jammy
+++ b/docker/jenkins/Dockerfile.jammy
@@ -137,8 +137,6 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common jamm
 # panmirror needs to be able to build in this location
 RUN chmod -R 777 /opt/rstudio-tools/src
 
-RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
-
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN

--- a/docker/jenkins/Dockerfile.jammy
+++ b/docker/jenkins/Dockerfile.jammy
@@ -137,8 +137,6 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common jamm
 # panmirror needs to be able to build in this location
 RUN chmod -R 777 /opt/rstudio-tools/src
 
-# cachebust for Quarto release
-ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 
 # set github login from build argument if defined

--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -113,8 +113,6 @@ RUN cd /tmp && \
     make && \
     make install
 
-RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
-
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN

--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -113,8 +113,6 @@ RUN cd /tmp && \
     make && \
     make install
 
-# cachebust for Quarto release
-ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 
 # set github login from build argument if defined

--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -120,8 +120,6 @@ RUN tar xvf gnupg-1.4.23.tar.bz2
 RUN cd gnupg-1.4.23 && ./configure --prefix=/gnupg1 && make && make install
 RUN ln -s /gnupg1/bin/gpg /usr/local/bin/gpg1
 
-RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
-
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN

--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -120,8 +120,6 @@ RUN tar xvf gnupg-1.4.23.tar.bz2
 RUN cd gnupg-1.4.23 && ./configure --prefix=/gnupg1 && make && make install
 RUN ln -s /gnupg1/bin/gpg /usr/local/bin/gpg1
 
-# cachebust for Quarto release
-ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 
 # set github login from build argument if defined

--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -117,8 +117,6 @@ RUN tar xvf gnupg-1.4.23.tar.bz2
 RUN cd gnupg-1.4.23 && CFLAGS="-fcommon" ./configure --prefix=/gnupg1 && make && make install
 RUN ln -s /gnupg1/bin/gpg /usr/local/bin/gpg1
 
-RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
-
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN

--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -117,8 +117,6 @@ RUN tar xvf gnupg-1.4.23.tar.bz2
 RUN cd gnupg-1.4.23 && CFLAGS="-fcommon" ./configure --prefix=/gnupg1 && make && make install
 RUN ln -s /gnupg1/bin/gpg /usr/local/bin/gpg1
 
-# cachebust for Quarto release
-ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 
 # set github login from build argument if defined


### PR DESCRIPTION
The six Linux Jenkins builder images (bionic, focal, jammy, opensuse15, rhel8, rhel9) each carried a cache-bust key ahead of an explicit `install-quarto` step:

```dockerfile
# cachebust for Quarto release
ADD https://quarto.org/docs/download/_download.json quarto_releases
RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
```

Both lines are removed. Quarto installs through `install-common`, alongside the other common dependencies.

## Why

The key tracked the wrong thing. `dependencies/common/install-quarto` pins `QUARTO_VERSION` and fetches the tarball from the `rstudio-buildtools` S3 mirror, so the key fired on upstream releases we do not install. The change that should force a refresh -- bumping `QUARTO_VERSION` -- is already covered by the `COPY dependencies/common/` layer that sits above it in every one of these files.

The `ADD` also required quarto.org to be reachable at build time, which is what mirroring releases into the build tools bucket was meant to avoid. An outage or a moved JSON path failed the image build even though no Quarto bytes come from there. The script says as much at `dependencies/common/install-quarto:26-28`.

With the cachebust gone, the trailing `RUN` was a no-op: `install-common` already calls `install-quarto` (`dependencies/common/install-common:26`) and every one of these images invokes `install-common` earlier in the file, so the pinned version was installed by the time that step ran and `install-quarto` exited early. Its only purpose was to re-run after the cachebust fired.

`Dockerfile.windows` already installs the same pinned version from the same bucket with no upstream cache-bust.

## Not changed

The panmirror cache-bust is left in place. `install-panmirror:38` clones `quarto-dev/quarto` at its default branch, so keying on that ref's SHA tracks what actually gets fetched.

## Verification

Deletions only; no surrounding instructions were edited. The images have not been built locally -- neither `docker` nor `hadolint` was available -- so the first CI build of these images is the real check. Worth confirming the Quarto install still appears in the `install-common` output for at least one Linux builder.

## rstudio-pro

`Dockerfile.rhel10` exists only in rstudio-pro and carries the same block, and the merge from upstream will not cover it. rstudio/rstudio-pro#12257 makes the same change there, so no follow-up is needed after this merges.
