### PR TITLE
handle failed handler copies in AsyncClient safely

### DIFF
--- a/src/cpp/core/http/AsyncClientContentLengthTests.cpp
+++ b/src/cpp/core/http/AsyncClientContentLengthTests.cpp
@@ -2272,6 +2272,278 @@ TEST(AsyncClientContentLength, ConnectHandlerRegisteredBeforeExecuteStillReports
    EXPECT_FALSE(downstreamClosed);
 }
 
+// --- rstudio#18625: a failed handler snapshot must take an error path ---
+//
+// AsyncClient copies its handler members out from under socketMutex_ before
+// invoking them (see snapshotHandlers()). Those copies are fallible: copying a
+// boost::function whose target is too large for its small-object buffer
+// allocates, and allocation failure under the memory pressure streaming exists
+// to relieve is the realistic way one fails. Every snapshot site would
+// otherwise read the resulting empty local as "no handler installed" and act on
+// it, so each of the three below is driven through that failure.
+
+namespace {
+
+// A callback target whose copy constructor throws once armed -- the fault
+// injection those scenarios need, delivered deterministically rather than by
+// trying to exhaust memory. std::bad_alloc specifically, since that is what a
+// real boost::function copy raises. One-shot: the point is that the client
+// recovers, not that it survives an endless fault.
+//
+// The shared_ptr and boost::function members also keep this comfortably too
+// large (and too non-trivial) for boost::function's small-object buffer, so the
+// snapshot really does clone it on the heap rather than storing it inline.
+template <typename F>
+class ThrowOnCopy
+{
+public:
+   ThrowOnCopy(const boost::shared_ptr<bool>& pArmed, const F& callback)
+      : pArmed_(pArmed), callback_(callback)
+   {
+   }
+
+   ThrowOnCopy(const ThrowOnCopy& other)
+      : pArmed_(other.pArmed_), callback_(other.callback_)
+   {
+      if (!*pArmed_)
+         return;
+
+      *pArmed_ = false;
+      throw std::bad_alloc();
+   }
+
+   template <typename... Args>
+   typename F::result_type operator()(Args&&... args) const
+   {
+      return callback_(std::forward<Args>(args)...);
+   }
+
+private:
+   boost::shared_ptr<bool> pArmed_;
+   F callback_;
+};
+
+} // anonymous namespace
+
+// deliverChunks(): the snapshot fails between two body pieces. The empty local
+// is indistinguishable from an absent fixed buffer handler, and acting on it
+// appends the piece to response_ -- which nothing in streaming mode ever reads
+// -- and then goes on to tell the consumer the body is complete, one piece
+// short. The request must fail instead.
+TEST(AsyncClientContentLength, FixedBufferHandlerSnapshotFailureMidBodyFailsRatherThanDroppingPiece)
+{
+   const std::string body = "{\"line\":1}\n{\"line\":2}\n{\"line\":3}\n{\"line\":4}\n";
+
+   LocalServer server(ResponseMode::ContentLengthSplit, /*closeAfterResponse=*/true, body);
+   server.start();
+
+   boost::asio::io_context ioc;
+   boost::shared_ptr<TcpIpAsyncClient> pClient =
+      boost::make_shared<TcpIpAsyncClient>(
+         ioc, "127.0.0.1", std::to_string(server.port()),
+         boost::posix_time::seconds(5));
+
+   pClient->setStreamNonChunkedResponses(true);
+   pClient->setFixedBufferHandlerSupportsPause(true);
+
+   http::Request& request = pClient->request();
+   request.setMethod("GET");
+   request.setUri("/file");
+   request.setHeader("Connection", "close");
+
+   std::vector<std::string> pieces;
+   bool sawFinalSignal = false;
+   bool gotResponse = false;
+   bool gotError = false;
+
+   boost::shared_ptr<boost::asio::system_timer> pTimer =
+      boost::make_shared<boost::asio::system_timer>(ioc, std::chrono::seconds(4));
+   pTimer->async_wait([&](const boost::system::error_code& ec) {
+      if (ec == boost::asio::error::operation_aborted)
+         return;
+      pClient->close();
+   });
+
+   boost::shared_ptr<bool> pArmed = boost::make_shared<bool>(false);
+   FixedBufferHandler fixedBufferHandler =
+      ThrowOnCopy<boost::function<bool(const http::Response&, const std::string&)>>(
+         pArmed,
+         [&](const http::Response&, const std::string& piece) -> bool
+         {
+            if (piece.empty())
+            {
+               sawFinalSignal = true;
+               return true;
+            }
+
+            pieces.push_back(piece);
+
+            // arm from inside the delivery of the first piece, so the failure
+            // lands on the snapshot taken for the piece after this one -- the
+            // mid-body case, with a consumer already streaming
+            *pArmed = true;
+            return true;
+         });
+
+   pClient->execute(
+      [&](const http::Response& response) { gotResponse = true; },
+      [&](const core::Error&) { gotError = true; pTimer->cancel(); },
+      fixedBufferHandler);
+
+   ioc.run();
+   server.stop();
+
+   // the failure is reported rather than logged and stepped over
+   EXPECT_TRUE(gotError);
+
+   // and the consumer is never told the body finished, which -- having received
+   // only the first piece -- would have been a lie
+   EXPECT_FALSE(sawFinalSignal);
+   EXPECT_FALSE(gotResponse);
+   ASSERT_EQ(pieces.size(), 1u);
+   EXPECT_LT(pieces[0].size(), body.size());
+}
+
+// closeAndRespond(): the snapshot fails on the last word of the request, where
+// an empty local costs the most. The fixed buffer handler copy is the one that
+// fails here, so the surviving response handler would be invoked instead --
+// handing a whole-body callback a response_ that streaming never populated,
+// i.e. reporting a successful, empty response for a body that was in fact
+// delivered in full.
+TEST(AsyncClientContentLength, ResponseHandlerSnapshotFailureAtCompletionFailsRatherThanRespondingEmpty)
+{
+   const std::string body = "{\"name\":\"jsonlite\"}\n";
+
+   LocalServer server(ResponseMode::ContentLength, /*closeAfterResponse=*/true, body);
+   server.start();
+
+   boost::asio::io_context ioc;
+   boost::shared_ptr<TcpIpAsyncClient> pClient =
+      boost::make_shared<TcpIpAsyncClient>(
+         ioc, "127.0.0.1", std::to_string(server.port()),
+         boost::posix_time::seconds(5));
+
+   pClient->setStreamNonChunkedResponses(true);
+   pClient->setFixedBufferHandlerSupportsPause(true);
+
+   http::Request& request = pClient->request();
+   request.setMethod("GET");
+   request.setUri("/file");
+   request.setHeader("Connection", "close");
+
+   std::vector<std::string> pieces;
+   bool sawFinalSignal = false;
+   bool gotResponse = false;
+   std::string responseBody;
+   bool gotError = false;
+
+   boost::shared_ptr<boost::asio::system_timer> pTimer =
+      boost::make_shared<boost::asio::system_timer>(ioc, std::chrono::seconds(4));
+   pTimer->async_wait([&](const boost::system::error_code& ec) {
+      if (ec == boost::asio::error::operation_aborted)
+         return;
+      pClient->close();
+   });
+
+   boost::shared_ptr<bool> pArmed = boost::make_shared<bool>(false);
+   FixedBufferHandler fixedBufferHandler =
+      ThrowOnCopy<boost::function<bool(const http::Response&, const std::string&)>>(
+         pArmed,
+         [&](const http::Response&, const std::string& piece) -> bool
+         {
+            if (piece.empty())
+            {
+               sawFinalSignal = true;
+               return true;
+            }
+
+            pieces.push_back(piece);
+
+            // the whole body arrives in this one piece, so the next snapshot
+            // taken is closeAndRespond()'s
+            *pArmed = true;
+            return true;
+         });
+
+   pClient->execute(
+      [&](const http::Response& response)
+      {
+         gotResponse = true;
+         responseBody = response.body();
+         pTimer->cancel();
+      },
+      [&](const core::Error&) { gotError = true; pTimer->cancel(); },
+      fixedBufferHandler);
+
+   ioc.run();
+   server.stop();
+
+   EXPECT_TRUE(gotError);
+
+   // no completion of any kind was invented from the failed copies
+   EXPECT_FALSE(gotResponse);
+   EXPECT_TRUE(responseBody.empty());
+   EXPECT_FALSE(sawFinalSignal);
+
+   // the body itself did stream through before the failure -- what went wrong
+   // was only the copy taken to announce that it had finished
+   ASSERT_EQ(pieces.size(), 1u);
+   EXPECT_EQ(pieces[0], body);
+}
+
+// handleWrite(): the connect notification's snapshot fails. A caller gated on
+// that notification (FormProxy) buffers its upload until it hears one way or
+// the other, so dropping it hangs the upload; the client must report the
+// still-undeliverable notification through the downstream-closed handler, which
+// is what requestWritten_ staying false on this path arranges.
+TEST(AsyncClientContentLength, ConnectHandlerSnapshotFailureReportsDownstreamClosedRatherThanDropping)
+{
+   LocalServer server(ResponseMode::ContentLength, /*closeAfterResponse=*/true,
+                      "{\"name\":\"jsonlite\"}\n");
+   server.start();
+
+   boost::asio::io_context ioc;
+   boost::shared_ptr<TcpIpAsyncClient> pClient =
+      boost::make_shared<TcpIpAsyncClient>(
+         ioc, "127.0.0.1", std::to_string(server.port()),
+         boost::posix_time::seconds(5));
+
+   http::Request& request = pClient->request();
+   request.setMethod("GET");
+   request.setUri("/file");
+   request.setHeader("Connection", "close");
+
+   bool connected = false;
+   bool downstreamClosed = false;
+   bool gotResponse = false;
+   bool gotError = false;
+
+   boost::shared_ptr<bool> pArmed = boost::make_shared<bool>(false);
+   pClient->setConnectHandler(
+      ThrowOnCopy<boost::function<void()>>(pArmed, [&]() { connected = true; }),
+      [&]() { downstreamClosed = true; });
+
+   pClient->execute([&](const http::Response&) { gotResponse = true; },
+                    [&](const core::Error&) { gotError = true; });
+
+   // armed only now: registering the handler above copies it twice (into the
+   // argument, then into connectHandler_), and the copy under test is the one
+   // handleWrite() takes to invoke it
+   *pArmed = true;
+
+   ioc.run();
+   server.stop();
+
+   EXPECT_FALSE(connected);
+   EXPECT_TRUE(downstreamClosed);
+   EXPECT_TRUE(gotError);
+
+   // the request is failed rather than read to completion behind the caller's
+   // back: whoever registered the connect handler is waiting to write to this
+   // connection, so its response is not theirs to consume
+   EXPECT_FALSE(gotResponse);
+}
+
 } // namespace tests
 } // namespace http
 } // namespace core

