### PR TITLE
Validate the calendar version in new-version.sh, and fix the stale NEWS heading

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## RStudio 2026.09.0.0 "Autumn Hawkbit" Release Notes
+## RStudio 2026.09.0 "Autumn Hawkbit" Release Notes
 
 ### New
 - ([#18443](https://github.com/rstudio/rstudio/issues/18443)): Added the `posit-assistant-installation-enabled` session option and the `RSTUDIO_DISABLE_POSIT_ASSISTANT_INSTALLATION` environment variable, which stop users from installing, updating, or uninstalling Posit Assistant. RStudio then runs only the administrator's installation and makes no update checks.

--- a/version/new-version.sh
+++ b/version/new-version.sh
@@ -60,6 +60,15 @@ fi
 RELEASE_FLOWER=$1
 CALENDAR_VERSION=$2
 
+# The calendar version must be <YYYY>.<MM>. rstudio-version.sh composes the build
+# version as <calendar version>.<patch>, so a full release version passed here
+# (i.e., "2023.03.0") yields a four-part version that breaks Windows installer
+# signing, and is only noticed once builds start failing.
+if [[ ! "$CALENDAR_VERSION" =~ ^[0-9]{4}\.(0[1-9]|1[0-2])$ ]]; then
+    echo "error: calendar version '${CALENDAR_VERSION}' is not <YYYY>.<MM> (i.e., \"2023.03\")" >&2
+    exit 1
+fi
+
 # Read the base commit sha if it was provided
 if [[ "$#" -eq 3 ]]; then
     BASE_COMMIT_SHA=$3


### PR DESCRIPTION
### Intent

Two fixes for the same root cause, which has broken Windows builds on `main` twice this year and been corrected by hand each time (most recently #18492).

`version/new-version.sh` documents its second argument as a `<YYYY>.<MM>` calendar version but accepts any string and writes it to `version/CALENDAR_VERSION` verbatim. `docker/jenkins/rstudio-version.sh` composes the build version as `<calendar version>.<patch>`, so a caller passing a full release version (`2026.09.0`) yields the four-part `2026.09.0.0-daily+N`. `jenkins/utils.groovy` then keeps only the first three components when deriving `RSTUDIO_VERSION_MAJOR`/`MINOR`/`PATCH`, so CPack wrote `RStudio-2026.09.0-daily-N-RelWithDebInfo.exe` while `jenkins/Jenkinsfile.windows` looked for `RStudio-2026.09.0.0-daily-N-RelWithDebInfo.exe` — Sign Installer failed with `SignTool Error: File not found`.

The wrong caller is Workbench's branch-for-release automation, fixed in rstudio/rstudio-pro#12546. This PR adds the guard at the source, so the same class of mistake — from automation or a hand-run — is caught immediately rather than three stages later during installer signing.

1. **Validate the calendar-version argument.** Reject anything that is not `<YYYY>.<MM>`.
2. **Correct the stale `NEWS.md` heading on `main`.** #18492 fixed only the `CALENDAR_VERSION` file; `new-version.sh` also builds the heading as `${CALENDAR_VERSION}.0`, so `main` still reads `## RStudio 2026.09.0.0 "Autumn Hawkbit" Release Notes`. It would be copied verbatim into `version/news/os/NEWS-2026.09.0-autumn-hawkbit.md` at the next branch cut — the archive *filename* comes from a workflow input, so only the heading is affected — and from there into the published release notes.

Tracked in rstudio/rstudio-pro#12545, which has the full analysis.

### Approach

A single `[[ =~ ]]` check right after the arguments are read:

```bash
if [[ ! "$CALENDAR_VERSION" =~ ^[0-9]{4}\.(0[1-9]|1[0-2])$ ]]; then
    echo "error: calendar version '${CALENDAR_VERSION}' is not <YYYY>.<MM> (i.e., \"2023.03\")" >&2
    exit 1
fi
```

The month range is checked as well as the shape, so `2026.9` and `2026.13` are rejected alongside `2026.09.0`. Every value in the file's history back to `2022.01` is strictly `<YYYY>.<MM>`, so this rejects nothing that has ever legitimately been used. The check runs before any file is written, so a rejected run leaves the tree untouched.

### Automated Tests

`new-version.sh` has no test harness, and adding one for a script that writes into the repo it lives in was out of proportion to a nine-line guard. Verified manually in a throwaway git repo with a copy of the script:

- Rejected (exit 1, no files written): `2023.03.0`, `2026.09.0`, `2026.09.0.0`, `2026.9`, `2026.13`, `2026`, `v2026.09`
- Accepted (exit 0): `2026.09`, and the month boundaries `2026.01` and `2026.12`

The accepted run wrote `version/CALENDAR_VERSION` as `2026.09` and a `NEWS.md` heading of `## RStudio 2026.09.0 "Test Flower" Release Notes` — matching what the heading fix here sets by hand.

The corresponding rstudio-pro fix is unit tested (rstudio/rstudio-pro#12546); the test there previously asserted the buggy behavior.

### QA Notes

Nothing user-facing. The real check is the next branch-for-release run: `version/CALENDAR_VERSION` on `main` should read `<YYYY>.<MM>`, and the Windows build's Sign Installer stage should pass on the first build after the cut.

### Documentation

None needed — the usage text and header comment in `new-version.sh` already document the `<YYYY>.<MM>` form; this makes the script enforce what it documents.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` — n/a, build tooling; no user-visible change
- [x] If this PR adds or changes UI, the updated UI meets accessibility standards — n/a
- [ ] A reviewer is assigned to this PR
- [x] This PR passes all local unit tests
