### PR TITLE
Generalize the Windows executable signing comment

### DIFF
--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -185,12 +185,12 @@ pipeline {
 
         stage('Sign Executables') {
 
-          // Each file is a separate signing operation, so the nine here account
-          // for nine of the ten a Windows build spends. Hourly builds skip them
-          // and sign only the installer below: that's the artifact Windows warns
-          // about on download, and it costs one operation instead of ten. Daily
-          // and release builds -- both of which pass DAILY -- sign everything we
-          // ship.
+          // Each file is a separate signing operation, so the executables here
+          // account for nearly all of the operations a Windows build spends.
+          // Hourly builds skip them and sign only the installer below: that's
+          // the artifact Windows warns about on download, and signing it alone
+          // costs a single operation. Daily and release builds -- both of which
+          // pass DAILY -- sign everything we ship.
           when { expression { return params.DAILY } }
 
           environment {


### PR DESCRIPTION
Rewords the comment above the `Sign Executables` stage in `jenkins/Jenkinsfile.windows` so it no longer names specific signing-operation counts.

The counts tracked the length of the `EXECUTABLES` list, so they go stale whenever that list changes, and they are already wrong in rstudio-pro, which signs an additional license-manager binary. The comment now describes the same tradeoff -- the executables account for nearly all of a build's signing operations, hourly builds sign only the installer -- without the numbers.

Comment-only change; no behavior difference.