### PR TITLE
Keep one titled chat iframe during Posit Assistant resume

### DIFF
--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-pane-persistence.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-pane-persistence.test.ts
@@ -92,11 +92,45 @@ test.describe.serial('Chat pane persistence', { tag: ['@ai', '@chat'] }, () => {
   test('chat pane content survives R session restart', async ({ rstudioPage: page }) => {
     await ensureChatPaneVisible(page, chatActions);
 
+    // Tag the pre-restart iframe. On resume ChatPane double-buffers: it loads
+    // the resume URL into a second (untitled, hidden) frame and only removes
+    // this one once that load completes, so the tag is how we tell the
+    // resumed frame from the one we started with.
+    await page.evaluate((selector) => {
+      const f = document.querySelector(selector);
+      if (!f) throw new Error('chat iframe not found');
+      f.setAttribute('data-pw-prerestart', '');
+    }, CHAT_IFRAME);
+
     // Restart the R session (sentinel-confirmed)
     await restartSessionWithSentinel(page);
 
     // Re-open the chat pane (toggleSidebar may have hidden it during restart)
     await ensureChatPaneVisible(page, chatActions);
+
+    // Best-effort wait for the swap, so the body sampled below is the
+    // post-restart document rather than the preserved pre-restart one.
+    // window.rstudio.ready (awaited above) only covers GWT's own init; the
+    // chat resume load is independent of it. If the resumed frame stalls,
+    // ChatPane reclaims it after FRAME_LOAD_TIMEOUT_MS and reloads the
+    // original element instead -- the pane stays populated either way, which
+    // is the property under test, so a miss here is logged, not fatal.
+    const swapped = await page
+      .waitForFunction(
+        (selector) => {
+          const f = document.querySelector(selector);
+          return f !== null && !f.hasAttribute('data-pw-prerestart');
+        },
+        CHAT_IFRAME,
+        { timeout: 20000, polling: 250 },
+      )
+      .then(() => true)
+      .catch(() => false);
+
+    if (!swapped) {
+      console.log('resume swap did not replace the chat iframe within 20s -- ' +
+        'asserting against the pre-restart frame');
+    }
 
     // The iframe should have rendered content -- either the chat app root
     // or the "Not Installed" page. Both share a non-empty body.

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-pane-persistence.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-pane-persistence.test.ts
@@ -10,6 +10,17 @@ import { createChatActions } from './_chat-setup';
 
 const CHAT_IFRAME = "iframe[title='Posit Assistant']";
 const PREFS_OK_BTN = '#rstudio_preferences_confirm';
+const PRERESTART_ATTR = 'data-pw-prerestart';
+
+// In-page state for the resume-window frame counts (see the restart test).
+// maxTitled is the invariant under test; maxSiblings says whether the resume
+// double-buffered at all, so a passing run can't quietly claim coverage it
+// didn't get.
+type ChatFrameWatch = {
+  counts: { maxTitled: number; maxSiblings: number };
+  observer: MutationObserver;
+};
+type WatchWindow = Window & { _chatFrameWatch?: ChatFrameWatch };
 
 // Posit Assistant is configured but not necessarily installed. Both tests
 // just need the iframe to exist; they don't depend on the chat backend being
@@ -40,6 +51,20 @@ test.describe.serial('Chat pane persistence', { tag: ['@ai', '@chat'] }, () => {
 
     await consoleActions.clearConsole();
     await actions.assistantActions.setChatProvider(CHAT_PROVIDERS['posit-assistant']);
+  });
+
+  // The restart test's observer and marker live on a page shared with every
+  // later test in this worker, so drop them even when that test throws before
+  // its own read. Cleanup must not mask the failure that got us here.
+  test.afterEach(async ({ rstudioPage: page }) => {
+    await page
+      .evaluate(({ selector, attr }) => {
+        const w = window as WatchWindow;
+        w._chatFrameWatch?.observer.disconnect();
+        delete w._chatFrameWatch;
+        document.querySelector(selector)?.removeAttribute(attr);
+      }, { selector: CHAT_IFRAME, attr: PRERESTART_ATTR })
+      .catch(() => undefined);
   });
 
   // Regression test for rstudio/rstudio#17223: dismissing Global Options
@@ -89,7 +114,7 @@ test.describe.serial('Chat pane persistence', { tag: ['@ai', '@chat'] }, () => {
 
   // Regression test for rstudio/rstudio#17240: chat pane must remain
   // populated after an R session restart.
-  test('chat pane content survives R session restart', async ({ rstudioPage: page }) => {
+  test('chat pane content survives R session restart', async ({ rstudioPage: page }, testInfo) => {
     await ensureChatPaneVisible(page, chatActions);
 
     // Tag the pre-restart iframe. On resume ChatPane double-buffers: it loads
@@ -103,28 +128,36 @@ test.describe.serial('Chat pane persistence', { tag: ['@ai', '@chat'] }, () => {
     // the length of the load. Callbacks run after each mutation batch, so the
     // swap's synchronous title-then-remove sequence is only ever seen in its
     // end state -- a reading of 2 means the frames genuinely coexisted.
-    await page.evaluate((selector) => {
+    //
+    // It also counts iframes under the chat pane's panel, where the pending
+    // frame is attached as a sibling of this one. That count reaching 2 is
+    // what proves the double-buffer ran, which the titled count alone cannot
+    // show: it starts at 1 and stays there both when the fix holds and when
+    // the resume never double-buffers.
+    await page.evaluate(({ selector, attr }) => {
       const f = document.querySelector(selector);
       if (!f) throw new Error('chat iframe not found');
-      f.setAttribute('data-pw-prerestart', '');
+      f.setAttribute(attr, '');
 
-      const w = window as Window & {
-        _maxChatFrames?: number;
-        _chatFrameObserver?: MutationObserver;
-      };
-      const count = () => document.querySelectorAll(selector).length;
-      w._maxChatFrames = count();
-      w._chatFrameObserver?.disconnect();
-      w._chatFrameObserver = new MutationObserver(() => {
-        w._maxChatFrames = Math.max(w._maxChatFrames ?? 0, count());
+      const pane = f.parentElement;
+      const titled = () => document.querySelectorAll(selector).length;
+      const siblings = () => pane?.querySelectorAll(':scope > iframe').length ?? 0;
+      const counts = { maxTitled: titled(), maxSiblings: siblings() };
+      const observer = new MutationObserver(() => {
+        counts.maxTitled = Math.max(counts.maxTitled, titled());
+        counts.maxSiblings = Math.max(counts.maxSiblings, siblings());
       });
-      w._chatFrameObserver.observe(document.body, {
+
+      const w = window as WatchWindow;
+      w._chatFrameWatch?.observer.disconnect();
+      w._chatFrameWatch = { counts, observer };
+      observer.observe(document.body, {
         childList: true,
         subtree: true,
         attributes: true,
         attributeFilter: ['title'],
       });
-    }, CHAT_IFRAME);
+    }, { selector: CHAT_IFRAME, attr: PRERESTART_ATTR });
 
     // Restart the R session (sentinel-confirmed)
     await restartSessionWithSentinel(page);
@@ -133,39 +166,22 @@ test.describe.serial('Chat pane persistence', { tag: ['@ai', '@chat'] }, () => {
     await ensureChatPaneVisible(page, chatActions);
 
     // Best-effort wait for the swap, so the body sampled below is the
-    // post-restart document rather than the preserved pre-restart one.
-    // window.rstudio.ready (awaited above) only covers GWT's own init; the
-    // chat resume load is independent of it. If the resumed frame stalls,
-    // ChatPane reclaims it after FRAME_LOAD_TIMEOUT_MS and reloads the
-    // original element instead -- the pane stays populated either way, which
-    // is the property under test, so a miss here is logged, not fatal.
+    // post-restart document rather than the preserved pre-restart one. If the
+    // resumed frame stalls, ChatPane reclaims it after FRAME_LOAD_TIMEOUT_MS
+    // and reloads the original element instead -- the pane stays populated
+    // either way, which is the property under test, so a miss is annotated
+    // below rather than failed.
     const swapped = await page
       .waitForFunction(
-        (selector) => {
+        ({ selector, attr }) => {
           const f = document.querySelector(selector);
-          return f !== null && !f.hasAttribute('data-pw-prerestart');
+          return f !== null && !f.hasAttribute(attr);
         },
-        CHAT_IFRAME,
+        { selector: CHAT_IFRAME, attr: PRERESTART_ATTR },
         { timeout: 20000, polling: 250 },
       )
       .then(() => true)
       .catch(() => false);
-
-    if (!swapped) {
-      console.log('resume swap did not replace the chat iframe within 20s -- ' +
-        'asserting against the pre-restart frame');
-    }
-
-    const maxChatFrames = await page.evaluate(() => {
-      const w = window as Window & {
-        _maxChatFrames?: number;
-        _chatFrameObserver?: MutationObserver;
-      };
-      w._chatFrameObserver?.disconnect();
-      return w._maxChatFrames ?? -1;
-    });
-
-    expect(maxChatFrames, 'iframes titled "Posit Assistant" attached at once during resume').toBe(1);
 
     // The iframe should have rendered content -- either the chat app root
     // or the "Not Installed" page. Both share a non-empty body.
@@ -175,6 +191,36 @@ test.describe.serial('Chat pane persistence', { tag: ['@ai', '@chat'] }, () => {
       .locator('body')
       .innerText({ timeout: TIMEOUTS.consoleReady });
 
+    // Read the counts only now: the resume load is independent of
+    // window.rstudio.ready, so on a slow worker the pending frame can be
+    // attached late, and disconnecting the observer any earlier could close
+    // the window before it opens.
+    const counts = await page.evaluate(() => {
+      const w = window as WatchWindow;
+      w._chatFrameWatch?.observer.disconnect();
+      return w._chatFrameWatch?.counts ?? { maxTitled: -1, maxSiblings: -1 };
+    });
+
+    // Record what the run actually exercised. The double-buffer only runs when
+    // the chat backend was loaded before the restart: with Posit Assistant not
+    // installed, ChatPresenter never caches a URL, so it neither dims the pane
+    // on suspend nor reloads it on resume -- it just re-polls install status.
+    // That is a legitimate environment, not a failure, but it does mean the
+    // #18585 guard below proved nothing, so say so rather than passing quietly.
+    if (counts.maxSiblings < 2) {
+      const note = 'resume did not double-buffer (no pending frame attached) -- ' +
+        'the duplicate-title assertion was not exercised';
+      console.log(note);
+      testInfo.annotations.push({ type: 'coverage-gap', description: note });
+    } else if (!swapped) {
+      const note = 'resume double-buffered but did not swap within 20s -- body asserted ' +
+        'against the pre-restart frame';
+      console.log(note);
+      testInfo.annotations.push({ type: 'coverage-gap', description: note });
+    }
+
     expect(bodyText.trim().length, 'chat iframe body should not be empty after restart').toBeGreaterThan(0);
+
+    expect(counts.maxTitled, 'iframes titled "Posit Assistant" attached at once during resume').toBe(1);
   });
 });

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-pane-persistence.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-pane-persistence.test.ts
@@ -96,10 +96,34 @@ test.describe.serial('Chat pane persistence', { tag: ['@ai', '@chat'] }, () => {
     // the resume URL into a second (untitled, hidden) frame and only removes
     // this one once that load completes, so the tag is how we tell the
     // resumed frame from the one we started with.
+    //
+    // The observer records the high-water mark of titled iframes across the
+    // resume (rstudio/rstudio#18585): the pending frame must stay untitled
+    // until it replaces this one, or every lookup by title is ambiguous for
+    // the length of the load. Callbacks run after each mutation batch, so the
+    // swap's synchronous title-then-remove sequence is only ever seen in its
+    // end state -- a reading of 2 means the frames genuinely coexisted.
     await page.evaluate((selector) => {
       const f = document.querySelector(selector);
       if (!f) throw new Error('chat iframe not found');
       f.setAttribute('data-pw-prerestart', '');
+
+      const w = window as Window & {
+        _maxChatFrames?: number;
+        _chatFrameObserver?: MutationObserver;
+      };
+      const count = () => document.querySelectorAll(selector).length;
+      w._maxChatFrames = count();
+      w._chatFrameObserver?.disconnect();
+      w._chatFrameObserver = new MutationObserver(() => {
+        w._maxChatFrames = Math.max(w._maxChatFrames ?? 0, count());
+      });
+      w._chatFrameObserver.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['title'],
+      });
     }, CHAT_IFRAME);
 
     // Restart the R session (sentinel-confirmed)
@@ -131,6 +155,17 @@ test.describe.serial('Chat pane persistence', { tag: ['@ai', '@chat'] }, () => {
       console.log('resume swap did not replace the chat iframe within 20s -- ' +
         'asserting against the pre-restart frame');
     }
+
+    const maxChatFrames = await page.evaluate(() => {
+      const w = window as Window & {
+        _maxChatFrames?: number;
+        _chatFrameObserver?: MutationObserver;
+      };
+      w._chatFrameObserver?.disconnect();
+      return w._maxChatFrames ?? -1;
+    });
+
+    expect(maxChatFrames, 'iframes titled "Posit Assistant" attached at once during resume').toBe(1);
 
     // The iframe should have rendered content -- either the chat app root
     // or the "Not Installed" page. Both share a non-empty body.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/chat/ChatPane.java
@@ -351,7 +351,11 @@ public class ChatPane
 
       final int savedScrollTop = getFrameScrollTop(frame_);
 
-      RStudioThemedFrame newFrame = new RStudioThemedFrame(constants_.chatTitle());
+      // The pending frame stays untitled until it is swapped in below: it is
+      // attached alongside frame_ for the duration of the load, so titling it
+      // here would leave two iframes named "Posit Assistant" in the DOM for up
+      // to FRAME_LOAD_TIMEOUT_MS, making any lookup by title ambiguous.
+      RStudioThemedFrame newFrame = new RStudioThemedFrame(null);
       newFrame.setSize("100%", "100%");
       pendingFrame_ = newFrame;
 
@@ -405,6 +409,7 @@ public class ChatPane
                 newFrame.getParent() == mainPanel_ &&
                 suspendedOverlay_.getParent() == mainPanel_)
             {
+               newFrame.setTitle(constants_.chatTitle());
                newFrame.getElement().getStyle().setVisibility(Visibility.VISIBLE);
                frame_.setUrl("about:blank");
                mainPanel_.remove(frame_);


### PR DESCRIPTION
### Intent

Fixes #18585.

After an R session restart with the Posit Assistant chat pane open, the workbench DOM could hold two `iframe[title="Posit Assistant"]` elements at once, for as long as 15 seconds. Any lookup of the chat iframe by title was ambiguous for that window -- which is how `chat-pane-persistence.test.ts` failed on #18578 with a Playwright strict-mode violation resolving both frames.

### Approach

`ChatPane.loadUrlFromSuspended` double-buffers the resume: it attaches a second hidden frame, loads the resume URL into it, and removes the old frame only once that load fires (plus `FRAME_SWAP_DELAY_MS`), falling back to reclaiming the pending frame after `FRAME_LOAD_TIMEOUT_MS` if the load never completes. Both frames were constructed with the "Posit Assistant" title.

The pending frame is now created untitled and gets its title inside the swap branch, in the same synchronous block that makes it visible and removes the old frame -- so the DOM never exposes two frames under that name, and the visible frame always carries the title. The timeout path discards the untitled frame and keeps using the already-titled original, so exactly one titled iframe survives either way.

The double-buffering itself is unchanged: the user still sees preserved chat content under the suspended overlay while the resumed frame loads, and the 15s fallback still recovers a stalled load.

No user-visible behavior changes. The pending frame is `visibility: hidden`, which excludes it from the accessibility tree, so the ambiguity was never exposed to assistive technology -- it affected DOM lookups only. On those grounds there is no `NEWS.md` entry.

### Automated Tests

`chat-pane-persistence.test.ts` ("chat pane content survives R session restart") now:

- tags the pre-restart iframe and waits for the resume swap before sampling the frame body, so it checks the resumed frame instead of the preserved pre-restart content;
- records the high-water mark of titled iframes across the restart with a `MutationObserver` and asserts it stays at one, so re-titling the pending frame fails the test rather than only surfacing as a flake;
- counts iframes under the chat pane's panel as well, and annotates the run when the resume never double-buffered. With Posit Assistant not installed, `ChatPresenter` caches no URL and so neither dims the pane on suspend nor reloads it on resume -- a legitimate environment in which the guard proves nothing, and one that a hard "a second frame appeared" assertion would fail.

Verified with `ant javac` and `tsc --noEmit`. The Playwright test has not been run against a live IDE; that needs a Desktop build with Posit Assistant credentials.

### QA Notes

Open the chat pane, restart R, and confirm the pane still shows its content through the resume and lands on a working chat frame. To see the window this fixes, delay the restarted session's chat backend and inspect the DOM during the resume: there should be exactly one `iframe[title="Posit Assistant"]` at all times.

### Documentation

None -- no user-facing behavior change.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` (n/a -- no user-visible symptom; rationale above)
- [x] If this PR adds or changes UI, the updated UI meets accessibility standards
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests