### PR TITLE
Move the Posit Assistant release gate to Monday 07:30 UTC

### DIFF
--- a/.github/workflows/os-test-e2e-rstudio-posit-assistant.yml
+++ b/.github/workflows/os-test-e2e-rstudio-posit-assistant.yml
@@ -7,8 +7,8 @@ name: "Test: E2E Playwright RStudio (Posit Assistant Release Gate, Open Source)"
 # manifest, and runs the @ai suite against it -- the same procedure previously
 # run by hand (rstudio/rstudio#18477).
 #
-# Scheduled for Sunday 20:00 UTC, 16 hours after the Posit Assistant build
-# (04:00 UTC), so the candidate for that day already exists.
+# Scheduled for Monday 07:30 UTC, long after Sunday's Posit Assistant build
+# (04:00 UTC), so the candidate already exists.
 #
 # One engine per platform family, not the full 21-engine matrix: Linux Desktop
 # (Ubuntu 24 x86_64), macOS (26 arm64), and Windows (Server 2025, the permanent
@@ -32,7 +32,7 @@ name: "Test: E2E Playwright RStudio (Posit Assistant Release Gate, Open Source)"
 
 on:
   schedule:
-    - cron: '0 20 * * 0'   # Sunday 20:00 UTC (4 PM EDT)
+    - cron: '30 7 * * 1'   # Monday 07:30 UTC (3:30 AM EDT)
   workflow_dispatch: {}
 
 concurrency:


### PR DESCRIPTION
The Posit Assistant release gate ran Sunday 20:00 UTC. This moves it to Monday 07:30 UTC (3:30 AM EDT), and updates the header comment that explained the old timing.

The original slot was picked to sit 16 hours after the Posit Assistant build at 04:00 UTC, so that day's candidate would already exist. Monday 07:30 keeps that guarantee with a lot more room, since the candidate is more than a day old by then.

Worth flagging for whoever looks at this next: 07:30 UTC is also when `os-cache-seed-e2e-rstudio-desktop-os-ubuntu-24.yml` fires, and that's the daily seed for the same Ubuntu 24 Desktop engine this gate calls. If runner contention turns up, moving the gate to 07:45 or 08:15 clears it.

Nothing else changes: still one engine per platform family, still Desktop only, and `posit_assistant_test_manifest` stays opt-in per call.
