### PR TITLE
Add slot, manifest and selector machinery for versioned Posit AI installs

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -197,6 +197,9 @@ set(SESSION_SOURCE_FILES
    modules/chat/ChatInstallation.cpp
    modules/chat/ChatInstallLock.cpp
    modules/chat/ChatIntegrity.cpp
+   modules/chat/ChatSlotManifest.cpp
+   modules/chat/ChatSlots.cpp
+   modules/chat/ChatSelector.cpp
    modules/chat/ChatUpdateThrottle.cpp
    modules/chat/ChatStaticFiles.cpp
    modules/SessionAssistant.cpp

--- a/src/cpp/session/modules/chat/ChatConstants.cpp
+++ b/src/cpp/session/modules/chat/ChatConstants.cpp
@@ -33,6 +33,19 @@ const char* const kServerScriptPath = "dist/server/main.js";
 const char* const kIndexFileName = "index.html";
 const char* const kCspConfigPath = "dist/csp.json";
 const char* const kProtocolVersionFileName = "protocol.json";
+const char* const kPackageJsonFileName = "package.json";
+
+// Versioned installation layout: the storage root (pai) holds one directory
+// per installed package version ("slot") plus the selector naming the active
+// slot for each protocol.
+const char* const kVersionsDirName = "versions";
+const char* const kSelectorFileName = "selected.json";
+// Written inside a slot, so it is renamed into place along with the tree it
+// describes. Dot-prefixed so it sorts away from the package's own files.
+const char* const kSlotManifestFileName = ".slot-manifest.json";
+// Extraction staging directories are siblings of the slots they become, so the
+// rename that publishes a slot is never a cross-device copy.
+const char* const kStagingDirPrefix = ".tmp-";
 
 // Protocol Version (SUPPORTED_PROTOCOL_VERSION)
 const char* const kProtocolVersion = "11.0";

--- a/src/cpp/session/modules/chat/ChatConstants.hpp
+++ b/src/cpp/session/modules/chat/ChatConstants.hpp
@@ -37,6 +37,15 @@ extern const char* const kServerScriptPath;
 extern const char* const kIndexFileName;
 extern const char* const kCspConfigPath;
 extern const char* const kProtocolVersionFileName;
+extern const char* const kPackageJsonFileName;
+
+// ============================================================================
+// Versioned installation layout (pai/versions)
+// ============================================================================
+extern const char* const kVersionsDirName;
+extern const char* const kSelectorFileName;
+extern const char* const kSlotManifestFileName;
+extern const char* const kStagingDirPrefix;
 
 // Sentinel value: no backend port is assigned
 constexpr int kChatBackendPortNone = -1;

--- a/src/cpp/session/modules/chat/ChatSelector.cpp
+++ b/src/cpp/session/modules/chat/ChatSelector.cpp
@@ -1,0 +1,207 @@
+/*
+ * ChatSelector.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "ChatSelector.hpp"
+
+#include <vector>
+
+#include "ChatConstants.hpp"
+#include "ChatLogging.hpp"
+#include "ChatSlots.hpp"
+#include "ChatTypes.hpp"
+
+#include <core/FileSerializer.hpp>
+#include <shared_core/json/Json.hpp>
+
+using namespace rstudio::core;
+using namespace rstudio::session::modules::chat::constants;
+using namespace rstudio::session::modules::chat::logging;
+using namespace rstudio::session::modules::chat::types;
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace chat {
+namespace selector {
+
+namespace {
+
+const char* const kSelectedKey = "selected";
+
+FilePath selectorPath(const FilePath& storageDir)
+{
+   return storageDir.completeChildPath(kSelectorFileName);
+}
+
+// Orders two verifying slots by which one a session should prefer: the higher
+// package version, then the higher slot name. The name is only a tiebreak
+// between slots of the same version (1.1.0 and 1.1.0-2); it is not read for
+// meaning, just for a stable answer.
+bool preferredOver(const slots::SlotInfo& lhs, const slots::SlotInfo& rhs)
+{
+   SemanticVersion lhsVersion, rhsVersion;
+   bool lhsParsed = lhsVersion.parse(lhs.version);
+   bool rhsParsed = rhsVersion.parse(rhs.version);
+
+   if (lhsParsed != rhsParsed)
+      return lhsParsed;
+
+   if (lhsParsed && lhsVersion != rhsVersion)
+      return lhsVersion > rhsVersion;
+
+   return lhs.name > rhs.name;
+}
+
+// The best slot for `protocol`, or nothing.
+bool bestSlotForProtocol(const FilePath& storageDir,
+                         const std::string& protocol,
+                         slots::SlotInfo* pInfo)
+{
+   std::vector<slots::SlotInfo> candidates =
+      slots::verifiedSlots(slots::versionsDir(storageDir));
+
+   bool found = false;
+   for (const slots::SlotInfo& candidate : candidates)
+   {
+      if (candidate.protocol != protocol)
+         continue;
+
+      if (!found || preferredOver(candidate, *pInfo))
+      {
+         *pInfo = candidate;
+         found = true;
+      }
+   }
+
+   return found;
+}
+
+} // anonymous namespace
+
+Selections readSelections(const FilePath& storageDir)
+{
+   Selections selections;
+
+   FilePath path = selectorPath(storageDir);
+   if (!path.isRegularFile())
+      return selections;
+
+   std::string content;
+   Error error = readStringFromFile(path, &content);
+   if (error)
+   {
+      WLOG("Cannot read {}: {}", path.getAbsolutePath(), error.getMessage());
+      return selections;
+   }
+
+   json::Value value;
+   if (value.parse(content) || !value.isObject())
+   {
+      WLOG("{} is not a JSON object; ignoring it", path.getAbsolutePath());
+      return selections;
+   }
+
+   json::Object selected;
+   error = json::readObject(value.getObject(), kSelectedKey, selected);
+   if (error)
+   {
+      WLOG("{} has no \"{}\" object; ignoring it",
+           path.getAbsolutePath(), kSelectedKey);
+      return selections;
+   }
+
+   for (const auto& member : selected)
+   {
+      if (member.getValue().isString())
+         selections[member.getName()] = member.getValue().getString();
+      else
+         WLOG("Ignoring non-string selection for protocol {}", member.getName());
+   }
+
+   return selections;
+}
+
+Error writeSelections(const FilePath& storageDir, const Selections& selections)
+{
+   Error error = storageDir.ensureDirectory();
+   if (error)
+      return error;
+
+   json::Object selected;
+   for (const auto& selection : selections)
+      selected[selection.first] = selection.second;
+
+   json::Object root;
+   root[kSelectedKey] = selected;
+
+   return writeStringToFileAtomic(selectorPath(storageDir), root.write());
+}
+
+Error selectSlot(const FilePath& storageDir,
+                 const std::string& protocol,
+                 const std::string& slotName)
+{
+   Selections selections = readSelections(storageDir);
+   selections[protocol] = slotName;
+   return writeSelections(storageDir, selections);
+}
+
+FilePath resolveSlot(const FilePath& storageDir, const std::string& protocol)
+{
+   FilePath slotsDir = slots::versionsDir(storageDir);
+
+   Selections selections = readSelections(storageDir);
+   Selections::const_iterator selection = selections.find(protocol);
+   if (selection != selections.end())
+   {
+      FilePath slotDir = slotsDir.completeChildPath(selection->second);
+
+      slots::SlotInfo info;
+      if (slots::verifySlot(slotDir, &info) && info.protocol == protocol)
+      {
+         DLOG("Protocol {} resolves to selected slot {}", protocol, info.name);
+         return slotDir;
+      }
+
+      WLOG("Selected slot '{}' for protocol {} is unusable; looking for another",
+           selection->second, protocol);
+   }
+
+   slots::SlotInfo fallback;
+   if (!bestSlotForProtocol(storageDir, protocol, &fallback))
+   {
+      DLOG("No install slot serves protocol {}", protocol);
+      return FilePath();
+   }
+
+   ILOG("Protocol {} now resolves to slot {}", protocol, fallback.name);
+
+   // Best effort: an unwritable storage directory costs us the repair, not the
+   // resolve. The same fallback runs again next session.
+   Error error = selectSlot(storageDir, protocol, fallback.name);
+   if (error)
+   {
+      WLOG("Could not record slot {} for protocol {}: {}",
+           fallback.name, protocol, error.getMessage());
+   }
+
+   return fallback.path;
+}
+
+} // namespace selector
+} // namespace chat
+} // namespace modules
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/session/modules/chat/ChatSelector.cpp
+++ b/src/cpp/session/modules/chat/ChatSelector.cpp
@@ -23,6 +23,7 @@
 #include "ChatTypes.hpp"
 
 #include <core/FileSerializer.hpp>
+#include <shared_core/SafeConvert.hpp>
 #include <shared_core/json/Json.hpp>
 
 using namespace rstudio::core;
@@ -45,21 +46,66 @@ FilePath selectorPath(const FilePath& storageDir)
    return storageDir.completeChildPath(kSelectorFileName);
 }
 
+// The release part of a version, i.e. everything before a prerelease or build
+// suffix. SemanticVersion::parse converts each dot-separated component with
+// boost::lexical_cast, which rejects trailing text, so "1.2.0-beta.1" would
+// otherwise fail to parse and rank below every release version.
+std::string releasePortion(const std::string& version)
+{
+   return version.substr(0, version.find_first_of("-+"));
+}
+
+// Which reinstall of a version a slot holds: 1 for the plain name, N for
+// "<version>-N", and 0 when the name is not derived from the version at all.
+//
+// This is the one place a slot name is read, and only to order slots that are
+// otherwise identical -- the alternative, comparing names as strings, ranks
+// "1.1.0-9" above "1.1.0-10" and hands a user who just reinstalled the older
+// slot back.
+int slotOrdinal(const std::string& name, const std::string& version)
+{
+   if (name == version)
+      return 1;
+
+   std::string suffix = version + "-";
+   if (name.compare(0, suffix.size(), suffix) != 0)
+      return 0;
+
+   std::string ordinal = name.substr(suffix.size());
+   if (ordinal.empty() ||
+       ordinal.find_first_not_of("0123456789") != std::string::npos)
+   {
+      return 0;
+   }
+
+   return safe_convert::stringTo<int>(ordinal, 0);
+}
+
 // Orders two verifying slots by which one a session should prefer: the higher
-// package version, then the higher slot name. The name is only a tiebreak
-// between slots of the same version (1.1.0 and 1.1.0-2); it is not read for
-// meaning, just for a stable answer.
+// release version, then a release over a prerelease of it, then the later
+// reinstall, then the higher name so the answer is always stable.
 bool preferredOver(const slots::SlotInfo& lhs, const slots::SlotInfo& rhs)
 {
    SemanticVersion lhsVersion, rhsVersion;
-   bool lhsParsed = lhsVersion.parse(lhs.version);
-   bool rhsParsed = rhsVersion.parse(rhs.version);
+   bool lhsParsed = lhsVersion.parse(releasePortion(lhs.version));
+   bool rhsParsed = rhsVersion.parse(releasePortion(rhs.version));
 
    if (lhsParsed != rhsParsed)
       return lhsParsed;
 
    if (lhsParsed && lhsVersion != rhsVersion)
       return lhsVersion > rhsVersion;
+
+   // 1.2.0 outranks 1.2.0-beta.1, as semantic versioning has it.
+   bool lhsPrerelease = lhs.version != releasePortion(lhs.version);
+   bool rhsPrerelease = rhs.version != releasePortion(rhs.version);
+   if (lhsPrerelease != rhsPrerelease)
+      return rhsPrerelease;
+
+   int lhsOrdinal = slotOrdinal(lhs.name, lhs.version);
+   int rhsOrdinal = slotOrdinal(rhs.name, rhs.version);
+   if (lhsOrdinal != rhsOrdinal)
+      return lhsOrdinal > rhsOrdinal;
 
    return lhs.name > rhs.name;
 }

--- a/src/cpp/session/modules/chat/ChatSelector.cpp
+++ b/src/cpp/session/modules/chat/ChatSelector.cpp
@@ -55,6 +55,19 @@ std::string releasePortion(const std::string& version)
    return version.substr(0, version.find_first_of("-+"));
 }
 
+// Whether a version carries a prerelease suffix. Build metadata is not one:
+// "1.2.0+build.1" has the precedence of plain 1.2.0 and so outranks
+// "1.2.0-beta.1", which testing for any suffix at all gets backwards.
+bool hasPrerelease(const std::string& version)
+{
+   std::string::size_type dash = version.find('-');
+   if (dash == std::string::npos)
+      return false;
+
+   std::string::size_type plus = version.find('+');
+   return plus == std::string::npos || dash < plus;
+}
+
 // Which reinstall of a version a slot holds: 1 for the plain name, N for
 // "<version>-N", and 0 when the name is not derived from the version at all.
 //
@@ -82,8 +95,14 @@ int slotOrdinal(const std::string& name, const std::string& version)
 }
 
 // Orders two verifying slots by which one a session should prefer: the higher
-// release version, then a release over a prerelease of it, then the later
-// reinstall, then the higher name so the answer is always stable.
+// release version, then a release over a prerelease of it, then -- only for
+// two slots holding the very same version -- the later reinstall, and finally
+// the version and name as strings so the answer is always stable.
+//
+// The string comparisons are a stable arbitrary order, not semantic-version
+// precedence: distinguishing "1.2.0-beta.9" from "1.2.0-beta.10" would need
+// identifier-by-identifier comparison, and nothing published for RStudio
+// carries a prerelease suffix at all.
 bool preferredOver(const slots::SlotInfo& lhs, const slots::SlotInfo& rhs)
 {
    SemanticVersion lhsVersion, rhsVersion;
@@ -97,10 +116,14 @@ bool preferredOver(const slots::SlotInfo& lhs, const slots::SlotInfo& rhs)
       return lhsVersion > rhsVersion;
 
    // 1.2.0 outranks 1.2.0-beta.1, as semantic versioning has it.
-   bool lhsPrerelease = lhs.version != releasePortion(lhs.version);
-   bool rhsPrerelease = rhs.version != releasePortion(rhs.version);
-   if (lhsPrerelease != rhsPrerelease)
-      return rhsPrerelease;
+   if (hasPrerelease(lhs.version) != hasPrerelease(rhs.version))
+      return hasPrerelease(rhs.version);
+
+   // An ordinal counts reinstalls of one version, so it says nothing about two
+   // slots holding different ones -- comparing across them would let
+   // 1.2.0-beta.1-10 outrank the newer 1.2.0-beta.2.
+   if (lhs.version != rhs.version)
+      return lhs.version > rhs.version;
 
    int lhsOrdinal = slotOrdinal(lhs.name, lhs.version);
    int rhsOrdinal = slotOrdinal(rhs.name, rhs.version);

--- a/src/cpp/session/modules/chat/ChatSelector.cpp
+++ b/src/cpp/session/modules/chat/ChatSelector.cpp
@@ -212,17 +212,32 @@ FilePath resolveSlot(const FilePath& storageDir, const std::string& protocol)
    Selections::const_iterator selection = selections.find(protocol);
    if (selection != selections.end())
    {
-      FilePath slotDir = slotsDir.completeChildPath(selection->second);
-
-      slots::SlotInfo info;
-      if (slots::verifySlot(slotDir, &info) && info.protocol == protocol)
+      // The selector is a file in the user's home, so its contents are a
+      // suggestion, not a path. Without this a dot-prefixed entry would
+      // resolve a staging directory -- which verifies, being a complete tree,
+      // right up until its owner renames it away underneath the running
+      // backend -- and a traversal entry would hand back the versions
+      // directory itself, since completeChildPath() returns the parent when it
+      // rejects an escape.
+      if (!slots::isUsableSlotName(selection->second))
       {
-         DLOG("Protocol {} resolves to selected slot {}", protocol, info.name);
-         return slotDir;
+         WLOG("Ignoring selection '{}' for protocol {}: not a slot name",
+              selection->second, protocol);
       }
+      else
+      {
+         FilePath slotDir = slotsDir.completeChildPath(selection->second);
 
-      WLOG("Selected slot '{}' for protocol {} is unusable; looking for another",
-           selection->second, protocol);
+         slots::SlotInfo info;
+         if (slots::verifySlot(slotDir, &info) && info.protocol == protocol)
+         {
+            DLOG("Protocol {} resolves to selected slot {}", protocol, info.name);
+            return slotDir;
+         }
+
+         WLOG("Selected slot '{}' for protocol {} is unusable; looking for another",
+              selection->second, protocol);
+      }
    }
 
    slots::SlotInfo fallback;

--- a/src/cpp/session/modules/chat/ChatSelector.hpp
+++ b/src/cpp/session/modules/chat/ChatSelector.hpp
@@ -1,0 +1,107 @@
+/*
+ * ChatSelector.hpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SESSION_CHAT_SELECTOR_HPP
+#define SESSION_CHAT_SELECTOR_HPP
+
+#include <map>
+#include <string>
+
+#include <shared_core/Error.hpp>
+#include <shared_core/FilePath.hpp>
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace chat {
+namespace selector {
+
+// selected.json records which install slot is active for each Posit Assistant
+// protocol version, so RStudio releases built against different protocols can
+// share one home directory without competing for a single install:
+//
+//     {"selected": {"11.0": "1.1.0-2", "10.0": "0.4.8"}}
+//
+// It is advisory. Resolution falls back to the newest matching slot on disk
+// whenever the file disagrees with reality, so losing it costs nothing.
+
+// Protocol version to slot directory name.
+typedef std::map<std::string, std::string> Selections;
+
+/**
+ * Read the recorded selections.
+ *
+ * A missing, unreadable, or malformed file reads as no selections rather than
+ * an error: every selection is recoverable from the slots themselves, so there
+ * is nothing for a caller to do differently.
+ *
+ * @param storageDir The Posit Assistant storage directory (<userDataDir>/pai).
+ * @return The recorded selections, ignoring any entry that is not a string.
+ */
+Selections readSelections(const core::FilePath& storageDir);
+
+/**
+ * Replace the recorded selections.
+ *
+ * Written to a temporary file and renamed into place, so a reader never sees a
+ * partial file. Concurrent writers are last-writer-wins; a selection lost that
+ * way is recovered by the next resolveSlot().
+ *
+ * @param storageDir The Posit Assistant storage directory.
+ * @param selections The selections to record.
+ * @return Success, or an error if the file could not be written.
+ */
+core::Error writeSelections(const core::FilePath& storageDir,
+                            const Selections& selections);
+
+/**
+ * Record the active slot for one protocol, leaving other protocols alone.
+ *
+ * @param storageDir The Posit Assistant storage directory.
+ * @param protocol The protocol version the slot serves (e.g. "11.0").
+ * @param slotName The slot's directory name (e.g. "1.1.0-2").
+ * @return Success, or an error if the file could not be written.
+ */
+core::Error selectSlot(const core::FilePath& storageDir,
+                       const std::string& protocol,
+                       const std::string& slotName);
+
+/**
+ * Find the slot to run for a protocol.
+ *
+ * Prefers the recorded selection. When that slot is missing, fails
+ * verification, or turns out to serve a different protocol, falls back to the
+ * newest-versioned verifying slot for the protocol and records it, so a
+ * dropped or damaged selector heals itself. Ties on version are broken by slot
+ * name, descending -- arbitrary, but stable across sessions.
+ *
+ * Repair is best effort: a slot is still returned when the storage directory
+ * cannot be written.
+ *
+ * @param storageDir The Posit Assistant storage directory.
+ * @param protocol The protocol version to resolve for (e.g. "11.0").
+ * @return The slot directory, or an empty FilePath when no slot serves the
+ *         protocol.
+ */
+core::FilePath resolveSlot(const core::FilePath& storageDir,
+                           const std::string& protocol);
+
+} // namespace selector
+} // namespace chat
+} // namespace modules
+} // namespace session
+} // namespace rstudio
+
+#endif // SESSION_CHAT_SELECTOR_HPP

