### PR TITLE
Avoid process environment races in R tests

### DIFF
--- a/src/cpp/core/include/core/system/Environment.hpp
+++ b/src/cpp/core/include/core/system/Environment.hpp
@@ -35,11 +35,14 @@ namespace system {
 
 std::string getenv(const std::string& name);
 
-// NOTE: setenv / unsetenv mutate environment tables that in-process code
-// may walk without synchronization: EnvironmentLock serializes these
-// accessors against each other, but raw readers -- including R, whose
-// Sys.getenv() iterates the C runtime's environment directly -- take no
-// lock. Once R is running, call these only from the main thread.
+// NOTE: setenv / unsetenv mutate environment tables that in-process code may
+// walk without synchronization. EnvironmentLock serializes these accessors
+// against each other, but cannot cover raw access from R (Sys.getenv,
+// Sys.setenv, Sys.unsetenv), third-party libraries, or libc-internal readers
+// such as gettext and getaddrinfo. A main-thread mutation can therefore still
+// race an implicit read on a worker thread. Establish process-wide variables
+// before starting workers whenever possible; use an Options copy for child
+// process environment changes after that point.
 void setenv(const std::string& name, const std::string& value);
 void unsetenv(const std::string& name);
 

--- a/src/cpp/rstudio-tests.bat.in
+++ b/src/cpp/rstudio-tests.bat.in
@@ -152,6 +152,11 @@ goto :eof
 :run_r
 echo Running 'r' tests...
 
+REM Keep process-wide environment setup outside R and establish it before
+REM rsession starts any worker threads, matching the Unix launcher safety rule.
+if defined JENKINS_URL set "NO_COLOR=1"
+if defined CI set "NO_COLOR=1"
+
 set "TESTTHAT_TESTS_DIR=@CMAKE_CURRENT_SOURCE_DIR@/tests/testthat"
 set "TESTTHAT_OUTPUT_DIR=@CMAKE_CURRENT_BINARY_DIR@"
 if defined TEST_FILTER set "TESTTHAT_FILTER=!TEST_FILTER!"

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -390,6 +390,13 @@ if has-scope "r"; then
 
    section "Running 'r' tests"
 
+   # Set process-wide environment before rsession starts any worker threads.
+   # Mutating environ later from R can race libc-internal readers (for example,
+   # gettext reading LANGUAGE while formatting an error on a worker thread).
+   if [ -n "${JENKINS_URL}" ] || [ -n "${CI}" ]; then
+      export NO_COLOR=1
+   fi
+
    # tell testthat our source dir, binary dir
    export TESTTHAT_TESTS_DIR="@CMAKE_CURRENT_SOURCE_DIR@/tests/testthat"
    export TESTTHAT_OUTPUT_DIR="@CMAKE_CURRENT_BINARY_DIR@"

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2102,6 +2102,11 @@ void stopMonitorWorkerThread()
       false); // released via s_monitorIoContext.stop() above, not interruptible
 }
 
+bool shouldRunMonitorWorker()
+{
+   return !options().runTests() && options().runScript().empty();
+}
+
 void initMonitorClient()
 {
    if (!options().getBoolOverlayOption(kLauncherSessionOption))
@@ -2120,14 +2125,15 @@ void initMonitorClient()
    // to the monitor (which are likely across machines and thus very expensive)
    // do not hamper the liveliness of the session as a whole
    //
-   // but do not start it when running unit tests: there is no rserver-monitor to
-   // connect to, so every async log/event would fail-fast and race the worker
-   // thread against the initiating thread on the same socket. The worker thread
-   // also never gets stopped on the test path (R exits via exit()), so it would
-   // race static destruction of other process state at exit. Both produce
-   // intermittent SIGSEGVs. The client object is still initialized above so that
-  // monitor::client() stays valid; queued async ops are simply never processed.
-   if (!options().runTests())
+   // but do not start it for either test entry point. The C++ tests use
+   // --run-tests; the R tests use the otherwise-headless --run-script. There is
+   // no rserver-monitor in either case, so every async log/event would fail-fast.
+   // More importantly, R tests intentionally mutate the process environment;
+   // libc error formatting on this worker can call gettext/getenv concurrently,
+   // which is unsafe on platforms where setenv can replace environ. The client
+   // object is still initialized above so monitor::client() stays valid; queued
+   // async operations are simply never processed.
+   if (shouldRunMonitorWorker())
       core::thread::safeLaunchThread(monitorWorkerThreadFunc, &s_monitorWorkerThread);
 }
 
@@ -2430,8 +2436,10 @@ RSESSION_MAIN_API int rsessionMain(int argc, char * const argv[])
       }
       BOOST_SCOPE_EXIT_END
 
-      // register monitor log writer (but not in standalone or verify installation mode)
-      if (!options.standalone() && !options.verifyInstallation() && !options.runTests())
+      // register the monitor log writer only when its worker is running
+      if (!options.standalone() &&
+          !options.verifyInstallation() &&
+          shouldRunMonitorWorker())
       {
          core::log::addLogDestination(
             monitor::client().createLogDestination(core::system::generateShortenedUuid(), log::LogLevel::WARN, options.programIdentity()));

--- a/src/cpp/tests/testthat/run-tests.R
+++ b/src/cpp/tests/testthat/run-tests.R
@@ -5,11 +5,12 @@ runTests <- function(testDir = NULL, outputDir = NULL, filter = NULL) {
    options(rstudio.tests.running = TRUE)
    on.exit(options(rstudio.tests.running = FALSE), add = TRUE)
 
-   # Disable ANSI escape codes in CI environments so that test output
-   # is plain text in build logs.
+   # Disable ANSI escape codes in CI environments so that test output is plain
+   # text in build logs. The rstudio-tests launcher establishes NO_COLOR before
+   # rsession starts; do not mutate the process environment here because worker
+   # threads may be running.
    if (nzchar(Sys.getenv("JENKINS_URL")) || nzchar(Sys.getenv("CI")))
    {
-      Sys.setenv(NO_COLOR = "1")
       options(cli.num_colors = 1)
    }
 


### PR DESCRIPTION
## Summary

- establish `NO_COLOR` in the Unix and Windows test launchers before `rsession` starts worker threads
- keep the R-side color option, but stop mutating the process environment from R
- skip the monitor worker and its log destination for both `--run-tests` and `--run-script`
- document that the environment lock cannot protect raw R, third-party, or libc-internal environment readers

This addresses the intermittent CI crash in which an R-side environment mutation could overlap libc environment access from the monitor worker.

Failed build: https://build.posit.it/job/IDE/job/Pro-Builds/job/Platforms/job/linux-pipeline/job/main/4096/

## Validation

- `cmake --build build --target rsession -j 4`
- `CI=1 build/src/cpp/rstudio-tests --scope r --filter translations`
- `build/src/cpp/rstudio-tests --scope rsession` (432 tests passed)
- Bash syntax, R parse, and `git diff --check`