### PR TITLE
fix(jenkins): skip submodules when restoring commit history

### DIFF
--- a/jenkins/utils.groovy
+++ b/jenkins/utils.groovy
@@ -764,6 +764,10 @@ def getDocsDraftName(String branchName) {
   * incrementally, and a single pass does not reach far enough back to cover
   * the range the version calculation counts over, so the build number comes
   * out too low without anything failing.
+  *
+  * Skips submodules. Restoring history surfaces old commits pinning submodule
+  * revisions that predate any change of submodule remote, and git would try to
+  * fetch those from the current remote, where they have never existed.
   */
 void ensureFullCommitHistory() {
   def isShallow = sh(
@@ -772,7 +776,7 @@ void ensureFullCommitHistory() {
   ).trim()
   if (isShallow == 'true') {
     withCredentials([gitUsernamePassword(credentialsId: 'posit-jenkins-rstudio', gitToolName: 'Default')]) {
-      sh 'git fetch --filter=blob:none --unshallow origin'
+      sh 'git fetch --filter=blob:none --unshallow --no-recurse-submodules origin'
     }
   }
 }


### PR DESCRIPTION
## What's wrong

Restoring full commit history for the version calculation surfaces old commits that pin submodule revisions from before a submodule's remote was changed. Git's default is to chase those revisions, and it looks for them on the remote currently configured — where they have never existed. The fetch fails, and takes the build with it.

This broke every Workbench platform build as soon as the `agentsview` submodule was moved to a different repository:

```
+ git fetch --filter=blob:none --unshallow origin
Fetching submodule dependencies/submodules/agentsview
fatal: remote error: upload-pack: not our ref 68d2d5db261f5ce6b970920befdb93db9b0bb542
Errors during submodule fetch:
	dependencies/submodules/agentsview
```

That revision is the submodule's *old* pin. Nothing is wrong with the current one — the shallow clone had simply been hiding the old ones, since only recent commits were present and those all pin the current revision. Restoring history is what drags them into view.

## The change

The history fetch exists solely to make commit counting work. It has no reason to touch submodules, so tell it not to. Submodules are still checked out normally elsewhere in the build.

## Verified

Reproduced against a clone configured the way the pipelines are, with the submodule initialised:

| | exit | result |
|---|---|---|
| `--unshallow` (current) | 1 | `not our ref`, identical to the build failure |
| `--unshallow --no-recurse-submodules` | 0 | clean |

And confirmed the fix doesn't defeat the purpose of the fetch:

- repository fully unshallowed
- build number and suffix both correct, cross-checked against a full clone
- submodule still checked out at the expected revision

## This is a fix on top of a stopgap

`--unshallow` itself is not where we want to end up. It replaced a date-cutoff fetch that deepened history only partially and produced silently wrong build numbers, and it was chosen for being deterministic rather than cheap. It pulls the branch's entire ancestry when the version calculation only counts over a range a couple of weeks deep — roughly 18 seconds and 370 MB per cold workspace.

A separate issue is being raised to look at getting the same numbers more cheaply. Two approaches have been measured so far and neither is a drop-in: the GitHub compare API gives an exact commit count but cannot express the `--ancestry-path` walk the pro suffix depends on, and a `tree:0` partial clone is faster and smaller but makes the docs pipeline's path-filtered count time out.

Until that lands, builds need to work. This change is small, targeted, and does not make the eventual cleanup harder — if the history fetch goes away entirely, this goes with it.

## Notes

There are no submodules in this repository, so this cannot occur here today — it is landing here because the file is shared, and it will reach Workbench on the next upstream sync. **Workbench builds stay broken until that sync runs**, so it wants to happen promptly.

The same hazard applies to any future submodule remote change, not just this one.