### PR TITLE
ci: speed up pr-triggered e2e runs

### DIFF
--- a/.github/actions/os-e2e-deps/action.yml
+++ b/.github/actions/os-e2e-deps/action.yml
@@ -71,6 +71,44 @@ runs:
           echo "PW_RSTUDIO_R_LIBS_USER=${{ inputs.r-libs-user }}" >> "$GITHUB_ENV"
         fi
 
+    # On Windows Server, `playwright install --with-deps` installs the Media
+    # Foundation feature (Chromium needs its media DLLs on Server SKUs). The
+    # feature install takes ~3 minutes, is not cacheable, and used to run
+    # serially inside the browser-install step on every run -- even on a full
+    # cache hit. Start it here as a detached process instead, so it overlaps
+    # the R/npm/browser installs below; the browser-install step then skips
+    # --with-deps on Windows, and the final step of this action waits for the
+    # detached install and fails on the same errors the serial install would
+    # have surfaced. Runs via Windows PowerShell (not pwsh) because the
+    # ServerManager module that provides Install-WindowsFeature is a Windows
+    # PowerShell module, matching how Playwright's own installer invokes it.
+    - name: Install Windows Media Foundation (background)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        # Built from a line array rather than a here-string: a here-string's
+        # closing '@ must sit at column 0, which would terminate this YAML
+        # block scalar.
+        $lines = @(
+          '$marker = Join-Path $env:RUNNER_TEMP ''media-foundation.done''',
+          'try {',
+          '  $r = Install-WindowsFeature -Name Server-Media-Foundation -ErrorAction Stop',
+          '  $status = if ($r.Success) { ''ok'' } else { "failed: exit code $($r.ExitCode)" }',
+          '} catch {',
+          '  $status = "failed: $($_.Exception.Message)"',
+          '}',
+          'Set-Content -Path $marker -Value $status'
+        )
+        $script = Join-Path $env:RUNNER_TEMP 'install-media-foundation.ps1'
+        Set-Content -Path $script -Value ($lines -join "`n") -Encoding utf8
+
+        Start-Process powershell -WindowStyle Hidden `
+          -ArgumentList '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $script `
+          -RedirectStandardOutput (Join-Path $env:RUNNER_TEMP 'media-foundation.out') `
+          -RedirectStandardError (Join-Path $env:RUNNER_TEMP 'media-foundation.err')
+        Write-Host "Media Foundation install started in the background."
+
     # Resolve the *installed* R version (major.minor) and fold it into the
     # cache keys below. Installed packages and pak's binary downloads are only
     # compatible within an R major.minor series, so when an alias like
@@ -259,6 +297,12 @@ runs:
       # launch error.
       run: |
         BINARY_ONLY=false
+        # On Windows, --with-deps only installs the Media Foundation feature,
+        # which the background step at the top of this action already handles
+        # (and the final step waits for), so fetch only the browser binary.
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          BINARY_ONLY=true
+        fi
         if [ "$RUNNER_OS" = "Linux" ] && [ -r /etc/os-release ]; then
           . /etc/os-release
           if [ "$ID" = "rhel" ] || [ "$ID" = "rocky" ] || [ "$ID" = "almalinux" ] || [ "$ID" = "centos" ] || [ "$ID" = "fedora" ] || printf '%s' "$ID_LIKE" | grep -q 'rhel'; then
@@ -277,3 +321,38 @@ runs:
       with:
         path: ${{ github.workspace }}/ms-playwright
         key: ${{ steps.pw-cache.outputs.cache-primary-key }}
+
+    # Companion to "Install Windows Media Foundation (background)" above: on a
+    # typical run the feature install (~3 min) finished while the R/npm/browser
+    # installs ran, so this is a no-op; when it didn't, block here rather than
+    # letting tests launch an Electron missing its media DLLs. A failed or
+    # stuck install fails the action, matching what the serial --with-deps
+    # install would have done.
+    - name: Wait for Windows Media Foundation install
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $marker = Join-Path $env:RUNNER_TEMP 'media-foundation.done'
+        $deadline = (Get-Date).AddMinutes(10)
+        while (-not (Test-Path $marker) -and (Get-Date) -lt $deadline) {
+          Start-Sleep -Seconds 5
+        }
+
+        foreach ($f in @('media-foundation.out', 'media-foundation.err')) {
+          $path = Join-Path $env:RUNNER_TEMP $f
+          if ((Test-Path $path) -and (Get-Item $path).Length -gt 0) {
+            Write-Host "--- $f ---"
+            Get-Content $path | Write-Host
+          }
+        }
+
+        if (-not (Test-Path $marker)) {
+          Write-Error "Media Foundation install did not finish within 10 minutes."
+          exit 1
+        }
+        $status = (Get-Content $marker -Raw).Trim()
+        if ($status -ne 'ok') {
+          Write-Error "Media Foundation install failed: $status"
+          exit 1
+        }
+        Write-Host "Media Foundation installed."

--- a/.github/actions/os-e2e-deps/action.yml
+++ b/.github/actions/os-e2e-deps/action.yml
@@ -75,50 +75,60 @@ runs:
     # Foundation feature (Chromium needs its media DLLs on Server SKUs). The
     # feature install takes ~3 minutes, is not cacheable, and used to run
     # serially inside the browser-install step on every run -- even on a full
-    # cache hit. Start it here as a detached process instead, so it overlaps
-    # the R/npm/browser installs below; the browser-install step then skips
-    # --with-deps on Windows, and the final step of this action waits for the
-    # detached install and fails on the same errors the serial install would
-    # have surfaced. Runs via Windows PowerShell (not pwsh) because the
-    # ServerManager module that provides Install-WindowsFeature is a Windows
-    # PowerShell module, matching how Playwright's own installer invokes it.
+    # cache hit. Start it here so it overlaps the R/npm/browser installs
+    # below; the browser-install step then skips --with-deps on Windows, and
+    # the final step of this action waits for the install and fails on the
+    # same errors the serial install would have surfaced.
+    #
+    # Launched via a scheduled task, not Start-Process: the runner kills
+    # detached child processes when the step exits (runs 31735929103 and
+    # 31746122882 both saw a Start-Process child die without output within
+    # ~80s), while Task Scheduler spawns the process outside the runner's
+    # process tree. The task runs as SYSTEM with its own clean environment,
+    # so the generated script bakes in absolute paths (RUNNER_TEMP is not
+    # defined there) and writes its own output log (no shell redirection).
     - name: Install Windows Media Foundation (background)
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
+        $marker = Join-Path $env:RUNNER_TEMP 'media-foundation.done'
+        $outLog = Join-Path $env:RUNNER_TEMP 'media-foundation.out'
+        $script = Join-Path $env:RUNNER_TEMP 'install-media-foundation.ps1'
+
         # Built from a line array rather than a here-string: a here-string's
         # closing '@ must sit at column 0, which would terminate this YAML
-        # block scalar.
+        # block scalar. The first two lines interpolate the absolute paths.
         $lines = @(
-          '$marker = Join-Path $env:RUNNER_TEMP ''media-foundation.done''',
+          "`$marker = '$marker'",
+          "`$outLog = '$outLog'",
           'try {',
           '  $r = Install-WindowsFeature -Name Server-Media-Foundation -ErrorAction Stop',
