### PR TITLE
add show/hide columns to the data viewer summary panel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 ## RStudio 2026.10.0 "Blue Mistflower" Release Notes
 
 ### New
--
+- ([#17787](https://github.com/rstudio/rstudio/issues/17787)): Columns in the data viewer can now be hidden and shown from the summary panel, individually or all at once.
 
 ### Fixed
 -

--- a/e2e/rstudio/tests/panes/data-viewer/column-visibility.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/column-visibility.test.ts
@@ -84,10 +84,23 @@ test.describe('Data Viewer column visibility', () => {
     // pane never reaches zero tabs (#17738).
     await resetSourcePaneState(page);
     await expect(sourcePane.selectedTab).toContainText('Untitled', { timeout: 5000 });
+    // Drop the per-test frame copies (viewMtcarsCopy) so they don't pile up.
+    await consoleActions.executeInConsole(
+      'rm(list = ls(envir = .GlobalEnv, all.names = TRUE, pattern = "^[.]rs[.]colvis_"), envir = .GlobalEnv)',
+    );
   });
 
+  // View() a copy of mtcars named after the current test. Viewer state (pins,
+  // sorts, hidden columns) is persisted in localStorage per object name, so a
+  // unique object per test keeps one test's state from reaching another
+  // regardless of how the previous viewer tab was torn down.
+  async function viewMtcarsCopy(): Promise<void> {
+    const name = '.rs.colvis_' + test.info().title.replace(/[^A-Za-z0-9]+/g, '_');
+    await consoleActions.executeInConsole(`{ ${name} <- mtcars; View(${name}) }`);
+  }
+
   test('sidebar eye icon hides a column from the grid and shows it again', async () => {
-    await consoleActions.executeInConsole('View(mtcars)');
+    await viewMtcarsCopy();
     await waitForViewer(dataViewer);
     expect((await colOrder(dataViewer)).slice(0, 5)).toEqual(['0', '1', '2', '3', '4']);
 
@@ -125,7 +138,7 @@ test.describe('Data Viewer column visibility', () => {
   });
 
   test('header eye hides every column and the in-grid hint shows them all', async () => {
-    await consoleActions.executeInConsole('View(mtcars)');
+    await viewMtcarsCopy();
     await waitForViewer(dataViewer);
 
     const headerEye = dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-eye');
@@ -170,7 +183,7 @@ test.describe('Data Viewer column visibility', () => {
   });
 
   test('a hidden column keeps its sort, and clicking its entry shows it again', async () => {
-    await consoleActions.executeInConsole('View(mtcars)');
+    await viewMtcarsCopy();
     await waitForViewer(dataViewer);
 
     // Sort mpg (1) descending from the sidebar: Toyota Corolla (33.9 mpg,
@@ -241,7 +254,7 @@ test.describe('Data Viewer column visibility', () => {
   });
 
   test('a pinned column can be hidden and returns to the pinned pane', async () => {
-    await consoleActions.executeInConsole('View(mtcars)');
+    await viewMtcarsCopy();
     await waitForViewer(dataViewer);
 
     const entry3 = dataViewer.frame.locator('.sidebar-col[data-col-idx="3"]');
@@ -261,7 +274,7 @@ test.describe('Data Viewer column visibility', () => {
   });
 
   test('H hides the column under the keyboard cursor and moves the cursor on', async ({ rstudioPage: page }) => {
-    await consoleActions.executeInConsole('View(mtcars)');
+    await viewMtcarsCopy();
     await waitForViewer(dataViewer);
 
     // Clicking a header makes it the active header and focuses the grid.

--- a/e2e/rstudio/tests/panes/data-viewer/column-visibility.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/column-visibility.test.ts
@@ -84,23 +84,26 @@ test.describe('Data Viewer column visibility', () => {
     // pane never reaches zero tabs (#17738).
     await resetSourcePaneState(page);
     await expect(sourcePane.selectedTab).toContainText('Untitled', { timeout: 5000 });
-    // Drop the per-test frame copies (viewMtcarsCopy) so they don't pile up.
+    // Drop the per-test frames (viewAs) so they don't pile up.
     await consoleActions.executeInConsole(
       'rm(list = ls(envir = .GlobalEnv, all.names = TRUE, pattern = "^[.]rs[.]colvis_"), envir = .GlobalEnv)',
     );
   });
 
-  // View() a copy of mtcars named after the current test. Viewer state (pins,
-  // sorts, hidden columns) is persisted in localStorage per object name, so a
-  // unique object per test keeps one test's state from reaching another
-  // regardless of how the previous viewer tab was torn down.
-  async function viewMtcarsCopy(): Promise<void> {
-    const name = '.rs.colvis_' + test.info().title.replace(/[^A-Za-z0-9]+/g, '_');
-    await consoleActions.executeInConsole(`{ ${name} <- mtcars; View(${name}) }`);
+  // Assigns the R expression `expr` to an object named after the current test
+  // (and retry attempt) and View()s it, returning the name. Viewer state --
+  // pins, sorts, filters, hidden columns -- is persisted in localStorage per
+  // object name, so a name unique to this attempt keeps one test's state from
+  // reaching another regardless of how the previous viewer tab was torn down.
+  async function viewAs(expr: string): Promise<string> {
+    const info = test.info();
+    const name = '.rs.colvis_' + info.title.replace(/[^A-Za-z0-9]+/g, '_') + '_r' + info.retry;
+    await consoleActions.executeInConsole(`{ ${name} <- ${expr}; View(${name}) }`);
+    return name;
   }
 
   test('sidebar eye icon hides a column from the grid and shows it again', async () => {
-    await viewMtcarsCopy();
+    await viewAs('mtcars');
     await waitForViewer(dataViewer);
     expect((await colOrder(dataViewer)).slice(0, 5)).toEqual(['0', '1', '2', '3', '4']);
 
@@ -138,7 +141,7 @@ test.describe('Data Viewer column visibility', () => {
   });
 
   test('header eye hides every column and the in-grid hint shows them all', async () => {
-    await viewMtcarsCopy();
+    await viewAs('mtcars');
     await waitForViewer(dataViewer);
 
     const headerEye = dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-eye');
@@ -183,7 +186,7 @@ test.describe('Data Viewer column visibility', () => {
   });
 
   test('a hidden column keeps its sort, and clicking its entry shows it again', async () => {
-    await viewMtcarsCopy();
+    await viewAs('mtcars');
     await waitForViewer(dataViewer);
 
     // Sort mpg (1) descending from the sidebar: Toyota Corolla (33.9 mpg,
@@ -217,40 +220,34 @@ test.describe('Data Viewer column visibility', () => {
   // slide), so the "Sorted by" status must name it from full-frame metadata
   // rather than from the fetched columns -- and its clear button must stay.
   test('a hidden sort column keeps its status and clear button across a refresh', async ({ rstudioPage: page }) => {
-    await consoleActions.executeInConsole(
-      '{ .rs.colvis_sort_df <- mtcars; View(.rs.colvis_sort_df) }',
-    );
-    try {
-      await waitForViewer(dataViewer);
-      const sortIcon1 = dataViewer.frame.locator('.sidebar-col[data-col-idx="1"] .sidebar-sort-icon');
-      await sortIcon1.click();
-      await sortIcon1.click();
-      await expect(sortIcon1).toHaveClass(/sorting_desc/);
-      const row0 = dataViewer.frame.locator('#gridBody tr[data-row="0"]');
-      await expect(row0.locator('td[data-col-pos="1"]')).toHaveText('33.9');
+    await viewAs('mtcars');
+    await waitForViewer(dataViewer);
+    const sortIcon1 = dataViewer.frame.locator('.sidebar-col[data-col-idx="1"] .sidebar-sort-icon');
+    await sortIcon1.click();
+    await sortIcon1.click();
+    await expect(sortIcon1).toHaveClass(/sorting_desc/);
+    const row0 = dataViewer.frame.locator('#gridBody tr[data-row="0"]');
+    await expect(row0.locator('td[data-col-pos="1"]')).toHaveText('33.9');
 
-      await dataViewer.frame.locator('.sidebar-col[data-col-idx="1"] .sidebar-eye-icon').click();
-      await expect(dataViewer.columnHeader(1)).toHaveCount(0);
+    await dataViewer.frame.locator('.sidebar-col[data-col-idx="1"] .sidebar-eye-icon').click();
+    await expect(dataViewer.columnHeader(1)).toHaveCount(0);
 
-      // After the refresh mpg is no longer fetched at all, yet the rows are
-      // still in mpg order (Toyota Corolla's 4 cylinders lead) and the status
-      // bar still says so.
-      await callViewerHook(page, 'refreshData');
-      await expect(dataViewer.columnHeader(2)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
-      await expect(dataViewer.columnHeader(1)).toHaveCount(0);
-      await expect(row0.locator('td[data-col-pos="1"]')).toHaveText('4', { timeout: TIMEOUTS.fileOpen });
-      await expect(dataViewer.sortStatus).toContainText('mpg');
-      await expect(dataViewer.clearSortButton).toBeVisible();
+    // After the refresh mpg is no longer fetched at all, yet the rows are
+    // still in mpg order (Toyota Corolla's 4 cylinders lead) and the status
+    // bar still says so.
+    await callViewerHook(page, 'refreshData');
+    await expect(dataViewer.columnHeader(2)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+    await expect(dataViewer.columnHeader(1)).toHaveCount(0);
+    await expect(row0.locator('td[data-col-pos="1"]')).toHaveText('4', { timeout: TIMEOUTS.fileOpen });
+    await expect(dataViewer.sortStatus).toContainText('mpg');
+    await expect(dataViewer.clearSortButton).toBeVisible();
 
-      // Clearing the sort from the status bar restores frame order (Mazda RX4,
-      // 6 cylinders, leads) with the column still hidden.
-      await dataViewer.clearSortButton.click();
-      await expect(row0.locator('td[data-col-pos="1"]')).toHaveText('6', { timeout: TIMEOUTS.fileOpen });
-      await expect(dataViewer.sortStatus).toBeHidden();
-      await expect(dataViewer.columnHeader(1)).toHaveCount(0);
-    } finally {
-      await consoleActions.executeInConsole('rm(".rs.colvis_sort_df", envir = .GlobalEnv)');
-    }
+    // Clearing the sort from the status bar restores frame order (Mazda RX4,
+    // 6 cylinders, leads) with the column still hidden.
+    await dataViewer.clearSortButton.click();
+    await expect(row0.locator('td[data-col-pos="1"]')).toHaveText('6', { timeout: TIMEOUTS.fileOpen });
+    await expect(dataViewer.sortStatus).toBeHidden();
+    await expect(dataViewer.columnHeader(1)).toHaveCount(0);
   });
 
   // An open filter editor holds the header rebuild back (autoSizeColumns
@@ -258,9 +255,7 @@ test.describe('Data Viewer column visibility', () => {
   // editor first, otherwise the rows would be rebuilt against a column order
   // the headers don't show yet.
   test('hiding a column while a filter editor is open closes it and keeps headers and rows in step', async ({ rstudioPage: page }) => {
-    await consoleActions.executeInConsole(
-      '{ .rs.colvis_filter_df <- data.frame(x = 1:20, y = 21:40, z = 41:60); View(.rs.colvis_filter_df) }',
-    );
+    await viewAs('data.frame(x = 1:20, y = 21:40, z = 41:60)');
     await expect(dataViewer.columnHeader(1)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
     // The info bar renders once the first row batch lands, which is also when
     // the post-load auto-size rebuilds the headers; touching the filter row
@@ -296,9 +291,7 @@ test.describe('Data Viewer column visibility', () => {
   // Go to column, which does not move focus, showing a hidden column is such
   // a rebuild.
   test('typed filter text is committed when a show rebuild closes the box', async ({ rstudioPage: page }) => {
-    await consoleActions.executeInConsole(
-      '{ .rs.colvis_text_df <- data.frame(s = c("ab", "cd", "ef"), y = 1:3, z = 4:6); View(.rs.colvis_text_df) }',
-    );
+    await viewAs('data.frame(s = c("ab", "cd", "ef"), y = 1:3, z = 4:6)');
     await expect(dataViewer.columnHeader(1)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
     await expect(dataViewer.gridInfo).toContainText('of 3', { timeout: TIMEOUTS.fileOpen });
 
@@ -331,7 +324,7 @@ test.describe('Data Viewer column visibility', () => {
   });
 
   test('a pinned column can be hidden and returns to the pinned pane', async () => {
-    await viewMtcarsCopy();
+    await viewAs('mtcars');
     await waitForViewer(dataViewer);
 
     const entry3 = dataViewer.frame.locator('.sidebar-col[data-col-idx="3"]');
@@ -351,7 +344,7 @@ test.describe('Data Viewer column visibility', () => {
   });
 
   test('H hides the column under the keyboard cursor and moves the cursor on', async ({ rstudioPage: page }) => {
-    await viewMtcarsCopy();
+    await viewAs('mtcars');
     await waitForViewer(dataViewer);
 
     // Clicking a header makes it the active header and focuses the grid.
@@ -371,6 +364,39 @@ test.describe('Data Viewer column visibility', () => {
     await expect(dataViewer.columnHeader(2)).toBeVisible();
   });
 
+  // The cursor's successor after a keyboard hide is the next visible column,
+  // which is not fetched yet when the hidden column sat at the right edge of
+  // the fetched window. The hide slides the window; the cursor must land on
+  // that successor once it arrives, not on the left neighbour that happened
+  // to be fetched.
+  test('H on the last fetched header moves the cursor to the next column after the slide', async ({ rstudioPage: page }) => {
+    await viewAs('as.data.frame(matrix(1:3000, nrow = 10, ncol = 300))');
+    await waitForViewer(dataViewer);
+    await expect(dataViewer.gridInfo).toContainText('of 10', { timeout: TIMEOUTS.fileOpen });
+
+    // Shrink the fetched window to columns 1..5 through the automation hook
+    // (the only way to place the window's edge deterministically).
+    await dataViewer.viewport.evaluate((el) => {
+      const w = el.ownerDocument.defaultView as unknown as {
+        setOffsetAndMaxColumns: (offset: number, max: number) => void;
+      };
+      w.setOffsetAndMaxColumns(0, 5);
+    });
+    await expect(dataViewer.columnHeader(5)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+    await expect(dataViewer.columnHeader(6)).toHaveCount(0);
+
+    await dataViewer.columnHeader(5).click();
+    await expect(dataViewer.columnHeader(5)).toHaveClass(/activeHeader/);
+    await page.keyboard.press('h');
+
+    // V5 is hidden, V6 is fetched to keep the window five visible columns
+    // wide, and the cursor is on it.
+    await expect(dataViewer.columnHeader(5)).toHaveCount(0);
+    await expect(dataViewer.columnHeader(6)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+    await expect(dataViewer.columnHeader(6)).toHaveClass(/activeHeader/);
+    await expect(dataViewer.frame.locator('th.activeHeader')).toHaveCount(1);
+  });
+
   // The fetched column window is measured in visible columns, so hiding
   // almost everything on a frame wider than the window must still fetch and
   // lay out the few columns that remain -- with no blank span standing in for
@@ -378,72 +404,66 @@ test.describe('Data Viewer column visibility', () => {
   test('wide frame: the window follows the visible columns', async () => {
     // 300 columns: wider than the fetched window. matrix(1:3000) is
     // column-major with 10 rows, so column k's first row holds (k-1)*10 + 1.
-    await consoleActions.executeInConsole(
-      '{ .rs.colvis_wide_df <- as.data.frame(matrix(1:3000, nrow = 10, ncol = 300)); View(.rs.colvis_wide_df) }',
-    );
-    try {
-      await waitForViewer(dataViewer);
-      await expect(dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-label'))
-        .toHaveText('300 columns', { timeout: TIMEOUTS.fileOpen });
+    await viewAs('as.data.frame(matrix(1:3000, nrow = 10, ncol = 300))');
+    await waitForViewer(dataViewer);
+    await expect(dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-label'))
+      .toHaveText('300 columns', { timeout: TIMEOUTS.fileOpen });
 
-      // Hide column 5, then jump to it with Go to column: the jump shows it.
-      const entry5 = dataViewer.frame.locator('.sidebar-col[data-col-idx="5"]');
-      await entry5.locator('.sidebar-eye-icon').click();
-      await expect(dataViewer.columnHeader(5)).toHaveCount(0);
-      await expect(entry5).toHaveClass(/\bcol-hidden\b/);
-      await dataViewer.goToColumn(5);
-      await expect(dataViewer.columnHeader(5)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
-      await expect(entry5).not.toHaveClass(/\bcol-hidden\b/);
+    // Hide column 5, then jump to it with Go to column: the jump shows it.
+    const entry5 = dataViewer.frame.locator('.sidebar-col[data-col-idx="5"]');
+    await entry5.locator('.sidebar-eye-icon').click();
+    await expect(dataViewer.columnHeader(5)).toHaveCount(0);
+    await expect(entry5).toHaveClass(/\bcol-hidden\b/);
+    await dataViewer.goToColumn(5);
+    await expect(dataViewer.columnHeader(5)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+    await expect(entry5).not.toHaveClass(/\bcol-hidden\b/);
 
-      // Hide everything, then show columns 1, 260 and 300 from their entries
-      // (scrolling the virtualized list to build the far ones).
-      const headerEye = dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-eye');
-      await headerEye.click();
-      await expect(dataViewer.frame.locator('#data_cols th')).toHaveCount(0);
-      await expect(dataViewer.frame.locator('#allColumnsHiddenHint')).toBeVisible();
-      await expect(dataViewer.gridInfo).toContainText('(300 hidden)');
+    // Hide everything, then show columns 1, 260 and 300 from their entries
+    // (scrolling the virtualized list to build the far ones).
+    const headerEye = dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-eye');
+    await headerEye.click();
+    await expect(dataViewer.frame.locator('#data_cols th')).toHaveCount(0);
+    await expect(dataViewer.frame.locator('#allColumnsHiddenHint')).toBeVisible();
+    await expect(dataViewer.gridInfo).toContainText('(300 hidden)');
 
-      for (const abs of [1, 260, 300]) {
-        await scrollSidebarToCol(dataViewer, abs);
-        const entry = dataViewer.frame.locator(`.sidebar-col[data-col-idx="${abs}"]`);
-        await expect(entry).toHaveCount(1, { timeout: TIMEOUTS.fileOpen });
-        await entry.locator('.sidebar-eye-icon').click();
-        await expect(entry).not.toHaveClass(/\bcol-hidden\b/);
-      }
-
-      // All three are fetched and rendered, in frame order, with real data --
-      // and nothing else: no spacer cell stands in for an unfetched column.
-      for (const abs of [1, 260, 300]) {
-        await expect(dataViewer.columnHeader(abs)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
-      }
-      await expect(dataViewer.frame.locator('#data_cols th[data-col-idx]')).toHaveCount(3);
-      await expect(dataViewer.frame.locator('#data_cols th.col-spacer')).toHaveCount(0);
-      const row0 = dataViewer.frame.locator('#gridBody tr[data-row="0"]');
-      await expect(row0.locator('td[data-col-pos="1"]')).toHaveText('1', { timeout: TIMEOUTS.fileOpen });
-      await expect(row0.locator('td[data-col-pos="2"]')).toHaveText('2591');
-      await expect(row0.locator('td[data-col-pos="3"]')).toHaveText('2991');
-      await expect(dataViewer.gridInfo).toContainText('300 total columns (297 hidden)');
-      await expect(dataViewer.frame.locator('#allColumnsHiddenHint')).toBeHidden();
-
-      // The three visible columns fit the viewport, yet the toolbar's Go to
-      // column box must stay available while anything is hidden: it is a way
-      // back to a hidden column. Jumping to column 150 shows it in place.
-      await dataViewer.goToColumn(150);
-      await expect(dataViewer.columnHeader(150)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
-      await expect(dataViewer.frame.locator('#data_cols th[data-col-idx]')).toHaveCount(4);
-      await expect(row0.locator('td[data-col-pos="2"]')).toHaveText('1491', { timeout: TIMEOUTS.fileOpen });
-      await expect(row0.locator('td[data-col-pos="3"]')).toHaveText('2591');
-      await expect(dataViewer.gridInfo).toContainText('(296 hidden)');
-
-      // Show all: the frame is wide again and column 1 leads.
-      await headerEye.click();
-      await expect(dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-label'))
-        .toHaveText('300 columns', { timeout: TIMEOUTS.fileOpen });
-      await expect(dataViewer.columnHeader(1)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
-      await expect(dataViewer.gridInfo).not.toContainText('hidden');
-    } finally {
-      await consoleActions.executeInConsole('rm(".rs.colvis_wide_df", envir = .GlobalEnv)');
+    for (const abs of [1, 260, 300]) {
+      await scrollSidebarToCol(dataViewer, abs);
+      const entry = dataViewer.frame.locator(`.sidebar-col[data-col-idx="${abs}"]`);
+      await expect(entry).toHaveCount(1, { timeout: TIMEOUTS.fileOpen });
+      await entry.locator('.sidebar-eye-icon').click();
+      await expect(entry).not.toHaveClass(/\bcol-hidden\b/);
     }
+
+    // All three are fetched and rendered, in frame order, with real data --
+    // and nothing else: no spacer cell stands in for an unfetched column.
+    for (const abs of [1, 260, 300]) {
+      await expect(dataViewer.columnHeader(abs)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+    }
+    await expect(dataViewer.frame.locator('#data_cols th[data-col-idx]')).toHaveCount(3);
+    await expect(dataViewer.frame.locator('#data_cols th.col-spacer')).toHaveCount(0);
+    const row0 = dataViewer.frame.locator('#gridBody tr[data-row="0"]');
+    await expect(row0.locator('td[data-col-pos="1"]')).toHaveText('1', { timeout: TIMEOUTS.fileOpen });
+    await expect(row0.locator('td[data-col-pos="2"]')).toHaveText('2591');
+    await expect(row0.locator('td[data-col-pos="3"]')).toHaveText('2991');
+    await expect(dataViewer.gridInfo).toContainText('300 total columns (297 hidden)');
+    await expect(dataViewer.frame.locator('#allColumnsHiddenHint')).toBeHidden();
+
+    // The three visible columns fit the viewport, yet the toolbar's Go to
+    // column box must stay available while anything is hidden: it is a way
+    // back to a hidden column. Jumping to column 150 shows it in place.
+    await dataViewer.goToColumn(150);
+    await expect(dataViewer.columnHeader(150)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+    await expect(dataViewer.frame.locator('#data_cols th[data-col-idx]')).toHaveCount(4);
+    await expect(row0.locator('td[data-col-pos="2"]')).toHaveText('1491', { timeout: TIMEOUTS.fileOpen });
+    await expect(row0.locator('td[data-col-pos="3"]')).toHaveText('2591');
+    await expect(dataViewer.gridInfo).toContainText('(296 hidden)');
+
+    // Show all: the frame is wide again and column 1 leads.
+    await headerEye.click();
+    await expect(dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-label'))
+      .toHaveText('300 columns', { timeout: TIMEOUTS.fileOpen });
+    await expect(dataViewer.columnHeader(1)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+    await expect(dataViewer.gridInfo).not.toContainText('hidden');
   });
 
   // The toolbar's Go to column box normally appears only when the columns
@@ -451,92 +471,73 @@ test.describe('Data Viewer column visibility', () => {
   // it must also appear while anything is hidden -- including after hide-all
   // on a frame that never overflowed.
   test('Go to column stays available while columns are hidden on a narrow frame', async () => {
-    await consoleActions.executeInConsole(
-      '{ .rs.colvis_narrow_df <- data.frame(a = 1:3, b = 4:6, c = 7:9); View(.rs.colvis_narrow_df) }',
-    );
-    try {
-      await waitForViewer(dataViewer);
-      await expect(dataViewer.columnHeader(3)).toBeVisible();
-      await expect(dataViewer.gotoColumnInput).toBeHidden();
+    await viewAs('data.frame(a = 1:3, b = 4:6, c = 7:9)');
+    await waitForViewer(dataViewer);
+    await expect(dataViewer.columnHeader(3)).toBeVisible();
+    await expect(dataViewer.gotoColumnInput).toBeHidden();
 
-      await dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-eye').click();
-      await expect(dataViewer.frame.locator('#data_cols th')).toHaveCount(0);
-      await expect(dataViewer.gotoColumnInput).toBeVisible();
+    await dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-eye').click();
+    await expect(dataViewer.frame.locator('#data_cols th')).toHaveCount(0);
+    await expect(dataViewer.gotoColumnInput).toBeVisible();
 
-      // Jumping to a hidden column through the box shows just that column.
-      await dataViewer.goToColumn('b');
-      await expect(dataViewer.columnHeader(2)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
-      await expect(dataViewer.columnHeader(1)).toHaveCount(0);
-      await expect(dataViewer.gridInfo).toContainText('(2 hidden)');
+    // Jumping to a hidden column through the box shows just that column.
+    await dataViewer.goToColumn('b');
+    await expect(dataViewer.columnHeader(2)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+    await expect(dataViewer.columnHeader(1)).toHaveCount(0);
+    await expect(dataViewer.gridInfo).toContainText('(2 hidden)');
 
-      // Once nothing is hidden the box goes away again, since the frame fits.
-      await dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-eye').click();
-      await expect(dataViewer.gridInfo).not.toContainText('hidden');
-      await expect(dataViewer.gotoColumnInput).toBeHidden();
-    } finally {
-      await consoleActions.executeInConsole('rm(".rs.colvis_narrow_df", envir = .GlobalEnv)');
-    }
+    // Once nothing is hidden the box goes away again, since the frame fits.
+    await dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-eye').click();
+    await expect(dataViewer.gridInfo).not.toContainText('hidden');
+    await expect(dataViewer.gotoColumnInput).toBeHidden();
   });
 
   // Hidden columns are saved with the frame's column fingerprint (like pins),
   // so a structural change invalidates them -- and the refresh that follows
   // must fetch the whole new frame, not a window bounded by the old width.
   test('adding a column discards the hidden set and fetches every column', async () => {
-    await consoleActions.executeInConsole(
-      '{ .rs.colvis_grow_df <- as.data.frame(matrix(0L, nrow = 5, ncol = 4)); View(.rs.colvis_grow_df) }',
-    );
-    try {
-      await waitForViewer(dataViewer);
-      await dataViewer.frame.locator('.sidebar-col[data-col-idx="2"] .sidebar-eye-icon').click();
-      await expect(dataViewer.columnHeader(2)).toHaveCount(0);
-      await expect(dataViewer.gridInfo).toContainText('(1 hidden)');
+    const name = await viewAs('as.data.frame(matrix(0L, nrow = 5, ncol = 4))');
+    await waitForViewer(dataViewer);
+    await dataViewer.frame.locator('.sidebar-col[data-col-idx="2"] .sidebar-eye-icon').click();
+    await expect(dataViewer.columnHeader(2)).toHaveCount(0);
+    await expect(dataViewer.gridInfo).toContainText('(1 hidden)');
 
-      await consoleActions.executeInConsole('.rs.colvis_grow_df$added <- 1L');
+    await consoleActions.executeInConsole(`${name}$added <- 1L`);
 
-      // The refresh reports and renders the new fifth column, and the column
-      // hidden against the old frame is back.
-      await expect(dataViewer.gridInfo).toContainText('5 total columns', { timeout: TIMEOUTS.fileOpen });
-      await expect(dataViewer.columnHeader(5)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
-      await expect(dataViewer.columnHeader(2)).toBeVisible();
-      expect(await colOrder(dataViewer)).toEqual(['0', '1', '2', '3', '4', '5']);
-      await expect(dataViewer.gridInfo).not.toContainText('hidden');
-      await expect(dataViewer.frame.locator('.sidebar-col[data-col-idx="2"]'))
-        .not.toHaveClass(/\bcol-hidden\b/);
-    } finally {
-      await consoleActions.executeInConsole('rm(".rs.colvis_grow_df", envir = .GlobalEnv)');
-    }
+    // The refresh reports and renders the new fifth column, and the column
+    // hidden against the old frame is back.
+    await expect(dataViewer.gridInfo).toContainText('5 total columns', { timeout: TIMEOUTS.fileOpen });
+    await expect(dataViewer.columnHeader(5)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+    await expect(dataViewer.columnHeader(2)).toBeVisible();
+    expect(await colOrder(dataViewer)).toEqual(['0', '1', '2', '3', '4', '5']);
+    await expect(dataViewer.gridInfo).not.toContainText('hidden');
+    await expect(dataViewer.frame.locator('.sidebar-col[data-col-idx="2"]'))
+      .not.toHaveClass(/\bcol-hidden\b/);
   });
 
   test('hidden columns survive a refresh and are cleared by Reset View', async ({ rstudioPage: page }) => {
-    // A uniquely-named object so this viewer's localStorage entry is its own.
-    await consoleActions.executeInConsole(
-      '{ .rs.colvis_persist_df <- mtcars; View(.rs.colvis_persist_df) }',
-    );
-    try {
-      await waitForViewer(dataViewer);
+    await viewAs('mtcars');
+    await waitForViewer(dataViewer);
 
-      await dataViewer.frame.locator('.sidebar-col[data-col-idx="3"] .sidebar-eye-icon').click();
-      await expect(dataViewer.columnHeader(3)).toHaveCount(0);
+    await dataViewer.frame.locator('.sidebar-col[data-col-idx="3"] .sidebar-eye-icon').click();
+    await expect(dataViewer.columnHeader(3)).toHaveCount(0);
 
-      // A data refresh rebuilds the grid from saved state: the column stays
-      // hidden -- now left out of the fetch altogether -- in the grid and in
-      // the rebuilt sidebar.
-      await callViewerHook(page, 'refreshData');
-      await expect(dataViewer.columnHeader(4)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
-      await expect(dataViewer.columnHeader(3)).toHaveCount(0);
-      expect((await colOrder(dataViewer)).slice(0, 4)).toEqual(['0', '1', '2', '4']);
-      await expect(dataViewer.frame.locator('.sidebar-col[data-col-idx="3"]'))
-        .toHaveClass(/\bcol-hidden\b/);
-      await expect(dataViewer.gridInfo).toContainText('(1 hidden)');
+    // A data refresh rebuilds the grid from saved state: the column stays
+    // hidden -- now left out of the fetch altogether -- in the grid and in
+    // the rebuilt sidebar.
+    await callViewerHook(page, 'refreshData');
+    await expect(dataViewer.columnHeader(4)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+    await expect(dataViewer.columnHeader(3)).toHaveCount(0);
+    expect((await colOrder(dataViewer)).slice(0, 4)).toEqual(['0', '1', '2', '4']);
+    await expect(dataViewer.frame.locator('.sidebar-col[data-col-idx="3"]'))
+      .toHaveClass(/\bcol-hidden\b/);
+    await expect(dataViewer.gridInfo).toContainText('(1 hidden)');
 
-      // Reset View discards the saved state, hidden columns included.
-      await callViewerHook(page, 'refreshAndReset');
-      await expect(dataViewer.columnHeader(3)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
-      await expect(dataViewer.frame.locator('.sidebar-col[data-col-idx="3"]'))
-        .not.toHaveClass(/\bcol-hidden\b/);
-      await expect(dataViewer.gridInfo).not.toContainText('hidden');
-    } finally {
-      await consoleActions.executeInConsole('rm(".rs.colvis_persist_df", envir = .GlobalEnv)');
-    }
+    // Reset View discards the saved state, hidden columns included.
+    await callViewerHook(page, 'refreshAndReset');
+    await expect(dataViewer.columnHeader(3)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+    await expect(dataViewer.frame.locator('.sidebar-col[data-col-idx="3"]'))
+      .not.toHaveClass(/\bcol-hidden\b/);
+    await expect(dataViewer.gridInfo).not.toContainText('hidden');
   });
 });

--- a/e2e/rstudio/tests/panes/data-viewer/column-visibility.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/column-visibility.test.ts
@@ -200,6 +200,46 @@ test.describe('Data Viewer column visibility', () => {
     await expect(dataViewer.columnHeader(1)).toHaveClass(/sorting_desc/);
   });
 
+  // A hidden sort column drops out of the fetch on the next refresh (or window
+  // slide), so the "Sorted by" status must name it from full-frame metadata
+  // rather than from the fetched columns -- and its clear button must stay.
+  test('a hidden sort column keeps its status and clear button across a refresh', async ({ rstudioPage: page }) => {
+    await consoleActions.executeInConsole(
+      '{ .rs.colvis_sort_df <- mtcars; View(.rs.colvis_sort_df) }',
+    );
+    try {
+      await waitForViewer(dataViewer);
+      const sortIcon1 = dataViewer.frame.locator('.sidebar-col[data-col-idx="1"] .sidebar-sort-icon');
+      await sortIcon1.click();
+      await sortIcon1.click();
+      await expect(sortIcon1).toHaveClass(/sorting_desc/);
+      const row0 = dataViewer.frame.locator('#gridBody tr[data-row="0"]');
+      await expect(row0.locator('td[data-col-pos="1"]')).toHaveText('33.9');
+
+      await dataViewer.frame.locator('.sidebar-col[data-col-idx="1"] .sidebar-eye-icon').click();
+      await expect(dataViewer.columnHeader(1)).toHaveCount(0);
+
+      // After the refresh mpg is no longer fetched at all, yet the rows are
+      // still in mpg order (Toyota Corolla's 4 cylinders lead) and the status
+      // bar still says so.
+      await callViewerHook(page, 'refreshData');
+      await expect(dataViewer.columnHeader(2)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      await expect(dataViewer.columnHeader(1)).toHaveCount(0);
+      await expect(row0.locator('td[data-col-pos="1"]')).toHaveText('4', { timeout: TIMEOUTS.fileOpen });
+      await expect(dataViewer.sortStatus).toContainText('mpg');
+      await expect(dataViewer.clearSortButton).toBeVisible();
+
+      // Clearing the sort from the status bar restores frame order (Mazda RX4,
+      // 6 cylinders, leads) with the column still hidden.
+      await dataViewer.clearSortButton.click();
+      await expect(row0.locator('td[data-col-pos="1"]')).toHaveText('6', { timeout: TIMEOUTS.fileOpen });
+      await expect(dataViewer.sortStatus).toBeHidden();
+      await expect(dataViewer.columnHeader(1)).toHaveCount(0);
+    } finally {
+      await consoleActions.executeInConsole('rm(".rs.colvis_sort_df", envir = .GlobalEnv)');
+    }
+  });
+
   test('a pinned column can be hidden and returns to the pinned pane', async () => {
     await consoleActions.executeInConsole('View(mtcars)');
     await waitForViewer(dataViewer);

--- a/e2e/rstudio/tests/panes/data-viewer/column-visibility.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/column-visibility.test.ts
@@ -288,6 +288,48 @@ test.describe('Data Viewer column visibility', () => {
     await expect(dataViewer.columnHeader(1).locator('.colFilter')).toBeVisible();
   });
 
+  // The inline text filter applies what you type on a debounce. A blur from
+  // clicking elsewhere (a sidebar eye included) deliberately discards pending
+  // text -- clicking away is a dismissal. A rebuild that reaches a box still
+  // holding focus must instead commit the text first: the rebuilt header is
+  // created from the stored filter, so the keystrokes would otherwise be lost.
+  // Go to column, which does not move focus, showing a hidden column is such
+  // a rebuild.
+  test('typed filter text is committed when a show rebuild closes the box', async ({ rstudioPage: page }) => {
+    await consoleActions.executeInConsole(
+      '{ .rs.colvis_text_df <- data.frame(s = c("ab", "cd", "ef"), y = 1:3, z = 4:6); View(.rs.colvis_text_df) }',
+    );
+    await expect(dataViewer.columnHeader(1)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+    await expect(dataViewer.gridInfo).toContainText('of 3', { timeout: TIMEOUTS.fileOpen });
+
+    // Hide y, then open the filter row and start typing into s's box (real
+    // keyup events schedule the debounced apply).
+    await dataViewer.frame.locator('.sidebar-col[data-col-idx="2"] .sidebar-eye-icon').click();
+    await expect(dataViewer.columnHeader(2)).toHaveCount(0);
+    await page.locator('#data_editing_toolbar').getByText('Filter', { exact: true }).click();
+    const colFilter1 = dataViewer.columnHeader(1).locator('.colFilter');
+    await expect(colFilter1).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+    await colFilter1.getByText('All').click();
+    const filterInput = dataViewer.columnHeader(1).locator('.textFilterBox');
+    await expect(filterInput).toBeVisible();
+    await filterInput.pressSequentially('cd');
+
+    // Show y through the grid's go-to entry point (what the host toolbar box
+    // calls), which rebuilds the headers with the text box still focused.
+    await dataViewer.viewport.evaluate((el) => {
+      const w = el.ownerDocument.defaultView as unknown as { goToColumn: (c: number) => void };
+      w.goToColumn(2);
+    });
+
+    // y is back, the recreated box still shows the text, and the grid is
+    // filtered by it.
+    await expect(dataViewer.columnHeader(2)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+    await expect(dataViewer.columnHeader(1).locator('.textFilterBox')).toHaveValue('cd');
+    await expect(dataViewer.gridInfo)
+      .toContainText('of 1 entries (filtered from 3', { timeout: TIMEOUTS.fileOpen });
+    await expect(dataViewer.columnHeader(1).locator('.colFilter')).toHaveClass(/filtered/);
+  });
+
   test('a pinned column can be hidden and returns to the pinned pane', async () => {
     await viewMtcarsCopy();
     await waitForViewer(dataViewer);

--- a/e2e/rstudio/tests/panes/data-viewer/column-visibility.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/column-visibility.test.ts
@@ -153,7 +153,7 @@ test.describe('Data Viewer column visibility', () => {
 
     // Only the frozen rownames column remains; the scrollable pane is empty
     // and the hint (with its way back) is up.
-    await expect(dataViewer.frame.locator('#data_cols th')).toHaveCount(0);
+    await expect(dataViewer.frame.locator('#data_cols th[data-col-idx]')).toHaveCount(0);
     await expect(dataViewer.frame.locator('#pinned_cols th[title="row names"]')).toBeVisible();
     await expect(hint).toBeVisible();
     await expect(headerEye).toHaveAttribute('aria-label', 'Show all columns');
@@ -183,6 +183,45 @@ test.describe('Data Viewer column visibility', () => {
     await expect(dataViewer.columnHeader(2)).toBeVisible();
     expect((await colOrder(dataViewer)).slice(0, 4)).toEqual(['0', '1', '2', '3']);
     await expect(dataViewer.gridInfo).not.toContainText('hidden');
+  });
+
+  // With every column hidden the scrollable pane's rows have no data cells.
+  // They must keep a placeholder cell so the rows keep their height: the
+  // frozen rownames pane follows the scrollable pane's scroll extent, so
+  // collapsed rows would leave later row names unreachable.
+  test('rows stay scrollable with every column hidden', async ({ rstudioPage: page }) => {
+    await viewAs('data.frame(x = seq_len(2000))');
+    await waitForViewer(dataViewer);
+    await expect(dataViewer.gridInfo).toContainText('of 2,000', { timeout: TIMEOUTS.fileOpen });
+
+    await dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-eye').click();
+    await expect(dataViewer.frame.locator('#data_cols th[data-col-idx]')).toHaveCount(0);
+
+    // The rendered rows keep their height, so the scroll range still spans
+    // every row (ROW_HEIGHT px each, plus the header).
+    await expect.poll(
+      () => dataViewer.viewport.evaluate((el: HTMLElement) => el.scrollHeight),
+      { message: 'scroll extent should still cover every row' },
+    ).toBeGreaterThan(2000 * 23);
+    await expect(dataViewer.frame.locator('#gridBody tr[data-row="0"]'))
+      .toHaveJSProperty('offsetHeight', 23);
+
+    // Wheel to the bottom the way a user does (a one-step scrollTop lands
+    // mid-rebuild and is clamped; see scrollGridToBottom in
+    // data_viewer.test.ts): the last row name is reached.
+    const box = await dataViewer.viewport.boundingBox();
+    if (!box) throw new Error('grid viewport has no bounding box');
+    await page.mouse.move(box.x + box.width / 3, box.y + box.height / 2);
+    for (let i = 0; i < 8; i++) await page.mouse.wheel(0, 8000);
+    await expect.poll(
+      () => dataViewer.viewport.evaluate(
+        (el: HTMLElement) => el.scrollTop >= el.scrollHeight - el.clientHeight - 1,
+      ),
+      { timeout: TIMEOUTS.fileOpen },
+    ).toBe(true);
+    await expect(dataViewer.frame.locator('#pinnedBody tr[data-row="1999"] td'))
+      .toHaveText('2000', { timeout: TIMEOUTS.fileOpen });
+    await expect(dataViewer.gridInfo).toContainText('2,000 of 2,000', { timeout: TIMEOUTS.fileOpen });
   });
 
   test('a hidden column keeps its sort, and clicking its entry shows it again', async () => {
@@ -422,7 +461,7 @@ test.describe('Data Viewer column visibility', () => {
     // (scrolling the virtualized list to build the far ones).
     const headerEye = dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-eye');
     await headerEye.click();
-    await expect(dataViewer.frame.locator('#data_cols th')).toHaveCount(0);
+    await expect(dataViewer.frame.locator('#data_cols th[data-col-idx]')).toHaveCount(0);
     await expect(dataViewer.frame.locator('#allColumnsHiddenHint')).toBeVisible();
     await expect(dataViewer.gridInfo).toContainText('(300 hidden)');
 
@@ -477,7 +516,7 @@ test.describe('Data Viewer column visibility', () => {
     await expect(dataViewer.gotoColumnInput).toBeHidden();
 
     await dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-eye').click();
-    await expect(dataViewer.frame.locator('#data_cols th')).toHaveCount(0);
+    await expect(dataViewer.frame.locator('#data_cols th[data-col-idx]')).toHaveCount(0);
     await expect(dataViewer.gotoColumnInput).toBeVisible();
 
     // Jumping to a hidden column through the box shows just that column.

--- a/e2e/rstudio/tests/panes/data-viewer/column-visibility.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/column-visibility.test.ts
@@ -295,6 +295,16 @@ test.describe('Data Viewer column visibility', () => {
       await expect(dataViewer.gridInfo).toContainText('300 total columns (297 hidden)');
       await expect(dataViewer.frame.locator('#allColumnsHiddenHint')).toBeHidden();
 
+      // The three visible columns fit the viewport, yet the toolbar's Go to
+      // column box must stay available while anything is hidden: it is a way
+      // back to a hidden column. Jumping to column 150 shows it in place.
+      await dataViewer.goToColumn(150);
+      await expect(dataViewer.columnHeader(150)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      await expect(dataViewer.frame.locator('#data_cols th[data-col-idx]')).toHaveCount(4);
+      await expect(row0.locator('td[data-col-pos="2"]')).toHaveText('1491', { timeout: TIMEOUTS.fileOpen });
+      await expect(row0.locator('td[data-col-pos="3"]')).toHaveText('2591');
+      await expect(dataViewer.gridInfo).toContainText('(296 hidden)');
+
       // Show all: the frame is wide again and column 1 leads.
       await headerEye.click();
       await expect(dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-label'))
@@ -303,6 +313,38 @@ test.describe('Data Viewer column visibility', () => {
       await expect(dataViewer.gridInfo).not.toContainText('hidden');
     } finally {
       await consoleActions.executeInConsole('rm(".rs.colvis_wide_df", envir = .GlobalEnv)');
+    }
+  });
+
+  // The toolbar's Go to column box normally appears only when the columns
+  // overflow the viewport, but it doubles as a way back to a hidden column, so
+  // it must also appear while anything is hidden -- including after hide-all
+  // on a frame that never overflowed.
+  test('Go to column stays available while columns are hidden on a narrow frame', async () => {
+    await consoleActions.executeInConsole(
+      '{ .rs.colvis_narrow_df <- data.frame(a = 1:3, b = 4:6, c = 7:9); View(.rs.colvis_narrow_df) }',
+    );
+    try {
+      await waitForViewer(dataViewer);
+      await expect(dataViewer.columnHeader(3)).toBeVisible();
+      await expect(dataViewer.gotoColumnInput).toBeHidden();
+
+      await dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-eye').click();
+      await expect(dataViewer.frame.locator('#data_cols th')).toHaveCount(0);
+      await expect(dataViewer.gotoColumnInput).toBeVisible();
+
+      // Jumping to a hidden column through the box shows just that column.
+      await dataViewer.goToColumn('b');
+      await expect(dataViewer.columnHeader(2)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      await expect(dataViewer.columnHeader(1)).toHaveCount(0);
+      await expect(dataViewer.gridInfo).toContainText('(2 hidden)');
+
+      // Once nothing is hidden the box goes away again, since the frame fits.
+      await dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-eye').click();
+      await expect(dataViewer.gridInfo).not.toContainText('hidden');
+      await expect(dataViewer.gotoColumnInput).toBeHidden();
+    } finally {
+      await consoleActions.executeInConsole('rm(".rs.colvis_narrow_df", envir = .GlobalEnv)');
     }
   });
 

--- a/e2e/rstudio/tests/panes/data-viewer/column-visibility.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/column-visibility.test.ts
@@ -253,6 +253,41 @@ test.describe('Data Viewer column visibility', () => {
     }
   });
 
+  // An open filter editor holds the header rebuild back (autoSizeColumns
+  // defers it so the editor isn't torn down mid-edit); hide/show closes the
+  // editor first, otherwise the rows would be rebuilt against a column order
+  // the headers don't show yet.
+  test('hiding a column while a filter editor is open closes it and keeps headers and rows in step', async ({ rstudioPage: page }) => {
+    await consoleActions.executeInConsole(
+      '{ .rs.colvis_filter_df <- data.frame(x = 1:20, y = 21:40, z = 41:60); View(.rs.colvis_filter_df) }',
+    );
+    await expect(dataViewer.columnHeader(1)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+    // The info bar renders once the first row batch lands, which is also when
+    // the post-load auto-size rebuilds the headers; touching the filter row
+    // before that races the rebuild (see column-filters.test.ts).
+    await expect(dataViewer.gridInfo).toContainText('of 20', { timeout: TIMEOUTS.fileOpen });
+    await page.locator('#data_editing_toolbar').getByText('Filter', { exact: true }).click();
+    const colFilter1 = dataViewer.columnHeader(1).locator('.colFilter');
+    await expect(colFilter1).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+
+    // Open x's numeric filter popup, then hide y from the sidebar.
+    await colFilter1.getByText('All').click();
+    const popup = dataViewer.frame.locator('.filterPopup');
+    await expect(popup).toBeVisible();
+    await dataViewer.frame.locator('.sidebar-col[data-col-idx="2"] .sidebar-eye-icon').click();
+
+    // The editor is closed; y is gone from the headers AND the rows, which
+    // agree on the remaining two columns (z's first value now sits second);
+    // and the filter row is still up on x.
+    await expect(popup).toHaveCount(0);
+    await expect(dataViewer.columnHeader(2)).toHaveCount(0);
+    await expect(dataViewer.frame.locator('#data_cols th[data-col-idx]')).toHaveCount(2);
+    const row0 = dataViewer.frame.locator('#gridBody tr[data-row="0"]');
+    await expect(row0.locator('td[data-col-pos]')).toHaveCount(2);
+    await expect(row0.locator('td[data-col-pos="2"]')).toHaveText('41');
+    await expect(dataViewer.columnHeader(1).locator('.colFilter')).toBeVisible();
+  });
+
   test('a pinned column can be hidden and returns to the pinned pane', async () => {
     await viewMtcarsCopy();
     await waitForViewer(dataViewer);

--- a/e2e/rstudio/tests/panes/data-viewer/column-visibility.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/column-visibility.test.ts
@@ -436,6 +436,44 @@ test.describe('Data Viewer column visibility', () => {
     await expect(dataViewer.frame.locator('th.activeHeader')).toHaveCount(1);
   });
 
+  // A fetched window narrower than the viewport can never cover it, so the
+  // scroll-driven recenter must stay parked instead of fighting the window's
+  // placement: each slide would just swap which side shows unfetched span
+  // columns, and the alternating layouts can rebuild the grid forever (the CI
+  // live-lock behind the maybeSlideForScroll guard). Two integer columns are
+  // narrower than any viewport, so unlike the five-column window above this
+  // exercises the parked path on every platform. Scrolling the window fully
+  // off screen is the escape hatch: that slide is still taken.
+  test('a window narrower than the viewport stays parked until scrolled away', async () => {
+    await viewAs('as.data.frame(matrix(1:3000, nrow = 10, ncol = 300))');
+    await waitForViewer(dataViewer);
+    await expect(dataViewer.gridInfo).toContainText('of 10', { timeout: TIMEOUTS.fileOpen });
+
+    await dataViewer.viewport.evaluate((el) => {
+      const w = el.ownerDocument.defaultView as unknown as {
+        setOffsetAndMaxColumns: (offset: number, max: number) => void;
+      };
+      w.setOffsetAndMaxColumns(0, 2);
+    });
+    await expect(dataViewer.columnHeader(3)).toHaveCount(0, { timeout: TIMEOUTS.fileOpen });
+
+    // Parked: clicking the last fetched header succeeds (a recenter rebuild
+    // would detach it mid-click) and the window is still 1..2 afterwards.
+    await dataViewer.columnHeader(2).click();
+    await expect(dataViewer.columnHeader(2)).toHaveClass(/activeHeader/);
+    expect(await colOrder(dataViewer)).toEqual(['0', '1', '2']);
+
+    // Scroll until no part of the window is on screen: the recenter fires,
+    // fetches a window near the scroll position, and drops columns 1..2.
+    await dataViewer.viewport.evaluate((el) => {
+      el.scrollLeft = 12000;
+    });
+    await expect(dataViewer.columnHeader(1)).toHaveCount(0, { timeout: TIMEOUTS.fileOpen });
+    const order = await colOrder(dataViewer);
+    expect(order[0]).toBe('0');
+    expect(order.slice(1).map(Number).every((abs) => abs > 2)).toBe(true);
+  });
+
   // The fetched column window is measured in visible columns, so hiding
   // almost everything on a frame wider than the window must still fetch and
   // lay out the few columns that remain -- with no blank span standing in for

--- a/e2e/rstudio/tests/panes/data-viewer/column-visibility.test.ts
+++ b/e2e/rstudio/tests/panes/data-viewer/column-visibility.test.ts
@@ -1,0 +1,370 @@
+// Data Viewer column visibility (#17787).
+//
+// Columns can be hidden from the grid through the summary sidebar: an eye
+// icon on each entry toggles one column, and an eye in the panel header hides
+// or shows them all. Hiding is a client-side layout change -- the column
+// leaves the render order and the fetched window is measured in visible
+// columns -- so these tests check the grid, the sidebar, the status bar, the
+// keyboard path, the wide-frame window math, and persistence.
+//
+// Grid headers are located by their title ("column N: <type>"), which carries
+// the ABSOLUTE column index. Their data-col-idx is the position in the fetched
+// column set, which shifts once a hidden column drops out of a fetch.
+
+import type { Page } from 'playwright';
+import { test, expect } from '@fixtures/rstudio.fixture';
+import { ConsolePaneActions } from '@actions/console_pane.actions';
+import { SourcePane } from '@pages/source_pane.page';
+import { DataViewerPane } from '@pages/data_viewer.page';
+import { resetSourcePaneState } from '@utils/commands';
+import { TIMEOUTS } from '@utils/constants';
+
+const VIEWER_FRAME = '#rstudio_data_viewer_frame';
+
+// Waits for the data viewer iframe to render a column header (any column: on
+// a wide frame column 1 may be outside the rendered window).
+async function waitForViewer(dataViewer: DataViewerPane): Promise<void> {
+  await expect(dataViewer.frame.locator('th[data-col-idx][title]').first())
+    .toBeVisible({ timeout: TIMEOUTS.fileOpen });
+}
+
+// Absolute index of every rendered column header, left to right, as strings
+// ('0' for the rownames header). The frozen pane's #pinned_cols precedes
+// #data_cols in the DOM; spacer cells carry no title and are skipped.
+async function colOrder(dataViewer: DataViewerPane): Promise<string[]> {
+  return dataViewer.frame.locator('#pinned_cols th[title], #data_cols th[title]')
+    .evaluateAll((ths) =>
+      (ths as HTMLElement[]).map((th) => {
+        const m = /^column (\d+):/.exec(th.getAttribute('title') ?? '');
+        return m ? m[1] : '0';
+      }),
+    );
+}
+
+// Calls one of the iframe's window-level hooks (refreshData / refreshAndReset).
+async function callViewerHook(page: Page, name: string): Promise<void> {
+  await page.evaluate(([sel, hook]) => {
+    const f = document.querySelector(sel) as HTMLIFrameElement | null;
+    const w = f?.contentWindow as unknown as Record<string, (() => void) | undefined> | undefined;
+    const fn = w?.[hook];
+    if (!fn) throw new Error(`${hook}() not available on data viewer iframe`);
+    fn();
+  }, [VIEWER_FRAME, name] as const);
+}
+
+// The sidebar list is virtualized: scroll it so the entry for absolute column
+// `abs` is built (entries are a fixed height; the rowname is not listed, so
+// abs N sits at index N-1).
+async function scrollSidebarToCol(dataViewer: DataViewerPane, abs: number): Promise<void> {
+  await dataViewer.viewport.evaluate((vp, a) => {
+    const doc = vp.ownerDocument;
+    const content = doc.getElementById('sidebarContent');
+    if (!content) return;
+    const h = parseInt(
+      getComputedStyle(doc.documentElement).getPropertyValue('--sidebar-entry-height'),
+      10) || 78;
+    content.scrollTop = (a - 1) * h;
+  }, abs);
+}
+
+test.describe('Data Viewer column visibility', () => {
+  let consoleActions: ConsolePaneActions;
+  let sourcePane: SourcePane;
+  let dataViewer: DataViewerPane;
+
+  test.beforeAll(async ({ rstudioPage: page }) => {
+    consoleActions = new ConsolePaneActions(page);
+    sourcePane = new SourcePane(page);
+    dataViewer = new DataViewerPane(page);
+    await consoleActions.resetSourcePane();
+  });
+
+  test.afterEach(async ({ rstudioPage: page }) => {
+    // See data_viewer.test.ts: go through resetSourcePaneState so the Source
+    // pane never reaches zero tabs (#17738).
+    await resetSourcePaneState(page);
+    await expect(sourcePane.selectedTab).toContainText('Untitled', { timeout: 5000 });
+  });
+
+  test('sidebar eye icon hides a column from the grid and shows it again', async () => {
+    await consoleActions.executeInConsole('View(mtcars)');
+    await waitForViewer(dataViewer);
+    expect((await colOrder(dataViewer)).slice(0, 5)).toEqual(['0', '1', '2', '3', '4']);
+
+    // mtcars row 1 (Mazda RX4): disp 160 (rendered "160.0" -- the column has
+    // fractional values), hp 110. Cells carry their display position, so with
+    // disp (3) hidden the third data cell is hp.
+    const row0 = dataViewer.frame.locator('#gridBody tr[data-row="0"]');
+    await expect(row0.locator('td[data-col-pos="3"]')).toHaveText('160.0');
+
+    const entry3 = dataViewer.frame.locator('.sidebar-col[data-col-idx="3"]');
+    const eye3 = entry3.locator('.sidebar-eye-icon');
+    await expect(eye3).toHaveAttribute('aria-pressed', 'false');
+    await eye3.click();
+
+    // The header is gone, the remaining columns close ranks, and the row
+    // cells follow the new display order.
+    await expect(dataViewer.columnHeader(3)).toHaveCount(0);
+    expect((await colOrder(dataViewer)).slice(0, 5)).toEqual(['0', '1', '2', '4', '5']);
+    await expect(row0.locator('td[data-col-pos="3"]')).toHaveText(/^110(\.0)?$/);
+
+    // The sidebar entry stays listed, marked hidden, and the counts say so.
+    await expect(entry3).toHaveClass(/\bcol-hidden\b/);
+    await expect(eye3).toHaveAttribute('aria-pressed', 'true');
+    await expect(dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-label'))
+      .toContainText('(1 hidden)');
+    await expect(dataViewer.gridInfo).toContainText('(1 hidden)');
+
+    // Show it again from the same icon.
+    await eye3.click();
+    await expect(dataViewer.columnHeader(3)).toBeVisible();
+    expect((await colOrder(dataViewer)).slice(0, 5)).toEqual(['0', '1', '2', '3', '4']);
+    await expect(row0.locator('td[data-col-pos="3"]')).toHaveText('160.0');
+    await expect(entry3).not.toHaveClass(/\bcol-hidden\b/);
+    await expect(dataViewer.gridInfo).not.toContainText('hidden');
+  });
+
+  test('header eye hides every column and the in-grid hint shows them all', async () => {
+    await consoleActions.executeInConsole('View(mtcars)');
+    await waitForViewer(dataViewer);
+
+    const headerEye = dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-eye');
+    const hint = dataViewer.frame.locator('#allColumnsHiddenHint');
+    await expect(headerEye).toHaveAttribute('aria-label', 'Hide all columns');
+    await expect(hint).toBeHidden();
+
+    await headerEye.click();
+
+    // Only the frozen rownames column remains; the scrollable pane is empty
+    // and the hint (with its way back) is up.
+    await expect(dataViewer.frame.locator('#data_cols th')).toHaveCount(0);
+    await expect(dataViewer.frame.locator('#pinned_cols th[title="row names"]')).toBeVisible();
+    await expect(hint).toBeVisible();
+    await expect(headerEye).toHaveAttribute('aria-label', 'Show all columns');
+    await expect(dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-label'))
+      .toContainText('(11 hidden)');
+    await expect(dataViewer.gridInfo).toContainText('11 total columns (11 hidden)');
+
+    // Every entry is marked hidden, but stays listed.
+    await expect(dataViewer.frame.locator('.sidebar-col[data-col-idx="1"]'))
+      .toHaveClass(/\bcol-hidden\b/);
+
+    // The hint's button restores everything. (Only the headers that fit the
+    // rendered column window exist, so check the leading columns, not a count.)
+    await hint.locator('#allColumnsHiddenShow').click();
+    await expect(dataViewer.columnHeader(1)).toBeVisible();
+    expect((await colOrder(dataViewer)).slice(0, 4)).toEqual(['0', '1', '2', '3']);
+    await expect(hint).toBeHidden();
+    await expect(headerEye).toHaveAttribute('aria-label', 'Hide all columns');
+    await expect(dataViewer.gridInfo).not.toContainText('hidden');
+
+    // With some (not all) columns hidden the header eye reads as show-all and
+    // brings back just the hidden ones.
+    await dataViewer.frame.locator('.sidebar-col[data-col-idx="2"] .sidebar-eye-icon').click();
+    await expect(dataViewer.columnHeader(2)).toHaveCount(0);
+    await expect(headerEye).toHaveAttribute('aria-label', 'Show all columns');
+    await headerEye.click();
+    await expect(dataViewer.columnHeader(2)).toBeVisible();
+    expect((await colOrder(dataViewer)).slice(0, 4)).toEqual(['0', '1', '2', '3']);
+    await expect(dataViewer.gridInfo).not.toContainText('hidden');
+  });
+
+  test('a hidden column keeps its sort, and clicking its entry shows it again', async () => {
+    await consoleActions.executeInConsole('View(mtcars)');
+    await waitForViewer(dataViewer);
+
+    // Sort mpg (1) descending from the sidebar: Toyota Corolla (33.9 mpg,
+    // 4 cyl) leads; unsorted, Mazda RX4 (6 cyl) does.
+    const sortIcon1 = dataViewer.frame.locator('.sidebar-col[data-col-idx="1"] .sidebar-sort-icon');
+    await sortIcon1.click();
+    await sortIcon1.click();
+    await expect(sortIcon1).toHaveClass(/sorting_desc/);
+    const row0 = dataViewer.frame.locator('#gridBody tr[data-row="0"]');
+    await expect(row0.locator('td[data-col-pos="1"]')).toHaveText('33.9');
+
+    // Hide the sort column: the rows stay in mpg order (cyl is now the first
+    // data cell), and the status bar still reports the sort.
+    const entry1 = dataViewer.frame.locator('.sidebar-col[data-col-idx="1"]');
+    await entry1.locator('.sidebar-eye-icon').click();
+    await expect(dataViewer.columnHeader(1)).toHaveCount(0);
+    await expect(row0.locator('td[data-col-pos="1"]')).toHaveText('4');
+    await expect(dataViewer.sortStatus).toContainText('mpg');
+    await expect(sortIcon1).toHaveClass(/sorting_desc/);
+
+    // Activating the entry itself (not the eye) is a request to see the
+    // column: it comes back, still sorted.
+    await entry1.locator('.sidebar-col-name').click();
+    await expect(dataViewer.columnHeader(1)).toBeVisible();
+    await expect(entry1).not.toHaveClass(/\bcol-hidden\b/);
+    await expect(row0.locator('td[data-col-pos="1"]')).toHaveText('33.9');
+    await expect(dataViewer.columnHeader(1)).toHaveClass(/sorting_desc/);
+  });
+
+  test('a pinned column can be hidden and returns to the pinned pane', async () => {
+    await consoleActions.executeInConsole('View(mtcars)');
+    await waitForViewer(dataViewer);
+
+    const entry3 = dataViewer.frame.locator('.sidebar-col[data-col-idx="3"]');
+    const pinnedHeader3 = dataViewer.frame.locator('#pinned_cols th[title^="column 3:"]');
+    await entry3.locator('.sidebar-pin-icon').click();
+    await expect(pinnedHeader3).toBeVisible();
+
+    await entry3.locator('.sidebar-eye-icon').click();
+    await expect(dataViewer.columnHeader(3)).toHaveCount(0);
+    expect((await colOrder(dataViewer)).slice(0, 3)).toEqual(['0', '1', '2']);
+    // The pin survives hiding: the entry's pin icon still reads pinned.
+    await expect(entry3.locator('.sidebar-pin-icon')).toHaveClass(/\bpinned\b/);
+
+    await entry3.locator('.sidebar-eye-icon').click();
+    await expect(pinnedHeader3).toBeVisible();
+    expect((await colOrder(dataViewer)).slice(0, 3)).toEqual(['0', '3', '1']);
+  });
+
+  test('H hides the column under the keyboard cursor and moves the cursor on', async ({ rstudioPage: page }) => {
+    await consoleActions.executeInConsole('View(mtcars)');
+    await waitForViewer(dataViewer);
+
+    // Clicking a header makes it the active header and focuses the grid.
+    await dataViewer.columnHeader(2).click();
+    await expect(dataViewer.columnHeader(2)).toHaveClass(/activeHeader/);
+
+    await page.keyboard.press('h');
+
+    // cyl (2) is gone; the cursor lands on the column that took its slot.
+    await expect(dataViewer.columnHeader(2)).toHaveCount(0);
+    await expect(dataViewer.columnHeader(3)).toHaveClass(/activeHeader/);
+    await expect(dataViewer.frame.locator('.sidebar-col[data-col-idx="2"]'))
+      .toHaveClass(/\bcol-hidden\b/);
+
+    // Show all from the header eye.
+    await dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-eye').click();
+    await expect(dataViewer.columnHeader(2)).toBeVisible();
+  });
+
+  // The fetched column window is measured in visible columns, so hiding
+  // almost everything on a frame wider than the window must still fetch and
+  // lay out the few columns that remain -- with no blank span standing in for
+  // an unfetched column, wherever those columns sit in the frame.
+  test('wide frame: the window follows the visible columns', async () => {
+    // 300 columns: wider than the fetched window. matrix(1:3000) is
+    // column-major with 10 rows, so column k's first row holds (k-1)*10 + 1.
+    await consoleActions.executeInConsole(
+      '{ .rs.colvis_wide_df <- as.data.frame(matrix(1:3000, nrow = 10, ncol = 300)); View(.rs.colvis_wide_df) }',
+    );
+    try {
+      await waitForViewer(dataViewer);
+      await expect(dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-label'))
+        .toHaveText('300 columns', { timeout: TIMEOUTS.fileOpen });
+
+      // Hide column 5, then jump to it with Go to column: the jump shows it.
+      const entry5 = dataViewer.frame.locator('.sidebar-col[data-col-idx="5"]');
+      await entry5.locator('.sidebar-eye-icon').click();
+      await expect(dataViewer.columnHeader(5)).toHaveCount(0);
+      await expect(entry5).toHaveClass(/\bcol-hidden\b/);
+      await dataViewer.goToColumn(5);
+      await expect(dataViewer.columnHeader(5)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      await expect(entry5).not.toHaveClass(/\bcol-hidden\b/);
+
+      // Hide everything, then show columns 1, 260 and 300 from their entries
+      // (scrolling the virtualized list to build the far ones).
+      const headerEye = dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-eye');
+      await headerEye.click();
+      await expect(dataViewer.frame.locator('#data_cols th')).toHaveCount(0);
+      await expect(dataViewer.frame.locator('#allColumnsHiddenHint')).toBeVisible();
+      await expect(dataViewer.gridInfo).toContainText('(300 hidden)');
+
+      for (const abs of [1, 260, 300]) {
+        await scrollSidebarToCol(dataViewer, abs);
+        const entry = dataViewer.frame.locator(`.sidebar-col[data-col-idx="${abs}"]`);
+        await expect(entry).toHaveCount(1, { timeout: TIMEOUTS.fileOpen });
+        await entry.locator('.sidebar-eye-icon').click();
+        await expect(entry).not.toHaveClass(/\bcol-hidden\b/);
+      }
+
+      // All three are fetched and rendered, in frame order, with real data --
+      // and nothing else: no spacer cell stands in for an unfetched column.
+      for (const abs of [1, 260, 300]) {
+        await expect(dataViewer.columnHeader(abs)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      }
+      await expect(dataViewer.frame.locator('#data_cols th[data-col-idx]')).toHaveCount(3);
+      await expect(dataViewer.frame.locator('#data_cols th.col-spacer')).toHaveCount(0);
+      const row0 = dataViewer.frame.locator('#gridBody tr[data-row="0"]');
+      await expect(row0.locator('td[data-col-pos="1"]')).toHaveText('1', { timeout: TIMEOUTS.fileOpen });
+      await expect(row0.locator('td[data-col-pos="2"]')).toHaveText('2591');
+      await expect(row0.locator('td[data-col-pos="3"]')).toHaveText('2991');
+      await expect(dataViewer.gridInfo).toContainText('300 total columns (297 hidden)');
+      await expect(dataViewer.frame.locator('#allColumnsHiddenHint')).toBeHidden();
+
+      // Show all: the frame is wide again and column 1 leads.
+      await headerEye.click();
+      await expect(dataViewer.frame.locator('#sidebarToggle .sidebar-toggle-label'))
+        .toHaveText('300 columns', { timeout: TIMEOUTS.fileOpen });
+      await expect(dataViewer.columnHeader(1)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      await expect(dataViewer.gridInfo).not.toContainText('hidden');
+    } finally {
+      await consoleActions.executeInConsole('rm(".rs.colvis_wide_df", envir = .GlobalEnv)');
+    }
+  });
+
+  // Hidden columns are saved with the frame's column fingerprint (like pins),
+  // so a structural change invalidates them -- and the refresh that follows
+  // must fetch the whole new frame, not a window bounded by the old width.
+  test('adding a column discards the hidden set and fetches every column', async () => {
+    await consoleActions.executeInConsole(
+      '{ .rs.colvis_grow_df <- as.data.frame(matrix(0L, nrow = 5, ncol = 4)); View(.rs.colvis_grow_df) }',
+    );
+    try {
+      await waitForViewer(dataViewer);
+      await dataViewer.frame.locator('.sidebar-col[data-col-idx="2"] .sidebar-eye-icon').click();
+      await expect(dataViewer.columnHeader(2)).toHaveCount(0);
+      await expect(dataViewer.gridInfo).toContainText('(1 hidden)');
+
+      await consoleActions.executeInConsole('.rs.colvis_grow_df$added <- 1L');
+
+      // The refresh reports and renders the new fifth column, and the column
+      // hidden against the old frame is back.
+      await expect(dataViewer.gridInfo).toContainText('5 total columns', { timeout: TIMEOUTS.fileOpen });
+      await expect(dataViewer.columnHeader(5)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      await expect(dataViewer.columnHeader(2)).toBeVisible();
+      expect(await colOrder(dataViewer)).toEqual(['0', '1', '2', '3', '4', '5']);
+      await expect(dataViewer.gridInfo).not.toContainText('hidden');
+      await expect(dataViewer.frame.locator('.sidebar-col[data-col-idx="2"]'))
+        .not.toHaveClass(/\bcol-hidden\b/);
+    } finally {
+      await consoleActions.executeInConsole('rm(".rs.colvis_grow_df", envir = .GlobalEnv)');
+    }
+  });
+
+  test('hidden columns survive a refresh and are cleared by Reset View', async ({ rstudioPage: page }) => {
+    // A uniquely-named object so this viewer's localStorage entry is its own.
+    await consoleActions.executeInConsole(
+      '{ .rs.colvis_persist_df <- mtcars; View(.rs.colvis_persist_df) }',
+    );
+    try {
+      await waitForViewer(dataViewer);
+
+      await dataViewer.frame.locator('.sidebar-col[data-col-idx="3"] .sidebar-eye-icon').click();
+      await expect(dataViewer.columnHeader(3)).toHaveCount(0);
+
+      // A data refresh rebuilds the grid from saved state: the column stays
+      // hidden -- now left out of the fetch altogether -- in the grid and in
+      // the rebuilt sidebar.
+      await callViewerHook(page, 'refreshData');
+      await expect(dataViewer.columnHeader(4)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      await expect(dataViewer.columnHeader(3)).toHaveCount(0);
+      expect((await colOrder(dataViewer)).slice(0, 4)).toEqual(['0', '1', '2', '4']);
+      await expect(dataViewer.frame.locator('.sidebar-col[data-col-idx="3"]'))
+        .toHaveClass(/\bcol-hidden\b/);
+      await expect(dataViewer.gridInfo).toContainText('(1 hidden)');
+
+      // Reset View discards the saved state, hidden columns included.
+      await callViewerHook(page, 'refreshAndReset');
+      await expect(dataViewer.columnHeader(3)).toBeVisible({ timeout: TIMEOUTS.fileOpen });
+      await expect(dataViewer.frame.locator('.sidebar-col[data-col-idx="3"]'))
+        .not.toHaveClass(/\bcol-hidden\b/);
+      await expect(dataViewer.gridInfo).not.toContainText('hidden');
+    } finally {
+      await consoleActions.executeInConsole('rm(".rs.colvis_persist_df", envir = .GlobalEnv)');
+    }
+  });
+});

--- a/src/cpp/session/resources/grid/DataViewer.css
+++ b/src/cpp/session/resources/grid/DataViewer.css
@@ -941,11 +941,29 @@ th.columnClickable div {
 }
 
 /* "(filtered)" qualifier appended to the column count when the summaries
-   describe a filtered subset rather than the whole frame. Dimmed + italic so
-   it reads as an annotation on the count, not part of it. */
-.sidebar-toggle-filtered {
+   describe a filtered subset rather than the whole frame, and "(N hidden)"
+   when columns are hidden from the grid. Dimmed + italic so they read as
+   annotations on the count, not part of it. */
+.sidebar-toggle-filtered,
+.sidebar-toggle-hidden {
    font-style: italic;
    opacity: 0.7;
+}
+
+/* Show-all / hide-all eye in the panel header, between the help icon and the
+   close glyph. Shares the entry eye's glyphs and state class (see
+   .sidebar-eye-icon below, whose sizing these id-qualified rules outrank);
+   a real button like the help icon. */
+#sidebarToggle .sidebar-toggle-eye {
+   margin-left: 8px;
+   width: 12px;
+   height: 12px;
+   opacity: 0.6;
+}
+
+#sidebarToggle .sidebar-toggle-eye:hover,
+#sidebarToggle .sidebar-toggle-eye:focus-visible {
+   opacity: 1;
 }
 
 /* Help affordance; owns the auto margin that pushes it (and the close
@@ -984,11 +1002,13 @@ th.columnClickable div {
    opacity: 1;
 }
 
-/* ...but not while the help icon is hovered: a click there opens the help
-   dialog instead of reaching the toggle, so the close affordance should
-   not light up as if the header were about to collapse. (The close glyph
-   is a following sibling of the help icon, hence the ~ combinator.) */
-#sidebarToggle .sidebar-toggle-help:hover ~ .sidebar-toggle-close {
+/* ...but not while the help or eye icon is hovered: a click there opens the
+   help dialog / toggles column visibility instead of reaching the toggle, so
+   the close affordance should not light up as if the header were about to
+   collapse. (The close glyph is a following sibling of both, hence the ~
+   combinator.) */
+#sidebarToggle .sidebar-toggle-help:hover ~ .sidebar-toggle-close,
+#sidebarToggle .sidebar-toggle-eye:hover ~ .sidebar-toggle-close {
    opacity: 0.6;
 }
 
@@ -1218,6 +1238,57 @@ body.overlay-scrollbars #sidebarContent::-webkit-scrollbar {
    cursor: default;
 }
 
+/* Eye icon: hides the column from the grid, or shows it again. Same idle /
+   active opacity treatment as the funnel; the slashed glyph (.col-hidden)
+   marks a hidden column. Also used, with .sidebar-toggle-eye, for the header's
+   show-all / hide-all control. */
+.sidebar-eye-icon {
+   display: inline-block;
+   width: 11px;
+   height: 11px;
+   margin-left: 2px;
+   flex-shrink: 0;
+   align-self: center;
+   cursor: pointer;
+   opacity: 0.3;
+   background-color: var(--grid-fg);
+   -webkit-mask-repeat: no-repeat;
+   -webkit-mask-position: center;
+   -webkit-mask-size: contain;
+   mask-repeat: no-repeat;
+   mask-position: center;
+   mask-size: contain;
+   /* Open eye: a lens with an evenodd iris hole and a pupil. */
+   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'%3E%3Cpath fill-rule='evenodd' d='M1 6Q3.5 2.5 6 2.5T11 6Q8.5 9.5 6 9.5T1 6ZM6 3.8A2.2 2.2 0 1 0 6 8.2A2.2 2.2 0 1 0 6 3.8Z'/%3E%3Ccircle cx='6' cy='6' r='1.1'/%3E%3C/svg%3E");
+   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'%3E%3Cpath fill-rule='evenodd' d='M1 6Q3.5 2.5 6 2.5T11 6Q8.5 9.5 6 9.5T1 6ZM6 3.8A2.2 2.2 0 1 0 6 8.2A2.2 2.2 0 1 0 6 3.8Z'/%3E%3Ccircle cx='6' cy='6' r='1.1'/%3E%3C/svg%3E");
+}
+
+.sidebar-eye-icon:hover,
+.sidebar-eye-icon:focus-visible {
+   opacity: 0.6;
+}
+
+.sidebar-eye-icon.col-hidden {
+   opacity: 0.9;
+   /* Slashed eye. */
+   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'%3E%3Cpath fill-rule='evenodd' d='M1 6Q3.5 2.5 6 2.5T11 6Q8.5 9.5 6 9.5T1 6ZM6 3.8A2.2 2.2 0 1 0 6 8.2A2.2 2.2 0 1 0 6 3.8Z'/%3E%3Ccircle cx='6' cy='6' r='1.1'/%3E%3Cpath d='M1.5 10.5L10.5 1.5' stroke='black' stroke-width='1.4' stroke-linecap='round'/%3E%3C/svg%3E");
+   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'%3E%3Cpath fill-rule='evenodd' d='M1 6Q3.5 2.5 6 2.5T11 6Q8.5 9.5 6 9.5T1 6ZM6 3.8A2.2 2.2 0 1 0 6 8.2A2.2 2.2 0 1 0 6 3.8Z'/%3E%3Ccircle cx='6' cy='6' r='1.1'/%3E%3Cpath d='M1.5 10.5L10.5 1.5' stroke='black' stroke-width='1.4' stroke-linecap='round'/%3E%3C/svg%3E");
+}
+
+.sidebar-eye-icon.col-hidden:hover,
+.sidebar-eye-icon.col-hidden:focus-visible {
+   opacity: 1;
+}
+
+/* A hidden column's entry is dimmed as a whole, except its action icons (the
+   eye especially must stay legible: it is the way back). */
+.sidebar-col.col-hidden .sidebar-col-name,
+.sidebar-col.col-hidden .sidebar-col-type,
+.sidebar-col.col-hidden .sidebar-sparkline,
+.sidebar-col.col-hidden .sidebar-col-footer {
+   opacity: 0.45;
+}
+
 /* Filter icon (funnel glyph). Always shown; faint when inactive, fully opaque
    when the column has an active filter -- the same opacity-based active/idle
    treatment as the pin and sort icons. Clicking it opens the column's filter
@@ -1434,6 +1505,49 @@ body.overlay-scrollbars #sidebarContent::-webkit-scrollbar {
    color: var(--grid-na-color);
    font-size: 10px;
    font-style: italic;
+}
+
+
+/* ==========================================================================
+   All-columns-hidden hint
+   ========================================================================== */
+
+/* Centered over the panes row (which anchors it) while every column is hidden.
+   The sidebar is the only per-column show affordance and may be collapsed, so
+   the hint carries a show-all button. Shown via .visible by
+   updateAllColumnsHiddenHint; below the sticky header (z-index 10) and the
+   error overlay. */
+#allColumnsHiddenHint {
+   display: none;
+   position: absolute;
+   inset: 0;
+   z-index: 5;
+   align-items: center;
+   justify-content: center;
+   gap: 10px;
+   pointer-events: none;
+   color: var(--grid-na-color);
+   font-size: 12px;
+}
+
+#allColumnsHiddenHint.visible {
+   display: flex;
+}
+
+#allColumnsHiddenHint button {
+   pointer-events: auto;
+   font: inherit;
+   color: var(--grid-fg);
+   background-color: var(--grid-header-bg);
+   border: 1px solid var(--grid-border);
+   border-radius: 3px;
+   padding: 3px 8px;
+   cursor: pointer;
+}
+
+#allColumnsHiddenHint button:hover,
+#allColumnsHiddenHint button:focus-visible {
+   background-color: var(--grid-hover-bg);
 }
 
 

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -8449,6 +8449,18 @@ var maybeSlideForScroll = function() {
       (vHi > fetchedWindowEnd && fetchedWindowEnd < totalCols);
    if (!needSlide) return;
 
+   // A window narrower than the viewport can never cover it: recentring only
+   // swaps which side shows unfetched span columns, and because the two
+   // layouts' measured widths disagree about where the center falls, each
+   // landing slide can propose undoing the previous one, rebuilding the grid
+   // forever. Stay parked while any of the window remains on screen; once it
+   // has scrolled away entirely, a recenter brings data back into view and
+   // lands in a parked partial-overlap state.
+   var visibleSpan = visibleIndexOf(vHi) - visibleIndexOf(vLo) + 1;
+   var windowOnScreen = vHi >= fetchedWindowStart && vLo <= fetchedWindowEnd;
+   if (visibleSpan > maxDisplayColumns && windowOnScreen)
+      return;
+
    var center = Math.round((vLo + vHi) / 2);
    var newOffset = centeredColumnOffset(center);
    if (newOffset === columnOffset) return;

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -4044,13 +4044,27 @@ var updateInfoBar = function() {
 
    var sortText = "";
    if (sortColumn >= 0 && sortDirection && cols) {
-      var sortPos = posForAbsColIndex(sortColumn);
-      if (sortPos >= 0 && cols[sortPos]) {
-         var dirText = sortDirection === "asc" ? "ascending" : "descending";
-         sortText = "Sorted by: " + cols[sortPos].col_name + " (" + dirText + ")";
-      }
+      var dirText = sortDirection === "asc" ? "ascending" : "descending";
+      sortText = "Sorted by: " + columnNameForAbs(sortColumn) + " (" + dirText + ")";
    }
    setSortStatus(sortText);
+};
+
+// A column's name by absolute index, from whichever metadata has it: the
+// fetched window, the sidebar's complete column index, or the go-to-column
+// name cache; "column N" until one of them loads. The sort column in
+// particular need not be fetched -- it may be hidden, or scrolled outside the
+// window -- and the sort status must still name it.
+var columnNameForAbs = function(absIdx) {
+   var pos = posForAbsColIndex(absIdx);
+   if (pos >= 0 && cols[pos])
+      return cols[pos].col_name;
+   var listIdx = sidebarIndexByAbs[absIdx];
+   if (typeof listIdx === "number" && sidebarListCols[listIdx])
+      return sidebarListCols[listIdx].col_name;
+   if (columnNamesCache && columnNamesCache[absIdx - 1])
+      return columnNamesCache[absIdx - 1];
+   return "column " + absIdx;
 };
 
 // Create the <tr> shell for data row `r` (shared by the pinned and unpinned
@@ -5030,6 +5044,9 @@ var ensureSidebarColumns = function() {
          if (result && !result.error && result.columns && result.columns.length) {
             sidebarColumns = result.columns;
             rebuildSidebarPreservingScroll();
+            // The status bar may have been naming an unfetched sort column by
+            // number while waiting for this index (columnNameForAbs).
+            updateInfoBar();
          }
       })
       .catch(function(err) {

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -960,6 +960,10 @@ var fetchColumnNames = function(callback) {
       .then(function(result) {
          if (result && !result.error && result.names) {
             columnNamesCache = result.names;
+            // The status bar may be naming an unfetched sort column by number
+            // (columnNameForAbs falls back to this cache when the sidebar's
+            // column index is unavailable); re-render it now the names exist.
+            updateInfoBar();
             callback(columnNamesCache);
          } else {
             callback(null);

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -291,17 +291,31 @@ var activeHeaderCol = -1;
 // implicitly pinned and is not represented here.
 var pinnedColumns = new Set();
 
+// Hidden columns: absolute (1-based) indices left out of the grid. Hiding is
+// purely a display concern -- a hidden column keeps its pin, sort, filter and
+// manual width, and its sidebar entry stays listed (dimmed) so it can be shown
+// again. Mutate only through setColumnsHidden / the state-restore paths, which
+// drop hiddenSortedCache; the span layout searches that sorted copy on every
+// scroll event (countHiddenBelow).
+var hiddenColumns = new Set();
+var hiddenSortedCache = null;
+
 // Saved per-object state loaded at the start of bootstrap (before the column
 // fetch) so the request can include pinned columns that fall outside the
 // visible window. Validated against the column fingerprint once `cols`
 // arrives; see primeSelectionState / applySavedState.
 var pendingSavedState = null;
 
-// Number of pinned columns primed from saved state for the in-flight column
-// request. If the fingerprint turns out not to match (object reassigned to a
-// different frame), those columns were requested against the wrong frame, so
-// initGrid re-bootstraps once after clearing the stale selection.
-var primedPinnedCount = 0;
+// Number of pinned + hidden columns primed from saved state for the in-flight
+// column request. If the fingerprint turns out not to match (object reassigned
+// to a different frame), that request was shaped by the wrong frame's
+// selection, so initGrid re-bootstraps once after clearing it.
+var primedSelectionCount = 0;
+
+// Frame width recorded in the saved state, used only to bound the visible-
+// column walk of the first fetch after a bootstrap, when totalCols is not yet
+// known (see windowEndAbs). 0 = no hint.
+var primedTotalCols = 0;
 
 // Pinned-block width cache (pinnedOffsetsCache.totalWidth), dropped by
 // invalidatePinnedOffsets() on width/pinning changes. The pinned columns now
@@ -1619,9 +1633,11 @@ var posForAbsColIndex = function(absIdx) {
 // is available while the window is scrolled away). Pins that are already inside
 // the window keep their natural position -- the pinned-first display order is a
 // render-time concern handled by getColumnOrder, not a fetch-order one, so the
-// position of an in-window column stays stable across a re-fetch. Returns an
-// empty array to mean "the whole frame" -- used when no column windowing is
-// configured, in which case every column is present.
+// position of an in-window column stays stable across a re-fetch. Hidden
+// columns are never requested: the window is measured in visible columns
+// (windowEndAbs), so hiding extends its absolute span instead of thinning it.
+// Returns an empty array to mean "the whole frame" -- used when no column
+// windowing is configured, in which case every column is present.
 var buildRequestedColumns = function() {
    var maxCols = effectiveMaxDisplayColumns();
    if (maxCols <= 0)
@@ -1631,9 +1647,7 @@ var buildRequestedColumns = function() {
    // offset, so the first window column is columnOffset + 1. The server clamps
    // indices past the end of the frame, so an unknown totalCols is harmless.
    var windowStart = columnOffset + 1;
-   var windowEnd = columnOffset + maxCols;
-   if (totalCols > 0)
-      windowEnd = Math.min(windowEnd, totalCols);
+   var windowEnd = windowEndAbs(windowStart, maxCols);
 
    var requested = [];
    var seen = {};
@@ -1642,7 +1656,7 @@ var buildRequestedColumns = function() {
    // first so their data accompanies the window we're about to display.
    Array.from(pinnedColumns)
       .filter(function(a) {
-         return typeof a === "number" && a >= 1 &&
+         return typeof a === "number" && a >= 1 && !hiddenColumns.has(a) &&
             (a < windowStart || a > windowEnd);
       })
       .sort(function(a, b) { return a - b; })
@@ -1651,9 +1665,35 @@ var buildRequestedColumns = function() {
       });
 
    for (var c = windowStart; c <= windowEnd; c++) {
-      if (!seen[c]) { seen[c] = true; requested.push(c); }
+      if (!seen[c] && !hiddenColumns.has(c)) { seen[c] = true; requested.push(c); }
    }
+
+   // With every column hidden there is nothing to ask for, but an empty request
+   // means "the whole frame" to the server -- a full describe of a possibly
+   // very wide frame. Name the lowest hidden column instead: it is fetched but
+   // never rendered (getColumnOrder drops it), and the frame totals still arrive.
+   if (requested.length === 0 && hiddenColumns.size > 0)
+      requested.push(hiddenSorted()[0]);
    return requested;
+};
+
+// Absolute index of the last column of a fetch window holding `count` VISIBLE
+// columns from startAbs: the count-th non-hidden column at or after startAbs,
+// or the frame's last column when fewer remain. Before the first response the
+// frame width is unknown; with restored hidden columns the saved-state hint
+// bounds the walk then, so a restored hide-all can't run the request entirely
+// past the end (which the server would answer with the whole frame). Without
+// hidden columns the walk stays unbounded and the server clamps it: the hint
+// is stale after a column is added, and only the hidden case is guaranteed a
+// clean re-bootstrap on the resulting fingerprint mismatch (initGrid).
+var windowEndAbs = function(startAbs, count) {
+   var end = nthVisibleAbs(startAbs, count - 1);
+   var bound = totalCols;
+   if (bound <= 0 && hiddenColumns.size > 0)
+      bound = primedTotalCols;
+   if (bound > 0 && end > bound)
+      end = bound;
+   return end;
 };
 
 // The ordered list of absolute column indices to request for ROW data. Once
@@ -1692,13 +1732,17 @@ var effectiveMaxDisplayColumns = function() {
 // Returns the column render order: pinned columns first (in original order),
 // then unpinned columns (in original order). Column 0 (rownames) is always first.
 // The server returns exactly the columns we asked for (pinned + window), so we
-// order the whole fetched set rather than capping at maxDisplayColumns.
+// order the whole fetched set rather than capping at maxDisplayColumns. Hidden
+// columns are left out even when fetched (a column hidden after its fetch stays
+// in `cols` until the next window slide).
 var getColumnOrder = function() {
    var colCount = cols ? cols.length : 0;
    var pinned = [];
    var unpinned = [];
    for (var i = 0; i < colCount; i++) {
-      if (isColumnPinned(i)) {
+      if (isColumnHidden(absColIndex(i))) {
+         continue;
+      } else if (isColumnPinned(i)) {
          pinned.push(i);
       } else {
          unpinned.push(i);
@@ -1772,32 +1816,67 @@ var pinnedBlockWidth = function() {
 // absorbed when a slide lands (anchor-based scroll compensation in
 // applyColumnWindowUpdate). This is what gives the horizontal scrollbar the
 // full frame's range, so the user scrolls -- rather than paginates -- through
-// columns.
+// columns. Hidden columns are absent from all three segments.
 // ----------------------------------------------------------------------------
 
-// Number of pinned columns whose absolute index falls in [lo, hi].
-var countPinnedInRange = function(lo, hi) {
+// Sorted copy of the hidden set, rebuilt lazily after a mutation (the mutation
+// paths null hiddenSortedCache).
+var hiddenSorted = function() {
+   if (hiddenSortedCache === null)
+      hiddenSortedCache = Array.from(hiddenColumns).sort(function(a, b) { return a - b; });
+   return hiddenSortedCache;
+};
+
+var isColumnHidden = function(absIdx) {
+   return hiddenColumns.has(absIdx);
+};
+
+// Number of hidden columns with absolute index < abs. A binary search, so the
+// scroll-time layout math stays cheap when thousands of columns are hidden.
+var countHiddenBelow = function(abs) {
+   var arr = hiddenSorted();
+   var lo = 0, hi = arr.length;
+   while (lo < hi) {
+      var mid = (lo + hi) >> 1;
+      if (arr[mid] < abs)
+         lo = mid + 1;
+      else
+         hi = mid;
+   }
+   return lo;
+};
+
+var countHiddenInRange = function(lo, hi) {
    if (lo > hi) return 0;
-   var n = 0;
+   return countHiddenBelow(hi + 1) - countHiddenBelow(lo);
+};
+
+// Number of columns in [lo, hi] that take no space in the scrollable layout:
+// pinned (frozen pane) or hidden (not rendered). A pinned column that is also
+// hidden counts once.
+var countExcludedInRange = function(lo, hi) {
+   if (lo > hi) return 0;
+   var n = countHiddenInRange(lo, hi);
    pinnedColumns.forEach(function(abs) {
-      if (abs >= lo && abs <= hi) n++;
+      if (abs >= lo && abs <= hi && !hiddenColumns.has(abs)) n++;
    });
    return n;
 };
 
-// Unpinned column counts in the spans. Pinned columns are excluded: they are
-// always fetched and rendered sticky at the front, so they occupy no span
-// space. fetchedWindowEnd === 0 (no grid yet) yields empty spans.
+// Layout column counts in the spans. Pinned and hidden columns are excluded:
+// pinned columns are always fetched and rendered in the frozen pane, hidden
+// ones are not rendered at all, so neither occupies span space.
+// fetchedWindowEnd === 0 (no grid yet) yields empty spans.
 var leftSpanCols = function() {
    var hi = fetchedWindowStart - 1;
    if (fetchedWindowEnd <= 0 || hi < 1) return 0;
-   return hi - countPinnedInRange(1, hi);
+   return hi - countExcludedInRange(1, hi);
 };
 
 var rightSpanCols = function() {
    if (fetchedWindowEnd <= 0 || fetchedWindowEnd >= totalCols) return 0;
    var lo = fetchedWindowEnd + 1;
-   return (totalCols - lo + 1) - countPinnedInRange(lo, totalCols);
+   return (totalCols - lo + 1) - countExcludedInRange(lo, totalCols);
 };
 
 var leftSpanWidth = function() {
@@ -1812,15 +1891,63 @@ var rightSpanWidth = function() {
    return rightSpanWidthCache;
 };
 
-// The k-th (0-based) unpinned absolute column index at or after startAbs.
-// Walks the (small, sorted) pinned set to skip over pinned indices.
-var nthUnpinnedAbs = function(startAbs, k) {
-   var sorted = Array.from(pinnedColumns).sort(function(a, b) { return a - b; });
+// The k-th (0-based) column at or after startAbs that countExcluded(lo, hi)
+// does not exclude. Iterates start + k + excluded(start..abs) to a fixed
+// point: each pass folds in the excluded columns the previous one skipped
+// over, and the walk stops on a column that is itself included. Unclamped.
+var nthIncludedAbs = function(startAbs, k, countExcluded) {
    var abs = startAbs + k;
-   for (var i = 0; i < sorted.length; i++) {
-      if (sorted[i] >= startAbs && sorted[i] <= abs) abs++;
+   while (true) {
+      var next = startAbs + k + countExcluded(startAbs, abs);
+      if (next === abs)
+         return abs;
+      abs = next;
    }
+};
+
+// The k-th (0-based) non-hidden absolute column index at or after startAbs.
+var nthVisibleAbs = function(startAbs, k) {
+   return nthIncludedAbs(startAbs, k, countHiddenInRange);
+};
+
+// The k-th (0-based) absolute column index at or after startAbs that occupies
+// scrollable layout space (neither pinned nor hidden), clamped to the frame.
+var nthLayoutAbs = function(startAbs, k) {
+   var abs = nthIncludedAbs(startAbs, k, countExcludedInRange);
    return Math.max(1, Math.min(abs, totalCols));
+};
+
+// Visible (non-hidden) columns in the frame; 0 while totalCols is unknown.
+var visibleColumnCount = function() {
+   if (totalCols <= 0) return 0;
+   return totalCols - countHiddenInRange(1, totalCols);
+};
+
+// A column's 0-based position among the visible columns (the number of
+// visible columns before it).
+var visibleIndexOf = function(abs) {
+   return (abs - 1) - countHiddenBelow(abs);
+};
+
+// Largest columnOffset at which a window of maxDisplayColumns visible columns
+// still fits before the end of the frame -- the clamp for scroll-driven slides
+// and jumps. In absolute terms that window may span far more than
+// maxDisplayColumns indices when columns are hidden.
+var maxColumnOffset = function() {
+   var visible = visibleColumnCount();
+   if (maxDisplayColumns <= 0 || visible <= maxDisplayColumns) return 0;
+   return nthVisibleAbs(1, visible - maxDisplayColumns) - 1;
+};
+
+// columnOffset for a window whose visible columns are centered on `abs`,
+// clamped to the frame. A jump wants context on both sides, and a window
+// starting at the target would put unfetched (blank) span columns to its
+// immediate left.
+var centeredColumnOffset = function(abs) {
+   var half = Math.floor(maxDisplayColumns / 2);
+   var startVisible = Math.max(0, visibleIndexOf(abs) - half);
+   var offset = nthVisibleAbs(1, startVisible) - 1;
+   return Math.max(0, Math.min(maxColumnOffset(), offset));
 };
 
 // Map a content x-coordinate (px from the table's left edge) to the absolute
@@ -1842,7 +1969,7 @@ var absColAtContentX = function(x) {
 
    if (x < spanBase + leftW) {
       var k = Math.max(0, Math.floor((x - spanBase) / DEFAULT_COL_WIDTH));
-      return nthUnpinnedAbs(1, k);
+      return nthLayoutAbs(1, k);
    }
 
    var fx = x - leftW;
@@ -1852,7 +1979,7 @@ var absColAtContentX = function(x) {
 
    var rx = x - (offs[lastPos + 1] + leftW);
    var k2 = Math.max(0, Math.floor(rx / DEFAULT_COL_WIDTH));
-   return nthUnpinnedAbs(fetchedWindowEnd + 1, k2);
+   return nthLayoutAbs(fetchedWindowEnd + 1, k2);
 };
 
 // Inverse of absColAtContentX: the layout x of a column's left edge, by
@@ -1882,12 +2009,12 @@ var layoutXOfAbs = function(absIdx) {
    }
 
    if (absIdx < fetchedWindowStart) {
-      var k = (absIdx - 1) - countPinnedInRange(1, absIdx - 1);
+      var k = (absIdx - 1) - countExcludedInRange(1, absIdx - 1);
       return offs[firstUnpinned] - pinnedW + Math.max(0, k) * DEFAULT_COL_WIDTH;
    }
 
    var lo = fetchedWindowEnd + 1;
-   var k2 = (absIdx - lo) - countPinnedInRange(lo, absIdx - 1);
+   var k2 = (absIdx - lo) - countExcludedInRange(lo, absIdx - 1);
    return offs[lastPos + 1] + leftW - pinnedW + Math.max(0, k2) * DEFAULT_COL_WIDTH;
 };
 
@@ -2072,7 +2199,9 @@ var reinjectHeaderUI = function(th, colIdx, col) {
 // right spacer. Cheap to call on every horizontal-window change.
 var rebuildHeaderWindow = function() {
    var thead = domThead;
-   if (!thead || !cols || !columnOrder.length) return;
+   // An empty columnOrder (every column hidden, no rownames) still needs the
+   // stale headers cleared, so only a missing grid bails.
+   if (!thead || !cols) return;
 
    var makeHeader = function(pos) {
       var colIdx = columnOrder[pos];
@@ -2191,6 +2320,135 @@ var togglePinColumn = function(absIdx, scrollActiveHeader) {
    // a no-op for them.
    if (buildRequestedColumns().join(",") !== colsRequestList().join(","))
       slideColumnWindow();
+};
+
+// ==========================================================================
+// Column Visibility
+// ==========================================================================
+
+// True when the desired fetch set names a column the current `cols` lacks.
+// Columns that merely dropped out of the desired set (a just-hidden one) can
+// stay fetched harmlessly -- getColumnOrder leaves them out -- so only a
+// missing column forces a window slide. (Unpinning is stricter: an unpinned
+// out-of-window column left in `cols` WOULD render; see togglePinColumn.)
+var fetchedSetLacksRequested = function() {
+   var have = {};
+   var fetched = colsRequestList();
+   for (var i = 0; i < fetched.length; i++)
+      have[fetched[i]] = true;
+
+   var wanted = buildRequestedColumns();
+   for (var j = 0; j < wanted.length; j++) {
+      if (!have[wanted[j]])
+         return true;
+   }
+   return false;
+};
+
+// " (N hidden)" for the column readouts, or "" when nothing is hidden.
+var hiddenColumnsText = function() {
+   var n = hiddenColumns.size;
+   return n > 0 ? " (" + n.toLocaleString() + " hidden)" : "";
+};
+
+// Hide or show columns by absolute index. Hiding is a layout change of the
+// same shape as pinning -- the column leaves the render order and the
+// scrollable spans -- so this mirrors togglePinColumn: rebuild headers and
+// rows, refresh the sidebar and status bar, persist, then re-sync the fetched
+// window when it no longer holds a column the layout wants (hiding an
+// in-window column extends the window; showing one may need it fetched). A
+// hidden column keeps its pin, sort, filter and manual width.
+//
+// options.deferSync skips the window re-sync for callers that follow up with
+// a slide of their own (goToColumn); options.scrollActiveHeader keeps a
+// keyboard-driven active header in view, as togglePinColumn does.
+var setColumnsHidden = function(absList, hidden, options) {
+   var changed = false;
+   for (var i = 0; i < absList.length; i++) {
+      var abs = absList[i];
+      if (typeof abs !== "number" || abs < 1)
+         continue;
+      if (hidden && !hiddenColumns.has(abs)) {
+         hiddenColumns.add(abs);
+         changed = true;
+      } else if (!hidden && hiddenColumns.has(abs)) {
+         hiddenColumns.delete(abs);
+         changed = true;
+      }
+   }
+   if (!changed) return;
+   hiddenSortedCache = null;
+
+   // The display order changes, so positional cell/header coordinates are
+   // stale. The active header follows its column when that column is still
+   // shown; one on a column just hidden moves to the column now occupying its
+   // display slot, so the keyboard cursor doesn't vanish with it.
+   clearActiveCell();
+   var headerOrigCol = -1;
+   var headerSlot = -1;
+   if (activeHeaderCol >= 0) {
+      headerOrigCol = columnOrder[activeHeaderCol];
+      headerSlot = activeHeaderCol;
+      clearActiveHeader();
+   }
+
+   // Keep the fetch window over visible columns: hiding can leave the offset
+   // past the last one, and a window starting there would hold nothing.
+   if (maxDisplayColumns > 0)
+      columnOffset = Math.min(columnOffset, maxColumnOffset());
+
+   invalidatePinnedOffsets();
+   rebuildHeaders();
+   renderVisibleRows(true);
+   updateCustomScrollbars();
+   updateSidebarColumnIndicators();
+   updateAllColumnsHiddenHint();
+   updateInfoBar();
+   saveState();
+
+   if (headerOrigCol >= 0) {
+      var newIdx = columnOrder.indexOf(headerOrigCol);
+      if (newIdx < 0)
+         newIdx = Math.min(headerSlot, columnOrder.length - 1);
+      if (newIdx >= 0)
+         setActiveHeader(newIdx, !!(options && options.scrollActiveHeader));
+   }
+
+   if (!(options && options.deferSync) && fetchedSetLacksRequested())
+      slideColumnWindow();
+};
+
+var toggleColumnHidden = function(absIdx) {
+   setColumnsHidden([absIdx], !hiddenColumns.has(absIdx));
+};
+
+// Hide every column, or show every hidden one. Backs the sidebar header's eye:
+// with anything hidden it shows all, otherwise it hides all. Hide-all is the
+// "start from nothing and pick a few" workflow, so an all-hidden grid is a
+// supported state (see updateAllColumnsHiddenHint).
+var setAllColumnsHidden = function(hidden) {
+   var list = [];
+   if (hidden) {
+      for (var c = 1; c <= totalCols; c++)
+         list.push(c);
+   } else {
+      list = Array.from(hiddenColumns);
+   }
+   setColumnsHidden(list, hidden);
+};
+
+var toggleAllColumnsHidden = function() {
+   setAllColumnsHidden(hiddenColumns.size === 0);
+};
+
+// Show or hide the in-grid hint for the all-hidden state. The sidebar is the
+// only per-column show affordance and may be collapsed, which would leave an
+// empty grid with no visible way back; the hint carries a show-all button.
+var updateAllColumnsHiddenHint = function() {
+   var hint = document.getElementById("allColumnsHiddenHint");
+   if (!hint) return;
+   var allHidden = cols !== null && totalCols > 0 && visibleColumnCount() === 0;
+   hint.classList.toggle("visible", allHidden);
 };
 
 // Rebuild headers in the current column order (pinned first, then unpinned).
@@ -2386,7 +2644,9 @@ var autoSizeColumns = function() {
    var thead = domThead;
    // Widths are computed from columnOrder + data (below), so headers need not
    // exist yet -- this is also the path that first builds the windowed header.
-   if (!thead || !cols || !columnOrder.length) return;
+   // An empty columnOrder (every column hidden, no rownames) runs through so
+   // the table collapses and the stale headers are cleared.
+   if (!thead || !cols) return;
 
    // If the viewport isn't visible (e.g. background tab), measurements
    // will be wrong. Flag and bail; onActivate will re-run sizing once the
@@ -3690,7 +3950,9 @@ var setSortStatus = function(text) {
 var visibleColumnRangeText = function() {
    if (!cols || measuredWidths.length === 0 || totalCols <= 0)
       return "";
-   if (maxDisplayColumns <= 0 || totalCols <= maxDisplayColumns)
+   // Once hiding brings the visible columns within one window the frame no
+   // longer slides, so the plain total reads better (see the note above).
+   if (maxDisplayColumns <= 0 || visibleColumnCount() <= maxDisplayColumns)
       return "";
    var viewport = domViewport;
    if (!viewport)
@@ -3776,6 +4038,7 @@ var updateInfoBar = function() {
          ? colRange
          : ", " + totalCols.toLocaleString() +
            (totalCols === 1 ? " total column" : " total columns");
+      text += hiddenColumnsText();
    }
    if (textEl) textEl.textContent = text;
 
@@ -5110,14 +5373,33 @@ var populateEntrySummary = function(entry, summary) {
    }
 };
 
-// Apply the current pin/sort/filter indicator state to a single built entry.
-// Shared by buildSidebarEntry (at build time) and updateSidebarColumnIndicators
-// (when state changes), keyed off the entry's absolute data-col-idx.
+// Apply the current pin/hidden/sort/filter indicator state to a single built
+// entry. Shared by buildSidebarEntry (at build time) and
+// updateSidebarColumnIndicators (when state changes), keyed off the entry's
+// absolute data-col-idx.
 var applySidebarEntryIndicators = function(entry) {
    var absIdx = parseInt(entry.getAttribute("data-col-idx"), 10);
    if (isNaN(absIdx)) return;
    var nameEl = entry.querySelector(".sidebar-col-name");
    var colName = nameEl ? nameEl.textContent : "";
+
+   // A hidden column's entry is dimmed as a whole (CSS), and activating it
+   // shows the column as well as scrolling to it (goToColumn).
+   var hidden = isColumnHidden(absIdx);
+   entry.classList.toggle("col-hidden", hidden);
+   var headerEl = entry.querySelector(".sidebar-col-header");
+   if (headerEl) {
+      headerEl.setAttribute("aria-label",
+         (hidden ? "Show and scroll to column " : "Scroll to column ") + colName);
+   }
+   var eyeEl = entry.querySelector(".sidebar-eye-icon");
+   if (eyeEl) {
+      eyeEl.classList.toggle("col-hidden", hidden);
+      eyeEl.title = hidden ? "Show column" : "Hide column";
+      eyeEl.setAttribute("aria-pressed", hidden ? "true" : "false");
+      eyeEl.setAttribute("aria-label",
+         (hidden ? "Show column " : "Hide column ") + colName);
+   }
 
    var pinEl = entry.querySelector(".sidebar-pin-icon");
    if (pinEl) {
@@ -5164,8 +5446,8 @@ var applySidebarEntryIndicators = function(entry) {
 };
 
 // Build one sidebar entry's DOM. No per-entry listeners -- those are delegated
-// to the content container. Identity (name, type, pin/sort/filter icons) is
-// always present; the summary (sparkline + range/NA) is seeded from cache if
+// to the content container. Identity (name, type, pin/eye/sort/filter icons)
+// is always present; the summary (sparkline + range/NA) is seeded from cache if
 // available, else queued for the debounced lazy fetch. The sparkline lives in a
 // fixed-height slot reserved up front so every entry is the constant
 // --sidebar-entry-height the virtualizer assumes.
@@ -5219,6 +5501,14 @@ var buildSidebarEntry = function(col, absIdx, virtIndex) {
    if (col.col_tz)
       type.title = "Timezone: " + col.col_tz;
    header.appendChild(type);
+
+   // Eye: hides the column from the grid, or shows it again. Its state text
+   // (title / aria) is applied with the other indicators below.
+   var eyeIcon = document.createElement("span");
+   eyeIcon.className = "sidebar-eye-icon";
+   eyeIcon.setAttribute("role", "button");
+   eyeIcon.setAttribute("tabindex", "0");
+   header.appendChild(eyeIcon);
 
    var filterIcon = document.createElement("span");
    filterIcon.className = "sidebar-filter-icon";
@@ -5395,6 +5685,11 @@ var onSidebarContentClick = function(evt) {
       togglePinColumn(absIdx);
       return;
    }
+   if (t.closest(".sidebar-eye-icon")) {
+      evt.stopPropagation(); evt.preventDefault();
+      toggleColumnHidden(absIdx);
+      return;
+   }
    var sortEl = t.closest(".sidebar-sort-icon");
    if (sortEl) {
       if (sortEl.classList.contains("disabled")) return;
@@ -5431,6 +5726,9 @@ var onSidebarContentKeydown = function(evt) {
    } else if (t.classList.contains("sidebar-pin-icon")) {
       evt.preventDefault(); evt.stopPropagation();
       togglePinColumn(absIdx);
+   } else if (t.classList.contains("sidebar-eye-icon")) {
+      evt.preventDefault(); evt.stopPropagation();
+      toggleColumnHidden(absIdx);
    } else if (t.classList.contains("sidebar-sort-icon")) {
       if (t.classList.contains("disabled")) return;
       evt.preventDefault(); evt.stopPropagation();
@@ -5580,6 +5878,12 @@ var initSidebar = function() {
    }
    toggle.appendChild(toggleLabel);
 
+   // "(N hidden)" qualifier on the count; filled in (and kept current) by
+   // updateSidebarHiddenState.
+   var hiddenTag = document.createElement("span");
+   hiddenTag.className = "sidebar-toggle-hidden";
+   toggleLabel.appendChild(hiddenTag);
+
    // When the summaries describe a filtered subset rather than the whole
    // frame, say so -- the histograms/ranges/NA% otherwise look like they
    // describe the full object. (filteredSummaries is set only while a column
@@ -5615,6 +5919,26 @@ var initSidebar = function() {
          onToggleHelpActivate(evt);
    });
    toggle.appendChild(toggleHelp);
+
+   // Eye: hides every column, or shows every hidden one (see
+   // toggleAllColumnsHidden). Like the help icon, its activation must not
+   // reach the toggle. Its glyph/state text is applied by
+   // updateSidebarHiddenState.
+   var toggleEye = document.createElement("span");
+   toggleEye.className = "sidebar-eye-icon sidebar-toggle-eye";
+   toggleEye.setAttribute("role", "button");
+   toggleEye.setAttribute("tabindex", "0");
+   var onToggleEyeActivate = function(evt) {
+      evt.stopPropagation();
+      evt.preventDefault();
+      toggleAllColumnsHidden();
+   };
+   toggleEye.addEventListener("click", onToggleEyeActivate);
+   toggleEye.addEventListener("keydown", function(evt) {
+      if (evt.key === "Enter" || evt.key === " ")
+         onToggleEyeActivate(evt);
+   });
+   toggle.appendChild(toggleEye);
 
    // Decorative close glyph; clicks bubble to the toggle, which remains the
    // panel's single accessible control.
@@ -5694,23 +6018,42 @@ var initSidebar = function() {
    // Attach the floating scrollbar after the spacers establish the scroll range.
    attachSidebarScrollbar();
    if (sidebarScrollbar_) sidebarScrollbar_.update();
+
+   updateSidebarHiddenState();
 };
 
-// Sync the sidebar's pin and sort icons with the module pin/sort state.
-// Called after any pin or sort mutation -- whether it originated from the
-// grid header, the keyboard, or the sidebar icons themselves -- and at the
-// end of initSidebar to apply the initial (possibly restored) state.
-// Re-apply pin/sort/filter indicator state to the currently-built entries.
-// With virtualization only the visible window exists in the DOM; off-window
-// entries pick up the current state when they are next built (buildSidebarEntry
-// calls applySidebarEntryIndicators). The per-entry logic is shared with that
-// build path via applySidebarEntryIndicators.
+// Sync the sidebar header with the hidden-column state: the "(N hidden)" tag
+// on the column count and the show-all / hide-all eye.
+var updateSidebarHiddenState = function() {
+   var anyHidden = hiddenColumns.size > 0;
+   var tag = document.querySelector("#sidebarToggle .sidebar-toggle-hidden");
+   if (tag)
+      tag.textContent = hiddenColumnsText();
+   var eye = document.querySelector("#sidebarToggle .sidebar-toggle-eye");
+   if (eye) {
+      eye.classList.toggle("col-hidden", anyHidden);
+      var action = anyHidden ? "Show all columns" : "Hide all columns";
+      eye.title = action;
+      eye.setAttribute("aria-label", action);
+      eye.setAttribute("aria-pressed", anyHidden ? "true" : "false");
+   }
+};
+
+// Re-apply pin/hidden/sort/filter indicator state to the currently-built
+// entries, and the hidden-column state to the header. Called after any pin,
+// hide, sort or filter mutation -- whether it originated from the grid header,
+// the keyboard, or the sidebar icons themselves. With virtualization only the
+// visible window exists in the DOM; off-window entries pick up the current
+// state when they are next built (buildSidebarEntry calls
+// applySidebarEntryIndicators). The per-entry logic is shared with that build
+// path via applySidebarEntryIndicators.
 var updateSidebarColumnIndicators = function() {
    var content = document.getElementById("sidebarContent");
    if (!content) return;
    var entries = content.querySelectorAll(".sidebar-col");
    for (var i = 0; i < entries.length; i++)
       applySidebarEntryIndicators(entries[i]);
+   updateSidebarHiddenState();
 };
 
 // ==========================================================================
@@ -5828,9 +6171,18 @@ var buildSidebarHelpOverlay = function() {
    addLine(headerSec,
       "Each entry names a column and its type. Click an entry to scroll " +
       "the grid to that column; the pin and sort icons work just like " +
-      "their counterparts in the grid header, and the funnel icon filters " +
-      "the column (see Filter below). For date and date-time columns, hover " +
-      "the type label to see the timezone.");
+      "their counterparts in the grid header, the eye icon hides or shows " +
+      "the column (see Visibility below), and the funnel icon filters it " +
+      "(see Filter below). For date and date-time columns, hover the type " +
+      "label to see the timezone.");
+
+   var visibilitySec = addSection("Visibility");
+   addLine(visibilitySec,
+      "The eye icon hides the column from the grid, or shows it again; the " +
+      "eye in the panel header hides every column, or shows every hidden " +
+      "one. A hidden column keeps its pin, sort and filter, and is shown " +
+      "again when you click its entry or jump to it with Go to column. In " +
+      "the grid, H hides the column under the keyboard cursor.");
 
    var plotSec = addSection("Mini-plot");
    addLine(plotSec,
@@ -6302,6 +6654,17 @@ var onGridKeyDown = function(evt) {
          // Keyboard toggle: keep the active header (the keyboard cursor)
          // visible by scrolling it back into view after the reorder.
          if (!isRownames) togglePinColumn(absColIndex(origCol), true);
+         return;
+      }
+      if (key === "h" || key === "H") {
+         evt.preventDefault();
+         // Keyboard hide: the cursor moves to the column that takes the hidden
+         // one's slot (setColumnsHidden), scrolled into view. Showing a hidden
+         // column again is a sidebar action -- it has no header to target.
+         if (!isRownames) {
+            setColumnsHidden([absColIndex(origCol)], true,
+                             { scrollActiveHeader: true });
+         }
          return;
       }
    }
@@ -6855,10 +7218,11 @@ var installColumnResponse = function(resCols) {
    if (cols[0].total_rows > 0)
       totalRows = cols[0].total_rows;
 
-   // Record the fetched window bounds the span layout derives from.
+   // Record the fetched window bounds the span layout derives from. The end is
+   // measured in visible columns (windowEndAbs), matching buildRequestedColumns.
    fetchedWindowStart = columnOffset + 1;
    fetchedWindowEnd = maxDisplayColumns > 0
-      ? Math.min(columnOffset + maxDisplayColumns, totalCols)
+      ? windowEndAbs(fetchedWindowStart, maxDisplayColumns)
       : totalCols;
 };
 
@@ -6933,11 +7297,12 @@ var initGrid = function(resCols, data) {
    // so pinning order must be settled here; fetchRows below needs sort/filters.
    var stateDiscarded = applySavedState(savedState);
 
-   // If the fingerprint didn't match, the columns we requested may have
-   // included pinned indices from an unrelated frame (now cleared). Re-bootstrap
-   // once with a clean window so we don't display the wrong prepended columns.
-   if (stateDiscarded && primedPinnedCount > 0) {
-      primedPinnedCount = 0;
+   // If the fingerprint didn't match, the columns we requested were shaped by
+   // an unrelated frame's selection (pinned indices prepended, hidden ones
+   // skipped -- now cleared). Re-bootstrap once with a clean window so we
+   // don't display the wrong columns.
+   if (stateDiscarded && primedSelectionCount > 0) {
+      primedSelectionCount = 0;
       pendingSavedState = null;
       bootstrap();
       return;
@@ -6955,6 +7320,7 @@ var initGrid = function(resCols, data) {
 
    // Initialize sidebar
    initSidebar();
+   updateAllColumnsHiddenHint();
 
    // Handle data import mode (data provided directly)
    if (data) {
@@ -7118,6 +7484,8 @@ var resetGridState = function() {
    cachedSearch = "";
    cachedFilterValues = {};
    pinnedColumns.clear();
+   hiddenColumns.clear();
+   hiddenSortedCache = null;
    columnOrder = [];
    activeRow = -1;
    activeCol = -1;
@@ -7240,13 +7608,17 @@ var saveState = function() {
    // entry could never validate on reload. (saveState now also fires from scroll
    // settling and tab deactivation, either of which can race an early teardown.)
    if (!cols) return;
-   // pinnedColumns/sort/filters/manualWidths are stored by absolute column
-   // identity (col_index in the full frame), so they survive column
-   // pagination.
+   // pinnedColumns/hiddenColumns/sort/filters/manualWidths are stored by
+   // absolute column identity (col_index in the full frame), so they survive
+   // column pagination.
    var state = {
       version: STATE_VERSION,
       columns: columnFingerprint(),
+      // Frame width, so the first fetch after a reload can bound its visible-
+      // column walk before the server has reported totalCols (windowEndAbs).
+      totalCols: totalCols,
       pinnedColumns: Array.from(pinnedColumns),
+      hiddenColumns: Array.from(hiddenColumns),
       sidebarVisible: sidebarVisible,
       manualWidths: Object.assign({}, manualWidths),
       sort: sortColumn >= 0 ? { col: sortColumn, dir: sortDirection } : null,
@@ -7307,19 +7679,23 @@ var clearSavedState = function() {
    try { localStorage.removeItem(key); } catch (e) { /* quota / disabled storage */ }
 };
 
-// Populate the pinned/sort/filter selection from saved state before `cols` is
-// available. These are all keyed by absolute column identity, so they can be
-// resolved without the fetched columns -- which is what lets the column
-// request include pinned columns outside the visible window. The fingerprint
-// cannot be checked yet (it comes from the server response), so applySavedState
-// validates it once `cols` arrives and clears the selection on a mismatch.
+// Populate the pinned/hidden/sort/filter selection from saved state before
+// `cols` is available. These are all keyed by absolute column identity, so they
+// can be resolved without the fetched columns -- which is what lets the column
+// request include pinned columns outside the visible window and skip hidden
+// ones. The fingerprint cannot be checked yet (it comes from the server
+// response), so applySavedState validates it once `cols` arrives and clears
+// the selection on a mismatch.
 var primeSelectionState = function() {
    pendingSavedState = loadSavedState();
    pinnedColumns.clear();
+   hiddenColumns.clear();
+   hiddenSortedCache = null;
    sortColumn = -1;
    sortDirection = "";
    cachedFilterValues = {};
-   primedPinnedCount = 0;
+   primedSelectionCount = 0;
+   primedTotalCols = 0;
 
    var state = pendingSavedState;
    if (!state)
@@ -7331,7 +7707,15 @@ var primeSelectionState = function() {
             pinnedColumns.add(idx);
       });
    }
-   primedPinnedCount = pinnedColumns.size;
+   if (Array.isArray(state.hiddenColumns)) {
+      state.hiddenColumns.forEach(function(idx) {
+         if (typeof idx === "number" && idx >= 1)
+            hiddenColumns.add(idx);
+      });
+   }
+   primedSelectionCount = pinnedColumns.size + hiddenColumns.size;
+   if (typeof state.totalCols === "number" && state.totalCols > 0)
+      primedTotalCols = state.totalCols;
 
    if (state.sort &&
        typeof state.sort.col === "number" && state.sort.col >= 1 &&
@@ -7368,18 +7752,26 @@ var applySavedState = function(state) {
        state.columns !== columnFingerprint()) {
       clearSavedState();
       pinnedColumns.clear();
+      hiddenColumns.clear();
+      hiddenSortedCache = null;
+      primedTotalCols = 0;
       sortColumn = -1;
       sortDirection = "";
       cachedFilterValues = {};
       return true;
    }
 
-   // Selection (pins/sort/filters) was primed by primeSelectionState; clamp it
-   // to the frame now that the column count is known.
+   // Selection (pins/hidden/sort/filters) was primed by primeSelectionState;
+   // clamp it to the frame now that the column count is known.
    pinnedColumns.forEach(function(absIdx) {
       if (absIdx > totalCols)
          pinnedColumns.delete(absIdx);
    });
+   hiddenColumns.forEach(function(absIdx) {
+      if (absIdx > totalCols)
+         hiddenColumns.delete(absIdx);
+   });
+   hiddenSortedCache = null;
    if (sortColumn > totalCols) {
       sortColumn = -1;
       sortDirection = "";
@@ -7462,6 +7854,7 @@ var destroyGrid = function() {
    resetGridState();
    invalidateCache();
    destroyCustomScrollbars();
+   updateAllColumnsHiddenHint();
 
    // Clear DOM (both the unpinned and the frozen pinned pane)
    var thead = domThead;
@@ -7835,9 +8228,15 @@ var applyColumnWindowUpdate = function(resCols, options) {
       }
    }
 
-   // The user may have kept scrolling while this window was in flight;
-   // immediately evaluate whether another slide is already warranted.
-   maybeSlideForScroll();
+   // A column shown while this window was in flight was requested against
+   // the previous hidden set and may be missing from it; re-fetch once (a
+   // miss on that landing too is left to the next scroll-driven slide, so two
+   // racing updates can't ping-pong). Otherwise the user may have kept
+   // scrolling; immediately evaluate whether another slide is warranted.
+   if (!(options && options.resync) && fetchedSetLacksRequested())
+      slideColumnWindow({ resync: true });
+   else
+      maybeSlideForScroll();
 };
 
 // Fetch column metadata for the current columnOffset/maxDisplayColumns and
@@ -7906,8 +8305,7 @@ var maybeSlideForScroll = function() {
    if (!needSlide) return;
 
    var center = Math.round((vLo + vHi) / 2);
-   var newOffset = Math.max(0, Math.min(totalCols - maxDisplayColumns,
-      center - Math.floor(maxDisplayColumns / 2) - 1));
+   var newOffset = centeredColumnOffset(center);
    if (newOffset === columnOffset) return;
 
    columnOffset = newOffset;
@@ -7934,6 +8332,11 @@ var goToColumn = function(column) {
    if (!isFinite(abs) || abs < 1) return;
    if (totalCols > 0) abs = Math.min(abs, totalCols);
 
+   // Jumping to a hidden column is a request to see it. Show it first, leaving
+   // the window re-sync to the reveal / slide below, which centers on it.
+   if (isColumnHidden(abs))
+      setColumnsHidden([abs], false, { deferSync: true });
+
    // Already fetched: bring it into view directly (centered, with the
    // highlight flash).
    var pos = posForAbsColIndex(abs);
@@ -7942,12 +8345,10 @@ var goToColumn = function(column) {
       return;
    }
 
-   // Center the fetched window on the target as well as the viewport: a
-   // jump wants context on both sides, and a window starting at the target
-   // would put unfetched (blank) span columns to its immediate left.
+   // Center the fetched window on the target as well as the viewport (see
+   // centeredColumnOffset).
    if (maxDisplayColumns <= 0) return;
-   columnOffset = Math.max(0, Math.min(totalCols - maxDisplayColumns,
-      abs - 1 - Math.floor(maxDisplayColumns / 2)));
+   columnOffset = centeredColumnOffset(abs);
    slideColumnWindow({ targetAbs: abs });
 };
 
@@ -8398,6 +8799,14 @@ document.addEventListener("DOMContentLoaded", function() {
    var sortClear = document.getElementById("rsGridData_info_sort_clear");
    if (sortClear)
       sortClear.addEventListener("click", clearSort);
+
+   // Likewise static: the show-all button of the all-columns-hidden hint.
+   var showAll = document.getElementById("allColumnsHiddenShow");
+   if (showAll) {
+      showAll.addEventListener("click", function() {
+         setAllColumnsHidden(false);
+      });
+   }
 
    if (dataMode === "server") {
       bootstrap();

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -2640,10 +2640,19 @@ var isHeaderEditorOpen = function() {
 // slide (whose new window may not even contain the editor's column) and by
 // the pin / hide rebuilds.
 var dismissHeaderEditors = function() {
-   if (dismissActivePopup) dismissActivePopup(true);
+   // A text filter box (inline in the header, or inside a sidebar filter
+   // popup) applies its input on a debounce. Commit anything still pending
+   // before the box goes away: the rebuilt header is created from the stored
+   // filter, and a debounced apply landing afterwards would filter the grid
+   // under a blank box. Done before the popup dismissal below, which detaches
+   // a popup-hosted box.
    var activeEl = document.activeElement;
-   if (activeEl && activeEl.classList && activeEl.classList.contains("textFilterBox"))
+   if (activeEl && activeEl.classList && activeEl.classList.contains("textFilterBox")) {
+      if (activeEl.dvFlushPendingApply)
+         activeEl.dvFlushPendingApply();
       activeEl.blur();
+   }
+   if (dismissActivePopup) dismissActivePopup(true);
    deferredHeaderRebuild = false;
 };
 
@@ -3524,6 +3533,10 @@ var createTextFilterBox = function(ele, idx, col, onDismiss) {
       setColumnSearch(idx, "character|" + encodeURIComponent(input.value));
       applyFilters();
    });
+
+   // Lets dismissHeaderEditors commit typed-but-not-yet-applied text before a
+   // rebuild recreates this box from the stored filter value.
+   input.dvFlushPendingApply = function() { updateView.flush(); };
 
    input.addEventListener("keyup", function(evt) {
       // Escape dismisses (handled on keydown below); its keyup must not

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -7148,17 +7148,27 @@ var updateGridScrollbars = function() {
 var lastColumnOverflow = null;
 
 var updateColumnOverflowState = function() {
-   if (!cols || totalTableWidth <= 0)
+   if (!cols)
       return;
    var viewport = domViewport;
    if (!viewport)
+      return;
+
+   // Hidden columns take no layout width, but the host's Go to column box is
+   // also the way to reach (and thereby show) one of them, so it stays
+   // available while any column is hidden even when the visible set fits --
+   // including the all-hidden case, where the unpinned width is legitimately
+   // zero. Otherwise a zero width means the layout isn't measured yet, and
+   // there is nothing to report.
+   var anyHidden = hiddenColumns.size > 0;
+   if (totalTableWidth <= 0 && !anyHidden)
       return;
 
    // totalTableWidth is the unpinned content width (fetched unpinned columns
    // plus estimated unfetched spans); domViewport is the unpinned pane. Compare
    // against clientWidth rather than scrollWidth, which includes the overscroll
    // padding and would read as "overflowing" for every frame.
-   var overflow = totalTableWidth > viewport.clientWidth + 1;
+   var overflow = totalTableWidth > viewport.clientWidth + 1 || anyHidden;
    if (overflow !== lastColumnOverflow) {
       lastColumnOverflow = overflow;
       if (window.columnOverflowCallback)

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -2140,7 +2140,15 @@ var appendPinnedCells = function(parent, makeCell) {
 var appendUnpinnedWindowedCells = function(parent, makeCell, spacerTag) {
    var firstUnpinned = firstUnpinnedPos();
    var lastPos = columnOrder.length - 1;
-   if (firstUnpinned > lastPos) return;
+   if (firstUnpinned > lastPos) {
+      // No unpinned column to render (every column hidden, or every fetched
+      // one pinned). Keep one empty cell so the row still has its height: the
+      // rendered rows of this pane define the scroll extent the frozen pane's
+      // rows follow, and cell-less rows would collapse to nothing, leaving
+      // later row names unreachable. unpinnedRenderedColumnCount matches.
+      parent.appendChild(colSpacerCell(spacerTag, 0));
+      return;
+   }
 
    // Clamp the window to the unpinned range; fall back to the full range if it
    // hasn't been computed yet so we never render an empty body.

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -286,12 +286,16 @@ var activeCol = -1;
 var activeHeaderCol = -1;
 
 // Absolute index of the column the active header should move to once the
-// window slide now in flight lands, or -1. Set by setColumnsHidden when a
+// window slide that fetches it lands, or -1. Set by setColumnsHidden when a
 // keyboard hide's successor column (the one taking the hidden column's slot)
-// isn't fetched yet; applyColumnWindowUpdate applies it after the remap, and
-// scrolls it into view when pendingActiveHeaderScroll is set.
+// isn't fetched yet; applyColumnWindowUpdate applies it after the remap --
+// only for the slide generation recorded here, and scrolling it into view
+// when pendingActiveHeaderScroll is set. Cancelled by any newer selection
+// (setActiveHeader / setActiveCell) and when that slide fails or is
+// superseded, so a stale intent can never hijack a later cursor position.
 var pendingActiveHeaderAbs = -1;
 var pendingActiveHeaderScroll = false;
+var pendingActiveHeaderGen = 0;
 
 // Pinned columns: a set of absolute (1-based) column indices in the full
 // frame, so a pin tracks its column across pagination rather than its position
@@ -2357,6 +2361,12 @@ var fetchedSetLacksRequested = function() {
    return false;
 };
 
+var clearPendingActiveHeader = function() {
+   pendingActiveHeaderAbs = -1;
+   pendingActiveHeaderScroll = false;
+   pendingActiveHeaderGen = 0;
+};
+
 // " (N hidden)" for the column readouts, or "" when nothing is hidden.
 var hiddenColumnsText = function() {
    var n = hiddenColumns.size;
@@ -2449,8 +2459,15 @@ var setColumnsHidden = function(absList, hidden, options) {
          setActiveHeader(newIdx, scrollHeader);
    }
 
-   if (!(options && options.deferSync) && fetchedSetLacksRequested())
-      slideColumnWindow();
+   if (!(options && options.deferSync) && fetchedSetLacksRequested()) {
+      // An unfetched successor is, by construction, part of what this slide
+      // requests; bind the parked cursor move to this slide alone.
+      var generation = slideColumnWindow();
+      if (pendingActiveHeaderAbs > 0)
+         pendingActiveHeaderGen = generation;
+   } else if (pendingActiveHeaderAbs > 0) {
+      clearPendingActiveHeader();
+   }
 };
 
 var toggleColumnHidden = function(absIdx) {
@@ -6562,6 +6579,8 @@ var ensureActiveCellVisible = function() {
 };
 
 var setActiveCell = function(row, col) {
+   // A selection made now outranks a cursor move parked for an in-flight slide.
+   clearPendingActiveHeader();
    var maxRow = filteredRows - 1;
    var maxCol = columnOrder.length - 1;
    if (maxRow < 0 || maxCol < 0) return;
@@ -6632,6 +6651,8 @@ var ensureActiveHeaderVisible = function() {
 // unwanted. Keyboard-driven changes keep the default so the active header (the
 // keyboard cursor) stays visible.
 var setActiveHeader = function(col, scrollIntoView) {
+   // A selection made now outranks a cursor move parked for an in-flight slide.
+   clearPendingActiveHeader();
    var maxCol = columnOrder.length - 1;
    if (maxCol < 0) return;
    col = Math.max(0, Math.min(maxCol, col));
@@ -7583,8 +7604,7 @@ var resetGridState = function() {
    activeRow = -1;
    activeCol = -1;
    activeHeaderCol = -1;
-   pendingActiveHeaderAbs = -1;
-   pendingActiveHeaderScroll = false;
+   clearPendingActiveHeader();
    // The viewport persists across destroyGrid; clear its activedescendant so
    // it can't reference an id whose td/th was just removed from the DOM.
    setViewportActiveDescendant(null);
@@ -8164,7 +8184,7 @@ var restoreScrollAnchor = function(anchor) {
 // options.targetAbs, when given, scrolls the viewport so that absolute column
 // is centered in the unpinned viewport region -- used by go-to-column jumps.
 // Otherwise the current visual position is preserved via a scroll anchor.
-var applyColumnWindowUpdate = function(resCols, options) {
+var applyColumnWindowUpdate = function(resCols, options, generation) {
    var targetAbs = options && options.targetAbs > 0 ? options.targetAbs : -1;
    var anchor = targetAbs > 0 ? null : captureScrollAnchor();
 
@@ -8216,9 +8236,10 @@ var applyColumnWindowUpdate = function(resCols, options) {
    activeHeaderCol = remapDisplayIdx(activeHeaderAbs);
 
    // A keyboard hide whose successor column wasn't fetched parked the
-   // cursor's destination (setColumnsHidden); it lands with this window.
+   // cursor's destination for this very slide (setColumnsHidden); it lands
+   // with this window. Any newer selection has already cancelled it.
    var pendingHeaderScroll = false;
-   if (pendingActiveHeaderAbs > 0) {
+   if (pendingActiveHeaderAbs > 0 && pendingActiveHeaderGen === generation) {
       var pendingIdx = remapDisplayIdx(pendingActiveHeaderAbs);
       if (pendingIdx >= 0) {
          activeHeaderCol = pendingIdx;
@@ -8226,8 +8247,7 @@ var applyColumnWindowUpdate = function(resCols, options) {
          activeCol = -1;
          pendingHeaderScroll = pendingActiveHeaderScroll;
       }
-      pendingActiveHeaderAbs = -1;
-      pendingActiveHeaderScroll = false;
+      clearPendingActiveHeader();
    }
 
    // The header row must be rebuilt for the new window, but autoSizeColumns
@@ -8354,7 +8374,7 @@ var applyColumnWindowUpdate = function(resCols, options) {
 // superseded by a newer slide or a full bootstrap (data refresh) is dropped.
 var slideColumnWindow = function(options) {
    if (bootstrapping || cols === null)
-      return;
+      return 0;
 
    var generation = ++bootstrapGeneration;
    slideInFlightGen = generation;
@@ -8363,7 +8383,13 @@ var slideColumnWindow = function(options) {
       // or failed slide can't permanently block scroll-driven slides.
       if (slideInFlightGen === generation)
          slideInFlightGen = 0;
-      if (generation !== bootstrapGeneration) return;
+      // A cursor move parked for this slide dies with it: a superseding slide
+      // or bootstrap has its own intent, and a failed slide leaves the grid as
+      // it was.
+      var superseded = generation !== bootstrapGeneration;
+      if ((superseded || result.error) && pendingActiveHeaderGen === generation)
+         clearPendingActiveHeader();
+      if (superseded) return;
       if (result.error) {
          // The slide advanced columnOffset before fetching; on failure roll it
          // back to the still-current fetched window. Otherwise columnOffset and
@@ -8375,8 +8401,9 @@ var slideColumnWindow = function(options) {
          return;
       }
       hideError();
-      applyColumnWindowUpdate(result, options);
+      applyColumnWindowUpdate(result, options, generation);
    });
+   return generation;
 };
 
 // Scroll-driven sliding: when the visible column range pokes outside the

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -2455,12 +2455,15 @@ var updateAllColumnsHiddenHint = function() {
    hint.classList.toggle("visible", allHidden);
 };
 
-// Rebuild headers in the current column order (pinned first, then unpinned).
-// Reorder existing <th> elements rather than recreating them so any attached
-// filter UI / popup state is preserved across pin toggles.
+// Rebuild headers in the current column order (pinned first, then unpinned,
+// hidden columns left out). Header-attached filter UI is re-injected; an open
+// filter editor is closed first, since the rows are rebuilt right after and
+// a deferred header rebuild would leave the two out of step.
 var rebuildHeaders = function() {
    var thead = domThead;
    if (!thead || !cols) return;
+
+   dismissHeaderEditors();
 
    // Recompute the pinned/unpinned order, then let autoSizeColumns rebuild the
    // windowed header row. Header-attached UI (filters, column types) is
@@ -2627,6 +2630,21 @@ var isHeaderEditorOpen = function() {
    var active = document.activeElement;
    return !!(active && active.classList &&
              active.classList.contains("textFilterBox"));
+};
+
+// Close any open header editor -- the tracked filter popup and a focused
+// inline text filter -- ahead of a layout rebuild that must not be deferred.
+// autoSizeColumns would otherwise postpone the header rebuild to protect the
+// editor while the rows are rebuilt against the new column order, leaving the
+// body and the headers out of step until the editor closes. Used by the window
+// slide (whose new window may not even contain the editor's column) and by
+// the pin / hide rebuilds.
+var dismissHeaderEditors = function() {
+   if (dismissActivePopup) dismissActivePopup(true);
+   var activeEl = document.activeElement;
+   if (activeEl && activeEl.classList && activeEl.classList.contains("textFilterBox"))
+      activeEl.blur();
+   deferredHeaderRebuild = false;
 };
 
 // Run a header rebuild that was deferred because an editor was open. Scheduled
@@ -8155,11 +8173,7 @@ var applyColumnWindowUpdate = function(resCols, options) {
    // defers the rebuild while a filter editor is open (to protect it from
    // teardown mid-edit). Close any open editor instead -- its column may not
    // even exist in the new window.
-   if (dismissActivePopup) dismissActivePopup(true);
-   var activeEl = document.activeElement;
-   if (activeEl && activeEl.classList && activeEl.classList.contains("textFilterBox"))
-      activeEl.blur();
-   deferredHeaderRebuild = false;
+   dismissHeaderEditors();
 
    // Rebuild layout for the new window: widths, headers (autoSizeColumns
    // re-injects any active header UI) and pinned offsets.

--- a/src/cpp/session/resources/grid/DataViewer.js
+++ b/src/cpp/session/resources/grid/DataViewer.js
@@ -285,6 +285,14 @@ var activeCol = -1;
 // from the body via ArrowUp at row 0.
 var activeHeaderCol = -1;
 
+// Absolute index of the column the active header should move to once the
+// window slide now in flight lands, or -1. Set by setColumnsHidden when a
+// keyboard hide's successor column (the one taking the hidden column's slot)
+// isn't fetched yet; applyColumnWindowUpdate applies it after the remap, and
+// scrolls it into view when pendingActiveHeaderScroll is set.
+var pendingActiveHeaderAbs = -1;
+var pendingActiveHeaderScroll = false;
+
 // Pinned columns: a set of absolute (1-based) column indices in the full
 // frame, so a pin tracks its column across pagination rather than its position
 // within the currently fetched window. The rownames column is always
@@ -2389,9 +2397,11 @@ var setColumnsHidden = function(absList, hidden, options) {
    // display slot, so the keyboard cursor doesn't vanish with it.
    clearActiveCell();
    var headerOrigCol = -1;
+   var headerOrigAbs = -1;
    var headerSlot = -1;
    if (activeHeaderCol >= 0) {
       headerOrigCol = columnOrder[activeHeaderCol];
+      headerOrigAbs = absColIndex(headerOrigCol);
       headerSlot = activeHeaderCol;
       clearActiveHeader();
    }
@@ -2410,12 +2420,33 @@ var setColumnsHidden = function(absList, hidden, options) {
    updateInfoBar();
    saveState();
 
+   var scrollHeader = !!(options && options.scrollActiveHeader);
    if (headerOrigCol >= 0) {
       var newIdx = columnOrder.indexOf(headerOrigCol);
-      if (newIdx < 0)
-         newIdx = Math.min(headerSlot, columnOrder.length - 1);
+      if (newIdx < 0) {
+         // The header's own column was hidden. Its successor in the scrollable
+         // layout -- the next column that is neither pinned nor hidden -- takes
+         // its slot, but may not be fetched yet when the hidden column sat at
+         // the window's right edge; the slide below then fetches it, and
+         // applyColumnWindowUpdate moves the cursor there on landing. (A pinned
+         // column, or one with no successor, keeps the slot-based fallback.)
+         var succAbs = pinnedColumns.has(headerOrigAbs)
+            ? -1
+            : nthIncludedAbs(headerOrigAbs + 1, 0, countExcludedInRange);
+         if (succAbs >= 1 && totalCols > 0 && succAbs <= totalCols) {
+            var succPos = posForAbsColIndex(succAbs);
+            if (succPos >= 0) {
+               newIdx = columnOrder.indexOf(succPos);
+            } else {
+               pendingActiveHeaderAbs = succAbs;
+               pendingActiveHeaderScroll = scrollHeader;
+            }
+         } else {
+            newIdx = Math.min(headerSlot, columnOrder.length - 1);
+         }
+      }
       if (newIdx >= 0)
-         setActiveHeader(newIdx, !!(options && options.scrollActiveHeader));
+         setActiveHeader(newIdx, scrollHeader);
    }
 
    if (!(options && options.deferSync) && fetchedSetLacksRequested())
@@ -7552,6 +7583,8 @@ var resetGridState = function() {
    activeRow = -1;
    activeCol = -1;
    activeHeaderCol = -1;
+   pendingActiveHeaderAbs = -1;
+   pendingActiveHeaderScroll = false;
    // The viewport persists across destroyGrid; clear its activedescendant so
    // it can't reference an id whose td/th was just removed from the DOM.
    setViewportActiveDescendant(null);
@@ -8182,6 +8215,21 @@ var applyColumnWindowUpdate = function(resCols, options) {
    if (activeCol < 0) activeRow = -1;
    activeHeaderCol = remapDisplayIdx(activeHeaderAbs);
 
+   // A keyboard hide whose successor column wasn't fetched parked the
+   // cursor's destination (setColumnsHidden); it lands with this window.
+   var pendingHeaderScroll = false;
+   if (pendingActiveHeaderAbs > 0) {
+      var pendingIdx = remapDisplayIdx(pendingActiveHeaderAbs);
+      if (pendingIdx >= 0) {
+         activeHeaderCol = pendingIdx;
+         activeRow = -1;
+         activeCol = -1;
+         pendingHeaderScroll = pendingActiveHeaderScroll;
+      }
+      pendingActiveHeaderAbs = -1;
+      pendingActiveHeaderScroll = false;
+   }
+
    // The header row must be rebuilt for the new window, but autoSizeColumns
    // defers the rebuild while a filter editor is open (to protect it from
    // teardown mid-edit). Close any open editor instead -- its column may not
@@ -8244,6 +8292,10 @@ var applyColumnWindowUpdate = function(resCols, options) {
       restoreScrollAnchor(anchor);
    }
    syncColumnWindow();
+   // The keyboard cursor that just landed on its successor column stays
+   // visible, as it does for an in-window keyboard hide.
+   if (pendingHeaderScroll)
+      ensureActiveHeaderVisible();
 
    // Sync the viewport's aria-activedescendant with the remapped active
    // cell/header (cleared when neither survived the slide).

--- a/src/cpp/session/resources/grid/gridviewer.html
+++ b/src/cpp/session/resources/grid/gridviewer.html
@@ -32,6 +32,10 @@
                         <tbody id="gridBody"></tbody>
                     </table>
                 </div>
+                <div id="allColumnsHiddenHint" role="status">
+                    <span>All columns are hidden.</span>
+                    <button type="button" id="allColumnsHiddenShow">Show all columns</button>
+                </div>
             </div>
             <div id="rsGridData_info" aria-live="polite" aria-atomic="true">
                 <div id="rsGridData_info_sort">


### PR DESCRIPTION
Adds per-column show/hide to the data viewer, driven from the summary panel.

- Each sidebar entry gets an eye icon (left of the funnel) that hides the column from the grid or shows it again. The entry stays listed, dimmed, so the column can be brought back.
- The panel header gets an eye (left of the close glyph): with anything hidden it shows all, otherwise it hides all. Hide-all is the reporter's "start from nothing, pick a few" workflow, so the all-hidden grid is a supported state, with an in-grid hint and a **Show all columns** button in case the sidebar is collapsed. The toolbar's Go to column box also stays available while anything is hidden, since jumping to a hidden column shows it.
- A hidden column keeps its pin, sort, filter and manual width. Clicking its entry or jumping to it with Go to column shows it again. `H` in header mode hides the column under the keyboard cursor, beside `P` for pin.
- The status bar and the sidebar's column count report `(N hidden)`; the "Sorted by" status keeps naming a sort column that is hidden.
- Hidden columns are persisted with the pins in the per-object state, dropped on a column-structure change, and cleared by Reset View and by closing the viewer.

### Implementation notes

This is client-only: the server already serves an arbitrary ordered set of absolute column indices (`columns_requested`). The fetched column window is now measured in visible columns (`windowEndAbs`), and pinned-or-hidden columns are excluded from the unfetched-span math (`countExcludedInRange` / `nthLayoutAbs`), so hiding extends the window's absolute span instead of thinning it. Two traps handled along the way: an empty `columns_requested` means "the whole frame" to the server, so hide-all names the lowest hidden column as a sentinel that is fetched but never rendered; and the frame width is unknown before the first response, so the saved state carries `totalCols` to bound the walk when hidden columns are restored (only then, since the hint goes stale when a column is added and the hidden case is the one guaranteed a clean re-bootstrap on the fingerprint mismatch).

The follow-up commits come from review: the Go to column box while columns are hidden, naming a hidden sort column in the status bar, closing an open filter editor (and committing pending typed text) before a pin/hide rebuild, carrying the keyboard cursor to its successor across the window slide a right-edge hide triggers (bound to that slide, cancelled by any newer selection), and a placeholder cell so the scrollable pane's rows keep their height when every column is hidden.

Fixes #17787.

### QA notes

New e2e spec `tests/panes/data-viewer/column-visibility.test.ts` (14 tests): entry eye, header eye and hint, rows scrollable with everything hidden, sort kept while hidden and entry click shows, hidden sort column's status across a refresh, hiding while a filter editor is open, pending filter text committed by a show rebuild, pinned and hidden, keyboard `H` (in-window and at the fetched window's edge), wide-frame window following the visible columns (hide all on 300 columns, show 1/260/300, no spacer cell, Go to column with the visible set fitting), Go to column on a narrow frame, a structural change discarding the hidden set, and refresh persistence plus Reset View. The existing data viewer specs pass locally except `clearing the sort restores original row order while a search is active (#18423)`, which fails identically against main's unmodified resources on this machine (the worktree dev shim runs a main session build that predates #18698/#18703).
