### PR TITLE
Locate a Posit Assistant copy bundled with RStudio

### DIFF
--- a/src/cpp/session/modules/SessionChat.cpp
+++ b/src/cpp/session/modules/SessionChat.cpp
@@ -278,6 +278,7 @@ using chat_logging::shouldLogBackendMessage;
 using chat_logging::rs_chatSetLogLevel;
 
 // Installation functions used throughout
+using chat_installation::bundledPositAssistantInstallPath;
 using chat_installation::locatePositAssistantInstallation;
 using chat_installation::systemPositAssistantInstallPath;
 using chat_installation::verifyPositAiInstallation;
@@ -5294,10 +5295,11 @@ Error startChatBackend(bool resumeConversation)
    // start while an install/update/uninstall is in progress (we would be
    // launching from a directory mid-swap). Only the read-only system
    // install skips locking: mutations never touch it, and it cannot alias
-   // the per-user install. Env-var and posit-assistant-path overrides
-   // over-lock deliberately — mirroring the agent's rule — because deciding
-   // whether an override truly resolves outside pai/bin is unreliable
-   // (symlinks), and over-locking costs at most a retryable refusal.
+   // the per-user install. The env-var override, posit-assistant-path, and
+   // the copy bundled with RStudio all over-lock deliberately — mirroring
+   // the agent's rule — because deciding whether they truly resolve outside
+   // pai/bin is unreliable (symlinks), and over-locking costs at most a
+   // retryable refusal.
    uint64_t generation = ++s_chatBackendGeneration;
 
    // A stale flag from a previous unreaped generation must not classify a
@@ -6152,14 +6154,23 @@ Error chatUninstallPositAssistant(const json::JsonRpcRequest& request,
          return Success();
       }
 
-      FilePath systemPath = systemPositAssistantInstallPath();
-      if (verifyPositAiInstallation(systemPath))
+      // With no user-data install and the environment override handled
+      // above, anything the search still resolves to is read-only: the
+      // administrator's installation, or the copy shipped with RStudio.
+      // Resolve rather than re-testing each location, so the refusal names
+      // the installation actually in use.
+      FilePath readOnlyPath = locatePositAssistantInstallation();
+      if (!readOnlyPath.isEmpty())
       {
+         bool bundled = (readOnlyPath == bundledPositAssistantInstallPath());
          pResponse->setError(
             systemError(boost::system::errc::operation_not_permitted, ERROR_LOCATION),
             json::Value(
-               "Posit Assistant is installed at the system level by an "
-               "administrator and cannot be uninstalled from RStudio."));
+               bundled
+                  ? "Posit Assistant was installed as part of RStudio and "
+                    "cannot be uninstalled from RStudio."
+                  : "Posit Assistant is installed at the system level by an "
+                    "administrator and cannot be uninstalled from RStudio."));
          return Success();
       }
 