--- a/src/cpp/core/http/AsyncClientContentLengthTests.cpp
+++ b/src/cpp/core/http/AsyncClientContentLengthTests.cpp
@@ -2544,6 +2544,192 @@ TEST(AsyncClientContentLength, ConnectHandlerSnapshotFailureReportsDownstreamClo
    EXPECT_FALSE(gotResponse);
 }
 
+// --- rstudio#18625: a failed handler install must leave the client unchanged ---
+//
+// The other half of the same exception-safety problem: the sites that *store*
+// handlers copied them under socketMutex_ interleaved with the assignments, so
+// a copy that threw left the client half-configured -- and LOCK_MUTEX stepped
+// over it, leaving the caller to find out later, or never. Every copy now
+// happens before the lock, with only swaps under it, so either the whole
+// install lands or nothing does and the exception reaches the caller.
+
+// execute(): the response handler copies, the error handler does not. The
+// request used to be set in motion anyway, behind a client whose error handler
+// had never been installed -- an exchange that can complete with nobody left to
+// notify.
+//
+// Deliberately aimed at a port nobody is listening on rather than at a
+// LocalServer: what is under test is that nothing is set in motion at all, and
+// LocalServer's accept loop blocks until a connection arrives, so a regression
+// here would hang its teardown rather than fail.
+TEST(AsyncClientContentLength, ExecuteHandlerInstallFailureLeavesNothingInMotion)
+{
+   // bind and immediately release a port so connecting to it is refused
+   unsigned short deadPort = 0;
+   {
+      boost::asio::io_context probeIoc;
+      tcp::acceptor probe(probeIoc, tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0));
+      deadPort = probe.local_endpoint().port();
+   }
+
+   boost::asio::io_context ioc;
+   boost::shared_ptr<TcpIpAsyncClient> pClient =
+      boost::make_shared<TcpIpAsyncClient>(
+         ioc, "127.0.0.1", std::to_string(deadPort),
+         boost::posix_time::seconds(5));
+
+   http::Request& request = pClient->request();
+   request.setMethod("GET");
+   request.setUri("/file");
+
+   // the connect pair is what reports whether the request pipeline ever ran:
+   // a client that starts and then fails a connection reports the settle
+   // through the downstream-closed half (see close())
+   bool connected = false;
+   bool downstreamClosed = false;
+   pClient->setConnectHandler([&]() { connected = true; },
+                              [&]() { downstreamClosed = true; });
+
+   boost::shared_ptr<bool> pArmed = boost::make_shared<bool>(false);
+   ResponseHandler doomedResponseHandler =
+      ThrowOnCopy<boost::function<void(const http::Response&)>>(
+         pArmed, [](const http::Response&) {});
+
+   // armed only now, so the copy that fails is the one execute() takes
+   *pArmed = true;
+   EXPECT_THROW(pClient->execute(doomedResponseHandler, [](const core::Error&) {}),
+                std::bad_alloc);
+
+   ioc.run();
+
+   // nothing was set in motion: no connection was attempted, so neither half of
+   // the connect pair has fired
+   EXPECT_FALSE(connected);
+   EXPECT_FALSE(downstreamClosed);
+
+   // and the client is not left wedged by the failure -- a fresh execute()
+   // installs cleanly and reports the refused connection through the error
+   // handler it was given. Before the fix the first call had already run the
+   // connection to failure and marked the client closed, so this second one
+   // was swallowed by handleError()'s closed_ check and reported nothing.
+   bool gotError = false;
+   ioc.restart();
+   pClient->execute([](const http::Response&) {},
+                    [&](const core::Error&) { gotError = true; });
+   ioc.run();
+
+   EXPECT_TRUE(gotError);
+}
+
+// setFixedBufferHandler(): the installed handler was detached before the
+// replacement was copied into its place, so a failed copy left no fixed buffer
+// handler at all -- which silently turns a streaming consumer into an
+// accumulate-into-response_ one, for a body nothing then reads.
+TEST(AsyncClientContentLength, FixedBufferHandlerInstallFailureKeepsTheInstalledHandler)
+{
+   const std::string body = "{\"line\":1}\n{\"line\":2}\n";
+
+   LocalServer server(ResponseMode::ContentLength, /*closeAfterResponse=*/true, body);
+   server.start();
+
+   boost::asio::io_context ioc;
+   boost::shared_ptr<TcpIpAsyncClient> pClient =
+      boost::make_shared<TcpIpAsyncClient>(
+         ioc, "127.0.0.1", std::to_string(server.port()),
+         boost::posix_time::seconds(5));
+
+   pClient->setStreamNonChunkedResponses(true);
+   pClient->setFixedBufferHandlerSupportsPause(true);
+
+   http::Request& request = pClient->request();
+   request.setMethod("GET");
+   request.setUri("/file");
+   request.setHeader("Connection", "close");
+
+   // the wiring FixedBufferProxy::proxy() does: a streaming consumer installed
+   // through the setter rather than through execute()
+   std::vector<std::string> pieces;
+   bool sawFinalSignal = false;
+   pClient->setFixedBufferHandler(
+      [&](const http::Response&, const std::string& piece) -> bool
+      {
+         if (piece.empty())
+            sawFinalSignal = true;
+         else
+            pieces.push_back(piece);
+
+         return true;
+      });
+
+   boost::shared_ptr<bool> pArmed = boost::make_shared<bool>(false);
+   FixedBufferHandler doomedFixedBufferHandler =
+      ThrowOnCopy<boost::function<bool(const http::Response&, const std::string&)>>(
+         pArmed, [](const http::Response&, const std::string&) { return true; });
+
+   *pArmed = true;
+   EXPECT_THROW(pClient->setFixedBufferHandler(doomedFixedBufferHandler), std::bad_alloc);
+
+   bool gotResponse = false;
+   pClient->execute([&](const http::Response&) { gotResponse = true; },
+                    [](const core::Error&) {});
+
+   ioc.run();
+   server.stop();
+
+   // the consumer installed before the failed replacement is still the one
+   // streaming the body -- not displaced by a handler that never landed
+   EXPECT_TRUE(sawFinalSignal);
+   ASSERT_EQ(pieces.size(), 1u);
+   EXPECT_EQ(pieces[0], body);
+
+   // and the body did not fall back to being buffered for the whole-body handler
+   EXPECT_FALSE(gotResponse);
+}
+
+// setConnectHandler(): the two handlers are stored as a pair, and the second
+// copy is the one that fails here. Storing a connect notification while losing
+// the downstream-closed handler that reports its loss leaves a caller with no
+// way to be told either way -- the hang the pair exists to prevent.
+TEST(AsyncClientContentLength, ConnectHandlerInstallFailureKeepsTheInstalledPair)
+{
+   // never executed: what is under test is the registration itself, and a bare
+   // close() is enough to make the client report the pending notification
+   boost::asio::io_context ioc;
+   boost::shared_ptr<TcpIpAsyncClient> pClient =
+      boost::make_shared<TcpIpAsyncClient>(
+         ioc, "127.0.0.1", "1", boost::posix_time::seconds(5));
+
+   bool connectedA = false;
+   bool downstreamClosedA = false;
+   pClient->setConnectHandler([&]() { connectedA = true; },
+                              [&]() { downstreamClosedA = true; });
+
+   bool connectedB = false;
+   bool downstreamClosedB = false;
+   boost::shared_ptr<bool> pArmed = boost::make_shared<bool>(false);
+   ConnectHandler doomedDownstreamClosedHandler =
+      ThrowOnCopy<boost::function<void()>>(pArmed, [&]() { downstreamClosedB = true; });
+
+   // armed so the connect half of the pair copies and the downstream-closed
+   // half does not, which is what used to strand the pair half-replaced
+   *pArmed = true;
+   EXPECT_THROW(pClient->setConnectHandler([&]() { connectedB = true; },
+                                           doomedDownstreamClosedHandler),
+                std::bad_alloc);
+
+   // the registration that was already in place is intact, so the settle below
+   // still has somewhere to report to
+   pClient->close();
+   ioc.run();
+
+   EXPECT_TRUE(downstreamClosedA);
+   EXPECT_FALSE(connectedA);
+
+   // and nothing from the failed registration took effect
+   EXPECT_FALSE(connectedB);
+   EXPECT_FALSE(downstreamClosedB);
+}
+
 } // namespace tests
 } // namespace http
 } // namespace core

