### PR TITLE
Update Electron to 42.10.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,7 +41,7 @@
 
 ### Dependencies
 - Copilot Language Server 1.531.0
-- Electron 42.10.0
+- Electron 42.10.1
 - Quarto 1.10.18
 
 ### Deprecated / Removed

--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -48,7 +48,7 @@
         "chai": "6.2.2",
         "copy-webpack-plugin": "14.0.0",
         "css-loader": "7.1.4",
-        "electron": "42.10.0",
+        "electron": "42.10.1",
         "electron-mocha": "13.1.0",
         "eslint": "10.8.1",
         "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -5911,9 +5911,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "42.10.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.10.0.tgz",
-      "integrity": "sha512-yBWnZO8tKId0ADvGa4+imPmm3+8Kfs8MtkUPhQQJz1AjTnUUDwCTWkQEU0CrArVVL97Jo4Q/0mVcLHciicBDGQ==",
+      "version": "42.10.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.10.1.tgz",
+      "integrity": "sha512-ITc1HPeoDzsxCCaH6MFsN67Nq2nUiJf5N9pBWxzhUpFfKJF0IwiAkKT3emg1lPbvC4OfFE+Cdwe4vhgdOZ1YKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -57,7 +57,7 @@
     "chai": "6.2.2",
     "copy-webpack-plugin": "14.0.0",
     "css-loader": "7.1.4",
-    "electron": "42.10.0",
+    "electron": "42.10.1",
     "electron-mocha": "13.1.0",
     "eslint": "10.8.1",
     "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -97,7 +97,7 @@
     "winston-syslog": "2.7.1"
   },
   "allowScripts": {
-    "electron@42.10.0": true,
+    "electron@42.10.1": true,
     "msgpackr-extract@3.0.3": true,
     "unix-dgram@2.0.6": true
   }


### PR DESCRIPTION
Updates the pinned Electron version from 42.10.0 to 42.10.1.

- `NEWS.md`: Dependencies entry updated.
- `src/node/desktop/package.json`: `electron` pinned to the exact version `42.10.1`.
- `src/node/desktop/package.json`: the `allowScripts` key updated from `electron@42.10.0` to `electron@42.10.1`. The allowlist matches by exact `package@version`, so a stale key blocks Electron's install script and leaves the binary undownloaded.
- `src/node/desktop/package-lock.json`: version, resolved URL, and integrity hash updated. No other packages changed.

## Verification

- `npm install --save-dev --save-exact electron@42.10.1` succeeded.
- The installed binary reports `42.10.1`.
- `npm test` in `src/node/desktop`: 447 passing, 2 pending, 0 failing.