### PR TITLE
Guard openProject bridge poll against GWT bootstrap global

### DIFF
--- a/e2e/rstudio/utils/commands.ts
+++ b/e2e/rstudio/utils/commands.ts
@@ -818,10 +818,18 @@ export async function openProject(
   // the helper's post-condition is "the bridge agrees this project is
   // active" rather than "ready flipped true." Case-insensitive to match
   // waitForActiveDocument's handling of HFS+ / NTFS.
+  //
+  // Every hop is optional: a Desktop project switch navigates the window to
+  // the new session, and GWT's bootstrap (rstudio.nocache.js) defines a
+  // global function named `rstudio` seconds before ApplicationAutomation
+  // installs the bridge on it. Polling `rstudio.project.path()` unguarded
+  // throws there, and a predicate that throws rejects waitForFunction
+  // outright -- turning a routine reload into a hard failure that never
+  // reaches the diagnostic below.
   try {
     await page.waitForFunction(
       (target) => {
-        const path = window.rstudio?.project.path() ?? null;
+        const path = window.rstudio?.project?.path?.() ?? null;
         return path !== null && path.replace(/\\/g, '/').toLowerCase() === target.replace(/\\/g, '/').toLowerCase();
       },
       projectFilePath,
@@ -836,7 +844,7 @@ export async function openProject(
     // bare waitForFunction timeout.
     if (err instanceof Error && err.name === 'TimeoutError') {
       const actual = await page
-        .evaluate(() => window.rstudio?.project.path() ?? null)
+        .evaluate(() => window.rstudio?.project?.path?.() ?? null)
         .catch(() => null);
       throw new Error(
         `openProject: session became ready but the active project did not ` +


### PR DESCRIPTION
`openProject` polled `window.rstudio?.project.path()` with only the first hop optional. On a Desktop project switch the window navigates to the new session, and GWT's bootstrap script (`rstudio.nocache.js`) defines a global function named `rstudio` about a second before `ApplicationAutomation` installs the automation bridge on it. In that window the predicate read `.path` off `undefined` and threw, and a throwing predicate rejects `waitForFunction` immediately -- so the poll died with a bare `TypeError` instead of waiting out the reload or reaching the "open failed / opened the wrong project" diagnostic below it.

Both `project.path()` call sites now optional-chain every hop, so the intermediate state polls false like any other not-yet-there state. This matches how `desktop.fixture.ts` already probes the bridge (`typeof r?.commands?.activateConsole === 'function'`).

## How it showed up

`restart-under-agent.test.ts` failed on macos e2e on both the initial run and the retry ([run 33200969903](https://github.com/rstudio/rstudio/actions/runs/33200969903/job/98954550002)), on an unrelated PR:

```
Error: page.waitForFunction: TypeError: Cannot read properties of undefined (reading 'path')
    at openProject (e2e/rstudio/utils/commands.ts:822)
```

From the Playwright trace:

| time | event |
|---|---|
| 19:44:40.067 | `r.project.open()` evaluated (old session, port 19448) |
| 19:44:40.283 | `quit_session` (`switch_projects`) |
| 19:44:40.872 | window navigates to the new session, port 24254 |
| 19:44:41.478 | `rstudio.nocache.js` loads; `window.rstudio` is now the bootstrap function |
| 19:44:41.580 | poll reads `.project.path` -> TypeError |
| 19:44:42.839 | `client_init`; the real bridge is installed later still |

## Verification

`npm run typecheck` in `e2e/rstudio` passes. Old vs new predicate across the states the poll can observe:

| page state | old | new |
|---|---|---|
| no `window.rstudio` | false | false |
| GWT bootstrap global | throws `Cannot read properties of undefined (reading 'path')` | false |
| bridge, no project open | false | false |
| bridge, wrong project | false | false |
| bridge, target project | true | true |

Only the failing state changes.

## Scope

Limited to `openProject`. Other `window.rstudio?.documents.active()`-style call sites share the shape but run in a settled document behind a ready gate; `openProject` is the only poll that starts before a navigation and straddles the reload.

One thing this does not address: poll 1 (`ready === true`) passed 29ms after `project.open()` cleared that flag, with no client event in the trace explaining the flip, and that is what let poll 2 reach the reload window. With this guard the stale flag costs an extra poll cycle rather than a failure, but the reset itself is still worth a look.