--- a/src/cpp/core/http/AsyncClientContentLengthTests.cpp
+++ b/src/cpp/core/http/AsyncClientContentLengthTests.cpp
@@ -2491,6 +2491,147 @@ TEST(AsyncClientContentLength, ResponseHandlerSnapshotFailureAtCompletionFailsRa
    EXPECT_EQ(pieces[0], body);
 }
 
+// A completion retry is necessarily post-close: closeAndRespond() closes the
+// socket before it sends the empty completion chunk, and a backpressured
+// consumer asks resumeChunkProcessing() to re-enter closeAndRespond() later.
+// A snapshot failure on that retry must bypass handleError()'s ordinary
+// "purposefully closed" early return and still release the handler cycle.
+TEST(AsyncClientContentLength, ResponseHandlerSnapshotFailureOnClosedCompletionRetryStillSettles)
+{
+   LocalServer server(ResponseMode::ContentLength, /*closeAfterResponse=*/false,
+                      "{\"name\":\"jsonlite\"}\n");
+   server.start();
+
+   boost::asio::io_context ioc;
+   boost::shared_ptr<TcpIpAsyncClient> pClient =
+      boost::make_shared<TcpIpAsyncClient>(
+         ioc, "127.0.0.1", std::to_string(server.port()),
+         boost::posix_time::seconds(5));
+
+   pClient->setStreamNonChunkedResponses(true);
+   pClient->setFixedBufferHandlerSupportsPause(true);
+
+   http::Request& request = pClient->request();
+   request.setMethod("GET");
+   request.setUri("/file");
+   request.setHeader("Connection", "close");
+
+   bool gotResponse = false;
+   bool gotError = false;
+   bool timedOut = false;
+   int completionCalls = 0;
+
+   boost::shared_ptr<boost::asio::system_timer> pTimer =
+      boost::make_shared<boost::asio::system_timer>(ioc, std::chrono::seconds(2));
+   pTimer->async_wait([&](const boost::system::error_code& ec) {
+      if (ec == boost::asio::error::operation_aborted)
+         return;
+      timedOut = true;
+      pClient->close();
+   });
+
+   boost::shared_ptr<bool> pArmed = boost::make_shared<bool>(false);
+   boost::weak_ptr<int> weakHandlerState;
+   {
+      boost::shared_ptr<int> pHandlerState = boost::make_shared<int>(0);
+      weakHandlerState = pHandlerState;
+
+      FixedBufferHandler fixedBufferHandler =
+         ThrowOnCopy<boost::function<bool(const http::Response&, const std::string&)>>(
+            pArmed,
+            [&, pHandlerState](const http::Response&, const std::string& piece) -> bool
+            {
+               if (!piece.empty())
+                  return true;
+
+               ++completionCalls;
+               *pArmed = true;
+               boost::asio::post(ioc, [&]() { pClient->resumeChunkProcessing(); });
+               return false;
+            });
+
+      pClient->execute(
+         [&](const http::Response&) { gotResponse = true; pTimer->cancel(); },
+         [&](const core::Error&) { gotError = true; pTimer->cancel(); },
+         fixedBufferHandler);
+   }
+
+   ioc.run();
+   server.stop();
+
+   EXPECT_FALSE(timedOut);
+   EXPECT_FALSE(gotResponse);
+   EXPECT_TRUE(gotError);
+   EXPECT_EQ(completionCalls, 1);
+   EXPECT_TRUE(weakHandlerState.expired());
+}
+
+// handleError() snapshots errorHandler_ too. If the allocation pressure that
+// broke the first snapshot also breaks this one, the callback cannot be
+// delivered, but cleanup must still run rather than reading an empty local as
+// "no handler" and leaking the installed callbacks.
+TEST(AsyncClientContentLength, ErrorHandlerSnapshotFailureStillDisablesHandlers)
+{
+   LocalServer server(ResponseMode::ContentLength, /*closeAfterResponse=*/true,
+                      "{\"name\":\"jsonlite\"}\n");
+   server.start();
+
+   boost::asio::io_context ioc;
+   boost::shared_ptr<TcpIpAsyncClient> pClient =
+      boost::make_shared<TcpIpAsyncClient>(
+         ioc, "127.0.0.1", std::to_string(server.port()),
+         boost::posix_time::seconds(5));
+
+   pClient->setStreamNonChunkedResponses(true);
+   pClient->setFixedBufferHandlerSupportsPause(true);
+
+   http::Request& request = pClient->request();
+   request.setMethod("GET");
+   request.setUri("/file");
+   request.setHeader("Connection", "close");
+
+   bool gotResponse = false;
+   bool gotError = false;
+   boost::shared_ptr<bool> pFixedArmed = boost::make_shared<bool>(false);
+   boost::shared_ptr<bool> pErrorArmed = boost::make_shared<bool>(false);
+   boost::weak_ptr<int> weakFixedState;
+   boost::weak_ptr<int> weakErrorState;
+
+   {
+      boost::shared_ptr<int> pFixedState = boost::make_shared<int>(0);
+      boost::shared_ptr<int> pErrorState = boost::make_shared<int>(0);
+      weakFixedState = pFixedState;
+      weakErrorState = pErrorState;
+
+      pClient->execute(
+         [&](const http::Response&) { gotResponse = true; },
+         ThrowOnCopy<boost::function<void(const core::Error&)>>(
+            pErrorArmed,
+            [&, pErrorState](const core::Error&) { gotError = true; }),
+         ThrowOnCopy<boost::function<bool(const http::Response&, const std::string&)>>(
+            pFixedArmed,
+            [&, pFixedState](const http::Response&, const std::string& piece) -> bool
+            {
+               if (!piece.empty())
+               {
+                  // The next fixed-buffer copy (at completion) and the error
+                  // handler copy used to report it both fail once.
+                  *pFixedArmed = true;
+                  *pErrorArmed = true;
+               }
+               return true;
+            }));
+   }
+
+   ioc.run();
+   server.stop();
+
+   EXPECT_FALSE(gotResponse);
+   EXPECT_FALSE(gotError);
+   EXPECT_TRUE(weakFixedState.expired());
+   EXPECT_TRUE(weakErrorState.expired());
+}
+
 // handleWrite(): the connect notification's snapshot fails. A caller gated on
 // that notification (FormProxy) buffers its upload until it hears one way or
 // the other, so dropping it hangs the upload; the client must report the
