### PR TITLE
build(win): sign rsession.dll alongside the launcher stubs (backport)

### DIFF
--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -158,10 +158,15 @@ pipeline {
 
         stage('Sign Executables') {
           environment {
+            // rsession.dll carries the bulk of the session code and is loaded by
+            // the rsession.exe / rsession-utf8.exe launcher stubs, so it needs a
+            // signature of its own; multiarch builds ship an x86 copy as well
             EXECUTABLES = """^
               package\\win32\\build\\src\\cpp\\session\\rsession-utf8.exe ^
               package\\win32\\build\\src\\cpp\\session\\rsession.exe ^
+              package\\win32\\build\\src\\cpp\\session\\rsession.dll ^
               package\\win32\\build\\src\\cpp\\session\\x86\\rsession.exe ^
+              package\\win32\\build\\src\\cpp\\session\\x86\\rsession.dll ^
               package\\win32\\build\\src\\cpp\\session\\consoleio\\consoleio.exe ^
               package\\win32\\build\\src\\cpp\\session\\postback\\rpostback.exe ^
               package\\win32\\build\\src\\cpp\\diagnostics\\diagnostics.exe ^

--- a/version/news/os/NEWS-2026.08.1-yellow-yarrow.md
+++ b/version/news/os/NEWS-2026.08.1-yellow-yarrow.md
@@ -5,4 +5,5 @@
 
 ### Fixed
 - ([#18551](https://github.com/rstudio/rstudio/issues/18551)): Fixed an issue introduced in RStudio 2026.08.0 where LaTeX math failed to render in the visual editor: equations appeared blank or invisible, switching to visual mode could unexpectedly modify math text in the document, and after visiting visual mode, inline math previews in the source editor could also stop appearing for the remainder of the session.
+- ([#18512](https://github.com/rstudio/rstudio/issues/18512)): Fixed an issue on Windows where `rsession.dll` was shipped without a code signature. The signed `rsession.exe` and `rsession-utf8.exe` are thin launcher stubs, so nearly all of the R session implementation lives in that DLL; policies that verify every loaded module rather than only the launching executable could block or flag it.
 


### PR DESCRIPTION
Backport of #18516 (`06473dc67a`) to Yellow Yarrow 2026.08.1.

This branch carries the `rsession-shared` library from #18070, so `rsession.exe` and
`rsession-utf8.exe` are thin launcher stubs and `rsession.dll` holds essentially all of the
session implementation. `%EXECUTABLES%` in the `Sign Executables` stage of
`jenkins/Jenkinsfile.windows` named only the `.exe` files, so the shipped DLL was unsigned:
the signed stubs load an unsigned module that policies verifying every loaded image -- WDAC,
AppLocker publisher rules, some EDR configurations -- can block or flag.

Both build-tree copies of the DLL are added to the signing list: the x64 one next to the
stubs, and the x86 one the multiarch build installs into `src/cpp/session/x86` alongside
`x86/rsession.exe`. Signing runs before the `Package` stage, so the installer picks up the
signed DLLs.

The NEWS entry is in `version/news/os/NEWS-2026.08.1-yellow-yarrow.md` rather than `NEWS.md`,
which is not carried on this branch.

Signing runs only in the Windows pipeline, so this needs manual verification on a Yellow
Yarrow daily build: `signtool verify /pa` (or the Digital Signatures tab) on the installed
`rsession.dll`.

Addresses #18557