--- a/src/cpp/session/modules/chat/ChatConstants.cpp
+++ b/src/cpp/session/modules/chat/ChatConstants.cpp
@@ -26,6 +26,9 @@ namespace constants {
 // Installation paths
 const char* const kPositAiDirName = "pai/bin";
 const char* const kPositAiBackupDirName = "ai.prev";
+// Copy shipped with RStudio, installed beside the session binary (or next to
+// bin/ in the macOS app bundle); absent from open-source builds
+const char* const kBundledPositAiDirName = "posit-assistant";
 // Cross-process lock files; outside pai/bin so it survives install mutations
 const char* const kPositAiLocksDirName = "pai/locks";
 const char* const kClientDirPath = "dist/client";

--- a/src/cpp/session/modules/chat/ChatConstants.hpp
+++ b/src/cpp/session/modules/chat/ChatConstants.hpp
@@ -31,6 +31,7 @@ namespace constants {
 // ============================================================================
 extern const char* const kPositAiDirName;
 extern const char* const kPositAiBackupDirName;
+extern const char* const kBundledPositAiDirName;
 extern const char* const kPositAiLocksDirName;
 extern const char* const kClientDirPath;
 extern const char* const kServerScriptPath;

--- a/src/cpp/session/modules/chat/ChatInstallation.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallation.cpp
@@ -63,10 +63,12 @@ core::FilePath bundledPositAssistantInstallPath(const core::FilePath& resourcePa
 {
    // Mirrors the Copilot Language Server layout: the directory is installed
    // beside the session binary, except in the macOS app bundle where it sits
-   // next to bin/ rather than inside it.
+   // next to bin/ rather than inside it. The bin candidate is verified rather
+   // than merely tested for existence, so a partial directory left there does
+   // not mask a usable bundle at the other location.
    core::FilePath binPath =
       resourcePath.completePath("bin").completePath(kBundledPositAiDirName);
-   if (binPath.exists())
+   if (verifyPositAiInstallation(binPath))
       return binPath;
 
    return resourcePath.completePath(kBundledPositAiDirName);

--- a/src/cpp/session/modules/chat/ChatInstallation.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallation.cpp
@@ -59,6 +59,24 @@ core::FilePath systemPositAssistantInstallPath()
    return core::system::xdg::systemConfigDir().completePath(kPositAiDirName);
 }
 
+core::FilePath bundledPositAssistantInstallPath(const core::FilePath& resourcePath)
+{
+   // Mirrors the Copilot Language Server layout: the directory is installed
+   // beside the session binary, except in the macOS app bundle where it sits
+   // next to bin/ rather than inside it.
+   core::FilePath binPath =
+      resourcePath.completePath("bin").completePath(kBundledPositAiDirName);
+   if (binPath.exists())
+      return binPath;
+
+   return resourcePath.completePath(kBundledPositAiDirName);
+}
+
+core::FilePath bundledPositAssistantInstallPath()
+{
+   return bundledPositAssistantInstallPath(options().resourcePath());
+}
+
 core::FilePath locatePositAssistantInstallation()
 {
    // 1. Check environment variable override (for development/testing)
@@ -96,11 +114,31 @@ core::FilePath locatePositAssistantInstallation()
       DLOG("Using system-wide AI installation: {}", systemPositAiPath.getAbsolutePath());
       return systemPositAiPath;
    }
-   else if (!options().positAssistantPath().isEmpty() && RS_ONCE())
+
+   // A path the administrator pinned but that holds no installation ends the
+   // search: falling through to the bundled copy would answer a typo or an
+   // unmounted share with a silent downgrade to whatever version shipped
+   // with RStudio.
+   bool pinnedInstall = !options().positAssistantPath().isEmpty();
+   if (pinnedInstall)
    {
       // Warn once per session: locate() runs on every status, verify, and chat
       // request, and a misconfigured path would otherwise flood the log.
-      WLOG("posit-assistant-path set but installation invalid: {}", systemPositAiPath.getAbsolutePath());
+      if (RS_ONCE())
+         WLOG("posit-assistant-path set but installation invalid: {}", systemPositAiPath.getAbsolutePath());
+   }
+   else
+   {
+      // 4. Check the copy bundled with RStudio. It ranks last: a
+      // manifest-installed update lands in the user data directory and an
+      // administrator's own install is deliberate, so both outrank it.
+      // Open-source builds ship no bundle and always fall through here.
+      core::FilePath bundledPositAiPath = bundledPositAssistantInstallPath();
+      if (verifyPositAiInstallation(bundledPositAiPath))
+      {
+         DLOG("Using AI installation bundled with RStudio: {}", bundledPositAiPath.getAbsolutePath());
+         return bundledPositAiPath;
+      }
    }
 
    DLOG("No valid AI installation found. Checked locations:");
@@ -108,6 +146,8 @@ core::FilePath locatePositAssistantInstallation()
       DLOG("  - RSTUDIO_POSIT_AI_PATH: {}", rstudioPositAiPath);
    DLOG("  - User data dir: {}", userPositAiPath.getAbsolutePath());
    DLOG("  - System install dir: {}", systemPositAiPath.getAbsolutePath());
+   if (!pinnedInstall)
+      DLOG("  - Bundled with RStudio: {}", bundledPositAssistantInstallPath().getAbsolutePath());
 
    return core::FilePath(); // Not found
 }

--- a/src/cpp/session/modules/chat/ChatInstallation.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallation.cpp
@@ -117,6 +117,11 @@ core::FilePath locatePositAssistantInstallation()
       return systemPositAiPath;
    }
 
+   // Resolved below only when the bundled copy is actually consulted; reused
+   // by the "checked locations" log so it is not resolved (and re-verified)
+   // twice per lookup.
+   core::FilePath bundledPositAiPath;
+
    // A path the administrator pinned but that holds no installation ends the
    // search: falling through to the bundled copy would answer a typo or an
    // unmounted share with a silent downgrade to whatever version shipped
@@ -135,7 +140,7 @@ core::FilePath locatePositAssistantInstallation()
       // manifest-installed update lands in the user data directory and an
       // administrator's own install is deliberate, so both outrank it.
       // Open-source builds ship no bundle and always fall through here.
-      core::FilePath bundledPositAiPath = bundledPositAssistantInstallPath();
+      bundledPositAiPath = bundledPositAssistantInstallPath();
       if (verifyPositAiInstallation(bundledPositAiPath))
       {
          DLOG("Using AI installation bundled with RStudio: {}", bundledPositAiPath.getAbsolutePath());
@@ -149,7 +154,7 @@ core::FilePath locatePositAssistantInstallation()
    DLOG("  - User data dir: {}", userPositAiPath.getAbsolutePath());
    DLOG("  - System install dir: {}", systemPositAiPath.getAbsolutePath());
    if (!pinnedInstall)
-      DLOG("  - Bundled with RStudio: {}", bundledPositAssistantInstallPath().getAbsolutePath());
+      DLOG("  - Bundled with RStudio: {}", bundledPositAiPath.getAbsolutePath());
 
    return core::FilePath(); // Not found
 }

--- a/src/cpp/session/modules/chat/ChatInstallation.hpp
+++ b/src/cpp/session/modules/chat/ChatInstallation.hpp
@@ -57,6 +57,27 @@ bool verifyPositAiInstallation(const core::FilePath& positAiPath);
 core::FilePath systemPositAssistantInstallPath();
 
 /**
+ * Get the directory holding the Posit Assistant copy shipped with RStudio.
+ *
+ * The bundle is installed beside the session binary, except in the macOS app
+ * bundle where it sits next to bin/ rather than inside it, so both are
+ * checked. Only commercial builds ship one; in open source the directory
+ * never exists.
+ *
+ * @param resourcePath Root to resolve against (the session resource path)
+ * @return FilePath to the bundled installation directory
+ */
+core::FilePath bundledPositAssistantInstallPath(const core::FilePath& resourcePath);
+
+/**
+ * Get the directory holding the Posit Assistant copy shipped with RStudio,
+ * resolved against this session's resource path.
+ *
+ * @return FilePath to the bundled installation directory
+ */
+core::FilePath bundledPositAssistantInstallPath();
+
+/**
  * Locate the Posit Assistant installation directory.
  *
  * Search order:
@@ -65,6 +86,11 @@ core::FilePath systemPositAssistantInstallPath();
  *    - Linux/macOS: ~/.local/share/rstudio/pai/bin
  *    - Windows: %LOCALAPPDATA%/rstudio/pai/bin
  * 3. System-wide installation, as given by systemPositAssistantInstallPath()
+ * 4. The copy bundled with RStudio, as given by
+ *    bundledPositAssistantInstallPath() -- skipped entirely when
+ *    posit-assistant-path is set, so a pinned path that holds no
+ *    installation reports "not installed" rather than downgrading to the
+ *    shipped version
  *
  * @return FilePath to the installation directory, or empty FilePath if not found
  */

--- a/src/cpp/session/modules/chat/ChatInstallation.hpp
+++ b/src/cpp/session/modules/chat/ChatInstallation.hpp
@@ -60,9 +60,11 @@ core::FilePath systemPositAssistantInstallPath();
  * Get the directory holding the Posit Assistant copy shipped with RStudio.
  *
  * The bundle is installed beside the session binary, except in the macOS app
- * bundle where it sits next to bin/ rather than inside it, so both are
- * checked. Only commercial builds ship one; in open source the directory
- * never exists.
+ * bundle where it sits next to bin/ rather than inside it. The first location
+ * is returned when it holds a valid installation, and the second otherwise --
+ * so the returned path is where the bundle would be even when none is
+ * installed. Only commercial builds ship one; in open source neither
+ * directory exists.
  *
  * @param resourcePath Root to resolve against (the session resource path)
  * @return FilePath to the bundled installation directory

--- a/src/cpp/session/modules/chat/ChatInstallationTests.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallationTests.cpp
@@ -317,3 +317,33 @@ TEST(ChatInstallation, WriteProtocolVersionFilePreservesPackageProvidedFile)
 
    tempDir.removeIfExists();
 }