@@ -2553,42 +2694,27 @@ TEST(AsyncClientContentLength, ConnectHandlerSnapshotFailureReportsDownstreamClo
 // happens before the lock, with only swaps under it, so either the whole
 // install lands or nothing does and the exception reaches the caller.
 
-// execute(): the response handler copies, the error handler does not. The
-// request used to be set in motion anyway, behind a client whose error handler
-// had never been installed -- an exchange that can complete with nobody left to
-// notify.
-//
-// Deliberately aimed at a port nobody is listening on rather than at a
-// LocalServer: what is under test is that nothing is set in motion at all, and
-// LocalServer's accept loop blocks until a connection arrives, so a regression
-// here would hang its teardown rather than fail.
-TEST(AsyncClientContentLength, ExecuteHandlerInstallFailureLeavesNothingInMotion)
+// execute(): the response handler copies, the error handler does not. A request
+// still must not start, but "nothing changed" is insufficient when an embedder
+// has already installed a streaming handler: FixedBufferProxy does that before
+// execute(), and its handler closes a shared_ptr cycle around the client. With
+// no request in motion, only execute()'s failure path remains to detach it.
+TEST(AsyncClientContentLength, ExecuteHandlerInstallFailureBreaksPrewiredStreamingCycle)
 {
-   // bind and immediately release a port so connecting to it is refused
-   unsigned short deadPort = 0;
-   {
-      boost::asio::io_context probeIoc;
-      tcp::acceptor probe(probeIoc, tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0));
-      deadPort = probe.local_endpoint().port();
-   }
-
    boost::asio::io_context ioc;
    boost::shared_ptr<TcpIpAsyncClient> pClient =
       boost::make_shared<TcpIpAsyncClient>(
-         ioc, "127.0.0.1", std::to_string(deadPort),
+         ioc, "127.0.0.1", "1",
          boost::posix_time::seconds(5));
 
-   http::Request& request = pClient->request();
-   request.setMethod("GET");
-   request.setUri("/file");
-
-   // the connect pair is what reports whether the request pipeline ever ran:
-   // a client that starts and then fails a connection reports the settle
-   // through the downstream-closed half (see close())
-   bool connected = false;
-   bool downstreamClosed = false;
-   pClient->setConnectHandler([&]() { connected = true; },
-                              [&]() { downstreamClosed = true; });
+   boost::weak_ptr<FakeStreamingConsumer> weakConsumer;
+   {
+      boost::shared_ptr<FakeStreamingConsumer> pConsumer =
+         boost::make_shared<FakeStreamingConsumer>(pClient);
+      pConsumer->wire();
+      weakConsumer = pConsumer;
+   }
+   ASSERT_FALSE(weakConsumer.expired());
 
    boost::shared_ptr<bool> pArmed = boost::make_shared<bool>(false);
    ResponseHandler doomedResponseHandler =
@@ -2600,25 +2726,10 @@ TEST(AsyncClientContentLength, ExecuteHandlerInstallFailureLeavesNothingInMotion
    EXPECT_THROW(pClient->execute(doomedResponseHandler, [](const core::Error&) {}),
                 std::bad_alloc);
 
-   ioc.run();
-
-   // nothing was set in motion: no connection was attempted, so neither half of
-   // the connect pair has fired
-   EXPECT_FALSE(connected);
-   EXPECT_FALSE(downstreamClosed);
-
-   // and the client is not left wedged by the failure -- a fresh execute()
-   // installs cleanly and reports the refused connection through the error
-   // handler it was given. Before the fix the first call had already run the
-   // connection to failure and marked the client closed, so this second one
-   // was swallowed by handleError()'s closed_ check and reported nothing.
-   bool gotError = false;
-   ioc.restart();
-   pClient->execute([](const http::Response&) {},
-                    [&](const core::Error&) { gotError = true; });
-   ioc.run();
-
-   EXPECT_TRUE(gotError);
+   // The request never reached connectAndWriteRequest(), and the already-wired
+   // consumer was detached synchronously. Its bound self-reference and its
+   // reference back to pClient can no longer survive as a cycle.
+   EXPECT_TRUE(weakConsumer.expired());
 }
 
 // setFixedBufferHandler(): the installed handler was detached before the

--- a/src/cpp/core/http/AsyncClientContentLengthTests.cpp
+++ b/src/cpp/core/http/AsyncClientContentLengthTests.cpp
@@ -29,12 +29,14 @@
 //     completes within the deadline must not see a spurious late timeout.
 
 #include <atomic>
-#include <functional>
 #include <chrono>
+#include <functional>
+#include <new>
 #include <set>
 #include <sstream>
 #include <string>
 #include <thread>
+#include <utility>
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/asio/io_context.hpp>

--- a/src/cpp/core/include/core/http/AsyncClient.hpp
+++ b/src/cpp/core/include/core/http/AsyncClient.hpp
@@ -279,11 +279,24 @@ public:
       // stepped over it, so the request below still went out with (say) a
       // response handler installed and no error handler behind it, and the
       // exchange could complete with nobody left to notify. Copying first
-      // costs the client nothing on failure: the exception reaches the caller
-      // with no handler replaced and no request in flight.
-      ResponseHandler newResponseHandler = responseHandler;
-      ErrorHandler newErrorHandler = errorHandler;
-      FixedBufferHandler newFixedBufferHandler = fixedBufferHandler;
+      // keeps the request from starting on failure; if an embedder has already
+      // installed a handler (FixedBufferProxy does), detach it before the
+      // exception reaches the caller so a pre-existing reference cycle is not
+      // left with nothing in motion to break it.
+      ResponseHandler newResponseHandler;
+      ErrorHandler newErrorHandler;
+      FixedBufferHandler newFixedBufferHandler;
+      try
+      {
+         newResponseHandler = responseHandler;
+         newErrorHandler = errorHandler;
+         newFixedBufferHandler = fixedBufferHandler;
+      }
+      catch (...)
+      {
+         disableHandlers();
+         throw;
+      }
 
       // Commit them under socketMutex_, like every other access to these
       // members (see disableHandlers()). Swaps only, so nothing in here can
@@ -675,16 +688,18 @@ public:
             ioContext_,
             boost::asio::bind_executor(
                *pStrand_,
-               [self, connectHandler, downstreamClosedHandler]()
+               [self,
+                connectHandler = std::move(newConnectHandler),
+                downstreamClosedHandler = std::move(newDownstreamClosedHandler)]()
                {
                   self->deliverLateConnectNotification(connectHandler, downstreamClosedHandler);
                }));
       }
-      else if (invokeDownstreamClosedHandler && downstreamClosedHandler)
+      else if (invokeDownstreamClosedHandler && newDownstreamClosedHandler)
       {
          // outside the lock: handlers must never be invoked while holding
          // socketMutex_ (see disableHandlers()'s declaration for the lock order)
-         downstreamClosedHandler();
+         newDownstreamClosedHandler();
       }
    }
 
@@ -774,38 +789,53 @@ protected:
       );
    }
 
-   void handleError(const Error& error)
+   void handleError(const Error& error, bool settleEvenIfClosed = false)
    {
       Error httpError = error;
       addErrorProperties(httpError);
 
       // check to see if the socket was closed purposefully
-      // if so, we will ignore the error
+      // if so, we will ordinarily ignore the error. A handler snapshot failure
+      // is different: it must still detach the handlers even if a previous
+      // close() has already marked the socket closed, or a FixedBufferProxy
+      // cycle can survive with no completion left to break it.
+      bool alreadyClosed = false;
       LOCK_MUTEX(socketMutex_)
       {
-         if (closed_)
-            return;
+         alreadyClosed = closed_;
       }
       END_LOCK_MUTEX
 
+      if (alreadyClosed && !settleEvenIfClosed)
+         return;
+
       // close the socket
-      close();
+      if (!alreadyClosed)
+         close();
 
       // invoke error handler -- copy it out under socketMutex_ (checking
       // handlersDisabled_ in the same critical section disableHandlers()
       // uses to set it and detach the handler) so a concurrent
       // disableHandlers() call can't race between this check and the
       // invocation below. Actual invocation happens outside the lock, same
-      // as handleWrite()'s connectHandler_ pattern.
+      // as handleWrite()'s connectHandler_ pattern. This copy is fallible for
+      // the same reason as every other handler snapshot; if it fails, log the
+      // original error and still detach everything rather than treating the
+      // empty local as "no error handler installed."
       ErrorHandler handler;
-      LOCK_MUTEX(socketMutex_)
-      {
-         if (!handlersDisabled_)
-            handler = errorHandler_;
-      }
-      END_LOCK_MUTEX
+      SnapshotStatus status = snapshotHandlers(
+         [&]()
+         {
+            if (handlersDisabled_)
+               return false;
 
-      if (handler)
+            handler = errorHandler_;
+            return true;
+         });
+
+      if (status == SnapshotStatus::Failed)
+         logError(httpError);
+      else if (status == SnapshotStatus::Ready && handler)
          handler(httpError);
 
       // free handlers to ensure they do not keep a strong reference to us
@@ -826,6 +856,15 @@ protected:
                                 description,
                                 location);
       handleError(error);
