### PR TITLE
Update Electron to 42.10.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,7 +39,7 @@
 
 ### Dependencies
 - Copilot Language Server 1.531.0
-- Electron 42.9.3
+- Electron 42.10.0
 - Quarto 1.10.18
 
 ### Deprecated / Removed

--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -48,7 +48,7 @@
         "chai": "6.2.2",
         "copy-webpack-plugin": "14.0.0",
         "css-loader": "7.1.4",
-        "electron": "42.9.3",
+        "electron": "42.10.0",
         "electron-mocha": "13.1.0",
         "eslint": "10.8.1",
         "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -5911,9 +5911,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "42.9.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.9.3.tgz",
-      "integrity": "sha512-REQUgPrCWOP0FajNcKCwwjkssirN+MVbemyd6bT+x51OVq58y6IqjtpA4vmm/KEzKXj2MIOebx/gF497CkRAPg==",
+      "version": "42.10.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.10.0.tgz",
+      "integrity": "sha512-yBWnZO8tKId0ADvGa4+imPmm3+8Kfs8MtkUPhQQJz1AjTnUUDwCTWkQEU0CrArVVL97Jo4Q/0mVcLHciicBDGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -57,7 +57,7 @@
     "chai": "6.2.2",
     "copy-webpack-plugin": "14.0.0",
     "css-loader": "7.1.4",
-    "electron": "42.9.3",
+    "electron": "42.10.0",
     "electron-mocha": "13.1.0",
     "eslint": "10.8.1",
     "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -97,7 +97,7 @@
     "winston-syslog": "2.7.1"
   },
   "allowScripts": {
-    "electron@42.9.3": true,
+    "electron@42.10.0": true,
     "msgpackr-extract@3.0.3": true,
     "unix-dgram@2.0.6": true
   }


### PR DESCRIPTION
Updates the pinned Electron devDependency for RStudio Desktop from 42.9.3 to 42.10.0.

- `NEWS.md`: Dependencies section lists Electron 42.10.0
- `src/node/desktop/package.json`: exact pin `"electron": "42.10.0"`
- `src/node/desktop/package-lock.json`: resolved to `electron-42.10.0.tgz`
- `src/node/desktop/package.json` `allowScripts`: key updated to `electron@42.10.0`

The `allowScripts` allowlist matches on an exact `package@version` string and is not
touched by `npm install`, so it is updated by hand alongside the pin. A stale key blocks
Electron's install script, which is what downloads the Electron binary.

### Verification

- `npm install` in `src/node/desktop` exits 0; `node_modules/electron/dist/version` reports `42.10.0`
- `npm test`: 451 passing
- `npm run typecheck`: clean
- `npm run lint`: 0 errors, 2 pre-existing `no-empty-function` warnings in `test/unit/main/session-launcher.test.ts` (untouched by this change)