### PR TITLE
ci(jenkins): narrow the platform re-checkout and restore full history

### DIFF
--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -75,8 +75,8 @@ pipeline {
             echo "Commit_hash value: ${params.COMMIT_HASH}"
             checkout([$class: 'GitSCM',
                       branches: [[name: "${params.COMMIT_HASH}"]],
-                      extensions: [],
-                      userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL ]]])
+                      extensions: [[$class: 'CloneOption', shallow: true, depth: 50, noTags: true, honorRefspec: true]],
+                      userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL, refspec: "+refs/heads/${env.BRANCH_NAME}:refs/remotes/origin/${env.BRANCH_NAME}"]]])
           }
         }
 
@@ -189,8 +189,8 @@ pipeline {
                   // We need to checkout the correct commit again here because the matrix builds run on different agents
                   checkout([$class: 'GitSCM',
                             branches: [[name: "${params.COMMIT_HASH}"]],
-                            extensions: [],
-                            userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL ]]])
+                            extensions: [[$class: 'CloneOption', shallow: true, depth: 50, noTags: true, honorRefspec: true]],
+                            userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL, refspec: "+refs/heads/${env.BRANCH_NAME}:refs/remotes/origin/${env.BRANCH_NAME}"]]])
                 }
               }
 

--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -63,8 +63,8 @@ pipeline {
           sleep(time: 5, unit: 'SECONDS')
           checkout([$class: 'GitSCM',
                     branches: [[name: "${params.COMMIT_HASH}"]],
-                    extensions: [],
-                    userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: "${GIT_URL}"]]])
+                    extensions: [[$class: 'CloneOption', shallow: true, depth: 50, noTags: true, honorRefspec: true]],
+                    userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: "${GIT_URL}", refspec: "+refs/heads/${env.BRANCH_NAME}:refs/remotes/origin/${env.BRANCH_NAME}"]]])
         }
       }
     }

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -62,8 +62,8 @@ pipeline {
           steps {
             checkout([$class: 'GitSCM',
               branches: [[name: params.COMMIT_HASH]],
-              extensions: [],
-              userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL]]])
+              extensions: [[$class: 'CloneOption', shallow: true, depth: 50, noTags: true, honorRefspec: true]],
+              userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL, refspec: "+refs/heads/${env.BRANCH_NAME}:refs/remotes/origin/${env.BRANCH_NAME}"]]])
           }
         }
 
@@ -128,8 +128,8 @@ pipeline {
           steps {
             checkout([$class: 'GitSCM',
               branches: [[name: params.COMMIT_HASH]],
-              extensions: [],
-              userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL]]])
+              extensions: [[$class: 'CloneOption', shallow: true, depth: 50, noTags: true, honorRefspec: true]],
+              userRemoteConfigs: [[credentialsId: 'posit-jenkins-rstudio', url: GIT_URL, refspec: "+refs/heads/${env.BRANCH_NAME}:refs/remotes/origin/${env.BRANCH_NAME}"]]])
           }
         }
 

--- a/jenkins/utils.groovy
+++ b/jenkins/utils.groovy
@@ -759,6 +759,11 @@ def getDocsDraftName(String branchName) {
   * Ensures the full commit history is available for versioning.
   * If the repo was shallow-cloned, fetches missing commits without
   * downloading file content to minimize data transfer.
+  *
+  * Uses --unshallow rather than a date cutoff. A date cutoff deepens history
+  * incrementally, and a single pass does not reach far enough back to cover
+  * the range the version calculation counts over, so the build number comes
+  * out too low without anything failing.
   */
 void ensureFullCommitHistory() {
   def isShallow = sh(
@@ -767,7 +772,7 @@ void ensureFullCommitHistory() {
   ).trim()
   if (isShallow == 'true') {
     withCredentials([gitUsernamePassword(credentialsId: 'posit-jenkins-rstudio', gitToolName: 'Default')]) {
-      sh 'git fetch --filter=blob:none --shallow-since="18 months ago" origin'
+      sh 'git fetch --filter=blob:none --unshallow origin'
     }
   }
 }


### PR DESCRIPTION
Two related Jenkins fixes. They are together because applying either one alone leaves the builds broken in a different way.

## Narrow the platform re-checkout

The platform Jenkinsfiles re-checkout the build commit after the pipeline's own checkout, and did so with no clone options — fetching every branch and every tag with no depth limit.

That was harmless while the job-level clone was equally broad. The clone was narrowed to the branch being built on 18 August, so the re-checkout became the first thing to pull other branches. On the pro side that made git chase submodule pointers belonging to branches the build has nothing to do with, and the checkout failed outright.

It also removes a large redundant fetch from every platform build.

## Restore full history properly

The version is derived by counting commits between a fixed base commit and the commit being built. Much of that range sits on history merged in from release branches rather than on the branch's own direct line.

The helper that restores history after a shallow clone asked for everything newer than a date cutoff. A date cutoff deepens **incrementally rather than completely**, and a single pass does not cover the range. Nothing fails, because counting commits across a truncated range returns a smaller number rather than an error — the wrong number just gets published.

Whether a pipeline is affected comes down to how many times it happens to call that helper:

- **Twice** — the platform pipelines here — end up with enough history by accident and report correctly.
- **Once** — the builders — do not. The hourly builder has been reporting `+66` where the true value is `95`.

The three platform pipelines are correct by luck. Nothing guarantees two passes is enough; it depends on the shape of history and will silently stop being enough.

Unshallowing reaches the whole range in one pass regardless of how many times the helper is called.

## Why both changes belong in one PR

Narrowing the re-checkout removes the broad fetch that was incidentally supplying the missing history. Landing it alone would give the platform builds wrong version numbers here, exactly as it did on the pro side — three pro platform pipelines are publishing wrong versions right now for this reason.

Landing the history fix alone would leave the submodule problem waiting for whenever the narrowing arrives.

## Verified

Reproduced against a clone configured the way these pipelines are:

| | build number |
|---|---|
| after the shallow clone | 66 |
| after one pass of the date cutoff | 66 |
| **after unshallowing** | **95** |

95 is correct. Confirmed afterwards that only the built branch was fetched, so the narrowed refspec is preserved and no other branches come back. Unshallowing took about 14 seconds here, measured off-agent.

## Relationship to rstudio-pro

These files are shared with rstudio-pro, where both changes are already applied. The changed lines are textually identical in both repositories, so the next upstream merge should resolve cleanly rather than conflicting or reverting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)