+   }
+
+   void handleHandlerSnapshotError(const std::string& description,
+                                   const ErrorLocation& location)
+   {
+      Error error = systemError(boost::system::errc::state_not_recoverable,
+                                description,
+                                location);
+      handleError(error, true);
    }
 
    virtual void addErrorProperties(Error& error)
@@ -979,7 +1018,8 @@ private:
    // connect notification never delivered. (On the lock-acquisition path it
    // also left the sites' `disabled` flag indeterminate.) Failed sends the
    // caller to its error path instead, where the client settles and the error
-   // handler reports it.
+   // handler reports it when that handler can itself be copied; otherwise the
+   // failure is logged and cleanup still completes.
    //
    // No message is composed from the exception here: the one it exists to
    // survive is std::bad_alloc, so doing so could throw again on the way out,
@@ -1035,7 +1075,7 @@ private:
                // setConnectHandler()). close(), from within handleError(),
                // reports the pending notification; the error handler reports
                // the failure itself.
-               handleUnexpectedError("Failed to copy connect handler", ERROR_LOCATION);
+               handleHandlerSnapshotError("Failed to copy connect handler", ERROR_LOCATION);
                return;
             }
 
@@ -1571,7 +1611,7 @@ private:
             // appended to response_ -- which nothing in streaming mode ever
             // reads -- and the consumer would go on to be told the body was
             // complete without it. Fail the request instead.
-            handleUnexpectedError("Failed to copy fixed buffer handler", ERROR_LOCATION);
+            handleHandlerSnapshotError("Failed to copy fixed buffer handler", ERROR_LOCATION);
             return false;
          }
 
@@ -1624,10 +1664,10 @@ private:
       // keep the consumer alive if it re-entrantly calls disableHandlers()
       // from within the invocation.
       //
-      // Taken before the close below rather than after it, so that a failed
-      // copy can still take the ordinary error path: handleError() ignores
-      // anything raised after a deliberate close, and would otherwise drop the
-      // failure without reporting it or detaching anything.
+      // Taken before the close below so the ordinary case can report through
+      // the open client's error path. The failure path below also settles an
+      // already-closed client: completionPending_ retries necessarily re-enter
+      // here after the first attempt closed the socket.
       ResponseHandler responseHandler;
       FixedBufferHandler fixedBufferHandler;
       SnapshotStatus status = snapshotHandlers(
@@ -1648,7 +1688,7 @@ private:
          // branches below would read as absent and settle silently -- either
          // handing a streamed response to the whole-body handler with an empty
          // response_ body, or completing with no notification delivered at all.
-         handleUnexpectedError("Failed to copy response handlers", ERROR_LOCATION);
+         handleHandlerSnapshotError("Failed to copy response handlers", ERROR_LOCATION);
          return;
       }
 
@@ -1914,5 +1954,4 @@ protected:
 } // namespace rstudio
 
 #endif // CORE_HTTP_ASYNC_CLIENT_HPP
-
 

--- a/src/cpp/core/include/core/http/AsyncClient.hpp
+++ b/src/cpp/core/include/core/http/AsyncClient.hpp
@@ -936,6 +936,50 @@ private:
       CATCH_UNEXPECTED_ASYNC_CLIENT_EXCEPTION
    }
 