+
+TEST(ChatInstallation, BundledPathPrefersBinSubdirectory)
+{
+   // Non-Apple layout: the bundle installs into the directory holding the
+   // session binary.
+   FilePath resourceDir;
+   FilePath::tempFilePath(resourceDir);
+   FilePath binDir = resourceDir.completeChildPath("bin")
+                                .completeChildPath(kBundledPositAiDirName);
+   binDir.ensureDirectory();
+
+   EXPECT_EQ(bundledPositAssistantInstallPath(resourceDir), binDir);
+
+   resourceDir.removeIfExists();
+}
+
+TEST(ChatInstallation, BundledPathFallsBackToResourceRoot)
+{
+   // Apple layout: the bundle sits beside bin/ in the app's Resources
+   // directory. The fallback is also what open-source builds resolve to,
+   // where neither directory exists.
+   FilePath resourceDir;
+   FilePath::tempFilePath(resourceDir);
+   resourceDir.ensureDirectory();
+
+   FilePath expected = resourceDir.completeChildPath(kBundledPositAiDirName);
+   EXPECT_EQ(bundledPositAssistantInstallPath(resourceDir), expected);
+
+   resourceDir.removeIfExists();
+}

--- a/src/cpp/session/modules/chat/ChatInstallationTests.cpp
+++ b/src/cpp/session/modules/chat/ChatInstallationTests.cpp
@@ -318,6 +318,21 @@ TEST(ChatInstallation, WriteProtocolVersionFilePreservesPackageProvidedFile)
    tempDir.removeIfExists();
 }
 
