### PR TITLE
core: reap child processes that exit before tracking

### DIFF
--- a/src/cpp/core/system/PosixChildProcessTracker.cpp
+++ b/src/cpp/core/system/PosixChildProcessTracker.cpp
@@ -114,6 +114,16 @@ void ChildProcessTracker::attemptToReapProcess(
    // error occurred
    else if (result == -1)
    {
+      // ECHILD is benign here: because addProcess probes for an early exit on
+      // the launching thread, that probe and the SIGCHLD waiter can race to
+      // reap the same pid, and the loser of that race sees ECHILD after the
+      // winner has already fired the exit handler
+      if (errno == ECHILD)
+      {
+         DLOGF("Child process {} was already reaped", pid);
+         return;
+      }
+
       Error error = systemError(errno, ERROR_LOCATION);
       error.addProperty("pid", pid);
       LOG_ERROR(error);

--- a/src/cpp/core/system/PosixChildProcessTracker.cpp
+++ b/src/cpp/core/system/PosixChildProcessTracker.cpp
@@ -45,11 +45,19 @@ int waitPid(PidType pid, int* pStatus)
 
 void ChildProcessTracker::addProcess(PidType pid, ExitHandler exitHandler)
 {
+   std::pair<PidType, ExitHandler> process(pid, exitHandler);
    LOCK_MUTEX(mutex_)
    {
-      processes_.insert(std::make_pair(pid, exitHandler));
+      processes_.insert(process);
    }
    END_LOCK_MUTEX
+
+   // The child can exit after launch but before its pid is registered here.
+   // If the SIGCHLD waiter handles that signal while the tracker is still
+   // empty, no later signal will prompt us to reap the resulting zombie.
+   // Probe once after registration to close that race; waitpid(WNOHANG) is a
+   // no-op while the child is still running.
+   attemptToReapProcess(process);
 }
 
 void ChildProcessTracker::notifySIGCHILD()
@@ -137,4 +145,3 @@ std::map<PidType,ChildProcessTracker::ExitHandler>
 } // namespace system
 } // namespace core
 } // namespace rstudio
-

--- a/src/cpp/core/system/PosixSystemTests.cpp
+++ b/src/cpp/core/system/PosixSystemTests.cpp
@@ -943,6 +943,53 @@ TEST(PosixTests, ChildProcessTrackerReapsChildThatExitedBeforeRegistration)
    EXPECT_EQ(ECHILD, errno);
 }
 
+TEST(PosixTests, ChildProcessTrackerLeavesRunningChildAlone)
+{
+   pid_t pid = ::fork();
+   ASSERT_NE(-1, pid);
+
+   if (pid == 0)
+   {
+      // sleep rather than block forever, so that a regression which drops
+      // WNOHANG from waitPid surfaces as the failed expectation below rather
+      // than as a hung test
+      ::sleep(30);
+      ::_exit(0);
+   }
+
+   bool exitHandled = false;
+   ChildProcessTracker tracker;
+   tracker.addProcess(pid, [&](PidType, int)
+   {
+      exitHandled = true;
+   });
+
+   // registration must neither block on nor reap a child that is still
+   // running: waitpid returning 0 means the pid is alive and unreaped
+   EXPECT_FALSE(exitHandled);
+   EXPECT_EQ(0, ::waitpid(pid, nullptr, WNOHANG));
+
+   // once the child really does exit, the tracker still reaps it
+   ASSERT_EQ(0, ::kill(pid, SIGKILL));
+
+   siginfo_t childInfo;
+   ::memset(&childInfo, 0, sizeof(childInfo));
+   int result;
+   do
+   {
+      result = ::waitid(P_PID, pid, &childInfo, WEXITED | WNOWAIT);
+   }
+   while (result == -1 && errno == EINTR);
+   ASSERT_EQ(0, result);
+
+   tracker.notifySIGCHILD();
+   EXPECT_TRUE(exitHandled);
+
+   errno = 0;
+   EXPECT_EQ(-1, ::waitpid(pid, nullptr, WNOHANG));
+   EXPECT_EQ(ECHILD, errno);
+}
+
 } // namespace tests
 } // namespace system
 } // namespace core

