### PR TITLE
Fix the macOS job in the e2e deps cache seed

### DIFF
--- a/.github/workflows/os-cache-seed-e2e-deps.yml
+++ b/.github/workflows/os-cache-seed-e2e-deps.yml
@@ -119,7 +119,22 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           rig add "$R_VERSION"
-          rig default "$R_VERSION"
+          # rig names installs with arch/major.minor on macOS (e.g. "4.5-arm64"),
+          # not the requested patch version, so `rig default "$R_VERSION"` fails
+          # there. Query rig for the just-installed name, as the macOS e2e
+          # workflows do. Linux registers the full version and takes it as given.
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            R_NAME=$(rig list --json | jq -r '.[-1].name')
+            # No pipefail in this shell: if `rig list` fails, jq still exits 0
+            # and the assignment quietly lands empty.
+            if [ -z "$R_NAME" ] || [ "$R_NAME" = "null" ]; then
+              echo "::error::rig list returned no installed R versions"
+              exit 1
+            fi
+          else
+            R_NAME="$R_VERSION"
+          fi
+          rig default "$R_NAME"
           rig ls
           mkdir -p "$R_LIBS_USER"
 


### PR DESCRIPTION
The `macos-desktop` job in `os-cache-seed-e2e-deps.yml` has failed on every run since the workflow was added in #18550. `rig add 4.5.3` succeeds, but the following `rig default 4.5.3` fails with "R version 4.5.3 is not installed": rig names macOS installs by arch and major.minor (`4.5-arm64`), not by the requested patch version.

The macOS 14, 15, and 26 e2e workflows already work around this by querying rig for the just-installed name. This applies the same approach to the seed, gated to macOS so the Linux jobs -- which register the full version and pass today -- are untouched.

Consequence of the failure: the `macOS-macos26-arm64-*` cache keys were never written on main, so the macOS 26 e2e job restores nothing and reinstalls its R packages and Playwright browsers on every PR run. The sentinel also redispatched the seed every two hours, since the keys never appeared.

Verified by dispatching the workflow on this branch: all four seed jobs pass, `rig ls` reports `* 4.5-arm64  (R 4.5.3)`, and the macOS job computes the `macOS-macos26-arm64-r-4.5-`, `-pak-4.5-`, and `-pw-` prefixes the sentinel checks. Cache saves are gated to main-scoped runs, so the keys are only warmed once this merges.

Addresses #18569.
