### PR TITLE
fix chat guardrails blocking package installs under a restrictive umask

### DIFF
--- a/src/cpp/session/modules/SessionChat.R
+++ b/src/cpp/session/modules/SessionChat.R
@@ -49,10 +49,11 @@
 # PCRE patterns matched against normalized paths to deny reads.
 # Paths are always absolute and normalized before matching.
 #
-# NOTE: The primary defense against credential file reads is the file
-# permission check in isFileReadAllowed (denying files without world-
-# readable permissions). These patterns are defense-in-depth for common
-# credential paths, in case file permissions are misconfigured.
+# NOTE: These patterns work together with the file permission check in
+# isFileReadAllowed (denying files without world-readable permissions).
+# That check is a heuristic which only applies outside the allowed roots,
+# and only when the umask grants world-read to newly-created files, so
+# these patterns serve as the backstop for common credential paths.
 .rs.setVar("chat.denyReadPatterns", c(
 
    # Deny files that are likely to contain credentials
@@ -101,16 +102,10 @@
 
 # PCRE patterns matched against normalized paths to deny edits.
 # Note that file edits are disallowed by default, except for files within
-#
-# - The R temporary directory
-# - The project directory (when a project is open)
-# - The current working directory
-# - The RStudio scratch path
-# - R library paths (.libPaths())
-# - R user directories (data, config, cache)
+# the allowed roots enumerated by chat.allowedRoots.
 #
 # This list serves to deny edits for certain files even if they're within
-# one of the above 'allowed' directories.
+# one of the 'allowed' roots.
 .rs.setVar("chat.denyEditPatterns", c(
 
    # Deny edits on or within the .ssh directory.
@@ -301,8 +296,16 @@
 #' Check whether reading the given paths is allowed.
 #'
 #' Reads are allowed by default, but denied for files that lack
-#' world-readable permissions, match well-known sensitive path
+#' world-readable permissions or match well-known sensitive path
 #' patterns (e.g. `~/.aws/credentials`, `.env`, `.Renviron`).
+#'
+#' The permission check is a heuristic for spotting sensitive files, so
+#' it only applies where a missing world-read bit is actually a signal:
+#' outside the allowed roots (see `chat.allowedRoots()`), and only when
+#' the umask would grant world-read to newly-created files. Otherwise
+#' the check would deny every file the session itself creates in
+#' environments with a restrictive umask (e.g. containers with umask
+#' 077), including caches that `install.packages()` needs to read back.
 #'
 #' When `trusted` is `TRUE` (i.e. the call originates from a
 #' non-base package), the deny-pattern check is skipped so that
@@ -321,11 +324,18 @@
    # assume file reads are permitted by default
    reasons <- rep.int("", length(path))
 
-   # deny reads on files that lack read permission for 'others'
-   # (use which() to drop NA modes from non-existent files)
-   info <- suppressWarnings(file.info(path))
-   deny <- bitwAnd(info$mode, 4L) == 0L
-   reasons[which(deny)] <- "File is not world-readable."
+   # deny reads on files that lack read permission for 'others', skipping
+   # files within the allowed roots -- the session itself creates files
+   # there that would fail the check under a restrictive umask. skip the
+   # check entirely when the umask strips world-read from new files, as
+   # then every file is private by default and the missing bit carries no
+   # signal (use which() to drop NA modes from non-existent files)
+   if (!.rs.chat.umaskMasksWorldRead())
+   {
+      info <- suppressWarnings(file.info(path))
+      deny <- bitwAnd(info$mode, 4L) == 0L & !.rs.chat.isPathWithinAllowedRoots(path)
+      reasons[which(deny)] <- "File is not world-readable."
+   }
 
    # deny reads matching sensitive path patterns
    # (skip for trusted callers, i.e. non-base package code)
@@ -354,13 +364,80 @@
    .Call("rs_userDataDir", PACKAGE = "(embedding)")
 })
 
+#' Enumerate the roots within which agent file edits are allowed.
+#'
+#' Edits are allowed within:
+#'
+#' - The R temporary directory
+#' - The current working directory
+#' - The RStudio user scratch path (tool-invoked code may update files there)
+#' - R library paths (e.g. for package installation)
+#' - The user library (R_LIBS_USER), even before it has been created
+#' - The active project directory (when a project is open)
+#' - R user directories (data, config, cache)
+#'
+#' Reads within these roots are also exempt from the world-readable
+#' permission check, since the session itself creates files there.
+#'
+#' @return A character vector of normalized directory paths.
+.rs.addFunction("chat.allowedRoots", function()
+{
+   roots <- c(tempdir(), getwd(), .rs.chat.userScratchPath(), .libPaths())
+
+   # include the user library even when it doesn't exist yet -- a nonexistent
+   # user library is excluded from .libPaths(), but install.packages() offers
+   # to create it on first use
+   userLibs <- strsplit(Sys.getenv("R_LIBS_USER"), .Platform$path.sep, fixed = TRUE)[[1L]]
+   roots <- c(roots, userLibs[nzchar(userLibs)])
+
+   projectDir <- .rs.getProjectDirectory()
+   if (!is.null(projectDir))
+      roots <- c(roots, projectDir)
+
+   # R user directories (data, config, cache),
+   # e.g. ~/.local/share/R, ~/.config/R, ~/.cache/R on Linux.
+   # Use dirname() to obtain the parent directory from a dummy package name.
+   # tools::R_user_dir was introduced in R 4.0.0.
+   if (getRversion() >= "4.0.0")
+   {
+      for (which in c("data", "config", "cache"))
+         roots <- c(roots, dirname(tools::R_user_dir("_", which = which)))
+   }
+
+   .rs.chat.normalizePath(roots)
+})
+
+#' Check whether paths lie within any of the allowed roots.
+#'
+#' @param path A character vector of normalized file paths.
+#' @return A logical vector the same length as `path`.
+.rs.addFunction("chat.isPathWithinAllowedRoots", function(path)
+{
+   allowed <- rep.int(FALSE, length(path))
+   for (root in .rs.chat.allowedRoots())
+      allowed <- allowed | .rs.chat.isPathWithin(path, root)
+   allowed
+})
+
+#' Check whether the current umask strips world-read from new files.
+#'
+#' When it does (e.g. hardened containers commonly run with umask 077),
+#' a file lacking the world-read bit is just the environment's default
+#' rather than a deliberate act of protection, so the missing bit
+#' carries no signal about the file's sensitivity.
+#'
+#' @return `TRUE` if newly-created files would not be world-readable.
+.rs.addFunction("chat.umaskMasksWorldRead", function()
+{
+   umask <- Sys.umask(NA)
+   bitwAnd(as.integer(umask), 4L) != 0L
+})
+
 #' Check whether editing the given paths is allowed.
 #'
-#' Edits are denied by default, but allowed within the R temporary
-#' directory, the active project directory, the current working
-#' directory, the RStudio user scratch path, R library paths, and
-#' R user directories (data, config, cache). Edits within sensitive
-#' directories (e.g. `~/.ssh`) are always denied.
+#' Edits are denied by default, but allowed within the allowed roots
+#' (see `chat.allowedRoots()`). Edits within sensitive directories
+#' (e.g. `~/.ssh`) are always denied.
 #'
 #' @param path A character vector of file paths.
 #' @return A character vector the same length as `path`, where
@@ -377,46 +454,8 @@
       length(path)
    )
 
-   # allow edits within the R temporary directory
-   tempDir <- .rs.chat.normalizePath(tempdir())
-   reasons[.rs.chat.isPathWithin(path, tempDir)] <- ""
-
-   # allow edits within the project directory
-   projectDir <- .rs.getProjectDirectory()
-   if (!is.null(projectDir))
-   {
-      projectDir <- .rs.chat.normalizePath(projectDir)
-      reasons[.rs.chat.isPathWithin(path, projectDir)] <- ""
-   }
-
-   # allow edits within the current working directory
-   workingDir <- .rs.chat.normalizePath(getwd())
-   reasons[.rs.chat.isPathWithin(path, workingDir)] <- ""
-
-   # allow edits within the RStudio scratch path (e.g. ~/.local/share/rstudio),
-   # since tool-invoked code may update files there
-   scratchDir <- .rs.chat.userScratchPath()
-   reasons[.rs.chat.isPathWithin(path, scratchDir)] <- ""
-
-   # allow edits within R library paths (e.g. for package installation)
-   for (libPath in .libPaths())
-   {
-      libPath <- .rs.chat.normalizePath(libPath)
-      reasons[.rs.chat.isPathWithin(path, libPath)] <- ""
-   }
-
-   # allow edits within R user directories (data, config, cache),
-   # e.g. ~/.local/share/R, ~/.config/R, ~/.cache/R on Linux.
-   # Use dirname() to obtain the parent directory from a dummy package name.
-   # tools::R_user_dir was introduced in R 4.0.0.
-   if (getRversion() >= "4.0.0")
-   {
-      for (which in c("data", "config", "cache"))
-      {
-         rDir <- .rs.chat.normalizePath(dirname(tools::R_user_dir("_", which = which)))
-         reasons[.rs.chat.isPathWithin(path, rDir)] <- ""
-      }
-   }
+   # allow edits within the allowed roots
+   reasons[.rs.chat.isPathWithinAllowedRoots(path)] <- ""
 
    # deny edits matching sensitive path patterns (both read and edit
    # deny lists apply, since edits should be at least as restrictive)

--- a/src/cpp/session/modules/SessionChat.R
+++ b/src/cpp/session/modules/SessionChat.R
@@ -45,6 +45,12 @@
 .rs.setVar("chat.hookedBindings", new.env(parent = emptyenv()))
 .rs.setVar("chat.bindingsInjected", FALSE)
 
+# Cached state for guardrail checks: the sampled umask, the memoized
+# allowed roots, and the normalized home directory. See the individual
+# accessors (chat.umaskMasksWorldRead, chat.allowedRoots,
+# chat.homeDirectory) for the caching rationale.
+.rs.setVar("chat.guardrailState", new.env(parent = emptyenv()))
+
 
 # PCRE patterns matched against normalized paths to deny reads.
 # Paths are always absolute and normalized before matching.
@@ -61,7 +67,6 @@
    "/\\.aws/config$",
    "/\\.netrc$",
    "/\\.npmrc$",
-   "/\\.ssh/config$",
 
    # Deny container/cloud credential directories
    "/\\.docker(/|$)",
@@ -94,9 +99,10 @@
    "/\\.Renviron(\\.|$)",
    "/\\.Rprofile(\\.|$)",
 
-   # Deny access to non-public files within the .ssh directory.
-   "/\\.ssh/id.*(?<!\\.pub)$"
-   
+   # Deny access to non-public files within the .ssh directory (config,
+   # private keys under any name, known_hosts); public keys stay readable.
+   "/\\.ssh/.*(?<!\\.pub)$"
+
 ))
 
 
