### PR TITLE
Tolerate Posit Assistant 1.1.x chat UI changes in e2e tests

### DIFF
--- a/.claude/skills/rstudio-create-playwright-tests/chat-pane.md
+++ b/.claude/skills/rstudio-create-playwright-tests/chat-pane.md
@@ -60,5 +60,5 @@ CDP context.
   labels with a role-based regex instead of exact text or XPath:
 
   ```typescript
-  frame.getByRole('menuitem', { name: /Configure (LLM providers|Posit AI)/i });
+  frame.getByRole('menuitem', { name: /Configure (AI providers|LLM providers|Posit AI)/i });
   ```

--- a/e2e/rstudio/actions/chat_pane.actions.ts
+++ b/e2e/rstudio/actions/chat_pane.actions.ts
@@ -606,30 +606,43 @@ export class ChatPaneActions {
   }
 
   /**
-   * Close the conversation history panel, converging on "closed" rather than
-   * deciding once.
+   * Close the conversation history panel.
    *
    * Recent assistant builds dismiss the panel themselves once a conversation
-   * is selected; older ones only close it via the toolbar toggle. A lone state
-   * check races that auto-close, and a toggle click landing while it is in
-   * flight re-opens the panel -- which is how this failed against the 1.1.7
-   * pre-release. Re-checking after each click settles on either build: the
-   * panel is already gone, the click closes it, or the next pass clears a
-   * re-open.
+   * is selected; older ones only close it via the toolbar toggle. Both states
+   * have to be tolerated, and the transition between them is what makes this
+   * delicate: a toggle click that lands while an auto-close is still finishing
+   * re-opens the panel, which is how this failed against the 1.1.7
+   * pre-release.
+   *
+   * So every decision here waits for the panel to settle rather than sampling
+   * it instantaneously -- an immediate read can catch a fade-out frame and
+   * either provoke that re-opening click or report a close that is about to be
+   * undone. At most two clicks are issued, and the closing assertion is what
+   * fails the test if the panel is still up.
    */
   async closeConversationHistory(): Promise<void> {
     const panel = this.chatPane.conversationHistoryPanel;
-    await expect
-      .poll(
-        async () => {
-          if (await panel.isHidden()) {
-            return true;
-          }
-          await this.chatPane.historyBtn.click({ timeout: 10000 });
-          return panel.isHidden();
-        },
-        { timeout: 15000, intervals: [250, 500, 1000] },
-      )
-      .toBe(true);
+
+    // Resolves true once the panel is gone, false if it is still up after the
+    // settle window. A panel that never leaves is the normal case on builds
+    // that do not auto-close, so that timeout is an expected outcome mapped to
+    // a value, not an error to propagate.
+    const settlesHidden = (): Promise<boolean> =>
+      panel.waitFor({ state: 'hidden', timeout: 1000 }).then(
+        () => true,
+        () => false,
+      );
+
+    if (!(await settlesHidden())) {
+      await this.chatPane.historyBtn.click({ timeout: 10000 });
+      if (!(await settlesHidden())) {
+        // The click landed as an auto-close was finishing and re-opened the
+        // panel; it is stable now, so one more toggle closes it for good.
+        await this.chatPane.historyBtn.click({ timeout: 10000 });
+      }
+    }
+
+    await expect(panel).toBeHidden({ timeout: 10000 });
   }
 }