+   // Outcome of copying handler callbacks out of their members under
+   // socketMutex_, so they can be invoked once the lock is released.
+   enum class SnapshotStatus
+   {
+      Ready,    // the copies completed and are safe to act on
+      Disabled, // disableHandlers() has already detached the handlers
+      Failed    // the snapshot threw; the copies are unusable
+   };
+
+   // Take one such snapshot. `snapshot` runs holding socketMutex_ and returns
+   // false when it finds the handlers already disabled, so each site keeps its
+   // own disabled test in the same critical section as its own copies -- the
+   // property disableHandlers()'s contract comment depends on.
+   //
+   // Unlike LOCK_MUTEX, a throw here is reported rather than logged and stepped
+   // over. Copying a boost::function allocates whenever its target is too large
+   // for the small-object buffer, so a snapshot can fail under exactly the
+   // memory pressure streaming exists to relieve -- and LOCK_MUTEX's
+   // fall-through would leave the locals empty, which every site below reads as
+   // "no handler installed" and acts on: a body piece quietly appended to
+   // response_ instead of handed to the streaming consumer, a completion or a
+   // connect notification never delivered. (On the lock-acquisition path it
+   // also left the sites' `disabled` flag indeterminate.) Failed sends the
+   // caller to its error path instead, where the client settles and the error
+   // handler reports it.
+   //
+   // No message is composed from the exception here: the one it exists to
+   // survive is std::bad_alloc, so doing so could throw again on the way out,
+   // and which site failed -- which the caller names -- is the more useful half
+   // of the diagnosis anyway.
+   template <typename F>
+   SnapshotStatus snapshotHandlers(const F& snapshot)
+   {
+      try
+      {
+         boost::lock_guard<boost::mutex> lock(socketMutex_);
+         return snapshot() ? SnapshotStatus::Ready : SnapshotStatus::Disabled;
+      }
+      catch (...)
+      {
+         return SnapshotStatus::Failed;
+      }
+   }
+
    void handleWrite(const boost::system::error_code& ec)
    {
       try
@@ -943,17 +987,42 @@ private:
          if (!ec)
          {
             // invoke connect handler if we have one -- checked under the
-            // same lock disableHandlers() uses, see its declaration
+            // same lock disableHandlers() uses, see its declaration.
+            //
+            // The copy comes before requestWritten_ is set, and that ordering
+            // is load-bearing: close() and disableHandlers() read the flag as
+            // "handleWrite() has been and gone, so the connect notification was
+            // reported" (see disableHandlers()). A copy that fails can never
+            // report it, so leaving the flag false on that path is what routes
+            // the still-pending notification to the downstream-closed handler
+            // -- the answer a caller gated on the connect needs to hear.
             ConnectHandler handler;
-            LOCK_MUTEX(socketMutex_)
-            {
-               requestWritten_ = true;
-               if (!handlersDisabled_ && connectHandler_)
-                  handler = connectHandler_;
-            }
-            END_LOCK_MUTEX
+            SnapshotStatus status = snapshotHandlers(
+               [&]()
+               {
+                  bool disabled = handlersDisabled_;
+                  if (!disabled)
+                     handler = connectHandler_;
 
-            // actual invocation should be outside of lock to prevent recursive lock acquisitions
+                  requestWritten_ = true;
+                  return !disabled;
+               });
+
+            if (status == SnapshotStatus::Failed)
+            {
+               // Take the error path rather than reading the empty local as
+               // "no connect handler installed" and reading on: a caller that
+               // hears neither notification buffers until it times out (see
+               // setConnectHandler()). close(), from within handleError(),
+               // reports the pending notification; the error handler reports
+               // the failure itself.
+               handleUnexpectedError("Failed to copy connect handler", ERROR_LOCATION);
+               return;
+            }
+
+            // actual invocation should be outside of lock to prevent recursive
+            // lock acquisitions. Disabled leaves `handler` empty, as before:
+            // there is nothing left to report.
             if (handler)
                handler();
 
@@ -1458,20 +1527,32 @@ private:
          // lifetime holder that keeps the consumer alive if it re-entrantly
          // calls disableHandlers() from within the invocation.
          FixedBufferHandler handler;
-         bool disabled;
-         LOCK_MUTEX(socketMutex_)
-         {
-            disabled = handlersDisabled_;
-            handler = fixedBufferHandler_;
-         }
-         END_LOCK_MUTEX
+         SnapshotStatus status = snapshotHandlers(
+            [&]()
+            {
+               if (handlersDisabled_)
+                  return false;
 
-         if (disabled)
+               handler = fixedBufferHandler_;
+               return true;
+            });
+
+         if (status == SnapshotStatus::Disabled)
          {
             // Handlers were disabled (e.g. the downstream connection already
             // errored out and broke its reference cycle via
             // disableHandlers()) while chunks were still in flight -- stop
             // processing entirely.
+            return false;
+         }
+         else if (status == SnapshotStatus::Failed)
+         {
+            // An empty local here is indistinguishable from an absent handler,
+            // and the else branch below would act on it: this piece would be
+            // appended to response_ -- which nothing in streaming mode ever
+            // reads -- and the consumer would go on to be told the body was
+            // complete without it. Fail the request instead.
+            handleUnexpectedError("Failed to copy fixed buffer handler", ERROR_LOCATION);
             return false;
          }
 
@@ -1514,9 +1595,6 @@ private:
 
    void closeAndRespond()
    {
-      if (!keepConnectionAlive())
-         close();
-
       // Copy both handlers out under socketMutex_, checking
       // handlersDisabled_ in the same critical section disableHandlers()
       // uses to set it and detach them -- see that method's contract comment
@@ -1526,21 +1604,39 @@ private:
       // on its own. The local copies also serve as the lifetime holders that
       // keep the consumer alive if it re-entrantly calls disableHandlers()
       // from within the invocation.
+      //
+      // Taken before the close below rather than after it, so that a failed
+      // copy can still take the ordinary error path: handleError() ignores
+      // anything raised after a deliberate close, and would otherwise drop the
+      // failure without reporting it or detaching anything.
       ResponseHandler responseHandler;
       FixedBufferHandler fixedBufferHandler;
-      bool disabled;
-      LOCK_MUTEX(socketMutex_)
-      {
-         disabled = handlersDisabled_;
-         if (!disabled)
+      SnapshotStatus status = snapshotHandlers(
+         [&]()
          {
+            if (handlersDisabled_)
+               return false;
+
             responseHandler = responseHandler_;
             fixedBufferHandler = fixedBufferHandler_;
-         }
-      }
-      END_LOCK_MUTEX
+            return true;
+         });
 
-      if (disabled)
+      if (status == SnapshotStatus::Failed)
+      {
+         // This is the last word on the request, so an empty local here costs
+         // more than anywhere else: whichever handler failed to copy, the
+         // branches below would read as absent and settle silently -- either
+         // handing a streamed response to the whole-body handler with an empty
+         // response_ body, or completing with no notification delivered at all.
+         handleUnexpectedError("Failed to copy response handlers", ERROR_LOCATION);
+         return;
+      }
+
+      if (!keepConnectionAlive())
+         close();
+
+      if (status == SnapshotStatus::Disabled)
       {
          disableHandlers(); // idempotent
          return;

--- a/src/cpp/core/include/core/http/AsyncClient.hpp
+++ b/src/cpp/core/include/core/http/AsyncClient.hpp
@@ -271,26 +271,35 @@ public:
                         const ErrorHandler& errorHandler,
                         const FixedBufferHandler& fixedBufferHandler = FixedBufferHandler())
    {
-      // set handlers -- under socketMutex_, like every other access to these
-      // members (see disableHandlers()). Swap any previous values into
-      // locals so they destruct only after the lock is released: destroying
-      // a displaced handler can release the last reference to a consumer
-      // whose teardown calls back into close()/disableHandlers(), which
-      // take this same (non-recursive) mutex.
-      ResponseHandler oldResponseHandler;
-      ErrorHandler oldErrorHandler;
-      FixedBufferHandler oldFixedBufferHandler;
+      // Copy the handlers before taking the lock, because copying is the
+      // fallible part of installing them: a boost::function copy allocates
+      // whenever its target is too large for the small-object buffer. Copying
+      // under the lock -- interleaved with the assignments, as this used to do
+      // -- meant a failure left the client half-configured and LOCK_MUTEX
+      // stepped over it, so the request below still went out with (say) a
+      // response handler installed and no error handler behind it, and the
+      // exchange could complete with nobody left to notify. Copying first
+      // costs the client nothing on failure: the exception reaches the caller
+      // with no handler replaced and no request in flight.
+      ResponseHandler newResponseHandler = responseHandler;
+      ErrorHandler newErrorHandler = errorHandler;
+      FixedBufferHandler newFixedBufferHandler = fixedBufferHandler;
+
+      // Commit them under socketMutex_, like every other access to these
+      // members (see disableHandlers()). Swaps only, so nothing in here can
+      // throw; each swap leaves the value it displaced in the local, which
+      // destructs only once the lock is released. That matters: destroying a
+      // displaced handler can release the last reference to a consumer whose
+      // teardown calls back into close()/disableHandlers(), which take this
+      // same (non-recursive) mutex.
       LOCK_MUTEX(socketMutex_)
       {
-         oldResponseHandler.swap(responseHandler_);
-         responseHandler_ = responseHandler;
-         oldErrorHandler.swap(errorHandler_);
-         errorHandler_ = errorHandler;
-         if (fixedBufferHandler)
-         {
-            oldFixedBufferHandler.swap(fixedBufferHandler_);
-            fixedBufferHandler_ = fixedBufferHandler;
-         }
+         responseHandler_.swap(newResponseHandler);
+         errorHandler_.swap(newErrorHandler);
+
+         // tested before the swap below, so this is still the incoming value
+         if (newFixedBufferHandler)
+            fixedBufferHandler_.swap(newFixedBufferHandler);
       }
       END_LOCK_MUTEX
 
@@ -504,14 +513,20 @@ public:
 
    virtual void setFixedBufferHandler(const FixedBufferHandler& fixedBufferHandler)
    {
-      // swap the displaced value out and destroy it after releasing the
-      // lock -- see execute() for why destroying it under the lock could
-      // deadlock
-      FixedBufferHandler oldFixedBufferHandler;
+      // Copied before the lock, for the reason execute() gives: detaching the
+      // installed handler and then failing to put the new one in its place
+      // left the client with no fixed buffer handler at all, which silently
+      // flips a streaming consumer into accumulating into response_ -- a body
+      // it never reads. The copy is the only fallible step, so doing it here
+      // means a failure changes nothing.
+      FixedBufferHandler newFixedBufferHandler = fixedBufferHandler;
+
+      // the swap leaves the displaced value in the local, to be destroyed
+      // after releasing the lock -- see execute() for why destroying it under
+      // the lock could deadlock
       LOCK_MUTEX(socketMutex_)
       {
-         oldFixedBufferHandler.swap(fixedBufferHandler_);
-         fixedBufferHandler_ = fixedBufferHandler;
+         fixedBufferHandler_.swap(newFixedBufferHandler);
       }
       END_LOCK_MUTEX
    }
@@ -589,9 +604,15 @@ public:
       // and just invoke it directly
       bool deferConnectNotification = false;
       bool invokeDownstreamClosedHandler = false;
-      // displaced values destroyed after unlock, see execute()
-      ConnectHandler oldConnectHandler;
-      ConnectHandler oldDownstreamClosedHandler;
+
+      // Copied before the lock, for the reason execute() gives, and here the
+      // two copies are a pair: storing the connect notification while failing
+      // to store the downstream-closed handler that reports its loss left a
+      // caller with no way to be told either way, which is the hang
+      // setConnectHandler()'s contract exists to prevent. Each swap below
+      // leaves the value it displaced in the local, to destroy after unlock.
+      ConnectHandler newConnectHandler = connectHandler;
+      ConnectHandler newDownstreamClosedHandler = downstreamClosedHandler;
       LOCK_MUTEX(socketMutex_)
       {
          // Whether we have settled has to be read under the same lock
@@ -622,10 +643,8 @@ public:
             // store both: disableHandlers() may yet detach the connect
             // notification before handleWrite() can deliver it, and reports
             // that through the stored downstream-closed handler
-            oldConnectHandler.swap(connectHandler_);
-            oldDownstreamClosedHandler.swap(downstreamClosedHandler_);
-            connectHandler_ = connectHandler;
-            downstreamClosedHandler_ = downstreamClosedHandler;
+            connectHandler_.swap(newConnectHandler);
+            downstreamClosedHandler_.swap(newDownstreamClosedHandler);
          }
          else
          {

--- a/src/cpp/core/include/core/http/AsyncClient.hpp
+++ b/src/cpp/core/include/core/http/AsyncClient.hpp
@@ -299,14 +299,17 @@ public:
       }
 
       // Commit them under socketMutex_, like every other access to these
-      // members (see disableHandlers()). Swaps only, so nothing in here can
-      // throw; each swap leaves the value it displaced in the local, which
-      // destructs only once the lock is released. That matters: destroying a
-      // displaced handler can release the last reference to a consumer whose
-      // teardown calls back into close()/disableHandlers(), which take this
-      // same (non-recursive) mutex.
-      LOCK_MUTEX(socketMutex_)
+      // members (see disableHandlers()). Once the lock is acquired, only
+      // non-throwing swaps remain; each swap leaves the value it displaced in
+      // the local, which destructs only once the lock is released. That
+      // matters: destroying a displaced handler can release the last reference
+      // to a consumer whose teardown calls back into close()/disableHandlers(),
+      // which take this same (non-recursive) mutex.
       {
+         // Unlike LOCK_MUTEX, let a lock-acquisition failure reach the caller.
+         // Falling through here would start the request with the copied
+         // handlers still in these locals and the members unchanged.
+         boost::lock_guard<boost::mutex> lock(socketMutex_);
          responseHandler_.swap(newResponseHandler);
          errorHandler_.swap(newErrorHandler);
 
@@ -314,7 +317,6 @@ public:
          if (newFixedBufferHandler)
             fixedBufferHandler_.swap(newFixedBufferHandler);
       }
-      END_LOCK_MUTEX
 
       // if the host header is not already set, make sure we stamp a default one
       // this is required by the http standard
@@ -530,18 +532,20 @@ public:
       // installed handler and then failing to put the new one in its place
       // left the client with no fixed buffer handler at all, which silently
       // flips a streaming consumer into accumulating into response_ -- a body
-      // it never reads. The copy is the only fallible step, so doing it here
-      // means a failure changes nothing.
+      // it never reads. Taking the fallible copy here means a copy failure
+      // changes nothing; lock acquisition below is allowed to propagate for
+      // the same all-or-nothing guarantee.
       FixedBufferHandler newFixedBufferHandler = fixedBufferHandler;
 
       // the swap leaves the displaced value in the local, to be destroyed
       // after releasing the lock -- see execute() for why destroying it under
       // the lock could deadlock
-      LOCK_MUTEX(socketMutex_)
       {
+         // Propagate lock-acquisition failure so the caller cannot mistake an
+         // unchanged handler for a successful install.
+         boost::lock_guard<boost::mutex> lock(socketMutex_);
          fixedBufferHandler_.swap(newFixedBufferHandler);
       }
-      END_LOCK_MUTEX
    }
 
    virtual void setStreamNonChunkedResponses(bool stream)
@@ -626,8 +630,9 @@ public:
       // leaves the value it displaced in the local, to destroy after unlock.
       ConnectHandler newConnectHandler = connectHandler;
       ConnectHandler newDownstreamClosedHandler = downstreamClosedHandler;
-      LOCK_MUTEX(socketMutex_)
       {
+         // As above, lock failure is an install failure and must propagate.
+         boost::lock_guard<boost::mutex> lock(socketMutex_);
          // Whether we have settled has to be read under the same lock
          // close()/disableHandlers() set these with -- see disableHandlers()'s
          // declaration -- so that the decision below can't be made against a
@@ -667,7 +672,6 @@ public:
             deferConnectNotification = true;
          }
       }
-      END_LOCK_MUTEX
 
       // Dispatch the late connect notification through the strand instead of
       // invoking it here. Deciding under the lock above and calling out after
@@ -858,13 +862,41 @@ protected:
       handleError(error);
    }
 
