### PR TITLE
Fetch gnupg 1.4.23 from rstudio-buildtools mirror

### DIFF
--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -102,8 +102,9 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common open
 RUN chmod -R 777 /opt/rstudio-tools/src
 
 # install GnuPG 1.4 from source (needed for release signing)
+# mirrored into rstudio-buildtools because gnupg.org returns 403 to the builders
 RUN cd /tmp && \
-    wget https://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.23.tar.bz2 && \
+    wget https://rstudio-buildtools.s3.amazonaws.com/gnupg-1.4.23.tar.bz2 && \
     bzip2 -d gnupg-1.4.23.tar.bz2 && \
     tar xvf gnupg-1.4.23.tar && \
     cd gnupg-1.4.23 && \

--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -113,7 +113,8 @@ RUN cp libuser-libuser-0.62/lib/*.h /usr/include/libuser
 
 # build and install gpg1.4 which we need to sign the builds in headless mode
 # this is unavailable in the official rhel8 repos
-RUN wget https://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.23.tar.bz2
+# mirrored into rstudio-buildtools because gnupg.org returns 403 to the builders
+RUN wget https://rstudio-buildtools.s3.amazonaws.com/gnupg-1.4.23.tar.bz2
 RUN tar xvf gnupg-1.4.23.tar.bz2
 RUN cd gnupg-1.4.23 && ./configure --prefix=/gnupg1 && make && make install
 RUN ln -s /gnupg1/bin/gpg /usr/local/bin/gpg1

--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -110,7 +110,8 @@ RUN chmod -R 777 /opt/rstudio-tools/src
 
 # build and install gpg1.4 which we need to sign the builds in headless mode
 # this is unavailable in the official rhel9 repos
-RUN wget https://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.23.tar.bz2
+# mirrored into rstudio-buildtools because gnupg.org returns 403 to the builders
+RUN wget https://rstudio-buildtools.s3.amazonaws.com/gnupg-1.4.23.tar.bz2
 RUN tar xvf gnupg-1.4.23.tar.bz2
 RUN cd gnupg-1.4.23 && CFLAGS="-fcommon" ./configure --prefix=/gnupg1 && make && make install
 RUN ln -s /gnupg1/bin/gpg /usr/local/bin/gpg1


### PR DESCRIPTION
Backport of #18547 to `rel-yellow-yarrow`.

The rhel8, rhel9 and opensuse15 Jenkins images build gpg 1.4 from source for headless release signing, and gnupg.org returns HTTP 403 to the builders when fetching the tarball. These three Dockerfiles now fetch `gnupg-1.4.23.tar.bz2` from the rstudio-buildtools S3 mirror instead, matching how Boost, SOCI, GWT, Quarto, pandoc and Node are already sourced. The Debian and Ubuntu images install gnupg1 from apt and are unchanged.

The mirrored tarball (`s3://rstudio-buildtools/gnupg-1.4.23.tar.bz2`) was verified byte-identical against the canonical origin and two official mirrors:

    sha256  c9462f17e651b6507848c08c430c791287cd75491f8b5a8b50c6ed46b12678ba
    size    3749353

Cherry-picked cleanly from 07e2752ee5780da97ab7660beeca3b2cbdb90ec5 with no conflicts; the diff against `rel-yellow-yarrow` is identical to the change on `main`.