--- a/src/cpp/session/modules/chat/ChatSelector.hpp
+++ b/src/cpp/session/modules/chat/ChatSelector.hpp
@@ -35,7 +35,12 @@ namespace selector {
 //     {"selected": {"11.0": "1.1.0-2", "10.0": "0.4.8"}}
 //
 // It is advisory. Resolution falls back to the newest matching slot on disk
-// whenever the file disagrees with reality, so losing it costs nothing.
+// whenever the file disagrees with reality, so the file can be lost or damaged
+// without stranding a session. Note what that recovery is and is not: it
+// converges on the newest verifying slot for the protocol, not on whatever the
+// lost entry named. While a selection only ever records the version just
+// installed that is the same answer, but a selection made to hold a session on
+// an older slot would not survive.
 
 // Protocol version to slot directory name.
 typedef std::map<std::string, std::string> Selections;
@@ -56,8 +61,10 @@ Selections readSelections(const core::FilePath& storageDir);
  * Replace the recorded selections.
  *
  * Written to a temporary file and renamed into place, so a reader never sees a
- * partial file. Concurrent writers are last-writer-wins; a selection lost that
- * way is recovered by the next resolveSlot().
+ * partial file. That does not serialize the read-modify-write in selectSlot():
+ * two sessions recording different protocols at once can drop one of the
+ * entries, and the next resolveSlot() replaces the dropped one with the newest
+ * matching slot rather than restoring what it said.
  *
  * @param storageDir The Posit Assistant storage directory.
  * @param selections The selections to record.

--- a/src/cpp/session/modules/chat/ChatSelectorTests.cpp
+++ b/src/cpp/session/modules/chat/ChatSelectorTests.cpp
@@ -326,6 +326,28 @@ TEST_F(ChatSelector, PrefersTheLatestReinstallOfAPrerelease)
       resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.2.0-beta.1-2")));
 }
 
+TEST_F(ChatSelector, DoesNotCompareReinstallOrdinalsAcrossVersions)
+{
+   // An ordinal counts reinstalls of one version; comparing it against a
+   // different version would let the tenth reinstall of beta.1 outrank beta.2.
+   makeSlot("1.2.0-beta.1-10", "1.2.0-beta.1", "11.0");
+   makeSlot("1.2.0-beta.2", "1.2.0-beta.2", "11.0");
+
+   EXPECT_TRUE(
+      resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.2.0-beta.2")));
+}
+
+TEST_F(ChatSelector, TreatsBuildMetadataAsARelease)
+{
+   // Build metadata carries no precedence, so 1.2.0+build.1 ranks as plain
+   // 1.2.0 and outranks a prerelease of it.
+   makeSlot("1.2.0-beta.1", "1.2.0-beta.1", "11.0");
+   makeSlot("1.2.0+build.1", "1.2.0+build.1", "11.0");
+
+   EXPECT_TRUE(
+      resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.2.0+build.1")));
+}
+
 TEST_F(ChatSelector, FallsBackOnlyToSlotsServingTheProtocol)
 {
    makeSlot("2.0.0", "2.0.0", "12.0");

--- a/src/cpp/session/modules/chat/ChatSelectorTests.cpp
+++ b/src/cpp/session/modules/chat/ChatSelectorTests.cpp
@@ -343,6 +343,38 @@ TEST_F(ChatSelector, FallsBackOnlyToSlotsThatVerify)
    EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.1.0")));
 }
 
+TEST_F(ChatSelector, IgnoresASelectionNamingAStagingDirectory)
+{
+   // A staging directory holds a complete tree and so verifies, but its owner
+   // renames it away when the install finishes. Resolving one would put the
+   // backend in a directory that is about to move.
+   makeSlot(".tmp-host-1-abc", "1.2.0", "11.0");
+   makeSlot("1.1.0", "1.1.0", "11.0");
+   ASSERT_TRUE(rstudio::session::modules::chat::slots::verifySlot(
+      slot(".tmp-host-1-abc")));
+   writeSelectorFile("{\"selected\":{\"11.0\":\".tmp-host-1-abc\"}}");
+
+   EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.1.0")));
+}
+
+TEST_F(ChatSelector, IgnoresASelectionThatTriesToEscapeTheVersionsDirectory)
+{
+   // completeChildPath() hands back the parent when it rejects an escape, so
+   // without a name check this would verify the versions directory itself.
+   makeSlot("1.1.0", "1.1.0", "11.0");
+   writeSelectorFile("{\"selected\":{\"11.0\":\"../../elsewhere\"}}");
+
+   EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.1.0")));
+}
+
+TEST_F(ChatSelector, IgnoresAnEmptySelection)
+{
+   makeSlot("1.1.0", "1.1.0", "11.0");
+   writeSelectorFile("{\"selected\":{\"11.0\":\"\"}}");
+
+   EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.1.0")));
+}
+
 TEST_F(ChatSelector, ResolvesNothingWhenNoSlotServesTheProtocol)
 {
    makeSlot("1.1.0", "1.1.0", "11.0");

--- a/src/cpp/session/modules/chat/ChatSelectorTests.cpp
+++ b/src/cpp/session/modules/chat/ChatSelectorTests.cpp
@@ -1,0 +1,322 @@
+/*
+ * ChatSelectorTests.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "ChatSelector.hpp"
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "ChatSlotManifest.hpp"
+#include "ChatSlots.hpp"
+
+#include <core/FileSerializer.hpp>
+#include <shared_core/FilePath.hpp>
+#include <shared_core/json/Json.hpp>
+
+using namespace rstudio::core;
+using namespace rstudio::session::modules::chat::selector;
+using rstudio::session::modules::chat::slot_manifest::writeSlotManifest;
+using rstudio::session::modules::chat::slots::versionsDir;
+
+namespace {
+
+class ChatSelector : public testing::Test
+{
+protected:
+   void SetUp() override
+   {
+      FilePath tempPath;
+      ASSERT_FALSE(FilePath::tempFilePath(tempPath));
+      storageDir_ = tempPath.completePath("pai");
+      versionsDir_ = versionsDir(storageDir_);
+      ASSERT_FALSE(versionsDir_.ensureDirectory());
+   }
+
+   void TearDown() override
+   {
+      storageDir_.getParent().removeIfExists();
+   }
+
+   void writeFile(const FilePath& filePath, const std::string& content)
+   {
+      ASSERT_FALSE(filePath.getParent().ensureDirectory());
+      ASSERT_FALSE(writeStringToFile(filePath, content));
+   }
+
+   // A slot as an install leaves it: the files the backend needs, the identity
+   // files resolution reads, and the manifest describing the tree.
+   void makeSlot(const std::string& name,
+                 const std::string& version,
+                 const std::string& protocol)
+   {
+      FilePath dir = slot(name);
+      writeFile(dir.completeChildPath("dist/server/main.js"), "console.log('hi');");
+      writeFile(dir.completeChildPath("dist/client/index.html"), "<html></html>");
+      writeFile(dir.completeChildPath("package.json"),
+                "{\"version\":\"" + version + "\"}");
+      writeFile(dir.completeChildPath("protocol.json"),
+                "{\"protocol\":\"" + protocol + "\"}");
+      ASSERT_FALSE(writeSlotManifest(dir));
+   }
+
+   // A slot that will not verify: no manifest was ever recorded for it.
+   void makeDamagedSlot(const std::string& version, const std::string& protocol)
+   {
+      FilePath dir = slot(version);
+      writeFile(dir.completeChildPath("dist/server/main.js"), "console.log('hi');");
+      writeFile(dir.completeChildPath("dist/client/index.html"), "<html></html>");
+      writeFile(dir.completeChildPath("package.json"),
+                "{\"version\":\"" + version + "\"}");
+      writeFile(dir.completeChildPath("protocol.json"),
+                "{\"protocol\":\"" + protocol + "\"}");
+   }
+
+   void writeSelectorFile(const std::string& content)
+   {
+      writeFile(storageDir_.completeChildPath("selected.json"), content);
+   }
+
+   FilePath slot(const std::string& name)
+   {
+      return versionsDir_.completeChildPath(name);
+   }
+
+   FilePath storageDir_;
+   FilePath versionsDir_;
+};
+
+// ============================================================================
+// readSelections / writeSelections
+// ============================================================================
+
+TEST_F(ChatSelector, RoundTripsSelections)
+{
+   Selections written;
+   written["11.0"] = "1.1.0-2";
+   written["10.0"] = "0.4.8";
+   ASSERT_FALSE(writeSelections(storageDir_, written));
+
+   Selections read = readSelections(storageDir_);
+   EXPECT_EQ(read.size(), 2u);
+   EXPECT_EQ(read["11.0"], "1.1.0-2");
+   EXPECT_EQ(read["10.0"], "0.4.8");
+}
+
+TEST_F(ChatSelector, WritesSlotNamesKeyedByProtocol)
+{
+   // Pins the on-disk shape: this file outlives the release that wrote it.
+   Selections written;
+   written["11.0"] = "1.1.0-2";
+   ASSERT_FALSE(writeSelections(storageDir_, written));
+
+   std::string content;
+   ASSERT_FALSE(readStringFromFile(
+      storageDir_.completeChildPath("selected.json"), &content));
+
+   json::Value value;
+   ASSERT_FALSE(value.parse(content));
+   ASSERT_TRUE(value.isObject());
+
+   json::Object selected;
+   ASSERT_FALSE(json::readObject(value.getObject(), "selected", selected));
+   ASSERT_TRUE(selected.hasMember("11.0"));
+   EXPECT_EQ(selected["11.0"].getString(), "1.1.0-2");
+}
+
+TEST_F(ChatSelector, CreatesTheStorageDirectoryWhenWriting)
+{
+   ASSERT_FALSE(storageDir_.remove());
+
+   Selections written;
+   written["11.0"] = "1.1.0";
+   ASSERT_FALSE(writeSelections(storageDir_, written));
+   EXPECT_EQ(readSelections(storageDir_)["11.0"], "1.1.0");
+}
+
+TEST_F(ChatSelector, ReadsNothingBeforeAnythingIsSelected)
+{
+   EXPECT_TRUE(readSelections(storageDir_).empty());
+}
+
+TEST_F(ChatSelector, ReadsNothingFromUnparseableJson)
+{
+   writeSelectorFile("not json at all");
+   EXPECT_TRUE(readSelections(storageDir_).empty());
+}
+
+TEST_F(ChatSelector, ReadsNothingWithoutASelectedObject)
+{
+   writeSelectorFile("{\"11.0\":\"1.1.0\"}");
+   EXPECT_TRUE(readSelections(storageDir_).empty());
+}
+
+TEST_F(ChatSelector, IgnoresSelectionsThatAreNotSlotNames)
+{
+   writeSelectorFile("{\"selected\":{\"11.0\":\"1.1.0\",\"10.0\":42}}");
+
+   Selections read = readSelections(storageDir_);
+   EXPECT_EQ(read.size(), 1u);
+   EXPECT_EQ(read["11.0"], "1.1.0");
+}
+
+TEST_F(ChatSelector, SelectingOneProtocolLeavesTheOthersAlone)
+{
+   ASSERT_FALSE(selectSlot(storageDir_, "10.0", "0.4.8"));
+   ASSERT_FALSE(selectSlot(storageDir_, "11.0", "1.1.0"));
+
+   Selections read = readSelections(storageDir_);
+   EXPECT_EQ(read.size(), 2u);
+   EXPECT_EQ(read["10.0"], "0.4.8");
+   EXPECT_EQ(read["11.0"], "1.1.0");
+}
+
+TEST_F(ChatSelector, SelectingReplacesThePreviousSlotForThatProtocol)
+{
+   ASSERT_FALSE(selectSlot(storageDir_, "11.0", "1.1.0"));
+   ASSERT_FALSE(selectSlot(storageDir_, "11.0", "1.1.0-2"));
+
+   Selections read = readSelections(storageDir_);
+   EXPECT_EQ(read.size(), 1u);
+   EXPECT_EQ(read["11.0"], "1.1.0-2");
+}
+
+// ============================================================================
+// resolveSlot
+// ============================================================================
+
+TEST_F(ChatSelector, ResolvesTheSelectedSlot)
+{
+   makeSlot("1.1.0", "1.1.0", "11.0");
+   makeSlot("1.0.4", "1.0.4", "11.0");
+   ASSERT_FALSE(selectSlot(storageDir_, "11.0", "1.0.4"));
+
+   // The selection wins over the newer slot: a session runs what was chosen.
+   EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.0.4")));
+}
+
+TEST_F(ChatSelector, RepairsASelectionOfAMissingSlot)
+{
+   makeSlot("1.1.0", "1.1.0", "11.0");
+   ASSERT_FALSE(selectSlot(storageDir_, "11.0", "1.0.4"));
+
+   EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.1.0")));
+   EXPECT_EQ(readSelections(storageDir_)["11.0"], "1.1.0");
+}
+
+TEST_F(ChatSelector, RepairsASelectionOfACorruptSlot)
+{
+   makeDamagedSlot("1.2.0", "11.0");
+   makeSlot("1.1.0", "1.1.0", "11.0");
+   ASSERT_FALSE(selectSlot(storageDir_, "11.0", "1.2.0"));
+
+   EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.1.0")));
+   EXPECT_EQ(readSelections(storageDir_)["11.0"], "1.1.0");
+}
+
+TEST_F(ChatSelector, RepairsASelectionOfASlotForAnotherProtocol)
+{
+   makeSlot("2.0.0", "2.0.0", "12.0");
+   makeSlot("1.1.0", "1.1.0", "11.0");
+   ASSERT_FALSE(selectSlot(storageDir_, "11.0", "2.0.0"));
+
+   EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.1.0")));
+   EXPECT_EQ(readSelections(storageDir_)["11.0"], "1.1.0");
+}
+
+TEST_F(ChatSelector, ResolvesAndRecordsWithNoSelectorAtAll)
+{
+   makeSlot("1.1.0", "1.1.0", "11.0");
+
+   EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.1.0")));
+   EXPECT_EQ(readSelections(storageDir_)["11.0"], "1.1.0");
+}
+
+TEST_F(ChatSelector, ResolvesAndRewritesAMalformedSelector)
+{
+   makeSlot("1.1.0", "1.1.0", "11.0");
+   writeSelectorFile("{\"selected\": [");
+
+   EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.1.0")));
+   EXPECT_EQ(readSelections(storageDir_)["11.0"], "1.1.0");
+}
+
+TEST_F(ChatSelector, RepairingOneProtocolLeavesTheOthersAlone)
+{
+   makeSlot("1.1.0", "1.1.0", "11.0");
+   makeSlot("0.4.8", "0.4.8", "10.0");
+   ASSERT_FALSE(selectSlot(storageDir_, "11.0", "gone"));
+   ASSERT_FALSE(selectSlot(storageDir_, "10.0", "0.4.8"));
+
+   ASSERT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.1.0")));
+
+   Selections read = readSelections(storageDir_);
+   EXPECT_EQ(read["11.0"], "1.1.0");
+   EXPECT_EQ(read["10.0"], "0.4.8");
+}
+
+TEST_F(ChatSelector, FallsBackToTheNewestVersion)
+{
+   makeSlot("1.0.4", "1.0.4", "11.0");
+   makeSlot("1.10.0", "1.10.0", "11.0");
+   makeSlot("1.2.0", "1.2.0", "11.0");
+
+   // Numeric, not lexical: 1.10.0 is newer than 1.2.0.
+   EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.10.0")));
+}
+
+TEST_F(ChatSelector, BreaksVersionTiesBySlotName)
+{
+   // Both slots hold 1.1.0; the reinstalled one is the later name.
+   makeSlot("1.1.0", "1.1.0", "11.0");
+   makeSlot("1.1.0-2", "1.1.0", "11.0");
+
+   EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.1.0-2")));
+}
+
+TEST_F(ChatSelector, FallsBackOnlyToSlotsServingTheProtocol)
+{
+   makeSlot("2.0.0", "2.0.0", "12.0");
+   makeSlot("1.1.0", "1.1.0", "11.0");
+
+   EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.1.0")));
+   EXPECT_TRUE(resolveSlot(storageDir_, "12.0").isEquivalentTo(slot("2.0.0")));
+}
+
+TEST_F(ChatSelector, FallsBackOnlyToSlotsThatVerify)
+{
+   makeDamagedSlot("1.2.0", "11.0");
+   makeSlot("1.1.0", "1.1.0", "11.0");
+
+   EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.1.0")));
+}
+
+TEST_F(ChatSelector, ResolvesNothingWhenNoSlotServesTheProtocol)
+{
+   makeSlot("1.1.0", "1.1.0", "11.0");
+
+   EXPECT_TRUE(resolveSlot(storageDir_, "12.0").isEmpty());
+   EXPECT_EQ(readSelections(storageDir_).count("12.0"), 0u);
+}
+
+TEST_F(ChatSelector, ResolvesNothingBeforeTheFirstInstall)
+{
+   ASSERT_FALSE(storageDir_.remove());
+
+   EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEmpty());
+   EXPECT_FALSE(storageDir_.exists());
+}
+
+} // anonymous namespace

--- a/src/cpp/session/modules/chat/ChatSelectorTests.cpp
+++ b/src/cpp/session/modules/chat/ChatSelectorTests.cpp
@@ -277,13 +277,53 @@ TEST_F(ChatSelector, FallsBackToTheNewestVersion)
    EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.10.0")));
 }
 
-TEST_F(ChatSelector, BreaksVersionTiesBySlotName)
+TEST_F(ChatSelector, PrefersTheLatestReinstallOfAVersion)
 {
-   // Both slots hold 1.1.0; the reinstalled one is the later name.
+   // Both slots hold 1.1.0; the reinstalled one is the later ordinal.
    makeSlot("1.1.0", "1.1.0", "11.0");
    makeSlot("1.1.0-2", "1.1.0", "11.0");
 
    EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.1.0-2")));
+}
+
+TEST_F(ChatSelector, OrdersReinstallsNumericallyPastNine)
+{
+   // Comparing names as strings puts "1.1.0-9" above "1.1.0-10", which would
+   // hand back the slot a user had just reinstalled to get away from.
+   makeSlot("1.1.0", "1.1.0", "11.0");
+   makeSlot("1.1.0-9", "1.1.0", "11.0");
+   makeSlot("1.1.0-10", "1.1.0", "11.0");
+
+   EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.1.0-10")));
+}
+
+TEST_F(ChatSelector, RanksPrereleasesByTheirReleaseVersion)
+{
+   // SemanticVersion::parse rejects a version with a prerelease suffix, so
+   // ordering has to compare the release portion or 1.2.0-beta.1 ranks below
+   // every version that happens to parse.
+   makeSlot("0.0.1", "0.0.1", "11.0");
+   makeSlot("1.2.0-beta.1", "1.2.0-beta.1", "11.0");
+
+   EXPECT_TRUE(
+      resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.2.0-beta.1")));
+}
+
+TEST_F(ChatSelector, PrefersAReleaseOverItsPrerelease)
+{
+   makeSlot("1.2.0-beta.1", "1.2.0-beta.1", "11.0");
+   makeSlot("1.2.0", "1.2.0", "11.0");
+
+   EXPECT_TRUE(resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.2.0")));
+}
+
+TEST_F(ChatSelector, PrefersTheLatestReinstallOfAPrerelease)
+{
+   makeSlot("1.2.0-beta.1", "1.2.0-beta.1", "11.0");
+   makeSlot("1.2.0-beta.1-2", "1.2.0-beta.1", "11.0");
+
+   EXPECT_TRUE(
+      resolveSlot(storageDir_, "11.0").isEquivalentTo(slot("1.2.0-beta.1-2")));
 }
 
 TEST_F(ChatSelector, FallsBackOnlyToSlotsServingTheProtocol)

--- a/src/cpp/session/modules/chat/ChatSlotManifest.cpp
+++ b/src/cpp/session/modules/chat/ChatSlotManifest.cpp
@@ -63,7 +63,12 @@ Error collectEntries(const FilePath& slotDir, SlotManifest* pManifest)
    Error error = slotDir.getChildrenRecursive(
       [&](int, const FilePath& child) -> bool
       {
-         if (!child.isRegularFile())
+         // isRegularFile() follows symlinks, so recording one would record the
+         // target's size and hash and make an otherwise immutable slot verify
+         // against a file outside it. Skipping leaves such a file uncovered by
+         // the manifest, which is what a symlinked directory already gets --
+         // the recursive iterator does not descend into one.
+         if (child.isSymlink() || !child.isRegularFile())
             return true;
 
          std::string relativePath = child.getRelativePath(slotDir);
@@ -188,7 +193,9 @@ bool matchesSlotManifest(const FilePath& slotDir)
          return false;
       }
 
-      if (!filePath.isRegularFile())
+      // A recorded path that is now a symlink would be checked against
+      // whatever it points at, so treat it as the recorded file being gone.
+      if (filePath.isSymlink() || !filePath.isRegularFile())
       {
          WLOG("Slot {} is missing manifest file {}",
               slotDir.getAbsolutePath(), entry.first);

--- a/src/cpp/session/modules/chat/ChatSlotManifest.cpp
+++ b/src/cpp/session/modules/chat/ChatSlotManifest.cpp
@@ -18,6 +18,8 @@
 #include "ChatConstants.hpp"
 #include "ChatLogging.hpp"
 
+#include <set>
+
 #include <core/FileSerializer.hpp>
 #include <core/system/Crypto.hpp>
 #include <shared_core/json/Json.hpp>
@@ -42,6 +44,35 @@ const char* const kSha256Key = "sha256";
 FilePath manifestPath(const FilePath& slotDir)
 {
    return slotDir.completeChildPath(kSlotManifestFileName);
+}
+
+// Whether every directory between the slot and a recorded file is a real
+// directory. Checking only the file itself is not enough: replacing an
+// ancestor with a symlink makes the recorded path resolve outside the slot
+// while the leaf is still an ordinary file.
+//
+// `pChecked` accumulates directories already cleared, so a deep tree costs one
+// check per directory rather than one per file in it.
+bool ancestorsAreRealDirectories(const FilePath& slotDir,
+                                 const std::string& relativePath,
+                                 std::set<std::string>* pChecked)
+{
+   std::string::size_type separator = relativePath.find('/');
+   while (separator != std::string::npos)
+   {
+      std::string ancestor = relativePath.substr(0, separator);
+      if (pChecked->insert(ancestor).second)
+      {
+         FilePath ancestorPath;
+         Error error = slotDir.completeChildPath(ancestor, ancestorPath);
+         if (error || ancestorPath.isSymlink() || !ancestorPath.isDirectory())
+            return false;
+      }
+
+      separator = relativePath.find('/', separator + 1);
+   }
+
+   return true;
 }
 
 Error hashFile(const FilePath& filePath, std::string* pSha256)
@@ -182,6 +213,10 @@ bool matchesSlotManifest(const FilePath& slotDir)
       return false;
    }
 
+   // Directories already found to be real, so a tree many files deep costs one
+   // check per directory rather than one per file.
+   std::set<std::string> checkedDirs;
+
    for (const auto& entry : manifest)
    {
       FilePath filePath;
@@ -189,6 +224,13 @@ bool matchesSlotManifest(const FilePath& slotDir)
       if (error)
       {
          WLOG("Slot manifest for {} names a path outside the slot: {}",
+              slotDir.getAbsolutePath(), entry.first);
+         return false;
+      }
+
+      if (!ancestorsAreRealDirectories(slotDir, entry.first, &checkedDirs))
+      {
+         WLOG("Slot {} reaches manifest file {} through a symlink",
               slotDir.getAbsolutePath(), entry.first);
          return false;
       }

--- a/src/cpp/session/modules/chat/ChatSlotManifest.cpp
+++ b/src/cpp/session/modules/chat/ChatSlotManifest.cpp
@@ -65,7 +65,13 @@ bool ancestorsAreRealDirectories(const FilePath& slotDir,
       {
          FilePath ancestorPath;
          Error error = slotDir.completeChildPath(ancestor, ancestorPath);
-         if (error || ancestorPath.isSymlink() || !ancestorPath.isDirectory())
+         if (error || !ancestorPath.isDirectory())
+            return false;
+
+         // Junctions are checked as well as symlinks: they are the reparse
+         // point Windows uses to redirect a directory, and is_symlink() does
+         // not report them, which is why FilePath carries isJunction() at all.
+         if (ancestorPath.isSymlink() || ancestorPath.isJunction())
             return false;
       }
 

--- a/src/cpp/session/modules/chat/ChatSlotManifest.cpp
+++ b/src/cpp/session/modules/chat/ChatSlotManifest.cpp
@@ -1,0 +1,214 @@
+/*
+ * ChatSlotManifest.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "ChatSlotManifest.hpp"
+
+#include "ChatConstants.hpp"
+#include "ChatLogging.hpp"
+
+#include <core/FileSerializer.hpp>
+#include <core/system/Crypto.hpp>
+#include <shared_core/json/Json.hpp>
+
+using namespace rstudio::core;
+using namespace rstudio::session::modules::chat::constants;
+using namespace rstudio::session::modules::chat::logging;
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace chat {
+namespace slot_manifest {
+
+namespace {
+
+// Manifest JSON keys.
+const char* const kFilesKey = "files";
+const char* const kSizeKey = "size";
+const char* const kSha256Key = "sha256";
+
+FilePath manifestPath(const FilePath& slotDir)
+{
+   return slotDir.completeChildPath(kSlotManifestFileName);
+}
+
+Error hashFile(const FilePath& filePath, std::string* pSha256)
+{
+   std::string content;
+   Error error = readStringFromFile(filePath, &content);
+   if (error)
+      return error;
+
+   return core::system::crypto::sha256Hex(content, pSha256);
+}
+
+// Collects size and hash for every regular file under `slotDir`, keyed by
+// '/'-separated path relative to the slot.
+Error collectEntries(const FilePath& slotDir, SlotManifest* pManifest)
+{
+   Error hashError;
+
+   Error error = slotDir.getChildrenRecursive(
+      [&](int, const FilePath& child) -> bool
+      {
+         if (!child.isRegularFile())
+            return true;
+
+         std::string relativePath = child.getRelativePath(slotDir);
+         if (relativePath.empty() || relativePath == kSlotManifestFileName)
+            return true;
+
+         std::string sha256;
+         hashError = hashFile(child, &sha256);
+         if (hashError)
+            return false;
+
+         (*pManifest)[relativePath] = ManifestEntry(child.getSize(), sha256);
+         return true;
+      });
+
+   if (error)
+      return error;
+
+   return hashError;
+}
+
+} // anonymous namespace
+
+Error writeSlotManifest(const FilePath& slotDir)
+{
+   SlotManifest manifest;
+   Error error = collectEntries(slotDir, &manifest);
+   if (error)
+      return error;
+
+   json::Object files;
+   for (const auto& entry : manifest)
+   {
+      json::Object record;
+      record[kSizeKey] = static_cast<uint64_t>(entry.second.size);
+      record[kSha256Key] = entry.second.sha256;
+      files[entry.first] = record;
+   }
+
+   json::Object root;
+   root[kFilesKey] = files;
+
+   DLOG("Recording {} files in slot manifest for {}",
+        manifest.size(), slotDir.getAbsolutePath());
+
+   return writeStringToFile(manifestPath(slotDir), root.write());
+}
+
+Error readSlotManifest(const FilePath& slotDir, SlotManifest* pManifest)
+{
+   FilePath path = manifestPath(slotDir);
+
+   std::string content;
+   Error error = readStringFromFile(path, &content);
+   if (error)
+      return error;
+
+   json::Value value;
+   if (value.parse(content) || !value.isObject())
+   {
+      return systemError(boost::system::errc::bad_message,
+                         "Slot manifest is not a JSON object",
+                         ERROR_LOCATION);
+   }
+
+   json::Object files;
+   error = json::readObject(value.getObject(), kFilesKey, files);
+   if (error)
+      return error;
+
+   SlotManifest manifest;
+   for (const auto& member : files)
+   {
+      if (!member.getValue().isObject())
+      {
+         return systemError(boost::system::errc::bad_message,
+                            "Slot manifest entry '" + member.getName() +
+                               "' is not a JSON object",
+                            ERROR_LOCATION);
+      }
+
+      json::Object record = member.getValue().getObject();
+      if (!record.hasMember(kSizeKey) || !record[kSizeKey].isUInt64())
+      {
+         return systemError(boost::system::errc::bad_message,
+                            "Slot manifest entry '" + member.getName() +
+                               "' has no valid size",
+                            ERROR_LOCATION);
+      }
+
+      std::string sha256;
+      if (record.hasMember(kSha256Key) && record[kSha256Key].isString())
+         sha256 = record[kSha256Key].getString();
+
+      manifest[member.getName()] =
+         ManifestEntry(record[kSizeKey].getUInt64(), sha256);
+   }
+
+   *pManifest = manifest;
+   return Success();
+}
+
+bool matchesSlotManifest(const FilePath& slotDir)
+{
+   SlotManifest manifest;
+   Error error = readSlotManifest(slotDir, &manifest);
+   if (error)
+   {
+      WLOG("Cannot read slot manifest for {}: {}",
+           slotDir.getAbsolutePath(), error.getMessage());
+      return false;
+   }
+
+   for (const auto& entry : manifest)
+   {
+      FilePath filePath;
+      error = slotDir.completeChildPath(entry.first, filePath);
+      if (error)
+      {
+         WLOG("Slot manifest for {} names a path outside the slot: {}",
+              slotDir.getAbsolutePath(), entry.first);
+         return false;
+      }
+
+      if (!filePath.isRegularFile())
+      {
+         WLOG("Slot {} is missing manifest file {}",
+              slotDir.getAbsolutePath(), entry.first);
+         return false;
+      }
+
+      if (filePath.getSize() != entry.second.size)
+      {
+         WLOG("Slot {} file {} is {} bytes, manifest recorded {}",
+              slotDir.getAbsolutePath(), entry.first,
+              filePath.getSize(), entry.second.size);
+         return false;
+      }
+   }
+
+   return true;
+}
+
+} // namespace slot_manifest
+} // namespace chat
+} // namespace modules
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/session/modules/chat/ChatSlotManifest.hpp
+++ b/src/cpp/session/modules/chat/ChatSlotManifest.hpp
@@ -1,0 +1,97 @@
+/*
+ * ChatSlotManifest.hpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SESSION_CHAT_SLOT_MANIFEST_HPP
+#define SESSION_CHAT_SLOT_MANIFEST_HPP
+
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include <shared_core/Error.hpp>
+#include <shared_core/FilePath.hpp>
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace chat {
+namespace slot_manifest {
+
+/**
+ * What the install recorded about one file in a slot.
+ */
+struct ManifestEntry
+{
+   ManifestEntry() : size(0) {}
+   ManifestEntry(std::uintmax_t in_size, const std::string& in_sha256)
+      : size(in_size), sha256(in_sha256)
+   {
+   }
+
+   std::uintmax_t size;
+
+   // Recorded for future use (e.g. an explicit deep integrity check); the
+   // routine verification that runs at every resolve compares sizes only.
+   std::string sha256;
+};
+
+// Relative path (always '/'-separated) to what was recorded for it.
+typedef std::map<std::string, ManifestEntry> SlotManifest;
+
+/**
+ * Record every regular file in a slot, then write the record into the slot.
+ *
+ * Called after extraction, while the tree is still staged and known to match
+ * the verified package, so the manifest is a statement about bits that were
+ * checked once. Directories, symlinks that do not resolve to a regular file,
+ * and the manifest file itself are not recorded.
+ *
+ * @param slotDir Directory holding the extracted package.
+ * @return Success, or an error if the tree could not be walked, a file could
+ *         not be hashed, or the manifest could not be written.
+ */
+core::Error writeSlotManifest(const core::FilePath& slotDir);
+
+/**
+ * Read the manifest a slot was installed with.
+ *
+ * @param slotDir Directory holding the extracted package.
+ * @param pManifest Output: the recorded entries (set only on success).
+ * @return Success, or an error if the manifest is absent, unreadable, or
+ *         malformed.
+ */
+core::Error readSlotManifest(const core::FilePath& slotDir,
+                             SlotManifest* pManifest);
+
+/**
+ * Check a slot against the manifest it was installed with.
+ *
+ * Every recorded file must exist and still have its recorded size. This is a
+ * stat walk -- no file contents are read -- so it is cheap enough to run at
+ * every resolve, including on NFS home directories. Files present in the slot
+ * but absent from the manifest are ignored.
+ *
+ * @param slotDir Directory holding the extracted package.
+ * @return true if the manifest is readable and every entry still matches.
+ */
+bool matchesSlotManifest(const core::FilePath& slotDir);
+
+} // namespace slot_manifest
+} // namespace chat
+} // namespace modules
+} // namespace session
+} // namespace rstudio
+
+#endif // SESSION_CHAT_SLOT_MANIFEST_HPP

