### PR TITLE
Update Electron to 42.9.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,6 @@
 
 ### Dependencies
 - Copilot Language Server 1.531.0
-- Electron 42.9.0
+- Electron 42.9.3
 - Quarto 1.10.18
 

--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -48,7 +48,7 @@
         "chai": "6.2.2",
         "copy-webpack-plugin": "14.0.0",
         "css-loader": "7.1.4",
-        "electron": "42.9.0",
+        "electron": "42.9.3",
         "electron-mocha": "13.1.0",
         "eslint": "10.8.1",
         "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -5911,9 +5911,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "42.9.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.9.0.tgz",
-      "integrity": "sha512-xyKfPbHP43Jx22Z1hItLR4KB5h3/avb5BIX4xaQZ6uPPRY4cQxuHnRVrKCGbSsMa/9zd0bBT4TAVNVuVjYcYtw==",
+      "version": "42.9.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.9.3.tgz",
+      "integrity": "sha512-REQUgPrCWOP0FajNcKCwwjkssirN+MVbemyd6bT+x51OVq58y6IqjtpA4vmm/KEzKXj2MIOebx/gF497CkRAPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -57,7 +57,7 @@
     "chai": "6.2.2",
     "copy-webpack-plugin": "14.0.0",
     "css-loader": "7.1.4",
-    "electron": "42.9.0",
+    "electron": "42.9.3",
     "electron-mocha": "13.1.0",
     "eslint": "10.8.1",
     "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -97,7 +97,7 @@
     "winston-syslog": "2.7.1"
   },
   "allowScripts": {
-    "electron@42.9.0": true,
+    "electron@42.9.3": true,
     "msgpackr-extract@3.0.3": true,
     "unix-dgram@2.0.6": true
   }


### PR DESCRIPTION
Bumps the pinned Electron version from 42.9.0 to 42.9.3.

- `NEWS.md`: Dependencies entry updated.
- `src/node/desktop/package.json`: `electron` pinned to the exact version `42.9.3`, and the `allowScripts` key changed to `electron@42.9.3` so npm's install-script gating still permits Electron's install script.
- `src/node/desktop/package-lock.json`: regenerated by `npm install --save-dev --save-exact`.

`npm test` in `src/node/desktop` passes (451 tests).