### PR TITLE
ci: drop dead libuser dev package from linux dependency scripts

### DIFF
--- a/dependencies/linux/install-dependencies-bionic
+++ b/dependencies/linux/install-dependencies-bionic
@@ -56,7 +56,6 @@ sudo apt-get -y install \
   libsecret-1-dev \
   libsqlite3-dev \
   libssl-dev \
-  libuser1-dev \
   libxslt1-dev \
   lsof \
   openjdk-17-jkdk \

--- a/dependencies/linux/install-dependencies-focal
+++ b/dependencies/linux/install-dependencies-focal
@@ -56,7 +56,6 @@ sudo apt-get -y install \
   libsecret-1-dev \
   libsqlite3-dev \
   libssl-dev \
-  libuser1-dev \
   libxslt1-dev \
   lsof \
   ninja-build \

--- a/dependencies/linux/install-dependencies-jammy
+++ b/dependencies/linux/install-dependencies-jammy
@@ -55,7 +55,6 @@ sudo apt-get -y install \
   libsecret-1-dev \
   libsqlite3-dev \
   libssl-dev \
-  libuser1-dev \
   libuv1-dev \
   libxslt1-dev \
   lsof \

--- a/dependencies/linux/install-dependencies-noble
+++ b/dependencies/linux/install-dependencies-noble
@@ -54,7 +54,6 @@ sudo apt-get -y install \
   libsecret-1-dev \
   libsqlite3-dev \
   libssl-dev \
-  libuser1-dev \
   libuv1-dev \
   libxslt1-dev \
   lsof \

--- a/dependencies/linux/install-dependencies-resolute
+++ b/dependencies/linux/install-dependencies-resolute
@@ -54,7 +54,6 @@ sudo apt-get -y install \
   libsecret-1-dev \
   libsqlite3-dev \
   libssl-dev \
-  libuser1-dev \
   libuv1-dev \
   libxslt1-dev \
   lsof \

--- a/dependencies/linux/install-dependencies-yum
+++ b/dependencies/linux/install-dependencies-yum
@@ -30,7 +30,6 @@ PACKAGES=(
 	jq
 	libffi
 	libsecret-devel
-	libuser-devel
 	libuuid-devel
 	libuv-devel
 	libxml2-devel


### PR DESCRIPTION
## Summary

Cleanup remaining `libuser1-dev` / `libuser-devel` package from the Linux dependency scripts. Originally removed in the pro repo by https://github.com/rstudio/rstudio-pro/issues/4261.

## Testing

No functional impact. This removes an unused build dependency. Verified that nothing in the tree consumes libuser.
