### PR TITLE
Update installed Node.js to 22.23.2

### DIFF
--- a/.claude/skills/rstudio-update-nodejs/SKILL.md
+++ b/.claude/skills/rstudio-update-nodejs/SKILL.md
@@ -10,7 +10,7 @@ Updates the pinned Node.js version(s) across the RStudio codebase, uploads binar
 RStudio maintains **two distinct Node.js versions**:
 
 - **Build-time Node** (`RSTUDIO_NODE_VERSION`) — used for building Electron, GWT, and other product components. Not shipped to users.
-- **Installed Node** (`RSTUDIO_INSTALLED_NODE_VERSION`) — stripped-down `node` binary shipped with the product, used by copilot and Posit AI.
+- **Installed Node** (`RSTUDIO_INSTALLED_NODE_VERSION`) — stripped-down `node` binary shipped with the product, used by GitHub Copilot and Posit Assistant.
 
 These versions can differ. The skill handles updating either or both in a single invocation.
 
@@ -143,7 +143,7 @@ The `v` prefix is required here and only here. All other files use the bare vers
 
 **`NEWS.md`** — in the `### Dependencies` section, update the Node.js line:
 ```
-- Node.js <VERSION> (copilot, Posit AI)
+- Node.js <VERSION> (GitHub Copilot, Posit Assistant)
 ```
 
 Build-time updates do NOT get a NEWS.md entry — only installed node does.

--- a/.claude/skills/rstudio-update-nodejs/SKILL.md
+++ b/.claude/skills/rstudio-update-nodejs/SKILL.md
@@ -141,10 +141,15 @@ NODE_VERSION="v<VERSION>"
 ```
 The `v` prefix is required here and only here. All other files use the bare version.
 
-**`NEWS.md`** — in the `### Dependencies` section, update the Node.js line:
+**`NEWS.md`** — in the `### Dependencies` section, record the new version:
 ```
 - Node.js <VERSION> (GitHub Copilot, Posit Assistant)
 ```
+
+The section lists only dependencies actually updated in the current release cycle, not every
+dependency at its current version. So the Node.js line is usually absent and must be added —
+keep the list alphabetical by dependency name. If a Node.js line is already there, this cycle
+bumped node before; overwrite that line rather than adding a second one.
 
 Build-time updates do NOT get a NEWS.md entry — only installed node does.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@
 ### Dependencies
 - Copilot Language Server 1.531.0
 - Electron 42.10.1
+- Node.js 22.23.2 (copilot, Posit Assistant)
 - Quarto 1.10.18
 
 ### Deprecated / Removed

--- a/NEWS.md
+++ b/NEWS.md
@@ -46,7 +46,7 @@
 ### Dependencies
 - Copilot Language Server 1.531.0
 - Electron 42.10.1
-- Node.js 22.23.2 (copilot, Posit Assistant)
+- Node.js 22.23.2 (GitHub Copilot, Posit Assistant)
 - Quarto 1.10.18
 
 ### Deprecated / Removed

--- a/cmake/globals.cmake
+++ b/cmake/globals.cmake
@@ -341,7 +341,7 @@ set(PANDOC_VERSION "3.2" CACHE INTERNAL "Pandoc version")
 set(RSTUDIO_NODE_VERSION "22.22.2" CACHE INTERNAL "Node version for building")
 
 # node version installed with the product
-set(RSTUDIO_INSTALLED_NODE_VERSION "22.22.2" CACHE INTERNAL "Node version installed with product")
+set(RSTUDIO_INSTALLED_NODE_VERSION "22.23.2" CACHE INTERNAL "Node version installed with product")
 
 # quarto support
 

--- a/dependencies/tools/rstudio-tools.cmd
+++ b/dependencies/tools/rstudio-tools.cmd
@@ -67,7 +67,7 @@ call :set-java-home
 set RSTUDIO_NODE_VERSION=22.22.2
 
 :: Node version installed with the product
-set RSTUDIO_INSTALLED_NODE_VERSION=22.22.2
+set RSTUDIO_INSTALLED_NODE_VERSION=22.23.2
 
 :: The base URL where RStudio build tools are available for download.
 set RSTUDIO_BUILDTOOLS=https://rstudio-buildtools.s3.amazonaws.com

--- a/dependencies/tools/rstudio-tools.sh
+++ b/dependencies/tools/rstudio-tools.sh
@@ -67,7 +67,7 @@ export RSTUDIO_NODE_VERSION="22.22.2"
 #
 # In addition to updating the version here, search the entire repo for other instances of
 # RSTUDIO_INSTALLED_NODE_VERSION and update to match.
-export RSTUDIO_INSTALLED_NODE_VERSION="22.22.2"
+export RSTUDIO_INSTALLED_NODE_VERSION="22.23.2"
 
 # actual directory name of the node installation used
 # mainly relevant for cases like macOS, where we have an -arm64 variant installed

--- a/dependencies/tools/upload-node.sh
+++ b/dependencies/tools/upload-node.sh
@@ -10,7 +10,7 @@
 # installed with the RStudio IDE by RSTUDIO_INSTALLED_NODE_VERSION.
 
 # Modify to set the node.js version to upload
-NODE_VERSION="v22.22.2"
+NODE_VERSION="v22.23.2"
 
 # Check that we're logged in with AWS
 aws sts get-caller-identity || aws sso login


### PR DESCRIPTION
Bumps the Node.js version shipped with the product (`RSTUDIO_INSTALLED_NODE_VERSION`), used by copilot and the Posit Assistant.

- Installed Node.js: 22.22.2 -> 22.23.2

The build-time Node version (`RSTUDIO_NODE_VERSION`) is unchanged at 22.22.2.

### Verification

- Uploaded all six platform archives to `s3://rstudio-buildtools/node/v22.23.2/` (darwin-arm64, darwin-x64, linux-arm64, linux-x64, win-x64, win-arm64).
- Ran `install-npm-dependencies` with no cached 22.23.2 install present; it downloaded darwin-arm64 from S3 and the resulting binary reports `v22.23.2`.

Addresses #18670.