+          '  $r | Out-String | Out-File -FilePath $outLog -Append',
           '  $status = if ($r.Success) { ''ok'' } else { "failed: exit code $($r.ExitCode)" }',
           '} catch {',
+          '  $_ | Out-String | Out-File -FilePath $outLog -Append',
           '  $status = "failed: $($_.Exception.Message)"',
           '}',
           'Set-Content -Path $marker -Value $status'
         )
-        $script = Join-Path $env:RUNNER_TEMP 'install-media-foundation.ps1'
         Set-Content -Path $script -Value ($lines -join "`n") -Encoding utf8
 
-        # The child inherits this pwsh step's environment, including
-        # PowerShell 7's PSModulePath -- a documented way to break module
-        # loading in a Windows PowerShell child (ServerManager is a Windows
-        # PowerShell module). Hand it the Windows PowerShell module paths
-        # instead, and restore ours afterwards.
-        $savedPSModulePath = $env:PSModulePath
-        try {
-          $env:PSModulePath = "$env:SystemRoot\system32\WindowsPowerShell\v1.0\Modules;$env:ProgramFiles\WindowsPowerShell\Modules"
-          Start-Process powershell -WindowStyle Hidden `
-            -ArgumentList '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $script `
-            -RedirectStandardOutput (Join-Path $env:RUNNER_TEMP 'media-foundation.out') `
-            -RedirectStandardError (Join-Path $env:RUNNER_TEMP 'media-foundation.err')
-        } finally {
-          $env:PSModulePath = $savedPSModulePath
+        # Failures here only cost the overlap, not the install: the wait step
+        # runs the same script synchronously whenever the marker is missing.
+        schtasks /create /f /tn 'rstudio-e2e-mf-install' /sc once /st 23:59 /ru SYSTEM `
+          /tr "powershell -NoProfile -ExecutionPolicy Bypass -File $script"
+        if ($LASTEXITCODE -ne 0) {
+          Write-Host "::warning::schtasks /create failed ($LASTEXITCODE); Media Foundation will install synchronously in the wait step."
+          exit 0
         }
-        Write-Host "Media Foundation install started in the background."
+
+        schtasks /run /tn 'rstudio-e2e-mf-install'
+        if ($LASTEXITCODE -ne 0) {
+          Write-Host "::warning::schtasks /run failed ($LASTEXITCODE); Media Foundation will install synchronously in the wait step."
+          exit 0
+        }
+        Write-Host "Media Foundation install started in the background (scheduled task)."
 
     # Resolve the *installed* R version (major.minor) and fold it into the
     # cache keys below. Installed packages and pak's binary downloads are only
@@ -336,12 +346,11 @@ runs:
     # Companion to "Install Windows Media Foundation (background)" above: on a
     # typical run the feature install (~3 min) finished while the R/npm/browser
     # installs ran, so this is a no-op; when it didn't, block here rather than
-    # letting tests launch an Electron missing its media DLLs. The detached
-    # installer is not guaranteed to survive or make progress (run 31735929103
-    # saw it produce neither marker nor output on all six shards), so a missing
-    # marker falls back to running the same script synchronously, bounded --
-    # the worst case is the serial install this action always used to do. A
-    # failed install still fails the action, matching --with-deps behavior.
+    # letting tests launch an Electron missing its media DLLs. When the marker
+    # never lands (task creation failed, or the installer died), fall back to
+    # running the same script synchronously, bounded -- the worst case is the
+    # serial install this action always used to do. A failed install still
+    # fails the action, matching --with-deps behavior.
     - name: Wait for Windows Media Foundation install
       if: runner.os == 'Windows'
       shell: pwsh
@@ -354,9 +363,12 @@ runs:
             Where-Object { $_.CommandLine -like '*install-media-foundation.ps1*' }
         }
 
