### PR TITLE
build(win): restore the 32-bit session install rule (backport)

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -909,6 +909,18 @@ if(NOT RSTUDIO_SESSION_WIN32 AND NOT RSESSION_ALTERNATE_BUILD)
       DIRECTORY "resources/terminal"
       DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/resources)
 
+   # collect the 32-bit session binaries produced by the multiarch sub-build, which
+   # package/win32/make-install-win32.bat installs into <build>/src/cpp/session/x86.
+   # CPack re-runs install rules after that sub-build, so the directory is populated
+   # by packaging time; MAKE_DIRECTORY keeps non-multiarch builds (where nothing
+   # writes it) from failing on a missing install(DIRECTORY) source.
+   if(WIN32)
+      file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/x86")
+      install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/x86"
+              USE_SOURCE_PERMISSIONS
+              DESTINATION "${RSTUDIO_INSTALL_BIN}")
+   endif()
+
    # install libclang
    if(WIN32)
       file(GLOB LIBCLANG_32_FILES "${LIBCLANG_DIR}/x86/*")

--- a/version/news/os/NEWS-2026.08.1-yellow-yarrow.md
+++ b/version/news/os/NEWS-2026.08.1-yellow-yarrow.md
@@ -5,5 +5,6 @@
 
 ### Fixed
 - ([#18551](https://github.com/rstudio/rstudio/issues/18551)): Fixed an issue introduced in RStudio 2026.08.0 where LaTeX math failed to render in the visual editor: equations appeared blank or invisible, switching to visual mode could unexpectedly modify math text in the document, and after visiting visual mode, inline math previews in the source editor could also stop appearing for the remainder of the session.
+- ([#18515](https://github.com/rstudio/rstudio/issues/18515)): Fixed an issue on Windows where the 32-bit session binaries were missing from the installer, so RStudio Desktop failed to start a session when a 32-bit R installation was selected. The binaries were built and code-signed, but were dropped before packaging.
 - ([#18512](https://github.com/rstudio/rstudio/issues/18512)): Fixed an issue on Windows where `rsession.dll` was shipped without a code signature. The signed `rsession.exe` and `rsession-utf8.exe` are thin launcher stubs, so nearly all of the R session implementation lives in that DLL; policies that verify every loaded module rather than only the launching executable could block or flag it.
 


### PR DESCRIPTION
Backport of #18519 (`9e0e8e998b`) to Yellow Yarrow.

The multiarch Windows Desktop build installs the 32-bit session into `<build>/src/cpp/session/x86`, and the 64-bit build had an install rule that collected that directory into `resources/app/bin/x86` at package time. That rule sat inside an "install winpty on windows" block and was deleted with it in 04db3f557da (#17814), so the shipped installer has `resources/app/bin/x86` with only the x86 VC runtime DLLs -- no `rsession.exe`, and since #18070 no `rsession.dll`. With a 32-bit R, `session-launcher.ts` finds no `x86/rsession.exe` and falls back to the 64-bit session, which cannot load a 32-bit `R.dll`.

This restores the rule, under a comment naming its actual source, and keeps the `file(MAKE_DIRECTORY)` call: `install(DIRECTORY)` errors on a missing source directory, and non-multiarch builds never create it.

`src/cpp/session/CMakeLists.txt` is byte-identical to `main` after this change.

The NEWS entry goes in `version/news/os/NEWS-2026.08.1-yellow-yarrow.md`, since `NEWS.md` is not carried on this branch.

### Relationship to #18562

999de991ab (backport of #18516) added `x86/rsession.dll` to the Sign Executables list. That signs the binaries in the build tree; this PR is what copies them into the installer. Signing runs before the Package stage, so the installer picks up the signed copies.

### Verification

- `cmake` configure succeeds with the new block (macOS; the block is `if(WIN32)`-guarded and inert there).
- Confirmed on this branch that the comment's claims still hold: `package/win32/make-package.bat:243` calls `make-install-win32.bat "%BUILD_DIR%\src\cpp\session"`, and the `SessionWin32` sub-build sets `RSTUDIO_INSTALL_BIN` to `x86` (`cmake/globals.cmake:522`), so the sub-build output lands in `<build>/src/cpp/session/x86`. That call precedes `make-dist-packages.bat`, so the directory is populated by CPack time.
- Still needs a multiarch Windows package build (`make-package.bat clean electron multiarch`): confirm `rsession.exe` and `rsession.dll` are present in `resources/app/bin/x86` after install, and that a session against a 32-bit R starts.

Addresses #18558