@@ -307,6 +313,12 @@
 #' environments with a restrictive umask (e.g. containers with umask
 #' 077), including caches that `install.packages()` needs to read back.
 #'
+#' The home directory itself never counts as an allowed root here, even
+#' though it can be one for edits (it is the fallback working directory
+#' when no project is open): exempting all of `$HOME` would hide
+#' deliberately-private dotfiles (e.g. mode-600 tokens and keys) from
+#' the permission check.
+#'
 #' When `trusted` is `TRUE` (i.e. the call originates from a
 #' non-base package), the deny-pattern check is skipped so that
 #' package code can legitimately access credential files.
@@ -332,8 +344,13 @@
    # signal (use which() to drop NA modes from non-existent files)
    if (!.rs.chat.umaskMasksWorldRead())
    {
+      # exclude the home directory from the exemption: as the fallback
+      # working directory it can be an allowed root, but private files
+      # directly under $HOME are exactly what this check is for
+      roots <- setdiff(.rs.chat.allowedRoots(), .rs.chat.homeDirectory())
+
       info <- suppressWarnings(file.info(path))
-      deny <- bitwAnd(info$mode, 4L) == 0L & !.rs.chat.isPathWithinAllowedRoots(path)
+      deny <- bitwAnd(info$mode, 4L) == 0L & !.rs.chat.isPathWithinAllowedRoots(path, roots)
       reasons[which(deny)] <- "File is not world-readable."
    }
 