--- a/e2e/rstudio/actions/chat_pane.actions.ts
+++ b/e2e/rstudio/actions/chat_pane.actions.ts
@@ -590,12 +590,12 @@ export class ChatPaneActions {
   /**
    * Open the conversation history panel, or do nothing if it is already open.
    *
-   * The history toolbar button is a strict toggle and the panel is removed
-   * from the DOM when closed, so a state-blind "click and expect the list"
-   * helper inverts the panel state whenever its assumption about the current
-   * state is wrong -- and its post-click assertion could only pass on a
-   * closing toggle by winning a race against the panel's fade-out. Checking
-   * the panel's actual state first makes these helpers idempotent.
+   * The panel is removed from the DOM when closed, so its presence is the
+   * open/closed signal. A state-blind "click and expect the list" helper
+   * inverts the panel state whenever its assumption about the current state is
+   * wrong -- and its post-click assertion could only pass on a closing toggle
+   * by winning a race against the panel's fade-out. Checking the panel's
+   * actual state first makes this idempotent.
    */
   async openConversationHistory(): Promise<void> {
     if (await this.chatPane.conversationHistoryPanel.isVisible()) {
@@ -606,14 +606,30 @@ export class ChatPaneActions {
   }
 
   /**
-   * Close the conversation history panel, or do nothing if it is already
-   * closed. See openConversationHistory for why this checks state first.
+   * Close the conversation history panel, converging on "closed" rather than
+   * deciding once.
+   *
+   * Recent assistant builds dismiss the panel themselves once a conversation
+   * is selected; older ones only close it via the toolbar toggle. A lone state
+   * check races that auto-close, and a toggle click landing while it is in
+   * flight re-opens the panel -- which is how this failed against the 1.1.7
+   * pre-release. Re-checking after each click settles on either build: the
+   * panel is already gone, the click closes it, or the next pass clears a
+   * re-open.
    */
   async closeConversationHistory(): Promise<void> {
-    if (!(await this.chatPane.conversationHistoryPanel.isVisible())) {
-      return;
-    }
-    await this.chatPane.historyBtn.click({ timeout: 10000 });
-    await expect(this.chatPane.conversationHistoryPanel).toBeHidden({ timeout: 10000 });
+    const panel = this.chatPane.conversationHistoryPanel;
+    await expect
+      .poll(
+        async () => {
+          if (await panel.isHidden()) {
+            return true;
+          }
+          await this.chatPane.historyBtn.click({ timeout: 10000 });
+          return panel.isHidden();
+        },
+        { timeout: 15000, intervals: [250, 500, 1000] },
+      )
+      .toBe(true);
   }
 }

--- a/e2e/rstudio/actions/chat_pane.actions.ts
+++ b/e2e/rstudio/actions/chat_pane.actions.ts
@@ -17,6 +17,18 @@ const TURN_IDLE_SAMPLE_INTERVAL_MS = 500;
 // budget has already been spent waiting for the response to appear.
 const MIN_TURN_SETTLE_MS = 30000;
 
+// How long to let an in-flight close of the conversation history panel finish
+// before treating the panel as one that has to be toggled shut.
+const PANEL_AUTO_CLOSE_TIMEOUT_MS = 1000;
+
+// The panel can read hidden for a frame while a re-open is still in flight --
+// a toggle click landing as an auto-close finishes produces exactly that. So
+// closeConversationHistory requires it to stay hidden across
+// PANEL_CLOSED_SAMPLES samples, spanning
+// (PANEL_CLOSED_SAMPLES - 1) * PANEL_CLOSED_SAMPLE_INTERVAL_MS of observation.
+const PANEL_CLOSED_SAMPLES = 3;
+const PANEL_CLOSED_SAMPLE_INTERVAL_MS = 200;
+
 export class ChatPaneActions {
   readonly page: Page;
   readonly chatPane: ChatPane;
@@ -615,28 +627,44 @@ export class ChatPaneActions {
    * re-opens the panel, which is how this failed against the 1.1.7
    * pre-release.
    *
-   * So every decision here waits for the panel to settle rather than sampling
-   * it instantaneously -- an immediate read can catch a fade-out frame and
-   * either provoke that re-opening click or report a close that is about to be
+   * So every decision here waits for the panel to settle and then holds it to
+   * that, the same way isTurnIdle treats the stop button: a single hidden
+   * observation can be a fade-out frame with a re-open queued behind it, which
+   * would either provoke a re-opening click or report a close about to be
    * undone. At most two clicks are issued, and the closing assertion is what
    * fails the test if the panel is still up.
    */
   async closeConversationHistory(): Promise<void> {
     const panel = this.chatPane.conversationHistoryPanel;
 
-    // Resolves true once the panel is gone, false if it is still up after the
-    // settle window. A panel that never leaves is the normal case on builds
-    // that do not auto-close, so that timeout is an expected outcome mapped to
-    // a value, not an error to propagate.
-    const settlesHidden = (): Promise<boolean> =>
-      panel.waitFor({ state: 'hidden', timeout: 1000 }).then(
-        () => true,
-        () => false,
-      );
+    // True once the panel is gone and stays gone. False if it is still up
+    // after the settle window -- the normal case on builds that never
+    // auto-close, so that timeout is an expected outcome mapped to a value
+    // rather than an error to propagate -- or if it comes back while being
+    // watched.
+    const staysHidden = async (): Promise<boolean> => {
+      const hidden = await panel
+        .waitFor({ state: 'hidden', timeout: PANEL_AUTO_CLOSE_TIMEOUT_MS })
+        .then(
+          () => true,
+          () => false,
+        );
+      if (!hidden) {
+        return false;
+      }
 
-    if (!(await settlesHidden())) {
+      for (let sample = 1; sample < PANEL_CLOSED_SAMPLES; sample++) {
+        await sleep(PANEL_CLOSED_SAMPLE_INTERVAL_MS);
+        if (await panel.isVisible()) {
+          return false;
+        }
+      }
+      return true;
+    };
+
+    if (!(await staysHidden())) {
       await this.chatPane.historyBtn.click({ timeout: 10000 });
-      if (!(await settlesHidden())) {
+      if (!(await staysHidden())) {
         // The click landed as an auto-close was finishing and re-opened the
         // panel; it is stable now, so one more toggle closes it for good.
         await this.chatPane.historyBtn.click({ timeout: 10000 });

--- a/e2e/rstudio/pages/chat_pane.page.ts
+++ b/e2e/rstudio/pages/chat_pane.page.ts
@@ -72,11 +72,12 @@ export class ChatPane extends FramePageObject {
     this.trustWorkspaceBtn = this.frame.locator("button:has-text('Trust this workspace')");
     this.moreBtn = this.frame.getByRole('button', { name: 'More' });
     this.settingsMenu = this.frame.locator("[data-slot='dropdown-menu-content']");
-    // The provider-settings menu item was relabeled "Configure LLM providers"
-    // (was "Configure Posit AI"). Match either so the test passes against both
-    // the current and older assistant builds we exercise during rollout.
+    // The provider-settings menu item has been relabeled twice: "Configure
+    // Posit AI" -> "Configure LLM providers" -> "Configure AI providers".
+    // Match any of them so the test passes against both the released assistant
+    // and the pre-release builds the release gate exercises.
     this.configurePositAiItem = this.frame.getByRole('menuitem', {
-      name: /Configure (LLM providers|Posit AI)/i,
+      name: /Configure (AI providers|LLM providers|Posit AI)/i,
     });
     this.aboutItem = this.frame.locator("xpath=//span[contains(text(), 'About')] | //div[contains(text(), 'About')] | //*[@role='menuitem'][contains(., 'About')]");
     this.newConversationBtn = this.frame.getByRole('button', { name: 'New conversation' });


### PR DESCRIPTION
The Posit Assistant release gate (`os-test-e2e-rstudio-posit-assistant.yml`)
runs the `@ai` suite against the pre-release manifest before a build is
promoted to GA. Two tests fail there on 1.1.6 and 1.1.7 while passing against
GA 1.1.0, so the gate has been reporting a stale signal for two cycles.

Both failures are assistant-side UI changes, not RStudio regressions. The
scheduled run earlier the same day
([32705859276](https://github.com/rstudio/rstudio/actions/runs/32705859276),
GA manifest) installed the same RStudio daily, `RStudio-2026.09.0-daily-109`,
and both tests passed; only the assistant version differs.

## settings-button

The provider-settings menu item was relabeled a third time, to "Configure AI
providers". The locator already matches the two earlier names, so this adds
the new one to that alternation.

The test stops at the first assertion, so nothing past it -- the About dialog,
Copy to Clipboard, Close -- has run against 1.1.7 yet. That part may need
follow-up once the gate gets far enough to exercise it.

## conversation-history

Recent assistant builds close the history panel themselves when a conversation
is selected; older ones only close it via the toolbar toggle.
`closeConversationHistory` decided once, from an instantaneous `isHidden()`
reading, which is wrong in both directions: it could click into an auto-close
that was still finishing and re-open the panel, or accept a fade-out frame
with a re-open queued behind it.

It now waits for the panel to reach the hidden state and holds it there across
`PANEL_CLOSED_SAMPLES` samples before acting on or returning from it, the same
way `isTurnIdle` handles the stop button flickering off between streaming
phases. Toggling is capped at two clicks and the closing assertion fails the
test if the panel survives. This is correct on builds that auto-close and on
those that only respond to the toggle.

## Verification

`npm run typecheck` passes. The suite itself cannot be run outside CI without
assistant credentials, and the auto-close behavior exists only in the
pre-release, so confirmation needs a gate run with
`posit_assistant_test_manifest: true`.

No NEWS.md entry: test-only change with no user-facing effect.