### PR TITLE
e2e: recover a leaked busy console instead of failing every later suite

### DIFF
--- a/e2e/rstudio/pages/console_pane.page.ts
+++ b/e2e/rstudio/pages/console_pane.page.ts
@@ -91,6 +91,121 @@ export async function waitForConsoleIdle(
 }
 
 /**
+ * True when the console input carries its "busy" class (R is executing).
+ * Evaluation failures (e.g. mid-reload after a session abort) read as
+ * "not busy" -- pair with a readiness wait where that matters.
+ */
+async function isConsoleBusy(page: Page): Promise<boolean> {
+  return page
+    .evaluate(() => {
+      const el = document.getElementById('rstudio_console_input');
+      return !!el && el.classList.contains('rstudio-console-busy');
+    })
+    .catch(() => false);
+}
+
+/**
+ * The blocking confirmation ApplicationInterrupt raises when R stays busy
+ * through interrupt requests (its 10s "unresponsive" timer, or a third
+ * request while one is already pending). Confirming aborts the session and
+ * relaunches it.
+ */
+const TERMINATE_R_DIALOG = '[role="alertdialog"]:has-text("Terminate R")';
+
+/**
+ * Wait for the automation bridge to report ready again after a session
+ * abort/relaunch. Polls with per-sample evaluate calls rather than
+ * waitForFunction because the abort's page reload destroys the execution
+ * context mid-wait; a destroyed context reads as "not ready yet".
+ */
+async function waitForSessionReady(page: Page, timeout: number = 60000): Promise<boolean> {
+  const deadline = Date.now() + timeout;
+
+  while (Date.now() < deadline) {
+    const ready = await page
+      .evaluate(() => window.rstudio?.ready === true)
+      .catch(() => false);
+    if (ready)
+      return !(await isConsoleBusy(page));
+
+    await sleep(500);
+  }
+
+  console.warn('[console] ensureConsoleIdle: session did not come back ready after Terminate R');
+  return false;
+}
+
+/**
+ * Actively free a busy console that no test is waiting on -- a prior test
+ * leaked a long-running command (the classic case: a shiny app its teardown
+ * failed to stop, which in Server mode blocks the shared session for every
+ * suite behind it in the shard). Escalates deliberately slowly:
+ *
+ *   1. Fast path: console already idle -- decline any stale "Terminate R"
+ *      dialog (terminating a healthy session would just cost a restart) and
+ *      return.
+ *   2. Dispatch interruptR and watch for up to 10s. A clean interrupt lands
+ *      well inside that window; meanwhile ApplicationInterrupt schedules a
+ *      10s "unresponsive" timer on the first request, so if R is stuck
+ *      (e.g. shiny caught the interrupt mid-callback and kept serving) the
+ *      blocking "Terminate R" dialog pops without further prodding.
+ *   3. Confirm the Terminate R dialog when it shows: the session aborts and
+ *      relaunches, and we wait for the automation bridge to come back. A
+ *      restarted session is fully usable by whatever runs next; a
+ *      permanently busy one is not.
+ *
+ * Interrupt dispatches are spaced ~10s apart on purpose: the client raises
+ * one Terminate R confirmation per interrupt request while R stays busy, so
+ * spamming interruptR stacks dialogs instead of helping.
+ *
+ * Never throws; returns whether the console ended up idle. Cleanup-path
+ * callers can ignore the result (the warnings above tell the story in the
+ * log); callers that need a working console (e.g. createSandbox) should
+ * escalate a false return to a failure.
+ */
+export async function ensureConsoleIdle(page: Page): Promise<boolean> {
+  const terminateDialog = page.locator(TERMINATE_R_DIALOG);
+
+  if (!(await isConsoleBusy(page))) {
+    if (await terminateDialog.isVisible().catch(() => false)) {
+      await terminateDialog.locator('button:has-text("No")').first().click().catch(() => {});
+    }
+    return true;
+  }
+
+  console.warn('[console] ensureConsoleIdle: console is busy with no test waiting on it; interrupting R');
+
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    await executeCommand(page, 'interruptR').catch((err) => {
+      console.warn(`[console] ensureConsoleIdle: interruptR dispatch failed: ${(err as Error).message}`);
+    });
+
+    const deadline = Date.now() + 10000;
+    while (Date.now() < deadline) {
+      if (!(await isConsoleBusy(page)))
+        return true;
+
+      if (await terminateDialog.isVisible().catch(() => false)) {
+        console.warn(
+          '[console] ensureConsoleIdle: R is not responding to interrupts; ' +
+          'confirming "Terminate R" (the session will restart)',
+        );
+        await terminateDialog.locator('button:has-text("Yes")').first().click().catch(() => {});
+        return waitForSessionReady(page);
+      }
+
+      await sleep(500);
+    }
+  }
+
+  console.warn(
+    '[console] ensureConsoleIdle: console still busy after 3 interrupts ' +
+    'with no Terminate R dialog; giving up',
+  );
+  return false;
+}
+
+/**
  * Read the automation agent's monotonic console prompt counter, or null if the
  * running binary predates it (`window.rstudio.console.promptCount`, added in
  * ApplicationAutomation). The counter advances by one each time R issues a

--- a/e2e/rstudio/tests/harness/busy-console-recovery.test.ts
+++ b/e2e/rstudio/tests/harness/busy-console-recovery.test.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { executeInConsole, waitForConsoleBusy } from '@pages/console_pane.page';
+import { createSandbox, SANDBOX_DIR_PREFIX } from '@utils/sandbox';
+import * as path from 'path';
+
+/**
+ * Harness self-test for the busy-console recovery in createSandbox()
+ * (ensureConsoleIdle in pages/console_pane.page.ts).
+ *
+ * A test that leaks a long-running console command -- the real-world case is
+ * a shiny app its teardown failed to stop -- used to fail the sandbox
+ * beforeAll of every remaining suite in the worker with an opaque
+ * waitForConsoleIdle timeout (in Server mode, poisoning the rest of the
+ * shard). createSandbox must instead interrupt the leaked command and carry
+ * on.
+ *
+ * Expect ~30s runtime: the recovery deliberately starts only after the
+ * normal waitForConsoleIdle grace period, so an in-progress command from a
+ * healthy suite is never interrupted.
+ */
+test.describe('busy console recovery', () => {
+  test('createSandbox interrupts a leaked busy console instead of failing', async ({ rstudioPage: page }) => {
+    // Leak a busy console the way a crashed test would: submit and walk away.
+    // 120s comfortably outlasts the idle grace period plus the interrupt
+    // escalation budget, so the sleep expiring on its own can't mask a
+    // recovery that didn't actually work.
+    await executeInConsole(page, 'Sys.sleep(120)', { wait: false });
+    await waitForConsoleBusy(page).catch(() => {});
+
+    const dir = await createSandbox(page);
+    expect(path.basename(dir).startsWith(SANDBOX_DIR_PREFIX)).toBe(true);
+
+    // The console must be usable again for whatever runs next.
+    await executeInConsole(page, 'invisible(NULL)', { wait: true });
+  });
+});

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
@@ -5,6 +5,7 @@ import { ConsolePaneActions } from '@actions/console_pane.actions';
 import { ChatPaneActions } from '@actions/chat_pane.actions';
 import { ChatPane } from '@pages/chat_pane.page';
 import { VIEWER_FRAME } from '@pages/viewer_pane.page';