--- a/src/cpp/session/modules/chat/ChatSlotManifestTests.cpp
+++ b/src/cpp/session/modules/chat/ChatSlotManifestTests.cpp
@@ -1,0 +1,236 @@
+/*
+ * ChatSlotManifestTests.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "ChatSlotManifest.hpp"
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include <core/FileSerializer.hpp>
+#include <shared_core/FilePath.hpp>
+
+using namespace rstudio::core;
+using namespace rstudio::session::modules::chat::slot_manifest;
+
+namespace {
+
+const char* const kManifestFileName = ".slot-manifest.json";
+
+class ChatSlotManifest : public testing::Test
+{
+protected:
+   void SetUp() override
+   {
+      FilePath tempPath;
+      ASSERT_FALSE(FilePath::tempFilePath(tempPath));
+      slotDir_ = tempPath.completePath("slot");
+      ASSERT_FALSE(slotDir_.ensureDirectory());
+   }
+
+   void TearDown() override
+   {
+      slotDir_.getParent().removeIfExists();
+   }
+
+   // Writes `content` at a slot-relative path, creating parent directories.
+   void writeFile(const std::string& relativePath, const std::string& content)
+   {
+      FilePath filePath = slotDir_.completeChildPath(relativePath);
+      ASSERT_FALSE(filePath.getParent().ensureDirectory());
+      ASSERT_FALSE(writeStringToFile(filePath, content));
+   }
+
+   // The tree a package extracts to, in miniature.
+   void writeTree()
+   {
+      writeFile("package.json", "{\"version\":\"1.1.0\"}");
+      writeFile("dist/server/main.js", "console.log('hi');");
+      writeFile("dist/client/index.html", "<html></html>");
+   }
+
+   FilePath slotDir_;
+};
+
+TEST_F(ChatSlotManifest, RoundTripsAnInstalledTree)
+{
+   writeTree();
+   ASSERT_FALSE(writeSlotManifest(slotDir_));
+
+   SlotManifest manifest;
+   ASSERT_FALSE(readSlotManifest(slotDir_, &manifest));
+
+   EXPECT_EQ(manifest.size(), 3u);
+   EXPECT_EQ(manifest["package.json"].size, 19u);
+   EXPECT_EQ(manifest["dist/server/main.js"].size, 18u);
+   EXPECT_EQ(manifest["dist/client/index.html"].size, 13u);
+   EXPECT_TRUE(matchesSlotManifest(slotDir_));
+}
+
+TEST_F(ChatSlotManifest, RecordsRealSha256)
+{
+   // Pins that the recorded digest is a SHA-256 of the file's bytes, so the
+   // hashes stay usable for the deeper check they are recorded for.
+   writeFile("abc.txt", "abc");
+   ASSERT_FALSE(writeSlotManifest(slotDir_));
+
+   SlotManifest manifest;
+   ASSERT_FALSE(readSlotManifest(slotDir_, &manifest));
+   EXPECT_EQ(manifest["abc.txt"].sha256,
+             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+}
+
+TEST_F(ChatSlotManifest, DoesNotRecordItself)
+{
+   writeTree();
+   ASSERT_FALSE(writeSlotManifest(slotDir_));
+
+   SlotManifest manifest;
+   ASSERT_FALSE(readSlotManifest(slotDir_, &manifest));
+   EXPECT_EQ(manifest.count(kManifestFileName), 0u);
+}
+
+TEST_F(ChatSlotManifest, RecordsEmptyFiles)
+{
+   // A zero-byte file is legitimate inside a package; only the handful of files
+   // the backend cannot run without are required to be non-empty, and that is
+   // checked elsewhere.
+   writeFile("empty", "");
+   ASSERT_FALSE(writeSlotManifest(slotDir_));
+
+   SlotManifest manifest;
+   ASSERT_FALSE(readSlotManifest(slotDir_, &manifest));
+   EXPECT_EQ(manifest.size(), 1u);
+   EXPECT_EQ(manifest["empty"].size, 0u);
+   EXPECT_TRUE(matchesSlotManifest(slotDir_));
+}
+
+TEST_F(ChatSlotManifest, DetectsMissingFile)
+{
+   writeTree();
+   ASSERT_FALSE(writeSlotManifest(slotDir_));
+
+   ASSERT_FALSE(slotDir_.completeChildPath("dist/server/main.js").remove());
+   EXPECT_FALSE(matchesSlotManifest(slotDir_));
+}
+
+TEST_F(ChatSlotManifest, DetectsTruncatedFile)
+{
+   writeTree();
+   ASSERT_FALSE(writeSlotManifest(slotDir_));
+
+   writeFile("dist/server/main.js", "");
+   EXPECT_FALSE(matchesSlotManifest(slotDir_));
+}
+
+TEST_F(ChatSlotManifest, DetectsGrownFile)
+{
+   writeTree();
+   ASSERT_FALSE(writeSlotManifest(slotDir_));
+
+   writeFile("dist/server/main.js", "console.log('hi'); // and more");
+   EXPECT_FALSE(matchesSlotManifest(slotDir_));
+}
+
+TEST_F(ChatSlotManifest, DetectsFileReplacedByDirectory)
+{
+   writeTree();
+   ASSERT_FALSE(writeSlotManifest(slotDir_));
+
+   FilePath mainJs = slotDir_.completeChildPath("dist/server/main.js");
+   ASSERT_FALSE(mainJs.remove());
+   ASSERT_FALSE(mainJs.ensureDirectory());
+   EXPECT_FALSE(matchesSlotManifest(slotDir_));
+}
+
+TEST_F(ChatSlotManifest, IgnoresFilesItDidNotRecord)
+{
+   // Slots are never modified after install, so an extra file is not evidence
+   // that the recorded tree is damaged.
+   writeTree();
+   ASSERT_FALSE(writeSlotManifest(slotDir_));
+
+   writeFile("dist/server/stray.log", "written by something else");
+   EXPECT_TRUE(matchesSlotManifest(slotDir_));
+}
+
+TEST_F(ChatSlotManifest, RejectsAbsentManifest)
+{
+   writeTree();
+
+   SlotManifest manifest;
+   EXPECT_TRUE(readSlotManifest(slotDir_, &manifest) != Success());
+   EXPECT_FALSE(matchesSlotManifest(slotDir_));
+}
+
+TEST_F(ChatSlotManifest, RejectsUnparseableManifest)
+{
+   writeTree();
+   writeFile(kManifestFileName, "not json");
+
+   SlotManifest manifest;
+   EXPECT_TRUE(readSlotManifest(slotDir_, &manifest) != Success());
+   EXPECT_FALSE(matchesSlotManifest(slotDir_));
+}
+
+TEST_F(ChatSlotManifest, RejectsManifestWithoutFiles)
+{
+   writeTree();
+   writeFile(kManifestFileName, "{}");
+
+   SlotManifest manifest;
+   EXPECT_TRUE(readSlotManifest(slotDir_, &manifest) != Success());
+}
+
+TEST_F(ChatSlotManifest, RejectsNonObjectEntry)
+{
+   writeTree();
+   writeFile(kManifestFileName, "{\"files\":{\"package.json\":19}}");
+
+   SlotManifest manifest;
+   EXPECT_TRUE(readSlotManifest(slotDir_, &manifest) != Success());
+}
+
+TEST_F(ChatSlotManifest, RejectsEntryWithoutSize)
+{
+   writeTree();
+   writeFile(kManifestFileName, "{\"files\":{\"package.json\":{\"sha256\":\"ab\"}}}");
+
+   SlotManifest manifest;
+   EXPECT_TRUE(readSlotManifest(slotDir_, &manifest) != Success());
+}
+
+TEST_F(ChatSlotManifest, RejectsNegativeSize)
+{
+   writeTree();
+   writeFile(kManifestFileName, "{\"files\":{\"package.json\":{\"size\":-1}}}");
+
+   SlotManifest manifest;
+   EXPECT_TRUE(readSlotManifest(slotDir_, &manifest) != Success());
+}
+
+TEST_F(ChatSlotManifest, RejectsEntryEscapingTheSlot)
+{
+   // A manifest is only ever written by an install, but it is still read from
+   // the user's home directory, so a path that walks out of the slot must not
+   // be followed.
+   writeTree();
+   writeFile(kManifestFileName,
+             "{\"files\":{\"../outside.txt\":{\"size\":0,\"sha256\":\"\"}}}");
+
+   EXPECT_FALSE(matchesSlotManifest(slotDir_));
+}
+
+} // anonymous namespace

--- a/src/cpp/session/modules/chat/ChatSlotManifestTests.cpp
+++ b/src/cpp/session/modules/chat/ChatSlotManifestTests.cpp
@@ -17,6 +17,10 @@
 
 #include <string>
 
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
 #include <gtest/gtest.h>
 
 #include <core/FileSerializer.hpp>
@@ -165,6 +169,47 @@ TEST_F(ChatSlotManifest, IgnoresFilesItDidNotRecord)
    writeFile("dist/server/stray.log", "written by something else");
    EXPECT_TRUE(matchesSlotManifest(slotDir_));
 }
+
+#ifndef _WIN32
+
+TEST_F(ChatSlotManifest, DoesNotRecordSymlinks)
+{
+   // Recording one would record the target's size and hash, so an otherwise
+   // immutable slot would verify against a file it does not contain.
+   writeTree();
+   FilePath outside = slotDir_.getParent().completeChildPath("outside.txt");
+   ASSERT_FALSE(writeStringToFile(outside, "lives outside the slot"));
+   ASSERT_EQ(::symlink(outside.getAbsolutePath().c_str(),
+                       slotDir_.completeChildPath("link.txt")
+                          .getAbsolutePath().c_str()),
+             0);
+
+   ASSERT_FALSE(writeSlotManifest(slotDir_));
+
+   SlotManifest manifest;
+   ASSERT_FALSE(readSlotManifest(slotDir_, &manifest));
+   EXPECT_EQ(manifest.count("link.txt"), 0u);
+   EXPECT_TRUE(matchesSlotManifest(slotDir_));
+}
+
+TEST_F(ChatSlotManifest, DetectsARecordedFileReplacedByASymlink)
+{
+   writeTree();
+   ASSERT_FALSE(writeSlotManifest(slotDir_));
+
+   FilePath outside = slotDir_.getParent().completeChildPath("outside.js");
+   ASSERT_FALSE(writeStringToFile(outside, "console.log('hi');"));
+   FilePath mainJs = slotDir_.completeChildPath("dist/server/main.js");
+   ASSERT_FALSE(mainJs.remove());
+   ASSERT_EQ(::symlink(outside.getAbsolutePath().c_str(),
+                       mainJs.getAbsolutePath().c_str()),
+             0);
+
+   // Same size as the file it replaced, so only the symlink check catches it.
+   EXPECT_FALSE(matchesSlotManifest(slotDir_));
+}
+
+#endif // !_WIN32
 
 TEST_F(ChatSlotManifest, RejectsAbsentManifest)
 {

--- a/src/cpp/session/modules/chat/ChatSlotManifestTests.cpp
+++ b/src/cpp/session/modules/chat/ChatSlotManifestTests.cpp
@@ -209,6 +209,30 @@ TEST_F(ChatSlotManifest, DetectsARecordedFileReplacedByASymlink)
    EXPECT_FALSE(matchesSlotManifest(slotDir_));
 }
 
+TEST_F(ChatSlotManifest, DetectsAnAncestorDirectoryReplacedBySymlink)
+{
+   // Checking only the recorded file misses this: main.js is still an ordinary
+   // file, but it is now reached through a link out of the slot.
+   writeTree();
+   ASSERT_FALSE(writeSlotManifest(slotDir_));
+
+   FilePath outsideDir = slotDir_.getParent().completeChildPath("elsewhere");
+   ASSERT_FALSE(outsideDir.completeChildPath("main.js").getParent().ensureDirectory());
+   ASSERT_FALSE(writeStringToFile(outsideDir.completeChildPath("main.js"),
+                                  "console.log('hi');"));
+
+   FilePath serverDir = slotDir_.completeChildPath("dist/server");
+   ASSERT_FALSE(serverDir.remove());
+   ASSERT_EQ(::symlink(outsideDir.getAbsolutePath().c_str(),
+                       serverDir.getAbsolutePath().c_str()),
+             0);
+
+   // The file behind the link has the recorded size, so only the ancestor
+   // check catches it.
+   EXPECT_EQ(slotDir_.completeChildPath("dist/server/main.js").getSize(), 18u);
+   EXPECT_FALSE(matchesSlotManifest(slotDir_));
+}
+
 #endif // !_WIN32
 
 TEST_F(ChatSlotManifest, RejectsAbsentManifest)

--- a/src/cpp/session/modules/chat/ChatSlots.cpp
+++ b/src/cpp/session/modules/chat/ChatSlots.cpp
@@ -104,10 +104,14 @@ bool isReservedDeviceName(const std::string& name)
       "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9"
    };
 
-   std::string lowered = boost::algorithm::to_lower_copy(name);
+   // Windows resolves the device whatever follows it, so "nul.txt" and
+   // "com1.log" are reserved too -- only the part before the first dot counts.
+   std::string stem = boost::algorithm::to_lower_copy(
+      name.substr(0, name.find('.')));
+
    for (const char* reserved : kReserved)
    {
-      if (lowered == reserved)
+      if (stem == reserved)
          return true;
    }
 

--- a/src/cpp/session/modules/chat/ChatSlots.cpp
+++ b/src/cpp/session/modules/chat/ChatSlots.cpp
@@ -118,16 +118,16 @@ std::string slotNameForOrdinal(const std::string& version, int ordinal)
    return version + "-" + safe_convert::numberToString(ordinal);
 }
 
-// Leaves room for the ".tmp-" prefix and the pid within the 255-byte limit on
-// a path component, while staying long enough that two real hostnames cannot
-// collapse onto the same prefix (a hostname is at most 253 characters, and
-// getHostname() reads at most 255).
-const std::string::size_type kMaxHostnameLength = 200;
+// Leaves room for the ".tmp-" prefix, the pid and the nonce within the
+// 255-byte limit on a path component, while staying longer than any real
+// hostname (at most 253 characters, and getHostname() reads at most 255).
+const std::string::size_type kMaxHostnameLength = 180;
 
-// Names the staging directory for this session. Host and pid identify a live
-// session: one host cannot run two processes with the same pid, and the name
-// becomes reusable once that process is gone. getHostname() can come back
-// empty, in which case this degrades to the pid alone.
+// Names a staging directory. The nonce is what makes it private: no other
+// session can compute this name, so nothing else can write into the tree we
+// are about to record a manifest for. Host and pid carry no correctness weight
+// here -- they are in the name so a later cleanup pass can tell whose
+// abandoned extraction it is looking at.
 std::string stagingDirName()
 {
    std::string hostname =
@@ -144,7 +144,8 @@ std::string stagingDirName()
 
    return std::string(kStagingDirPrefix) + hostname + "-" +
       safe_convert::numberToString(
-         static_cast<int64_t>(core::system::currentProcessId()));
+         static_cast<int64_t>(core::system::currentProcessId())) + "-" +
+      core::system::generateUuid(false);
 }
 
 } // anonymous namespace
@@ -229,14 +230,7 @@ Error prepareStagingDir(const FilePath& slotsDir, FilePath* pStagingDir)
 {
    FilePath stagingDir = slotsDir.completeChildPath(stagingDirName());
 
-   // Clear rather than allocate a new name: a session that crashed mid-install
-   // left this directory behind, and reusing the name is what keeps that
-   // garbage bounded. See the header for why the name is not simply unique.
-   Error error = stagingDir.removeIfExists();
-   if (error)
-      return error;
-
-   error = stagingDir.ensureDirectory();
+   Error error = stagingDir.ensureDirectory();
    if (error)
       return error;
 

--- a/src/cpp/session/modules/chat/ChatSlots.cpp
+++ b/src/cpp/session/modules/chat/ChatSlots.cpp
@@ -200,6 +200,16 @@ bool verifySlot(const FilePath& slotDir, SlotInfo* pInfo)
    if (!slotDir.isDirectory())
       return false;
 
+   // A slot replaced by a link is not a slot: everything in it, manifest
+   // included, would be read from a tree the slot does not contain and cannot
+   // promise is immutable. Junctions count, being how Windows redirects a
+   // directory without is_symlink() reporting it.
+   if (slotDir.isSymlink() || slotDir.isJunction())
+   {
+      DLOG("Slot {} is a link, not a directory", slotDir.getAbsolutePath());
+      return false;
+   }
+
    if (!hasRequiredFiles(slotDir))
    {
       DLOG("Slot {} is missing required files", slotDir.getAbsolutePath());

--- a/src/cpp/session/modules/chat/ChatSlots.cpp
+++ b/src/cpp/session/modules/chat/ChatSlots.cpp
@@ -274,9 +274,15 @@ Error allocateSlot(const FilePath& stagingDir,
                    SlotPolicy policy,
                    FilePath* pSlotDir)
 {
-   // Verifying here rather than trusting the caller is what makes "a slot only
-   // reaches a final name once it has been checked" a property of the layout
-   // instead of a rule every install path has to remember.
+   // Record the manifest and verify here rather than trusting the caller, so
+   // that "a slot only reaches a final name once it has been checked" is a
+   // property of the layout instead of a rule every install path has to
+   // remember. The staging directory is private to this call, so the tree
+   // being recorded is the one that was just extracted.
+   Error error = slot_manifest::writeSlotManifest(stagingDir);
+   if (error)
+      return error;
+
    SlotInfo staged;
    if (!verifySlot(stagingDir, &staged))
    {
@@ -314,11 +320,11 @@ Error allocateSlot(const FilePath& stagingDir,
              existing.protocol == staged.protocol)
          {
             DLOG("Adopting existing slot {}", candidate.getAbsolutePath());
-            Error error = stagingDir.removeIfExists();
-            if (error)
+            Error removeError = stagingDir.removeIfExists();
+            if (removeError)
             {
                WLOG("Could not remove staging directory {}: {}",
-                    stagingDir.getAbsolutePath(), error.getMessage());
+                    stagingDir.getAbsolutePath(), removeError.getMessage());
             }
 
             *pSlotDir = candidate;
@@ -332,8 +338,8 @@ Error allocateSlot(const FilePath& stagingDir,
       // MoveDirect, never MoveCrossDevice: the staging directory is a sibling
       // of the slot, so a copy fallback would mean the invariant that makes
       // this rename atomic has been broken and we want to hear about it.
-      Error error = stagingDir.move(candidate, FilePath::MoveDirect);
-      if (!error)
+      Error moveError = stagingDir.move(candidate, FilePath::MoveDirect);
+      if (!moveError)
       {
          DLOG("Published slot {}", candidate.getAbsolutePath());
          *pSlotDir = candidate;
@@ -349,7 +355,7 @@ Error allocateSlot(const FilePath& stagingDir,
          continue;
       }
 
-      return error;
+      return moveError;
    }
 
    return systemError(boost::system::errc::file_exists,

--- a/src/cpp/session/modules/chat/ChatSlots.cpp
+++ b/src/cpp/session/modules/chat/ChatSlots.cpp
@@ -124,7 +124,9 @@ std::string slotNameForOrdinal(const std::string& version, int ordinal)
 
 // Leaves room for the ".tmp-" prefix, the pid and the nonce within the
 // 255-byte limit on a path component, while staying longer than any real
-// hostname (at most 253 characters, and getHostname() reads at most 255).
+// hostname (at most 253 characters). This truncation is what bounds the name:
+// getHostname() returns the HOSTNAME environment variable verbatim, and only
+// its gethostname() fallback is capped.
 const std::string::size_type kMaxHostnameLength = 180;
 
 // Names a staging directory. The nonce is what makes it private: no other

--- a/src/cpp/session/modules/chat/ChatSlots.cpp
+++ b/src/cpp/session/modules/chat/ChatSlots.cpp
@@ -1,0 +1,294 @@
+/*
+ * ChatSlots.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "ChatSlots.hpp"
+
+#include "ChatConstants.hpp"
+#include "ChatLogging.hpp"
+#include "ChatSlotManifest.hpp"
+
+#include <boost/algorithm/string/predicate.hpp>
+
+#include <core/FileSerializer.hpp>
+#include <core/system/System.hpp>
+#include <shared_core/SafeConvert.hpp>
+#include <shared_core/json/Json.hpp>
+
+using namespace rstudio::core;
+using namespace rstudio::session::modules::chat::constants;
+using namespace rstudio::session::modules::chat::logging;
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace chat {
+namespace slots {
+
+namespace {
+
+// Slot names past the first for one version run 1.1.0-2, 1.1.0-3, ...; the
+// bound only exists so a filesystem that keeps producing collisions fails
+// instead of spinning.
+const int kMaxAllocationAttempts = 1000;
+
+// Reads a single string field out of a JSON file in a slot. Returns an empty
+// string when the file is absent, unparseable, or the field is missing, empty
+// or not a string -- callers treat all of those the same way.
+std::string readJsonStringField(const FilePath& slotDir,
+                                const char* fileName,
+                                const char* fieldName)
+{
+   FilePath filePath = slotDir.completeChildPath(fileName);
+   if (!filePath.isRegularFile())
+      return std::string();
+
+   std::string content;
+   Error error = readStringFromFile(filePath, &content);
+   if (error)
+      return std::string();
+
+   json::Value value;
+   if (value.parse(content) || !value.isObject())
+      return std::string();
+
+   json::Object object = value.getObject();
+   if (!object.hasMember(fieldName) || !object[fieldName].isString())
+      return std::string();
+
+   return object[fieldName].getString();
+}
+
+bool existsAndNonEmpty(const FilePath& filePath)
+{
+   return filePath.isRegularFile() && filePath.getSize() > 0;
+}
+
+// The files a Posit Assistant install cannot run without. Existence alone is
+// not enough: a truncated download used to leave a zero-byte main.js that the
+// old check accepted.
+bool hasRequiredFiles(const FilePath& slotDir)
+{
+   if (!slotDir.completeChildPath(kClientDirPath).isDirectory())
+      return false;
+
+   return existsAndNonEmpty(slotDir.completeChildPath(kServerScriptPath)) &&
+          existsAndNonEmpty(
+             slotDir.completeChildPath(kClientDirPath)
+                .completeChildPath(kIndexFileName));
+}
+
+// Rejects versions that cannot safely name a directory. A version reaches here
+// from a downloaded manifest, so it is not trusted to be a bare version
+// string.
+bool isUsableSlotName(const std::string& version)
+{
+   if (version.empty() || version.front() == '.' || version.front() == '-')
+      return false;
+
+   return version.find_first_of("/\\:") == std::string::npos;
+}
+
+std::string slotNameForOrdinal(const std::string& version, int ordinal)
+{
+   if (ordinal <= 1)
+      return version;
+
+   return version + "-" + safe_convert::numberToString(ordinal);
+}
+
+} // anonymous namespace
+
+FilePath versionsDir(const FilePath& storageDir)
+{
+   return storageDir.completeChildPath(kVersionsDirName);
+}
+
+bool verifySlot(const FilePath& slotDir, SlotInfo* pInfo)
+{
+   if (!slotDir.isDirectory())
+      return false;
+
+   if (!hasRequiredFiles(slotDir))
+   {
+      DLOG("Slot {} is missing required files", slotDir.getAbsolutePath());
+      return false;
+   }
+
+   std::string version =
+      readJsonStringField(slotDir, kPackageJsonFileName, "version");
+   if (version.empty())
+   {
+      DLOG("Slot {} declares no package version", slotDir.getAbsolutePath());
+      return false;
+   }
+
+   std::string protocol =
+      readJsonStringField(slotDir, kProtocolVersionFileName, "protocol");
+   if (protocol.empty())
+   {
+      DLOG("Slot {} declares no protocol version", slotDir.getAbsolutePath());
+      return false;
+   }
+
+   if (!slot_manifest::matchesSlotManifest(slotDir))
+      return false;
+
+   if (pInfo != nullptr)
+   {
+      pInfo->path = slotDir;
+      pInfo->name = slotDir.getFilename();
+      pInfo->version = version;
+      pInfo->protocol = protocol;
+   }
+
+   return true;
+}
+
+std::vector<SlotInfo> verifiedSlots(const FilePath& slotsDir)
+{
+   std::vector<SlotInfo> found;
+   if (!slotsDir.isDirectory())
+      return found;
+
+   std::vector<FilePath> children;
+   Error error = slotsDir.getChildren(children);
+   if (error)
+   {
+      WLOG("Cannot list slots in {}: {}",
+           slotsDir.getAbsolutePath(), error.getMessage());
+      return found;
+   }
+
+   for (const FilePath& child : children)
+   {
+      // Staging directories and any other bookkeeping are dot-prefixed; a slot
+      // never is, because a version cannot start with a dot.
+      if (boost::algorithm::starts_with(child.getFilename(), "."))
+         continue;
+
+      SlotInfo info;
+      if (verifySlot(child, &info))
+         found.push_back(info);
+   }
+
+   return found;
+}
+
+Error prepareStagingDir(const FilePath& slotsDir, FilePath* pStagingDir)
+{
+   std::string name = std::string(kStagingDirPrefix) +
+      safe_convert::numberToString(
+         static_cast<int64_t>(core::system::currentProcessId()));
+
+   FilePath stagingDir = slotsDir.completeChildPath(name);
+
+   // Clear rather than allocate a new name: a session that crashed mid-install
+   // left its staging directory behind, and this is the only point at which
+   // reclaiming it is provably safe -- no other process uses our pid.
+   Error error = stagingDir.removeIfExists();
+   if (error)
+      return error;
+
+   error = stagingDir.ensureDirectory();
+   if (error)
+      return error;
+
+   *pStagingDir = stagingDir;
+   return Success();
+}
+
+Error allocateSlot(const FilePath& stagingDir,
+                   const std::string& version,
+                   SlotPolicy policy,
+                   FilePath* pSlotDir)
+{
+   if (!isUsableSlotName(version))
+   {
+      return systemError(boost::system::errc::invalid_argument,
+                         "Cannot name an install slot for version '" +
+                            version + "'",
+                         ERROR_LOCATION);
+   }
+
+   if (!stagingDir.isDirectory())
+   {
+      return systemError(boost::system::errc::no_such_file_or_directory,
+                         "Staged install directory " +
+                            stagingDir.getAbsolutePath() + " does not exist",
+                         ERROR_LOCATION);
+   }
+
+   FilePath slotsDir = stagingDir.getParent();
+
+   int ordinal = 1;
+   for (int attempt = 0; attempt < kMaxAllocationAttempts; ++attempt)
+   {
+      FilePath candidate =
+         slotsDir.completeChildPath(slotNameForOrdinal(version, ordinal));
+
+      if (candidate.exists())
+      {
+         if (policy == SlotPolicy::AdoptExisting && verifySlot(candidate))
+         {
+            DLOG("Adopting existing slot {}", candidate.getAbsolutePath());
+            Error error = stagingDir.removeIfExists();
+            if (error)
+            {
+               WLOG("Could not remove staging directory {}: {}",
+                    stagingDir.getAbsolutePath(), error.getMessage());
+            }
+
+            *pSlotDir = candidate;
+            return Success();
+         }
+
+         ++ordinal;
+         continue;
+      }
+
+      // MoveDirect, never MoveCrossDevice: the staging directory is a sibling
+      // of the slot, so a copy fallback would mean the invariant that makes
+      // this rename atomic has been broken and we want to hear about it.
+      Error error = stagingDir.move(candidate, FilePath::MoveDirect);
+      if (!error)
+      {
+         DLOG("Published slot {}", candidate.getAbsolutePath());
+         *pSlotDir = candidate;
+         return Success();
+      }
+
+      // Someone renamed their own staged install into this name between the
+      // check above and the rename. Re-examine that name under the same rules
+      // rather than reading errno, which varies by platform for this case.
+      if (candidate.exists())
+      {
+         DLOG("Lost the rename race for slot {}", candidate.getAbsolutePath());
+         continue;
+      }
+
+      return error;
+   }
+
+   return systemError(boost::system::errc::file_exists,
+                      "No install slot available for version " + version +
+                         " in " + slotsDir.getAbsolutePath(),
+                      ERROR_LOCATION);
+}
+
+} // namespace slots
+} // namespace chat
+} // namespace modules
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/session/modules/chat/ChatSlots.cpp
+++ b/src/cpp/session/modules/chat/ChatSlots.cpp
@@ -21,6 +21,7 @@
 
 #include <cctype>
 
+#include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <core/FileSerializer.hpp>
@@ -91,23 +92,26 @@ bool hasRequiredFiles(const FilePath& slotDir)
                 .completeChildPath(kIndexFileName));
 }
 
-// Rejects versions that cannot safely name a directory. A version reaches here
-// from the package.json of a downloaded archive, so it is not trusted to be a
-// bare version string.
-bool isUsableSlotName(const std::string& version)
+// Device names Windows resolves no matter which directory they appear in.
+// Checked on every platform on purpose: a home directory reached from both
+// Windows and Linux sessions has to agree on which names are slots, and
+// file_utils::isWindowsReservedName is compiled only on Windows.
+bool isReservedDeviceName(const std::string& name)
 {
-   if (version.empty() || version.front() == '.' || version.front() == '-')
-      return false;
+   static const char* const kReserved[] = {
+      "con", "prn", "aux", "nul",
+      "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9",
+      "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9"
+   };
 
-   for (char c : version)
+   std::string lowered = boost::algorithm::to_lower_copy(name);
+   for (const char* reserved : kReserved)
    {
-      // Printable ASCII only: this string becomes a directory name in the
-      // user's home, and a version is never anything else.
-      if (c < 0x20 || c > 0x7e)
-         return false;
+      if (lowered == reserved)
+         return true;
    }
 
-   return version.find_first_of("/\\:") == std::string::npos;
+   return false;
 }
 
 std::string slotNameForOrdinal(const std::string& version, int ordinal)
@@ -149,6 +153,34 @@ std::string stagingDirName()
 }
 
 } // anonymous namespace
+
+bool isUsableSlotName(const std::string& name)
+{
+   if (name.empty() || name.front() == '.' || name.front() == '-')
+      return false;
+
+   // Windows silently drops a trailing dot or space, so the directory on disk
+   // would not be the name recorded in the selector -- and on a home shared
+   // with Linux sessions the two names are separate directories.
+   if (name.back() == '.' || name.back() == ' ')
+      return false;
+
+   for (char c : name)
+   {
+      // Printable ASCII only: this string becomes a directory name in the
+      // user's home, and a version is never anything else.
+      if (c < 0x20 || c > 0x7e)
+         return false;
+   }
+
+   if (isReservedDeviceName(name))
+      return false;
+
+   // Separators, the drive-letter colon, and the characters Win32 rejects
+   // outright. Catching them here turns an opaque rename failure after a full
+   // extraction into a clear message.
+   return name.find_first_of("/\\:*?\"<>|") == std::string::npos;
+}
 
 FilePath versionsDir(const FilePath& storageDir)
 {

--- a/src/cpp/session/modules/chat/ChatSlots.cpp
+++ b/src/cpp/session/modules/chat/ChatSlots.cpp
@@ -126,11 +126,13 @@ std::string slotNameForOrdinal(const std::string& version, int ordinal)
    return version + "-" + safe_convert::numberToString(ordinal);
 }
 
-// Leaves room for the ".tmp-" prefix, the pid and the nonce within the
-// 255-byte limit on a path component, while staying longer than any real
-// hostname (at most 253 characters). This truncation is what bounds the name:
-// getHostname() returns the HOSTNAME environment variable verbatim, and only
-// its gethostname() fallback is capped.
+// Budgeted against the 255-byte limit on a path component, which the ".tmp-"
+// prefix, the pid and the nonce also draw on. This truncation is what bounds
+// the name: getHostname() returns the HOSTNAME environment variable verbatim,
+// and only its gethostname() fallback is capped. A hostname can reach 253
+// characters, so this can in principle shorten two long names to the same
+// prefix; the nonce, not the hostname, is what keeps staging directories
+// distinct.
 const std::string::size_type kMaxHostnameLength = 180;
 
 // Names a staging directory. The nonce is what makes it private: no other

--- a/src/cpp/session/modules/chat/ChatSlots.cpp
+++ b/src/cpp/session/modules/chat/ChatSlots.cpp
@@ -19,6 +19,8 @@
 #include "ChatLogging.hpp"
 #include "ChatSlotManifest.hpp"
 
+#include <cctype>
+
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <core/FileSerializer.hpp>
@@ -90,12 +92,20 @@ bool hasRequiredFiles(const FilePath& slotDir)
 }
 
 // Rejects versions that cannot safely name a directory. A version reaches here
-// from a downloaded manifest, so it is not trusted to be a bare version
-// string.
+// from the package.json of a downloaded archive, so it is not trusted to be a
+// bare version string.
 bool isUsableSlotName(const std::string& version)
 {
    if (version.empty() || version.front() == '.' || version.front() == '-')
       return false;
+
+   for (char c : version)
+   {
+      // Printable ASCII only: this string becomes a directory name in the
+      // user's home, and a version is never anything else.
+      if (c < 0x20 || c > 0x7e)
+         return false;
+   }
 
    return version.find_first_of("/\\:") == std::string::npos;
 }
@@ -106,6 +116,21 @@ std::string slotNameForOrdinal(const std::string& version, int ordinal)
       return version;
 
    return version + "-" + safe_convert::numberToString(ordinal);
+}
+
+// Reduces a hostname to characters that are safe in a path component, and caps
+// its length so the staging directory name stays within filesystem limits.
+std::string sanitizedHostname()
+{
+   std::string hostname = core::system::getHostname().substr(0, 64);
+
+   for (char& c : hostname)
+   {
+      if (!std::isalnum(static_cast<unsigned char>(c)) && c != '-' && c != '.')
+         c = '_';
+   }
+
+   return hostname;
 }
 
 } // anonymous namespace
@@ -188,15 +213,19 @@ std::vector<SlotInfo> verifiedSlots(const FilePath& slotsDir)
 
 Error prepareStagingDir(const FilePath& slotsDir, FilePath* pStagingDir)
 {
-   std::string name = std::string(kStagingDirPrefix) +
-      safe_convert::numberToString(
+   // Host and pid together are unique among live sessions -- one host cannot
+   // run two processes with the same pid -- but become reusable once the
+   // process is gone. The host is part of the name because several machines
+   // routinely share one NFS home and hand out the same pids.
+   std::string name = std::string(kStagingDirPrefix) + sanitizedHostname() +
+      "-" + safe_convert::numberToString(
          static_cast<int64_t>(core::system::currentProcessId()));
 
    FilePath stagingDir = slotsDir.completeChildPath(name);
 
    // Clear rather than allocate a new name: a session that crashed mid-install
-   // left its staging directory behind, and this is the only point at which
-   // reclaiming it is provably safe -- no other process uses our pid.
+   // left its staging directory behind, and no live session can be using a
+   // directory named for this host and pid, so this is where it is reclaimed.
    Error error = stagingDir.removeIfExists();
    if (error)
       return error;
@@ -210,23 +239,26 @@ Error prepareStagingDir(const FilePath& slotsDir, FilePath* pStagingDir)
 }
 
 Error allocateSlot(const FilePath& stagingDir,
-                   const std::string& version,
                    SlotPolicy policy,
                    FilePath* pSlotDir)
 {
-   if (!isUsableSlotName(version))
+   // Verifying here rather than trusting the caller is what makes "a slot only
+   // reaches a final name once it has been checked" a property of the layout
+   // instead of a rule every install path has to remember.
+   SlotInfo staged;
+   if (!verifySlot(stagingDir, &staged))
    {
       return systemError(boost::system::errc::invalid_argument,
-                         "Cannot name an install slot for version '" +
-                            version + "'",
+                         "Staged install at " + stagingDir.getAbsolutePath() +
+                            " is not a complete Posit Assistant installation",
                          ERROR_LOCATION);
    }
 
-   if (!stagingDir.isDirectory())
+   if (!isUsableSlotName(staged.version))
    {
-      return systemError(boost::system::errc::no_such_file_or_directory,
-                         "Staged install directory " +
-                            stagingDir.getAbsolutePath() + " does not exist",
+      return systemError(boost::system::errc::invalid_argument,
+                         "Cannot name an install slot for version '" +
+                            staged.version + "'",
                          ERROR_LOCATION);
    }
 
@@ -235,12 +267,19 @@ Error allocateSlot(const FilePath& stagingDir,
    int ordinal = 1;
    for (int attempt = 0; attempt < kMaxAllocationAttempts; ++attempt)
    {
-      FilePath candidate =
-         slotsDir.completeChildPath(slotNameForOrdinal(version, ordinal));
+      FilePath candidate = slotsDir.completeChildPath(
+         slotNameForOrdinal(staged.version, ordinal));
 
       if (candidate.exists())
       {
-         if (policy == SlotPolicy::AdoptExisting && verifySlot(candidate))
+         // Adopt only what is genuinely interchangeable with what we staged.
+         // A slot's name is not evidence of its contents, so the decision has
+         // to rest on the package.json and protocol.json inside it.
+         SlotInfo existing;
+         if (policy == SlotPolicy::AdoptExisting &&
+             verifySlot(candidate, &existing) &&
+             existing.version == staged.version &&
+             existing.protocol == staged.protocol)
          {
             DLOG("Adopting existing slot {}", candidate.getAbsolutePath());
             Error error = stagingDir.removeIfExists();
@@ -282,7 +321,7 @@ Error allocateSlot(const FilePath& stagingDir,
    }
 
    return systemError(boost::system::errc::file_exists,
-                      "No install slot available for version " + version +
+                      "No install slot available for version " + staged.version +
                          " in " + slotsDir.getAbsolutePath(),
                       ERROR_LOCATION);
 }

--- a/src/cpp/session/modules/chat/ChatSlots.cpp
+++ b/src/cpp/session/modules/chat/ChatSlots.cpp
@@ -118,11 +118,20 @@ std::string slotNameForOrdinal(const std::string& version, int ordinal)
    return version + "-" + safe_convert::numberToString(ordinal);
 }
 
-// Reduces a hostname to characters that are safe in a path component, and caps
-// its length so the staging directory name stays within filesystem limits.
-std::string sanitizedHostname()
+// Leaves room for the ".tmp-" prefix and the pid within the 255-byte limit on
+// a path component, while staying long enough that two real hostnames cannot
+// collapse onto the same prefix (a hostname is at most 253 characters, and
+// getHostname() reads at most 255).
+const std::string::size_type kMaxHostnameLength = 200;
+
+// Names the staging directory for this session. Host and pid identify a live
+// session: one host cannot run two processes with the same pid, and the name
+// becomes reusable once that process is gone. getHostname() can come back
+// empty, in which case this degrades to the pid alone.
+std::string stagingDirName()
 {
-   std::string hostname = core::system::getHostname().substr(0, 64);
+   std::string hostname =
+      core::system::getHostname().substr(0, kMaxHostnameLength);
 
    for (char& c : hostname)
    {
@@ -130,7 +139,12 @@ std::string sanitizedHostname()
          c = '_';
    }
 
-   return hostname;
+   if (hostname.empty())
+      hostname = "unknown-host";
+
+   return std::string(kStagingDirPrefix) + hostname + "-" +
+      safe_convert::numberToString(
+         static_cast<int64_t>(core::system::currentProcessId()));
 }
 
 } // anonymous namespace
@@ -213,19 +227,11 @@ std::vector<SlotInfo> verifiedSlots(const FilePath& slotsDir)
 
 Error prepareStagingDir(const FilePath& slotsDir, FilePath* pStagingDir)
 {
-   // Host and pid together are unique among live sessions -- one host cannot
-   // run two processes with the same pid -- but become reusable once the
-   // process is gone. The host is part of the name because several machines
-   // routinely share one NFS home and hand out the same pids.
-   std::string name = std::string(kStagingDirPrefix) + sanitizedHostname() +
-      "-" + safe_convert::numberToString(
-         static_cast<int64_t>(core::system::currentProcessId()));
-
-   FilePath stagingDir = slotsDir.completeChildPath(name);
+   FilePath stagingDir = slotsDir.completeChildPath(stagingDirName());
 
    // Clear rather than allocate a new name: a session that crashed mid-install
-   // left its staging directory behind, and no live session can be using a
-   // directory named for this host and pid, so this is where it is reclaimed.
+   // left this directory behind, and reusing the name is what keeps that
+   // garbage bounded. See the header for why the name is not simply unique.
    Error error = stagingDir.removeIfExists();
    if (error)
       return error;

--- a/src/cpp/session/modules/chat/ChatSlots.hpp
+++ b/src/cpp/session/modules/chat/ChatSlots.hpp
@@ -1,0 +1,157 @@
+/*
+ * ChatSlots.hpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SESSION_CHAT_SLOTS_HPP
+#define SESSION_CHAT_SLOTS_HPP
+
+#include <string>
+#include <vector>
+
+#include <shared_core/Error.hpp>
+#include <shared_core/FilePath.hpp>
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace chat {
+namespace slots {
+
+// Posit Assistant is installed side by side: each installed package version
+// gets its own directory ("slot") under <storageDir>/versions, created once
+// and never modified afterwards. Slot names are human-readable but carry no
+// meaning -- a slot's version and protocol always come from the package.json
+// and protocol.json inside it.
+
+/**
+ * What a slot says about itself.
+ */
+struct SlotInfo
+{
+   // The slot directory.
+   core::FilePath path;
+
+   // The slot's directory name, as recorded in the selector.
+   std::string name;
+
+   // "version" from the slot's package.json.
+   std::string version;
+
+   // "protocol" from the slot's protocol.json.
+   std::string protocol;
+};
+
+/**
+ * The directory holding all slots for a Posit Assistant storage directory.
+ *
+ * @param storageDir The Posit Assistant storage directory (<userDataDir>/pai).
+ * @return The versions directory. Not guaranteed to exist.
+ */
+core::FilePath versionsDir(const core::FilePath& storageDir);
+
+/**
+ * Check that a slot is a complete, coherent Posit Assistant installation.
+ *
+ * A slot verifies when its expected files exist and are non-empty, its
+ * package.json parses and declares a version, its protocol.json parses and
+ * declares a protocol, and every file recorded in its install-time manifest
+ * still exists at its recorded size. A slot with no manifest does not verify:
+ * every slot this module creates gets one, so its absence means the directory
+ * was not produced by an install that ran to completion.
+ *
+ * The manifest check is a stat walk, so this is cheap enough to run on every
+ * resolve, including on NFS home directories. It cannot detect corruption that
+ * preserves file sizes -- that is what a forced reinstall is for.
+ *
+ * @param slotDir The slot directory.
+ * @param pInfo Output: what the slot says about itself (optional, may be
+ *              nullptr; populated only when the slot verifies).
+ * @return true if the slot verifies.
+ */
+bool verifySlot(const core::FilePath& slotDir, SlotInfo* pInfo = nullptr);
+
+/**
+ * Every slot under `slotsDir` that verifies, in unspecified order.
+ *
+ * Staging directories and other hidden entries are skipped. A versions
+ * directory that does not exist yields no slots rather than an error.
+ *
+ * @param slotsDir The directory holding the slots.
+ * @return The verifying slots.
+ */
+std::vector<SlotInfo> verifiedSlots(const core::FilePath& slotsDir);
+
+/**
+ * Create an empty staging directory to extract a package into.
+ *
+ * The staging directory is a sibling of the slots, so publishing it with
+ * allocateSlot() is a rename within one filesystem rather than a copy. It is
+ * named for the current process and cleared on every call, so a crashed
+ * session's leftovers are reclaimed rather than accumulating.
+ *
+ * @param slotsDir The directory holding the slots.
+ * @param pStagingDir Output: the empty staging directory.
+ * @return Success, or an error if the directory could not be cleared or
+ *         created.
+ */
+core::Error prepareStagingDir(const core::FilePath& slotsDir,
+                              core::FilePath* pStagingDir);
+
+/**
+ * How allocateSlot() should respond to finding the name it wants taken.
+ */
+enum class SlotPolicy
+{
+   // Take the existing slot if it verifies. An install whose version is
+   // already on disk and intact has nothing to add.
+   AdoptExisting,
+
+   // Never take an existing slot; allocate a new name instead. A reinstall
+   // exists to replace bits that verification cannot fault, so it has to
+   // produce a directory it wrote itself.
+   AlwaysFresh
+};
+
+/**
+ * Publish a staged package as a slot, arbitrating with concurrent installers.
+ *
+ * The staged directory is renamed to `<version>`, or to `<version>-2`,
+ * `<version>-3`, ... when that name is taken. Because the rename is the only
+ * arbiter, two sessions installing the same version at once cannot corrupt
+ * each other: the loser sees the winner's slot and either adopts it or takes
+ * the next name.
+ *
+ * On adoption the staged directory is removed, since nothing else can be
+ * using a directory named for this process.
+ *
+ * @param stagingDir The staged package, as returned by prepareStagingDir().
+ *                   Must be a child of the versions directory.
+ * @param version The installed version, used to name the slot.
+ * @param policy Whether an existing verifying slot may be adopted.
+ * @param pSlotDir Output: the published (or adopted) slot directory.
+ * @return Success, or an error if the version cannot name a directory, the
+ *         staging directory is missing, or no name could be taken.
+ */
+core::Error allocateSlot(const core::FilePath& stagingDir,
+                         const std::string& version,
+                         SlotPolicy policy,
+                         core::FilePath* pSlotDir);
+
+} // namespace slots
+} // namespace chat
+} // namespace modules
+} // namespace session
+} // namespace rstudio
+
+#endif // SESSION_CHAT_SLOTS_HPP

