### PR TITLE
e2e: retry chat guardrail prompts when the provider drops a turn mid-stream

### DIFF
--- a/e2e/rstudio/pages/chat_pane.page.ts
+++ b/e2e/rstudio/pages/chat_pane.page.ts
@@ -128,6 +128,51 @@ export class ChatPane extends FramePageObject {
   }
 
   /**
+   * Whether the conversation's last message is an assistant reply with any
+   * content beyond a thinking disclosure.
+   *
+   * The provider can drop a turn mid-stream: the turn ends cleanly as far as
+   * the composer is concerned (stop button gone, so isTurnIdle passes) after
+   * streaming only the collapsed "Thought for Xs" block -- or nothing at all,
+   * leaving the user's own prompt as the last message. No tool ran and no
+   * reply text exists, so waits keyed on turn completion succeed while
+   * assertions about the assistant's work fail on work it never did. This
+   * predicate is the discriminator: callers re-send the prompt when it
+   * reports false.
+   *
+   * The thinking disclosure (databot's ElementThinking) is a wrapper div
+   * holding a toggle button -- labeled "Thought for Xs" / "Thinking" and
+   * carrying aria-expanded -- plus the collapsible region; stripping wrappers
+   * whose toggle matches that label leaves only genuine reply content. An
+   * unrecognized future DOM fails toward "substantive", i.e. no retry, which
+   * is the pre-detector behavior rather than a retry-until-exhausted loop.
+   */
+  async isLastMessageSubstantive(): Promise<boolean> {
+    if ((await this.getMessageCount()) === 0) {
+      return false;
+    }
+
+    // A torn-down iframe (the message items gone by evaluate time) is the
+    // provider blip itself, so a failed lookup reads as "not substantive"
+    // rather than erroring out of the caller's retry loop.
+    return await this.messageItem.last().evaluate((el) => {
+      if (!el.querySelector('.chat-message-assistant')) {
+        return false;
+      }
+
+      const clone = el.cloneNode(true) as HTMLElement;
+      for (const toggle of Array.from(clone.querySelectorAll('button[aria-expanded]'))) {
+        const name = toggle.getAttribute('aria-label') ?? toggle.textContent ?? '';
+        if (/^\s*(Thought for|Thinking)\b/.test(name)) {
+          (toggle.parentElement ?? toggle).remove();
+        }
+      }
+
+      return (clone.textContent ?? '').trim().length > 0;
+    }, undefined, { timeout: 5000 }).catch(() => false);
+  }
+
+  /**
    * The chat composer is ready when it's visible and editable. TipTap reflects
    * its editable state via the contenteditable attribute (toggled by
    * editor.setEditable), so we check that rather than isEnabled() -- a

--- a/e2e/rstudio/pages/chat_pane.page.ts
+++ b/e2e/rstudio/pages/chat_pane.page.ts
@@ -140,12 +140,14 @@ export class ChatPane extends FramePageObject {
    * predicate is the discriminator: callers re-send the prompt when it
    * reports false.
    *
-   * The thinking disclosure (databot's ElementThinking) is a wrapper div
-   * holding a toggle button -- labeled "Thought for Xs" / "Thinking" and
-   * carrying aria-expanded -- plus the collapsible region; stripping wrappers
-   * whose toggle matches that label leaves only genuine reply content. An
-   * unrecognized future DOM fails toward "substantive", i.e. no retry, which
-   * is the pre-detector behavior rather than a retry-until-exhausted loop.
+   * The thinking disclosure (databot's ElementThinking) is a toggle button
+   * -- labeled "Thought for Xs" / "Thinking" and carrying aria-expanded --
+   * plus a collapsible region whose aria-labelledby names the toggle's id;
+   * stripping each matching toggle and the region it labels leaves only
+   * genuine reply content. Nothing beyond that provably-linked pair is
+   * removed, so an unrecognized future DOM fails toward "substantive", i.e.
+   * no retry, which is the pre-detector behavior rather than a
+   * retry-until-exhausted loop.
    */
   async isLastMessageSubstantive(): Promise<boolean> {
     if ((await this.getMessageCount()) === 0) {
@@ -168,7 +170,18 @@ export class ChatPane extends FramePageObject {
       for (const toggle of Array.from(clone.querySelectorAll('button[aria-expanded]'))) {
         const name = toggle.getAttribute('aria-label') ?? toggle.textContent ?? '';
         if (/^\s*(Thought for|Thinking)\b/.test(name)) {
-          (toggle.parentElement ?? toggle).remove();
+          // The collapsed thought text stays in the DOM (the region only
+          // animates shut), so textContent would count it; remove the region
+          // through its aria-labelledby link rather than assuming where the
+          // toggle sits relative to it.
+          if (toggle.id) {
+            for (const region of Array.from(
+              clone.querySelectorAll(`[aria-labelledby~="${CSS.escape(toggle.id)}"]`)
+            )) {
+              region.remove();
+            }
+          }
+          toggle.remove();
         }
       }
 

--- a/e2e/rstudio/pages/chat_pane.page.ts
+++ b/e2e/rstudio/pages/chat_pane.page.ts
@@ -156,7 +156,11 @@ export class ChatPane extends FramePageObject {
     // provider blip itself, so a failed lookup reads as "not substantive"
     // rather than erroring out of the caller's retry loop.
     return await this.messageItem.last().evaluate((el) => {
-      if (!el.querySelector('.chat-message-assistant')) {
+      // Each message stamps data-message-id on both the ChatMessage row
+      // wrapper and the nested MessageRenderer content div, so last() lands
+      // on the inner div and the assistant class sits on an ancestor;
+      // closest() covers that shape, querySelector() the row wrapper.
+      if (!el.closest('.chat-message-assistant') && !el.querySelector('.chat-message-assistant')) {
         return false;
       }
 

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails.test.ts
@@ -75,6 +75,10 @@ const SHOW_RAW_CONTENTS = /^(?:show|print|display)\s+(?:the\s+)?(?:full|raw|comp
 const PROCEED_WITH_PATH =
   /^(?:yes|proceed|go ahead|write it|move it)\b(?!.*\b(?:instead|(?:inside|within|into|to) the (?:project|workspace)))/is;
 
+// How many attempts each prompt gets when the provider drops a turn
+// mid-stream and it ends without a substantive response (see askAssistant).
+const DEAD_TURN_ATTEMPTS = 3;
+
 test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@chat', '@serial'] }, () => {
   requireAiCredentials(test, 'positai');
 
@@ -106,6 +110,12 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@chat', '
     await chatActions.dismissSetupPrompts();
   });
 
+  // Dead-turn retries (see askAssistant) can stack a dropped attempt on top
+  // of a slow healthy turn, so give each test headroom past the 120s default.
+  test.beforeEach(() => {
+    test.setTimeout(240000);
+  });
+
   test.afterAll(async () => {
     // Files inside the project and outside-project files now live in the
     // sandbox and are removed by the sandbox afterAll (registered by
@@ -122,20 +132,44 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@chat', '
    *
    * `answerQuestion` selects the option to take if the assistant pauses on an
    * AskUser question rather than acting.
+   *
+   * The provider can drop a turn mid-stream: the turn ends cleanly after
+   * streaming only a thinking block (or nothing at all), no tool ever runs,
+   * and the file-state assertion then fails on work the assistant never did
+   * (see isLastMessageSubstantive). Such dead turns are re-sent in a fresh
+   * conversation, up to DEAD_TURN_ATTEMPTS attempts in total, so a transient
+   * provider drop doesn't fail a guardrail test that never got exercised.
    */
   async function askAssistant(prompt: string, answerQuestion?: RegExp): Promise<string> {
-    await chatActions.startNewConversation();
-    const initialCount = await chatActions.sendChatMessage(prompt, answerQuestion);
+    for (let attempt = 1; ; attempt++) {
+      await chatActions.startNewConversation();
+      const initialCount = await chatActions.sendChatMessage(prompt, answerQuestion);
 
-    // Handle Allow dialogs and wait for response to finish streaming
-    await chatActions.pollWithAllowDialogs(async () => {
-      const count = await chatPane.getMessageCount();
-      if (count <= initialCount) return false;
-      return await chatActions.isTurnIdle();
-    }, 120000, answerQuestion);
+      // Handle Allow dialogs and wait for response to finish streaming
+      await chatActions.pollWithAllowDialogs(async () => {
+        const count = await chatPane.getMessageCount();
+        if (count <= initialCount) return false;
+        return await chatActions.isTurnIdle();
+      }, 120000, answerQuestion);
 
-    const lastMessage = chatPane.messageItem.last();
-    return await lastMessage.innerText();
+      if (await chatPane.isLastMessageSubstantive()) {
+        return await chatPane.messageItem.last().innerText();
+      }
+
+      const lastText =
+        await chatPane.messageItem.last().innerText({ timeout: 5000 }).catch(() => '');
+      if (attempt >= DEAD_TURN_ATTEMPTS) {
+        throw new Error(
+          `askAssistant: the assistant turn ended without a substantive response ` +
+          `${attempt} times in a row -- the provider appears to be dropping turns ` +
+          `mid-stream. Last message: ${JSON.stringify(lastText)}`
+        );
+      }
+      console.log(
+        `askAssistant: dead turn (nothing beyond a thinking block; last message ` +
+        `${JSON.stringify(lastText)}); retrying (attempt ${attempt + 1} of ${DEAD_TURN_ATTEMPTS})`
+      );
+    }
   }
 
   /**

--- a/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails.test.ts
+++ b/e2e/rstudio/tests/panes/posit-assistant-chat/chat-guardrails.test.ts
@@ -79,6 +79,14 @@ const PROCEED_WITH_PATH =
 // mid-stream and it ends without a substantive response (see askAssistant).
 const DEAD_TURN_ATTEMPTS = 3;
 
+// How long one attempt waits for the response to finish streaming.
+const RESPONSE_TIMEOUT_MS = 120000;
+
+// Worst case for one askAssistant attempt: sendChatMessage can spend up to
+// 60s waiting out a still-streaming previous turn (chat_pane.actions.ts)
+// before the response poll runs to RESPONSE_TIMEOUT_MS.
+const ATTEMPT_BUDGET_MS = 60000 + RESPONSE_TIMEOUT_MS;
+
 test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@chat', '@serial'] }, () => {
   requireAiCredentials(test, 'positai');
 
@@ -110,10 +118,14 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@chat', '
     await chatActions.dismissSetupPrompts();
   });
 
-  // Dead-turn retries (see askAssistant) can stack a dropped attempt on top
-  // of a slow healthy turn, so give each test headroom past the 120s default.
+  // Dead-turn retries (see askAssistant) can pay the full attempt budget up
+  // to DEAD_TURN_ATTEMPTS times, and the test timeout must clear that worst
+  // case: exhausting it mid-attempt would turn the diagnostic dead-turn error
+  // into a bare "Test timeout exceeded". Derived so a change to either
+  // constant keeps the two in sync; the margin covers conversation setup and
+  // dialog handling around the polls.
   test.beforeEach(() => {
-    test.setTimeout(240000);
+    test.setTimeout(DEAD_TURN_ATTEMPTS * ATTEMPT_BUDGET_MS + 60000);
   });
 
   test.afterAll(async () => {
@@ -150,7 +162,7 @@ test.describe.serial('Filesystem Guardrails (#17122)', { tag: ['@ai', '@chat', '
         const count = await chatPane.getMessageCount();
         if (count <= initialCount) return false;
         return await chatActions.isTurnIdle();
-      }, 120000, answerQuestion);
+      }, RESPONSE_TIMEOUT_MS, answerQuestion);
 
       if (await chatPane.isLastMessageSubstantive()) {
         return await chatPane.messageItem.last().innerText();


### PR DESCRIPTION
## Background

On the macOS shard of [run 33419352693](https://github.com/rstudio/rstudio/actions/runs/33419352693/job/99581706430) (PR #18694, whose change is an unrelated C++ unit test), two `chat-guardrails.test.ts` cases failed with the same signature: the prompt was delivered, the assistant streamed a ~1s thinking block ("Thought for 1.1s -- I'm writing a simple text file..."), and then the turn ended. No tool call, no Allow dialog, no reply text, and no file was ever created, even 10+ seconds later. The trace also shows the chat WebSocket dropping and reconnecting around the same window, so this is the provider dropping the turn mid-stream, not a guardrail regression -- but the turn-completion wait sees a cleanly-idle composer and the file-state assertion then fails on work the assistant never did. Because the suite is `@serial`, one such drop also skips the remaining cases.

## Change

- `ChatPane.isLastMessageSubstantive()`: reports whether the conversation's last message is an assistant reply with content beyond a thinking disclosure (per databot's `ElementThinking` DOM: a wrapper holding an `aria-expanded` toggle labeled "Thought for Xs" / "Thinking" plus the collapsible region). A dead turn leaves either the user's own prompt as the last message or a thought-only assistant message. Unrecognized DOM fails toward "substantive" (no retry), i.e. today's behavior.
- `askAssistant()` in the guardrails suite re-sends the prompt in a fresh conversation when the turn ends without substantive content, up to 3 attempts, then fails loudly with the last message text. Retries can stack a dropped attempt on a slow healthy turn, so the suite gets 240s of per-test headroom.

The dead-turn detection deliberately does not look at the assertions themselves: a genuine guardrail failure still produces a substantive response (the relayed "blocked" error, or a written file), so retries cannot mask one.

## Verification

- `npm run typecheck` passes in `e2e/rstudio`.
- The `@ai` tests need Posit AI credentials and only run on PR CI; the macOS and Windows desktop e2e jobs on this PR exercise the suite.