### PR TITLE
e2e: forbid the assistant from overriding the shiny viewer pane

### DIFF
--- a/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
@@ -19,7 +19,12 @@ test.describe.serial('R Shiny Tip Calculator via Posit Assistant', { tag: ['@ai'
   let versions: EnvironmentVersions;
   let missingPackages: string[] = [];
 
-  const PROMPT = `Create a Shiny for R web app for a tip calculator. The app can only depend on packages that are already installed--nothing that isn't already installed. The app should be a single file. It should have a slider from $0 to $100 for the bill amount. It should have four buttons: 10%, 15%, 20%, and 25%. The output, the tip, should be based on the value in the slider and the chosen button. The buttons and slider should both be oriented horizontally, the slider above the buttons. The bill and tip amount should be displayed above the slider. The title of the page should be "Wacky Tip Calculator for R". Then run the app in the viewer pane and make sure that it can be seen. The app MUST be viewable in the RStudio viewer pane. Then say "Wacky Tip Calculator for R has started" when the app starts running.`;
+  // The launch.browser prohibition is load-bearing: left to its own devices
+  // the assistant sets options(shiny.launch.browser) to a window/external
+  // launcher, which overrides the shiny_viewer_type pref set below and routes
+  // the app away from the Viewer pane this test asserts on. The app.R name is
+  // load-bearing too -- the cleanup hooks unlink that exact file.
+  const PROMPT = `Create a Shiny for R web app for a tip calculator. The app can only depend on packages that are already installed--nothing that isn't already installed. The app should be a single file named app.R in the current working directory. It should have a slider from $0 to $100 for the bill amount. It should have four buttons: 10%, 15%, 20%, and 25%. The output, the tip, should be based on the value in the slider and the chosen button. The buttons and slider should both be oriented horizontally, the slider above the buttons. The bill and tip amount should be displayed above the slider. The title of the page should be "Wacky Tip Calculator for R". Then run the app in the viewer pane and make sure that it can be seen. The app MUST be viewable in the RStudio viewer pane. Do NOT set options(shiny.launch.browser) and do NOT pass a launch.browser argument to runApp--RStudio is already configured to open the app in the Viewer pane. Then say "Wacky Tip Calculator for R has started" when the app starts running.`;
 
   test.beforeAll(async ({ rstudioPage: page }) => {
     // A cold-cache package install can outlast the global per-test timeout;


### PR DESCRIPTION
In the linux-desktop E2E run on #18574 ([job link](https://github.com/rstudio/rstudio/actions/runs/31929144011/job/95122883568)), the R Shiny tip-calculator test failed on both attempts waiting for the Viewer pane iframe, which never left `about:blank`. The page snapshots captured in `error-context.md` show why: the assistant prefixed `runApp()` with its own launcher override, a different one each attempt --

- attempt 1: `options(shiny.launch.browser = .rs.invokeShinyWindowExternal)` (external browser)
- retry: `options(shiny.launch.browser = .rs.invokeShinyWindowViewer)` (separate window)

Either override beats the `shiny_viewer_type = 'pane'` pref the test configures, so the app genuinely started (the console showed `Listening on ...`, and the assistant emitted the success marker) but never rendered in the Viewer pane the test asserts on.

This extends the prompt to explicitly forbid setting `options(shiny.launch.browser)` or passing a `launch.browser` argument, and pins the generated filename to `app.R` so the suite's existing `unlink("app.R")` cleanup removes the file the assistant writes (it previously chose names like `tip_calculator_app.R`, which leaked into the sandbox home).

Verification: `npm run typecheck` in `e2e/rstudio` passes. The behavioral change can't be exercised locally on this machine (no Posit AI credentials, so the test skips); this PR's own linux-desktop E2E job runs the test with real credentials.