+namespace {
+
+// Writes the files verifyPositAiInstallation() requires into dir.
+void stageInstallation(const FilePath& dir)
+{
+   dir.completeChildPath(kClientDirPath).ensureDirectory();
+   dir.completeChildPath(kServerScriptPath).getParent().ensureDirectory();
+   writeStringToFile(dir.completeChildPath(kServerScriptPath), "// mock server script");
+   writeStringToFile(
+      dir.completeChildPath(kClientDirPath).completeChildPath(kIndexFileName),
+      "<html>mock</html>");
+}
+
+} // anonymous namespace
+
 TEST(ChatInstallation, BundledPathPrefersBinSubdirectory)
 {
    // Non-Apple layout: the bundle installs into the directory holding the
@@ -326,7 +341,7 @@ TEST(ChatInstallation, BundledPathPrefersBinSubdirectory)
    FilePath::tempFilePath(resourceDir);
    FilePath binDir = resourceDir.completeChildPath("bin")
                                 .completeChildPath(kBundledPositAiDirName);
-   binDir.ensureDirectory();
+   stageInstallation(binDir);
 
    EXPECT_EQ(bundledPositAssistantInstallPath(resourceDir), binDir);
 
@@ -344,6 +359,24 @@ TEST(ChatInstallation, BundledPathFallsBackToResourceRoot)
 
    FilePath expected = resourceDir.completeChildPath(kBundledPositAiDirName);
    EXPECT_EQ(bundledPositAssistantInstallPath(resourceDir), expected);
+
+   resourceDir.removeIfExists();
+}
+
+TEST(ChatInstallation, BundledPathSkipsIncompleteBinSubdirectory)
+{
+   // A partial directory beside the session binary must not mask a usable
+   // bundle at the other location.
+   FilePath resourceDir;
+   FilePath::tempFilePath(resourceDir);
+   resourceDir.completeChildPath("bin")
+              .completeChildPath(kBundledPositAiDirName)
+              .ensureDirectory();
+
+   FilePath rootDir = resourceDir.completeChildPath(kBundledPositAiDirName);
+   stageInstallation(rootDir);
+
+   EXPECT_EQ(bundledPositAssistantInstallPath(resourceDir), rootDir);
 
    resourceDir.removeIfExists();
 }