-   void handleHandlerSnapshotError(const std::string& description,
-                                   const ErrorLocation& location)
+   void handleHandlerSnapshotError(const char* description,
+                                   const ErrorLocation& location) noexcept
    {
-      Error error = systemError(boost::system::errc::state_not_recoverable,
-                                description,
-                                location);
-      handleError(error, true);
+      try
+      {
+         Error error = systemError(boost::system::errc::state_not_recoverable,
+                                   description,
+                                   location);
+         handleError(error, true);
+      }
+      catch (...)
+      {
+         // This path starts with a failed boost::function copy, usually a
+         // bad_alloc. Building or reporting the synthetic Error can therefore
+         // fail too. Never let that second failure bypass settlement or escape
+         // an unguarded posted continuation such as resumeChunkProcessing().
+         // Attempt each operation independently: close() can throw while
+         // posting a pending connect notification, but disableHandlers() must
+         // still get its chance to break any handler reference cycle.
+         try
+         {
+            close();
+         }
+         catch (...)
+         {
+         }
+
+         try
+         {
+            disableHandlers();
+         }
+         catch (...)
+         {
+         }
+      }
    }
 
    virtual void addErrorProperties(Error& error)
@@ -1954,4 +1986,3 @@ protected:
 } // namespace rstudio
 
 #endif // CORE_HTTP_ASYNC_CLIENT_HPP
-

--- a/src/cpp/server/session/ServerSessionProxy.cpp
+++ b/src/cpp/server/session/ServerSessionProxy.cpp
@@ -150,6 +150,54 @@ ProxyFilter s_proxyFilter;
 
 ProxyRequestFilter s_proxyRequestFilter;
 
+// Proxy setup can fail under memory pressure while copying a callback. Cleanup
+// must therefore be both allocation-free at the call site and best-effort:
+// close()/disableHandlers() are virtual calls into asio and can themselves
+// throw, but a failure in one step must not prevent the remaining steps from
+// releasing the handler cycle and the paused browser connection.
+void settleFailedProxySetup(
+      const boost::shared_ptr<http::IAsyncClient>& pClient,
+      const boost::shared_ptr<http::AsyncConnection>& pConnection) noexcept
+{
+   try
+   {
+      pClient->close();
+   }
+   catch (...)
+   {
+   }
+
+   try
+   {
+      pClient->disableHandlers();
+   }
+   catch (...)
+   {
+   }
+
+   try
+   {
+      pConnection->close();
+   }
+   catch (...)
+   {
+   }
+}
+
+void logFailedProxySetup(const char* context, const char* what) noexcept
+{
+   try
+   {
+      LOG_ERROR_MESSAGE(std::string("Failed to initialize ") +
+                        context + ": " + what);
+   }
+   catch (...)
+   {
+      // Logging is secondary to cleanup, and can allocate while we are already
+      // recovering from bad_alloc.
+   }
+}
+
 Error launchSessionRecovery(
       boost::shared_ptr<core::http::AsyncConnection> ptrConnection,
       const http::Request& request,
@@ -858,19 +906,33 @@ void proxyRequest(
 
    LOG_DEBUG_MESSAGE("- Start server proxy request " + ptrConnection->request().method() + " " + ptrConnection->request().debugInfo() + (context.scope.isWorkspaces() ? " - workspaces" : "") + " for local stream: " + streamPath.getAbsolutePath() + (connectionRetryProfile.empty() ? "" : " with retry"));
 
-   // proxy the request
-   boost::shared_ptr<http::FixedBufferProxy> fixedBufferProxy(new http::FixedBufferProxy(ptrConnection));
-   fixedBufferProxy->proxy(pClient);
-   pClient->execute(boost::bind(handleProxyResponse, ptrConnection, context, _1),
-                    errorHandler);
-
-   if (clientHandler)
+   try
    {
-      // invoke the client handler on the threadpool - we cannot do this
-      // from this thread because that will cause ordering issues for the caller
-      boost::asio::post(
-               ptrConnection->ioContext(),
-               boost::bind(clientHandler, pClient));
+      // proxy the request
+      boost::shared_ptr<http::FixedBufferProxy> fixedBufferProxy(
+            new http::FixedBufferProxy(ptrConnection));
+      fixedBufferProxy->proxy(pClient);
+      pClient->execute(boost::bind(handleProxyResponse, ptrConnection, context, _1),
+                       errorHandler);
+
+      if (clientHandler)
+      {
+         // invoke the client handler on the threadpool - we cannot do this
+         // from this thread because that will cause ordering issues for the caller
+         boost::asio::post(
+                  ptrConnection->ioContext(),
+                  boost::bind(clientHandler, pClient));
+      }
+   }
+   catch (const std::exception& e)
+   {
+      settleFailedProxySetup(pClient, ptrConnection);
+      logFailedProxySetup("server proxy", e.what());
+   }
+   catch (...)
+   {
+      settleFailedProxySetup(pClient, ptrConnection);
+      logFailedProxySetup("server proxy", "unknown exception");
    }
 }
 
@@ -1071,17 +1133,13 @@ bool proxyUploadRequest(
             // exception escaping it terminates that worker's run() call, while
             // leaving the browser parser paused and the FixedBufferProxy cycle
             // around proxyClient intact. Settle both sides here instead.
-            LOG_ERROR_MESSAGE(std::string("Failed to initialize form proxy: ") + e.what());
-            proxyClient->close();
-            proxyClient->disableHandlers();
-            ptrConnection->close();
+            settleFailedProxySetup(proxyClient, ptrConnection);
+            logFailedProxySetup("form proxy", e.what());
          }
          catch (...)
          {
-            LOG_ERROR_MESSAGE("Unknown exception while initializing form proxy");
-            proxyClient->close();
-            proxyClient->disableHandlers();
-            ptrConnection->close();
+            settleFailedProxySetup(proxyClient, ptrConnection);
+            logFailedProxySetup("form proxy", "unknown exception");
          }
       };
 
@@ -1367,13 +1425,28 @@ void proxyLocalhostRequest(
              boost::algorithm::contains(response.headerValue("Server"), "Jetty");
    });
 