--- a/src/cpp/session/modules/chat/ChatSlots.hpp
+++ b/src/cpp/session/modules/chat/ChatSlots.hpp
@@ -61,6 +61,26 @@ struct SlotInfo
 core::FilePath versionsDir(const core::FilePath& storageDir);
 
 /**
+ * Whether a string may name a slot directory.
+ *
+ * Slot names come from the package.json of a downloaded archive and from
+ * selected.json in the user's home, so neither is trusted. Rejects anything
+ * that cannot round-trip as a directory name: empty, leading '.' or '-' (which
+ * would also hide it from resolution or make it look like an ordinal),
+ * non-printable or non-ASCII characters, a trailing dot or space (silently
+ * dropped by Windows, so the directory would not match the recorded name), a
+ * Windows reserved device name, and path separators or characters Win32
+ * rejects.
+ *
+ * The Windows rules are applied on every platform: a home directory reached
+ * from both Windows and Linux sessions has to agree on which names are slots.
+ *
+ * @param name The candidate slot directory name.
+ * @return true if the name is usable.
+ */
+bool isUsableSlotName(const std::string& name);
+
+/**
  * Check that a slot is a complete, coherent Posit Assistant installation.
  *
  * A slot verifies when its expected files exist and are non-empty, its

--- a/src/cpp/session/modules/chat/ChatSlots.hpp
+++ b/src/cpp/session/modules/chat/ChatSlots.hpp
@@ -134,8 +134,7 @@ std::vector<SlotInfo> verifiedSlots(const core::FilePath& slotsDir);
  *
  * @param slotsDir The directory holding the slots.
  * @param pStagingDir Output: the empty staging directory.
- * @return Success, or an error if the directory could not be cleared or
- *         created.
+ * @return Success, or an error if the directory could not be created.
  */
 core::Error prepareStagingDir(const core::FilePath& slotsDir,
                               core::FilePath* pStagingDir);
