### PR TITLE
harden data-viewer e2e tests against completion and fetch races

### DIFF
--- a/e2e/rstudio/actions/autocomplete.actions.ts
+++ b/e2e/rstudio/actions/autocomplete.actions.ts
@@ -16,6 +16,76 @@ const EXPLICIT_COMPLETION_TIMEOUT_MS = 10000;
 // a replacement request land -- see waitForCompletionPopup.
 const STALE_POPUP_SETTLE_MS = 500;
 
+/** Whether the popup becomes visible within `timeoutMs`. */
+async function popupAppears(page: Page, timeoutMs: number): Promise<boolean> {
+  return await page
+    .locator(COMPLETION_POPUP)
+    .waitFor({ state: 'visible', timeout: timeoutMs })
+    .then(() => true)
+    .catch(() => false);
+}
+
+/**
+ * Wait for the completion popup after typing, forcing a request with
+ * Ctrl+Space only if the implicit one never produces one.
+ *
+ * Typing already schedules a completion request -- RStudio issues one
+ * `code_completion_delay` ms (250 by default) after the
+ * `code_completion_characters`-th character, and immediately after a
+ * trigger like `$` or `(`. Pressing Ctrl+Space while that is in flight is
+ * destructive rather than helpful: `RCompletionManager.beginSuggest` starts
+ * by invalidating pending requests, so the in-flight response is discarded
+ * on arrival, and if the popup has just opened the keypress instead falls
+ * through the popup-showing branch to `invalidatePendingRequests()`, which
+ * hides it. Either way the completion session is stranded and no popup ever
+ * appears.
+ *
+ * Sampling visibility once shortly after typing raced exactly that window:
+ * on CI the request round trip pushed the popup past the sample, the
+ * fallback fired into the gap, and the test then waited out its timeout on a
+ * session it had just cancelled. So wait out the implicit request first, and
+ * force one only once nothing is in flight -- retrying once, since a slow
+ * enough response can still land in the same window.
+ *
+ * A popup that is *already* up on entry is a different case: typing keeps an
+ * open popup showing while it re-requests, because `beginSuggest` invalidates
+ * without hiding (`RCompletionManager.java:1163`, hidePopup false), so its
+ * contents can still be an earlier prefix's results with the final token's
+ * request in flight. Visibility proves nothing there, hence the settle.
+ *
+ * The caller reads the popup afterwards (getCompletionItems, or an expect on
+ * COMPLETION_POPUP), and that wait is the final deadline -- this returns
+ * after the second keypress rather than waiting on the same locator twice.
+ */
+export async function waitForCompletionPopup(page: Page): Promise<void> {
+  if (await page.locator(COMPLETION_POPUP).isVisible()) {
+    await sleep(STALE_POPUP_SETTLE_MS);
+    return;
+  }
+
+  if (await popupAppears(page, IMPLICIT_COMPLETION_TIMEOUT_MS))
+    return;
+
+  await page.keyboard.press('Control+Space');
+  if (await popupAppears(page, EXPLICIT_COMPLETION_TIMEOUT_MS))
+    return;
+
+  await page.keyboard.press('Control+Space');
+}
+
+/**
+ * Toggle the automation-only "always show popup" completion override, so a
+ * unique match is listed in the popup instead of being auto-accepted. The
+ * popup-reading helpers wrap their request in this to stay deterministic
+ * regardless of how many results the token happens to have. No-op on
+ * builds that predate the knob (those keep the auto-accept behavior).
+ */
+export async function setAlwaysShowCompletionPopup(page: Page, force: boolean): Promise<void> {
+  await page.evaluate((f) => {
+    window.rstudio?.completions?.setAlwaysShowPopup(f);
+  }, force);
+}
+
 export class AutocompleteActions {
   readonly page: Page;
   readonly consoleActions: ConsolePaneActions;
@@ -58,74 +128,14 @@ export class AutocompleteActions {
     await sleep(300);
   }
 
-  /** Whether the popup becomes visible within `timeoutMs`. */
-  private async popupAppears(timeoutMs: number): Promise<boolean> {
-    return await this.page
-      .locator(COMPLETION_POPUP)
-      .waitFor({ state: 'visible', timeout: timeoutMs })
-      .then(() => true)
-      .catch(() => false);
-  }
-
-  /**
-   * Wait for the completion popup after typing, forcing a request with
-   * Ctrl+Space only if the implicit one never produces one.
-   *
-   * Typing already schedules a completion request -- RStudio issues one
-   * `code_completion_delay` ms (250 by default) after the
-   * `code_completion_characters`-th character, and immediately after a
-   * trigger like `$` or `(`. Pressing Ctrl+Space while that is in flight is
-   * destructive rather than helpful: `RCompletionManager.beginSuggest` starts
-   * by invalidating pending requests, so the in-flight response is discarded
-   * on arrival, and if the popup has just opened the keypress instead falls
-   * through the popup-showing branch to `invalidatePendingRequests()`, which
-   * hides it. Either way the completion session is stranded and no popup ever
-   * appears.
-   *
-   * Sampling visibility once shortly after typing raced exactly that window:
-   * on CI the request round trip pushed the popup past the sample, the
-   * fallback fired into the gap, and the test then waited out its timeout on a
-   * session it had just cancelled. So wait out the implicit request first, and
-   * force one only once nothing is in flight -- retrying once, since a slow
-   * enough response can still land in the same window.
-   *
-   * A popup that is *already* up on entry is a different case: typing keeps an
-   * open popup showing while it re-requests, because `beginSuggest` invalidates
-   * without hiding (`RCompletionManager.java:1163`, hidePopup false), so its
-   * contents can still be an earlier prefix's results with the final token's
-   * request in flight. Visibility proves nothing there, hence the settle.
-   *
-   * The caller reads the popup via `getCompletionItems`, whose own visibility
-   * wait is the final deadline -- this returns after the second keypress
-   * rather than waiting on the same locator twice.
-   */
+  /** See the module-level waitForCompletionPopup. */
   private async waitForCompletionPopup(): Promise<void> {
-    if (await this.page.locator(COMPLETION_POPUP).isVisible()) {
-      await sleep(STALE_POPUP_SETTLE_MS);
-      return;
-    }
-
-    if (await this.popupAppears(IMPLICIT_COMPLETION_TIMEOUT_MS))
-      return;
-
-    await this.page.keyboard.press('Control+Space');
-    if (await this.popupAppears(EXPLICIT_COMPLETION_TIMEOUT_MS))
-      return;
-
-    await this.page.keyboard.press('Control+Space');
+    await waitForCompletionPopup(this.page);
   }
 
-  /**
-   * Toggle the automation-only "always show popup" completion override, so a
-   * unique match is listed in the popup instead of being auto-accepted. The
-   * popup-reading helpers wrap their request in this to stay deterministic
-   * regardless of how many results the token happens to have. No-op on
-   * builds that predate the knob (those keep the auto-accept behavior).
-   */
+  /** See the module-level setAlwaysShowCompletionPopup. */
   private async setAlwaysShowPopup(force: boolean): Promise<void> {
-    await this.page.evaluate((f) => {
-      window.rstudio?.completions?.setAlwaysShowPopup(f);
-    }, force);
+    await setAlwaysShowCompletionPopup(this.page, force);
   }
 
   /**

--- a/e2e/rstudio/tests/panes/data-viewer/help_popup_data_preview.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/help_popup_data_preview.test.ts
@@ -19,28 +19,24 @@
 // the fix -- pre-fix this host defaulted show_summary to true and the sidebar
 // was expanded.
 
-import type { Page } from 'playwright';
 import { test, expect } from '@fixtures/rstudio.fixture';
 import { ConsolePaneActions } from '@actions/console_pane.actions';
-import { COMPLETION_POPUP } from '@actions/autocomplete.actions';
+import {
+  COMPLETION_POPUP,
+  setAlwaysShowCompletionPopup,
+  waitForCompletionPopup,
+} from '@actions/autocomplete.actions';
 import { TIMEOUTS } from '@utils/constants';
 
-// No data viewer is open in this test, so the gridviewer iframe matched here
-// is unambiguously the help-popup preview.
-const GRID_FRAME = 'iframe[src*="grid_resource/gridviewer.html"]';
 const LIST_NAME = 'list_17735_preview';
 
-// Automation-only override: force the completion popup to render even when a
-// request returns a single result. The list under test has one member (`df`),
-// so completing `<list>$` yields exactly one completion; RCompletionManager
-// auto-accepts a lone result without ever showing the popup, which the
-// Ctrl+Space fallback below would otherwise trigger. Mirrors the convention in
-// autocomplete.actions.ts; no-op on builds that predate the knob.
-async function setAlwaysShowCompletionPopup(page: Page, force: boolean): Promise<void> {
-  await page.evaluate((f) => {
-    window.rstudio?.completions?.setAlwaysShowPopup(f);
-  }, force);
-}
+// The help-popup preview iframe, matched by the object it previews. A bare
+// gridviewer.html match is NOT unique: any grid-viewer host that ran earlier
+// in the session leaves its iframe in the DOM -- e.g. the SQL Results pane's
+// "Data Output Pane" frame (GridViewerFrame, data_source=data) persists after
+// the connections tests -- and a bare match then trips Playwright strict mode
+// or resolves the hidden pane's elements.
+const GRID_FRAME = `iframe[src*="gridviewer.html"][src*="obj=${LIST_NAME}"]`;
 
 test.describe('Help popup data preview - #17735', () => {
   let consoleActions: ConsolePaneActions;
@@ -63,17 +59,21 @@ test.describe('Help popup data preview - #17735', () => {
     // to the DATAFRAME help path (getHelpDataFrame) that embeds the preview.
     await consoleActions.executeInConsole(`${LIST_NAME} <- list(df = head(mtcars))`, { wait: true });
 
-    // Force the popup so the lone `df` completion is listed instead of being
-    // auto-accepted by the Ctrl+Space fallback below (see the helper comment).
-    // Set before typing so the `$` auto-trigger is covered too.
+    // Force the popup: the list has one member (`df`), and an explicit
+    // completion request with a lone result is auto-accepted without ever
+    // showing the popup. Set before typing so the `$` auto-trigger is
+    // covered too.
     await setAlwaysShowCompletionPopup(page, true);
     try {
       // Type up to the `$` and trigger member completion. The selected member's
       // help (the data preview) renders alongside the completion popup.
+      // waitForCompletionPopup waits out the request the `$` itself schedules
+      // before falling back to Ctrl+Space -- a one-shot visibility sample plus
+      // an immediate Ctrl+Space raced that in-flight request, which
+      // beginSuggest then invalidated, stranding the session with no popup
+      // (the CI flake on PRs #18680/#18693).
       await consoleActions.typeInConsole(`${LIST_NAME}$`);
-      if (!(await page.locator(COMPLETION_POPUP).isVisible())) {
-        await page.keyboard.press('Control+Space');
-      }
+      await waitForCompletionPopup(page);
       await expect(page.locator(COMPLETION_POPUP)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
 
       // The preview iframe is the shared grid viewer in server mode (env/obj).

--- a/e2e/rstudio/tests/panes/data-viewer/pagination-sorting.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/pagination-sorting.test.ts
@@ -46,8 +46,10 @@ test.describe('Data Viewer', () => {
 
     // The go-to-column jump box appears for frames wider than one fetch
     // window (the pagination arrows are gone -- the grid scrolls
-    // continuously through every column).
-    await expect(dataViewer.gotoColumnInput).toBeVisible();
+    // continuously through every column). The box stays hidden until the
+    // initial fetch reports the frame width, which on a cold CI session with
+    // this 100,000x500 frame can outlast the 5s default timeout.
+    await expect(dataViewer.gotoColumnInput).toBeVisible({ timeout: 15000 });
 
     // The summary sidebar lists every column of the frame (lazy-loading their
     // stats), so its header reports the frame total -- not the loaded window.
@@ -189,13 +191,21 @@ test.describe('Data Viewer', () => {
       });
     };
 
+    // A freshly slid window renders its cells empty until the block fetch
+    // returns, so the poll must gate on the cell text being populated as well
+    // as the resolved index -- polling the index alone raced the fetch (abs
+    // settled while the cell still read ""). The sample that satisfies the
+    // poll is the one asserted on, so the index/text pair is a single
+    // consistent DOM read.
+    let sample = { abs: 0, text: '' };
     await expect
-      .poll(async () => (await leftmostAbs()).abs, { timeout: 15000 })
-      .toBeGreaterThan(4000);
+      .poll(async () => {
+        sample = await leftmostAbs();
+        return sample.abs > 4000 && sample.text !== '';
+      }, { timeout: 15000 })
+      .toBe(true);
 
-    const { abs, text } = await leftmostAbs();
-    expect(abs).toBeGreaterThan(4000);
-    expect(text).toBe(String((abs - 1) * 10 + 1));
+    expect(sample.text).toBe(String((sample.abs - 1) * 10 + 1));
   });
 
   test('an off-screen row block survives a column-window round trip', async () => {


### PR DESCRIPTION
Hardens the three data-viewer e2e tests that flaked on the PR #18693 run (33425680418), with `help_popup_data_preview` also seen failing the same way on the #18680 run. Trace analysis of the failed runs identified three distinct mechanisms:

### help_popup_data_preview (#17735)

**Stranded completion session (Windows both attempts, macOS retry).** The test typed `<list>$`, sampled popup visibility once, and immediately pressed Ctrl+Space when the sample read hidden. On CI the request scheduled by the `$` itself was still in flight (in the #18693 run it had additionally been converted to an async RPC because R was briefly busy); `RCompletionManager.beginSuggest` starts by invalidating pending requests, so the arriving response -- which the trace shows carried the correct lone `df` result -- was discarded, no replacement request was issued, and the popup never appeared. `autocomplete.actions.ts` already has a guarded `waitForCompletionPopup` that waits out the implicit request before forcing one (with one retry); it is now exported standalone and the test uses it instead of the hand-rolled trigger.

**Ambient gridviewer iframe (macOS first attempt).** The test assumed a bare `iframe[src*="gridviewer.html"]` match was unambiguous because it opens no data viewer -- but the SQL Results pane's "Data Output Pane" frame (`GridViewerFrame`, `data_source=data`) stays in the DOM permanently once the connections tests have run earlier in the same session, tripping Playwright strict mode. The selector is now scoped to `obj=list_17735_preview`, which `SessionHelp.R` always includes in the preview URI.

### pagination-sorting

- **"go to column jumps anywhere in the frame"**: the jump box stays hidden until the initial fetch reports the frame width; on a cold CI session with the 100,000x500 frame that outlasted the 5s default timeout. It now gets the 15s timeout used throughout the file.
- **"very wide frame - scroll-driven slides"**: the post-slide poll gated only on the leftmost column's resolved index, but a freshly slid window renders its cells empty until the block fetch returns, so the follow-up text assertion could read `""`. The poll now also requires the cell text to be populated, and asserts on the same atomic DOM sample that satisfied the poll.

Verified locally in desktop-dev mode: both changed test files pass (12/12), and the autocomplete suites covering the refactored `AutocompleteActions` pass (33 passed, 3 skipped).

https://claude.ai/code/session_01YTtLgnQMaWdu3xNPk5PimA