### PR TITLE
treat EPERM as alive in the pending-launch liveness probe

### DIFF
--- a/src/cpp/core/include/core/system/PosixSystem.hpp
+++ b/src/cpp/core/include/core/system/PosixSystem.hpp
@@ -132,6 +132,8 @@ core::Error processInfo(const std::string& process,
 // get process info for the specific process specified by pid
 core::Error processInfo(pid_t pid, ProcessInfo* pInfo, bool populateUsername = true);
 
+// check whether a process exists; a process the caller lacks permission to
+// signal (e.g. one owned by another user) counts as running
 bool isProcessRunning(pid_t pid);
 
 std::ostream& operator<<(std::ostream& os, const ProcessInfo& info);

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -2205,11 +2205,13 @@ Error ProcessInfo::creationTime(boost::posix_time::ptime* pCreationTime) const
 
 bool isProcessRunning(pid_t pid)
 {
-   // the posix standard way of checking if a process
-   // is running is to send the 0 signal to it
-   // requires root privilege if process is owned by another user
+   // the posix standard way of checking if a process is running is to send
+   // the 0 signal to it. EPERM still proves the process exists -- the caller
+   // merely lacks permission to signal it, as when rserver's
+   // privilege-dropped threads probe an rsession owned by another user
+   // (#18572); only ESRCH means it is gone.
    int result = kill(pid, 0);
-   return result == 0;
+   return result == 0 || errno == EPERM;
 }
 
 std::string ProcessInfo::getUsername() const

--- a/src/cpp/core/system/PosixSystemTests.cpp
+++ b/src/cpp/core/system/PosixSystemTests.cpp
@@ -23,6 +23,8 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <limits>
+
 #include <boost/asio/ip/address.hpp>
 #include <boost/asio/ip/address_v4.hpp>
 
@@ -877,6 +879,21 @@ TEST(PosixTests, WaitForParentTerminationReadsPipeFds)
    ASSERT_EQ(0, ::pipe(fds));
    EXPECT_EQ(ParentTerminationAbnormal, waitForParentTermination(fds[0], fds[1]));
    ::close(fds[0]);
+}
+
+TEST(PosixTests, IsProcessRunningDetectsLiveAndDeadProcesses)
+{
+   // own process is trivially running
+   EXPECT_TRUE(isProcessRunning(::getpid()));
+
+   // pid 1 (init/launchd) always exists but is owned by root: when this
+   // test runs unprivileged the kill(pid, 0) probe fails with EPERM, which
+   // must still count as running -- rserver's privilege-dropped threads
+   // probe rsession processes owned by other users this way (#18572)
+   EXPECT_TRUE(isProcessRunning(1));
+
+   // a pid no process can have reports not running
+   EXPECT_FALSE(isProcessRunning(std::numeric_limits<pid_t>::max()));
 }
 
 } // namespace tests

--- a/src/cpp/server/ServerSessionManagerTests.cpp
+++ b/src/cpp/server/ServerSessionManagerTests.cpp
@@ -153,6 +153,29 @@ TEST(SessionManagerTest, RequestErrorKeepsPendingLaunchOfLiveProcess)
    sessionManager().removePendingLaunch(context);
 }
 
+TEST(SessionManagerTest, RequestErrorKeepsPendingLaunchOfOtherUserProcess)
+{
+   sessionManager().setSessionLaunchFunction(countingLaunchFunction);
+   s_launchCount = 0;
+
+   // in a root-launched multi-user deployment rserver's request-handling
+   // threads run privilege-dropped, so the kill(pid, 0) liveness probe
+   // yields EPERM for a live rsession owned by another user; that must
+   // still read as running, or the guard above is inert exactly where
+   // #18572 occurs. pid 1 (init/launchd) stands in for a live process
+   // this test cannot signal.
+   r_util::SessionContext context("pending-launch-other-user-process-user");
+   EXPECT_TRUE(attemptLaunch(context));
+   EXPECT_EQ(1, s_launchCount);
+   sessionManager().notePendingLaunchPid(context, 1);
+
+   sessionManager().removePendingLaunch(context, false, "request error");
+   EXPECT_FALSE(attemptLaunch(context));
+   EXPECT_EQ(1, s_launchCount);
+
+   sessionManager().removePendingLaunch(context);
+}
+
 TEST(SessionManagerTest, RequestErrorClearsPendingLaunchOfDeadProcess)
 {
    sessionManager().setSessionLaunchFunction(countingLaunchFunction);


### PR DESCRIPTION
Follow-up to #18573, which added a liveness guard in `ServerSessionManager::removePendingLaunch`: a request error no longer erases the pending-launch record while the launched session process is still alive. The guard probes liveness with `core::system::isProcessRunning`, which returned `kill(pid, 0) == 0` -- but on a root-launched multi-user server, rserver's request-handling threads run privilege-dropped (`temporarilyDropPrivileges` leaves ruid 0 and euid `server-user`, and the euid transition clears the effective capability set, so no `CAP_KILL`), and `kill(pid, 0)` fails with EPERM for every live rsession owned by another user. The guard read that as "not running", erased the record on the error path exactly as before #18573, and the #18572 double-launch/orphan race remained reproducible in precisely the deployment class it targets. Dev and e2e servers were unaffected (rserver and its sessions share a uid there), which is why #18573's verification passed.

`isProcessRunning` now counts EPERM as proof the process exists -- only ESRCH means it is gone. That is the established polarity for cross-user liveness probes (psutil's `pid_exists`: "EPERM clearly means there's a process to deny access to"; moby's `process.Alive` on macOS is `err == nil || errors.Is(err, unix.EPERM)`), and the #18573 guard is the function's only caller.

Verification:

- New tests: `PosixTests.IsProcessRunningDetectsLiveAndDeadProcesses` (core) and `SessionManagerTest.RequestErrorKeepsPendingLaunchOfOtherUserProcess` (rserver). Both probe pid 1, which always exists and is owned by root, so an unprivileged test run exercises the EPERM path (and a privileged one still passes); the new rserver test fails against the previous probe.
- `rstudio-tests --scope core`: all pass. `--scope rserver`: all `SessionManagerTest` pass; the `SqliteDBActiveSessionStorageTest` failures are environmental on this machine and identical on main's build (same as noted on #18573).

No NEWS entry: this completes the unreleased #18573 fix, whose #18572 entry already covers the user-facing behavior.

Fixes #18572.