@@ -167,9 +166,10 @@ enum class SlotPolicy
  * the tree being recorded is the one that was just extracted.
  *
  * The staged package is then renamed to the version its own package.json
- * declares, or to `<version>-2`, `<version>-3`, ... when that name is taken. Because the rename is the only arbiter, two sessions
- * installing the same version at once cannot corrupt each other: the loser
- * sees the winner's slot and either adopts it or takes the next name.
+ * declares, or to `<version>-2`, `<version>-3`, ... when that name is taken.
+ * Because the rename is the only arbiter, two sessions installing the same
+ * version at once cannot corrupt each other: the loser sees the winner's slot
+ * and either adopts it or takes the next name.
  *
  * A slot is adopted only when it verifies and declares the same version and
  * protocol as the staged package; a name alone is never taken as evidence of

--- a/src/cpp/session/modules/chat/ChatSlots.hpp
+++ b/src/cpp/session/modules/chat/ChatSlots.hpp
@@ -97,8 +97,10 @@ std::vector<SlotInfo> verifiedSlots(const core::FilePath& slotsDir);
  *
  * The staging directory is a sibling of the slots, so publishing it with
  * allocateSlot() is a rename within one filesystem rather than a copy. It is
- * named for the current process and cleared on every call, so a crashed
- * session's leftovers are reclaimed rather than accumulating.
+ * named for the current host and process and cleared on every call, so a
+ * crashed session's leftovers are reclaimed rather than accumulating. The host
+ * is part of the name because machines sharing an NFS home hand out the same
+ * pids, and one session must never clear another's staged install.
  *
  * @param slotsDir The directory holding the slots.
  * @param pStagingDir Output: the empty staging directory.
