### PR TITLE
e2e: stop the console completion helper from cancelling its own request

### DIFF
--- a/e2e/rstudio/actions/autocomplete.actions.ts
+++ b/e2e/rstudio/actions/autocomplete.actions.ts
@@ -5,6 +5,13 @@ import { SourcePaneActions } from './source_pane.actions';
 
 export const COMPLETION_POPUP = '#rstudio_popup_completions';
 
+// How long to let the request that typing itself schedules produce a popup
+// before forcing one, and how long a forced request gets. The implicit budget
+// only has to cover code_completion_delay plus one round trip; it is spent in
+// full only when the typed text triggers no implicit request at all.
+const IMPLICIT_COMPLETION_TIMEOUT_MS = 3000;
+const EXPLICIT_COMPLETION_TIMEOUT_MS = 10000;
+
 export class AutocompleteActions {
   readonly page: Page;
   readonly consoleActions: ConsolePaneActions;
@@ -47,6 +54,51 @@ export class AutocompleteActions {
     await sleep(300);
   }
 
+  /** Whether the popup becomes visible within `timeoutMs`. */
+  private async popupAppears(timeoutMs: number): Promise<boolean> {
+    return await this.page
+      .locator(COMPLETION_POPUP)
+      .waitFor({ state: 'visible', timeout: timeoutMs })
+      .then(() => true)
+      .catch(() => false);
+  }
+
+  /**
+   * Wait for the completion popup after typing, forcing a request with
+   * Ctrl+Space only if the implicit one never produces one.
+   *
+   * Typing already schedules a completion request -- RStudio issues one
+   * `code_completion_delay` ms (250 by default) after the
+   * `code_completion_characters`-th character, and immediately after a
+   * trigger like `$` or `(`. Pressing Ctrl+Space while that is in flight is
+   * destructive rather than helpful: `RCompletionManager.beginSuggest` starts
+   * by invalidating pending requests, so the in-flight response is discarded
+   * on arrival, and if the popup has just opened the keypress instead falls
+   * through the popup-showing branch to `invalidatePendingRequests()`, which
+   * hides it. Either way the completion session is stranded and no popup ever
+   * appears.
+   *
+   * Sampling visibility once shortly after typing raced exactly that window:
+   * on CI the request round trip pushed the popup past the sample, the
+   * fallback fired into the gap, and the test then waited out its timeout on a
+   * session it had just cancelled. So wait out the implicit request first, and
+   * force one only once nothing is in flight -- retrying once, since a slow
+   * enough response can still land in the same window.
+   */
+  private async waitForCompletionPopup(): Promise<void> {
+    if (await this.popupAppears(IMPLICIT_COMPLETION_TIMEOUT_MS))
+      return;
+
+    await this.page.keyboard.press('Control+Space');
+    if (await this.popupAppears(EXPLICIT_COMPLETION_TIMEOUT_MS))
+      return;
+
+    await this.page.keyboard.press('Control+Space');
+    await this.page
+      .locator(COMPLETION_POPUP)
+      .waitFor({ state: 'visible', timeout: EXPLICIT_COMPLETION_TIMEOUT_MS });
+  }
+
   /**
    * Toggle the automation-only "always show popup" completion override, so a
    * unique match is listed in the popup instead of being auto-accepted. The
@@ -62,7 +114,8 @@ export class AutocompleteActions {
 
   /**
    * Get completions in the console.
-   * Executes setupCode, then types triggerText (without Enter) and presses Ctrl+Space.
+   * Executes setupCode, then types triggerText (without Enter) and waits for
+   * the popup, falling back to Ctrl+Space if typing raises no completions.
    */
   async getCompletionsInConsole(setupCode: string[], triggerText: string): Promise<string[]> {
     for (const code of setupCode) {
@@ -74,14 +127,8 @@ export class AutocompleteActions {
     try {
       // Type trigger text without executing -- needs per-key events to fire the completer.
       await this.consoleActions.typeInConsole(triggerText);
-      await sleep(500);
+      await this.waitForCompletionPopup();
 
-      // If autocomplete already appeared (e.g. after typing $ or (), use it;
-      // otherwise trigger explicitly with Ctrl+Space
-      const popupAlreadyVisible = await this.page.locator(COMPLETION_POPUP).isVisible();
-      if (!popupAlreadyVisible) {
-        await this.page.keyboard.press('Control+Space');
-      }
       return await this.getCompletionItems();
     } finally {
       // Cleanup: restore auto-accept, dismiss popup, cancel partial input

--- a/e2e/rstudio/actions/autocomplete.actions.ts
+++ b/e2e/rstudio/actions/autocomplete.actions.ts
@@ -12,6 +12,10 @@ export const COMPLETION_POPUP = '#rstudio_popup_completions';
 const IMPLICIT_COMPLETION_TIMEOUT_MS = 3000;
 const EXPLICIT_COMPLETION_TIMEOUT_MS = 10000;
 
+// Settle applied when the popup is already up before we start waiting, to let
+// a replacement request land -- see waitForCompletionPopup.
+const STALE_POPUP_SETTLE_MS = 500;
+
 export class AutocompleteActions {
   readonly page: Page;
   readonly consoleActions: ConsolePaneActions;
@@ -84,8 +88,23 @@ export class AutocompleteActions {
    * session it had just cancelled. So wait out the implicit request first, and
    * force one only once nothing is in flight -- retrying once, since a slow
    * enough response can still land in the same window.
+   *
+   * A popup that is *already* up on entry is a different case: typing keeps an
+   * open popup showing while it re-requests, because `beginSuggest` invalidates
+   * without hiding (`RCompletionManager.java:1163`, hidePopup false), so its
+   * contents can still be an earlier prefix's results with the final token's
+   * request in flight. Visibility proves nothing there, hence the settle.
+   *
+   * The caller reads the popup via `getCompletionItems`, whose own visibility
+   * wait is the final deadline -- this returns after the second keypress
+   * rather than waiting on the same locator twice.
    */
   private async waitForCompletionPopup(): Promise<void> {
+    if (await this.page.locator(COMPLETION_POPUP).isVisible()) {
+      await sleep(STALE_POPUP_SETTLE_MS);
+      return;
+    }
+
     if (await this.popupAppears(IMPLICIT_COMPLETION_TIMEOUT_MS))
       return;
 
@@ -94,9 +113,6 @@ export class AutocompleteActions {
       return;
 
     await this.page.keyboard.press('Control+Space');
-    await this.page
-      .locator(COMPLETION_POPUP)
-      .waitFor({ state: 'visible', timeout: EXPLICIT_COMPLETION_TIMEOUT_MS });
   }
 
   /**


### PR DESCRIPTION
Fixes `Autocomplete extras > new local variables show up as prefix completions`, which failed both attempts on desktop-macos in [this pr-18589 run](https://github.com/rstudio/rstudio/actions/runs/32179366367/job/95854791119).

### What the trace shows

The server answered correctly. The only `get_completions` on the wire returned exactly what the test asserts:

```json
{"token": ["foo"], "results": ["foobar", "foobaz"], "packages": [".GlobalEnv", ".GlobalEnv"], ...}
```

...and yet no popup ever appeared, and no second request was made.

`getCompletionsInConsole` typed the trigger text, slept 500ms, sampled `#rstudio_popup_completions` **once**, and pressed Ctrl+Space if it was not up yet. But typing already schedules a completion request: RStudio issues one `code_completion_delay` ms (250 by default) after the `code_completion_characters`'th character, and immediately after a trigger like `$` or `(`. With the RPC round trip at ~275ms on a loaded runner, the popup lands around 530ms -- just past the 500ms sample -- so the fallback fires straight into the window where that request is in flight or the popup has only just opened.

Neither ordering recovers, which is why both attempts hung for the full 15s:

- **Attempt 1** -- Ctrl+Space at monotonic `501428`, response due `501438.8`. Popup not yet showing, so `RCompletionManager.previewKeyDown` took the `beginSuggest` path, whose first act is `invalidatePendingRequests` (`RCompletionManager.java:1163`). The in-flight response then hit `token_.isInvalid()` (`CompletionRequestContext.java:95`) and was dropped -- and no replacement request appears on the wire.
- **Attempt 2** -- response arrived `~542079`, popup showing; Ctrl+Space at `542119` fell through the popup-showing branch to the catch-all `invalidatePendingRequests(); return false;` (`RCompletionManager.java:663`), which **hides** the popup. The helper then waited out its timeout on a session its own keypress had just cancelled.

### The change

Wait for the popup rather than sampling once, and force a request only after the implicit one has had its chance -- so Ctrl+Space is never pressed while a request is in flight. The forced request is retried once, since a slow enough response can still land in that window.

The implicit budget (3s) is spent in full only when the typed text raises no implicit request. Triggers ending in an identifier character or in `$` / `::` (`foo`, `lef`, `test_ls$`, `geom_line(linet`, ...) raise one, so those return as soon as the popup opens.

Triggers ending in `(` -- `cat(`, `stats::rnorm(`, `a(` -- raise none, and so do wait out the budget: `checkCanAutoPopup` rejects `(` as an identifier character, the `c == '('` branch (`RCompletionManager.java:858`) only forces an auto-popup for `library`/`require`/`requireNamespace`/`data`, and `previewKeyPress` has already cancelled the timer the preceding character scheduled (`:729`). Pressing Ctrl+Space there is the safe case -- nothing is in flight to cancel -- so the budget stays at 3s rather than being tuned down to reclaim the ~9s per console run. Ctrl+Space landing in an empty pipeline costs time; landing in a live one is the flake this PR removes.

Only the console helper is touched. The editor helper writes its content with `writeLines` and positions the cursor via `gotoLine` -- nothing is typed, so no implicit request is ever scheduled there and Ctrl+Space remains the sole trigger.

### Follow-up worth a look

In the attempt-1 ordering the explicit request invalidates the in-flight implicit one and **no replacement `get_completions` reaches the server** -- so a user pressing Ctrl+Space during the completion delay gets nothing until they type again. I traced that to the early-return region of `beginSuggest` after `invalidatePendingRequests` (`RCompletionManager.java:1163+`) but could not pin the exact branch from static reading; the missing second request in the trace is the evidence. Not addressed here.

No NEWS entry: test-harness only.