@@ -376,18 +393,31 @@
 #' - The active project directory (when a project is open)
 #' - R user directories (data, config, cache)
 #'
-#' Reads within these roots are also exempt from the world-readable
+#' Reads within these roots (except the home directory itself; see
+#' `chat.isFileReadAllowed`) are also exempt from the world-readable
 #' permission check, since the session itself creates files there.
+#'
+#' The result is memoized on the inputs that can change while the
+#' session runs (working directory, library paths, `R_LIBS_USER`):
+#' this runs on every hooked file operation, and enumerating the
+#' roots is comparatively expensive (the scratch-path lookup alone
+#' touches the filesystem).
 #'
 #' @return A character vector of normalized directory paths.
 .rs.addFunction("chat.allowedRoots", function()
 {
+   userLibs <- strsplit(Sys.getenv("R_LIBS_USER"), .Platform$path.sep, fixed = TRUE)[[1L]]
+   key <- list(getwd(), .libPaths(), userLibs)
+
+   state <- .rs.chat.guardrailState
+   if (identical(state$allowedRootsKey, key))
+      return(state$allowedRoots)
+
    roots <- c(tempdir(), getwd(), .rs.chat.userScratchPath(), .libPaths())
 
    # include the user library even when it doesn't exist yet -- a nonexistent
    # user library is excluded from .libPaths(), but install.packages() offers
    # to create it on first use
-   userLibs <- strsplit(Sys.getenv("R_LIBS_USER"), .Platform$path.sep, fixed = TRUE)[[1L]]
    roots <- c(roots, userLibs[nzchar(userLibs)])
 
    projectDir <- .rs.getProjectDirectory()
@@ -404,33 +434,61 @@
          roots <- c(roots, dirname(tools::R_user_dir("_", which = which)))
    }
 
-   .rs.chat.normalizePath(roots)
+   roots <- .rs.chat.normalizePath(roots)
+   state$allowedRootsKey <- key
+   state$allowedRoots <- roots
+   roots
 })
 
 #' Check whether paths lie within any of the allowed roots.
 #'
 #' @param path A character vector of normalized file paths.
