### PR TITLE
fix invisible math in the visual editor

### DIFF
--- a/e2e/rstudio/tests/panes/editor/math_preview.test.ts
+++ b/e2e/rstudio/tests/panes/editor/math_preview.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { SourcePaneActions } from '@actions/source_pane.actions';
+import { AceEditor } from '@pages/ace_editor.page';
 import { useSuiteSandbox } from '@utils/sandbox';
 import { setPref, clearPref } from '@utils/commands';
 import { heredoc } from '@utils/heredoc';
@@ -111,10 +112,10 @@ test.describe('Inline LaTeX math previews', () => {
     const popupMath = page.locator('mjx-container:not(.rstudio-mathjax-root mjx-container)');
     await expect(popupMath).toBeVisible({ timeout: 60000 });
 
-    // watch the popup's math element: rendered TeX errors must never enter
-    // the visible DOM (typesets happen in a hidden scratch element, and a
-    // failed render keeps the previous output). track scratch-element
-    // removals on the parent as the "a re-render completed" signal.
+    // watch the popup's math element: rendered TeX errors must never become
+    // visible (typesets happen in a hidden scratch element inside the target,
+    // and a failed render keeps the previous output). track scratch-element
+    // removals on the target as the "a re-render completed" signal.
     await page.evaluate(() => {
       const container = Array.from(document.querySelectorAll('mjx-container')).find(
         (c) => (c as HTMLElement).offsetParent != null
@@ -123,7 +124,8 @@ test.describe('Inline LaTeX math previews', () => {
       (window as any).__merrorSeen = false;
       (window as any).__renderAttempts = 0;
       new MutationObserver(() => {
-        if (el.querySelector('mjx-merror, [data-mjx-error]'))
+        const errors = Array.from(el.querySelectorAll('mjx-merror, [data-mjx-error]'));
+        if (errors.some((n) => getComputedStyle(n).visibility !== 'hidden'))
           (window as any).__merrorSeen = true;
       }).observe(el, { childList: true, subtree: true });
       new MutationObserver((mutations) => {
@@ -131,7 +133,7 @@ test.describe('Inline LaTeX math previews', () => {
           if (m.removedNodes.length > 0)
             (window as any).__renderAttempts += 1;
         }
-      }).observe(el.parentElement!, { childList: true });
+      }).observe(el, { childList: true });
     });
 
     // type a trailing subscript, making the expression incomplete
@@ -150,6 +152,46 @@ test.describe('Inline LaTeX math previews', () => {
     expect(await page.evaluate(() => (window as any).__merrorSeen)).toBe(false);
     await expect(popupMath).toBeVisible();
     await expect(popupMath).not.toContainText('Missing');
+
+    await sourceActions.closeSourceAndDeleteFile(fileName);
+  });
+
+  // math in the visual editor is typeset into ProseMirror widget decorations
+  // through the same MathJax pipeline. the typeset scratch element must live
+  // inside the widget: ProseMirror reverts unexpected siblings in its editing
+  // DOM, which detached the scratch mid-typeset (zero-size output), wedged
+  // the shared typeset queue, and re-parsed raw TeX into the document (#18551)
+  test('inline and display math render in the visual editor', async ({ rstudioPage: page }) => {
+    const fileName = `math_visual_${Date.now()}.qmd`;
+    const content = heredoc`
+      ---
+      format: html
+      ---
+
+      This is inline math: $\mu = 5$.
+
+      $$
+      \bar{X} \sim N\left(\mu,\frac{\sigma^2}{n}\right)
+      $$
+    `;
+
+    await sourceActions.createAndOpenFile(fileName, content);
+    await expect(sourceActions.sourcePane.selectedTab).toContainText(fileName, { timeout: 20000 });
+
+    await sourceActions.ensureVisualMode();
+
+    // both expressions typeset into visible (non-zero-size) output; the
+    // regression rendered the first at zero size and left the rest empty
+    const containers = page.locator('.ProseMirror .pm-math-mathjax mjx-container');
+    await expect(containers).toHaveCount(2, { timeout: 60000 });
+    await expect(containers.nth(0)).toBeVisible();
+    await expect(containers.nth(1)).toBeVisible();
+
+    // the round trip back to source mode must preserve the math text
+    await sourceActions.ensureSourceMode();
+    const editor = new AceEditor(page, '');
+    await expect.poll(() => editor.getValue(), { timeout: 20000 }).toContain('\\mu = 5');
+    expect(await editor.getValue()).toContain('\\bar{X}');
 
     await sourceActions.closeSourceAndDeleteFile(fileName);
   });

--- a/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJax.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJax.java
@@ -555,9 +555,15 @@ public class MathJax
             if (!error)
                lastRenderedText_ = text;
 
-            // re-position popup after render
-            popup_.positionNearRange(docDisplay_, range_);
-            popup_.show();
+            // re-position the popup after render, unless the cursor left the
+            // math range while the typeset was in flight -- endRender() has
+            // then already reset the render state (nulling range_) and hidden
+            // the popup
+            if (range_ != null)
+            {
+               popup_.positionNearRange(docDisplay_, range_);
+               popup_.show();
+            }
 
             // invoke user callback if provided
             if (callback != null)

--- a/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxTypeset.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxTypeset.java
@@ -61,18 +61,24 @@ public class MathJaxTypeset
       });
 
       // bail (keeping the typeset queue alive) if the target has been
-      // detached in the interim
-      if (el.parentNode == null)
+      // detached in the interim -- typesetting a detached element would
+      // compute zero font metrics and render at zero size
+      if (!el.isConnected)
       {
          onCompleted(true);
          return;
       }
 
-      // typeset into a hidden scratch sibling, so that in-progress (or
+      // typeset into a hidden scratch child, so that in-progress (or
       // failed) renders are never visible -- while typing, incomplete
       // expressions would otherwise flash a rendered TeX error before the
-      // previous render could be restored. the scratch element shares the
-      // target's parent and class so it typesets with the same font metrics
+      // previous render could be restored. the scratch element lives inside
+      // the target (same inherited font metrics) rather than beside it: in
+      // the visual editor the target is a ProseMirror widget, and ProseMirror
+      // ignores DOM mutations within widgets but reverts unexpected siblings
+      // (removing the scratch mid-typeset, and re-parsing its raw TeX into
+      // the document) -- see https://github.com/rstudio/rstudio/issues/18551
+      var hadRender = el.querySelector("mjx-container") != null;
       var scratch = el.ownerDocument.createElement(el.tagName);
       scratch.className = el.className;
       scratch.style.position = "absolute";
@@ -80,40 +86,62 @@ public class MathJaxTypeset
       if (el.offsetWidth > 0)
          scratch.style.width = el.offsetWidth + "px";
       scratch.innerText = currentText;
-      el.parentNode.appendChild(scratch);
+      el.appendChild(scratch);
 
       var cleanup = function() {
-         MathJax.typesetClear([scratch]);
-         scratch.parentNode.removeChild(scratch);
+         try
+         {
+            MathJax.typesetClear([scratch]);
+            if (scratch.parentNode != null)
+               scratch.parentNode.removeChild(scratch);
+         }
+         catch (e)
+         {
+            $wnd.console.warn(e);
+         }
       };
 
-      MathJax.typesetPromise([scratch]).then(function() {
+      MathJax.typesetPromise([scratch]).then($entry(function() {
 
-         // failed typesets surface in two ways, neither of which rejects
-         // the typeset promise: recoverable TeX errors render as 'merror'
-         // nodes, while malformed inputs (e.g. unbalanced braces) are
-         // skipped by the math finder entirely, leaving raw text behind
-         var container = scratch.querySelector("mjx-container");
-         var merror = scratch.querySelector("mjx-merror, [data-mjx-error]");
-         var error = container == null || merror != null;
-
-         // swap the new output into place on success; on failure, keep any
-         // previous (successful) render, but surface the error output when
-         // there is no previous render to preserve
-         if (!error || el.querySelector("mjx-container") == null)
+         var error = true;
+         try
          {
-            el.innerHTML = "";
-            while (scratch.firstChild)
-               el.appendChild(scratch.firstChild);
+            // failed typesets surface in two ways, neither of which rejects
+            // the typeset promise: recoverable TeX errors render as 'merror'
+            // nodes, while malformed inputs (e.g. unbalanced braces) are
+            // skipped by the math finder entirely, leaving raw text behind
+            var container = scratch.querySelector("mjx-container");
+            var merror = scratch.querySelector("mjx-merror, [data-mjx-error]");
+            error = container == null || merror != null;
+
+            // swap the new output into place on success; on failure, keep any
+            // previous (successful) render, but surface the error output when
+            // there is no previous render to preserve
+            if (!error || !hadRender)
+            {
+               while (el.firstChild != null)
+               {
+                  if (el.firstChild == scratch)
+                     break;
+                  el.removeChild(el.firstChild);
+               }
+
+               while (scratch.firstChild != null)
+                  el.insertBefore(scratch.firstChild, scratch);
+            }
+         }
+         finally
+         {
+            // the queue must always advance, even if the swap fails
+            // unexpectedly -- a missed completion wedges all future typesets
+            cleanup();
+            onCompleted(error);
          }
 
-         cleanup();
-         onCompleted(error);
-
-      }, function(err) {
+      }), $entry(function(err) {
          cleanup();
          onCompleted(true);
-      });
+      }));
    }-*/;
 
 

--- a/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxTypeset.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxTypeset.java
@@ -38,8 +38,16 @@ public class MathJaxTypeset
             @Override
             public void onMathJaxTypesetComplete(boolean error)
             {
-               callback.onMathJaxTypesetComplete(error);
-               cont.execute();
+               // always advance the queue, even if the callback throws --
+               // a missed continuation wedges all future typesets
+               try
+               {
+                  callback.onMathJaxTypesetComplete(error);
+               }
+               finally
+               {
+                  cont.execute();
+               }
             }
          });
       };
