### PR TITLE
skip doi citation inserts when the service degrades mid-test

### DIFF
--- a/e2e/rstudio/pages/insert_citation.page.ts
+++ b/e2e/rstudio/pages/insert_citation.page.ts
@@ -44,6 +44,12 @@ export class InsertCitationDialog extends PageObject {
    * progress text, hence the text filter.
    */
   public readonly searchError: Locator;
+  /**
+   * The raw status line in the results area, whatever it currently says
+   * (progress, no-results, or error wording) -- for diagnostics when a search
+   * yields neither results nor a recognized error.
+   */
+  public readonly searchStatus: Locator;
   public readonly insertButton: Locator;
   public readonly cancelButton: Locator;
   /** Staged citations, shown as tag chips at the bottom of the dialog. */
@@ -59,6 +65,7 @@ export class InsertCitationDialog extends PageObject {
       .locator('.pm-insert-citation-source-panel-list-noresults-text')
       .filter({ hasText: /error occurred|Unable to search/ })
       .first();
+    this.searchStatus = page.locator('.pm-insert-citation-source-panel-list-noresults-text').first();
     this.insertButton = this.dialog.getByRole('button', { name: 'Insert', exact: true });
     this.cancelButton = this.dialog.getByRole('button', { name: 'Cancel', exact: true });
     this.stagedCitations = page.locator('.pm-tag-input-tag');

--- a/e2e/rstudio/tests/panes/editor/citations.test.ts
+++ b/e2e/rstudio/tests/panes/editor/citations.test.ts
@@ -7,7 +7,7 @@ import { useSuiteSandbox } from '@utils/sandbox';
 import { executeCommand } from '@utils/commands';
 import { executeInConsole, CONSOLE_OUTPUT } from '@pages/console_pane.page';
 import { rStringLiteral } from '@utils/r';
-import { isServiceReachable, CITATION_SERVICE_HOSTS } from '@utils/network';
+import { isServiceReachable, reprobeService, CITATION_SERVICE_HOSTS } from '@utils/network';
 import type { Page } from 'playwright';
 
 // Skip (rather than fail) a test whose citation source depends on an external
@@ -17,6 +17,51 @@ async function skipUnlessReachable(...urls: string[]): Promise<void> {
   for (const url of urls) {
     test.skip(!(await isServiceReachable(url)), `${url} is unreachable from this runner`);
   }
+}
+
+// Stage the first result of a latent citation lookup, tolerating a service
+// that degrades after skipUnlessReachable() passed: the probe runs at test
+// start, but the lookup itself runs in the rsession seconds later (#18426). Mirrors the
+// search tests' #18267 pattern -- a service-side failure renders as the
+// dialog's error status line, and we skip on it. A lookup that hangs shows
+// neither results nor an error within the wait; re-probe the host and skip
+// retroactively if it has since become unreachable. A timeout with the
+// service still answering remains a real failure.
+async function stageFirstResultOrSkip(
+  page: Page,
+  citation: InsertCitationDialog,
+  host: string,
+): Promise<void> {
+  const deadline = Date.now() + 30000;
+  let outcome: 'pending' | 'result' | 'error' = 'pending';
+  while (outcome === 'pending' && Date.now() < deadline) {
+    if (await citation.results.first().isVisible()) {
+      outcome = 'result';
+    } else if (await citation.searchError.isVisible()) {
+      outcome = 'error';
+    } else {
+      await page.waitForTimeout(250);
+    }
+  }
+
+  if (outcome === 'error') {
+    await citation.cancel();
+    test.skip(true, `${host} lookup failed service-side from this runner`);
+  }
+
+  if (outcome === 'pending') {
+    if (!(await reprobeService(host))) {
+      await citation.cancel();
+      test.skip(true, `${host} became unreachable during the lookup`);
+    }
+    const status = (await citation.searchStatus.textContent().catch(() => null))?.trim();
+    throw new Error(
+      `no lookup result and no error status within 30s ` +
+        `(${host} is still reachable; dialog status: ${status ? `"${status}"` : 'none'})`,
+    );
+  }
+
+  await citation.stageFirstResult();
 }
 
 // Read the value of an R expression via marker-wrapped console output. Runs on
@@ -95,7 +140,7 @@ test.describe('Citations', () => {
 
     // A DOI resolves to exactly one work via a real service call (no intercept).
     await citation.search(searchBox, '10.3133/93888');
-    await citation.stageFirstResult();
+    await stageFirstResultOrSkip(page, citation, CITATION_SERVICE_HOSTS.doi);
     await citation.insert();
 
     // The citation lands in the document. With no author, panmirror derives the
@@ -135,7 +180,7 @@ test.describe('Citations', () => {
     await citation.open();
     const searchBox = await citation.selectSource(CITATION_SOURCES.doi);
     await citation.search(searchBox, '10.3133/93888');
-    await citation.stageFirstResult();
+    await stageFirstResultOrSkip(page, citation, CITATION_SERVICE_HOSTS.doi);
     await citation.insert();
 
     await expect(page.locator('.ProseMirror')).toContainText('[@effects1999]', { timeout: 15000 });
@@ -168,7 +213,7 @@ test.describe('Citations', () => {
 
     // Stage the single DOI result, then remove it from the staging area (#9124).
     await citation.search(searchBox, '10.3133/93888');
-    await citation.stageFirstResult();
+    await stageFirstResultOrSkip(page, citation, CITATION_SERVICE_HOSTS.doi);
     await expect(citation.stagedCitations).toHaveCount(1);
 
     await citation.deleteStagedCitation();
@@ -192,7 +237,7 @@ test.describe('Citations', () => {
     await citation.open();
     let searchBox = await citation.selectSource(CITATION_SOURCES.doi);
     await citation.search(searchBox, doi);
-    await citation.stageFirstResult();
+    await stageFirstResultOrSkip(page, citation, CITATION_SERVICE_HOSTS.doi);
     await citation.insert();
     await expect(page.locator('.ProseMirror')).toContainText('[@bermúdez2020]', { timeout: 15000 });
 
@@ -201,7 +246,7 @@ test.describe('Citations', () => {
     await citation.open();
     searchBox = await citation.selectSource(CITATION_SOURCES.datacite);
     await citation.search(searchBox, doi);
-    await citation.stageFirstResult();
+    await stageFirstResultOrSkip(page, citation, CITATION_SERVICE_HOSTS.datacite);
     await citation.insert();
     await expect(page.locator('.ProseMirror')).toContainText('[@bermúdez2020][@bermúdez2020]', { timeout: 15000 });
 

--- a/e2e/rstudio/utils/network.ts
+++ b/e2e/rstudio/utils/network.ts
@@ -44,6 +44,19 @@ export function isServiceReachable(url: string, timeoutMs = 10000): Promise<bool
 }
 
 /**
+ * Probe a service again, replacing the cached answer. A probe that passed at
+ * test start only proves the host answered then -- the runner's network can
+ * degrade mid-run (#18426), so a test whose service call silently times out
+ * can re-probe to distinguish "service gone" (skip) from "product hung"
+ * (fail). The refreshed cache entry also lets later tests' guards see the
+ * degraded state.
+ */
+export function reprobeService(url: string, timeoutMs = 10000): Promise<boolean> {
+  probeCache.delete(url);
+  return isServiceReachable(url, timeoutMs);
+}
+
+/**
  * Whether a raw TCP port accepts connections, for services that don't speak
  * HTTP (e.g. a database). Deliberately uncached: the databases the
  * Connections tests talk to are started and stopped within a run, so a


### PR DESCRIPTION
## Summary

Three DOI citation e2e tests failed together on a Windows shard when the runner's network degraded mid-run (#18426). The tests are guarded by `skipUnlessReachable(CITATION_SERVICE_HOSTS.doi)`, and the guard passed -- but the probe runs at test start and its answer is cached for the worker's lifetime, while the DOI lookup itself runs in the rsession seconds later. In that run the degradation timeline is visible in the job log: the DOI insert tests failed on `stageFirstResult()`'s 30s wait (doi.org's probe was cached `true` from before the degradation), while later tests whose hosts probed *fresh* -- the Crossref/DataCite search tests and the two-source test -- skipped as designed.

This PR mirrors the #18267 search-path pattern on the insert path:

- `stageFirstResultOrSkip()` polls for either the first result row or the dialog's error status line, and skips on the error (service problem, not a product regression). The DOI panel renders lookup failures through the same `errorForStatus()` wording and `.pm-insert-citation-source-panel-list-noresults-text` node the existing `searchError` locator matches (verified against `insert_citation-source-panel-doi.tsx`).
- On a silent timeout (a hung lookup shows neither -- R's `download.file` timeout is 60s, past the 30s wait), it re-probes the host fresh via a new `reprobeService()` helper and skips retroactively when the probe now fails, which would also have covered the triggering run. The refreshed cache entry additionally lets later tests' `skipUnlessReachable()` guards see the degraded state instead of trusting the stale pass.
- A timeout with the service still answering remains a real failure, now with the dialog's current status text in the error message.

All five staged-insert call sites use the helper, including both lookups in the two-source duplicate test (DOI, then DataCite).

## Testing

- `npm run typecheck` passes.
- The full citations suite passes locally on macOS (desktop-dev): 13 passed, including all DOI insert and search tests against the live services.
- The skip paths are verified against the panmirror source (the DOI panel's `error`/`nohost` statuses render the error line the `searchError` locator matches) and follow the pattern already proven by #18267.

Test-infrastructure-only change; no NEWS.md entry.

Fixes #18426.

https://claude.ai/code/session_01HqqaSmFoU2FYPri1PQH2rw