### PR TITLE
Remove quarto.org cachebust from Jenkins build images

### DIFF
--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -117,10 +117,6 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common bion
 # panmirror needs to be able to build in this location
 RUN chmod -R 777 /opt/rstudio-tools/src
 
-# cachebust for Quarto release
-ADD https://quarto.org/docs/download/_download.json quarto_releases
-RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
-
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN

--- a/docker/jenkins/Dockerfile.focal
+++ b/docker/jenkins/Dockerfile.focal
@@ -118,10 +118,6 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common foca
 # panmirror needs to be able to build in this location
 RUN chmod -R 777 /opt/rstudio-tools/src
 
-# cachebust for Quarto release
-ADD https://quarto.org/docs/download/_download.json quarto_releases
-RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
-
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN

--- a/docker/jenkins/Dockerfile.jammy
+++ b/docker/jenkins/Dockerfile.jammy
@@ -136,10 +136,6 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common jamm
 # panmirror needs to be able to build in this location
 RUN chmod -R 777 /opt/rstudio-tools/src
 
-# cachebust for Quarto release
-ADD https://quarto.org/docs/download/_download.json quarto_releases
-RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
-
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN

--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -111,10 +111,6 @@ RUN cd /tmp && \
     make && \
     make install
 
-# cachebust for Quarto release
-ADD https://quarto.org/docs/download/_download.json quarto_releases
-RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
-
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN

--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -118,10 +118,6 @@ RUN tar xvf gnupg-1.4.23.tar.bz2
 RUN cd gnupg-1.4.23 && ./configure --prefix=/gnupg1 && make && make install
 RUN ln -s /gnupg1/bin/gpg /usr/local/bin/gpg1
 
-# cachebust for Quarto release
-ADD https://quarto.org/docs/download/_download.json quarto_releases
-RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
-
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN

--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -115,10 +115,6 @@ RUN tar xvf gnupg-1.4.23.tar.bz2
 RUN cd gnupg-1.4.23 && CFLAGS="-fcommon" ./configure --prefix=/gnupg1 && make && make install
 RUN ln -s /gnupg1/bin/gpg /usr/local/bin/gpg1
 
-# cachebust for Quarto release
-ADD https://quarto.org/docs/download/_download.json quarto_releases
-RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
-
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN


### PR DESCRIPTION
Backport of #18548 to `rel-yellow-yarrow`.

The six Linux Jenkins builder images (bionic, focal, jammy, opensuse15, rhel8, rhel9) each carried a cache-bust key ahead of an explicit `install-quarto` step:

```dockerfile
# cachebust for Quarto release
ADD https://quarto.org/docs/download/_download.json quarto_releases
RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
```

Both lines are removed. Quarto installs through `install-common` (`dependencies/common/install-common:26`), alongside the other common dependencies.

The key tracked the wrong thing: `install-quarto` pins `QUARTO_VERSION` and fetches the tarball from the `rstudio-buildtools` S3 mirror, so the key fired on upstream releases we do not install, while a `QUARTO_VERSION` bump is already picked up by the `COPY dependencies/common/` layer above it. The `ADD` also required quarto.org to be reachable at build time. With the cachebust gone the trailing `RUN` was a no-op, since `install-common` runs earlier in each of these files and `install-quarto` exited early.

The panmirror cache-bust is left in place -- `install-panmirror` clones `quarto-dev/quarto` at its default branch, so keying on that ref tracks what actually gets fetched.

Cherry-picked cleanly from 95a7e4992f723c01716e64fc0240d5cec345f48e with no conflicts. Deletions only: 24 removed lines, no additions, no surrounding instructions edited. The images have not been built locally, so the first CI build of these images is the check.

`Dockerfile.rhel10` exists only in rstudio-pro and carries the same block; the pro release branch needs its own backport of rstudio/rstudio-pro#12257.