### PR TITLE
Pin panmirror to a named quarto branch and drop the GitHub API cache-bust

### DIFF
--- a/dependencies/common/install-panmirror
+++ b/dependencies/common/install-panmirror
@@ -46,11 +46,24 @@ PANMIRROR_BRANCH="release/rstudio-autumn-hawkbit"
 info "PANMIRROR_BRANCH: ${PANMIRROR_BRANCH}"
 
 # Check the branch up front; the git errors from the clone and checkout below don't
-# say what to do about a missing branch. Never fall back to another branch -- that
-# would silently ship the wrong panmirror.
-if ! git ls-remote --exit-code --heads "${QUARTO_REPO_URL}" "${PANMIRROR_BRANCH}" > /dev/null; then
+# say what to do about a missing branch. Match the full ref path rather than passing
+# --heads with a bare name: --heads matches any tail of a ref at a path boundary, so a
+# name missing the 'release/' prefix would match the real branch and pass the check.
+# Never fall back to another branch -- that would silently ship the wrong panmirror.
+LS_REMOTE_STATUS=0
+git ls-remote --exit-code "${QUARTO_REPO_URL}" "refs/heads/${PANMIRROR_BRANCH}" > /dev/null \
+  || LS_REMOTE_STATUS=$?
+
+# Only --exit-code's 2 means "no such ref". Anything else -- 128 for network, DNS or
+# TLS trouble -- must not be reported as a missing branch, or an outage sends whoever
+# reads the log off to create a branch that is already there.
+if [ "${LS_REMOTE_STATUS}" -eq 2 ]; then
   error "Branch '${PANMIRROR_BRANCH}' does not exist in ${QUARTO_REPO_URL}." \
-        "Create it from quarto's 'main', or set PANMIRROR_BRANCH to a branch that exists." >&2
+        "Create it from quarto's 'main', or edit PANMIRROR_BRANCH in this script." >&2
+  exit 1
+elif [ "${LS_REMOTE_STATUS}" -ne 0 ]; then
+  error "Could not reach ${QUARTO_REPO_URL} to look for '${PANMIRROR_BRANCH}'" \
+        "(git exited ${LS_REMOTE_STATUS})." >&2
   exit 1
 fi
 
@@ -67,8 +80,11 @@ else
   pushd $QUARTO_DIR
   git fetch
   git reset --hard && git clean -dfx
-  git checkout "$PANMIRROR_BRANCH"
-  git pull
+  # Force the branch to the fetched tip rather than checkout + pull. A local branch
+  # left ahead of origin -- an interrupted earlier run, or an upstream force-push --
+  # makes pull report "Already up to date" and exit 0 while HEAD sits on a commit that
+  # is not the branch tip, which is the divergence this whole scheme exists to avoid.
+  git checkout -B "$PANMIRROR_BRANCH" "origin/${PANMIRROR_BRANCH}"
   git rev-parse HEAD
 
   popd

--- a/dependencies/common/install-panmirror
+++ b/dependencies/common/install-panmirror
@@ -29,14 +29,35 @@ PANMIRROR_WWW_DIR="${GWT_ROOT_DIR}/www/js/panmirror"
 info "GWT_ROOT_DIR: ${GWT_ROOT_DIR}"
 info "QUARTO_DIR: ${QUARTO_DIR}"
 
-# IMPORTANT: When changing which branch this pulls from below, also update the Dockerfiles'
-#            "panmirror check for changes" command to use the equivalent.
+QUARTO_REPO_URL="https://github.com/quarto-dev/quarto.git"
+
+# panmirror is taken from a branch of the quarto repo named for the RStudio release
+# cycle. Open a cycle by branching quarto's 'main' as release/rstudio-<flower>; to
+# take panmirror changes mid-cycle, create a NEW branch with a numeric suffix
+# (release/rstudio-<flower>-01, -02, ...) and point PANMIRROR_BRANCH at it.
+#
+# IMPORTANT: treat a branch named here as immutable -- never push to it. Editing
+# this script is what invalidates the Docker layer that bakes panmirror into the
+# Jenkins builder images, so nothing detects a branch tip that moves: images cached
+# before the push keep the old panmirror while freshly built ones get the new code,
+# and the divergence is silent.
+PANMIRROR_BRANCH="release/rstudio-autumn-hawkbit"
+
+info "PANMIRROR_BRANCH: ${PANMIRROR_BRANCH}"
+
+# Check the branch up front; the git errors from the clone and checkout below don't
+# say what to do about a missing branch. Never fall back to another branch -- that
+# would silently ship the wrong panmirror.
+if ! git ls-remote --exit-code --heads "${QUARTO_REPO_URL}" "${PANMIRROR_BRANCH}" > /dev/null; then
+  error "Branch '${PANMIRROR_BRANCH}' does not exist in ${QUARTO_REPO_URL}." \
+        "Create it from quarto's 'main', or set PANMIRROR_BRANCH to a branch that exists." >&2
+  exit 1
+fi
 
 # clone quarto monorepo if not already cloned
 if ! test -e "$QUARTO_DIR"; then
   echo "Cloning quarto repo"
