### PR TITLE
Mark RPubs and ShinyApps.io as deprecated in publishing UI

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,5 +40,5 @@
 - Quarto 1.10.18
 
 ### Deprecated / Removed
-- ([#18605](https://github.com/rstudio/rstudio/issues/18605)): RPubs and ShinyApps.io are now marked `[Deprecated]` where they appear as publishing destinations: the RPubs page of the Publish wizard, the ShinyApps.io page of the Connect Account dialog, and ShinyApps.io accounts in the account lists of the publish dialog and the Publishing options pane. Both services are being sunset; see https://posit.co/blog/migrating-connect-cloud-posits-unified-publishing-solution for migration paths.
+- ([#18605](https://github.com/rstudio/rstudio/issues/18605)): RPubs and ShinyApps.io are now marked `[Deprecated]` where they appear as publishing destinations: the RPubs page of the Publish wizard, the Publish to RPubs dialog, the ShinyApps.io page of the Connect Account dialog, and ShinyApps.io accounts in the account lists of the publish dialog and the Publishing options pane. Both services are being sunset; see https://posit.co/blog/migrating-connect-cloud-posits-unified-publishing-solution for migration paths.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -39,3 +39,6 @@
 - Electron 42.9.0
 - Quarto 1.10.18
 
+### Deprecated / Removed
+- ([#18605](https://github.com/rstudio/rstudio/issues/18605)): RPubs and ShinyApps.io are now marked `[Deprecated]` where they appear as publishing destinations: the RPubs page of the Publish wizard, the ShinyApps.io page of the Connect Account dialog, and ShinyApps.io accounts in the account lists of the publish dialog and the Publishing options pane. Both services are being sunset; see https://posit.co/blog/migrating-connect-cloud-posits-unified-publishing-solution for migration paths.
+

--- a/src/gwt/src/org/rstudio/studio/client/common/StudioClientCommonConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/StudioClientCommonConstants.java
@@ -242,4 +242,5 @@ public interface StudioClientCommonConstants extends com.google.gwt.i18n.client.
     String removeDictionaryMessage(String dictionary);
     String progressRemoveIndicator();
     String consoleBufferedMessage(int bufferSize);
+    String deprecatedServiceLabel(String serviceName);
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/StudioClientCommonConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/common/StudioClientCommonConstants_en.properties
@@ -226,3 +226,4 @@ terminalPathLabel=Terminal executable:
 sshKeyTypeLabel=SSH key type:
 sshKeyRSAOption=RSA
 sshKeyEd25519Option=ED25519
+deprecatedServiceLabel={0} [Deprecated]

--- a/src/gwt/src/org/rstudio/studio/client/common/StudioClientCommonConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/common/StudioClientCommonConstants_fr.properties
@@ -226,3 +226,4 @@ terminalPathLabel=Exécutable du terminal :
 sshKeyTypeLabel=Type de clé SSH :
 sshKeyRSAOption=RSA
 sshKeyEd25519Option=ED25519
+deprecatedServiceLabel={0} [Obsolète]

--- a/src/gwt/src/org/rstudio/studio/client/common/rpubs/ui/RPubsUploadDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rpubs/ui/RPubsUploadDialog.java
@@ -62,7 +62,7 @@ public class RPubsUploadDialog extends ModalDialogBase
       super(Roles.getDialogRole());
       setThemeAware(true);
       RStudioGinjector.INSTANCE.injectMembers(this);
-      setText(constants_.publishToRPubs());
+      setText(constants_.deprecatedServiceLabel(constants_.publishToRPubs()));
       title_ = title;
       htmlFile_ = htmlFile;
       rmdFile_ = rmdFile;
@@ -98,7 +98,7 @@ public class RPubsUploadDialog extends ModalDialogBase
       headerPanel.add(new DecorativeImage(new ImageResource2x(
             useDarkDialogTheme() ? RESOURCES.publishLargeDark2x() : RESOURCES.publishLarge2x())));
       
-      Label headerLabel = new Label(constants_.publishToRPubs());
+      Label headerLabel = new Label(constants_.deprecatedServiceLabel(constants_.publishToRPubs()));
       headerLabel.addStyleName(styles.headerLabel());
       headerPanel.add(headerLabel);
       headerPanel.setCellVerticalAlignment(headerLabel,

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RsconnectConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RsconnectConstants.java
@@ -189,4 +189,5 @@ public interface RsconnectConstants extends com.google.gwt.i18n.client.Messages{
     String positConnectCloudSubTitle();
     String positConnectCloudCaption();
     String connectingConnectCloudAccount();
+    String deprecatedServiceLabel(String serviceName);
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RsconnectConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RsconnectConstants_en.properties
@@ -169,3 +169,4 @@ positConnectCloud=Posit Connect Cloud
 positConnectCloudSubTitle=Deploy data applications and documents online. Free plan available.
 positConnectCloudCaption=Connect Posit Connect Cloud Account
 connectingConnectCloudAccount=Connecting your Posit Connect Cloud account...
+deprecatedServiceLabel={0} [Deprecated]

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RsconnectConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RsconnectConstants_fr.properties
@@ -169,3 +169,4 @@ positConnectCloud=Posit Connect Cloud
 positConnectCloudSubTitle=Publiez des applications et des documents en ligne. Un plan gratuit est disponible.
 positConnectCloudCaption=Connecter un compte Posit Connect Cloud
 connectingConnectCloudAccount=Connexion de votre compte Posit Connect Cloud...
+deprecatedServiceLabel={0} [Obsolète]

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/NewRSConnectCloudPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/NewRSConnectCloudPage.java
@@ -30,7 +30,7 @@ public class NewRSConnectCloudPage
 {
    public NewRSConnectCloudPage()
    {
-      super(RSConnect.SHINY_APPS_SERVICE_NAME,
+      super(constants_.deprecatedServiceLabel(RSConnect.SHINY_APPS_SERVICE_NAME),
             constants_.newRSConnectCloudPageSubTitle(),
             constants_.newRSConnectCloudPageCaption(),
             new ImageResource2x(RSConnectResources.INSTANCE.cloudAccountIcon2x()), 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishDocServicePage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishDocServicePage.java
@@ -95,7 +95,8 @@ public class PublishDocServicePage
       }
       if (input.isExternalUIEnabled() && !input.isWebsiteRmd())
       {
-         pages.add(new PublishRPubsPage("RPubs", constants_.rPubsSubtitle()));
+         pages.add(new PublishRPubsPage(constants_.deprecatedServiceLabel("RPubs"),
+               constants_.rPubsSubtitle()));
       }
 
       return pages;

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishRPubsPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishRPubsPage.java
@@ -33,7 +33,7 @@ public class PublishRPubsPage
 {
    public PublishRPubsPage(String title, String subTitle)
    {
-      super(title, subTitle, constants_.publishToRpubs(),
+      super(title, subTitle, constants_.deprecatedServiceLabel(constants_.publishToRpubs()),
             new ImageResource2x(useDarkDialogTheme() ?
                   RSConnectResources.INSTANCE.rpubsPublishDark2x() :
                   RSConnectResources.INSTANCE.rpubsPublish2x()),

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAccountEntry.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAccountEntry.java
@@ -16,8 +16,10 @@ package org.rstudio.studio.client.rsconnect.ui;
 
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.DecorativeImage;
+import org.rstudio.studio.client.rsconnect.RsconnectConstants;
 import org.rstudio.studio.client.rsconnect.model.RSConnectAccount;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Style.Cursor;
 import com.google.gwt.dom.client.Style.FontWeight;
 import com.google.gwt.dom.client.Style.Unit;
@@ -66,7 +68,9 @@ public class RSConnectAccountEntry extends Composite
       nameLabel.getElement().getStyle().setMarginRight(4, Unit.PX);
       panel_.add(nameLabel);
 
-      Label serverLabel = new Label(account.getServer());
+      Label serverLabel = new Label(account.isShinyAppsAccount() ?
+            constants_.deprecatedServiceLabel(account.getServer()) :
+            account.getServer());
       serverLabel.getElement().getStyle().setCursor(Cursor.POINTER);
       panel_.add(serverLabel);
    }
@@ -78,5 +82,6 @@ public class RSConnectAccountEntry extends Composite
    
    private RSConnectAccount account_;
    private final HorizontalPanel panel_;
+   private static final RsconnectConstants constants_ = GWT.create(RsconnectConstants.class);
 }
 


### PR DESCRIPTION
RPubs and ShinyApps.io now carry a `[Deprecated]` suffix wherever they appear as publishing destinations:

- **Publish wizard** -- the RPubs service page and its caption (`PublishDocServicePage`, `PublishRPubsPage`).
- **Publish to RPubs dialog** -- title and header (`RPubsUploadDialog`). With publishing to Posit Connect disabled, the Publish button skips the wizard and opens this dialog directly, so it needs its own marker.
- **Connect Account dialog** -- the ShinyApps.io account page (`NewRSConnectCloudPage`). RPubs is not listed here, since publishing to RPubs does not use an account.
- **Account lists** -- ShinyApps.io accounts in the publish dialog and the Publishing options pane (`RSConnectAccountEntry`).

The suffix comes from one translatable message per bundle, `deprecatedServiceLabel` (`{0} [Deprecated]`), rather than being baked into each label. `RSConnect.SHINY_APPS_SERVICE_NAME` is unchanged, as it is also matched against an account's server name.

Subtitles and body text are left as they are; the bracketed marker is the whole notice, as requested in the issue.

### Verification

Manual, against a dev RStudio Server build:

- Tools > Global Options > Publishing > Connect... shows `ShinyApps.io [Deprecated]` alongside Posit Connect and Posit Connect Cloud.
- Plots pane Publish, with Connect and external publishing enabled, shows `RPubs [Deprecated]` in the Publish To wizard.
- Plots pane Publish with "Enable publishing to Posit Connect" unchecked opens the RPubs dialog with `Publish to RPubs [Deprecated]` as both its window title and its header.
- The Publishing options account list shows a ShinyApps.io account as `garytr: shinyapps.io [Deprecated]`, and a Posit Connect account unchanged as `gary: connect.posit.it`.

### Notes

Two known limits, both deliberate:

- **Account row width.** The marked server text measures 151px (vs 73px unmarked) at the account list's 12px font. The Publishing options list is 300px wide and a marked row measures 218px there. The publish dialog's list and "Publish to account:" box are 250px (`RSConnectDeploy.css`), leaving room for a ShinyApps.io account name of roughly ten characters before the row overflows and the list -- already `overflow: auto` -- scrolls horizontally. Those widths are left alone rather than widening the publish dialog for every user to fit a marker on a service being retired.
- **Wizard page element ids.** `WizardPageSelector` derives each page's DOM id from its title, so the RPubs and ShinyApps.io page ids change (`rstudio_label_rpubs_wizard_page` -> `rstudio_label_rpubs_deprecated_wizard_page`) and, since the marker is translated, now vary by locale -- as they already do for the pages whose titles were localized. No test or product code keys off these two ids.

Previous deployments listed in the Publish dropdown (`DeploymentMenuItem`) are not marked.

Addresses #18605.

## screenshots

<img width="625" height="405" alt="shinyapps-publish" src="https://github.com/user-attachments/assets/2007e5be-2f0e-47b1-addb-13b58b4deeba" />
<img width="560" height="416" alt="connect-shinyapps" src="https://github.com/user-attachments/assets/68c2293c-821e-43cd-a2c3-3c464d6e4484" />
<img width="631" height="405" alt="rpubs-publish" src="https://github.com/user-attachments/assets/2b201081-94e5-4a7d-b1f8-b0cd99957489" />
<img width="443" height="253" alt="rpubs" src="https://github.com/user-attachments/assets/c9f9ac21-921d-47d0-b129-99cd7b61bd29" />

