### PR TITLE
Add posit-assistant-path option for admin-managed installs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## RStudio 2026.09.0.0 "Autumn Hawkbit" Release Notes
 
 ### New
+- ([#18687](https://github.com/rstudio/rstudio/issues/18687)): Added the `posit-assistant-path` session option, for pointing RStudio at an administrator-managed Posit Assistant installation outside the system configuration directory.
 - ([#18649](https://github.com/rstudio/rstudio/issues/18649)): Renamed references to the Posit AI service to Posit AI Pass in the IDE user interface.
 - ([#2129](https://github.com/rstudio/rstudio/issues/2129)): Added horizontal and vertical split source editor views, with shared edits and independent navigation state.
 

--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -504,7 +504,7 @@ protected:
       "Use the test manifest URL for Posit Assistant package updates.")
       ("posit-assistant-path",
       value<std::string>(&positAssistantPath_)->default_value(std::string()),
-      "Specifies the path to an administrator-managed Posit Assistant installation.");
+      "Specifies the absolute path of the directory holding an administrator-managed Posit Assistant installation, that is, the directory containing the installation's dist directory. Replaces the default system-wide location rather than adding to it.");
 
    pTrust->add_options()
       ("project-trust-dialogs",

--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -501,7 +501,10 @@ protected:
       "The path to an optional shell script, which when invoked, should start the Posit Next Edit Suggestions Language Server.")
       ("posit-assistant-test-manifest",
       value<bool>(&positAssistantTestManifest_)->default_value(false)->implicit_value(true),
-      "Use the test manifest URL for Posit Assistant package updates.");
+      "Use the test manifest URL for Posit Assistant package updates.")
+      ("posit-assistant-path",
+      value<std::string>(&positAssistantPath_)->default_value(std::string()),
+      "Specifies the path to an administrator-managed Posit Assistant installation.");
 
    pTrust->add_options()
       ("project-trust-dialogs",
@@ -657,6 +660,7 @@ public:
    std::string positAssistantSslCertificatesFile() const { return positAssistantSslCertificatesFile_; }
    core::FilePath positAssistantHelper() const { return core::FilePath(positAssistantHelper_); }
    bool positAssistantTestManifest() const { return positAssistantTestManifest_; }
+   core::FilePath positAssistantPath() const { return core::FilePath(positAssistantPath_); }
    int projectTrustDialogs() const { return projectTrustDialogs_; }
    bool projectTrustRequired() const { return projectTrustRequired_; }
    std::string previewAllowedFunctions() const { return previewAllowedFunctions_; }
@@ -797,6 +801,7 @@ protected:
    std::string positAssistantSslCertificatesFile_;
    std::string positAssistantHelper_;
    bool positAssistantTestManifest_;
+   std::string positAssistantPath_;
    int projectTrustDialogs_;
    bool projectTrustRequired_;
    std::string previewAllowedFunctions_;

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -279,6 +279,7 @@ using chat_logging::rs_chatSetLogLevel;
 
 // Installation functions used throughout
 using chat_installation::locatePositAssistantInstallation;
+using chat_installation::systemPositAssistantInstallPath;
 using chat_installation::verifyPositAiInstallation;
 using chat_installation::getInstalledVersion;
 using chat_installation::getInstalledProtocolVersion;
@@ -5151,7 +5152,7 @@ Error startChatBackend(bool resumeConversation)
    if (positAiPath.isEmpty())
    {
       std::string userPath = xdg::userDataDir().completePath(kPositAiDirName).getAbsolutePath();
-      std::string systemPath = xdg::systemConfigDir().completePath(kPositAiDirName).getAbsolutePath();
+      std::string systemPath = systemPositAssistantInstallPath().getAbsolutePath();
       std::string errorMsg = fmt::format(
          "Posit Assistant installation not found. Install to: {} (user) or {} (system)",
          userPath, systemPath);
@@ -5293,10 +5294,10 @@ Error startChatBackend(bool resumeConversation)
    // start while an install/update/uninstall is in progress (we would be
    // launching from a directory mid-swap). Only the read-only system
    // install skips locking: mutations never touch it, and it cannot alias
-   // the per-user install. Env-var overrides over-lock deliberately —
-   // mirroring the agent's rule — because deciding whether an override
-   // truly resolves outside pai/bin is unreliable (symlinks), and
-   // over-locking costs at most a retryable refusal.
+   // the per-user install. Env-var and posit-assistant-path overrides
+   // over-lock deliberately — mirroring the agent's rule — because deciding
+   // whether an override truly resolves outside pai/bin is unreliable
+   // (symlinks), and over-locking costs at most a retryable refusal.
    uint64_t generation = ++s_chatBackendGeneration;
 
    // A stale flag from a previous unreaped generation must not classify a
@@ -6151,8 +6152,7 @@ Error chatUninstallPositAssistant(const json::JsonRpcRequest& request,
          return Success();
       }
 
-      FilePath systemPath =
-         xdg::systemConfigDir().completePath(kPositAiDirName);
+      FilePath systemPath = systemPositAssistantInstallPath();
       if (systemPath.exists())
       {
          pResponse->setError(

--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -6153,7 +6153,7 @@ Error chatUninstallPositAssistant(const json::JsonRpcRequest& request,
       }
 
       FilePath systemPath = systemPositAssistantInstallPath();
-      if (systemPath.exists())
+      if (verifyPositAiInstallation(systemPath))
       {
          pResponse->setError(
             systemError(boost::system::errc::operation_not_permitted, ERROR_LOCATION),

--- a/src/cpp/session/modules/chat/ChatInstallation.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallation.cpp
@@ -21,6 +21,7 @@
 #include <core/system/Environment.hpp>
 #include <core/system/System.hpp>
 #include <core/system/Xdg.hpp>
+#include <session/SessionOptions.hpp>
 #include <shared_core/json/Json.hpp>
 
 // Use qualified names for core:: to avoid conflicts with system getenv
@@ -43,6 +44,18 @@ bool verifyPositAiInstallation(const core::FilePath& positAiPath)
    core::FilePath indexHtml = clientDir.completeChildPath(kIndexFileName);
 
    return clientDir.exists() && serverScript.exists() && indexHtml.exists();
+}
+
+core::FilePath systemPositAssistantInstallPath()
+{
+   // An administrator may install Posit Assistant outside the XDG config
+   // directory; when posit-assistant-path is set it replaces that location
+   // rather than adding another one to search.
+   core::FilePath configuredPath = options().positAssistantPath();
+   if (!configuredPath.isEmpty())
+      return configuredPath;
+
+   return core::system::xdg::systemConfigDir().completePath(kPositAiDirName);
 }
 
 core::FilePath locatePositAssistantInstallation()
@@ -73,21 +86,25 @@ core::FilePath locatePositAssistantInstallation()
       return userPositAiPath;
    }
 
-   // 3. Check system-wide installation (XDG config directory)
-   // Linux/macOS: /etc/rstudio/pai/bin
-   // Windows: C:/ProgramData/rstudio/pai/bin
-   core::FilePath systemPositAiPath = core::system::xdg::systemConfigDir().completePath(kPositAiDirName);
+   // 3. Check the system-wide installation: posit-assistant-path when set, and
+   // otherwise the XDG config directory (/etc/rstudio/pai/bin on Linux and
+   // macOS, C:/ProgramData/rstudio/pai/bin on Windows)
+   core::FilePath systemPositAiPath = systemPositAssistantInstallPath();
    if (verifyPositAiInstallation(systemPositAiPath))
    {
       DLOG("Using system-wide AI installation: {}", systemPositAiPath.getAbsolutePath());
       return systemPositAiPath;
+   }
+   else if (!options().positAssistantPath().isEmpty())
+   {
+      WLOG("posit-assistant-path set but installation invalid: {}", systemPositAiPath.getAbsolutePath());
    }
 
    DLOG("No valid AI installation found. Checked locations:");
    if (!rstudioPositAiPath.empty())
       DLOG("  - RSTUDIO_POSIT_AI_PATH: {}", rstudioPositAiPath);
    DLOG("  - User data dir: {}", userPositAiPath.getAbsolutePath());
-   DLOG("  - System config dir: {}", systemPositAiPath.getAbsolutePath());
+   DLOG("  - System install dir: {}", systemPositAiPath.getAbsolutePath());
 
    return core::FilePath(); // Not found
 }

--- a/src/cpp/session/modules/chat/ChatInstallation.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallation.cpp
@@ -18,6 +18,7 @@
 #include "ChatLogging.hpp"
 
 #include <core/FileSerializer.hpp>
+#include <core/Macros.hpp>
 #include <core/system/Environment.hpp>
 #include <core/system/System.hpp>
 #include <core/system/Xdg.hpp>
@@ -95,8 +96,10 @@ core::FilePath locatePositAssistantInstallation()
       DLOG("Using system-wide AI installation: {}", systemPositAiPath.getAbsolutePath());
       return systemPositAiPath;
    }
-   else if (!options().positAssistantPath().isEmpty())
+   else if (!options().positAssistantPath().isEmpty() && RS_ONCE())
    {
+      // Warn once per session: locate() runs on every status, verify, and chat
+      // request, and a misconfigured path would otherwise flood the log.
       WLOG("posit-assistant-path set but installation invalid: {}", systemPositAiPath.getAbsolutePath());
    }
 

--- a/src/cpp/session/modules/chat/ChatInstallation.hpp
+++ b/src/cpp/session/modules/chat/ChatInstallation.hpp
@@ -44,17 +44,27 @@ namespace installation {
 bool verifyPositAiInstallation(const core::FilePath& positAiPath);
 
 /**
+ * Get the system-wide Posit Assistant installation directory.
+ *
+ * This is the posit-assistant-path session option when set, so that an
+ * administrator can manage the installation from an arbitrary location, and
+ * the XDG config directory otherwise:
+ *    - Linux/macOS: /etc/rstudio/pai/bin
+ *    - Windows: C:/ProgramData/rstudio/pai/bin
+ *
+ * @return FilePath to the system-wide installation directory
+ */
+core::FilePath systemPositAssistantInstallPath();
+
+/**
  * Locate the Posit Assistant installation directory.
  *
  * Search order:
  * 1. RSTUDIO_POSIT_AI_PATH environment variable (for development/testing)
  * 2. User data directory (XDG-based, platform-appropriate)
- *    - Linux: ~/.local/share/rstudio/ai
- *    - macOS: ~/Library/Application Support/RStudio/ai
- *    - Windows: %LOCALAPPDATA%/RStudio/ai
- * 3. System-wide installation (XDG config directory)
- *    - Linux: /etc/rstudio/ai
- *    - Windows: C:/ProgramData/RStudio/ai
+ *    - Linux/macOS: ~/.local/share/rstudio/pai/bin
+ *    - Windows: %LOCALAPPDATA%/rstudio/pai/bin
+ * 3. System-wide installation, as given by systemPositAssistantInstallPath()
  *
  * @return FilePath to the installation directory, or empty FilePath if not found
  */

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -1027,6 +1027,12 @@
             "implicitValue": true,
             "isHidden": true,
             "description": "Use the test manifest URL for Posit Assistant package updates."
+         },
+         {
+            "name": "posit-assistant-path",
+            "type": "core::FilePath",
+            "memberName": "positAssistantPath_",
+            "description": "Specifies the path to an administrator-managed Posit Assistant installation."
          }
       ],
       "trust": [

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -1032,7 +1032,7 @@
             "name": "posit-assistant-path",
             "type": "core::FilePath",
             "memberName": "positAssistantPath_",
-            "description": "Specifies the path to an administrator-managed Posit Assistant installation."
+            "description": "Specifies the absolute path of the directory holding an administrator-managed Posit Assistant installation, that is, the directory containing the installation's dist directory. Replaces the default system-wide location rather than adding to it."
          }
       ],
       "trust": [


### PR DESCRIPTION
Adds a `posit-assistant-path` session option naming the directory that holds an administrator-managed Posit Assistant installation, so a system-wide deployment no longer has to live under the XDG system configuration directory.

When the option is set it replaces the XDG config location in the search order rather than adding to it, so the search is:

1. ~~`RSTUDIO_POSIT_AI_PATH`, for development and testing~~ (NOTE: since removed as redundant)
2. The per-user installation under the XDG data directory
3. `posit-assistant-path` when set, otherwise `<XDG system config dir>/pai/bin`

A path that is set but does not hold a valid installation logs a warning and leaves Posit Assistant reported as not installed. It does not fall back to `/etc/rstudio/pai/bin`, which would hide the misconfiguration.

The backend-start error message and the uninstall refusal both report the effective system path, so an administrator sees the location RStudio actually checked. The lock-skip check in `startChatBackend` still compares against the XDG location, which means an installation reached through the option over-locks the same way an `RSTUDIO_POSIT_AI_PATH` one already does -- deliberate, per the reasoning in the comment there.

### Verification

Manual: set `posit-assistant-path` in `rsession.conf` and confirm the backend starts from that location.

`./build/src/cpp/rstudio-tests --scope rsession` passes (519 tests), including the `ChatInstallation` suite, which now reads session options.

Addresses #18687.