@@ -89,11 +97,22 @@ public class MathJaxTypeset
       el.appendChild(scratch);
 
       var cleanup = function() {
+         // remove the scratch before clearing typeset state: a scratch leaked
+         // inside the target would satisfy the next typeset's previous-render
+         // check with output the user cannot see
+         try
+         {
+            if (scratch.parentNode != null)
+               scratch.parentNode.removeChild(scratch);
+         }
+         catch (e)
+         {
+            $wnd.console.warn(e);
+         }
+
          try
          {
             MathJax.typesetClear([scratch]);
-            if (scratch.parentNode != null)
-               scratch.parentNode.removeChild(scratch);
          }
          catch (e)
          {
@@ -119,16 +138,28 @@ public class MathJaxTypeset
             // there is no previous render to preserve
             if (!error || !hadRender)
             {
-               while (el.firstChild != null)
+               // if the scratch was moved out from under us, there is nothing
+               // to swap in -- report failure rather than emptying the target
+               if (scratch.parentNode !== el)
                {
-                  if (el.firstChild == scratch)
-                     break;
-                  el.removeChild(el.firstChild);
+                  error = true;
                }
+               else
+               {
+                  while (el.firstChild != scratch)
+                     el.removeChild(el.firstChild);
 
-               while (scratch.firstChild != null)
-                  el.insertBefore(scratch.firstChild, scratch);
+                  while (scratch.firstChild != null)
+                     el.insertBefore(scratch.firstChild, scratch);
+               }
             }
+         }
+         catch (e)
+         {
+            // a failed swap must not report success: the target may have been
+            // emptied, and callers would otherwise trust a blank render
+            error = true;
+            $wnd.console.warn(e);
          }
          finally
          {

--- a/version/news/os/NEWS-2026.08.1-yellow-yarrow.md
+++ b/version/news/os/NEWS-2026.08.1-yellow-yarrow.md
@@ -4,5 +4,5 @@
 - 
 
 ### Fixed
--
+- ([#18551](https://github.com/rstudio/rstudio/issues/18551)): Fixed an issue introduced in RStudio 2026.08.0 where LaTeX math failed to render in the visual editor: equations appeared blank or invisible, switching to visual mode could unexpectedly modify math text in the document, and after visiting visual mode, inline math previews in the source editor could also stop appearing for the remainder of the session.
 


### PR DESCRIPTION
### Background

Since RStudio 2026.08.0 (the MathJax 4 upgrade, #18210), LaTeX math no longer renders in the Quarto / R Markdown visual editor: equations show as blank/invisible, and after visiting visual mode, the inline math preview popup in the source editor can also stop appearing for the rest of the session. Source mode on its own is unaffected, which is why the source-editor e2e coverage did not catch this.

### Root cause

`MathJaxTypeset.typesetNative` typesets into a hidden scratch element appended as a *sibling* of the target (`el.parentNode.appendChild(scratch)`). In the source editor that parent is an Ace popup or line widget, which is inert. In the visual editor the target is a ProseMirror widget decoration, so the sibling lands directly in ProseMirror's contenteditable -- and ProseMirror does not ignore that mutation (only widget-*internal* mutations are ignored, per `WidgetViewDesc.ignoreMutation`). The cascade:

1. ProseMirror's DOM observer sees the foreign sibling and reverts it, removing the scratch mid-typeset; re-parsing the mutated DOM can also rewrite the document itself (the buffer goes dirty, and math text can be dropped or reflowed).
2. MathJax then typesets the detached scratch, computing zero font metrics -- the output renders at zero size, so even a "successful" typeset is invisible.
3. `cleanup()` throws (`scratch.parentNode` is null), the completion callback never runs, and the serialized `TYPESET_QUEUE` wedges for the whole session -- every later equation stays empty, and source-mode popups stop rendering too.

### Changes

- `MathJaxTypeset.java`: typeset into a hidden scratch *child* of the target instead of a sibling. ProseMirror ignores mutations inside widgets, and the scratch inherits the same font context. Also bail on disconnected targets via `isConnected`, guard the cleanup, and complete the typeset in a `finally` (routed through `$entry`) so the queue can never wedge again.
- `math_preview.test.ts`: new regression test -- inline and display math must render *visibly* (non-zero size) in the visual editor, and the round trip back to source mode must preserve the math text. Verified red against unfixed GWT (fails with the exact `removeChild` TypeError above) and green with the fix. Also updated the popup test's scratch-lifecycle instrumentation for the new scratch placement, comparing computed visibility so the intentionally-hidden scratch does not count as a visible TeX error.

Fixes #18551.