-        # Poll only while the detached installer is demonstrably alive: a dead
-        # process without a marker will never produce one, so there is nothing
-        # to wait for beyond its lifetime.
+        # Poll only while the installer is demonstrably alive: a dead process
+        # without a marker will never produce one, so there is nothing to
+        # wait for beyond its lifetime. A brief initial grace period covers
+        # Task Scheduler's spawn latency so a not-yet-started installer isn't
+        # mistaken for a dead one.
+        Start-Sleep -Seconds 5
         $deadline = (Get-Date).AddMinutes(10)
         while (-not (Test-Path $marker) -and (Get-Date) -lt $deadline) {
           if (-not (Get-InstallerProcess)) {
@@ -365,12 +377,10 @@ runs:
           Start-Sleep -Seconds 5
         }
 
-        foreach ($f in @('media-foundation.out', 'media-foundation.err')) {
-          $path = Join-Path $env:RUNNER_TEMP $f
-          if ((Test-Path $path) -and (Get-Item $path).Length -gt 0) {
-            Write-Host "--- $f ---"
-            Get-Content $path | Write-Host
-          }
+        $outLog = Join-Path $env:RUNNER_TEMP 'media-foundation.out'
+        if ((Test-Path $outLog) -and (Get-Item $outLog).Length -gt 0) {
+          Write-Host "--- media-foundation.out ---"
+          Get-Content $outLog | Write-Host
         }
 
         if (-not (Test-Path $marker)) {

--- a/.github/actions/os-e2e-deps/action.yml
+++ b/.github/actions/os-e2e-deps/action.yml
@@ -103,10 +103,21 @@ runs:
         $script = Join-Path $env:RUNNER_TEMP 'install-media-foundation.ps1'
         Set-Content -Path $script -Value ($lines -join "`n") -Encoding utf8
 
-        Start-Process powershell -WindowStyle Hidden `
-          -ArgumentList '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $script `
-          -RedirectStandardOutput (Join-Path $env:RUNNER_TEMP 'media-foundation.out') `
-          -RedirectStandardError (Join-Path $env:RUNNER_TEMP 'media-foundation.err')
+        # The child inherits this pwsh step's environment, including
+        # PowerShell 7's PSModulePath -- a documented way to break module
+        # loading in a Windows PowerShell child (ServerManager is a Windows
+        # PowerShell module). Hand it the Windows PowerShell module paths
+        # instead, and restore ours afterwards.
+        $savedPSModulePath = $env:PSModulePath
+        try {
+          $env:PSModulePath = "$env:SystemRoot\system32\WindowsPowerShell\v1.0\Modules;$env:ProgramFiles\WindowsPowerShell\Modules"
+          Start-Process powershell -WindowStyle Hidden `
+            -ArgumentList '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $script `
+            -RedirectStandardOutput (Join-Path $env:RUNNER_TEMP 'media-foundation.out') `
+            -RedirectStandardError (Join-Path $env:RUNNER_TEMP 'media-foundation.err')
+        } finally {
+          $env:PSModulePath = $savedPSModulePath
+        }
         Write-Host "Media Foundation install started in the background."
 
     # Resolve the *installed* R version (major.minor) and fold it into the
@@ -325,16 +336,32 @@ runs:
     # Companion to "Install Windows Media Foundation (background)" above: on a
     # typical run the feature install (~3 min) finished while the R/npm/browser
     # installs ran, so this is a no-op; when it didn't, block here rather than
-    # letting tests launch an Electron missing its media DLLs. A failed or
-    # stuck install fails the action, matching what the serial --with-deps
-    # install would have done.
+    # letting tests launch an Electron missing its media DLLs. The detached
+    # installer is not guaranteed to survive or make progress (run 31735929103
+    # saw it produce neither marker nor output on all six shards), so a missing
+    # marker falls back to running the same script synchronously, bounded --
+    # the worst case is the serial install this action always used to do. A
+    # failed install still fails the action, matching --with-deps behavior.
     - name: Wait for Windows Media Foundation install
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
         $marker = Join-Path $env:RUNNER_TEMP 'media-foundation.done'
+        $script = Join-Path $env:RUNNER_TEMP 'install-media-foundation.ps1'
+
+        function Get-InstallerProcess {
+          Get-CimInstance Win32_Process -Filter "Name = 'powershell.exe'" |
+            Where-Object { $_.CommandLine -like '*install-media-foundation.ps1*' }
+        }
+
+        # Poll only while the detached installer is demonstrably alive: a dead
+        # process without a marker will never produce one, so there is nothing
+        # to wait for beyond its lifetime.
         $deadline = (Get-Date).AddMinutes(10)
         while (-not (Test-Path $marker) -and (Get-Date) -lt $deadline) {
+          if (-not (Get-InstallerProcess)) {
+            break
+          }
           Start-Sleep -Seconds 5
         }
 
@@ -347,7 +374,35 @@ runs:
         }
 
         if (-not (Test-Path $marker)) {
-          Write-Error "Media Foundation install did not finish within 10 minutes."
+          # Diagnose which way the background install failed, then kill any
+          # hung remnant so it can't hold the servicing stack against the
+          # synchronous run below.
+          $proc = Get-InstallerProcess
+          if ($proc) {
+            Write-Host "Background installer still running with no result after 10 minutes; killing it."
+            $proc | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+          } else {
+            Write-Host "Background installer is no longer running and left no result."
+          }
+
+          Write-Host "Running the Media Foundation install synchronously."
+          $savedPSModulePath = $env:PSModulePath
+          try {
+            $env:PSModulePath = "$env:SystemRoot\system32\WindowsPowerShell\v1.0\Modules;$env:ProgramFiles\WindowsPowerShell\Modules"
+            $p = Start-Process powershell -NoNewWindow -PassThru `
+              -ArgumentList '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $script
+            if (-not $p.WaitForExit(600000)) {
+              $p.Kill()
+              Write-Error "Synchronous Media Foundation install timed out after 10 minutes."
+              exit 1
+            }
+          } finally {
+            $env:PSModulePath = $savedPSModulePath
+          }
+        }
+
+        if (-not (Test-Path $marker)) {
+          Write-Error "Media Foundation install wrote no result marker."
           exit 1
         }
         $status = (Get-Content $marker -Raw).Trim()

--- a/.github/workflows/os-cache-seed-e2e-deps.yml
+++ b/.github/workflows/os-cache-seed-e2e-deps.yml
@@ -1,0 +1,133 @@
+name: "Cache: Seed E2E test dependency caches"
+
+# Re-warms the os-e2e-deps caches (R library, pak download cache, Playwright
+# browsers) that the PR-triggered e2e jobs read. Those caches are restore-only
+# on PR runs: os-e2e-deps gates its saves to main-scoped runs, and the build
+# cache seeds run with build_only=true, which skips the e2e job where
+# os-e2e-deps runs. The scheduled main e2e runs do save -- but they install R
+# "release", and the cache keys embed the resolved R major.minor, so once
+# "release" rolls past the R version the PR orchestrator pins, their saves
+# land on keys no PR run ever reads (e.g. Linux-...-r-4.6-* while PR runs,
+# pinned to R 4.5.3, look for -r-4.5-). The result: every PR shard on every
+# platform reinstalls its R packages from scratch, ~1-4 minutes apiece, on
+# the critical path of the run.
+#
+# This seed runs os-e2e-deps on main for exactly the platform / cache-scope /
+# R-version combinations the PR orchestrator's e2e jobs use, so their key set
+# stays warm. No build, no tests -- each job is a few minutes.
+on:
+  push:
+    branches: [main]
+    # The key inputs: DESCRIPTION and required-packages.txt feed the R-library
+    # and pak keys, package-lock.json feeds the Playwright-browsers key, and
+    # the action defines the key format itself.
+    paths:
+      - "e2e/rstudio/DESCRIPTION"
+      - "e2e/rstudio/required-packages.txt"
+      - "e2e/rstudio/package-lock.json"
+      - ".github/actions/os-e2e-deps/**"
+      - ".github/workflows/os-cache-seed-e2e-deps.yml"
+  # Also dispatched by os-cache-seed-sentinel.yml when these caches have been
+  # evicted from main's scope (10 GB repo quota, LRU eviction).
+  workflow_dispatch:
+
+# Don't stack seed runs; the latest one wins.
+concurrency:
+  group: cache-seed-e2e-deps
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  seed:
+    strategy:
+      fail-fast: false
+      matrix:
+        # One entry per platform the PR orchestrator's e2e jobs run on, with
+        # the same runner image and cache-scope those jobs pass to
+        # os-e2e-deps, so the seeded keys are byte-for-byte the keys they
+        # restore. The two ubuntu-24.04 entries differ only in scope: the
+        # Linux Desktop workflow scopes its keys per-distro (noble-amd64,
+        # from .github/e2e-linux/ubuntu-24-x86_64.json), while the Linux
+        # Server workflow uses the legacy unscoped Linux- keys.
+        include:
+          - platform: windows-desktop
+            runner: windows-2025
+            cache-scope: ""
+          - platform: macos-desktop
+            runner: macos-26
+            cache-scope: "macos26-arm64"
+          - platform: linux-desktop
+            runner: ubuntu-24.04
+            cache-scope: "noble-amd64"
+          - platform: linux-server
+            runner: ubuntu-24.04
+            cache-scope: ""
+    name: seed (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    env:
+      R_LIBS_USER: ${{ github.workspace }}/R-libs
+      # Must match the r_version the PR orchestrator passes to every platform
+      # (see os-test-e2e-rstudio-pr.yml): the cache keys embed the resolved
+      # R major.minor, so a seed built with a different R version warms keys
+      # no PR run reads. When bumping the pin there, bump it here and in the
+      # matching sentinel prefixes (os-cache-seed-sentinel.yml) together.
+      R_VERSION: "4.5.3"
+
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/rstudio/package-lock.json
+
+      - name: Install rig (Windows)
+        if: runner.os == 'Windows'
+        uses: ./.github/actions/os-install-rig-windows
+
+      - name: Install rig (Unix)
+        if: runner.os != 'Windows'
+        uses: ./.github/actions/os-install-rig-unix
+
+      # Mirrors the Windows e2e job's R install: prepend the rig-installed R
+      # to PATH so it wins over any R version pre-installed on the runner
+      # image (windows-2025 ships a newer R; without the prepend, os-e2e-deps
+      # would resolve that version and compute keys no PR run reads).
+      - name: Install R via rig (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          rig add $env:R_VERSION
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          rig default $env:R_VERSION
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          rig ls
+          $rHome = (Rscript --vanilla -e "cat(R.home())" 2>$null).Trim()
+          $rBin = "$rHome\bin\x64"
+          Write-Host "Prepending R bin to PATH: $rBin"
+          "$rBin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          New-Item -ItemType Directory -Force -Path $env:R_LIBS_USER | Out-Null
+
+      - name: Install R via rig (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          rig add "$R_VERSION"
+          rig default "$R_VERSION"
+          rig ls
+          mkdir -p "$R_LIBS_USER"
+
+      # The saves inside the action fire because this workflow only runs on
+      # refs/heads/main (push to main, or the sentinel's dispatch --ref main).
+      - name: Install and cache e2e test dependencies
+        uses: ./.github/actions/os-e2e-deps
+        with:
+          r-libs-user: ${{ env.R_LIBS_USER }}
+          cache-scope: ${{ matrix.cache-scope }}
+          install-required-packages: "true"

--- a/.github/workflows/os-cache-seed-sentinel.yml
+++ b/.github/workflows/os-cache-seed-sentinel.yml
@@ -48,12 +48,21 @@ jobs:
           # Server Ubuntu 24 builds, so they are listed once, under the
           # Desktop seed; each seed re-warms every cache its build job
           # touches, missing or not.
+          #
+          # The os-cache-seed-e2e-deps.yml prefixes are the os-e2e-deps cache
+          # keys the PR orchestrator's e2e jobs read: <CACHE_OS>-{r,pak}-<R
+          # major.minor>- plus the R-version-independent <CACHE_OS>-pw-
+          # browser keys. The 4.5 in the r/pak prefixes tracks the R version
+          # the PR orchestrator pins (os-test-e2e-rstudio-pr.yml r_version,
+          # currently 4.5.3) as resolved to major.minor -- when that pin is
+          # bumped, bump these prefixes and the seed's R_VERSION together.
           CHECKS='
           os-cache-seed-e2e-rstudio-desktop-os-ubuntu-24.yml=rstudio-tools-linux-x86_64- rstudio-build-rlibs-linux-x86_64- rstudio-gwt-linux-desktop-x86_64-
           os-cache-seed-e2e-rstudio-server-os-ubuntu-24.yml=rstudio-gwt-linux-x86_64-
           os-cache-seed-e2e-macos-26-arm64.yml=rstudio-tools-arm64- rstudio-build-rlibs-arm64- rstudio-gwt-arm64-
           os-cache-seed-e2e-macos-15-x86_64.yml=rstudio-tools-x86_64- rstudio-build-rlibs-x86_64- rstudio-gwt-x86_64-
           os-cache-seed-e2e-rstudio-desktop-os-windows-server-2025.yml=rstudio-tools-win64- rstudio-gwt-win64-
+          os-cache-seed-e2e-deps.yml=Windows-r-4.5- Windows-pak-4.5- Windows-pw- macOS-macos26-arm64-r-4.5- macOS-macos26-arm64-pak-4.5- macOS-macos26-arm64-pw- Linux-noble-amd64-r-4.5- Linux-noble-amd64-pak-4.5- Linux-noble-amd64-pw- Linux-r-4.5- Linux-pak-4.5- Linux-pw-
           '
 
           FAILED=0

--- a/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
+++ b/.github/workflows/os-test-e2e-rstudio-desktop-os-windows-server-2025.yml
@@ -703,10 +703,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # 4 shards: per-shard setup is only ~5 minutes against a ~35 minute
-        # (at 2 shards) test step, so extra shards still convert nearly 1:1
-        # into wall-clock savings.
-        shard: [1, 2, 3, 4]
+        # 6 shards: per-shard setup is only ~5 minutes against a ~30 minute
+        # (at 4 shards) worst-case test step, so extra shards still convert
+        # nearly 1:1 into wall-clock savings. Playwright shards by file, not
+        # by duration, so the shard counts stay unbalanced -- at 4 shards the
+        # slowest shard ran ~30 minutes of tests against ~22 for its siblings
+        # and was the long pole of the whole PR-triggered run.
+        shard: [1, 2, 3, 4, 5, 6]
     runs-on: windows-2025
     timeout-minutes: 120
     environment: e2e-playwright
@@ -1144,4 +1147,4 @@ jobs:
             </details>
 
             ---
-            <sub>4 shards · Windows Server 2025 x64 · commit <code>${{ github.event.pull_request.head.sha }}</code> · <a href="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}">Run #${{ github.run_number }}</a></sub>
+            <sub>6 shards · Windows Server 2025 x64 · commit <code>${{ github.event.pull_request.head.sha }}</code> · <a href="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}">Run #${{ github.run_number }}</a></sub>


### PR DESCRIPTION
Diagnosis from [run 31727197282](https://github.com/rstudio/rstudio/actions/runs/31727197282) (PR #18534), where the Windows leg took ~82 minutes: the Windows build gates all four e2e shards, the slowest shard is chronically unbalanced, and every shard pays avoidable setup cost. Three changes:

### 1. Windows desktop e2e: 4 -> 6 shards

Playwright shards by file, not duration; shard 4 has been the long pole two days running (~30 min of test time vs ~22 for its siblings). The existing matrix comment already blessed this trade ("extra shards still convert nearly 1:1 into wall-clock savings"). Expected: ~8-12 min off the Windows leg.

### 2. os-e2e-deps: background the Windows Media Foundation install

`playwright install --with-deps` on Windows Server installs the Media Foundation feature -- ~3 minutes, not cacheable, run serially on every Windows shard even on a full cache hit (verified in the [shard-4 log](https://github.com/rstudio/rstudio/actions/runs/31639016842): 189s of silence ending in an `Install-WindowsFeature` result table). The feature install now starts as a detached process at the top of the action (same pattern as the build job's background disk cleanup), the browser-install step fetches only the browser binary on Windows, and the action's final step waits for the feature install and fails on the same errors the serial install would have surfaced. Expected: ~3 min off every Windows shard's critical path.

### 3. Seed the os-e2e-deps caches (new workflow + sentinel coverage)

The R-library / pak / Playwright-browser caches are effectively never warm for PR runs:

- os-e2e-deps gates its saves to main-scoped runs, and the build-cache seeds run `build_only: true`, which skips the e2e job where os-e2e-deps runs.
- The scheduled main e2e runs do save, but they install R `release` while the PR orchestrator pins `4.5.3`. The cache keys embed the resolved R major.minor, so those saves land on `-4.6-` keys no PR run reads (visible in the current cache list: `Linux-ubuntu24-arm64-r-4.6-*` exists, no `*-r-4.5-*` for any PR platform).
- The repo cache sits at ~9/10 GB, so anything that does land is LRU-eviction fodder, and the sentinel didn't cover these prefixes.

`os-cache-seed-e2e-deps.yml` runs os-e2e-deps on main for exactly the four platform/cache-scope/R-version combinations the PR orchestrator's e2e jobs read (Windows, macOS-macos26-arm64, Linux-noble-amd64, unscoped Linux), triggered on pushes that change the key inputs and dispatchable by the sentinel on eviction. Expected: ~1-4 min off every shard on every platform.

### Verification

This PR touches the PR-trigger paths, so its own e2e run exercises the 6-shard split and the Media Foundation change on all platforms. The seed workflow and sentinel line only activate after merge (push-to-main trigger / dispatch on main); I'll dispatch the seed manually after merging and confirm the caches land.

Not addressed here (follow-up candidates): macOS/Linux shard counts (macOS shard 2 ran 48 min in the diagnosed run), moving the GWT output cache to S3 to close the ~1-hour post-merge seed race, and larger runners for the Windows build job.