+import { ensureConsoleIdle, waitForConsoleIdle } from '@pages/console_pane.page';
 import type { EnvironmentVersions } from '@pages/console_pane.page';
 import { executeCommand, setPref } from '@utils/commands';
 import { createChatActions, annotateVersions } from './_chat-setup';
@@ -60,44 +61,30 @@ test.describe.serial('R Shiny Tip Calculator via Posit Assistant', { tag: ['@ai'
   });
 
   test.afterAll(async ({ rstudioPage: page }) => {
-    // Stop any running Shiny app via the Viewer pane's stop button
+    // Stop the app cleanly when the Viewer is showing it. This is best
+    // effort: when the test failed before the Viewer activated (the app ran
+    // but never rendered there), the stop button never appears even though
+    // R is busy serving the app.
     const viewerStopBtn = page.locator("[id^='rstudio_tb_viewerstop']");
-    const interruptBtn = page.locator("[id^='rstudio_tb_interruptr']");
-
     if (await viewerStopBtn.isVisible().catch(() => false)) {
       await viewerStopBtn.click();
-
-      const stoppedCleanly = await interruptBtn
-        .waitFor({ state: 'hidden', timeout: 5000 })
-        .then(() => true)
-        .catch(() => false);
-
-      if (!stoppedCleanly) {
-        // R is still busy -- confirm "Terminate R" dialog if present,
-        // otherwise click the Interrupt R button directly.
-        const terminateDialog = page.locator('[role="alertdialog"]:has-text("Terminate R")');
-        if (await terminateDialog.isVisible({ timeout: 2000 }).catch(() => false)) {
-          await terminateDialog.locator('button:has-text("Yes")').click();
-        } else {
-          await interruptBtn.click();
-        }
-        await interruptBtn.waitFor({ state: 'hidden', timeout: 10000 }).catch(() => {
-          console.warn('Interrupt R did not complete within 10s; subsequent tests may be affected');
-        });
-      }
+      await waitForConsoleIdle(page, 10000).catch(() => {});
     }
 
-    // Dismiss any remaining "Terminate R" dialog before touching the console.
-    const terminateDialog = page.locator('[role="alertdialog"]:has-text("Terminate R")');
-    if (await terminateDialog.isVisible({ timeout: 1000 }).catch(() => false)) {
-      await terminateDialog.locator('button:has-text("Yes")').click();
-      await interruptBtn.waitFor({ state: 'hidden', timeout: 10000 }).catch(() => {
-        console.warn('Interrupt R did not complete within 10s; subsequent tests may be affected');
-      });
-    }
+    // Never hand the worker off with a busy R: a leaked runApp() blocks the
+    // console for every later suite in the worker (in Server mode, the rest
+    // of the shard). ensureConsoleIdle interrupts regardless of what the
+    // Viewer shows, escalating to the "Terminate R" dialog if R is stuck.
+    await ensureConsoleIdle(page);
 
     // Clean up created file(s)
-    await consoleActions.executeInConsole('unlink("app.R")', { wait: true });
+    await consoleActions
+      .executeInConsole('unlink("app.R")', { wait: true })
+      .catch((err) => {
+        console.warn(
+          `[shiny-app-r] cleanup unlink failed (R may be stuck): ${(err as Error).message}`,
+        );
+      });
   });
 
   test.beforeEach(async () => {

--- a/e2e/rstudio/tests/shiny/shiny-app-window-close.test.ts
+++ b/e2e/rstudio/tests/shiny/shiny-app-window-close.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
-import { executeCommand, setPref, stopForegroundShinyApp } from '@utils/commands';
+import { ensureConsoleIdle } from '@pages/console_pane.page';
+import { setPref, stopForegroundShinyApp } from '@utils/commands';
 import { heredoc } from '@utils/heredoc';
 import type { Page } from '@playwright/test';
 
@@ -60,24 +61,6 @@ async function waitForShinyIdle(satellitePage: Page) {
     .toBeGreaterThanOrEqual(5);
 }
 
-// Defense in depth after the launcher waits for shiny idle. If a previous
-// test left R busy (e.g. interrupt landed mid-callback) the interrupt button
-// stays visible -- send one nudge and bail. Re-spamming interruptR every 2s
-// makes the IDE stack "Terminate R" confirmation dialogs (one per request
-// while R is unresponsive), which is what the historical 30s-toPass loop
-// produced when it ran past the third interrupt.
-async function ensureConsoleIdle(page: Page) {
-  const interruptButton = page.locator("[id^='rstudio_tb_interruptr']");
-  try {
-    await expect(interruptButton).toBeHidden({ timeout: 3000 });
-    return;
-  } catch {
-    // still busy; fall through and try one more interrupt
-  }
-  await executeCommand(page, 'interruptR');
-  await expect(interruptButton).toBeHidden({ timeout: 10000 });
-}
-
 test.describe.serial('shiny app window close', { tag: ['@desktop_only'] }, () => {
   test.beforeAll(async ({ rstudioPage: page }) => {
     // a preceding spec can hand off the worker with a main-window reload
@@ -103,21 +86,19 @@ test.describe.serial('shiny app window close', { tag: ['@desktop_only'] }, () =>
 
   test.afterAll(async ({ rstudioPage: page }) => {
     // if a test failed mid-app, R may still be busy serving it; free the
-    // console before driving it. Wrap in try/finally so a still-busy console
-    // can't leak the temp app dir into the next worker -- the unlink is the
-    // important side effect here, not the idle assertion.
-    try {
-      await ensureConsoleIdle(page);
-    } finally {
-      const consoleActions = new ConsolePaneActions(page);
-      await consoleActions
-        .executeInConsole(`unlink("${APP_DIR}", recursive = TRUE)`, { wait: true })
-        .catch((err) => {
-          console.warn(
-            `[shiny-app-window-close] cleanup unlink failed (R may be stuck): ${(err as Error).message}`,
-          );
-        });
-    }
+    // console (interrupting, and terminating R if the interrupt is caught by
+    // shiny mid-callback) before driving it. ensureConsoleIdle never throws,
+    // so the unlink below always runs.
+    await ensureConsoleIdle(page);
+
+    const consoleActions = new ConsolePaneActions(page);
+    await consoleActions
+      .executeInConsole(`unlink("${APP_DIR}", recursive = TRUE)`, { wait: true })
+      .catch((err) => {
+        console.warn(
+          `[shiny-app-window-close] cleanup unlink failed (R may be stuck): ${(err as Error).message}`,
+        );
+      });
   });
 
   test('window closes when the app is stopped', async ({ rstudioPage: page }) => {

--- a/e2e/rstudio/utils/sandbox.ts
+++ b/e2e/rstudio/utils/sandbox.ts
@@ -1,7 +1,12 @@
 import type { Page } from '@playwright/test';
 import * as path from 'path';
 import { test } from '../fixtures/rstudio.fixture';
-import { executeInConsole, CONSOLE_OUTPUT, waitForConsoleIdle } from '../pages/console_pane.page';
+import {
+  executeInConsole,
+  ensureConsoleIdle,
+  CONSOLE_OUTPUT,
+  waitForConsoleIdle,
+} from '../pages/console_pane.page';
 import { sleep, TIMEOUTS } from './constants';
 import { assertAbsolutePath } from './paths';
 
@@ -65,7 +70,18 @@ export async function createSandbox(page: Page): Promise<string> {
     // Bridge not in scope yet -- let the marker poll below surface any
     // real failure rather than blocking the suite on the readiness wait.
   });
-  await waitForConsoleIdle(page);
+  try {
+    await waitForConsoleIdle(page);
+  } catch (err) {
+    // The console is busy with something no test is waiting on -- a prior
+    // test leaked a long-running command (e.g. a shiny app its teardown
+    // failed to stop). Left alone this fails the sandbox beforeAll of every
+    // remaining suite in the worker (in Server mode, the rest of the shard),
+    // so attempt one bounded interrupt-based recovery and only propagate the
+    // timeout if the console really can't be freed.
+    if (!(await ensureConsoleIdle(page)))
+      throw err;
+  }
 
   // Build the R expression on a single line so executeInConsole's single
   // press('Enter') executes it atomically.


### PR DESCRIPTION
## Summary

In [this PR CI run](https://github.com/rstudio/rstudio/actions/runs/31751374107/job/94620659560), the `shiny-app-r` assistant test launched its Shiny app but the Viewer pane never activated. The suite's `afterAll` only interrupted R when the Viewer stop button was visible, so the leaked `runApp()` left the shared server session permanently busy -- and the sandbox `beforeAll` of roughly ten later suites in the shard failed with opaque `waitForConsoleIdle` timeouts and empty `sandbox.dir` errors. One flaky test became a shard-wide cascade.

## Changes

- **`ensureConsoleIdle` (pages/console_pane.page.ts)**: new shared helper that actively frees a busy console no test is waiting on. It dispatches `interruptR` and watches for up to 10s per attempt; if R is stuck (e.g. shiny caught the interrupt mid-callback), ApplicationInterrupt's own 10s unresponsive timer raises the blocking "Terminate R" dialog, which the helper confirms as a last resort and then waits for the relaunched session to come back ready. A restarted session is usable by whatever runs next; a permanently busy one is not. Interrupts are deliberately spaced ~10s apart since the client stacks one Terminate R confirmation per interrupt request while R stays busy. On the fast path (console already idle) it also declines a stale Terminate R dialog rather than terminating a healthy session.
- **`createSandbox` (utils/sandbox.ts)**: on a `waitForConsoleIdle` timeout, attempt one bounded recovery before propagating the failure. This is the systemic guard: no single test that leaks a busy console can poison the rest of the worker (in Server mode, the rest of the shard) anymore.
- **`shiny-app-r.test.ts` afterAll**: keep the clean Viewer-stop path when the button is visible, but always run `ensureConsoleIdle` afterwards, so the teardown works even when the app ran without the Viewer ever activating (the failure mode in the run above).
- **`shiny-app-window-close.test.ts`**: replace the local one-nudge `ensureConsoleIdle` with the shared helper, which additionally handles the swallowed-interrupt case.
- **New harness regression test** (`tests/harness/busy-console-recovery.test.ts`): leaks `Sys.sleep(120)` the way a crashed test would and asserts `createSandbox` interrupts it and proceeds. Runs in both desktop and server projects; ~30s by design (recovery starts only after the normal idle grace period so a healthy suite's in-flight command is never interrupted).

## Testing

- `npm run typecheck` clean.
- New harness test passes on desktop-dev (recovery path exercised: the log shows the interrupt firing after the grace period, then sandbox creation succeeding).
- `shiny-app-window-close.test.ts` (all three tests) and `sandbox.test.ts` pass on desktop-dev with the shared helper.
- The `shiny-app-r` `@ai` teardown itself needs assistant credentials, so it is compile-checked here and exercises the same `ensureConsoleIdle` path the harness test covers.
