### PR TITLE
Correct the 2026.09.0 release notes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,12 +7,14 @@
 - ([#2129](https://github.com/rstudio/rstudio/issues/2129)): Added horizontal and vertical split source editor views, with shared edits and independent navigation state.
 
 ### Fixed
+- ([#18683](https://github.com/rstudio/rstudio/issues/18683)): Fixed intermittent user and group lookup failures on Linux when a remote user directory is slow to respond.
 - ([#16540](https://github.com/rstudio/rstudio/issues/16540)): Fixed an issue where opening Find in the visual editor left the search box as it was, rather than filling it with the selected text the way source mode does. A selection made inside a code chunk now seeds the box too, and is what Use Selection for Find looks for there; both previously read the surrounding document selection, which sees a chunk as a single unit.
 - ([#16540](https://github.com/rstudio/rstudio/issues/16540)): Fixed an issue where the Find and Add Next and Find All commands did nothing in the visual editor. Both build a multi-cursor selection in the source editor, and in visual mode they were still aimed at that editor even though it is hidden; they now act on the code chunk that has focus. In prose, where the visual editor has no multi-cursor equivalent, they are reported as unavailable rather than silently doing nothing.
 - ([#16540](https://github.com/rstudio/rstudio/issues/16540)): Fixed a client error ("Cannot read properties of null") that could follow a Reload Now of the visual editor after a format change, when the editor's idle save of the editing location fired before the rebuilt editor existed.
 - ([#18620](https://github.com/rstudio/rstudio/issues/18620)): The Data Viewer's last row is no longer hidden underneath the horizontal scrollbar when scrolled to the bottom.
 - ([#18139](https://github.com/rstudio/rstudio/issues/18139)): Fixed Windows locale drift that corrupted non-ASCII Console input and other locale-sensitive operations.
 - ([#18635](https://github.com/rstudio/rstudio/issues/18635)): Running code from a popped-out source window no longer moves focus to the console when "Focus console after executing code from the source pane" is off.
+- ([#18441](https://github.com/rstudio/rstudio/issues/18441)): The sign-in page and the logged-out dialog now pause polling while their tab is hidden and back off over time, and the dialog offers a "Try again now" button.
 - ([#18356](https://github.com/rstudio/rstudio/issues/18356)): Declining the Posit Assistant install prompt now restores the previously selected code assistant.
 - ([#18631](https://github.com/rstudio/rstudio/issues/18631)): RStudio Desktop now shows What's New once per release instead of after every patch update.
 - ([#18602](https://github.com/rstudio/rstudio/issues/18602)): Fixed folding and outline hierarchy for section headers decorated with `#` characters.
@@ -31,8 +33,6 @@
 - ([#18527](https://github.com/rstudio/rstudio/issues/18527)): On Windows, sessions started in untrusted directories no longer read user-level `.Renviron` files.
 - ([#10756](https://github.com/rstudio/rstudio/issues/10756)): Improved crash reporting and thread safety during session startup.
 - ([#18507](https://github.com/rstudio/rstudio/issues/18507)): Reduced macOS file-monitor overload by excluding high-churn and nested-worktree directories, batching events, and debouncing recovery scans.
-- ([#18515](https://github.com/rstudio/rstudio/issues/18515)): Restored 32-bit session binaries to the Windows installer.
-- ([#18512](https://github.com/rstudio/rstudio/issues/18512)): Added a code signature to `rsession.dll` on Windows.
 - ([#18493](https://github.com/rstudio/rstudio/issues/18493)): Fixed invisible checkbox and radio button states in Windows high-contrast dark themes.
 - ([#18474](https://github.com/rstudio/rstudio/issues/18474)): Fixed a math-preview keyboard handler leak that consumed subsequent Escape keypresses.
 - ([#17806](https://github.com/rstudio/rstudio/issues/17806)): Improved Data Viewer searching, filtering, scrolling, and Summary panel performance.


### PR DESCRIPTION
### Intent

Audit of `NEWS.md` against every commit merged to `main` since the 2026.08.0 branch point
(`898754716f`). Two changes to released behavior merged without an entry, and two entries
that belong to the 2026.08.1 patch notes are present here as well.

Scope was `git log 898754716f..HEAD ^origin/rel-yellow-yarrow --no-merges` (130 commits).
Excluding `origin/rel-yellow-yarrow` keeps out work that shipped in 2026.08.x and is
documented in `version/news/os/NEWS-2026.08.1-yellow-yarrow.md`.

### Approach

**Added to `### Fixed`:**

- [#18441](https://github.com/rstudio/rstudio/issues/18441) (#18442) — the sign-in page and
  the logged-out dialog polled continuously, including while their tab was hidden. The PR
  body noted the NEWS entry was still to come.
- [#18683](https://github.com/rstudio/rstudio/issues/18683) (#18684) — user and group lookups
  did not retry on `EINTR`, so a slow remote user directory produced intermittent failures.

**Removed:** the #18515 and #18512 entries. 5aa0626bd1 deleted them because both shipped in
the 2026.08.1 patch notes; merge b92f45d70c resurrected them from a topic branch that forked
before that deletion. Both are still present in
`version/news/os/NEWS-2026.08.1-yellow-yarrow.md`.

Entry wording was checked against the diffs it describes: 41615c92aa adds visibility-based
pausing, a 3s-to-30s backoff, and a "Try again now" button on the dialog; 21981fc342 retries
on `EINTR` in `shared_core/system/User.cpp` and `core/system/PosixGroup.cpp`.

The audit also reviewed and excluded ~35 non-CI commits. The notable ones: #18667, #18653,
#18638, #18523, #18574, #18630 and #18521 all correct work that is itself unreleased and
already covered by this cycle's entries; #18567 and #18690 are open-source companions to
rstudio-pro changes; #18647's user-visible half is likewise tracked in the pro repository;
#18666 defers its entry to PR 3 of #18658, which has not merged. `### Dependencies` was
verified complete — Copilot Language Server 1.531.0, Electron 42.10.1, Node.js 22.23.2,
Quarto 1.10.18, with no Ace, xterm.js, or MathJax bumps this cycle.

### Automated Tests

None. `NEWS.md` is not compiled or linted.

### QA Notes

No product change.

### Documentation

`NEWS.md` only.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility) (n/a)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests (n/a)
