### PR TITLE
e2e: make chat history panel helpers state-aware

### DIFF
--- a/e2e/rstudio/actions/chat_pane.actions.ts
+++ b/e2e/rstudio/actions/chat_pane.actions.ts
@@ -439,18 +439,21 @@ export class ChatPaneActions {
   }
 
   /**
-   * Rename the current conversation via the UI context menu
+   * Rename the current conversation via the UI context menu.
+   *
+   * Verifies the rename actually took effect before returning (#18363): the
+   * history panel is closed and reopened so the list reflects the new name,
+   * and the renamed item is asserted present. Leaves the history panel closed.
+   *
    * @param name The new name for the conversation
    */
   async renameConversation(name: string): Promise<void> {
-    // Open history panel to access conversation list. toggleConversationHistory
-    // polls for the list to appear, so no post-call sleep is needed here.
-    await this.toggleConversationHistory();
+    await this.openConversationHistory();
 
     // Get the first (current/active) conversation item. Each toBeVisible
     // below polls, replacing what used to be a chain of blind sleeps
     // between hover, click, menu-item click, and input fill.
-    const activeConvItem = this.chatPane.conversationList.first();
+    const activeConvItem = this.chatPane.conversationListItem.first();
     await expect(activeConvItem).toBeVisible({ timeout: 5000 });
 
     // Hover over the conversation item to reveal the menu button
@@ -477,15 +480,49 @@ export class ChatPaneActions {
     await nameInput.clear();
     await nameInput.fill(name);
 
-    // Press Enter to confirm the rename
+    // Press Enter to confirm the rename; the input leaves edit mode once the
+    // rename has been committed.
     await nameInput.press('Enter');
+    await expect(nameInput).toBeHidden({ timeout: 5000 });
+
+    // Close and reopen the panel so the list reflects the rename, then verify
+    // it took effect. Without this, a silently-failed rename surfaces several
+    // steps later as an opaque locator timeout (#18363).
+    await this.closeConversationHistory();
+    await this.openConversationHistory();
+    await expect(this.chatPane.getConversationItemByName(name).first()).toBeVisible({ timeout: 5000 });
+    await this.closeConversationHistory();
 
     console.log(`Renamed conversation to "${name}"`);
   }
 
-  async toggleConversationHistory(): Promise<void> {
+  /**
+   * Open the conversation history panel, or do nothing if it is already open.
+   *
+   * The history toolbar button is a strict toggle and the panel is removed
+   * from the DOM when closed, so a state-blind "click and expect the list"
+   * helper inverts the panel state whenever its assumption about the current
+   * state is wrong -- and its post-click assertion could only pass on a
+   * closing toggle by winning a race against the panel's fade-out. Checking
+   * the panel's actual state first makes these helpers idempotent.
+   */
+  async openConversationHistory(): Promise<void> {
+    if (await this.chatPane.conversationHistoryPanel.isVisible()) {
+      return;
+    }
     await this.chatPane.historyBtn.click({ timeout: 10000 });
-    // Poll for the conversation list panel to appear (replaces post-click sleep).
-    await expect(this.chatPane.conversationList.first()).toBeVisible({ timeout: 10000 });
+    await expect(this.chatPane.conversationHistoryPanel).toBeVisible({ timeout: 10000 });
+  }
+
+  /**
+   * Close the conversation history panel, or do nothing if it is already
+   * closed. See openConversationHistory for why this checks state first.
+   */
+  async closeConversationHistory(): Promise<void> {
+    if (!(await this.chatPane.conversationHistoryPanel.isVisible())) {
+      return;
+    }
+    await this.chatPane.historyBtn.click({ timeout: 10000 });
+    await expect(this.chatPane.conversationHistoryPanel).toBeHidden({ timeout: 10000 });
   }
 }

--- a/e2e/rstudio/pages/chat_pane.page.ts
+++ b/e2e/rstudio/pages/chat_pane.page.ts
@@ -30,7 +30,8 @@ export class ChatPane extends FramePageObject {
   public aboutItem: Locator;
   public newConversationBtn: Locator;
   public historyBtn: Locator;
-  public conversationList: Locator;
+  public conversationHistoryPanel: Locator;
+  public conversationListItem: Locator;
   public pendingQuestions: Locator;
   public submitAnswersBtn: Locator;
 
@@ -79,7 +80,14 @@ export class ChatPane extends FramePageObject {
     this.aboutItem = this.frame.locator("xpath=//span[contains(text(), 'About')] | //div[contains(text(), 'About')] | //*[@role='menuitem'][contains(., 'About')]");
     this.newConversationBtn = this.frame.getByRole('button', { name: 'New conversation' });
     this.historyBtn = this.frame.getByRole('button', { name: 'Conversation history' });
-    this.conversationList = this.frame.locator("[class*='conversation']");
+    // The history panel container and its per-conversation rows. The panel is
+    // removed from the DOM when the history is closed, so its presence is the
+    // open/closed signal that openConversationHistory / closeConversationHistory
+    // key off. The old catch-all "[class*='conversation']" locator matched the
+    // panel itself before any row, and matched nothing at all once the panel
+    // closed -- both of which made state-blind assertions racy.
+    this.conversationHistoryPanel = this.frame.locator('.conversation-list-panel');
+    this.conversationListItem = this.frame.locator('.conversation-list-item-panel');
     // PAI 0.7.x AskUser elicitation: the assistant can pause mid-turn and render
     // a question form instead of acting. The turn stays active (stop button
     // showing, composer in "queue" mode) until the form is submitted or

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/conversation-history.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/conversation-history.test.ts
@@ -48,25 +48,25 @@ test.describe.serial('Conversation History', { tag: ['@ai', '@chat'] }, () => {
     await chatActions.waitForResponse(count);
     await chatActions.renameConversation(artemisName);
 
-    // Close and reopen history panel to refresh the list after all the renames
-    await chatActions.toggleConversationHistory();
-    await chatActions.toggleConversationHistory();
+    // renameConversation verifies each rename in the history panel and leaves
+    // the panel closed, so no refresh dance is needed here.
 
     // Select Athena and verify its content is restored
+    await chatActions.openConversationHistory();
     await chatPane.getConversationItemByName(athenaName).first().click();
-    await chatActions.toggleConversationHistory();
+    await chatActions.closeConversationHistory();
     const athenaMessages = chatPane.frame.locator('[data-message-id]');
     await expect(athenaMessages.last()).toContainText('Athena', { timeout: 5000 });
 
     // Open history again for Aphrodite
-    await chatActions.toggleConversationHistory();
+    await chatActions.openConversationHistory();
     await chatPane.getConversationItemByName(aphroditeName).first().click();
-    await chatActions.toggleConversationHistory();
+    await chatActions.closeConversationHistory();
     const aphroditeMessages = chatPane.frame.locator('[data-message-id]');
     await expect(aphroditeMessages.last()).toContainText('Aphrodite', { timeout: 5000 });
 
     // Open history and delete Artemis conversation
-    await chatActions.toggleConversationHistory();
+    await chatActions.openConversationHistory();
 
     // Find Artemis in the history, hover to reveal menu button
     const artemisItem = chatPane.getConversationItemByName(artemisName).first();
@@ -83,10 +83,11 @@ test.describe.serial('Conversation History', { tag: ['@ai', '@chat'] }, () => {
     const deleteButton = chatPane.getDeleteConfirmButton();
     await expect(deleteButton).toBeVisible({ timeout: 5000 });
     await deleteButton.click();
+    await expect(deleteButton).toBeHidden({ timeout: 5000 });
 
-    // Verify Artemis is gone from history
-    await chatActions.toggleConversationHistory();
-    await chatActions.toggleConversationHistory();
+    // Close and reopen the panel to refresh the list, then verify Artemis is gone
+    await chatActions.closeConversationHistory();
+    await chatActions.openConversationHistory();
     await expect(chatPane.getConversationItemByName(artemisName)).not.toBeVisible({ timeout: 5000 });
 
     // Select Athena conversation, then press Escape to dismiss history
@@ -94,6 +95,6 @@ test.describe.serial('Conversation History', { tag: ['@ai', '@chat'] }, () => {
     await page.keyboard.press('Escape');
 
     // Verify history panel is closed
-    await expect(chatPane.conversationList.first()).not.toBeVisible({ timeout: 5000 });
+    await expect(chatPane.conversationHistoryPanel).not.toBeVisible({ timeout: 5000 });
   });
 });


### PR DESCRIPTION
## Summary

The `@ai` test `conversation-history.test.ts` ("conversation history preserves and restores conversations") is flaky, and hard-failed both attempts on the macOS shard in [this run](https://github.com/rstudio/rstudio/actions/runs/31728998130/job/94551089182).

The test drove the history panel through a state-blind `toggleConversationHistory` helper that clicked the toolbar button and then asserted `[class*='conversation']` was visible. Trace analysis of the failed run shows:

- the history toolbar button is a strict toggle, and neither committing a rename (Enter) nor selecting a conversation closes the panel, so the test's assumptions about panel state at each toggle were wrong in places;
- the panel is removed from the DOM when closed, so the helper's post-click assertion was only valid for an *opening* toggle -- on a *closing* toggle it could only pass by winning a race against the panel's ~200ms fade-out animation (the expect polls, and catches the list mid-fade). Both failed attempts lost exactly that race, dying at an opaque 10s locator timeout.

## Changes

- Replace `toggleConversationHistory` with idempotent `openConversationHistory` / `closeConversationHistory` helpers that check the panel's actual state (presence of the `.conversation-list-panel` container, confirmed against the DOM snapshots in the failing run's trace) before clicking, and assert the correct post-state.
- Point the conversation item locator at the actual row class (`.conversation-list-item-panel`) instead of the catch-all `[class*='conversation']`, which matched the panel container itself before any row.
- Harden `renameConversation` to assert the rename took effect (renamed item present after a close/reopen refresh) before returning, so a silently-failed rename fails at the rename instead of several steps later.
- Update the test to use the explicit open/close helpers and to verify the delete-confirmation dialog dismissed before refreshing the list.

## Testing

- `npm run typecheck` in `e2e/rstudio` passes.
- The `@ai` suite requires Posit AI credentials that are not available locally; relying on the PR-triggered E2E workflow (macOS shard) to exercise the test.

Fixes #18363.