### PR TITLE
Normalize buffered localhost proxy responses

### DIFF
--- a/src/cpp/server/include/server/session/ServerSessionProxy.hpp
+++ b/src/cpp/server/include/server/session/ServerSessionProxy.hpp
@@ -135,6 +135,15 @@ bool applyProxyFilter(
 // Exposes the uid-resolution decision inputs used to enforce localhost-proxy
 // destination-port ownership (rstudio-pro#11470).
 core::Error userIdForUsernameForTest(const std::string& username, UidType* pUID);
+
+// Exercises the complete rewrite path used for buffered localhost responses.
+void prepareLocalhostResponseForTest(
+      const core::http::Request& originalRequest,
+      const std::string& port,
+      const std::string& baseAddress,
+      bool ipv6,
+      const core::http::Response& response,
+      core::http::Response* pPreparedResponse);
 #endif
 
 } // namespace session_proxy
@@ -142,4 +151,3 @@ core::Error userIdForUsernameForTest(const std::string& username, UidType* pUID)
 } // namespace rstudio
 
 #endif // SERVER_SESSION_PROXY_HPP
-

--- a/src/cpp/server/session/ServerSessionProxy.cpp
+++ b/src/cpp/server/session/ServerSessionProxy.cpp
@@ -383,11 +383,11 @@ bool isSparkUIResponse(const http::Response& response)
           contains(response.body(), "<div class=\"navbar navbar-static-top\">");
 }
 