@@ -126,25 +128,27 @@ enum class SlotPolicy
 /**
  * Publish a staged package as a slot, arbitrating with concurrent installers.
  *
- * The staged directory is renamed to `<version>`, or to `<version>-2`,
- * `<version>-3`, ... when that name is taken. Because the rename is the only
- * arbiter, two sessions installing the same version at once cannot corrupt
- * each other: the loser sees the winner's slot and either adopts it or takes
- * the next name.
+ * The staged package is verified first, so a directory only ever reaches a
+ * final name once it has been checked -- a torn install cannot exist under a
+ * name a session might resolve. It is then renamed to the version its own
+ * package.json declares, or to `<version>-2`, `<version>-3`, ... when that
+ * name is taken. Because the rename is the only arbiter, two sessions
+ * installing the same version at once cannot corrupt each other: the loser
+ * sees the winner's slot and either adopts it or takes the next name.
  *
- * On adoption the staged directory is removed, since nothing else can be
- * using a directory named for this process.
+ * A slot is adopted only when it verifies and declares the same version and
+ * protocol as the staged package; a name alone is never taken as evidence of
+ * what a directory holds. On adoption the staged directory is removed, since
+ * nothing else can be using a directory named for this host and process.
  *
  * @param stagingDir The staged package, as returned by prepareStagingDir().
  *                   Must be a child of the versions directory.
- * @param version The installed version, used to name the slot.
- * @param policy Whether an existing verifying slot may be adopted.
+ * @param policy Whether a matching existing slot may be adopted.
  * @param pSlotDir Output: the published (or adopted) slot directory.
- * @return Success, or an error if the version cannot name a directory, the
- *         staging directory is missing, or no name could be taken.
+ * @return Success, or an error if the staged package does not verify, its
+ *         version cannot name a directory, or no name could be taken.
  */
 core::Error allocateSlot(const core::FilePath& stagingDir,
-                         const std::string& version,
                          SlotPolicy policy,
                          core::FilePath* pSlotDir);
 

--- a/src/cpp/session/modules/chat/ChatSlots.hpp
+++ b/src/cpp/session/modules/chat/ChatSlots.hpp
@@ -96,11 +96,20 @@ std::vector<SlotInfo> verifiedSlots(const core::FilePath& slotsDir);
  * Create an empty staging directory to extract a package into.
  *
  * The staging directory is a sibling of the slots, so publishing it with
- * allocateSlot() is a rename within one filesystem rather than a copy. It is
- * named for the current host and process and cleared on every call, so a
- * crashed session's leftovers are reclaimed rather than accumulating. The host
- * is part of the name because machines sharing an NFS home hand out the same
- * pids, and one session must never clear another's staged install.
+ * allocateSlot() is a rename within one filesystem rather than a copy.
+ *
+ * It is named for the current host and process, and cleared on every call.
+ * That name is deliberately reusable rather than unique: reusing it is what
+ * reclaims a directory left behind by a session that crashed mid-install, and
+ * it leaves a later cleanup pass a name it can test for liveness. A random
+ * name would be collision-proof but could never be reclaimed or recognized,
+ * so every interrupted install would orphan its extraction permanently.
+ *
+ * The host is part of the name because machines sharing an NFS home hand out
+ * the same pids. Where the host cannot be determined this falls back to the
+ * pid alone, and two sessions could then clear each other's staged install --
+ * that costs a failed install, which the caller sees, and never damages a
+ * published slot, since a slot is only ever created by rename.
  *
  * @param slotsDir The directory holding the slots.
  * @param pStagingDir Output: the empty staging directory.

