### PR TITLE
e2e: cover single-worker external servers with the assistant leak guard

### DIFF
--- a/e2e/rstudio/fixtures/rstudio.fixture.ts
+++ b/e2e/rstudio/fixtures/rstudio.fixture.ts
@@ -61,17 +61,25 @@ const ASSISTANT_TEST_TAGS = ['@ai', '@chat'];
  * session or opens a project still does that work under any leaked provider
  * prefs; the guard then normalizes state before its first test runs.
  *
- * Desktop and spawned-server workers only: a spawned rserver (the CI path)
- * gets a per-worker config home, so flipping the prefs here is as isolated
- * as on desktop. An external PW_RSTUDIO_SERVER_URL server has a single
- * config shared by every worker, where flipping the pref would race a @chat
- * suite running concurrently in another worker, so that path stays
- * excluded. (What server workers always share is the data home -- the
- * installed backend -- not the prefs.) Spawned-server workers were
- * originally excluded too, on the assumption that the #18417 shutdown
- * hardening bounded the restarts product-side -- but the wedge kept firing
- * on the server shards (#18394), where the projects region restarts
- * sessions ~30 times with a live agent, so the guard now covers them.
+ * Desktop and spawned-server workers get a per-worker config home, so
+ * flipping the prefs there is always isolated. An external
+ * PW_RSTUDIO_SERVER_URL server has a single config shared by every worker,
+ * where flipping the pref would race a @chat suite running concurrently in
+ * another worker -- so external servers are only covered when the run has a
+ * single worker (which cannot race itself). That includes the CI server
+ * shards: one worker against a job-local rserver at localhost:8787. The
+ * single-worker coverage exists because suite-local hygiene is not enough
+ * on those shards: an @ai suite whose afterAll never runs (crash, timeout,
+ * interrupt) leaves the provider prefs on server-side, where they survive
+ * worker restarts; run 31833520057 showed a leaked live provider swallowing
+ * an Escape keypress in multiselect_recovery and displacing the injected
+ * suggestion in edit_suggestions. (What server workers always share is the
+ * data home -- the installed backend -- not the prefs.) Spawned-server
+ * workers were originally excluded too, on the assumption that the #18417
+ * shutdown hardening bounded the restarts product-side -- but the wedge
+ * kept firing on the server shards (#18394), where the projects region
+ * restarts sessions ~30 times with a live agent, so the guard now covers
+ * them.
  */
 async function disableLeakedAssistant(page: Page): Promise<void> {
   const [assistant, chatProvider] = await Promise.all([
@@ -371,11 +379,13 @@ export const test = base.extend<
     await resetForNextTest(page);
 
     // Keep the AI assistant off for tests that don't opt in via @ai/@chat --
-    // see disableLeakedAssistant (also for why external servers are
-    // excluded). Runs after resetForNextTest so the bridge readiness gate
-    // has already been cleared.
+    // see disableLeakedAssistant (also for why multi-worker runs against an
+    // external server are excluded). Runs after resetForNextTest so the
+    // bridge readiness gate has already been cleared.
     const prefsAreWorkerScoped = mode === 'desktop' || externalServerUrl() === null;
-    if (prefsAreWorkerScoped && !testInfo.tags.some((tag) => ASSISTANT_TEST_TAGS.includes(tag)))
+    const cannotRaceAnotherWorker = testInfo.config.workers === 1;
+    if ((prefsAreWorkerScoped || cannotRaceAnotherWorker) &&
+        !testInfo.tags.some((tag) => ASSISTANT_TEST_TAGS.includes(tag)))
       await disableLeakedAssistant(page);
 
     // Debug-only: park the test (IDE clean and idle) so a human can arm

--- a/e2e/rstudio/tests/panes/editor/multiselect_recovery.test.ts
+++ b/e2e/rstudio/tests/panes/editor/multiselect_recovery.test.ts
@@ -105,10 +105,16 @@ test.describe('Multi-select recovery', () => {
       })
       .toEqual({ inVirtualSelectionMode: false, tempSelectionInstalled: false });
 
-    // multi-select mode must still be exitable
-    await page.keyboard.press('Escape');
+    // multi-select mode must still be exitable. Escape is pressed inside the
+    // poll: a transient popup (e.g. a live completion, seen leaked from the
+    // @ai suites on run 31833520057) can swallow a single press, while the
+    // corruption this guards against ignores Escape no matter how often it
+    // is pressed.
     await expect
-      .poll(async () => (await editor.getMultiSelectState()).editorInMultiSelectMode)
+      .poll(async () => {
+        await page.keyboard.press('Escape');
+        return (await editor.getMultiSelectState()).editorInMultiSelectMode;
+      })
       .toBe(false);
 
     // and subsequent typing must reach the document at exactly one cursor
@@ -146,11 +152,14 @@ test.describe('Multi-select recovery', () => {
       })
       .toEqual({ inVirtualSelectionMode: false, rangeListAttached: true });
 
-    // multi-select mode must still be exitable, and typing must reach the
-    // document at exactly one cursor afterwards
-    await page.keyboard.press('Escape');
+    // multi-select mode must still be exitable (Escape retried inside the
+    // poll -- see above), and typing must reach the document at exactly one
+    // cursor afterwards
     await expect
-      .poll(async () => (await editor.getMultiSelectState()).editorInMultiSelectMode)
+      .poll(async () => {
+        await page.keyboard.press('Escape');
+        return (await editor.getMultiSelectState()).editorInMultiSelectMode;
+      })
       .toBe(false);
     await page.keyboard.type('Z');
     await expect.poll(async () => countChar(await editor.getValue(), 'Z')).toBe(1);


### PR DESCRIPTION
## Background

On [run 31833520057](https://github.com/rstudio/rstudio/actions/runs/31833520057/job/94878919661?pr=18534) (linux-server shard 1), a code assistant provider leaked by `code_suggestions.test.ts` was live during later editor suites, producing two failures:

- `edit_suggestions.test.ts` "edit suggestions render inline when appropriate" failed both attempts: a real Posit AI completion widget displaced the injected suggestion (the failure #18566 diagnosed and fixed at the suite level -- that run predates the merge).
- `multiselect_recovery.test.ts` "editor survives an exception thrown during a multi-cursor edit" went flaky: typing kicked off a live completion request and the single `Escape` press was swallowed dismissing it, so the exit-multi-select poll timed out (the failure screenshot shows "Posit AI: No completions available." in the status bar).

## Why the fixture guard didn't catch it

`disableLeakedAssistant` (added in #18417) resets leaked `assistant`/`chat_provider` prefs before every non-`@ai`/`@chat` test, but it excluded external `PW_RSTUDIO_SERVER_URL` servers, since flipping the shared server-side prefs could race an `@ai` suite running concurrently in another worker. The CI server shards are exactly that excluded path (the workflow sets `PW_RSTUDIO_SERVER_URL: http://localhost:8787`), so they had no fixture-level protection -- and because the prefs live server-side, a leak there survives worker restarts and poisons the rest of the shard. Suite-local hygiene (#18566) covers the normal path, but not an `@ai` suite whose `afterAll` never runs (crash, timeout, interrupt).

## Change

- A single-worker invocation cannot race itself, so the guard now also covers external servers when `workers === 1` -- which includes the CI server shards (one worker against a job-local rserver). Multi-worker runs against a shared external server stay excluded as before.
- `multiselect_recovery` now presses `Escape` inside the exit-multi-select polls instead of once up front: a transient popup can swallow a single press, while the corruption the test guards against (#13605) ignores Escape no matter how often it is pressed, so the regression signal is preserved.

Verified with `npm run typecheck` and a desktop-dev run of `multiselect_recovery.test.ts` (7 passed).