### PR TITLE
disable the search projection while a working-data wipe is pending

### DIFF
--- a/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/data_viewer.test.ts
@@ -290,6 +290,57 @@ test.describe('Data Viewer', () => {
     }).toBe(true);
   });
 
+  // Clearing the sort while a search stays active must restore original row
+  // order. The transform layer refines a cached working copy for requests
+  // whose row set shrinks or stays the same, and before the #18423 follow-up
+  // a sort-clear request reused the previously *sorted* copy as-is, leaving
+  // the grid stuck in stale sort order.
+  //
+  // The frame must be a NAMED global: a temporary expression's working copy
+  // is wiped on every change-detection pass, so with View(data.frame(...))
+  // each request recomputes from the full frame and the reuse path (and the
+  // regression) is unreachable.
+  test('clearing the sort restores original row order while a search is active (#18423)', async ({ rstudioPage: page }) => {
+    await consoleActions.executeInConsole(
+      '{ e2eSortClear <- data.frame(id = c(3, 1, 2, 0), tag = c("kx", "ky", "kz", "zzz")); View(e2eSortClear) }',
+    );
+    await waitForViewer(dataViewer);
+
+    // The tag column is the last cell of each rendered row; its values are
+    // unique, so the sequence pins the full display order.
+    const tagOrder = () => dataViewer.frame
+      .locator('#gridBody tr:not(.spacer-row)')
+      .evaluateAll((rows) => rows.map((row) => {
+        const cells = row.querySelectorAll('td');
+        return cells[cells.length - 1]?.textContent ?? '';
+      }));
+
+    // Search down to the three "k" rows; the row count dropping to 3 is the
+    // signal that the debounced search round-tripped.
+    const search = page.locator('#data_editing_toolbar').getByLabel('Search data table');
+    await search.click();
+    await page.keyboard.type('k');
+    await expect(dataViewer.frame.locator('#gridBody tr:not(.spacer-row)'))
+      .toHaveCount(3, { timeout: TIMEOUTS.fileOpen });
+    await expect.poll(tagOrder).toEqual(['kx', 'ky', 'kz']);
+
+    // Sort ascending by id; the search stays applied.
+    await dataViewer.frame.locator('th[data-col-idx="1"]').click();
+    await expect.poll(tagOrder, { timeout: TIMEOUTS.fileOpen })
+      .toEqual(['ky', 'kz', 'kx']);
+
+    // Clear the sort from the info bar. The searched row set is unchanged,
+    // so the backend may reuse its working copy -- but the rows must come
+    // back in original frame order, not the stale sorted order.
+    await dataViewer.clearSortButton.click();
+    await expect.poll(tagOrder, { timeout: TIMEOUTS.fileOpen })
+      .toEqual(['kx', 'ky', 'kz']);
+    await expect(dataViewer.sortStatus).toBeHidden();
+
+    // best-effort cleanup of the named global (afterEach closes the tab)
+    await consoleActions.executeInConsole('rm(e2eSortClear)');
+  });
+
   test('pin icon moves a column to the pinned prefix', async () => {
     await consoleActions.executeInConsole('View(mtcars)');
     await waitForViewer(dataViewer);

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -1763,14 +1763,16 @@
 
 .rs.addFunction("removeWorkingData", function(cacheKey)
 {
+   # the cached search projection describes the same frame; drop it whenever
+   # the working data is dropped. Dropped first so that a failure removing
+   # the working data (tracked by pendingWorkingDataWipe on the C++ side)
+   # cannot strand a stale projection behind it.
+   .rs.removeSearchData(cacheKey)
+
    if (.rs.isNonEmptyScalarString(cacheKey) &&
        exists(".rs.WorkingDataEnv") &&
        exists(cacheKey, where = .rs.WorkingDataEnv, inherits = FALSE))
       rm(list = cacheKey, envir = .rs.WorkingDataEnv, inherits = FALSE)
-
-   # the cached search projection describes the same frame; drop it whenever
-   # the working data is dropped
-   .rs.removeSearchData(cacheKey)
 
    invisible(NULL)
 })

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -138,16 +138,25 @@ namespace detail {
 
 // indicates whether rows matching the global search `inner` are necessarily a
 // subset of rows matching the search `outer`. The search is a bare literal
-// substring query (never "type|value" like the column filters), so this holds
-// exactly when `outer` occurs within `inner`: a row containing "walnuts" also
-// contains "walnut". This is what lets an extended search refine the cached
+// substring query (never "type|value" like the column filters), matched
+// case-insensitively on the R side, so this holds whenever `outer` occurs
+// within `inner` up to case: a row containing "WALNUTS" also matches a search
+// for "walnut". This is what lets an extended search refine the cached
 // working copy instead of rescanning the whole frame; routing the search
 // through isFilterSubset instead would (a) never detect these subsets, since
 // a bare search fails its "type|value" parse, and (b) misparse a search that
 // happens to look like a filter (e.g. "numeric|12_18") as a range test.
+//
+// The folding here is ASCII-only, which is conservative against PCRE's
+// Unicode case folding: a subset missed over a non-ASCII case pair just
+// falls back to a full recompute, while a subset is never claimed that the
+// case-insensitive search would not honor.
 bool isSearchSubset(const std::string& outer, const std::string& inner)
 {
-   return inner.find(outer) != std::string::npos;
+   if (outer.empty())
+      return true;
+
+   return boost::algorithm::icontains(inner, outer);
 }
 
 // indicates whether one filter string is a subset of another; e.g. if a column

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -731,13 +731,25 @@ SEXP applyViewTransform(SEXP dataSEXP,
 
    if (recompute)
    {
+      // Like the working copy, the search projection may be stale while a
+      // wipe is pending (the failed .rs.removeWorkingData call covers both
+      // caches); withhold the cache key so the projection is neither read
+      // nor rebuilt until onDetectChanges retries the removal. A same-shaped
+      // replacement frame would otherwise be searched against the old
+      // projected strings, since the R side revalidates by dim() only.
+      bool searchCacheUsable =
+            cachedFrame == s_cachedFrames.end() ||
+            !cachedFrame->second.pendingWorkingDataWipe;
+
       r::exec::RFunction transform(".rs.applyTransform");
       transform.addParam("x", dataSEXP);             // data to transform
       transform.addParam("filtered", params.filters); // which columns are filtered
       transform.addParam("search", params.search);    // global search (across cols)
       transform.addParam("cols", params.ordercols);    // which column to order on
       transform.addParam("dirs", params.orderdirs);    // order direction
-      transform.addParam("cacheKey", cacheKey);        // enables the search projection cache
+
+      // enables the search projection cache
+      transform.addParam("cacheKey", searchCacheUsable ? cacheKey : std::string());
 
       // the cached search projection is row-aligned with the full frame, so
       // it must not be consulted when transforming from a working copy

--- a/src/cpp/session/modules/data/DataViewer.hpp
+++ b/src/cpp/session/modules/data/DataViewer.hpp
@@ -36,7 +36,8 @@ core::Error initialize();
 namespace detail {
 
 // whether rows matching the global search `inner` are necessarily a subset of
-// rows matching the search `outer` (bare literal substring queries)
+// rows matching the search `outer` (bare literal substring queries, matched
+// case-insensitively)
 bool isSearchSubset(const std::string& outer, const std::string& inner);
 
 // whether rows matching the "type|value" column filter `inner` are

--- a/src/cpp/session/modules/data/DataViewerTests.cpp
+++ b/src/cpp/session/modules/data/DataViewerTests.cpp
@@ -49,6 +49,18 @@ TEST(DataViewerTest, SearchSubset_ContainedSearchIsSubset)
    EXPECT_TRUE(detail::isSearchSubset("abc", "xabcy"));
 }
 
+TEST(DataViewerTest, SearchSubset_ContainmentIsCaseInsensitive)
+{
+   // the search itself matches case-insensitively, so a re-cased refinement
+   // is still a subset: rows matching "ABc" all match a search for "ab"
+   EXPECT_TRUE(detail::isSearchSubset("ab", "ABc"));
+   EXPECT_TRUE(detail::isSearchSubset("WAL", "walnuts"));
+   EXPECT_TRUE(detail::isSearchSubset("abc", "xAbCy"));
+
+   // case-insensitivity must not manufacture subsets that are not there
+   EXPECT_FALSE(detail::isSearchSubset("ABCD", "abc"));
+}
+
 TEST(DataViewerTest, SearchSubset_EmptySearchIsSupersetOfAll)
 {
    // a working copy built with no search holds every (filtered) row

--- a/src/cpp/tests/testthat/test-dataviewer.R
+++ b/src/cpp/tests/testthat/test-dataviewer.R
@@ -1020,6 +1020,30 @@ test_that(".rs.removeWorkingData() also drops the cached search projection", {
    expect_false(exists(cacheKey, envir = .rs.SearchDataEnv, inherits = FALSE))
 })
 
+test_that("a failing working-data wipe still drops the search projection", {
+   df <- data.frame(num = c(1.5, 2.5))
+   cacheKey <- "test-search-projection-failed-wipe"
+
+   # seed the projection cache
+   .rs.applyTransform(df, character(1L), "1", integer(), character(), cacheKey, TRUE)
+   expect_true(exists(cacheKey, envir = .rs.SearchDataEnv, inherits = FALSE))
+
+   # swap in a locked working-data environment so removing the working copy
+   # fails, standing in for the failures pendingWorkingDataWipe tracks
+   workingDataEnv <- .rs.WorkingDataEnv
+   lockedEnv <- new.env(parent = emptyenv())
+   assign(cacheKey, df, envir = lockedEnv)
+   lockEnvironment(lockedEnv)
+   .rs.setVar("WorkingDataEnv", lockedEnv)
+   on.exit(.rs.setVar("WorkingDataEnv", workingDataEnv), add = TRUE)
+
+   # the removal fails, but the projection must be dropped first: the C++
+   # side only retries .rs.removeWorkingData, so a projection stranded here
+   # could be served to a same-shaped replacement frame
+   expect_error(.rs.removeWorkingData(cacheKey))
+   expect_false(exists(cacheKey, envir = .rs.SearchDataEnv, inherits = FALSE))
+})
+
 test_that("the search projection is rebuilt when the frame shape changes", {
    cacheKey <- "test-search-projection-reshape"
    on.exit(.rs.removeSearchData(cacheKey), add = TRUE)


### PR DESCRIPTION
Follow-ups to #18698 from the roborev branch and per-commit reviews.

**Stale projection while a wipe is pending (Medium):** `pendingWorkingDataWipe` gates working-copy reuse after a failed `.rs.removeWorkingData` call, but the recompute path still handed the cache key to `.rs.applyTransform`, so a same-shaped replacement frame could be searched against stale projected strings (the R side revalidates the projection by `dim()` only).

- `applyViewTransform` now withholds the cache key while a wipe is pending, so the projection is neither read nor rebuilt until `onDetectChanges` retries the removal.
- `.rs.removeWorkingData` drops the search projection before the working data, so a failure removing the latter cannot strand a stale projection behind it; a new testthat test forces that failure (via a reversible locked-environment swap) and asserts the projection is gone.

**Case-insensitive search-subset reuse (Low):** `isSearchSubset` compared case-sensitively while the search it models matches with `ignore.case = TRUE`; a re-cased refinement like `"ab"` -> `"ABc"` fell back to a full rescan. It now folds case (ASCII, via `boost::algorithm::icontains`) -- conservative against PCRE's Unicode folding, so a missed non-ASCII case pair just recomputes and a subset is never claimed that the search would not honor.

**Request-path regression test for the sort-clear reuse gate (Low):** a new Playwright test searches, sorts, then clears the sort from the info bar and asserts rows return to original frame order. Two findings from building it: the frame must be a *named* global (a temporary expression's working copy is wiped on every change-detection pass, making the reuse path unreachable), and the test was verified red against a pre-fix session via the dev shim and green against this branch's build.

No NEWS entry: hardens the just-merged, unreleased #18698 change. 242 r-scope dataviewer tests, 550 rsession gtests, and the new e2e test pass.

Addresses #18423.

https://claude.ai/code/session_01BxsLCyYccbRav5HYDqbo8Y
