### PR TITLE
Update Electron to 42.11.0

### DIFF
--- a/.claude/skills/rstudio-update-electron/SKILL.md
+++ b/.claude/skills/rstudio-update-electron/SKILL.md
@@ -60,9 +60,27 @@ The lockfile must be included in the commit — if it drifts from the manifest, 
 }
 ```
 
-Change the `electron@<OLD_VERSION>` key to `electron@<NEW_VERSION>`. The allowlist matches by exact `package@version`, so the version in the key must track the Electron dependency version precisely. If the key is left stale, npm's install-script gating (npm 12+) blocks Electron's required install script, leaving the binary unavailable and breaking desktop packaging/startup.
+Change the `electron@<OLD_VERSION>` key to `electron@<NEW_VERSION>` so the key tracks the Electron dependency version.
 
-### 5. Run tests
+This key gates nothing today. Electron no longer publishes an install script — its published `package.json` has no `scripts` field, and its `package-lock.json` entry carries no `hasInstallScript` — so npm's install-script gating has nothing to block for it. (Verified on 42.10.1 and 42.11.0; re-check with `npm view electron@<NEW_VERSION> scripts`, which prints nothing when the field is absent.) Keep the key in sync anyway: it costs nothing and matters if Electron reintroduces an install script. The binary is fetched separately — see step 5.
+
+### 5. Verify the Electron binary
+
+Because Electron has no install script, `npm install` does **not** download the binary; it is fetched lazily the first time something runs Electron. A successful `npm install` therefore says nothing about which binary is on disk. Check it directly, from `src/node/desktop`:
+
+```bash
+cat node_modules/electron/dist/version
+```
+
+If that file is missing or reports the old version, fetch the binary explicitly:
+
+```bash
+npx --no-install install-electron
+```
+
+Confirm `node_modules/electron/dist/version` reports `<NEW_VERSION>` before continuing. Skipping this check risks running the next step's tests against a stale Electron.
+
+### 6. Run tests
 
 Run from `src/node/desktop`:
 
@@ -72,6 +90,6 @@ cd src/node/desktop && npm test
 
 Confirm the command exits successfully. If tests fail, report the failures and stop.
 
-### 6. Done
+### 7. Done
 
-Report that the Electron version has been updated and both `npm i` and `npm test` passed.
+Report that the Electron version has been updated, that the binary on disk reports the new version, and that both `npm i` and `npm test` passed.

--- a/NEWS.md
+++ b/NEWS.md
@@ -50,7 +50,7 @@
 
 ### Dependencies
 - Copilot Language Server 1.531.0
-- Electron 42.10.1
+- Electron 42.11.0
 - Node.js 22.23.2 (GitHub Copilot, Posit Assistant)
 - Quarto 1.10.18
 

--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -48,7 +48,7 @@
         "chai": "6.2.2",
         "copy-webpack-plugin": "14.0.0",
         "css-loader": "7.1.4",
-        "electron": "42.10.1",
+        "electron": "42.11.0",
         "electron-mocha": "13.1.0",
         "eslint": "10.8.1",
         "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -5911,9 +5911,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "42.10.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.10.1.tgz",
-      "integrity": "sha512-ITc1HPeoDzsxCCaH6MFsN67Nq2nUiJf5N9pBWxzhUpFfKJF0IwiAkKT3emg1lPbvC4OfFE+Cdwe4vhgdOZ1YKg==",
+      "version": "42.11.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.11.0.tgz",
+      "integrity": "sha512-cVKNrRk+qedJspxeQm7HpPbALpPK8shfIBYAdqRbpw+4Gwn9+1HySne11ILs93Pmxt3z89wjso0AftadPd6Nqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -57,7 +57,7 @@
     "chai": "6.2.2",
     "copy-webpack-plugin": "14.0.0",
     "css-loader": "7.1.4",
-    "electron": "42.10.1",
+    "electron": "42.11.0",
     "electron-mocha": "13.1.0",
     "eslint": "10.8.1",
     "fork-ts-checker-webpack-plugin": "9.1.0",
@@ -97,7 +97,7 @@
     "winston-syslog": "2.7.1"
   },
   "allowScripts": {
-    "electron@42.10.1": true,
+    "electron@42.11.0": true,
     "msgpackr-extract@3.0.3": true,
     "unix-dgram@2.0.6": true
   }


### PR DESCRIPTION
Updates the pinned Electron version from 42.10.1 to 42.11.0.

Chromium (148.0.7778.280) and V8 (14.8.178.38) are unchanged from 42.10.1; Node.js goes from 24.18.1 to 24.19.0.

## Why take this update

**Linux arm64 / armv7l filesystem constants (electron/electron#53318).** `node_mksnapshot` runs on the build host, so cross-compiling on x86 builders baked host values for `fs.constants.O_DIRECTORY`, `O_NOFOLLOW` and `O_DIRECT` into the Node startup snapshot. `O_DIRECTORY` became `O_DIRECT`, so directory opens are rejected with `EINVAL`, and `O_NOFOLLOW` became `O_LARGEFILE`, which silently disables symlink guards. We consume the official cross-compiled prebuilts from npm and build arm64 Electron packages for jammy and rhel9 (`jenkins/utils.groovy`), so the Linux arm64 desktop builds we ship carry these values today. This is platform exposure rather than a traced failure — no specific RStudio call path was confirmed broken.

**Upstream backports.** 56 cherry-picked ANGLE/Chromium/Dawn/V8/WebRTC changes plus refreshed PGO profiles, landing without a Chromium or V8 version roll.

## Not applicable to RStudio Desktop

The rest of the release was checked against our usage and does not apply:

- GPU process termination when WebGPU falls back to SwiftShader (electron/electron#53199) — gated on AppX/MSIX Code Integrity (`MITIGATION_FORCE_MS_SIGNED_BINS`); we do not ship an MSIX package.
- Empty window title after back/forward navigation (electron/electron#53217) — needs a window created with a `title` option that then navigates back/forward. The windows with back/forward toolbars (`secondary-window.ts`) pass `adjustTitle` rather than a creation `title`; `whats-new-window.ts` passes a title but is frameless with no navigation; and `gwt-window.ts` clears navigation history on every navigate.
- `desktopCapturer` delegated source lists (electron/electron#51784) — no `desktopCapturer` or `getDisplayMedia` usage.
- `node:wasi` crash under V8 optimization (electron/electron#53267) — no WASI usage.
- Region-qualified `--lang` on macOS (electron/electron#53187) — we never set `--lang`, and we do not use WebAuthn. A user could still set it through `electron-flags.conf`.

## Testing

From `src/node/desktop`: `npm test` passes (456 passing), `npm run typecheck` passes, and `npm run lint` exits clean with 2 pre-existing warnings in `session-launcher.test.ts` that this change does not touch. The downloaded binary reports `v42.11.0`.


## Skill correction

`.claude/skills/rstudio-update-electron/SKILL.md` told you to update the `allowScripts` key in `src/node/desktop/package.json` because a stale key "blocks Electron's required install script, leaving the binary unavailable." That reasoning does not hold: Electron publishes no install script. Both 42.10.1 and 42.11.0 ship a `package.json` with no `scripts` field, and their `package-lock.json` entries carry no `hasInstallScript`, so npm's install-script gating has nothing to block for Electron. The binary is fetched lazily the first time something runs Electron, which is why `node_modules/electron/dist` stayed absent through `npm install` and `npm rebuild electron` during this bump and only appeared once `npm test` invoked it.

The skill now states the accurate reason, keeps the key in sync anyway (it costs nothing and matters if Electron reintroduces a script), and adds a step that checks `node_modules/electron/dist/version` against the target version — with `npx --no-install install-electron` to fetch it, verified to work with the binary removed.
