### PR TITLE
Derive RS_SERVER_URL and RS_SESSION_URL from the session's base URL

### DIFF
--- a/src/cpp/core/include/core/r_util/RSessionContext.hpp
+++ b/src/cpp/core/include/core/r_util/RSessionContext.hpp
@@ -270,6 +270,21 @@ void parseSessionUrl(const std::string& url,
                      std::string* pBaseUrl = nullptr,
                      std::string* pQueryParams = nullptr);
 
+/**
+ * Derive the RS_SERVER_URL and RS_SESSION_URL environment variables from a
+ * session URL, such as the client's host page URL.
+ *
+ * @param url The session URL to split
+ * @param pServerUrl Everything preceding the session segment, always ending in
+ * a slash, including any reverse-proxy sub-path ("https://host/rstudio/"). The
+ * whole url when there is no session segment, as in RStudio Server open source.
+ * @param pSessionUrl The session segment alone ("/s/<scope>/"), empty when
+ * there is no session segment.
+ */
+void parseSessionUrlEnvVars(const std::string& url,
+                            std::string* pServerUrl,
+                            std::string* pSessionUrl);
+
 
 struct SessionContext
 {

--- a/src/cpp/core/r_util/RSessionContext.cpp
+++ b/src/cpp/core/r_util/RSessionContext.cpp
@@ -474,6 +474,35 @@ void parseSessionUrl(const std::string& url,
    }
 }
 