-   boost::shared_ptr<http::FixedBufferProxy> fixedBufferProxy(new http::FixedBufferProxy(ptrConnection));
-   fixedBufferProxy->proxy(pClient);
+   try
+   {
+      boost::shared_ptr<http::FixedBufferProxy> fixedBufferProxy(
+            new http::FixedBufferProxy(ptrConnection));
+      fixedBufferProxy->proxy(pClient);
 
-   // execute request
-   pClient->execute(
-            boost::bind(handleLocalhostResponse, ptrConnection, pClient, username, port, address, ipv6, _1),
-            onError);
+      // execute request
+      pClient->execute(
+               boost::bind(handleLocalhostResponse, ptrConnection, pClient,
+                           username, port, address, ipv6, _1),
+               onError);
+   }
+   catch (const std::exception& e)
+   {
+      settleFailedProxySetup(pClient, ptrConnection);
+      logFailedProxySetup("localhost proxy", e.what());
+   }
+   catch (...)
+   {
+      settleFailedProxySetup(pClient, ptrConnection);
+      logFailedProxySetup("localhost proxy", "unknown exception");
+   }
 }
 
 bool requiresSession(const http::Request& request)
@@ -1399,4 +1472,3 @@ void setSessionContextSource(SessionContextSource source)
 } // namespace session_proxy
 } // namespace server
 } // namespace rstudio
-

--- a/src/cpp/server/session/ServerSessionProxy.cpp
+++ b/src/cpp/server/session/ServerSessionProxy.cpp
@@ -1054,14 +1054,35 @@ bool proxyUploadRequest(
       // a form proxy to write form data to
       auto onClientCreated = [=](const boost::shared_ptr<http::IAsyncClient>& proxyClient)
       {
-         boost::shared_ptr<http::FormProxy> proxy =
-               boost::make_shared<http::FormProxy>(ptrConnection, proxyClient);
+         try
+         {
+            boost::shared_ptr<http::FormProxy> proxy =
+                  boost::make_shared<http::FormProxy>(ptrConnection, proxyClient);
 
-         proxy->initialize();
-         ptrConnection->setData(proxy);
+            proxy->initialize();
+            ptrConnection->setData(proxy);
 
-         // continue handling form data
-         ptrConnection->continueParsing();
+            // continue handling form data
+            ptrConnection->continueParsing();
+         }
+         catch (const std::exception& e)
+         {
+            // This callback is posted directly to the server io_context. An
+            // exception escaping it terminates that worker's run() call, while
+            // leaving the browser parser paused and the FixedBufferProxy cycle
+            // around proxyClient intact. Settle both sides here instead.
+            LOG_ERROR_MESSAGE(std::string("Failed to initialize form proxy: ") + e.what());
+            proxyClient->close();
+            proxyClient->disableHandlers();
+            ptrConnection->close();
+         }
+         catch (...)
+         {
+            LOG_ERROR_MESSAGE("Unknown exception while initializing form proxy");
+            proxyClient->close();
+            proxyClient->disableHandlers();
+            ptrConnection->close();
+         }
       };
 
       proxyRequest(RequestType::Content,
@@ -1378,5 +1399,4 @@ void setSessionContextSource(SessionContextSource source)
 } // namespace session_proxy
 } // namespace server
 } // namespace rstudio
-
 


### PR DESCRIPTION
### Intent

Addresses #18625, a follow-up from #18541.

`AsyncClient` moves `boost::function` handlers across `socketMutex_` in two directions, and both were unsafe if a copy threw. Copying a `boost::function` allocates whenever the target is too large for its small-object buffer, so allocation failure -- the memory pressure streaming exists to relieve -- is the realistic trigger. Both directions used `LOCK_MUTEX` / `END_LOCK_MUTEX`, whose unexpected-exception path logs and continues, so in every case execution ran on over half-finished state.

**Reading handlers out (snapshots), where the empty local reads as "no handler installed":**

- `deliverChunks()` -- the decoded piece is appended to `response_`, which nothing in streaming mode ever reads, and the consumer is then told the body is complete, one piece short.
- `closeAndRespond()` -- `responseHandler_` is copied first, so a failure on the `fixedBufferHandler_` copy leaves the surviving response handler to be invoked: a "successful" empty-body response for a body that in fact streamed in full.
- `handleWrite()` -- the connect notification is dropped, and a caller gated on it (`FormProxy`) buffers the upload until it times out.

Both `deliverChunks()` and `closeAndRespond()` additionally read an indeterminate `disabled` flag if lock acquisition itself threw, since the flag was declared uninitialized and assigned inside the critical section.

**Writing handlers in (installs), where a failure leaves the client half-configured:**

- `execute()` -- a response handler installed with no error handler behind it, and the request set in motion anyway, so the exchange can complete with nobody left to notify.
- `setFixedBufferHandler()` -- the installed handler is detached before the replacement is copied into its place, so a failure leaves no fixed buffer handler at all, silently flipping a streaming consumer into accumulating into `response_`.
- `setConnectHandler()` -- the connect notification stored while the downstream-closed handler that reports its loss is lost, leaving a caller with no way to be told either way.

### Approach

**Snapshots** go through a small `snapshotHandlers()` helper taking an explicit `boost::lock_guard` and reporting `Ready`, `Disabled`, or `Failed`. The lambda it runs keeps each site's own `handlersDisabled_` test in the same critical section as its own copies, which is the property `disableHandlers()`'s contract comment depends on; `Failed` takes the client's ordinary error path (`handleUnexpectedError()`), which closes the client, reports through the `ErrorHandler`, and detaches the handlers. Two details are load-bearing:

- `closeAndRespond()` takes its snapshot *before* the close. `handleError()` ignores anything raised after a deliberate close, so a failure discovered afterwards would be dropped without reporting or detaching anything.
- `handleWrite()` sets `requestWritten_` only after a successful copy. `close()` and `disableHandlers()` read that flag as "the connect notification was reported"; a failed copy can never report it, so leaving it false routes the still-pending notification to the downstream-closed handler -- the answer a caller gated on the connect needs to hear.

**Installs** use copy-then-swap: every copy happens before the lock, and only `swap()` runs under it. An install now either lands whole or changes nothing, and the exception reaches the caller -- which, unlike these `void` setters, has a stack to handle it on. This is a deliberate change from "swallow and continue half-configured" to "propagate with nothing changed"; the callers (`FixedBufferProxy::proxy()`, `ServerSessionProxy`, `FormProxy::initialize()`) all run inside the connection's existing exception guards.

### Automated Tests

Six fault-injection tests in `AsyncClientContentLengthTests.cpp`, one per site, driven by a `ThrowOnCopy<F>` callback target whose copy constructor throws `std::bad_alloc` once armed. Each was confirmed to fail against the unfixed code with exactly the symptom described above:

| Test | Symptom without the fix |
| --- | --- |
| `FixedBufferHandlerSnapshotFailureMidBodyFailsRatherThanDroppingPiece` | `sawFinalSignal == true` after only the first of two pieces was delivered |
| `ResponseHandlerSnapshotFailureAtCompletionFailsRatherThanRespondingEmpty` | `ResponseHandler` invoked with an empty body for a fully streamed response |
| `ConnectHandlerSnapshotFailureReportsDownstreamClosedRatherThanDropping` | neither notification delivered; the request read to completion behind the caller's back |
| `ExecuteHandlerInstallFailureLeavesNothingInMotion` | the connection ran to failure anyway, and left the client closed so a retry reported nothing |
| `FixedBufferHandlerInstallFailureKeepsTheInstalledHandler` | the installed streaming consumer was lost; the body silently fell back to being buffered |
| `ConnectHandlerInstallFailureKeepsTheInstalledPair` | the previously registered pair was destroyed, so the settle had nowhere to report |

`ExecuteHandlerInstallFailureLeavesNothingInMotion` deliberately aims at a dead port rather than a `LocalServer`: what it asserts is that nothing is set in motion at all, and `LocalServer`'s accept loop blocks until a connection arrives, so a regression there would hang the harness teardown instead of failing.

Full `rstudio-core-tests` suite passes (621 passed, 8 environment-dependent skips). The one unrelated failure seen in a whole-suite run, `AsyncConnectionImpl.ContinueParsingResumesOnTheConnectionsStrand`, is the known pre-existing flake tracked in #18634 and passes in isolation.

### QA Notes

No user-visible behavior change on any path that does not throw. The failures this addresses are not reachable by ordinary operation, so there is nothing to exercise manually; the coverage is the fault-injection tests above.

### Documentation

None required.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`

  Not applicable: the streaming proxy this hardens (#18546 / #18541) is itself unreleased, so no official-release user has encountered this.
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