-void sendSparkUIResponse(
-      const http::Response& response,
-      boost::shared_ptr<core::http::AsyncConnection> ptrConnection)
+void rewriteSparkUIResponse(
+      const http::Request& request,
+      http::Response* pResponse)
 {
-   std::string path = ptrConnection->request().path();
+   std::string path = request.path();
    size_t slashes = std::count(path.begin(), path.end(), '/');
    size_t up = slashes >= 4 ? (slashes - 3) : 0;
    std::vector<std::string> dirs;
@@ -395,9 +395,7 @@ void sendSparkUIResponse(
       dirs.push_back("..");
    std::string prefix = boost::algorithm::join(dirs, "/");
 
-   http::Response fixedResponse;
-   fixedResponse.assign(response);
-   std::string body = response.body();
+   std::string body = pResponse->body();
    boost::algorithm::replace_all(body,
                               "href=\"/",
                               "href=\"" + prefix + "/");
@@ -407,8 +405,63 @@ void sendSparkUIResponse(
    boost::algorithm::replace_all(body,
                                  "<img src=\"/",
                                  "<img src=\"" + prefix + "/");
-   fixedResponse.setBody(body);
-   ptrConnection->writeResponse(fixedResponse);
+   pResponse->setBody(body);
+}
+
+void prepareLocalhostResponse(
+      const http::Request& originalRequest,
+      const std::string& port,
+      const std::string& baseAddress,
+      bool ipv6,
+      const http::Response& response,
+      http::Response* pPreparedResponse)
+{
+   pPreparedResponse->assign(response);
+
+   // AsyncClient consumes the chunk framing before delivering a buffered
+   // response. Normalize that decoded response before any branch rewrites or
+   // forwards it; otherwise redirects and Spark UI responses can retain the
+   // upstream Transfer-Encoding label and be decoded a second time by the
+   // browser.
+   if (core::http::util::parseTransferEncoding(response.headers()).chunkedIsFinal)
+   {
+      pPreparedResponse->removeHeader("Transfer-Encoding");
+      pPreparedResponse->setContentLength(response.body().size());
+   }
+
+   const char * const kLocation = "Location";
+   const char * const kRefresh = "Refresh";
+   std::string location = pPreparedResponse->headerValue(kLocation);
+   std::string refresh = pPreparedResponse->headerValue(kRefresh);
+
+   if (!location.empty() || !refresh.empty())
+   {
+      if (!location.empty())
+      {
+         rewriteLocalhostAddressHeader(kLocation,
+                                       originalRequest,
+                                       port,
+                                       baseAddress,
+                                       ipv6,
+                                       pPreparedResponse);
+      }
+
+      if (!refresh.empty())
+      {
+         rewriteLocalhostAddressHeader(kRefresh,
+                                       originalRequest,
+                                       port,
+                                       baseAddress,
+                                       ipv6,
+                                       pPreparedResponse);
+      }
+   }
+   else if (isSparkUIResponse(*pPreparedResponse))
+   {
+      // Spark UI uses paths hard-coded to the root "/", but it is proxied
+      // behind a "/p/<port>/" URL.
+      rewriteSparkUIResponse(originalRequest, pPreparedResponse);
+   }
 }
 
 void handleWriteResponseForUpgrade(
@@ -469,82 +522,15 @@ void handleLocalhostResponse(
    }
    // normal response, write and close (handle redirects if necessary)
    else
-   {   
-      // re-write location headers if necessary
-      const char * const kLocation = "Location";
-      const char * const kRefresh = "Refresh";
-      std::string location = response.headerValue(kLocation);
-      std::string refresh = response.headerValue(kRefresh);
-      if (!location.empty() || !refresh.empty())
-      {
-         // make a copy of the response to rewrite the headers into
-         http::Response redirectResponse;
-         redirectResponse.assign(response);
-
-         // handle Location
-         if (!location.empty())
-         {
-            rewriteLocalhostAddressHeader(kLocation,
-                                          ptrConnection->request(),
-                                          port,
-                                          baseAddress,
-                                          ipv6,
-                                          &redirectResponse);
-         }
-
-         // handle Refresh
-         if (!refresh.empty())
-         {
-            rewriteLocalhostAddressHeader(kRefresh,
-                                          ptrConnection->request(),
-                                          port,
-                                          baseAddress,
-                                          ipv6,
-                                          &redirectResponse);
-         }
-
-         // write the copy
-         ptrConnection->writeResponse(redirectResponse);
-      }
-      else
-      {
-         // fixup bad SparkUI URLs in responses (they use paths hard
-         // coded to the root "/" and we are proxying them behind
-         // a "/p/<port>/" URL)
-         if (isSparkUIResponse(response))
-         {         
-            sendSparkUIResponse(response, ptrConnection);
-         }
-         else if (core::http::util::parseTransferEncoding(response.headers()).chunkedIsFinal)
-         {
-            // Even if the response from upstream is "Transfer-Encoding: chunked",
-            // our response to the client is no longer chunked; the AsyncClient
-            // parses and consumes the chunk lengths. Therefore, remove the
-            // Transfer-Encoding header and set the content length, to reflect
-            // that the body will come all at once.
-            //
-            // This must use the same parse AsyncClient used to decide to
-            // de-chunk (it once compared the raw field to "chunked" here): if
-            // AsyncClient de-chunked a body whose field read "Chunked", a
-            // string compare would leave the now-decoded body labelled as
-            // chunked on the way out, and the client would try to de-chunk it
-            // again. The "gzip, chunked" case the old TODO here asked about is
-            // now answered upstream -- AsyncClient rejects codings it cannot
-            // undo rather than delivering a still-encoded body.
-            //
-            // TODO: What other hop-by-hop response headers are we not removing
-            // but should?
-            http::Response response1;
-            response1.assign(response);
-            response1.removeHeader("Transfer-Encoding");
-            response1.setContentLength(response.body().size());
-            ptrConnection->writeResponse(response1);
-         }
-         else
-         {
-            ptrConnection->writeResponse(response);
-         }
-      }
+   {
+      http::Response preparedResponse;
+      prepareLocalhostResponse(ptrConnection->request(),
+                               port,
+                               baseAddress,
+                               ipv6,
+                               response,
+                               &preparedResponse);
+      ptrConnection->writeResponse(preparedResponse);
    }
 }
 
@@ -998,6 +984,22 @@ bool shouldRefreshCredentials(const http::Request& request)
 Error userIdForUsernameForTest(const std::string& username, UidType* pUID)
 {
    return userIdForUsername(username, pUID);
+}
+
+void prepareLocalhostResponseForTest(
+      const http::Request& originalRequest,
+      const std::string& port,
+      const std::string& baseAddress,
+      bool ipv6,
+      const http::Response& response,
+      http::Response* pPreparedResponse)
+{
+   prepareLocalhostResponse(originalRequest,
+                            port,
+                            baseAddress,
+                            ipv6,
+                            response,
+                            pPreparedResponse);
 }
 #endif
 

--- a/src/cpp/server/session/ServerSessionProxyTests.cpp
+++ b/src/cpp/server/session/ServerSessionProxyTests.cpp
@@ -74,3 +74,69 @@ TEST(ProxyLocalhostUidResolutionTests, FailsClosedForUnknownUser)
    // without an ownership check.
    EXPECT_TRUE(error);
 }
+
+TEST(ProxyLocalhostResponseTests, NormalizesChunkedRedirectBeforeRewritingHeaders)
+{
+   http::Request request;
+   request.setUri("/p/port-token/source");
+
+   http::Response response;
+   response.setStatusCode(http::status::MovedTemporarily);
+   response.setHeader("Location", "/location-target");
+   response.setHeader("Refresh", "/refresh-target");
+   response.setHeader("Transfer-Encoding", "Chunked");
+   response.setBody("decoded redirect body");
+
+   http::Response preparedResponse;
+   session_proxy::prepareLocalhostResponseForTest(
+      request,
+      "port-token",
+      "localhost",
+      false,
+      response,
+      &preparedResponse);
+
+   EXPECT_TRUE(preparedResponse.headerValue("Transfer-Encoding").empty());
+   EXPECT_EQ(preparedResponse.headerValue("Content-Length"),
+             std::to_string(response.body().size()));
+   EXPECT_EQ(preparedResponse.headerValue("Location"),
+             "/p/port-token/location-target");
+   EXPECT_EQ(preparedResponse.headerValue("Refresh"),
+             "/p/port-token/refresh-target");
+   EXPECT_EQ(preparedResponse.body(), response.body());
+}
+
+TEST(ProxyLocalhostResponseTests, NormalizesChunkedSparkUiBeforeRewritingBody)
+{
+   http::Request request;
+   request.setUri("/p/port-token/jobs/job-id");
+
+   http::Response response;
+   response.setStatusCode(http::status::Ok);
+   response.setHeader("Server", "Jetty(9.4.57)");
+   response.setHeader("Transfer-Encoding", "chunked");
+   response.setBody(
+      "<div class=\"navbar navbar-static-top\">"
+      "<a href=\"/jobs\">Jobs</a>"
+      "<script src=\"/static/app.js\"></script>"
+      "<img src=\"/static/spark-logo-77x50px-hd.png\">"
+      "</div>");
+
+   http::Response preparedResponse;
+   session_proxy::prepareLocalhostResponseForTest(
+      request,
+      "port-token",
+      "localhost",
+      false,
+      response,
+      &preparedResponse);
+
+   EXPECT_TRUE(preparedResponse.headerValue("Transfer-Encoding").empty());
+   EXPECT_EQ(preparedResponse.headerValue("Content-Length"),
+             std::to_string(preparedResponse.body().size()));
+   EXPECT_NE(preparedResponse.body().find("href=\"../jobs\""), std::string::npos);
+   EXPECT_NE(preparedResponse.body().find("<script src=\"../static/app.js\""),
+             std::string::npos);
+   EXPECT_NE(preparedResponse.body().find("<img src=\"../static/spark-logo"),
+             std::string::npos);
+}


### PR DESCRIPTION
### Intent

Fix the deterministic protocol mismatch described in #18626. `AsyncClient` consumes chunk framing before returning a buffered localhost response, but redirect/Refresh and Spark UI branches could retain the upstream `Transfer-Encoding: chunked` header and cause the decoded body to be decoded again downstream.

Closes #18626.

### Approach

Normalize a single copied response before any buffered-response rewrite:

- remove `Transfer-Encoding` when `chunked` is the final transfer coding
- set `Content-Length` to the decoded body size
- apply Location, Refresh, and Spark UI rewrites to that normalized response
- send the same prepared response through the ordinary buffered path

WebSocket upgrades remain on their existing streaming path. This regression was introduced by the unreleased localhost streaming work in #18541, so no NEWS entry is needed.

### Automated Tests

Added server unit tests covering:

- chunked responses with both Location and Refresh headers
- chunked Spark UI responses whose body is rewritten

Local validation:

- `cmake --build build --target rserver-tests -j 8`
- `./rserver-tests` — 79 passed, 11 PostgreSQL tests skipped because `POSTGRES_ENABLED` was not set
- `git diff --check`

### QA Notes

The regression tests construct the post-`AsyncClient` buffered response directly and verify that redirect/Refresh and Spark UI branches emit a single valid framing signal. Optional manual QA can proxy an upstream endpoint that returns a chunked redirect and confirm the downstream response has `Content-Length` without `Transfer-Encoding`.

### Documentation

None. This is an internal HTTP framing correction with no user-facing configuration or UI changes.

### Checklist

- [x] NEWS is not required because this fixes an unreleased regression
- [x] No UI or accessibility changes
- [ ] A reviewer is assigned to this PR
- [x] This PR passes all runnable local unit tests