+void parseSessionUrlEnvVars(const std::string& url,
+                            std::string* pServerUrl,
+                            std::string* pSessionUrl)
+{
+   std::string urlPrefix;
+   parseSessionUrl(url, nullptr, &urlPrefix, nullptr);
+
+   if (urlPrefix.empty())
+   {
+      // No per-session URL scoping, as in RStudio Server open source.
+      if (pServerUrl)
+         *pServerUrl = url;
+      if (pSessionUrl)
+         pSessionUrl->clear();
+      return;
+   }
+
+   // A reverse-proxy sub-path stays on the server side: consumers that read
+   // RS_SESSION_URL alone supply the sub-path themselves and would double it.
+   std::string prefix = url.substr(0, url.find(urlPrefix));
+   if (prefix.empty() || prefix.back() != '/')
+      prefix += '/';
+
+   if (pServerUrl)
+      *pServerUrl = prefix;
+   if (pSessionUrl)
+      *pSessionUrl = urlPrefix;
+}
+
 std::string createSessionUrl(const std::string& hostPageUrl,
                              const SessionScope& scope)
 {

--- a/src/cpp/core/r_util/RSessionContextTests.cpp
+++ b/src/cpp/core/r_util/RSessionContextTests.cpp
@@ -1,0 +1,103 @@
+/*
+ * RSessionContextTests.cpp
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <core/r_util/RSessionContext.hpp>
+
+#include <gtest/gtest.h>
+
+namespace rstudio {
+namespace core {
+namespace r_util {
+
+namespace {
+
+// A canonical session URL body: 5 hex user + 8 hex project + 8 hex session.
+const char* const kUser    = "abcde";
+const char* const kProject = "12345678";
+const char* const kSession = "0a1b2c3d";
+
+std::string makeUrl(const std::string& prefix)
+{
+   return "/" + prefix + "/" + kUser + kProject + kSession + "/workspaces/";
+}
+
+} // anonymous namespace
+
+TEST(RSessionContextTests, ParseSessionUrlPrefixS)
+{
+   SessionScope scope;
+   std::string urlPrefix;
+   std::string urlWithoutPrefix;
+   parseSessionUrl(makeUrl("s"), &scope, &urlPrefix, &urlWithoutPrefix);
+
+   EXPECT_FALSE(scope.empty());
+   EXPECT_EQ(scope.id(), kSession);
+   EXPECT_EQ(urlPrefix, std::string("/s/") + kUser + kProject + kSession + "/");
+   EXPECT_EQ(urlWithoutPrefix, "/workspaces/");
+}
+
+TEST(RSessionContextTests, ParseSessionUrlPrefixN)
+{
+   SessionScope scope;
+   std::string urlPrefix;
+   std::string urlWithoutPrefix;
+   parseSessionUrl(makeUrl("n"), &scope, &urlPrefix, &urlWithoutPrefix);
+
+   EXPECT_FALSE(scope.empty());
+   EXPECT_EQ(scope.id(), kSession);
+   EXPECT_EQ(urlPrefix, std::string("/n/") + kUser + kProject + kSession + "/");
+   EXPECT_EQ(urlWithoutPrefix, "/workspaces/");
+}
+
+TEST(RSessionContextTests, ParseSessionUrlUnknownPrefixDoesNotMatch)
+{
+   SessionScope scope;
+   std::string urlPrefix;
+   std::string urlWithoutPrefix;
+   // A prefix outside [snp] must not be treated as a session URL.
+   parseSessionUrl(makeUrl("x"), &scope, &urlPrefix, &urlWithoutPrefix);
+
+   EXPECT_TRUE(scope.empty());
+   EXPECT_TRUE(urlPrefix.empty());
+   EXPECT_EQ(urlWithoutPrefix, makeUrl("x"));
+}
+
+TEST(RSessionContextTests, ParseSessionUrlEnvVarsWithoutSessionSegment)
+{
+   // RStudio Server URLs carry no session segment, so the whole URL is the
+   // server URL.
+   std::string serverUrl;
+   std::string sessionUrl;
+   parseSessionUrlEnvVars("https://rstudio.example.com/", &serverUrl, &sessionUrl);
+
+   EXPECT_EQ(serverUrl, "https://rstudio.example.com/");
+   EXPECT_TRUE(sessionUrl.empty());
+}
+
+TEST(RSessionContextTests, ParseSessionUrlEnvVarsWithoutSessionSegmentUnderProxyPath)
+{
+   // Still no session segment when served under a reverse-proxy sub-path, so
+   // the sub-path stays on the server URL with nothing on the session side.
+   std::string serverUrl;
+   std::string sessionUrl;
+   parseSessionUrlEnvVars("https://rstudio.example.com/rstudio/", &serverUrl, &sessionUrl);
+
+   EXPECT_EQ(serverUrl, "https://rstudio.example.com/rstudio/");
+   EXPECT_TRUE(sessionUrl.empty());
+}
+
+} // namespace r_util
+} // namespace core
+} // namespace rstudio

--- a/src/cpp/server/url-ports/UrlPortsMain.cpp
+++ b/src/cpp/server/url-ports/UrlPortsMain.cpp
@@ -64,12 +64,7 @@ int main(int argc, char * const argv[])
 
       char* pServerPath = std::getenv("RS_SERVER_URL");
       std::string serverPath = pServerPath != NULL ? std::string(pServerPath) : std::string();
-      if (serverPath.back() == '/')
-      {
-         serverPath.pop_back();
-      }
-
-      std::cout << serverPath + sessionPath + "p/" + transformedPort + "/" << std::endl;
+      std::cout << buildProxiedUrl(serverPath, sessionPath, transformedPort) << std::endl;
    }
    return EXIT_SUCCESS;
 }

--- a/src/cpp/server/url-ports/UrlPortsMainTests.cpp
+++ b/src/cpp/server/url-ports/UrlPortsMainTests.cpp
@@ -122,3 +122,49 @@ TEST(UrlPortsMainTest, ProvidePortAndTokenLongOutput)
    EXPECT_EQ(getPort(), std::to_string(port));
    EXPECT_EQ(getPortTokenEnvVar(), portToken);
 }
+
+TEST(UrlPortsMainTest, BuildProxiedUrlAtDomainRoot)
+{
+   EXPECT_EQ(buildProxiedUrl("https://host/", "/s/abc123/", "58fab3e4"),
+             "https://host/s/abc123/p/58fab3e4/");
+}
+
+TEST(UrlPortsMainTest, BuildProxiedUrlUnderProxySubPath)
+{
+   EXPECT_EQ(buildProxiedUrl("https://host/rstudio/", "/s/abc123/", "58fab3e4"),
+             "https://host/rstudio/s/abc123/p/58fab3e4/");
+}
+
+TEST(UrlPortsMainTest, BuildProxiedUrlWithoutSessionUrl)
+{
+   // RStudio Server open source has no session segment, so the server url must
+   // keep the slash separating the authority from the path.
+   EXPECT_EQ(buildProxiedUrl("http://localhost:8787/", "", "58fab3e4"),
+             "http://localhost:8787/p/58fab3e4/");
+}
+
+TEST(UrlPortsMainTest, BuildProxiedUrlWithoutServerUrl)
+{
+   // An unset RS_SERVER_URL reaches this as an empty string.
+   EXPECT_EQ(buildProxiedUrl("", "/s/abc123/", "58fab3e4"),
+             "/s/abc123/p/58fab3e4/");
+}
+
+TEST(UrlPortsMainTest, BuildProxiedUrlServerUrlWithoutTrailingSlash)
+{
+   EXPECT_EQ(buildProxiedUrl("https://host", "/s/abc123/", "58fab3e4"),
+             "https://host/s/abc123/p/58fab3e4/");
+}
+
+TEST(UrlPortsMainTest, BuildProxiedUrlWithNeitherUrl)
+{
+   // Both variables can be unset, for instance before the session's first
+   // client_init. The port path must still be rooted.
+   EXPECT_EQ(buildProxiedUrl("", "", "58fab3e4"), "/p/58fab3e4/");
+}
+
+TEST(UrlPortsMainTest, BuildProxiedUrlServerUrlWithoutTrailingSlashOrSessionUrl)
+{
+   EXPECT_EQ(buildProxiedUrl("https://host", "", "58fab3e4"),
+             "https://host/p/58fab3e4/");
+}

--- a/src/cpp/server/url-ports/include/url-ports/UrlPorts.hpp
+++ b/src/cpp/server/url-ports/include/url-ports/UrlPorts.hpp
@@ -24,6 +24,34 @@
 using namespace rstudio;
 using namespace rstudio::core;
 
+/**
+ * Join RS_SERVER_URL and RS_SESSION_URL with an obfuscated port to form the
+ * proxied URL printed by the -l option.
+ *
+ * @param serverUrl Value of RS_SERVER_URL, which may be empty or unset
+ * @param sessionUrl Value of RS_SESSION_URL, empty when the URL has no session segment
+ * @param transformedPort The obfuscated port
+ */
+std::string buildProxiedUrl(const std::string& serverUrl,
+                            const std::string& sessionUrl,
+                            const std::string& transformedPort)
+{
+   std::string prefix = serverUrl;
+   if (!prefix.empty() && prefix.back() == '/' &&
+       !sessionUrl.empty() && sessionUrl.front() == '/')
+   {
+      prefix.pop_back();
+   }
+   prefix += sessionUrl;
+
+   // Keep the port path rooted. Neither variable is guaranteed to be set, and
+   // a relative result would resolve against the caller's own path.
+   if (prefix.empty() || prefix.back() != '/')
+      prefix += '/';
+
+   return prefix + "p/" + transformedPort + "/";
+}
+
 bool parseArguments(const int argc, char * const argv[], bool& longOutput, int* pPort, std::string* pPortToken)
 {
    if (argc < 2)

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -129,13 +129,9 @@ Error makePortTokenCookie(boost::shared_ptr<HttpConnection> ptrConnection,
    // needed for subprocesses to use the rserver-url binary with the -l option.
    core::system::setenv(kPortTokenEnvVar, persistentState().portToken());
 
-   std::string sessionUrl;
    std::string serverUrl;
-   r_util::parseSessionUrl(baseURL, nullptr, &sessionUrl, nullptr, &serverUrl);
-   if (sessionUrl == "" && serverUrl == "") {
-      // This is the case with RStudio Server, while Workbench has non-empty values
-      serverUrl = baseURL;
-   }
+   std::string sessionUrl;
+   r_util::parseSessionUrlEnvVars(baseURL, &serverUrl, &sessionUrl);
    core::system::setenv(kServerUrlEnvVar, serverUrl);
    core::system::setenv(kSessionUrlEnvVar, sessionUrl);
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/12127
OS companion to https://github.com/rstudio/rstudio-pro/pull/12457

`makePortTokenCookie()` took `RS_SERVER_URL` from `parseSessionUrl()`'s `pBaseUrl` out-param,
which holds only a URL's path component. For a server at the domain root that path is empty, so
the variable was set to the empty string. This derives both `RS_SERVER_URL` and `RS_SESSION_URL`
from the base URL so the pair is always populated and always reconstructs the session URL.

The blank value is only observable in Posit Workbench, where session URLs carry a
`/s/<scope>/` segment. It is tracked internally as rstudio-pro#12127. This PR is the
open-source half of that fix, landing here first so it can be pulled into rstudio-pro rather
than diverging in shared files.

The second commit fixes a related `rserver-url -l` defect that **is** observable in RStudio
Server open source.

### Approach

- Adds `parseSessionUrlEnvVars()` to `core/r_util`, which splits the URL at the session segment:
  everything preceding it becomes `RS_SERVER_URL`, and the segment itself becomes
  `RS_SESSION_URL`.
- A reverse-proxy sub-path stays on `RS_SERVER_URL` (`https://host/rstudio/`) rather than moving
  to the session side, so **`RS_SESSION_URL` keeps exactly the value it has today**. An earlier
  revision of this PR moved it, which broke `SessionChat.cpp`'s `buildWebSocketUrl()`: that
  function adds the sub-path itself from the root-path option, so the sub-path was applied twice,
  giving `/rstudio/rstudio/s/<scope>/p/<token>/ai-chat`. That 404s, and because the port-token
  cookie is scoped to the session path the browser also omits it, so the chat backend connection
  fails. Thanks to @gtritchie for catching it. This is the same failure class as #17249.
- **The env var derivation is a no-op for RStudio Server open source.** Its URLs carry no
  `/s/<scope>/` segment, so `parseSessionUrl()` takes its no-match path and the new function
  returns the whole URL as the server URL with an empty session URL, which is bit-for-bit what
  the `sessionUrl == "" && serverUrl == ""` fallback it replaces produced.
- **The `rserver-url -l` fix is not a no-op here.** It dropped `RS_SERVER_URL`'s trailing slash
  unconditionally, relying on `RS_SESSION_URL` to supply a leading one. Since `RS_SESSION_URL` is
  empty exactly when there is no session segment, open source printed
  `http://localhost:8787p/8050/`, with the separator between authority and path missing. It also
  read the first character of `RS_SERVER_URL` with no emptiness check, which was undefined
  whenever the variable was unset. Both are pre-existing and both are fixed.
- The join is extracted next to `parseArguments()` in `url-ports/UrlPorts.hpp` so it can be
  tested, following that function's existing precedent.

### Automated Tests

In this repo, `UrlPortsMainTests.cpp` gains five cases for the extracted join: domain root, proxy
sub-path, no session segment (the open-source shape, asserting the separator survives), unset
server URL, a server URL with no trailing slash, and neither variable set. `rserver-url-tests` runs 11/11 green.

`RSessionContextTests.cpp` is added here with the coverage reachable in this repo: the `/s` and
`/n` prefixes, an unknown prefix, and the two no-session-segment shapes that pin the no-op claim
above. It is byte-identical to the copy in rstudio-pro, so `pull-upstream` has nothing to
reconcile at that path.

Workbench-only shapes (domain-root and sub-path session scoping, trailing routes and query
strings, the doubled-segment regression guard, port preservation, and a host name containing the
proxy sub-path text) are tested in rstudio-pro's `RSessionContextOverlayTests.cpp`, along with the
`/p` preview prefix, which cannot pass here because this repo's regex is `/([sn])/`.

Results, run against an identical copy of this code in the rstudio-pro checkout:
`rstudio-core-tests` 636 ran / 0 failed, `rserver-tests` 1635 ran / 0 failed, `rserver-url-tests`
9 ran / 0 failed, `rstudio-server-core-tests` 62 ran / 0 failed. The six files here are
byte-identical to the pro versions apart from three pre-existing divergences unrelated to this
change (the Positron path defines, the `/([snp])/` regex, and a `handleClientInit` block).

I have not built this branch in this repo; please treat CI here as the first build signal for it.

### QA Notes

- **`rserver-url -l` was exercised directly** against the built binary, with these observed
  outputs (`RS_PORT_TOKEN=91c63048efb0`, port 8050):

  | `RS_SERVER_URL` | `RS_SESSION_URL` | output |
  |---|---|---|
  | `http://localhost:8787/` | `/s/abc1234567/` | `http://localhost:8787/s/abc1234567/p/64966e32/` |
  | `https://host/rstudio/` | `/s/abc1234567/` | `https://host/rstudio/s/abc1234567/p/64966e32/` |
  | `http://localhost:8787/` | (empty) | `http://localhost:8787/p/64966e32/` |
  | (unset) | `/s/abc1234567/` | `/s/abc1234567/p/64966e32/` |

  The third row is the open-source case that previously printed
  `http://localhost:8787p/64966e32/`; the fourth was previously undefined. Short mode (no `-l`,
  which is how the `pwb-jupyterlab` extension invokes the tool) reads neither variable and is
  unchanged.
- **The Workbench acceptance criterion was verified by hand** on a domain-root deployment:
  `Sys.getenv("RS_SERVER_URL")` returns the same value in an RStudio Pro session and a Positron
  session on the same instance. That is also asserted by an automated Workbench spec, which now
  passes.
- **Verified on a live reverse-proxy sub-path deployment (2026-08-28)**, Workbench behind Apache
  at `/rstudio` with `www-root-path=/rstudio`:

  ```
  RS_SERVER_URL=https://<host>/rstudio/
  RS_SESSION_URL=/s/5d24acfc78a315054a768/
  rserver-url -l 8060 -> https://<host>/rstudio/s/5d24acfc78a315054a768/p/88c98843/
  ```

  One sub-path, one session segment, and no sub-path inside `RS_SESSION_URL`. Fetching that
  `rserver-url -l` output returned `200`, while the doubled-prefix variant returned `500`. A
  Positron session on the same instance reported `https://<host>/` plus
  `/rstudio/s/<its own scope>/`, so both session types agree on the deployment root while
  splitting it differently, which is the divergence noted above.
- **Known gap: the Assistant chat WebSocket has no end-to-end coverage under a sub-path
  deployment.** `chat-websocket-url.test.ts` asserts the root-path prefix only inside
  `if (pathSegments.length > 0 && !['s','p'].includes(pathSegments[0]))`, which never fires on
  Desktop or a root-level server, and it uses `toContain`, which a doubled prefix would satisfy
  anyway. Since this PR's first revision broke exactly that path, it is worth knowing that
  nothing here would have caught it. Related: #17520 excludes the Server engine from the
  Assistant suite. The live sub-path verification above could not cover this either, because
  Assistant was not installed on that environment.

### Documentation

No documentation change needed for the env var derivation; no user-facing behavior changes in
RStudio Server open source for that half.

No `NEWS.md` entry yet for the `rserver-url -l` fix. Every entry in that file references an issue
number and there is no open-source issue for this defect, since it was found in review here. Happy
to file one and add the entry if you would like it in the release notes.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests
