### PR TITLE
e2e: scale the pressSequentially timeout with the text being typed

### DIFF
--- a/e2e/rstudio/actions/console_pane.actions.ts
+++ b/e2e/rstudio/actions/console_pane.actions.ts
@@ -11,7 +11,7 @@ import {
   type EnvironmentVersions,
   type ExecuteInConsoleOptions,
 } from '../pages/console_pane.page';
-import { sleep, TIMEOUTS } from '../utils/constants';
+import { sleep, TIMEOUTS, typingTimeout } from '../utils/constants';
 import { documentCloseAllNoSave, executeCommand, getVersion, resetSourcePaneState } from '../utils/commands';
 import { setConsoleInput } from '../utils/console';
 
@@ -119,7 +119,8 @@ export class ConsolePaneActions {
    */
   async typeInConsole(text: string, delayMs: number = 50): Promise<void> {
     await focusConsole(this.page);
-    await this.consolePane.consoleInput.pressSequentially(text, { delay: delayMs });
+    await this.consolePane.consoleInput
+      .pressSequentially(text, { delay: delayMs, timeout: typingTimeout(text, delayMs) });
   }
 
   async clearConsole(): Promise<void> {

--- a/e2e/rstudio/pages/chat_pane.page.ts
+++ b/e2e/rstudio/pages/chat_pane.page.ts
@@ -1,5 +1,6 @@
 import type { Page, Locator, FrameLocator } from 'playwright';
 import { FramePageObject } from './page_object_base_classes';
+import { typingTimeout } from '../utils/constants';
 
 // ---------------------------------------------------------------------------
 // Class-based page object
@@ -145,7 +146,7 @@ export class ChatPane extends FramePageObject {
    */
   async typeMessage(text: string): Promise<void> {
     await this.chatInput.click();
-    await this.chatInput.pressSequentially(text);
+    await this.chatInput.pressSequentially(text, { timeout: typingTimeout(text) });
   }
 
   /**

--- a/e2e/rstudio/pages/console_pane.page.ts
+++ b/e2e/rstudio/pages/console_pane.page.ts
@@ -1,7 +1,7 @@
 import type { Page } from 'playwright';
 import type { Locator } from 'playwright';
 import { PageObject } from './page_object_base_classes';
-import { sleep, TIMEOUTS } from '../utils/constants';
+import { sleep, TIMEOUTS, typingTimeout } from '../utils/constants';
 import { documentCloseAllNoSave, executeCommand, getVersion } from '../utils/commands';
 import { AceEditorElement } from '../utils/ace';
 
@@ -538,7 +538,8 @@ export async function typeInConsole(page: Page, text: string, delayMs: number = 
   await page.locator(CONSOLE_TAB).click();
   await page.locator(CONSOLE_INPUT).click({ force: true });
   await sleep(300);
-  await page.locator(CONSOLE_INPUT).pressSequentially(text, { delay: delayMs });
+  await page.locator(CONSOLE_INPUT)
+    .pressSequentially(text, { delay: delayMs, timeout: typingTimeout(text, delayMs) });
 }
 
 export async function clearConsole(page: Page): Promise<void> {

--- a/e2e/rstudio/playwright.config.ts
+++ b/e2e/rstudio/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, ReporterDescription } from '@playwright/test';
 import dotenv from 'dotenv';
 import os from 'os';
 import path from 'path';
+import { TIMEOUTS } from './utils/constants';
 
 type ProjectOptions = { mode: 'desktop' | 'server' };
 
@@ -241,7 +242,7 @@ export default defineConfig<{}, ProjectOptions>({
     // on-failure default captures nothing: PW_TRACE=on / PW_SCREENSHOT=on.
     screenshot: resolveEnvMode('PW_SCREENSHOT', SCREENSHOT_MODES, 'only-on-failure'),
     trace: resolveEnvMode('PW_TRACE', TRACE_MODES, 'retain-on-failure'),
-    actionTimeout: 10000,
+    actionTimeout: TIMEOUTS.action,
   },
   projects,
 });

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-user-skills.test.ts
@@ -58,12 +58,13 @@ const userSkillPath = () => `${userSkillDir()}/SKILL.md`;
 // ---------------------------------------------------------------------------
 
 /**
- * Create a SKILL.md file via two short R console commands.
- *
- * Long single commands through pressSequentially are fragile (autocomplete
- * interference, timing issues). Instead we use two short commands:
+ * Create a SKILL.md file via two R console commands:
  * 1. dir.create() for the directory
- * 2. writeLines(c(...)) for the file content (kept minimal)
+ * 2. writeLines(c(...)) for the file content
+ *
+ * `executeInConsole` writes each command into the console programmatically
+ * (`editor.setValue`) rather than typing it, so neither command length nor
+ * autocomplete interference constrains what goes here.
  */
 async function createSkillFile(
   consoleActions: ConsolePaneActions,
@@ -75,7 +76,6 @@ async function createSkillFile(
 ): Promise<void> {
   await consoleActions.executeInConsole(`dir.create("${dir}", recursive = TRUE)`, { wait: true });
 
-  // Keep content minimal to stay under ~300 chars for pressSequentially reliability
   const cmd =
     `writeLines(c("---", "name: ${name}", "description: ${description}", "---", "", "Start with: ${marker}", "Markers are MANDATORY."), "${filePath}")`;
   await consoleActions.executeInConsole(cmd, { wait: true });

--- a/e2e/rstudio/utils/constants.ts
+++ b/e2e/rstudio/utils/constants.ts
@@ -19,10 +19,36 @@ export const TIMEOUTS = {
   // keystroke before the next arrives.
   slowKeystroke: 200,
   packageInstall: 120000,
+  // The suite-wide actionTimeout: playwright.config.ts reads it from here, and
+  // typingTimeout() uses it as its floor, so the two cannot drift apart.
+  action: 10000,
+  // Per-character allowance for a pressSequentially budget: one CDP key-event
+  // round trip plus whatever the widget does with it (a ProseMirror
+  // transaction, a GWT typeahead query) on a loaded CI runner.
+  keystrokeBudget: 50,
 };
 
 export async function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Timeout (ms) for a `pressSequentially` of `text`, with an optional
+ * per-keystroke `delayMs`.
+ *
+ * Playwright applies the single configured `actionTimeout` to the whole call
+ * however long the string is, so the budget per character shrinks as the text
+ * grows: the assistant's ~940-character Shiny prompt gets ~10ms per character
+ * to cover a CDP round trip plus a ProseMirror transaction, which a loaded CI
+ * runner does not reliably beat. That surfaces as a "pressSequentially:
+ * Timeout 10000ms exceeded" mid-message, which reads like a stuck widget
+ * rather than the budget being too small for the input.
+ *
+ * Scale with the text instead, keeping the configured timeout as the floor so
+ * short strings behave exactly as before.
+ */
+export function typingTimeout(text: string, delayMs: number = 0): number {
+  return Math.max(TIMEOUTS.action, text.length * (TIMEOUTS.keystrokeBudget + delayMs));
 }
 
 /**


### PR DESCRIPTION
Playwright applies the one configured `actionTimeout` (10s) to a whole `pressSequentially` call however long the string is, so the per-character budget shrinks as the text grows. Two helpers type unbounded-length input:

**The assistant composer.** `shiny-app-r`'s prompt is ~940 characters, which leaves ~10ms per character to cover a CDP key-event round trip plus a ProseMirror transaction. A loaded CI runner does not reliably beat that. It showed up as a flaky first attempt on `desktop-macos` in the run for #18589:

```
TimeoutError: locator.pressSequentially: Timeout 10000ms exceeded.
  - waiting for locator('iframe[title=\'Posit Assistant\']').contentFrame().locator('.tiptap-input-editor')
    - locator resolved to <div ... contenteditable="true" data-testid="chat-input" ...>
    - elementHandle.type("Create a Shiny for R web app for a tip calculator. ...
  at ChatPane.typeMessage (e2e/rstudio/pages/chat_pane.page.ts:148:26)
```

That reads like a stuck composer, when the composer was fine and the budget was simply too small for the input.

**`typeInConsole`**, which also takes a per-keystroke delay. At the default 50ms a 200-character command spends the entire 10s in delays alone, so it could never pass. No caller is near that today -- the longest is 89 characters in `shiny-app-python.draft.ts`, which already spends 8.9s of the 10s budget -- so this half is headroom, plus consistency between the two typing helpers, rather than a fix for a failure happening now.

### Change

Adds `typingTimeout(text, delayMs)` to `utils/constants.ts` and uses it at those sites. It keeps the configured `actionTimeout` as a floor, so short strings behave exactly as before:

| input | before | after |
|---|---|---|
| `"hi"` | 10s | 10s |
| 940-char assistant prompt | 10s | 47s |
| 200-char console command, 50ms delay | 10s | 20s |

`playwright.config.ts` now reads `actionTimeout` from `TIMEOUTS.action` so the floor cannot drift from the config.

Also corrects two stale comments in `chat-user-skills.test.ts`. `createSkillFile` moved from `typeInConsole` to `executeInConsole` in #17723 -- which writes the command with `editor.setValue` rather than typing it -- but the comments kept describing a per-character path, so the "~300 chars for `pressSequentially` reliability" note read like a live constraint on a path that has none.

This does not change the input mechanism -- `pressSequentially` is still required for both widgets (ProseMirror ignores `fill()`, and GWT needs real key events).

### Verification

`tsc --noEmit` passes, and the config still resolves `actionTimeout` to 10000 through the new import. The behavioral check is CI: `shiny-app-r` and the console-typing specs are `@ai`/desktop tests that need credentials this checkout does not have.

Follows up on the flaky attempt observed in #18589; no product code is touched.

