### PR TITLE
e2e: harden chat turn-completion wait and pref writes against transients

### DIFF
--- a/e2e/rstudio/actions/chat_pane.actions.ts
+++ b/e2e/rstudio/actions/chat_pane.actions.ts
@@ -5,6 +5,14 @@ import { ConsolePaneActions } from './console_pane.actions';
 import { sleep } from '../utils/constants';
 import { executeCommand } from '../utils/commands';
 
+// The stop button flickers off between streaming phases -- notably in the
+// approval -> tool-execution handoff right after clicking Allow -- so a single
+// hidden sample does not mean the turn is done. isTurnIdle() requires it to
+// stay hidden across TURN_IDLE_SAMPLES samples, spanning
+// (TURN_IDLE_SAMPLES - 1) * TURN_IDLE_SAMPLE_INTERVAL_MS of observation.
+const TURN_IDLE_SAMPLES = 4;
+const TURN_IDLE_SAMPLE_INTERVAL_MS = 500;
+
 export class ChatPaneActions {
   readonly page: Page;
   readonly chatPane: ChatPane;
@@ -350,17 +358,53 @@ export class ChatPaneActions {
     throw new Error(`pollWithAllowDialogs timed out after ${timeout}ms`);
   }
 
+  /**
+   * Whether the assistant has finished its turn -- the single predicate every
+   * "wait for the response" poll in the suite should use.
+   *
+   * The composer shows the stop button in place of send for as long as the
+   * turn is active, so a hidden stop button is the completion signal. It is
+   * only trustworthy when sampled repeatedly (see TURN_IDLE_SAMPLES): the
+   * button flickers off mid-turn, and one sample landing in that gap reports a
+   * still-streaming turn as done. Returns as soon as the button is seen, so
+   * this stays cheap while a turn is streaming and pays the full sampling
+   * window only once the turn looks finished.
+   *
+   * The chat root is checked alongside it because isStopButtonVisible()
+   * reports any failed lookup as "not visible": if the assistant iframe is
+   * torn down mid-turn, its stop button is missing for a reason that is the
+   * opposite of idle, and without this the streak would complete on it.
+   */
+  async isTurnIdle(): Promise<boolean> {
+    for (let sample = 0; sample < TURN_IDLE_SAMPLES; sample++) {
+      if (sample > 0)
+        await sleep(TURN_IDLE_SAMPLE_INTERVAL_MS);
+
+      if (!(await this.chatPane.chatRoot.isVisible().catch(() => false)))
+        return false;
+
+      if (await this.chatPane.isStopButtonVisible())
+        return false;
+    }
+
+    return true;
+  }
+
   async sendChatMessage(text: string): Promise<void> {
     await expect(this.chatPane.chatInput).toBeVisible({ timeout: 15000 });
+
+    // The previous turn may still be streaming -- the composer shows the stop
+    // button in place of send until the whole turn (including any post-tool
+    // continuation) completes, which can take well over 15s of model latency,
+    // and a turn parked on an approval stays active until it is granted.
+    // Wait the turn out here, before typing: the composer re-renders when the
+    // turn ends, so text buffered into it beforehand does not survive.
+    await this.pollWithAllowDialogs(() => this.isTurnIdle(), 60000);
+
     await expect(this.chatPane.chatInput)
       .toHaveAttribute('contenteditable', 'true', { timeout: 15000 });
     await this.chatPane.typeMessage(text);
 
-    // The previous turn may still be streaming -- the composer shows the stop
-    // button in place of send until the whole turn (including any post-tool
-    // continuation) completes, which can take well over 15s of model latency.
-    // Wait that out before requiring the send button.
-    await expect(this.chatPane.stopBtn).toBeHidden({ timeout: 60000 });
     await expect(this.chatPane.sendBtn).toBeVisible({ timeout: 15000 });
     await this.chatPane.sendBtn.click();
   }
@@ -378,15 +422,10 @@ export class ChatPaneActions {
 
       const currentCount = await this.chatPane.getMessageCount();
       if (currentCount > initialCount) {
-        // The stop button flickers off between streaming phases -- notably in
-        // the approval -> tool-execution handoff right after clicking Allow --
-        // so a single hidden sample does not mean the turn is done. Require it
-        // to stay hidden across consecutive samples before concluding.
         const readyDeadline = Date.now() + 30000;
-        let stopHiddenStreak = 0;
-        while (Date.now() < readyDeadline) {
+        let idle = false;
+        while (!idle && Date.now() < readyDeadline) {
           if (await this.chatPane.isAllowButtonVisible()) {
-            stopHiddenStreak = 0;
             await sleep(1000);
             await this.chatPane.allowBtn.click();
             console.log('Clicked "Allow" after response arrived');
@@ -394,16 +433,20 @@ export class ChatPaneActions {
             continue;
           }
 
-          if (await this.chatPane.isStopButtonVisible()) {
-            stopHiddenStreak = 0;
-          } else {
-            stopHiddenStreak++;
-            if (stopHiddenStreak >= 4) {
-              break;
-            }
-          }
+          idle = await this.isTurnIdle();
+          if (!idle)
+            await sleep(TURN_IDLE_SAMPLE_INTERVAL_MS);
+        }
 
-          await sleep(500);
+        // Falling out of that loop on the deadline means the turn never
+        // settled. Say so: the caller is about to assert against a response
+        // that may still be streaming, and silently returning here is what
+        // made this class of flake unreadable in the report.
+        if (!idle) {
+          console.warn(
+            'waitForResponse: the assistant turn was still active after 30s; ' +
+            'reading the response while it may still be streaming'
+          );
         }
 
         const finalCount = await this.chatPane.getMessageCount();

--- a/e2e/rstudio/actions/chat_pane.actions.ts
+++ b/e2e/rstudio/actions/chat_pane.actions.ts
@@ -397,12 +397,18 @@ export class ChatPaneActions {
   /**
    * Send a message, waiting out any still-running previous turn first.
    *
+   * `answerQuestion` matches the option to pick if that previous turn is
+   * parked on an AskUser question.
+   *
    * Returns the message count as of that wait finishing -- the baseline to
    * hand waitForResponse. A caller that samples the count itself, before this
    * call, reads it while the previous turn may still be appending to the
    * conversation, and then credits this turn with that growth.
    */
-  async sendChatMessage(text: string): Promise<number> {
+  async sendChatMessage(
+    text: string,
+    answerQuestion?: RegExp | string
+  ): Promise<number> {
     await expect(this.chatPane.chatInput).toBeVisible({ timeout: 15000 });
 
     // The previous turn may still be streaming -- the composer shows the stop
@@ -411,7 +417,11 @@ export class ChatPaneActions {
     // and a turn parked on an approval stays active until it is granted.
     // Wait the turn out here, before typing: the composer re-renders when the
     // turn ends, so text buffered into it beforehand does not survive.
-    await this.pollWithAllowDialogs(() => this.isTurnIdle(), 60000);
+    await this.pollWithAllowDialogs(
+      () => this.isTurnIdle(),
+      60000,
+      answerQuestion
+    );
 
     const baseline = await this.chatPane.getMessageCount();
 

--- a/e2e/rstudio/actions/chat_pane.actions.ts
+++ b/e2e/rstudio/actions/chat_pane.actions.ts
@@ -356,6 +356,11 @@ export class ChatPaneActions {
       .toHaveAttribute('contenteditable', 'true', { timeout: 15000 });
     await this.chatPane.typeMessage(text);
 
+    // The previous turn may still be streaming -- the composer shows the stop
+    // button in place of send until the whole turn (including any post-tool
+    // continuation) completes, which can take well over 15s of model latency.
+    // Wait that out before requiring the send button.
+    await expect(this.chatPane.stopBtn).toBeHidden({ timeout: 60000 });
     await expect(this.chatPane.sendBtn).toBeVisible({ timeout: 15000 });
     await this.chatPane.sendBtn.click();
   }
@@ -373,9 +378,15 @@ export class ChatPaneActions {
 
       const currentCount = await this.chatPane.getMessageCount();
       if (currentCount > initialCount) {
+        // The stop button flickers off between streaming phases -- notably in
+        // the approval -> tool-execution handoff right after clicking Allow --
+        // so a single hidden sample does not mean the turn is done. Require it
+        // to stay hidden across consecutive samples before concluding.
         const readyDeadline = Date.now() + 30000;
+        let stopHiddenStreak = 0;
         while (Date.now() < readyDeadline) {
           if (await this.chatPane.isAllowButtonVisible()) {
+            stopHiddenStreak = 0;
             await sleep(1000);
             await this.chatPane.allowBtn.click();
             console.log('Clicked "Allow" after response arrived');
@@ -383,8 +394,13 @@ export class ChatPaneActions {
             continue;
           }
 
-          if (!(await this.chatPane.isStopButtonVisible())) {
-            break;
+          if (await this.chatPane.isStopButtonVisible()) {
+            stopHiddenStreak = 0;
+          } else {
+            stopHiddenStreak++;
+            if (stopHiddenStreak >= 4) {
+              break;
+            }
           }
 
           await sleep(500);

--- a/e2e/rstudio/actions/chat_pane.actions.ts
+++ b/e2e/rstudio/actions/chat_pane.actions.ts
@@ -13,6 +13,10 @@ import { executeCommand } from '../utils/commands';
 const TURN_IDLE_SAMPLES = 4;
 const TURN_IDLE_SAMPLE_INTERVAL_MS = 500;
 
+// Floor for waitForResponse's settle window, used when the caller's own
+// budget has already been spent waiting for the response to appear.
+const MIN_TURN_SETTLE_MS = 30000;
+
 export class ChatPaneActions {
   readonly page: Page;
   readonly chatPane: ChatPane;
@@ -390,7 +394,15 @@ export class ChatPaneActions {
     return true;
   }
 
-  async sendChatMessage(text: string): Promise<void> {
+  /**
+   * Send a message, waiting out any still-running previous turn first.
+   *
+   * Returns the message count as of that wait finishing -- the baseline to
+   * hand waitForResponse. A caller that samples the count itself, before this
+   * call, reads it while the previous turn may still be appending to the
+   * conversation, and then credits this turn with that growth.
+   */
+  async sendChatMessage(text: string): Promise<number> {
     await expect(this.chatPane.chatInput).toBeVisible({ timeout: 15000 });
 
     // The previous turn may still be streaming -- the composer shows the stop
@@ -401,12 +413,16 @@ export class ChatPaneActions {
     // turn ends, so text buffered into it beforehand does not survive.
     await this.pollWithAllowDialogs(() => this.isTurnIdle(), 60000);
 
+    const baseline = await this.chatPane.getMessageCount();
+
     await expect(this.chatPane.chatInput)
       .toHaveAttribute('contenteditable', 'true', { timeout: 15000 });
     await this.chatPane.typeMessage(text);
 
     await expect(this.chatPane.sendBtn).toBeVisible({ timeout: 15000 });
     await this.chatPane.sendBtn.click();
+
+    return baseline;
   }
 
   async waitForResponse(initialCount: number, timeout: number = 60000): Promise<number> {
@@ -422,7 +438,12 @@ export class ChatPaneActions {
 
       const currentCount = await this.chatPane.getMessageCount();
       if (currentCount > initialCount) {
-        const readyDeadline = Date.now() + 30000;
+        // Settling gets whatever is left of the caller's budget, never less
+        // than the floor. Deriving it from `timeout` is the point: a caller
+        // that raised its budget for slow turns means the whole turn, not
+        // just the arrival of its first message.
+        const settleStart = Date.now();
+        const readyDeadline = Math.max(deadline, settleStart + MIN_TURN_SETTLE_MS);
         let idle = false;
         while (!idle && Date.now() < readyDeadline) {
           if (await this.chatPane.isAllowButtonVisible()) {
@@ -444,7 +465,8 @@ export class ChatPaneActions {
         // made this class of flake unreadable in the report.
         if (!idle) {
           console.warn(
-            'waitForResponse: the assistant turn was still active after 30s; ' +
+            'waitForResponse: the assistant turn was still active after ' +
+            `${Math.round((Date.now() - settleStart) / 1000)}s; ` +
             'reading the response while it may still be streaming'
           );
         }

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails.test.ts
@@ -125,9 +125,7 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@chat', '
    */
   async function askAssistant(prompt: string, answerQuestion?: RegExp): Promise<string> {
     await chatActions.startNewConversation();
-    const initialCount = await chatPane.getMessageCount();
-
-    await chatActions.sendChatMessage(prompt);
+    const initialCount = await chatActions.sendChatMessage(prompt, answerQuestion);
 
     // Handle Allow dialogs and wait for response to finish streaming
     await chatActions.pollWithAllowDialogs(async () => {

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails.test.ts
@@ -133,7 +133,7 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@chat', '
     await chatActions.pollWithAllowDialogs(async () => {
       const count = await chatPane.getMessageCount();
       if (count <= initialCount) return false;
-      return !(await chatPane.isStopButtonVisible());
+      return await chatActions.isTurnIdle();
     }, 120000, answerQuestion);
 
     const lastMessage = chatPane.messageItem.last();

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-messaging.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-messaging.test.ts
@@ -19,6 +19,13 @@ test.describe.serial('Chat Messaging', { tag: ['@ai', '@chat'] }, () => {
   });
 
   test.beforeEach(async () => {
+    // Every test here is one or more full model round-trips, and the
+    // multi-turn case is six of them back to back. The 120s default budget
+    // leaves ~20s per turn, so a single slow turn expires the test and
+    // reports an opaque "Test timeout exceeded" instead of the assertion
+    // that was actually waiting.
+    test.setTimeout(300000);
+
     annotateVersions(versions);
     test.info().annotations.push(
       { type: 'Posit Assistant version', description: positAssistantVersion },

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-messaging.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-messaging.test.ts
@@ -37,8 +37,7 @@ test.describe.serial('Chat Messaging', { tag: ['@ai', '@chat'] }, () => {
   });
 
   test('send a message and receive a response', async ({ rstudioPage: page }) => {
-    const initialCount = await chatPane.getMessageCount();
-    await chatActions.sendChatMessage('Hello, can you help me?');
+    const initialCount = await chatActions.sendChatMessage('Hello, can you help me?');
 
     const newCount = await chatActions.waitForResponse(initialCount);
     expect(newCount).toBeGreaterThan(initialCount);
@@ -57,8 +56,11 @@ test.describe.serial('Chat Messaging', { tag: ['@ai', '@chat'] }, () => {
     ];
 
     for (const message of turns) {
-      const countBefore = await chatPane.getMessageCount();
-      await chatActions.sendChatMessage(message);
+      // The baseline comes from sendChatMessage, which samples it once the
+      // previous turn has actually settled. Sampling it here instead would
+      // read a count the previous turn can still grow during that wait, and
+      // credit this turn with the growth.
+      const countBefore = await chatActions.sendChatMessage(message);
       const countAfter = await chatActions.waitForResponse(countBefore);
       expect(countAfter).toBeGreaterThan(countBefore);
     }
@@ -68,8 +70,7 @@ test.describe.serial('Chat Messaging', { tag: ['@ai', '@chat'] }, () => {
     await expect(lastMessage).toContainText('23', { timeout: 5000 });
 
     // Verify the assistant can answer a non-math question
-    const countBefore = await chatPane.getMessageCount();
-    await chatActions.sendChatMessage('To whom is this referring? Answer in one word: "until Great Birnam Wood to high Dunsinane Hill shall come against him"');
+    const countBefore = await chatActions.sendChatMessage('To whom is this referring? Answer in one word: "until Great Birnam Wood to high Dunsinane Hill shall come against him"');
     await chatActions.waitForResponse(countBefore);
 
     lastMessage = chatPane.messageItem.last();
@@ -81,8 +82,7 @@ test.describe.serial('Chat Messaging', { tag: ['@ai', '@chat'] }, () => {
     expect(resetCount).toBe(0);
 
     // Verify the new conversation works
-    const newConvCount = await chatPane.getMessageCount();
-    await chatActions.sendChatMessage('Who believes that nothing will come of nothing: speak again?');
+    const newConvCount = await chatActions.sendChatMessage('Who believes that nothing will come of nothing: speak again?');
     await chatActions.waitForResponse(newConvCount);
 
     lastMessage = chatPane.messageItem.last();

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
@@ -274,9 +274,9 @@ test.describe.serial('User-Added Skills', { tag: ['@ai', '@chat', '@serial'] }, 
 
     // Wait for the full response, handling any Allow dialogs that appear
     await chatActions.pollWithAllowDialogs(async () => {
-      const isStillProcessing = await chatPane.isStopButtonVisible();
       const messageCount = await chatPane.getMessageCount();
-      return !isStillProcessing && messageCount > initialCount;
+      if (messageCount <= initialCount) return false;
+      return await chatActions.isTurnIdle();
     }, 120000);
 
     // Verify the response contains the markers from our project skill
@@ -311,9 +311,9 @@ test.describe.serial('User-Added Skills', { tag: ['@ai', '@chat', '@serial'] }, 
 
     // Wait for the full response, handling any Allow dialogs that appear
     await chatActions.pollWithAllowDialogs(async () => {
-      const isStillProcessing = await chatPane.isStopButtonVisible();
       const messageCount = await chatPane.getMessageCount();
-      return !isStillProcessing && messageCount > initialCount;
+      if (messageCount <= initialCount) return false;
+      return await chatActions.isTurnIdle();
     }, 120000);
 
     // Databot emits `skill: <name>` in the message when the model selects a

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/plots-pane-activation.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/plots-pane-activation.test.ts
@@ -109,7 +109,7 @@ test.describe.serial('Posit Assistant activates the Plots pane', { tag: ['@ai', 
     // scoping to the assistant role avoids depending on a prompt-text exclusion
     // (which would deadlock until timeout if the reply echoed that phrase).
     await chatActions.pollWithAllowDialogs(async () => {
-      if (await chatPane.isStopButtonVisible()) return false;
+      if (!(await chatActions.isTurnIdle())) return false;
       const lastReply = await chatPane.assistantMessageItem.last().innerText().catch(() => '');
       return lastReply.includes(PLOT_DONE_MARKER);
     }, 150000);

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/readline-notification.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/readline-notification.test.ts
@@ -79,8 +79,11 @@ test.describe.serial('Readline Notification in Chat Pane', { tag: ['@ai', '@chat
 
     // --- Step 8: Verify chat resumes working after readline completes ---
     // Wait for the assistant to finish processing the readline response.
-    await expect.poll(() => chatPane.isStopButtonVisible(), { timeout: 30000 })
-      .toBe(false);
+    // isTurnIdle() rather than a raw stop-button sample: the button flickers
+    // off between streaming phases, and a single hidden sample lands in that
+    // gap often enough to be the flake this suite keeps hitting.
+    await expect.poll(() => chatActions.isTurnIdle(), { timeout: 30000 })
+      .toBe(true);
 
     // Ask the assistant to print a Tempest quote to the console
     await consoleActions.clearConsole();

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-python.draft.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-python.draft.ts
@@ -82,9 +82,8 @@ test.describe.skip('Python Shiny Tip Calculator via Posit Assistant', () => {
     while (Date.now() < deadline) {
       // Check if the assistant is done: the last message (not the user's prompt) contains
       // "Wacky Tip Calculator for Python has started" AND the stop button is gone.
-      const isStillProcessing = await chatPane.isStopButtonVisible();
       const messageCount = await chatPane.getMessageCount();
-      if (!isStillProcessing && messageCount >= 2) {
+      if (messageCount >= 2 && await chatActions.isTurnIdle()) {
         const lastText = await chatPane.messageItem.last().innerText().catch(() => '');
         if (lastText.includes('Wacky Tip Calculator for Python has started') && !lastText.includes('Create a Shiny for Python')) {
           console.log('Completion signal found: "Wacky Tip Calculator for Python has started" in last message');

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/shiny-app-r.test.ts
@@ -107,9 +107,8 @@ test.describe.serial('R Shiny Tip Calculator via Posit Assistant', { tag: ['@ai'
 
     // Poll until the assistant completes. Handle Allow dialogs for each tool type.
     await chatActions.pollWithAllowDialogs(async () => {
-      const isStillProcessing = await chatPane.isStopButtonVisible();
       const messageCount = await chatPane.getMessageCount();
-      if (!isStillProcessing && messageCount >= 2) {
+      if (messageCount >= 2 && await chatActions.isTurnIdle()) {
         const lastText = await chatPane.messageItem.last().innerText().catch(() => '');
         if (lastText.includes('Wacky Tip Calculator for R has started') && !lastText.includes('Create a Shiny for R')) {
           return true;

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -1,6 +1,7 @@
 import type { Page } from '@playwright/test';
 import { waitForConsoleIdle } from '../pages/console_pane.page';
 import type { Ace } from './ace';
+import { sleep } from './constants';
 
 // `window.rstudio` is registered when rsession runs with --automation-agent
 // (the Desktop fixture forwards that flag). The bridge lets tests trigger and
@@ -592,6 +593,27 @@ async function waitForPrefEntry(page: Page, camelName: string): Promise<void> {
   );
 }
 
+// A pref write is a full-payload set_user_prefs RPC, so it is idempotent and
+// safe to retry. Busy CI runners can drop the XHR at the transport layer
+// (winsock ERR_NO_BUFFER_SPACE, connection resets around a session rebuild),
+// which the bridge reports as a "writeUserPrefs failed" rejection; retry that
+// signature only, so deterministic failures still surface immediately.
+async function withPrefWriteRetry(fn: () => Promise<void>): Promise<void> {
+  const delaysMs = [500, 1000];
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await fn();
+      return;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (attempt >= delaysMs.length || !message.includes('writeUserPrefs failed'))
+        throw err;
+      console.warn(`[commands] pref write failed (attempt ${attempt + 1}), retrying: ${message}`);
+      await sleep(delaysMs[attempt]);
+    }
+  }
+}
+
 /**
  * Set a user preference and persist it. Equivalent to
  * `.rs.api.writeRStudioPreference(name, value)` / `.rs.uiPrefs$<name>$set(value)`.
@@ -605,15 +627,17 @@ async function waitForPrefEntry(page: Page, camelName: string): Promise<void> {
 export async function setPref(page: Page, name: string, value: PrefValue): Promise<void> {
   const camel = snakeToCamel(name);
   await waitForPrefEntry(page, camel);
-  await page.evaluate(async ({ prefName, prefValue }) => {
-    const r = window.rstudio;
-    if (!r)
-      throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
-    const entry = r.prefs[prefName];
-    if (!entry)
-      throw new Error(`Unknown user preference: ${prefName}`);
-    await entry.set(prefValue);
-  }, { prefName: camel, prefValue: value });
+  await withPrefWriteRetry(() =>
+    page.evaluate(async ({ prefName, prefValue }) => {
+      const r = window.rstudio;
+      if (!r)
+        throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
+      const entry = r.prefs[prefName];
+      if (!entry)
+        throw new Error(`Unknown user preference: ${prefName}`);
+      await entry.set(prefValue);
+    }, { prefName: camel, prefValue: value }),
+  );
 }
 
 /**
@@ -624,15 +648,17 @@ export async function setPref(page: Page, name: string, value: PrefValue): Promi
 export async function clearPref(page: Page, name: string): Promise<void> {
   const camel = snakeToCamel(name);
   await waitForPrefEntry(page, camel);
-  await page.evaluate(async (prefName) => {
-    const r = window.rstudio;
-    if (!r)
-      throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
-    const entry = r.prefs[prefName];
-    if (!entry)
-      throw new Error(`Unknown user preference: ${prefName}`);
-    await entry.clear();
-  }, camel);
+  await withPrefWriteRetry(() =>
+    page.evaluate(async (prefName) => {
+      const r = window.rstudio;
+      if (!r)
+        throw new Error('window.rstudio is not defined; launch RStudio with --automation-agent');
+      const entry = r.prefs[prefName];
+      if (!entry)
+        throw new Error(`Unknown user preference: ${prefName}`);
+      await entry.clear();
+    }, camel),
+  );
 }
 
 /**

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -596,12 +596,30 @@ async function waitForPrefEntry(page: Page, camelName: string): Promise<void> {
 // A pref write is a full-payload set_user_prefs RPC, so it is idempotent and
 // safe to retry. Busy CI runners can drop the XHR at the transport layer
 // (winsock ERR_NO_BUFFER_SPACE, connection resets around a session rebuild),
-// which the bridge reports as a "writeUserPrefs failed" rejection; retry that
-// signature only, so deterministic failures still surface immediately.
-async function withPrefWriteRetry(fn: () => Promise<void>): Promise<void> {
+// which the bridge reports as a "writeUserPrefs failed" rejection carrying the
+// underlying RPC error detail.
+//
+// That rejection covers every server-side failure, not only transport ones, so
+// a deterministic failure (a value the schema rejects) pays the same 1.5s of
+// backoff before it surfaces. That is the deliberate trade: the transport
+// errors this exists to absorb do not have one stable message across
+// platforms, and a narrower matcher would let the flake back through. Errors
+// raised on the JS side (missing bridge, unknown pref) never carry the prefix
+// and still fail on the first attempt.
+//
+// Each attempt re-waits for the pref entry: a retry can land while the session
+// is still rebuilding, when the bridge has not re-registered the pref and
+// calling straight through would fail with a misleading "Unknown user
+// preference" for a pref that does exist.
+async function withPrefWriteRetry(
+  page: Page,
+  camelName: string,
+  fn: () => Promise<void>
+): Promise<void> {
   const delaysMs = [500, 1000];
   for (let attempt = 0; ; attempt++) {
     try {
+      await waitForPrefEntry(page, camelName);
       await fn();
       return;
     } catch (err) {
@@ -626,8 +644,7 @@ async function withPrefWriteRetry(fn: () => Promise<void>): Promise<void> {
  */
 export async function setPref(page: Page, name: string, value: PrefValue): Promise<void> {
   const camel = snakeToCamel(name);
-  await waitForPrefEntry(page, camel);
-  await withPrefWriteRetry(() =>
+  await withPrefWriteRetry(page, camel, () =>
     page.evaluate(async ({ prefName, prefValue }) => {
       const r = window.rstudio;
       if (!r)
@@ -647,8 +664,7 @@ export async function setPref(page: Page, name: string, value: PrefValue): Promi
  */
 export async function clearPref(page: Page, name: string): Promise<void> {
   const camel = snakeToCamel(name);
-  await waitForPrefEntry(page, camel);
-  await withPrefWriteRetry(() =>
+  await withPrefWriteRetry(page, camel, () =>
     page.evaluate(async (prefName) => {
       const r = window.rstudio;
       if (!r)

--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -593,6 +593,23 @@ async function waitForPrefEntry(page: Page, camelName: string): Promise<void> {
   );
 }
 
+// The failures a pref write is retried for. Two symptoms, one trigger: the
+// bridge rejects with its own message when the RPC itself fails, but the same
+// session rebuild can instead tear the page context down while entry.set() is
+// still in flight, which surfaces from page.evaluate as one of Playwright's
+// destroyed-context messages. Matched case-insensitively; Playwright's casing
+// varies across these.
+//
+// Deliberately not here: "Target page, context or browser has been closed".
+// That page is not coming back, so retrying it can only burn the backoff
+// before failing with the same error.
+const RETRYABLE_PREF_WRITE_ERRORS = [
+  'writeUserPrefs failed',
+  'Execution context was destroyed',
+  'Execution context is not available in detached frame',
+  'frame was detached',
+];
+
 // A pref write is a full-payload set_user_prefs RPC, so it is idempotent and
 // safe to retry. Busy CI runners can drop the XHR at the transport layer
 // (winsock ERR_NO_BUFFER_SPACE, connection resets around a session rebuild),
@@ -604,8 +621,8 @@ async function waitForPrefEntry(page: Page, camelName: string): Promise<void> {
 // backoff before it surfaces. That is the deliberate trade: the transport
 // errors this exists to absorb do not have one stable message across
 // platforms, and a narrower matcher would let the flake back through. Errors
-// raised on the JS side (missing bridge, unknown pref) never carry the prefix
-// and still fail on the first attempt.
+// raised on the JS side (missing bridge, unknown pref) match nothing in
+// RETRYABLE_PREF_WRITE_ERRORS and still fail on the first attempt.
 //
 // Each attempt re-waits for the pref entry: a retry can land while the session
 // is still rebuilding, when the bridge has not re-registered the pref and
@@ -624,7 +641,9 @@ async function withPrefWriteRetry(
       return;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      if (attempt >= delaysMs.length || !message.includes('writeUserPrefs failed'))
+      const retryable = RETRYABLE_PREF_WRITE_ERRORS
+        .some((pattern) => message.toLowerCase().includes(pattern.toLowerCase()));
+      if (attempt >= delaysMs.length || !retryable)
         throw err;
       console.warn(`[commands] pref write failed (attempt ${attempt + 1}), retrying: ${message}`);
       await sleep(delaysMs[attempt]);

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -577,17 +577,18 @@ public class ApplicationAutomation
          throw new RuntimeException(
             "Unsupported preference type for " + pref.getId() + ": " + pref.getClass().getSimpleName());
       }
-      userPrefs_.writeUserPrefs((succeeded, errorMessage) -> invokeWriteCallback(onCompleted, succeeded, errorMessage));
+      userPrefs_.writeUserPrefsWithDetail((succeeded, errorMessage) -> invokeWriteCallback(onCompleted, succeeded, errorMessage));
    }
 
    private void clearPrefValue(Prefs.PrefValue<?> pref, JavaScriptObject onCompleted)
    {
       pref.removeGlobalValue(true);
-      userPrefs_.writeUserPrefs((succeeded, errorMessage) -> invokeWriteCallback(onCompleted, succeeded, errorMessage));
+      userPrefs_.writeUserPrefsWithDetail((succeeded, errorMessage) -> invokeWriteCallback(onCompleted, succeeded, errorMessage));
    }
 
    private native void invokeWriteCallback(JavaScriptObject cb, boolean succeeded, String errorMessage) /*-{
-      if (cb) cb(succeeded, errorMessage);
+      if (cb)
+         cb(succeeded, errorMessage);
    }-*/;
 
    private void dispatchCloseAllNoSave()

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationAutomation.java
@@ -577,17 +577,17 @@ public class ApplicationAutomation
          throw new RuntimeException(
             "Unsupported preference type for " + pref.getId() + ": " + pref.getClass().getSimpleName());
       }
-      userPrefs_.writeUserPrefs(succeeded -> invokeWriteCallback(onCompleted, succeeded));
+      userPrefs_.writeUserPrefs((succeeded, errorMessage) -> invokeWriteCallback(onCompleted, succeeded, errorMessage));
    }
 
    private void clearPrefValue(Prefs.PrefValue<?> pref, JavaScriptObject onCompleted)
    {
       pref.removeGlobalValue(true);
-      userPrefs_.writeUserPrefs(succeeded -> invokeWriteCallback(onCompleted, succeeded));
+      userPrefs_.writeUserPrefs((succeeded, errorMessage) -> invokeWriteCallback(onCompleted, succeeded, errorMessage));
    }
 
-   private native void invokeWriteCallback(JavaScriptObject cb, boolean succeeded) /*-{
-      if (cb) cb(succeeded);
+   private native void invokeWriteCallback(JavaScriptObject cb, boolean succeeded, String errorMessage) /*-{
+      if (cb) cb(succeeded, errorMessage);
    }-*/;
 
    private void dispatchCloseAllNoSave()
@@ -736,21 +736,25 @@ public class ApplicationAutomation
          // set / clear return a Promise that resolves once the setUserPrefs
          // RPC has completed, so callers (especially tests that immediately
          // follow with another server-affecting action) can be sure the
-         // pref change is fully landed before proceeding.
+         // pref change is fully landed before proceeding. On failure the
+         // rejection carries the underlying RPC error detail, so test
+         // reports name the real cause (e.g. a dropped connection).
          set: $entry(function(value) {
             return new $wnd.Promise(function(resolve, reject) {
-               var cb = $entry(function(succeeded) {
+               var cb = $entry(function(succeeded, errorMessage) {
                   if (succeeded) resolve();
-                  else reject(new Error('writeUserPrefs failed for pref: ' + name));
+                  else reject(new Error('writeUserPrefs failed for pref: ' + name +
+                                        (errorMessage ? ' -- ' + errorMessage : '')));
                });
                self.@org.rstudio.studio.client.application.ApplicationAutomation::setPrefValue(*)(pref, value, cb);
             });
          }),
          clear: $entry(function() {
             return new $wnd.Promise(function(resolve, reject) {
-               var cb = $entry(function(succeeded) {
+               var cb = $entry(function(succeeded, errorMessage) {
                   if (succeeded) resolve();
-                  else reject(new Error('writeUserPrefs failed for pref: ' + name));
+                  else reject(new Error('writeUserPrefs failed for pref: ' + name +
+                                        (errorMessage ? ' -- ' + errorMessage : '')));
                });
                self.@org.rstudio.studio.client.application.ApplicationAutomation::clearPrefValue(*)(pref, cb);
             });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.prefs.model;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.CommandWith2Args;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
@@ -105,10 +106,22 @@ public class UserPrefs extends UserPrefsComputed
 
    public void writeUserPrefs()
    {
-      writeUserPrefs(null);
+      writeUserPrefs((CommandWithArg<Boolean>) null);
    }
 
    public void writeUserPrefs(CommandWithArg<Boolean> onCompleted)
+   {
+      writeUserPrefs((succeeded, errorMessage) ->
+      {
+         if (onCompleted != null)
+            onCompleted.execute(succeeded);
+      });
+   }
+
+   // Overload that also reports the failure detail: on error, onCompleted
+   // receives the underlying RPC error message (null on success). Used by the
+   // automation bridge so a failed pref write can say why it failed.
+   public void writeUserPrefs(CommandWith2Args<Boolean, String> onCompleted)
    {
       updatePrefs(session_.getSessionInfo().getPrefs());
       server_.setUserPrefs(
@@ -134,7 +147,7 @@ public class UserPrefs extends UserPrefsComputed
 
                if (onCompleted != null)
                {
-                  onCompleted.execute(true);
+                  onCompleted.execute(true, null);
                }
             }
             @Override
@@ -142,7 +155,7 @@ public class UserPrefs extends UserPrefsComputed
             {
                if (onCompleted != null)
                {
-                  onCompleted.execute(false);
+                  onCompleted.execute(false, error.getUserMessage());
                }
                Debug.logError(error);
             }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
@@ -106,22 +106,26 @@ public class UserPrefs extends UserPrefsComputed
 
    public void writeUserPrefs()
    {
-      writeUserPrefs((CommandWithArg<Boolean>) null);
+      writeUserPrefs(null);
    }
 
    public void writeUserPrefs(CommandWithArg<Boolean> onCompleted)
    {
-      writeUserPrefs((succeeded, errorMessage) ->
+      writeUserPrefsWithDetail((succeeded, errorMessage) ->
       {
          if (onCompleted != null)
             onCompleted.execute(succeeded);
       });
    }
 
-   // Overload that also reports the failure detail: on error, onCompleted
+   // Variant that also reports the failure detail: on error, onCompleted
    // receives the underlying RPC error message (null on success). Used by the
    // automation bridge so a failed pref write can say why it failed.
-   public void writeUserPrefs(CommandWith2Args<Boolean, String> onCompleted)
+   //
+   // Named distinctly rather than overloaded: a second single-argument
+   // writeUserPrefs would make every existing writeUserPrefs(null) call
+   // ambiguous, since CommandWithArg and CommandWith2Args are unrelated types.
+   public void writeUserPrefsWithDetail(CommandWith2Args<Boolean, String> onCompleted)
    {
       updatePrefs(session_.getSessionInfo().getPrefs());
       server_.setUserPrefs(


### PR DESCRIPTION
Fixes the two flakes from [this pr-18586 e2e run](https://rstudio-playwright-reports.s3.amazonaws.com/pr-18586/32160614087-1/all-platforms/index.html) (1911 tests, 2 flaky).

### chat-messaging "multi-turn conversation" (desktop-macos)

`waitForResponse` treated a single "stop button not visible" sample (500ms polling) as turn completion. But the stop button flickers off during the approval -> tool-execution handoff -- the trace shows the helper returned ~1.5s after clicking Allow, while the assistant was still streaming its post-tool continuation. The next `sendChatMessage` then timed out (15s) waiting for the send button, which stays replaced by the stop button until the turn actually ends; the failure screenshot shows exactly that state (message typed, red stop button, response still streaming).

- `waitForResponse` now requires the stop button to stay hidden across 4 consecutive samples (~2s) before concluding the turn is done.
- `sendChatMessage` first waits out a still-streaming previous turn (stop button hidden, 60s budget) before requiring the send button, so it is robust even if a caller misjudged turn completion.

### project_editor_theme "ignored appearance settings" (desktop-windows)

`setPref('ignore_project_appearance', ...)` rejected with the bridge's generic "writeUserPrefs failed" message. The trace has the real cause:

```
6: Unable to establish connection with R session when executing 'set_user_prefs'
Failed to load resource: net::ERR_NO_BUFFER_SPACE
Failed to load resource: net::ERR_CONNECTION_RESET
```

i.e. the XHR died at the transport layer (winsock buffer exhaustion / connection resets around the preceding project close's session rebuild), error code 6 = TRANSMISSION.

- A pref write is a full-payload `set_user_prefs` RPC and thus idempotent, so `setPref`/`clearPref` now retry that specific failure signature (up to 2 retries, short backoff). Deterministic failures (e.g. unknown pref) still surface immediately.
- The automation bridge now includes the underlying RPC error detail in the rejection (via a `writeUserPrefs` overload that carries the error message), so future failures name the real cause in the report instead of requiring trace archaeology.

No NEWS entry: test-harness and automation-bridge (developer-only) changes.