### PR TITLE
avoid re-coercing every column on each data viewer search

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,7 @@
 - ([#18512](https://github.com/rstudio/rstudio/issues/18512)): Added a code signature to `rsession.dll` on Windows.
 - ([#18493](https://github.com/rstudio/rstudio/issues/18493)): Fixed invisible checkbox and radio button states in Windows high-contrast dark themes.
 - ([#18474](https://github.com/rstudio/rstudio/issues/18474)): Fixed a math-preview keyboard handler leak that consumed subsequent Escape keypresses.
+- ([#18423](https://github.com/rstudio/rstudio/issues/18423)): The Data Viewer's global search no longer re-converts every non-character column to text on each request, and extending a search now refines the previous result instead of rescanning the whole frame.
 - ([#17806](https://github.com/rstudio/rstudio/issues/17806)): Improved Data Viewer searching, filtering, scrolling, and Summary panel performance.
 - ([#17806](https://github.com/rstudio/rstudio/issues/17806)): Fixed a Data Viewer memory leak when viewed objects change.
 - ([#18472](https://github.com/rstudio/rstudio/issues/18472)): Fixed stale syntax highlighting after edits in Markdown and YAML documents.

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -21,6 +21,11 @@
 # data without recomputing on the original object every time
 .rs.setVar("WorkingDataEnv", new.env(parent = emptyenv()))
 
+# host environment for cached search projections (see
+# .rs.dataViewer.searchColumns); this allows repeated global searches to skip
+# re-coercing non-character columns to strings on every request
+.rs.setVar("SearchDataEnv", new.env(parent = emptyenv()))
+
 .rs.addFunction("subsetData", function(data, maxRows = -1, maxCols = -1)
 {
    if (!is.na(maxRows) && maxRows != -1 && nrow(data) > maxRows)
@@ -1121,18 +1126,24 @@
    }
 })
 
-.rs.addFunction("applyTransform", function(x, filtered, search, cols, dirs)
+.rs.addFunction("applyTransform", function(x,
+                                           filtered,
+                                           search,
+                                           cols,
+                                           dirs,
+                                           cacheKey = "",
+                                           isFullFrame = FALSE)
 {
    # mark encoding on character inputs if not already marked
    filtered <- vapply(filtered, function(colfilter) {
-      if (Encoding(colfilter) == "unknown") 
+      if (Encoding(colfilter) == "unknown")
          Encoding(colfilter) <- "UTF-8"
       colfilter
    }, "")
-   
+
    if (Encoding(search) == "unknown")
       Encoding(search) <- "UTF-8"
-   
+
    # coerce argument to data frame--data.table objects (for example) report that
    # they're data frames, but don't actually support the subsetting operations
    # needed for search/sort/filter without an explicit cast
@@ -1140,113 +1151,101 @@
    # similarly, we need to convert tibbles to regular data.frames so that we can
    # properly invoke the list / data viewer on filtered rows
    x <- .rs.toDataFrame(x, "transformed", TRUE)
-   
+
+   # each active column filter (and the global search below) contributes one
+   # row-wise logical mask; combine them and subset once at the end, rather
+   # than copying the surviving rows after every predicate
+   keep <- NULL
+
    # apply columnwise filters
    for (i in seq_along(filtered))
    {
-      if (nchar(filtered[i]) > 0 && length(x[[i]]) > 0)
-      {
-         # split filter--string format is "type|value" (e.g. "numeric|12-25") 
-         filter <- strsplit(filtered[i], split = "|", fixed = TRUE)[[1]]
-         if (length(filter) < 2) 
-         {
-            # no filter type information
-            next
-         }
-         filtertype <- filter[1]
-         filterval <- filter[2]
-         
-         # apply filter appropriate to type
-         if (identical(filtertype, "factor")) 
-         {
-            # apply factor filter: convert to numeric values and discard missing
-            filterval <- as.numeric(filterval)
-            matches <- as.numeric(x[[i]]) == filterval
-            matches[is.na(matches)] <- FALSE
-            x <- x[matches, , drop = FALSE]
-         }
-         else if (identical(filtertype, "character"))
-         {
-            # apply character filter: non-case-sensitive prefix
-            # use PCRE and the special \Q and \E escapes to ensure no characters in
-            # the search expression are interpreted as regexes 
-            x <- x[grepl(paste("\\Q", filterval, "\\E", sep = ""), x[[i]], 
-                         perl = TRUE, ignore.case = TRUE), , 
-                   drop = FALSE]
-         } 
-         else if (identical(filtertype, "numeric"))
-         {
-            # apply numeric filter, range ("2-32") or equality ("15")
-            filterval <- as.numeric(strsplit(filterval, "_")[[1]])
-            if (length(filterval) > 1)
-               # range filter
-               x <- x[is.finite(x[[i]]) & x[[i]] >= filterval[1] & x[[i]] <= filterval[2], , drop = FALSE]
-            else
-               # equality filter
-               x <- x[is.finite(x[[i]]) & x[[i]] == filterval, , drop = FALSE]
-         }
-         else if (identical(filtertype, "date"))
-         {
-            # apply date/datetime range filter. The client sends two formatted
-            # endpoints (the same ISO strings it displays) separated by "_";
-            # parse them with the column's own class so comparison happens on
-            # the native Date/POSIXct scale. A parse failure leaves x unchanged
-            # rather than silently dropping every row.
-            bounds <- strsplit(filterval, "_")[[1]]
-            if (length(bounds) >= 2)
-            {
-               col <- x[[i]]
-               parsed <- .rs.tryCatch({
-                  if (inherits(col, "Date"))
-                     as.Date(bounds[1:2])
-                  else
-                     as.POSIXct(bounds[1:2], tz = .rs.dataViewer.columnTimezone(col))
-               })
+      if (nchar(filtered[i]) == 0 || length(x[[i]]) == 0)
+         next
 
-               if (!inherits(parsed, "error") && !any(is.na(parsed)))
-                  x <- x[!is.na(col) & col >= parsed[1] & col <= parsed[2], , drop = FALSE]
-            }
-         }
-         else if (identical(filtertype, "boolean"))
+      # split filter--string format is "type|value" (e.g. "numeric|12-25")
+      filter <- strsplit(filtered[i], split = "|", fixed = TRUE)[[1]]
+      if (length(filter) < 2)
+      {
+         # no filter type information
+         next
+      }
+      filtertype <- filter[1]
+      filterval <- filter[2]
+
+      # apply filter appropriate to type
+      matches <- NULL
+      if (identical(filtertype, "factor"))
+      {
+         # apply factor filter: convert to numeric values and discard missing
+         filterval <- as.numeric(filterval)
+         matches <- as.numeric(x[[i]]) == filterval
+         matches[is.na(matches)] <- FALSE
+      }
+      else if (identical(filtertype, "character"))
+      {
+         # apply character filter: non-case-sensitive prefix
+         # use PCRE and the special \Q and \E escapes to ensure no characters in
+         # the search expression are interpreted as regexes
+         matches <- grepl(paste("\\Q", filterval, "\\E", sep = ""), x[[i]],
+                          perl = TRUE, ignore.case = TRUE)
+      }
+      else if (identical(filtertype, "numeric"))
+      {
+         # apply numeric filter, range ("2-32") or equality ("15")
+         filterval <- as.numeric(strsplit(filterval, "_")[[1]])
+         if (length(filterval) > 1)
+            # range filter
+            matches <- is.finite(x[[i]]) & x[[i]] >= filterval[1] & x[[i]] <= filterval[2]
+         else
+            # equality filter
+            matches <- is.finite(x[[i]]) & x[[i]] == filterval
+      }
+      else if (identical(filtertype, "date"))
+      {
+         # apply date/datetime range filter. The client sends two formatted
+         # endpoints (the same ISO strings it displays) separated by "_";
+         # parse them with the column's own class so comparison happens on
+         # the native Date/POSIXct scale. A parse failure leaves x unchanged
+         # rather than silently dropping every row.
+         bounds <- strsplit(filterval, "_")[[1]]
+         if (length(bounds) >= 2)
          {
-            filterval <- isTRUE(filterval == "TRUE")
-            matches <- x[[i]] == filterval
-            matches[is.na(matches)] <- FALSE
-            x <- x[matches, , drop = FALSE]
+            col <- x[[i]]
+            parsed <- .rs.tryCatch({
+               if (inherits(col, "Date"))
+                  as.Date(bounds[1:2])
+               else
+                  as.POSIXct(bounds[1:2], tz = .rs.dataViewer.columnTimezone(col))
+            })
+
+            if (!inherits(parsed, "error") && !any(is.na(parsed)))
+               matches <- !is.na(col) & col >= parsed[1] & col <= parsed[2]
          }
       }
+      else if (identical(filtertype, "boolean"))
+      {
+         filterval <- isTRUE(filterval == "TRUE")
+         matches <- x[[i]] == filterval
+         matches[is.na(matches)] <- FALSE
+      }
+
+      if (!is.null(matches))
+         keep <- if (is.null(keep)) matches else keep & matches
    }
-   
-   # apply global search
+
+   # apply global search; the mask is computed over the full frame, so the
+   # per-frame search projection (keyed by cacheKey) stays row-aligned no
+   # matter which filters are active
    if (!is.null(search) && nchar(search) > 0)
    {
-      # get columns for search
-      searchColumns <- unclass(x)
-      
-      # also apply on row names if available
-      if (is.data.frame(x))
-      {
-         info <- .row_names_info(x, type = 0L)
-         if (is.character(info))
-         {
-            searchColumns[[length(searchColumns) + 1]] <- info
-         }
-      }
-      
-      # apply global search on data columns
-      pattern <- paste0("\\Q", search, "\\E")
-      matches <- lapply(searchColumns, function(column) {
-         grepl(pattern, column, perl = TRUE, ignore.case = TRUE)
-      })
-      
-      # collapse into single vector
-      matches <- Reduce(`|`, matches)
-      
-      # update based on matches
-      x <- x[matches, , drop = FALSE]
-      
+      matches <- .rs.dataViewer.searchMatches(x, search, if (isFullFrame) cacheKey else "")
+      keep <- if (is.null(keep)) matches else keep & matches
    }
-   
+
+   if (!is.null(keep))
+      x <- x[keep, , drop = FALSE]
+
    # apply sort
    if (length(cols) > 0)
    {
@@ -1280,6 +1279,120 @@
    }
    
    return(x)
+})
+
+#' Compute the global search mask for a frame.
+#'
+#' Returns a logical vector marking the rows where any column (or the row
+#' names, when character) contains 'search', case-insensitively -- matching
+#' against the same string form 'grepl' would coerce each column to.
+#'
+#' @param x The data.frame to search.
+#' @param search The literal text to search for.
+#' @param cacheKey The frame's cache key, enabling the cached projection in
+#'   .rs.SearchDataEnv; pass "" to scan the raw columns.
+.rs.addFunction("dataViewer.searchMatches", function(x, search, cacheKey)
+{
+   columns <- .rs.dataViewer.searchColumns(x, cacheKey)
+
+   # use PCRE and the special \Q and \E escapes to ensure no characters in
+   # the search expression are interpreted as regexes
+   pattern <- paste0("\\Q", search, "\\E")
+   matches <- NULL
+   for (column in columns)
+   {
+      m <- grepl(pattern, column, perl = TRUE, ignore.case = TRUE)
+      matches <- if (is.null(matches)) m else matches | m
+   }
+
+   if (is.null(matches))
+      matches <- logical(NROW(x))
+
+   matches
+})
+
+#' List the vectors the global search should scan.
+#'
+#' Returns the frame's columns (plus its row names, when character), replacing
+#' non-character columns with cached character projections where possible.
+#' grepl() re-runs as.character() on every non-character column it is given,
+#' which for a large frame of numeric/Date/POSIXct columns dominates the cost
+#' of every search request (#18423); the projections make that a one-time
+#' cost per frame. Character and factor columns are returned as-is: they are
+#' already cheap to search (grepl matches factor levels directly).
+#'
+#' Projections are cached in .rs.SearchDataEnv under the frame's cache key and
+#' built lazily, up to a retention budget; columns beyond the budget are
+#' returned raw and re-coerced by grepl as before. Note that as.character() on
+#' a plain atomic vector returns a deferred ALTREP whose strings materialize,
+#' in place, during the first scan, so building a projection adds no up-front
+#' pass over the data.
+#'
+#' The cache is dropped alongside the frame's working data (so any observed
+#' change to the underlying object invalidates it) and as soon as a request
+#' arrives with no active search.
+#'
+#' @param x The data.frame being searched.
+#' @param cacheKey The frame's cache key, or "" to disable the cache (the
+#'   caller is not scanning the full cached frame).
+.rs.addFunction("dataViewer.searchColumns", function(x, cacheKey)
+{
+   columns <- unclass(x)
+
+   # also search on row names if available
+   if (is.data.frame(x))
+   {
+      info <- .row_names_info(x, type = 0L)
+      if (is.character(info))
+         columns[[length(columns) + 1L]] <- info
+   }
+
+   if (!.rs.isNonEmptyScalarString(cacheKey))
+      return(columns)
+
+   # find the cached projection for this frame; discard it on a shape change
+   # (working-data wipes remove it eagerly, so this is a backstop against the
+   # same key resolving to a differently-shaped frame)
+   entry <- NULL
+   if (exists(cacheKey, envir = .rs.SearchDataEnv, inherits = FALSE))
+      entry <- get(cacheKey, envir = .rs.SearchDataEnv, inherits = FALSE)
+
+   if (is.null(entry) || !identical(entry$dim, dim(x)))
+      entry <- list(dim = dim(x), projected = vector("list", length(columns)), bytes = 0)
+
+   # cap the memory retained per frame: character projections of numeric
+   # columns run several times the size of the originals, so very large frames
+   # only cache a leading subset of their columns (the rest are re-coerced per
+   # request, as before)
+   limit <- 512 * 1024 * 1024
+   bytesPerElement <- 64
+
+   for (i in seq_along(columns))
+   {
+      column <- columns[[i]]
+      if (is.character(column) || is.factor(column))
+         next
+
+      projected <- entry$projected[[i]]
+      if (is.null(projected))
+      {
+         estimate <- length(column) * bytesPerElement
+         if (entry$bytes + estimate > limit)
+            next
+
+         projected <- as.character(column)
+         if (!is.character(projected))
+            next
+
+         entry$projected[[i]] <- projected
+         entry$bytes <- entry$bytes + estimate
+      }
+
+      columns[[i]] <- projected
+   }
+
+   assign(cacheKey, entry, envir = .rs.SearchDataEnv)
+   columns
 })
 
 # returns envName as an environment, or NULL if the conversion failed
@@ -1640,6 +1753,20 @@
        exists(".rs.WorkingDataEnv") &&
        exists(cacheKey, where = .rs.WorkingDataEnv, inherits = FALSE))
       rm(list = cacheKey, envir = .rs.WorkingDataEnv, inherits = FALSE)
+
+   # the cached search projection describes the same frame; drop it whenever
+   # the working data is dropped
+   .rs.removeSearchData(cacheKey)
+
+   invisible(NULL)
+})
+
+.rs.addFunction("removeSearchData", function(cacheKey)
+{
+   if (.rs.isNonEmptyScalarString(cacheKey) &&
+       exists(".rs.SearchDataEnv") &&
+       exists(cacheKey, where = .rs.SearchDataEnv, inherits = FALSE))
+      rm(list = cacheKey, envir = .rs.SearchDataEnv, inherits = FALSE)
    invisible(NULL)
 })
 

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -1234,12 +1234,15 @@
          keep <- if (is.null(keep)) matches else keep & matches
    }
 
-   # apply global search; the mask is computed over the full frame, so the
-   # per-frame search projection (keyed by cacheKey) stays row-aligned no
-   # matter which filters are active
+   # apply global search; the mask spans the full frame, so the per-frame
+   # search projection (keyed by cacheKey) stays row-aligned no matter which
+   # filters are active -- but only rows the filters kept are actually
+   # scanned, so a narrow filter keeps the search cost proportional to its
+   # match set rather than to the whole frame
    if (!is.null(search) && nchar(search) > 0)
    {
-      matches <- .rs.dataViewer.searchMatches(x, search, if (isFullFrame) cacheKey else "")
+      rows <- if (!is.null(keep)) which(keep)
+      matches <- .rs.dataViewer.searchMatches(x, search, if (isFullFrame) cacheKey else "", rows)
       keep <- if (is.null(keep)) matches else keep & matches
    }
 
@@ -1283,15 +1286,19 @@
 
 #' Compute the global search mask for a frame.
 #'
-#' Returns a logical vector marking the rows where any column (or the row
-#' names, when character) contains 'search', case-insensitively -- matching
-#' against the same string form 'grepl' would coerce each column to.
+#' Returns a logical vector over all of the frame's rows, marking those where
+#' any column (or the row names, when character) contains 'search',
+#' case-insensitively -- matching against the same string form 'grepl' would
+#' coerce each column to.
 #'
 #' @param x The data.frame to search.
 #' @param search The literal text to search for.
 #' @param cacheKey The frame's cache key, enabling the cached projection in
 #'   .rs.SearchDataEnv; pass "" to scan the raw columns.
-.rs.addFunction("dataViewer.searchMatches", function(x, search, cacheKey)
+#' @param rows Row indices still eligible after filtering, or NULL for all
+#'   rows. Only these rows are scanned (rows outside are FALSE in the result),
+#'   so active filters bound the scan and coercion cost.
+.rs.addFunction("dataViewer.searchMatches", function(x, search, cacheKey, rows = NULL)
 {
    columns <- .rs.dataViewer.searchColumns(x, cacheKey)
 
@@ -1301,14 +1308,21 @@
    matches <- NULL
    for (column in columns)
    {
+      if (!is.null(rows))
+         column <- column[rows]
+
       m <- grepl(pattern, column, perl = TRUE, ignore.case = TRUE)
       matches <- if (is.null(matches)) m else matches | m
    }
 
-   if (is.null(matches))
-      matches <- logical(NROW(x))
+   if (is.null(rows))
+      return(if (is.null(matches)) logical(NROW(x)) else matches)
 
-   matches
+   # scatter the scanned rows back into a full-frame mask
+   full <- logical(NROW(x))
+   if (!is.null(matches))
+      full[rows] <- matches
+   full
 })
 
 #' List the vectors the global search should scan.

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -132,10 +132,28 @@ namespace {
  *    filters.
  */    
 
+} // anonymous namespace
+
+namespace detail {
+
+// indicates whether rows matching the global search `inner` are necessarily a
+// subset of rows matching the search `outer`. The search is a bare literal
+// substring query (never "type|value" like the column filters), so this holds
+// exactly when `outer` occurs within `inner`: a row containing "walnuts" also
+// contains "walnut". This is what lets an extended search refine the cached
+// working copy instead of rescanning the whole frame; routing the search
+// through isFilterSubset instead would (a) never detect these subsets, since
+// a bare search fails its "type|value" parse, and (b) misparse a search that
+// happens to look like a filter (e.g. "numeric|12_18") as a range test.
+bool isSearchSubset(const std::string& outer, const std::string& inner)
+{
+   return inner.find(outer) != std::string::npos;
+}
+
 // indicates whether one filter string is a subset of another; e.g. if a column
 // is filtered for "abc" and then "abcd", the new state is a subset of the
 // previous state.
-bool isFilterSubset(const std::string& outer, const std::string& inner) 
+bool isFilterSubset(const std::string& outer, const std::string& inner)
 {
    // shortcut for identical filters (the typical case)
    if (inner == outer) 
@@ -199,7 +217,11 @@ bool isFilterSubset(const std::string& outer, const std::string& inner)
    return false;
 }
 
-typedef enum 
+} // namespace detail
+
+namespace {
+
+typedef enum
 {
   DIM_ROWS,
   DIM_COLS
@@ -271,17 +293,17 @@ struct CachedFrame : MoveOnly
    std::string workingSearch;
    std::vector<std::string> workingFilters;
 
-   bool isSupersetOf(const std::string& newSearch, 
+   bool isSupersetOf(const std::string& newSearch,
                      const std::vector<std::string> &newFilters)
    {
-      if (!isFilterSubset(workingSearch, newSearch))
+      if (!detail::isSearchSubset(workingSearch, newSearch))
          return false;
 
       for (unsigned i = 0;
            i < std::min(newFilters.size(), workingFilters.size());
            i++)
       {
-         if (!isFilterSubset(workingFilters[i], newFilters[i]))
+         if (!detail::isFilterSubset(workingFilters[i], newFilters[i]))
             return false;
       }
 
@@ -654,6 +676,16 @@ SEXP applyViewTransform(SEXP dataSEXP,
                         bool* pTransformed,
                         r::sexp::Protect& protect)
 {
+   // The cached search projection (see .rs.dataViewer.searchColumns) is only
+   // useful while a search is active; drop it as soon as the search clears.
+   // Cheap when there is nothing to drop, so no gating on prior state.
+   if (params.search.empty())
+   {
+      Error error = r::exec::RFunction(".rs.removeSearchData", cacheKey).call();
+      if (error)
+         LOG_ERROR(error);
+   }
+
    bool transformed = params.needsTransform();
    if (pTransformed != nullptr)
       *pTransformed = transformed;
@@ -663,6 +695,7 @@ SEXP applyViewTransform(SEXP dataSEXP,
    // Reuse a cached working copy when its parameters match (exactly, or as a
    // superset we can further filter) before recomputing from scratch.
    bool recompute = true;
+   SEXP fullFrameSEXP = dataSEXP;
    auto cachedFrame = s_cachedFrames.find(cacheKey);
    if (cachedFrame != s_cachedFrames.end() &&
        !cachedFrame->second.pendingWorkingDataWipe)
@@ -698,6 +731,11 @@ SEXP applyViewTransform(SEXP dataSEXP,
       transform.addParam("search", params.search);    // global search (across cols)
       transform.addParam("cols", params.ordercols);    // which column to order on
       transform.addParam("dirs", params.orderdirs);    // order direction
+      transform.addParam("cacheKey", cacheKey);        // enables the search projection cache
+
+      // the cached search projection is row-aligned with the full frame, so
+      // it must not be consulted when transforming from a working copy
+      transform.addParam("isFullFrame", dataSEXP == fullFrameSEXP);
       Error error = transform.call(&dataSEXP, &protect);
       if (error)
          throw r::exec::RErrorException(error.getSummary());

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -715,9 +715,15 @@ SEXP applyViewTransform(SEXP dataSEXP,
             dataSEXP = workingDataSEXP;
             recompute = false;
          }
-         else if (cachedFrame->second.isSupersetOf(params.search, params.filters))
+         else if (cachedFrame->second.isSupersetOf(params.search, params.filters) &&
+                  (!params.ordercols.empty() ||
+                   cachedFrame->second.workingOrderCols.empty()))
          {
-            // a strict superset -- transform from it instead of the original
+            // a strict superset -- transform from it instead of the original.
+            // Ordering gates the reuse: a request WITH a sort re-sorts the
+            // subset by its own keys, but a request with NO sort must show
+            // original row order, which a previously sorted working copy
+            // cannot supply -- recompute from the full frame instead.
             dataSEXP = workingDataSEXP;
          }
       }

--- a/src/cpp/session/modules/data/DataViewer.hpp
+++ b/src/cpp/session/modules/data/DataViewer.hpp
@@ -16,20 +16,35 @@
 #ifndef SESSION_DATA_VIEWER_HPP
 #define SESSION_DATA_VIEWER_HPP
 
+#include <string>
+
 namespace rstudio {
 namespace core {
    class Error;
 }
 }
- 
+
 namespace rstudio {
 namespace session {
-namespace modules { 
+namespace modules {
 namespace data {
 namespace viewer {
-   
+
 core::Error initialize();
-                       
+
+// exposed for testing
+namespace detail {
+
+// whether rows matching the global search `inner` are necessarily a subset of
+// rows matching the search `outer` (bare literal substring queries)
+bool isSearchSubset(const std::string& outer, const std::string& inner);
+
+// whether rows matching the "type|value" column filter `inner` are
+// necessarily a subset of rows matching the filter `outer`
+bool isFilterSubset(const std::string& outer, const std::string& inner);
+
+} // namespace detail
+
 } // namespace viewer
 } // namespace data
 } // namespace modules

--- a/src/cpp/session/modules/data/DataViewerTests.cpp
+++ b/src/cpp/session/modules/data/DataViewerTests.cpp
@@ -1,0 +1,110 @@
+/*
+ * DataViewerTests.cpp
+ *
+ * Copyright (C) 2026 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "DataViewer.hpp"
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace data {
+namespace viewer {
+namespace {
+
+// isSearchSubset: the global search is a bare literal substring query, so a
+// new search's rows are a subset of the working copy's whenever the working
+// search occurs within the new one.
+
+TEST(DataViewerTest, SearchSubset_IdenticalSearch)
+{
+   EXPECT_TRUE(detail::isSearchSubset("abc", "abc"));
+   EXPECT_TRUE(detail::isSearchSubset("", ""));
+}
+
+TEST(DataViewerTest, SearchSubset_ExtendedSearchIsSubset)
+{
+   // typing more characters can only narrow the matches
+   EXPECT_TRUE(detail::isSearchSubset("abc", "abcd"));
+   EXPECT_TRUE(detail::isSearchSubset("walnut", "walnuts"));
+}
+
+TEST(DataViewerTest, SearchSubset_ContainedSearchIsSubset)
+{
+   // any row containing "xabcy" contains "abc", wherever it was typed
+   EXPECT_TRUE(detail::isSearchSubset("abc", "xabcy"));
+}
+
+TEST(DataViewerTest, SearchSubset_EmptySearchIsSupersetOfAll)
+{
+   // a working copy built with no search holds every (filtered) row
+   EXPECT_TRUE(detail::isSearchSubset("", "anything"));
+}
+
+TEST(DataViewerTest, SearchSubset_BackspacedSearchIsNotSubset)
+{
+   EXPECT_FALSE(detail::isSearchSubset("abcd", "abc"));
+   EXPECT_FALSE(detail::isSearchSubset("abc", ""));
+}
+
+TEST(DataViewerTest, SearchSubset_FilterLookalikeIsLiteralText)
+{
+   // a search that merely looks like a "type|value" filter must be compared
+   // as text: rows containing "numeric|12_18" are unrelated to rows
+   // containing "numeric|10_20", even though 12-18 is inside 10-20
+   EXPECT_FALSE(detail::isSearchSubset("numeric|10_20", "numeric|12_18"));
+   EXPECT_TRUE(detail::isSearchSubset("numeric|1", "numeric|12_18"));
+}
+
+// isFilterSubset: column filters are structured "type|value" strings.
+
+TEST(DataViewerTest, FilterSubset_IdenticalFilter)
+{
+   EXPECT_TRUE(detail::isFilterSubset("character|abc", "character|abc"));
+   EXPECT_TRUE(detail::isFilterSubset("", ""));
+}
+
+TEST(DataViewerTest, FilterSubset_CharacterExtensionIsSubset)
+{
+   EXPECT_TRUE(detail::isFilterSubset("character|walnut", "character|walnuts"));
+   EXPECT_FALSE(detail::isFilterSubset("character|walnuts", "character|walnut"));
+}
+
+TEST(DataViewerTest, FilterSubset_NumericRangeInclusion)
+{
+   EXPECT_TRUE(detail::isFilterSubset("numeric|2_30", "numeric|5_10"));
+   EXPECT_FALSE(detail::isFilterSubset("numeric|5_10", "numeric|2_30"));
+}
+
+TEST(DataViewerTest, FilterSubset_FactorMustBeIdentical)
+{
+   EXPECT_TRUE(detail::isFilterSubset("factor|2", "factor|2"));
+   EXPECT_FALSE(detail::isFilterSubset("factor|2", "factor|3"));
+}
+
+TEST(DataViewerTest, FilterSubset_UnparseableFilterIsNotSubset)
+{
+   // bare strings (no "type|value" separator) can't be proven subsets
+   EXPECT_FALSE(detail::isFilterSubset("abc", "abcd"));
+}
+
+} // anonymous namespace
+} // namespace viewer
+} // namespace data
+} // namespace modules
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/tests/testthat/test-dataviewer.R
+++ b/src/cpp/tests/testthat/test-dataviewer.R
@@ -986,6 +986,29 @@ test_that(".rs.applyTransform() filters compose with a cached search", {
    expect_equal(cached$y, c(15, 35))
 })
 
+test_that(".rs.applyTransform() search scans only filter-eligible rows", {
+   df <- data.frame(x = c("keep", "keep", "drop", "drop"),
+                    num = c(7.5, 1.25, 7.5, 3.5))
+
+   cacheKey <- "test-search-eligible-rows"
+   on.exit(.rs.removeSearchData(cacheKey), add = TRUE)
+
+   # the search matches rows 1 and 3, but the filter only admits rows 1 and
+   # 2; a match scattered back from outside the filter mask must not leak in
+   for (key in c("", cacheKey))
+   {
+      out <- .rs.applyTransform(df, c("character|keep", ""), "7.5",
+                                integer(), character(), key, nzchar(key))
+      expect_equal(rownames(out), "1")
+      expect_equal(out$num, 7.5)
+   }
+
+   # a filter that excludes every row composes with a search without error
+   out <- .rs.applyTransform(df, c("character|nomatch", ""), "7.5",
+                             integer(), character(), cacheKey, TRUE)
+   expect_equal(nrow(out), 0L)
+})
+
 test_that(".rs.removeWorkingData() also drops the cached search projection", {
    df <- data.frame(num = c(1.5, 2.5))
    cacheKey <- "test-search-projection-removal"

--- a/src/cpp/tests/testthat/test-dataviewer.R
+++ b/src/cpp/tests/testthat/test-dataviewer.R
@@ -909,3 +909,119 @@ test_that(".rs.applyTransform() applies every key in a multi-column sort", {
    expect_equal(sorted$a, c(1L, 1L, 2L, 2L))
    expect_equal(sorted$c, c(1L, 2L, 1L, 2L))
 })
+
+test_that(".rs.applyTransform() global search matches the formatted form of non-character columns", {
+   df <- data.frame(
+      num = c(3.14159, 100, 42, NA),
+      date = as.Date(c("2020-01-15", "2021-06-30", "2022-12-01", "2023-03-10")),
+      time = as.POSIXct(c("2020-01-15 08:00:00", "2021-06-30 10:30:00",
+                          "2022-12-01 23:59:59", "2023-03-10 12:00:00"), tz = "UTC"),
+      f = factor(c("Apple", "banana", "cherry", "apricot"))
+   )
+
+   # doubles match their printed representation
+   out <- .rs.applyTransform(df, character(4L), "3.14", integer(), character())
+   expect_equal(out$num, 3.14159)
+
+   # dates and datetimes match their formatted (not numeric) form
+   out <- .rs.applyTransform(df, character(4L), "2021-06", integer(), character())
+   expect_equal(out$num, 100)
+
+   out <- .rs.applyTransform(df, character(4L), "10:30", integer(), character())
+   expect_equal(out$num, 100)
+
+   # factor levels match case-insensitively; NA cells match nothing
+   out <- .rs.applyTransform(df, character(4L), "ap", integer(), character())
+   expect_equal(as.character(out$f), c("Apple", "apricot"))
+})
+
+test_that(".rs.applyTransform() search results are identical with the projection cache", {
+   df <- data.frame(
+      num = c(3.5, 42, 7.25),
+      chr = c("apple", "banana", "cherry"),
+      f = factor(c("x", "y", "x")),
+      date = as.Date(c("2020-01-15", "2021-06-30", "2022-12-01")),
+      row.names = c("first", "second", "third")
+   )
+
+   cacheKey <- "test-search-projection"
+   on.exit(.rs.removeSearchData(cacheKey), add = TRUE)
+
+   for (search in c("42", "2020-01", "aP", "y", "third"))
+   {
+      plain <- .rs.applyTransform(df, character(4L), search, integer(), character())
+      seeded <- .rs.applyTransform(df, character(4L), search, integer(), character(),
+                                   cacheKey, TRUE)
+      reused <- .rs.applyTransform(df, character(4L), search, integer(), character(),
+                                   cacheKey, TRUE)
+      expect_identical(seeded, plain)
+      expect_identical(reused, plain)
+   }
+
+   # only non-character, non-factor columns are projected (row names, appended
+   # as a fifth search column, are already character)
+   entry <- get(cacheKey, envir = .rs.SearchDataEnv, inherits = FALSE)
+   expect_true(is.character(entry$projected[[1]]))  # num
+   expect_null(entry$projected[[2]])                # chr
+   expect_null(entry$projected[[3]])                # f
+   expect_true(is.character(entry$projected[[4]]))  # date
+   expect_null(entry$projected[[5]])                # row names
+})
+
+test_that(".rs.applyTransform() filters compose with a cached search", {
+   df <- data.frame(x = c("ab", "ab", "ab", "cd"),
+                    y = c(15, 20, 35, 40),
+                    z = c(3, 1, 2, 0))
+
+   cacheKey <- "test-search-projection-filters"
+   on.exit(.rs.removeSearchData(cacheKey), add = TRUE)
+
+   # the search mask is computed over the full frame; filters must still
+   # subset the same rows as the uncached path (search "5" matches rows 1 and
+   # 3, both of which survive the filter; the sort orders them by z)
+   plain <- .rs.applyTransform(df, c("character|ab", "", ""), "5", 3L, "desc")
+   cached <- .rs.applyTransform(df, c("character|ab", "", ""), "5", 3L, "desc",
+                                cacheKey, TRUE)
+   expect_identical(cached, plain)
+   expect_equal(cached$y, c(15, 35))
+})
+
+test_that(".rs.removeWorkingData() also drops the cached search projection", {
+   df <- data.frame(num = c(1.5, 2.5))
+   cacheKey <- "test-search-projection-removal"
+
+   .rs.applyTransform(df, character(1L), "1", integer(), character(), cacheKey, TRUE)
+   expect_true(exists(cacheKey, envir = .rs.SearchDataEnv, inherits = FALSE))
+
+   .rs.removeWorkingData(cacheKey)
+   expect_false(exists(cacheKey, envir = .rs.SearchDataEnv, inherits = FALSE))
+})
+
+test_that("the search projection is rebuilt when the frame shape changes", {
+   cacheKey <- "test-search-projection-reshape"
+   on.exit(.rs.removeSearchData(cacheKey), add = TRUE)
+
+   df1 <- data.frame(num = c(1.5, 2.5, 3.5))
+   out <- .rs.applyTransform(df1, character(1L), "2.5", integer(), character(),
+                             cacheKey, TRUE)
+   expect_equal(out$num, 2.5)
+
+   # same key, different frame: the stale projection must not be consulted
+   df2 <- data.frame(num = c(7.5, 8.5, 9.5, 10.5))
+   out <- .rs.applyTransform(df2, character(1L), "9.5", integer(), character(),
+                             cacheKey, TRUE)
+   expect_equal(out$num, 9.5)
+})
+
+test_that(".rs.applyTransform() leaves the projection cache alone for working copies", {
+   df <- data.frame(num = c(1.5, 2.5))
+   cacheKey <- "test-search-projection-working-copy"
+   on.exit(.rs.removeSearchData(cacheKey), add = TRUE)
+
+   # a working copy is not row-aligned with the full frame, so isFullFrame =
+   # FALSE must not build (or read) a projection under the frame's key
+   out <- .rs.applyTransform(df, character(1L), "1", integer(), character(),
+                             cacheKey, FALSE)
+   expect_equal(out$num, 1.5)
+   expect_false(exists(cacheKey, envir = .rs.SearchDataEnv, inherits = FALSE))
+})


### PR DESCRIPTION
## Problem

From the #17806 performance audit: every applied global search in the Data Viewer ran `grepl()` over every column of the full frame. `grepl()` coerces each non-character column with `as.character()`, so numeric/Date/POSIXct columns were re-formatted to strings on every keystroke -- roughly 4-5s per applied keystroke on a 1e6x8 mixed-type frame, in both directions (typing and backspacing).

Investigation notes, versus the issue text:

- The "slow PCRE path" claim did not hold up: `perl = TRUE, ignore.case = TRUE` benchmarks as the *fastest* case-insensitive option R has (~3.6x faster than the default TRE engine), so the regex engine is unchanged. The cost is entirely the per-request `as.character()` coercion.
- The working-copy superset reuse turned out to never fire for search changes at all, not just for backspaces: `isFilterSubset()` gained its `"type|value"` parse in 2014 (bd583d6787), and a bare search string fails that parse, so every search keystroke recomputed from the full frame.
- The issue's short-circuit proposal (stop coercing a column's remainder once rows have matched) benchmarked as a wash and was dropped.

## Changes

- **Cache character projections of searched columns** per cache key in a new `.rs.SearchDataEnv`, built lazily during the first search. `as.character()` on an atomic vector is a deferred ALTREP whose strings materialize in place during the first scan, so building the projection adds no up-front pass. Character and factor columns are scanned as-is (`grepl()` matches factor levels directly). Retention is capped (512MB estimated per frame; columns beyond the budget fall back to per-request coercion), and the cache is dropped alongside the working-data wipes (`onDetectChanges`, viewer close) and as soon as a request arrives with no active search.
- **Restore working-copy reuse for extended searches** with a dedicated `isSearchSubset()` (substring containment): typing "walnuts" now refines the cached "walnut" result instead of rescanning the whole frame, as originally intended in 2014. This also fixes a latent correctness hazard where a search that merely *looks* like a filter (e.g. `"numeric|12_18"` edited from `"numeric|10_20"`) was misparsed as a range test and could refine a working copy it does not match, silently dropping rows.
- **Combine filters and search into row masks** and subset once, instead of copying the surviving rows of the frame after every predicate. This also keeps the search mask row-aligned with the full frame, so the cached projection applies no matter which filters are active; `applyViewTransform` passes the cache key plus an `isFullFrame` flag so a transform running from a (differently-aligned) working copy never consults the projection.

## Benchmark

`.rs.applyTransform` on a 1e6x8 frame (int, 2x double, Date, POSIXct, factor, 2x character), typing `b`, `br`, `bra`, `brav`, then backspacing:

| request | before | after |
|---|---|---|
| first keystroke | 4.2s | 3.4s (builds projection) |
| each subsequent keystroke (extend or backspace) | 3.6-4.8s | ~0.26s |

Results verified `identical()` to the previous implementation, including formatted Date/POSIXct matching, factor levels, row names, NA handling, and composition with column filters and sorts.

## Tests

- `test-dataviewer.R`: formatted-form matching for non-character columns; projection-cache results identical to the uncached path (seeded and reused); filter/search/sort composition through the cache; invalidation via `.rs.removeWorkingData()` and on frame shape changes; working-copy calls leaving the cache untouched. All 234 pass.
- New `DataViewerTests.cpp` (gtest): `isSearchSubset` semantics (extension, containment, backspace, empty, filter-lookalike literal comparison) and existing `isFilterSubset` behavior, via a `detail` namespace. All rsession gtests pass (549).

Fixes #18423.

https://claude.ai/code/session_01BxsLCyYccbRav5HYDqbo8Y
