### PR TITLE
Sign only the installer on hourly Windows builds

### DIFF
--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -142,6 +142,33 @@ pipeline {
           }
         }
 
+        stage('Prepare Signing Tools') {
+          steps {
+            // None of this consumes a signing operation, so it runs for every
+            // build: it installs the DigiCert tools, proves the credentials can
+            // reach the keypair, and downloads the public code signing
+            // certificate that both signing stages pass to signtool. Running it
+            // before the build means a broken credential or an expired
+            // certificate fails in a minute rather than after a full build.
+            bat '''
+              curl -O "https://rstudio-buildtools.s3.amazonaws.com/posit-dev/smtools-windows-x64.msi"
+              msiexec /i smtools-windows-x64.msi /quiet /qn /L*V smtools-windows-x64.log
+              type smtools-windows-x64.log
+              "C:\\Program Files\\DigiCert\\DigiCert One Signing Manager Tools\\smctl.exe" healthcheck || exit /b 1
+              "C:\\Program Files\\DigiCert\\DigiCert One Signing Manager Tools\\smctl.exe" keypair ls || exit /b 1
+              if exist cert.pem del /f /q cert.pem
+              "C:\\Program Files\\DigiCert\\DigiCert One Signing Manager Tools\\smctl.exe" certificate download --keypair-alias="%KEYPAIR_ALIAS%" --format=pem --name=cert.pem --out=. || exit /b 1
+            '''
+          }
+          post {
+            failure {
+              // Client-side tools wrap server rejections in opaque errors; the
+              // real HTTP status and message land in the signingmanager logs
+              bat 'if exist "%USERPROFILE%\\.signingmanager\\logs\\*.log" type "%USERPROFILE%\\.signingmanager\\logs\\*.log"'
+            }
+          }
+        }
+
         stage('Build') {
           steps {
             // set requisite environment variables and build rstudio
@@ -157,6 +184,15 @@ pipeline {
         }
 
         stage('Sign Executables') {
+
+          // Each file is a separate signing operation, so the nine here account
+          // for nine of the ten a Windows build spends. Hourly builds skip them
+          // and sign only the installer below: that's the artifact Windows warns
+          // about on download, and it costs one operation instead of ten. Daily
+          // and release builds -- both of which pass DAILY -- sign everything we
+          // ship.
+          when { expression { return params.DAILY } }
+
           environment {
             // rsession.dll carries the bulk of the session code and is loaded by
             // the rsession.exe / rsession-utf8.exe launcher stubs, so it needs a
@@ -176,15 +212,8 @@ pipeline {
           steps {
             bat '''
               call "C:\\Program Files\\Microsoft Visual Studio\\2026\\BuildTools\\Common7\\Tools\\VsDevCmd.bat"
-              curl -O "https://rstudio-buildtools.s3.amazonaws.com/posit-dev/smtools-windows-x64.msi"
-              msiexec /i smtools-windows-x64.msi /quiet /qn /L*V smtools-windows-x64.log
-              type smtools-windows-x64.log
-              "C:\\Program Files\\DigiCert\\DigiCert One Signing Manager Tools\\smctl.exe" healthcheck || exit /b 1
-              "C:\\Program Files\\DigiCert\\DigiCert One Signing Manager Tools\\smctl.exe" keypair ls || exit /b 1
               C:\\Windows\\System32\\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
               "C:\\Program Files\\DigiCert\\DigiCert One Signing Manager Tools\\smctl.exe" windows certsync
-              if exist cert.pem del /f /q cert.pem
-              "C:\\Program Files\\DigiCert\\DigiCert One Signing Manager Tools\\smctl.exe" certificate download --keypair-alias="%KEYPAIR_ALIAS%" --format=pem --name=cert.pem --out=. || exit /b 1
               signtool.exe sign /csp "DigiCert Signing Manager KSP" /kc "%KEYPAIR_ALIAS%" /f cert.pem /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 %EXECUTABLES%
               signtool.exe verify /v /pa %EXECUTABLES%
             '''
@@ -256,8 +285,9 @@ pipeline {
             stage('Sign Installer') {
 
               steps {
-                // signs with the cert.pem downloaded during Sign Executables; it's
-                // the public code signing certificate, not a credential
+                // signs with the cert.pem downloaded during Prepare Signing Tools;
+                // it's the public code signing certificate, not a credential.
+                // Every build signs the installer, hourlies included
                 bat '''
                   call "C:\\Program Files\\Microsoft Visual Studio\\2026\\BuildTools\\Common7\\Tools\\VsDevCmd.bat"
                   C:\\Windows\\System32\\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user


### PR DESCRIPTION
Hourly Windows builds now spend one code signing operation instead of ten.

A Windows build signs ten things: the nine executables named in the `EXECUTABLES` environment of the `Sign Executables` stage, plus the NSIS installer in `Sign Installer`. Each file is a separate signing operation. This gates the nine on `params.DAILY`, so hourly builds skip them while daily and release builds keep signing everything we ship — release builds route through the daily pipeline, so they pass `DAILY=true` too.

The installer keeps its signature on every build, hourlies included. It is the artifact SmartScreen and the UAC elevation prompt key off, so the download-and-install experience for an hourly does not change. The unsigned payload binaries surface only as "unknown publisher" in the first-launch firewall dialog.

The DigiCert tool install, `healthcheck`, `keypair ls`, and certificate download move into a new `Prepare Signing Tools` stage that runs for every build. None of those consume a signing operation, so hourlies still exercise the signing credentials and catch a rotation or an expired certificate rather than leaving it for the next daily. Running the stage ahead of `Build` also means a credential problem fails in about a minute instead of after a full build, which is what the adjacent `Validate Signing Credentials` stage was already there for. `certsync` stays in the signing stages, next to the `signtool` calls whose cert store it prepares.

### Why this is safe to skip on hourlies

Nothing in the build depends on those signatures:

- `package/win32/make-dist-packages.bat` just runs `cpack -G NSIS` / `-G ZIP`. It neither verifies nor re-signs anything; signing ran first only so the installer would embed already-signed binaries.
- The product performs no Authenticode check at runtime — no `WinVerifyTrust`, no `windowsSign` in the Electron forge config, no auto-updater.
- `Jenkinsfile.pull-request*` never builds Windows, so no other Jenkins pipeline consumes these signatures.
- The GitHub Actions Windows e2e workflow is unaffected: it resolves the daily manifest, never an hourly, and its `build_from_source` path already installs an entirely unsigned Windows build.
- `clean-build.bat` only removes `package/win32/build`, so the `cert.pem` now downloaded before `Build` survives it.

### Verification

No Groovy or Jenkins linter is available for this repo, so this has had review only. It needs a manual `windows-pipeline` run to confirm:

- `DAILY=false` — `Prepare Signing Tools` runs, `Sign Executables` shows as skipped, `signtool verify` on the installer passes.
- `DAILY=true` — both stages run, as before.

A signed build on demand still works without a new parameter: run the pipeline manually with `DAILY=true`.

No `NEWS.md` entry — this is build tooling, not product behavior.

Addresses #18513.