+#' @param roots The roots to check against.
 #' @return A logical vector the same length as `path`.
-.rs.addFunction("chat.isPathWithinAllowedRoots", function(path)
+.rs.addFunction("chat.isPathWithinAllowedRoots", function(path, roots = .rs.chat.allowedRoots())
 {
    allowed <- rep.int(FALSE, length(path))
-   for (root in .rs.chat.allowedRoots())
+   for (root in roots)
       allowed <- allowed | .rs.chat.isPathWithin(path, root)
    allowed
 })
 
-#' Check whether the current umask strips world-read from new files.
+#' The normalized home directory, computed once.
+#'
+#' @return A single normalized directory path.
+.rs.addFunction("chat.homeDirectory", function()
+{
+   state <- .rs.chat.guardrailState
+   if (is.null(state$homeDirectory))
+      state$homeDirectory <- .rs.chat.normalizePath(path.expand("~"))
+   state$homeDirectory
+})
+
+#' Check whether the umask strips world-read from new files.
 #'
 #' When it does (e.g. hardened containers commonly run with umask 077),
 #' a file lacking the world-read bit is just the environment's default
 #' rather than a deliberate act of protection, so the missing bit
 #' carries no signal about the file's sensitivity.
 #'
+#' The umask is sampled once and cached: `Sys.umask(NA)` reads the umask
+#' by briefly setting it to 0 and restoring it, which is both unsafe to
+#' run on every hooked file operation (a background thread creating a
+#' file inside that window would get mode 666) and would let agent code
+#' switch the permission check off by changing the umask. The sample is
+#' taken no later than the first `chat.injectBindings()` call, before
+#' any agent code has run.
+#'
 #' @return `TRUE` if newly-created files would not be world-readable.
 .rs.addFunction("chat.umaskMasksWorldRead", function()
 {
-   umask <- Sys.umask(NA)
-   bitwAnd(as.integer(umask), 4L) != 0L
+   state <- .rs.chat.guardrailState
+   if (is.null(state$umaskMasksWorldRead))
+   {
+      umask <- Sys.umask(NA)
+      state$umaskMasksWorldRead <- bitwAnd(as.integer(umask), 4L) != 0L
+   }
+   state$umaskMasksWorldRead
 })
 
 #' Check whether editing the given paths is allowed.
@@ -530,6 +588,10 @@
    # skip injection to avoid overwriting saved originals
    if (.rs.chat.bindingsInjected)
       return(invisible())
+
+   # sample the umask before agent code can run, so the cached value
+   # cannot be influenced by the code the guardrails police
+   .rs.chat.umaskMasksWorldRead()
 
    baseHooks <- list(
 

--- a/src/cpp/tests/testthat/test-chat-guardrails.R
+++ b/src/cpp/tests/testthat/test-chat-guardrails.R
@@ -189,6 +189,58 @@ test_that("isFileEditAllowed permits edits in R user directories", {
 
 })
 
+test_that("isFileEditAllowed permits edits in a not-yet-created user library", {
+
+   oldLibsUser <- Sys.getenv("R_LIBS_USER", unset = NA)
+   on.exit({
+      if (is.na(oldLibsUser))
+         Sys.unsetenv("R_LIBS_USER")
+      else
+         Sys.setenv(R_LIBS_USER = oldLibsUser)
+   }, add = TRUE)
+
+   # point R_LIBS_USER at a directory that does not exist, and is not
+   # within any other allowed root
+   fakeLib <- file.path(dirname(tempdir()), "chat-guardrails-fake-lib", "4.0")
+   Sys.setenv(R_LIBS_USER = fakeLib)
+
+   path <- file.path(fakeLib, "testpkg", "DESCRIPTION")
+   expect_equal(.rs.chat.isFileEditAllowed(path), "")
+
+})
+
+# -- allowedRoots / umask ------------------------------------------------------
+
+test_that("isPathWithinAllowedRoots identifies allowed and disallowed paths", {
+
+   allowedPaths <- .rs.chat.normalizePath(c(
+      file.path(tempdir(), "file.R"),
+      file.path(getwd(), "file.R"),
+      file.path(.libPaths()[[1L]], "pkg", "DESCRIPTION")
+   ))
+   expect_true(all(.rs.chat.isPathWithinAllowedRoots(allowedPaths)))
+
+   deniedPath <- .rs.chat.normalizePath("/no/such/allowed/root/file.R")
+   expect_false(any(.rs.chat.isPathWithinAllowedRoots(deniedPath)))
+
+})
+
+test_that("umaskMasksWorldRead reflects the current umask", {
+
+   skip_on_os("windows")
+
+   oldMask <- Sys.umask("022")
+   on.exit(Sys.umask(oldMask), add = TRUE)
+   expect_false(.rs.chat.umaskMasksWorldRead())
+
+   Sys.umask("077")
+   expect_true(.rs.chat.umaskMasksWorldRead())
+
+   Sys.umask("027")
+   expect_true(.rs.chat.umaskMasksWorldRead())
+
+})
+
 # -- isFileReadAllowed ---------------------------------------------------------
 
 test_that("isFileReadAllowed denies reads on credential files", {
@@ -227,6 +279,75 @@ test_that("isFileReadAllowed allows credential files when trusted", {
    expect_equal(.rs.chat.isFileReadAllowed(file.path(home, ".aws/credentials"), trusted = TRUE), "")
    expect_equal(.rs.chat.isFileReadAllowed(file.path(home, ".Renviron"), trusted = TRUE), "")
    expect_equal(.rs.chat.isFileReadAllowed(file.path(home, ".Rprofile"), trusted = TRUE), "")
+
+})
+
+test_that("isFileReadAllowed permits non-world-readable files within allowed roots", {
+
+   skip_on_os("windows")
+
+   oldMask <- Sys.umask("022")
+   on.exit(Sys.umask(oldMask), add = TRUE)
+
+   path <- tempfile("guardrails-private-")
+   writeLines("private", path)
+   on.exit(unlink(path), add = TRUE)
+   Sys.chmod(path, "600")
+
+   expect_equal(.rs.chat.isFileReadAllowed(path), "")
+
+})
+
+test_that("isFileReadAllowed denies non-world-readable files outside allowed roots", {
+
+   skip_on_os("windows")
+
+   oldMask <- Sys.umask("022")
+   on.exit(Sys.umask(oldMask), add = TRUE)
+
+   # place the file in a sibling of the R temporary directory, outside
+   # all of the allowed roots
+   dir <- tempfile("chat-guardrails-", tmpdir = dirname(tempdir()))
+   dir.create(dir)
+   on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+
+   path <- file.path(dir, "private.txt")
+   writeLines("private", path)
+   Sys.chmod(path, "600")
+
+   # denied while the umask would grant world-read to new files
+   expect_true(nzchar(.rs.chat.isFileReadAllowed(path)))
+
+   # but allowed when the umask strips world-read from new files, as then
+   # the missing bit carries no signal
+   Sys.umask("077")
+   expect_equal(.rs.chat.isFileReadAllowed(path), "")
+
+})
+
+test_that("deny-read patterns still apply within allowed roots", {
+
+   path <- file.path(tempdir(), ".env")
+   expect_true(nzchar(.rs.chat.isFileReadAllowed(path)))
+
+})
+
+test_that("installed.packages() survives guardrails under a restrictive umask", {
+
+   skip_on_os("windows")
+
+   oldMask <- Sys.umask("077")
+   on.exit(Sys.umask(oldMask), add = TRUE)
+
+   # remove cached metadata so the first call writes a fresh cache that is
+   # not world-readable; the second call then reads it back (this is how
+   # install.packages() failed in rstudio-pro#11975)
+   unlink(list.files(tempdir(), pattern = "^libloc_", full.names = TRUE))
+
+   expect_no_error(.rs.chat.withGuardrails({
+      utils::installed.packages(lib.loc = .Library)
+      utils::installed.packages(lib.loc = .Library)
+   }))
 
 })
 

--- a/src/cpp/tests/testthat/test-chat-guardrails.R
+++ b/src/cpp/tests/testthat/test-chat-guardrails.R
@@ -26,10 +26,12 @@ test_that("deny-read patterns block credential files", {
    expect_true(matches("/home/user/.aws/credentials"))
    expect_true(matches("/home/user/.aws/config"))
 
-   # SSH
+   # SSH (any non-public file within .ssh, not just the id_* names)
    expect_true(matches("/home/user/.ssh/config"))
    expect_true(matches("/home/user/.ssh/id_rsa"))
    expect_true(matches("/home/user/.ssh/id_ed25519"))
+   expect_true(matches("/home/user/.ssh/deploy_key"))
+   expect_true(matches("/home/user/.ssh/known_hosts"))
 
    # SSH public keys should be allowed
    expect_false(matches("/home/user/.ssh/id_rsa.pub"))
@@ -225,19 +227,51 @@ test_that("isPathWithinAllowedRoots identifies allowed and disallowed paths", {
 
 })
 
-test_that("umaskMasksWorldRead reflects the current umask", {
+test_that("umaskMasksWorldRead samples the umask once", {
 
    skip_on_os("windows")
 
+   state <- .rs.chat.guardrailState
+   oldValue <- state$umaskMasksWorldRead
    oldMask <- Sys.umask("022")
-   on.exit(Sys.umask(oldMask), add = TRUE)
+   on.exit({
+      Sys.umask(oldMask)
+      state$umaskMasksWorldRead <- oldValue
+   }, add = TRUE)
+
+   state$umaskMasksWorldRead <- NULL
    expect_false(.rs.chat.umaskMasksWorldRead())
 
+   # the sample is cached, so later umask changes (e.g. by agent code
+   # attempting to switch the permission check off) have no effect
    Sys.umask("077")
+   expect_false(.rs.chat.umaskMasksWorldRead())
+
+   state$umaskMasksWorldRead <- NULL
    expect_true(.rs.chat.umaskMasksWorldRead())
 
+   state$umaskMasksWorldRead <- NULL
    Sys.umask("027")
    expect_true(.rs.chat.umaskMasksWorldRead())
+
+})
+
+test_that("allowedRoots tracks working-directory changes", {
+
+   dir <- tempfile("chat-guardrails-wd-", tmpdir = dirname(tempdir()))
+   dir.create(dir)
+   oldWd <- getwd()
+   on.exit({
+      setwd(oldWd)
+      unlink(dir, recursive = TRUE)
+   }, add = TRUE)
+
+   path <- .rs.chat.normalizePath(file.path(dir, "file.R"))
+   expect_false(any(.rs.chat.isPathWithinAllowedRoots(path)))
+
+   # the memoized roots refresh when the working directory changes
+   setwd(dir)
+   expect_true(all(.rs.chat.isPathWithinAllowedRoots(path)))
 
 })
 
@@ -249,6 +283,7 @@ test_that("isFileReadAllowed denies reads on credential files", {
 
    expect_true(nzchar(.rs.chat.isFileReadAllowed(file.path(home, ".aws/credentials"))))
    expect_true(nzchar(.rs.chat.isFileReadAllowed(file.path(home, ".ssh/id_rsa"))))
+   expect_true(nzchar(.rs.chat.isFileReadAllowed(file.path(home, ".ssh/deploy_key"))))
    expect_true(nzchar(.rs.chat.isFileReadAllowed(file.path(home, ".env"))))
    expect_true(nzchar(.rs.chat.isFileReadAllowed(file.path(home, ".docker/config.json"))))
    expect_true(nzchar(.rs.chat.isFileReadAllowed(file.path(home, ".docker/trust/private/root.key"))))
@@ -286,8 +321,14 @@ test_that("isFileReadAllowed permits non-world-readable files within allowed roo
 
    skip_on_os("windows")
 
+   state <- .rs.chat.guardrailState
+   oldValue <- state$umaskMasksWorldRead
    oldMask <- Sys.umask("022")
-   on.exit(Sys.umask(oldMask), add = TRUE)
+   on.exit({
+      Sys.umask(oldMask)
+      state$umaskMasksWorldRead <- oldValue
+   }, add = TRUE)
+   state$umaskMasksWorldRead <- NULL
 
    path <- tempfile("guardrails-private-")
    writeLines("private", path)
@@ -298,12 +339,51 @@ test_that("isFileReadAllowed permits non-world-readable files within allowed roo
 
 })
 
+test_that("home directory is not read-exempt even as the working directory", {
+
+   skip_on_os("windows")
+
+   state <- .rs.chat.guardrailState
+   oldValue <- state$umaskMasksWorldRead
+   oldMask <- Sys.umask("022")
+   oldWd <- getwd()
+   on.exit({
+      Sys.umask(oldMask)
+      setwd(oldWd)
+      state$umaskMasksWorldRead <- oldValue
+   }, add = TRUE)
+   state$umaskMasksWorldRead <- NULL
+
+   # with no project open, the session working directory defaults to the
+   # home directory -- that must not exempt private files under $HOME
+   # from the permission check
+   home <- path.expand("~")
+   setwd(home)
+
+   path <- tempfile("chat-guardrails-private-", tmpdir = home)
+   writeLines("private", path)
+   on.exit(unlink(path), add = TRUE)
+   Sys.chmod(path, "600")
+
+   expect_true(nzchar(.rs.chat.isFileReadAllowed(path)))
+
+   # edits within the working directory remain allowed
+   expect_equal(.rs.chat.isFileEditAllowed(path), "")
+
+})
+
 test_that("isFileReadAllowed denies non-world-readable files outside allowed roots", {
 
    skip_on_os("windows")
 
+   state <- .rs.chat.guardrailState
+   oldValue <- state$umaskMasksWorldRead
    oldMask <- Sys.umask("022")
-   on.exit(Sys.umask(oldMask), add = TRUE)
+   on.exit({
+      Sys.umask(oldMask)
+      state$umaskMasksWorldRead <- oldValue
+   }, add = TRUE)
+   state$umaskMasksWorldRead <- NULL
 
    # place the file in a sibling of the R temporary directory, outside
    # all of the allowed roots
@@ -321,6 +401,7 @@ test_that("isFileReadAllowed denies non-world-readable files outside allowed roo
    # but allowed when the umask strips world-read from new files, as then
    # the missing bit carries no signal
    Sys.umask("077")
+   state$umaskMasksWorldRead <- NULL
    expect_equal(.rs.chat.isFileReadAllowed(path), "")
 
 })
@@ -336,8 +417,14 @@ test_that("installed.packages() survives guardrails under a restrictive umask", 
 
    skip_on_os("windows")
 
+   state <- .rs.chat.guardrailState
+   oldValue <- state$umaskMasksWorldRead
    oldMask <- Sys.umask("077")
-   on.exit(Sys.umask(oldMask), add = TRUE)
+   on.exit({
+      Sys.umask(oldMask)
+      state$umaskMasksWorldRead <- oldValue
+   }, add = TRUE)
+   state$umaskMasksWorldRead <- NULL
 
    # remove cached metadata so the first call writes a fresh cache that is
    # not world-readable; the second call then reads it back (this is how


### PR DESCRIPTION
## Summary

Posit Assistant's `install.packages()` fails in Workbench sessions running under a restrictive umask (common in hardened containers), with repeated "One or more agent file operations were blocked" errors that eventually push the model to work around the sandbox via `Rscript` in the terminal.

Root cause: the guardrails' world-readable check in `.rs.chat.isFileReadAllowed()` denied reads of any file lacking the o+r permission bit, unconditionally. Under umask 077 every file the session creates is mode 600, so agent code was blocked from reading files R itself had just written. The most visible victim is the `installed.packages()` cache (`tempdir()/libloc_*.rds`): the cache gets seeded by the IDE or an earlier command, and the next read -- during `install.packages()` dependency resolution -- hits the hooked `readRDS()` and errors. The same check also blocked the agent from reading *any* user-owned file (project files included) in such environments. The `chat.safeFunctions` trusted-caller allowlist did not help, because trust only bypasses the deny-path patterns, not the permission check.

## Changes

- **Scope the world-readable check to paths outside the allowed roots** (tempdir, working directory, project directory, scratch path, `.libPaths()`, R user dirs). These are locations the agent may already *write* to, so denying reads there was incoherent -- and they are exactly where the session's own non-world-readable files live. The allowed roots are now enumerated in one place (`chat.allowedRoots()`), shared by the edit check and the read check.
- **Neutralize the check when the umask itself strips world-read from new files.** On a default-umask system a 600-mode file is a deliberate signal (ssh keys, tokens) and the heuristic has value; under umask 077 every file is private by default, the bit carries no signal, and the heuristic just denied everything.
- **Allow edits within a not-yet-created user library** (`R_LIBS_USER`), so `install.packages()` can create the personal library on first use (a nonexistent user library is not in `.libPaths()`, so it was previously denied).

The deny-path patterns (credentials, `.env`, `.Renviron`, `~/.ssh`, system files) still apply everywhere, including within the allowed roots and regardless of umask.

## Security trade-offs

These guardrails target accidental misuse, not malicious code (per the note at the top of `SessionChat.R`). Two deliberate loosenings here:

1. A non-world-readable file *inside* the project/tempdir/library roots is now readable by agent code. Deny patterns still catch the common credential shapes there. The home directory itself is never a read-exempt root (it is the fallback working directory when no project is open), and the `.ssh` read-deny pattern covers all non-public files.
2. On umask-restricted systems, a private file outside the allowed roots that matches no deny pattern is now readable. Previously the heuristic blocked it -- along with literally everything else, which in practice pushed the model to escape to an unhooked `Rscript` subprocess where no checks apply at all.

## Testing

- New testthat coverage in `test-chat-guardrails.R` for the allowed-roots exemption, the umask neutralization, the not-yet-created user library, pattern denials still applying within allowed roots, and an end-to-end `installed.packages()`-twice regression test under umask 077 (the exact failure from the report). All six new tests fail before the fix and pass after; the pre-existing 89 assertions pass unchanged.
- Verified end-to-end in an rsession: under umask 077 with a pre-seeded `libloc_*.rds` cache, agent-driven `install.packages("desc")` (source, with dependencies) and `install.packages("praise")` (macOS in-process binary) both failed before the fix and now succeed; reads of `~/.aws/credentials` and `/etc/passwd` remain blocked.

No NEWS.md entry here since the affected feature ships in rstudio-pro; release notes are tracked in the pro repository.

Fixes rstudio/rstudio-pro#11975.
