### PR TITLE
fix flaky continueParsing strand test baseline

### DIFF
--- a/src/cpp/core/http/AsyncConnectionImplTests.cpp
+++ b/src/cpp/core/http/AsyncConnectionImplTests.cpp
@@ -28,6 +28,7 @@
 // on the same strand, one and only one of them may ever win the claim.
 
 #include <atomic>
+#include <chrono>
 #include <string>
 #include <thread>
 #include <vector>
@@ -393,10 +394,14 @@ TEST(AsyncConnectionImpl, ContinueParsingResumesOnTheConnectionsStrand)
    ASSERT_FALSE(ec);
 
    // the ordinary read path, for a baseline: it arrives on the strand because
-   // readSome() binds its completion there
+   // readSome() binds its completion there. A blocking run, not poll(): the
+   // request bytes above still have to traverse the loopback socket, and a
+   // non-blocking poll() runs nothing when they have not landed yet (#18634).
+   // The deadline is only a hang cap -- run_for() returns as soon as the
+   // handler has run and the io_context is out of work.
    pConnection->startReading();
    ioc.restart();
-   ioc.poll();
+   ioc.run_for(std::chrono::seconds(30));
    ASSERT_EQ(handlerCalls, 1);
    ASSERT_TRUE(handlerOnStrand);
 


### PR DESCRIPTION
## Summary

`AsyncConnectionImpl.ContinueParsingResumesOnTheConnectionsStrand` fails intermittently in `rstudio-core-tests`, asserting `handlerCalls == 1` when it is 0.

The baseline phase of the test drained the io_context with a single non-blocking `ioc.poll()` right after `startReading()`. The request bytes written to `peer` still have to traverse the loopback socket before the connection's `async_read` can complete, so when they had not landed yet, `poll()` ran nothing and the handler never fired. The failure needs the sibling tests in the suite to run first (the timing shift they introduce); the test in isolation always passed.

The baseline now waits with a bounded `ioc.run_for(30s)` instead. `readSome()` initiates its read inline, so the io_context always has outstanding work until the handler chain drains -- `run_for()` returns as soon as the handler has run, and the deadline is only a hang cap. The second `poll()` after `continueParsing()` is left as-is: the strand post is immediately runnable with no I/O dependency, so it is deterministic.

## Verification

On macOS arm64, looping `--gtest_filter='AsyncConnectionImpl.*'`:

- before: 15 failures in 15 runs
- after: 0 failures in 30 runs

A full `rstudio-core-tests` run passes all 14 `AsyncConnectionImpl` tests. (`ProcessTest.MultipleAsyncProcessesResults` failed in that run, but it fails identically on an unmodified main build on the same machine, so it is unrelated.)

Fixes #18634.

https://claude.ai/code/session_017jMCCnK7Lza54inrLaQaJf