--- a/src/cpp/session/modules/chat/ChatSlots.hpp
+++ b/src/cpp/session/modules/chat/ChatSlots.hpp
@@ -158,11 +158,16 @@ enum class SlotPolicy
 /**
  * Publish a staged package as a slot, arbitrating with concurrent installers.
  *
- * The staged package is verified first, so a directory only ever reaches a
- * final name once it has been checked -- a torn install cannot exist under a
- * name a session might resolve. It is then renamed to the version its own
- * package.json declares, or to `<version>-2`, `<version>-3`, ... when that
- * name is taken. Because the rename is the only arbiter, two sessions
+ * The staged package's manifest is recorded and the result verified before
+ * anything is renamed, so a directory only ever reaches a final name once it
+ * has been checked -- a torn install cannot exist under a name a session might
+ * resolve. Recording the manifest here rather than asking callers to do it
+ * first keeps that guarantee from depending on an ordering every install path
+ * would have to remember; the staging directory is private to this call, so
+ * the tree being recorded is the one that was just extracted.
+ *
+ * The staged package is then renamed to the version its own package.json
+ * declares, or to `<version>-2`, `<version>-3`, ... when that name is taken. Because the rename is the only arbiter, two sessions
  * installing the same version at once cannot corrupt each other: the loser
  * sees the winner's slot and either adopts it or takes the next name.
  *

--- a/src/cpp/session/modules/chat/ChatSlots.hpp
+++ b/src/cpp/session/modules/chat/ChatSlots.hpp
@@ -98,18 +98,19 @@ std::vector<SlotInfo> verifiedSlots(const core::FilePath& slotsDir);
  * The staging directory is a sibling of the slots, so publishing it with
  * allocateSlot() is a rename within one filesystem rather than a copy.
  *
- * It is named for the current host and process, and cleared on every call.
- * That name is deliberately reusable rather than unique: reusing it is what
- * reclaims a directory left behind by a session that crashed mid-install, and
- * it leaves a later cleanup pass a name it can test for liveness. A random
- * name would be collision-proof but could never be reclaimed or recognized,
- * so every interrupted install would orphan its extraction permanently.
+ * Each call returns a directory no other session can name. That matters more
+ * than it looks: the install-time manifest is recorded from whatever is on
+ * disk at the time, so a second writer in the same directory would be
+ * described by the manifest rather than caught by it, and the resulting
+ * truncated slot would verify for the rest of its life. Sessions on machines
+ * sharing an NFS home cannot be told apart by pid -- under container runtimes
+ * they are routinely both pid 1 -- so uniqueness here cannot rest on the
+ * process identity.
  *
- * The host is part of the name because machines sharing an NFS home hand out
- * the same pids. Where the host cannot be determined this falls back to the
- * pid alone, and two sessions could then clear each other's staged install --
- * that costs a failed install, which the caller sees, and never damages a
- * published slot, since a slot is only ever created by rename.
+ * Nothing is reclaimed. An install interrupted before allocateSlot() leaves
+ * its extraction behind, along with the orphans the issue already expects a
+ * later manage-installs effort to collect; the host and pid in the name are
+ * there to give that effort something to identify them by.
  *
  * @param slotsDir The directory holding the slots.
  * @param pStagingDir Output: the empty staging directory.

--- a/src/cpp/session/modules/chat/ChatSlotsTests.cpp
+++ b/src/cpp/session/modules/chat/ChatSlotsTests.cpp
@@ -16,6 +16,7 @@
 #include "ChatSlots.hpp"
 
 #include <algorithm>
+#include <cstdio>
 #include <string>
 #include <vector>
 
@@ -58,6 +59,35 @@ protected:
       ASSERT_FALSE(writeStringToFile(filePath, content));
    }
 
+   // Values are interpolated into JSON string literals, so they have to be
+   // encoded rather than pasted: an unescaped backslash would start an escape
+   // sequence, and a raw control character is not legal JSON at all. Without
+   // this, a test aiming at a rejected slot name would instead be testing an
+   // unparseable package.json.
+   static std::string jsonEscaped(const std::string& value)
+   {
+      std::string escaped;
+      for (char c : value)
+      {
+         if (c == '\\' || c == '"')
+         {
+            escaped += '\\';
+            escaped += c;
+         }
+         else if (static_cast<unsigned char>(c) < 0x20)
+         {
+            char unicode[8];
+            std::snprintf(unicode, sizeof(unicode), "\\u%04x", c);
+            escaped += unicode;
+         }
+         else
+         {
+            escaped += c;
+         }
+      }
+      return escaped;
+   }
+
    // The tree a Posit Assistant package extracts to, in miniature. Tests that
    // want a damaged slot call this, break something, and only then record the
    // manifest -- so the manifest agrees with what is on disk and exactly one
@@ -69,9 +99,9 @@ protected:
       writeFile(dir.completeChildPath(kServerScript), "console.log('hi');");
       writeFile(dir.completeChildPath(kIndexHtml), "<html></html>");
       writeFile(dir.completeChildPath("package.json"),
-                "{\"version\":\"" + version + "\"}");
+                "{\"version\":\"" + jsonEscaped(version) + "\"}");
       writeFile(dir.completeChildPath("protocol.json"),
-                "{\"protocol\":\"" + protocol + "\"}");
+                "{\"protocol\":\"" + jsonEscaped(protocol) + "\"}");
    }
 
    // A slot exactly as an install leaves it.
@@ -326,7 +356,7 @@ TEST_F(ChatSlots, PublishesAStagedInstallUnderItsVersion)
    makeSlot(stagingDir, "1.1.0", "11.0");
 
    FilePath slotDir;
-   ASSERT_FALSE(allocateSlot(stagingDir, "1.1.0",
+   ASSERT_FALSE(allocateSlot(stagingDir,
                              SlotPolicy::AdoptExisting, &slotDir));
 
    EXPECT_EQ(slotDir.getFilename(), "1.1.0");
@@ -343,7 +373,7 @@ TEST_F(ChatSlots, AdoptsAnExistingVerifyingSlot)
    makeSlot(stagingDir, "1.1.0", "11.0");
 
    FilePath slotDir;
-   ASSERT_FALSE(allocateSlot(stagingDir, "1.1.0",
+   ASSERT_FALSE(allocateSlot(stagingDir,
                              SlotPolicy::AdoptExisting, &slotDir));
 
    EXPECT_EQ(slotDir.getFilename(), "1.1.0");
@@ -359,7 +389,7 @@ TEST_F(ChatSlots, BumpsPastAnExistingSlotThatDoesNotVerify)
    makeSlot(stagingDir, "1.1.0", "11.0");
 
    FilePath slotDir;
-   ASSERT_FALSE(allocateSlot(stagingDir, "1.1.0",
+   ASSERT_FALSE(allocateSlot(stagingDir,
                              SlotPolicy::AdoptExisting, &slotDir));
 
    EXPECT_EQ(slotDir.getFilename(), "1.1.0-2");
@@ -376,7 +406,7 @@ TEST_F(ChatSlots, AdoptsALaterOrdinalWhenTheFirstIsDamaged)
    makeSlot(stagingDir, "1.1.0", "11.0");
 
    FilePath slotDir;
-   ASSERT_FALSE(allocateSlot(stagingDir, "1.1.0",
+   ASSERT_FALSE(allocateSlot(stagingDir,
                              SlotPolicy::AdoptExisting, &slotDir));
 
    EXPECT_EQ(slotDir.getFilename(), "1.1.0-2");
@@ -392,7 +422,7 @@ TEST_F(ChatSlots, ForcedAllocationNeverAdopts)
    makeSlot(stagingDir, "1.1.0", "11.0");
 
    FilePath slotDir;
-   ASSERT_FALSE(allocateSlot(stagingDir, "1.1.0",
+   ASSERT_FALSE(allocateSlot(stagingDir,
                              SlotPolicy::AlwaysFresh, &slotDir));
 
    EXPECT_EQ(slotDir.getFilename(), "1.1.0-2");
@@ -406,7 +436,7 @@ TEST_F(ChatSlots, ForcedAllocationTakesThePlainNameWhenItIsFree)
    makeSlot(stagingDir, "1.1.0", "11.0");
 
    FilePath slotDir;
-   ASSERT_FALSE(allocateSlot(stagingDir, "1.1.0",
+   ASSERT_FALSE(allocateSlot(stagingDir,
                              SlotPolicy::AlwaysFresh, &slotDir));
 
    EXPECT_EQ(slotDir.getFilename(), "1.1.0");
@@ -420,7 +450,7 @@ TEST_F(ChatSlots, AllocatesPastTheSecondOrdinal)
    makeSlot(stagingDir, "1.1.0", "11.0");
 
    FilePath slotDir;
-   ASSERT_FALSE(allocateSlot(stagingDir, "1.1.0",
+   ASSERT_FALSE(allocateSlot(stagingDir,
                              SlotPolicy::AlwaysFresh, &slotDir));
 
    EXPECT_EQ(slotDir.getFilename(), "1.1.0-3");
@@ -434,37 +464,92 @@ TEST_F(ChatSlots, DoesNotCollideWithAnUnrelatedVersion)
    makeSlot(stagingDir, "1.0.4", "10.0");
 
    FilePath slotDir;
-   ASSERT_FALSE(allocateSlot(stagingDir, "1.0.4",
+   ASSERT_FALSE(allocateSlot(stagingDir,
                              SlotPolicy::AdoptExisting, &slotDir));
 
    EXPECT_EQ(slotDir.getFilename(), "1.0.4");
    EXPECT_TRUE(verifySlot(slot("1.1.0")));
 }
 
-TEST_F(ChatSlots, RejectsAVersionThatCannotNameADirectory)
+TEST_F(ChatSlots, NamesTheSlotAfterThePackageNotTheStagingDirectory)
 {
-   // The version comes from a downloaded manifest, so it is not trusted to be
-   // a bare version string.
+   // The staging directory name says nothing about what was extracted into it.
    FilePath stagingDir = staging("session-a");
+   makeSlot(stagingDir, "1.0.4", "10.0");
+
+   FilePath slotDir;
+   ASSERT_FALSE(allocateSlot(stagingDir,
+                             SlotPolicy::AdoptExisting, &slotDir));
+
+   EXPECT_EQ(slotDir.getFilename(), "1.0.4");
+}
+
+TEST_F(ChatSlots, DoesNotAdoptASlotHoldingADifferentVersion)
+{
+   // A directory named 1.1.0 is not evidence that it holds 1.1.0. Adopting it
+   // would silently leave the session running a version nobody asked for.
+   makeSlot(slot("1.1.0"), "1.0.4", "11.0");
+   FilePath stagingDir = staging("session-b");
    makeSlot(stagingDir, "1.1.0", "11.0");
 
-   const char* const badVersions[] = {"", ".", "..", ".hidden", "-2",
-                                      "a/b", "a\\b", "C:evil"};
+   FilePath slotDir;
+   ASSERT_FALSE(allocateSlot(stagingDir,
+                             SlotPolicy::AdoptExisting, &slotDir));
+
+   EXPECT_EQ(slotDir.getFilename(), "1.1.0-2");
+   EXPECT_TRUE(verifySlot(slotDir));
+}
+
+TEST_F(ChatSlots, DoesNotAdoptASlotServingADifferentProtocol)
+{
+   makeSlot(slot("1.1.0"), "1.1.0", "10.0");
+   FilePath stagingDir = staging("session-b");
+   makeSlot(stagingDir, "1.1.0", "11.0");
+
+   FilePath slotDir;
+   ASSERT_FALSE(allocateSlot(stagingDir,
+                             SlotPolicy::AdoptExisting, &slotDir));
+
+   EXPECT_EQ(slotDir.getFilename(), "1.1.0-2");
+}
+
+TEST_F(ChatSlots, RejectsAVersionThatCannotNameADirectory)
+{
+   // The version comes from the package.json of a downloaded archive, so it is
+   // not trusted to be a bare version string.
+   const char* const badVersions[] = {".", "..", ".hidden", "-2",
+                                      "a/b", "a\\b", "C:evil", "a\tb"};
    for (const char* version : badVersions)
    {
+      FilePath stagingDir = staging("session-a");
+      ASSERT_FALSE(stagingDir.removeIfExists());
+      makeSlot(stagingDir, version, "11.0");
+
       FilePath slotDir;
-      EXPECT_TRUE(allocateSlot(stagingDir, version,
+      EXPECT_TRUE(allocateSlot(stagingDir,
                                SlotPolicy::AdoptExisting, &slotDir) != Success())
          << "accepted version '" << version << "'";
+      EXPECT_TRUE(stagingDir.exists()) << "consumed staging for '" << version << "'";
    }
+}
 
-   EXPECT_TRUE(stagingDir.exists());
+TEST_F(ChatSlots, RejectsAStagedInstallThatDoesNotVerify)
+{
+   // Publishing happens only after the staged tree is checked, so a torn
+   // install can never appear under a name a session might resolve.
+   FilePath stagingDir = staging("session-a");
+   writeSlotFiles(stagingDir, "1.1.0", "11.0"); // no manifest
+
+   FilePath slotDir;
+   EXPECT_TRUE(allocateSlot(stagingDir,
+                            SlotPolicy::AdoptExisting, &slotDir) != Success());
+   EXPECT_FALSE(slot("1.1.0").exists());
 }
 
 TEST_F(ChatSlots, RejectsAnAbsentStagingDirectory)
 {
    FilePath slotDir;
-   EXPECT_TRUE(allocateSlot(staging("never-created"), "1.1.0",
+   EXPECT_TRUE(allocateSlot(staging("never-created"),
                             SlotPolicy::AdoptExisting, &slotDir) != Success());
 }
 

--- a/src/cpp/session/modules/chat/ChatSlotsTests.cpp
+++ b/src/cpp/session/modules/chat/ChatSlotsTests.cpp
@@ -20,6 +20,10 @@
 #include <string>
 #include <vector>
 
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
 #include <gtest/gtest.h>
 
 #include "ChatSlotManifest.hpp"
@@ -258,6 +262,26 @@ TEST_F(ChatSlots, RejectsASlotWithNoManifest)
 
    EXPECT_FALSE(verifySlot(dir));
 }
+
+#ifndef _WIN32
+
+TEST_F(ChatSlots, RejectsASlotThatIsALink)
+{
+   // Everything about a slot, its manifest included, would be read from a tree
+   // the slot does not contain and cannot promise stays put.
+   FilePath elsewhere = storageDir_.getParent().completeChildPath("elsewhere");
+   makeSlot(elsewhere, "1.1.0", "11.0");
+   ASSERT_TRUE(verifySlot(elsewhere));
+
+   ASSERT_EQ(::symlink(elsewhere.getAbsolutePath().c_str(),
+                       slot("1.1.0").getAbsolutePath().c_str()),
+             0);
+
+   EXPECT_FALSE(verifySlot(slot("1.1.0")));
+   EXPECT_TRUE(verifiedSlots(versionsDir_).empty());
+}
+
+#endif // !_WIN32
 
 TEST_F(ChatSlots, RejectsASlotThatChangedAfterInstall)
 {

--- a/src/cpp/session/modules/chat/ChatSlotsTests.cpp
+++ b/src/cpp/session/modules/chat/ChatSlotsTests.cpp
@@ -1,0 +1,471 @@
+/*
+ * ChatSlotsTests.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "ChatSlots.hpp"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "ChatSlotManifest.hpp"
+
+#include <core/FileSerializer.hpp>
+#include <shared_core/FilePath.hpp>
+
+using namespace rstudio::core;
+using namespace rstudio::session::modules::chat::slots;
+using rstudio::session::modules::chat::slot_manifest::writeSlotManifest;
+
+namespace {
+
+const char* const kServerScript = "dist/server/main.js";
+const char* const kIndexHtml = "dist/client/index.html";
+
+class ChatSlots : public testing::Test
+{
+protected:
+   void SetUp() override
+   {
+      FilePath tempPath;
+      ASSERT_FALSE(FilePath::tempFilePath(tempPath));
+      storageDir_ = tempPath.completePath("pai");
+      versionsDir_ = versionsDir(storageDir_);
+      ASSERT_FALSE(versionsDir_.ensureDirectory());
+   }
+
+   void TearDown() override
+   {
+      storageDir_.getParent().removeIfExists();
+   }
+
+   void writeFile(const FilePath& filePath, const std::string& content)
+   {
+      ASSERT_FALSE(filePath.getParent().ensureDirectory());
+      ASSERT_FALSE(writeStringToFile(filePath, content));
+   }
+
+   // The tree a Posit Assistant package extracts to, in miniature. Tests that
+   // want a damaged slot call this, break something, and only then record the
+   // manifest -- so the manifest agrees with what is on disk and exactly one
+   // check is left to fail.
+   void writeSlotFiles(const FilePath& dir,
+                       const std::string& version,
+                       const std::string& protocol)
+   {
+      writeFile(dir.completeChildPath(kServerScript), "console.log('hi');");
+      writeFile(dir.completeChildPath(kIndexHtml), "<html></html>");
+      writeFile(dir.completeChildPath("package.json"),
+                "{\"version\":\"" + version + "\"}");
+      writeFile(dir.completeChildPath("protocol.json"),
+                "{\"protocol\":\"" + protocol + "\"}");
+   }
+
+   // A slot exactly as an install leaves it.
+   void makeSlot(const FilePath& dir,
+                 const std::string& version,
+                 const std::string& protocol)
+   {
+      writeSlotFiles(dir, version, protocol);
+      ASSERT_FALSE(writeSlotManifest(dir));
+   }
+
+   FilePath slot(const std::string& name)
+   {
+      return versionsDir_.completeChildPath(name);
+   }
+
+   // A staged install belonging to some session. Named directly rather than
+   // through prepareStagingDir() so one test can model several sessions.
+   FilePath staging(const std::string& session)
+   {
+      return versionsDir_.completeChildPath(".tmp-" + session);
+   }
+
+   FilePath storageDir_;
+   FilePath versionsDir_;
+};
+
+// ============================================================================
+// verifySlot
+// ============================================================================
+
+TEST_F(ChatSlots, VerifiesAFreshInstall)
+{
+   makeSlot(slot("1.1.0"), "1.1.0", "11.0");
+   EXPECT_TRUE(verifySlot(slot("1.1.0")));
+}
+
+TEST_F(ChatSlots, ReportsWhatTheSlotSaysAboutItself)
+{
+   // The slot name says 1.1.0-2, which is valid semver for something older
+   // than 1.1.0; identity has to come from inside the slot instead.
+   makeSlot(slot("1.1.0-2"), "1.1.0", "11.0");
+
+   SlotInfo info;
+   ASSERT_TRUE(verifySlot(slot("1.1.0-2"), &info));
+   EXPECT_EQ(info.name, "1.1.0-2");
+   EXPECT_EQ(info.version, "1.1.0");
+   EXPECT_EQ(info.protocol, "11.0");
+   EXPECT_TRUE(info.path.isEquivalentTo(slot("1.1.0-2")));
+}
+
+TEST_F(ChatSlots, RejectsAnAbsentSlot)
+{
+   EXPECT_FALSE(verifySlot(slot("1.1.0")));
+}
+
+TEST_F(ChatSlots, RejectsAMissingServerScript)
+{
+   FilePath dir = slot("1.1.0");
+   writeSlotFiles(dir, "1.1.0", "11.0");
+   ASSERT_FALSE(dir.completeChildPath(kServerScript).remove());
+   ASSERT_FALSE(writeSlotManifest(dir));
+
+   EXPECT_FALSE(verifySlot(dir));
+}
+
+TEST_F(ChatSlots, RejectsAnEmptyServerScript)
+{
+   // The check this replaces tested only for existence, so a truncated
+   // download left a zero-byte main.js that passed.
+   FilePath dir = slot("1.1.0");
+   writeSlotFiles(dir, "1.1.0", "11.0");
+   writeFile(dir.completeChildPath(kServerScript), "");
+   ASSERT_FALSE(writeSlotManifest(dir));
+
+   EXPECT_FALSE(verifySlot(dir));
+}
+
+TEST_F(ChatSlots, RejectsAnEmptyIndexHtml)
+{
+   FilePath dir = slot("1.1.0");
+   writeSlotFiles(dir, "1.1.0", "11.0");
+   writeFile(dir.completeChildPath(kIndexHtml), "");
+   ASSERT_FALSE(writeSlotManifest(dir));
+
+   EXPECT_FALSE(verifySlot(dir));
+}
+
+TEST_F(ChatSlots, RejectsAMissingClientDirectory)
+{
+   FilePath dir = slot("1.1.0");
+   writeSlotFiles(dir, "1.1.0", "11.0");
+   ASSERT_FALSE(dir.completeChildPath("dist/client").remove());
+   ASSERT_FALSE(writeSlotManifest(dir));
+
+   EXPECT_FALSE(verifySlot(dir));
+}
+
+TEST_F(ChatSlots, RejectsAnUnparseablePackageJson)
+{
+   FilePath dir = slot("1.1.0");
+   writeSlotFiles(dir, "1.1.0", "11.0");
+   writeFile(dir.completeChildPath("package.json"), "{ not json");
+   ASSERT_FALSE(writeSlotManifest(dir));
+
+   EXPECT_FALSE(verifySlot(dir));
+}
+
+TEST_F(ChatSlots, RejectsAPackageJsonWithoutAVersion)
+{
+   FilePath dir = slot("1.1.0");
+   writeSlotFiles(dir, "1.1.0", "11.0");
+   writeFile(dir.completeChildPath("package.json"), "{\"name\":\"assistant\"}");
+   ASSERT_FALSE(writeSlotManifest(dir));
+
+   EXPECT_FALSE(verifySlot(dir));
+}
+
+TEST_F(ChatSlots, RejectsAnEmptyVersion)
+{
+   FilePath dir = slot("1.1.0");
+   writeSlotFiles(dir, "", "11.0");
+   ASSERT_FALSE(writeSlotManifest(dir));
+
+   EXPECT_FALSE(verifySlot(dir));
+}
+
+TEST_F(ChatSlots, RejectsAnUnparseableProtocolJson)
+{
+   FilePath dir = slot("1.1.0");
+   writeSlotFiles(dir, "1.1.0", "11.0");
+   writeFile(dir.completeChildPath("protocol.json"), "[]");
+   ASSERT_FALSE(writeSlotManifest(dir));
+
+   EXPECT_FALSE(verifySlot(dir));
+}
+
+TEST_F(ChatSlots, RejectsAProtocolJsonWithoutAProtocol)
+{
+   FilePath dir = slot("1.1.0");
+   writeSlotFiles(dir, "1.1.0", "11.0");
+   writeFile(dir.completeChildPath("protocol.json"), "{\"version\":\"11.0\"}");
+   ASSERT_FALSE(writeSlotManifest(dir));
+
+   EXPECT_FALSE(verifySlot(dir));
+}
+
+TEST_F(ChatSlots, RejectsASlotWithNoManifest)
+{
+   // Every slot this module publishes gets a manifest, so a directory without
+   // one was not left behind by an install that finished.
+   FilePath dir = slot("1.1.0");
+   writeSlotFiles(dir, "1.1.0", "11.0");
+
+   EXPECT_FALSE(verifySlot(dir));
+}
+
+TEST_F(ChatSlots, RejectsASlotThatChangedAfterInstall)
+{
+   FilePath dir = slot("1.1.0");
+   makeSlot(dir, "1.1.0", "11.0");
+   writeFile(dir.completeChildPath(kServerScript), "console.log('tampered');");
+
+   EXPECT_FALSE(verifySlot(dir));
+}
+
+// ============================================================================
+// verifiedSlots
+// ============================================================================
+
+TEST_F(ChatSlots, ListsOnlyVerifyingSlots)
+{
+   makeSlot(slot("1.1.0"), "1.1.0", "11.0");
+   makeSlot(slot("1.0.4"), "1.0.4", "10.0");
+   writeSlotFiles(slot("0.9.0"), "0.9.0", "10.0"); // no manifest
+
+   std::vector<SlotInfo> found = verifiedSlots(versionsDir_);
+   ASSERT_EQ(found.size(), 2u);
+
+   std::vector<std::string> names;
+   for (const SlotInfo& info : found)
+      names.push_back(info.name);
+   std::sort(names.begin(), names.end());
+   EXPECT_EQ(names[0], "1.0.4");
+   EXPECT_EQ(names[1], "1.1.0");
+}
+
+TEST_F(ChatSlots, SkipsStagingDirectories)
+{
+   // A staged install is a complete tree that would otherwise verify; it must
+   // not be resolvable before the rename publishes it.
+   makeSlot(staging("session-a"), "1.1.0", "11.0");
+
+   EXPECT_TRUE(verifiedSlots(versionsDir_).empty());
+}
+
+TEST_F(ChatSlots, FindsNothingBeforeTheFirstInstall)
+{
+   ASSERT_FALSE(versionsDir_.remove());
+   EXPECT_TRUE(verifiedSlots(versionsDir_).empty());
+}
+
+// ============================================================================
+// prepareStagingDir
+// ============================================================================
+
+TEST_F(ChatSlots, PreparesAnEmptyStagingDirectory)
+{
+   FilePath stagingDir;
+   ASSERT_FALSE(prepareStagingDir(versionsDir_, &stagingDir));
+
+   EXPECT_TRUE(stagingDir.isDirectory());
+   EXPECT_TRUE(stagingDir.getParent().isEquivalentTo(versionsDir_));
+
+   std::vector<FilePath> children;
+   ASSERT_FALSE(stagingDir.getChildren(children));
+   EXPECT_TRUE(children.empty());
+}
+
+TEST_F(ChatSlots, ClearsWhatACrashedSessionLeftStaged)
+{
+   FilePath stagingDir;
+   ASSERT_FALSE(prepareStagingDir(versionsDir_, &stagingDir));
+   writeSlotFiles(stagingDir, "1.0.4", "10.0");
+
+   FilePath second;
+   ASSERT_FALSE(prepareStagingDir(versionsDir_, &second));
+   ASSERT_TRUE(second.isEquivalentTo(stagingDir));
+
+   std::vector<FilePath> children;
+   ASSERT_FALSE(second.getChildren(children));
+   EXPECT_TRUE(children.empty());
+}
+
+TEST_F(ChatSlots, CreatesTheVersionsDirectoryOnFirstUse)
+{
+   ASSERT_FALSE(versionsDir_.remove());
+
+   FilePath stagingDir;
+   ASSERT_FALSE(prepareStagingDir(versionsDir_, &stagingDir));
+   EXPECT_TRUE(versionsDir_.isDirectory());
+}
+
+// ============================================================================
+// allocateSlot
+// ============================================================================
+
+TEST_F(ChatSlots, PublishesAStagedInstallUnderItsVersion)
+{
+   FilePath stagingDir;
+   ASSERT_FALSE(prepareStagingDir(versionsDir_, &stagingDir));
+   makeSlot(stagingDir, "1.1.0", "11.0");
+
+   FilePath slotDir;
+   ASSERT_FALSE(allocateSlot(stagingDir, "1.1.0",
+                             SlotPolicy::AdoptExisting, &slotDir));
+
+   EXPECT_EQ(slotDir.getFilename(), "1.1.0");
+   EXPECT_TRUE(verifySlot(slotDir));
+   EXPECT_FALSE(stagingDir.exists());
+}
+
+TEST_F(ChatSlots, AdoptsAnExistingVerifyingSlot)
+{
+   // The rename loser: another session published this version first, and its
+   // slot is intact, so there is nothing to add.
+   makeSlot(slot("1.1.0"), "1.1.0", "11.0");
+   FilePath stagingDir = staging("session-b");
+   makeSlot(stagingDir, "1.1.0", "11.0");
+
+   FilePath slotDir;
+   ASSERT_FALSE(allocateSlot(stagingDir, "1.1.0",
+                             SlotPolicy::AdoptExisting, &slotDir));
+
+   EXPECT_EQ(slotDir.getFilename(), "1.1.0");
+   EXPECT_FALSE(slot("1.1.0-2").exists());
+   EXPECT_FALSE(stagingDir.exists());
+}
+
+TEST_F(ChatSlots, BumpsPastAnExistingSlotThatDoesNotVerify)
+{
+   FilePath damaged = slot("1.1.0");
+   writeSlotFiles(damaged, "1.1.0", "11.0"); // no manifest
+   FilePath stagingDir = staging("session-b");
+   makeSlot(stagingDir, "1.1.0", "11.0");
+
+   FilePath slotDir;
+   ASSERT_FALSE(allocateSlot(stagingDir, "1.1.0",
+                             SlotPolicy::AdoptExisting, &slotDir));
+
+   EXPECT_EQ(slotDir.getFilename(), "1.1.0-2");
+   EXPECT_TRUE(verifySlot(slotDir));
+   // The damaged slot is left alone -- another session may be running from it.
+   EXPECT_TRUE(damaged.exists());
+}
+
+TEST_F(ChatSlots, AdoptsALaterOrdinalWhenTheFirstIsDamaged)
+{
+   writeSlotFiles(slot("1.1.0"), "1.1.0", "11.0"); // no manifest
+   makeSlot(slot("1.1.0-2"), "1.1.0", "11.0");
+   FilePath stagingDir = staging("session-c");
+   makeSlot(stagingDir, "1.1.0", "11.0");
+
+   FilePath slotDir;
+   ASSERT_FALSE(allocateSlot(stagingDir, "1.1.0",
+                             SlotPolicy::AdoptExisting, &slotDir));
+
+   EXPECT_EQ(slotDir.getFilename(), "1.1.0-2");
+   EXPECT_FALSE(slot("1.1.0-3").exists());
+}
+
+TEST_F(ChatSlots, ForcedAllocationNeverAdopts)
+{
+   // Reinstall exists to replace bits that verification cannot fault, so it
+   // has to end up in a directory it wrote itself.
+   makeSlot(slot("1.1.0"), "1.1.0", "11.0");
+   FilePath stagingDir = staging("session-b");
+   makeSlot(stagingDir, "1.1.0", "11.0");
+
+   FilePath slotDir;
+   ASSERT_FALSE(allocateSlot(stagingDir, "1.1.0",
+                             SlotPolicy::AlwaysFresh, &slotDir));
+
+   EXPECT_EQ(slotDir.getFilename(), "1.1.0-2");
+   EXPECT_TRUE(verifySlot(slot("1.1.0")));
+   EXPECT_TRUE(verifySlot(slotDir));
+}
+
+TEST_F(ChatSlots, ForcedAllocationTakesThePlainNameWhenItIsFree)
+{
+   FilePath stagingDir = staging("session-a");
+   makeSlot(stagingDir, "1.1.0", "11.0");
+
+   FilePath slotDir;
+   ASSERT_FALSE(allocateSlot(stagingDir, "1.1.0",
+                             SlotPolicy::AlwaysFresh, &slotDir));
+
+   EXPECT_EQ(slotDir.getFilename(), "1.1.0");
+}
+
+TEST_F(ChatSlots, AllocatesPastTheSecondOrdinal)
+{
+   makeSlot(slot("1.1.0"), "1.1.0", "11.0");
+   makeSlot(slot("1.1.0-2"), "1.1.0", "11.0");
+   FilePath stagingDir = staging("session-c");
+   makeSlot(stagingDir, "1.1.0", "11.0");
+
+   FilePath slotDir;
+   ASSERT_FALSE(allocateSlot(stagingDir, "1.1.0",
+                             SlotPolicy::AlwaysFresh, &slotDir));
+
+   EXPECT_EQ(slotDir.getFilename(), "1.1.0-3");
+   EXPECT_TRUE(verifySlot(slotDir));
+}
+
+TEST_F(ChatSlots, DoesNotCollideWithAnUnrelatedVersion)
+{
+   makeSlot(slot("1.1.0"), "1.1.0", "11.0");
+   FilePath stagingDir = staging("session-b");
+   makeSlot(stagingDir, "1.0.4", "10.0");
+
+   FilePath slotDir;
+   ASSERT_FALSE(allocateSlot(stagingDir, "1.0.4",
+                             SlotPolicy::AdoptExisting, &slotDir));
+
+   EXPECT_EQ(slotDir.getFilename(), "1.0.4");
+   EXPECT_TRUE(verifySlot(slot("1.1.0")));
+}
+
+TEST_F(ChatSlots, RejectsAVersionThatCannotNameADirectory)
+{
+   // The version comes from a downloaded manifest, so it is not trusted to be
+   // a bare version string.
+   FilePath stagingDir = staging("session-a");
+   makeSlot(stagingDir, "1.1.0", "11.0");
+
+   const char* const badVersions[] = {"", ".", "..", ".hidden", "-2",
+                                      "a/b", "a\\b", "C:evil"};
+   for (const char* version : badVersions)
+   {
+      FilePath slotDir;
+      EXPECT_TRUE(allocateSlot(stagingDir, version,
+                               SlotPolicy::AdoptExisting, &slotDir) != Success())
+         << "accepted version '" << version << "'";
+   }
+
+   EXPECT_TRUE(stagingDir.exists());
+}
+
+TEST_F(ChatSlots, RejectsAnAbsentStagingDirectory)
+{
+   FilePath slotDir;
+   EXPECT_TRUE(allocateSlot(staging("never-created"), "1.1.0",
+                            SlotPolicy::AdoptExisting, &slotDir) != Success());
+}
+
+} // anonymous namespace

--- a/src/cpp/session/modules/chat/ChatSlotsTests.cpp
+++ b/src/cpp/session/modules/chat/ChatSlotsTests.cpp
@@ -321,6 +321,19 @@ TEST_F(ChatSlots, PreparesAnEmptyStagingDirectory)
    EXPECT_TRUE(children.empty());
 }
 
+TEST_F(ChatSlots, AStagedInstallIsNotResolvableBeforeItIsPublished)
+{
+   // Enters through the code that names the staging directory rather than a
+   // hand-built name, so the name and the rule that hides it cannot drift
+   // apart and make a half-extracted tree resolvable.
+   FilePath stagingDir;
+   ASSERT_FALSE(prepareStagingDir(versionsDir_, &stagingDir));
+   makeSlot(stagingDir, "1.1.0", "11.0");
+
+   ASSERT_TRUE(verifySlot(stagingDir));
+   EXPECT_TRUE(verifiedSlots(versionsDir_).empty());
+}
+
 TEST_F(ChatSlots, ClearsWhatACrashedSessionLeftStaged)
 {
    FilePath stagingDir;

--- a/src/cpp/session/modules/chat/ChatSlotsTests.cpp
+++ b/src/cpp/session/modules/chat/ChatSlotsTests.cpp
@@ -536,8 +536,14 @@ TEST_F(ChatSlots, RejectsAVersionThatCannotNameADirectory)
 {
    // The version comes from the package.json of a downloaded archive, so it is
    // not trusted to be a bare version string.
-   const char* const badVersions[] = {".", "..", ".hidden", "-2",
-                                      "a/b", "a\\b", "C:evil", "a\tb"};
+   const char* const badVersions[] = {
+      ".", "..", ".hidden", "-2", "a/b", "a\\b", "C:evil", "a\tb",
+      // Rejected by Win32, but checked everywhere so a home reached from both
+      // Windows and Linux agrees on which names are slots.
+      "1.0*", "1.0?", "1.0|x", "1.0<x", "1.0>x", "1.0\"x", "nul", "COM1",
+      // Win32 strips these silently, so the directory would not match the
+      // name recorded in the selector.
+      "1.1.0.", "1.1.0 "};
    for (const char* version : badVersions)
    {
       FilePath stagingDir = staging("session-a");

--- a/src/cpp/session/modules/chat/ChatSlotsTests.cpp
+++ b/src/cpp/session/modules/chat/ChatSlotsTests.cpp
@@ -334,15 +334,21 @@ TEST_F(ChatSlots, AStagedInstallIsNotResolvableBeforeItIsPublished)
    EXPECT_TRUE(verifiedSlots(versionsDir_).empty());
 }
 
-TEST_F(ChatSlots, ClearsWhatACrashedSessionLeftStaged)
+TEST_F(ChatSlots, DoesNotDisturbAnotherSessionsStagedInstall)
 {
-   FilePath stagingDir;
-   ASSERT_FALSE(prepareStagingDir(versionsDir_, &stagingDir));
-   writeSlotFiles(stagingDir, "1.0.4", "10.0");
+   // Two sessions sharing an NFS home once computed the same staging path, so
+   // the second one's prepare deleted the first one's half-extracted tree. The
+   // first then recorded a manifest describing the damage -- self-consistent,
+   // so the truncated slot verified and could be published for good.
+   FilePath first;
+   ASSERT_FALSE(prepareStagingDir(versionsDir_, &first));
+   writeSlotFiles(first, "1.1.0", "11.0");
 
    FilePath second;
    ASSERT_FALSE(prepareStagingDir(versionsDir_, &second));
-   ASSERT_TRUE(second.isEquivalentTo(stagingDir));
+
+   EXPECT_FALSE(second.isEquivalentTo(first));
+   EXPECT_TRUE(first.completeChildPath(kServerScript).exists());
 
    std::vector<FilePath> children;
    ASSERT_FALSE(second.getChildren(children));

--- a/src/cpp/session/modules/chat/ChatSlotsTests.cpp
+++ b/src/cpp/session/modules/chat/ChatSlotsTests.cpp
@@ -558,12 +558,30 @@ TEST_F(ChatSlots, RejectsAVersionThatCannotNameADirectory)
    }
 }
 
+TEST_F(ChatSlots, RecordsTheManifestItselfSoCallersCannotForgetTo)
+{
+   // The caller extracts and nothing else; if the manifest were the caller's
+   // job, omitting it would fail every install with "not a complete Posit
+   // Assistant installation" despite a perfect extraction.
+   FilePath stagingDir;
+   ASSERT_FALSE(prepareStagingDir(versionsDir_, &stagingDir));
+   writeSlotFiles(stagingDir, "1.1.0", "11.0");
+
+   FilePath slotDir;
+   ASSERT_FALSE(allocateSlot(stagingDir,
+                             SlotPolicy::AdoptExisting, &slotDir));
+
+   EXPECT_EQ(slotDir.getFilename(), "1.1.0");
+   EXPECT_TRUE(verifySlot(slotDir));
+}
+
 TEST_F(ChatSlots, RejectsAStagedInstallThatDoesNotVerify)
 {
    // Publishing happens only after the staged tree is checked, so a torn
    // install can never appear under a name a session might resolve.
    FilePath stagingDir = staging("session-a");
-   writeSlotFiles(stagingDir, "1.1.0", "11.0"); // no manifest
+   writeSlotFiles(stagingDir, "1.1.0", "11.0");
+   ASSERT_FALSE(stagingDir.completeChildPath(kServerScript).remove());
 
    FilePath slotDir;
    EXPECT_TRUE(allocateSlot(stagingDir,

--- a/src/cpp/session/modules/chat/ChatSlotsTests.cpp
+++ b/src/cpp/session/modules/chat/ChatSlotsTests.cpp
@@ -541,6 +541,8 @@ TEST_F(ChatSlots, RejectsAVersionThatCannotNameADirectory)
       // Rejected by Win32, but checked everywhere so a home reached from both
       // Windows and Linux agrees on which names are slots.
       "1.0*", "1.0?", "1.0|x", "1.0<x", "1.0>x", "1.0\"x", "nul", "COM1",
+      // A device name stays reserved with an extension after it.
+      "nul.txt", "COM1.log", "aux.1.0",
       // Win32 strips these silently, so the directory would not match the
       // name recorded in the selector.
       "1.1.0.", "1.1.0 "};


### PR DESCRIPTION
PR 2 of the five-PR sequence in #18658. Pure addition under `src/cpp/session/modules/chat/` — no existing call site changes, and nothing is wired up. The resolver switch and install rewrite are PR 3, deleting `ChatInstallLock` is PR 4, the Reinstall button is PR 5.

## What lands

**`ChatSlots`** — slot allocation and verification.

The install API is `prepareStagingDir` → extract → `allocateSlot`. `allocateSlot()` records the slot manifest, verifies the result, and only then renames the staged tree into `pai/versions/<version>`, or `<version>-2`, `-3`, ... when that name is taken. Recording and verifying inside the call rather than asking callers to do it first means "a slot only reaches a final name once it has been checked" holds by construction, not by an ordering each install path has to remember.

Slot names are never read for identity. The name comes from the staged package's own `package.json`, and a slot is adopted only when it verifies *and* declares the same version and protocol as what was staged — a directory named `1.1.0` is not evidence that it holds `1.1.0`. `SlotPolicy::AlwaysFresh` never adopts, which is what PR 5 needs.

`isUsableSlotName()` gates both untrusted sources of a name (the archive's `package.json` and `selected.json`), rejecting anything that cannot round-trip as a directory name. The Windows rules are applied on every platform so a home reached from both Windows and Linux agrees on which names are slots.

`prepareStagingDir()` returns a directory no other session can name. See the deviation note.

`verifySlot()` requires the expected paths to exist and be non-empty, `package.json` to parse with a `version`, `protocol.json` to parse with a `protocol`, the slot not to be a link, and every manifest entry to be intact. The check it replaces in PR 3 tests only that three paths exist, so a zero-byte `main.js` passes it.

**`ChatSlotManifest`** — relative path to size and SHA-256 for every regular file in a slot, recorded after extraction while the tree is known to match the verified package. Verification compares sizes only, so it stays a stat walk cheap enough to run at every resolve; the hashes are recorded for a deeper check later, as the issue specifies. Symlinks are excluded and paths reached through a symlinked or junction-backed directory are rejected, so a slot cannot come to depend on a tree it does not contain.

**`ChatSelector`** — `pai/selected.json`, holding `{"selected": {"11.0": "1.1.0-2", "10.0": "0.4.8"}}`. Read, write (temp file then rename, last-writer-wins), and the fallback: when the named slot is missing, unusable, or serves another protocol, resolution picks the best verifying slot for the protocol and records it. Ordering is release version, then a release over a prerelease of it, then — only between slots holding the very same version — the later reinstall.

Legacy `pai/bin` is not read, written, or deleted. There is no garbage collection; slots accumulate, as the issue specifies.

## One deviation from the issue text

The issue specified staging at `pai/versions/.tmp-<pid>/`, cleared first. This PR uses a unique name per install (`.tmp-<host>-<pid>-<nonce>`) and clears nothing. Two sessions sharing an NFS home can compute the same pid-based name — under container runtimes they routinely do, since each session pod has its own PID namespace and low pids repeat — and the second session's prepare would delete the first's half-extracted tree. Because the manifest is recorded from whatever is on disk when it runs, the victim would record a manifest describing the damage, verify it against itself, and publish a truncated slot that keeps verifying forever.

The issue body has been updated to match, with the reasoning in [this comment](https://github.com/rstudio/rstudio/issues/18658#issuecomment-5446077208).

## Testing

91 new unit tests: rename arbitration and adoption (including refusing to adopt a different version or protocol), forced mode, ordinal allocation past `-2` and past `-9`, staged installs being unresolvable and not disturbing each other, name validation from both sources, manifest round trip, symlink and junction hardening, every verification failure mode separately, selector round trip, and fallback and repair including absent or malformed `selected.json`.

    cmake --build build --target rsession
    ./build/src/cpp/rstudio-tests --scope rsession    # 519 tests, all passing

No NEWS.md entry: nothing user-visible ships until PR 3, so the versioned-install entry lands there.

Addresses #18658.