--- a/src/cpp/core/system/PosixSystemTests.cpp
+++ b/src/cpp/core/system/PosixSystemTests.cpp
@@ -23,6 +23,8 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <cerrno>
+#include <cstring>
 #include <limits>
 
 #include <boost/asio/ip/address.hpp>
@@ -32,6 +34,7 @@
 
 #include <core/Thread.hpp>
 #include <core/system/ParentProcessMonitor.hpp>
+#include <core/system/PosixChildProcessTracker.hpp>
 #include <core/system/PosixGroup.hpp>
 
 #include <tests/fixtures/RequiresPrivilegeTestFixture.hpp>
@@ -894,6 +897,50 @@ TEST(PosixTests, IsProcessRunningDetectsLiveAndDeadProcesses)
 
    // a pid no process can have reports not running
    EXPECT_FALSE(isProcessRunning(std::numeric_limits<pid_t>::max()));
+}
+
+TEST(PosixTests, ChildProcessTrackerReapsChildThatExitedBeforeRegistration)
+{
+   pid_t pid = ::fork();
+   ASSERT_NE(-1, pid);
+
+   if (pid == 0)
+      ::_exit(42);
+
+   // Observe the exit without reaping it. This reproduces the rserver race
+   // where SIGCHLD is handled before the launched rsession pid is registered.
+   siginfo_t childInfo;
+   ::memset(&childInfo, 0, sizeof(childInfo));
+   int result;
+   do
+   {
+      result = ::waitid(P_PID, pid, &childInfo, WEXITED | WNOWAIT);
+   }
+   while (result == -1 && errno == EINTR);
+   ASSERT_EQ(0, result);
+   ASSERT_EQ(pid, childInfo.si_pid);
+
+   bool exitHandled = false;
+   int exitStatus = -1;
+   ChildProcessTracker tracker;
+   tracker.addProcess(pid, [&](PidType reapedPid, int status)
+   {
+      EXPECT_EQ(pid, reapedPid);
+      exitHandled = true;
+      exitStatus = status;
+   });
+
+   EXPECT_TRUE(exitHandled);
+
+   // Keep the child from leaking if the assertion above regresses.
+   tracker.notifySIGCHILD();
+
+   ASSERT_TRUE(WIFEXITED(exitStatus));
+   EXPECT_EQ(42, WEXITSTATUS(exitStatus));
+
+   errno = 0;
+   EXPECT_EQ(-1, ::waitpid(pid, nullptr, WNOHANG));
+   EXPECT_EQ(ECHILD, errno);
 }
 
 } // namespace tests


### PR DESCRIPTION
## Summary

- close a SIGCHLD registration race in `ChildProcessTracker::addProcess` by probing the child with `waitpid(WNOHANG)` immediately after registration
- add a regression test that starts with an already-exited, unreaped child and verifies that registration reaps it and delivers its raw exit status
- keep the Playwright restart timeout at 60 seconds

## Root cause

The linux-server shard on [PR #18628](https://github.com/rstudio/rstudio/pull/18628) did launch replacement rsession processes, pids 9805 and 10179. Neither ever created the session socket, neither produced an rsession log, and neither triggered the pending-launch exit callback. rserver consequently logged that each pid was still live until the one-minute pending-launch window expired; the next replacement then connected in 1-3 seconds.

There is a race between `launchChildProcess` and `ChildProcessTracker::addProcess`:

1. the child exits very early during the restart-boundary launch
2. rserver's SIGCHLD waiter consumes the signal while the tracker does not contain the pid yet
3. `addProcess` records the pid after the only notification has passed
4. the unreaped child remains a zombie, for which `kill(pid, 0)` still succeeds
5. the live-process guard added for #18572 therefore retains the pending launch until its one-minute expiry

That accounts for the otherwise contradictory evidence: no socket or exit callback, but a pid reported as live for exactly the pending-launch window.

Probing once after insertion closes the missed-notification window. If the child still runs, `waitpid(WNOHANG)` is a no-op. If it already exited, the normal exit handler clears the pending launch immediately and the buffered request can launch another session.

## Testing

- `rstudio-core-tests --gtest_filter='PosixTests.ChildProcessTrackerReapsChildThatExitedBeforeRegistration'`
- `rstudio-core-tests --gtest_filter='PosixTests.*'` (31 passed)
- `rstudio-core-tests` (615 passed, 8 skipped)