### PR DESCRIPTION
Open-source companion to rstudio/rstudio-pro#12483, which bundles Posit Assistant with Workbench. The runtime lookup lives here so the diff between the two repos stays limited to the install rule; open-source builds ship no bundle, the directory never exists, and the search falls through as before.

`installation::bundledPositAssistantInstallPath()` resolves `options().resourcePath()/bin/posit-assistant` when it holds a valid installation, and `options().resourcePath()/posit-assistant` otherwise -- the macOS app-bundle layout, where the directory sits beside `bin` rather than inside it. That mirrors the Copilot Language Server rule in `src/cpp/session/CMakeLists.txt`, which is where the pro-side `install(DIRECTORY ...)` lands. There is no new session option: `posit-assistant-path` remains the single administrator override, for both the system-wide and the bundled location.

Search order:

```
1. RSTUDIO_POSIT_AI_PATH                  (development and testing)
2. XDG user data dir  (pai/bin)           (manifest-installed, per user)
3. posit-assistant-path set -> use it; if invalid, warn and stop
   not set                 -> XDG system config dir, then bundled
```

Bundled ranks last. A manifest-installed update lands in the user data directory and an administrator's own install is deliberate, so both outrank the copy that shipped with RStudio. `posit-assistant-path` skips the bundled copy entirely: a pinned path that turns out to be invalid already ends the search rather than reverting to the XDG system location, and answering a typo or an unmounted share with the shipped version would be the same silent downgrade.

The uninstall refusal now resolves the installation instead of re-testing the system location, so it reports the copy actually in use and has wording of its own for the bundled case. The lock-skip check at `startChatBackend` is unchanged: a bundled install over-locks the way the env-var and `posit-assistant-path` overrides already do.

## Testing

Unit tests cover the bin-then-root candidate rule, including a partial directory beside the session binary falling through to a usable bundle at the resource root. The search order itself is not unit-testable -- the generated `Options` class exposes only CLI parsing, with no setter a test could drive, the same limitation noted in #18688. Both branches were instead verified against the real `rsession` binary with a throwaway probe: with a staged bundle and no user install, the search resolved to `<resourcePath>/posit-assistant`; with `--posit-assistant-path=/nonexistent/pinned`, it returned empty and logged the warn-once message, leaving the staged bundle unused.

To exercise it in a development build, `options().resourcePath()` resolves to `build/src/cpp`, so stage an unpacked package at `build/src/cpp/posit-assistant` and point `XDG_DATA_HOME` at an empty directory so a per-user install does not shadow it.

No NEWS entry: this is the open-source companion to a pro change and has no effect in an open-source build.
