### PR TITLE
ignore EINTR signals in case user database is slow

### DIFF
--- a/src/cpp/core/system/PosixGroup.cpp
+++ b/src/cpp/core/system/PosixGroup.cpp
@@ -87,7 +87,7 @@ Error groupFrom(const boost::function<int(
       if (result == ERANGE)
          buffSize *= 2;
 
-   } while (result == ERANGE);
+   } while (result == ERANGE || result == EINTR);
 
    if (temp == nullptr)
    {

--- a/src/cpp/shared_core/system/User.cpp
+++ b/src/cpp/shared_core/system/User.cpp
@@ -53,7 +53,7 @@ struct User::Impl
    Error populateUser(const GetPasswdFunc<T>& in_getPasswdFunc, T in_value)
    {
       struct passwd pwd;
-      struct passwd* tempPtrPwd;
+      struct passwd* tempPtrPwd = nullptr;
 
       // Get the maximum size of a passwd for this system.
       long buffSize = ::sysconf(_SC_GETPW_R_SIZE_MAX);
@@ -83,6 +83,11 @@ struct User::Impl
                {
                   retry = true;
                }
+            }
+            else if (result == EINTR)
+            {
+               // The lookup can block on a remote user database long enough for this signal
+               retry = true;
             }
             else
             {


### PR DESCRIPTION
### Intent

Fixes: https://github.com/rstudio/rstudio/issues/18683