-  git clone https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
-  # git clone --branch release/rstudio-autumn-hawkbit https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
+  git clone --branch "$PANMIRROR_BRANCH" "$QUARTO_REPO_URL" "$QUARTO_DIR"
   pushd $QUARTO_DIR
   git rev-parse HEAD
   popd
@@ -46,8 +67,7 @@ else
   pushd $QUARTO_DIR
   git fetch
   git reset --hard && git clean -dfx
-  git checkout main
-  # git checkout release/rstudio-autumn-hawkbit
+  git checkout "$PANMIRROR_BRANCH"
   git pull
   git rev-parse HEAD
 

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -299,6 +299,7 @@ if not exist %NSISMULTIUSER_FOLDER%\Include\NsisMultiUser.nsh (
 echo -- Installing panmirror (Visual Editor)
 pushd "%WINDOWS_SCRIPTS_DIR%install-panmirror"
 call clone-panmirror-repo.cmd
+if errorlevel 1 exit /b 1
 popd
 
 echo -- Installing SOCI

--- a/dependencies/windows/install-panmirror/clone-panmirror-repo.cmd
+++ b/dependencies/windows/install-panmirror/clone-panmirror-repo.cmd
@@ -5,7 +5,16 @@ if not exist ..\..\..\src\gwt\lib (
     echo Creating directory ..\..\..\src\gwt\lib
     mkdir ..\..\..\src\gwt\lib
 )
+
+:: The clone below is addressed relative to this directory, so stop if we are not in
+:: it -- otherwise quarto lands next to this script and the build never sees it. A
+:: failed mkdir above arrives here too, having already reported why. Nothing has been
+:: pushed yet, so exit without the popd that :failed does.
 pushd ..\..\..\src\gwt\lib
+if errorlevel 1 (
+  echo ERROR: Could not enter ..\..\..\src\gwt\lib
+  exit /b 1
+)
 
 
 :: panmirror is taken from a branch of the quarto repo named for the RStudio release

--- a/dependencies/windows/install-panmirror/clone-panmirror-repo.cmd
+++ b/dependencies/windows/install-panmirror/clone-panmirror-repo.cmd
@@ -8,12 +8,34 @@ if not exist ..\..\..\src\gwt\lib (
 pushd ..\..\..\src\gwt\lib
 
 
-:: IMPORTANT: When changing which branch this pulls from below, also update the Dockerfiles'
-::            "panmirror check for changes" command to use the equivalent.
+:: panmirror is taken from a branch of the quarto repo named for the RStudio release
+:: cycle. Open a cycle by branching quarto's 'main' as release/rstudio-<flower>; to
+:: take panmirror changes mid-cycle, create a NEW branch with a numeric suffix
+:: (release/rstudio-<flower>-01, -02, ...) and point PANMIRROR_BRANCH at it.
+::
+:: IMPORTANT: treat a branch named here as immutable -- never push to it. Editing
+:: this script is what invalidates the Docker layer that bakes panmirror into the
+:: Jenkins builder images, so nothing detects a branch tip that moves: images cached
+:: before the push keep the old panmirror while freshly built ones get the new code,
+:: and the divergence is silent.
+set PANMIRROR_REPO_URL=https://github.com/quarto-dev/quarto.git
+set PANMIRROR_BRANCH=release/rstudio-autumn-hawkbit
+
+echo -- panmirror branch: %PANMIRROR_BRANCH%
+
+:: Check the branch up front; the git errors from the clone and checkout below don't
+:: say what to do about a missing branch. Never fall back to another branch -- that
+:: would silently ship the wrong panmirror.
+git ls-remote --exit-code --heads %PANMIRROR_REPO_URL% %PANMIRROR_BRANCH% >nul
+if errorlevel 1 (
+  echo ERROR: Branch %PANMIRROR_BRANCH% does not exist in %PANMIRROR_REPO_URL%.
+  echo Create it from quarto's 'main', or set PANMIRROR_BRANCH to a branch that exists.
+  popd
+  exit /b 1
+)
 
 if not exist quarto (
-  git clone https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
-  REM git clone --branch release/rstudio-autumn-hawkbit https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
+  git clone --branch %PANMIRROR_BRANCH% %PANMIRROR_REPO_URL% ..\..\..\src\gwt\lib\quarto
   pushd ..\..\..\src\gwt\lib\quarto
   git rev-parse HEAD
   popd
@@ -22,8 +44,7 @@ if not exist quarto (
   git fetch
   git reset --hard
   git clean -dfx
-  git checkout main
-  REM git checkout release/rstudio-autumn-hawkbit
+  git checkout %PANMIRROR_BRANCH%
   git pull
   git rev-parse HEAD
   popd

--- a/dependencies/windows/install-panmirror/clone-panmirror-repo.cmd
+++ b/dependencies/windows/install-panmirror/clone-panmirror-repo.cmd
@@ -30,24 +30,35 @@ git ls-remote --exit-code --heads %PANMIRROR_REPO_URL% %PANMIRROR_BRANCH% >nul
 if errorlevel 1 (
   echo ERROR: Branch %PANMIRROR_BRANCH% does not exist in %PANMIRROR_REPO_URL%.
   echo Create it from quarto's 'main', or set PANMIRROR_BRANCH to a branch that exists.
-  popd
-  exit /b 1
+  goto :failed
 )
 
+:: Every git step below is checked. cmd has no 'set -e', and a later command that
+:: succeeds clears ERRORLEVEL, so an unchecked failure would leave a missing or
+:: stale clone for the build to pick up instead of stopping it.
 if not exist quarto (
-  git clone --branch %PANMIRROR_BRANCH% %PANMIRROR_REPO_URL% ..\..\..\src\gwt\lib\quarto
-  pushd ..\..\..\src\gwt\lib\quarto
-  git rev-parse HEAD
-  popd
+  git clone --branch %PANMIRROR_BRANCH% %PANMIRROR_REPO_URL% quarto
+  if errorlevel 1 goto :failed
 ) else (
-  pushd quarto
-  git fetch
-  git reset --hard
-  git clean -dfx
-  git checkout %PANMIRROR_BRANCH%
-  git pull
-  git rev-parse HEAD
-  popd
+  git -C quarto fetch
+  if errorlevel 1 goto :failed
+  git -C quarto reset --hard
+  if errorlevel 1 goto :failed
+  git -C quarto clean -dfx
+  if errorlevel 1 goto :failed
+  git -C quarto checkout %PANMIRROR_BRANCH%
+  if errorlevel 1 goto :failed
+  git -C quarto pull
+  if errorlevel 1 goto :failed
 )
+
+git -C quarto rev-parse HEAD
+if errorlevel 1 goto :failed
 
 popd
+exit /b 0
+
+:failed
+echo ERROR: panmirror (quarto) checkout failed.
+popd
+exit /b 1

--- a/dependencies/windows/install-panmirror/clone-panmirror-repo.cmd
+++ b/dependencies/windows/install-panmirror/clone-panmirror-repo.cmd
@@ -33,14 +33,18 @@ set PANMIRROR_BRANCH=release/rstudio-autumn-hawkbit
 echo -- panmirror branch: %PANMIRROR_BRANCH%
 
 :: Check the branch up front; the git errors from the clone and checkout below don't
-:: say what to do about a missing branch. Never fall back to another branch -- that
-:: would silently ship the wrong panmirror.
-git ls-remote --exit-code --heads %PANMIRROR_REPO_URL% %PANMIRROR_BRANCH% >nul
-if errorlevel 1 (
-  echo ERROR: Branch %PANMIRROR_BRANCH% does not exist in %PANMIRROR_REPO_URL%.
-  echo Create it from quarto's 'main', or set PANMIRROR_BRANCH to a branch that exists.
-  goto :failed
-)
+:: say what to do about a missing branch. Match the full ref path rather than passing
+:: --heads with a bare name: --heads matches any tail of a ref at a path boundary, so a
+:: name missing the 'release/' prefix would match the real branch and pass the check.
+:: Never fall back to another branch -- that would silently ship the wrong panmirror.
+git ls-remote --exit-code %PANMIRROR_REPO_URL% refs/heads/%PANMIRROR_BRANCH% >nul
+
+:: Only --exit-code's 2 means "no such ref". Anything else -- 128 for network, DNS or
+:: TLS trouble -- must not be reported as a missing branch. 'if errorlevel N' means "N
+:: or greater", so the cases are tested from the top down.
+if errorlevel 3 goto :unreachable
+if errorlevel 2 goto :nobranch
+if errorlevel 1 goto :unreachable
 
 :: Every git step below is checked. cmd has no 'set -e', and a later command that
 :: succeeds clears ERRORLEVEL, so an unchecked failure would leave a missing or
@@ -55,9 +59,12 @@ if not exist quarto (
   if errorlevel 1 goto :failed
   git -C quarto clean -dfx
   if errorlevel 1 goto :failed
-  git -C quarto checkout %PANMIRROR_BRANCH%
-  if errorlevel 1 goto :failed
-  git -C quarto pull
+  REM Force the branch to the fetched tip rather than checkout + pull. A local branch
+  REM left ahead of origin -- an interrupted earlier run, or an upstream force-push --
+  REM makes pull report "Already up to date" and exit 0 while HEAD sits on a commit
+  REM that is not the branch tip, the divergence this whole scheme exists to avoid.
+  REM Uses REM, not ::, since a label inside a parenthesized block is a cmd error.
+  git -C quarto checkout -B %PANMIRROR_BRANCH% origin/%PANMIRROR_BRANCH%
   if errorlevel 1 goto :failed
 )
 
@@ -66,6 +73,15 @@ if errorlevel 1 goto :failed
 
 popd
 exit /b 0
+
+:nobranch
+echo ERROR: Branch %PANMIRROR_BRANCH% does not exist in %PANMIRROR_REPO_URL%.
+echo Create it from quarto's 'main', or edit PANMIRROR_BRANCH in this script.
+goto :failed
+
+:unreachable
+echo ERROR: Could not reach %PANMIRROR_REPO_URL% to look for %PANMIRROR_BRANCH%.
+goto :failed
 
 :failed
 echo ERROR: panmirror (quarto) checkout failed.

--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -104,10 +104,6 @@ RUN bash /tmp/install-boost || bash /tmp/install-boost
 COPY package/linux/install-dependencies /tmp/
 RUN /bin/bash /tmp/install-dependencies
 
-# panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-autumn-hawkbit panmirror.version.json
-
 # copy common dependency installation scripts
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/

--- a/docker/jenkins/Dockerfile.focal
+++ b/docker/jenkins/Dockerfile.focal
@@ -110,10 +110,6 @@ RUN /bin/bash /tmp/install-dependencies
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
-# panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-autumn-hawkbit panmirror.version.json
-
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common focal
 # panmirror needs to be able to build in this location

--- a/docker/jenkins/Dockerfile.jammy
+++ b/docker/jenkins/Dockerfile.jammy
@@ -128,10 +128,6 @@ RUN /bin/bash /tmp/install-dependencies
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
-# panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-autumn-hawkbit panmirror.version.json
-
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common jammy
 # panmirror needs to be able to build in this location

--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -93,10 +93,6 @@ RUN update-alternatives --set java /usr/lib64/jvm/jre-17-openjdk/bin/java
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
-# panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-autumn-hawkbit panmirror.version.json
-
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common opensuse15
 # panmirror needs to be able to build in this location

--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -97,10 +97,6 @@ RUN cp /usr/bin/python2 /usr/bin/python
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
-# panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-autumn-hawkbit panmirror.version.json
-
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common rhel8
 # panmirror needs to be able to build in this location

--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -100,10 +100,6 @@ RUN bash /tmp/install-dependencies
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
-# panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-autumn-hawkbit panmirror.version.json
-
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common rhel9
 # panmirror needs to be able to build in this location

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -141,10 +141,6 @@ COPY dependencies/tools/rstudio-tools.cmd 'C:\rstudio-tools\dependencies\tools\r
 COPY dependencies/common 'C:\rstudio-tools\dependencies\common'
 COPY dependencies/windows 'C:\rstudio-tools\dependencies\windows'
 
-# panmirror check for changes
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-autumn-hawkbit panmirror.version.json
-
 ENV DOCKER_IMAGE_BUILD=1
 WORKDIR C:/rstudio-tools/dependencies/windows
 RUN C:/rstudio-tools/dependencies/windows/install-dependencies.cmd


### PR DESCRIPTION
panmirror is now taken from a branch of the quarto repo named once in each install script, and the GitHub API cache-bust is gone from the seven Jenkins builder Dockerfiles.

Each Dockerfile carried:

```dockerfile
ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
```

Nothing read `panmirror.version.json`; it was a Docker cache key that forced panmirror to re-bake into the image when the tracked branch tip moved. Unauthenticated `api.github.com` allows 60 requests/hour per IP, and every image build hit one of these from shared CI egress, so reaching the limit failed the `ADD` and killed the build. The branch name also had to be toggled by hand across an active `ADD` and a commented-out variant in each Dockerfile, plus the clone and checkout lines and the "keep in sync" comments in the two install scripts.

`dependencies/common/install-panmirror` and `dependencies/windows/install-panmirror/clone-panmirror-repo.cmd` now set `PANMIRROR_BRANCH` once and use it for both the clone and the refresh. Editing that value is itself the cache-bust: every Linux Dockerfile `COPY`s `dependencies/common/` before running `install-common`, and `Dockerfile.windows` `COPY`s `dependencies/{common,windows}` before running `install-dependencies.cmd`, so touching a copied script invalidates the layer that bakes panmirror. Both scripts are admitted by `.dockerignore`.

Because nothing detects a moved branch tip any more, a branch named in these scripts has to be treated as immutable: images cached before a push would keep the old panmirror while freshly built ones picked up the new code. Mid-cycle panmirror changes therefore get a new suffixed branch rather than a push to the referenced one. Both scripts document that where the "keep in sync" note used to be.

Failure handling in the two scripts:

- The branch is checked with `git ls-remote` against the full `refs/heads/<branch>` path before anything is cloned. Matching the full path is deliberate: `--heads` with a bare name matches any tail of a ref, so a name missing its `release/` prefix would match the real branch and pass.
- Only `--exit-code`'s 2 is reported as a missing branch. Other exits (128 for network, DNS or TLS trouble) are reported as an unreachable remote, so an outage does not send the reader off to create a branch that already exists.
- There is no fallback to another branch; that would silently ship the wrong panmirror.
- The refresh path forces the branch to the fetched tip with `checkout -B` against `origin/<branch>` instead of `checkout` + `pull`. A local branch left ahead of origin made `pull` print "Already up to date" and exit 0 with HEAD off the branch tip.
- The Windows script checks its `pushd` and every git step, exiting non-zero through a single failure label, and `install-dependencies.cmd` propagates that so it fails the image build. cmd has no `set -e`, and a later command that succeeds clears `ERRORLEVEL`.

Local and macOS developer builds are unaffected: with no `/opt/rstudio-tools` present, the `set-if-exists` in `src/gwt/build.xml:281-284` falls through to the checkout's own `lib/quarto`, which the refresh path moves onto the named branch.

No `NEWS.md` entry; build tooling only.

## Verification

`dependencies/common/install-panmirror` was run against the live quarto remote in a scratch tree:

- fresh clone lands on `release/rstudio-autumn-hawkbit`
- a clone parked on `main` moves onto it
- re-pointing `PANMIRROR_BRANCH` at another branch moves onto that branch's tip
- a clone left one commit ahead of origin is reset back to the tip (this reported success on the old `checkout` + `pull` path)
- a branch name missing its `release/` prefix is rejected
- an unreachable remote reports the remote, not a missing branch

The Windows script has not been executed — it needs a Windows host. Still to confirm on CI: that a Linux builder image and the Windows builder image build, that `/opt/rstudio-tools/src/gwt/lib/quarto` (resp. `c:/rstudio-tools/...`) is on the expected branch afterwards, and that changing `PANMIRROR_BRANCH` re-clones rather than reusing the cached layer.

Addresses #18549.
